### PR TITLE
fix(activerecord): emit the MySQL 8.0.19 row-alias INSERT arm in build_insert_sql

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2239,7 +2239,7 @@ export class AbstractAdapter implements Quoting {
   // The base adapter only knows plain inserts; adapters that support upsert /
   // skip-duplicates override this. `into()` already bundles the VALUES list,
   // mirroring `"INSERT #{insert.into} #{insert.values_list}"`.
-  buildInsertSql(insert: InsertBuilder): string {
+  async buildInsertSql(insert: InsertBuilder): Promise<string> {
     if (insert.skipDuplicates() || insert.updateDuplicates()) {
       // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:843
       throw new NotImplementedError(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -87,7 +87,13 @@ import {
   tableAliasLength as mysqlTableAliasLength,
   MysqlSchemaStatements,
 } from "./mysql/schema-statements.js";
-import { compactBlank, include, isPresent, presence } from "@blazetrails/activesupport";
+import {
+  compactBlank,
+  include,
+  isPresent,
+  parameterize,
+  presence,
+} from "@blazetrails/activesupport";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
 import {
@@ -1096,25 +1102,56 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#build_insert_sql.
-  override buildInsertSql(insert: InsertBuilder): string {
-    let sql = `INSERT ${insert.into()}`;
+  override async buildInsertSql(insert: InsertBuilder): Promise<string> {
+    // Can use any column as it will be assigned to itself.
     const noOpColumn = insert.firstColumn();
 
-    if (insert.skipDuplicates()) {
-      if (noOpColumn) {
-        sql += ` ON DUPLICATE KEY UPDATE ${noOpColumn}=${noOpColumn}`;
+    // MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
+    // then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .
+    let sql: string;
+    if (await this.supportsInsertRawAliasSyntax()) {
+      const quotedTableName = insert.model.quotedTableName();
+      const valuesAlias = this.quoteTableName(`${parameterize(insert.model.tableName)}_values`);
+      sql = `INSERT ${insert.into()} AS ${valuesAlias}`;
+
+      if (insert.skipDuplicates()) {
+        if (noOpColumn) {
+          sql += ` ON DUPLICATE KEY UPDATE ${noOpColumn}=${quotedTableName}.${noOpColumn}`;
+        }
+      } else if (insert.updateDuplicates()) {
+        const raw = insert.rawUpdateSql();
+        if (raw) {
+          sql = `INSERT ${insert.into()} ON DUPLICATE KEY UPDATE ${raw.value}`;
+        } else {
+          sql += " ON DUPLICATE KEY UPDATE ";
+          sql += insert.touchModelTimestampsUnless(
+            (column) => `${quotedTableName}.${column}<=>${valuesAlias}.${column}`,
+          );
+          sql += insert
+            .updatableColumns()
+            .map((column) => `${column}=${valuesAlias}.${column}`)
+            .join(",");
+        }
       }
-    } else if (insert.updateDuplicates()) {
-      const raw = insert.rawUpdateSql();
-      if (raw) {
-        sql += ` ON DUPLICATE KEY UPDATE ${raw.value}`;
-      } else {
+    } else {
+      sql = `INSERT ${insert.into()}`;
+
+      if (insert.skipDuplicates()) {
+        if (noOpColumn) {
+          sql += ` ON DUPLICATE KEY UPDATE ${noOpColumn}=${noOpColumn}`;
+        }
+      } else if (insert.updateDuplicates()) {
         sql += " ON DUPLICATE KEY UPDATE ";
-        sql += insert.touchModelTimestampsUnless((column) => `${column}<=>VALUES(${column})`);
-        sql += insert
-          .updatableColumns()
-          .map((column) => `${column}=VALUES(${column})`)
-          .join(",");
+        const raw = insert.rawUpdateSql();
+        if (raw) {
+          sql += raw.value;
+        } else {
+          sql += insert.touchModelTimestampsUnless((column) => `${column}<=>VALUES(${column})`);
+          sql += insert
+            .updatableColumns()
+            .map((column) => `${column}=VALUES(${column})`)
+            .join(",");
+        }
       }
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1101,7 +1101,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return index.using == null || index.using.toUpperCase() === "BTREE";
   }
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#build_insert_sql.
+  // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#build_insert_sql
+  // (abstract_mysql_adapter.rb:638-682). Async where Rails is sync: the arm is
+  // selected by `supports_insert_raw_alias_syntax?` (rb:892-894), which reads
+  // `database_version` — a server round-trip trails can only await.
   override async buildInsertSql(insert: InsertBuilder): Promise<string> {
     // Can use any column as it will be assigned to itself.
     const noOpColumn = insert.firstColumn();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3049,7 +3049,7 @@ export class PostgreSQLAdapter
   // Like the SQLite form, but the timestamp-touch guard uses
   // `<table>.<col> IS NOT DISTINCT FROM excluded.<col>` (Rails qualifies the
   // target with the table name and uses Postgres-correct NULL comparison).
-  override buildInsertSql(insert: InsertBuilder): string {
+  override async buildInsertSql(insert: InsertBuilder): Promise<string> {
     let sql = `INSERT ${insert.into()}`;
 
     if (insert.skipDuplicates()) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1958,7 +1958,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#build_insert_sql.
-  override buildInsertSql(insert: InsertBuilder): string {
+  override async buildInsertSql(insert: InsertBuilder): Promise<string> {
     let sql = `INSERT ${insert.into()}`;
 
     if (insert.skipDuplicates()) {

--- a/packages/activerecord/src/insert-all.trails.test.ts
+++ b/packages/activerecord/src/insert-all.trails.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-fixtures.js";
 import "./support/canonical-model-index.js";
 import { Ship } from "./test-helpers/models/ship.js";
+import { adapterType } from "./test-adapter.js";
+import { assertQueriesMatch } from "./testing/query-assertions.js";
 import type { Base } from "./base.js";
 
 async function withRecordTimestamps(
@@ -52,6 +54,31 @@ describe("InsertAll verify_attributes", () => {
       await expect(
         Ship.insertAll([{ name: "RSS Boaty McBoatface" }, { treasures_count: 3 }]),
       ).rejects.toThrow(/All objects being inserted must have the same keys/);
+    });
+  });
+});
+
+describe("InsertAll build_insert_sql raw alias syntax", () => {
+  fixtures([]);
+
+  // abstract_mysql_adapter.rb:638-682 has two arms: MySQL >= 8.0.19 emits the
+  // row-alias form (`... AS ships_values` + `ships.col<=>ships_values.col`),
+  // everything older — and MariaDB, which `supports_insert_raw_alias_syntax?`
+  // excludes outright (rb:892-894) — keeps the `VALUES(<expr>)` form MySQL
+  // 8.0.20 deprecates.
+  it.skipIf(adapterType !== "mysql")("selects the alias arm on MySQL >= 8.0.19", async () => {
+    const connection = Ship.connection as unknown as {
+      supportsInsertRawAliasSyntax(): Promise<boolean>;
+    };
+    const rawAlias = await connection.supportsInsertRawAliasSyntax();
+    const expected = rawAlias
+      ? /INSERT INTO .* AS `ships_values` ON DUPLICATE KEY UPDATE updated_at=\(CASE WHEN \(`ships`\.`name`<=>`ships_values`\.`name`\) THEN `ships`\.updated_at .*`name`=`ships_values`\.`name`/
+      : /ON DUPLICATE KEY UPDATE updated_at=\(CASE WHEN \(`name`<=>VALUES\(`name`\)\).*`name`=VALUES\(`name`\)/;
+
+    await withRecordTimestamps(Ship as unknown as typeof Base, true, async () => {
+      await assertQueriesMatch(expected, 1, false, async () => {
+        await Ship.upsertAll([{ id: 1, name: "RSS Boaty McBoatface" }]);
+      });
     });
   });
 });

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -139,7 +139,7 @@ export class InsertAll {
     let message = `${this.model.name} `;
     if (this.inserts.length > 1) message += "Bulk ";
     message += this.onDuplicate === "update" ? "Upsert" : "Insert";
-    return this.connection.execInsertAll(this.toSql(), message);
+    return this.connection.execInsertAll(await this.toSql(), message);
   }
 
   /**
@@ -147,7 +147,7 @@ export class InsertAll {
    * dialect-specific statement from the Builder's fragments.
    * @internal
    */
-  toSql(): string {
+  async toSql(): Promise<string> {
     return this.connection.buildInsertSql(
       new Builder(this, this.connection.adapterName as AdapterName),
     );
@@ -582,6 +582,8 @@ export class InsertAll {
  * step but isn't part of this contract.
  */
 export interface InsertBuilder {
+  /** Mirrors Rails `InsertAll::Builder`’s `attr_reader :model` (insert_all.rb:226). */
+  readonly model: ModelClass;
   into(): string;
   conflictTarget(): string;
   returning(): string | undefined;

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -16,20 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_insert_sql",
-    "call": "quote_table_name",
-    "reason": "Verified per-site (RFC 0106): same arm as the `table_name` row — `quote_table_name(\"#{insert.model.table_name.parameterize}_values\")` (abstract_mysql_adapter.rb:646) is only reached under `supports_insert_raw_alias_syntax?`, which a synchronous `buildInsertSql` cannot await."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_insert_sql",
-    "call": "table_name",
-    "reason": "Verified per-site (RFC 0106): both calls live only in the `supports_insert_raw_alias_syntax?` arm (abstract_mysql_adapter.rb:644-661), which trails does not emit — `supportsInsertRawAliasSyntax()` is async and `buildInsertSql` is a synchronous adapter hook, so the MySQL 8.0.19 row-alias INSERT form cannot be selected from here. Tracked separately as the async-buildInsertSql convergence."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "columns_for_distinct",
     "call": "compact_blank",
     "kind": "args",


### PR DESCRIPTION
`abstract_mysql_adapter.rb:638-682` has two arms and trails only ported the
second: the legacy `VALUES(<expression>)` form that MySQL 8.0.20 deprecates
(<https://dev.mysql.com/worklog/task/?id=13325>). Every `insert_all` /
`upsert_all` with `update_duplicates` therefore emitted deprecated SQL on a
modern MySQL 8 server.

The arm is selected by `supports_insert_raw_alias_syntax?` (rb:892-894), which
in trails reads `databaseVersion` and is async, so `buildInsertSql` is now
`async` across all three dialects (abstract, SQLite, PostgreSQL, MySQL) and
`InsertAll#toSql` awaits it. There was no remaining synchronous caller.

Emitted on MySQL >= 8.0.19 (verified against a live `mysql:8` 8.4.9, not just
MariaDB — the predicate is `!mariadb?`):

```sql
INSERT INTO `ships` (...) VALUES (...) AS `ships_values`
  ON DUPLICATE KEY UPDATE updated_at=(CASE WHEN (`ships`.`name`<=>`ships_values`.`name`)
    THEN `ships`.updated_at ELSE CURRENT_TIMESTAMP(6) END),
  `name`=`ships_values`.`name`
```

MariaDB and MySQL < 8.0.19 keep the legacy arm.

The two `build_insert_sql` rows (`table_name`, `quote_table_name`) are deleted
by hand from
`scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json`
— no reseed.

Regression test: `insert-all.trails.test.ts` (no like-named Rails test exists),
gated to the MySQL lane and branching on the predicate so it covers both arms.
It fails on baseline (baseline never emits `AS \`ships_values\``).

Closes-story: mysql-build-insert-sql-missing-raw-alias-arm
