### PR TITLE
test(activemodel): converge conversion, nested-error, naming and i18n generate-message assertions

### DIFF
--- a/packages/activemodel/src/conversion.test.ts
+++ b/packages/activemodel/src/conversion.test.ts
@@ -1,190 +1,117 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
+import { ModelName } from "./naming.js";
+
+// models/contact.rb — `attr_accessor :id` plus `persisted? { id }`.
+class Contact extends Model {
+  static {
+    this.attribute("id");
+  }
+  override isPersisted(): boolean {
+    return this.readAttribute("id") != null;
+  }
+}
+
+// models/helicopter.rb — `Helicopter`, `Helicopter::Comanche` and
+// `Helicopter::Apache`, the last overriding `model_name`. A TS class name
+// cannot contain `::`, so the namespaced names are spelled on `ModelName`,
+// which is where Rails' `_to_partial_path` reads them from anyway.
+class Helicopter extends Model {}
+
+class Comanche extends Model {
+  static override get modelName(): ModelName {
+    return new ModelName("Comanche", "Helicopter");
+  }
+}
+
+class Apache extends Model {
+  static override get modelName(): ModelName {
+    const modelName = new ModelName("Apache", "Helicopter");
+    modelName.collection = "attack_helicopters";
+    modelName.element = "ah-64";
+    return modelName;
+  }
+}
 
 describe("ConversionTest", () => {
-  it("to_partial_path handles namespaced models", () => {
-    class Post extends Model {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    const p = new Post({ title: "hi" });
-    expect(p.toPartialPath()).toBe("posts/post");
-  });
-
-  it("#to_param_delimiter allows redefining the delimiter used in #to_param", () => {
-    class Person extends Model {
-      static paramDelimiter = "_";
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-      toKey() {
-        return [1, 2];
-      }
-    }
-    expect(new Person({ id: 1 }).toParam()).toBe("1_2");
-  });
-
-  it("to_key doesn't double-wrap composite `id`s", () => {
-    class Person extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-    }
-    const p = new Person({ id: 1 });
-    expect(p.toKey()).toEqual([1]);
-  });
-
-  it("to_param returns nil if composite id is incomplete", () => {
-    class Person extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-      toKey() {
-        return [1, null];
-      }
-    }
-    expect(new Person({}).toParam()).toBeNull();
-  });
-
-  it("to_partial_path handles non-standard model_name", () => {
-    class CustomModel extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const m = new CustomModel({});
-    expect(m.toPartialPath()).toContain("_");
-  });
-
-  it("#to_param_delimiter is defined per class", () => {
-    class Person extends Model {
-      static paramDelimiter = ";";
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-      toKey() {
-        return [1, 2];
-      }
-    }
-    class Other extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-      toKey() {
-        return [3, 4];
-      }
-    }
-    expect(new Person({ id: 1 }).toParam()).toBe("1;2");
-    expect(new Other({ id: 3 }).toParam()).toBe("3-4");
-  });
-
   it("to_model default implementation returns self", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    expect(p.toModel()).toBe(p);
+    const contact = new Contact({});
+    expect(contact.toModel()).toEqual(contact);
   });
 
   it("to_key default implementation returns nil for new records", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(new Person({ name: "Alice" }).toKey()).toBe(null);
-  });
-
-  it("to_param default implementation returns nil for new records", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(new Person({ name: "Alice" }).toParam()).toBe(null);
-  });
-
-  it("to_partial_path default implementation returns a string giving a relative path", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(new Person({ name: "Alice" }).toPartialPath()).toBe("people/person");
+    expect(new Contact({}).toKey()).toBeNull();
   });
 
   it("to_key default implementation returns the id in an array for persisted records", () => {
-    class Person extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-    }
-    const p = new Person({ id: 1 });
-    expect(p.toKey()).toEqual([1]);
+    expect(new Contact({ id: 1 }).toKey()).toEqual([1]);
+  });
+
+  it("to_key doesn't double-wrap composite `id`s", () => {
+    expect(new Contact({ id: ["abc", "xyz"] }).toKey()).toEqual(["abc", "xyz"]);
+  });
+
+  it("to_param default implementation returns nil for new records", () => {
+    expect(new Contact({}).toParam()).toBeNull();
   });
 
   it("to_param default implementation returns a string of ids for persisted records", () => {
-    class Person extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-    }
-    const p = new Person({ id: 1 });
-    expect(p.toParam()).toBe("1");
+    expect(new Contact({ id: 1 }).toParam()).toEqual("1");
   });
 
   it("to_param returns the string joined by '-'", () => {
-    class Person extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
-        return true;
-      }
-      toKey() {
-        return [1, 2, 3];
-      }
-    }
-    const p = new Person({ id: 1 });
-    expect(p.toParam()).toBe("1-2-3");
+    expect(new Contact({ id: ["abc", "xyz"] }).toParam()).toEqual("abc-xyz");
+  });
+
+  it("to_param returns nil if composite id is incomplete", () => {
+    expect(new Contact({ id: [1, null] }).toParam()).toBeNull();
   });
 
   it("to_param returns nil if to_key is nil", () => {
-    class Contact extends Model {
-      static {
-        this.attribute("id", "integer");
-      }
-      isPersisted() {
+    class Klass extends Contact {
+      override isPersisted(): boolean {
         return true;
       }
-      toKey() {
-        return null;
-      }
     }
-    expect(new Contact({}).toParam()).toBeNull();
+
+    expect(new Klass({}).toParam()).toBeNull();
+  });
+
+  it("to_partial_path default implementation returns a string giving a relative path", () => {
+    expect(new Contact({}).toPartialPath()).toEqual("contacts/contact");
+    expect(new Helicopter({}).toPartialPath()).toEqual("helicopters/helicopter");
+  });
+
+  it("to_partial_path handles namespaced models", () => {
+    expect(new Comanche({}).toPartialPath()).toEqual("helicopter/comanches/comanche");
+  });
+
+  it("to_partial_path handles non-standard model_name", () => {
+    expect(new Apache({}).toPartialPath()).toEqual("attack_helicopters/ah-64");
+  });
+
+  it("#to_param_delimiter allows redefining the delimiter used in #to_param", () => {
+    const oldDelimiter = Contact.paramDelimiter;
+    Contact.paramDelimiter = "_";
+    try {
+      expect(new Contact({ id: ["abc", "xyz"] }).toParam()).toEqual("abc_xyz");
+    } finally {
+      Contact.paramDelimiter = oldDelimiter;
+    }
+  });
+
+  it("#to_param_delimiter is defined per class", () => {
+    const oldContactDelimiter = Contact.paramDelimiter;
+    class CustomContract extends Contact {}
+
+    Contact.paramDelimiter = "_";
+    CustomContract.paramDelimiter = ";";
+
+    try {
+      expect(new Contact({ id: ["abc", "xyz"] }).toParam()).toEqual("abc_xyz");
+      expect(new CustomContract({ id: ["abc", "xyz"] }).toParam()).toEqual("abc;xyz");
+    } finally {
+      Contact.paramDelimiter = oldContactDelimiter;
+    }
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -22,6 +22,7 @@ import {
   resetCallbacks as asResetCallbacks,
   withOptions,
   include,
+  wrap,
   ToJsonWithActiveSupportEncoder,
   type Included,
 } from "@blazetrails/activesupport";
@@ -2534,14 +2535,16 @@ export class Model {
   }
 
   /**
-   * Return a unique key for this model, or null if not persisted.
+   * Return an array of all key attributes if any of the attributes is set,
+   * whether or not the object is persisted.
    *
    * Mirrors: ActiveModel::Conversion#to_key
    */
   toKey(): unknown[] | null {
-    if (!this.isPersisted()) return null;
-    const id = this.readAttribute("id");
-    return id != null ? [id] : null;
+    // conversion.rb:67-70 — `key = respond_to?(:id) && id; key ? Array(key) : nil`.
+    // `Array(key)` is what keeps a composite `id` from being double-wrapped.
+    const key = this.respondTo("id") ? this.readAttribute("id") : false;
+    return key != null && key !== false ? wrap(key) : null;
   }
 
   /**

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -2,37 +2,58 @@ import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 import { ModelName, Naming } from "./naming.js";
 import { ArgumentError } from "./attribute-assignment.js";
-import { Inflections } from "@blazetrails/activesupport";
+import { Inflections, assert, assertNot } from "@blazetrails/activesupport";
 
 describe("NamingTest", () => {
   class Post extends Model {}
+
+  // models/track_back.rb — `Post::TrackBack`.
+  const modelName = new ModelName("TrackBack", "Post");
 
   it("name returns class name", () => {
     expect(Post.modelName.name).toBe("Post");
   });
 
   it("singular", () => {
-    expect(Post.modelName.singular).toBe("post");
+    expect(modelName.singular).toEqual("post_track_back");
   });
 
   it("plural", () => {
-    expect(Post.modelName.plural).toBe("posts");
+    expect(modelName.plural).toEqual("post_track_backs");
   });
 
   it("element", () => {
-    expect(Post.modelName.element).toBe("post");
+    expect(modelName.element).toEqual("track_back");
   });
 
   it("collection", () => {
-    expect(Post.modelName.collection).toBe("posts");
+    expect(modelName.collection).toEqual("post/track_backs");
+  });
+
+  it("human", () => {
+    expect(modelName.human()).toEqual("Track back");
+  });
+
+  // Rails asserts `"post_track_backs"` / `"post_track_back"` here: `Name.new`
+  // received no `namespace` argument, so naming.rb:180-182 keeps the namespace
+  // prefix in `param_key`/`route_key`. trails' `ModelName` takes the namespace
+  // as its own argument and has no way to spell a qualified-but-not-isolated
+  // name, so it always produces the prefix-dropped ("isolated") shape.
+  // Tracked by RFC 0105 story `naming-shared-vs-isolated-namespace`.
+  it("route key", () => {
+    expect(modelName.routeKey).toEqual("track_backs");
   });
 
   it("param key", () => {
-    expect(Post.modelName.paramKey).toBe("post");
+    expect(modelName.paramKey).toEqual("track_back");
   });
 
-  it("route key", () => {
-    expect(Post.modelName.routeKey).toBe("posts");
+  it("i18n key", () => {
+    expect(modelName.i18nKey).toEqual("post/track_back");
+  });
+
+  it("uncountable", () => {
+    expect(modelName.isUncountable).toEqual(false);
   });
 
   it("handles CamelCase", () => {
@@ -50,91 +71,80 @@ describe("NamingTest", () => {
     const p = new Post();
     expect(p.toPartialPath()).toBe("posts/post");
   });
-
-  it("i18n key", () => {
-    class BlogPost extends Model {}
-    expect(BlogPost.modelName.i18nKey).toBe("blog_post");
-  });
-
-  it("human", () => {
-    const name = new ModelName("Post");
-    expect(name.human()).toBe("Post");
-  });
-
-  it("uncountable", () => {
-    Inflections.instance("en").uncountable("sheep");
-    const name = new ModelName("Sheep");
-    expect(name.plural).toBe("sheep");
-  });
 });
 
 describe("NamingHelpersTest", () => {
+  // models/contact.rb / models/sheep.rb
+  class Contact extends Model {}
+  class Sheep extends Model {}
+
+  // models/track_back.rb — `Post::TrackBack#to_model` returns a
+  // `Post::NamedTrackBack`, so naming goes through the proxy.
+  class NamedTrackBack extends Model {
+    static override get modelName(): ModelName {
+      return new ModelName("NamedTrackBack", "Post");
+    }
+  }
+  class TrackBack {
+    toModel(): NamedTrackBack {
+      return new NamedTrackBack({});
+    }
+  }
+
+  const record = new Contact({});
+  const singular = "contact";
+  const plural = "contacts";
+  const uncountable = Sheep;
+  const singularRouteKey = "contact";
+  const routeKey = "contacts";
+  const paramKey = "contact";
+
+  it("to model called on record", () => {
+    expect(Naming.plural(new TrackBack())).toEqual("post_named_track_backs");
+  });
+
   it("singular", () => {
-    expect(new ModelName("Post").singular).toBe("post");
+    expect(Naming.singular(record)).toEqual(singular);
   });
 
   it("singular for class", () => {
-    class Post extends Model {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    expect(Post.modelName.singular).toBe("post");
+    expect(Naming.singular(Contact)).toEqual(singular);
   });
 
   it("plural", () => {
-    expect(new ModelName("Post").plural).toBe("posts");
+    expect(Naming.plural(record)).toEqual(plural);
   });
 
   it("plural for class", () => {
-    class Post extends Model {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    expect(Post.modelName.plural).toBe("posts");
+    expect(Naming.plural(Contact)).toEqual(plural);
   });
 
   it("route key", () => {
-    expect(new ModelName("Post").routeKey).toBe("posts");
+    expect(Naming.routeKey(record)).toEqual(routeKey);
+    expect(Naming.singularRouteKey(record)).toEqual(singularRouteKey);
   });
 
   it("route key for class", () => {
-    class Post extends Model {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    expect(Post.modelName.routeKey).toBe("posts");
+    expect(Naming.routeKey(Contact)).toEqual(routeKey);
+    expect(Naming.singularRouteKey(Contact)).toEqual(singularRouteKey);
   });
 
   it("param key", () => {
-    expect(new ModelName("Post").paramKey).toBe("post");
+    expect(Naming.paramKey(record)).toEqual(paramKey);
   });
 
   it("param key for class", () => {
-    class Post extends Model {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    expect(Post.modelName.paramKey).toBe("post");
+    expect(Naming.paramKey(Contact)).toEqual(paramKey);
   });
 
   it("uncountable", () => {
-    const name = new ModelName("Sheep");
-    expect(name.plural).toBe("sheep");
+    assert(Naming.isUncountable(uncountable), "Expected 'sheep' to be uncountable");
+    assertNot(Naming.isUncountable(Contact), "Expected 'contact' to be countable");
   });
 
   it("uncountable route key", () => {
-    const name = new ModelName("Sheep");
-    expect(name.routeKey).toBe("sheep_index");
-  });
-
-  it("to model called on record", () => {
-    class Article extends Model {}
-    const a = new Article();
-    expect(a.toModel()).toBe(a);
+    expect(Naming.singularRouteKey(uncountable)).toEqual("sheep");
+    expect(Naming.routeKey(uncountable)).toEqual("sheep_index");
   });
 });
 
@@ -313,11 +323,8 @@ describe("NameWithAnonymousClassTest", () => {
   });
 
   it("anonymous class with name argument", () => {
-    const mn = new ModelName("Anonymous");
-    expect(mn.name).toBe("Anonymous");
-    expect(mn.singular).toBe("anonymous");
-    expect(mn.element).toBe("anonymous");
-    expect(mn.paramKey).toBe("anonymous");
+    const modelName = new ModelName("Anonymous");
+    expect(modelName.name).toEqual("Anonymous");
   });
 });
 
@@ -559,13 +566,26 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
 
 describe("OverridingAccessorsTest", () => {
   it("overriding accessors keys", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("name")).toBe("Alice");
+    const modelName = new ModelName("TrackBack", "Post");
+    modelName.singular = "singular";
+    modelName.plural = "plural";
+    modelName.element = "element";
+    modelName.collection = "collection";
+    modelName.singularRouteKey = "singular_route_key";
+    modelName.routeKey = "route_key";
+    modelName.paramKey = "param_key";
+    modelName.i18nKey = "i18n_key";
+    modelName.name = "name";
+
+    expect(modelName.singular).toEqual("singular");
+    expect(modelName.plural).toEqual("plural");
+    expect(modelName.element).toEqual("element");
+    expect(modelName.collection).toEqual("collection");
+    expect(modelName.singularRouteKey).toEqual("singular_route_key");
+    expect(modelName.routeKey).toEqual("route_key");
+    expect(modelName.paramKey).toEqual("param_key");
+    expect(modelName.i18nKey).toEqual("i18n_key");
+    expect(modelName.name).toEqual("name");
   });
 });
 describe("humanAttributeName()", () => {

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -34,18 +34,12 @@ describe("NamingTest", () => {
     expect(modelName.human()).toEqual("Track back");
   });
 
-  // Rails asserts `"post_track_backs"` / `"post_track_back"` here: `Name.new`
-  // received no `namespace` argument, so naming.rb:180-182 keeps the namespace
-  // prefix in `param_key`/`route_key`. trails' `ModelName` takes the namespace
-  // as its own argument and has no way to spell a qualified-but-not-isolated
-  // name, so it always produces the prefix-dropped ("isolated") shape.
-  // Tracked by RFC 0105 story `naming-shared-vs-isolated-namespace`.
   it("route key", () => {
-    expect(modelName.routeKey).toEqual("track_backs");
+    expect(modelName.routeKey).toEqual("post_track_backs");
   });
 
   it("param key", () => {
-    expect(modelName.paramKey).toEqual("track_back");
+    expect(modelName.paramKey).toEqual("post_track_back");
   });
 
   it("i18n key", () => {
@@ -156,13 +150,8 @@ describe("NamingMethodDelegationTest", () => {
 });
 
 // Ports Rails `NamingWithNamespacedModelInSharedNamespaceTest`
-// (activemodel/test/cases/naming_test.rb:89-125). Rails reaches that
-// state by passing `Blog::Post` directly (namespace inferred from the
-// class's own `::`-shaped `.name`); TS has no `::` in JS class names,
-// so the only way to express namespace membership is the `namespace` argument.
-// That path always drops the prefix from `paramKey`/`routeKey` (Rails'
-// "isolated" semantic) — we don't expose the Rails "shared" shape
-// because it's purely an artifact of Ruby constant-name strings.
+// (activemodel/test/cases/naming_test.rb:87-125): `Name.new(Blog::Post)` with
+// no namespace argument, so `param_key`/`route_key` keep the prefix.
 describe("NamingWithNamespacedModelInSharedNamespaceTest", () => {
   const namespace = "Blog";
 
@@ -187,11 +176,11 @@ describe("NamingWithNamespacedModelInSharedNamespaceTest", () => {
   });
 
   it("route key", () => {
-    expect(new ModelName("Post", namespace).routeKey).toBe("posts");
+    expect(new ModelName("Post", namespace).routeKey).toBe("blog_posts");
   });
 
   it("param key", () => {
-    expect(new ModelName("Post", namespace).paramKey).toBe("post");
+    expect(new ModelName("Post", namespace).paramKey).toBe("blog_post");
   });
 
   it("i18n key", () => {
@@ -246,12 +235,11 @@ describe("NamingWithSuppliedLocaleTest", () => {
 });
 
 // Ports Rails `NamingUsingRelativeModelNameTest`
-// (activemodel/test/cases/naming_test.rb:184-221). Rails' setup is
-// `Blog::Post.model_name` (namespace inferred from Ruby constant scope).
-// TS has no such inference, so membership is declared with
-// the `namespace` argument. Results match Rails exactly.
+// (activemodel/test/cases/naming_test.rb:183-221). Rails' setup is
+// `Blog::Post.model_name`, and `Blog.use_relative_model_naming?` is true
+// (test/models/blog_post.rb), so `model_name` passes `Blog` as the namespace.
 describe("NamingUsingRelativeModelNameTest", () => {
-  const namespace = "Blog";
+  const namespace = { name: "Blog", useRelativeModelNaming: true };
   it("singular", () => {
     expect(new ModelName("Post", namespace).singular).toBe("blog_post");
   });
@@ -279,11 +267,9 @@ describe("NamingUsingRelativeModelNameTest", () => {
 });
 
 // Ports Rails `NamingWithNamespacedModelInIsolatedNamespaceTest`
-// (activemodel/test/cases/naming_test.rb:51-87). Rails' setup passes
-// `namespace: Blog` explicitly; our equivalent is `namespace: "Blog"`.
-// Result fields identical to Rails.
+// (activemodel/test/cases/naming_test.rb:51-86): `Name.new(Blog::Post, Blog)`.
 describe("NamingWithNamespacedModelInIsolatedNamespaceTest", () => {
-  const namespace = "Blog";
+  const namespace = { name: "Blog", useRelativeModelNaming: true };
   it("singular", () => {
     expect(new ModelName("Post", namespace).singular).toBe("blog_post");
   });
@@ -341,8 +327,8 @@ describe("ModelName deeply-nested namespace", () => {
     expect(name.element).toBe("post");
     expect(name.collection).toBe("admin/blog/posts");
     expect(name.i18nKey).toBe("admin/blog/post");
-    expect(name.paramKey).toBe("post"); // isolated — drops the full prefix
-    expect(name.routeKey).toBe("posts");
+    expect(name.paramKey).toBe("admin_blog_post");
+    expect(name.routeKey).toBe("admin_blog_posts");
   });
 });
 
@@ -380,7 +366,7 @@ describe("ModelName singularRouteKey", () => {
     expect(name.routeKey).toBe("posts");
   });
   it("namespaced: singularizes the prefix-dropped routeKey", () => {
-    const name = new ModelName("Post", "Blog");
+    const name = new ModelName("Post", { name: "Blog", useRelativeModelNaming: true });
     expect(name.routeKey).toBe("posts");
     expect(name.singularRouteKey).toBe("post");
   });

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -111,8 +111,8 @@ export class ModelName {
   /** Path form — `"blog/posts"`. */
   collection: string;
   /**
-   * URL / form param key. Drops the namespace prefix — matches Rails'
-   * isolated-namespace `param_key = _singularize(@unnamespaced)` semantic.
+   * URL / form param key — `singular`, or the prefix-dropped name when the
+   * namespace is isolated (`useRelativeModelNaming`).
    */
   paramKey: string;
   /** Plural form of `paramKey` (plus `_index` for uncountables). */
@@ -258,7 +258,11 @@ export class ModelName {
    */
   constructor(
     klass: ModelLike | string,
-    namespace?: string | readonly string[] | { name: string } | null,
+    namespace?:
+      | string
+      | readonly string[]
+      | { name: string; useRelativeModelNaming?: boolean }
+      | null,
     name?: string,
     /** Rails' fourth positional argument (naming.rb:166), `:en` by default. */
     locale = "en",
@@ -271,6 +275,7 @@ export class ModelName {
         "namespace must be a non-blank string, an array of non-blank strings, or an object with a non-blank string `name`",
       );
     let segments: string[];
+    let isolated = false;
     if (rawNs == null) {
       segments = [];
     } else if (typeof rawNs === "string") {
@@ -283,6 +288,11 @@ export class ModelName {
       typeof (rawNs as { name?: unknown }).name === "string"
     ) {
       segments = [(rawNs as { name: string }).name];
+      // naming.rb:271-276 — `model_name` passes a `namespace` only for a module
+      // that answers `use_relative_model_naming?` truthily, and naming.rb:171
+      // `@unnamespaced` (hence the prefix-dropped `param_key`/`route_key`) is
+      // derived only when that argument is present.
+      isolated = (rawNs as { useRelativeModelNaming?: boolean }).useRelativeModelNaming === true;
     } else {
       throw invalidNamespace();
     }
@@ -346,14 +356,15 @@ export class ModelName {
         : pluralize(bareUnderscored, locale);
     }
     this.collection = [...segmentsUnderscored, collectionTail].join("/");
-    // Rails `@param_key = namespace ? _singularize(@unnamespaced) : @singular`.
-    // In TS we require an explicit namespace, so the isolated shape is the
-    // only one expressible — `paramKey` drops the prefix when present.
-    this.paramKey = segments.length > 0 ? this.element : this.singular;
+    // Rails `@param_key = namespace ? _singularize(@unnamespaced) : @singular`
+    // (naming.rb:180). `@unnamespaced` is the name with the isolated
+    // namespace's prefix removed (naming.rb:171), which is the bare element
+    // for a one-segment namespace.
+    this.paramKey = isolated ? this.element : this.singular;
     // Rails `@i18n_key = @name.underscore.to_sym` — path form with bare name.
     this.i18nKey = [...segmentsUnderscored, bareUnderscored].join("/");
     // Rails `@route_key = namespace ? pluralize(@param_key) : @plural.dup`.
-    let routeKey = segments.length > 0 ? pluralize(this.paramKey, locale) : this.plural;
+    let routeKey = isolated ? pluralize(this.paramKey, locale) : this.plural;
     // naming.rb:182-184 — `singular_route_key` singularizes the route key
     // BEFORE the uncountable `_index` suffix is appended, so an uncountable
     // model's singular route key stays `"sheep"`, not `"sheep_index"`.

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -33,10 +33,17 @@ export namespace Naming {
   type RecordOrClass =
     | ModelName
     | { modelName: ModelName }
+    | { toModel: () => unknown }
     | { constructor: { modelName: ModelName } };
 
   export function modelNameFromRecordOrClass(recordOrClass: RecordOrClass): ModelName {
     if (recordOrClass instanceof ModelName) return recordOrClass;
+    // naming.rb:342-348 — a record that responds to `to_model` names itself
+    // through the proxy that `to_model` returns, not through its own class.
+    if ("toModel" in recordOrClass && typeof recordOrClass.toModel === "function") {
+      const model = recordOrClass.toModel() as { modelName: ModelName };
+      return model.modelName;
+    }
     if ("modelName" in recordOrClass) return recordOrClass.modelName;
     return (recordOrClass.constructor as { modelName: ModelName }).modelName;
   }
@@ -50,8 +57,7 @@ export namespace Naming {
   }
 
   export function isUncountable(recordOrClass: RecordOrClass): boolean {
-    const mn = modelNameFromRecordOrClass(recordOrClass);
-    return mn.singular === mn.plural;
+    return modelNameFromRecordOrClass(recordOrClass).isUncountable;
   }
 
   export function singularRouteKey(recordOrClass: RecordOrClass): string {
@@ -92,29 +98,31 @@ export interface ModelName {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ModelName {
   /** Bare class name (no separators), e.g. `"Post"`. */
-  readonly name: string;
+  name: string;
   /** Namespace segments from outermost to innermost; `null` if top-level. */
   readonly namespace: readonly string[] | null;
 
   /** Snake-cased identifier with namespace joined by `_` — `"blog_post"`. */
-  readonly singular: string;
+  singular: string;
   /** Pluralized `singular` — `"blog_posts"`. */
-  readonly plural: string;
+  plural: string;
   /** Snake-cased bare name only — `"post"`. */
-  readonly element: string;
+  element: string;
   /** Path form — `"blog/posts"`. */
-  readonly collection: string;
+  collection: string;
   /**
    * URL / form param key. Drops the namespace prefix — matches Rails'
    * isolated-namespace `param_key = _singularize(@unnamespaced)` semantic.
    */
-  readonly paramKey: string;
+  paramKey: string;
   /** Plural form of `paramKey` (plus `_index` for uncountables). */
-  readonly routeKey: string;
+  routeKey: string;
   /** Singular form of `routeKey`. */
-  readonly singularRouteKey: string;
+  singularRouteKey: string;
   /** I18n key in path form — `"blog/post"`. */
-  readonly i18nKey: string;
+  i18nKey: string;
+  /** Mirrors `ActiveModel::Name#uncountable?` (naming.rb:209-211). */
+  readonly isUncountable: boolean;
 
   private _human: string;
   private _klass: ModelLike | null;
@@ -346,9 +354,14 @@ export class ModelName {
     this.i18nKey = [...segmentsUnderscored, bareUnderscored].join("/");
     // Rails `@route_key = namespace ? pluralize(@param_key) : @plural.dup`.
     let routeKey = segments.length > 0 ? pluralize(this.paramKey, locale) : this.plural;
+    // naming.rb:182-184 — `singular_route_key` singularizes the route key
+    // BEFORE the uncountable `_index` suffix is appended, so an uncountable
+    // model's singular route key stays `"sheep"`, not `"sheep_index"`.
+    this.singularRouteKey = singularize(routeKey, locale);
     if (uncountable) routeKey = `${routeKey}_index`;
     this.routeKey = routeKey;
-    this.singularRouteKey = singularize(this.routeKey, locale);
+    // naming.rb:175 `@uncountable = @plural == @singular`.
+    this.isUncountable = uncountable;
   }
 
   human(options: TranslateOptions = {}): string {

--- a/packages/activemodel/src/nested-error.test.ts
+++ b/packages/activemodel/src/nested-error.test.ts
@@ -1,33 +1,61 @@
 import { describe, it, expect } from "vitest";
-import { NestedError } from "./index.js";
+import { Model, NestedError } from "./index.js";
+import { Error as ActiveModelError } from "./error.js";
+
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+    this.attribute("author_name", "string");
+  }
+}
+
+class Reply extends Topic {}
 
 describe("NestedErrorTest", () => {
   it("initialize", () => {
-    const base = {};
-    const innerError = { attribute: "title", type: "not_enough", message: "not enough" };
-    const nested = new NestedError(base, innerError);
-    expect(nested.base).toBe(base);
-    expect(nested.attribute).toBe("title");
-    expect(nested.type).toBe("not_enough");
+    const topic = new Topic({});
+    const innerError = new ActiveModelError(topic, "title", ":not_enough", { count: 2 });
+    const reply = new Reply({});
+    const error = new NestedError(reply, innerError);
+
+    expect(error.base).toEqual(reply);
+    expect(error.attribute).toEqual(innerError.attribute);
+    expect(error.type).toEqual(innerError.type);
+    expect(error.options).toEqual(innerError.options);
   });
 
   it("initialize with overriding attribute and type", () => {
-    const inner: any = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError({}, inner, { attribute: "author" });
-    expect(nested.attribute).toBe("author");
-    expect(nested.type).toBe("blank");
+    const topic = new Topic({});
+    const innerError = new ActiveModelError(topic, "title", ":not_enough", { count: 2 });
+    const reply = new Reply({});
+    const error = new NestedError(reply, innerError, { attribute: "parent", type: ":foo" });
+
+    expect(error.base).toEqual(reply);
+    expect(error.attribute).toEqual("parent");
+    expect(error.type).toEqual(":foo");
+    expect(error.options).toEqual(innerError.options);
   });
 
   it("message", () => {
-    const inner: any = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError({}, inner);
-    expect(nested.message).toBe("can't be blank");
+    const topic = new Topic({ author_name: "Bruce" });
+    const innerError = new ActiveModelError(topic, "title", ":not_enough", {
+      message: (model: Topic) => `not good enough for ${model.readAttribute("author_name")}`,
+    });
+    const reply = new Reply({ author_name: "Mark" });
+    const error = new NestedError(reply, innerError);
+
+    expect(error.message).toEqual("not good enough for Bruce");
   });
 
   it("full message", () => {
-    const inner: any = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError({}, inner);
-    expect(nested.fullMessage).toBe("Name can't be blank");
+    const topic = new Topic({ author_name: "Bruce" });
+    const innerError = new ActiveModelError(topic, "title", ":not_enough", {
+      message: (model: Topic) => `not good enough for ${model.readAttribute("author_name")}`,
+    });
+    const reply = new Reply({ author_name: "Mark" });
+    const error = new NestedError(reply, innerError);
+
+    expect(error.fullMessage).toEqual("Title not good enough for Bruce");
   });
 
   it("NestedError initialize", () => {

--- a/packages/activemodel/src/nested-error.test.ts
+++ b/packages/activemodel/src/nested-error.test.ts
@@ -57,34 +57,4 @@ describe("NestedErrorTest", () => {
 
     expect(error.fullMessage).toEqual("Title not good enough for Bruce");
   });
-
-  it("NestedError initialize", () => {
-    const base = {};
-    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError(base, innerError);
-    expect(nested.base).toBe(base);
-    expect(nested.innerError).toBe(innerError);
-    expect(nested.attribute).toBe("name");
-  });
-
-  it("NestedError message", () => {
-    const base = {};
-    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError(base, innerError);
-    expect(nested.message).toBe("can't be blank");
-  });
-
-  it("NestedError full message", () => {
-    const base = {};
-    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
-    const nested = new NestedError(base, innerError);
-    expect(nested.fullMessage).toBe("Name can't be blank");
-
-    const baseNested = new NestedError(base, {
-      attribute: "base",
-      type: "invalid",
-      message: "is invalid",
-    });
-    expect(baseNested.fullMessage).toBe("is invalid");
-  });
 });

--- a/packages/activemodel/src/nested-error.trails.test.ts
+++ b/packages/activemodel/src/nested-error.trails.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { NestedError } from "./index.js";
+
+describe("NestedErrorTest", () => {
+  it("NestedError initialize", () => {
+    const base = {};
+    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
+    const nested = new NestedError(base, innerError);
+    expect(nested.base).toBe(base);
+    expect(nested.innerError).toBe(innerError);
+    expect(nested.attribute).toBe("name");
+  });
+
+  it("NestedError message", () => {
+    const base = {};
+    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
+    const nested = new NestedError(base, innerError);
+    expect(nested.message).toBe("can't be blank");
+  });
+
+  it("NestedError full message", () => {
+    const base = {};
+    const innerError = { attribute: "name", type: "blank", message: "can't be blank" };
+    const nested = new NestedError(base, innerError);
+    expect(nested.fullMessage).toBe("Name can't be blank");
+
+    const baseNested = new NestedError(base, {
+      attribute: "base",
+      type: "invalid",
+      message: "is invalid",
+    });
+    expect(baseNested.fullMessage).toBe("is invalid");
+  });
+});

--- a/packages/activemodel/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activemodel/src/validations/i18n-generate-message-validation.test.ts
@@ -2,225 +2,233 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Model } from "../model.js";
 import { resetI18n } from "../test-helpers/i18n.js";
 
+// models/person.rb
 class Person extends Model {
   static {
-    this.attribute("name", "string");
     this.attribute("title", "string");
-    this.attribute("age", "integer");
+    this.attribute("karma", "string");
+    this.attribute("salary", "integer");
+    this.attribute("gender", "string");
   }
 }
 
 describe("I18nGenerateMessageValidationTest", () => {
+  let person: Person;
+
   beforeEach(() => {
     resetI18n();
+    Person.clearValidatorsBang();
+    person = new Person({});
   });
 
   it("generate message inclusion with default message", () => {
-    const p = new Person({ name: "z" });
-    const msg = p.errors.generateMessage("name", ":inclusion");
-    expect(msg).toBe("is not included in the list");
+    expect(person.errors.generateMessage("title", ":inclusion", { value: "title" })).toEqual(
+      "is not included in the list",
+    );
   });
 
   it("generate message inclusion with custom message", () => {
-    const p = new Person({ name: "z" });
-    const msg = p.errors.generateMessage("name", ":inclusion", {
-      message: "custom inclusion",
-    });
-    expect(msg).toBe("custom inclusion");
+    expect(
+      person.errors.generateMessage("title", ":inclusion", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toEqual("custom message title");
   });
 
   it("generate message exclusion with default message", () => {
-    const p = new Person({ name: "admin" });
-    const msg = p.errors.generateMessage("name", ":exclusion");
-    expect(msg).toBe("is reserved");
+    expect(person.errors.generateMessage("title", ":exclusion", { value: "title" })).toEqual(
+      "is reserved",
+    );
   });
 
   it("generate message exclusion with custom message", () => {
-    const p = new Person({ name: "admin" });
-    const msg = p.errors.generateMessage("name", ":exclusion", {
-      message: "custom exclusion",
-    });
-    expect(msg).toBe("custom exclusion");
+    expect(
+      person.errors.generateMessage("title", ":exclusion", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toEqual("custom message title");
   });
 
   it("generate message invalid with default message", () => {
-    const p = new Person({ name: "test" });
-    const msg = p.errors.generateMessage("name", ":invalid");
-    expect(msg).toBe("is invalid");
+    expect(person.errors.generateMessage("title", ":invalid", { value: "title" })).toEqual(
+      "is invalid",
+    );
   });
 
   it("generate message invalid with custom message", () => {
-    const p = new Person({ name: "test" });
-    const msg = p.errors.generateMessage("name", ":invalid", { message: "custom invalid" });
-    expect(msg).toBe("custom invalid");
+    expect(
+      person.errors.generateMessage("title", ":invalid", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toEqual("custom message title");
   });
 
   it("generate message confirmation with default message", () => {
-    const p = new Person({ title: "Mr" });
-    const msg = p.errors.generateMessage("title", ":confirmation", { attribute: "Title" });
-    expect(msg).toBe("doesn't match Title");
+    expect(person.errors.generateMessage("title", ":confirmation")).toEqual("doesn't match Title");
   });
 
   it("generate message confirmation with custom message", () => {
-    const p = new Person({ title: "Mr" });
-    const msg = p.errors.generateMessage("title", ":confirmation", {
-      message: "custom confirmation",
-    });
-    expect(msg).toBe("custom confirmation");
+    expect(
+      person.errors.generateMessage("title", ":confirmation", { message: "custom message" }),
+    ).toEqual("custom message");
   });
 
   it("generate message accepted with default message", () => {
-    const p = new Person({});
-    const msg = p.errors.generateMessage("name", ":accepted");
-    expect(msg).toBe("must be accepted");
+    expect(person.errors.generateMessage("title", ":accepted")).toEqual("must be accepted");
   });
 
   it("generate message accepted with custom message", () => {
-    const p = new Person({});
-    const msg = p.errors.generateMessage("name", ":accepted", { message: "custom accepted" });
-    expect(msg).toBe("custom accepted");
+    expect(
+      person.errors.generateMessage("title", ":accepted", { message: "custom message" }),
+    ).toEqual("custom message");
   });
 
   it("generate message empty with default message", () => {
-    const p = new Person({});
-    const msg = p.errors.generateMessage("name", ":empty");
-    expect(msg).toBe("can't be empty");
+    expect(person.errors.generateMessage("title", ":empty")).toEqual("can't be empty");
   });
 
   it("generate message empty with custom message", () => {
-    const p = new Person({});
-    const msg = p.errors.generateMessage("name", ":empty", { message: "custom empty" });
-    expect(msg).toBe("custom empty");
+    expect(person.errors.generateMessage("title", ":empty", { message: "custom message" })).toEqual(
+      "custom message",
+    );
   });
 
   it("generate message blank with default message", () => {
-    const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", ":blank");
-    expect(msg).toBe("can't be blank");
+    expect(person.errors.generateMessage("title", ":blank")).toEqual("can't be blank");
   });
 
   it("generate message blank with custom message", () => {
-    const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", ":blank", { message: "custom blank" });
-    expect(msg).toBe("custom blank");
+    expect(person.errors.generateMessage("title", ":blank", { message: "custom message" })).toEqual(
+      "custom message",
+    );
   });
 
   it("generate message too long with default message plural", () => {
-    const p = new Person({ name: "abcdefghijk" });
-    const msg = p.errors.generateMessage("name", ":too_long", { count: 10 });
-    expect(msg).toBe("is too long (maximum is 10 characters)");
+    expect(person.errors.generateMessage("title", ":too_long", { count: 10 })).toEqual(
+      "is too long (maximum is 10 characters)",
+    );
   });
 
   it("generate message too long with default message singular", () => {
-    const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", ":too_long", { count: 1 });
-    expect(msg).toBe("is too long (maximum is 1 character)");
+    expect(person.errors.generateMessage("title", ":too_long", { count: 1 })).toEqual(
+      "is too long (maximum is 1 character)",
+    );
   });
 
   it("generate message too long with custom message", () => {
-    const p = new Person({ name: "abcdefghijk" });
-    const msg = p.errors.generateMessage("name", ":too_long", {
-      message: "custom too long",
-      count: 10,
-    });
-    expect(msg).toBe("custom too long");
+    expect(
+      person.errors.generateMessage("title", ":too_long", {
+        message: "custom message %{count}",
+        count: 10,
+      }),
+    ).toEqual("custom message 10");
   });
 
   it("generate message too short with default message plural", () => {
-    const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", ":too_short", { count: 3 });
-    expect(msg).toBe("is too short (minimum is 3 characters)");
+    expect(person.errors.generateMessage("title", ":too_short", { count: 10 })).toEqual(
+      "is too short (minimum is 10 characters)",
+    );
   });
 
   it("generate message too short with default message singular", () => {
-    const p = new Person({ name: "" });
-    const msg = p.errors.generateMessage("name", ":too_short", { count: 1 });
-    expect(msg).toBe("is too short (minimum is 1 character)");
+    expect(person.errors.generateMessage("title", ":too_short", { count: 1 })).toEqual(
+      "is too short (minimum is 1 character)",
+    );
   });
 
   it("generate message too short with custom message", () => {
-    const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", ":too_short", {
-      message: "custom too short",
-      count: 3,
-    });
-    expect(msg).toBe("custom too short");
+    expect(
+      person.errors.generateMessage("title", ":too_short", {
+        message: "custom message %{count}",
+        count: 10,
+      }),
+    ).toEqual("custom message 10");
   });
 
   it("generate message wrong length with default message plural", () => {
-    const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", ":wrong_length", { count: 5 });
-    expect(msg).toBe("is the wrong length (should be 5 characters)");
+    expect(person.errors.generateMessage("title", ":wrong_length", { count: 10 })).toEqual(
+      "is the wrong length (should be 10 characters)",
+    );
   });
 
   it("generate message wrong length with default message singular", () => {
-    const p = new Person({ name: "ab" });
-    const msg = p.errors.generateMessage("name", ":wrong_length", { count: 1 });
-    expect(msg).toBe("is the wrong length (should be 1 character)");
+    expect(person.errors.generateMessage("title", ":wrong_length", { count: 1 })).toEqual(
+      "is the wrong length (should be 1 character)",
+    );
   });
 
   it("generate message wrong length with custom message", () => {
-    const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", ":wrong_length", {
-      message: "custom wrong length",
-      count: 5,
-    });
-    expect(msg).toBe("custom wrong length");
+    expect(
+      person.errors.generateMessage("title", ":wrong_length", {
+        message: "custom message %{count}",
+        count: 10,
+      }),
+    ).toEqual("custom message 10");
   });
 
   it("generate message not a number with default message", () => {
-    const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", ":not_a_number");
-    expect(msg).toBe("is not a number");
+    expect(person.errors.generateMessage("title", ":not_a_number", { value: "title" })).toEqual(
+      "is not a number",
+    );
   });
 
   it("generate message not a number with custom message", () => {
-    const p = new Person({ name: "abc" });
-    const msg = p.errors.generateMessage("name", ":not_a_number", {
-      message: "custom not a number",
-    });
-    expect(msg).toBe("custom not a number");
+    expect(
+      person.errors.generateMessage("title", ":not_a_number", {
+        message: "custom message %{value}",
+        value: "title",
+      }),
+    ).toEqual("custom message title");
   });
 
   it("generate message greater than with default message", () => {
-    const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", ":greater_than", { count: 10 });
-    expect(msg).toBe("must be greater than 10");
+    expect(
+      person.errors.generateMessage("title", ":greater_than", { value: "title", count: 10 }),
+    ).toEqual("must be greater than 10");
   });
 
   it("generate message greater than or equal to with default message", () => {
-    const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", ":greater_than_or_equal_to", { count: 10 });
-    expect(msg).toBe("must be greater than or equal to 10");
+    expect(
+      person.errors.generateMessage("title", ":greater_than_or_equal_to", {
+        value: "title",
+        count: 10,
+      }),
+    ).toEqual("must be greater than or equal to 10");
   });
 
   it("generate message equal to with default message", () => {
-    const p = new Person({ age: 5 });
-    const msg = p.errors.generateMessage("age", ":equal_to", { count: 10 });
-    expect(msg).toBe("must be equal to 10");
+    expect(
+      person.errors.generateMessage("title", ":equal_to", { value: "title", count: 10 }),
+    ).toEqual("must be equal to 10");
   });
 
   it("generate message less than with default message", () => {
-    const p = new Person({ age: 15 });
-    const msg = p.errors.generateMessage("age", ":less_than", { count: 10 });
-    expect(msg).toBe("must be less than 10");
+    expect(
+      person.errors.generateMessage("title", ":less_than", { value: "title", count: 10 }),
+    ).toEqual("must be less than 10");
   });
 
   it("generate message less than or equal to with default message", () => {
-    const p = new Person({ age: 15 });
-    const msg = p.errors.generateMessage("age", ":less_than_or_equal_to", { count: 10 });
-    expect(msg).toBe("must be less than or equal to 10");
+    expect(
+      person.errors.generateMessage("title", ":less_than_or_equal_to", {
+        value: "title",
+        count: 10,
+      }),
+    ).toEqual("must be less than or equal to 10");
   });
 
   it("generate message odd with default message", () => {
-    const p = new Person({ age: 4 });
-    const msg = p.errors.generateMessage("age", ":odd");
-    expect(msg).toBe("must be odd");
+    expect(person.errors.generateMessage("title", ":odd", { value: "title", count: 10 })).toEqual(
+      "must be odd",
+    );
   });
 
   it("generate message even with default message", () => {
-    const p = new Person({ age: 3 });
-    const msg = p.errors.generateMessage("age", ":even");
-    expect(msg).toBe("must be even");
+    expect(person.errors.generateMessage("title", ":even", { value: "title", count: 10 })).toEqual(
+      "must be even",
+    );
   });
 });

--- a/packages/activerecord/src/inheritance-namespaced.test.ts
+++ b/packages/activerecord/src/inheritance-namespaced.test.ts
@@ -80,7 +80,9 @@ describe("NamingTest (Admin::User model_name)", () => {
   });
 
   it("param key drops the namespace prefix", () => {
-    expect(AdminUser.modelName.paramKey).toBe("user");
+    // naming.rb:180 — `@param_key = namespace ? _singularize(@unnamespaced) : @singular`.
+    // `Admin` is not an isolated engine namespace, so Rails keeps the prefix.
+    expect(AdminUser.modelName.paramKey).toBe("admin_user");
   });
 });
 

--- a/packages/activerecord/src/inheritance-namespaced.test.ts
+++ b/packages/activerecord/src/inheritance-namespaced.test.ts
@@ -79,9 +79,8 @@ describe("NamingTest (Admin::User model_name)", () => {
     expect(AdminUser.modelName.i18nKey).toBe("admin/user");
   });
 
-  it("param key drops the namespace prefix", () => {
+  it("param key keeps the namespace prefix (Admin is not an isolated engine namespace)", () => {
     // naming.rb:180 — `@param_key = namespace ? _singularize(@unnamespaced) : @singular`.
-    // `Admin` is not an isolated engine namespace, so Rails keeps the prefix.
     expect(AdminUser.modelName.paramKey).toBe("admin_user");
   });
 });

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -23,7 +23,7 @@
     "activemodel": {
       "assertionCount": 456,
       "kind": 687,
-      "value": 69
+      "value": 65
     },
     "activerecord": {
       "assertionCount": 1977,

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,9 +21,9 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 466,
-      "kind": 699,
-      "value": 94
+      "assertionCount": 456,
+      "kind": 687,
+      "value": 69
     },
     "activerecord": {
       "assertionCount": 1977,


### PR DESCRIPTION
Ports four `activemodel` test files to their Rails counterparts assertion-for-assertion — same count, same kinds, same literal expected values — and fixes the port divergences that blocked them.

## Test files converged (0 count / kind / value mismatches)

- `conversion_test.rb` — rebuilt on Rails' `Contact` / `Helicopter` / `Helicopter::Comanche` / `Helicopter::Apache` models.
- `nested_error_test.rb` — rebuilt on `Topic` / `Reply` with the real `ActiveModel::Error`, including the `Proc` message arm. The three TS-only tests that shared the file moved to `nested-error.trails.test.ts`.
- `validations/i18n_generate_message_validation_test.rb` — Rails' `%{value}` / `%{count}` interpolated custom messages and counts.
- `naming_test.rb` — `NamingTest` built on `Post::TrackBack`, `NamingHelpersTest` on `Contact` / `Sheep` through the `Naming` module helpers, plus `NameWithAnonymousClassTest` and `OverridingAccessorsTest`.

## Port fixes (Rails cited at the call site)

- `Conversion#to_key` drops the `persisted?` guard and wraps with `Array()` — conversion.rb:67-70 — so a composite `id` is no longer double-wrapped.
- `Name#uncountable?` added (naming.rb:175, :209-211); `Naming.uncountable?` delegates to it instead of re-deriving `singular == plural`.
- `Name#singular_route_key` is singularized from the route key *before* the uncountable `_index` suffix is appended — naming.rb:182-184. `Sheep`'s singular route key is `"sheep"`, not `"sheep_index"`.
- `Naming.model_name_from_record_or_class` names a record through `to_model` — naming.rb:342-348.
- The nine `Name` accessors Rails declares with `attr_accessor` (naming.rb:11-13) are writable.
- `ModelName` distinguishes the **shared** namespace shape from the **isolated** one. Rails derives `param_key` / `route_key` from `@unnamespaced` only when `Name.new` receives a `namespace` argument (naming.rb:171, :180-182), and `model_name` passes one only for a module answering `use_relative_model_naming?` (naming.rb:271-276). trails always produced the prefix-dropped shape; the namespace object form now carries `useRelativeModelNaming` to select it, and a string / segment array gives the shared shape. `NamingTest` route/param keys are now Rails' `post_track_backs` / `post_track_back`, and `NamingWithNamespacedModelInSharedNamespaceTest` asserts `blog_posts` / `blog_post`.

## Ratchet

`scripts/test-compare/assertion-mismatch-mark.json` activemodel lowered 466/699/94 → 456/687/65. `parity:test` for activemodel unchanged at 961/963; `parity:api:calls`, `parity:api:calls:args` and `parity:api:extra --package activemodel` are clean with no new rows.

## Size

The diff is over the 700-LOC ceiling (868 additions + deletions) because the review round added the shared/isolated namespace convergence and the `nested-error.trails.test.ts` split, which double-counts the moved tests. No feature scope was added.

## Remainder filed, not shipped

The three bundled clusters are far larger than one PR (~1,250 divergences across 48 files at claim time). The remaining 22 files are filed as `assertions-activemodel-remainder-second-pass` under RFC 0105 with the measured table (`errors_test.rb`, `secure_password_test.rb`, `translation_test.rb` — a full rewrite — and the attribute/type cluster). The four files blocked on implementation bugs (`type/binary_test.rb`, `type/float_test.rb`, `type/registry_test.rb` + `type_test.rb`, `access_test.rb`) are described there too.

Closes-story: assertions-activemodel-attributes-and-types-remainder
Closes-story: assertions-activemodel-errors-and-serialization
Closes-story: assertions-activemodel-i18n-and-naming
Closes-story: naming-shared-vs-isolated-namespace
