### PR TITLE
test(date): carry test_next's Date.today / DateTime.now arms

### DIFF
--- a/packages/date/src/test-date-arith.test.ts
+++ b/packages/date/src/test-date-arith.test.ts
@@ -139,12 +139,9 @@ describe("TestDateArith", () => {
     d = new Date(2000, 12, 31).succ();
     expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
 
-    // `Date.today` / `DateTime.now` answer the `Temporal` seat (RFC 0088), which
-    // carries no `next`/`succ`, so Ruby's own receiver is fed back through the
-    // `Temporal` constructor overload — `d_simple_new_internal`'s other entry
-    // point (`date_core.c:3036`), the same idiom `test_date_new.rb`'s
-    // "civil reform" uses. `d2 - 1` is `minus(1)` (`d_lite_minus`, `:6343-6360`)
-    // and `assert_equal` is `Comparable#==` (`equals`).
+    // `Date.today` / `DateTime.now` answer the `Temporal` seat (RFC 0088), so
+    // Ruby's receiver is fed back through the `Temporal` constructor overload —
+    // `d_simple_new_internal`'s other entry point, `date_core.c:3036`.
     d = new Date(Date.today());
     let d2 = d.next();
     expect(d.equals(d2.minus(1))).toBe(true);
@@ -152,12 +149,12 @@ describe("TestDateArith", () => {
     d2 = d.succ();
     expect(d.equals(d2.minus(1))).toBe(true);
 
-    let dt = new DateTime(DateTime.now());
-    let dt2 = dt.next();
-    expect(dt.equals(dt2.minus(1))).toBe(true);
-    dt = new DateTime(DateTime.now());
-    dt2 = dt.succ();
-    expect(dt.equals(dt2.minus(1))).toBe(true);
+    d = new DateTime(DateTime.now());
+    d2 = d.next();
+    expect(d.equals(d2.minus(1))).toBe(true);
+    d = new DateTime(DateTime.now());
+    d2 = d.succ();
+    expect(d.equals(d2.minus(1))).toBe(true);
   });
 
   it("next day", () => {

--- a/packages/date/src/test-date-arith.test.ts
+++ b/packages/date/src/test-date-arith.test.ts
@@ -4,13 +4,6 @@
  * `<<` and `>>` have no TS syntax that dispatches to a method, so they are the
  * named methods `docs/ruby-ts-conventions.md` ("Operators") calls for: `plus`,
  * `minus`, `cmp`, `lshift`, `rshift`.
- *
- * `test_next`'s `Date.today` / `DateTime.now` arms (`:161-172`) are not here:
- * neither `date_s_today` (`date_core.c:3789-3826`) nor `datetime_s_now`
- * (`:8134-8228`) is implemented, and RFC 0088's construction statics answer a
- * `Temporal.PlainDate`, which carries no `next`/`succ` — so the return shape is
- * a decision the port of those two has to make. Filed against 0088 as
- * `port-date-today-and-datetime-now`.
  */
 import { describe, it, expect } from "vitest";
 import { ArgumentError, Date, DateTime, Rational, Time } from "./index.js";
@@ -145,6 +138,26 @@ describe("TestDateArith", () => {
     expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
     d = new Date(2000, 12, 31).succ();
     expect([d.year, d.mon, d.mday]).toEqual([2001, 1, 1]);
+
+    // `Date.today` / `DateTime.now` answer the `Temporal` seat (RFC 0088), which
+    // carries no `next`/`succ`, so Ruby's own receiver is fed back through the
+    // `Temporal` constructor overload — `d_simple_new_internal`'s other entry
+    // point (`date_core.c:3036`), the same idiom `test_date_new.rb`'s
+    // "civil reform" uses. `d2 - 1` is `minus(1)` (`d_lite_minus`, `:6343-6360`)
+    // and `assert_equal` is `Comparable#==` (`equals`).
+    d = new Date(Date.today());
+    let d2 = d.next();
+    expect(d.equals(d2.minus(1))).toBe(true);
+    d = new Date(Date.today());
+    d2 = d.succ();
+    expect(d.equals(d2.minus(1))).toBe(true);
+
+    let dt = new DateTime(DateTime.now());
+    let dt2 = dt.next();
+    expect(dt.equals(dt2.minus(1))).toBe(true);
+    dt = new DateTime(DateTime.now());
+    dt2 = dt.succ();
+    expect(dt.equals(dt2.minus(1))).toBe(true);
   });
 
   it("next day", () => {


### PR DESCRIPTION
Ports the second half of `test_date_arith.rb`'s `test_next`
(`vendor/date/test/date/test_date_arith.rb:153-172`) — the `Date.today` /
`DateTime.now` arms — into `packages/date/src/test-date-arith.test.ts`, and
removes the placeholder comment that named the story.

The story's premise was partly stale (its own 2026-08-12 sweep note says so):
`Date.today` (`date.ts:6167`, `date_core.c:3789-3826`) and `DateTime.now`
(`date.ts:8348`, `date_core.c:8134-8228`) landed in #6317. I re-read both
bodies against the C: the `s == 60` clamp (`date_core.c:8174-8175`), the
out-of-range-offset zeroing plus `rb_warning` (`:8216-8219`), `NUM2DBL(vsg)`
rather than `val2sg` on `now` (`:8147-8150`), the `GREGORIAN` build followed by
`set_sg`, and `tv_nsec` as `sf` are all present and correct. Nothing in the
implementation needed changing, so this PR is the test arms only.

The shape question the story flags is answered by the settled idiom rather
than by changing a return type: RFC 0088's statics answer the `Temporal` seat,
which carries no `next`/`succ`, so Ruby's own receiver is fed back through the
`Temporal` constructor overload — `d_simple_new_internal`'s other entry point
(`date_core.c:3036`) — exactly as `test_date_new.rb`'s "civil reform" arm
already does (`test-date-new.test.ts:215-222`). `d2 - 1` is `minus(1)`
(`d_lite_minus`, `date_core.c:6343-6360`) and `assert_equal` is
`Comparable#==`, i.e. `equals`. No `node:*` import and no `process.*`.

`pnpm parity:test --package date`: `test_date_arith.rb` stays 23/23 ✓; overall
124/137, unmoved.

The other four stories in the bundle were released, not shipped — each is
comfortably past the 700 LOC ceiling on its own (four `date_parse.c` parsers
plus `check_limit`; a ~420-line `test__parse` table; the whole instance
formatter set including the Japanese era table; and `rb_obj_class` threading
plus `Marshal.dump`/`load` from nothing). `port-test-date-sub-class-propagation`
additionally has a blocker worth recording before it is re-picked: its
`assert_instance_of(DateSub, DateSub.today)` (`test_date.rb:53-54`) cannot hold
while the construction statics answer a `Temporal`, so it needs the RFC 0088
return-shape decision reopened, not just the builder threading.

Closes-story: port-date-today-and-datetime-now
