### PR TITLE
refactor(activerecord): CollectionProxy mutation terminals through scope, buildArel's connection is never null, limit! is a bare assignment

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -849,11 +849,11 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
 });
 
 // The mutation terminals invoked on the PROXY itself (not a spawned relation)
-// route through `Relation`'s implementations with `this` = the proxy, so
-// they hit the base `_isEmptyRelation()` chokepoint on the proxy. The
-// `CollectionProxy#_isEmptyRelation` override rebases the stale new-owner
-// `1=0` seed there, giving the mutation side the same rebase reads already
-// get through `_finderScope`.
+// route through `scope()`, which the association rebuilds against the resolved
+// FK — so the proxy's own stale new-owner `1=0` seed is never read. Rails gets
+// this from `delegate(*delegate_methods, to: :scope)`
+// (collection_proxy.rb:1128-1137) sending the QueryMethods value readers the
+// inherited `update_all` uses to `@association.scope`.
 describe("CollectionProxy — mutation terminals invoked on the proxy itself on stale new-owner seed", () => {
   fixtures(["authors", "posts"]);
 

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -967,6 +967,23 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
   });
 });
 
+// The other side of `calculate`'s none branch: a proxy whose own state is a none
+// relation for a reason that has nothing to do with a new owner — here
+// `Tag has_many :null_taggings, -> { none }` on a PERSISTED tag. Deferring to
+// `scope()` must return the same answer the in-memory short-circuit did, since
+// the association scope carries the same `none`.
+describe("CollectionProxy — a none-scoped association on a persisted owner", () => {
+  const { tags } = fixtures(["tags", "taggings"]);
+
+  it("still counts zero through the association scope", async () => {
+    const tag = await Tag.find(tags("general").id);
+    const nullTaggings = association(tag as any, "nullTaggings") as any;
+    expect(tag.isNewRecord()).toBe(false);
+    expect(await nullTaggings.count()).toBe(0);
+    expect(await nullTaggings.size()).toBe(0);
+  });
+});
+
 // The in-memory `CollectionProxy#find` path (loaded `inverse_of` collection,
 // scanned in memory) must emit the identical not-found message as the SQL
 // `performFind` path — Rails routes both through

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -907,17 +907,17 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
     expect((await Post.find(theirs.id)).author_id).toBe(otherAuthor.id);
   });
 
-  // #6609 made `scope()` memoize (`@scope ||= @association.scope`,
-  // collection_proxy.rb:949-950), so a proxy whose scope was built while the
-  // owner was still new holds a `1=0` unresolved-FK memo that outlives the save.
-  // The memo is an AssociationRelation, so the FIRST mutation terminal rebases
-  // it in place through `AssociationRelation#_isEmptyRelation` — this pins that
-  // the terminals routed through `scope()` still land on the resolved FK.
-  it("resolves the persisted FK on updateAll when the proxy scope was memoized before save", async () => {
+  // Rails' `reader` (collection_association.rb:34-43) ends in
+  // `@proxy.reset_scope`, so every collection read drops the memoized `@scope`
+  // (collection_proxy.rb:1112-1116) and rebuilds it from the association. A
+  // proxy whose scope was memoized while the owner was new therefore resolves
+  // the persisted FK on the next read — which is how #6612's delegated value
+  // readers reach a live scope rather than the stale `1=0` seed.
+  it("resolves the persisted FK on updateAll read again after save", async () => {
     const author = new Author({ name: "Proxy Mutation Four" });
-    const posts = association<Post>(author, "posts") as any;
-    // `whereBang` is delegated to `scope()`, so this memoizes the `1=0` scope.
-    posts.whereBang({ title: "mine" });
+    // `whereBang` is delegated to `scope()`, so this memoizes the `1=0` scope
+    // while the owner is still new.
+    (association<Post>(author, "posts") as any).whereBang({ title: "mine" });
 
     await author.save();
     const authorId = author.id as number;
@@ -925,22 +925,18 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
     const otherAuthor = await Author.create({ name: "Someone Else Three" });
     const theirs = await Post.create({ title: "mine", body: "2", author_id: otherAuthor.id });
 
-    // A stale `1=0` memo would update nothing; a memo carrying no owner FK
-    // would also catch the other author's identically-titled post.
+    // Re-read through the reader, as Rails' `person.posts.update_all` does.
+    const posts = association<Post>(author, "posts") as any;
     expect(await posts.updateAll({ body: "updated" })).toBe(1);
     expect((await Post.find(mine.id)).body).toBe("updated");
     expect((await Post.find(theirs.id)).body).toBe("2");
   });
 
-  // A read terminal on the SAME proxy, before and after the save: the first call
-  // happens while the owner is new, so the proxy keeps its `1=0` seed; the second
-  // must still count against the resolved FK. `calculate`'s non-null-scope arm
-  // reads the proxy's own state, and `null_scope?` is already false by then
-  // (collection_proxy.rb:1150-1152), so the seed has to defer to `scope()`.
-  it("counts against the persisted FK when the proxy was first read before save", async () => {
+  // The same reader contract on a read terminal: a count taken while the owner
+  // was new must not pin the collection to the `1=0` seed for later reads.
+  it("counts against the persisted FK when read again after save", async () => {
     const author = new Author({ name: "Proxy Mutation Five" });
-    const posts = association<Post>(author, "posts") as any;
-    expect(await posts.count()).toBe(0);
+    expect(await (association<Post>(author, "posts") as any).count()).toBe(0);
 
     await author.save();
     const authorId = author.id as number;
@@ -948,7 +944,7 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
     const otherAuthor = await Author.create({ name: "Someone Else Four" });
     await Post.create({ title: "theirs", body: "2", author_id: otherAuthor.id });
 
-    // A stale `1=0` seed counts 0; a seed with no owner FK counts both posts.
+    const posts = association<Post>(author, "posts") as any;
     expect(await posts.count()).toBe(1);
     expect(await posts.size()).toBe(1);
   });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -907,6 +907,52 @@ describe("CollectionProxy — mutation terminals invoked on the proxy itself on 
     expect((await Post.find(theirs.id)).author_id).toBe(otherAuthor.id);
   });
 
+  // #6609 made `scope()` memoize (`@scope ||= @association.scope`,
+  // collection_proxy.rb:949-950), so a proxy whose scope was built while the
+  // owner was still new holds a `1=0` unresolved-FK memo that outlives the save.
+  // The memo is an AssociationRelation, so the FIRST mutation terminal rebases
+  // it in place through `AssociationRelation#_isEmptyRelation` — this pins that
+  // the terminals routed through `scope()` still land on the resolved FK.
+  it("resolves the persisted FK on updateAll when the proxy scope was memoized before save", async () => {
+    const author = new Author({ name: "Proxy Mutation Four" });
+    const posts = association<Post>(author, "posts") as any;
+    // `whereBang` is delegated to `scope()`, so this memoizes the `1=0` scope.
+    posts.whereBang({ title: "mine" });
+
+    await author.save();
+    const authorId = author.id as number;
+    const mine = await Post.create({ title: "mine", body: "1", author_id: authorId });
+    const otherAuthor = await Author.create({ name: "Someone Else Three" });
+    const theirs = await Post.create({ title: "mine", body: "2", author_id: otherAuthor.id });
+
+    // A stale `1=0` memo would update nothing; a memo carrying no owner FK
+    // would also catch the other author's identically-titled post.
+    expect(await posts.updateAll({ body: "updated" })).toBe(1);
+    expect((await Post.find(mine.id)).body).toBe("updated");
+    expect((await Post.find(theirs.id)).body).toBe("2");
+  });
+
+  // A read terminal on the SAME proxy, before and after the save: the first call
+  // happens while the owner is new, so the proxy keeps its `1=0` seed; the second
+  // must still count against the resolved FK. `calculate`'s non-null-scope arm
+  // reads the proxy's own state, and `null_scope?` is already false by then
+  // (collection_proxy.rb:1150-1152), so the seed has to defer to `scope()`.
+  it("counts against the persisted FK when the proxy was first read before save", async () => {
+    const author = new Author({ name: "Proxy Mutation Five" });
+    const posts = association<Post>(author, "posts") as any;
+    expect(await posts.count()).toBe(0);
+
+    await author.save();
+    const authorId = author.id as number;
+    await Post.create({ title: "mine", body: "1", author_id: authorId });
+    const otherAuthor = await Author.create({ name: "Someone Else Four" });
+    await Post.create({ title: "theirs", body: "2", author_id: otherAuthor.id });
+
+    // A stale `1=0` seed counts 0; a seed with no owner FK counts both posts.
+    expect(await posts.count()).toBe(1);
+    expect(await posts.size()).toBe(1);
+  });
+
   it("resolves the persisted FK on touchAll invoked on the proxy after save", async () => {
     const ship = new Ship({ name: "Proxy Mutation Three" });
     const parts = association<ShipPart>(ship, "parts") as any;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2678,7 +2678,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // the whole table. Route those through the DJAR, which resolves the walk first.
     // Convergence story: 0106-wide-call-set-direct-burndown/
     // djar-eager-chain-ids-drop-disable-joins-arms.
-    if (this.isNullScope()) return this.scope().calculate(operation, columnName);
+    // `null_scope?` is evaluated at CALL time (collection_proxy.rb:1150-1152 →
+    // `@association.null_scope?`), so Rails' `super` arm never reads a stale
+    // seed: the proxy owns no relation state, and its `where_clause` comes from
+    // `scope` through the delegated readers (:1128-1137). trails' proxy DOES own
+    // that state, and a proxy built for a then-new owner still carries the `1=0`
+    // seed after the owner is saved — so a proxy whose own state is a none
+    // relation defers to the rebuilt scope, exactly as the mutation terminals do.
+    if (this.isNullScope() || this._isEmptyRelation()) {
+      return this.scope().calculate(operation, columnName);
+    }
     if (this._assocDef.options.disableJoins) {
       return this.scope().calculate(operation, columnName);
     }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -603,6 +603,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // proxy's own inherited state rather than called on the proxy.
     const seedNone = (): void => {
       proxySelf.initializeCopy((targetModel as any).all().noneBang() as Relation<T>);
+      // Rails never sets `@none` on a CollectionProxy: `none!` is one of the
+      // methods delegated to `scope` (collection_proxy.rb:1128-1137), so it
+      // flips the SCOPE's flag and the proxy sees the `1=0` only through the
+      // delegated `where_clause` reader. Copying the seed's predicates onto our
+      // own inherited state must not also copy that flag, or the inherited
+      // `update_all`'s `return 0 if @none` (relation.rb:1013) — and every other
+      // `@none` short-circuit — fires on the proxy itself.
+      (this as unknown as { _isNone: boolean })._isNone = false;
     };
     if (assocDef.options.through) {
       // Config validation FIRST, outside the try — missing through
@@ -2678,16 +2686,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // the whole table. Route those through the DJAR, which resolves the walk first.
     // Convergence story: 0106-wide-call-set-direct-burndown/
     // djar-eager-chain-ids-drop-disable-joins-arms.
-    // `null_scope?` is evaluated at CALL time (collection_proxy.rb:1150-1152 →
-    // `@association.null_scope?`), so Rails' `super` arm never reads a stale
-    // seed: the proxy owns no relation state, and its `where_clause` comes from
-    // `scope` through the delegated readers (:1128-1137). trails' proxy DOES own
-    // that state, and a proxy built for a then-new owner still carries the `1=0`
-    // seed after the owner is saved — so a proxy whose own state is a none
-    // relation defers to the rebuilt scope, exactly as the mutation terminals do.
-    if (this.isNullScope() || this._isEmptyRelation()) {
-      return this.scope().calculate(operation, columnName);
-    }
+    if (this.isNullScope()) return this.scope().calculate(operation, columnName);
     if (this._assocDef.options.disableJoins) {
       return this.scope().calculate(operation, columnName);
     }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -47,7 +47,6 @@ import {
   CompositePrimaryKeyMismatchError,
   AssociationNotFoundError,
 } from "./errors.js";
-import { rebaseNewOwnerSeed } from "./new-owner-seed-rebase.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
@@ -143,21 +142,6 @@ export type AssociationProxy<
  */
 function sameRecordList(a: Base[], b: Base[]): boolean {
   return a.length === b.length && a.every((record, i) => record.equals(b[i]));
-}
-
-/**
- * Validate a numeric limit (safe non-negative integer) and raise the
- * same error shape as Relation#limitBang. Rails' `first(n)` / `last(n)`
- * / `take(n)` all route through `limit(limit)` which validates; our
- * TS finder methods bypass validation for first/take via
- * `limitValue = n` (a TS-internal shortcut that diverges from Rails).
- * For Rails fidelity at the CollectionProxy layer we validate all
- * three.
- */
-function assertValidLimit(n: number): void {
-  if (!Number.isSafeInteger(Number(n)) || Number(n) < 0) {
-    throw new Error(`Invalid limit value: ${String(n)}`);
-  }
 }
 
 /** @internal */
@@ -641,12 +625,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // errors — worse than letting construction fail.
       const throughRel = this._buildThroughScope() as Relation<T>;
       proxySelf.initializeCopy(throughRel);
-      // A new owner's through/HABTM scope collapses to `none()` (unresolvable
-      // FK) — mark it so a mutation terminal run on the proxy rebases onto the
-      // resolved join scope once the owner is saved (see `_maybeRebaseProxySeed`).
-      if ((throughRel as unknown as { _isNone: boolean })._isNone) {
-        this._seededNoneNewOwner = true;
-      }
     } else {
       // Build via the `scope()` seam so CP's inherited Relation
       // state matches `scope()` / direct Relation callers: default
@@ -677,9 +655,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (seedRel === null) {
         if (this._deferredFkError === undefined) {
           seedNone();
-          // New-owner seed: the `1=0` base must be rebased onto the resolved
-          // scope once the owner is saved (see `_maybeRebaseProxySeed`).
-          this._seededNoneNewOwner = true;
         }
       } else {
         proxySelf.initializeCopy(seedRel);
@@ -699,62 +674,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       const extensions = Array.isArray(ext) ? ext : [ext];
       relationProto.extendingBang.call(this, ...extensions);
     }
-
-    // Capture the seed WHERE predicates so a later rebase (new-owner `1=0`
-    // seed, owner then saved) can separate them from mutation predicates. Read
-    // through `Relation.prototype` for the same reason the seeding bangs above
-    // are called that way: `where_clause` is one of the readers delegated to
-    // `scope` (collection_proxy.rb:1128-1137), and the seed lives in the
-    // proxy's OWN inherited state — going through the delegation here would
-    // also force an eager `scope()` build, which Rails defers to load time.
-    const ownWhereClause = Object.getOwnPropertyDescriptor(
-      Relation.prototype,
-      "whereClause",
-    )?.get?.call(this) as { predicates: unknown[] } | undefined;
-    this._seedWherePredicates = [...(ownWhereClause?.predicates ?? [])];
-  }
-
-  /**
-   * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`), overridden
-   * so mutation terminals invoked on the PROXY itself resolve a stale new-owner
-   * `1=0` seed once the owner is saved. `updateAll` / `touchAll` / `updateCounters`
-   * have no `CollectionProxy` override — they run `Relation`'s with `this` = the
-   * proxy — so they reach this before building SQL. Rebasing here (mirroring the
-   * `AssociationRelation` override) gives the mutation side the same rebase that
-   * reads already get through the `scope` delegation, from one place.
-   */
-  _isEmptyRelation(): boolean {
-    this._maybeRebaseProxySeed();
-    return super._isEmptyRelation();
-  }
-
-  /**
-   * @internal Rebase this proxy in place when it still carries a stale new-owner
-   * `1=0` seed and the owner has since been saved (so `scope()` resolves a real
-   * FK). Mirrors `AssociationRelation`'s rebase, but mutates `this` — a mutation
-   * terminal runs against the proxy's own relation state, so the resolved FK
-   * must land there. Clears the seed marker so it runs exactly once.
-   */
-  private _maybeRebaseProxySeed(): void {
-    if (!this._seededNoneNewOwner) return;
-    // Both memo levels were populated while the owner was still new, so both
-    // carry the unresolved FK — drop them before rebuilding, exactly as Rails'
-    // two `reset_scope`s do (`CollectionProxy#reset_scope`,
-    // collection_proxy.rb:1112-1116, clearing `@scope`; `Association#reset_scope`,
-    // association.rb:119-121, clearing `@association_scope`). Mirrors the same
-    // pair in `AssociationRelation#_maybeRebaseAssociationSeed`.
-    this.resetScope();
-    (
-      this._record.association(this._assocName) as unknown as { resetScope?(): void }
-    ).resetScope?.();
-    const fresh = this.scope() as unknown as { _isNone: boolean };
-    if (fresh._isNone) return;
-    rebaseNewOwnerSeed(
-      this as unknown as Parameters<typeof rebaseNewOwnerSeed>[0],
-      fresh as unknown,
-      this._seedWherePredicates,
-    );
-    this._seededNoneNewOwner = false;
   }
 
   /**
@@ -1982,7 +1901,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override last(): Promise<T | null>;
   override last(n: number): Promise<T[]>;
   override async last(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
     // `load_target if find_from_target?; super` (collection_proxy.rb:259-262).
     // `super` is `Relation#last`, whose `loaded?` arm (finder_methods.rb:203)
     // fires on the proxy via the `isLoaded` / `records` overrides; the
@@ -2011,7 +1929,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   override take(): Promise<T | null>;
   override take(limit: number): Promise<T[]>;
   override async take(n?: number): Promise<T | T[] | null> {
-    if (n !== undefined) assertValidLimit(n);
     // `load_target if find_from_target?; super` (collection_proxy.rb:289-292).
     // `super` is `Relation#take`, which dispatches to the `findTake` /
     // `findTakeWithLimit` seams below; the `@take` memo and the loaded arm are

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -736,7 +736,7 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit("asdfadf" as any).toSql()).toThrow(/invalid value for Integer/i);
+    expect(() => User.limit("asdfadf").toSql()).toThrow(/invalid value for Integer/i);
   });
   it("limit should sanitize sql injection for limit without commas", () => {
     class User extends Base {
@@ -744,7 +744,7 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit("1 select * from schema" as any).toSql()).toThrow(
+    expect(() => User.limit("1 select * from schema").toSql()).toThrow(
       /invalid value for Integer/i,
     );
   });
@@ -754,9 +754,7 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit("1, 7 procedure help()" as any).toSql()).toThrow(
-      /invalid value for Integer/i,
-    );
+    expect(() => User.limit("1, 7 procedure help()").toSql()).toThrow(/invalid value for Integer/i);
   });
   it("preserving time objects", async () => {
     class Topic extends Base {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -725,13 +725,18 @@ describe("BasicsTest", () => {
     const pkTypes = pk?.type == null ? [ref.type] : [pk.type];
     expect(pkTypes[0]).toBe(ref.type);
   });
+  // `limit!` stores the raw value (query_methods.rb:1215-1218); the value is
+  // only vetted when `build_arel` runs it through `connection.sanitize_limit`
+  // (:1757, database_statements.rb:508-514), so — as in Rails, where these
+  // tests raise from `to_a` — the throw lands at query-build time, not at
+  // `limit(...)`.
   it("invalid limit", () => {
     class User extends Base {
       static {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit(-1)).toThrow(/invalid limit/i);
+    expect(() => User.limit("asdfadf" as any).toSql()).toThrow(/invalid value for Integer/i);
   });
   it("limit should sanitize sql injection for limit without commas", () => {
     class User extends Base {
@@ -739,7 +744,9 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit("1 ; DROP TABLE users" as any)).toThrow(/invalid limit/i);
+    expect(() => User.limit("1 select * from schema" as any).toSql()).toThrow(
+      /invalid value for Integer/i,
+    );
   });
   it("limit should sanitize sql injection for limit with commas", () => {
     class User extends Base {
@@ -747,7 +754,9 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(() => User.limit("1, 7 ; DROP TABLE users" as any)).toThrow(/invalid limit/i);
+    expect(() => User.limit("1, 7 procedure help()" as any).toSql()).toThrow(
+      /invalid value for Integer/i,
+    );
   });
   it("preserving time objects", async () => {
     class Topic extends Base {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -637,6 +637,21 @@ describe("DatabaseStatements", () => {
       );
       expect(sanitizeLimit(3.9)).toBe(3);
       expect(sanitizeLimit(-3.9)).toBe(-3);
+      // `Integer(str)` parses with base detection, not as plain decimal: a bare
+      // leading `0` is octal, `0x`/`0b`/`0o`/`0d` set the radix, and `_`
+      // separates digits. Every pair below was taken from `ruby -e`.
+      expect(sanitizeLimit("012")).toBe(10);
+      expect(sanitizeLimit("0x1f")).toBe(31);
+      expect(sanitizeLimit("0b101")).toBe(5);
+      expect(sanitizeLimit("0o17")).toBe(15);
+      expect(sanitizeLimit("0d19")).toBe(19);
+      expect(sanitizeLimit("1_000")).toBe(1000);
+      expect(sanitizeLimit("0_1")).toBe(1);
+      expect(sanitizeLimit(" 12 ")).toBe(12);
+      expect(sanitizeLimit("-0x10")).toBe(-16);
+      for (const bad of ["1__0", "1e3", "12.5", "08", "0b2", "0xg", "_1", "1_", "--5"]) {
+        expect(() => sanitizeLimit(bad)).toThrow(ArgumentError);
+      }
     });
 
     it("with yaml fallback passes scalar through", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { Rollback, StatementInvalid } from "../../errors.js";
 import {
   buildFixtureSql,
@@ -617,7 +618,11 @@ describe("DatabaseStatements", () => {
     });
 
     it("sanitize limit with invalid value", () => {
-      expect(() => sanitizeLimit("abc")).toThrow(TypeError);
+      // `Integer("abc")` (database_statements.rb:512) raises ArgumentError, not
+      // TypeError — TypeError is Ruby's arm for a value with no integer
+      // conversion at all (`Integer(nil)`).
+      expect(() => sanitizeLimit("abc")).toThrow(ArgumentError);
+      expect(() => sanitizeLimit(null)).toThrow(TypeError);
     });
 
     it("with yaml fallback passes scalar through", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -623,6 +623,20 @@ describe("DatabaseStatements", () => {
       // conversion at all (`Integer(nil)`).
       expect(() => sanitizeLimit("abc")).toThrow(ArgumentError);
       expect(() => sanitizeLimit(null)).toThrow(TypeError);
+      // `Integer(nil)` / `Integer([1])` / `Integer(true)` name the value's class
+      // (nil/true/false render as themselves); `Integer(Float::NAN)` and
+      // `Integer(Float::INFINITY)` raise FloatDomainError, not TypeError.
+      expect(() => sanitizeLimit(null)).toThrow("can't convert nil into Integer");
+      expect(() => sanitizeLimit([1])).toThrow("can't convert Array into Integer");
+      expect(() => sanitizeLimit(true)).toThrow("can't convert true into Integer");
+      expect(() => sanitizeLimit(NaN)).toThrow(
+        expect.objectContaining({ name: "FloatDomainError", message: "NaN" }),
+      );
+      expect(() => sanitizeLimit(Infinity)).toThrow(
+        expect.objectContaining({ name: "FloatDomainError", message: "Infinity" }),
+      );
+      expect(sanitizeLimit(3.9)).toBe(3);
+      expect(sanitizeLimit(-3.9)).toBe(-3);
     });
 
     it("with yaml fallback passes scalar through", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -611,32 +611,14 @@ describe("DatabaseStatements", () => {
 
     it("sanitize limit with integer", () => {
       expect(sanitizeLimit(10)).toBe(10);
+      // A non-Integer Float falls to `Integer(limit)` (database_statements.rb:512),
+      // which truncates toward zero rather than flooring.
+      expect(sanitizeLimit(3.9)).toBe(3);
+      expect(sanitizeLimit(-3.9)).toBe(-3);
     });
 
     it("sanitize limit with string integer", () => {
       expect(sanitizeLimit("10")).toBe(10);
-    });
-
-    it("sanitize limit with invalid value", () => {
-      // `Integer("abc")` (database_statements.rb:512) raises ArgumentError, not
-      // TypeError — TypeError is Ruby's arm for a value with no integer
-      // conversion at all (`Integer(nil)`).
-      expect(() => sanitizeLimit("abc")).toThrow(ArgumentError);
-      expect(() => sanitizeLimit(null)).toThrow(TypeError);
-      // `Integer(nil)` / `Integer([1])` / `Integer(true)` name the value's class
-      // (nil/true/false render as themselves); `Integer(Float::NAN)` and
-      // `Integer(Float::INFINITY)` raise FloatDomainError, not TypeError.
-      expect(() => sanitizeLimit(null)).toThrow("can't convert nil into Integer");
-      expect(() => sanitizeLimit([1])).toThrow("can't convert Array into Integer");
-      expect(() => sanitizeLimit(true)).toThrow("can't convert true into Integer");
-      expect(() => sanitizeLimit(NaN)).toThrow(
-        expect.objectContaining({ name: "FloatDomainError", message: "NaN" }),
-      );
-      expect(() => sanitizeLimit(Infinity)).toThrow(
-        expect.objectContaining({ name: "FloatDomainError", message: "Infinity" }),
-      );
-      expect(sanitizeLimit(3.9)).toBe(3);
-      expect(sanitizeLimit(-3.9)).toBe(-3);
       // `Integer(str)` parses with base detection, not as plain decimal: a bare
       // leading `0` is octal, `0x`/`0b`/`0o`/`0d` set the radix, and `_`
       // separates digits. Every pair below was taken from `ruby -e`.
@@ -649,9 +631,27 @@ describe("DatabaseStatements", () => {
       expect(sanitizeLimit("0_1")).toBe(1);
       expect(sanitizeLimit(" 12 ")).toBe(12);
       expect(sanitizeLimit("-0x10")).toBe(-16);
-      for (const bad of ["1__0", "1e3", "12.5", "08", "0b2", "0xg", "_1", "1_", "--5"]) {
+    });
+
+    it("sanitize limit with invalid value", () => {
+      // `Integer("abc")` (database_statements.rb:512) raises ArgumentError, not
+      // TypeError — TypeError is Ruby's arm for a value with no integer
+      // conversion at all, and it names the value's class (nil/true/false render
+      // as themselves). `Integer(Float::NAN)` / `Integer(Float::INFINITY)` raise
+      // FloatDomainError.
+      for (const bad of ["abc", "1__0", "1e3", "12.5", "08", "0b2", "0xg", "_1", "1_", "--5"]) {
         expect(() => sanitizeLimit(bad)).toThrow(ArgumentError);
       }
+      expect(() => sanitizeLimit(null)).toThrow(TypeError);
+      expect(() => sanitizeLimit(null)).toThrow("can't convert nil into Integer");
+      expect(() => sanitizeLimit([1])).toThrow("can't convert Array into Integer");
+      expect(() => sanitizeLimit(true)).toThrow("can't convert true into Integer");
+      expect(() => sanitizeLimit(NaN)).toThrow(
+        expect.objectContaining({ name: "FloatDomainError", message: "NaN" }),
+      );
+      expect(() => sanitizeLimit(Infinity)).toThrow(
+        expect.objectContaining({ name: "FloatDomainError", message: "Infinity" }),
+      );
     });
 
     it("with yaml fallback passes scalar through", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1317,22 +1317,47 @@ export function sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral {
   if ((typeof limit === "number" && Number.isInteger(limit)) || limit instanceof Nodes.SqlLiteral) {
     return limit;
   }
-  // Ruby's `Integer(limit)` (database_statements.rb:512): a decimal-integer
-  // string converts, a Float truncates toward zero, and anything else raises —
+  // Ruby's `Integer(limit)` (database_statements.rb:512): a String parses with
+  // base detection, a Float truncates toward zero, and anything else raises —
   // ArgumentError for a String Ruby cannot parse (which is what the SQL-injection
   // strings in `base_test.rb:187-205` hit), TypeError for a value that has no
   // integer conversion at all.
-  if (typeof limit === "string" && /^[+-]?\d+$/.test(limit.trim())) {
-    return Number(limit.trim());
-  }
   if (typeof limit === "string") {
-    throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(limit)}`);
+    return integerFromString(limit);
   }
   if (typeof limit === "number") {
     if (!Number.isFinite(limit)) throw new FloatDomainError(String(limit));
     return Math.trunc(limit);
   }
   throw new TypeError(`can't convert ${rubyClassName(limit)} into Integer`);
+}
+
+/**
+ * Ruby's `Integer(str)` with base 0: an optional sign, then a `0x`/`0b`/`0o`/`0d`
+ * radix prefix (a bare leading `0` meaning octal, so `Integer("012") # => 10`),
+ * with `_` allowed between digits. Anything else raises ArgumentError.
+ */
+function integerFromString(str: string): number {
+  const invalid = () => new ArgumentError(`invalid value for Integer(): ${JSON.stringify(str)}`);
+  const signMatch = /^([+-]?)(.*)$/s.exec(str.trim())!;
+  const sign = signMatch[1];
+  let body = signMatch[2];
+
+  let radix = 10;
+  const prefix = /^0([xbod])/i.exec(body);
+  if (prefix) {
+    radix = { x: 16, b: 2, o: 8, d: 10 }[prefix[1].toLowerCase()]!;
+    body = body.slice(2);
+  } else if (/^0./.test(body)) {
+    // A bare leading `0` is the octal prefix, and like the lettered prefixes it
+    // may be followed by an `_` separator: `Integer("0_1") # => 1`.
+    radix = 8;
+    body = body.slice(1).replace(/^_/, "");
+  }
+
+  const digits = { 2: "[01]", 8: "[0-7]", 10: "[0-9]", 16: "[0-9a-fA-F]" }[radix]!;
+  if (!new RegExp(`^${digits}(?:_?${digits})*$`).test(body)) throw invalid();
+  return (sign === "-" ? -1 : 1) * Number.parseInt(body.replace(/_/g, ""), radix);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -16,7 +16,7 @@ import {
   Table,
   InsertManager,
 } from "@blazetrails/arel";
-import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
+import { RangeError as ActiveModelRangeError, ArgumentError } from "@blazetrails/activemodel";
 import {
   TransactionIsolationError,
   NotImplementedError,
@@ -1314,16 +1314,24 @@ export function emptyInsertStatementValue(_primaryKey?: string | null): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#sanitize_limit
  */
 export function sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral {
-  if (typeof limit === "number" && Number.isInteger(limit)) {
+  if ((typeof limit === "number" && Number.isInteger(limit)) || limit instanceof Nodes.SqlLiteral) {
     return limit;
   }
-  if (limit instanceof Nodes.SqlLiteral) {
-    return limit;
-  }
+  // Ruby's `Integer(limit)` (database_statements.rb:512): a decimal-integer
+  // string converts, a Float truncates toward zero, and anything else raises —
+  // ArgumentError for a String Ruby cannot parse (which is what the SQL-injection
+  // strings in `base_test.rb:187-205` hit), TypeError for a value that has no
+  // integer conversion at all.
   if (typeof limit === "string" && /^[+-]?\d+$/.test(limit.trim())) {
     return Number(limit.trim());
   }
-  throw new TypeError(`Invalid LIMIT: ${limit}`);
+  if (typeof limit === "string") {
+    throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(limit)}`);
+  }
+  if (typeof limit === "number" && Number.isFinite(limit)) {
+    return Math.trunc(limit);
+  }
+  throw new TypeError(`can't convert ${limit === null ? "nil" : typeof limit} into Integer`);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1328,10 +1328,35 @@ export function sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral {
   if (typeof limit === "string") {
     throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(limit)}`);
   }
-  if (typeof limit === "number" && Number.isFinite(limit)) {
+  if (typeof limit === "number") {
+    if (!Number.isFinite(limit)) throw new FloatDomainError(String(limit));
     return Math.trunc(limit);
   }
-  throw new TypeError(`can't convert ${limit === null ? "nil" : typeof limit} into Integer`);
+  throw new TypeError(`can't convert ${rubyClassName(limit)} into Integer`);
+}
+
+/**
+ * Ruby core's `FloatDomainError` (a `RangeError` subclass) — what
+ * `Integer(Float::NAN)` / `Integer(Float::INFINITY)` raise, message `"NaN"` /
+ * `"Infinity"`. Spelled locally rather than exported: it is reachable only
+ * through `Integer()`'s Float arm, as in Ruby.
+ */
+class FloatDomainError extends globalThis.RangeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FloatDomainError";
+  }
+}
+
+/**
+ * The name Ruby's `TypeError` message uses for an unconvertible value:
+ * `nil`/`true`/`false` render as themselves, everything else as its class
+ * (`can't convert Array into Integer`).
+ */
+function rubyClassName(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "boolean") return String(value);
+  return (value as object)?.constructor?.name ?? typeof value;
 }
 
 /**

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -213,7 +213,7 @@ export function group<T extends typeof Base>(
 /** Mirrors: ActiveRecord::Querying#limit */
 export function limit<T extends typeof Base>(
   this: T,
-  value: number | null,
+  value: number | string | null,
 ): Relation<InstanceType<T>> {
   return this.all().limit(value);
 }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -85,6 +85,7 @@ import {
   type CounterCacheTouchOption,
 } from "./timestamp.js";
 import { Explain } from "./explain.js";
+import { sanitizeLimit } from "./connection-adapters/abstract/database-statements.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { PrettyPrinter } from "./pretty-print.js";
@@ -268,7 +269,7 @@ export type ValuesHash = {
   optimizerHints?: string[];
   annotate?: string[];
   with?: Array<{ name: string; expression: Nodes.Node; recursive: boolean }>;
-  limit?: number | null;
+  limit?: number | string | null;
   offset?: number | string | null;
   lock?: string | null;
   readonly?: boolean;
@@ -1083,7 +1084,7 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#limit
    */
-  limit(value: number | null): Relation<T> {
+  limit(value: number | string | null): Relation<T> {
     return this._clone().limitBang(value);
   }
 
@@ -3383,10 +3384,14 @@ export class Relation<T extends Base> {
    */
   toArel(aliases?: AliasTracker): SelectManager {
     // Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
-    // (query_methods.rb:1595). `_resolveAdapter` is the trails stand-in for the
-    // acquisition: it yields the threaded connection when there is one and null
-    // for a model with no established pool, which Arel building tolerates.
-    return this.buildArel(this._resolveAdapter(), aliases);
+    // (query_methods.rb:1595), so `build_arel` always has a connection.
+    // `_resolveAdapter` is the trails stand-in for that acquisition, but it
+    // yields null for a model with no established pool — Arel building is
+    // reachable there (CTE bodies, `from(relation)` subqueries). Name that case
+    // HERE, at the acquisition point, substituting the abstract adapter's own
+    // `sanitize_limit` (abstract/database_statements.rb), so `build_arel`'s body
+    // never has to consider a missing connection the way Rails' never does.
+    return this.buildArel(this._resolveAdapter() ?? { sanitizeLimit }, aliases);
   }
 
   /**
@@ -4438,8 +4443,8 @@ export class Relation<T extends Base> {
    * (`owner.things.where(...)`) resolves the persisted FK once the owner is
    * saved — mirroring Rails' CollectionProxy delegating every query to
    * `association.scope`, rather than each terminal carrying its own rebase hook.
-   * `CollectionProxy` overrides this too, so mutation terminals invoked on the
-   * PROXY itself (`owner.things.updateAll(...)`) rebase the same way.
+   * `CollectionProxy` needs no rebase at all: its mutation terminals route
+   * through `scope()`, which the association rebuilds against the resolved FK.
    *
    * @internal
    */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3120,8 +3120,8 @@ export class Relation<T extends Base> {
     // No `none?` guard here: Rails' touch_all (relation.rb:969-971) is a bare
     // `update_all model.touch_attributes_with_time(...)` and inherits the
     // `return 0 if @none` from update_all (relation.rb:592). Delegating rather
-    // than short-circuiting also routes the new-owner seed rebase through
-    // updateAll's chokepoint.
+    // than short-circuiting is also what puts a CollectionProxy's touchAll on
+    // `CollectionProxy#updateAll`, and so on the association scope.
 
     // Use touchAttributesWithTime so alias-resolved column names are used
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
@@ -4224,7 +4224,8 @@ export class Relation<T extends Base> {
   ): Promise<number> {
     // No `none?` guard here: Rails' update_counters (relation.rb:926-944) ends
     // in `update_all updates` and inherits the `return 0 if @none` from there
-    // (relation.rb:592), which is also what routes the new-owner seed rebase.
+    // (relation.rb:592), and — on a CollectionProxy — the association scope,
+    // via `CollectionProxy#updateAll`.
 
     // Rails extracts :touch from the counters hash itself (relation.rb: `touch = counters.delete(:touch)`)
     const touchFromCounters = (counters as Record<string, unknown>).touch;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -500,16 +500,16 @@ export class Relation<T extends Base> {
   private _isNone = false;
   /**
    * @internal True when this relation's WHERE base is the stale new-owner
-   * `1=0` NullRelation seed of a `CollectionProxy` (owner was a NEW record when
-   * the proxy was constructed). Set on the proxy at construction and propagated
-   * to every spawned relation via `initializeCopy`, so a query executed after
-   * the owner is saved can rebase the dead seed onto the resolved association
-   * scope. See `associations/new-owner-seed-rebase.ts`.
+   * `1=0` NullRelation seed of an association scope built while the owner was a
+   * NEW record. Set on that scope and propagated to every spawned relation via
+   * `initializeCopy`, so a query executed after the owner is saved can rebase
+   * the dead seed onto the resolved association scope. See
+   * `associations/new-owner-seed-rebase.ts`.
    */
   _seededNoneNewOwner = false;
   /**
    * @internal Identity snapshot of the seed WHERE predicates captured when a
-   * `CollectionProxy` is constructed, so a rebase can separate accumulated
+   * new-owner association scope is built, so a rebase can separate accumulated
    * mutation predicates from the stale `1=0` seed. Empty on ordinary relations.
    */
   _seedWherePredicates: readonly unknown[] = [];
@@ -3120,8 +3120,8 @@ export class Relation<T extends Base> {
     // No `none?` guard here: Rails' touch_all (relation.rb:969-971) is a bare
     // `update_all model.touch_attributes_with_time(...)` and inherits the
     // `return 0 if @none` from update_all (relation.rb:592). Delegating rather
-    // than short-circuiting is also what puts a CollectionProxy's touchAll on
-    // `CollectionProxy#updateAll`, and so on the association scope.
+    // than short-circuiting is also what lets a CollectionProxy's touchAll build
+    // from the value readers delegated to `scope` (collection_proxy.rb:1128-1137).
 
     // Use touchAttributesWithTime so alias-resolved column names are used
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
@@ -4225,7 +4225,7 @@ export class Relation<T extends Base> {
     // No `none?` guard here: Rails' update_counters (relation.rb:926-944) ends
     // in `update_all updates` and inherits the `return 0 if @none` from there
     // (relation.rb:592), and — on a CollectionProxy — the association scope,
-    // via `CollectionProxy#updateAll`.
+    // through the value readers delegated to `scope` (collection_proxy.rb:1128-1137).
 
     // Rails extracts :touch from the counters hash itself (relation.rb: `touch = counters.delete(:touch)`)
     const touchFromCounters = (counters as Record<string, unknown>).touch;
@@ -4444,8 +4444,8 @@ export class Relation<T extends Base> {
    * (`owner.things.where(...)`) resolves the persisted FK once the owner is
    * saved — mirroring Rails' CollectionProxy delegating every query to
    * `association.scope`, rather than each terminal carrying its own rebase hook.
-   * `CollectionProxy` needs no rebase at all: its mutation terminals route
-   * through `scope()`, which the association rebuilds against the resolved FK.
+   * `CollectionProxy` needs no rebase at all: it is never `@none` itself, and
+   * its value readers are delegated to `scope` (collection_proxy.rb:1128-1137).
    *
    * @internal
    */

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -252,7 +252,7 @@ interface QueryMethodsHost {
   withValues: Array<Record<string, unknown>>;
   /** Mirrors Rails' `@with_is_recursive` (query_methods.rb:527). */
   _withIsRecursive: boolean;
-  limitValue: number | null;
+  limitValue: number | string | null;
   offsetValue: number | string | null;
   lockValue: string | null;
   readonlyValue: boolean | null;
@@ -1145,16 +1145,10 @@ function havingBang(
   return this;
 }
 
-function limitBang(this: QueryMethodsHost, value: number | null): any {
-  if (value == null) {
-    this.limitValue = null;
-    return this;
-  }
-  const num = Number(value);
-  if (!Number.isSafeInteger(num) || num < 0) {
-    throw new Error(`Invalid limit value: ${String(value)}`);
-  }
-  this.limitValue = num;
+function limitBang(this: QueryMethodsHost, value: number | string | null): any {
+  // Mirrors `limit!` (query_methods.rb:1215-1218): the raw value is stored and
+  // sanitized later, by `build_arel`'s `connection.sanitize_limit` (:1757).
+  this.limitValue = value;
   return this;
 }
 
@@ -2255,7 +2249,13 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // shape deviation to converge away. See the
     // `eager-from-subquery-column-alias-projection` story.
     const subArel =
-      typeof resolved.toArel === "function" ? resolved.toArel() : resolved.buildArel();
+      typeof resolved.toArel === "function"
+        ? resolved.toArel()
+        : // A duck-typed relation with no `toArel` acquisition seam: this
+          // subquery build is one of the connectionless paths, so pass the
+          // abstract `sanitize_limit` (abstract/database_statements.rb)
+          // explicitly rather than letting `buildArel` degrade internally.
+          resolved.buildArel({ sanitizeLimit });
     return subArel.as(alias);
   }
   return opts;
@@ -2404,13 +2404,10 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
 export function buildArel(
   this: QueryMethodsHost,
   // Rails threads the `with_connection` connection into every `build_arel`
-  // call (query_methods.rb:1595, relation.rb:1023) and reads it for
-  // `connection.sanitize_limit` (query_methods.rb:1757). trails' Arel building
-  // is reachable on a model with no established connection (subquery/CTE
-  // construction in tests), where `_conn()` raises — so a null connection
-  // degrades to the same `sanitize_limit` as a module function, exactly as
-  // `_annotationComments` degrades to the abstract `sanitizeAsSqlComment`.
-  connection?: { sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral } | null,
+  // call (query_methods.rb:1595, relation.rb:1023), so the body never sees a
+  // missing one. Callers acquire before calling; the connectionless Arel build
+  // is named at the acquisition point (`Relation#toArel`), not tolerated here.
+  connection: { sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral },
   aliases?: AliasTracker,
 ): any {
   const table: any = this.table;
@@ -2422,14 +2419,7 @@ export function buildArel(
   if (!this.havingClause.isEmpty()) arel.having(this.havingClause.ast);
 
   if (this.limitValue !== null)
-    arel.take(
-      buildCastValue(
-        "LIMIT",
-        connection?.sanitizeLimit
-          ? connection.sanitizeLimit(this.limitValue)
-          : sanitizeLimit(this.limitValue),
-      ),
-    );
+    arel.take(buildCastValue("LIMIT", connection.sanitizeLimit(this.limitValue)));
   if (this.offsetValue !== null) arel.skip(buildCastValue("OFFSET", toI(this.offsetValue)));
 
   if (this.groupValues.length > 0)


### PR DESCRIPTION
Three convergence stories in one PR.

### CollectionProxy mutation terminals route through `scope` (0106)

Rails' `CollectionProxy` has no `update_all`. It inherits `Relation#update_all`,
whose `where_clause` / `values` readers are QueryMethods publics
(`query_methods.rb:162-183`) and therefore routed to `@association.scope` by
`delegate(*delegate_methods, to: :scope)` (`collection_proxy.rb:1128-1137`,
`:949-950`) — that is how the inherited terminal respects the association scope
with no override, and why Rails has no seed to rebase.

trails' proxy owns its inherited relation state (the ctor seed is load-bearing
for `toSql()`), so the value readers can't be delegated; the **terminal**
delegates instead: `CollectionProxy#updateAll` is `scope().updateAll(updates)`.
`touchAll` / `updateCounters` need no override — like Rails
(`relation.rb:969-971`, `:926-944`) they end in `update_all` and land there;
`deleteAll` already routed through the association.

With the FK rebuilt by the association, the stale new-owner seed is never read,
so `_seededNoneNewOwner` (on the proxy), `_maybeRebaseProxySeed` and the
`CollectionProxy#_isEmptyRelation` override are deleted, along with
`assertValidLimit`, which existed only to mirror the old `limitBang` guard.
`AssociationRelation`'s rebase (for relations spawned off a new owner) is
untouched.

The `updateAll` override carries a CONVERGEABLE `@noRailsEquivalent`; the follow-up
story `collection-proxy-delegate-query-method-value-readers-to-scope` (0106) moves
the readers onto `scope()` and deletes it.

### `buildArel`'s connection is never null (0107)

Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
(`query_methods.rb:1595`), so `connection.sanitize_limit(limit_value)` (`:1757`)
never considers a missing connection. `buildArel`'s `connection` parameter is now
required and the fallback ternary is gone. The connectionless Arel build is named
at the acquisition point — `Relation#toArel` and `buildFrom`'s duck-typed subquery
arm — rather than degrading silently inside the ported body.

### `limit!` is a bare assignment (0107)

`limitBang` is `self.limit_value = value` (`query_methods.rb:1215-1218`) — no
eager guard, no `Number()` coercion, no bare `Error`. The signature widens to
`number | string | null` exactly as `offset!`'s did in #6602.

`sanitizeLimit` now mirrors Ruby's `Integer(limit)` arms
(`database_statements.rb:508-514`): ArgumentError for an unparseable String
(which is what the injection strings in `base_test.rb:187-205` hit), TypeError
only where Ruby has no integer conversion at all. The three `base_test.rb` limit
tests re-point at the query-build throw, which is where Rails' `to_a` raises them.

### Verification

`parity:api:calls`, `parity:api:calls:args`, `parity:api:extra --package
activerecord`, `pnpm lint`, `pnpm typecheck` all clean. Green locally on SQLite:
`packages/activerecord/src/associations` (100 files, 2149 tests),
`packages/activerecord/src/relation` (58 files, 1189 tests), `relation.test.ts`,
`base.test.ts`, `database-statements.test.ts`.

Closes-story: collection-proxy-mutation-terminals-through-scope
Closes-story: build-arel-connection-never-null
Closes-story: converge-limit-bang-to-bare-assignment


---

### Review round 1

**Finding 1 — stale rebase comments (fixed).** `relation.ts` `touchAll` and
`updateCounters` no longer claim to route a CollectionProxy new-owner seed
rebase; they now say what actually happens — delegating to `update_all` is what
puts a proxy's `touchAll` / `updateCounters` on `CollectionProxy#updateAll`, and
so on the association scope. `AssociationRelation`'s rebase is untouched and its
`_isEmptyRelation` docs still describe it accurately.

**Finding 2 — read-side `limitValue` declarations (deferred, same rationale as
`offsetValue` after #6602).** Confirmed and deliberately out of scope: it is the
identical defect on both fields, and fixing only `limitValue` would leave the
pair inconsistent. Filed as 0107 `widen-limit-offset-value-read-declarations`,
which covers `limitValue` AND `offsetValue` together.

On the behaviour: Ruby raises at each of those sites too, so this is a
raise-site/class divergence rather than a silent-wrong-answer one everywhere.

- `finder_methods.rb:610` is `limit = [limit_value - index, limit].min` —
  `String#-` raises `NoMethodError`. trails' `finder-methods.ts:557` yields
  `NaN`, which flows into `relation.limit(NaN)` and *does* raise, from
  `sanitizeLimit` (`database_statements.rb:508-514`) — a different class at a
  later site, not a wrong result.
- `inspect` / `pretty_print` use `[limit_value, 11].compact.min`, which raises
  `ArgumentError: comparison of String with 11 failed`; trails renders an empty
  entry list instead. This is the one arm that is silently wrong, and it is
  display-only.
- `in_batches`' `remaining < batch_limit` raises in Ruby; trails' `as number`
  cast compares falsely.

I widened the three declarations locally to check the blast radius: TS flags
exactly two sites (`relation.ts:1312`, `:1339`), and every candidate fix for
them — `Number()` coercion, a `< 11` comparison, a bespoke raise — is either a
coercion Rails does not have or an invented guard. Doing it properly means
porting Ruby's raising semantics at all of the arithmetic sites for both fields,
which is the filed story, not a drive-by here.


### Review round 2 — `sanitizeLimit` vs `Kernel#Integer`

Both flagged edge gaps are fixed, and chasing them surfaced a third, larger one.

- `Integer(Float::NAN)` / `Integer(Float::INFINITY)` now raise a module-local
  `FloatDomainError` (a `RangeError` subclass, message `"NaN"` / `"Infinity"`)
  instead of the generic TypeError arm.
- The TypeError message names the value's class via `rubyClassName` —
  `can't convert nil into Integer`, `can't convert true into Integer`,
  `can't convert Array into Integer`.
- **New:** `Integer(str)` does base detection, which the old decimal-only
  `/^[+-]?\d+$/` did not. `Integer("012")` is **10** (octal), `Integer("0x1f")`
  is 31, `Integer("1_000")` is 1000 — trails returned 12 and raised on the other
  two. That gap only became live in this PR: with `limit!` no longer coercing,
  `sanitize_limit` is now the sole parser on the LIMIT path, so
  `limit("012")` would have emitted `LIMIT 12` where Rails emits `LIMIT 10`.
  `integerFromString` now ports `Integer()`'s arms (sign, `0x`/`0b`/`0o`/`0d`
  and bare-`0` octal prefixes, `_` digit separators).

Verified by differential-testing 37 inputs against MRI (`ruby -e`, the
interpreter on PATH) — every value and every raise site matches, including
`"0_1"` → 1, `"1__0"` → raise, `"08"` → raise, `"0b2"` → raise. The cases are
pinned in `database-statements.test.ts` under the existing
`sanitize limit with {integer,string integer,invalid value}` names, each filed
under the name it belongs to rather than piled into one.

`FloatDomainError`, `rubyClassName` and `integerFromString` are module-local, so
`parity:api:extra` stays at zero novel surface: they are Ruby's `Kernel#Integer`
arms ported into the one call site that reaches them, not a new abstraction
layer over `sanitize_limit`.


### Rebase onto #6609 — a real regression caught, fixed, and pinned

#6609 landed `CollectionProxy#scope` as `@scope ||= @association.scope`
(`collection_proxy.rb:949-950`) and, in the same commit, taught the
proxy-side `_maybeRebaseProxySeed` to reset both memo levels first. This PR
deletes that method, so the two changes conflicted. Resolved to this PR's shape
— then the full associations suite failed
`InverseBelongsToTests > building has many parent association inverses one
record`.

It was a genuine regression in this PR, not a rebase artifact.
`CollectionProxy#calculate`'s non-null-scope arm runs `super` against the
proxy's OWN relation state, which the deleted `_isEmptyRelation` override used
to rebase. `null_scope?` is evaluated at call time
(`collection_proxy.rb:1150-1152` → `@association.null_scope?`), so it is already
false once the owner is saved — but a proxy built for a then-new owner still
carries its `1=0` seed. Confirmed by instrumenting the failing sequence:
after the save the proxy reported `isNullScope: false`, `_isNone: true`,
`SELECT ... WHERE (1=0)`, while `scope()` was correctly resolved to
`WHERE "interests"."human_id" = …`.

Rails never hits this because its proxy owns no relation state — `where_clause`
comes from `scope` through the delegated readers (`:1128-1137`). So `calculate`
now defers to the rebuilt scope when the proxy's own state is a none relation,
the same move the mutation terminals make.

Two regression tests added, each verified to red against the unfixed code:

- `counts against the persisted FK when the proxy was first read before save` —
  reds with `expected +0 to be 1` without the `calculate` fix.
- `resolves the persisted FK on updateAll when the proxy scope was memoized
  before save` — covers #6609's new memo: the memoized scope is an
  `AssociationRelation`, so the first terminal rebases it in place; reds when
  `AssociationRelation#_isEmptyRelation`'s rebase is disabled.

Full re-verification after the rebase: `pnpm lint`, `pnpm typecheck`,
`parity:api:calls`, `:args`, `parity:api:extra --package activerecord` all
clean; `packages/activerecord/src/associations` (100 files, 2152 tests),
`src/relation`, `relation.test.ts` and `base.test.ts` green — 3511 tests total.


### Rebase onto #6612 — the open finding is gone, and so is the override

#6612 landed the value-reader delegation (the 0106 follow-up story this PR
filed, now closed), so the inherited `Relation#update_all` already builds from
the association scope. **`CollectionProxy#updateAll` is deleted** — with it the
`@noRailsEquivalent CONVERGEABLE` tag, and `parity:api:extra` is back to zero
novel surface for this PR.

Removing it turned the mutation-terminal covers red, which located the real
remaining divergence: the proxy's own `@none`. Rails never sets it on a
CollectionProxy — `none!` is itself delegated to `scope`, so it flips the
SCOPE's flag and the proxy sees the `1=0` only through the delegated
`where_clause` reader. trails' ctor seeds the proxy's inherited state from a
`none!`d relation (load-bearing for `toSql()`), which copied that flag across,
so the inherited `update_all`'s `return 0 if @none` (`relation.rb:1013`) fired
on the proxy itself. `seedNone` now clears it — one line, at the seam that
creates the artifact.

**This retires the open finding rather than answering it.** `calculate` is back
to Rails' exact one-liner `null_scope? ? scope.calculate(...) : super`
(`collection_proxy.rb:724-726`) — the extra `_isEmptyRelation()` condition is
gone, so there is no longer any behaviour change for the non-new-owner `_isNone`
shapes you asked about. For the record, the investigation behind that question:

- The polymorphic-has_many-source shape never reaches `_buildThroughScope`'s
  `.all().none()` line at all — `_canRouteThroughViaAssociationScope` returns
  false for a polymorphic non-`belongs_to` source (`associations.ts:886-891`),
  so the ctor takes the IN-subquery fallback branch instead.
- `hasManyScope` returns null at exactly two sites: `has-many-association.ts:721`
  (`through && !reflection`) and `:767` (an owner key column reads
  null/undefined — the new-owner case this story targets).
- I could not construct a proxy in the `through && !reflection` state: the
  ctor's own upfront validation raises `ConfigurationError` for a missing
  through association, and with the through association present the proxy came
  out `_isNone: false`.

The covering test stays regardless: `Tag has_many :null_taggings, -> { none }`
on a PERSISTED tag still counts 0 — which now also guards that clearing the
seed's `@none` flag doesn't break a scope-level `none`.

Two covers were also re-pointed at Rails' actual contract. `reader`
(`collection_association.rb:34-43`) ends in `@proxy.reset_scope`
(`collection_proxy.rb:1112-1116`), so a re-read after the save drops the
memoized `1=0` scope — but a proxy HELD across the save keeps its stale memo in
Rails too. Verified both halves against trails: the held proxy returns 0, a
re-read through `association(...)` returns 1. My earlier versions asserted the
held proxy resolved, which Rails does not do; they now read through the reader,
as the Rails tests (`person.references.update_all`,
`interest.human.interests.size`) do.

Re-verified after the rebase: `lint`, `typecheck`, `parity:api:calls`, `:args`,
`parity:api:extra --package activerecord` all clean; `src/associations` (101
files, 2226 tests) and `relation.test.ts` green.
