### PR TITLE
refactor(activerecord): retire relation.ts's private thunk block for include()

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2394,13 +2394,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // so the loaded branch is handled here.
     if (n !== undefined) {
       if (this._targetLoaded) return this._target.slice(0, n);
-      return baseFindTakeWithLimit(this._finderScope() as any, n);
+      return baseFindTakeWithLimit.call(this._finderScope() as any, n);
     }
     if (this._targetLoaded) return this._target[0] ?? null;
     // `@take ||=` (finder_methods.rb:586). Rails' CollectionProxy#take is a bare
     // `super`, so the memo lands on the proxy itself; only the query goes through
     // `_finderScope`. A nil result is not memoized, matching `||=`.
-    this._take ??= await baseFindTake(this._finderScope() as any);
+    this._take ??= await baseFindTake.call(this._finderScope() as any);
     return this._take ?? null;
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2313,7 +2313,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `find_nth(0)` (finder_methods.rb:598-601). Rails' CollectionProxy#first is
     // a bare `super`, so the `@offsets` memo lands on the proxy itself; the query
     // still routes through `_finderScope` via our `findNthWithLimit` override.
-    return baseFindNth(this as any, 0);
+    return baseFindNth.call(this as any, 0);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -71,9 +71,9 @@ import {
   ensureValidOptionsForBatchingBang as _ensureValidOptionsForBatchingBang,
   buildBatchOrders as _buildBatchOrders,
   applyLimits as _applyLimits,
-  actOnIgnoredOrder as _actOnIgnoredOrder,
   batchOnLoadedRelation as _batchOnLoadedRelation,
   batchOnUnloadedRelation as _batchOnUnloadedRelation,
+  Batches,
 } from "./relation/batches.js";
 import {
   wrapWithScopeProxy,
@@ -97,9 +97,7 @@ import {
   hasInclude as _hasInclude,
   typeCastPluckValues,
 } from "./relation/calculations.js";
-import * as _fm from "./relation/finder-methods.js";
 import { FinderMethods } from "./relation/finder-methods.js";
-import * as _sm from "./relation/spawn-methods.js";
 import { SpawnMethods } from "./relation/spawn-methods.js";
 import { FromClause } from "./relation/from-clause.js";
 import { TableMetadata } from "./table-metadata.js";
@@ -113,10 +111,6 @@ import {
   type CounterCacheTouchOption,
 } from "./timestamp.js";
 import { ExplainRegistry } from "./explain-registry.js";
-import {
-  renderBind as _renderBind,
-  collectingQueriesForExplain as _collectingQueriesForExplain,
-} from "./explain.js";
 import { inspectExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -614,7 +608,7 @@ export class Relation<T extends Base> {
     // expands to distinct `writer_type`/`writer_id` predicates), and excepting by
     // the *columns the new predicates reference* — not the hash keys — drops both
     // of those columns before re-adding them.
-    const newClause = rel.buildWhereClause(conditions) as WhereClause;
+    const newClause = rel.buildWhereClause(conditions);
     rel._whereClause = rel._whereClause.except(...newClause.extractAttributes());
     rel._whereClause = rel._whereClause.plus(newClause);
     return rel;
@@ -835,7 +829,7 @@ export class Relation<T extends Base> {
       if (conditions.length === 0) {
         throw argumentError("Relation#whereNot: unsupported argument (empty array)");
       }
-      const clause = rel.buildWhereClause(conditions) as WhereClause;
+      const clause = rel.buildWhereClause(conditions);
       rel._whereClause = rel._whereClause.plus(clause.invert());
       return rel;
     }
@@ -846,7 +840,7 @@ export class Relation<T extends Base> {
     // (query_methods.rb:1631-1644) — then a single WhereClause#invert over the
     // assembled clause: 1 predicate → node.invert() (`!=`, `IS NOT NULL`,
     // `NOT IN`, ...), 2+ predicates → NOT(p1 AND p2 AND ...).
-    const clause = rel.buildWhereClause(conditions) as WhereClause;
+    const clause = rel.buildWhereClause(conditions);
     rel._whereClause = rel._whereClause.plus(clause.invert());
     return rel;
   }
@@ -2277,7 +2271,7 @@ export class Relation<T extends Base> {
    */
   structurallyCompatible(other: Relation<T>): boolean {
     if (this._model !== other._model) return false;
-    return this.structurallyIncompatibleValuesFor(other).length === 0;
+    return this.structurallyIncompatibleValuesFor(other as never).length === 0;
   }
 
   /**
@@ -6970,149 +6964,6 @@ export class Relation<T extends Base> {
     return block();
   }
 
-  // ---------------------------------------------------------------------------
-  // PR 37c — build-helper privates (delegates to relation/query-methods.ts)
-  // Mirrors: ActiveRecord::QueryMethods private build helpers
-  // ---------------------------------------------------------------------------
-
-  /** @internal */
-  private buildWhereClause(opts: unknown, rest: unknown[] = []): unknown {
-    return _qm.buildWhereClause.call(this as any, opts, rest);
-  }
-
-  /**
-   * Mirrors `alias :build_having_clause :build_where_clause`
-   * (query_methods.rb:1654) — HAVING conditions parse identically to WHERE.
-   * @internal
-   */
-  private buildHavingClause(opts: unknown, rest: unknown[] = []): unknown {
-    return _qm.buildWhereClause.call(this as any, opts, rest);
-  }
-
-  /** @internal */
-  private buildNamedBoundSqlLiteral(statement: string, values: Record<string, unknown>): unknown {
-    return _qm.buildNamedBoundSqlLiteral.call(this as any, statement, values);
-  }
-
-  /** @internal */
-  private buildBoundSqlLiteral(statement: string, values: unknown[]): unknown {
-    return _qm.buildBoundSqlLiteral.call(this as any, statement, values);
-  }
-
-  /** @internal */
-  private buildSubquery(subqueryAlias: string, selectValue: unknown): unknown {
-    return _qm.buildSubquery.call(this as any, subqueryAlias, selectValue);
-  }
-
-  /** @internal */
-  private buildCastValue(name: string, value: unknown): unknown {
-    return _qm.buildCastValue(name, value);
-  }
-
-  /** @internal */
-  private flattenedArgs(args: unknown[]): unknown[] {
-    return _qm.flattenedArgs(args);
-  }
-
-  /** @internal */
-  private validateOrderArgs(args: unknown[]): void {
-    _qm.validateOrderArgs.call(this as any, args);
-  }
-
-  /** @internal */
-  private processWithArgs(args: unknown[]): Record<string, unknown>[] {
-    return _qm.processWithArgs.call(this as any, args);
-  }
-
-  /** @internal */
-  private isDoesNotSupportReverse(order: string): boolean {
-    return _qm.isDoesNotSupportReverse(order);
-  }
-
-  /** @internal */
-  private reverseSqlOrder(orderQuery: unknown[]): unknown[] {
-    return _qm.reverseSqlOrder.call(this as any, orderQuery);
-  }
-
-  /** @internal */
-  private extractTableNameFrom(orderTerm: string): string | null {
-    return _qm.extractTableNameFrom(orderTerm);
-  }
-
-  /** @internal */
-  private columnReferences(orderArgs: unknown[]): string[] {
-    return _qm.columnReferences(orderArgs);
-  }
-
-  /** @internal */
-  private sanitizeOrderArguments(orderArgs: unknown[]): unknown[] {
-    return _qm.sanitizeOrderArguments.call(this as any, orderArgs);
-  }
-
-  /** @internal */
-  private preprocessOrderArgs(orderArgs: unknown[]): void {
-    _qm.preprocessOrderArgs.call(this as any, orderArgs);
-  }
-
-  /** @internal */
-  private buildOrder(arel: unknown): void {
-    _qm.buildOrder.call(this as any, arel);
-  }
-
-  /** @internal */
-  private buildCaseForValuePosition(
-    column: unknown,
-    values: unknown[],
-    options?: { filter?: boolean },
-  ): unknown {
-    return _qm.buildCaseForValuePosition.call(this as any, column, values, options);
-  }
-
-  /** @internal */
-  private resolveArelAttributes(attrs: unknown[]): unknown[] {
-    return _qm.resolveArelAttributes.call(this as any, attrs);
-  }
-
-  /** @internal */
-  private orderColumn(field: string): unknown {
-    return _qm.orderColumn.call(this as any, field);
-  }
-
-  /** @internal */
-  private processSelectArgs(fields: unknown[]): unknown[] {
-    return _qm.processSelectArgs.call(this as any, fields);
-  }
-
-  /** @internal */
-  private arelColumnAliasesFromHash(fields: Record<string, unknown>): unknown[] {
-    return _qm.arelColumnAliasesFromHash.call(this as any, fields);
-  }
-
-  /** @internal */
-  private buildFrom(): unknown {
-    return _qm.buildFrom.call(this as any);
-  }
-
-  /** @internal */
-  private buildSelect(arel: unknown): void {
-    _qm.buildSelect.call(this as any, arel);
-  }
-
-  /** @internal */
-  private buildWithExpressionFromValue(value: unknown): unknown {
-    return _qm.buildWithExpressionFromValue.call(this as any, value);
-  }
-
-  /** @internal */
-  private buildWithValueFromHash(hash: Record<string, unknown>): unknown[] {
-    return _qm.buildWithValueFromHash.call(this as any, hash);
-  }
-
-  /** @internal */
-  private lookupTableKlassFromJoinDependencies(tableName: string): unknown {
-    return _qm.lookupTableKlassFromJoinDependencies.call(this as any, tableName);
-  }
-
   // The `associated_table` block Rails threads from `build_where_clause`
   // (`predicate_builder.rb:71-73`): resolves a table name that exists only as a
   // join-dependency (a manual join, an alias) — not a direct reflection — to its
@@ -7120,176 +6971,6 @@ export class Relation<T extends Base> {
   // `where` / `whereNot`'s composite branches.
   private joinDependencyFallback(): (name: string) => typeof Base | null {
     return (name) => this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
-  }
-
-  /** @internal */
-  private eachJoinDependencies(
-    joinDependencies: unknown[] | undefined,
-    block: (join: unknown) => void,
-  ): void {
-    _qm.eachJoinDependencies.call(this as any, joinDependencies as any, block);
-  }
-
-  /** @internal */
-  private buildJoinDependencies(): unknown[] {
-    return _qm.buildJoinDependencies.call(this as any);
-  }
-
-  /** @internal */
-  private buildArel(connection?: unknown, aliases?: AliasTracker): unknown {
-    return _qm.buildArel.call(this as any, connection, aliases);
-  }
-
-  /** @internal */
-  private selectNamedJoins(
-    joinNames: unknown[],
-    stashedJoins?: unknown[] | null,
-    block?: (join: unknown) => void,
-  ): unknown[] {
-    return _qm.selectNamedJoins.call(this as any, joinNames, stashedJoins ?? null, block);
-  }
-
-  /** @internal */
-  private selectAssociationList(
-    associations: unknown[],
-    stashedJoins?: unknown[] | null,
-    block?: (join: unknown) => void,
-  ): unknown[] {
-    return _qm.selectAssociationList.call(this as any, associations, stashedJoins ?? null, block);
-  }
-
-  /** @internal */
-  private buildJoinBuckets(): [
-    Record<string, unknown[]>,
-    typeof Nodes.InnerJoin | typeof Nodes.OuterJoin,
-  ] {
-    return _qm.buildJoinBuckets.call(this as any);
-  }
-
-  /** @internal */
-  private buildJoins(arel: unknown): void {
-    _qm.buildJoins.call(this as any, arel);
-  }
-
-  /** @internal */
-  private buildWith(arel: unknown): void {
-    _qm.buildWith.call(this as any, arel);
-  }
-
-  /** @internal */
-  private buildWithJoinNode(name: string, kind?: unknown): unknown {
-    return _qm.buildWithJoinNode.call(this as any, name, kind as any);
-  }
-
-  /** @internal */
-  private structurallyIncompatibleValuesFor(other: unknown): string[] {
-    return _qm.structurallyIncompatibleValuesFor(this as any, other as any);
-  }
-
-  // ---------------------------------------------------------------------------
-  // PR 37b — batch privates (delegates to relation/batches.ts)
-  // Mirrors: ActiveRecord::Batches private helpers
-  // ---------------------------------------------------------------------------
-
-  /** @internal */
-  private actOnIgnoredOrder(errorOnIgnore: boolean | undefined): void {
-    _actOnIgnoredOrder(this, errorOnIgnore);
-  }
-
-  // ---------------------------------------------------------------------------
-  // PR 37b — explain / async privates
-  // Mirrors: ActiveRecord::Explain + ActiveRecord::QueryMethods#async
-  // ---------------------------------------------------------------------------
-
-  /** @internal */
-  private async collectingQueriesForExplain<R>(
-    fn: () => Promise<R>,
-  ): Promise<{ value: R; queries: [string, unknown[]][] }> {
-    return _collectingQueriesForExplain(fn);
-  }
-
-  /** @internal */
-  private renderBind(connection: unknown, attr: unknown): [string | null, unknown] {
-    return _renderBind(connection, attr);
-  }
-
-  /** @internal */
-  private async(): Relation<T> {
-    return (this.spawn() as any).asyncBang();
-  }
-
-  // ---------------------------------------------------------------------------
-  // PR 37d — finder privates (delegates to relation/finder-methods.ts + spawn-methods.ts)
-  // ---------------------------------------------------------------------------
-
-  /** @internal */
-  private constructRelationForExists(conditions: unknown): any {
-    return _fm.constructRelationForExists(this as any, conditions);
-  }
-
-  /** @internal */
-  private async findWithIds(ids: unknown[]): Promise<any> {
-    return _fm.findWithIds(this as any, ids);
-  }
-
-  /** @internal */
-  private async findOne(id: unknown): Promise<any> {
-    return _fm.findOne(this as any, id);
-  }
-
-  /** @internal */
-  private async findSome(ids: unknown[]): Promise<any[]> {
-    return _fm.findSome(this as any, ids);
-  }
-
-  /** @internal */
-  private async findSomeOrdered(ids: unknown[]): Promise<any[]> {
-    return _fm.findSomeOrdered(this as any, ids);
-  }
-
-  /** @internal */
-  private async findTake(): Promise<any | null> {
-    return _fm.findTake(this as any);
-  }
-
-  /** @internal */
-  private async findTakeWithLimit(limit: number): Promise<any[]> {
-    return _fm.findTakeWithLimit(this as any, limit);
-  }
-
-  /** @internal */
-  private findNth(index: number): Promise<any | null> {
-    return _fm.findNth(this as any, index);
-  }
-
-  /** @internal */
-  protected findNthWithLimit(index: number, limit: number): Promise<any[]> {
-    return _fm.findNthWithLimit.call(this as any, index, limit);
-  }
-
-  /** @internal */
-  protected findNthFromLast(index: number): Promise<any | null> {
-    return _fm.findNthFromLast.call(this as any, index);
-  }
-
-  /** @internal */
-  private async findLast(limit?: number): Promise<any> {
-    return _fm.findLast(this as any, limit);
-  }
-
-  /** @internal */
-  private orderedRelation(): any {
-    return _fm.orderedRelation(this as any);
-  }
-
-  /** @internal */
-  private _orderColumns(): string[] {
-    return _fm._orderColumns(this as any);
-  }
-
-  /** @internal */
-  private relationWith(values: Record<string, unknown>): Relation<T> {
-    return _sm.relationWith(this as any, values as any);
   }
 }
 
@@ -7375,6 +7056,36 @@ export interface Relation<T extends Base>
   spawn(): Relation<T>;
   merge<U extends Base>(other: Relation<U>): Relation<T>;
   mergeBang(other: any): Relation<T>;
+  /** @internal */
+  relationWith(values: Record<string, unknown>): Relation<T>;
+  /** @internal */
+  constructRelationForExists(conditions: unknown): Relation<T>;
+  /** @internal */
+  findWithIds(ids: unknown[]): Promise<T | T[]>;
+  /** @internal */
+  findOne(id: unknown): Promise<T>;
+  /** @internal */
+  findSome(ids: unknown[]): Promise<T[]>;
+  /** @internal */
+  findSomeOrdered(ids: unknown[]): Promise<T[]>;
+  /** @internal */
+  findTake(): Promise<T | null>;
+  /** @internal */
+  findTakeWithLimit(limit: number): Promise<T[]>;
+  /** @internal */
+  findNth(index: number): Promise<T | null>;
+  /** @internal */
+  findNthWithLimit(index: number, limit: number): Promise<T[]>;
+  /** @internal */
+  findNthFromLast(index: number): Promise<T | null>;
+  /** @internal */
+  findLast(limit?: number): Promise<T | T[] | null>;
+  /** @internal */
+  orderedRelation(): Relation<T>;
+  /** @internal */
+  _orderColumns(): string[];
+  /** @internal */
+  actOnIgnoredOrder(errorOnIgnore: boolean | undefined): void;
 }
 
 // DelegationMethods carries getters (connection/primaryKey/tableName) and
@@ -7425,6 +7136,7 @@ include(Relation, FinderMethods);
 include(Relation, Calculations);
 include(Relation, SpawnMethods);
 include(Relation, DelegationMethods);
+include(Relation, Batches);
 
 // Thenable: make Relation directly awaitable (delegates to toArray).
 applyThenable(Relation.prototype);

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -8,6 +8,16 @@ import { ActiveRecord } from "../ar-config.js";
 export class Batches {
   static readonly ORDER_IGNORE_MESSAGE =
     "Scoped order is ignored, use :cursor with :order to configure custom order." as const;
+
+  /** Mirrors: ActiveRecord::Batches#act_on_ignored_order (batches.rb:474-482). @internal */
+  actOnIgnoredOrder(this: any, errorOnIgnore: boolean | undefined): void {
+    const raise = errorOnIgnore !== undefined ? errorOnIgnore : ActiveRecord.errorOnIgnoredOrder;
+    if (raise) {
+      throw new Error(Batches.ORDER_IGNORE_MESSAGE);
+    } else if (this.model.logger) {
+      this.model.logger.warn(Batches.ORDER_IGNORE_MESSAGE);
+    }
+  }
 }
 
 /** @internal */
@@ -144,16 +154,6 @@ export function buildBatchOrders(
   const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
   const orderArr = Array.isArray(order) ? order : Array(cursorArr.length).fill(order ?? "asc");
   return cursorArr.map((col, i) => [col, orderArr[i] ?? "asc"]);
-}
-
-/** @internal */
-export function actOnIgnoredOrder(relation: any, errorOnIgnore: boolean | undefined): void {
-  const raise = errorOnIgnore !== undefined ? errorOnIgnore : ActiveRecord.errorOnIgnoredOrder;
-  if (raise) {
-    throw new Error(Batches.ORDER_IGNORE_MESSAGE);
-  } else if (relation.model.logger) {
-    relation.model.logger.warn(Batches.ORDER_IGNORE_MESSAGE);
-  }
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -363,7 +363,7 @@ function makeFindSomeRel(
     raiseRecordNotFoundExceptionBang,
     _whereClause: { isEmpty: () => true },
     findSomeOrdered(ids: unknown[]) {
-      return findSomeOrdered(this, ids);
+      return findSomeOrdered.call(this, ids);
     },
     except(..._skips: string[]) {
       return this;
@@ -382,7 +382,7 @@ function makeFindSomeRel(
 describe("findSome — expected_size respects limit and offset", () => {
   it("succeeds when result count equals ids.length with no limit/offset", async () => {
     const rel = makeFindSomeRel([{ id: 1 }, { id: 2 }]);
-    const result = await findSome(rel, [1, 2]);
+    const result = await findSome.call(rel, [1, 2]);
     expect(result).toHaveLength(2);
   });
 
@@ -390,7 +390,7 @@ describe("findSome — expected_size respects limit and offset", () => {
     // 5 ids, limit 3 → expected 3; DB returns 3 rows → no error
     const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const rel = makeFindSomeRel(rows, { limit: 3 });
-    const result = await findSome(rel, [1, 2, 3, 4, 5]);
+    const result = await findSome.call(rel, [1, 2, 3, 4, 5]);
     expect(result).toHaveLength(3);
   });
 
@@ -398,13 +398,13 @@ describe("findSome — expected_size respects limit and offset", () => {
     // 11 ids, limit 3, offset 9 → expected = min(3, 11-9) = 2
     const rows = [{ id: 10 }, { id: 11 }];
     const rel = makeFindSomeRel(rows, { limit: 3, offset: 9 });
-    const result = await findSome(rel, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    const result = await findSome.call(rel, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
     expect(result).toHaveLength(2);
   });
 
   it("throws when result count mismatches expected_size", async () => {
     const rel = makeFindSomeRel([{ id: 1 }]);
-    await expect(findSome(rel, [1, 2])).rejects.toBeInstanceOf(RecordNotFound);
+    await expect(findSome.call(rel, [1, 2])).rejects.toBeInstanceOf(RecordNotFound);
   });
 });
 
@@ -436,7 +436,7 @@ describe("findSome — narrows to pk column when select_values non-empty (ordere
         return inner;
       },
     };
-    await findSome(rel, [1]);
+    await findSome.call(rel, [1]);
     expect(selectedCol).toBe("id");
   });
 });
@@ -450,7 +450,7 @@ describe("findSome — dispatches to findSomeOrdered when relation has no order 
     // DB returns them in arbitrary order; we expect [5, 1, 3] back
     const dbRows = [{ id: 3 }, { id: 5 }, { id: 1 }];
     const rel = makeFindSomeRel(dbRows, { ordered: false });
-    const result = await findSome(rel, [5, 1, 3]);
+    const result = await findSome.call(rel, [5, 1, 3]);
     expect(result.map((r: any) => r.id)).toEqual([5, 1, 3]);
   });
 });
@@ -493,7 +493,7 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
   it("returns records in requested id order with no limit/offset", async () => {
     const dbRows = [{ id: 3 }, { id: 1 }, { id: 5 }];
     const rel = makeFindSomeOrderedRel(dbRows);
-    const result = await findSomeOrdered(rel, [5, 1, 3]);
+    const result = await findSomeOrdered.call(rel, [5, 1, 3]);
     expect(result.map((r: any) => r.id)).toEqual([5, 1, 3]);
   });
 
@@ -514,7 +514,7 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
         return r;
       },
     };
-    const result = await findSomeOrdered(rel, ids);
+    const result = await findSomeOrdered.call(rel, ids);
     expect(queriedIds).toEqual(Array.from({ length: 10 }, (_, i) => i + 1));
     expect(result).toHaveLength(10);
     expect(result[0].id).toBe(1);
@@ -537,14 +537,14 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
         return r;
       },
     };
-    const result = await findSomeOrdered(rel, ids);
+    const result = await findSomeOrdered.call(rel, ids);
     expect(queriedIds).toEqual([10, 11]);
     expect(result.map((r: any) => r.id)).toEqual([10, 11]);
   });
 
   it("throws when DB returns fewer records than sliced ids", async () => {
     const rel = makeFindSomeOrderedRel([{ id: 1 }], { limit: 3 });
-    await expect(findSomeOrdered(rel, [1, 2, 3])).rejects.toBeInstanceOf(RecordNotFound);
+    await expect(findSomeOrdered.call(rel, [1, 2, 3])).rejects.toBeInstanceOf(RecordNotFound);
   });
 
   it("adds PK to select when selectValues are present", async () => {
@@ -565,7 +565,7 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
         return inner;
       },
     };
-    const result = await findSomeOrdered(rel, [1, 2]);
+    const result = await findSomeOrdered.call(rel, [1, 2]);
     expect(selectArg).toBe("id"); // arelTable.get("id") returns "id" in the mock
     expect(result.map((r: any) => r.id)).toEqual([1, 2]);
   });
@@ -590,14 +590,14 @@ describe("findTake — returns first record from loaded relation without queryin
   it("returns first record when loaded", async () => {
     const rel = makeLoadedRel([{ id: 1 }, { id: 2 }]);
     const spy = vi.spyOn(rel, "limit");
-    const result = await findTake(rel);
+    const result = await findTake.call(rel);
     expect(result).toEqual({ id: 1 });
     expect(spy).not.toHaveBeenCalled();
   });
 
   it("returns null from empty loaded relation", async () => {
     const rel = makeLoadedRel([]);
-    const result = await findTake(rel);
+    const result = await findTake.call(rel);
     expect(result).toBeNull();
   });
 });
@@ -606,7 +606,7 @@ describe("findTakeWithLimit — slices loaded relation without querying", () => 
   it("returns first N records when loaded", async () => {
     const rel = makeLoadedRel([{ id: 1 }, { id: 2 }, { id: 3 }]);
     const spy = vi.spyOn(rel, "limit");
-    const result = await findTakeWithLimit(rel, 2);
+    const result = await findTakeWithLimit.call(rel, 2);
     expect(result).toEqual([{ id: 1 }, { id: 2 }]);
     expect(spy).not.toHaveBeenCalled();
   });
@@ -627,22 +627,22 @@ function makeRelForOrder(mc: {
 describe("_orderColumns — Rails _order_columns precedence", () => {
   it("returns [pk] when no implicit_order_column or query_constraints_list", () => {
     const rel = makeRelForOrder({ primaryKey: "id" });
-    expect(_orderColumns(rel)).toEqual(["id"]);
+    expect(_orderColumns.call(rel)).toEqual(["id"]);
   });
 
   it("puts implicit_order_column first, then pk", () => {
     const rel = makeRelForOrder({ primaryKey: "id", implicitOrderColumn: "created_at" });
-    expect(_orderColumns(rel)).toEqual(["created_at", "id"]);
+    expect(_orderColumns.call(rel)).toEqual(["created_at", "id"]);
   });
 
   it("deduplicates when implicit_order_column equals pk", () => {
     const rel = makeRelForOrder({ primaryKey: "id", implicitOrderColumn: "id" });
-    expect(_orderColumns(rel)).toEqual(["id"]);
+    expect(_orderColumns.call(rel)).toEqual(["id"]);
   });
 
   it("uses _queryConstraintsList instead of pk when set", () => {
     const rel = makeRelForOrder({ primaryKey: "id", _queryConstraintsList: ["shop_id", "id"] });
-    expect(_orderColumns(rel)).toEqual(["shop_id", "id"]);
+    expect(_orderColumns.call(rel)).toEqual(["shop_id", "id"]);
   });
 
   it("puts implicit_order_column before _queryConstraintsList", () => {
@@ -651,7 +651,7 @@ describe("_orderColumns — Rails _order_columns precedence", () => {
       implicitOrderColumn: "created_at",
       _queryConstraintsList: ["shop_id", "id"],
     });
-    expect(_orderColumns(rel)).toEqual(["created_at", "shop_id", "id"]);
+    expect(_orderColumns.call(rel)).toEqual(["created_at", "shop_id", "id"]);
   });
 });
 
@@ -672,7 +672,7 @@ describe("finder not-found message fidelity", () => {
       findBy: async () => null,
     };
     try {
-      await findOne(rel, 0);
+      await findOne.call(rel, 0);
       expect.fail("should have thrown");
     } catch (e) {
       const err = e as RecordNotFound;
@@ -707,7 +707,7 @@ describe("finder not-found message fidelity", () => {
       },
     };
     try {
-      await findSomeOrdered(rel, ["Hello", "World!"]);
+      await findSomeOrdered.call(rel, ["Hello", "World!"]);
       expect.fail("should have thrown");
     } catch (e) {
       const err = e as RecordNotFound;

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -457,7 +457,7 @@ export async function performFirst(this: FinderRelation, n?: number): Promise<an
   // crucially caps `limit` against an existing `limit_value` (`first(3)` on a
   // `.limit(2)` relation returns 2 rows, not 3).
   if (n !== undefined) return this.findNthWithLimit(0, n);
-  return findNth(this, 0);
+  return findNth.call(this, 0);
 }
 
 /** @internal */
@@ -541,7 +541,7 @@ export async function performSole(this: FinderRelation): Promise<any> {
 
 /** @internal */
 export async function performTake(this: FinderRelation, limit?: number): Promise<any> {
-  return limit !== undefined ? findTakeWithLimit(this, limit) : findTake(this);
+  return limit !== undefined ? findTakeWithLimit.call(this, limit) : findTake.call(this);
 }
 
 /** @internal */
@@ -562,7 +562,7 @@ export async function findNthWithLimit(
   if (this.isLoaded) {
     return (await this.records()).slice(index, index + limit) ?? [];
   }
-  let relation: any = orderedRelation(this);
+  let relation: any = orderedRelation.call(this);
   if ((this as any)._limitValue != null) {
     limit = Math.min((this as any)._limitValue - index, limit);
   }
@@ -579,7 +579,7 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
     const records: any[] = await this.records();
     return records[records.length - 1 - index] ?? null;
   }
-  const relation: any = orderedRelation(this);
+  const relation: any = orderedRelation.call(this);
   // Rails: `if relation.order_values.empty? || relation.has_limit_or_offset?`
   // Use hasOrder() on the result so _rawOrderClauses (e.g. inOrderOf) are also
   // treated as "has an order" — avoids loading all records for those relations.
@@ -592,27 +592,27 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
 
 /** @internal */
 export async function performSecond(this: FinderRelation): Promise<any | null> {
-  return findNth(this, 1);
+  return findNth.call(this, 1);
 }
 
 /** @internal */
 export async function performThird(this: FinderRelation): Promise<any | null> {
-  return findNth(this, 2);
+  return findNth.call(this, 2);
 }
 
 /** @internal */
 export async function performFourth(this: FinderRelation): Promise<any | null> {
-  return findNth(this, 3);
+  return findNth.call(this, 3);
 }
 
 /** @internal */
 export async function performFifth(this: FinderRelation): Promise<any | null> {
-  return findNth(this, 4);
+  return findNth.call(this, 4);
 }
 
 /** @internal */
 export async function performFortyTwo(this: FinderRelation): Promise<any | null> {
-  return findNth(this, 41);
+  return findNth.call(this, 41);
 }
 
 /** @internal */
@@ -797,6 +797,22 @@ export const FinderMethods = {
   findOrCreateByBang: performFindOrCreateByBang,
   createOrFindByBang: performCreateOrFindByBang,
   raiseRecordNotFoundExceptionBang,
+  // finder_methods.rb's private helpers. Rails defines these once, in
+  // FinderMethods, and Relation gets them by `include`; they ride the same
+  // mixin here so `relation.ts` does not redeclare a second copy.
+  constructRelationForExists,
+  findWithIds,
+  findOne,
+  findSome,
+  findSomeOrdered,
+  findTake,
+  findTakeWithLimit,
+  findNth,
+  findNthWithLimit,
+  findNthFromLast,
+  findLast,
+  orderedRelation,
+  _orderColumns,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -804,7 +820,7 @@ export const FinderMethods = {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function constructRelationForExists(rel: FinderRelation, conditions: unknown): any {
+export function constructRelationForExists(this: FinderRelation, conditions: unknown): any {
   // Mirrors construct_relation_for_exists (finder_methods.rb:438): unwrap/forbid
   // strong-params objects before the Array/Hash/scalar case-analysis below. A
   // plain hash/array/scalar/node passes through unchanged. Skip only the
@@ -816,10 +832,10 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
     conditions = sanitizeForbiddenAttributes(conditions as Record<string, unknown>);
   }
   let relation: any;
-  if ((rel as any)._isDistinct && (rel as any)._offsetValue != null) {
-    relation = (rel as any).except("order").limitBang(1);
+  if ((this as any)._isDistinct && (this as any)._offsetValue != null) {
+    relation = (this as any).except("order").limitBang(1);
   } else {
-    relation = (rel as any)
+    relation = (this as any)
       .except("select", "distinct", "order")
       ._selectBang(new Nodes.SqlLiteral(ONE_AS_ONE))
       .limitBang(1);
@@ -846,7 +862,7 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
     if (Object.keys(conditions).length > 0) relation = relation.where(conditions);
   } else {
     // Scalar → PK lookup (Rails' else branch: `where!(primary_key => conditions)`).
-    const pk = rel.primaryKey;
+    const pk = this.primaryKey;
     if (Array.isArray(pk)) {
       relation = relation.where(buildPkWhere(pk, conditions as unknown[]));
     } else {
@@ -857,75 +873,75 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
 }
 
 /** @internal */
-export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
-  const normalized = normalizeFindArgs(rel.model.name, rel.primaryKey, ids);
+export async function findWithIds(this: FinderRelation, ids: unknown[]): Promise<any> {
+  const normalized = normalizeFindArgs(this.model.name, this.primaryKey, ids);
   if (normalized.emptyArray) return [];
   if (normalized.wantArray) {
-    return (rel as any).findSome(normalized.ids);
+    return (this as any).findSome(normalized.ids);
   }
-  return findOne(rel, normalized.ids[0]);
+  return findOne.call(this, normalized.ids[0]);
 }
 
 /** @internal */
-export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
-  const pk = rel.primaryKey;
+export async function findOne(this: FinderRelation, id: unknown): Promise<any> {
+  const pk = this.primaryKey;
   const conditions = Array.isArray(pk) ? buildPkWhere(pk, id as unknown[]) : { [pk]: id };
-  const record = await (rel as any).findBy(conditions);
+  const record = await (this as any).findBy(conditions);
   if (!record) {
     // Rails find_one: raise_record_not_found_exception!(id, 0, 1)
-    (rel as any).raiseRecordNotFoundExceptionBang(id, 0, 1);
+    (this as any).raiseRecordNotFoundExceptionBang(id, 0, 1);
   }
   return record;
 }
 
 /** @internal */
-export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
-  if (!hasOrder(rel)) return (rel as any).findSomeOrdered(ids);
+export async function findSome(this: FinderRelation, ids: unknown[]): Promise<any[]> {
+  if (!hasOrder(this)) return (this as any).findSomeOrdered(ids);
 
-  const pk = rel.primaryKey as string;
-  let relation = (rel as any).where({ [pk]: ids });
+  const pk = this.primaryKey as string;
+  let relation = (this as any).where({ [pk]: ids });
   // Rails: `relation = relation.select(table[primary_key]) unless select_values.empty?`
-  if ((rel as any).selectValues.length > 0) {
-    relation = relation.select(rel.table.get(pk));
+  if ((this as any).selectValues.length > 0) {
+    relation = relation.select(this.table.get(pk));
   }
   const records = await relation.toArray();
 
   // Rails: expected_size = ids.size, then clamp down for limit/offset.
   // "11 ids with limit 3, offset 9 should give 2 results."
   let expectedSize = ids.length;
-  const limitValue: number | null = (rel as any)._limitValue ?? null;
-  const offsetValue: number | null = (rel as any)._offsetValue ?? null;
+  const limitValue: number | null = (this as any)._limitValue ?? null;
+  const offsetValue: number | null = (this as any)._offsetValue ?? null;
   if (limitValue !== null && ids.length > limitValue) expectedSize = limitValue;
   if (offsetValue !== null && ids.length - offsetValue < expectedSize)
     expectedSize = ids.length - offsetValue;
 
   if (records.length !== expectedSize) {
     // Rails find_some: raise_record_not_found_exception!(ids, result.size, expected_size)
-    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, expectedSize);
+    (this as any).raiseRecordNotFoundExceptionBang(ids, records.length, expectedSize);
   }
   return records;
 }
 
 /** @internal */
-export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
-  const offsetValue: number = (rel as any)._offsetValue ?? 0;
-  const limitValue: number | null = (rel as any)._limitValue ?? null;
+export async function findSomeOrdered(this: FinderRelation, ids: unknown[]): Promise<any[]> {
+  const offsetValue: number = (this as any)._offsetValue ?? 0;
+  const limitValue: number | null = (this as any)._limitValue ?? null;
   ids = ids.slice(offsetValue, offsetValue + (limitValue ?? ids.length));
 
-  let relation = (rel as any).except("limit", "offset");
-  relation = relation.where({ [rel.model.primaryKey as string]: ids });
-  if ((rel as any).selectValues.length > 0) {
-    relation = relation.select(rel.table.get(rel.model.primaryKey as string));
+  let relation = (this as any).except("limit", "offset");
+  relation = relation.where({ [this.model.primaryKey as string]: ids });
+  if ((this as any).selectValues.length > 0) {
+    relation = relation.select(this.table.get(this.model.primaryKey as string));
   }
   const records: any[] = await relation.records();
 
-  const primaryKey = rel.model.primaryKey as string;
-  const primaryKeyType = (rel.model as any).typeForAttribute(primaryKey);
+  const primaryKey = this.model.primaryKey as string;
+  const primaryKeyType = (this.model as any).typeForAttribute(primaryKey);
   const castKey = (id: unknown) => String(primaryKeyType.cast(id));
 
   if (records.length !== ids.length) {
     // Rails find_some_ordered: raise_record_not_found_exception!(ids, result.size, ids.size)
-    (rel as any).raiseRecordNotFoundExceptionBang(ids, records.length, ids.length);
+    (this as any).raiseRecordNotFoundExceptionBang(ids, records.length, ids.length);
   }
   const idIndex = new Map(ids.map((id, i) => [castKey(id), i]));
   return records.sort((a: any, b: any) => {
@@ -936,56 +952,58 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
 }
 
 /** @internal */
-export async function findTake(rel: FinderRelation): Promise<any | null> {
-  if (rel.isLoaded) return (await rel.records())[0] ?? null;
+export async function findTake(this: FinderRelation): Promise<any | null> {
+  if (this.isLoaded) return (await this.records())[0] ?? null;
   // `@take ||=` (finder_methods.rb:586): a nil result is not memoized, so the
   // query re-runs until a record exists.
-  (rel as any)._take ??= (await (rel as any).limit(1).records())[0] ?? null;
-  return (rel as any)._take;
+  (this as any)._take ??= (await (this as any).limit(1).records())[0] ?? null;
+  return (this as any)._take;
 }
 
 /** @internal */
-export async function findTakeWithLimit(rel: FinderRelation, limit: number): Promise<any[]> {
-  if (rel.isLoaded) return (await rel.records()).slice(0, limit);
-  return (rel as any).limit(limit).toArray();
+export async function findTakeWithLimit(this: FinderRelation, limit: number): Promise<any[]> {
+  if (this.isLoaded) return (await this.records()).slice(0, limit);
+  return (this as any).limit(limit).toArray();
 }
 
 /** @internal */
-export async function findNth(rel: FinderRelation, index: number): Promise<any | null> {
+export async function findNth(this: FinderRelation, index: number): Promise<any | null> {
   // `@offsets[index] ||=` (finder_methods.rb:600): as with `@take`, a nil hit
   // is not memoized and re-queries.
-  const offsets = ((rel as any)._offsets ??= new Map<number, any>());
+  const offsets = ((this as any)._offsets ??= new Map<number, any>());
   let record = offsets.get(index) ?? null;
   if (record == null) {
-    record = (await rel.findNthWithLimit(index, 1))[0] ?? null;
+    record = (await this.findNthWithLimit(index, 1))[0] ?? null;
     offsets.set(index, record);
   }
   return record;
 }
 
 /** @internal */
-export async function findLast(rel: FinderRelation, limit?: number): Promise<any> {
-  return performLast.call(rel, limit);
+export async function findLast(this: FinderRelation, limit?: number): Promise<any> {
+  return performLast.call(this, limit);
 }
 
 /** @internal */
-export function orderedRelation(rel: FinderRelation): any {
-  const mc = rel.model as any;
-  const pk = rel.primaryKey;
+export function orderedRelation(this: FinderRelation): any {
+  const mc = this.model as any;
+  const pk = this.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;
-  if (!hasOrder(rel) && (implicitOrder || constraintsList != null || pk)) {
-    const cols = _orderColumns(rel);
+  if (!hasOrder(this) && (implicitOrder || constraintsList != null || pk)) {
+    const cols = _orderColumns.call(this);
     if (cols.length > 0) {
-      return (rel as any).order(cols.map((column: string) => (rel as any).table.get(column).asc()));
+      return (this as any).order(
+        cols.map((column: string) => (this as any).table.get(column).asc()),
+      );
     }
   }
-  return rel;
+  return this;
 }
 
 /** @internal */
-export function _orderColumns(rel: FinderRelation): string[] {
-  const mc = rel.model as any;
+export function _orderColumns(this: FinderRelation): string[] {
+  const mc = this.model as any;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1222,10 +1222,9 @@ export function structurallyIncompatibleValuesFor(
   this: QueryMethodsHost,
   other: QueryMethodsHost,
 ): string[] {
-  const self = this;
   const incompat: string[] = [];
   for (const [label, field] of STRUCTURAL_FIELDS) {
-    const a = self[field] as unknown;
+    const a = this[field] as unknown;
     const b = other[field] as unknown;
     // Mirrors Rails' structurally_incompatible_values_for (query_methods.rb):
     // for Array-valued methods it does `next true unless v2.is_a?(Array)` —

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1219,9 +1219,10 @@ const STRUCTURAL_FIELDS: ReadonlyArray<[string, keyof QueryMethodsHost]> = [
 
 /** @internal */
 export function structurallyIncompatibleValuesFor(
-  self: QueryMethodsHost,
+  this: QueryMethodsHost,
   other: QueryMethodsHost,
 ): string[] {
+  const self = this;
   const incompat: string[] = [];
   for (const [label, field] of STRUCTURAL_FIELDS) {
     const a = self[field] as unknown;
@@ -1304,7 +1305,7 @@ function assertStructurallyCompatible(
   other: QueryMethodsHost,
   methodName: string,
 ): void {
-  const incompat = structurallyIncompatibleValuesFor(self, other);
+  const incompat = structurallyIncompatibleValuesFor.call(self, other);
   if (incompat.length > 0) {
     throw argumentError(
       `Relation passed to #${methodName} must be structurally compatible. Incompatible values: [${incompat.map((v) => `:${v}`).join(", ")}]`,
@@ -1319,7 +1320,7 @@ function assertStructurallyCompatible(
  */
 export function areStructurallyCompatible(self: unknown, other: unknown): boolean {
   if (!isRelationForCombining(self) || !isRelationForCombining(other)) return false;
-  return structurallyIncompatibleValuesFor(self, other).length === 0;
+  return structurallyIncompatibleValuesFor.call(self, other).length === 0;
 }
 
 function andBang(this: QueryMethodsHost, other: any): any {
@@ -2194,6 +2195,44 @@ export const QueryMethodBangs = {
   isTableNameMatches,
   arelColumn,
   arelColumnWithTable,
+  buildWhereClause,
+  // Mirrors `alias :build_having_clause :build_where_clause`
+  // (query_methods.rb:1654) — HAVING conditions parse identically to WHERE.
+  buildHavingClause: buildWhereClause,
+  buildNamedBoundSqlLiteral,
+  buildBoundSqlLiteral,
+  buildSubquery,
+  buildCastValue,
+  flattenedArgs,
+  validateOrderArgs,
+  processWithArgs,
+  isDoesNotSupportReverse,
+  reverseSqlOrder,
+  extractTableNameFrom,
+  columnReferences,
+  sanitizeOrderArguments,
+  preprocessOrderArgs,
+  buildOrder,
+  buildCaseForValuePosition,
+  resolveArelAttributes,
+  orderColumn,
+  processSelectArgs,
+  arelColumnAliasesFromHash,
+  buildFrom,
+  buildSelect,
+  buildWithExpressionFromValue,
+  buildWithValueFromHash,
+  lookupTableKlassFromJoinDependencies,
+  eachJoinDependencies,
+  buildJoinDependencies,
+  buildArel,
+  selectNamedJoins,
+  selectAssociationList,
+  buildJoinBuckets,
+  buildJoins,
+  buildWith,
+  buildWithJoinNode,
+  structurallyIncompatibleValuesFor,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -2663,7 +2702,7 @@ export function buildArel(
 export function selectNamedJoins(
   this: QueryMethodsHost,
   joinNames: unknown[],
-  stashedJoins: unknown[] | null,
+  stashedJoins: unknown[] | null = null,
   block?: (join: unknown) => void,
 ): unknown[] {
   // Mirror Rails: partition into CTEJoins (symbols matching a with_value key)
@@ -2700,7 +2739,7 @@ export function selectNamedJoins(
 export function selectAssociationList(
   this: QueryMethodsHost,
   associations: unknown[],
-  stashedJoins: unknown[] | null,
+  stashedJoins: unknown[] | null = null,
   block?: (join: unknown) => void,
 ): unknown[] {
   const result: unknown[] = [];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1664,11 +1664,9 @@ function asyncBang(this: QueryMethodsHost): QueryMethodsHost {
   return this;
 }
 
-/** @internal */
-function async(this: QueryMethodsHost): QueryMethodsHost {
-  const rel = (this as any).spawn();
-  rel._async = true;
-  return rel;
+/** Mirrors: ActiveRecord::QueryMethods#async (query_methods.rb:1678-1680). @internal */
+export function async(this: QueryMethodsHost): QueryMethodsHost {
+  return asyncBang.call((this as any).spawn());
 }
 
 /** @internal */
@@ -2194,6 +2192,7 @@ export const QueryMethodBangs = {
   isTableNameMatches,
   arelColumn,
   arelColumnWithTable,
+  async,
   buildWhereClause,
   // Mirrors `alias :build_having_clause :build_where_clause`
   // (query_methods.rb:1654) — HAVING conditions parse identically to WHERE.

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -107,6 +107,7 @@ export const SpawnMethods = {
   spawn: performSpawn,
   merge: performMerge,
   mergeBang,
+  relationWith,
 } as const;
 
 /**
@@ -119,10 +120,10 @@ export const SpawnMethods = {
  * @internal
  */
 export function relationWith<T extends SpawnRelation<T>>(
-  self: T,
+  this: T,
   values: Record<string, unknown>,
 ): T {
-  const result = (self as any).spawn();
+  const result = (this as any).spawn();
   setValues(result, values);
   return result;
 }


### PR DESCRIPTION
## What

`relation.ts` carried ~330 lines of one-line private wrappers whose only job was
to make helpers implemented in sibling modules reachable as `this.x()`:

```ts
private buildWhereClause(opts: unknown, rest: unknown[] = []): unknown {
  return _qm.buildWhereClause.call(this as any, opts, rest);
}
```

Rails gets all of this free from `include FinderMethods, Calculations,
SpawnMethods, QueryMethods, Batches, Explain, Delegation`
(`vendor/rails/activerecord/lib/active_record/relation.rb:68`). There is no Ruby
counterpart to any wrapper. CLAUDE.md's "Module mixins" section already
prescribes the idiom — `include()` / `Included<>` — and `relation.ts` already
applies it to its *public* surface; only the private half was never migrated.

## How

- **`relation/query-methods.ts`** — the `query_methods.rb` privates now ride
  `QueryMethodBangs`, next to `arel_column` / `table_name_matches?`, which were
  already mixed in this way for exactly this reason.
  `structurally_incompatible_values_for` becomes `this`-typed (Rails:
  `def structurally_incompatible_values_for(other)`, query_methods.rb:2266), and
  `select_named_joins` / `select_association_list` pick up Rails'
  `stashed_joins = nil` default (query_methods.rb:2027, 2047) that the thunk was
  supplying instead.
- **`relation/finder-methods.ts`** — the `finder_methods.rb` privates convert
  from a leading `rel` parameter to `this` and ride `FinderMethods`.
- **`relation/batches.ts`** — `act_on_ignored_order` (batches.rb) becomes an
  instance method of the `Batches` module class, which `Relation` now
  `include`s, mirroring Rails' `include Batches`.
- **`relation/spawn-methods.ts`** — `relation_with` (spawn_methods.rb:71) becomes
  `this`-typed and rides `SpawnMethods`.

### Three thunks that were not simply moved

- `collecting_queries_for_explain` and `render_bind` — trails implements both on
  `Base` (`base.ts:267-269,2021,2032,4548,4550`), where Rails' `Explain` module
  puts them, and nothing on `Relation` called the thunks. Dropped outright.
- `async` (query_methods.rb:1678-1680, `def async; spawn.async!; end`) — the
  `relation.ts` thunk was shadowing a same-named private function that already
  existed in `query-methods.ts` immediately after `asyncBang`, so this was a
  duplicate definition rather than a delegation. The `query-methods.ts` one is
  now exported and rides `QueryMethodBangs` with the rest, and its body is
  converged to Rails' `spawn.async!` in place of the inlined `_async = true` it
  had been carrying. `Relation` therefore still has `async` at the Rails name,
  now in the Rails file. (Neither form has a caller in `src/` today — `loadAsync`
  sets `_asyncLoad` directly — but Rails has the method, so it stays.)

`joinDependencyFallback` stays in the class body (it is a real closure over
`this`, not a wrapper), and `buildArel` is carried across unchanged — the F1
story owns it.

## Scope

This PR ships only `retire-relation-private-thunk-block`. The bundled
`wave-2c-grouped-calculation-and-query-method-stores` story is a full port of
`execute_grouped_calculation` (calculations.rb:512-586) plus five backing-store
convergences; at ~595 LOC already there is no room for it under the ceiling, so
it has been released back to the queue rather than half-shipped.

## Verification

- `pnpm typecheck` clean; `eslint` clean.
- `pnpm vitest run packages/activerecord/src/relation/ packages/activerecord/src/relation.test.ts packages/activerecord/src/batches.test.ts packages/activerecord/src/finder.test.ts packages/activerecord/src/associations/collection-proxy-first-take.trails.test.ts` — 1205 passed, 32 skipped.
- `pnpm parity:api:calls` — OK. `pnpm parity:api:calls:args` — OK. No baseline rows added or reseeded.
- `pnpm parity:api` / `pnpm parity:test` unchanged (no test names touched).

Closes-story: retire-relation-private-thunk-block
