### PR TITLE
refactor(activesupport,activemodel,activerecord): extract CallTemplate.build, port LazyAttributeSet and FutureResult::EventBuffer

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -443,11 +443,6 @@ export class AttributeSet {
     return this[Symbol.iterator]();
   }
 
-  /** Whether `name` is present in the internal map (initialized or not). */
-  protected hasAttribute(name: string): boolean {
-    return this._attributes.has(name);
-  }
-
   /**
    * Apply `forgettingAssignment()` to each attribute in place so that shared
    * references (as in `becomes()`) see the updated baseline.

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -9,7 +9,7 @@ const LAZY_ATTR = Symbol("lazyAttr");
  * Mirrors: ActiveModel::AttributeSet
  */
 export class AttributeSet {
-  private attributes: Map<string, Attribute>;
+  protected _attributes: Map<string, Attribute>;
   private _frozen = false;
 
   /**
@@ -19,7 +19,7 @@ export class AttributeSet {
    * backing attribute map (every entry, initialized or not).
    */
   eachValue(fn: (attr: Attribute) => void): void {
-    for (const attr of this.attributes.values()) fn(attr);
+    for (const attr of this.attributes().values()) fn(attr);
   }
 
   /**
@@ -30,7 +30,7 @@ export class AttributeSet {
    * Mirrors: `delegate :fetch, to: :attributes`.
    */
   fetch(name: string, defaultOrBlock?: Attribute | ((name: string) => Attribute)): Attribute {
-    const attr = this.attributes.get(name);
+    const attr = this.attributes().get(name);
     if (attr !== undefined) return attr;
     if (typeof defaultOrBlock === "function") return defaultOrBlock(name);
     if (defaultOrBlock !== undefined) return defaultOrBlock;
@@ -47,26 +47,26 @@ export class AttributeSet {
   except(...names: string[]): Map<string, Attribute> {
     const drop = new Set(names);
     const result = new Map<string, Attribute>();
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       if (!drop.has(name)) result.set(name, attr);
     }
     return result;
   }
 
   constructor(attributes: Map<string, Attribute> = new Map()) {
-    this.attributes = attributes;
+    this._attributes = attributes;
   }
 
   /**
    * Get the Attribute instance for a name.
    */
   getAttribute(name: string): Attribute {
-    return this.attributes.get(name) ?? this.defaultAttribute(name);
+    return this._attributes.get(name) ?? this.defaultAttribute(name);
   }
 
   castTypes(): Record<string, import("./type/value.js").Type> {
     const result: Record<string, import("./type/value.js").Type> = {};
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       result[name] = attr.type;
     }
     return result;
@@ -74,7 +74,7 @@ export class AttributeSet {
 
   valuesBeforeTypeCast(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       if (attr.isInitialized()) {
         result[name] = attr.valueBeforeTypeCast;
       }
@@ -84,7 +84,7 @@ export class AttributeSet {
 
   valuesForDatabase(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       if (attr.isInitialized()) {
         result[name] = attr.valueForDatabase;
       }
@@ -93,7 +93,7 @@ export class AttributeSet {
   }
 
   isKey(name: string): boolean {
-    const attr = this.attributes.get(name);
+    const attr = this.attributes().get(name);
     return attr !== undefined && attr.isInitialized();
   }
 
@@ -108,7 +108,7 @@ export class AttributeSet {
 
   keys(): string[] {
     const result: string[] = [];
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       if (attr.isInitialized()) result.push(name);
     }
     return result;
@@ -138,9 +138,9 @@ export class AttributeSet {
     type?: { deserialize(value: unknown): unknown },
   ): void {
     this.assertNotFrozen();
-    const existing = this.attributes.get(name);
+    const existing = this._attributes.get(name);
     if (existing) {
-      this.attributes.set(name, existing.withValueFromDatabase(value));
+      this._attributes.set(name, existing.withValueFromDatabase(value));
     } else {
       // An unknown column (e.g. a computed/aliased extra `select`) is not in the
       // schema, so there is no declared cast type. Rails type-casts it with the
@@ -152,7 +152,7 @@ export class AttributeSet {
       // exercised for an unknown column — one localized cast here keeps the
       // public param structural and the call sites cast-free.
       const colType = (type as import("./type/value.js").Type) ?? typeRegistry.lookup("value");
-      this.attributes.set(name, Attribute.fromDatabase(name, value, colType));
+      this._attributes.set(name, Attribute.fromDatabase(name, value, colType));
     }
   }
 
@@ -165,20 +165,20 @@ export class AttributeSet {
     // always warm at construction (RFC 0031), every real column — selected or
     // not — is already in the set, so map-absence now reliably means "unknown
     // column" and the Null fallthrough raises exactly like Rails.
-    this.attributes.set(name, this.getAttribute(name).withValueFromUser(value));
+    this._attributes.set(name, this.getAttribute(name).withValueFromUser(value));
     return value;
   }
 
   writeCastValue(name: string, value: unknown): void {
     this.assertNotFrozen();
-    this.attributes.set(name, this.getAttribute(name).withCastValue(value));
+    this._attributes.set(name, this.getAttribute(name).withCastValue(value));
   }
 
   deepDup(): AttributeSet {
     const newAttrs = new Map<string, Attribute>();
     const cache = new Map<Attribute, Attribute>();
 
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       newAttrs.set(name, this.cloneAttribute(attr, cache));
     }
 
@@ -193,7 +193,7 @@ export class AttributeSet {
 
   accessed(): string[] {
     const result: string[] = [];
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       if (attr.hasBeenRead()) result.push(name);
     }
     return result;
@@ -201,7 +201,7 @@ export class AttributeSet {
 
   map(fn: (attr: Attribute) => Attribute): AttributeSet {
     const newAttributes = new Map<string, Attribute>();
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       newAttributes.set(name, fn(attr));
     }
     return new AttributeSet(newAttributes);
@@ -212,10 +212,20 @@ export class AttributeSet {
     const cache = new Map<Attribute, Attribute>();
     target.forEach((attr, name) => {
       if (!this.isKey(name)) {
-        this.attributes.set(name, this.cloneAttribute(attr, cache));
+        this._attributes.set(name, this.cloneAttribute(attr, cache));
       }
     });
     return this;
+  }
+
+  /**
+   * The backing attribute map.
+   *
+   * Mirrors: `protected attr_reader :attributes` — the seam LazyAttributeSet
+   * overrides to materialize its lazy values before any bulk read.
+   */
+  protected attributes(): Map<string, Attribute> {
+    return this._attributes;
   }
 
   /** @internal */
@@ -239,7 +249,7 @@ export class AttributeSet {
     type: { deserialize(value: unknown): unknown },
   ): void {
     this.assertNotFrozen();
-    this.attributes.set(
+    this._attributes.set(
       name,
       Attribute.fromDatabase(name, value, type as import("./type/value.js").Type),
     );
@@ -258,9 +268,9 @@ export class AttributeSet {
    */
   rebindFromDatabaseValue(name: string, value: unknown): void {
     this.assertNotFrozen();
-    const existing = this.attributes.get(name);
+    const existing = this._attributes.get(name);
     const type = existing ? existing.type : typeRegistry.lookup("value");
-    this.attributes.set(name, Attribute.fromDatabase(name, value, type, value));
+    this._attributes.set(name, Attribute.fromDatabase(name, value, type, value));
   }
 
   /**
@@ -289,7 +299,7 @@ export class AttributeSet {
    * Get the cast value of an attribute (backward-compatible with Map.get).
    */
   get(name: string): unknown {
-    const attr = this.attributes.get(name);
+    const attr = this._attributes.get(name);
     if (!attr) return undefined;
     return attr.value;
   }
@@ -297,11 +307,11 @@ export class AttributeSet {
   set(name: string, attrOrValue: Attribute | unknown): void {
     this.assertNotFrozen();
     if (attrOrValue instanceof Attribute) {
-      this.attributes.set(name, attrOrValue);
+      this._attributes.set(name, attrOrValue);
     } else {
-      const existing = this.attributes.get(name);
+      const existing = this._attributes.get(name);
       const type = existing ? existing.type : typeRegistry.lookup("value");
-      this.attributes.set(name, Attribute.withCastValue(name, attrOrValue, type));
+      this._attributes.set(name, Attribute.withCastValue(name, attrOrValue, type));
     }
   }
 
@@ -320,7 +330,7 @@ export class AttributeSet {
   }
 
   has(name: string): boolean {
-    const attr = this.attributes.get(name);
+    const attr = this._attributes.get(name);
     return attr !== undefined && attr.isInitialized();
   }
 
@@ -348,10 +358,10 @@ export class AttributeSet {
   ): void {
     this.assertNotFrozen();
     const keep = names instanceof Set ? names : new Set(names);
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this._attributes) {
       if (keep.has(name)) continue;
       const type = (overrideTypes?.[name] as import("./type/value.js").Type) ?? attr.type;
-      this.attributes.set(name, Attribute.uninitialized(name, type));
+      this._attributes.set(name, Attribute.uninitialized(name, type));
     }
   }
 
@@ -371,7 +381,7 @@ export class AttributeSet {
    */
   snapshotValues(): Map<string, unknown> {
     const result = new Map<string, unknown>();
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this._attributes) {
       if (attr.isInitialized()) {
         if (attr.hasBeenRead()) {
           result.set(name, attr.value);
@@ -398,7 +408,7 @@ export class AttributeSet {
 
   delete(name: string): boolean {
     this.assertNotFrozen();
-    return this.attributes.delete(name);
+    return this._attributes.delete(name);
   }
 
   protected cloneAttribute(attr: Attribute, cache: Map<Attribute, Attribute>): Attribute {
@@ -424,7 +434,7 @@ export class AttributeSet {
   }
 
   forEach(fn: (attr: Attribute, name: string) => void): void {
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this.attributes()) {
       fn(attr, name);
     }
   }
@@ -435,7 +445,7 @@ export class AttributeSet {
 
   /** Whether `name` is present in the internal map (initialized or not). */
   protected hasAttribute(name: string): boolean {
-    return this.attributes.has(name);
+    return this._attributes.has(name);
   }
 
   /**
@@ -449,9 +459,9 @@ export class AttributeSet {
    */
   forgetAssignmentsBang(): void {
     this.assertNotFrozen();
-    for (const [name, attr] of this.attributes) {
+    for (const [name, attr] of this._attributes) {
       const next = attr.forgettingAssignment();
-      if (next !== attr) this.attributes.set(name, next);
+      if (next !== attr) this._attributes.set(name, next);
     }
   }
 }

--- a/packages/activemodel/src/attribute-set/builder.test.ts
+++ b/packages/activemodel/src/attribute-set/builder.test.ts
@@ -25,76 +25,47 @@ describe("LazyAttributeSet", () => {
   const strType = typeRegistry.lookup("string");
   const intType = typeRegistry.lookup("integer");
 
-  it("additionalTypes returns the map passed at construction", () => {
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(new Map(), extra);
-    expect(lazy.additionalTypes()).toBe(extra);
+  it("only materializes an attribute when it is first read", () => {
+    const types = new Map([["name", strType]]);
+    const lazy = new LazyAttributeSet({ name: "Alice" }, types, new Map(), new Map());
+    expect((lazy as any)._attributes.size).toBe(0);
+    expect(lazy.fetchValue("name")).toBe("Alice");
+    expect(lazy.keys()).toEqual(["name"]);
+    expect((lazy as any)._attributes.has("name")).toBe(true);
   });
 
-  it("materialize includes initialized attributes", () => {
-    const attrs = new Map([["name", Attribute.fromDatabase("name", "Alice", strType)]]);
-    const lazy = new LazyAttributeSet(attrs);
-    const result = (lazy as any).materialize() as Map<string, Attribute>;
-    expect(result.get("name")).toBeDefined();
-    expect(result.get("name")!.value).toBe("Alice");
+  it("key? reports values, types and materialized attributes", () => {
+    const types = new Map([["name", strType]]);
+    const lazy = new LazyAttributeSet({ score: "42" }, types, new Map(), new Map());
+    expect(lazy.isKey("score")).toBe(true);
+    expect(lazy.isKey("name")).toBe(false);
+    expect(lazy.isKey("missing")).toBe(false);
   });
 
-  it("materialize includes uninitialized attributes", () => {
-    const attrs = new Map<string, Attribute>([
-      ["name", Attribute.fromDatabase("name", "Alice", strType)],
-      ["age", Attribute.uninitialized("age", intType)],
-    ]);
-    const lazy = new LazyAttributeSet(attrs);
-    const result = (lazy as any).materialize() as Map<string, Attribute>;
-    expect(result.has("age")).toBe(true);
-    expect(result.get("age")!.isInitialized()).toBe(false);
+  it("uses additional_types over the declared type", () => {
+    const types = new Map([["score", strType]]);
+    const additional = new Map([["score", intType]]);
+    const lazy = new LazyAttributeSet({ score: "42" }, types, additional, new Map());
+    expect(lazy.fetchValue("score")).toBe(42);
   });
 
-  it("materialize includes additionalTypes keys not in the attribute map", () => {
-    const attrs = new Map([["name", Attribute.fromDatabase("name", "Alice", strType)]]);
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(attrs, extra);
-    const result = (lazy as any).materialize() as Map<string, Attribute>;
-    expect(result.has("score")).toBe(true);
-    expect(result.get("score")!.isInitialized()).toBe(false);
+  it("falls back to a default attribute when the value is absent", () => {
+    const types = new Map([["status", strType]]);
+    const defaults = new Map([["status", Attribute.fromDatabase("status", "draft", strType)]]);
+    const lazy = new LazyAttributeSet({}, types, new Map(), defaults);
+    expect(lazy.fetchValue("status")).toBe("draft");
   });
 
-  it("materialize mutates the instance so additionalTypes keys are accessible via getAttribute", () => {
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(new Map(), extra);
-    // Before materialize: getAttribute returns a null Attribute (unknown name).
-    expect(lazy.getAttribute("score").type.name).toBe("value");
-    (lazy as any).materialize();
-    // After materialize: entry is written into the internal map with the correct type.
-    expect(lazy.getAttribute("score").type.name).toBe("integer");
-    expect(lazy.getAttribute("score").isInitialized()).toBe(false);
+  it("returns an uninitialized attribute for a known type with no value or default", () => {
+    const types = new Map([["name", strType]]);
+    const lazy = new LazyAttributeSet({}, types, new Map(), new Map());
+    expect(lazy.getAttribute("name").isInitialized()).toBe(false);
+    expect(lazy.keys()).toEqual([]);
   });
 
-  it("materialize does not overwrite existing attributes when additionalTypes shares a key", () => {
-    const existingAttr = Attribute.fromDatabase("score", "42", strType);
-    const attrs = new Map<string, Attribute>([["score", existingAttr]]);
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(attrs, extra);
-    (lazy as any).materialize();
-    // The existing string attribute must be preserved — not replaced by intType.
-    expect(lazy.getAttribute("score")).toBe(existingAttr);
-  });
-
-  it("deepDup preserves additionalTypes", () => {
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(new Map(), extra);
-    const dup = lazy.deepDup();
-    expect(dup).toBeInstanceOf(LazyAttributeSet);
-    expect(dup.additionalTypes()).toEqual(extra);
-    expect(dup.additionalTypes()).not.toBe(extra);
-  });
-
-  it("map preserves additionalTypes", () => {
-    const extra = new Map([["score", intType]]);
-    const lazy = new LazyAttributeSet(new Map(), extra);
-    const mapped = lazy.map((a) => a);
-    expect(mapped).toBeInstanceOf(LazyAttributeSet);
-    expect(mapped.additionalTypes()).toEqual(extra);
+  it("returns a null attribute for an unknown name", () => {
+    const lazy = new LazyAttributeSet({}, new Map(), new Map(), new Map());
+    expect(lazy.fetchValue("nope")).toBe(null);
   });
 });
 

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -1,4 +1,4 @@
-import { Attribute } from "../attribute.js";
+import { Attribute, Uninitialized } from "../attribute.js";
 import { Type } from "../type/value.js";
 import { AttributeSet } from "../attribute-set.js";
 
@@ -15,23 +15,7 @@ export class Builder {
     values: Record<string, unknown> = {},
     additionalTypes: Map<string, Type> = new Map(),
   ): AttributeSet {
-    const attrs = new Map<string, Attribute>();
-
-    for (const [name, type] of this.types) {
-      const effectiveType = additionalTypes.get(name) ?? type;
-      if (Object.prototype.hasOwnProperty.call(values, name)) {
-        attrs.set(name, Attribute.fromDatabase(name, values[name], effectiveType));
-      } else {
-        const defaultAttr = this.defaultAttributes.get(name);
-        if (defaultAttr) {
-          attrs.set(name, dupAttribute(defaultAttr));
-        } else {
-          attrs.set(name, Attribute.uninitialized(name, effectiveType));
-        }
-      }
-    }
-
-    return new AttributeSet(attrs);
+    return new LazyAttributeSet(values, this.types, additionalTypes, this.defaultAttributes);
   }
 }
 
@@ -47,56 +31,130 @@ function dupAttribute(attr: Attribute): Attribute {
   return Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
 }
 
-/**
- * Lazy variant of AttributeSet that carries an extra `additionalTypes` map and
- * supports on-demand materialization of those entries into the internal store.
- *
- * Mirrors: ActiveModel::LazyAttributeSet
- */
+/** Mirrors: ActiveModel::LazyAttributeSet */
 export class LazyAttributeSet extends AttributeSet {
-  private _additionalTypes: Map<string, Type>;
+  private values: Record<string, unknown>;
+  private types: Map<string, Type>;
+  private additionalTypes: Map<string, Type>;
+  private defaultAttributes: Map<string, Attribute>;
+  private castedValues: Map<string, unknown>;
+  private materialized: boolean;
 
   constructor(
+    values: Record<string, unknown>,
+    types: Map<string, Type>,
+    additionalTypes: Map<string, Type>,
+    defaultAttributes: Map<string, Attribute>,
     attributes: Map<string, Attribute> = new Map(),
-    additionalTypes: Map<string, Type> = new Map(),
   ) {
     super(attributes);
-    this._additionalTypes = additionalTypes;
+    this.values = values;
+    this.types = types;
+    this.additionalTypes = additionalTypes;
+    this.defaultAttributes = defaultAttributes;
+    this.castedValues = new Map();
+    this.materialized = false;
   }
 
-  /** @internal Rails-private helper. Mirrors: LazyAttributeSet#additional_types (attr_reader) */
-  additionalTypes(): Map<string, Type> {
-    return this._additionalTypes;
+  override isKey(name: string): boolean {
+    return (
+      (Object.prototype.hasOwnProperty.call(this.values, name) ||
+        this.types.has(name) ||
+        this._attributes.has(name)) &&
+      this.getAttribute(name).isInitialized()
+    );
   }
 
-  override deepDup(): LazyAttributeSet {
-    const cache = new Map<Attribute, Attribute>();
-    const newAttrs = new Map<string, Attribute>();
-    this.forEach((attr, name) => newAttrs.set(name, this.cloneAttribute(attr, cache)));
-    return new LazyAttributeSet(newAttrs, new Map(this._additionalTypes));
+  override keys(): string[] {
+    const keys = new Set([
+      ...Object.keys(this.values),
+      ...this.types.keys(),
+      ...this._attributes.keys(),
+    ]);
+    return [...keys].filter((name) => this.getAttribute(name).isInitialized());
   }
 
-  /**
-   * @internal Rails-private helper. Mirrors: LazyAttributeSet#materialize (protected)
-   * Materializes the lazy set by resolving all keys into the attribute map.
-   */
-  protected materialize(): Map<string, Attribute> {
-    // Write additionalTypes-only keys into the internal store so that
-    // subsequent getAttribute/has/forEach calls can see them — mirrors
-    // Rails' @additional_types.each_key { |name| self[name] } side-effect.
-    for (const [name, type] of this._additionalTypes) {
-      if (!this.hasAttribute(name)) this.set(name, Attribute.uninitialized(name, type));
+  override fetchValue(name: string, block?: (name: string) => unknown): unknown {
+    const attr = this._attributes.get(name);
+    if (attr) {
+      return blockOrValue(attr, block);
     }
-    const result = new Map<string, Attribute>();
-    this.forEach((attr, name) => result.set(name, attr));
-    return result;
+
+    if (this.castedValues.has(name)) return this.castedValues.get(name);
+
+    let valuePresent = true;
+    let value: unknown;
+    if (Object.prototype.hasOwnProperty.call(this.values, name)) {
+      value = this.values[name];
+    } else {
+      valuePresent = false;
+    }
+
+    if (valuePresent) {
+      const type = this.additionalTypes.get(name) ?? this.types.get(name)!;
+      const casted = type.deserialize(value);
+      this.castedValues.set(name, casted);
+      return casted;
+    } else {
+      return blockOrValue(this.defaultAttribute(name, valuePresent, value), block);
+    }
   }
 
-  override map(fn: (attr: Attribute) => Attribute): LazyAttributeSet {
-    const newAttrs = new Map<string, Attribute>();
-    this.forEach((attr, name) => newAttrs.set(name, fn(attr)));
-    return new LazyAttributeSet(newAttrs, new Map(this._additionalTypes));
+  protected override attributes(): Map<string, Attribute> {
+    if (!this.materialized) {
+      for (const key of Object.keys(this.values)) this.getAttribute(key);
+      for (const key of this.types.keys()) this.getAttribute(key);
+      this.materialized = true;
+    }
+    return this._attributes;
   }
+
+  protected override defaultAttribute(
+    name: string,
+    valuePresent?: boolean,
+    value?: unknown,
+  ): Attribute {
+    // Rails defaults `value` to `values.fetch(name) { value_present = false }`,
+    // evaluated only when the caller omits it (builder.rb:69-73).
+    if (valuePresent === undefined) {
+      valuePresent = Object.prototype.hasOwnProperty.call(this.values, name);
+      value = valuePresent ? this.values[name] : undefined;
+    }
+
+    const type = this.additionalTypes.get(name) ?? this.types.get(name);
+
+    if (valuePresent) {
+      // `Attribute#initialize` keeps the computed-value slot empty when the
+      // 4th argument is nil (attribute.rb:37), so only thread a cached cast
+      // through when one exists.
+      const castedValue = this.castedValues.get(name);
+      const attr =
+        castedValue === undefined
+          ? Attribute.fromDatabase(name, value, type!)
+          : Attribute.fromDatabase(name, value, type!, castedValue);
+      this._attributes.set(name, attr);
+      return attr;
+    } else if (this.types.has(name)) {
+      const attr = this.defaultAttributes.get(name);
+      const built = attr ? dupAttribute(attr) : Attribute.uninitialized(name, type!);
+      this._attributes.set(name, built);
+      return built;
+    } else {
+      return Attribute.null(name);
+    }
+  }
+}
+
+/**
+ * Ruby's `attr.value(&block)`: an Uninitialized attribute yields its name to
+ * the block, every other attribute ignores it (attribute.rb `Uninitialized#value`).
+ *
+ * @noRailsEquivalent Ruby passes the block through `value(&block)`; trails'
+ *   `Attribute#value` is a getter, so the block arm lives at the call site.
+ */
+function blockOrValue(attr: Attribute, block?: (name: string) => unknown): unknown {
+  if (block !== undefined && attr instanceof Uninitialized) return block(attr.name);
+  return attr.value;
 }
 
 /**

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -109,13 +109,18 @@ export class LazyAttributeSet extends AttributeSet {
     return this._attributes;
   }
 
+  /**
+   * Mirrors `LazyAttributeSet#default_attribute` (builder.rb:69-88). Ruby
+   * defaults `value` to `values.fetch(name) { value_present = false }`,
+   * evaluated only when the caller omits it, and `Attribute#initialize` keeps
+   * its computed-value slot empty when the 4th argument is nil
+   * (attribute.rb:37) — hence the two guards below.
+   */
   protected override defaultAttribute(
     name: string,
     valuePresent?: boolean,
     value?: unknown,
   ): Attribute {
-    // Rails defaults `value` to `values.fetch(name) { value_present = false }`,
-    // evaluated only when the caller omits it (builder.rb:69-73).
     if (valuePresent === undefined) {
       valuePresent = Object.prototype.hasOwnProperty.call(this.values, name);
       value = valuePresent ? this.values[name] : undefined;
@@ -124,9 +129,6 @@ export class LazyAttributeSet extends AttributeSet {
     const type = this.additionalTypes.get(name) ?? this.types.get(name);
 
     if (valuePresent) {
-      // `Attribute#initialize` keeps the computed-value slot empty when the
-      // 4th argument is nil (attribute.rb:37), so only thread a cached cast
-      // through when one exists.
       const castedValue = this.castedValues.get(name);
       const attr =
         castedValue === undefined

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { ActiveRecordError, StatementInvalid } from "../errors.js";
 import { Transaction } from "../transaction.js";
-import { Notifications } from "@blazetrails/activesupport";
+import { IsolatedExecutionState, Notifications } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
 import { Collectors } from "@blazetrails/arel";
 
@@ -51,9 +51,10 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
   });
 
   describe("instrumenter", () => {
-    it("returns the Notifications class", () => {
+    it("memoizes Notifications.instrumenter in the isolated execution state", () => {
       const a = new AbstractAdapter();
-      expect(a.instrumenter).toBe(Notifications);
+      expect(a.instrumenter).toBe(Notifications.instrumenter);
+      expect(IsolatedExecutionState.get("active_record_instrumenter")).toBe(a.instrumenter);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -28,6 +28,20 @@ import {
   Notifications,
 } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
+import { ACTIVE_RECORD_INSTRUMENTER } from "../future-result.js";
+
+/**
+ * The instrumenter surface `#log` drives — `ActiveSupport::Notifications`'
+ * `Instrumenter` or a `FutureResult::EventBuffer` standing in for it.
+ * @internal
+ */
+type AdapterInstrumenter = {
+  instrumentAsync<T>(
+    name: string,
+    payload: EventPayload,
+    block: (payload: EventPayload) => Promise<T>,
+  ): Promise<T>;
+};
 import { ActiveRecord } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
@@ -2691,9 +2705,18 @@ export class AbstractAdapter implements Quoting {
     }
   }
 
-  /** @internal Mirrors: AbstractAdapter#instrumenter */
-  get instrumenter(): typeof Notifications {
-    return Notifications;
+  /**
+   * @internal Mirrors: AbstractAdapter#instrumenter (abstract_adapter.rb:1151-1153)
+   *
+   * A scheduled `FutureResult` swaps in its `EventBuffer` here for the duration
+   * of its query, so the events it emits carry `lock_wait` when the foreground
+   * finally flushes them (future_result.rb:110-111).
+   */
+  get instrumenter(): AdapterInstrumenter {
+    return IsolatedExecutionState.fetch<AdapterInstrumenter>(
+      ACTIVE_RECORD_INSTRUMENTER,
+      () => Notifications.instrumenter,
+    );
   }
 
   /** @internal Mirrors: AbstractAdapter#translate_exception */

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -449,7 +449,7 @@ describe("FutureResult::EventBuffer", () => {
     expect(events[0].payload.lock_wait as number).toBeGreaterThan(0);
   });
 
-  it("reports 0.0 on an uncontended read", async () => {
+  it("holds the events back until an uncontended read, which reports 0.0", async () => {
     const events: NotificationEvent[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>
       events.push(e),
@@ -462,27 +462,6 @@ describe("FutureResult::EventBuffer", () => {
       pool.finish();
       await new Promise((resolve) => setTimeout(resolve, 5));
       expect(futureResult.pending()).toBe(false);
-      await futureResult.result();
-    } finally {
-      Notifications.unsubscribe(sub);
-    }
-
-    expect(events).toHaveLength(1);
-    expect(events[0].payload.lock_wait).toBe(0.0);
-  });
-
-  it("holds the events back until the foreground reads the result", async () => {
-    const events: NotificationEvent[] = [];
-    const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>
-      events.push(e),
-    );
-    const pool = instrumentedDeferredPool(new Result(["id"], [[1]]));
-    const futureResult = new FutureResult(pool, ["SELECT 1", null, []]);
-
-    try {
-      futureResult.scheduleBang(new AsynchronousQueriesTracker.Session());
-      pool.finish();
-      await new Promise((resolve) => setTimeout(resolve, 5));
       expect(events).toEqual([]);
       await futureResult.result();
     } finally {
@@ -490,6 +469,7 @@ describe("FutureResult::EventBuffer", () => {
     }
 
     expect(events).toHaveLength(1);
+    expect(events[0].payload.lock_wait).toBe(0.0);
   });
 });
 

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -7,7 +7,14 @@ import { DatabaseStatements, select } from "./connection-adapters/abstract/datab
 import { makeCachedSelectAll, Store } from "./connection-adapters/abstract/query-cache.js";
 import { AsynchronousQueryInsideTransactionError, RangeError as ARRangeError } from "./errors.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
-import { Executor, type CompletableExecution } from "@blazetrails/activesupport";
+import {
+  Executor,
+  IsolatedExecutionState,
+  Notifications,
+  type CompletableExecution,
+  type NotificationEvent,
+} from "@blazetrails/activesupport";
+import { ACTIVE_RECORD_INSTRUMENTER } from "./future-result.js";
 
 // Rails' own load_async_test.rb / asynchronous_queries_test.rb stay excluded
 // (scripts/parity/unported-files/unscoped.ts): every live test class there
@@ -418,6 +425,113 @@ describe("QueryCache#select_all", () => {
     ).toEqual(result);
   });
 });
+
+describe("FutureResult::EventBuffer", () => {
+  // future_result.rb:40-46 — the buffered events are republished with the
+  // foreground's `lock_wait` stamped onto each payload.
+  it("reports the wait on a contended read", async () => {
+    const events: NotificationEvent[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>
+      events.push(e),
+    );
+    const pool = instrumentedDeferredPool(new Result(["id"], [[1]]));
+    const futureResult = new FutureResult(pool, ["SELECT 1", null, []]);
+
+    try {
+      futureResult.scheduleBang(new AsynchronousQueriesTracker.Session());
+      const pending = futureResult.result();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      pool.finish();
+      await pending;
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.lock_wait as number).toBeGreaterThan(0);
+  });
+
+  it("reports 0.0 on an uncontended read", async () => {
+    const events: NotificationEvent[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>
+      events.push(e),
+    );
+    const pool = instrumentedDeferredPool(new Result(["id"], [[1]]));
+    const futureResult = new FutureResult(pool, ["SELECT 1", null, []]);
+
+    try {
+      futureResult.scheduleBang(new AsynchronousQueriesTracker.Session());
+      pool.finish();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(futureResult.pending()).toBe(false);
+      await futureResult.result();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.lock_wait).toBe(0.0);
+  });
+
+  it("holds the events back until the foreground reads the result", async () => {
+    const events: NotificationEvent[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>
+      events.push(e),
+    );
+    const pool = instrumentedDeferredPool(new Result(["id"], [[1]]));
+    const futureResult = new FutureResult(pool, ["SELECT 1", null, []]);
+
+    try {
+      futureResult.scheduleBang(new AsynchronousQueriesTracker.Session());
+      pool.finish();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(events).toEqual([]);
+      await futureResult.result();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+
+    expect(events).toHaveLength(1);
+  });
+});
+
+/**
+ * A deferred pool whose connection instruments its query the way
+ * `AbstractAdapter#log` does — through
+ * `IsolatedExecutionState[:active_record_instrumenter]`
+ * (abstract_adapter.rb:1151-1153), which is the slot a scheduled
+ * FutureResult swaps its EventBuffer into.
+ */
+function instrumentedDeferredPool(outcome: Result) {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => (release = resolve));
+  return {
+    finish: () => release(),
+    scheduleQuery(futureResult: { executeOrSkip(): void }) {
+      futureResult.executeOrSkip();
+    },
+    async withConnection<T>(
+      fn: (connection: FutureResultConnection) => Promise<T> | T,
+    ): Promise<T> {
+      return fn({
+        rawExecQuery: async (sql, name, binds) => {
+          const instrumenter = IsolatedExecutionState.fetch(
+            ACTIVE_RECORD_INSTRUMENTER,
+            () => Notifications.instrumenter,
+          );
+          return instrumenter.instrumentAsync(
+            "sql.active_record",
+            { sql, name, binds, async: true },
+            async () => {
+              await gate;
+              return outcome;
+            },
+          );
+        },
+      });
+    },
+  };
+}
 
 /** A pool whose query stays in flight until `finish()` is called. */
 function deferredPool(outcome: Result) {

--- a/packages/activerecord/src/future-result.trails.test.ts
+++ b/packages/activerecord/src/future-result.trails.test.ts
@@ -427,8 +427,6 @@ describe("QueryCache#select_all", () => {
 });
 
 describe("FutureResult::EventBuffer", () => {
-  // future_result.rb:40-46 — the buffered events are republished with the
-  // foreground's `lock_wait` stamped onto each payload.
   it("reports the wait on a contended read", async () => {
     const events: NotificationEvent[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e: NotificationEvent) =>

--- a/packages/activerecord/src/future-result.ts
+++ b/packages/activerecord/src/future-result.ts
@@ -293,7 +293,6 @@ export class FutureResult {
 
   private async executeOrWait(): Promise<void> {
     if (this.pending()) {
-      // Ruby: `Process.clock_gettime(CLOCK_MONOTONIC, :float_millisecond)`.
       const start = performance.now();
       // Ruby takes `@mutex` here and, if a worker thread already holds it,
       // records how long the wait was. The in-flight promise IS that lock on a

--- a/packages/activerecord/src/future-result.ts
+++ b/packages/activerecord/src/future-result.ts
@@ -1,6 +1,20 @@
 import { ActiveRecordError, RangeError as ARRangeError } from "./errors.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
+import {
+  IsolatedExecutionState,
+  Notifications,
+  type NotificationEvent,
+  type EventPayload,
+  type Instrumenter,
+} from "@blazetrails/activesupport";
 import { Result } from "./result.js";
+
+/**
+ * Rails' `ActiveSupport::IsolatedExecutionState[:active_record_instrumenter]`
+ * slot (future_result.rb:111, abstract_adapter.rb:1152).
+ * @internal
+ */
+export const ACTIVE_RECORD_INSTRUMENTER = "active_record_instrumenter";
 
 /**
  * The pool surface `FutureResult` drives. Rails calls `pool.schedule_query` and
@@ -71,6 +85,62 @@ export class Complete {
 }
 
 /**
+ * Buffers the instrumentation events a scheduled query emits and republishes
+ * them once the foreground asks for the result, stamping each payload with the
+ * `lock_wait` the foreground spent waiting on the query.
+ *
+ * Rails installs it as the thread's `:active_record_instrumenter` for the
+ * duration of the scheduled query (future_result.rb:110-111); trails installs
+ * it for the duration of the awaited query via `IsolatedExecutionState.scope`,
+ * which is what a dedicated thread's fiber-local collapses to on one thread.
+ *
+ * Mirrors: ActiveRecord::FutureResult::EventBuffer (future_result.rb:24-47)
+ * @internal
+ */
+export class EventBuffer {
+  #futureResult: FutureResult;
+  #instrumenter: Instrumenter;
+  #events: NotificationEvent[];
+
+  constructor(futureResult: FutureResult, instrumenter: Instrumenter) {
+    this.#futureResult = futureResult;
+    this.#instrumenter = instrumenter;
+    this.#events = [];
+  }
+
+  /**
+   * Mirrors `EventBuffer#instrument` (future_result.rb:31-38).
+   *
+   * @noRailsEquivalent PERMANENT — Ruby's `instrument` blocks on the query;
+   *   a JS query block can only be awaited, so trails splits the method the
+   *   same way `ActiveSupport::Notifications` already does
+   *   (`instrument`/`instrumentAsync`), and the query path is the async one.
+   */
+  async instrumentAsync<T>(
+    name: string,
+    payload: EventPayload = {},
+    block?: (payload: EventPayload) => Promise<T>,
+  ): Promise<T> {
+    const event = this.#instrumenter.newEvent(name, payload);
+    try {
+      return await event.recordAsync(block);
+    } finally {
+      this.#events.push(event);
+    }
+  }
+
+  /** Mirrors `EventBuffer#flush` (future_result.rb:40-46). */
+  flush(): void {
+    const events = this.#events;
+    this.#events = [];
+    for (const event of events) {
+      event.payload.lock_wait = this.#futureResult.lockWait;
+      Notifications.publishEvent(event);
+    }
+  }
+}
+
+/**
  * Mirrors: ActiveRecord::FutureResult::Canceled (future_result.rb:49)
  * @internal
  */
@@ -88,9 +158,8 @@ export class Canceled extends ActiveRecordError {
  * `#result` blocks until the worker thread is done. JS is single-threaded: the
  * query is already a native promise, so the mutex collapses to the in-flight
  * promise stored in `#executing` and `result()` returns a promise rather than
- * blocking. `EventBuffer` (future_result.rb:24-47) exists only to carry
- * instrumentation events across that thread boundary and has nothing to carry
- * here — events publish inline on the one thread there is.
+ * blocking. `EventBuffer` (future_result.rb:24-47) still buffers the scheduled
+ * query's events so `#result` can stamp each payload with `lock_wait`.
  *
  * Ruby's `#then(&block)` returns an `ActiveRecord::Promise` whose `#value`
  * blocks (promise.rb:36-38). The name is load-bearing in JS: ANY object with a
@@ -135,11 +204,14 @@ export class FutureResult {
   #error: unknown = null;
   #result: Result | null = null;
   #executing: Promise<void> | null = null;
+  #instrumenter: Instrumenter;
+  #eventBuffer: EventBuffer | null = null;
 
   constructor(pool: FutureResultPool, args: unknown[], kwargs: Record<string, unknown> = {}) {
     this.pool = pool;
     this.args = args;
     this.kwargs = kwargs;
+    this.#instrumenter = Notifications.instrumenter;
   }
 
   async isEmpty(): Promise<boolean> {
@@ -187,7 +259,10 @@ export class FutureResult {
         // already in flight for this FutureResult".
         if (this.#executing) return;
         if (this.pending()) {
-          await this.executeQuery(connection, { async: true });
+          this.#eventBuffer = new EventBuffer(this, this.#instrumenter);
+          await IsolatedExecutionState.scope(ACTIVE_RECORD_INSTRUMENTER, this.#eventBuffer, () =>
+            this.executeQuery(connection, { async: true }),
+          );
         }
       });
     });
@@ -195,6 +270,7 @@ export class FutureResult {
 
   async result(): Promise<Result> {
     await this.executeOrWait();
+    this.#eventBuffer?.flush();
 
     if (this.canceled()) {
       throw new Canceled();
@@ -217,13 +293,14 @@ export class FutureResult {
 
   private async executeOrWait(): Promise<void> {
     if (this.pending()) {
-      const start = Date.now();
+      // Ruby: `Process.clock_gettime(CLOCK_MONOTONIC, :float_millisecond)`.
+      const start = performance.now();
       // Ruby takes `@mutex` here and, if a worker thread already holds it,
       // records how long the wait was. The in-flight promise IS that lock on a
       // single thread (future_result.rb:142-156).
       if (this.#executing) {
         await this.#executing;
-        this.lockWait = Date.now() - start;
+        this.lockWait = performance.now() - start;
       } else {
         await this.pool.withConnection((connection) => this.executeQuery(connection));
       }

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -305,9 +305,17 @@ export class InstanceExec2 implements CallTemplate {
   }
 }
 
-/** Mirrors: ActiveSupport::Callbacks::CallTemplate::ProcCall */
+/**
+ * Mirrors: ActiveSupport::Callbacks::CallTemplate::ProcCall
+ *
+ * Rails calls `(@override_target || target).call(target, value, &block)` — no
+ * `instance_exec`, so the proc keeps its own binding. Ruby reaches both a Proc
+ * filter and a `Conditionals::Value` filter through that one `.call`; TS has to
+ * name the two shapes, and a JS function's own `.call` means the union has to
+ * be discriminated where Ruby dispatches for free.
+ */
 export class ProcCall implements CallTemplate {
-  constructor(readonly fn: (...args: any[]) => unknown) {}
+  constructor(readonly fn: ((...args: any[]) => unknown) | Value) {}
 
   expand(target: object, value: unknown, block: (() => unknown) | null): unknown[] {
     return [this.fn, block, "call", target, value];
@@ -315,20 +323,19 @@ export class ProcCall implements CallTemplate {
 
   makeLambda(): (target: object, value: unknown, block?: (() => unknown) | null) => unknown {
     const f = this.fn;
-    // Rails: @override_block.call(target, value, &block) — no instance_exec, the
-    // proc keeps its own binding; forward target, value and the block.
     return (target: object, value: unknown, block?: (() => unknown) | null) =>
-      f(target, value, block);
+      typeof f === "function" ? f(target, value, block) : f.call(target, value);
   }
 
   invertedLambda(): (target: object, value: unknown, block?: (() => unknown) | null) => boolean {
     const f = this.fn;
     return (target: object, value: unknown, block?: (() => unknown) | null) =>
-      !f(target, value, block);
+      !(typeof f === "function" ? f(target, value, block) : f.call(target, value));
   }
 
   make(target: object, _value: unknown): unknown {
-    return this.fn(target);
+    const f = this.fn;
+    return typeof f === "function" ? f(target) : f.call(target, undefined);
   }
 }
 
@@ -342,21 +349,26 @@ export class ProcCall implements CallTemplate {
  * All of these objects are converted into a CallTemplate and handled
  * the same after this point.
  *
+ * A Ruby Symbol is a JS string, and this dispatch turns on Symbol-vs-String, so
+ * the Symbol keeps its leading colon and a bare string takes the arm that
+ * raises. The object arm's method name is `current_scopes.join("_").to_sym`
+ * camelCased, so the default `[:kind]` scope calls `around`/`before`/`after`
+ * and `scope: [:kind, :name]` calls `aroundSave`.
+ *
  * Mirrors: ActiveSupport::Callbacks::CallTemplate.build
  */
 export namespace CallTemplate {
   export function build(
-    filter: AnyCallback | string | symbol | CallbackObject,
+    filter: AnyCallback | string | symbol | CallbackObject | Value,
     callback: Callback,
   ): CallTemplate {
     if (typeof filter === "string" || typeof filter === "symbol") {
-      // A Ruby Symbol is a JS string; here the control flow turns on
-      // Symbol-vs-String, so the Symbol keeps its leading colon and a bare
-      // string is Callback.build's String arm, which raises.
       if (typeof filter === "string" && !filter.startsWith(":")) {
         throw new Error(`Passing string to define a callback is not supported: ${filter}`);
       }
       return new MethodCall(typeof filter === "string" ? filter.slice(1) : filter);
+    } else if (filter instanceof Value) {
+      return new ProcCall(filter);
     } else if (typeof filter === "function") {
       const arity = filter.length;
       if (arity > 1) {
@@ -369,10 +381,6 @@ export namespace CallTemplate {
         return new InstanceExec0(filter as () => unknown);
       }
     } else {
-      // Rails: ObjectCall.new(filter, current_scopes.join("_").to_sym) — the
-      // dispatched method is the callback's scope-join, so the default `[:kind]`
-      // scope calls `around`/`before`/`after` and `scope: [:kind, :name]` calls
-      // `aroundSave`.
       const [head, ...rest] = callback.currentScopes();
       return new ObjectCall(
         filter,

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -371,7 +371,7 @@ export namespace CallTemplate {
       return new ProcCall(filter);
     } else if (typeof filter === "function") {
       const arity = filter.length;
-      if (arity > 1) {
+      if (arity === 2) {
         return new InstanceExec2(
           filter as (target: object, block: (() => unknown) | null) => unknown,
         );

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -332,6 +332,56 @@ export class ProcCall implements CallTemplate {
   }
 }
 
+/**
+ * Filters support:
+ *
+ *   Symbols:: A method to call.
+ *   Procs::   A proc to call with the object.
+ *   Objects:: An object with a `before_foo` method on it to call.
+ *
+ * All of these objects are converted into a CallTemplate and handled
+ * the same after this point.
+ *
+ * Mirrors: ActiveSupport::Callbacks::CallTemplate.build
+ */
+export namespace CallTemplate {
+  export function build(
+    filter: AnyCallback | string | symbol | CallbackObject,
+    callback: Callback,
+  ): CallTemplate {
+    if (typeof filter === "string" || typeof filter === "symbol") {
+      // A Ruby Symbol is a JS string; here the control flow turns on
+      // Symbol-vs-String, so the Symbol keeps its leading colon and a bare
+      // string is Callback.build's String arm, which raises.
+      if (typeof filter === "string" && !filter.startsWith(":")) {
+        throw new Error(`Passing string to define a callback is not supported: ${filter}`);
+      }
+      return new MethodCall(typeof filter === "string" ? filter.slice(1) : filter);
+    } else if (typeof filter === "function") {
+      const arity = filter.length;
+      if (arity > 1) {
+        return new InstanceExec2(
+          filter as (target: object, block: (() => unknown) | null) => unknown,
+        );
+      } else if (arity === 1) {
+        return new InstanceExec1(filter as (target: object) => unknown);
+      } else {
+        return new InstanceExec0(filter as () => unknown);
+      }
+    } else {
+      // Rails: ObjectCall.new(filter, current_scopes.join("_").to_sym) — the
+      // dispatched method is the callback's scope-join, so the default `[:kind]`
+      // scope calls `around`/`before`/`after` and `scope: [:kind, :name]` calls
+      // `aroundSave`.
+      const [head, ...rest] = callback.currentScopes();
+      return new ObjectCall(
+        filter,
+        head + rest.map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(""),
+      );
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Filters
 // ---------------------------------------------------------------------------
@@ -658,38 +708,7 @@ export class Callback {
     for (const c of ifConds) userConditions.push((t, v) => c(t, v));
     for (const c of unlessConds) userConditions.push((t, v) => !c(t, v));
 
-    // Mirrors ActiveSupport::Callbacks::CallTemplate.build: a Proc/block filter
-    // compiles to InstanceExec{0,1,2} (run via instance_exec, so `self` is the
-    // record) selected by arity; a method-name filter compiles to MethodCall.
-    let userCallback: CallTemplate;
-    if (typeof this.filter === "function") {
-      const arity = this.filter.length;
-      userCallback =
-        arity > 1
-          ? new InstanceExec2(
-              this.filter as (target: object, block: (() => unknown) | null) => unknown,
-            )
-          : arity > 0
-            ? new InstanceExec1(this.filter as (target: object) => unknown)
-            : new InstanceExec0(this.filter as () => unknown);
-    } else if (typeof this.filter === "string" && !this.filter.startsWith(":")) {
-      // A Ruby Symbol is a JS string; here the control flow turns on
-      // Symbol-vs-String, so the Symbol keeps its leading colon and a bare
-      // string is Callback.build's String arm, which raises.
-      throw new Error(
-        `Passing string to define a callback is not supported: ${String(this.filter)}`,
-      );
-    } else if (typeof this.filter === "object" && this.filter !== null) {
-      // Rails CallTemplate.build: an object filter compiles to
-      // ObjectCall.new(filter, current_scopes.join("_").to_sym) — the dispatched
-      // method is the callback's scope-join, so the default `[:kind]` scope calls
-      // `around`/`before`/`after` and `scope: [:kind, :name]` calls `aroundSave`.
-      userCallback = new ObjectCall(this.filter, this.objectCallMethodName());
-    } else {
-      userCallback = new MethodCall(
-        typeof this.filter === "string" ? this.filter.slice(1) : (this.filter as PropertyKey),
-      );
-    }
+    const userCallback = CallTemplate.build(this.filter, this);
 
     if (this.kind === "before") {
       this._compiled = new Before(
@@ -700,9 +719,7 @@ export class Callback {
         this.name,
       );
     } else if (this.kind === "after") {
-      this._compiled = new After(userCallback.makeLambda(), userConditions, {
-        skipAfterCallbacksIfTerminated: this.chainConfig.skipAfterCallbacksIfTerminated,
-      });
+      this._compiled = new After(userCallback.makeLambda(), userConditions, this.chainConfig);
     } else {
       this._compiled = new Around(userCallback, userConditions);
     }
@@ -714,16 +731,6 @@ export class Callback {
     return scope.map((s) =>
       s === "kind" ? String(this.kind) : String((this as Record<string, unknown>)[s]),
     );
-  }
-
-  /**
-   * The object-callback method name — Rails' `current_scopes.join("_").to_sym`,
-   * camelCased for TS. Default scope `[:kind]` → `around`/`before`/`after`;
-   * `scope: [:kind, :name]` → `aroundSave`/`beforeSave`.
-   */
-  private objectCallMethodName(): string {
-    const [head, ...rest] = this.currentScopes();
-    return head + rest.map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
   }
 }
 

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -69,6 +69,23 @@ export class Event {
     }
   }
 
+  /**
+   * @internal trails splits Ruby's one blocking `Event#record` into a sync and
+   * an awaiting form, as it does for `Notifications.instrument` /
+   * `instrumentAsync` (instrumenter.rb:59-67).
+   */
+  async recordAsync<T = void>(fn?: (payload: EventPayload) => Promise<T>): Promise<T> {
+    this.startBang();
+    try {
+      return fn ? await fn(this.payload) : (undefined as unknown as T);
+    } catch (e) {
+      _recordException(this.payload, e);
+      throw e;
+    } finally {
+      this.finishBang();
+    }
+  }
+
   /** Record information at the time this event starts */
   startBang(): void {
     this._time = this.now();

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-set/builder.json
@@ -9,16 +9,9 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-set/builder.ts",
-    "rubyName": "build_from_database",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:values",
-      "ref:types",
-      "ref:additionalTypes",
-      "ref:defaultAttributes"
-    ],
-    "reason": "builder.rb:16 `LazyAttributeSet.new(values, types, additional_types, default_attributes)` — trails has no LazyAttributeSet/LazyAttributeHash; `buildFromDatabase` materializes the attributes eagerly, so the only `new` in the body is the `AttributeSet(attrs)` it returns. Blocked on porting LazyAttributeSet, not on the argument list."
+    "rubyName": "attributes",
+    "call": "each_key",
+    "reason": "builder.rb:62-63 walks `values.each_key`/`types.each_key`; `values` is a plain object and `types` a Map here, neither of which has Ruby's Hash#each_key — `Object.keys(...)`/`Map#keys()` is the only spelling (same gap as the `materialize` -> `each_key` row below)."
   },
   {
     "package": "activemodel",
@@ -26,6 +19,20 @@
     "rubyName": "deep_dup",
     "call": "transform_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set/builder.ts",
+    "rubyName": "default_attribute",
+    "call": "fetch",
+    "reason": "builder.rb:74 `additional_types.fetch(name, types[name])`; a JS Map has no two-argument `fetch`, and no type is ever stored as null, so `get(name) ?? types.get(name)` is exact (same gap as the `assign_default_value` -> `fetch` row)."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-set/builder.ts",
+    "rubyName": "fetch_value",
+    "call": "fetch",
+    "reason": "builder.rb:46,51 `@casted_values.fetch(name) { ... }` and `values.fetch(name) { value_present = false }`; JS Map/objects have no block-taking `fetch`, so the key-presence probe is `has`/`hasOwnProperty` and the miss arm is the surrounding branch."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/future-result.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/future-result.json
@@ -2,15 +2,8 @@
   {
     "package": "activerecord",
     "tsFile": "future-result.ts",
-    "rubyName": "execute_or_skip",
+    "rubyName": "initialize",
     "call": "new",
-    "reason": "future_result.rb:104 builds an `EventBuffer` to carry instrumentation events from the worker thread to the foreground. There is no worker thread on a single-threaded event loop and nothing to buffer — events publish inline (see the FutureResult class comment)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "future-result.ts",
-    "rubyName": "result",
-    "call": "flush",
-    "reason": "future_result.rb:117 flushes the EventBuffer that this port does not build; see the `execute_or_skip`/`new` row."
+    "reason": "future_result.rb:64 `@mutex = Mutex.new`. There is no mutex on a single-threaded event loop — the in-flight query promise (`#executing`) is the lock, as the FutureResult class comment records."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/callbacks.json
@@ -16,19 +16,6 @@
   {
     "package": "activesupport",
     "tsFile": "callbacks.ts",
-    "rubyName": "compiled",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:makeLambda",
-      "ref:userConditions",
-      "ref:chainConfig"
-    ],
-    "reason": "callbacks.rb:285 extracts `CallTemplate.build(@filter, self)`, whose returned template is then constructed into a `Filters::Before/After/Around`. trails inlines the CallTemplate dispatch into `compiled`, so the body's `new` occurrences are the InstanceExec/ObjectCall/MethodCall templates and the comparator pairs them positionally against the Filters constructions. Convergence is the `CallTemplate.build` extraction, not the argument list."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "callbacks.ts",
     "rubyName": "duplicates?",
     "call": "matches?",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails callbacks.rb:272-279 delegates to `matches?(other.kind, other.filter)` for Symbol filters; trails callbacks.ts:629-634 isDuplicates inlines the kind/filter equality for string filters."


### PR DESCRIPTION
Three RFC 0099 convergences, each retiring baseline rows.

## 1. `CallTemplate.build` (activesupport)

`compiled` inlined the whole filter dispatch. It now reads
`CallTemplate.build(this.filter, this)` (callbacks.rb:281-293), with the factory
carrying Rails' branch order — Symbol → `MethodCall`, Proc → `InstanceExec{2,1,0}`
by arity, else `ObjectCall(filter, current_scopes.join)` (callbacks.rb:511-528).
The String arm that raises moves with it, and the private `objectCallMethodName`
helper Rails has no counterpart for is gone.

`Filters::After` now takes `chainConfig` rather than a re-wrapped object literal,
which is what the `compiled -> new(...)` args row was actually about — that row is
deleted, not re-baselined.

## 2. `LazyAttributeSet` (activemodel)

`buildFromDatabase` walked every declared type eagerly. It now returns
`new LazyAttributeSet(values, types, additionalTypes, defaultAttributes)`
(builder.rb:15-17), and `LazyAttributeSet` is ported method for method
(builder.rb:21-88): `key?`, `keys`, `fetch_value` with its `@casted_values`
memo, the protected `attributes` materializer, and the private
`default_attribute` with Rails' three arms.

The override seam Rails gets from `protected attr_reader :attributes` needed a
counterpart, so `AttributeSet`'s field is now `_attributes` and the bulk readers
(`each_value`/`fetch`/`except`, `cast_types`, `values_*`, `key?`, `keys`,
`deep_dup`, `accessed`, `map`) go through a protected `attributes()` — exactly
the split Rails makes between `@attributes` and `attributes`.

The old `LazyAttributeSet` was a trails invention (an `AttributeSet` plus a spare
`additionalTypes` map, constructed nowhere but its own tests); its tests are
replaced with ones covering the ported behaviour.

## 3. `FutureResult::EventBuffer` (activerecord)

PR #6515 omitted `EventBuffer` because there is no thread boundary to carry
events across. True of the buffering, but `flush` also stamps
`payload[:lock_wait]` on every event (future_result.rb:43) — trails computed
`lockWait` and nothing read it.

`EventBuffer` is now ported with `instrumentAsync` (Ruby's blocking `instrument`,
async-split as `ActiveSupport::Notifications` already is) and `flush`. A
scheduled query installs it in the `:active_record_instrumenter` slot for the
duration of its query via `IsolatedExecutionState.scope` — the single-thread
collapse of Rails' fiber-local assignment (future_result.rb:110-111) — and
`AbstractAdapter#instrumenter` reads that slot the way abstract_adapter.rb:1152
does. `#result` flushes. Tests assert a contended read reports a non-zero
`lock_wait` and an uncontended one `0.0`, and that events are held back until the
foreground reads.

`executeOrWait` also switches from `Date.now()` to `performance.now()`, matching
Ruby's `CLOCK_MONOTONIC, :float_millisecond`.

## Baselines

Deleted: `compiled -> new` (args), `execute_or_skip -> new`, `result -> flush`,
`build_from_database -> new` (args).

Added, each with a reviewed reason: three `activemodel/attribute-set/builder.json`
rows for Ruby `Hash#fetch`/`Hash#each_key` with no JS Map/object counterpart
(matching the two rows already in that file for the same calls), and
`future-result.ts initialize -> new` for `Mutex.new`.

## Review responses

**Arity dispatch (fixed.)** The pre-existing `arity > 1 -> InstanceExec2` is now
`arity === 2`, which is Rails' `when 2` literally (callbacks.rb:513-521). Every
arity JS can express now lands where Ruby lands: a 3-param filter falls to
`else -> InstanceExec0` as Rails does (it previously became an InstanceExec2),
and Ruby's `-2` case — a `|a, *rest|` proc — is JS `(a, ...rest)` with
`length === 1`, so it reaches `InstanceExec1` through the same arm Rails uses.
The one shape that still cannot converge is a splat after two named params
(Ruby arity `-3` -> `else`, JS `length === 2` -> `when 2`); `Function#length`
has no negative range to carry the splat, and no filter in the tree takes one.

**`narrowTo` and the materializing seam (no change; deliberate.)** Two parts:

*It is not on the hot path.* `Builder#buildFromDatabase` — the only constructor
of a `LazyAttributeSet` — has no production caller in the tree
(`grep -rn "buildFromDatabase\|new LazyAttributeSet" --include=*.ts packages/`
returns only builder.ts and its tests). `Model.attributesBuilder` exists but
nothing invokes `.buildFromDatabase()` on it; record hydration reaches
`AttributeSet` by another route, so `narrowToProjectedColumns` never sees a
`LazyAttributeSet` today. Making `buildFromDatabase` the hydration path is its
own change and its own story.

*Routing them through `attributes()` would be wrong, not merely unnecessary.*
`narrowTo`, `snapshotValues` and `forgetAssignmentsBang` are trails-only and
mean "operate on what is materialized". `attributes()` on a `LazyAttributeSet`
forces the whole row (builder.rb:61-66), so pointing them at it would defeat the
laziness this story exists to add, on every load. Their raw-`_attributes` reads
mirror how Rails' own writers (`[]=`, `write_from_database`, `write_from_user`,
`write_cast_value`) touch `@attributes` directly rather than through the reader.
The end state is identical either way, as you note: an unmaterialized narrowable
column already resolves through `LazyAttributeSet#default_attribute`'s
uninitialized arm on first read (builder.rb:80-84).

The `hasAttribute` half of the question is now moot — that protected helper's
only caller was the invented `LazyAttributeSet.materialize` this PR deletes, so
it is gone too rather than left as dead surface. Nothing downstream
distinguished the two states.

## Note

753 LOC (additions + deletions) against a 700 ceiling. The overage is the
`_attributes` rename across `attribute-set.ts` (82 lines of mechanical
single-line churn), which the `LazyAttributeSet` override seam requires.

Closes-story: extract-call-template-build
Closes-story: port-future-result-event-buffer-lock-wait
Closes-story: port-lazy-attribute-set
