### PR TITLE
refactor(activerecord): QueryMethods flag/annotation members move to query-methods.ts; arel_column replaces _isKnownColumn

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -19,16 +19,10 @@ describeIfSqlite("SQLite3ExplainTest", () => {
   // from the template clone.
   const { authors } = fixtures(["authors", "authorAddresses"]);
 
-  // The `[[nil, 1]]` alternative is trails-only. Rails' `sql.active_record`
-  // payload carries QueryAttribute binds, so `render_bind` (explain.rb:40-51)
-  // emits `[["id", 1]]`; trails' adapters instrument plain bind VALUES, so the
-  // non-Attribute arm of `render_bind` fires and the name comes out `nil`.
-  // Tracked by `explain-payload-binds-carry-query-attributes`.
-
   it("explain for one query", async () => {
     const explain = await Author.where({ id: authors("david").id }).explain();
     expect(explain).toMatch(
-      /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|\? \[\[nil, 1\]\]|1)/,
+      /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|1)/,
     );
     expect(explain).toMatch(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/);
   });
@@ -38,11 +32,11 @@ describeIfSqlite("SQLite3ExplainTest", () => {
       .includes("posts")
       .explain();
     expect(explain).toMatch(
-      /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|\? \[\[nil, 1\]\]|1)/,
+      /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|1)/,
     );
     expect(explain).toMatch(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/);
     expect(explain).toMatch(
-      /EXPLAIN for: SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\? \[\["author_id", 1\]\]|\? \[\[nil, 1\]\]|1)/,
+      /EXPLAIN for: SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\? \[\["author_id", 1\]\]|1)/,
     );
     expect(explain).toMatch(/(SEARCH |(SCAN )?(TABLE ))posts/);
   });

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -392,7 +392,7 @@ export class Association {
    * @internal
    */
   protected cascadeStrictLoading(scope: any): any {
-    return this.preloadScope?.isStrictLoading ? (scope.strictLoading?.() ?? scope) : scope;
+    return this.preloadScope?.strictLoadingValue ? (scope.strictLoading?.() ?? scope) : scope;
   }
 
   private _uniqueOwners(owners: Base[]): Base[] {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -225,6 +225,6 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
 
     const loader = throughLoader([david], "annotatedComments", Comment.all().strictLoading());
     const scope = (loader as any).throughScope();
-    expect(scope.isStrictLoading).toBe(true);
+    expect(scope.strictLoadingValue).toBe(true);
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -913,7 +913,7 @@ export class Relation<T extends Base> {
       // The `lookup_table_klass_from_join_dependencies` block (see `where`'s
       // composite branch) so a qualified col naming a manual-join table binds
       // through the joined model's type rather than the generic
-      // `TypeCasterConnection`.
+      // `TypeCasterConnection` (query_methods.rb:1643-1645).
       const nodes = this.predicateBuilder.buildComposite(
         conditions as string[],
         tuples,
@@ -3676,9 +3676,7 @@ export class Relation<T extends Base> {
         .replace(/\s+(?:ASC|DESC)\b.*$/i, "")
         .trim();
       if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return new Nodes.SqlLiteral(raw);
-      // Rails resolves a bare column name through `arel_column`
-      // (query_methods.rb:1662-1676): `table[field]` when the model's
-      // `columns_hash` knows it, else the block's fallback.
+      // Rails' `arel_column(field) { ... }` (query_methods.rb:1662-1676).
       return this.arelColumn(bare, () => new Nodes.SqlLiteral(raw)) as Nodes.Node;
     });
     const values = adapter.columnsForDistinct ? adapter.columnsForDistinct(pkSql, orders) : pkSql;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -211,7 +211,7 @@ function validateExplainOptions(options: ExplainOption[]): void {
 /**
  * Sentinel preload scope threaded into the preloader when the parent relation
  * is strict-loading. The preloader's `cascade_strict_loading` reads
- * `isStrictLoading` to propagate strictness onto the derived scope, while
+ * `strictLoadingValue` to propagate strictness onto the derived scope, while
  * `isEmptyScope` keeps it from being merged like a real scope.
  *
  * Rails nests this `:nodoc:` inside `Relation`; kept module-private here.
@@ -221,7 +221,7 @@ function validateExplainOptions(options: ExplainOption[]): void {
  */
 const StrictLoadingScope = {
   isEmptyScope: true,
-  isStrictLoading: true,
+  strictLoadingValue: true,
 } as const;
 
 /**
@@ -537,7 +537,8 @@ export class Relation<T extends Base> {
       (typeof v === "string" && (v.startsWith(":") || this._isAssociationName(v)))
     );
   }
-  private _skipPreloading = false;
+  /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
+  skipPreloadingValue = false;
   private _loaded = false;
   // Rails `@delegate_to_model` (relation.rb:90) — true only while a scope body
   // runs via `_exec_scope`, which is what makes `already_in_scope?` (and hence
@@ -682,13 +683,14 @@ export class Relation<T extends Base> {
       // buildWhereClause spreads buildFromHash's result, so a single tuple stays
       // flat (`WHERE c1 = ? AND c2 = ?`, no wrapping Grouping) like Rails.
       //
-      // Thread the join-dependency fallback (Rails' block to `build_where_clause`
-      // / `predicate_builder.rb:71-73`) so a qualified col naming a manual-join
-      // table binds through the joined model's column type.
+      // Rails passes `lookup_table_klass_from_join_dependencies` as the block to
+      // `predicate_builder.build_from_hash` (query_methods.rb:1643-1645) so a
+      // qualified col naming a manual-join table binds through the joined
+      // model's column type.
       const nodes = this.predicateBuilder.buildComposite(
         cols,
         tuples,
-        this.joinDependencyFallback(),
+        (tableName) => this.lookupTableKlassFromJoinDependencies(tableName) as typeof Base | null,
       );
       if (nodes.length === 0) return this._clone().noneBang();
       const rel = this._clone();
@@ -908,13 +910,14 @@ export class Relation<T extends Base> {
           "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
       }
-      // Thread the join-dependency fallback (see `where`'s composite branch)
-      // so a qualified col naming a manual-join table binds through the joined
-      // model's type rather than the generic `TypeCasterConnection`.
+      // The `lookup_table_klass_from_join_dependencies` block (see `where`'s
+      // composite branch) so a qualified col naming a manual-join table binds
+      // through the joined model's type rather than the generic
+      // `TypeCasterConnection`.
       const nodes = this.predicateBuilder.buildComposite(
         conditions as string[],
         tuples,
-        this.joinDependencyFallback(),
+        (tableName) => this.lookupTableKlassFromJoinDependencies(tableName) as typeof Base | null,
       );
       // Empty/all-filtered → NOT (no rows) = ALL rows = no predicate added
       // (matches Rails' `where.not(...)` no-op for empty hashes).
@@ -1359,33 +1362,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Returns a relation that will always produce an empty result.
-   *
-   * Mirrors: ActiveRecord::Relation#none
-   */
-  none(): Relation<T> {
-    return this._clone().noneBang();
-  }
-
-  /**
-   * Add a lock clause (FOR UPDATE by default).
-   *
-   * Mirrors: ActiveRecord::Relation#lock
-   */
-  lock(locks: string | boolean = true): Relation<T> {
-    return this._clone().lockBang(locks);
-  }
-
-  /**
-   * Mark loaded records as readonly.
-   *
-   * Mirrors: ActiveRecord::Relation#readonly
-   */
-  readonly(value = true): Relation<T> {
-    return this._clone().readonlyBang(value);
-  }
-
-  /**
    * Check if this relation is marked readonly.
    *
    * Mirrors: ActiveRecord::Relation#readonly?
@@ -1404,53 +1380,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * The relation's lock clause, or null when unlocked.
-   *
-   * Mirrors: ActiveRecord::Relation#lock_value (SINGLE_VALUE_METHODS).
-   */
-  get lockValue(): string | null {
-    return this.lockValue;
-  }
-
-  /**
-   * Check if this relation has strict loading enabled.
-   *
-   * Mirrors: ActiveRecord::Relation#strict_loading?
-   */
-  get isStrictLoading(): boolean {
-    return this.strictLoadingValue ?? false;
-  }
-
-  /**
-   * Enable strict loading — lazily-loaded associations will raise.
-   *
-   * Mirrors: ActiveRecord::Relation#strict_loading
-   */
-  strictLoading(value = true): Relation<T> {
-    return this._clone().strictLoadingBang(value);
-  }
-
-  /**
-   * Add SQL comments to the query.
-   *
-   * Mirrors: ActiveRecord::Relation#annotate
-   */
-  annotate(...args: string[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":annotate", args);
-    return this._clone().annotateBang(...args);
-  }
-
-  /**
-   * Add optimizer hints to the query.
-   *
-   * Mirrors: ActiveRecord::Relation#optimizer_hints
-   */
-  optimizerHints(...args: string[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":optimizer_hints", args);
-    return this._clone().optimizerHintsBang(...args);
-  }
-
-  /**
    * Return a fresh unscoped relation for the model, discarding any
    * WHERE/ORDER/etc. conditions on this relation.
    *
@@ -1461,53 +1390,6 @@ export class Relation<T extends Base> {
   }
 
   // merge and spawn are mixed in from spawn-methods.ts
-
-  /**
-   * Change the FROM clause (for subqueries or alternate table names).
-   *
-   * Mirrors: ActiveRecord::Relation#from
-   */
-  from(value: string | Relation<any> | Nodes.Node, subqueryName?: string): Relation<T> {
-    return this._clone().fromBang(value, subqueryName);
-  }
-
-  /**
-   * Set default attributes for create operations on this relation.
-   *
-   * Mirrors: ActiveRecord::Relation#create_with
-   */
-  createWith(value: Record<string, unknown> | null): Relation<T> {
-    return this._clone().createWithBang(value);
-  }
-
-  /**
-   * Remove specific query parts.
-   *
-   * Mirrors: ActiveRecord::Relation#unscope
-   */
-  unscope(...args: Array<UnscopeType | { where: string | string[] }>): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":unscope", args as unknown[]);
-    return this._clone().unscopeBang(...args);
-  }
-
-  /**
-   * Add custom methods to this relation instance.
-   * Accepts an object with methods, or a function that receives the relation.
-   *
-   * Mirrors: ActiveRecord::Relation#extending
-   */
-  extending<M extends Record<string, (...args: any[]) => any>>(mod: M): Relation<T> & M;
-  extending<M extends Record<string, (...args: any[]) => any>>(
-    mod: M | undefined,
-  ): Relation<T> & Partial<M>;
-  extending(fn: (rel: Relation<T>) => void): Relation<T>;
-  extending(): Relation<T>;
-  extending(
-    mod?: Record<string, (...args: any[]) => any> | ((rel: Relation<T>) => void),
-  ): Relation<T> | (Relation<T> & Record<string, (...args: any[]) => any>) {
-    if (!mod) return this._clone();
-    return this._clone().extendingBang(mod);
-  }
 
   /**
    * Add one or more INNER JOINs. Accepts:
@@ -3793,9 +3675,11 @@ export class Relation<T extends Base> {
         .trim()
         .replace(/\s+(?:ASC|DESC)\b.*$/i, "")
         .trim();
-      return /^[A-Za-z_$][\w$]*$/.test(bare) && this._isKnownColumn(bare)
-        ? table.get(bare)
-        : new Nodes.SqlLiteral(raw);
+      if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return new Nodes.SqlLiteral(raw);
+      // Rails resolves a bare column name through `arel_column`
+      // (query_methods.rb:1662-1676): `table[field]` when the model's
+      // `columns_hash` knows it, else the block's fallback.
+      return this.arelColumn(bare, () => new Nodes.SqlLiteral(raw)) as Nodes.Node;
     });
     const values = adapter.columnsForDistinct ? adapter.columnsForDistinct(pkSql, orders) : pkSql;
     return Array.isArray(values) ? values.join(", ") : values;
@@ -3891,16 +3775,6 @@ export class Relation<T extends Base> {
    */
   arelColumns(columns: ReadonlyArray<unknown>): unknown[] {
     return _arelColumns.call(this as any, columns as unknown[]);
-  }
-
-  // Returns true when `col` is a known schema attribute OR is (part of) the
-  // model's primary key. The PK check is needed because `_attributeDefinitions`
-  // may not yet contain `id` (before schema reflection), but it must still be
-  // table-qualified to avoid ambiguous-column errors on joined relations.
-  private _isKnownColumn(col: string): boolean {
-    if (this._model._attributeDefinitions.has(col)) return true;
-    const pk = this._model.primaryKey;
-    return Array.isArray(pk) ? pk.includes(col) : pk === col;
   }
 
   /**
@@ -4416,10 +4290,6 @@ export class Relation<T extends Base> {
     return pb;
   }
 
-  get skipPreloadingValue(): boolean {
-    return this._skipPreloading;
-  }
-
   get isScheduled(): boolean {
     return false;
   }
@@ -4931,7 +4801,7 @@ export class Relation<T extends Base> {
         }
       }
     }
-    this._skipPreloading = source._skipPreloading;
+    this.skipPreloadingValue = source.skipPreloadingValue;
     this._seededNoneNewOwner = source._seededNoneNewOwner;
     this._seedWherePredicates = [...source._seedWherePredicates];
     // `_delegateToModel` is deliberately NOT copied: Rails' `initialize_copy`
@@ -5063,15 +4933,6 @@ export class Relation<T extends Base> {
       return this.model.uncached(block);
     }
     return block();
-  }
-
-  // The `associated_table` block Rails threads from `build_where_clause`
-  // (`predicate_builder.rb:71-73`): resolves a table name that exists only as a
-  // join-dependency (a manual join, an alias) — not a direct reflection — to its
-  // model, so a qualified col binds through that model's column type. Shared by
-  // `where` / `whereNot`'s composite branches.
-  private joinDependencyFallback(): (name: string) => typeof Base | null {
-    return (name) => this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
   }
 }
 
@@ -5224,6 +5085,24 @@ export interface Relation<T extends Base>
     key?: string,
     notFoundIds?: unknown[],
   ): never;
+  // QueryMethods' flag / annotation / scope-shaping methods (query-methods.ts),
+  // whose mixin signatures return `any` — declared here with the relation's own
+  // element type.
+  none(): Relation<T>;
+  lock(locks?: string | boolean): Relation<T>;
+  readonly(value?: boolean): Relation<T>;
+  strictLoading(value?: boolean): Relation<T>;
+  createWith(value: Record<string, unknown> | null): Relation<T>;
+  from(value: string | Relation<any> | Nodes.Node, subqueryName?: string): Relation<T>;
+  extending<M extends Record<string, (...args: any[]) => any>>(mod: M): Relation<T> & M;
+  extending<M extends Record<string, (...args: any[]) => any>>(
+    mod: M | undefined,
+  ): Relation<T> & Partial<M>;
+  extending(fn: (rel: Relation<T>) => void): Relation<T>;
+  extending(): Relation<T>;
+  optimizerHints(...args: string[]): Relation<T>;
+  annotate(...args: string[]): Relation<T>;
+  unscope(...args: Array<UnscopeType | { where: string | string[] }>): Relation<T>;
   spawn(): Relation<T>;
   merge<U extends Base>(other: Relation<U>): Relation<T>;
   mergeBang(other: any): Relation<T>;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3676,7 +3676,7 @@ export class Relation<T extends Base> {
         .replace(/\s+(?:ASC|DESC)\b.*$/i, "")
         .trim();
       if (!/^[A-Za-z_$][\w$]*$/.test(bare)) return new Nodes.SqlLiteral(raw);
-      // Rails' `arel_column(field) { ... }` (query_methods.rb:1662-1676).
+      // Rails' `arel_column(field) { ... }` (query_methods.rb:1990-2005).
       return this.arelColumn(bare, () => new Nodes.SqlLiteral(raw)) as Nodes.Node;
     });
     const values = adapter.columnsForDistinct ? adapter.columnsForDistinct(pkSql, orders) : pkSql;
@@ -5086,8 +5086,9 @@ export interface Relation<T extends Base>
   // QueryMethods' flag / annotation / scope-shaping methods (query-methods.ts),
   // whose mixin signatures return `any` — declared here with the relation's own
   // element type.
-  none(): Relation<T>;
+  unscope(...args: Array<UnscopeType | { where: string | string[] }>): Relation<T>;
   lock(locks?: string | boolean): Relation<T>;
+  none(): Relation<T>;
   readonly(value?: boolean): Relation<T>;
   strictLoading(value?: boolean): Relation<T>;
   createWith(value: Record<string, unknown> | null): Relation<T>;
@@ -5100,7 +5101,6 @@ export interface Relation<T extends Base>
   extending(): Relation<T>;
   optimizerHints(...args: string[]): Relation<T>;
   annotate(...args: string[]): Relation<T>;
-  unscope(...args: Array<UnscopeType | { where: string | string[] }>): Relation<T>;
   spawn(): Relation<T>;
   merge<U extends Base>(other: Relation<U>): Relation<T>;
   mergeBang(other: any): Relation<T>;

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -194,7 +194,7 @@ describe("RelationMutationTest", () => {
   it("skip_preloading!", () => {
     const rel = relation();
     expect(rel.skipPreloadingBang()).toBe(rel);
-    expect(rel._skipPreloading).toBe(true);
+    expect(rel.skipPreloadingValue).toBe(true);
   });
 
   it("#regroup!", () => {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -286,7 +286,10 @@ interface QueryMethodsHost {
   // leading-colon string — or a string naming an association; everything else
   // (Arel join nodes, raw SQL strings) is a raw join value.
   _isNamedJoinValue(v: unknown): boolean;
-  _skipPreloading: boolean;
+  /** Rails' `clone` behind `spawn` (spawn_methods.rb:9-11). */
+  _clone(): any;
+  /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
+  skipPreloadingValue: boolean;
   _model: typeof import("../base.js").Base;
   model: QueryMethodsHost["_model"];
   /** Rails `attr_reader :table` (relation.rb:71) — the relation's own Arel table. */
@@ -695,6 +698,19 @@ export function setValues(host: QueryMethodsHost, values: Record<string, unknown
   for (const scope of SIDECAR_BACKED_KEYS) {
     if (!(scope in values)) resetValueForScope(host, scope);
   }
+}
+
+/**
+ * Remove specific query parts.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#unscope (query_methods.rb:806-809)
+ */
+function unscope(
+  this: QueryMethodsHost,
+  ...args: Array<UnscopeType | { where: string | string[] }>
+): any {
+  checkIfMethodHasArgumentsBang.call(this, ":unscope", args as unknown[]);
+  return unscopeBang.apply(this._clone(), args as any);
 }
 
 function unscopeBang(
@@ -1159,6 +1175,15 @@ function offsetBang(this: QueryMethodsHost, value: number | string | null): any 
   return this;
 }
 
+/**
+ * Add a lock clause (FOR UPDATE by default).
+ *
+ * Mirrors: ActiveRecord::QueryMethods#lock (query_methods.rb:1238-1240)
+ */
+function lock(this: QueryMethodsHost, locks: string | boolean = true): any {
+  return lockBang.call(this._clone(), locks);
+}
+
 function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
   if (typeof locks === "string") {
     this.lockValue = locks;
@@ -1166,6 +1191,15 @@ function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
     this.lockValue = locks ? "FOR UPDATE" : null;
   }
   return this;
+}
+
+/**
+ * Returns a relation that will always produce an empty result.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#none (query_methods.rb:1281-1283)
+ */
+function none(this: QueryMethodsHost): any {
+  return noneBang.call(this._clone());
 }
 
 function noneBang(this: QueryMethodsHost): any {
@@ -1180,14 +1214,41 @@ function isNullRelation(this: QueryMethodsHost): boolean {
   return this._isNone;
 }
 
+/**
+ * Mark loaded records as readonly.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#readonly (query_methods.rb:1309-1311)
+ */
+function readonly(this: QueryMethodsHost, value = true): any {
+  return readonlyBang.call(this._clone(), value);
+}
+
 function readonlyBang(this: QueryMethodsHost, value = true): any {
   this.readonlyValue = value;
   return this;
 }
 
+/**
+ * Enable strict loading — lazily-loaded associations will raise.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#strict_loading (query_methods.rb:1324-1326)
+ */
+function strictLoading(this: QueryMethodsHost, value = true): any {
+  return strictLoadingBang.call(this._clone(), value);
+}
+
 function strictLoadingBang(this: QueryMethodsHost, value = true): any {
   this.strictLoadingValue = value;
   return this;
+}
+
+/**
+ * Set default attributes for create operations on this relation.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#create_with (query_methods.rb:1346-1348)
+ */
+function createWith(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
+  return createWithBang.call(this._clone(), value);
 }
 
 function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
@@ -1201,6 +1262,15 @@ function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> |
   return this;
 }
 
+/**
+ * Change the FROM clause (for subqueries or alternate table names).
+ *
+ * Mirrors: ActiveRecord::QueryMethods#from (query_methods.rb:1391-1393)
+ */
+function from(this: QueryMethodsHost, value: any, subqueryName?: string): any {
+  return fromBang.call(this._clone(), value, subqueryName);
+}
+
 function fromBang(this: QueryMethodsHost, value: any, subqueryName?: string): any {
   this.fromClause = new FromClause(value ?? null, subqueryName ?? null);
   return this;
@@ -1209,6 +1279,20 @@ function fromBang(this: QueryMethodsHost, value: any, subqueryName?: string): an
 function distinctBang(this: QueryMethodsHost, value = true): any {
   this.distinctValue = value;
   return this;
+}
+
+/**
+ * Add custom methods to this relation instance.
+ * Accepts an object with methods, or a function that receives the relation.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#extending (query_methods.rb:1456-1462)
+ */
+function extending(
+  this: QueryMethodsHost,
+  mod?: Record<string, (...args: any[]) => any> | ((rel: any) => void),
+): any {
+  if (!mod) return this._clone();
+  return extendingBang.call(this._clone(), mod);
 }
 
 function extendingBang(
@@ -1231,6 +1315,16 @@ function extendingBang(
     }
   }
   return this;
+}
+
+/**
+ * Add optimizer hints to the query.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#optimizer_hints (query_methods.rb:1485-1488)
+ */
+function optimizerHints(this: QueryMethodsHost, ...args: string[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":optimizer_hints", args);
+  return optimizerHintsBang.apply(this._clone(), args);
 }
 
 function optimizerHintsBang(this: QueryMethodsHost, ...args: string[]): any {
@@ -1320,8 +1414,18 @@ function skipQueryCacheBang(this: QueryMethodsHost, value = true): any {
 }
 
 function skipPreloadingBang(this: QueryMethodsHost): any {
-  this._skipPreloading = true;
+  this.skipPreloadingValue = true;
   return this;
+}
+
+/**
+ * Add SQL comments to the query.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#annotate (query_methods.rb:1529-1532)
+ */
+function annotate(this: QueryMethodsHost, ...args: string[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":annotate", args);
+  return annotateBang.apply(this._clone(), args);
 }
 
 function annotateBang(this: QueryMethodsHost, ...comments: string[]): any {
@@ -1932,6 +2036,7 @@ export const QueryMethodBangs = {
   regroupBang,
   orderBang,
   reorderBang,
+  unscope,
   unscopeBang,
   joinsBang,
   leftOuterJoinsBang,
@@ -1942,19 +2047,28 @@ export const QueryMethodBangs = {
   havingBang,
   limitBang,
   offsetBang,
+  lock,
   lockBang,
+  none,
   noneBang,
   isNullRelation,
+  readonly,
   readonlyBang,
+  strictLoading,
   strictLoadingBang,
+  createWith,
   createWithBang,
+  from,
   fromBang,
   distinctBang,
+  extending,
   extendingBang,
+  optimizerHints,
   optimizerHintsBang,
   reverseOrderBang,
   skipQueryCacheBang,
   skipPreloadingBang,
+  annotate,
   annotateBang,
   uniqBang,
   excludingBang,


### PR DESCRIPTION
refactor(activerecord): QueryMethods flag/annotation members move to query-methods.ts; arel_column replaces _isKnownColumn

Moves the flag, annotation and scope-shaping query methods out of
`relation.ts` into `relation/query-methods.ts`, each beside its own bang
variant as in `query_methods.rb`: `unscope` (:806), `lock` (:1238),
`none` (:1281), `readonly` (:1309), `strict_loading` (:1324),
`create_with` (:1346), `from` (:1391), `extending` (:1456),
`optimizer_hints` (:1485), `annotate` (:1529). `parity:api` now resolves
all ten to `relation/query-methods.ts` instead of reporting them moved.

Members Rails keeps in `relation.rb` stay in `relation.ts`: `readonly?`
(relation.rb:1278) and `locked?` (the `alias :locked? :lock_value` at
relation.rb:75). The hand-written `lockValue` getter is deleted — it was
dead, `defineValueMethods` redefines it from `SINGLE_VALUE_METHODS`
(query_methods.rb:162-183) — as is `isStrictLoading`, which Rails' Relation
has no counterpart for; `StrictLoadingScope` now exposes
`strictLoadingValue` (relation.rb:1316), which is what
`cascade_strict_loading` reads (preloader/association.rb:311).
`skipPreloadingValue` becomes a plain field, matching
`attr_accessor :skip_preloading_value` (relation.rb:72).

`_isKnownColumn` is retired: `_distinctSelectForLimitedIds` resolves a bare
order column through `arel_column` with a block, as Rails does
(query_methods.rb:1990-2005). `joinDependencyFallback` is retired too —
Rails inlines `lookup_table_klass_from_join_dependencies` as the block at
each call site (query_methods.rb:1643-1645), so `where`/`whereNot`'s
composite branches pass it directly.

`_promotedIncludes` cannot converge without flipping trails' per-association
promotion to Rails' all-or-nothing `eager_loading?` boolean
(relation.rb:1481-1487), which reaches into the surface
`converge-apply-join-dependency-eager-cluster` owns; filed as
`converge-promoted-includes-into-eager-loading`.

The `sql.active_record` payload already carries `QueryAttribute` binds, so
`render_bind`'s Attribute arm (explain.rb:41-46) fires and `exec_explain`
renders `[["id", 1]]`; the trails-only `[[nil, 1]]` alternatives are deleted
from the SQLite explain test, leaving Rails' regex verbatim.

Closes-story: converge-relation-select-and-join-residue
Closes-story: explain-payload-binds-carry-query-attributes
Closes-story: fan-out-query-methods-flags-and-annotations




---

## Note on the red CI referenced in review

Job 95243014231 (and its MariaDB/SQLite siblings) ran against `63ad295773f5e1`,
which is the commit *before* the fix. The `strictLoadingValue` rename left one
stale reader behind in `through-association-scope.test.ts:228`; that is exactly
what those three lanes caught, and `c918e5bd8` fixes it.

```
$ gh api repos/blazetrailsdev/trails/actions/jobs/95243014231 --jq '{conclusion,sha:.head_sha}'
{"conclusion":"failure","sha":"63ad295773f5e12759c474ac2a57e28420bab593"}
```

No shared-state pollution is involved: the assertion read a getter that the diff
deleted on purpose (`Relation#strict_loading?` has no Rails counterpart), so it
returned `undefined` on every adapter — which is why all three lanes failed
identically rather than one lane flaking. The run on current HEAD `c918e5bd8` is
the one to judge.
