### PR TITLE
refactor(activerecord): retire the _isEmptyRelation guard from finder entry points

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -24,7 +24,6 @@ export function _setAssociationRelationCtor(
 }
 import { applyThenable, stripThenable } from "../relation/thenable.js";
 import {
-  findNth as baseFindNth,
   findNthFromLast as baseFindNthFromLast,
   findNthWithLimit as baseFindNthWithLimit,
   performLast as basePerformLast,
@@ -2304,28 +2303,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return loaded.some((r) => this._identityFor(r) === targetId);
     }
     return loaded.includes(record);
-  }
-
-  /**
-   * Return the first associated record.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#first
-   */
-  override first(): Promise<T | null>;
-  override first(n: number): Promise<T[]>;
-  override async first(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
-    // Rails' CollectionProxy has no `first` override at all: `Relation#first`
-    // runs with `self` = the proxy and reaches the target through the overridden
-    // `find_nth_with_limit` (collection_proxy.rb:1140-1143), which is where the
-    // `load_target if find_from_target?` lives. We keep a body only for the
-    // limit validation and to skip `Relation#first`'s `_isEmptyRelation`
-    // short-circuit, which has no Rails counterpart and would swallow a loaded
-    // target sitting on a new-owner `1=0` seed. Everything else is
-    // `performFirst` verbatim: `first(n)` → `find_nth_with_limit(0, n)`,
-    // no-arg → `find_nth(0)` and its `@offsets` memo (finder_methods.rb:173-179).
-    if (n !== undefined) return this.findNthWithLimit(0, n);
-    return baseFindNth.call(this as any, 0);
   }
 
   /**

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -451,11 +451,6 @@ function hasReversibleOrder(rel: FinderRelation): boolean {
 
 /** @internal */
 export async function performFirst(this: FinderRelation, n?: number): Promise<any> {
-  // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
-  // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
-  // live association scope, so a saved owner's persisted FK is picked up instead
-  // of returning null.
-  if (this._isEmptyRelation()) return n !== undefined ? [] : null;
   // Rails: Relation#first(limit) → find_nth_with_limit(0, limit); no-arg
   // first → find_nth(0) → find_nth_with_limit(0, 1). find_nth_with_limit reads
   // the loaded cache when present, otherwise runs an ordered LIMIT query — and
@@ -488,15 +483,10 @@ export async function performLast(this: FinderRelation, n?: number): Promise<any
   // (finder_methods.rb:203). When the relation is already loaded — or carries a
   // `limit`/`offset` that a reverse-order query would otherwise discard — Rails
   // materializes the records and reads the tail in Ruby rather than issuing a
-  // fresh reversed query. This arm runs BEFORE the none short-circuit below, as
-  // in Rails, so a loaded relation reports its records even when its (stale)
-  // clauses would build an empty query.
+  // fresh reversed query.
   if (this.isLoaded || (this as any)._limitValue != null || (this as any)._offsetValue != null) {
     return findLast.call(this, n);
   }
-  // See performFirst: `_isEmptyRelation()` rebases a stale new-owner seed before
-  // reporting the none short-circuit. Rails has no counterpart.
-  if (this._isEmptyRelation()) return n !== undefined ? [] : null;
   let rel: any;
   if (!hasReversibleOrder(this)) {
     rel = orderByPk(this, "desc");


### PR DESCRIPTION
`Relation#first` / `#last` opened with a short-circuit Rails does not have:

```ts
if (this._isEmptyRelation()) return n !== undefined ? [] : null;
```

Rails' bodies are `limit ? find_nth_with_limit(0, limit) : find_nth(0)` (`vendor/rails/activerecord/lib/active_record/relation/finder_methods.rb:173-179`) and `return find_last(limit) if loaded? || has_limit_or_offset?` then the reverse-order query (`:202-208`). A `none` relation returns nothing because `NullRelation#exec_queries` yields `[]`, not because the finder checks a flag.

Both guards are gone. The none short-circuit still fires — from `toArray`'s `_isEmptyRelation()` chokepoint on the relation the finder builds, which is the exec path Rails uses — and the stale new-owner `1=0` seed is rebased there (`AssociationRelation`) and through `_finderScope()` (`CollectionProxy`), off the finder entry points.

`CollectionProxy#first` is deleted. Rails has no such override; the proxy reaches a loaded target through its `find_nth_with_limit` override, which carries the `load_target if find_from_target?` (`collection_proxy.rb:1140-1143`).

Relation, null-relation, finder-methods, collection-proxy and has-many association tests green locally; `parity:api:calls` and `parity:api:calls:args` both OK.

Closes-story: retire-is-empty-relation-guard-from-finder-entry-points