### PR TITLE
refactor(activerecord): converge JoinDependency#build onto Rails' recursive node tree, site hasLimitOrOffset

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -194,14 +194,12 @@ export class JoinDependency {
       this._baseTableAliasLength(),
       new Map([[this._baseAlias, 1]]),
     );
-    this._joinRoot = new JoinBase(baseModel, baseTable);
+    // `@join_type` is assigned after `@join_root` in Rails; here `build` reads it
+    // to construct each node's provisional join, so it is set first.
     this._joinType = joinType ?? Nodes.OuterJoin;
-
-    const specs =
-      associations == null ? [] : Array.isArray(associations) ? associations : [associations];
-    for (const spec of specs) {
-      this.build(JoinDependency.makeTree(spec), baseModel, this._baseAlias, "");
-    }
+    const tree = JoinDependency.makeTree(associations ?? []);
+    this._joinRoot = new JoinBase(baseModel, baseTable, this.build(tree, baseModel));
+    this._assignPaths(this._joinRoot, null);
   }
 
   /**
@@ -233,16 +231,35 @@ export class JoinDependency {
 
   /**
    * The t-index for the next table to join: 0 is the base (join root), then one
-   * per joined node in allocation order. Derived from the live tree rather than
-   * a mutable counter, so rollback (node pruning) restores it for free.
+   * per joined node in allocation order. A counter rather than a walk of the
+   * live tree: `build` mirrors Rails in returning the subtree to its caller, so
+   * a node is not reachable from the root until the whole tree is built.
    * @internal
    */
+  private _tableIndexCounter = 1;
+
+  /** @internal */
   private _nextTableIndex(): number {
-    let count = 1;
-    this._joinRoot.each((p) => {
-      if (p !== this._joinRoot) count++;
-    });
-    return count;
+    return this._tableIndexCounter++;
+  }
+
+  /**
+   * Stamp each node's dotted association path (`comments.author`) from the tree
+   * shape, once the tree is complete. Rails' JoinAssociation carries no path —
+   * it is a trails affordance for path-addressed lookups (`jd.nodes`, preload
+   * wiring) — so it cannot be threaded through `build`'s Rails signature.
+   * @internal
+   */
+  private _assignPaths(node: JoinPart, parentPath: string | null): void {
+    if (node !== this._joinRoot) {
+      node.parentPath = parentPath;
+      node.assocName = parentPath
+        ? `${parentPath}.${node.immediateAssocName}`
+        : node.immediateAssocName;
+    }
+    for (const child of node.children) {
+      this._assignPaths(child, node === this._joinRoot ? null : node.assocName);
+    }
   }
 
   /** @internal */
@@ -261,47 +278,24 @@ export class JoinDependency {
   }
 
   /**
-   * Materialize one JOIN node under `options.fromModel`/`fromAlias`. Internal
-   * helper of the constructor's `build` walk — the tree is never grown after
-   * construction.
+   * Materialize the JOIN node(s) for one already-checked reflection off
+   * `modelClass` — the body of Rails' `JoinAssociation.new(reflection, ...)`,
+   * which in trails also allocates the node's t-index and its provisional join.
+   * A `through` reflection materializes one node per chain link (the target plus
+   * its `_through_` leaves), so the return is an array; the target is last.
    * @internal
    */
-  private addAssociation(
-    assocName: string,
-    options?: {
-      fromModel?: any;
-      fromAlias?: string;
-      parentAssocName?: string;
-    },
-  ): JoinPart {
-    const modelClass = options?.fromModel ?? this._baseModel;
+  private addAssociation(reflection: any, modelClass: typeof Base): JoinPart[] {
+    // A joined-to table is only ever aliased at emit, so a nested node's source
+    // is its parent model's real table; only the root can carry a base alias
+    // the caller chose (the `table` constructor argument).
+    const sourceAlias =
+      modelClass === this._baseModel ? this._baseAlias : (modelClass as any).tableName;
 
-    // Mirrors: ActiveRecord::Associations::JoinDependency#build
-    // (join_dependency.rb:229-231) — `find_reflection`, then `check_validity!`
-    // before `check_eager_loadable!`. `find_reflection` raises
-    // ConfigurationError for a name that doesn't resolve; `check_validity!`
-    // raises CompositePrimaryKeyMismatchError for a composite PK/FK arity
-    // mismatch, so a mismatched composite collection surfaces that error here
-    // rather than the generic join-key arity error deeper in `joinConstraints`.
-    const reflection = this.findReflection(modelClass, assocName);
-    reflection.checkValidityBang?.();
-    reflection.checkEagerLoadableBang?.();
-
-    const sourceAlias = options?.fromAlias ?? this._baseAlias;
-
-    // Rails raises for polymorphic eager loads — the join target table is not
-    // known statically (join_dependency.rb#build).
-    if (reflection.isPolymorphic?.()) {
-      throw new EagerLoadPolymorphicError(assocName);
-    }
     if (reflection.isThroughReflection()) {
-      return this._addThroughViaJoinAssociation(
-        reflection,
-        modelClass,
-        sourceAlias,
-        options?.parentAssocName,
-      );
+      return this._addThroughViaJoinAssociation(reflection, modelClass, sourceAlias);
     }
+    const assocName: string = reflection.name;
 
     const assocType: "hasMany" | "hasOne" | "belongsTo" =
       reflection.macro === "hasAndBelongsToMany" ? "hasMany" : reflection.macro;
@@ -350,88 +344,47 @@ export class JoinDependency {
     treePart.tableAlias = tableAlias;
     treePart.effectiveSqlName = effectiveName;
     treePart.columns = columns;
-    treePart.assocName = options?.parentAssocName
-      ? `${options.parentAssocName}.${assocName}`
-      : assocName;
     treePart.immediateAssocName = assocName;
-    treePart.parentPath = options?.parentAssocName ?? null;
     treePart.assocType = assocType;
     treePart.arelJoin = arelJoin;
     treePart.nodeReflection = reflection;
     treePart.isThroughNode = false;
-    this._insertTreeNode(treePart);
-    return treePart;
+    return [treePart];
   }
 
   /**
-   * Build the join tree from a normalized make_tree-style hash (dotted strings
-   * already split into nested keys by `walkTree`). Each key becomes a JOIN via
-   * `_addOrReuse`; children recurse under the joined node's model and effective
-   * alias — `effectiveSqlName` is the name that actually appears in the JOIN
-   * SQL (the real table name unless aliased due to a collision), so using
-   * `tableAlias` here would emit ON clauses referencing e.g. "t1" against SQL
-   * that names the real table.
-   *
-   * Called once per top-level spec, from the constructor. Like Rails, a name
-   * that doesn't resolve raises `ConfigurationError` from `findReflection`
-   * (Rails' `find_reflection`); every reflection that does resolve is JOINed.
-   * There is no lenient mode.
-   *
    * Mirrors: ActiveRecord::Associations::JoinDependency#build
-   * (join_dependency.rb:228).
+   * (join_dependency.rb:228-240) — map the normalized make_tree hash to a tree
+   * of JoinAssociation nodes, each owning the nodes built from its own nested
+   * hash. `findReflection` (Rails' `find_reflection`) raises ConfigurationError
+   * for a name that doesn't resolve; `check_validity!` raises
+   * CompositePrimaryKeyMismatchError for a composite PK/FK arity mismatch, so a
+   * mismatched composite collection surfaces that error here rather than the
+   * generic join-key arity error deeper in `joinConstraints`. There is no
+   * lenient mode: every reflection that does resolve is JOINed.
+   *
+   * Rails' `JoinAssociation.new(reflection, build(right, reflection.klass))`
+   * builds the children first; trails materializes the node before recursing
+   * because it also allocates the node's t-index, which numbers the tables in
+   * tree order.
    * @internal
    */
-  private build(
-    hash: Record<string, any>,
-    model: typeof Base,
-    alias: string,
-    parentPath: string,
-  ): void {
-    for (const name of Object.keys(hash)) {
-      const node = this._addOrReuse(name, model, alias, parentPath);
-      const child = hash[name];
-      const childPath = parentPath ? `${parentPath}.${name}` : name;
-      if (child != null && Reflect.ownKeys(child).length > 0) {
-        this.build(child, node.baseKlass, node.effectiveSqlName, childPath);
+  private build(associations: Record<string, any>, baseKlass: typeof Base): JoinPart[] {
+    return Object.keys(associations).flatMap((name) => {
+      const right = associations[name];
+      const reflection = this.findReflection(baseKlass, name);
+      reflection.checkValidityBang?.();
+      reflection.checkEagerLoadableBang?.();
+      // Rails raises for polymorphic eager loads — the join target table is not
+      // known statically.
+      if (reflection.isPolymorphic?.()) {
+        throw new EagerLoadPolymorphicError(name);
       }
-    }
-  }
-
-  /**
-   * Add `assocName` under `parentPath`, reusing an existing tree node when the
-   * same path was already joined (shared-prefix dedup).
-   * @internal
-   */
-  private _addOrReuse(
-    assocName: string,
-    fromModel: typeof Base,
-    fromAlias: string,
-    parentPath: string,
-  ): JoinPart {
-    const existing = this._findNodeByPath(parentPath ? `${parentPath}.${assocName}` : assocName);
-    if (existing) return existing;
-    return this.addAssociation(assocName, {
-      fromModel,
-      fromAlias,
-      parentAssocName: parentPath || undefined,
+      const nodes = this.addAssociation(reflection, baseKlass);
+      const node = nodes[nodes.length - 1];
+      if (right != null) node.children.push(...this.build(right, reflection.klass));
+      return nodes;
     });
-  }
-
-  /**
-   * Resolve a tree node by its dotted association path (`comments.author`) by
-   * walking children from the root. Replaces the `_treeNodesByPath` index:
-   * the tree itself is the source of truth. Empty/null path is the root.
-   * @internal
-   */
-  private _findNodeByPath(path: string | null): JoinPart | null {
-    if (!path) return this._joinRoot;
-    let node: JoinPart = this._joinRoot;
-    for (const segment of path.split(".")) {
-      const child = node.children.find((c) => c.immediateAssocName === segment);
-      if (!child) return null;
-      node = child;
-    }
-    return node;
   }
 
   private _buildSelectArelNodes(): Nodes.As[] {
@@ -1196,8 +1149,8 @@ export class JoinDependency {
    * The base table is keyed by the join root; each joined node supplies its own
    * column names and Arel table. Replaces the index-keyed `_aliases`/`_arelTablesByIndex`.
    *
-   * Memoized like Rails' `@aliases ||=`; the cache is cleared on any tree
-   * mutation (`_insertTreeNode`) so it can never go stale.
+   * Memoized like Rails' `@aliases ||=`; the tree is fully built in the
+   * constructor and never mutated afterwards, so the memo can never go stale.
    * @internal
    */
   private aliases(): Aliases {
@@ -1366,28 +1319,15 @@ export class JoinDependency {
     }
   }
 
-  private _insertTreeNode(treePart: JoinPart): void {
-    const parentPath = treePart.parentPath;
-    const parent = this._findNodeByPath(parentPath);
-    if (!parent) {
-      throw new Error(
-        `JoinDependency tree: parent path "${parentPath}" not found for "${treePart.immediateAssocName}"`,
-      );
-    }
-    parent.children.push(treePart);
-    this._aliasesCache = undefined;
-  }
-
   private _addThroughViaJoinAssociation(
     reflection: any,
     modelClass: any,
     sourceAlias: string,
-    parentAssocName?: string,
-  ): JoinPart {
+  ): JoinPart[] {
     // A through reflection's `chain` is `[self, *through_reflection.chain]`, so
     // it always carries the target plus at least one through link, and
     // `joinConstraints` emits one join per link — the walk below always reaches
-    // the target (chain index 0) and assigns `targetNode`.
+    // the target (chain index 0), which is the last node returned.
     const chain = reflection.chain;
 
     const joinAssoc = new JoinAssociation(reflection);
@@ -1409,9 +1349,10 @@ export class JoinDependency {
       model: typeof Base;
     }> = [];
 
-    // Nothing is inserted into the tree yet, so the indices for the whole chain
-    // are allocated up front off the current next-index (base + already-joined).
-    const startIndex = this._nextTableIndex();
+    // The indices for the whole chain are allocated up front, before any
+    // nested association under the target claims one.
+    const startIndex = this._tableIndexCounter;
+    this._tableIndexCounter += chain.length;
     for (let i = 0; i < chain.length; i++) {
       const refl = chain[i];
       const model = refl.klass as typeof Base;
@@ -1449,7 +1390,7 @@ export class JoinDependency {
       nodes: new Array(chain.length),
       resolved: false,
     };
-    let targetNode: JoinPart | null = null;
+    const nodes: JoinPart[] = [];
 
     for (let i = 0; i < joins.length; i++) {
       const chainIdx = chain.length - 1 - i;
@@ -1460,18 +1401,13 @@ export class JoinDependency {
       const columns = getModelColumns(entry.model);
 
       if (isTarget) {
-        const fullAssocName = parentAssocName
-          ? `${parentAssocName}.${reflection.name}`
-          : reflection.name;
         const treePart = new JoinAssociation(reflection);
         treePart.tableIndex = entry.tableIndex;
         treePart.arelTable = entry.table;
         treePart.tableAlias = entry.tableAlias;
         treePart.effectiveSqlName = entry.tableName;
         treePart.columns = columns;
-        treePart.assocName = fullAssocName;
         treePart.immediateAssocName = reflection.name;
-        treePart.parentPath = parentAssocName ?? null;
         treePart.assocType =
           reflection.macro === "hasAndBelongsToMany" ? "hasMany" : reflection.macro;
         treePart.arelJoin = arelJoin;
@@ -1480,12 +1416,10 @@ export class JoinDependency {
         treePart.scopeJoinSources = stepJoinSources;
         treePart.throughGroup = group;
         group.nodes[chainIdx] = treePart;
-        this._insertTreeNode(treePart);
-        targetNode = treePart;
+        nodes.push(treePart);
       } else {
         const reflName = chain[chainIdx].name ?? entry.tableName;
         const throughName = `_through_${reflName}`;
-        const throughNodeName = parentAssocName ? `${parentAssocName}.${throughName}` : throughName;
         const refl = chain[chainIdx];
         const treePart = new JoinLeaf(entry.model);
         treePart.tableIndex = entry.tableIndex;
@@ -1493,20 +1427,18 @@ export class JoinDependency {
         treePart.tableAlias = entry.tableAlias;
         treePart.effectiveSqlName = entry.tableName;
         treePart.columns = columns;
-        treePart.assocName = throughNodeName;
         treePart.immediateAssocName = throughName;
-        treePart.parentPath = parentAssocName ?? null;
         treePart.assocType = (refl._reflection ?? refl).macro === "hasOne" ? "hasOne" : "hasMany";
         treePart.arelJoin = arelJoin;
         treePart.isThroughNode = true;
         treePart.scopeJoinSources = stepJoinSources;
         treePart.throughGroup = group;
         group.nodes[chainIdx] = treePart;
-        this._insertTreeNode(treePart);
+        nodes.push(treePart);
       }
     }
 
-    return targetNode!;
+    return nodes;
   }
 }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2705,8 +2705,7 @@ export class Relation<T extends Base> {
     // materialize the limited parent IDs, then re-queries with `pk IN (ids)`.
     // This avoids `IN (SELECT ... LIMIT n)`, which MariaDB does not support.
     let limitedIds: unknown[] | undefined;
-    const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
+    if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
       limitedIds = await this._materializeLimitedIds(jd, basePk);
       if (limitedIds.length === 0) {
         this._records = [];
@@ -3115,10 +3114,9 @@ export class Relation<T extends Base> {
     // a scoped source through a composite-PK model JOINs like Rails. The
     // LIMIT+collection+composite gap is trails' remaining capability gap (tracked
     // for convergence — see RFC 0054).
-    const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
     const compositePkBypass =
       Array.isArray(basePk) &&
-      hasLimitOrOffset &&
+      this.hasLimitOrOffset &&
       !this._eagerJoinDependencyIsLimitable(
         this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs()),
       );
@@ -3483,8 +3481,7 @@ export class Relation<T extends Base> {
       const basePk = (this._model as any).primaryKey ?? "id";
       const jd = this._buildEagerJoinDependency(eagerSpecs);
 
-      const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-      if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
+      if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
         // A composite base PK can't be materialized here — `_materializeLimitedIds`
         // (Rails' zip/transpose over `Array(primary_key)`) has no composite
         // support, so it would emit a wrong single-column `"col1,col2"` predicate.
@@ -3636,9 +3633,8 @@ export class Relation<T extends Base> {
       rel._eagerLoadAssociations = [];
       rel._includesAssociations = [];
 
-      const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
       const jd = this._buildEagerJoinDependency(eagerSpecs);
-      if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
+      if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
         // Same two guards `pluck`'s arm carries: `hasInclude` returns true off
         // `_eagerLoadAssociations` alone, so `pk` can still be null here (a
         // view), and `_materializeLimitedIds` — Rails' zip/transpose over
@@ -4794,8 +4790,7 @@ export class Relation<T extends Base> {
     if (eagerSpecs.length === 0) return run(this);
     const jd = this._buildEagerJoinDependency(eagerSpecs);
     const basePk = (this._model as any).primaryKey ?? "id";
-    const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-    if (eagerLoading && hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
+    if (eagerLoading && this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
       const limitedIds = await this._materializeLimitedIds(jd, basePk);
       return run(this._applyEagerJoinDependency(jd, basePk, limitedIds));
     }
@@ -4838,7 +4833,7 @@ export class Relation<T extends Base> {
   _isDeferredDistinctPkSubquery(): boolean {
     if (this._groupColumns.length > 0) return false;
     if (!this._eagerLoadingForSql()) return false;
-    if (this._limitValue === null && this._offsetValue === null) return false;
+    if (!this.hasLimitOrOffset) return false;
     return !this._eagerJoinDependencyIsLimitable(
       this._buildEagerJoinDependency(this._deferredDistinctPkEagerSpecs()),
     );
@@ -5074,8 +5069,7 @@ export class Relation<T extends Base> {
   ): Relation<T> {
     let rel = this.except("includes", "eagerLoad", "preload");
     QueryMethodBangs.joinsBang.call(rel as any, jd as any);
-    const hasLimit = this._limitValue !== null || this._offsetValue !== null;
-    if (hasLimit && !this._eagerJoinDependencyIsLimitable(jd)) {
+    if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
       if (Array.isArray(basePk)) {
         // Rails `where!(**Array(primary_key).zip(limited_ids.transpose).to_h)`
         // (schema_statements.rb:1448) — a per-column `IN`, not a tuple `IN`.
@@ -6608,10 +6602,13 @@ export class Relation<T extends Base> {
         const rel = this._clone();
         rel._eagerLoadAssociations = [];
         rel._includesAssociations = [];
-        const hasLimitOrOffset = this._limitValue !== null || (this._offsetValue ?? 0) > 0;
         const pk = (this._model as { primaryKey?: string | string[] }).primaryKey ?? "id";
         const jd = this._buildEagerJoinDependency(eagerSpecs);
-        if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd) && !Array.isArray(pk)) {
+        if (
+          this.hasLimitOrOffset &&
+          !this._eagerJoinDependencyIsLimitable(jd) &&
+          !Array.isArray(pk)
+        ) {
           // Rails' distinct_relation_for_primary_key (finder_methods.rb:463):
           // materialize the limited DISTINCT primary keys, rewrite as
           // `WHERE pk IN (ids)`, and clear limit/offset. Single-column PK only —
@@ -6625,7 +6622,7 @@ export class Relation<T extends Base> {
           collection = rel.leftOuterJoins(eagerSpecs).where({ [pk]: limitedIds });
           collection._limitValue = null;
           collection._offsetValue = null;
-        } else if (hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
+        } else if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
           // Composite-PK, non-limitable eager limit/offset: unsupported here —
           // surfaces NotImplementedError rather than a wrong predicate. Tracked
           // by 0023-surfaced-deviations/converge-composite-pk-distinct-relation-materialization.
@@ -6639,7 +6636,7 @@ export class Relation<T extends Base> {
       const countStar = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
       const maxNode = tsColumn.maximum();
 
-      if (collection._limitValue !== null || (collection._offsetValue ?? 0) > 0) {
+      if (collection.hasLimitOrOffset) {
         // Has LIMIT/OFFSET — wrap in a subquery (mirrors Rails' build_subquery).
         const subqueryAlias = "subquery_for_cache_key";
         const inner = collection._clone();

--- a/packages/activerecord/src/support/join-dependency-aliased-row.ts
+++ b/packages/activerecord/src/support/join-dependency-aliased-row.ts
@@ -10,7 +10,22 @@ import type { JoinPart } from "../associations/join-dependency/join-part.js";
  */
 interface AliasReadableJoinDependency {
   aliases(): { columnAlias(node: JoinPart | null, column: string): string | undefined };
-  _findNodeByPath(path: string | null): JoinPart | null;
+  joinRoot: JoinPart;
+}
+
+/**
+ * Resolve a tree node by its dotted association path ("comments.author"),
+ * walking children from the join root. Empty/null path is the root.
+ */
+function findNodeByPath(root: JoinPart, path: string | null): JoinPart | null {
+  if (!path) return root;
+  let node: JoinPart = root;
+  for (const segment of path.split(".")) {
+    const child: JoinPart | undefined = node.children.find((c) => c.immediateAssocName === segment);
+    if (!child) return null;
+    node = child;
+  }
+  return node;
 }
 
 /**
@@ -29,7 +44,7 @@ export function aliasedRow(
   const aliases = inner.aliases();
   const row: Record<string, unknown> = {};
   for (const [path, columns] of Object.entries(spec)) {
-    const node = inner._findNodeByPath(path || null);
+    const node = findNodeByPath(inner.joinRoot, path || null);
     if (!node) {
       throw new ArgumentError(`aliasedRow: no join node at path "${path}"`);
     }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -9,18 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
-    "rubyName": "build",
-    "call": "build",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:right",
-      "ref:klass"
-    ],
-    "reason": "join_dependency.rb:238 `build(right, reflection.klass)` recurses over a nested associations hash and returns a `JoinAssociation` tree. trails builds the tree by mutating a node list keyed by association PATH (for shared-prefix dedup), so the recursion also carries the alias and the parent path. Tracked by the join-dependency fidelity RFC; converging the argument list means porting Rails' tree shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
     "rubyName": "instantiate",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Two convergences in the eager-join/limit area.

## `has_limit_or_offset?` call sites (`relation.ts`)

Rails calls `has_limit_or_offset?` (relation.rb:1303) wherever it needs the
test; `relation.ts` re-spelled it inline at eight sites, mostly as a
`const hasLimitOrOffset = ...` local shadowing the getter. All now read
`this.hasLimitOrOffset` (and `collection.hasLimitOrOffset` at the
`compute_cache_version` site, relation.rb:487).

The two `(this._offsetValue ?? 0) > 0` variants in the cache-version arm were
also folded in: Rails' body is `limit_value || offset_value` (relation.rb:1304),
and `0` is truthy in Ruby, so `offset(0)` *does* have an offset — the `> 0`
spelling was a real divergence, not a deliberate one.

## `JoinDependency#build` (`associations/join-dependency.ts`)

`build(associations, baseKlass)` now mirrors join_dependency.rb:228-240: it maps
the normalized `make_tree` hash, does `find_reflection` →
`check_validity!` → `check_eager_loadable!` → `polymorphic?` in Rails' order,
recurses with `build(right, reflection.klass)`, and **returns** the node subtree,
which the caller attaches — `JoinBase.new(base, table, build(tree, base))`
(join_dependency.rb:71).

Consequences:

- `make_tree` runs once over the whole spec instead of once per spec, which is
  how Rails dedupes a shared prefix (`["comments", {comments: :author}]` merges
  in `walk_tree`). The path-keyed side table that did that job in trails —
  `_addOrReuse`, `_findNodeByPath`, `_insertTreeNode` — is deleted.
- `build` no longer threads a parent alias or a parent path. The source alias is
  derived (only the root can carry a caller-chosen base alias; a nested node's
  source is its parent model's real table, since joined tables are aliased at
  emit), and the dotted `assocName`/`parentPath` — a trails affordance Rails'
  JoinAssociation has no equivalent of — is stamped from the tree shape once it
  is complete.
- t-indices come from a counter rather than a walk of the live tree, since a
  node is no longer reachable from the root while it is being built.
- A `through` reflection still materializes one node per chain link, so the
  helper returns an array (target last) that `build` flattens; that remains the
  known divergence from Rails' one-node-per-reflection chain.

The `build -> build` `kind: "args"` row is deleted by hand from its shard (no
`--write`, no reseed). `pnpm parity:api:calls`, `pnpm parity:api:calls:args`,
`parity:api:extra` (no novel names) and `pnpm lint` are green; the whole
`associations/`, `relation/`, `relations.test.ts`, `collection-cache-key`,
`cache-key`, `calculations` and `support/` suites pass locally on SQLite.

Closes-story: converge-relation-has-limit-or-offset-call-sites
Closes-story: converge-join-dependency-build-recursive-tree
