### PR TITLE
refactor(activerecord): inline update_all/delete_all statement build, converge performLast and calculations member order

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2951,66 +2951,59 @@ export class Relation<T extends Base> {
     // Mirrors Rails relation.rb#update_all: accepts a Hash, a SQL string, or an
     // Array [sql, *binds] (sanitize_sql_for_assignment). The blank/none checks
     // mirror Rails' order (blank precedes none?).
+    const table = this.table;
+    let values: [Nodes.Node, unknown][] | Nodes.SqlLiteral | Nodes.BoundSqlLiteral;
     if (Array.isArray(updates)) {
       const [sql, ...binds] = updates;
       if (!sql || typeof sql !== "string")
         throw new ArgumentError("Empty list of attributes to change");
       if (this._isEmptyRelation()) return 0;
       await this._materializeDeferredDistinctPkPredicates();
-      const boundSql = new Nodes.BoundSqlLiteral(
-        sql,
-        binds.map((v) => {
-          return _qm.normalizeBoundValue.call(this as any, v);
-        }),
-        {},
-      );
-      return this._execUpdateAll(boundSql);
-    }
-    if (typeof updates === "string") {
+      const normalizedBinds: unknown[] = [];
+      for (const v of binds) {
+        normalizedBinds.push(_qm.normalizeBoundValue.call(this as any, v));
+      }
+      values = new Nodes.BoundSqlLiteral(sql, normalizedBinds, {});
+    } else if (typeof updates === "string") {
       if (!updates) throw new ArgumentError("Empty list of attributes to change");
       if (this._isEmptyRelation()) return 0;
       await this._materializeDeferredDistinctPkPredicates();
-      return this._execUpdateAll(new Nodes.SqlLiteral(updates));
-    }
-    // Mirrors Rails: blank check precedes none? check (relation.rb:588-591).
-    if (Object.keys(updates).length === 0)
-      throw new ArgumentError("Empty list of attributes to change");
-    if (this._isEmptyRelation()) return 0;
-    await this._materializeDeferredDistinctPkPredicates();
+      values = new Nodes.SqlLiteral(updates);
+    } else {
+      // Mirrors Rails: blank check precedes none? check (relation.rb:588-591).
+      if (Object.keys(updates).length === 0)
+        throw new ArgumentError("Empty list of attributes to change");
+      if (this._isEmptyRelation()) return 0;
+      await this._materializeDeferredDistinctPkPredicates();
 
-    const table = this.table;
-    if (
-      this.model.lockingEnabled &&
-      !Object.prototype.hasOwnProperty.call(updates, this.model.lockingColumn)
-    ) {
-      const attr = table.get(this.model.lockingColumn);
-      updates[attr.name] = this._incrementAttribute(attr);
+      if (
+        this.model.lockingEnabled &&
+        !Object.prototype.hasOwnProperty.call(updates, this.model.lockingColumn)
+      ) {
+        const attr = table.get(this.model.lockingColumn);
+        updates[attr.name] = this._incrementAttribute(attr);
+      }
+      values = this._substituteValues(Object.entries(updates));
     }
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = this._substituteValues(
-      Object.entries(updates),
-    );
-    return this._execUpdateAll(updateValues);
-  }
 
-  private async _execUpdateAll(
-    updateValues: [Nodes.Node, unknown][] | Nodes.SqlLiteral | Nodes.BoundSqlLiteral,
-  ): Promise<number> {
-    const table = this.table;
+    // Mirrors `relation.rb:606-616`.
+    const arel = this._eagerLoadingForSql()
+      ? this.applyJoinDependency().arel()
+      : this.buildArel(this._conn());
+    arel.source.left = table;
+    const groupValuesArelColumns = this.arelColumns(
+      Array.from(new Set(this._groupColumns)),
+    ) as Nodes.Node[];
+    const havingClauseAst = this._havingClause.isEmpty() ? null : this._havingClause.ast;
     const primaryKey = this.primaryKey;
     let stmtAst;
     if (typeof primaryKey === "string" || Array.isArray(primaryKey)) {
-      const arel = this._eagerLoadingForSql()
-        ? this.applyJoinDependency().buildArel()
-        : this.buildArel(this._conn());
-      arel.source.left = table;
-      const havingAst = this._havingClause.isEmpty() ? null : this._havingClause.ast;
-      const groupColumns = this._groupColumns.map((col) => groupColumnToArel(col, table));
       const key = Array.isArray(primaryKey)
         ? primaryKey.map((pk) => table.get(pk))
         : table.get(primaryKey);
-      stmtAst = arel.compileUpdate(updateValues, key, havingAst, groupColumns).ast;
+      stmtAst = arel.compileUpdate(values, key, havingClauseAst, groupValuesArelColumns).ast;
     } else {
-      const um = new UpdateManager().table(table).set(updateValues);
+      const um = new UpdateManager().table(table).set(values);
       for (const node of this._whereClause.predicatesWithWrappedSqlLiterals()) {
         um.where(node);
       }
@@ -3063,41 +3056,43 @@ export class Relation<T extends Base> {
     }
 
     const table = this.table;
+    // Mirrors Rails `delete_all`: always run `build_arel` + `compile_delete`
+    // with the primary key, having clause, and group columns. For a
+    // limited/ordered/grouped delete the visitor rewrites it into
+    // `WHERE (pk...) IN (SELECT pk... ORDER BY ... LIMIT ...)`; for the
+    // unconstrained case it emits a plain `DELETE FROM ... WHERE`, identical
+    // to a hand-built DeleteManager. A composite primary key maps each column
+    // into a row-value tuple (`relation.rb`: `primary_key.map { |pk| table[pk] }`).
+    // Routing both PK shapes through one path keeps the TS port structurally
+    // faithful to Rails (no second code path to sync).
+    //
+    // Mirrors `relation.rb:1023`: when the relation requires eager loading
+    // (e.g. an `includes` promoted to a join by a `where`/`order` reference),
+    // build the arel from the join-dependency relation
+    // (`apply_join_dependency.arel`) instead of the plain `build_arel`. Rails
+    // passes `apply_join_dependency(eager_loading: group_values.empty?)`
+    // implicitly here (the no-arg default, finder_methods.rb:457), so a
+    // grouped delete skips the limit/offset materialization guard.
+    const arel = this._eagerLoadingForSql()
+      ? this.applyJoinDependency().arel()
+      : this.buildArel(this._conn());
+    // Mirrors `relation.rb:1024` (`arel.source.left = table`): force the FROM
+    // target back to the bare table before `compile_delete`. For the common
+    // and join cases `source.left` is already the table, but an explicit
+    // `from(custom)` would otherwise leave the DELETE targeting the custom
+    // FROM node rather than the model table.
+    arel.source.left = table;
+    const groupValuesArelColumns = this.arelColumns(
+      Array.from(new Set(this._groupColumns)),
+    ) as Nodes.Node[];
+    const havingClauseAst = this._havingClause.isEmpty() ? null : this._havingClause.ast;
     const primaryKey = this.model.primaryKey;
     let stmtAst;
     if (typeof primaryKey === "string" || Array.isArray(primaryKey)) {
-      // Mirrors Rails `delete_all`: always run `build_arel` + `compile_delete`
-      // with the primary key, having clause, and group columns. For a
-      // limited/ordered/grouped delete the visitor rewrites it into
-      // `WHERE (pk...) IN (SELECT pk... ORDER BY ... LIMIT ...)`; for the
-      // unconstrained case it emits a plain `DELETE FROM ... WHERE`, identical
-      // to a hand-built DeleteManager. A composite primary key maps each column
-      // into a row-value tuple (`relation.rb`: `primary_key.map { |pk| table[pk] }`).
-      // Routing both PK shapes through one path keeps the TS port structurally
-      // faithful to Rails (no second code path to sync).
-      //
-      // Mirrors `relation.rb:1023`: when the relation requires eager loading
-      // (e.g. an `includes` promoted to a join by a `where`/`order` reference),
-      // build the arel from the join-dependency relation
-      // (`apply_join_dependency.arel`) instead of the plain `build_arel`. Rails
-      // passes `apply_join_dependency(eager_loading: group_values.empty?)`
-      // implicitly here (the no-arg default, finder_methods.rb:457), so a
-      // grouped delete skips the limit/offset materialization guard.
-      const arel = this._eagerLoadingForSql()
-        ? this.applyJoinDependency().buildArel()
-        : this.buildArel(this._conn());
-      // Mirrors `relation.rb:1024` (`arel.source.left = table`): force the FROM
-      // target back to the bare table before `compile_delete`. For the common
-      // and join cases `source.left` is already the table, but an explicit
-      // `from(custom)` would otherwise leave the DELETE targeting the custom
-      // FROM node rather than the model table.
-      arel.source.left = table;
-      const havingAst = this._havingClause.isEmpty() ? null : this._havingClause.ast;
-      const groupColumns = this._groupColumns.map((col) => groupColumnToArel(col, table));
       const key = Array.isArray(primaryKey)
         ? primaryKey.map((pk) => table.get(pk))
         : table.get(primaryKey);
-      stmtAst = arel.compileDelete(key, havingAst, groupColumns).ast;
+      stmtAst = arel.compileDelete(key, havingClauseAst, groupValuesArelColumns).ast;
     } else {
       // No primary key — fall back to a plain DeleteManager.
       const dm = new DeleteManager().from(table);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -78,11 +78,7 @@ import { Result } from "./result.js";
 import { ScopeRegistry } from "./scoping.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { include, type Included } from "@blazetrails/activesupport";
-import {
-  Calculations,
-  type CalculationMethods,
-  groupColumnToArel,
-} from "./relation/calculations.js";
+import { Calculations, type CalculationMethods } from "./relation/calculations.js";
 import { FinderMethods } from "./relation/finder-methods.js";
 import { SpawnMethods } from "./relation/spawn-methods.js";
 import { FromClause } from "./relation/from-clause.js";

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -630,60 +630,61 @@ export function asyncCount(
   return this.count(columnName);
 }
 
-/**
- * Mirrors: ActiveRecord::Calculations#calculate (calculations.rb:217-246).
- */
-export async function calculate(
+export async function performAverage(
   this: CalculationRelation,
-  operation: string,
-  columnName?: string | Nodes.Node | number | null,
-): Promise<unknown> {
-  operation = operation.toLowerCase();
+  column: string | Nodes.Node,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  // Returns `unknown` (not just number) because non-numeric column types
+  // — interval (Duration), money, time — route through the column type's
+  // deserialize and yield a domain object. Rails' AVG return type is
+  // similarly polymorphic (BigDecimal for integer/decimal, Duration for
+  // interval, etc.). Numeric averages still narrow to JS number at the
+  // call site.
+  return calculate.call(this, "average", column);
+}
 
-  // Rails' `@none`. `_isEmptyRelation()` is the shared none-short-circuit
-  // chokepoint: on an AssociationRelation it first rebases a stale new-owner
-  // `1=0` seed onto the live association scope, so a calculation on a relation
-  // spawned off a new owner picks up the persisted FK after `save`.
-  if (this._isEmptyRelation()) {
-    switch (operation) {
-      case "count":
-      case "sum":
-        return any(this.groupValues) ? new Map() : 0;
-      case "average":
-      case "minimum":
-      case "maximum":
-        return any(this.groupValues) ? new Map() : null;
-    }
-  }
+/**
+ * Mirrors: ActiveRecord::Calculations#async_average (calculations.rb:122).
+ */
+export function asyncAverage(
+  this: CalculationRelation,
+  columnName: string,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  return this.average(columnName);
+}
 
-  if (hasInclude(this, columnName ?? null)) {
-    // Rails takes `relation = apply_join_dependency`; a trails `Relation` is
-    // thenable, so the joined relation is delivered to a block instead (the
-    // block form `apply_join_dependency` also has).
-    return this._applyJoinDependencyAsync(async (relation) => {
-      if (operation === "count") {
-        if (
-          !this._isDistinct &&
-          !isDistinctSelect(this, columnName ?? (await selectForCount(this)))
-        ) {
-          relation.distinctBang();
-          const primaryKey = this.model.primaryKey;
-          relation._selectColumns =
-            primaryKey == null
-              ? [new Nodes.SqlLiteral("*")]
-              : Array.isArray(primaryKey)
-                ? [...primaryKey]
-                : [primaryKey];
-        }
-        // PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
-        if (this.groupValues.length === 0) relation._orderClauses = [];
-      }
+export async function performMinimum(
+  this: CalculationRelation,
+  column: string | Nodes.Node,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  return calculate.call(this, "minimum", column);
+}
 
-      return relation.calculate(operation, columnName);
-    });
-  } else {
-    return performCalculation(this, operation, columnName ?? null);
-  }
+/**
+ * Mirrors: ActiveRecord::Calculations#async_minimum (calculations.rb:137).
+ */
+export function asyncMinimum(
+  this: CalculationRelation,
+  columnName: string,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  return this.minimum(columnName);
+}
+
+export async function performMaximum(
+  this: CalculationRelation,
+  column: string | Nodes.Node,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  return calculate.call(this, "maximum", column);
+}
+
+/**
+ * Mirrors: ActiveRecord::Calculations#async_maximum (calculations.rb:152).
+ */
+export function asyncMaximum(
+  this: CalculationRelation,
+  columnName: string,
+): Promise<unknown | null | Map<unknown, unknown>> {
+  return this.maximum(columnName);
 }
 
 /**
@@ -760,61 +761,60 @@ export function asyncSum(
   return this.sum(identityOrColumn);
 }
 
-export async function performAverage(
-  this: CalculationRelation,
-  column: string | Nodes.Node,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  // Returns `unknown` (not just number) because non-numeric column types
-  // — interval (Duration), money, time — route through the column type's
-  // deserialize and yield a domain object. Rails' AVG return type is
-  // similarly polymorphic (BigDecimal for integer/decimal, Duration for
-  // interval, etc.). Numeric averages still narrow to JS number at the
-  // call site.
-  return calculate.call(this, "average", column);
-}
-
 /**
- * Mirrors: ActiveRecord::Calculations#async_average (calculations.rb:122).
+ * Mirrors: ActiveRecord::Calculations#calculate (calculations.rb:217-246).
  */
-export function asyncAverage(
+export async function calculate(
   this: CalculationRelation,
-  columnName: string,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  return this.average(columnName);
-}
+  operation: string,
+  columnName?: string | Nodes.Node | number | null,
+): Promise<unknown> {
+  operation = operation.toLowerCase();
 
-export async function performMinimum(
-  this: CalculationRelation,
-  column: string | Nodes.Node,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  return calculate.call(this, "minimum", column);
-}
+  // Rails' `@none`. `_isEmptyRelation()` is the shared none-short-circuit
+  // chokepoint: on an AssociationRelation it first rebases a stale new-owner
+  // `1=0` seed onto the live association scope, so a calculation on a relation
+  // spawned off a new owner picks up the persisted FK after `save`.
+  if (this._isEmptyRelation()) {
+    switch (operation) {
+      case "count":
+      case "sum":
+        return any(this.groupValues) ? new Map() : 0;
+      case "average":
+      case "minimum":
+      case "maximum":
+        return any(this.groupValues) ? new Map() : null;
+    }
+  }
 
-/**
- * Mirrors: ActiveRecord::Calculations#async_minimum (calculations.rb:137).
- */
-export function asyncMinimum(
-  this: CalculationRelation,
-  columnName: string,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  return this.minimum(columnName);
-}
+  if (hasInclude(this, columnName ?? null)) {
+    // Rails takes `relation = apply_join_dependency`; a trails `Relation` is
+    // thenable, so the joined relation is delivered to a block instead (the
+    // block form `apply_join_dependency` also has).
+    return this._applyJoinDependencyAsync(async (relation) => {
+      if (operation === "count") {
+        if (
+          !this._isDistinct &&
+          !isDistinctSelect(this, columnName ?? (await selectForCount(this)))
+        ) {
+          relation.distinctBang();
+          const primaryKey = this.model.primaryKey;
+          relation._selectColumns =
+            primaryKey == null
+              ? [new Nodes.SqlLiteral("*")]
+              : Array.isArray(primaryKey)
+                ? [...primaryKey]
+                : [primaryKey];
+        }
+        // PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
+        if (this.groupValues.length === 0) relation._orderClauses = [];
+      }
 
-export async function performMaximum(
-  this: CalculationRelation,
-  column: string | Nodes.Node,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  return calculate.call(this, "maximum", column);
-}
-
-/**
- * Mirrors: ActiveRecord::Calculations#async_maximum (calculations.rb:152).
- */
-export function asyncMaximum(
-  this: CalculationRelation,
-  columnName: string,
-): Promise<unknown | null | Map<unknown, unknown>> {
-  return this.maximum(columnName);
+      return relation.calculate(operation, columnName);
+    });
+  } else {
+    return performCalculation(this, operation, columnName ?? null);
+  }
 }
 
 /**
@@ -1197,17 +1197,17 @@ function inQueryConnection<A extends unknown[], R>(
 }
 
 export const Calculations = {
-  calculate: inQueryConnection(calculate),
   count: inQueryConnection(performCount),
   asyncCount,
-  sum: inQueryConnection(performSum),
-  asyncSum,
   average: inQueryConnection(performAverage),
   asyncAverage,
   minimum: inQueryConnection(performMinimum),
   asyncMinimum,
   maximum: inQueryConnection(performMaximum),
   asyncMaximum,
+  sum: inQueryConnection(performSum),
+  asyncSum,
+  calculate: inQueryConnection(calculate),
   // `pluck` / `ids` do their own `with_connection` (and `skip_query_cache_if_necessary`)
   // around the one query they issue, exactly as calculations.rb:316/396 does —
   // so they are NOT wrapped in `inQueryConnection`, which is the seam for the

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -82,28 +82,6 @@ interface AliasingConnection {
   tableAliasLength(): number;
 }
 
-/**
- * Qualify a GROUP BY column string as an Arel attribute node when it is a
- * plain SQL identifier (letters, digits, underscores), mirroring Rails'
- * `arel_columns` / `build_group` behaviour. Positional args ("1"), cast
- * expressions ("created_at::date"), and SQL expressions pass through as
- * SqlLiteral.
- *
- * @internal exported so Relation can share the implementation.
- */
-export function groupColumnToArel(col: string | Nodes.Node, table: Table): Nodes.Node {
-  if (col instanceof Nodes.Node) return col;
-  const trimmed = col.trim();
-  // Plain identifier → qualify via model table (e.g. "created_at" → "orders"."created_at").
-  if (/^[A-Za-z_]\w*$/.test(trimmed)) return table.get(trimmed);
-  // Simple table.column → create a cross-table Attribute (e.g. "authors.name" → "authors"."name").
-  // Mirrors Rails' arel_columns which calls table[column] on the referenced table.
-  const dotMatch = trimmed.match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)$/);
-  if (dotMatch) return new Table(dotMatch[1]).get(dotMatch[2]);
-  // SQL expressions, casts, positional args, etc. pass through as raw SQL.
-  return new Nodes.SqlLiteral(trimmed);
-}
-
 interface CalculationConnection {
   adapterName: AdapterName;
   visitor?: { compile(node: any): string; compileWithBinds?(node: any): [string, unknown[]] };

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -442,13 +442,6 @@ function hasOrder(rel: FinderRelation): boolean {
   return rel._orderClauses.length > 0 || rel._rawOrderClauses.length > 0;
 }
 
-function hasReversibleOrder(rel: FinderRelation): boolean {
-  // Only _orderClauses can be reversed by reverseOrder().
-  // _rawOrderClauses (e.g. from inOrderOf) contain arbitrary SQL
-  // that can't be reliably reversed.
-  return rel._orderClauses.length > 0;
-}
-
 /** @internal */
 export async function performFirst(this: FinderRelation, n?: number): Promise<any> {
   // Rails: Relation#first(limit) → find_nth_with_limit(0, limit); no-arg
@@ -469,14 +462,6 @@ export async function performFirstBang(this: FinderRelation): Promise<any> {
   return record;
 }
 
-function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
-  const pk = rel.primaryKey;
-  if (Array.isArray(pk)) {
-    return rel.order(...pk.map((col: string) => ({ [col]: direction })));
-  }
-  return rel.order({ [pk]: direction });
-}
-
 /** @internal */
 export async function performLast(this: FinderRelation, n?: number): Promise<any> {
   // `return find_last(limit) if loaded? || has_limit_or_offset?`
@@ -487,20 +472,12 @@ export async function performLast(this: FinderRelation, n?: number): Promise<any
   if (this.isLoaded || (this as any)._limitValue != null || (this as any)._offsetValue != null) {
     return findLast.call(this, n);
   }
-  let rel: any;
-  if (!hasReversibleOrder(this)) {
-    rel = orderByPk(this, "desc");
-  } else {
-    rel = this.reverseOrder();
-  }
-  if (n !== undefined) {
-    rel = rel.limit(n);
-    const records = await rel.toArray();
-    return records.reverse();
-  }
-  rel = rel.limit(1);
-  const records = await rel.toArray();
-  return records[0] ?? null;
+  // `result = ordered_relation.limit(limit); result = result.reverse_order!;
+  //  limit ? result.reverse : result.first` (finder_methods.rb:205-207).
+  let result: any = orderedRelation.call(this).limit(n ?? null);
+  result = result.reverseOrderBang();
+  if (n !== undefined) return (await result.toArray()).reverse();
+  return await performFirst.call(result);
 }
 
 /** @internal */

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1485,11 +1485,24 @@ function reverseOrderBang(this: QueryMethodsHost): any {
   // false for an Arel node (it has no #empty?), so routing clauses through it
   // would drop every Ordering. Only nil/blank-string clauses are blank in this
   // list; Arel nodes never are.
+  // `_rawOrderClauses` is the trails-side carrier for order SQL Rails keeps in
+  // the same `order_values` list, so `reverse_sql_order`'s String branch owns
+  // them here rather than at a caller-side "is this order reversible" branch.
+  const rawClauses = this._rawOrderClauses;
+  if (rawClauses.length > 0) {
+    this._rawOrderClauses = (reverseSqlOrder.call(this, rawClauses) as string[]).map((clause) =>
+      String(clause),
+    );
+  }
   const clauses = this._orderClauses.filter(
     (clause) => clause != null && !(typeof clause === "string" && /^\s*$/.test(clause)),
   );
   if (clauses.length === 0) {
-    this._orderClauses = reverseSqlOrder.call(this, []) as typeof this._orderClauses;
+    // A raw order clause is still an order_values entry in Rails, so the
+    // default ORDER BY <pk> DESC branch does not apply when one is present.
+    if (rawClauses.length === 0) {
+      this._orderClauses = reverseSqlOrder.call(this, []) as typeof this._orderClauses;
+    }
     return this;
   }
   this._orderClauses = clauses.map((clause) => {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1485,6 +1485,7 @@ function reverseOrderBang(this: QueryMethodsHost): any {
   // false for an Arel node (it has no #empty?), so routing clauses through it
   // would drop every Ordering. Only nil/blank-string clauses are blank in this
   // list; Arel nodes never are.
+  //
   // `_rawOrderClauses` is the trails-side carrier for order SQL Rails keeps in
   // the same `order_values` list, so `reverse_sql_order`'s String branch owns
   // them here rather than at a caller-side "is this order reversible" branch.

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -58,27 +58,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "arel",
-    "reason": "Surfaced, not introduced (RFC 0107 fan-out): relation.ts's updateAll/deleteAll build the statement in the private helpers _execUpdateAll/_execDeleteAll, which Rails inlines into update_all/delete_all (relation.rb:606-616, :1023-1033) — so the gate reads only the outer body and cannot see the helper's `applyJoinDependency()._buildArel()` / `groupColumnToArel(...)`. The rows appeared when `pluck`/`ids` moved to relation/calculations.ts and took relation.ts's last `arel()`/`arelColumns(...)` call sites with them. The real convergence is inlining the two helpers back per CLAUDE.md's Decomposition rule; tracked separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "arel_columns",
-    "reason": "Surfaced, not introduced (RFC 0107 fan-out): relation.ts's updateAll/deleteAll build the statement in the private helpers _execUpdateAll/_execDeleteAll, which Rails inlines into update_all/delete_all (relation.rb:606-616, :1023-1033) — so the gate reads only the outer body and cannot see the helper's `applyJoinDependency()._buildArel()` / `groupColumnToArel(...)`. The rows appeared when `pluck`/`ids` moved to relation/calculations.ts and took relation.ts's last `arel()`/`arelColumns(...)` call sites with them. The real convergence is inlining the two helpers back per CLAUDE.md's Decomposition rule; tracked separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "order:primaryKey,applyJoinDependency",
-    "reason": "Baseline (RFC 0084): ORDER-only divergence seeded when the call-sequence comparison landed — the port makes every call Rails makes, in a different sequence; pending per-body control-flow convergence review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "exec_main_query",
     "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -159,20 +138,6 @@
     "rubyName": "to_sql",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "arel",
-    "reason": "Surfaced, not introduced (RFC 0107 fan-out): relation.ts's updateAll/deleteAll build the statement in the private helpers _execUpdateAll/_execDeleteAll, which Rails inlines into update_all/delete_all (relation.rb:606-616, :1023-1033) — so the gate reads only the outer body and cannot see the helper's `applyJoinDependency()._buildArel()` / `groupColumnToArel(...)`. The rows appeared when `pluck`/`ids` moved to relation/calculations.ts and took relation.ts's last `arel()`/`arelColumns(...)` call sites with them. The real convergence is inlining the two helpers back per CLAUDE.md's Decomposition rule; tracked separately."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "arel_columns",
-    "reason": "Surfaced, not introduced (RFC 0107 fan-out): relation.ts's updateAll/deleteAll build the statement in the private helpers _execUpdateAll/_execDeleteAll, which Rails inlines into update_all/delete_all (relation.rb:606-616, :1023-1033) — so the gate reads only the outer body and cannot see the helper's `applyJoinDependency()._buildArel()` / `groupColumnToArel(...)`. The rows appeared when `pluck`/`ids` moved to relation/calculations.ts and took relation.ts's last `arel()`/`arelColumns(...)` call sites with them. The real convergence is inlining the two helpers back per CLAUDE.md's Decomposition rule; tracked separately."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Three of the four bundled stories. `collection-proxy-delegate-query-method-bangs-to-scope` is **released back to the queue**, not shipped here: delegating the bang half also requires deleting `_installMutationTracker` / `_cpMutated` / `_relationStateDiverged`, the new-owner seed rebase (`_seededNoneNewOwner`, `_maybeRebaseProxySeed`, the `_isEmptyRelation` override) and the divergence branches in ~10 `CollectionProxy` methods — on its own that is at/over the LOC ceiling and is the highest-regression-risk piece in the bundle. It deserves its own PR.

## What's here

**`inline-exec-update-delete-all-helpers`** — `_execUpdateAll` is inlined into `updateAll` (there was no `_execDeleteAll` left on main); both bodies now follow `relation.rb:606-616` / `:1023-1033` line for line: `arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)`, `arel.source.left = table`, `arel_columns(group_values.uniq)`, `having_clause.ast unless empty?`, then the key. The trails-only `groupColumnToArel(...)` map is replaced by the Rails call `arelColumns(...)`, and `this.arel()` replaces `this._buildArel()`. Five baseline rows deleted by hand from `scripts/api-compare/call-mismatches-exclude/activerecord/relation.json` (the four `arel`/`arel_columns` rows plus the `delete_all` order row the hoist converged); no rows added.

**`perform-last-reverse-order-arm-uses-ordered-relation`** — `performLast` is now `orderedRelation.call(this).limit(n ?? null)` → `reverseOrderBang()` → `n !== undefined ? records.reverse() : first` (`finder_methods.rb:204-208`). `hasReversibleOrder` and `orderByPk` are deleted. The irreversibility concern they encoded moves into `reverseOrderBang`, where Rails' `reverse_order!` owns it: `_rawOrderClauses` (trails' carrier for order SQL Rails keeps in the same `order_values` list) go through `reverse_sql_order`'s String branch, and a raw clause suppresses the empty-order `ORDER BY <pk> DESC` default just as a non-empty `order_values` does in Rails.

**`converge-calculations-member-order-to-rails`** — pure reordering in `relation/calculations.ts`: `sum`/`asyncSum` move after `maximum`, `calculate` after `sum` (calculations.rb :94, :116, :131, :146, :172, :217). The `Calculations` module object's key order follows. No body or signature changes.

## Verification

- `pnpm typecheck`, `eslint` on the touched files: clean.
- `pnpm parity:api:calls` and `parity:api:calls:args`: green, no new rows; the unreviewed marks were already tight after the deletions.
- `pnpm parity:api:extra --package activerecord`: no novel surface.
- Local: `finder`, `relations`, `relation`, `calculations`, `persistence`, `associations`, `querying`, `querying-methods-delegation`, plus the `.trails` twins — 1300+ tests green on SQLite. PG/MySQL via CI.

Closes-story: perform-last-reverse-order-arm-uses-ordered-relation
Closes-story: converge-calculations-member-order-to-rails
Closes-story: inline-exec-update-delete-all-helpers