### PR TITLE
refactor(activerecord,activesupport): one home for apply_join_dependency's limitability guard, Rails block arity for HWIA enumerable members

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3118,7 +3118,9 @@ export class Relation<T extends Base> {
     const compositePkBypass =
       Array.isArray(basePk) &&
       hasLimitOrOffset &&
-      !this._applyJoinDependencyIsLimitable(this._deferredDistinctPkEagerSpecs());
+      !this._eagerJoinDependencyIsLimitable(
+        this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs()),
+      );
     return compositePkBypass || this._ctes.length > 0 || !this._fromClause.isEmpty();
   }
 
@@ -3156,29 +3158,11 @@ export class Relation<T extends Base> {
     new JoinDependency(this._model, this.table, specs, Nodes.OuterJoin);
   }
 
-  /**
-   * Rails `apply_join_dependency` hands the eager JoinDependency to the query
-   * builder by pushing it into `joins_values`
-   * (`joins!(construct_join_dependency(...))`, finder_methods.rb:457-461) — not
-   * as a side-channel argument. Mirror that for the eager SELECT/calculation
-   * paths, which construct their JoinDependency locally: spawn a relation whose
-   * `joins_values` carries the JD, so `build_joins` picks it up through the same
-   * `select_named_joins` partition that stashes any other JoinDependency in
-   * `joins_values`.
-   * @internal
-   */
-  _withEagerJoinDependency(jd?: JoinDependency): Relation<T> {
-    if (jd === undefined) return this;
-    const rel = this._clone();
-    QueryMethodBangs.joinsBang.call(rel as any, jd as any);
-    return rel;
-  }
-
   private _applyJoinsToManager(manager: SelectManager, aliases?: AliasTracker): void {
     // Live SQL path: assemble a JoinEmissionPlan and hand it to the shared
     // `build_joins` port (`emitJoinPlan`), which `buildJoins` (the
     // `from(relation)` subquery path) also delegates to. An eager JoinDependency
-    // rides in `joins_values` (see `_withEagerJoinDependency`) exactly as Rails
+    // rides in `joins_values` exactly as Rails
     // `apply_join_dependency` puts it there, so `emitJoinPlan`'s
     // `select_named_joins` partition folds it into `stashedJoins`: the manual
     // joins AND the eager JD emit through ONE `build_joins` call with ONE shared
@@ -3499,7 +3483,7 @@ export class Relation<T extends Base> {
       const jd = this._buildEagerJoinDependency(eagerSpecs);
 
       const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-      if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
+      if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
         // A composite base PK can't be materialized here — `_materializeLimitedIds`
         // (Rails' zip/transpose over `Array(primary_key)`) has no composite
         // support, so it would emit a wrong single-column `"col1,col2"` predicate.
@@ -3652,7 +3636,8 @@ export class Relation<T extends Base> {
       rel._includesAssociations = [];
 
       const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-      if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
+      const jd = this._buildEagerJoinDependency(eagerSpecs);
+      if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
         // Same two guards `pluck`'s arm carries: `hasInclude` returns true off
         // `_eagerLoadAssociations` alone, so `pk` can still be null here (a
         // view), and `_materializeLimitedIds` — Rails' zip/transpose over
@@ -3661,7 +3646,6 @@ export class Relation<T extends Base> {
         // applyJoinDependency's explicit NotImplementedError instead.
         const basePk = pk ?? "id";
         if (Array.isArray(basePk)) this.applyJoinDependency();
-        const jd = this._buildEagerJoinDependency(eagerSpecs);
         const limitedIds = await this._materializeLimitedIds(jd, basePk);
         const limited = rel.leftOuterJoins(eagerSpecs).where({ [basePk as string]: limitedIds });
         limited._limitValue = null;
@@ -4699,15 +4683,10 @@ export class Relation<T extends Base> {
    * Rails only rewrites the relation via `distinct_relation_for_primary_key`
    * when `eager_loading` is truthy.
    *
-   * The second `using_limitable_reflections?` clause (finder_methods.rb:466-470)
-   * reads `_namedInnerJoins` where Rails reads `joins_values`. Rails'
-   * `select_association_list` (query_methods.rb:1810-1823) keeps only the
-   * `Hash, Symbol, Array` members and drops raw SQL Strings; TypeScript collapses
-   * Ruby's Symbol and String onto one type, so that `when` cannot be spelled by
-   * type — `_namedInnerJoins` is the `joins_values` subset it selects, under the
-   * same discriminator `joins()` itself uses. `left_outer_joins_values` needs no
-   * such subset: `assertValidLeftOuterJoinsBang` already rejects a raw String
-   * there, exactly where Rails raises for it.
+   * The two-clause `using_limitable_reflections?` test Rails spells inline here
+   * (finder_methods.rb:463-470) lives in `_eagerJoinDependencyIsLimitable`, its
+   * single home — see there for why the second clause reads `_namedInnerJoins`
+   * where Rails reads `joins_values`.
    * @internal
    */
   applyJoinDependency({
@@ -4739,20 +4718,7 @@ export class Relation<T extends Base> {
     // claim parity we reject this combination explicitly. Tracked by the
     // `converge-relation-subquery-distinct-pk-materialization` continuation story.
     const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-    const isLimitable =
-      this.usingLimitableReflections(joinDependency.reflections as never) &&
-      this.usingLimitableReflections(
-        QueryMethodBangs.constructJoinDependency.call(
-          this as any,
-          _qm.selectAssociationList
-            .call(this as any, this._namedInnerJoins, null)
-            .concat(
-              _qm.selectAssociationList.call(this as any, this._leftOuterJoinsValues, null),
-            ) as AssociationSpec[],
-          null,
-        ).reflections as never,
-      );
-    if (eagerLoading && hasLimitOrOffset && !isLimitable) {
+    if (eagerLoading && hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(joinDependency)) {
       // @nie disposition=TODO
       throw new NotImplementedError(
         "Using an eager-loaded relation with a limit/offset over a collection " +
@@ -4799,17 +4765,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirror Rails' two-clause `using_limitable_reflections?` test in
-   * `apply_join_dependency` (finder_methods.rb:464-470) for the callers that
-   * hold the eager specs rather than the built dependency: resolve them through
-   * a JoinDependency, as `construct_join_dependency(eager_load_values |
-   * includes_values, …)` does, and apply the same guard.
-   */
-  private _applyJoinDependencyIsLimitable(eagerSpecs: AssociationSpec[]): boolean {
-    return this._eagerJoinDependencyIsLimitable(this._buildEagerJoinDependency(eagerSpecs));
-  }
-
-  /**
    * Mirror Rails `using_limitable_reflections?` (finder_methods.rb:487):
    * `reflections.none?(&:collection?)` — a set of reflections is limitable
    * when none of them is a collection association.
@@ -4844,7 +4799,9 @@ export class Relation<T extends Base> {
     if (this._groupColumns.length > 0) return false;
     if (!this._eagerLoadingForSql()) return false;
     if (this._limitValue === null && this._offsetValue === null) return false;
-    return !this._applyJoinDependencyIsLimitable(this._deferredDistinctPkEagerSpecs());
+    return !this._eagerJoinDependencyIsLimitable(
+      this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs()),
+    );
   }
 
   /**
@@ -5105,10 +5062,24 @@ export class Relation<T extends Base> {
    * `select_association_list(joins_values) ∪ select_association_list(left_outer_joins_values)`
    * must be non-collection. A collection reflection in `joins`/`leftOuterJoins`
    * forces the distinct-parent-id rewrite even when every eager reflection is
-   * singular. Sibling of `_applyJoinDependencyIsLimitable`, which resolves the
-   * first clause from specs instead of a built dependency. See
-   * {@link applyJoinDependency} for why the second clause reads
-   * `_namedInnerJoins` where Rails reads `joins_values`.
+   * singular.
+   *
+   * Rails spells this guard inline in `apply_join_dependency` because that one
+   * block-form method is its only entry point; trails still has several
+   * (`applyJoinDependency`, `_applyJoinDependencyAsync`,
+   * `_applyEagerJoinDependency`, `_executeEagerLoad`,
+   * `_isDeferredDistinctPkSubquery`) pending the sync/async collapse tracked by
+   * `converge-relation-subquery-distinct-pk-materialization`, so the guard has
+   * exactly ONE home here and every entry point calls it — never a second copy.
+   *
+   * The second clause reads `_namedInnerJoins` where Rails reads `joins_values`:
+   * `select_association_list` (query_methods.rb:1810-1823) keeps only the
+   * `Hash, Symbol, Array` members and drops raw SQL Strings, and TypeScript
+   * collapses Ruby's Symbol and String onto one type, so that `when` cannot be
+   * spelled by type — `_namedInnerJoins` is the `joins_values` subset it selects,
+   * under the same discriminator `joins()` itself uses. `left_outer_joins_values`
+   * needs no such subset: `assertValidLeftOuterJoinsBang` already rejects a raw
+   * String there, exactly where Rails raises for it.
    */
   private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
     return (
@@ -5166,7 +5137,14 @@ export class Relation<T extends Base> {
     // shared `AliasTracker` spanning the eager JoinDependency and the manual
     // joins, deduping coinciding nodes via `walk` — same threading as the
     // relation `_applyEagerJoinDependency` yields.
-    this._withEagerJoinDependency(jd)._applyJoinsToManager(idSubquery);
+    // Rails `apply_join_dependency` hands the eager JoinDependency to the query
+    // builder by pushing it into `joins_values`
+    // (`joins!(construct_join_dependency(...))`, finder_methods.rb:461) — not as
+    // a side-channel argument — so `build_joins` picks it up through the same
+    // `select_named_joins` partition that stashes any other JoinDependency there.
+    const joined = this._clone();
+    QueryMethodBangs.joinsBang.call(joined as any, jd as any);
+    joined._applyJoinsToManager(idSubquery);
     this._applyWheresToManager(idSubquery, table);
     this._applyOrderToManager(idSubquery);
     if (this._limitValue !== null) idSubquery.take(this._limitValue);
@@ -6598,11 +6576,7 @@ export class Relation<T extends Base> {
         const hasLimitOrOffset = this._limitValue !== null || (this._offsetValue ?? 0) > 0;
         const pk = (this._model as { primaryKey?: string | string[] }).primaryKey ?? "id";
         const jd = this._buildEagerJoinDependency(eagerSpecs);
-        if (
-          hasLimitOrOffset &&
-          !this._applyJoinDependencyIsLimitable(eagerSpecs) &&
-          !Array.isArray(pk)
-        ) {
+        if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd) && !Array.isArray(pk)) {
           // Rails' distinct_relation_for_primary_key (finder_methods.rb:463):
           // materialize the limited DISTINCT primary keys, rewrite as
           // `WHERE pk IN (ids)`, and clear limit/offset. Single-column PK only —
@@ -6616,7 +6590,7 @@ export class Relation<T extends Base> {
           collection = rel.leftOuterJoins(eagerSpecs).where({ [pk]: limitedIds });
           collection._limitValue = null;
           collection._offsetValue = null;
-        } else if (hasLimitOrOffset && !this._applyJoinDependencyIsLimitable(eagerSpecs)) {
+        } else if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
           // Composite-PK, non-limitable eager limit/offset: unsupported here —
           // surfaces NotImplementedError rather than a wrong predicate. Tracked
           // by 0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4717,8 +4717,11 @@ export class Relation<T extends Base> {
     // materialized-ID shape and ordered-distinct handling — so rather than
     // claim parity we reject this combination explicitly. Tracked by the
     // `converge-relation-subquery-distinct-pk-materialization` continuation story.
-    const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-    if (eagerLoading && hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(joinDependency)) {
+    if (
+      eagerLoading &&
+      this.hasLimitOrOffset &&
+      !this._eagerJoinDependencyIsLimitable(joinDependency)
+    ) {
       // @nie disposition=TODO
       throw new NotImplementedError(
         "Using an eager-loaded relation with a limit/offset over a collection " +
@@ -5137,11 +5140,6 @@ export class Relation<T extends Base> {
     // shared `AliasTracker` spanning the eager JoinDependency and the manual
     // joins, deduping coinciding nodes via `walk` — same threading as the
     // relation `_applyEagerJoinDependency` yields.
-    // Rails `apply_join_dependency` hands the eager JoinDependency to the query
-    // builder by pushing it into `joins_values`
-    // (`joins!(construct_join_dependency(...))`, finder_methods.rb:461) — not as
-    // a side-channel argument — so `build_joins` picks it up through the same
-    // `select_named_joins` partition that stashes any other JoinDependency there.
     const joined = this._clone();
     QueryMethodBangs.joinsBang.call(joined as any, jd as any);
     joined._applyJoinsToManager(idSubquery);

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -222,33 +222,35 @@ describe("HashWithIndifferentAccessTest", () => {
 
   it("count with predicate — counts matching entries", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2, c: 3 });
-    expect(h.count((_k, v) => (v as number) > 1)).toBe(2);
+    expect(h.count(([, v]) => (v as number) > 1)).toBe(2);
   });
 
   it("find — returns first matching [key, value] pair", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    const found = h.find((_k, v) => (v as number) === 2);
+    const found = h.find(([, v]) => (v as number) === 2);
     expect(found).toEqual(["b", 2]);
-    expect(h.find((_k, v) => (v as number) === 99)).toBeUndefined();
+    expect(h.find(([, v]) => (v as number) === 99)).toBeUndefined();
   });
 
   it("each — iterates key-value pairs", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
     const result: [string, unknown][] = [];
-    h.each((k, v) => result.push([k, v]));
+    h.each((pair) => {
+      result.push(pair);
+    });
     expect(result).toContainEqual(["a", 1]);
     expect(result).toContainEqual(["b", 2]);
   });
 
   it("map — maps over entries returning array", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    const result = h.map((k, v) => `${k}=${v}`);
+    const result = h.map(([k, v]) => `${k}=${v}`);
     expect(result.sort()).toEqual(["a=1", "b=2"]);
   });
 
   it("flatMap — flatMaps over entries", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    const result = h.flatMap((k, v) => [k, v]);
+    const result = h.flatMap(([k, v]) => [k, v]);
     expect(result).toContain("a");
     expect(result).toContain(1);
   });
@@ -264,13 +266,13 @@ describe("HashWithIndifferentAccessTest", () => {
   // minBy / maxBy
   it("minBy — finds entry with minimum value", () => {
     const h = new HashWithIndifferentAccess({ a: 3, b: 1, c: 2 });
-    const result = h.minBy((_k, v) => v as number);
+    const result = h.minBy(([, v]) => v as number);
     expect(result).toEqual(["b", 1]);
   });
 
   it("maxBy — finds entry with maximum value", () => {
     const h = new HashWithIndifferentAccess({ a: 3, b: 1, c: 2 });
-    const result = h.maxBy((_k, v) => v as number);
+    const result = h.maxBy(([, v]) => v as number);
     expect(result).toEqual(["a", 3]);
   });
 

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -296,7 +296,8 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * Select — returns new HWIA with pairs where predicate returns true.
+   * Mirror Rails `select` (hash_with_indifferent_access.rb:323-326), which
+   * delegates to `Hash#select!` and so yields `|key, value|`.
    */
   select(fn: (key: string, value: V) => boolean): HashWithIndifferentAccess<V> {
     const result = new HashWithIndifferentAccess<V>();
@@ -309,7 +310,8 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * Reject — returns new HWIA with pairs where predicate returns false.
+   * Mirror Rails `reject` (hash_with_indifferent_access.rb:328-331), which
+   * delegates to `Hash#reject!` and so yields `|key, value|`.
    */
   reject(fn: (key: string, value: V) => boolean): HashWithIndifferentAccess<V> {
     return this.select((k, v) => !fn(k, v));
@@ -385,55 +387,60 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * count — count all entries or matching entries.
+   * Ruby `Enumerable#count` over a Hash: the block is yielded the `[key, value]`
+   * pair, not two arguments.
    */
-  count(fn?: (key: string, value: V) => boolean): number {
+  count(fn?: (pair: [string, V]) => boolean): number {
     if (!fn) return this.data.size;
     let n = 0;
-    for (const [k, v] of this.data) {
-      if (fn(k, v)) n++;
+    for (const pair of this.data) {
+      if (fn(pair)) n++;
     }
     return n;
   }
 
   /**
-   * find — returns the first [key, value] pair matching predicate, or undefined.
+   * Ruby `Enumerable#find` over a Hash: the block is yielded the `[key, value]`
+   * pair, and the matching pair is returned.
    */
-  find(fn: (key: string, value: V) => boolean): [string, V] | undefined {
-    for (const [k, v] of this.data) {
-      if (fn(k, v)) return [k, v];
+  find(fn: (pair: [string, V]) => boolean): [string, V] | undefined {
+    for (const pair of this.data) {
+      if (fn(pair)) return pair;
     }
     return undefined;
   }
 
   /**
-   * each — iterate key-value pairs.
+   * Ruby `Hash#each` / `each_pair`: the block is yielded the `[key, value]`
+   * pair.
    */
-  each(fn: (key: string, value: V) => void): this {
-    for (const [k, v] of this.data) {
-      fn(k, v);
+  each(fn: (pair: [string, V]) => void): this {
+    for (const pair of this.data) {
+      fn(pair);
     }
     return this;
   }
 
   /**
-   * map — map over entries, returning an array.
+   * Ruby `Hash#map`: the block is yielded the `[key, value]` pair, so
+   * `hash.map((pair) => pair[0])` is spellable as Ruby's `hash.map(&:first)` is.
    */
-  map<T>(fn: (key: string, value: V) => T): T[] {
+  map<T>(fn: (pair: [string, V]) => T): T[] {
     const result: T[] = [];
-    for (const [k, v] of this.data) {
-      result.push(fn(k, v));
+    for (const pair of this.data) {
+      result.push(fn(pair));
     }
     return result;
   }
 
   /**
-   * flatMap — flatMap over entries, returning a flattened array.
+   * Ruby `Enumerable#flat_map` over a Hash: the block is yielded the
+   * `[key, value]` pair.
    */
-  flatMap<T>(fn: (key: string, value: V) => T[]): T[] {
+  flatMap<T>(fn: (pair: [string, V]) => T[]): T[] {
     const result: T[] = [];
-    for (const [k, v] of this.data) {
-      result.push(...fn(k, v));
+    for (const pair of this.data) {
+      result.push(...fn(pair));
     }
     return result;
   }
@@ -482,32 +489,34 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * minBy — returns the [key, value] pair with the minimum computed value.
+   * Ruby `Enumerable#min_by` over a Hash: the block is yielded the
+   * `[key, value]` pair, and that pair is returned.
    */
-  minBy(fn: (key: string, value: V) => number): [string, V] | undefined {
+  minBy(fn: (pair: [string, V]) => number): [string, V] | undefined {
     let min: number | undefined;
     let minEntry: [string, V] | undefined;
-    for (const [k, v] of this.data) {
-      const n = fn(k, v);
+    for (const pair of this.data) {
+      const n = fn(pair);
       if (min === undefined || n < min) {
         min = n;
-        minEntry = [k, v];
+        minEntry = pair;
       }
     }
     return minEntry;
   }
 
   /**
-   * maxBy — returns the [key, value] pair with the maximum computed value.
+   * Ruby `Enumerable#max_by` over a Hash: the block is yielded the
+   * `[key, value]` pair, and that pair is returned.
    */
-  maxBy(fn: (key: string, value: V) => number): [string, V] | undefined {
+  maxBy(fn: (pair: [string, V]) => number): [string, V] | undefined {
     let max: number | undefined;
     let maxEntry: [string, V] | undefined;
-    for (const [k, v] of this.data) {
-      const n = fn(k, v);
+    for (const pair of this.data) {
+      const n = fn(pair);
       if (max === undefined || n > max) {
         max = n;
-        maxEntry = [k, v];
+        maxEntry = pair;
       }
     }
     return maxEntry;


### PR DESCRIPTION
## What

Two small fidelity convergences.

### 1. `apply_join_dependency`'s limitability guard has one home

`vendor/rails/activerecord/lib/active_record/relation/finder_methods.rb:463-470`
spells the two-clause `using_limitable_reflections?` test inline inside
`apply_join_dependency`. trails carried it twice, plus two trails-only privates
around it. Removed:

- `_applyJoinDependencyIsLimitable(eagerSpecs)` — a spec-taking wrapper; its six
  call sites now pass the JoinDependency they already have in scope (or build it
  with `_buildEagerJoinDependency`) to the one guard.
- `_withEagerJoinDependency(jd)` — public surface with a single call site
  (`_buildEagerIdSubquery`); inlined there as the `_clone()` + `joins!(jd)` Rails
  does at finder_methods.rb:461.
- the duplicated inline copy in `applyJoinDependency`, which now calls the guard.

`_eagerJoinDependencyIsLimitable(jd)` is the single remaining home, and its
doc comment now carries the whole `select_association_list` / `_namedInnerJoins`
rationale. It stays extracted (rather than inlined as Rails has it) only because
trails still has several apply-join-dependency entry points pending the
sync/async collapse tracked by
`converge-relation-subquery-distinct-pk-materialization` — every one of them
calls it, so the guard text exists once.

While in that guard, `applyJoinDependency` now calls the existing
`hasLimitOrOffset` getter — Rails' `has_limit_or_offset?` (finder_methods.rb:463)
— instead of re-spelling `_limitValue !== null || _offsetValue !== null` inline.

`pnpm parity:api:extra --package activerecord` shrinks by one on `relation.ts`
(`_withEagerJoinDependency`).

### 2. HashWithIndifferentAccess block members take Ruby `Hash` arity

`hash_with_indifferent_access.rb:323-343` delegates `select`/`reject` to
`Hash#select!`/`reject!`, so those keep `|key, value|` — unchanged here, they
already matched. The Enumerable-derived members yield the `[key, value]` **pair**
as one argument in Ruby, which trails spelled as `(key, value)` of its own
invention. Converged to the pair for `each`, `map`, `flatMap`, `find`, `count`,
`minBy` and `maxBy`, so `hash.map(([k]) => k)` is spellable exactly as Ruby's
`hash.map(&:first)` is. Callers updated (all in the file's own test).

## Verification

- `pnpm typecheck` clean.
- `pnpm parity:api:calls`, `pnpm parity:api:calls:args` — both OK, no new rows.
- Green: `relations.test.ts`, `relation.test.ts`, `relation.trails.test.ts`,
  `relation-exec-main-query.test.ts`, the whole `associations/` tree
  (100 files, 2150 tests), `hash-with-indifferent-access.test.ts`.

Closes-story: apply-join-dependency-limitability-guard-extracted-twice
Closes-story: hwia-block-members-take-rails-arity
