### PR TITLE
test(activemodel,activesupport): mirror Rails assertions in conditional/presence/absence validation tests

### DIFF
--- a/packages/activemodel/src/validations/absence-validation.test.ts
+++ b/packages/activemodel/src/validations/absence-validation.test.ts
@@ -1,79 +1,106 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
 import { Model } from "../index.js";
 
-describe("AbsenceValidationTest", () => {
-  it("validates absence of for ruby class", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { absence: true });
-      }
-    }
-    const p = new Person();
-    expect(await p.isValid()).toBe(true);
-    const p2 = new Person({ name: "Alice" });
-    expect(await p2.isValid()).toBe(false);
-  });
+// Mirrors: activemodel/test/models/topic.rb
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+    this.attribute("content", "string");
+  }
+}
 
-  it("validates absence of for ruby class with custom reader", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { absence: true });
-      }
-    }
-    const p = new Person({});
-    expect(await p.isValid()).toBe(true);
+// Mirrors: activemodel/test/models/person.rb
+class Person extends Model {
+  static {
+    this.attribute("karma", "string");
+  }
+}
+
+// Mirrors: activemodel/test/models/custom_reader.rb — validation reads through
+// `read_attribute_for_validation`, and `p[:karma] = x` writes the backing hash.
+class CustomReader extends Model {
+  data: Record<string, unknown> = {};
+
+  override readAttributeForValidation(attribute: string): unknown {
+    return this.data[attribute];
+  }
+}
+
+describe("AbsenceValidationTest", () => {
+  afterEach(() => {
+    Topic.clearValidatorsBang();
+    Person.clearValidatorsBang();
+    CustomReader.clearValidatorsBang();
   });
 
   it("validates absence of", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { absence: true });
-      }
-    }
-    expect(await new Person({ name: "Alice" }).isValid()).toBe(false);
-    expect(await new Person({ name: "" }).isValid()).toBe(true);
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("validates absence of with custom error using quotes", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { absence: { message: "must not be given" } });
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    await p.isValid();
-    expect(p.errors.get("name")).toContain("must not be given");
+    Topic.validatesAbsenceOf("title", "content");
+    const t = new Topic();
+    t.title = "foo";
+    t.content = "bar";
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["must be blank"]);
+    expect(t.errors.get("content")).toEqual(["must be blank"]);
+    t.title = "";
+    t.content = "something";
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("content")).toEqual(["must be blank"]);
+    expect(t.errors.get("title")).toEqual([]);
+    t.content = "";
+    assertPredicate(await t.isValid(), (valid) => valid);
   });
 
   it("validates absence of with array arguments", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("email", "string");
-        this.validates("name", { absence: true });
-        this.validates("email", { absence: true });
-      }
-    }
-    const p = new Person({ name: "Alice", email: "a@b.com" });
-    await p.isValid();
-    expect(p.errors.count).toBe(2);
-    expect(p.errors.get("name").length).toBeGreaterThan(0);
-    expect(p.errors.get("email").length).toBeGreaterThan(0);
+    Topic.validatesAbsenceOf(["title", "content"]);
+    const t = new Topic();
+    t.title = "foo";
+    t.content = "bar";
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["must be blank"]);
+    expect(t.errors.get("content")).toEqual(["must be blank"]);
+  });
+
+  it("validates absence of with custom error using quotes", async () => {
+    Person.validatesAbsenceOf("karma", {
+      message: "This string contains 'single' and \"double\" quotes",
+    });
+    const p = new Person();
+    p.karma = "good";
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+    expect(p.errors.get("karma").at(-1)).toEqual(
+      "This string contains 'single' and \"double\" quotes",
+    );
+  });
+
+  it("validates absence of for ruby class", async () => {
+    Person.validatesAbsenceOf("karma");
+    const p = new Person();
+    p.karma = "good";
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+    expect(p.errors.get("karma")).toEqual(["must be blank"]);
+    p.karma = null;
+    assertPredicate(await p.isValid(), (valid) => valid);
+  });
+
+  it("validates absence of for ruby class with custom reader", async () => {
+    CustomReader.validatesAbsenceOf("karma");
+    const p = new CustomReader();
+    p.data["karma"] = "excellent";
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+    expect(p.errors.get("karma")).toEqual(["must be blank"]);
+    p.data["karma"] = "";
+    assertPredicate(await p.isValid(), (valid) => valid);
   });
 
   it("passes custom interpolation vars through to errors.add", async () => {
-    class Person extends Model {
+    class Interpolated extends Model {
       static {
         this.attribute("name", "string");
         this.validates("name", { absence: { message: "must be %{kind}", kind: "empty" } });
       }
     }
-    const p = new Person({ name: "Alice" });
+    const p = new Interpolated({ name: "Alice" });
     await p.isValid();
     expect(p.errors.get("name")).toContain("must be empty");
   });

--- a/packages/activemodel/src/validations/absence-validation.test.ts
+++ b/packages/activemodel/src/validations/absence-validation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { assertPredicate } from "@blazetrails/activesupport";
 import { Model } from "../index.js";
 
-// Mirrors: activemodel/test/models/topic.rb
+// Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
 class Topic extends Model {
   static {
     this.attribute("title", "string");
@@ -10,15 +10,14 @@ class Topic extends Model {
   }
 }
 
-// Mirrors: activemodel/test/models/person.rb
+// Mirrors: activemodel/test/models/person.rb — the subset this file exercises.
 class Person extends Model {
   static {
     this.attribute("karma", "string");
   }
 }
 
-// Mirrors: activemodel/test/models/custom_reader.rb — validation reads through
-// `read_attribute_for_validation`, and `p[:karma] = x` writes the backing hash.
+// Mirrors: activemodel/test/models/custom_reader.rb
 class CustomReader extends Model {
   data: Record<string, unknown> = {};
 

--- a/packages/activemodel/src/validations/conditional-validation.test.ts
+++ b/packages/activemodel/src/validations/conditional-validation.test.ts
@@ -1,161 +1,196 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { assertEmpty, assertPredicate } from "@blazetrails/activesupport";
 import { Model } from "../index.js";
 
+// Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+    this.attribute("content", "string");
+  }
+
+  conditionIsTrue(): boolean {
+    return true;
+  }
+
+  conditionIsFalse(): boolean {
+    return false;
+  }
+}
+
 describe("ConditionalValidationTest", () => {
-  it("if validation using block true", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: () => true });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(false);
-  });
-
-  it("if validation using block false", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: () => false });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("unless validation using block true", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: () => true });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("unless validation using block false", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: () => false });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(false);
-  });
-
-  it("validation using combining if true and unless true conditions", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: () => true, unless: () => true });
-      }
-    }
-    // unless returns true, so validation is skipped
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("validation using combining if true and unless false conditions", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: () => true, unless: () => false });
-      }
-    }
-    // both conditions met, validation runs
-    expect(await new Person({}).isValid()).toBe(false);
+  afterEach(() => {
+    Topic.clearValidatorsBang();
   });
 
   it("if validation using method true", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: "shouldValidateName" });
-      }
-      shouldValidateName() {
-        return true;
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(false);
-  });
-
-  it("if validation using method false", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: "shouldValidateName" });
-      }
-      shouldValidateName() {
-        return false;
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("unless validation using method true", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: "skipValidation" });
-      }
-      skipValidation() {
-        return true;
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(true);
-  });
-
-  it("unless validation using method false", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: "skipValidation" });
-      }
-      skipValidation() {
-        return false;
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(false);
+    // When the method returns true
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: "conditionIsTrue",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
   });
 
   it("if validation using array of true methods", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: [() => true, () => true] });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(false);
-  });
-
-  it("if validation using array of true and false methods", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, if: [() => true, () => false] });
-      }
-    }
-    // One returns false, so validation is skipped
-    expect(await new Person({}).isValid()).toBe(true);
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: ["conditionIsTrue", "conditionIsTrue"],
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
   });
 
   it("unless validation using array of false methods", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: [() => false, () => false] });
-      }
-    }
-    // None return true, so validation runs
-    expect(await new Person({}).isValid()).toBe(false);
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: ["conditionIsFalse", "conditionIsFalse"],
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
+  });
+
+  it("unless validation using method true", async () => {
+    // When the method returns true
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: "conditionIsTrue",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("if validation using array of true and false methods", async () => {
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: ["conditionIsTrue", "conditionIsFalse"],
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
   });
 
   it("unless validation using array of true and false methods", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, unless: [() => true, () => false] });
-      }
-    }
-    // One returns true, so validation is skipped
-    expect(await new Person({}).isValid()).toBe(true);
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: ["conditionIsTrue", "conditionIsFalse"],
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("if validation using method false", async () => {
+    // When the method returns false
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: "conditionIsFalse",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("unless validation using method false", async () => {
+    // When the method returns false
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: "conditionIsFalse",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
+  });
+
+  it("if validation using block true", async () => {
+    // When the block returns true
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: (r: Topic) => (r.content as string).length > 4,
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
+  });
+
+  it("unless validation using block true", async () => {
+    // When the block returns true
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: (r: Topic) => (r.content as string).length > 4,
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("if validation using block false", async () => {
+    // When the block returns false
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: (r: Topic) => r.title !== "uhohuhoh",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("unless validation using block false", async () => {
+    // When the block returns false
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      unless: (r: Topic) => r.title !== "uhohuhoh",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
+  });
+
+  it("validation using combining if true and unless true conditions", async () => {
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: "conditionIsTrue",
+      unless: "conditionIsTrue",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertEmpty(t.errors.get("title"));
+  });
+
+  it("validation using combining if true and unless false conditions", async () => {
+    Topic.validatesLengthOf("title", {
+      maximum: 5,
+      tooLong: "hoo %{count}",
+      if: "conditionIsTrue",
+      unless: "conditionIsFalse",
+    });
+    const t = new Topic({ title: "uhohuhoh", content: "whatever" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+    expect(t.errors.get("title")).toEqual(["hoo 5"]);
   });
 });

--- a/packages/activemodel/src/validations/presence-validation.test.ts
+++ b/packages/activemodel/src/validations/presence-validation.test.ts
@@ -1,124 +1,156 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
 import { Model, StrictValidationFailed } from "../index.js";
 
+// Mirrors: activemodel/test/models/topic.rb
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+    this.attribute("content", "string");
+  }
+}
+
+// Mirrors: activemodel/test/models/person.rb
+class Person extends Model {
+  static {
+    this.attribute("karma", "string");
+  }
+}
+
+// Mirrors: activemodel/test/models/custom_reader.rb — validation reads through
+// `read_attribute_for_validation`, and `p[:karma] = x` writes the backing hash.
+class CustomReader extends Model {
+  data: Record<string, unknown> = {};
+
+  override readAttributeForValidation(attribute: string): unknown {
+    return this.data[attribute];
+  }
+}
+
 describe("PresenceValidationTest", () => {
-  it("accepts array arguments", async () => {
-    // Rails: `Topic.validates_presence_of %w(title content)` — a single array
-    // argument, flattened by `_merge_attributes` (`attr_names.flatten!`).
-    class Topic extends Model {
-      static {
-        this.attribute("title", "string");
-        this.attribute("content", "string");
-        this.validatesPresenceOf(["title", "content"]);
-      }
-    }
-    const t = new Topic();
-    await t.isValid();
-    expect(t.errors.get("title").length).toBeGreaterThan(0);
-    expect(t.errors.get("content").length).toBeGreaterThan(0);
-  });
-
-  it("validates presence of for ruby class", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person();
-    expect(await p.isValid()).toBe(false);
-    const p2 = new Person({ name: "Alice" });
-    expect(await p2.isValid()).toBe(true);
-  });
-
-  it("validates presence of for ruby class with custom reader", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person({ name: "test" });
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates presence of with allow nil option", async () => {
-    class Topic extends Model {
-      static {
-        this.attribute("title", "string");
-        this.validatesPresenceOf("title", { allowNil: true });
-      }
-    }
-    expect(await new Topic({ title: "something" }).isValid()).toBe(true);
-
-    const blank = new Topic({ title: "" });
-    expect(await blank.isValid()).toBe(false);
-    expect(blank.errors.get("title")).toContain("can't be blank");
-
-    const whitespace = new Topic({ title: "  " });
-    expect(await whitespace.isValid()).toBe(false);
-    expect(whitespace.errors.get("title")).toContain("can't be blank");
-
-    expect(await new Topic({ title: null }).isValid()).toBe(true);
-  });
-
-  it("validates presence of with allow blank option", async () => {
-    class Topic extends Model {
-      static {
-        this.attribute("title", "string");
-        this.validatesPresenceOf("title", { allowBlank: true });
-      }
-    }
-    expect(await new Topic({ title: "something" }).isValid()).toBe(true);
-    expect(await new Topic({ title: "" }).isValid()).toBe(true);
-    expect(await new Topic({ title: "  " }).isValid()).toBe(true);
-    expect(await new Topic({ title: null }).isValid()).toBe(true);
+  afterEach(() => {
+    Topic.clearValidatorsBang();
+    Person.clearValidatorsBang();
+    CustomReader.clearValidatorsBang();
   });
 
   it("validate presences", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-        this.validatesPresenceOf("name", "age");
-      }
-    }
-    const p = new Person({});
-    expect(await p.isValid()).toBe(false);
-    expect(p.errors.get("name").length).toBeGreaterThan(0);
+    Topic.validatesPresenceOf("title", "content");
+
+    const t = new Topic();
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["can't be blank"]);
+    expect(t.errors.get("content")).toEqual(["can't be blank"]);
+
+    t.title = "something";
+    t.content = "   ";
+
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("content")).toEqual(["can't be blank"]);
+
+    t.content = "like stuff";
+
+    assertPredicate(await t.isValid(), (valid) => valid);
+  });
+
+  it("accepts array arguments", async () => {
+    // Rails: `Topic.validates_presence_of %w(title content)` — a single array
+    // argument, flattened by `_merge_attributes` (`attr_names.flatten!`).
+    Topic.validatesPresenceOf(["title", "content"]);
+    const t = new Topic();
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["can't be blank"]);
+    expect(t.errors.get("content")).toEqual(["can't be blank"]);
   });
 
   it("validates acceptance of with custom error using quotes", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: { message: "is required!" } });
-      }
-    }
-    const p = new Person({});
-    await p.isValid();
-    expect(p.errors.get("name")).toContain("is required!");
+    Person.validatesPresenceOf("karma", {
+      message: "This string contains 'single' and \"double\" quotes",
+    });
+    const p = new Person();
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+    expect(p.errors.get("karma").at(-1)).toEqual(
+      "This string contains 'single' and \"double\" quotes",
+    );
+  });
+
+  it("validates presence of for ruby class", async () => {
+    Person.validatesPresenceOf("karma");
+
+    const p = new Person();
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+
+    expect(p.errors.get("karma")).toEqual(["can't be blank"]);
+
+    p.karma = "Cold";
+    assertPredicate(await p.isValid(), (valid) => valid);
+  });
+
+  it("validates presence of for ruby class with custom reader", async () => {
+    CustomReader.validatesPresenceOf("karma");
+
+    const p = new CustomReader();
+    assertPredicate(await p.isInvalid(), (invalid) => invalid);
+
+    expect(p.errors.get("karma")).toEqual(["can't be blank"]);
+
+    p.data["karma"] = "Cold";
+    assertPredicate(await p.isValid(), (valid) => valid);
+  });
+
+  it("validates presence of with allow nil option", async () => {
+    Topic.validatesPresenceOf("title", { allowNil: true });
+
+    const t = new Topic({ title: "something" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+
+    t.title = "";
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["can't be blank"]);
+
+    t.title = "  ";
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["can't be blank"]);
+
+    t.title = null;
+    assertPredicate(await t.isValid(), (valid) => valid);
+  });
+
+  it("validates presence of with allow blank option", async () => {
+    Topic.validatesPresenceOf("title", { allowBlank: true });
+
+    const t = new Topic({ title: "something" });
+    assertPredicate(await t.isValid(), (valid) => valid);
+
+    t.title = "";
+    assertPredicate(await t.isValid(), (valid) => valid);
+
+    t.title = "  ";
+    assertPredicate(await t.isValid(), (valid) => valid);
+
+    t.title = null;
+    assertPredicate(await t.isValid(), (valid) => valid);
   });
 
   it("passes custom interpolation vars through to errors.add", async () => {
-    class Person extends Model {
+    class Interpolated extends Model {
       static {
         this.attribute("name", "string");
         this.validates("name", { presence: { message: "is %{kind}", kind: "wrong" } });
       }
     }
-    const p = new Person({});
+    const p = new Interpolated({});
     await p.isValid();
     expect(p.errors.get("name")).toContain("is wrong");
   });
 
   it("strict: true raises StrictValidationFailed via filteredErrorOptions", async () => {
-    class Person extends Model {
+    class Strict extends Model {
       static {
         this.attribute("name", "string");
         this.validates("name", { presence: { strict: true } });
       }
     }
-    await expect(new Person({}).isValid()).rejects.toThrow(StrictValidationFailed);
+    await expect(new Strict({}).isValid()).rejects.toThrow(StrictValidationFailed);
   });
 });

--- a/packages/activemodel/src/validations/presence-validation.test.ts
+++ b/packages/activemodel/src/validations/presence-validation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { assertPredicate } from "@blazetrails/activesupport";
 import { Model, StrictValidationFailed } from "../index.js";
 
-// Mirrors: activemodel/test/models/topic.rb
+// Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
 class Topic extends Model {
   static {
     this.attribute("title", "string");
@@ -10,15 +10,14 @@ class Topic extends Model {
   }
 }
 
-// Mirrors: activemodel/test/models/person.rb
+// Mirrors: activemodel/test/models/person.rb — the subset this file exercises.
 class Person extends Model {
   static {
     this.attribute("karma", "string");
   }
 }
 
-// Mirrors: activemodel/test/models/custom_reader.rb — validation reads through
-// `read_attribute_for_validation`, and `p[:karma] = x` writes the backing hash.
+// Mirrors: activemodel/test/models/custom_reader.rb
 class CustomReader extends Model {
   data: Record<string, unknown> = {};
 

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -615,6 +615,8 @@ export {
   assert,
   assertNot,
   assertPredicate,
+  assertEmpty,
+  assertNotEmpty,
   assertSame,
   assertNotSame,
   assertRaises,

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -542,6 +542,28 @@ export function assertPredicate<T>(
 }
 
 /**
+ * @noRailsEquivalent PERMANENT — Minitest's `assert_empty` (minitest/assertions.rb),
+ * which sends `empty?` to the collection. Rails inherits it from Minitest, so
+ * there is no Ruby counterpart in a mapped file. JS has no `empty?` protocol, so
+ * the check is `length`/`size`, whichever the collection carries.
+ */
+export function assertEmpty(actual: unknown, message?: string): void {
+  assert(collectionSize(actual) === 0, message ?? `Expected ${inspect(actual)} to be empty`);
+}
+
+/** @noRailsEquivalent PERMANENT — Minitest's `assert_not_empty` / `refute_empty`. */
+export function assertNotEmpty(actual: unknown, message?: string): void {
+  assert(collectionSize(actual) !== 0, message ?? `Expected ${inspect(actual)} to not be empty`);
+}
+
+function collectionSize(actual: unknown): number {
+  const collection = actual as { length?: number; size?: number };
+  if (typeof collection?.length === "number") return collection.length;
+  if (typeof collection?.size === "number") return collection.size;
+  return Object.keys(actual as object).length;
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Minitest's `assert_same`
  * (minitest/assertions.rb), object identity rather than value equality.
  */

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,8 +21,8 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 456,
-      "kind": 687,
+      "assertionCount": 433,
+      "kind": 661,
       "value": 65
     },
     "activerecord": {


### PR DESCRIPTION
Burns down activemodel assertion-parity debt (RFC 0105) for three validation
test files, ported assertion-for-assertion against `vendor/rails/activemodel/test/cases/validations/`:

- `conditional_validation_test.rb` — was entirely invented (`Person` + `presence`);
  now mirrors Rails' `Topic.validates_length_of(:title, maximum: 5, too_long: "hoo %{count}", …)`
  with the `condition_is_true` / `condition_is_false` methods from `models/topic.rb`.
- `presence_validation_test.rb`, `absence_validation_test.rb` — now assert through the
  Rails models (`Topic`, `Person`, `CustomReader`) and the Rails expected values
  (`["can't be blank"]`, `["must be blank"]`, the quoted custom message).

`assert_predicate x, :invalid?` ports as `assertPredicate(await t.isInvalid(), (invalid) => invalid)`
— trails' `invalid?` is async, so the predicate is applied to the awaited value.
`assert_empty` had no trails spelling, so `assertEmpty` / `assertNotEmpty` join
`assertPredicate` in `activesupport/src/testing/assertions.ts` as the same kind of
`@noRailsEquivalent PERMANENT` Minitest helper (Rails inherits them from Minitest,
so there is no Ruby counterpart in a mapped file).

activemodel assertion mark: 456/687/65 → **433/661/65** (23 count + 26 kind
converged). No test names changed; `parity:test` for activemodel stays at
961/963 (99.8%). Other packages' marks are left at their committed values.

The bundle's other two stories (`assertions-activemodel-length-numericality-comparison`,
`assertions-activemodel-remainder-second-pass`) were released untouched — the
remaining clusters do not fit under the LOC ceiling. The rest of this story's
cluster (8 files) is filed as
`0105-ar-deps-test-parity-100/stories/assertions-activemodel-remaining-validations-second-pass`.

Closes-story: assertions-activemodel-remaining-validations
