### PR TITLE
refactor(activerecord): move the finder_methods.rb members out of relation.ts

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -34,7 +34,6 @@ import {
 } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { isStiSubclass } from "./inheritance.js";
-import { isBaseInstance } from "./relation/predicate-builder/is-base-instance.js";
 import { QueryAttribute } from "./relation/query-attribute.js";
 import {
   underscore as _toUnderscore,
@@ -2148,8 +2147,9 @@ export class Relation<T extends Base> {
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
     if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
-    if (this._loaded) return this._records.length > 0;
-    return this.exists();
+    // Rails relation.rb `any?` is `!empty?` — the `loaded?` short-circuit lives
+    // in `empty?` (relation.rb:271-274), not here.
+    return !(await this.isEmpty());
   }
 
   /**
@@ -2903,80 +2903,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Check if any records exist, optionally with conditions.
-   *
-   * Mirrors: ActiveRecord::Relation#exists? — ending in
-   * `skip_query_cache_if_necessary { with_connection { |c|
-   * c.select_rows(relation.arel, "#{model.name} Exists?").size == 1 } }`
-   * (finder_methods.rb:377-381), the cached read path.
-   */
-  async exists(conditions?: Record<string, unknown> | unknown): Promise<boolean> {
-    if (this._isEmptyRelation()) return false;
-    // Rails FinderMethods#exists?: `return false if !conditions` — treats an
-    // explicit `false` / `null` argument as "no match possible". This precedes
-    // the `if eager_loading?` branch, so it short-circuits before the
-    // eager-load validation below (finder_methods.rb:367-369).
-    if (conditions === false || conditions === null) return false;
-    // Rails FinderMethods#exists?: `return false if !conditions || limit_value == 0`
-    // (finder_methods.rb:367). A relation limited to zero rows can never match, so
-    // short-circuit to false without emitting any query.
-    if (this.limitValue === 0) return false;
-    // Rails FinderMethods#exists? (finder_methods.rb:360-364): reject an
-    // ActiveRecord instance argument with `if Base === conditions` before any
-    // query is built. Detect it via the inherited `_isActiveRecordBase` marker
-    // so a model of any class (not just this relation's) is caught.
-    // Rails runs this Base check just *before* `return false if !conditions`;
-    // we run it just after. The branches are mutually exclusive (an AR instance
-    // is never `false`/`null`), so the order is behaviorally identical.
-    if (isBaseInstance(conditions)) {
-      throw new ArgumentError(
-        "You are passing an instance of ActiveRecord::Base to `exists?`. " +
-          "Please pass the id of the object by calling `.id`.",
-      );
-    }
-    // Rails exists? then routes through apply_join_dependency when eager
-    // loading, raising EagerLoadPolymorphicError for polymorphic specs.
-    this._checkEagerLoadable();
-    // Mirrors Rails FinderMethods#exists? `if eager_loading?` (finder_methods.rb:369):
-    // the eager-load check precedes construct_relation_for_exists, and conditions
-    // thread through to the recursion (`apply_join_dependency(eager_loading: false)
-    // .exists?(conditions)`) — the hardcoded `false` skips the limit/offset guard.
-    if (this._eagerLoadingForSql()) {
-      return this.applyJoinDependency({ eagerLoading: false }).exists(conditions);
-    }
-    // Mirrors Rails FinderMethods#construct_relation_for_exists
-    // (finder_methods.rb:438): shape the existence probe and apply the argument's
-    // `case conditions` (Array/Hash → where!, else → where!(primary_key =>
-    // conditions)) in one place — `exists?` no longer reimplements that
-    // case-analysis. When `distinct_value && offset_value` keep the relation's
-    // select/distinct/group/having/offset and drop only the order
-    // (`except(:order).limit!(1)`); otherwise `except(:select, :distinct,
-    // :order)._select!(ONE_AS_ONE).limit!(1)` — group/having/offset survive.
-    // `undefined` is our `:none` sentinel, so the helper adds no where!. Building
-    // the probe through the real relation reuses the shared select-list builder,
-    // so the distinct+offset branch's default `*` projection is `ignoredColumns`-
-    // aware, matching Rails' `build_select`.
-    const probe: Relation<T> = this.constructRelationForExists(conditions);
-    // Resolve any deferred distinct-PK subquery markers to a literal id list
-    // before compiling the probe (Rails materializes at `.where()`-build time).
-    await probe._materializeDeferredDistinctPkPredicates();
-    // Rails: `return false if relation.where_clause.contradiction?`
-    // (finder_methods.rb:375) — evaluated on the post-construct relation.
-    if (probe.whereClause.isContradiction()) return false;
-    // Tag the probe query `<Model> Exists?` — the name Rails passes to its
-    // existence query (`select_rows(relation.arel, "#{model.name} Exists?")`,
-    // finder_methods.rb) — so LogSubscriber labels it instead of falling back
-    // to the adapter's generic "SQL" default.
-    const [existsSql, existsBinds] = this._compileAstWithBinds(probe.toArel().ast);
-    return await this.skipQueryCacheIfNecessary(() =>
-      this.withConnection(
-        async (c) =>
-          (await c.selectRows(existsSql, `${this.model.name} Exists?`, existsBinds)).length === 1,
-      ),
-    );
-  }
-
-  /**
    * Update all matching records.
    *
    * Mirrors: ActiveRecord::Relation#update_all
@@ -3513,17 +3439,6 @@ export class Relation<T extends Base> {
     const relation = this.except("includes", "eagerLoad", "preload");
     QueryMethodBangs.joinsBang.call(relation as any, jd as any);
     return run(relation);
-  }
-
-  /**
-   * Mirror Rails `using_limitable_reflections?` (finder_methods.rb:487):
-   * `reflections.none?(&:collection?)` — a set of reflections is limitable
-   * when none of them is a collection association.
-   *
-   * @internal
-   */
-  usingLimitableReflections(reflections: Array<{ isCollection(): boolean }>): boolean {
-    return reflections.every((r) => !r.isCollection());
   }
 
   /** Eager-load specs that `apply_join_dependency` would join (eager_load ∪ includes). */
@@ -4714,51 +4629,6 @@ export class Relation<T extends Base> {
     return this;
   }
 
-  /**
-   * Check if the given record is present in the relation.
-   *
-   * Mirrors: ActiveRecord::Relation#include? (finder_methods.rb:389-407).
-   * A non-model argument short-circuits to `false` without querying. A loaded
-   * relation — or one carrying offset/limit/having — compares in memory; an
-   * unloaded relation without those issues a cheap `exists?(id)` rather than
-   * materializing every row.
-   */
-  async include(record: T): Promise<boolean> {
-    if (!(record instanceof this.model)) return false;
-    if (
-      this.isLoaded ||
-      this.offsetValue !== null ||
-      this.limitValue !== null ||
-      !this.havingClause.isEmpty()
-    ) {
-      const records = await this.toArray();
-      return records.some((r) => r.equals(record));
-    }
-    // Unloaded fast path: probe existence by primary key. The composite-PK arm
-    // (Rails `record.class.composite_primary_key?`) is a `primary_key.zip(id)`
-    // hash rather than the tuple, which exists()'s array branch would read as
-    // `[sql, ...binds]`.
-    const recordClass = record.constructor as typeof Base;
-    const id = recordClass.compositePrimaryKey
-      ? Object.fromEntries(
-          (recordClass.primaryKey as string[]).map((column, index) => [
-            column,
-            (record.id as unknown[])[index],
-          ]),
-        )
-      : record.id;
-
-    return this.exists(id);
-  }
-
-  /**
-   * Alias of {@link include} — mirrors `alias :member? :include?`
-   * (finder_methods.rb:407).
-   */
-  member(record: T): Promise<boolean> {
-    return this.include(record);
-  }
-
   // ---------------------------------------------------------------------------
   // Missing relation.rb methods — accessors, cache keys, scoping
   // ---------------------------------------------------------------------------
@@ -5590,6 +5460,9 @@ export interface Relation<T extends Base>
   fortyTwoBang(): Promise<T>;
   secondToLastBang(): Promise<T>;
   thirdToLastBang(): Promise<T>;
+  exists(conditions?: Record<string, unknown> | unknown): Promise<boolean>;
+  include(record: T): Promise<boolean>;
+  member(record: T): Promise<boolean>;
   findOrCreateByBang(
     conditions: Record<string, unknown>,
     extra?: Record<string, unknown>,
@@ -5613,6 +5486,8 @@ export interface Relation<T extends Base>
   relationWith(values: Record<string, unknown>): Relation<T>;
   /** @internal */
   constructRelationForExists(conditions: unknown): Relation<T>;
+  /** @internal */
+  usingLimitableReflections(reflections: Array<{ isCollection(): boolean }>): boolean;
   /** @internal */
   findWithIds(ids: unknown[]): Promise<T | T[]>;
   /** @internal */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2142,13 +2142,12 @@ export class Relation<T extends Base> {
   /**
    * Check if there are any matching records.
    *
-   * Mirrors: ActiveRecord::Relation#any?
+   * Mirrors: ActiveRecord::Relation#any? (relation.rb:391-396) — `!empty?`;
+   * the `loaded?` short-circuit lives in `empty?` (relation.rb:362-370).
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
     if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
-    // Rails relation.rb `any?` is `!empty?` — the `loaded?` short-circuit lives
-    // in `empty?` (relation.rb:271-274), not here.
     return !(await this.isEmpty());
   }
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -708,61 +708,33 @@ export async function exists(
   conditions?: Record<string, unknown> | unknown,
 ): Promise<boolean> {
   if (this._isEmptyRelation()) return false;
-  // Rails FinderMethods#exists?: `return false if !conditions` — treats an
-  // explicit `false` / `null` argument as "no match possible". This precedes
-  // the `if eager_loading?` branch, so it short-circuits before the
-  // eager-load validation below (finder_methods.rb:367-369).
-  if (conditions === false || conditions === null) return false;
-  // Rails FinderMethods#exists?: `return false if !conditions || limit_value == 0`
-  // (finder_methods.rb:367). A relation limited to zero rows can never match, so
-  // short-circuit to false without emitting any query.
-  if (this.limitValue === 0) return false;
-  // Rails FinderMethods#exists? (finder_methods.rb:360-364): reject an
-  // ActiveRecord instance argument with `if Base === conditions` before any
-  // query is built. Detect it via the inherited `_isActiveRecordBase` marker
-  // so a model of any class (not just this relation's) is caught.
-  // Rails runs this Base check just *before* `return false if !conditions`;
-  // we run it just after. The branches are mutually exclusive (an AR instance
-  // is never `false`/`null`), so the order is behaviorally identical.
+  // `Base === conditions` (finder_methods.rb:360) — detected via the inherited
+  // `_isActiveRecordBase` marker so a model of any class (not just this
+  // relation's) is caught.
   if (isBaseInstance(conditions)) {
     throw new ArgumentError(
       "You are passing an instance of ActiveRecord::Base to `exists?`. " +
         "Please pass the id of the object by calling `.id`.",
     );
   }
-  // Rails exists? then routes through apply_join_dependency when eager
-  // loading, raising EagerLoadPolymorphicError for polymorphic specs.
+  // `return false if !conditions || limit_value == 0` (finder_methods.rb:367).
+  // Ruby's `!conditions` is true only for nil/false, so `undefined` — our
+  // stand-in for the `:none` default, a truthy Symbol in Ruby — passes through.
+  if (conditions === false || conditions === null || this.limitValue === 0) return false;
+  // Rails builds the JoinDependency inside `apply_join_dependency`
+  // (finder_methods.rb:370) even on the arm that never reaches it, so the
+  // EagerLoadPolymorphicError it raises for a polymorphic spec has to be
+  // surfaced here rather than only where the joins are actually built.
   this._checkEagerLoadable();
-  // Mirrors Rails FinderMethods#exists? `if eager_loading?` (finder_methods.rb:369):
-  // the eager-load check precedes construct_relation_for_exists, and conditions
-  // thread through to the recursion (`apply_join_dependency(eager_loading: false)
-  // .exists?(conditions)`) — the hardcoded `false` skips the limit/offset guard.
   if (this._eagerLoadingForSql()) {
     return this.applyJoinDependency({ eagerLoading: false }).exists(conditions);
   }
-  // Mirrors Rails FinderMethods#construct_relation_for_exists
-  // (finder_methods.rb:438): shape the existence probe and apply the argument's
-  // `case conditions` (Array/Hash → where!, else → where!(primary_key =>
-  // conditions)) in one place — `exists?` no longer reimplements that
-  // case-analysis. When `distinct_value && offset_value` keep the relation's
-  // select/distinct/group/having/offset and drop only the order
-  // (`except(:order).limit!(1)`); otherwise `except(:select, :distinct,
-  // :order)._select!(ONE_AS_ONE).limit!(1)` — group/having/offset survive.
-  // `undefined` is our `:none` sentinel, so the helper adds no where!. Building
-  // the probe through the real relation reuses the shared select-list builder,
-  // so the distinct+offset branch's default `*` projection is `ignoredColumns`-
-  // aware, matching Rails' `build_select`.
   const relation = this.constructRelationForExists(conditions);
   // Resolve any deferred distinct-PK subquery markers to a literal id list
-  // before compiling the probe (Rails materializes at `.where()`-build time).
+  // before compiling: Arel has no such marker, so Rails materializes them at
+  // `.where()`-build time and never carries one into `arel`.
   await relation._materializeDeferredDistinctPkPredicates();
-  // Rails: `return false if relation.where_clause.contradiction?`
-  // (finder_methods.rb:375) — evaluated on the post-construct relation.
   if (relation.whereClause.isContradiction()) return false;
-  // Tag the probe query `<Model> Exists?` — the name Rails passes to its
-  // existence query (`select_rows(relation.arel, "#{model.name} Exists?")`,
-  // finder_methods.rb) — so LogSubscriber labels it instead of falling back
-  // to the adapter's generic "SQL" default.
   const [existsSql, existsBinds] = this._compileAstWithBinds(relation.toArel().ast);
   return await this.skipQueryCacheIfNecessary(() =>
     this.withConnection(
@@ -810,9 +782,7 @@ export async function include(this: FinderRelation, record: any): Promise<boolea
  * Alias of {@link include} — mirrors `alias :member? :include?`
  * (finder_methods.rb:407).
  */
-export function member(this: FinderRelation, record: any): Promise<boolean> {
-  return include.call(this, record);
-}
+export const member = include;
 
 // Mirrors ActiveRecord::FinderMethods#raise_record_not_found_exception!
 // (finder_methods.rb:417). Composes the faithful not-found messages from the

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -12,12 +12,14 @@ import { Nodes } from "@blazetrails/arel";
 import { wrap } from "@blazetrails/activesupport";
 import { pluralize } from "@blazetrails/activesupport/core-ext/string/inflections";
 import {
+  ArgumentError,
   RangeError as ActiveModelRangeError,
   sanitizeForMassAssignment as sanitizeForbiddenAttributes,
 } from "@blazetrails/activemodel";
 import { RecordNotFound, RecordNotSaved, RecordNotUnique, SoleRecordExceeded } from "../errors.js";
 import { queryConstraintsList as _queryConstraintsListFn } from "../persistence.js";
 import { compactUniqIds, compactUniqTuples } from "./compact-uniq-ids.js";
+import { isBaseInstance } from "./predicate-builder/is-base-instance.js";
 
 /** Mirrors: `ActiveRecord::FinderMethods::ONE_AS_ONE` (finder_methods.rb:7). */
 const ONE_AS_ONE = "1 AS one";
@@ -294,7 +296,8 @@ interface FinderRelation {
   _scopeAttributes(): Record<string, unknown>;
   scopeForCreate(): Record<string, unknown>;
   _clone(): any;
-  whereClause: { isEmpty(): boolean };
+  whereClause: { isEmpty(): boolean; isContradiction(): boolean };
+  havingClause: { isEmpty(): boolean };
   /** Relation#arel — the built SelectManager (relation.ts). */
   arel(): { whereSql(engine: unknown): Nodes.SqlLiteral | null };
   where(conditions: unknown, ...rest: unknown[]): any;
@@ -317,6 +320,23 @@ interface FinderRelation {
   findNthWithLimit(index: number, limit: number): Promise<any[]>;
   /** @internal */
   findNthFromLast(index: number): Promise<any | null>;
+  /** @internal Relation#exists? — recursed into by the eager-loading arm. */
+  exists(conditions?: unknown): Promise<boolean>;
+  /** @internal */
+  constructRelationForExists(conditions: unknown): any;
+  /** @internal Relation#eager_loading? (relation.ts). */
+  _eagerLoadingForSql(): boolean;
+  /** @internal Rails raises EagerLoadPolymorphicError from apply_join_dependency. */
+  _checkEagerLoadable(): void;
+  /** @internal Relation#apply_join_dependency (relation.ts). */
+  applyJoinDependency(options?: { eagerLoading?: boolean }): any;
+  /** @internal */
+  _materializeDeferredDistinctPkPredicates(): Promise<void>;
+  /** @internal */
+  _compileAstWithBinds(ast: unknown): [string, unknown[]];
+  toArel(): { ast: unknown };
+  skipQueryCacheIfNecessary<R>(block: () => R): R;
+  withConnection<R>(block: (c: any) => R): R;
 }
 
 function buildPkWhere(pk: string[], tuple: unknown[]): Record<string, unknown> {
@@ -675,6 +695,125 @@ export async function performCreateOrFindByBang(
   }
 }
 
+/**
+ * Check if any records exist, optionally with conditions.
+ *
+ * Mirrors: ActiveRecord::FinderMethods#exists? — ending in
+ * `skip_query_cache_if_necessary { with_connection { |c|
+ * c.select_rows(relation.arel, "#{model.name} Exists?").size == 1 } }`
+ * (finder_methods.rb:377-381), the cached read path.
+ */
+export async function exists(
+  this: FinderRelation,
+  conditions?: Record<string, unknown> | unknown,
+): Promise<boolean> {
+  if (this._isEmptyRelation()) return false;
+  // Rails FinderMethods#exists?: `return false if !conditions` — treats an
+  // explicit `false` / `null` argument as "no match possible". This precedes
+  // the `if eager_loading?` branch, so it short-circuits before the
+  // eager-load validation below (finder_methods.rb:367-369).
+  if (conditions === false || conditions === null) return false;
+  // Rails FinderMethods#exists?: `return false if !conditions || limit_value == 0`
+  // (finder_methods.rb:367). A relation limited to zero rows can never match, so
+  // short-circuit to false without emitting any query.
+  if (this.limitValue === 0) return false;
+  // Rails FinderMethods#exists? (finder_methods.rb:360-364): reject an
+  // ActiveRecord instance argument with `if Base === conditions` before any
+  // query is built. Detect it via the inherited `_isActiveRecordBase` marker
+  // so a model of any class (not just this relation's) is caught.
+  // Rails runs this Base check just *before* `return false if !conditions`;
+  // we run it just after. The branches are mutually exclusive (an AR instance
+  // is never `false`/`null`), so the order is behaviorally identical.
+  if (isBaseInstance(conditions)) {
+    throw new ArgumentError(
+      "You are passing an instance of ActiveRecord::Base to `exists?`. " +
+        "Please pass the id of the object by calling `.id`.",
+    );
+  }
+  // Rails exists? then routes through apply_join_dependency when eager
+  // loading, raising EagerLoadPolymorphicError for polymorphic specs.
+  this._checkEagerLoadable();
+  // Mirrors Rails FinderMethods#exists? `if eager_loading?` (finder_methods.rb:369):
+  // the eager-load check precedes construct_relation_for_exists, and conditions
+  // thread through to the recursion (`apply_join_dependency(eager_loading: false)
+  // .exists?(conditions)`) — the hardcoded `false` skips the limit/offset guard.
+  if (this._eagerLoadingForSql()) {
+    return this.applyJoinDependency({ eagerLoading: false }).exists(conditions);
+  }
+  // Mirrors Rails FinderMethods#construct_relation_for_exists
+  // (finder_methods.rb:438): shape the existence probe and apply the argument's
+  // `case conditions` (Array/Hash → where!, else → where!(primary_key =>
+  // conditions)) in one place — `exists?` no longer reimplements that
+  // case-analysis. When `distinct_value && offset_value` keep the relation's
+  // select/distinct/group/having/offset and drop only the order
+  // (`except(:order).limit!(1)`); otherwise `except(:select, :distinct,
+  // :order)._select!(ONE_AS_ONE).limit!(1)` — group/having/offset survive.
+  // `undefined` is our `:none` sentinel, so the helper adds no where!. Building
+  // the probe through the real relation reuses the shared select-list builder,
+  // so the distinct+offset branch's default `*` projection is `ignoredColumns`-
+  // aware, matching Rails' `build_select`.
+  const relation = this.constructRelationForExists(conditions);
+  // Resolve any deferred distinct-PK subquery markers to a literal id list
+  // before compiling the probe (Rails materializes at `.where()`-build time).
+  await relation._materializeDeferredDistinctPkPredicates();
+  // Rails: `return false if relation.where_clause.contradiction?`
+  // (finder_methods.rb:375) — evaluated on the post-construct relation.
+  if (relation.whereClause.isContradiction()) return false;
+  // Tag the probe query `<Model> Exists?` — the name Rails passes to its
+  // existence query (`select_rows(relation.arel, "#{model.name} Exists?")`,
+  // finder_methods.rb) — so LogSubscriber labels it instead of falling back
+  // to the adapter's generic "SQL" default.
+  const [existsSql, existsBinds] = this._compileAstWithBinds(relation.toArel().ast);
+  return await this.skipQueryCacheIfNecessary(() =>
+    this.withConnection(
+      async (c) =>
+        (await c.selectRows(existsSql, `${this.model.name} Exists?`, existsBinds)).length === 1,
+    ),
+  );
+}
+
+/**
+ * Check if the given record is present in the relation.
+ *
+ * Mirrors: ActiveRecord::FinderMethods#include? (finder_methods.rb:389-407).
+ * A non-model argument short-circuits to `false` without querying. A loaded
+ * relation — or one carrying offset/limit/having — compares in memory; an
+ * unloaded relation without those issues a cheap `exists?(id)` rather than
+ * materializing every row.
+ */
+export async function include(this: FinderRelation, record: any): Promise<boolean> {
+  if (!(record instanceof (this.model as unknown as new (...args: any[]) => any))) return false;
+  if (
+    this.isLoaded ||
+    this.offsetValue !== null ||
+    this.limitValue !== null ||
+    !this.havingClause.isEmpty()
+  ) {
+    const records = await this.toArray();
+    return records.some((r) => r.equals(record));
+  }
+  // Unloaded fast path: probe existence by primary key. The composite-PK arm
+  // (Rails `record.class.composite_primary_key?`) is a `primary_key.zip(id)`
+  // hash rather than the tuple, which exists()'s array branch would read as
+  // `[sql, ...binds]`.
+  const recordClass = record.constructor;
+  const id = recordClass.compositePrimaryKey
+    ? Object.fromEntries(
+        (recordClass.primaryKey as string[]).map((column, index) => [column, record.id[index]]),
+      )
+    : record.id;
+
+  return this.exists(id);
+}
+
+/**
+ * Alias of {@link include} — mirrors `alias :member? :include?`
+ * (finder_methods.rb:407).
+ */
+export function member(this: FinderRelation, record: any): Promise<boolean> {
+  return include.call(this, record);
+}
+
 // Mirrors ActiveRecord::FinderMethods#raise_record_not_found_exception!
 // (finder_methods.rb:417). Composes the faithful not-found messages from the
 // same ids / result_size / expected_size / key / not_found_ids arguments Rails
@@ -765,6 +904,9 @@ export const FinderMethods = {
   secondToLastBang: performSecondToLastBang,
   thirdToLast: performThirdToLast,
   thirdToLastBang: performThirdToLastBang,
+  exists,
+  include,
+  member,
   findOrCreateByBang: performFindOrCreateByBang,
   createOrFindByBang: performCreateOrFindByBang,
   raiseRecordNotFoundExceptionBang,
@@ -772,6 +914,7 @@ export const FinderMethods = {
   // FinderMethods, and Relation gets them by `include`; they ride the same
   // mixin here so `relation.ts` does not redeclare a second copy.
   constructRelationForExists,
+  usingLimitableReflections,
   findWithIds,
   findOne,
   findSome,
@@ -841,6 +984,20 @@ export function constructRelationForExists(this: FinderRelation, conditions: unk
     }
   }
   return relation;
+}
+
+/**
+ * Mirror Rails `using_limitable_reflections?` (finder_methods.rb:487):
+ * `reflections.none?(&:collection?)` — a set of reflections is limitable
+ * when none of them is a collection association.
+ *
+ * @internal
+ */
+export function usingLimitableReflections(
+  this: FinderRelation,
+  reflections: Array<{ isCollection(): boolean }>,
+): boolean {
+  return reflections.every((r) => !r.isCollection());
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/finder-methods.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
+    "rubyName": "exists?",
+    "call": "size",
+    "reason": "Verified per-site (RFC 0106): Ruby `Array#size` on the plain Array `select_rows` returns (finder_methods.rb:379 — `c.select_rows(relation.arel, \"#{model.name} Exists?\").size == 1`, ported as `(await c.selectRows(...)).length === 1`), whose faithful JS spelling emits no callee, so no TS call can ever credit the Ruby one — nothing in the TS body was dropped."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_last",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
`exists?`, `include?`/`member?` and `using_limitable_reflections?` are finder_methods.rb members (finder_methods.rb:357, :389, :407, :487) that were parked in `relation.ts`. This moves them into `packages/activerecord/src/relation/finder-methods.ts`, which already owns the FinderMethods mixin wiring, in finder_methods.rb source order — `exists` → `include` → `member` → `raiseRecordNotFoundExceptionBang`, with `usingLimitableReflections` in the private block after `constructRelationForExists`.

`applyJoinDependency` is deliberately left in `relation.ts`: it is owned by the `apply_join_dependency` story.

### Fidelity fixes carried by the move

- **`exists?` branch order** now matches finder_methods.rb:357-382 exactly. The `Base === conditions` raise (:360) is back ahead of `!conditions || limit_value == 0` (:367); the old order was justified only for the `!conditions` half, and `limit_value == 0` preceding the raise made `Post.limit(0).exists?(record)` return `false` where Rails raises `ArgumentError`. The two halves of :367 are one guard, as in Ruby. `probe` is renamed to Rails' `relation` (:374).
- **`member?` is a real alias** (`export const member = include`), mirroring `alias :member? :include?` (finder_methods.rb:407), not a delegating wrapper.
- **`Relation#any?`** converges to Rails' `!empty?` (relation.rb:391-396); the `loaded?` short-circuit it duplicated already lives in `empty?` (relation.rb:362-370). This surfaced as a new call-set mismatch once `exists` left `relation.ts`, and converging was the right fix — it also makes `CollectionProxy#any?` route through the proxy's own `empty?`, as Rails does.

Two trails-only calls survive in `exists?` (`_checkEagerLoadable`, the deferred distinct-PK materialization). Each is justified at the call site with its Rails cite; comments that merely restated the body, or duplicated `constructRelationForExists`' own doc now that it is a sibling function, are dropped.

### Gates

`pnpm parity:api:calls` OK (RFC 0084 folded the old narrow/wide split into this one gate), `pnpm parity:api:calls:args` OK, `parity:api`/`parity:test` deltas non-negative, `pnpm parity:api:extra --package activerecord` unchanged for both files (`relation/finder-methods.ts` stays at 2 novel / 2 moved). One new call-set baseline row: `exists? | size` — Ruby `Array#size` on the plain Array `select_rows` returns, the same language mapping already baselined for `raise_record_not_found_exception!` in the same shard.

No behavior change and no test changes: `relation/` (54 files), `relation.test.ts`, `finder.test.ts`, `null-relation.test.ts`, `relation.trails.test.ts`, `collection-proxy.test.ts`, `eager.test.ts`, `has-many-through-associations.test.ts`, `query-cache.test.ts`, `log-subscriber.test.ts`, `relation-scoping.test.ts` all pass unchanged.

### Bundled story not in this PR

`converge-execute-grouped-calculation-body-to-rails-source-order` is **blocked on #6603**, which makes `executeGroupedCalculation` the Rails body outright. On `main` the method is still a thin wrapper over the bespoke `groupedAggregate` helper and all 14 `execute_grouped_calculation` call-set baseline rows are live, so the follow-up work (the `with_connection` position, `type_for`'s block, inlining `qualifiedGroupFieldForModel`/`resolveGroupAssociation`, source order) cannot be done without redoing #6603's diff and conflicting with it. Marked blocked with that reason; it re-readies once #6603 merges.

Closes-story: fan-out-finder-methods-from-relation
