### PR TITLE
refactor(activerecord): remaining joins_values readers stop going through _namedInnerJoins

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2534,8 +2534,8 @@ export class Relation<T extends Base> {
    */
   private _joinedIncludesValues(): string[] {
     if (this._includesAssociations.length === 0) return [];
-    if (this._namedInnerJoins.length === 0) return [];
-    const joined = new Set(this._namedInnerJoins.filter((v): v is string => typeof v === "string"));
+    if (this._joinsValues.length === 0) return [];
+    const joined = new Set(this._joinsValues.filter((v): v is string => typeof v === "string"));
     return this._includesAssociations.filter(
       (spec): spec is string => typeof spec === "string" && joined.has(spec),
     );
@@ -2603,10 +2603,15 @@ export class Relation<T extends Base> {
     // from the resulting join nodes. We resolve via _resolveAssocTables to
     // get the actual table name (handles camelCase → snake_case mappings).
     const leftOuterTables = this._resolveAssocTables(this._leftOuterJoinsValues);
-    // _namedInnerJoins holds association names too (joins(:assoc) routed through
-    // JoinDependency with InnerJoin). Resolve to table names so references to
-    // those tables don't spuriously promote includes to eager_load.
-    const namedInnerTables = this._resolveAssocTables(this._namedInnerJoins);
+    // joins_values holds association names too (joins(:assoc) routed through
+    // JoinDependency with InnerJoin). Run them through `select_association_list`
+    // — the same partition build_joins applies — and resolve the surviving specs
+    // to table names so references to those tables don't spuriously promote
+    // includes to eager_load. The raw SQL strings it drops are handled by the
+    // `tablesInString` arm below, exactly as Rails' StringJoin branch does.
+    const namedInnerTables = this._resolveAssocTables(
+      this.selectAssociationList(this._joinsValues, null) as AssociationSpec[],
+    );
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
       ...leftOuterTables,
@@ -3222,9 +3227,9 @@ export class Relation<T extends Base> {
     // left-outer JD and folding it into the stash. This keeps the shape identical
     // to the subquery `from(relation)` path.
     //
-    // The emptiness checks below are Rails' `joins_values.empty?`, which
-    // `_namedInnerJoins` + `_joinValues` partition; `_joinClauses` is trails-only
-    // compensation for raw join clauses living outside `joins_values`.
+    // The emptiness check below is Rails' `joins_values.empty?`; `_joinClauses`
+    // is trails-only compensation for raw join clauses living outside
+    // `joins_values`.
     //
     // Fires whenever left_outer_joins_values is non-empty (Rails' `unless
     // left_outer_joins_values.empty?`, query_methods.rb:1828), even when the
@@ -3232,10 +3237,7 @@ export class Relation<T extends Base> {
     // a CTE symbol, already routed into `joinNodes` above. Rails returns early there
     // too (`buckets[:named_join] = left_joins` with an empty `left_joins`); the
     // empty-named early return emits the same SQL as the stash-fold path.
-    const pureLeftOuter =
-      this._namedInnerJoins.length === 0 &&
-      this._joinValues.length === 0 &&
-      this._joinClauses.length === 0;
+    const pureLeftOuter = this._joinsValues.length === 0 && this._joinClauses.length === 0;
     const leftOuterIsNamed = pureLeftOuter && this._leftOuterJoinsValues.length > 0;
     if (this._leftOuterJoinsValues.length > 0 && !leftOuterIsNamed) {
       // query_methods.rb:1843: `stashed_left_joins.unshift` — unconditional, so
@@ -3250,32 +3252,54 @@ export class Relation<T extends Base> {
       );
     }
 
-    // query_methods.rb:1848-1850: the eager stash is the trailing `joins_values`
-    // JoinDependency whose base_klass is this model — a cross-klass merged JD
-    // fails that test and stays in the stream for `select_named_joins`.
-    const lastJoinsValue = this._joinsValues[this._joinsValues.length - 1];
-    const stashedEagerLoad =
-      lastJoinsValue instanceof JoinDependency && lastJoinsValue.baseKlass === this._model;
-    const hasStashed = stashedEagerLoad || leftStashed.length > 0;
-    // query_methods.rb:1855-1862: only the LEADING run of Join nodes is routed by
-    // `hasStashed`; a raw join BEHIND a named join falls through to
-    // `select_named_joins`, which buckets it as a join_node unconditionally
-    // (query_methods.rb:1866-1867). Iterate the unified `_joinsValues`, which
-    // preserves the raw-vs-named interleaving `_joinValues` alone cannot see.
-    const toJoinNode = (v: string | Nodes.Join): Nodes.Join =>
-      typeof v === "string" ? new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim())) : v;
-    let leading = true;
-    for (const v of this._joinsValues) {
-      if (this._isNamedJoinValue(v)) {
-        leading = false;
-        continue;
+    // query_methods.rb:1847-1876, the `joins_values` half of build_join_buckets,
+    // run only when the pure-left-outer early return above did not fire.
+    const stashedJoins: JoinDependency[] = [];
+    const namedJoins: AssociationSpec[] = [];
+    if (!leftOuterIsNamed) {
+      const joins: unknown[] = [...this._joinsValues];
+      // query_methods.rb:1848-1850: the eager stash is the trailing `joins_values`
+      // JoinDependency whose base_klass is this model — a cross-klass merged JD
+      // fails that test and stays in the stream for `select_named_joins`.
+      const lastJoinsValue = joins[joins.length - 1];
+      const stashedEagerLoad =
+        lastJoinsValue instanceof JoinDependency && lastJoinsValue.baseKlass === this._model
+          ? (joins.pop() as JoinDependency)
+          : undefined;
+
+      // query_methods.rb:1851-1853. Rails wraps every String; trails collapses
+      // Ruby's Symbol and String into one type, so an association-name string
+      // stays a named join value instead of becoming a raw SQL fragment.
+      for (const [i, v] of joins.entries()) {
+        if (typeof v === "string" && !this._isNamedJoinValue(v)) {
+          joins[i] = new Nodes.StringJoin(new Nodes.SqlLiteral(v.trim()));
+        }
       }
-      const node = toJoinNode(v as string | Nodes.Join);
-      if (leading && (node instanceof Nodes.LeadingJoin || !hasStashed)) {
-        leadingJoins.push(node);
-      } else {
-        joinNodes.push(node);
+
+      const hasStashed = stashedEagerLoad !== undefined || leftStashed.length > 0;
+      // query_methods.rb:1855-1862: only the LEADING run of Join nodes is shifted
+      // off and routed by `hasStashed`; a raw join BEHIND a named join falls
+      // through to `select_named_joins`, which buckets it as a join_node
+      // unconditionally (query_methods.rb:1866-1867).
+      while (joins[0] instanceof Nodes.Join) {
+        const joinNode = joins.shift() as Nodes.Join;
+        if (!(joinNode instanceof Nodes.LeadingJoin) && hasStashed) {
+          joinNodes.push(joinNode);
+        } else {
+          leadingJoins.push(joinNode);
+        }
       }
+
+      // query_methods.rb:1864-1873.
+      namedJoins.push(
+        ..._qm.selectInnerNamedJoins.call(this as any, joins, stashedJoins, joinNodes),
+      );
+
+      // query_methods.rb:1875-1876 — the eager stash goes in LAST.
+      stashedJoins.push(...leftStashed);
+      if (stashedEagerLoad) stashedJoins.push(stashedEagerLoad);
+    } else {
+      stashedJoins.push(...leftStashed);
     }
 
     // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
@@ -3298,8 +3322,9 @@ export class Relation<T extends Base> {
     _qm.emitJoinPlan.call(this as any, manager, {
       leadingJoins,
       joinNodes,
-      stashedJoins: [...leftStashed],
-      namedJoins: leftOuterIsNamed ? (leftAssociations as any) : [],
+      stashedJoins,
+      namedJoins: leftOuterIsNamed ? (leftAssociations as any) : namedJoins,
+      joinType: leftOuterIsNamed ? Nodes.OuterJoin : Nodes.InnerJoin,
       aliases,
       tracker,
     });
@@ -6351,9 +6376,8 @@ export class Relation<T extends Base> {
       this._groupColumns.length === 0 &&
       this._havingClause.isEmpty() &&
       this._joinClauses.length === 0 &&
-      this._joinValues.length === 0 &&
+      this._joinsValues.length === 0 &&
       this._leftOuterJoinsValues.length === 0 &&
-      this._namedInnerJoins.length === 0 &&
       this._includesAssociations.length === 0 &&
       this._eagerLoadAssociations.length === 0 &&
       this._preloadAssociations.length === 0 &&

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2758,7 +2758,7 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
  *
  * @internal
  */
-function selectInnerNamedJoins(
+export function selectInnerNamedJoins(
   this: QueryMethodsHost,
   values: unknown[],
   stashedJoins: unknown[],
@@ -2899,20 +2899,13 @@ export interface JoinEmissionPlan {
    * When no named/left-outer association join exists, the first is the primary.
    */
   stashedJoins: JoinDependency[];
-  /**
-   * `buckets[:named_join]`. On the live path (which does not go through
-   * `buildJoinBuckets`) this carries only the pure left-outer-only association
-   * names and `joinType` is absent, so the named inner joins are partitioned
-   * out of `_namedInnerJoins` here instead.
-   */
+  /** `buckets[:named_join]`, already partitioned by the caller. */
   namedJoins: AssociationSpec[];
   /**
    * The join type `build_join_buckets` returned alongside the buckets
-   * (query_methods.rb:1841/1878). Present only when the caller ran
-   * `buildJoinBuckets`, in which case `namedJoins` is already the partitioned
-   * `buckets[:named_join]` and must not be re-derived.
+   * (query_methods.rb:1841/1878).
    */
-  joinType?: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
+  joinType: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
   /** Tracker threaded in from `build_from`; absent on the live path. */
   aliases?: AliasTracker;
   /**
@@ -2992,48 +2985,20 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // mirrors `unless named_joins.empty? && stashed_joins.empty?`; when named_joins
   // is empty but the stash is not, Rails still builds an empty
   // `construct_join_dependency([], InnerJoin)` and folds the stash into it.
-  //
-  // Rails build_join_buckets (query_methods.rb:1865-1873) runs the inner
-  // joins_values through select_named_joins, whose block routes a CTEJoin — a
-  // joins() symbol matching a with(...) CTE name — to build_with_join_node(name)
-  // (an InnerJoin node), while ordinary association names fold into the named
-  // JoinDependency. Mirror it here so BOTH the live path (_applyJoinsToManager)
-  // and the subquery path (buildJoins) route the CTE symbol; without the
-  // partition the bare Symbol reaches the arel visitor and raises
-  // "Unknown node type: Symbol".
-  const cteInnerJoinNodes: Nodes.Join[] = [];
-  const innerNamed =
-    plan.joinType === undefined && this._namedInnerJoins.length > 0
-      ? selectInnerNamedJoins.call(
-          this,
-          this._namedInnerJoins,
-          plan.stashedJoins,
-          cteInnerJoinNodes,
-        )
-      : ([] as AssociationSpec[]);
-  const [namedJoins, joinType] =
-    plan.joinType !== undefined
-      ? ([plan.namedJoins, plan.joinType] as const)
-      : innerNamed.length > 0
-        ? ([innerNamed, Nodes.InnerJoin] as const)
-        : plan.namedJoins.length > 0
-          ? ([plan.namedJoins, Nodes.OuterJoin] as const)
-          : ([[] as AssociationSpec[], Nodes.InnerJoin] as const);
+  const namedJoins = plan.namedJoins;
+  const joinType = plan.joinType;
   if (namedJoins.length > 0 || plan.stashedJoins.length > 0) {
     const jd = constructJoinDependency.call(this, namedJoins, joinType);
     for (const node of jd.joinConstraints(plan.stashedJoins, sharedTracker(), references))
       manager.appendJoinNode(node);
   }
 
-  // Rails' single `buckets[:join_node]` array is populated raw joins_values Join
-  // nodes FIRST (the `while joins.first.is_a?(Arel::Nodes::Join)` loop,
-  // query_methods.rb:1856-1863), THEN CTE nodes appended by the select_named_joins
-  // block (query_methods.rb:1865-1873); `build_joins` concats the whole array once
-  // (query_methods.rb:1899). Preserve that order: raw `plan.joinNodes` before the
-  // partitioned `cteInnerJoinNodes`.
+  // `build_joins` concats `buckets[:join_node]` once (query_methods.rb:1899);
+  // both callers filled it in Rails' order — raw joins_values Join nodes from
+  // the `while joins.first.is_a?(Arel::Nodes::Join)` loop
+  // (query_methods.rb:1856-1863) before the CTE nodes the select_named_joins
+  // block appends (query_methods.rb:1865-1873).
   for (const node of plan.joinNodes) manager.appendJoinNode(node);
-
-  for (const node of cteInnerJoinNodes) manager.appendJoinNode(node);
 
   // When a tracker was threaded in (Rails passes the alias HASH itself to
   // `join_scope.arel(alias_tracker.aliases)`, so claims made while building this


### PR DESCRIPTION
Converges the remaining trails-only `_namedInnerJoins` readers onto `joins_values`, where Rails reads it.

- `_joinedIncludesValues` — Rails is `includes_values & joins_values` (relation.rb:1248-1250), so it intersects `_joinsValues` directly.
- `referencesEagerLoadedTables` — resolves the specs `select_association_list` keeps out of `joins_values` (query_methods.rb:1810-1823); the raw SQL strings it drops are still handled by the `tablesInString` arm, as Rails' StringJoin branch does (relation.rb:1474-1481).
- `_applyJoinsToManager`'s pure-left-outer guard is now Rails' own `joins_values.empty?` (query_methods.rb:1838), plus the trails-only `_joinClauses` compensation.
- `_isEmptyScope` folds the `_joinValues` / `_namedInnerJoins` pair back into the single `joins_values` key.
- `emitJoinPlan` no longer re-derives the named inner joins from relation state: the live path now mirrors `build_join_buckets`' `joins_values` half verbatim (query_methods.rb:1847-1876) — pop the eager stash, wrap raw Strings as StringJoin, shift the leading Join run, then `select_named_joins` into `named_join` / `join_node` / `stashed_join` — and hands the emitter a plan with `namedJoins` and `joinType` already resolved, exactly as the subquery path does. `JoinEmissionPlan.joinType` is now required and the fallback join-type ladder is gone.

`pnpm parity:api:calls` / `:args` both OK; relation, associations, calculations and relations suites green locally.

Closes-story: converge-remaining-named-inner-joins-readers
