### PR TITLE
refactor(activerecord,activesupport): selectAssociationList drops raw-SQL joins itself, retire HWIA's invented enumerable members

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4722,8 +4722,7 @@ export class Relation<T extends Base> {
    *
    * The two-clause `using_limitable_reflections?` test Rails spells inline here
    * (finder_methods.rb:463-470) lives in `_eagerJoinDependencyIsLimitable`, its
-   * single home — see there for why the second clause reads `_namedInnerJoins`
-   * where Rails reads `joins_values`.
+   * single home.
    * @internal
    */
   applyJoinDependency({
@@ -5111,15 +5110,6 @@ export class Relation<T extends Base> {
    * `_isDeferredDistinctPkSubquery`) pending the sync/async collapse tracked by
    * `converge-relation-subquery-distinct-pk-materialization`, so the guard has
    * exactly ONE home here and every entry point calls it — never a second copy.
-   *
-   * The second clause reads `_namedInnerJoins` where Rails reads `joins_values`:
-   * `select_association_list` (query_methods.rb:1810-1823) keeps only the
-   * `Hash, Symbol, Array` members and drops raw SQL Strings, and TypeScript
-   * collapses Ruby's Symbol and String onto one type, so that `when` cannot be
-   * spelled by type — `_namedInnerJoins` is the `joins_values` subset it selects,
-   * under the same discriminator `joins()` itself uses. `left_outer_joins_values`
-   * needs no such subset: `assertValidLeftOuterJoinsBang` already rejects a raw
-   * String there, exactly where Rails raises for it.
    */
   private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
     return (
@@ -5128,7 +5118,7 @@ export class Relation<T extends Base> {
         QueryMethodBangs.constructJoinDependency.call(
           this as any,
           _qm.selectAssociationList
-            .call(this as any, this._namedInnerJoins, null)
+            .call(this as any, this.joinsValues, null)
             .concat(
               _qm.selectAssociationList.call(this as any, this._leftOuterJoinsValues, null),
             ) as AssociationSpec[],

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2607,7 +2607,7 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
   const addNames = (specs: ReadonlyArray<AssociationSpec>) => {
     for (const a of specs) if (!joinNames.includes(a)) joinNames.push(a);
   };
-  addNames(this.joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[]);
+  addNames(this.joinsValues as AssociationSpec[]);
   addNames(this.leftOuterJoinsValues);
   addNames(this._eagerLoadAssociations);
   addNames(this._includesAssociations);
@@ -2687,7 +2687,17 @@ export function selectNamedJoins(
   return selectAssociationList.call(this, associations, stashedJoins, block);
 }
 
-/** @internal */
+/**
+ * Mirrors `select_association_list` (query_methods.rb:1810-1823).
+ *
+ * Its `when Hash, Symbol, Array` arm keeps association specs and drops a raw
+ * SQL String through the `else`. TypeScript collapses Ruby's Symbol and String
+ * onto one type, so that `when` cannot be spelled by type: a string is a Symbol
+ * here only when it names an association (or carries the leading colon), the
+ * same discriminator `joins()` applies at insert time.
+ *
+ * @internal
+ */
 export function selectAssociationList(
   this: QueryMethodsHost,
   associations: unknown[],
@@ -2696,12 +2706,6 @@ export function selectAssociationList(
 ): unknown[] {
   const result: unknown[] = [];
   for (const association of associations) {
-    // query_methods.rb:1813-1815 `when Hash, Symbol, Array`. TypeScript
-    // collapses Ruby's Symbol and String onto one type, so the `when` cannot be
-    // spelled by type: a string is a Symbol here only when it names an
-    // association (or carries the leading colon), which is the same
-    // discriminator `joins()` applies at insert time. A raw SQL String is
-    // dropped, exactly as Rails' `else` arm drops it.
     if (
       Array.isArray(association) ||
       isPlainObject(association) ||

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2696,10 +2696,16 @@ export function selectAssociationList(
 ): unknown[] {
   const result: unknown[] = [];
   for (const association of associations) {
+    // query_methods.rb:1813-1815 `when Hash, Symbol, Array`. TypeScript
+    // collapses Ruby's Symbol and String onto one type, so the `when` cannot be
+    // spelled by type: a string is a Symbol here only when it names an
+    // association (or carries the leading colon), which is the same
+    // discriminator `joins()` applies at insert time. A raw SQL String is
+    // dropped, exactly as Rails' `else` arm drops it.
     if (
-      typeof association === "string" ||
       Array.isArray(association) ||
-      isPlainObject(association)
+      isPlainObject(association) ||
+      (typeof association === "string" && this._isNamedJoinValue(association))
     ) {
       result.push(association);
     } else if (association instanceof JoinDependency) {

--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -531,10 +531,10 @@ describe("HashWithIndifferentAccess", () => {
   it("supports get/set/has/delete", () => {
     const h = new HashWithIndifferentAccess<number>();
     h.set("x", 10);
-    expect(h.has("x")).toBe(true);
+    expect(h.hasKey("x")).toBe(true);
     expect(h.get("x")).toBe(10);
     h.delete("x");
-    expect(h.has("x")).toBe(false);
+    expect(h.hasKey("x")).toBe(false);
   });
 
   it("reports size", () => {
@@ -547,7 +547,7 @@ describe("HashWithIndifferentAccess", () => {
     const h2 = h1.merge({ b: 2 });
     expect(h2.get("a")).toBe(1);
     expect(h2.get("b")).toBe(2);
-    expect(h1.has("b")).toBe(false);
+    expect(h1.hasKey("b")).toBe(false);
   });
 
   it("merge with another HashWithIndifferentAccess", () => {

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -189,7 +189,7 @@ describe("HashWithIndifferentAccessTest", () => {
     expect(plain).not.toBeInstanceOf(HashWithIndifferentAccess);
   });
 
-  // any / all / none / count / find / each / map / flatMap
+  // any / all / none / count / find / each / map
   it("any — true if any entries exist", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
     expect(h.any()).toBe(true);
@@ -248,32 +248,12 @@ describe("HashWithIndifferentAccessTest", () => {
     expect(result.sort()).toEqual(["a=1", "b=2"]);
   });
 
-  it("flatMap — flatMaps over entries", () => {
-    const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    const result = h.flatMap(([k, v]) => [k, v]);
-    expect(result).toContain("a");
-    expect(result).toContain(1);
-  });
-
   // invert
   it("invert — swaps keys and values", () => {
     const h = new HashWithIndifferentAccess({ a: "x", b: "y" });
     const inverted = h.invert();
     expect(inverted.get("x")).toBe("a");
     expect(inverted.get("y")).toBe("b");
-  });
-
-  // minBy / maxBy
-  it("minBy — finds entry with minimum value", () => {
-    const h = new HashWithIndifferentAccess({ a: 3, b: 1, c: 2 });
-    const result = h.minBy(([, v]) => v as number);
-    expect(result).toEqual(["b", 1]);
-  });
-
-  it("maxBy — finds entry with maximum value", () => {
-    const h = new HashWithIndifferentAccess({ a: 3, b: 1, c: 2 });
-    const result = h.maxBy(([, v]) => v as number);
-    expect(result).toEqual(["a", 3]);
   });
 
   // store

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -22,14 +22,14 @@ describe("HashWithIndifferentAccessTest", () => {
 
   it("has — reports key presence", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
-    expect(h.has("a")).toBe(true);
-    expect(h.has("z")).toBe(false);
+    expect(h.hasKey("a")).toBe(true);
+    expect(h.hasKey("z")).toBe(false);
   });
 
   it("delete — removes key", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
     expect(h.delete("a")).toBe(true);
-    expect(h.has("a")).toBe(false);
+    expect(h.hasKey("a")).toBe(false);
     expect(h.delete("a")).toBe(false);
   });
 
@@ -119,7 +119,7 @@ describe("HashWithIndifferentAccessTest", () => {
     expect(compacted).toBeInstanceOf(HashWithIndifferentAccess);
     expect(compacted.toHash()).toEqual({ a: 1, d: 2 });
     // original unchanged
-    expect(h.has("b")).toBe(true);
+    expect(h.hasKey("b")).toBe(true);
   });
 
   it("compact on hash with no nil values returns equivalent hash", () => {
@@ -197,22 +197,22 @@ describe("HashWithIndifferentAccessTest", () => {
     expect(empty.any()).toBe(false);
   });
 
-  it("anyWith — true if predicate matches at least one pair", () => {
+  it("any — true if predicate matches at least one pair", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    expect(h.anyWith((_k, v) => (v as number) > 1)).toBe(true);
-    expect(h.anyWith((_k, v) => (v as number) > 99)).toBe(false);
+    expect(h.any(([, v]) => (v as number) > 1)).toBe(true);
+    expect(h.any(([, v]) => (v as number) > 99)).toBe(false);
   });
 
-  it("allWith — true if predicate matches all pairs", () => {
+  it("all — true if predicate matches all pairs", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    expect(h.allWith((_k, v) => (v as number) > 0)).toBe(true);
-    expect(h.allWith((_k, v) => (v as number) > 1)).toBe(false);
+    expect(h.all(([, v]) => (v as number) > 0)).toBe(true);
+    expect(h.all(([, v]) => (v as number) > 1)).toBe(false);
   });
 
-  it("noneWith — true if predicate matches no pairs", () => {
+  it("none — true if predicate matches no pairs", () => {
     const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    expect(h.noneWith((_k, v) => (v as number) > 99)).toBe(true);
-    expect(h.noneWith((_k, v) => (v as number) > 1)).toBe(false);
+    expect(h.none(([, v]) => (v as number) > 99)).toBe(true);
+    expect(h.none(([, v]) => (v as number) > 1)).toBe(false);
   });
 
   it("count — counts all entries when no predicate", () => {
@@ -315,7 +315,7 @@ describe("HashWithIndifferentAccessTest", () => {
   it("replace — clears and repopulates hash", () => {
     const h = new HashWithIndifferentAccess<unknown>({ a: 42 });
     h.replace({ b: 12 });
-    expect(h.has("a")).toBe(false);
+    expect(h.hasKey("a")).toBe(false);
     expect(h.get("b")).toBe(12);
   });
 
@@ -334,14 +334,6 @@ describe("HashWithIndifferentAccessTest", () => {
     expect(dup).toBeInstanceOf(HashWithIndifferentAccess);
     expect(dup).not.toBe(h);
     expect(dup.get("a")).toBe(1);
-  });
-
-  // flatten
-  it("flatten — returns flat array of key-value pairs", () => {
-    const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    const flat = h.flatten();
-    expect(flat).toContain("a");
-    expect(flat).toContain(1);
   });
 
   it("to options for hash with indifferent access", () => {
@@ -517,14 +509,14 @@ describe("HashWithIndifferentAccessTest", () => {
   it("indifferent replace", () => {
     const h = new HashWithIndifferentAccess<unknown>({ a: 42 });
     h.replace({ b: 12 });
-    expect(h.has("a")).toBe(false);
+    expect(h.hasKey("a")).toBe(false);
     expect(h.get("b")).toBe(12);
   });
 
   it("replace with to hash conversion", () => {
     const h = new HashWithIndifferentAccess<unknown>({ a: 1 });
     h.replace({ b: 2 });
-    expect(h.has("a")).toBe(false);
+    expect(h.hasKey("a")).toBe(false);
     expect(h.get("b")).toBe(2);
   });
 
@@ -556,7 +548,7 @@ describe("HashWithIndifferentAccessTest", () => {
   it("indifferent deleting", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
     expect(h.delete("a")).toBe(true);
-    expect(h.has("a")).toBe(false);
+    expect(h.hasKey("a")).toBe(false);
     expect(h.delete("a")).toBe(false);
   });
 
@@ -626,8 +618,8 @@ describe("HashWithIndifferentAccessTest", () => {
     // transformKeys returns new HWIA, original unchanged
     const h = new HashWithIndifferentAccess({ a: 1 });
     const transformed = h.transformKeys((k) => k.toUpperCase());
-    expect(h.has("a")).toBe(true);
-    expect(transformed.has("A")).toBe(true);
+    expect(h.hasKey("a")).toBe(true);
+    expect(transformed.hasKey("A")).toBe(true);
   });
 
   it("indifferent deep transform keys bang", () => {
@@ -665,7 +657,7 @@ describe("HashWithIndifferentAccessTest", () => {
     const compacted = h.compact();
     expect(compacted).toBeInstanceOf(HashWithIndifferentAccess);
     expect(compacted.toHash()).toEqual({ a: 1, d: 2 });
-    expect(h.has("b")).toBe(true);
+    expect(h.hasKey("b")).toBe(true);
   });
 
   it("indifferent to hash", () => {
@@ -679,7 +671,7 @@ describe("HashWithIndifferentAccessTest", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
     const dup = h.withIndifferentAccess();
     dup.set("b", 2);
-    expect(h.has("b")).toBe(false);
+    expect(h.hasKey("b")).toBe(false);
   });
 
   it("indifferent hash with array of hashes", () => {
@@ -741,7 +733,7 @@ describe("HashWithIndifferentAccessTest", () => {
   it("argless default with existing nil key", () => {
     const h = new HashWithIndifferentAccess<unknown>({ a: null });
     expect(h.get("a")).toBeNull();
-    expect(h.has("a")).toBe(true);
+    expect(h.hasKey("a")).toBe(true);
   });
 
   it("default with argument", () => {

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -429,18 +429,6 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * Ruby `Enumerable#flat_map` over a Hash: the block is yielded the
-   * `[key, value]` pair.
-   */
-  flatMap<T>(fn: (pair: [string, V]) => T[]): T[] {
-    const result: T[] = [];
-    for (const pair of this.data) {
-      result.push(...fn(pair));
-    }
-    return result;
-  }
-
-  /**
    * assoc — returns [key, value] pair for the given key, or undefined.
    */
   assoc(key: string): [string, V] | undefined {
@@ -460,40 +448,6 @@ export class HashWithIndifferentAccess<V = unknown> {
       result.set(String(v), k);
     }
     return result;
-  }
-
-  /**
-   * Ruby `Enumerable#min_by` over a Hash: the block is yielded the
-   * `[key, value]` pair, and that pair is returned.
-   */
-  minBy(fn: (pair: [string, V]) => number): [string, V] | undefined {
-    let min: number | undefined;
-    let minEntry: [string, V] | undefined;
-    for (const pair of this.data) {
-      const n = fn(pair);
-      if (min === undefined || n < min) {
-        min = n;
-        minEntry = pair;
-      }
-    }
-    return minEntry;
-  }
-
-  /**
-   * Ruby `Enumerable#max_by` over a Hash: the block is yielded the
-   * `[key, value]` pair, and that pair is returned.
-   */
-  maxBy(fn: (pair: [string, V]) => number): [string, V] | undefined {
-    let max: number | undefined;
-    let maxEntry: [string, V] | undefined;
-    for (const pair of this.data) {
-      const n = fn(pair);
-      if (max === undefined || n > max) {
-        max = n;
-        maxEntry = pair;
-      }
-    }
-    return maxEntry;
   }
 
   /**

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -117,10 +117,6 @@ export class HashWithIndifferentAccess<V = unknown> {
     return this.key(key);
   }
 
-  has(key: string): boolean {
-    return this.key(key);
-  }
-
   /**
    * Mirrors `fetch` (hash_with_indifferent_access.rb:195-197) — `Hash#fetch`
    * semantics over the converted key: a stored value wins over the default
@@ -353,37 +349,36 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * any() — true if any entries exist.
+   * `Enumerable#any?` — with no block, true when any entry exists; with one,
+   * true when it matches at least one `[key, value]` pair.
    */
-  any(): boolean {
-    return this.data.size > 0;
-  }
-
-  /**
-   * anyWith — true if predicate matches at least one pair.
-   */
-  anyWith(fn: (key: string, value: V) => boolean): boolean {
-    for (const [k, v] of this.data) {
-      if (fn(k, v)) return true;
+  any(fn?: (pair: [string, V]) => boolean): boolean {
+    if (!fn) return this.data.size > 0;
+    for (const pair of this.data) {
+      if (fn(pair)) return true;
     }
     return false;
   }
 
   /**
-   * allWith — true if predicate matches all pairs.
+   * `Enumerable#all?` — with no block, true when every entry is truthy (a
+   * `[key, value]` pair always is); with one, true when it matches every pair.
    */
-  allWith(fn: (key: string, value: V) => boolean): boolean {
-    for (const [k, v] of this.data) {
-      if (!fn(k, v)) return false;
+  all(fn?: (pair: [string, V]) => boolean): boolean {
+    if (!fn) return true;
+    for (const pair of this.data) {
+      if (!fn(pair)) return false;
     }
     return true;
   }
 
   /**
-   * noneWith — true if predicate matches no pairs.
+   * `Enumerable#none?` — with no block, true when the hash is empty; with one,
+   * true when it matches no `[key, value]` pair.
    */
-  noneWith(fn: (key: string, value: V) => boolean): boolean {
-    return !this.anyWith(fn);
+  none(fn?: (pair: [string, V]) => boolean): boolean {
+    if (!fn) return this.data.size === 0;
+    return !this.any(fn);
   }
 
   /**
@@ -457,33 +452,12 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * rassoc — returns [key, value] by value match, or undefined.
-   */
-  rassoc(value: V): [string, V] | undefined {
-    for (const [k, v] of this.data) {
-      if (v === value) return [k, v];
-    }
-    return undefined;
-  }
-
-  /**
    * invert — swaps keys and values, returning a new HWIA.
    */
   invert(): HashWithIndifferentAccess<string> {
     const result = new HashWithIndifferentAccess<string>();
     for (const [k, v] of this.data) {
       result.set(String(v), k);
-    }
-    return result;
-  }
-
-  /**
-   * flatten — returns all key-value pairs as a flat array.
-   */
-  flatten(): unknown[] {
-    const result: unknown[] = [];
-    for (const [k, v] of this.data) {
-      result.push(k, v);
     }
     return result;
   }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/module-ext.json
@@ -24,13 +24,6 @@
     "package": "activesupport",
     "tsFile": "module-ext.ts",
     "rubyName": "descendants",
-    "call": "flat_map",
-    "reason": "Same one-line delegation to `DescendantsTracker.descendants` — the recursion, and its `flat_map`, live there."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "module-ext.ts",
-    "rubyName": "descendants",
     "call": "subclasses",
     "reason": "Same delegation; the tracker reads the subclass set directly, not through this file's `subclasses`."
   },


### PR DESCRIPTION
## `select_association_list` takes `joins_values` verbatim

`query_methods.rb:1810-1823`'s `when Hash, Symbol, Array` arm is what drops a
raw-SQL `String` join, and `finder_methods.rb:466-470` passes `joins_values` /
`left_outer_joins_values` verbatim. trails ported that arm as
`typeof association === "string"`, so a raw SQL string survived; every caller
worked around it by passing the pre-filtered `_namedInnerJoins`.

The named-vs-raw discriminator now lives inside `selectAssociationList` itself
(`_isNamedJoinValue`, the same rule `joins()` applies at insert time), so
`applyJoinDependency` and `_eagerJoinDependencyIsLimitable` pass `joinsValues`
and `leftOuterJoinsValues` as Rails does, and both `_namedInnerJoins` deviation
notes are deleted. `selectNamedJoins` / `selectInnerNamedJoins` already hand it
filtered lists, so it is a no-op there.

## Retire HWIA's 9 invented enumerable members

`allWith` / `anyWith` / `noneWith` fold into `any` / `all` / `none` with the
optional block Ruby's `Enumerable` predicates take (yielded the `[key, value]`
pair, matching the arity #6575 converged the sibling members to); `has` is
deleted (it is the Map-shaped duplicate of `key?`,
hash_with_indifferent_access.rb:151-157 — callers use `hasKey`); `flatMap`,
`flatten`, `rassoc`, `minBy`, `maxBy` had no callers outside their own tests and
are deleted. #6575 landed a block-arity convergence on `flatMap`/`minBy`/`maxBy`
while this was open; the names still score novel (no Rails counterpart at all),
so they are retired here — its arity work on `map`/`each`/`find`/`count`, which
do have counterparts, stands untouched.

`pnpm parity:api:extra --package activesupport` for
`hash-with-indifferent-access.ts`: **9 novel → 0**.

One `call-mismatches-exclude` row (`activesupport module-ext.ts descendants
flat_map`) goes stale with `flatMap`'s deletion and is removed by hand (no
reseed).

Rebased onto #6575; `applyJoinDependency`'s guard now lives in
`_eagerJoinDependencyIsLimitable`, so the `joinsValues` change and the deviation
-note deletion land at that single home.

Closes-story: select-association-list-takes-joins-values-verbatim
Closes-story: retire-hwia-invented-enumerable-members
