### PR TITLE
fix(activerecord): clear_cache! deallocates under the connection lock

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -466,8 +466,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         other.preparedStatements = true;
         await other.execute("SELECT $1::integer AS n", [1]);
         await other.beginDbTransaction();
-        // `resetColumnInformation`'s shape (model-schema.rb:441): a sync caller
-        // that drops the returned chain.
+        // `reset_column_information`'s shape (model_schema.rb:523-524): a sync
+        // caller that drops the returned chain.
         void other.clearCacheBang();
         // The DEALLOCATE is dispatched from a microtask off the pool's chain,
         // so let the turn end before sampling — a read in the same tick sees

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -448,6 +448,39 @@ describeIfPg("PostgreSQLAdapter", () => {
     // `synchronize`, the shape RFC 0085 removed; there is no Rails-faithful way
     // to put a query on the wire under a lock this chain holds.
 
+    // Regression for RFC 0061 pg-query-canceled-unhandled-rejection-recurrence:
+    // `clear_cache!` mutates the statement pool under `@lock`
+    // (abstract_adapter.rb:741-747), which is the precondition `dealloc` states
+    // outright — "the statement pool is only accessed while holding the
+    // connection's lock" (postgresql_adapter.rb:308-310). The port skipped that
+    // lock, so `resetColumnInformation`'s sync, promise-dropping call left
+    // eviction DEALLOCATEs on the wire beside a chain that owned the
+    // connection; the rollback behind it read PQTRANS_ACTIVE where Rails reads
+    // PQTRANS_INTRANS and fired a CancelRequest, which — being addressed to a
+    // backend, not a statement — landed on a later query and surfaced as
+    // vitest's run-end unhandled QueryCanceled.
+    it("clearCacheBang deallocates under the connection lock", async () => {
+      const PQTRANS_INTRANS = 2;
+      const other = new PostgreSQLAdapter(PG_TEST_URL);
+      try {
+        other.preparedStatements = true;
+        await other.execute("SELECT $1::integer AS n", [1]);
+        await other.beginDbTransaction();
+        // `resetColumnInformation`'s shape (model-schema.rb:441): a sync caller
+        // that drops the returned chain.
+        void other.clearCacheBang();
+        // The DEALLOCATE is dispatched from a microtask off the pool's chain,
+        // so let the turn end before sampling — a read in the same tick sees
+        // the wire before it has anything on it.
+        await new Promise<void>((r) => setTimeout(r, 0));
+        const status = await other.lock.synchronize(() => other.transactionStatus);
+        expect(status).toBe(PQTRANS_INTRANS);
+        await other.rollbackDbTransaction();
+      } finally {
+        await other.close();
+      }
+    });
+
     it("translate exception serialization failure", async () => {
       await adapter.exec(`CREATE TABLE "ex_ser" ("id" SERIAL PRIMARY KEY, "val" INTEGER)`);
       await adapter.executeMutation(`INSERT INTO "ex_ser" (val) VALUES (0)`);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3049,17 +3049,29 @@ export class PostgreSQLAdapter
     newConnection = false,
   }: { newConnection?: boolean } = {}): void | Promise<void> {
     void super.clearCacheBang({ newConnection });
-    if (newConnection) {
-      // Rails' `new_connection: true` branch (statement_pool.rb:44-46) drops the
-      // map without DEALLOCATE: the session that owned those statement names is
-      // gone, so naming them again is an error, not a cleanup.
-      this._statements.reset();
-    } else if (this._rawConnection) {
-      return this._statements.clear();
-    } else {
-      this._statements.reset();
-      this._needsDeallocateAll = true;
-    }
+    // Rails wraps the whole pool mutation in `@lock.synchronize`
+    // (abstract_adapter.rb:741-747), which is what `dealloc`'s own comment
+    // relies on: "the statement pool is only accessed while holding the
+    // connection's lock" (postgresql_adapter.rb:308-310). Without it the
+    // eviction DEALLOCATEs go onto the wire beside a chain that owns the
+    // connection, and `_commandSettled` is false while they are in flight — so
+    // a rollback sampling `transactionStatus` reads PQTRANS_ACTIVE where Rails
+    // reads PQTRANS_INTRANS and fires a CancelRequest at a backend it does not
+    // own. A CancelRequest is addressed to a backend, not to a statement, so
+    // that one lands on whatever query the backend runs next.
+    return this.lock.synchronize(() => {
+      if (newConnection) {
+        // Rails' `new_connection: true` branch (statement_pool.rb:44-46) drops the
+        // map without DEALLOCATE: the session that owned those statement names is
+        // gone, so naming them again is an error, not a cleanup.
+        this._statements.reset();
+      } else if (this._rawConnection) {
+        return this._statements.clear();
+      } else {
+        this._statements.reset();
+        this._needsDeallocateAll = true;
+      }
+    });
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3049,16 +3049,10 @@ export class PostgreSQLAdapter
     newConnection = false,
   }: { newConnection?: boolean } = {}): void | Promise<void> {
     void super.clearCacheBang({ newConnection });
-    // Rails wraps the whole pool mutation in `@lock.synchronize`
-    // (abstract_adapter.rb:741-747), which is what `dealloc`'s own comment
-    // relies on: "the statement pool is only accessed while holding the
-    // connection's lock" (postgresql_adapter.rb:308-310). Without it the
-    // eviction DEALLOCATEs go onto the wire beside a chain that owns the
-    // connection, and `_commandSettled` is false while they are in flight — so
-    // a rollback sampling `transactionStatus` reads PQTRANS_ACTIVE where Rails
-    // reads PQTRANS_INTRANS and fires a CancelRequest at a backend it does not
-    // own. A CancelRequest is addressed to a backend, not to a statement, so
-    // that one lands on whatever query the backend runs next.
+    // Rails wraps the pool mutation in `@lock.synchronize`
+    // (abstract_adapter.rb:741-747) — the precondition `dealloc` states
+    // outright: "the statement pool is only accessed while holding the
+    // connection's lock" (postgresql_adapter.rb:308-310).
     return this.lock.synchronize(() => {
       if (newConnection) {
         // Rails' `new_connection: true` branch (statement_pool.rb:44-46) drops the


### PR DESCRIPTION
## What

`PostgreSQLAdapter#clearCacheBang` now mutates the statement pool under the
connection lock, mirroring Rails' `clear_cache!`
(`abstract_adapter.rb:741-747`), which wraps the whole `@statements.reset` /
`@statements.clear` in `@lock.synchronize`.

## Why

This is the root cause of the recurring PG-shard flake `Unhandled Rejection:
QueryCanceled: canceling statement due to user request` — the red on main
@2856c975 (`Active Record PostgreSQL Tests (2)`), where every test file passed
and only the run-end rejection failed the job.

PG's `dealloc` states the precondition outright: "the statement pool is only
accessed while holding the connection's lock"
(`postgresql_adapter.rb:308-310`). The port skipped that lock, so
`resetColumnInformation`'s sync, promise-dropping `clearCacheBang()` put the
eviction `DEALLOCATE`s on the wire beside a chain that owned the connection.

Traced with a probe on `_cancelAnyRunningQuery` over a full PG shard-2 run.
Every production CancelRequest fired from fixture teardown
(`unpinConnectionBang` → `rollbackTransaction` → `execRollbackDbTransaction`),
and every one reported `readyForQuery=false settled=false rfqStatus=T` with the
unsettling frame in the statement pool's `dealloc`. With a `DEALLOCATE` in
flight `_commandSettled` is false, so `transactionStatus` answers
`PQTRANS_ACTIVE` where Rails answers `PQTRANS_INTRANS` — and
`cancel_any_running_query`'s `IDLE_TRANSACTION_STATUSES` gate
(`postgresql/database_statements.rb:128`) therefore does not return early. A
CancelRequest is addressed to a *backend*, not a statement, so the one it sends
lands on whatever that backend runs next; with nothing left to observe the
rejection it surfaces as vitest's run-end unhandled `QueryCanceled`.

## Test

`clearCacheBang deallocates under the connection lock` — populates the
statement pool, opens a transaction, drops the `clearCacheBang()` promise the
way `resetColumnInformation` does, then samples `transactionStatus` from inside
`lock.synchronize`. Baseline reads `PQTRANS_ACTIVE` (1) and fails; with the fix
the sample queues behind the DEALLOCATE and reads `PQTRANS_INTRANS` (2).

## Verification

- New test fails on baseline (`expected 1 to be 2`), passes with the fix.
- `adapters/postgresql/` + `connection-adapters/` against PG 17: 2754 passed,
  1 pre-existing local failure (`structure dump`, the pg_dump-newer-server
  abort).
- Full `--shard=2/2` against PG 17: 7001 passed, only the two pre-existing
  local-environment failures (`structure dump`, `connection in local time`).
- `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra` 0 novel,
  `pnpm typecheck` + `pnpm lint` clean.

Closes-story: red-2856c975
