### PR TITLE
refactor(activerecord): retire the _namedInnerJoins/_joinValues getters

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1014,7 +1014,8 @@ export class AssociationScope {
     if (namedInner.length > 0) {
       if (sameKlass) {
         for (const v of namedInner)
-          if (!target.joinsValues.includes(v)) target._joinsValues.push(v);
+          if (!target.joinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
+            target._joinsValues.push(v);
       } else {
         target._joinsValues.push(
           constructJoinDependency.call(item as never, namedInner as never, Nodes.InnerJoin),

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -976,9 +976,9 @@ export class AssociationScope {
   private _mergeReferencedJoins(scope: unknown, evaluated: unknown): void {
     const item = evaluated as {
       _referencesValues?: string[];
-      _joinValues?: unknown[];
+      joinsValues?: unknown[];
+      _isNamedJoinValue?: (v: unknown) => boolean;
       _joinClauses?: unknown[];
-      _namedInnerJoins?: unknown[];
       _leftOuterJoinsValues?: unknown[];
       _includesAssociations?: unknown[];
       _eagerLoadAssociations?: unknown[];
@@ -988,9 +988,8 @@ export class AssociationScope {
     if (refs.length === 0) return;
     const target = scope as {
       _joinsValues: unknown[];
-      _joinValues: unknown[];
+      joinsValues: unknown[];
       _joinClauses: unknown[];
-      _namedInnerJoins: unknown[];
       _leftOuterJoinsValues: unknown[];
       _model?: typeof Base;
     };
@@ -999,20 +998,29 @@ export class AssociationScope {
     // straight across, then union named association joins (same-klass) or build
     // cross-klass JoinDependencies (Merger#merge_joins / #merge_outer_joins).
     for (const jc of item._joinClauses ?? []) target._joinClauses.push(jc);
-    for (const jv of item._joinValues ?? []) target._joinsValues.push(jv);
-    const namedInner = (item._namedInnerJoins ?? []).filter((v) => !(v instanceof JoinDependency));
-    const innerDeps = (item._namedInnerJoins ?? []).filter((v) => v instanceof JoinDependency);
+    // merger.rb:123-126 — `other.joins_values.partition { |join| case join when
+    // Hash, Symbol, Array; true end }`: association specs on one side, raw SQL /
+    // Arel nodes and stashed JoinDependencies on the other.
+    const namedInner: unknown[] = [];
+    const others: unknown[] = [];
+    for (const v of item.joinsValues ?? []) {
+      if (!(v instanceof JoinDependency) && item._isNamedJoinValue?.(v) === true) {
+        namedInner.push(v);
+      } else {
+        others.push(v);
+      }
+    }
+    for (const v of others) target._joinsValues.push(v);
     if (namedInner.length > 0) {
       if (sameKlass) {
         for (const v of namedInner)
-          if (!target._namedInnerJoins.includes(v)) target._joinsValues.push(v);
+          if (!target.joinsValues.includes(v)) target._joinsValues.push(v);
       } else {
         target._joinsValues.push(
           constructJoinDependency.call(item as never, namedInner as never, Nodes.InnerJoin),
         );
       }
     }
-    target._joinsValues.push(...innerDeps);
     const namedLeft = (item._leftOuterJoinsValues ?? []).filter(
       (v) => !(v instanceof JoinDependency),
     );

--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -22,7 +22,7 @@
  * So the fidelity behavior is to raise, not to silently defer the raw join to the
  * source-preloader stage (where it is valid SQL against the source base table) — a
  * lenient deviation Rails itself rejects. We mirror Rails by nesting the scope's raw
- * `_joinValues` under the source reflection name; trails' join builder rejects
+ * raw joins_values under the source reflection name; trails' join builder rejects
  * `{source => [<raw string>]}` with the identical `ConfigurationError`.
  *
  * No canonical has_many-through model scope uses a raw join, so this pins the

--- a/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
@@ -19,7 +19,7 @@
  *
  * So the fidelity behavior is to raise the same `ConfigurationError`, not to
  * silently carry the join (which would be a deviation Rails itself rejects). We
- * mirror Rails by nesting the scope's raw `_joinValues` under the source
+ * mirror Rails by nesting the scope's raw joins_values under the source
  * reflection name; trails' join builder rejects `{source => [<raw string>]}`
  * with the identical `ConfigurationError`. Symbol-association joins (the `general`
  * scope's `left_joins(:category)`) are the only `joins` case Rails supports in

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -421,10 +421,8 @@ export class ThroughAssociation extends Association {
 
         // joins!(source_reflection.name => joins) (rb:132-134): Rails applies the
         // whole flattened `values[:joins]` bucket ONCE, nested under the source
-        // reflection name. trails splits that bucket into `_namedInnerJoins`
-        // (symbol association joins) and `_joinValues` (raw string / Arel-node
-        // joins), so their UNION is Rails' single `values[:joins]` — applied here
-        // exactly once. A raw string / Arel join anywhere in the FLATTENED chain
+        // reflection name — trails reads the same single `joins_values` store, in
+        // insertion order. A raw string / Arel join anywhere in the FLATTENED chain
         // scope raises `ConfigurationError` in Rails (`JoinDependency` rejects the
         // bogus association name symbolized from the raw string), regardless of
         // the collection/nested strategy — nesting it under the source reflection
@@ -434,10 +432,9 @@ export class ThroughAssociation extends Association {
         // Rails means raising here too — a raw join declared only on a deeper
         // sub-chain link is NOT deferred to its own recursive stage (verified
         // against a live Rails nested-through repro).
-        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
-        const nestedJoins: any[] = reflScope?._namedInnerJoins ?? [];
-        if (nestedRawJoinValues.length > 0 || nestedJoins.length > 0) {
-          scope = scope.joins({ [sourceName]: [...nestedRawJoinValues, ...nestedJoins] });
+        const nestedJoins: any[] = reflScope?.joinsValues ?? [];
+        if (nestedJoins.length > 0) {
+          scope = scope.joins({ [sourceName]: nestedJoins });
         }
 
         // left_outer_joins!(source_reflection.name => left_outer_joins) (rb:136-137).

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -115,7 +115,7 @@ describe("lookupCastTypeFromJoinDependencies integration", () => {
 
   fixtures(["topics", "authors"]);
 
-  // A plain `joins(:assoc)` now feeds buildJoinDependencies (via _namedInnerJoins),
+  // A plain `joins(:assoc)` now feeds buildJoinDependencies (via joins_values),
   // so lookupCastTypeFromJoinDependencies recovers the joined column's cast type
   // through the join-dependency walk — no `_joinClauses`-klass fallback. Replaces
   // the unit tests that asserted the (removed) `_joinClauses.klass` recovery.

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -344,7 +344,7 @@ describe("RelationTest", () => {
   });
 
   it("eagerLoad + leftJoins: buildJoinBuckets short-circuit does not drop eager stash", () => {
-    // Regression: when _joinValues and _joinClauses are empty, buildJoinBuckets
+    // Regression: when joins_values and _joinClauses are empty, buildJoinBuckets
     // short-circuits for the left-outer-only path. If _eagerLoadAssociations is
     // also present, the short-circuit must not fire — eager stash would be skipped.
     class Author extends Base {
@@ -361,7 +361,7 @@ describe("RelationTest", () => {
     }
     registerModel("EagerLeftAuthor", Author);
     registerModel("EagerLeftPost", Post);
-    // Both eagerLoad and leftJoins present, no explicit _joinValues/_joinClauses
+    // Both eagerLoad and leftJoins present, no explicit joins_values/_joinClauses
     const rel = Author.leftJoins("posts").eagerLoad("posts");
     expect((rel as any)._eagerLoadAssociations).toContain("posts");
     expect((rel as any)._leftOuterJoinsValues).toContain("posts");
@@ -381,7 +381,7 @@ describe("RelationTest", () => {
       new Nodes.On(new Nodes.SqlLiteral("books.author_id = authors.id")),
     );
     const relation = Book.joins(node);
-    const joinValues = (relation as any)._joinValues as unknown[];
+    const joinValues = relation.joinsValues as unknown[];
     expect(relation.toSql()).toContain("INNER JOIN");
     expect(relation.toSql()).toContain("authors");
     expect(joinValues).toHaveLength(1);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -399,7 +399,7 @@ export class Relation<T extends Base> {
   // order — Arel join nodes and raw SQL strings alongside association names and
   // nested-association hashes — so `joins_values=`/`joins_values` round-trip
   // faithfully with no named-before-raw reorder. The named-vs-raw split the
-  // builders need is derived on read (`_namedInnerJoins` / `_joinValues`), not
+  // builders need is derived on read by `select_association_list`, not
   // stored separately.
   private _joinsValues: (AssociationSpec | string | Nodes.Join)[] = [];
   private _leftOuterJoinsValues: AssociationSpec[] = [];
@@ -409,28 +409,14 @@ export class Relation<T extends Base> {
   // `joins(":name")` — or a string naming an association; everything else (Arel
   // join nodes, raw SQL strings) is a raw join value. The two derived getters
   // below partition `_joinsValues` by this rule — the same rule `joins` uses at
-  // insert time. A raw Symbol misrouted to `_joinValues` would reach the arel
-  // visitor and raise "Unknown node type: Symbol", so Symbols must land in
-  // `_namedInnerJoins`.
+  // insert time. A raw Symbol routed to the raw-join bucket would reach the arel
+  // visitor and raise "Unknown node type: Symbol", so Symbols must be named.
   private _isNamedJoinValue(v: unknown): boolean {
     return (
       _isPlainObject(v) ||
       v instanceof JoinDependency ||
       (typeof v === "string" && (v.startsWith(":") || this._isAssociationName(v)))
     );
-  }
-  // INNER `joins(:assoc)` association names (and nested hash/through specs),
-  // resolved through JoinDependency — mirroring Rails' joins_values, which feed
-  // build_join_dependencies so every node in the chain carries its base_klass
-  // and shares Rails' AliasTracker self-join aliasing. Derived from the unified
-  // store so insertion order is preserved.
-  get _namedInnerJoins(): AssociationSpec[] {
-    return this._joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[];
-  }
-  // Raw join values (Arel `Nodes.Join` and non-association SQL strings). Derived
-  // from the unified store; the complement of `_namedInnerJoins`.
-  get _joinValues(): (string | Nodes.Join)[] {
-    return this._joinsValues.filter((v) => !this._isNamedJoinValue(v)) as (string | Nodes.Join)[];
   }
   private _includesAssociations: AssociationSpec[] = [];
   private _preloadAssociations: AssociationSpec[] = [];
@@ -1473,7 +1459,7 @@ export class Relation<T extends Base> {
     // eql?/hash (structural for Arel `Nodes.Binary`, plain strings, and Hash
     // specs alike). A single unified store preserves insertion order across
     // named and raw joins; the named-vs-raw partition the builders need is
-    // derived on read (see `_namedInnerJoins` / `_joinValues`).
+    // derived on read by `select_association_list`.
     return QueryMethodBangs.joinsBang.call(
       this._clone() as any,
       ...(args as (string | Nodes.Join)[]),
@@ -2609,14 +2595,17 @@ export class Relation<T extends Base> {
     // to table names so references to those tables don't spuriously promote
     // includes to eager_load. The raw SQL strings it drops are handled by the
     // `tablesInString` arm below, exactly as Rails' StringJoin branch does.
+    const rawJoinValues: (string | Nodes.Join)[] = [];
     const namedInnerTables = this._resolveAssocTables(
-      this.selectAssociationList(this._joinsValues, null) as AssociationSpec[],
+      this.selectAssociationList(this._joinsValues, null, (join) =>
+        rawJoinValues.push(join as string | Nodes.Join),
+      ) as AssociationSpec[],
     );
     const joinedTables = new Set<string>([
       ...this._joinClauses.map((j) => j.table.toLowerCase()),
       ...leftOuterTables,
       ...namedInnerTables,
-      ...this._joinValues.flatMap((v) => {
+      ...rawJoinValues.flatMap((v) => {
         if (typeof v === "string") {
           const join = new Nodes.StringJoin(new Nodes.SqlLiteral(v));
           return this.tablesInString(join.left);
@@ -4222,7 +4211,7 @@ export class Relation<T extends Base> {
    * array. trails backs that directly with `_joinsValues`, so the reader returns
    * the stored array (a copy) and preserves the exact order in which joins were
    * added. The named-vs-raw split the builders need is derived from this store
-   * on read (`_namedInnerJoins` / `_joinValues`).
+   * on read by `select_association_list`.
    */
   get joinsValues(): (AssociationSpec | string | Nodes.Join)[] {
     return [...this._joinsValues];

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -23,11 +23,9 @@ import { Author } from "../test-helpers/models/author.js";
 
 interface JoinValueHost {
   // Public Rails-mirrored accessor for `left_outer_joins_values`
-  // (relation.ts get leftOuterJoinsValues, ~:4578). `_namedInnerJoins` has no
-  // public accessor — it is a trails-internal storage split of `joins_values`
-  // for association-name specs, so it is read through the underscore field.
+  // (relation.ts get leftOuterJoinsValues, ~:4578), alongside `joins_values`.
   leftOuterJoinsValues: unknown[];
-  _namedInnerJoins: unknown[];
+  joinsValues: unknown[];
   toSql(): string;
 }
 
@@ -46,10 +44,10 @@ describe("join value union structural dedup", () => {
   });
 
   it("emits a single INNER JOIN for a structurally-equal Hash spec joined twice", () => {
-    // The inner-joins Hash path previously pushed to _namedInnerJoins with no
-    // dedup at all; joins_values |= folds the structurally-equal spec in Rails.
+    // The inner-joins Hash path previously pushed with no dedup at all;
+    // joins_values |= folds the structurally-equal spec in Rails.
     const rel = Author.joins({ posts: "comments" }).joins({ posts: "comments" });
-    expect(asHost(rel)._namedInnerJoins).toHaveLength(1);
+    expect(asHost(rel).joinsValues).toHaveLength(1);
     const sql = asHost(rel).toSql();
     expect((sql.match(/INNER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
   });
@@ -65,6 +63,6 @@ describe("join value union structural dedup", () => {
     // Rails merge_joins unions via joins! (joins_values |=), so a same-klass
     // merge dedups the equal spec structurally rather than by reference.
     const rel = Author.joins({ posts: "comments" }).merge(Author.joins({ posts: "comments" }));
-    expect(asHost(rel)._namedInnerJoins).toHaveLength(1);
+    expect(asHost(rel).joinsValues).toHaveLength(1);
   });
 });

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -147,13 +147,11 @@ export class Merger {
     const joinsValues = other.joinsValues ?? [];
     if (joinsValues.length === 0) return;
     if (other.model === rel.model) {
+      // merger.rb:121 `relation.joins_values |= other.joins_values` — one union
+      // over the whole store, named and raw alike.
       for (const v of joinsValues) {
-        if (!other._isNamedJoinValue(v)) {
-          if (!rel._joinValues.some((existing: unknown) => structuralUnionEq(existing, v)))
-            rel._joinsValues.push(v);
-        } else if (!rel._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v))) {
+        if (!rel.joinsValues.some((existing: unknown) => structuralUnionEq(existing, v)))
           rel._joinsValues.push(v);
-        }
       }
       return;
     }

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -32,7 +32,7 @@ describe("RelationMutationTest", () => {
       ["eagerLoadBang", "_eagerLoadAssociations"],
       ["preloadBang", "_preloadAssociations"],
       ["groupBang", "_groupColumns"],
-      ["joinsBang", "_joinValues"],
+      ["joinsBang", "_joinsValues"],
       ["leftOuterJoinsBang", "_leftOuterJoinsValues"],
       ["referencesBang", "_referencesValues"],
       ["optimizerHintsBang", "_optimizerHints"],

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -196,20 +196,19 @@ interface QueryMethodsHost {
     klass?: unknown;
   }>;
   // Unified insertion-ordered `joins_values` backing store; `joinsValues`
-  // exposes it (Rails' `@values[:joins]`). `_joinValues` / `_namedInnerJoins`
-  // are read-only getters derived from it via `_isNamedJoinValue`.
+  // exposes it (Rails' `@values[:joins]`). The named-vs-raw split is derived on
+  // read by `select_association_list` / `select_named_joins`, which discriminate
+  // with `_isNamedJoinValue`.
   _joinsValues: (AssociationSpec | string | Nodes.Join)[];
   joinsValues: (AssociationSpec | string | Nodes.Join)[];
   // Converged Rails `Relation#alias_tracker(joins, aliases)` (relation.rb:1307);
   // `buildJoins` reads it to build the shared `build_joins` tracker.
   aliasTracker(joins?: Nodes.Node[], aliases?: Map<string, number>): AliasTracker;
   _isNamedJoinValue(v: unknown): boolean;
-  readonly _joinValues: (string | Nodes.Join)[];
   _leftOuterJoinsValues: AssociationSpec[];
   // Public `left_outer_joins_values` value method (relation.ts getter); reads it
   // over the backing field so extractCalls credits the Rails value-method read.
   leftOuterJoinsValues: AssociationSpec[];
-  readonly _namedInnerJoins: AssociationSpec[];
   _includesAssociations: AssociationSpec[];
   _preloadAssociations: AssociationSpec[];
   _eagerLoadAssociations: AssociationSpec[];
@@ -997,7 +996,7 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
 
 function leftOuterJoinsBang(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   // Mirrors Rails left_outer_joins! which stores into left_outer_joins_values
-  // (separate from joins_values / _joinValues which is the inner-join path).
+  // (separate from joins_values, which is the inner-join path).
   // |= dedups by eql?/hash — structural for Hash specs, not JS reference.
   for (const arg of args) {
     if (!this._leftOuterJoinsValues.some((seen) => structuralUnionEq(seen, arg)))
@@ -1207,9 +1206,8 @@ const STRUCTURAL_FIELDS: ReadonlyArray<[string, keyof QueryMethodsHost]> = [
   ["order", "_orderClauses"],
   ["rawOrder", "_rawOrderClauses"],
   ["joins", "_joinClauses"],
-  ["joinValues", "_joinValues"],
+  ["joins", "_joinsValues"],
   ["leftOuterJoinsValues", "_leftOuterJoinsValues"],
-  ["namedInnerJoins", "_namedInnerJoins"],
   ["limit", "_limitValue"],
   ["offset", "_offsetValue"],
   ["lock", "_lockValue"],
@@ -1241,13 +1239,17 @@ export function structurallyIncompatibleValuesFor(
     // "never set" and "unscoped" as an empty array, so an empty `b` always
     // stands in for that `nil`. Matching populated values are compared after
     // `uniq` (see relation/or_test.rb `test_or_with_unscope_order`).
+    // Rails' `:joins` is one value method; trails splits its storage across the
+    // joins_values store and the trails-only `_joinClauses`, so two rows carry
+    // the same label and the name must not be reported twice.
     if (Array.isArray(a)) {
       if (!Array.isArray(b)) continue;
       if (b.length === 0) continue;
-      if (!deepEqual(uniqArray(a), uniqArray(b as unknown[]))) incompat.push(label);
+      if (!deepEqual(uniqArray(a), uniqArray(b as unknown[])) && !incompat.includes(label))
+        incompat.push(label);
       continue;
     }
-    if (!deepEqual(a, b)) incompat.push(label);
+    if (!deepEqual(a, b) && !incompat.includes(label)) incompat.push(label);
   }
   return incompat;
 }
@@ -1557,7 +1559,7 @@ const UNIQ_BANG_FIELDS: Partial<Record<string, keyof QueryMethodsHost>> = {
   select: "_selectColumns",
   group: "_groupColumns",
   order: "_orderClauses",
-  joins: "_joinValues",
+  joins: "_joinsValues",
   left_outer_joins: "_leftOuterJoinsValues",
   references: "_referencesValues",
   extending: "_extending",
@@ -2889,9 +2891,9 @@ export function buildJoinBuckets(
  * @internal
  */
 export interface JoinEmissionPlan {
-  /** LeadingJoin nodes (and, when no stash exists, all `_joinValues`), prepended. */
+  /** LeadingJoin nodes (and, when no stash exists, all raw join nodes), prepended. */
   leadingJoins: Nodes.Join[];
-  /** Non-leading `_joinValues` nodes, appended last. */
+  /** Non-leading raw join nodes, appended last. */
   joinNodes: Nodes.Join[];
   /**
    * JoinDependencies folded into the primary named/left JD's `joinConstraints`

--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -3,7 +3,7 @@
  * accessors (query_methods.rb:162-181): the `joins_values=` split-routing
  * writer, the nil-vs-false tri-state of the single-value flags, and the
  * stored-reference reader semantics of the array readers. These exercise
- * trails-specific storage details (the `_namedInnerJoins`/`_joinValues` split,
+ * trails-specific storage details (the unified `joins_values` store,
  * the `boolean | undefined` flag fields), so the names are descriptive rather
  * than mirrored from a metaprogrammed Rails test.
  */
@@ -18,8 +18,7 @@ import { EXCEPT_ONLY_KEYS } from "./query-methods.js";
 fixtures([]);
 /** The split join-storage and group fields the reader semantics build on. */
 type JoinInternals = {
-  _namedInnerJoins: unknown[];
-  _joinValues: unknown[];
+  _joinsValues: unknown[];
   _groupColumns: string[];
   _orderClauses: unknown[];
 };
@@ -36,8 +35,8 @@ describe("Relation value accessor Rails semantics", () => {
   it("joins_values= split-routes association hashes and raw joins", () => {
     const rel = relation();
     rel.joinsValues = [{ category: {} }, "LEFT JOIN comments ON comments.post_id = posts.id"];
-    expect(internals(rel)._namedInnerJoins).toEqual([{ category: {} }]);
-    expect(internals(rel)._joinValues).toEqual([
+    expect(internals(rel)._joinsValues).toEqual([
+      { category: {} },
       "LEFT JOIN comments ON comments.post_id = posts.id",
     ]);
   });
@@ -52,8 +51,7 @@ describe("Relation value accessor Rails semantics", () => {
     const rel = relation();
     rel.joinsValues = [{ category: {} }];
     rel.joinsValues = ["RAW JOIN x"];
-    expect(internals(rel)._namedInnerJoins).toEqual([]);
-    expect(internals(rel)._joinValues).toEqual(["RAW JOIN x"]);
+    expect(internals(rel)._joinsValues).toEqual(["RAW JOIN x"]);
   });
 
   it("readonly_value defaults to nil (undefined) when unset", () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -807,7 +807,7 @@ describe("RelationTest", () => {
   // Rails compact_blank!s blank join specs before joins!/left_outer_joins!, so a
   // blank hash/array must not linger in relation state (query_methods.rb:868-890).
   it("blank join arguments are not retained in relation state", () => {
-    expect((Topic as any).joins({})._namedInnerJoins).toEqual([]);
+    expect((Topic as any).joins({}).joinsValues).toEqual([]);
     expect((Topic as any).leftJoins({})._leftOuterJoinsValues).toEqual([]);
     expect((Topic as any).leftJoins([])._leftOuterJoinsValues).toEqual([]);
   });


### PR DESCRIPTION
The last three trails-only readers of the derived join-partition getters now read `joins_values` directly and let `select_association_list` (query_methods.rb:1810-1823) do the named-vs-raw partition, as Rails does at each corresponding site:

- `association-scope.ts` `_mergeReferencedJoins` — partitions `item.joins_values` with Rails' `when Hash, Symbol, Array` rule (merger.rb:123-126, association_scope.rb:138-146).
- `preloader/through-association.ts` `through_scope` — nests the single `values[:joins]` bucket once, in insertion order (preloader/through_association.rb:132-134).
- `relation/merger.ts` `merge_joins` — the same-model arm is one `joins_values |=` union (merger.rb:121).
- `relation.ts` reference-table scan — collects the raw joins through `select_association_list`'s block instead of the getter.

`_isNamedJoinValue` survives as the insert-time discriminator; both derived getters are deleted, along with their `QueryMethodsHost` declarations. `uniq!(:joins)` and the structural-compatibility table now name the `joins_values` store, matching Rails' single `:joins` value method.

Tests: relations, merging, or, mutation, value-accessor-semantics, left-outer-joins dedup, inner-join-association, has-many-through, eager, through-association raw-join scopes — all green locally. `parity:api:calls` / `:args` OK, `parity:api:extra` unchanged (two names removed).

Closes-story: retire-named-inner-joins-getter