### PR TITLE
refactor(activerecord): arel_column_with_table is Rails' two arms; one relation copy path at the Rails names

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -74,13 +74,10 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * covers all of them from one place. Reports the (possibly rebased)
    * `_isNone`.
    */
-  override isNullRelation = (): boolean => {
+  override isNullRelation(): boolean {
     this._maybeRebaseAssociationSeed();
-    // `super.isNullRelation()` is not available: the base definition comes from
-    // the QueryMethods mixin (query_methods.rb:1293), so it lands as a property
-    // on `Relation.prototype` rather than as a class method.
-    return Relation.prototype.isNullRelation.call(this);
-  };
+    return super.isNullRelation();
+  }
 
   /**
    * @internal Rebase a relation spawned off a stale new-owner `1=0` seed onto

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -6,7 +6,7 @@ import type { Association } from "./associations/association.js";
 import { setAssociationRelationFactory } from "./associations/_scope-slots.js";
 import { _cacheSingularTarget } from "./associations.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
-import { associationRelationClassFor } from "./relation/delegation.js";
+import { associationRelationClassFor, wrapWithScopeProxy } from "./relation/delegation.js";
 import { rebaseNewOwnerSeed } from "./associations/new-owner-seed-rebase.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
@@ -51,17 +51,22 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Preserve the AssociationRelation subclass across `_clone()` so chains
-   * like `blog.posts.where(...).order(...).create(...)` still route writes
-   * through the association.
+   * Preserve the AssociationRelation subclass across `clone()` — Ruby's
+   * `Object#clone` allocates the receiver's own class — so chains like
+   * `blog.posts.where(...).order(...).create(...)` still route writes through
+   * the association.
+   *
+   * @internal
    */
-  protected _newRelation(): Relation<T> {
+  override clone(): Relation<T> {
     const Ctor = associationRelationClassFor(this.model);
-    return new Ctor(this.model, this._association);
+    const rel = new Ctor(this.model, this._association) as Relation<T>;
+    rel.initializeCopy(this);
+    return wrapWithScopeProxy(rel);
   }
 
   /**
-   * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`): every
+   * The none-short-circuit chokepoint (see `Relation#isNullRelation`): every
    * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and
    * the mutation terminals (`updateAll`/`deleteAll`, plus `touchAll`/
    * `updateCounters` via their `updateAll` delegation) consult this before
@@ -69,10 +74,13 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * covers all of them from one place. Reports the (possibly rebased)
    * `_isNone`.
    */
-  _isEmptyRelation(): boolean {
+  override isNullRelation = (): boolean => {
     this._maybeRebaseAssociationSeed();
-    return super._isEmptyRelation();
-  }
+    // `super.isNullRelation()` is not available: the base definition comes from
+    // the QueryMethods mixin (query_methods.rb:1293), so it lands as a property
+    // on `Relation.prototype` rather than as a class method.
+    return Relation.prototype.isNullRelation.call(this);
+  };
 
   /**
    * @internal Rebase a relation spawned off a stale new-owner `1=0` seed onto
@@ -89,19 +97,26 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
       resetScope?: () => void;
     };
     if (typeof assoc.scope !== "function") return;
+    // Clear the marker BEFORE rebuilding: the rebuild runs the merger, which
+    // itself consults `isNullRelation()` (merger.rb:70), and that would re-enter
+    // this hook. Restored below if the rebuilt scope is still unresolved, so a
+    // later call retries.
+    this._seededNoneNewOwner = false;
     // The association memoized its `@association_scope` while the owner was
     // still new (that memo is what seeded this relation), so it carries the
     // unresolved FK too — drop it before rebuilding, exactly as Rails'
     // `reset_scope` does (association.rb:119-121).
     assoc.resetScope?.();
     const fresh = assoc.scope();
-    if (fresh._isNone) return;
+    if (fresh._isNone) {
+      this._seededNoneNewOwner = true;
+      return;
+    }
     rebaseNewOwnerSeed(
       this as unknown as Parameters<typeof rebaseNewOwnerSeed>[0],
       fresh as unknown,
       this._seedWherePredicates,
     );
-    this._seededNoneNewOwner = false;
   }
 
   /**
@@ -285,7 +300,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    */
   async toArray(): Promise<T[]> {
     // The stale new-owner seed rebase runs in `super.toArray()` via the shared
-    // `_isEmptyRelation()` chokepoint, before the query is built.
+    // `isNullRelation()` chokepoint, before the query is built.
     const owner = this._association.owner;
     const reflection = this._association.reflection;
     // Resolve the inverse association name via the registered Reflection,

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -792,7 +792,7 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
 
   it("resolves the persisted FK on updateAll/updateCounters after save", async () => {
     // The mutation terminals carry their own none short-circuits, so they must
-    // consult the same `_isEmptyRelation()` chokepoint the read terminals do.
+    // consult the same `isNullRelation()` chokepoint the read terminals do.
     const author = new Author({ name: "New Owner Four" });
     const rel = (association<Post>(author, "posts") as any).where({ title: "match" });
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -8,7 +8,11 @@ import {
 } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
-import { associationRelationClassFor, collectionProxyClassFor } from "../relation/delegation.js";
+import {
+  associationRelationClassFor,
+  collectionProxyClassFor,
+  wrapWithScopeProxy,
+} from "../relation/delegation.js";
 import { _registerRelationFamily } from "../relation/uncacheable-methods-slot.js";
 
 // Late-bound AssociationRelation constructor to break circular imports
@@ -2849,15 +2853,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * AR still routes writes through `_association` (this CP) so the FK,
    * inverse, and loaded target stay wired up.
    */
-  protected override _newRelation(): Relation<T> {
+  override clone(): Relation<T> {
     if (!_AssociationRelationCtor) {
       throw new ConfigurationError(
-        "CollectionProxy._newRelation: AssociationRelation constructor not set — " +
+        "CollectionProxy.clone: AssociationRelation constructor not set — " +
           "association-relation.ts must be loaded first",
       );
     }
     const Ctor = associationRelationClassFor(this.model);
-    return new Ctor(this.model, this) as Relation<T>;
+    const rel = new Ctor(this.model, this) as Relation<T>;
+    rel.initializeCopy(this as unknown as Relation<T>);
+    return wrapWithScopeProxy(rel);
   }
 }
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -249,7 +249,7 @@ export class ThroughAssociation extends Association {
     const sourceIsNested = (sourceRefl as any).isThroughReflection?.() ?? false;
     const hasSourceType = !!(this.reflection as any).options?.sourceType;
     if (!sourceIsNested && !this.reflectionScope.isEmptyScope) {
-      sourceScope = this.reflectionScope._clone();
+      sourceScope = this.reflectionScope.clone();
       if (!hasSourceType) {
         sourceScope.whereClause = new WhereClause([]);
       }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2384,7 +2384,7 @@ export class Base extends Model {
       // merge the inherited scope into it, rather than cloning the parent's
       // type-unconstrained relation.
       if (scope._model === this) {
-        return scope._clone();
+        return scope.clone();
       }
       return this._buildUnscopedRelation().merge(scope);
     }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -1,14 +1,17 @@
 import { Relation } from "./relation.js";
 import { argumentError } from "./relation/query-methods.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
-import { disableJoinsAssociationRelationClassFor } from "./relation/delegation.js";
+import {
+  disableJoinsAssociationRelationClassFor,
+  wrapWithScopeProxy,
+} from "./relation/delegation.js";
 import { normalizeAssociationKey } from "./associations/key-normalization.js";
 import type { Base } from "./base.js";
 import type { Nodes } from "@blazetrails/arel";
 
 /**
  * Module-private token for the DJAR fast-clone path. Unexported — only
- * `_newRelation` inside this module can forge a payload carrying it,
+ * `clone` inside this module can forge a payload carrying it,
  * so external callers can't reach the trusted constructor branch even
  * via `any`/`unknown` erasure (they have no reference to the symbol).
  */
@@ -140,7 +143,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   );
   // The implementation signature accepts an internal
   // `TrustedClonePayload<T>` (gated by the unexported `TRUSTED_CLONE`
-  // symbol) as the fourth argument so `_newRelation` can take the
+  // symbol) as the fourth argument so `clone` can take the
   // fast-clone path. It is intentionally NOT declared as a public
   // overload — external callers only see the two correlated forms
   // above, and they can't construct a valid trusted payload without
@@ -152,7 +155,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     chainWalkerOrTrusted?: (() => Promise<{ relation: Relation<T> }>) | TrustedClonePayload<T>,
   ) {
     super(klass);
-    // Fast clone path: `_newRelation` hands us already-normalized
+    // Fast clone path: `clone` hands us already-normalized
     // state from another DJAR. Skip dedup / arity checks / per-tuple
     // JSON.stringify and just adopt the frozen outputs.
     if (
@@ -518,13 +521,15 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   }
 
   /**
-   * Preserve the subclass on `_clone()` (and any chained `where`/`order`
+   * Preserve the subclass on `clone()` (and any chained `where`/`order`
    * /`merge`) so the custom `toArray` reordering and `limit`/`first`
-   * overrides survive chaining. Without this, Relation#_clone() would
+   * overrides survive chaining. Without this, Relation#clone() would
    * spawn a plain Relation and silently drop the wrapping behavior.
+   *
+   * @internal
    */
-  protected override _newRelation(): Relation<T> {
-    // `_newRelation` runs on every `_clone()` — including the
+  override clone(): Relation<T> {
+    // This runs on every `clone()` — including the
     // limit/offset-free load clone inside `toArray()`, and every
     // chained `.where(...)` / `.order(...)` — so re-running the
     // full constructor (dedup + per-tuple JSON.stringify) on every
@@ -547,10 +552,16 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // module.
     const trusted = payload as unknown as () => Promise<{ relation: Relation<T> }>;
     const Ctor = disableJoinsAssociationRelationClassFor(this.model);
-    const clone = this._composite
+    const rel = (this._composite
       ? new Ctor(this.model, this.key as string[], this._storedIds as unknown[][], trusted)
-      : new Ctor(this.model, this.key as string, this._storedIds as unknown[], trusted);
-    return clone as unknown as Relation<T>;
+      : new Ctor(
+          this.model,
+          this.key as string,
+          this._storedIds as unknown[],
+          trusted,
+        )) as unknown as Relation<T>;
+    rel.initializeCopy(this as unknown as Relation<T>);
+    return wrapWithScopeProxy(rel);
   }
 
   override async toArray(): Promise<T[]> {
@@ -581,11 +592,11 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // observing the original configured state.
     type LimitOffset = { limitValue?: number | null; offsetValue?: number | null };
     const self = this as unknown as LimitOffset & {
-      _clone: () => DisableJoinsAssociationRelation<T>;
+      clone: () => DisableJoinsAssociationRelation<T>;
     };
     const limitVal = self.limitValue ?? null;
     const offsetVal = self.offsetValue ?? null;
-    const loadClone = self._clone() as unknown as LimitOffset;
+    const loadClone = self.clone() as unknown as LimitOffset;
     loadClone.limitValue = null;
     loadClone.offsetValue = null;
     // Call Relation's toArray directly on the clone — going through

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -70,9 +70,9 @@ describe("RelationTest", () => {
   // No like-named Rails test: relation_test.rb only covers the invalid-key path
   // ("merging a hash with unknown keys raises"). This guards the positive
   // HashMerger path — a valid VALUE_METHODS-keyed hash builds a fresh base
-  // Relation (via `_newRelation`) and dispatches each key to its value-method
+  // Relation (merger.rb:26-30) and dispatches each key to its value-method
   // bang setter, then merges through Merger — so a regression to the old
-  // where-conditions behavior (or a missing base-class `_newRelation`) is caught.
+  // where-conditions behavior is caught.
   it("merging a valid-key hash dispatches to value-methods", () => {
     const rel = CanonPost.all().merge({ where: { title: "a" }, limit: 5, order: "id" } as any);
     const sql = rel.toSql();

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -58,7 +58,10 @@ import {
   type ToSentenceOptions,
   type ToXmlOptions,
 } from "./relation/delegation.js";
-import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
+import {
+  _registerRelationFamily,
+  _relationFamilySlot,
+} from "./relation/uncacheable-methods-slot.js";
 import { resolveAliasedColumn } from "./reflection.js";
 import { InsertAll, type InsertAllOptions } from "./insert-all.js";
 import { Result } from "./result.js";
@@ -647,7 +650,7 @@ export class Relation<T extends Base> {
     conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | string[] | unknown[] | null,
     ...rest: unknown[]
   ): Relation<T> | WhereChain<Relation<T>> {
-    if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this._clone());
+    if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this.clone());
     // Rails: a single blank-ish argument (`args.length == 1 && args.first.blank?`,
     // query_methods.rb:1036) makes `where` a no-op returning the relation
     // unchanged — `where({})` / `where([])` / `where(null)` / `where("")` all
@@ -658,7 +661,7 @@ export class Relation<T extends Base> {
     // lets a NESTED empty hash (`where(posts: {})`) still expand to the `1=0`
     // contradiction Rails' `expand_from_hash` returns.
     if (rest.length === 0 && _qm.isBlankArgument(conditionsOrSql)) {
-      return this._clone();
+      return this.clone();
     }
     // Composite-key form: array of column names + array of tuples. It is
     // always a two-argument call (`where(cols, tuples)`), so it is
@@ -692,12 +695,12 @@ export class Relation<T extends Base> {
         tuples,
         (tableName) => this.lookupTableKlassFromJoinDependencies(tableName) as typeof Base | null,
       );
-      if (nodes.length === 0) return this._clone().noneBang();
-      const rel = this._clone();
+      if (nodes.length === 0) return this.clone().noneBang();
+      const rel = this.clone();
       rel.whereClause = rel.whereClause.plus(new WhereClause([...nodes]));
       return rel;
     }
-    return this._clone().whereBang(
+    return this.clone().whereBang(
       conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
       ...rest,
     );
@@ -712,7 +715,7 @@ export class Relation<T extends Base> {
     // Mirrors rewhere (query_methods.rb): `return unscope(:where) if conditions.nil?`.
     if (conditions == null) return this.unscope("where");
     conditions = sanitizeForbiddenAttributes(conditions);
-    const rel = this._clone();
+    const rel = this.clone();
     // Mirrors rewhere (query_methods.rb): `where_clause = build_where_clause(...)`,
     // `unscope!(where: where_clause.extract_attributes)`, `where_clause += ...`.
     // Building through the same `build_where_clause` path as `where` keeps the
@@ -739,7 +742,7 @@ export class Relation<T extends Base> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       const reflection = rel._whereChainReflection(assocName);
-      const scope = rel._clone();
+      const scope = rel.clone();
       // Rails query_methods.rb:89-91: `@scope.joins!(association)` unless it is
       // already present in joins_values / left_outer_joins_values. Routing the
       // join through JoinDependency (joins!) rather than a bespoke resolver is
@@ -770,7 +773,7 @@ export class Relation<T extends Base> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       const reflection = rel._whereChainReflection(assocName);
-      const scope = rel._clone();
+      const scope = rel.clone();
       // Rails query_methods.rb:126-128: `@scope.left_outer_joins!(association)`
       // then `@scope.where!(reflection.table_name => Array(pk).index_with(nil))`
       // (or `association => …` for a `:class_name` self-join).
@@ -892,7 +895,7 @@ export class Relation<T extends Base> {
     conditions = sanitizeForbiddenAttributes(conditions as Record<string, unknown>) as
       | Record<string, unknown>
       | string[];
-    const rel = this._clone();
+    const rel = this.clone();
     rel.referencesBang(...referencesFromConditions(conditions));
     if (
       Array.isArray(conditions) &&
@@ -962,8 +965,8 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#or
    */
   or(other: Relation<T>): Relation<T> {
-    if (this._isNone) return other._clone();
-    return this._clone().orBang(other);
+    if (this._isNone) return other.clone();
+    return this.clone().orBang(other);
   }
 
   /**
@@ -973,7 +976,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#and
    */
   and(other: Relation<T>): Relation<T> {
-    return this._clone().andBang(other);
+    return this.clone().andBang(other);
   }
 
   /**
@@ -993,7 +996,7 @@ export class Relation<T extends Base> {
     for (let i = 1; i < conditions.length; i++) {
       combined = combined.or(buildClause(conditions[i]));
     }
-    const rel = this._clone();
+    const rel = this.clone();
     if (combined.predicates.length > 0)
       rel.whereClause = rel.whereClause.plus(new WhereClause([combined.ast]));
     return rel;
@@ -1021,7 +1024,7 @@ export class Relation<T extends Base> {
   excluding(...records: unknown[]): Relation<T> {
     const combined = this._excludingArgs(records, "excluding");
     if (combined.length === 0) return this;
-    return this._clone().excludingBang(combined);
+    return this.clone().excludingBang(combined);
   }
 
   /**
@@ -1032,7 +1035,7 @@ export class Relation<T extends Base> {
   without(...records: unknown[]): Relation<T> {
     const combined = this._excludingArgs(records, "without");
     if (combined.length === 0) return this;
-    return this._clone().excludingBang(combined);
+    return this.clone().excludingBang(combined);
   }
 
   /**
@@ -1086,7 +1089,7 @@ export class Relation<T extends Base> {
     this.checkIfMethodHasArgumentsBang(":order", args as unknown[], undefined, () => {
       this.sanitizeOrderArguments(args as unknown[]);
     });
-    return this._clone().orderBang(...args);
+    return this.clone().orderBang(...args);
   }
 
   /**
@@ -1095,7 +1098,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#limit
    */
   limit(value: number | string | null): Relation<T> {
-    return this._clone().limitBang(value);
+    return this.clone().limitBang(value);
   }
 
   /**
@@ -1104,7 +1107,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#offset
    */
   offset(value: number | string | null): Relation<T> {
-    return this._clone().offsetBang(value);
+    return this.clone().offsetBang(value);
   }
 
   /**
@@ -1131,7 +1134,7 @@ export class Relation<T extends Base> {
     }
     this.checkIfMethodHasArgumentsBang(":select", fields, "Call `select' with at least one field.");
     fields = this.processSelectArgs(fields);
-    return this._clone()._selectBang(...fields);
+    return this.clone()._selectBang(...fields);
   }
 
   /**
@@ -1142,7 +1145,7 @@ export class Relation<T extends Base> {
   reselect(...args: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":reselect", args as unknown[]);
     args = this.processSelectArgs(args as unknown[]) as typeof args;
-    return this._clone().reselectBang(...args);
+    return this.clone().reselectBang(...args);
   }
 
   /**
@@ -1151,7 +1154,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#distinct
    */
   distinct(value = true): Relation<T> {
-    return this._clone().distinctBang(value);
+    return this.clone().distinctBang(value);
   }
 
   /**
@@ -1160,7 +1163,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#distinct_on (PostgreSQL only)
    */
   distinctOn(...columns: string[]): Relation<T> {
-    const rel = this._clone();
+    const rel = this.clone();
     rel.distinctValue = true;
     rel._distinctOnColumns = columns;
     return rel;
@@ -1173,7 +1176,7 @@ export class Relation<T extends Base> {
    */
   group(...args: (string | import("@blazetrails/arel").Nodes.Node)[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":group", args as unknown[]);
-    return this._clone().groupBang(...(args as string[]));
+    return this.clone().groupBang(...(args as string[]));
   }
 
   /**
@@ -1189,7 +1192,7 @@ export class Relation<T extends Base> {
     condition: string | Record<string, unknown> | Nodes.Node,
     ...binds: unknown[]
   ): Relation<T> {
-    return this._clone().havingBang(condition, ...binds);
+    return this.clone().havingBang(condition, ...binds);
   }
 
   /**
@@ -1199,7 +1202,7 @@ export class Relation<T extends Base> {
    */
   regroup(...args: string[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":regroup", args);
-    return this._clone().regroupBang(...args);
+    return this.clone().regroupBang(...args);
   }
 
   /**
@@ -1211,7 +1214,7 @@ export class Relation<T extends Base> {
     this.checkIfMethodHasArgumentsBang(":reorder", args as unknown[], undefined, () => {
       this.sanitizeOrderArguments(args as unknown[]);
     });
-    return this._clone().reorderBang(...args);
+    return this.clone().reorderBang(...args);
   }
 
   /**
@@ -1220,7 +1223,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reverse_order
    */
   reverseOrder(): Relation<T> {
-    return this._clone().reverseOrderBang();
+    return this.clone().reverseOrderBang();
   }
 
   /**
@@ -1239,7 +1242,7 @@ export class Relation<T extends Base> {
 
     if (values.length === 0) return this.none();
 
-    const rel = this._clone();
+    const rel = this.clone();
 
     // Mirrors Rails: `references = column_references([column]);
     // self.references_values |= references unless references.empty?`
@@ -1305,7 +1308,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#invert_where
    */
   invertWhere(): Relation<T> {
-    return this._clone().invertWhereBang();
+    return this.clone().invertWhereBang();
   }
 
   /**
@@ -1419,7 +1422,7 @@ export class Relation<T extends Base> {
     // named and raw joins; the named-vs-raw partition the builders need is
     // derived on read by `select_association_list`.
     return QueryMethodBangs.joinsBang.call(
-      this._clone() as any,
+      this.clone() as any,
       ...(args as (string | Nodes.Join)[]),
     ) as Relation<T>;
   }
@@ -1479,7 +1482,7 @@ export class Relation<T extends Base> {
     // `build_join_buckets` (query_methods.rb:1828-1834) — not eagerly here. See
     // `buildJoinBuckets` for the raise.
     return QueryMethodBangs.leftOuterJoinsBang.call(
-      this._clone() as any,
+      this.clone() as any,
       ...(args as AssociationSpec[]),
     ) as Relation<T>;
   }
@@ -1908,7 +1911,7 @@ export class Relation<T extends Base> {
    */
   includes(...args: AssociationSpec[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":includes", args);
-    return this._clone().includesBang(...args);
+    return this.clone().includesBang(...args);
   }
 
   /**
@@ -1918,7 +1921,7 @@ export class Relation<T extends Base> {
    */
   preload(...args: AssociationSpec[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":preload", args);
-    return this._clone().preloadBang(...args);
+    return this.clone().preloadBang(...args);
   }
 
   /**
@@ -1928,7 +1931,7 @@ export class Relation<T extends Base> {
    */
   eagerLoad(...args: AssociationSpec[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":eager_load", args);
-    return this._clone().eagerLoadBang(...args);
+    return this.clone().eagerLoadBang(...args);
   }
 
   // -- Relation state --
@@ -2149,7 +2152,7 @@ export class Relation<T extends Base> {
    * the `loaded?` short-circuit lives in `empty?` (relation.rb:362-370).
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
-    if (this._isEmptyRelation()) return false;
+    if (this.isNullRelation()) return false;
     if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
     return !(await this.isEmpty());
   }
@@ -2160,7 +2163,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#many?
    */
   async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
-    if (this._isEmptyRelation()) return false;
+    if (this.isNullRelation()) return false;
     if (predicate !== undefined) return (await this._countMatching(predicate, 2)) > 1;
     if (this._loaded) return this._records.length > 1;
     return (await this.limitedCount()) > 1;
@@ -2172,7 +2175,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#one?
    */
   async isOne(pattern?: EnumerablePattern<T>): Promise<boolean> {
-    if (this._isEmptyRelation()) return false;
+    if (this.isNullRelation()) return false;
     if (pattern !== undefined) return (await this._countMatching(pattern, 2)) === 1;
     if (this._loaded) return this._records.length === 1;
     return (await this.limitedCount()) === 1;
@@ -2319,7 +2322,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#to_a / #load
    */
   async toArray(): Promise<T[]> {
-    if (this._isEmptyRelation()) return [];
+    if (this.isNullRelation()) return [];
     if (this._loaded) return [...this._records];
     if (this._loadAsyncPromise) {
       // A prior loadAsync() kicked off the query — share the in-flight
@@ -2813,7 +2816,7 @@ export class Relation<T extends Base> {
     const table = this.table;
     // Mirrors Rails: blank check precedes none? check (relation.rb:589-591).
     if (isBlank(updates)) throw new ArgumentError("Empty list of attributes to change");
-    if (this._isEmptyRelation()) return 0;
+    if (this.isNullRelation()) return 0;
     await this._materializeDeferredDistinctPkPredicates();
 
     let values: [Nodes.Node, unknown][] | Nodes.SqlLiteral;
@@ -2870,7 +2873,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#delete_all
    */
   async deleteAll(): Promise<number> {
-    if (this._isEmptyRelation()) return 0;
+    if (this.isNullRelation()) return 0;
     await this._materializeDeferredDistinctPkPredicates();
 
     // Mirrors Rails `INVALID_METHODS_FOR_DELETE_ALL.select` (relation.rb:1014):
@@ -3589,7 +3592,7 @@ export class Relation<T extends Base> {
     // shared `AliasTracker` spanning the eager JoinDependency and the manual
     // joins, deduping coinciding nodes via `walk` — same threading as the
     // relation `_applyEagerJoinDependency` yields.
-    const joined = this._clone();
+    const joined = this.clone();
     QueryMethodBangs.joinsBang.call(joined as any, jd as any);
     _qm.buildJoins.call(joined as any, idSubquery);
     if (!this.whereClause.isEmpty()) idSubquery.where(this.whereClause.ast);
@@ -3839,7 +3842,7 @@ export class Relation<T extends Base> {
     // `compact_blank!` (a blank arg like `null`/`[]`/`{}` compacts away, so
     // `with(null)` no-ops). It mutates `args` in place.
     this.checkIfMethodHasArgumentsBang(":with", args);
-    return this._clone().withBang(...args);
+    return this.clone().withBang(...args);
   }
 
   /**
@@ -3856,7 +3859,7 @@ export class Relation<T extends Base> {
     // empty varargs, then mirrors `args.flatten!` (arrays only) and `compact_blank!`
     // (so `withRecursive(null)` no-ops). It mutates `args` in place.
     this.checkIfMethodHasArgumentsBang(":with_recursive", args);
-    return this._clone().withRecursiveBang(...args);
+    return this.clone().withRecursiveBang(...args);
   }
 
   // -- Other query methods --
@@ -3868,7 +3871,7 @@ export class Relation<T extends Base> {
    */
   references(...tableNames: Array<string | Nodes.SqlLiteral>): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":references", tableNames);
-    return this._clone().referencesBang(...tableNames) as Relation<T>;
+    return this.clone().referencesBang(...tableNames) as Relation<T>;
   }
 
   /**
@@ -4141,15 +4144,37 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Check equality with another relation.
+   * Compares two relations for equality.
    *
-   * Mirrors: ActiveRecord::Relation#==
+   * Mirrors: ActiveRecord::Relation#== (relation.rb:1253-1262) — a
+   * `case/when` whose arms are, in order: a `CollectionProxy`/
+   * `AssociationRelation` (re-dispatch on its `records`), any other `Relation`
+   * (compare `to_sql`), an Array (compare the loaded `records`). Anything else
+   * falls off the `case` and returns `nil`.
+   *
+   * The two relation-family classes are read off the zero-import registration
+   * slot rather than imported: they are `Relation` subclasses, so a value
+   * import here would close a subclass cycle. Reading them at call time is
+   * where Ruby resolves the constants anyway.
    */
-  async equals(other: Relation<T>): Promise<boolean> {
-    const a = await this.toArray();
-    const b = await other;
-    if (a.length !== b.length) return false;
-    return a.every((rec, i) => rec.equals(b[i]));
+  async equals(other: unknown): Promise<boolean | undefined> {
+    const CollectionProxyCtor = _relationFamilySlot.collectionProxy;
+    const AssociationRelationCtor = _relationFamilySlot.associationRelation;
+    if (
+      (CollectionProxyCtor && other instanceof CollectionProxyCtor) ||
+      (AssociationRelationCtor && other instanceof AssociationRelationCtor)
+    ) {
+      return this.equals(await (other as Relation<T>).records());
+    }
+    if (other instanceof Relation) {
+      return other.toSql() === this.toSql();
+    }
+    if (Array.isArray(other)) {
+      const records = await this.records();
+      if (records.length !== other.length) return false;
+      return records.every((rec, i) => rec.equals(other[i]));
+    }
+    return undefined;
   }
 
   /**
@@ -4228,31 +4253,9 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#none?
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
-    if (this._isEmptyRelation()) return true;
+    if (this.isNullRelation()) return true;
     if (pattern !== undefined) return !(await this.toArray()).some(this._patternMatcher(pattern));
     return this.isEmpty();
-  }
-
-  /**
-   * The single none-short-circuit chokepoint consulted by every query terminal
-   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and by the mutation
-   * terminals (`updateAll`/`deleteAll`) BEFORE returning an empty result.
-   * `touchAll`/`updateCounters` reach it by delegating to `updateAll`, as they
-   * do in Rails.
-   *
-   * On a plain relation this is just `_isNone`; the override in
-   * `AssociationRelation` first rebases a stale new-owner `1=0` seed onto the
-   * live association scope, so a relation SPAWNED off a new owner
-   * (`owner.things.where(...)`) resolves the persisted FK once the owner is
-   * saved — mirroring Rails' CollectionProxy delegating every query to
-   * `association.scope`, rather than each terminal carrying its own rebase hook.
-   * `CollectionProxy` needs no rebase at all: it is never `@none` itself, and
-   * its value readers are delegated to `scope` (collection_proxy.rb:1128-1137).
-   *
-   * @internal
-   */
-  _isEmptyRelation(): boolean {
-    return this._isNone;
   }
 
   /**
@@ -4615,7 +4618,7 @@ export class Relation<T extends Base> {
       let collection: Relation<T> = this;
       if (this._eagerLoadingForSql()) {
         const eagerSpecs = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
-        const rel = this._clone();
+        const rel = this.clone();
         rel.eagerLoadValues = [];
         rel.includesValues = [];
         const pk = (this._model as { primaryKey?: string | string[] }).primaryKey ?? "id";
@@ -4655,7 +4658,7 @@ export class Relation<T extends Base> {
       if (collection.hasLimitOrOffset) {
         // Has LIMIT/OFFSET — wrap in a subquery (mirrors Rails' build_subquery).
         const subqueryAlias = "subquery_for_cache_key";
-        const inner = collection._clone();
+        const inner = collection.clone();
         // Rails appends `select("<col> AS collection_cache_key_timestamp")` to
         // whatever the collection already selects — a custom `select(...)` must
         // survive so its aliases (e.g. an `ORDER BY` on a `name AS dev_name`
@@ -4691,7 +4694,7 @@ export class Relation<T extends Base> {
         size = Number(rows[0]?.size ?? 0);
         timestamp = rows[0]?.timestamp;
       } else {
-        const query = collection._clone();
+        const query = collection.clone();
         query.orderValues = [];
         query._rawOrderClauses = [];
         query.selectValues = [countStar.as("size"), maxNode.as("timestamp")];
@@ -4752,20 +4755,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * @internal Subclasses (e.g. AssociationRelation) override this to return
-   * an instance of themselves so `_clone()` preserves the subclass through
-   * chains like `blog.posts.where(...).order(...)`.
-   */
-  protected _newRelation(): Relation<T> {
-    // Spawn from the per-model `Relation` subclass carrier (`relationClassFor`)
-    // so cloned relations keep the prototype that carries generated relation
-    // methods — otherwise `.where(...).someClassMethod()` would spawn a bare
-    // shared `Relation` and lose the real-method resolution.
-    const ctor = relationClassFor(this._model as unknown as typeof Base);
-    return new ctor(this._model) as Relation<T>;
-  }
-
-  /**
    * Copy query state from `source` onto `this`.
    *
    * Mirrors: ActiveRecord::Relation#initialize_copy (relation.rb:97-100) —
@@ -4809,9 +4798,22 @@ export class Relation<T extends Base> {
     // spawn `model.all` and discard the values accumulated so far.
   }
 
-  /** @internal */
-  _clone(): Relation<T> {
-    const rel = this._newRelation();
+  /**
+   * Ruby's `Object#clone` — the allocation `spawn` (spawn_methods.rb:10) copies
+   * through. Ruby copies the receiver's ivars into a same-class allocation and
+   * then runs `initialize_copy`; TypeScript has no `allocate`, so the class is
+   * re-instantiated here (subclasses override to reach their own constructor)
+   * and `initializeCopy` does the ivar copy.
+   *
+   * @internal
+   */
+  clone(): Relation<T> {
+    // Allocate from the per-model `Relation` subclass carrier
+    // (`relationClassFor`) so cloned relations keep the prototype that carries
+    // generated relation methods — otherwise `.where(...).someClassMethod()`
+    // would spawn a bare shared `Relation` and lose the real-method resolution.
+    const ctor = relationClassFor(this._model as unknown as typeof Base);
+    const rel = new ctor(this._model) as Relation<T>;
     rel.initializeCopy(this);
     return wrapWithScopeProxy(rel);
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4943,6 +4943,10 @@ _registerRelationFamily("relation", Relation);
 // ---------------------------------------------------------------------------
 
 export interface Relation<T extends Base> {
+  // Declared as a METHOD signature (the mixin's object-literal type makes it a
+  // function-valued PROPERTY) so `AssociationRelation` can override it with a
+  // plain method and reach `super.isNullRelation()`.
+  isNullRelation(): boolean;
   then<TResult1 = T[], TResult2 = never>(
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,

--- a/packages/activerecord/src/relation/arel-column-with-table-schema-qualified.trails.test.ts
+++ b/packages/activerecord/src/relation/arel-column-with-table-schema-qualified.trails.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Customer } from "../test-helpers/models/customer.js";
+import { quoteTableName, quoteColumnName } from "../support/quote-regex.js";
+
+/**
+ * `arel_column_with_table` (query_methods.rb:1978-1987) has exactly two arms:
+ * the Symbol/`\W` discriminant routing through
+ * `predicate_builder.resolve_arel_attribute`, and the `quote_table_name`
+ * fallback. trails carried a third arm ahead of them for a schema-qualified
+ * `table_name`, which put `quoteTableName` ahead of `resolveArelAttribute` in
+ * the call set. This locks the quoting that arm was protecting: it comes from
+ * each adapter's `quote_table_name`, which splits on "." (sqlite3/quoting.rb:48,
+ * postgresql/quoting.rb:58, mysql/quoting.rb) exactly as Rails' does.
+ */
+describe("arel_column_with_table schema-qualified quoting", () => {
+  fixtures([]);
+
+  it("quotes each segment of a schema-qualified table", () => {
+    const sql = Customer.select("myschema.customers.name").toSql();
+    expect(sql).toContain(`${quoteTableName("myschema.customers")}.${quoteColumnName("name")}`);
+  });
+});

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -206,7 +206,7 @@ export class Batches {
       generator = async function* () {
         await ensureValidOptions();
         for (const batchRows of loadedBatches) {
-          const batchRel = self._clone();
+          const batchRel = self.clone();
           batchRel.orderValues = batchOrders.map(([col, dir]) =>
             dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
           );
@@ -229,7 +229,7 @@ export class Batches {
           remaining,
           useRanges,
         })) {
-          const batchRel = self._clone();
+          const batchRel = self.clone();
           batchRel.orderValues = batchOrders.map(([col, dir]) =>
             dir === "desc" ? self.table.get(col).desc() : self.table.get(col).asc(),
           );

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -137,7 +137,7 @@ interface CalculationRelation {
   optimizerHintsValues: string[];
   _isNone: boolean;
   /** @internal Rebase-then-report none short-circuit; see Relation. */
-  _isEmptyRelation(): boolean;
+  isNullRelation(): boolean;
   distinctValue: boolean;
   /** Mirrors `Relation#distinct!` (query_methods.rb). */
   distinctBang(value?: boolean): unknown;
@@ -221,7 +221,7 @@ interface CalculationRelation {
   eagerLoadValues: unknown[];
   includesValues: unknown[];
   /** @internal trails: `spawn` without the scoping re-application; see Relation. */
-  _clone(): CalculationRelation;
+  clone(): CalculationRelation;
   /** @internal trails: builds the JoinDependency `apply_join_dependency` would. */
   _buildEagerJoinDependency(specs: unknown[]): JoinDependency;
   /** Mirrors `Relation#limit_or_offset?`. */
@@ -747,11 +747,11 @@ export async function calculate(
 ): Promise<unknown> {
   operation = operation.toLowerCase();
 
-  // Rails' `@none`. `_isEmptyRelation()` is the shared none-short-circuit
+  // Rails' `@none`. `isNullRelation()` is the shared none-short-circuit
   // chokepoint: on an AssociationRelation it first rebases a stale new-owner
   // `1=0` seed onto the live association scope, so a calculation on a relation
   // spawned off a new owner picks up the persisted FK after `save`.
-  if (this._isEmptyRelation()) {
+  if (this.isNullRelation()) {
     switch (operation) {
       case "count":
       case "sum":
@@ -803,7 +803,7 @@ export async function pluck(
   ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
 ): Promise<unknown[]> {
   // `pick` routes through `limit(1).pluck(...)`, so it inherits this rebase.
-  if (this._isEmptyRelation()) return [];
+  if (this.isNullRelation()) return [];
 
   // calculations.rb:300 — a loaded relation whose plucked columns are all
   // attributes reads the materialized records instead of issuing SQL, the same
@@ -844,7 +844,7 @@ export async function pluck(
       // hasInclude is true only when eagerLoadValues or
       // includesValues is non-empty, so the union is always non-empty here.
       const eagerSpecs = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
-      const rel = this._clone();
+      const rel = this.clone();
       rel.eagerLoadValues = [];
       rel.includesValues = [];
 
@@ -930,7 +930,7 @@ export async function pluck(
     // the spawn's select before building is essential: resolving the discarded
     // select list would mutate referencesValues and could promote includes
     // (adding joins Rails would not add for the pluck columns).
-    const rel = this._clone();
+    const rel = this.clone();
     delete rel._values.select;
     // calculations.rb:315-316 — `relation.select_values = columns; relation.arel`.
     // Going through `select_values` (rather than overwriting `manager.projections`)
@@ -1031,7 +1031,7 @@ export async function ids(this: CalculationRelation): Promise<unknown[]> {
     const eagerSpecs = [...this.eagerLoadValues, ...this.includesValues].filter(
       (spec, i, all) => all.indexOf(spec) === i,
     );
-    const rel = this._clone();
+    const rel = this.clone();
     rel.eagerLoadValues = [];
     rel.includesValues = [];
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -287,7 +287,7 @@ interface FinderRelation {
   };
   _isNone: boolean;
   /** @internal Rebase-then-report none short-circuit; see Relation. */
-  _isEmptyRelation(): boolean;
+  isNullRelation(): boolean;
   limitValue: number | null;
   offsetValue: number | null;
   orderValues: unknown[];
@@ -295,7 +295,7 @@ interface FinderRelation {
   createWithValue: Record<string, unknown>;
   _scopeAttributes(): Record<string, unknown>;
   scopeForCreate(): Record<string, unknown>;
-  _clone(): any;
+  clone(): any;
   whereClause: { isEmpty(): boolean; isContradiction(): boolean };
   havingClause: { isEmpty(): boolean };
   /** Relation#arel — the built SelectManager (relation.ts). */
@@ -517,7 +517,7 @@ export async function performLastBang(this: FinderRelation): Promise<any> {
 
 /** @internal */
 export async function performSole(this: FinderRelation): Promise<any> {
-  const rel = this._clone();
+  const rel = this.clone();
   rel.limitValue = 2;
   const records = await rel.toArray();
   if (records.length === 0) {
@@ -713,7 +713,7 @@ export async function exists(
   this: FinderRelation,
   conditions?: Record<string, unknown> | unknown,
 ): Promise<boolean> {
-  if (this._isEmptyRelation()) return false;
+  if (this.isNullRelation()) return false;
   // `Base === conditions` (finder_methods.rb:360) — detected via the inherited
   // `_isActiveRecordBase` marker so a model of any class (not just this
   // relation's) is caught.

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -286,7 +286,13 @@ export class HashMerger {
   // to it via `public_send("#{k}!", *v)` so where-value interpolation etc.
   // happens on the built relation rather than by directly merging raw values.
   private buildOther(): any {
-    const other = this.relation._newRelation();
+    // `Relation.create(relation.model, table:, predicate_builder:)`
+    // (merger.rb:26-30) — trails' constructor takes the same three.
+    const other: any = new Relation(
+      this.relation.model,
+      this.relation.table,
+      this.relation.predicateBuilder,
+    );
     for (const [key, value] of Object.entries(this.hash)) {
       // `select` dispatches to `_select!` (Rails renames `:select` → `:_select`
       // to avoid Enumerable#select!); trails mirrors this with `_selectBang`.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -287,7 +287,7 @@ interface QueryMethodsHost {
   // (Arel join nodes, raw SQL strings) is a raw join value.
   _isNamedJoinValue(v: unknown): boolean;
   /** Rails' `clone` behind `spawn` (spawn_methods.rb:9-11). */
-  _clone(): any;
+  clone(): any;
   /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
   skipPreloadingValue: boolean;
   _model: typeof import("../base.js").Base;
@@ -710,7 +710,7 @@ function unscope(
   ...args: Array<UnscopeType | { where: string | string[] }>
 ): any {
   checkIfMethodHasArgumentsBang.call(this, ":unscope", args as unknown[]);
-  return unscopeBang.apply(this._clone(), args as any);
+  return unscopeBang.apply(this.clone(), args as any);
 }
 
 function unscopeBang(
@@ -1181,7 +1181,7 @@ function offsetBang(this: QueryMethodsHost, value: number | string | null): any 
  * Mirrors: ActiveRecord::QueryMethods#lock (query_methods.rb:1238-1240)
  */
 function lock(this: QueryMethodsHost, locks: string | boolean = true): any {
-  return lockBang.call(this._clone(), locks);
+  return lockBang.call(this.clone(), locks);
 }
 
 function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
@@ -1199,7 +1199,7 @@ function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
  * Mirrors: ActiveRecord::QueryMethods#none (query_methods.rb:1281-1283)
  */
 function none(this: QueryMethodsHost): any {
-  return noneBang.call(this._clone());
+  return noneBang.call(this.clone());
 }
 
 function noneBang(this: QueryMethodsHost): any {
@@ -1210,6 +1210,18 @@ function noneBang(this: QueryMethodsHost): any {
   return this;
 }
 
+/**
+ * Mirrors: ActiveRecord::QueryMethods#null_relation? (query_methods.rb:1293) —
+ * `@none`.
+ *
+ * This is also the single none-short-circuit chokepoint consulted by every
+ * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and
+ * by the mutation terminals (`updateAll`/`deleteAll`) BEFORE returning an empty
+ * result. `AssociationRelation` overrides it to first rebase a stale new-owner
+ * `1=0` seed onto the live association scope, so a relation spawned off a new
+ * owner (`owner.things.where(...)`) resolves the persisted FK once the owner is
+ * saved.
+ */
 function isNullRelation(this: QueryMethodsHost): boolean {
   return this._isNone;
 }
@@ -1220,7 +1232,7 @@ function isNullRelation(this: QueryMethodsHost): boolean {
  * Mirrors: ActiveRecord::QueryMethods#readonly (query_methods.rb:1309-1311)
  */
 function readonly(this: QueryMethodsHost, value = true): any {
-  return readonlyBang.call(this._clone(), value);
+  return readonlyBang.call(this.clone(), value);
 }
 
 function readonlyBang(this: QueryMethodsHost, value = true): any {
@@ -1234,7 +1246,7 @@ function readonlyBang(this: QueryMethodsHost, value = true): any {
  * Mirrors: ActiveRecord::QueryMethods#strict_loading (query_methods.rb:1324-1326)
  */
 function strictLoading(this: QueryMethodsHost, value = true): any {
-  return strictLoadingBang.call(this._clone(), value);
+  return strictLoadingBang.call(this.clone(), value);
 }
 
 function strictLoadingBang(this: QueryMethodsHost, value = true): any {
@@ -1248,7 +1260,7 @@ function strictLoadingBang(this: QueryMethodsHost, value = true): any {
  * Mirrors: ActiveRecord::QueryMethods#create_with (query_methods.rb:1346-1348)
  */
 function createWith(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
-  return createWithBang.call(this._clone(), value);
+  return createWithBang.call(this.clone(), value);
 }
 
 function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
@@ -1268,7 +1280,7 @@ function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> |
  * Mirrors: ActiveRecord::QueryMethods#from (query_methods.rb:1391-1393)
  */
 function from(this: QueryMethodsHost, value: any, subqueryName?: string): any {
-  return fromBang.call(this._clone(), value, subqueryName);
+  return fromBang.call(this.clone(), value, subqueryName);
 }
 
 function fromBang(this: QueryMethodsHost, value: any, subqueryName?: string): any {
@@ -1291,8 +1303,8 @@ function extending(
   this: QueryMethodsHost,
   mod?: Record<string, (...args: any[]) => any> | ((rel: any) => void),
 ): any {
-  if (!mod) return this._clone();
-  return extendingBang.call(this._clone(), mod);
+  if (!mod) return this.clone();
+  return extendingBang.call(this.clone(), mod);
 }
 
 function extendingBang(
@@ -1324,7 +1336,7 @@ function extendingBang(
  */
 function optimizerHints(this: QueryMethodsHost, ...args: string[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":optimizer_hints", args);
-  return optimizerHintsBang.apply(this._clone(), args);
+  return optimizerHintsBang.apply(this.clone(), args);
 }
 
 function optimizerHintsBang(this: QueryMethodsHost, ...args: string[]): any {
@@ -1425,7 +1437,7 @@ function skipPreloadingBang(this: QueryMethodsHost): any {
  */
 function annotate(this: QueryMethodsHost, ...args: string[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":annotate", args);
-  return annotateBang.apply(this._clone(), args);
+  return annotateBang.apply(this.clone(), args);
 }
 
 function annotateBang(this: QueryMethodsHost, ...comments: string[]): any {
@@ -2223,14 +2235,6 @@ export function arelColumnWithTable(
   const isSymbol = isRubySymbol(columnName);
   if (isSymbol) columnName = symbolToName(columnName);
   const modelClass: any = this.model;
-  // Schema-qualified table names (e.g. "schema.table") must not be passed to
-  // ArelTable — the visitor quotes the whole string as one identifier, producing
-  // "schema.table"."col" instead of "schema"."table"."col".
-  if (tableName.includes(".")) {
-    return Arel.sql(
-      `${connectionFor(modelClass).quoteTableName(tableName)}.${connectionFor(modelClass).quoteColumnName(columnName)}`,
-    );
-  }
   if (isSymbol || !/\W/.test(columnName)) {
     const builder = (this as any).predicateBuilder;
     // Rails passes `lookup_table_klass_from_join_dependencies` as the block

--- a/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
+++ b/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
@@ -21,7 +21,7 @@ registerModel([Post]);
 /** The relation internals these tests reach into. */
 interface ScopeInternals {
   isAlreadyInScope(registry: ScopeRegistryLike): boolean;
-  _clone(): ScopeInternals;
+  clone(): ScopeInternals;
   spawn(): ScopeInternals;
   where(conditions: Record<string, unknown>): ScopeInternals;
   toSql(): Promise<string>;
@@ -127,7 +127,7 @@ describe("SpawnAlreadyInScopeTest", () => {
     let clonedFlag: boolean | undefined;
 
     defineAndCallScope("clonedInBody", (rel) => {
-      const cloned = rel._clone();
+      const cloned = rel.clone();
       withCurrentScope(cloned, (registry) => {
         clonedFlag = cloned.isAlreadyInScope(registry);
       });

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -10,7 +10,7 @@ import { argumentError, setValues } from "./query-methods.js";
 import type { ExceptSkip } from "./query-methods.js";
 
 interface SpawnRelation<T = unknown> {
-  _clone(): T;
+  clone(): T;
   isAlreadyInScope(registry: unknown): boolean;
   values(): Record<string, unknown>;
   /** @internal */
@@ -32,7 +32,7 @@ interface SpawnRelation<T = unknown> {
  * fidelity with `spawn_methods.rb:9-11`.
  */
 export function performSpawn<T extends SpawnRelation<T>>(this: T): T {
-  return this.isAlreadyInScope(this._model.scopeRegistry()) ? this._model.all() : this._clone();
+  return this.isAlreadyInScope(this._model.scopeRegistry()) ? this._model.all() : this.clone();
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/query-methods.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "order:quoteTableName,resolveArelAttribute",
-    "reason": "Every call Rails makes is made here, in Rails' order; the inversion is the extra schema-qualified guard trails keeps ahead of query_methods.rb:1981 — a dotted `table_name` (\"schema.table\") must be quoted segment-by-segment through `quote_table_name` rather than handed to Arel::Table, which quotes the whole string as one identifier. Removing that branch is a separate change from converging the references_values store (RFC 0106)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
     "call": "include?",
     "reason": "Satisfied in `Relation#whereAssociated`, which is where Rails' `associations.each` body lives in this port: the already-joined guard (`query_methods.rb:91`) reads `joinsValues` / `leftOuterJoinsValues` and `includes` there, per-iteration, exactly as Rails does. Same split as the existing `joins!` / `not` entries for this method."


### PR DESCRIPTION
## converge-arel-column-with-table-schema-qualified-guard

`arelColumnWithTable` kept a third arm ahead of Rails' two (query_methods.rb:1978-1987)
for a dotted `table_name`. Every adapter's `quoteTableName` already splits on `.`
(sqlite3/quoting.rb:48, postgresql/quoting.rb:58, mysql/quoting.rb), which is exactly
where Rails fixes schema-qualified quoting — so the guard only inverted the call order,
and no Arel-side fix was needed. Removed; a regression test locks
`"schema"."table"."col"` through the `resolve_arel_attribute` arm the guard used to skip.

The `arel_column_with_table` / `order:quoteTableName,resolveArelAttribute` row is deleted
from its shard by hand (no reseed); `parity:api:calls` and `:args` are green, and
`:tighten` reports nothing stale.

## retire-relation-parallel-spawn-and-clone-path

- `_clone` → `clone` — Ruby's `Object#clone`, the allocation `spawn` copies through
  (spawn_methods.rb:10) — and `_newRelation` is folded into it. The three subclasses
  (`AssociationRelation`, `CollectionProxy`, `DisableJoinsAssociationRelation`) override
  `clone` instead, which is what Ruby's `clone` does implicitly by allocating the
  receiver's own class. One copy path: `clone` → `initializeCopy` (relation.rb:97).
- `Merger::HashMerger#other` built its scratch relation via `_newRelation`; it now
  constructs a `Relation` from model / table / predicate_builder, as merger.rb:26-30 does.
- `_isEmptyRelation` was a duplicate of `null_relation?` (query_methods.rb:1293) — same
  body, `@none` — and is retired onto the existing `isNullRelation`. The
  AssociationRelation new-owner seed-rebase hook now clears its marker *before*
  rebuilding, because the rebuild runs the merger, which itself reads
  `isNullRelation()` (merger.rb:70) and would otherwise re-enter the hook; the marker is
  restored if the rebuilt scope is still unresolved.
- `Relation#equals` is now relation.rb:1253-1262's `case/when` in Rails' order:
  CollectionProxy/AssociationRelation re-dispatch on `records`, any other `Relation`
  compares `to_sql`, an Array compares the loaded `records`, anything else returns `nil`.
  The two relation-family constructors are read off the existing zero-import
  registration slot at call time rather than imported — they are `Relation` subclasses,
  so a value import would close a subclass cycle.

`equals` keeps its name: `==` is in `OPERATORS` in `scripts/parity/conventions.ts`, which
maps operators to no expected TS counterpart, and `equals` is already the settled trails
spelling for Ruby `==` (`Base#==`).

## Verification

- `relation/**`, `associations/**`, `association-relation`, `disable-joins-association-relation`,
  `relation.test.ts`, `scoping/**`, `merger`, `spawn-already-in-scope` — all green locally (SQLite).
- `pnpm parity:api:calls` / `:args` OK; `parity:api:extra` shows no new novel names;
  `pnpm lint --fix` and `pnpm typecheck` clean.

Closes-story: converge-arel-column-with-table-schema-qualified-guard
Closes-story: retire-relation-parallel-spawn-and-clone-path