### PR TITLE
fix(activerecord): memoize find_take/find_nth on Relation

### DIFF
--- a/packages/activerecord/src/finder.trails.test.ts
+++ b/packages/activerecord/src/finder.trails.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vitest";
 import "./index.js";
 import { registerModel } from "./associations.js";
 import { fixtures } from "./test-fixtures.js";
+import { assertNoQueries, assertQueriesCount } from "./testing/query-assertions.js";
 import { Post } from "./test-helpers/models/post.js";
 
 registerModel(Post);
@@ -29,5 +30,31 @@ describe("FinderTrailsTest", () => {
     const thinking = posts("thinking");
     const found = (await Post.find(["1-foo", "2-bar"])) as Post[];
     expect(found.map((r) => r.id)).toStrictEqual([welcome.id, thinking.id]);
+  });
+
+  it("take memoizes the record so a second call issues no query", async () => {
+    const relation = Post.all();
+    const first = await relation.take();
+    expect(first).not.toBeNull();
+    await assertNoQueries(false, async () => {
+      expect(await relation.take()).toStrictEqual(first);
+    });
+    relation.reset();
+    await assertQueriesCount(1, false, async () => {
+      expect(await relation.take()).toStrictEqual(first);
+    });
+  });
+
+  it("second memoizes per offset so a second call issues no query", async () => {
+    const relation = Post.order({ id: "asc" });
+    const second = await relation.second();
+    expect(second).not.toBeNull();
+    await assertNoQueries(false, async () => {
+      expect(await relation.second()).toStrictEqual(second);
+    });
+    relation.reset();
+    await assertQueriesCount(1, false, async () => {
+      expect(await relation.second()).toStrictEqual(second);
+    });
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -444,6 +444,11 @@ export class Relation<T extends Base> {
   // `spawn`'s `model.all` branch) reachable at all.
   private _delegateToModel = false;
   private _records: T[] = [];
+  // Rails `@take` / `@offsets` (finder_methods.rb:586, 599-600): the memoized
+  // `find_take` record and the per-index `find_nth` cache, both cleared by
+  // `reset` (relation.rb:1199).
+  private _take?: T | null;
+  private _offsets?: Map<number, T | null>;
   /**
    * Per-record loader block, run on each freshly instantiated record BEFORE
    * its find/initialize callbacks fire — the trails analog of the block Rails
@@ -1992,6 +1997,9 @@ export class Relation<T extends Base> {
   reset(): this {
     this._loaded = false;
     this._delegateToModel = false;
+    // Rails: `@offsets = @take = nil` (relation.rb:1199).
+    this._offsets = undefined;
+    this._take = undefined;
     this._records = [];
     this._cacheKeys = undefined;
     this._cacheVersions = undefined;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -444,9 +444,7 @@ export class Relation<T extends Base> {
   // `spawn`'s `model.all` branch) reachable at all.
   private _delegateToModel = false;
   private _records: T[] = [];
-  // Rails `@take` / `@offsets` (finder_methods.rb:586, 599-600): the memoized
-  // `find_take` record and the per-index `find_nth` cache, both cleared by
-  // `reset` (relation.rb:1199).
+  // Rails `@take` / `@offsets` (finder_methods.rb:586, 599-600).
   private _take?: T | null;
   private _offsets?: Map<number, T | null>;
   /**
@@ -1997,7 +1995,6 @@ export class Relation<T extends Base> {
   reset(): this {
     this._loaded = false;
     this._delegateToModel = false;
-    // Rails: `@offsets = @take = nil` (relation.rb:1199).
     this._offsets = undefined;
     this._take = undefined;
     this._records = [];

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -457,7 +457,7 @@ export async function performFirst(this: FinderRelation, n?: number): Promise<an
   // crucially caps `limit` against an existing `limit_value` (`first(3)` on a
   // `.limit(2)` relation returns 2 rows, not 3).
   if (n !== undefined) return this.findNthWithLimit(0, n);
-  return (await this.findNthWithLimit(0, 1))[0] ?? null;
+  return findNth(this, 0);
 }
 
 /** @internal */
@@ -541,14 +541,8 @@ export async function performSole(this: FinderRelation): Promise<any> {
 
 /** @internal */
 export async function performTake(this: FinderRelation, limit?: number): Promise<any> {
-  const rel = this._clone();
-  if (limit !== undefined) {
-    rel._limitValue = limit;
-    return rel.toArray();
-  }
-  rel._limitValue = 1;
-  const records = await rel.toArray();
-  return records[0] ?? null;
+  // Rails: `limit ? find_take_with_limit(limit) : find_take` (finder_methods.rb:129).
+  return limit !== undefined ? findTakeWithLimit(this, limit) : findTake(this);
 }
 
 /** @internal */
@@ -599,27 +593,27 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
 
 /** @internal */
 export async function performSecond(this: FinderRelation): Promise<any | null> {
-  return (await this.findNthWithLimit(1, 1))[0] ?? null;
+  return findNth(this, 1);
 }
 
 /** @internal */
 export async function performThird(this: FinderRelation): Promise<any | null> {
-  return (await this.findNthWithLimit(2, 1))[0] ?? null;
+  return findNth(this, 2);
 }
 
 /** @internal */
 export async function performFourth(this: FinderRelation): Promise<any | null> {
-  return (await this.findNthWithLimit(3, 1))[0] ?? null;
+  return findNth(this, 3);
 }
 
 /** @internal */
 export async function performFifth(this: FinderRelation): Promise<any | null> {
-  return (await this.findNthWithLimit(4, 1))[0] ?? null;
+  return findNth(this, 4);
 }
 
 /** @internal */
 export async function performFortyTwo(this: FinderRelation): Promise<any | null> {
-  return (await this.findNthWithLimit(41, 1))[0] ?? null;
+  return findNth(this, 41);
 }
 
 /** @internal */
@@ -945,7 +939,10 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
 /** @internal */
 export async function findTake(rel: FinderRelation): Promise<any | null> {
   if (rel.isLoaded) return (await rel.records())[0] ?? null;
-  return (await (rel as any).limit(1).records())[0] ?? null;
+  // Rails memoizes with `@take ||=` (finder_methods.rb:586): a nil result is
+  // not memoized, so the query re-runs until it finds a record.
+  (rel as any)._take ??= (await (rel as any).limit(1).records())[0] ?? null;
+  return (rel as any)._take;
 }
 
 /** @internal */
@@ -956,7 +953,15 @@ export async function findTakeWithLimit(rel: FinderRelation, limit: number): Pro
 
 /** @internal */
 export async function findNth(rel: FinderRelation, index: number): Promise<any | null> {
-  return (await rel.findNthWithLimit(index, 1))[0] ?? null;
+  // Rails: `@offsets ||= {}; @offsets[index] ||= find_nth_with_limit(index, 1).first`
+  // (finder_methods.rb:598-601) — a nil hit is not memoized, so it re-queries.
+  const offsets = ((rel as any)._offsets ??= new Map<number, any>());
+  let record = offsets.get(index) ?? null;
+  if (record == null) {
+    record = (await rel.findNthWithLimit(index, 1))[0] ?? null;
+    offsets.set(index, record);
+  }
+  return record;
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -541,7 +541,6 @@ export async function performSole(this: FinderRelation): Promise<any> {
 
 /** @internal */
 export async function performTake(this: FinderRelation, limit?: number): Promise<any> {
-  // Rails: `limit ? find_take_with_limit(limit) : find_take` (finder_methods.rb:129).
   return limit !== undefined ? findTakeWithLimit(this, limit) : findTake(this);
 }
 
@@ -939,8 +938,8 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
 /** @internal */
 export async function findTake(rel: FinderRelation): Promise<any | null> {
   if (rel.isLoaded) return (await rel.records())[0] ?? null;
-  // Rails memoizes with `@take ||=` (finder_methods.rb:586): a nil result is
-  // not memoized, so the query re-runs until it finds a record.
+  // `@take ||=` (finder_methods.rb:586): a nil result is not memoized, so the
+  // query re-runs until a record exists.
   (rel as any)._take ??= (await (rel as any).limit(1).records())[0] ?? null;
   return (rel as any)._take;
 }
@@ -953,8 +952,8 @@ export async function findTakeWithLimit(rel: FinderRelation, limit: number): Pro
 
 /** @internal */
 export async function findNth(rel: FinderRelation, index: number): Promise<any | null> {
-  // Rails: `@offsets ||= {}; @offsets[index] ||= find_nth_with_limit(index, 1).first`
-  // (finder_methods.rb:598-601) — a nil hit is not memoized, so it re-queries.
+  // `@offsets[index] ||=` (finder_methods.rb:600): as with `@take`, a nil hit
+  // is not memoized and re-queries.
   const offsets = ((rel as any)._offsets ??= new Map<number, any>());
   let record = offsets.get(index) ?? null;
   if (record == null) {


### PR DESCRIPTION
Ports the `@take` / `@offsets` memo slots from Rails' `FinderMethods`:

- `find_take` memoizes with `@take ||= limit(1).records.first` (`finder_methods.rb:582-588`) and `find_nth` with `@offsets[index] ||= …` (`finder_methods.rb:598-601`). Both are ported with the `||=` semantics — a nil result is not memoized, so the query re-runs until a record exists.
- `Relation` now carries `_take` / `_offsets`, cleared by `reset` exactly where Rails clears them (`relation.rb:1199`: `@offsets = @take = nil`). They are not copied by `_copyStateFrom`, matching Rails' `initialize_copy` ending in `reset`.
- The memo was unreachable because `take`/`first`/`second`…`fortyTwo` bypassed `findTake`/`findNth` and called `findNthWithLimit` (or an inline clone+limit) directly. They now route through them as Rails does (`finder_methods.rb:128-130, 173-179, 223-289`).

Tests: `finder.trails.test.ts` pins that a second `take()` / `second()` issues no query and that `reset()` restores the query.

Closes-story: finder-methods-take-offsets-memoization