### PR TITLE
refactor(activesupport): ParameterFilter joins one Regexp per group and allocates through params.constructor

### DIFF
--- a/packages/activesupport/src/parameter-filter.test.ts
+++ b/packages/activesupport/src/parameter-filter.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { ParameterFilter } from "./parameter-filter.js";
 
+/** Ruby's `String#swapcase`, which JS has no built-in for. */
+function swapcase(str: string): string {
+  return str.replace(/\p{L}/gu, (c) => (c === c.toLowerCase() ? c.toUpperCase() : c.toLowerCase()));
+}
+
 describe("ParameterFilterTest", () => {
   it("process parameter filter", () => {
     const f = new ParameterFilter(["password", "credit_card"]);
@@ -63,7 +68,19 @@ describe("ParameterFilterTest", () => {
     const precompiled = ParameterFilter.precompileFilters([...patterns, ...deepPatterns, ...procs]);
 
     const regexps = precompiled.filter((f): f is RegExp => f instanceof RegExp);
-    expect(precompiled.length).toBe(regexps.length + procs.length);
+    expect(regexps.length).toBe(2);
+    expect(precompiled.length).toBe(2 + procs.length);
+
+    const regexp = regexps.find((r) => r.source.includes((patterns[0] as RegExp).source))!;
+    for (const key of keys) expect(regexp.test(key)).toBe(true);
+    expect(regexp.test(swapcase(keys[0]))).toBe(false);
+
+    const deepRegexp = regexps.find((r) => r.source.includes((deepPatterns[0] as RegExp).source))!;
+    for (const deepKey of deepKeys) expect(deepRegexp.test(deepKey)).toBe(true);
+    expect(deepRegexp.test(swapcase(deepKeys[0]))).toBe(false);
+
+    expect(regexp).not.toEqual(deepRegexp);
+    expect(precompiled.filter((f) => procs.includes(f as () => void))).toEqual(procs);
 
     const filter = new ParameterFilter(precompiled);
     for (const key of keys) expect(filter.filterParam(key, "x")).toBe("[FILTERED]");

--- a/packages/activesupport/src/parameter-filter.trails.test.ts
+++ b/packages/activesupport/src/parameter-filter.trails.test.ts
@@ -31,4 +31,37 @@ describe("ParameterFilter (trails)", () => {
     expect(result.other).toBe("abc");
     expect(seen).toEqual(["secret", "other"]);
   });
+
+  it("keeps a case-insensitive pattern the flag expansion cannot rewrite as its own Regexp", () => {
+    // Ruby folds every pattern of a group into ONE Regexp with an inline
+    // `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag
+    // group, so the port expands each cased character to `[aA]` — which is
+    // unsafe for a source carrying a character class, a Unicode property
+    // escape or a named group. Those keep their own `i`-flagged Regexp
+    // instead of being folded in, which is the one case where a group ends
+    // up with more than one Regexp.
+    const unexpandable = [/[xy]z/i, /\p{L}q/iu, /(?<tail>vw)/i];
+    for (const pattern of unexpandable) {
+      const precompiled = ParameterFilter.precompileFilters([/plain/, pattern]);
+      expect(precompiled).toContain(pattern);
+      expect(precompiled.length).toBe(2);
+      expect((precompiled[0] as RegExp).source).toBe("plain");
+    }
+
+    // Riding along as its own Regexp keeps the `i` flag, so `new
+    // ParameterFilter(precompiled)` still matches case-insensitively.
+    const filter = new ParameterFilter(ParameterFilter.precompileFilters([/[xy]z/i, "ccC"]));
+    expect(filter.filterParam("XZ", "v")).toBe("[FILTERED]");
+    expect(filter.filterParam("cCc", "v")).toBe("[FILTERED]");
+    expect(filter.filterParam("zzz", "v")).toBe("v");
+  });
+
+  it("keeps a deep case-insensitive pattern the flag expansion cannot rewrite as its own Regexp", () => {
+    const precompiled = ParameterFilter.precompileFilters([/a\.a/, /[xy]\.z/i]);
+    expect(precompiled.length).toBe(2);
+    const filter = new ParameterFilter(precompiled);
+    expect(filter.filter({ X: { Z: "v" } }).X).toEqual({ Z: "[FILTERED]" });
+    expect(filter.filter({ a: { a: "v" } }).a).toEqual({ a: "[FILTERED]" });
+    expect(filter.filter({ a: { b: "v" } }).a).toEqual({ b: "v" });
+  });
 });

--- a/packages/activesupport/src/parameter-filter.ts
+++ b/packages/activesupport/src/parameter-filter.ts
@@ -30,7 +30,8 @@
  * hands the block `key.dup` (parameter_filter.rb:149), a copy local to
  * `value_for_key`, while `call` writes `filtered_params[key]` with its own
  * unmutated key (:129) — so a key mutation never reaches the filtered hash in
- * Rails either. `value_for_key` returns the value alone in both.
+ * Rails either. `value_for_key` returns the value alone in both, which is why
+ * a `{ key, value }` return shape would be surface Rails' block does not have.
  */
 export type FilterProc = (
   key: string,
@@ -55,21 +56,24 @@ export class ParameterFilter {
    * precompiled filters can be retained).
    *
    * Ruby joins the escaped string patterns and the given Regexps into a single
-   * Regexp, spelling each string's case-insensitivity with the inline
-   * `(?i:...)` group. JS regular expressions have no inline flag groups — `i`
-   * is a whole-pattern flag — so the case-insensitive patterns are joined into
-   * their own Regexp rather than sharing one with the case-sensitive ones. The
-   * shallow-before-deep ordering, and the contents of each group, are Rails'.
+   * Regexp per group, spelling each case-insensitive part with the inline
+   * `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag group,
+   * so {@link ignoreCaseSource} spells the same matching case-sensitively —
+   * each cased character expanded to a `[aA]` class — and the group is joined
+   * into ONE Regexp exactly as Rails'. A source that expansion cannot rewrite
+   * safely (a character class, a Unicode property escape, a named group or
+   * backreference) rides on as the caller's own Regexp after the joined one,
+   * rather than being folded into it.
    */
   static precompileFilters(filters: Filter[]): Array<FilterProc | RegExp> {
-    const patterns: Array<{ source: string; ignoreCase: boolean }> = [];
+    const patterns: Array<{ source: string; ignoreCase: boolean; regexp?: RegExp }> = [];
     const compiled: Array<FilterProc | RegExp> = [];
 
     for (const filter of filters) {
       if (typeof filter === "function") {
         compiled.push(filter);
       } else if (filter instanceof RegExp) {
-        patterns.push({ source: filter.source, ignoreCase: filter.ignoreCase });
+        patterns.push({ source: filter.source, ignoreCase: filter.ignoreCase, regexp: filter });
       } else {
         patterns.push({ source: escapeRegexp(String(filter)), ignoreCase: true });
       }
@@ -81,12 +85,15 @@ export class ParameterFilter {
     }
 
     for (const group of [patterns, deepPatterns]) {
-      for (const ignoreCase of [false, true]) {
-        const sources = group.filter((p) => p.ignoreCase === ignoreCase).map((p) => p.source);
-        if (sources.length > 0) {
-          compiled.push(new RegExp(sources.join("|"), ignoreCase ? "i" : ""));
-        }
+      const sources: string[] = [];
+      const unexpandable: RegExp[] = [];
+      for (const pattern of group) {
+        const source = pattern.ignoreCase ? ignoreCaseSource(pattern.source) : pattern.source;
+        if (source === null) unexpandable.push(pattern.regexp!);
+        else sources.push(source);
       }
+      if (sources.length > 0) compiled.push(new RegExp(sources.join("|")));
+      compiled.push(...unexpandable);
     }
 
     return compiled;
@@ -167,9 +174,13 @@ export class ParameterFilter {
     fullParentKey: string | null = null,
     originalParams: Record<string, unknown> | null = params,
   ): Record<string, unknown> {
-    // `params.class.new` (parameter_filter.rb:126): a plain JS object has no
-    // constructor to call, so the same prototype is the same class.
-    const filteredParams = Object.create(Object.getPrototypeOf(params)) as Record<string, unknown>;
+    // `params.class.new` (parameter_filter.rb:126). A null-prototype hash has
+    // no constructor — no class, in Ruby's terms — so it allocates a plain
+    // Object, the nearest thing JS has to its class.
+    const filteredParams = new ((params.constructor ?? Object) as ObjectConstructor)() as Record<
+      string,
+      unknown
+    >;
 
     for (const [key, value] of Object.entries(params)) {
       filteredParams[key] = this.valueForKey(key, value, fullParentKey, originalParams);
@@ -206,6 +217,39 @@ export class ParameterFilter {
 
     return value;
   }
+}
+
+/**
+ * Ruby spells a case-insensitive alternative inline as `(?i:...)`
+ * (parameter_filter.rb:59) so one Regexp can carry both case-sensitive and
+ * case-insensitive parts. JS has no inline flag group, so the same matching is
+ * spelled case-sensitively by expanding each cased character to a `[aA]` class.
+ *
+ * Returns null for a source whose letters are not all literal — a character
+ * class (where `[aA]` cannot be nested and a range must not be expanded), a
+ * Unicode property escape, a named group or a named backreference — where the
+ * expansion would silently corrupt the pattern. `Regexp.escape`d strings, the
+ * only sources Rails itself wraps in `(?i:...)`, never contain any of them.
+ */
+function ignoreCaseSource(source: string): string | null {
+  let out = "";
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    if (char === "\\") {
+      const next = source[i + 1];
+      if (next === "p" || next === "P" || next === "k") return null;
+      out += char + (next ?? "");
+      i++;
+      continue;
+    }
+    if (char === "[") return null;
+    if (source.startsWith("(?<", i) && source[i + 3] !== "=" && source[i + 3] !== "!") return null;
+    const lower = char.toLowerCase();
+    const upper = char.toUpperCase();
+    out +=
+      lower === upper || lower.length !== 1 || upper.length !== 1 ? char : `[${lower}${upper}]`;
+  }
+  return out;
 }
 
 /** Mirrors Ruby's `Regexp.escape`, which JS has no built-in for. */

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/parameter-filter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/parameter-filter.json
@@ -2,13 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "parameter-filter.ts",
-    "rubyName": "call",
-    "call": "new",
-    "reason": "`params.class.new` (parameter_filter.rb:126) allocates a hash of the receiver's class; a plain JS object has no constructor to call, so `Object.create(Object.getPrototypeOf(params))` is the same allocation and keeps a null-prototype params hash null-prototype."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "parameter-filter.ts",
     "rubyName": "compile_filters!",
     "call": "new",
     "kind": "args",
@@ -16,6 +9,6 @@
       "ref:join",
       "bool:true"
     ],
-    "reason": "`Regexp.new(strings.join(\"|\"), true)` (parameter_filter.rb:121-122) — Ruby's second Regexp argument is the ignore-case boolean; the JS constructor takes a flag string, so `\"i\"` is the same argument spelled the way the language spells it. Language shortcoming."
+    "reason": "`Regexp.new(strings.join(\"|\"), true)` (parameter_filter.rb:121-122) — Ruby's second Regexp argument is the ignore-case boolean; the JS constructor's second argument is a flag string, so `\"i\"` is the same argument spelled the way the language spells it. Irreducible language shortcoming, demonstrated under burn-down-parameter-filter-regexp-and-block-deviations (RFC 0098): the flag is whole-pattern in both languages here, so there is no closer spelling."
   }
 ]


### PR DESCRIPTION
Burns down the ParameterFilter deviations shipped with #6608, against
`activesupport/lib/active_support/parameter_filter.rb`.

**1. `precompile_filters`' inline `(?i:...)` group — converged.** Ruby joins each
group into ONE Regexp, spelling a case-insensitive part with an inline flag group
(parameter_filter.rb:58-65). JS has no inline flag group, but the same matching is
spelled case-sensitively by expanding each cased character to a `[aA]` class, which
`ignoreCaseSource` now does — so `precompileFilters` returns one Regexp per group
with Rails' ordering, length and contents. The mirrored test now carries
parameter_filter_test.rb:125-146's `assert_equal 2, precompiled.grep(Regexp).length`
and `assert_equal 2 + procs.length` assertions plus the swapcase non-match, which
the port could not satisfy before.

Residual: a source whose letters are not all literal — a character class (where
`[aA]` cannot be nested and a range must not be expanded), a Unicode property
escape, a named group or backreference — cannot be rewritten safely, so it rides on
as the caller's own Regexp after the joined one. `Regexp.escape`d strings, the only
sources Rails itself wraps in `(?i:...)`, never contain one.

**2. `Regexp.new(strings.join("|"), true)` (parameter_filter.rb:121-122) —
irreducible, row kept.** Ruby's second Regexp argument is the ignore-case boolean,
JS's is a flag string; the flag is whole-pattern on both sides here, so `"i"` is
the same argument spelled the way the language spells it and there is no closer
spelling. The row's `reason` now cites this story instead of restating the
shortcoming. Teaching the extractor a global `bool:true` ≡ `str:i` equivalence was
rejected: it holds only for `Regexp.new`, so it would mask real mismatches
elsewhere.

**3. `params.class.new` (parameter_filter.rb:126) — converged, row deleted.**
`call` now allocates with `new (params.constructor ?? Object)()`, which IS
`params.class.new`. The `?? Object` arm covers a null-prototype hash, which has no
constructor — no class, in Ruby's terms — and is covered by the existing
`filters null-prototype objects` test.

**4. Block filters returning their replacement — confirmed correct, no register
row.** Rails' block redacts via `String#replace` on the `value` dup and its return
is discarded; a JS string is an immutable primitive. Rails' `key = key.dup` (:149)
never reaches `filtered_params`, which `call` writes with its own key (:129), so
`value_for_key` returns the value alone on both sides — a `{ key, value }` return
shape would be surface Rails' block does not have. No caller in the repo passes a
block filter.

Baseline `scripts/api-compare/call-mismatches-exclude/activesupport/parameter-filter.json`
goes 2 rows → 1 (only-shrink, hand-deleted, no reseed). `pnpm parity:api:calls` OK
(1457 baselined, down 1), `pnpm parity:api:calls:args` OK with no new rows,
`pnpm lint` clean, activesupport + actionpack filter-parameters suites green.

The bundled story `collection-proxy-retire-own-seeded-relation-state` is NOT in this
PR: #6610 landed it in main while this branch was in flight (the proxy's
`_isEmptyRelation` override, `_maybeRebaseProxySeed` and the `_seedWherePredicates`
capture are already gone there, with `@none` forced false on the proxy per
collection_proxy.rb:32-38 / 1128-1137). It is marked done against #6610.

Closes-story: burn-down-parameter-filter-regexp-and-block-deviations
