### PR TITLE
refactor(activerecord): move Batches methods into relation/batches.ts and include Explain into Relation

### DIFF
--- a/packages/activerecord/src/explain.ts
+++ b/packages/activerecord/src/explain.ts
@@ -95,3 +95,22 @@ export async function buildExplainClause(
   }
   return "EXPLAIN for:";
 }
+
+/**
+ * The mixin itself. Rails mixes `ActiveRecord::Explain` in on both sides —
+ * `extend Explain` at base.rb:294 (class level) and `include ... Explain ...`
+ * at relation.rb:68 (instance level) — so both receivers resolve the same
+ * method objects. `base.ts` wires the class side; `relation.ts` does
+ * `include(Relation, Explain)` for the instance side. Neither redefines a
+ * member: the definitions above are the single source for both.
+ *
+ * `execExplain` is not a member here — it takes the receiving model class as
+ * an explicit first argument on the class side, and `Relation` carries its own
+ * `execExplain` mirror of explain.rb:19-36 already.
+ *
+ * Mirrors: ActiveRecord::Explain
+ */
+export const Explain = {
+  collectingQueriesForExplain,
+  renderBind,
+} as const;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -67,14 +67,7 @@ import {
 } from "./relation/query-methods.js";
 import * as _qm from "./relation/query-methods.js";
 import { seedJoinClauseAliases } from "./relation/merged-join-alias-tracker.js";
-import {
-  ensureValidOptionsForBatchingBang as _ensureValidOptionsForBatchingBang,
-  buildBatchOrders as _buildBatchOrders,
-  applyLimits as _applyLimits,
-  batchOnLoadedRelation as _batchOnLoadedRelation,
-  batchOnUnloadedRelation as _batchOnUnloadedRelation,
-  Batches,
-} from "./relation/batches.js";
+import { Batches } from "./relation/batches.js";
 import {
   wrapWithScopeProxy,
   relationClassFor,
@@ -103,7 +96,7 @@ import { FromClause } from "./relation/from-clause.js";
 import { TableMetadata } from "./table-metadata.js";
 import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { WhereClause } from "./relation/where-clause.js";
-import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
+import type { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import {
   touchAttributesWithTime,
   parseTouchAllArgs,
@@ -111,6 +104,7 @@ import {
   type CounterCacheTouchOption,
 } from "./timestamp.js";
 import { ExplainRegistry } from "./explain-registry.js";
+import { Explain } from "./explain.js";
 import { inspectExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -4433,261 +4427,6 @@ export class Relation<T extends Base> {
     return this._whereClause.toH(this.model.tableName, { equalityOnly: true });
   }
 
-  // -- Batches --
-
-  /**
-   * Yields arrays of records in batches.
-   *
-   * Mirrors: ActiveRecord::Relation#find_in_batches
-   */
-  findInBatches({
-    batchSize = 1000,
-    start,
-    finish,
-    order,
-    cursor = this.primaryKey,
-    errorOnIgnore,
-  }: {
-    batchSize?: number;
-    start?: unknown;
-    finish?: unknown;
-    order?: "asc" | "desc" | ("asc" | "desc")[];
-    cursor?: string | string[];
-    errorOnIgnore?: boolean;
-  } = {}): AsyncGenerator<T[]> & { size(): Promise<number> } {
-    const relation = this;
-    // Rails' `to_enum(:find_in_batches, ...) { ... }` size block
-    // (batches.rb:161-168). An async iterator has no `Enumerator#size`, so the
-    // block hangs off the returned iterator under the same name; `size` is
-    // async here only because the count reaches the database.
-    const size = async (): Promise<number> => {
-      const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
-      const total = await _applyLimits(
-        relation,
-        cursorArr,
-        start,
-        finish,
-        _buildBatchOrders(cursorArr, order),
-      ).size();
-      return Math.floor((total - 1) / batchSize) + 1;
-    };
-    const enumerator = (async function* () {
-      const enumerator = relation.inBatches({
-        of: batchSize,
-        start,
-        finish,
-        load: true,
-        errorOnIgnore,
-        cursor,
-        order,
-      });
-      for await (const batchRel of enumerator._generator()) {
-        yield ((batchRel as any)._records ?? []) as T[];
-      }
-    })() as AsyncGenerator<T[]> & { size(): Promise<number> };
-    enumerator.size = size;
-    return enumerator;
-  }
-
-  /**
-   * Yields individual records in batches for memory efficiency.
-   *
-   * Mirrors: ActiveRecord::Relation#find_each
-   */
-  findEach({
-    batchSize = 1000,
-    start,
-    finish,
-    order,
-    cursor = this.primaryKey,
-    errorOnIgnore,
-  }: {
-    batchSize?: number;
-    start?: unknown;
-    finish?: unknown;
-    order?: "asc" | "desc" | ("asc" | "desc")[];
-    cursor?: string | string[];
-    errorOnIgnore?: boolean;
-  } = {}): AsyncGenerator<T> & { size(): Promise<number> } {
-    const relation = this;
-    const enumerator = (async function* () {
-      for await (const batch of relation.findInBatches({
-        batchSize,
-        start,
-        finish,
-        order,
-        cursor,
-        errorOnIgnore,
-      })) {
-        for (const record of batch) {
-          yield record;
-        }
-      }
-    })() as AsyncGenerator<T> & { size(): Promise<number> };
-    // Rails' `enum_for(:find_each, ...) { ... }` size block (batches.rb:90-95);
-    // see findInBatches above for why it lives on the iterator.
-    enumerator.size = async (): Promise<number> => {
-      const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
-      return _applyLimits(
-        relation,
-        cursorArr,
-        start,
-        finish,
-        _buildBatchOrders(cursorArr, order),
-      ).size();
-    };
-    return enumerator;
-  }
-
-  /**
-   * Returns a BatchEnumerator that yields Relations scoped to each batch.
-   * Unlike findInBatches which yields arrays of records, this yields
-   * Relation objects that can be further refined, and supports batch-level
-   * operations like deleteAll/updateAll.
-   *
-   * Mirrors: ActiveRecord::Batches#in_batches
-   */
-  inBatches(
-    opts: InBatchesOptions,
-    block: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
-  ): Promise<void>;
-  inBatches(opts?: InBatchesOptions): BatchEnumerator<LoadedRelation<Relation<T>>>;
-  inBatches(
-    {
-      of = 1000,
-      start,
-      finish,
-      order,
-      cursor: cursorOption,
-      errorOnIgnore,
-      load = false,
-      useRanges,
-    }: InBatchesOptions = {},
-    block?: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
-  ): BatchEnumerator<LoadedRelation<Relation<T>>> | Promise<void> {
-    const self = this;
-    const effectiveCursor = cursorOption ?? this.primaryKey;
-    const cursor = (Array.isArray(effectiveCursor) ? effectiveCursor : [effectiveCursor]).map(
-      String,
-    );
-    // `ensure_valid_options_for_batching!` reaches the schema cache, which is
-    // async here, so the validation runs when the batches are first pulled
-    // rather than at `in_batches` call time.
-    const ensureValidOptions = () =>
-      _ensureValidOptionsForBatchingBang(self, cursor, start, finish, (order ?? "asc") as any);
-
-    if (this._orderClauses.length > 0) {
-      this.actOnIgnoredOrder(errorOnIgnore);
-    }
-
-    const batchOrders = _buildBatchOrders(cursor, order as any);
-
-    const enumerator = block
-      ? null
-      : new BatchEnumerator<LoadedRelation<Relation<T>>>({
-          of,
-          start,
-          finish,
-          relation: self,
-          cursor,
-          order,
-          useRanges,
-        });
-
-    let remaining: number | null = null;
-    let batchLimit = of;
-    if (this._limitValue !== null) {
-      remaining = this._limitValue;
-      if (remaining < batchLimit) batchLimit = remaining;
-    }
-
-    let generator: () => AsyncGenerator<LoadedRelation<Relation<T>>>;
-    if (remaining === 0) {
-      generator = async function* () {};
-    } else if (this._loaded) {
-      const loadedBatches = _batchOnLoadedRelation({
-        relation: this,
-        start,
-        finish,
-        cursor,
-        order: (order ?? "asc") as any,
-        batchLimit,
-      });
-      generator = async function* () {
-        await ensureValidOptions();
-        for (const batchRows of loadedBatches) {
-          const batchRel = self._clone();
-          batchRel._orderClauses = batchOrders.map(([col, dir]) =>
-            dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
-          );
-          (batchRel as any)._records = batchRows;
-          (batchRel as any)._loaded = true;
-          yield stripThenable(batchRel) as LoadedRelation<Relation<T>>;
-        }
-      };
-    } else {
-      generator = async function* () {
-        await ensureValidOptions();
-        for await (const { rows: batchRows, useRanges: batchUseRanges } of _batchOnUnloadedRelation(
-          {
-            relation: self,
-            start,
-            finish,
-            cursor,
-            order: (order ?? "asc") as any,
-            batchLimit,
-            load,
-            remaining,
-            useRanges,
-          },
-        )) {
-          const batchRel = self._clone();
-          batchRel._orderClauses = batchOrders.map(([col, dir]) =>
-            dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
-          );
-          const tuples = batchRows.map((r) => cursor.map((c) => r.readAttribute(c)));
-          if (batchUseRanges && !load && cursor.length === 1 && tuples.length > 0) {
-            // Range-mode: emit `col >= first AND col <= last` (reversed for desc)
-            // instead of `col IN (...)`. Mirrors Rails apply_finish_limit path.
-            const col = cursor[0];
-            const dir = batchOrders[0][1];
-            const first = tuples[0][0];
-            const last = tuples[tuples.length - 1][0];
-            const attr = self.table.get(col) as any;
-            const lo = dir === "desc" ? last : first;
-            const hi = dir === "desc" ? first : last;
-            batchRel._whereClause.predicates.push(attr.gteq(lo).and(attr.lteq(hi)));
-          } else if (cursor.length === 1) {
-            const ids = tuples.map((t) => t[0]);
-            batchRel._whereClause.predicates.push(
-              ...self.predicateBuilder.buildFromHash({ [cursor[0]]: ids }),
-            );
-          } else {
-            batchRel._whereClause.predicates.push(
-              ...self.predicateBuilder.buildComposite(cursor, tuples),
-            );
-          }
-          if (load) {
-            (batchRel as any)._records = batchRows;
-            (batchRel as any)._loaded = true;
-          }
-          yield stripThenable(batchRel);
-        }
-      } as () => AsyncGenerator<LoadedRelation<Relation<T>>>;
-    }
-
-    if (block) {
-      return (async () => {
-        for await (const batchRelation of generator()) {
-          await block(batchRelation);
-        }
-      })();
-    }
-
-    enumerator!._generator = generator;
-    return enumerator!;
-  }
-
   // -- SQL generation --
 
   /**
@@ -7008,7 +6747,7 @@ export interface Relation<T extends Base> {
 // FinderMethods and SpawnMethods return T-typed values — explicit signatures needed.
 
 export interface Relation<T extends Base>
-  extends Included<typeof QueryMethodBangs>, CalculationMethods {
+  extends Included<typeof QueryMethodBangs>, Included<typeof Explain>, CalculationMethods {
   find(ids: unknown[]): Promise<T[]>;
   find(id: unknown): Promise<T>;
   find(...ids: unknown[]): Promise<T | T[]>;
@@ -7086,6 +6825,27 @@ export interface Relation<T extends Base>
   _orderColumns(): string[];
   /** @internal */
   actOnIgnoredOrder(errorOnIgnore: boolean | undefined): void;
+  findEach(opts?: {
+    batchSize?: number;
+    start?: unknown;
+    finish?: unknown;
+    order?: "asc" | "desc" | ("asc" | "desc")[];
+    cursor?: string | string[];
+    errorOnIgnore?: boolean;
+  }): AsyncGenerator<T> & { size(): Promise<number> };
+  findInBatches(opts?: {
+    batchSize?: number;
+    start?: unknown;
+    finish?: unknown;
+    order?: "asc" | "desc" | ("asc" | "desc")[];
+    cursor?: string | string[];
+    errorOnIgnore?: boolean;
+  }): AsyncGenerator<T[]> & { size(): Promise<number> };
+  inBatches(
+    opts: InBatchesOptions,
+    block: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
+  ): Promise<void>;
+  inBatches(opts?: InBatchesOptions): BatchEnumerator<LoadedRelation<Relation<T>>>;
 }
 
 // DelegationMethods carries getters (connection/primaryKey/tableName) and
@@ -7137,6 +6897,10 @@ include(Relation, Calculations);
 include(Relation, SpawnMethods);
 include(Relation, DelegationMethods);
 include(Relation, Batches);
+// relation.rb:68 — `include FinderMethods, ..., Batches, Explain, Delegation`.
+// Rails also does `extend Explain` on Base (base.rb:294); both sides read the
+// one definition in `explain.ts`.
+include(Relation, Explain);
 
 // Thenable: make Relation directly awaitable (delegates to toArray).
 applyThenable(Relation.prototype);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6897,9 +6897,6 @@ include(Relation, Calculations);
 include(Relation, SpawnMethods);
 include(Relation, DelegationMethods);
 include(Relation, Batches);
-// relation.rb:68 — `include FinderMethods, ..., Batches, Explain, Delegation`.
-// Rails also does `extend Explain` on Base (base.rb:294); both sides read the
-// one definition in `explain.ts`.
 include(Relation, Explain);
 
 // Thenable: make Relation directly awaitable (delegates to toArray).

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -4,10 +4,276 @@
  * Mirrors: ActiveRecord::Batches
  */
 import { ActiveRecord } from "../ar-config.js";
+import { stripThenable } from "./thenable.js";
+import { BatchEnumerator } from "./batches/batch-enumerator.js";
+import type { Base } from "../base.js";
+import type { InBatchesOptions, LoadedRelation, Relation } from "../relation.js";
 
 export class Batches {
   static readonly ORDER_IGNORE_MESSAGE =
     "Scoped order is ignored, use :cursor with :order to configure custom order." as const;
+
+  /**
+   * Yields individual records in batches for memory efficiency.
+   *
+   * Mirrors: ActiveRecord::Batches#find_each (batches.rb:36)
+   */
+  findEach<T extends Base>(
+    this: any,
+    {
+      batchSize = 1000,
+      start,
+      finish,
+      order,
+      cursor = this.primaryKey,
+      errorOnIgnore,
+    }: {
+      batchSize?: number;
+      start?: unknown;
+      finish?: unknown;
+      order?: "asc" | "desc" | ("asc" | "desc")[];
+      cursor?: string | string[];
+      errorOnIgnore?: boolean;
+    } = {},
+  ): AsyncGenerator<T> & { size(): Promise<number> } {
+    const relation = this;
+    const enumerator = (async function* () {
+      for await (const batch of relation.findInBatches({
+        batchSize,
+        start,
+        finish,
+        order,
+        cursor,
+        errorOnIgnore,
+      })) {
+        for (const record of batch as T[]) {
+          yield record;
+        }
+      }
+    })() as AsyncGenerator<T> & { size(): Promise<number> };
+    // Rails' `enum_for(:find_each, ...) { ... }` size block (batches.rb:90-95);
+    // see findInBatches below for why it lives on the iterator.
+    enumerator.size = async (): Promise<number> => {
+      const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
+      return applyLimits(
+        relation,
+        cursorArr,
+        start,
+        finish,
+        buildBatchOrders(cursorArr, order),
+      ).size();
+    };
+    return enumerator;
+  }
+
+  /**
+   * Yields arrays of records in batches.
+   *
+   * Mirrors: ActiveRecord::Batches#find_in_batches (batches.rb:96)
+   */
+  findInBatches<T extends Base>(
+    this: any,
+    {
+      batchSize = 1000,
+      start,
+      finish,
+      order,
+      cursor = this.primaryKey,
+      errorOnIgnore,
+    }: {
+      batchSize?: number;
+      start?: unknown;
+      finish?: unknown;
+      order?: "asc" | "desc" | ("asc" | "desc")[];
+      cursor?: string | string[];
+      errorOnIgnore?: boolean;
+    } = {},
+  ): AsyncGenerator<T[]> & { size(): Promise<number> } {
+    const relation = this;
+    // Rails' `to_enum(:find_in_batches, ...) { ... }` size block
+    // (batches.rb:161-168). An async iterator has no `Enumerator#size`, so the
+    // block hangs off the returned iterator under the same name; `size` is
+    // async here only because the count reaches the database.
+    const size = async (): Promise<number> => {
+      const cursorArr = Array.isArray(cursor) ? cursor : [cursor];
+      const total = await applyLimits(
+        relation,
+        cursorArr,
+        start,
+        finish,
+        buildBatchOrders(cursorArr, order),
+      ).size();
+      return Math.floor((total - 1) / batchSize) + 1;
+    };
+    const enumerator = (async function* () {
+      const enumerator = relation.inBatches({
+        of: batchSize,
+        start,
+        finish,
+        load: true,
+        errorOnIgnore,
+        cursor,
+        order,
+      });
+      for await (const batchRel of enumerator._generator()) {
+        yield (batchRel._records ?? []) as T[];
+      }
+    })() as AsyncGenerator<T[]> & { size(): Promise<number> };
+    enumerator.size = size;
+    return enumerator;
+  }
+
+  /**
+   * Returns a BatchEnumerator that yields Relations scoped to each batch.
+   * Unlike findInBatches which yields arrays of records, this yields
+   * Relation objects that can be further refined, and supports batch-level
+   * operations like deleteAll/updateAll.
+   *
+   * Mirrors: ActiveRecord::Batches#in_batches (batches.rb:167)
+   */
+  inBatches<T extends Base>(
+    this: any,
+    opts: InBatchesOptions,
+    block: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
+  ): Promise<void>;
+  inBatches<T extends Base>(
+    this: any,
+    opts?: InBatchesOptions,
+  ): BatchEnumerator<LoadedRelation<Relation<T>>>;
+  inBatches<T extends Base>(
+    this: any,
+    {
+      of = 1000,
+      start,
+      finish,
+      order,
+      cursor: cursorOption,
+      errorOnIgnore,
+      load = false,
+      useRanges,
+    }: InBatchesOptions = {},
+    block?: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
+  ): BatchEnumerator<LoadedRelation<Relation<T>>> | Promise<void> {
+    const self = this;
+    const effectiveCursor = cursorOption ?? this.primaryKey;
+    const cursor = (Array.isArray(effectiveCursor) ? effectiveCursor : [effectiveCursor]).map(
+      String,
+    );
+    // `ensure_valid_options_for_batching!` reaches the schema cache, which is
+    // async here, so the validation runs when the batches are first pulled
+    // rather than at `in_batches` call time.
+    const ensureValidOptions = () =>
+      ensureValidOptionsForBatchingBang(self, cursor, start, finish, (order ?? "asc") as any);
+
+    if (this._orderClauses.length > 0) {
+      this.actOnIgnoredOrder(errorOnIgnore);
+    }
+
+    const batchOrders = buildBatchOrders(cursor, order as any);
+
+    const enumerator = block
+      ? null
+      : new BatchEnumerator<LoadedRelation<Relation<T>>>({
+          of,
+          start,
+          finish,
+          relation: self,
+          cursor,
+          order,
+          useRanges,
+        });
+
+    let remaining: number | null = null;
+    let batchLimit = of;
+    if (this._limitValue !== null) {
+      remaining = this._limitValue as number;
+      if (remaining < batchLimit) batchLimit = remaining;
+    }
+
+    let generator: () => AsyncGenerator<LoadedRelation<Relation<T>>>;
+    if (remaining === 0) {
+      generator = async function* () {};
+    } else if (this.loaded) {
+      const loadedBatches = batchOnLoadedRelation({
+        relation: this,
+        start,
+        finish,
+        cursor,
+        order: (order ?? "asc") as any,
+        batchLimit,
+      });
+      generator = async function* () {
+        await ensureValidOptions();
+        for (const batchRows of loadedBatches) {
+          const batchRel = self._clone();
+          batchRel._orderClauses = batchOrders.map(([col, dir]) =>
+            dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
+          );
+          batchRel._records = batchRows;
+          batchRel._loaded = true;
+          yield stripThenable(batchRel) as LoadedRelation<Relation<T>>;
+        }
+      };
+    } else {
+      generator = async function* () {
+        await ensureValidOptions();
+        for await (const { rows: batchRows, useRanges: batchUseRanges } of batchOnUnloadedRelation({
+          relation: self,
+          start,
+          finish,
+          cursor,
+          order: (order ?? "asc") as any,
+          batchLimit,
+          load,
+          remaining,
+          useRanges,
+        })) {
+          const batchRel = self._clone();
+          batchRel._orderClauses = batchOrders.map(([col, dir]) =>
+            dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
+          );
+          const tuples = batchRows.map((r) => cursor.map((c) => r.readAttribute(c)));
+          if (batchUseRanges && !load && cursor.length === 1 && tuples.length > 0) {
+            // Range-mode: emit `col >= first AND col <= last` (reversed for desc)
+            // instead of `col IN (...)`. Mirrors Rails apply_finish_limit path.
+            const col = cursor[0];
+            const dir = batchOrders[0][1];
+            const first = tuples[0][0];
+            const last = tuples[tuples.length - 1][0];
+            const attr = self.table.get(col);
+            const lo = dir === "desc" ? last : first;
+            const hi = dir === "desc" ? first : last;
+            batchRel._whereClause.predicates.push(attr.gteq(lo).and(attr.lteq(hi)));
+          } else if (cursor.length === 1) {
+            const ids = tuples.map((t: unknown[]) => t[0]);
+            batchRel._whereClause.predicates.push(
+              ...self.predicateBuilder.buildFromHash({ [cursor[0]]: ids }),
+            );
+          } else {
+            batchRel._whereClause.predicates.push(
+              ...self.predicateBuilder.buildComposite(cursor, tuples),
+            );
+          }
+          if (load) {
+            batchRel._records = batchRows;
+            batchRel._loaded = true;
+          }
+          yield stripThenable(batchRel);
+        }
+      } as () => AsyncGenerator<LoadedRelation<Relation<T>>>;
+    }
+
+    if (block) {
+      return (async () => {
+        for await (const batchRelation of generator()) {
+          await block(batchRelation);
+        }
+      })();
+    }
+
+    enumerator!._generator = generator;
+    return enumerator!;
+  }
 
   /** Mirrors: ActiveRecord::Batches#act_on_ignored_order (batches.rb:474-482). @internal */
   actOnIgnoredOrder(this: any, errorOnIgnore: boolean | undefined): void {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -121,13 +121,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "in_batches",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "instantiate_records",
     "call": "instantiate",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
@@ -23,6 +23,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation/batches.ts",
+    "rubyName": "in_batches",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/batches.ts",
     "rubyName": "record_cursor_values",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Two RFC 0107 `relation.ts` decomposition steps.

### `fan-out-batches-from-relation`

`findEach`, `findInBatches` and `inBatches` (265 lines of `relation.ts`)
implement `active_record/relation/batches.rb`. They now live in
`packages/activerecord/src/relation/batches.ts` next to the private helpers
they already called, mixed into `Relation` via the existing
`include(Relation, Batches)` — Rails' `relation.rb:68`
`include FinderMethods, ..., Batches, Explain, Delegation`.

Member order follows batches.rb source order: `find_each` (:36),
`find_in_batches` (:96), `in_batches` (:167), then `act_on_ignored_order`
(:474), which was already there.

Bodies move unchanged with one convergence: `this._loaded` becomes
`this.loaded`, which is what `batches.rb:212`'s `loaded?` reads. That retires
the `in_batches`/`loaded?` call-set row the move surfaced. The pre-existing
`in_batches`/`arel` baseline row moves with the method from
`relation.json` to `relation/batches.json` with its reason unchanged — net
baseline row count is unchanged.

Precise `Relation<T>` signatures for the three methods are declared in the
`Relation` interface (as `FinderMethods`' T-returning members already are);
`Included<>` can't carry the generic.

### `include-explain-into-relation`

Rails mixes `ActiveRecord::Explain` in on both sides — `base.rb:294`
`extend Explain` and `relation.rb:68` `include ... Explain ...` — so a
`Relation` receiver has `collecting_queries_for_explain` (explain.rb:9) and
the private `render_bind` (explain.rb:40). trails had only the class-level
half.

`explain.ts` now exports an `Explain` module object over its existing
definitions, and `relation.ts` does `include(Relation, Explain)`. `base.ts`'s
`extend`-side wiring is untouched and reads the same two function objects —
nothing is duplicated or reimplemented. `execExplain` is deliberately not a
member: it takes the receiving model class explicitly on the class side, and
`Relation` already carries its own mirror of `explain.rb:19-36`.

### Not in this PR

`wave-2c-grouped-calculation-and-query-method-stores` (RFC 0106) was bundled
with these two but its `execute_grouped_calculation` port does not fit under
the remaining LOC budget. It has been released back to the pool unclaimed and
untouched; nothing here overlaps it.

### Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `batches.test.ts`, `batches.trails.test.ts`, `explain.test.ts`,
  `relation/thenable.test.ts`, `relation/delegation.test.ts`,
  `scoping/named-scoping.test.ts`, `transactions.trails.test.ts` — 295 passed.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK.
- `pnpm parity:api:extra --package activerecord` — no novel names in
  `relation/batches.ts` or `explain.ts`.

Closes-story: fan-out-batches-from-relation
Closes-story: include-explain-into-relation
