### PR TITLE
refactor(activesupport,activerecord): rewire module-mixin-receiver naming rows to the this-typed idiom

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -794,6 +794,14 @@ export class Model {
       }
       this._registerValidator(validator, explicitAttributes);
 
+      // The `validator.validate(...)` calls below carry the RECORD, which is a
+      // callback parameter here, not a receiver: this is the CLASS-side
+      // `validates_with` (with.rb:88-105), whose Rails body ends in
+      // `validate(validator, options)` and never invokes the validator itself.
+      // The recorder pairs them with the INSTANCE `validates_with`
+      // (with.rb:143-151), whose `validator.validate(self)` trails has no
+      // counterpart for — a real gap, filed as
+      // `activemodel-instance-validates-with`, not a receiver-parameter shape.
       let callbackFn: CallbackFn;
       if (isStrict) {
         callbackFn = (record: object) => {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -794,14 +794,9 @@ export class Model {
       }
       this._registerValidator(validator, explicitAttributes);
 
-      // The `validator.validate(...)` calls below carry the RECORD, which is a
-      // callback parameter here, not a receiver: this is the CLASS-side
-      // `validates_with` (with.rb:88-105), whose Rails body ends in
-      // `validate(validator, options)` and never invokes the validator itself.
-      // The recorder pairs them with the INSTANCE `validates_with`
-      // (with.rb:143-151), whose `validator.validate(self)` trails has no
-      // counterpart for — a real gap, filed as
-      // `activemodel-instance-validates-with`, not a receiver-parameter shape.
+      // Only the CLASS-side `validates_with` (with.rb:88-105) is ported; the
+      // instance one (with.rb:143-151) is a real gap, filed as
+      // `activemodel-instance-validates-with`.
       let callbackFn: CallbackFn;
       if (isStrict) {
         callbackFn = (record: object) => {

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -53,7 +53,7 @@ const delegatedTypeRegistry = new WeakMap<
  *
  * This adds:
  *   - entry.entryableClass         → constantized model class for the current foreign_type (Rails: `entryable_class`)
- *   - entry.entryableName          → StringInquirer (e.g. inquiry("message"))
+ *   - entry.entryableName          → StringInquirer (e.g. inquiry.call("message"))
  *   - entry.isMessage()            → type predicate
  *   - entry.isComment()            → type predicate
  *   - Entry.messages()             → scope (returns Relation)
@@ -133,7 +133,7 @@ export function delegatedType(
       // Rails: model_name.singular == name.underscore.tr("/", "_").
       // "Access::NoticeMessage" → "access/notice_message" → "access_notice_message".
       const singular = underscore(typeName).replace(/\//g, "_");
-      return inquiry(singular);
+      return inquiry.call(singular);
     },
     configurable: true,
   });

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -797,19 +797,23 @@ export class UnknownAttributeReference extends ActiveRecordError {
   }
 }
 
-/** @noRailsEquivalent Ruby is duck-typed; TS needs a name for `table_name`. */
+/**
+ * What `errors.rb:475` duck-types: anything answering `table_name`. Rails
+ * raises this with a Relation as often as with a model class
+ * (`token_for.rb:42`).
+ *
+ * @noRailsEquivalent Ruby needs no name for a duck type.
+ */
 type UnknownPrimaryKeyModel = { readonly tableName: string; readonly name?: unknown };
 
 export class UnknownPrimaryKey extends ActiveRecordError {
-  // Rails takes whatever responds to `table_name` — `token_for.rb:42` raises
-  // it with a Relation, not a model class (errors.rb:475).
   readonly model: UnknownPrimaryKeyModel | null;
 
   constructor(model?: UnknownPrimaryKeyModel | null, description?: string) {
     let msg: string;
     if (model) {
-      // Ruby's `#{model}` (errors.rb:477): a Class interpolates as its name,
-      // anything else as its own `to_s`.
+      // Ruby's `#{model}` (errors.rb:477) — a Class interpolates as its name,
+      // anything else as its own `to_s`; JS stringifies a class as its source.
       msg = `Unknown primary key for table ${model.tableName} in model ${String(model.name ?? model)}.`;
       if (description) msg += `\n${description}`;
     } else {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -797,13 +797,20 @@ export class UnknownAttributeReference extends ActiveRecordError {
   }
 }
 
-export class UnknownPrimaryKey extends ActiveRecordError {
-  readonly model: typeof import("./base.js").Base | null;
+/** @noRailsEquivalent Ruby is duck-typed; TS needs a name for `table_name`. */
+type UnknownPrimaryKeyModel = { readonly tableName: string; readonly name?: unknown };
 
-  constructor(model?: typeof import("./base.js").Base | null, description?: string) {
+export class UnknownPrimaryKey extends ActiveRecordError {
+  // Rails takes whatever responds to `table_name` — `token_for.rb:42` raises
+  // it with a Relation, not a model class (errors.rb:475).
+  readonly model: UnknownPrimaryKeyModel | null;
+
+  constructor(model?: UnknownPrimaryKeyModel | null, description?: string) {
     let msg: string;
     if (model) {
-      msg = `Unknown primary key for table ${model.tableName} in model ${model.name}.`;
+      // Ruby's `#{model}` (errors.rb:477): a Class interpolates as its name,
+      // anything else as its own `to_s`.
+      msg = `Unknown primary key for table ${model.tableName} in model ${String(model.name ?? model)}.`;
       if (description) msg += `\n${description}`;
     } else {
       msg = "Unknown primary key.";

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -148,9 +148,7 @@ export class InsertAll {
    * @internal
    */
   async toSql(): Promise<string> {
-    return this.connection.buildInsertSql(
-      new Builder(this, this.connection.adapterName as AdapterName),
-    );
+    return this.connection.buildInsertSql(new Builder(this));
   }
 
   updatableColumns(): string[] {
@@ -619,10 +617,14 @@ export class Builder implements InsertBuilder {
   private _insertAll: InsertAll;
   private _dialect: AdapterDialect;
 
-  constructor(insertAll: InsertAll, dialect: AdapterDialect = "sqlite") {
+  // Rails: `@insert_all, @model, @connection = insert_all, insert_all.model,
+  // insert_all.connection` (insert_all.rb:229-231). `_dialect` stands in for
+  // `@connection`, which the SQL fragments below only ever consult for its
+  // adapter name.
+  constructor(insertAll: InsertAll) {
     this._insertAll = insertAll;
     this.model = insertAll.model;
-    this._dialect = dialect;
+    this._dialect = insertAll.connection.adapterName as AdapterDialect;
   }
 
   /** Mirrors Rails `quote_column` → `connection.quote_column_name`. @internal */

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -7,12 +7,10 @@ import type { Base } from "./base.js";
 
 import { isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
-import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 import { Result } from "./result.js";
 import { withConnection } from "./connection-handling.js";
 
 type ModelClass = typeof Base;
-type AdapterDialect = AdapterName;
 
 const TIMESTAMP_COLUMNS = ["created_at", "created_on", "updated_at", "updated_on"] as const;
 const UPDATE_TIMESTAMP_COLUMNS = ["updated_at", "updated_on"] as const;
@@ -615,26 +613,22 @@ export interface InsertBuilder {
 export class Builder implements InsertBuilder {
   readonly model: ModelClass;
   private _insertAll: InsertAll;
-  private _dialect: AdapterDialect;
+  private _connection: ModelClass["connection"];
 
-  // Rails: `@insert_all, @model, @connection = insert_all, insert_all.model,
-  // insert_all.connection` (insert_all.rb:229-231). `_dialect` stands in for
-  // `@connection`, which the SQL fragments below only ever consult for its
-  // adapter name.
   constructor(insertAll: InsertAll) {
     this._insertAll = insertAll;
     this.model = insertAll.model;
-    this._dialect = insertAll.connection.adapterName as AdapterDialect;
+    this._connection = insertAll.connection;
   }
 
   /** Mirrors Rails `quote_column` → `connection.quote_column_name`. @internal */
   private quoteColumn(name: string): string {
-    return this._insertAll.connection.quoteColumnName(name);
+    return this._connection.quoteColumnName(name);
   }
 
   /** Mirrors Rails `connection.quote_table_name`. @internal */
   private quoteTable(name: string): string {
-    return this._insertAll.connection.quoteTableName(name);
+    return this._connection.quoteTableName(name);
   }
 
   returning(): string | undefined {
@@ -669,7 +663,7 @@ export class Builder implements InsertBuilder {
       if (this._insertAll.inserts.length > 1) {
         throw new Error("Bulk insert with no explicit columns is not supported");
       }
-      if (this._dialect === "mysql2") {
+      if (this._connection.adapterName === "mysql2") {
         return `INTO ${tableName} () VALUES ()`;
       }
       return `INTO ${tableName} DEFAULT VALUES`;
@@ -755,7 +749,7 @@ export class Builder implements InsertBuilder {
           `${columnName}=(CASE WHEN (${this.updatableColumns()
             .map(block)
             .join(" AND ")}) THEN ${this.quotedTableName()}.${columnName} ELSE ${String(
-            this._insertAll.connection.highPrecisionCurrentTimestamp(),
+            this._connection.highPrecisionCurrentTimestamp(),
           )} END),`,
       )
       .join("");
@@ -776,11 +770,11 @@ export class Builder implements InsertBuilder {
   }
 
   private _visitor(): Visitors.ToSql {
-    const v = this._insertAll.connection.visitor;
+    const v = this._connection.visitor;
     if (v) return v;
-    const q = this._insertAll.connection as unknown as Visitors.ArelConnection;
-    if (this._dialect === "mysql2") return new Visitors.MySQL(q);
-    if (this._dialect === "postgres") return new Visitors.PostgreSQL(q);
+    const q = this._connection as unknown as Visitors.ArelConnection;
+    if (this._connection.adapterName === "mysql2") return new Visitors.MySQL(q);
+    if (this._connection.adapterName === "postgres") return new Visitors.PostgreSQL(q);
     return new Visitors.SQLite(q);
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6489,7 +6489,8 @@ export class Relation<T extends Base> {
    */
   async findByTokenFor(purpose: string, token: string): Promise<T | null> {
     const primaryKey = this.model.primaryKey as string | string[] | null;
-    if (!primaryKey || primaryKey.length === 0) throw new UnknownPrimaryKey(this.model);
+    // Rails raises with the RELATION, not its model (token_for.rb:42).
+    if (!primaryKey || primaryKey.length === 0) throw new UnknownPrimaryKey(this);
     const record = await this.model.tokenDefinitions.fetch(purpose).resolveToken(token, (id) => {
       // Rails passes `model.primary_key => [id]`; with a composite key that
       // hash key is the key array, which trails' findBy spells one column at

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6489,7 +6489,6 @@ export class Relation<T extends Base> {
    */
   async findByTokenFor(purpose: string, token: string): Promise<T | null> {
     const primaryKey = this.model.primaryKey as string | string[] | null;
-    // Rails raises with the RELATION, not its model (token_for.rb:42).
     if (!primaryKey || primaryKey.length === 0) throw new UnknownPrimaryKey(this);
     const record = await this.model.tokenDefinitions.fetch(purpose).resolveToken(token, (id) => {
       // Rails passes `model.primary_key => [id]`; with a composite key that

--- a/packages/activesupport/src/class-attribute.test.ts
+++ b/packages/activesupport/src/class-attribute.test.ts
@@ -4,14 +4,14 @@ import { classAttribute } from "./class-attribute.js";
 describe("classAttribute", () => {
   it("defines a class-level attribute with default", () => {
     class Model {}
-    classAttribute(Model, "tableName", { default: "models" });
+    classAttribute.call(Model, "tableName", { default: "models" });
 
     expect((Model as any).tableName).toBe("models");
   });
 
   it("allows overriding the class-level value", () => {
     class Model {}
-    classAttribute(Model, "tableName", { default: "models" });
+    classAttribute.call(Model, "tableName", { default: "models" });
     (Model as any).tableName = "users";
 
     expect((Model as any).tableName).toBe("users");
@@ -19,7 +19,7 @@ describe("classAttribute", () => {
 
   it("instance reads fall back to class value", () => {
     class Model {}
-    classAttribute(Model, "tableName", { default: "models" });
+    classAttribute.call(Model, "tableName", { default: "models" });
 
     const instance = new Model() as any;
     expect(instance.tableName).toBe("models");
@@ -27,7 +27,7 @@ describe("classAttribute", () => {
 
   it("instance can override the value locally", () => {
     class Model {}
-    classAttribute(Model, "tableName", { default: "models" });
+    classAttribute.call(Model, "tableName", { default: "models" });
 
     const a = new Model() as any;
     const b = new Model() as any;
@@ -39,7 +39,7 @@ describe("classAttribute", () => {
 
   it("subclass inherits from parent", () => {
     class Base {}
-    classAttribute(Base, "color", { default: "red" });
+    classAttribute.call(Base, "color", { default: "red" });
 
     class Child extends Base {}
     // Child should inherit
@@ -48,7 +48,7 @@ describe("classAttribute", () => {
 
   it("subclass can override without affecting parent", () => {
     class Base {}
-    classAttribute(Base, "color", { default: "red" });
+    classAttribute.call(Base, "color", { default: "red" });
 
     class Child extends Base {}
     (Child as any).color = "blue";
@@ -59,7 +59,7 @@ describe("classAttribute", () => {
 
   it("instanceWriter: false prevents instance writes", () => {
     class Model {}
-    classAttribute(Model, "locked", { default: true, instanceWriter: false });
+    classAttribute.call(Model, "locked", { default: true, instanceWriter: false });
 
     const instance = new Model() as any;
     expect(instance.locked).toBe(true);
@@ -72,7 +72,7 @@ describe("classAttribute", () => {
 
   it("instanceReader: false prevents instance reads", () => {
     class Model {}
-    classAttribute(Model, "secret", {
+    classAttribute.call(Model, "secret", {
       default: "hidden",
       instanceReader: false,
     });
@@ -86,7 +86,7 @@ describe("classAttribute", () => {
 
   it("instancePredicate creates isName getter", () => {
     class Model {}
-    classAttribute(Model, "active", {
+    classAttribute.call(Model, "active", {
       default: true,
       instancePredicate: true,
     });
@@ -97,21 +97,21 @@ describe("classAttribute", () => {
 
   it("defines several attributes at once", () => {
     class Model {}
-    classAttribute(Model, "one", "two", { default: 1 });
+    classAttribute.call(Model, "one", "two", { default: 1 });
 
     expect((Model as any).one).toBe(1);
     expect((Model as any).two).toBe(1);
   });
 
   it("raises a TypeError on a name that is neither a symbol nor a string", () => {
-    expect(() => classAttribute(class {}, 1 as unknown as string)).toThrow(
+    expect(() => classAttribute.call(class {}, 1 as unknown as string)).toThrow(
       new TypeError("1 is not a symbol nor a string"),
     );
   });
 
   it("predicate reflects current value", () => {
     class Model {}
-    classAttribute(Model, "active", {
+    classAttribute.call(Model, "active", {
       default: false,
       instancePredicate: true,
     });

--- a/packages/activesupport/src/class-attribute.ts
+++ b/packages/activesupport/src/class-attribute.ts
@@ -62,8 +62,12 @@ export namespace ClassAttribute {
 /**
  * Define a class-level attribute that is inherited by subclasses.
  * Reads walk the constructor chain; writes are local to the class/instance.
+ *
+ * Rails defines this on Module (core_ext/class/attribute.rb:86), so the class
+ * being extended is `self` — here the `this`-typed mixin idiom (CLAUDE.md,
+ * _Module mixins_), which callers reach with `classAttribute.call(Klass, ...)`.
  */
-export function classAttribute(klass: any, ...attrs: (string | ClassAttributeOptions)[]): void {
+export function classAttribute(this: any, ...attrs: (string | ClassAttributeOptions)[]): void {
   const last = attrs[attrs.length - 1];
   const options: ClassAttributeOptions =
     typeof last === "object" && last !== null ? (attrs.pop() as ClassAttributeOptions) : {};
@@ -84,9 +88,9 @@ export function classAttribute(klass: any, ...attrs: (string | ClassAttributeOpt
     }
 
     const namespacedName = `__class_attr_${name}`;
-    ClassAttribute.redefine(klass, name, namespacedName, defaultValue);
+    ClassAttribute.redefine(this, name, namespacedName, defaultValue);
 
-    Object.defineProperty(klass, name, {
+    Object.defineProperty(this, name, {
       configurable: true,
       enumerable: false,
       get(this: any) {
@@ -113,16 +117,16 @@ export function classAttribute(klass: any, ...attrs: (string | ClassAttributeOpt
           this[`@${name}`] = value;
         };
       }
-      Object.defineProperty(klass.prototype, name, descriptor);
+      Object.defineProperty(this.prototype, name, descriptor);
     }
 
     if (instancePredicate) {
       const predicateName = `is${name.charAt(0).toUpperCase()}${name.slice(1)}`;
-      ClassAttribute.redefineMethod(klass, predicateName, false, function (this: any) {
+      ClassAttribute.redefineMethod(this, predicateName, false, function (this: any) {
         return !!this[name];
       });
       if (instanceReader) {
-        ClassAttribute.redefineMethod(klass.prototype, predicateName, false, function (this: any) {
+        ClassAttribute.redefineMethod(this.prototype, predicateName, false, function (this: any) {
           return !!this[name];
         });
       }

--- a/packages/activesupport/src/core-ext/class/attribute.test.ts
+++ b/packages/activesupport/src/core-ext/class/attribute.test.ts
@@ -7,9 +7,9 @@ describe("ClassAttributeTest", () => {
 
   beforeEach(() => {
     Klass = class {};
-    classAttribute(Klass, "setting");
-    classAttribute(Klass, "timeout", { default: 5 });
-    classAttribute(Klass, "system");
+    classAttribute.call(Klass, "setting");
+    classAttribute.call(Klass, "timeout", { default: 5 });
+    classAttribute.call(Klass, "system");
     Sub = class extends Klass {};
   });
 
@@ -70,7 +70,7 @@ describe("ClassAttributeTest", () => {
 
   it("disabling instance writer", () => {
     const Cls = class {};
-    classAttribute(Cls, "setting", { instanceWriter: false });
+    classAttribute.call(Cls, "setting", { instanceWriter: false });
     const object = new (Cls as any)();
     expect(() => {
       object.setting = "boom";
@@ -82,7 +82,7 @@ describe("ClassAttributeTest", () => {
 
   it("disabling instance reader", () => {
     const Cls = class {};
-    classAttribute(Cls, "setting", { instanceReader: false });
+    classAttribute.call(Cls, "setting", { instanceReader: false });
     const object = new (Cls as any)();
     expect(object.setting).toBeUndefined();
     expect(
@@ -94,7 +94,7 @@ describe("ClassAttributeTest", () => {
 
   it("disabling both instance writer and reader", () => {
     const Cls = class {};
-    classAttribute(Cls, "setting", { instanceAccessor: false });
+    classAttribute.call(Cls, "setting", { instanceAccessor: false });
     const object = new (Cls as any)();
     expect(object.setting).toBeUndefined();
     expect(Object.getPrototypeOf(object)).not.toHaveProperty("setting");
@@ -104,7 +104,7 @@ describe("ClassAttributeTest", () => {
 
   it("disabling instance predicate", () => {
     const Cls = class {};
-    classAttribute(Cls, "setting", { instancePredicate: false });
+    classAttribute.call(Cls, "setting", { instancePredicate: false });
     const object = new (Cls as any)();
     expect(object.isSetting).toBeUndefined();
     expect(Object.getPrototypeOf(object)).not.toHaveProperty("isSetting");

--- a/packages/activesupport/src/reloader.ts
+++ b/packages/activesupport/src/reloader.ts
@@ -176,5 +176,5 @@ export class Reloader extends ExecutionWrapper {
   }
 }
 
-classAttribute(Reloader, "executor", { default: Executor });
-classAttribute(Reloader, "check", { default: () => false });
+classAttribute.call(Reloader, "executor", { default: Executor });
+classAttribute.call(Reloader, "check", { default: () => false });

--- a/packages/activesupport/src/string-inquirer.test.ts
+++ b/packages/activesupport/src/string-inquirer.test.ts
@@ -3,35 +3,35 @@ import { StringInquirer, inquiry } from "./string-inquirer.js";
 
 describe("StringInquirerTest", () => {
   it("match", () => {
-    const env = inquiry("production");
+    const env = inquiry.call("production");
     expect((env as any).production()).toBe(true);
   });
 
   it("miss", () => {
-    const env = inquiry("production");
+    const env = inquiry.call("production");
     expect((env as any).development()).toBe(false);
   });
 
   it("missing question mark", () => {
-    const env = inquiry("test");
+    const env = inquiry.call("test");
     // Without ? still returns a callable function (TS adaptation)
     expect(typeof (env as any).test).toBe("function");
   });
 
   it("respond to", () => {
-    const env = inquiry("production");
+    const env = inquiry.call("production");
     expect(typeof (env as any).production).toBe("function");
   });
 
   it("respond to fallback to string respond to", () => {
-    const env = inquiry("production");
+    const env = inquiry.call("production");
     expect(env.toString()).toBe("production");
   });
 });
 
 describe("StringInquirer", () => {
   it("inquiry factory creates inquirer from string", () => {
-    const env = inquiry("test");
+    const env = inquiry.call("test");
     expect(env.is("test")).toBe(true);
     expect(env.is("production")).toBe(false);
   });
@@ -43,18 +43,18 @@ describe("StringInquirer", () => {
   });
 
   it("toString returns original string", () => {
-    const s = inquiry("development");
+    const s = inquiry.call("development");
     expect(s.toString()).toBe("development");
     expect(String(s)).toBe("development");
   });
 
   it("valueOf returns original string", () => {
-    const s = inquiry("test");
+    const s = inquiry.call("test");
     expect(s.valueOf()).toBe("test");
   });
 
   it("question mark methods return true/false", () => {
-    const env = inquiry("production");
+    const env = inquiry.call("production");
     expect((env as any).production()).toBe(true);
     expect((env as any).staging()).toBe(false);
     expect((env as any).development()).toBe(false);

--- a/packages/activesupport/src/string-inquirer.ts
+++ b/packages/activesupport/src/string-inquirer.ts
@@ -47,8 +47,10 @@ export class StringInquirer {
 }
 
 /**
- * Factory — mirrors Rails' String#inquiry core ext.
+ * `String#inquiry` (core_ext/string/inquiry.rb:11-13). Ruby reopens String, so
+ * the receiver is `self`; TS spells that with the `this`-typed mixin idiom
+ * (CLAUDE.md, _Module mixins_) and callers write `inquiry.call(str)`.
  */
-export function inquiry(value: string): StringInquirer & Record<string, () => boolean> {
-  return new StringInquirer(value) as any;
+export function inquiry(this: string): StringInquirer & Record<string, () => boolean> {
+  return new StringInquirer(this) as any;
 }


### PR DESCRIPTION
Rewires the RFC 0096 `module-mixin-receiver` naming rows this story owns: Ruby
writes `self` where trails passed the receiver as a named leading parameter.
Converged by the `this`-typed mixin idiom (CLAUDE.md, _Module mixins_) — no
renames, no baseline rows.

## Converged

- **`activesupport/string-inquirer.ts` `inquiry`** — Ruby reopens String
  (`core_ext/string/inquiry.rb:11-13`), so the receiver is `self`. Now
  `inquiry(this: string)` returning `new StringInquirer(this)`; callers use
  `inquiry.call(str)`.
- **`activesupport/class-attribute.ts` `classAttribute`** — Rails defines it on
  Module (`core_ext/class/attribute.rb:86`) and passes `self` to
  `ClassAttribute.redefine` (attribute.rb:97). Now `classAttribute(this: any, …)`;
  callers use `classAttribute.call(Klass, …)`. The row's remaining pair
  (`default` → `defaultValue`) is `js-reserved-word`, a permanent class.
- **`activerecord/insert-all.ts` `toSql`** — Rails is `Builder.new(self)`
  (`insert_all.rb:193`); ours passed an extra `adapterName` argument that the
  recorder lined up against `self`. `Builder`'s constructor now takes only
  `insertAll` and derives the dialect from `insertAll.connection`, mirroring
  `@connection = insert_all.connection` (insert_all.rb:229-231).
- **`activerecord/relation.ts` `findByTokenFor`** — Rails raises
  `UnknownPrimaryKey.new(self)` with the RELATION (`token_for.rb:42`), not its
  model. `UnknownPrimaryKey`'s parameter is widened to the `table_name`-carrying
  shape Ruby duck-types (`errors.rb:475`), and its `#{model}` interpolation now
  reads a Class's `name` and anything else's `to_s`, matching `errors.rb:477`.

The story also listed `activesupport/notifications/fanout.ts` `buildHandle`; that
row is already gone from the artifact on `main`, so nothing was left to do there.

## Left standing (justified at the call site)

- **`activemodel/model.ts` `validatesWith` × 2** — recorder shape, not a receiver
  parameter. `validates_with` has two Ruby definitions; trails ports only the
  class one (`with.rb:88-105`, which ends in `validate(validator, options)`), so
  the recorder pairs our callback-scoped `validator.validate(record)` against the
  INSTANCE definition's `validator.validate(self)` (`with.rb:143-151`). The
  missing instance method is a real gap and is filed as
  `0096-naming-identifier-burndown/activemodel-instance-validates-with`; the call
  site carries a comment pointing there.

## Measurements

`pnpm build` + `API_COMPARE_FORCE=1 pnpm parity:api --calls`, then
`pnpm parity:api:calls:args:report`:

- `module-mixin-receiver` (burndown): **12 → 8**
- naming rows total: **293 → 290** (`class-attribute.ts` reclassified into the
  permanent `js-reserved-word` bucket, 6 → 7)
- `shape` rows: **192 → 192** — no new rows; `pnpm parity:api:calls:args` OK.
- `pnpm parity:api:calls` OK; no baseline row added, widened or reseeded.

Closes-story: wave-4-naming-mixin-receiver-rewire
