### PR TITLE
refactor(activerecord,activesupport): inline apply_join_dependency's except/select_association_list, HWIA#initialize via update, site nested_under_indifferent_access

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4762,6 +4762,16 @@ export class Relation<T extends Base> {
    * relation), the limit/offset materialization guard below is skipped, because
    * Rails only rewrites the relation via `distinct_relation_for_primary_key`
    * when `eager_loading` is truthy.
+   *
+   * The second `using_limitable_reflections?` clause (finder_methods.rb:466-470)
+   * reads `_namedInnerJoins` where Rails reads `joins_values`. Rails'
+   * `select_association_list` (query_methods.rb:1810-1823) keeps only the
+   * `Hash, Symbol, Array` members and drops raw SQL Strings; TypeScript collapses
+   * Ruby's Symbol and String onto one type, so that `when` cannot be spelled by
+   * type — `_namedInnerJoins` is the `joins_values` subset it selects, under the
+   * same discriminator `joins()` itself uses. `left_outer_joins_values` needs no
+   * such subset: `assertValidLeftOuterJoinsBang` already rejects a raw String
+   * there, exactly where Rails raises for it.
    * @internal
    */
   applyJoinDependency({
@@ -5160,7 +5170,9 @@ export class Relation<T extends Base> {
    * must be non-collection. A collection reflection in `joins`/`leftOuterJoins`
    * forces the distinct-parent-id rewrite even when every eager reflection is
    * singular. Sibling of `_applyJoinDependencyIsLimitable`, which resolves the
-   * first clause from specs instead of a built dependency.
+   * first clause from specs instead of a built dependency. See
+   * {@link applyJoinDependency} for why the second clause reads
+   * `_namedInnerJoins` where Rails reads `joins_values`.
    */
   private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
     return (

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4776,7 +4776,8 @@ export class Relation<T extends Base> {
       eagerSpecs as any,
       Nodes.OuterJoin,
     );
-    const rel = this._exceptEagerValues(joinDependency);
+    const rel = this.except("includes", "eagerLoad", "preload");
+    QueryMethodBangs.joinsBang.call(rel as any, joinDependency as any);
 
     // Rails `apply_join_dependency`, for a limit/offset over non-limitable
     // (collection) reflections, replaces the relation with
@@ -4794,7 +4795,17 @@ export class Relation<T extends Base> {
     const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
     const isLimitable =
       this.usingLimitableReflections(joinDependency.reflections as never) &&
-      this._joinsReflectionsAreLimitable();
+      this.usingLimitableReflections(
+        QueryMethodBangs.constructJoinDependency.call(
+          this as any,
+          _qm.selectAssociationList
+            .call(this as any, this._namedInnerJoins, null)
+            .concat(
+              _qm.selectAssociationList.call(this as any, this._leftOuterJoinsValues, null),
+            ) as AssociationSpec[],
+          null,
+        ).reflections as never,
+      );
     if (eagerLoading && hasLimitOrOffset && !isLimitable) {
       // @nie disposition=TODO
       throw new NotImplementedError(
@@ -4836,67 +4847,20 @@ export class Relation<T extends Base> {
       const limitedIds = await this._materializeLimitedIds(jd, basePk);
       return run(this._applyEagerJoinDependency(jd, basePk, limitedIds));
     }
-    return run(this._exceptEagerValues(jd));
-  }
-
-  /**
-   * Limitability of Rails' first `using_limitable_reflections?` clause: the
-   * reflections of `construct_join_dependency(eager_load_values | includes_values)`
-   * (finder_methods.rb:457-470, join_dependency.rb:81-82). Specs are resolved
-   * through a JoinDependency so nested-hash/array eager chains
-   * (`eagerLoad({ author: "profile" })`) contribute every reflection in the tree
-   * — matching Rails' `JoinDependency#reflections` — rather than short-circuiting
-   * to non-limitable on the first non-string spec. Shares the resolution path
-   * with `_joinsReflectionsAreLimitable`.
-   */
-  private _eagerReflectionsAreLimitable(specs: AssociationSpec[]): boolean {
-    if (specs.length === 0) return true;
-    const jd = this._buildEagerJoinDependency(specs);
-    return this.usingLimitableReflections(jd.reflections);
+    const relation = this.except("includes", "eagerLoad", "preload");
+    QueryMethodBangs.joinsBang.call(relation as any, jd as any);
+    return run(relation);
   }
 
   /**
    * Mirror Rails' two-clause `using_limitable_reflections?` test in
-   * `apply_join_dependency` (finder_methods.rb:464-470): a limit/offset over an
-   * eager join dependency is deferral-free (limitable) only when BOTH the eager
-   * join-dependency reflections (`eager_load_values | includes_values`) AND a
-   * second join-dependency built from
-   * `select_association_list(joins_values) ∪ select_association_list(left_outer_joins_values)`
-   * are limitable. A collection reflection in joins/leftOuterJoins forces
-   * `distinct_relation_for_primary_key` materialization even when every eager
-   * reflection is singular.
+   * `apply_join_dependency` (finder_methods.rb:464-470) for the callers that
+   * hold the eager specs rather than the built dependency: resolve them through
+   * a JoinDependency, as `construct_join_dependency(eager_load_values |
+   * includes_values, …)` does, and apply the same guard.
    */
   private _applyJoinDependencyIsLimitable(eagerSpecs: AssociationSpec[]): boolean {
-    return this._eagerReflectionsAreLimitable(eagerSpecs) && this._joinsReflectionsAreLimitable();
-  }
-
-  /**
-   * Limitability of Rails' second `using_limitable_reflections?` clause: the
-   * reflections of `construct_join_dependency(select_association_list(joins_values)
-   * .concat(select_association_list(left_outer_joins_values)), nil)`
-   * (finder_methods.rb:466-470). `_namedInnerJoins` holds the association
-   * references routed out of `joins` (Rails' `select_association_list(joins_values)`,
-   * query_methods.rb:1810); `_leftOuterJoinsValues` the same for left joins. Raw
-   * SQL/Arel joins stay in `_joinValues` and are not reflections. Specs are
-   * resolved through a JoinDependency so nested-hash/array chains
-   * (`joins({ account: "profile" })`) contribute every reflection in the tree —
-   * matching Rails' `JoinDependency#reflections` rather than the conservative
-   * eager-spec resolver, which rejects every non-string spec.
-   */
-  private _joinsReflectionsAreLimitable(): boolean {
-    const specs = [...this._namedInnerJoins, ...this._leftOuterJoinsValues];
-    if (specs.length === 0) return true;
-    const mergedReflections: unknown[] = [];
-    const namedSpecs: AssociationSpec[] = [];
-    for (const spec of specs) {
-      if (spec instanceof JoinDependency) {
-        mergedReflections.push(...spec.reflections);
-        continue;
-      }
-      namedSpecs.push(spec);
-    }
-    const jd = this._buildEagerJoinDependency(namedSpecs);
-    return this.usingLimitableReflections([...jd.reflections, ...mergedReflections] as never);
+    return this._eagerJoinDependencyIsLimitable(this._buildEagerJoinDependency(eagerSpecs));
   }
 
   /**
@@ -5165,7 +5129,8 @@ export class Relation<T extends Base> {
     basePk: string | string[],
     limitedIds?: unknown[],
   ): Relation<T> {
-    let rel = this._exceptEagerValues(jd);
+    let rel = this.except("includes", "eagerLoad", "preload");
+    QueryMethodBangs.joinsBang.call(rel as any, jd as any);
     const hasLimit = this._limitValue !== null || this._offsetValue !== null;
     if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
       if (Array.isArray(basePk)) {
@@ -5200,23 +5165,18 @@ export class Relation<T extends Base> {
   private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
     return (
       this.usingLimitableReflections(jd.reflections as never) &&
-      this._joinsReflectionsAreLimitable()
+      this.usingLimitableReflections(
+        QueryMethodBangs.constructJoinDependency.call(
+          this as any,
+          _qm.selectAssociationList
+            .call(this as any, this._namedInnerJoins, null)
+            .concat(
+              _qm.selectAssociationList.call(this as any, this._leftOuterJoinsValues, null),
+            ) as AssociationSpec[],
+          null,
+        ).reflections as never,
+      )
     );
-  }
-
-  /**
-   * Rails `except(:includes, :eager_load, :preload).joins!(join_dependency)`
-   * (finder_methods.rb:460) — the relation rewrite both `apply_join_dependency`
-   * entry points share. With the JoinDependency in `joins_values`, `build_joins`
-   * folds it into the single `join_constraints` call alongside the manual joins,
-   * under one shared AliasTracker and the `walk` dedup.
-   */
-  private _exceptEagerValues(jd: JoinDependency): Relation<T> {
-    const rel = this._withEagerJoinDependency(jd);
-    rel._eagerLoadAssociations = [];
-    rel._includesAssociations = [];
-    rel._preloadAssociations = [];
-    return rel;
   }
 
   /**

--- a/packages/activesupport/src/core-ext/hash/indifferent-access.ts
+++ b/packages/activesupport/src/core-ext/hash/indifferent-access.ts
@@ -1,0 +1,19 @@
+import { HashWithIndifferentAccess } from "../../hash-with-indifferent-access.js";
+
+type AnyObject = Record<string, unknown>;
+
+/**
+ * Returns a HashWithIndifferentAccess out of its receiver — Ruby's
+ * `Hash#with_indifferent_access` (core_ext/hash/indifferent_access.rb:9-11).
+ * The receiver is the first argument here because TypeScript has no way to
+ * define the method on `Object.prototype`.
+ */
+export function withIndifferentAccess(obj: AnyObject): HashWithIndifferentAccess<unknown> {
+  return new HashWithIndifferentAccess(obj);
+}
+
+/**
+ * `alias nested_under_indifferent_access with_indifferent_access`
+ * (core_ext/hash/indifferent_access.rb:23).
+ */
+export const nestedUnderIndifferentAccess = withIndifferentAccess;

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -397,21 +397,14 @@ export function exceptBang<T extends AnyObject>(hash: T, ...keys: string[]): T {
   return hash;
 }
 
-/**
- * Returns a HashWithIndifferentAccess out of its receiver — Ruby's
- * `Hash#with_indifferent_access` (core_ext/hash/indifferent_access.rb:9). The
- * receiver is the first argument here because TypeScript has no way to define
- * the method on `Object.prototype`.
- */
-export function withIndifferentAccess(obj: AnyObject): HashWithIndifferentAccess<unknown> {
-  return new HashWithIndifferentAccess(obj);
-}
-
-/**
- * `alias nested_under_indifferent_access with_indifferent_access`
- * (core_ext/hash/indifferent_access.rb:23).
- */
-export const nestedUnderIndifferentAccess = withIndifferentAccess;
+// `Hash#with_indifferent_access` and its `nested_under_indifferent_access`
+// alias live in the file Rails puts them in,
+// core_ext/hash/indifferent_access.rb; re-exported here so existing importers
+// are untouched.
+export {
+  withIndifferentAccess,
+  nestedUnderIndifferentAccess,
+} from "./core-ext/hash/indifferent-access.js";
 
 /**
  * Assert that all keys in obj are within the allowed set of validKeys.

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -10,12 +10,8 @@
  * Rails' own name.
  */
 
-import {
-  deepMerge as deepMergeObj,
-  isPlainObject,
-  nestedUnderIndifferentAccess,
-  symbolizeKeysBang,
-} from "./hash-utils.js";
+import { deepMerge as deepMergeObj, isPlainObject, symbolizeKeysBang } from "./hash-utils.js";
+import { nestedUnderIndifferentAccess } from "./core-ext/hash/indifferent-access.js";
 import { KeyError } from "./core-ext/key-error.js";
 
 type AnyObject = Record<string, unknown>;
@@ -35,18 +31,14 @@ type DefaultBlock<V> = (key: string) => V;
 export class HashWithIndifferentAccess<V = unknown> {
   private data: Map<string, V>;
 
-  constructor(constructor?: AnyObject | Map<string, V> | HashWithIndifferentAccess<V>) {
+  constructor(constructor?: AnyObject | HashWithIndifferentAccess<V>) {
     this.data = new Map();
-    if (constructor) {
-      if (constructor instanceof Map) {
-        for (const [key, value] of constructor) {
-          this.data.set(String(key), value);
-        }
-      } else {
-        // Mirrors Rails HashWithIndifferentAccess#initialize, which populates
-        // via `update(constructor)` rather than inlining the copy.
-        this.update(constructor);
-      }
+    // Mirrors `initialize` (hash_with_indifferent_access.rb:70-83): the
+    // populated arm goes through `update`, so every key gets `convert_key` and
+    // every value `convert_value`. Rails' `else super(constructor)` arm sets a
+    // Hash default value, which this class does not model.
+    if (constructor != null) {
+      this.update(constructor);
     }
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -10,20 +10,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
-    "call": "except",
-    "reason": "Verified per-site (RFC 0106): Rails' `except(:includes, :eager_load, :preload).joins!(join_dependency)` (finder_methods.rb:461) is spelled by `_exceptEagerValues(jd)`, which performs exactly that rewrite; the extraction exists because trails has three apply-join-dependency entry points (sync, async, eager) sharing the one Rails expression."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "select_association_list",
-    "reason": "Verified per-site (RFC 0106): Rails re-selects the association subset of joins_values/left_outer_joins_values here (finder_methods.rb:466-470); trails routes named association joins out at `joins()` time into `_namedInnerJoins`/`_leftOuterJoinsValues`, so the selection is already done and `_joinsReflectionsAreLimitable` reads those lists directly."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "apply_join_dependency",
     "call": "skip_query_cache_if_necessary",
     "reason": "Verified per-site (RFC 0106): the call sits in Rails' `distinct_relation_for_primary_key` arm (finder_methods.rb:473-477), which executes a query. The synchronous `applyJoinDependency` cannot and throws NotImplementedError instead; the awaitable `_applyJoinDependencyAsync` carries that arm, and the gate matches only the Rails-named method."
   },

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -271,7 +271,6 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   "activesupport:core_ext/hash/slice.rb": "core-ext/hash/slice.ts",
   "activesupport:core_ext/hash/except.rb": "hash-utils.ts",
   "activesupport:core_ext/hash/deep_merge.rb": "hash-utils.ts",
-  "activesupport:core_ext/hash/indifferent_access.rb": "hash-with-indifferent-access.ts",
   "activesupport:core_ext/array/conversions.rb": "array-utils.ts",
   "activesupport:core_ext/string/exclude.rb": "string-utils.ts",
   "activesupport:core_ext/object/inclusion.rb": "enumerable-utils.ts",


### PR DESCRIPTION
Three related fidelity convergences (RFC 0106 + RFC 0098).

## `apply_join_dependency` (finder_methods.rb:457-485)

- The `except(:includes, :eager_load, :preload).joins!(join_dependency)`
  expression Rails inlines (finder_methods.rb:461) is now spelled inline at
  each of the three trails entry points; `_exceptEagerValues` is deleted.
- The second `using_limitable_reflections?` clause now runs
  `selectAssociationList(...)` on the inner/left-outer join values and feeds
  the result to `constructJoinDependency(..., null)`, matching
  finder_methods.rb:466-470; `_joinsReflectionsAreLimitable` and its sibling
  `_eagerReflectionsAreLimitable` are deleted. Rails passes no `stashed_joins`
  here, so a stashed `JoinDependency` contributes no reflections — trails now
  matches that.
- The two `apply_join_dependency` rows (`except`, `select_association_list`) in
  `call-mismatches-exclude/activerecord/relation.json` are deleted by hand via
  `serializeBaseline`. No reseed; `parity:api:calls` and
  `parity:api:calls:args` are green.

## `HashWithIndifferentAccess#initialize` (hash_with_indifferent_access.rb:70-83)

Every populated arm in Rails goes through `update`, so every key gets
`convert_key` and every value `convert_value`. The `constructor instanceof Map`
arm wrote `data` directly, bypassing both — the last non-`regularWriter` write
path past the converters. No caller passed a `Map`, so the arm is dropped.

## `Hash#nested_under_indifferent_access` siting

`with_indifferent_access` and its `nested_under_indifferent_access` alias move
from `hash-utils.ts` to `core-ext/hash/indifferent-access.ts`, the path
`docs/ruby-ts-conventions.md` produces from `core_ext/hash/indifferent_access.rb`,
and the `RUBY_FILE_TS_OVERRIDES` row that pointed that Ruby file at
`hash-with-indifferent-access.ts` is removed. Re-exported from `hash-utils.ts`,
so `index.ts`'s exported names are unchanged.

Closes-story: apply-join-dependency-inlines-except-and-select-association-list
Closes-story: hwia-initialize-routes-through-update
Closes-story: site-nested-under-indifferent-access-in-core-ext