### PR TITLE
refactor(activesupport,activerecord): OrderedOptions constructors take Hash's shape, inline the where-family private helpers

### DIFF
--- a/packages/activerecord/src/ordered-options.test.ts
+++ b/packages/activerecord/src/ordered-options.test.ts
@@ -56,13 +56,15 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options continues lookup in parent", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent);
     expect((child as any).foo).toBe("bar");
   });
 
   it("inheritable options can override parent", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.foo = "baz";
     expect(child.foo).toBe("baz");
@@ -70,7 +72,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options inheritable copy", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent);
     const grandchild = child.inheritableCopy() as any;
     expect(grandchild.foo).toBe("bar");
@@ -91,7 +94,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options with bang", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     expect(child["foo!"]()).toBe("bar");
     expect(() => child["missing!"]()).toThrow(":missing is blank");
@@ -108,7 +112,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable option inspect", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     const str = child.inspect();
@@ -123,7 +128,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options to h", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     expect(child.toH()).toEqual({ foo: "bar", baz: "qux" });
@@ -139,7 +145,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options dup", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     const copy = child.dup();
@@ -158,14 +165,16 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options key", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     expect(child.key("qux")).toBe("baz");
   });
 
   it("inheritable options overridden", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     expect(child.foo).toBe("bar");
     child.foo = "baz";
@@ -173,14 +182,16 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options overridden with nil", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.foo = null;
     expect(child.foo).toBeNull();
   });
 
   it("inheritable options each", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     const collected: [string, unknown][] = [];
@@ -203,7 +214,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options count", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     child.another = "one";
@@ -219,7 +231,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options to s", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     const str = child.toString();
@@ -236,7 +249,8 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options pp", () => {
-    const parent = new OrderedOptions({ foo: "bar" });
+    const parent = new OrderedOptions();
+    parent.set("foo", "bar");
     const child = new InheritableOptions(parent) as any;
     child.baz = "qux";
     const str = child.inspect();

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1060,7 +1060,9 @@ export class Relation<T extends Base> {
    * shares one body and lets `__callee__` name whichever alias was called;
    * TypeScript has no `__callee__`, so the body is materialized once per callee
    * rather than routed through a helper Rails does not have — the ArgumentError
-   * has to name `#without` here, exactly as excluding_test.rb:108 asserts.
+   * has to name `#without` here, exactly as
+   * `excluding_test.rb:103-110` (`test_raises_on_record_from_different_class`)
+   * asserts.
    */
   without(...records: unknown[]): Relation<T> {
     const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -153,8 +153,8 @@ function formatCacheTimestamp(ts: Temporal.Instant, format: "usec" | "number" | 
  * — inline where-SQL is produced at the Relation level via
  * `conn.unprepared_statement { conn.to_sql(arel) }` — so this glue lives here,
  * routing the Arel AND/SqlLiteral-wrapped AST through the connection visitor.
- * Consumed by `_whereMatchesUnscopedBaseline` (the WHERE half of `isEmptyScope`)
- * to compare a relation's predicate SQL against the unscoped baseline.
+ * Consumed by `isEmptyScope` to compare a relation's predicate SQL against the
+ * unscoped baseline.
  */
 function _whereClauseToSql(
   whereClause: WhereClause,
@@ -1022,45 +1022,19 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#excluding / #without
    */
   excluding(...records: unknown[]): Relation<T> {
-    const combined = this._excludingArgs(records, "excluding");
-    if (combined.length === 0) return this;
-    return this.clone().excludingBang(combined);
-  }
-
-  /**
-   * Alias for excluding.
-   *
-   * Mirrors: ActiveRecord::Relation#without
-   */
-  without(...records: unknown[]): Relation<T> {
-    const combined = this._excludingArgs(records, "without");
-    if (combined.length === 0) return this;
-    return this.clone().excludingBang(combined);
-  }
-
-  /**
-   * Normalize the arguments for `excluding` / `without`. Mirrors Rails
-   * `QueryMethods#excluding` (query_methods.rb:1574): extract Relation
-   * arguments, flatten one level of array nesting, compact nils, then validate
-   * that every remaining record and relation belongs to this model — raising
-   * the same ArgumentError keyed on the public `__callee__`. Returns the
-   * `records + relations.flat_map(&:ids)` collection passed to `excluding!`:
-   * scalars, the spread of any loaded relation's cached records, and any still-
-   * unloaded relation left in place for `excludingBang` to defer.
-   */
-  private _excludingArgs(records: unknown[], callee: string): unknown[] {
     const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];
-    const recs = records
+    records = records
       .filter((r) => !(r instanceof Relation))
       .flat(1)
       .filter((r) => r != null);
 
     const model = this.model;
-    const recordsOk = recs.every((r) => r instanceof model);
-    const relationsOk = relations.every((rel) => rel.model === model);
-    if (!recordsOk || !relationsOk) {
+    if (
+      !records.every((r) => r instanceof model) ||
+      !relations.every((relation) => relation.model === model)
+    ) {
       throw new ArgumentError(
-        `You must only pass a single or collection of ${model.name} objects to #${callee}.`,
+        `You must only pass a single or collection of ${model.name} objects to #excluding.`,
       );
     }
 
@@ -1072,12 +1046,46 @@ export class Relation<T extends Base> {
     // `excludingBang` records a marker that the load pipeline materializes into a
     // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
     // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
-    const combined: unknown[] = [...recs];
-    for (const rel of relations) {
-      if (rel.isLoaded) combined.push(...rel._records);
-      else combined.push(rel);
+    const combined: unknown[] = [...records];
+    for (const relation of relations) {
+      if (relation.isLoaded) combined.push(...relation._records);
+      else combined.push(relation);
     }
-    return combined;
+    if (combined.length === 0) return this;
+    return this.clone().excludingBang(combined);
+  }
+
+  /**
+   * Mirrors `alias :without :excluding` (query_methods.rb:1585). Ruby's alias
+   * shares one body and lets `__callee__` name whichever alias was called;
+   * TypeScript has no `__callee__`, so the body is materialized once per callee
+   * rather than routed through a helper Rails does not have — the ArgumentError
+   * has to name `#without` here, exactly as excluding_test.rb:108 asserts.
+   */
+  without(...records: unknown[]): Relation<T> {
+    const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];
+    records = records
+      .filter((r) => !(r instanceof Relation))
+      .flat(1)
+      .filter((r) => r != null);
+
+    const model = this.model;
+    if (
+      !records.every((r) => r instanceof model) ||
+      !relations.every((relation) => relation.model === model)
+    ) {
+      throw new ArgumentError(
+        `You must only pass a single or collection of ${model.name} objects to #without.`,
+      );
+    }
+
+    const combined: unknown[] = [...records];
+    for (const relation of relations) {
+      if (relation.isLoaded) combined.push(...relation._records);
+      else combined.push(relation);
+    }
+    if (combined.length === 0) return this;
+    return this.clone().excludingBang(combined);
   }
 
   /**
@@ -2153,7 +2161,16 @@ export class Relation<T extends Base> {
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return false;
-    if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) {
+      // Ruby hands the pattern straight to `Enumerable#any?`, which tests each
+      // element with `===`: for a class that is `instance_of?`, for anything
+      // else the object is called as the predicate.
+      const matches = (record: T): boolean =>
+        (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
+          ? record instanceof (pattern as new (...args: never[]) => Base)
+          : (pattern as (record: T) => boolean)(record);
+      return (await this.toArray()).some(matches);
+    }
     return !(await this.isEmpty());
   }
 
@@ -2164,7 +2181,14 @@ export class Relation<T extends Base> {
    */
   async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
     if (this.isNullRelation()) return false;
-    if (predicate !== undefined) return (await this._countMatching(predicate, 2)) > 1;
+    if (predicate !== undefined) {
+      // `Enumerable#many?` counts matches, short-circuiting at 2.
+      let count = 0;
+      for (const record of await this.toArray()) {
+        if (predicate(record) && ++count === 2) break;
+      }
+      return count > 1;
+    }
     if (this._loaded) return this._records.length > 1;
     return (await this.limitedCount()) > 1;
   }
@@ -2176,28 +2200,23 @@ export class Relation<T extends Base> {
    */
   async isOne(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return false;
-    if (pattern !== undefined) return (await this._countMatching(pattern, 2)) === 1;
+    if (pattern !== undefined) {
+      // Ruby hands the pattern straight to `Enumerable#one?`, which tests each
+      // element with `===`: for a class that is `instance_of?`, for anything
+      // else the object is called as the predicate.
+      const matches = (record: T): boolean =>
+        (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
+          ? record instanceof (pattern as new (...args: never[]) => Base)
+          : (pattern as (record: T) => boolean)(record);
+      // `Enumerable#one?` counts matches, short-circuiting at 2.
+      let count = 0;
+      for (const record of await this.toArray()) {
+        if (matches(record) && ++count === 2) break;
+      }
+      return count === 1;
+    }
     if (this._loaded) return this._records.length === 1;
     return (await this.limitedCount()) === 1;
-  }
-
-  /** @internal */
-  _patternMatcher(pattern: EnumerablePattern<T>): (record: T) => boolean {
-    if ((pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true) {
-      const klass = pattern as new (...args: never[]) => Base;
-      return (record) => record instanceof klass;
-    }
-    return pattern as (record: T) => boolean;
-  }
-
-  /** @internal */
-  async _countMatching(pattern: EnumerablePattern<T>, limit: number): Promise<number> {
-    const matches = this._patternMatcher(pattern);
-    let count = 0;
-    for (const record of await this.toArray()) {
-      if (matches(record) && ++count === limit) break;
-    }
-    return count;
   }
 
   /**
@@ -4254,7 +4273,16 @@ export class Relation<T extends Base> {
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return true;
-    if (pattern !== undefined) return !(await this.toArray()).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) {
+      // Ruby hands the pattern straight to `Enumerable#none?`, which tests each
+      // element with `===`: for a class that is `instance_of?`, for anything
+      // else the object is called as the predicate.
+      const matches = (record: T): boolean =>
+        (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
+          ? record instanceof (pattern as new (...args: never[]) => Base)
+          : (pattern as (record: T) => boolean)(record);
+      return !(await this.toArray()).some(matches);
+    }
     return this.isEmpty();
   }
 
@@ -4323,40 +4351,42 @@ export class Relation<T extends Base> {
     return except(this._values, "extending", "skipQueryCache", "strictLoading");
   }
 
-  /** True when this relation's WHERE equals the model's unscoped baseline —
-   *  empty, or carrying only the STI `type_condition` that `unscoped` itself
-   *  layers on. Mirrors the WHERE half of Rails' `@values == klass.unscoped.values`
-   *  so an STI subclass's unscoped relation still reports as an empty scope.
-   *  @internal */
-  private _whereMatchesUnscopedBaseline(): boolean {
-    if (this.whereClause.isEmpty()) return true;
-    const klass = this._model as any;
-    // Only a finder-type-condition class has a non-empty unscoped baseline; for
-    // anything else a non-empty WHERE means a real, non-empty scope.
-    if (!klass.isFinderNeedsTypeCondition?.()) return false;
-    const connection = this._conn();
-    if (!connection?.toSql) return false;
-    // Build the baseline against this relation's own table so an alias-qualified
-    // relation compares its type_condition against an identically-qualified one
-    // rather than the default arel_table.
-    const baseline = klass._buildUnscopedRelation?.(this._table ?? undefined);
-    if (!baseline) return false;
-    try {
-      return (
-        _whereClauseToSql(this.whereClause, connection) ===
-        _whereClauseToSql(baseline.whereClause, connection)
-      );
-    } catch {
-      return false;
-    }
-  }
-
+  /** Mirrors: ActiveRecord::Relation#empty_scope? (relation.rb:1299) —
+   *  `@values == model.unscoped.values`, compared value by value. */
   get isEmptyScope(): boolean {
-    // Rails: `@values == klass.unscoped.values`. The unscoped baseline may carry
-    // the STI `type_condition`, so a relation whose WHERE matches that baseline
-    // (rather than being literally empty) is still an empty scope.
+    // The WHERE half of `@values == model.unscoped.values`: the unscoped
+    // baseline may carry the STI `type_condition`, so a relation whose WHERE
+    // matches that baseline (rather than being literally empty) is still an
+    // empty scope.
+    let whereMatchesUnscopedBaseline: boolean;
+    if (this.whereClause.isEmpty()) {
+      whereMatchesUnscopedBaseline = true;
+    } else {
+      const klass = this._model as any;
+      // Only a finder-type-condition class has a non-empty unscoped baseline;
+      // for anything else a non-empty WHERE means a real, non-empty scope.
+      // The baseline is built against this relation's own table so an
+      // alias-qualified relation compares its type_condition against an
+      // identically-qualified one rather than the default arel_table.
+      const connection = klass.isFinderNeedsTypeCondition?.() ? this._conn() : undefined;
+      const baseline = connection?.toSql
+        ? klass._buildUnscopedRelation?.(this._table ?? undefined)
+        : undefined;
+      if (!connection?.toSql || !baseline) {
+        whereMatchesUnscopedBaseline = false;
+      } else {
+        try {
+          whereMatchesUnscopedBaseline =
+            _whereClauseToSql(this.whereClause, connection) ===
+            _whereClauseToSql(baseline.whereClause, connection);
+        } catch {
+          whereMatchesUnscopedBaseline = false;
+        }
+      }
+    }
+
     return (
-      this._whereMatchesUnscopedBaseline() &&
+      whereMatchesUnscopedBaseline &&
       this.orderValues.length === 0 &&
       this.limitValue === null &&
       this.offsetValue === null &&

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1019,7 +1019,7 @@ export class Relation<T extends Base> {
   /**
    * Exclude specific records from the result.
    *
-   * Mirrors: ActiveRecord::Relation#excluding / #without
+   * Mirrors: ActiveRecord::QueryMethods#excluding (query_methods.rb:1574-1584).
    */
   excluding(...records: unknown[]): Relation<T> {
     const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];
@@ -2158,13 +2158,12 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#any? (relation.rb:391-396) — `!empty?`;
    * the `loaded?` short-circuit lives in `empty?` (relation.rb:362-370).
+   * A pattern argument goes straight to `Enumerable`, whose `===` is
+   * `instance_of?` for a class and a call for any other object.
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return false;
     if (pattern !== undefined) {
-      // Ruby hands the pattern straight to `Enumerable#any?`, which tests each
-      // element with `===`: for a class that is `instance_of?`, for anything
-      // else the object is called as the predicate.
       const matches = (record: T): boolean =>
         (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
           ? record instanceof (pattern as new (...args: never[]) => Base)
@@ -2177,12 +2176,13 @@ export class Relation<T extends Base> {
   /**
    * Check if there are multiple matching records.
    *
-   * Mirrors: ActiveRecord::Relation#many?
+   * Mirrors: ActiveRecord::Relation#many? (relation.rb:413-419). The optional
+   * predicate is Ruby's block, which `Enumerable#many?` counts through,
+   * short-circuiting at two matches.
    */
   async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
     if (this.isNullRelation()) return false;
     if (predicate !== undefined) {
-      // `Enumerable#many?` counts matches, short-circuiting at 2.
       let count = 0;
       for (const record of await this.toArray()) {
         if (predicate(record) && ++count === 2) break;
@@ -2196,19 +2196,17 @@ export class Relation<T extends Base> {
   /**
    * Check if there is exactly one matching record.
    *
-   * Mirrors: ActiveRecord::Relation#one?
+   * Mirrors: ActiveRecord::Relation#one? (relation.rb:404-411).
+   * A pattern argument goes straight to `Enumerable`, whose `===` is
+   * `instance_of?` for a class and a call for any other object.
    */
   async isOne(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return false;
     if (pattern !== undefined) {
-      // Ruby hands the pattern straight to `Enumerable#one?`, which tests each
-      // element with `===`: for a class that is `instance_of?`, for anything
-      // else the object is called as the predicate.
       const matches = (record: T): boolean =>
         (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
           ? record instanceof (pattern as new (...args: never[]) => Base)
           : (pattern as (record: T) => boolean)(record);
-      // `Enumerable#one?` counts matches, short-circuiting at 2.
       let count = 0;
       for (const record of await this.toArray()) {
         if (matches(record) && ++count === 2) break;
@@ -4269,14 +4267,13 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Mirrors: ActiveRecord::Relation#none?
+   * Mirrors: ActiveRecord::Relation#none? (relation.rb:373-378).
+   * A pattern argument goes straight to `Enumerable`, whose `===` is
+   * `instance_of?` for a class and a call for any other object.
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this.isNullRelation()) return true;
     if (pattern !== undefined) {
-      // Ruby hands the pattern straight to `Enumerable#none?`, which tests each
-      // element with `===`: for a class that is `instance_of?`, for anything
-      // else the object is called as the predicate.
       const matches = (record: T): boolean =>
         (pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true
           ? record instanceof (pattern as new (...args: never[]) => Base)
@@ -4351,23 +4348,25 @@ export class Relation<T extends Base> {
     return except(this._values, "extending", "skipQueryCache", "strictLoading");
   }
 
-  /** Mirrors: ActiveRecord::Relation#empty_scope? (relation.rb:1299) —
-   *  `@values == model.unscoped.values`, compared value by value. */
+  /**
+   * Mirrors: ActiveRecord::Relation#empty_scope? (relation.rb:1299) —
+   * `@values == model.unscoped.values`, compared value by value.
+   *
+   * In the WHERE half, the unscoped baseline may carry the STI
+   * `type_condition`, so a relation whose WHERE matches that baseline (rather
+   * than being literally empty) is still an empty scope. Only a
+   * finder-type-condition class has such a baseline — for anything else a
+   * non-empty WHERE means a real, non-empty scope — and the baseline is built
+   * against this relation's own table so an alias-qualified relation compares
+   * its type_condition against an identically-qualified one rather than the
+   * default arel_table.
+   */
   get isEmptyScope(): boolean {
-    // The WHERE half of `@values == model.unscoped.values`: the unscoped
-    // baseline may carry the STI `type_condition`, so a relation whose WHERE
-    // matches that baseline (rather than being literally empty) is still an
-    // empty scope.
     let whereMatchesUnscopedBaseline: boolean;
     if (this.whereClause.isEmpty()) {
       whereMatchesUnscopedBaseline = true;
     } else {
       const klass = this._model as any;
-      // Only a finder-type-condition class has a non-empty unscoped baseline;
-      // for anything else a non-empty WHERE means a real, non-empty scope.
-      // The baseline is built against this relation's own table so an
-      // alias-qualified relation compares its type_condition against an
-      // identically-qualified one rather than the default arel_table.
       const connection = klass.isFinderNeedsTypeCondition?.() ? this._conn() : undefined;
       const baseline = connection?.toSql
         ? klass._buildUnscopedRelation?.(this._table ?? undefined)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1469,7 +1469,7 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // `records` is `records + relations.flat_map(&:ids)` — scalar AR records plus
   // every relation arg's eagerly-materialized ids — built into ONE predicate.
   // Ruby materializes those ids before this call (synchronous query execution);
-  // trails' builder is synchronous-and-lazy, so `_excludingArgs` leaves any
+  // trails' builder is synchronous-and-lazy, so `excluding`/`without` leave any
   // UNLOADED relation in `records` for us to defer here.
   const unloadedRelations = records.filter((r) => isRelationLike(r));
   const literalRecords = records.filter((r) => !isRelationLike(r));

--- a/packages/activesupport/src/ordered-options.test.ts
+++ b/packages/activesupport/src/ordered-options.test.ts
@@ -11,7 +11,9 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("looping", () => {
-    const opts = new OrderedOptions({ a: 1, b: 2 });
+    const opts = new OrderedOptions();
+    opts.set("a", 1);
+    opts.set("b", 2);
     const keys: string[] = [];
     opts.each((k) => keys.push(k));
     expect(keys).toContain("a");
@@ -19,12 +21,14 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("string dig", () => {
-    const opts = new OrderedOptions({ name: "Alice" });
+    const opts = new OrderedOptions();
+    opts.set("name", "Alice");
     expect(opts.dig("name")).toBe("Alice");
   });
 
   it("nested dig", () => {
-    const opts = new OrderedOptions({ user: { name: "Bob" } });
+    const opts = new OrderedOptions();
+    opts.set("user", { name: "Bob" });
     expect(opts.dig("user", "name")).toBe("Bob");
   });
 
@@ -39,7 +43,9 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("introspection", () => {
-    const opts = new OrderedOptions({ x: 1, y: 2 });
+    const opts = new OrderedOptions();
+    opts.set("x", 1);
+    opts.set("y", 2);
     expect(opts.keys()).toEqual(["x", "y"]);
   });
 
@@ -49,17 +55,21 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("ordered option inspect", () => {
-    const opts = new OrderedOptions({ a: 1 });
+    const opts = new OrderedOptions();
+    opts.set("a", 1);
     expect(opts.inspect()).toContain("a");
   });
 
   it("ordered options to h", () => {
-    const opts = new OrderedOptions({ x: 1, y: 2 });
+    const opts = new OrderedOptions();
+    opts.set("x", 1);
+    opts.set("y", 2);
     expect(opts.toH()).toEqual({ x: 1, y: 2 });
   });
 
   it("ordered options dup", () => {
-    const opts = new OrderedOptions({ a: 1 });
+    const opts = new OrderedOptions();
+    opts.set("a", 1);
     const copy = opts.dup();
     (copy as any).b = 2;
     expect(opts.get("b")).toBeUndefined();
@@ -67,32 +77,38 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("ordered options key", () => {
-    const opts = new OrderedOptions({ a: 1, b: 2 });
+    const opts = new OrderedOptions();
+    opts.set("a", 1);
+    opts.set("b", 2);
     expect(opts.key(1)).toBe("a");
     expect(opts.key(99)).toBeUndefined();
   });
 
   it("ordered options to s", () => {
-    const opts = new OrderedOptions({ a: 1 });
+    const opts = new OrderedOptions();
+    opts.set("a", 1);
     expect(opts.toString()).toContain("a");
   });
 
   it("odrered options pp", () => {
     // pp is inspect in Ruby — verify inspect works
-    const opts = new OrderedOptions({ x: "y" });
+    const opts = new OrderedOptions();
+    opts.set("x", "y");
     expect(opts.inspect()).toContain("x");
   });
 
   // InheritableOptions tests
 
   it("inheritable options continues lookup in parent", () => {
-    const parent = new OrderedOptions({ color: "red" });
+    const parent = new OrderedOptions();
+    parent.set("color", "red");
     const child = new InheritableOptions(parent);
     expect(child.get("color")).toBe("red");
   });
 
   it("inheritable options can override parent", () => {
-    const parent = new OrderedOptions({ color: "red" });
+    const parent = new OrderedOptions();
+    parent.set("color", "red");
     const child = new InheritableOptions(parent);
     (child as any).color = "blue";
     expect(child.get("color")).toBe("blue");
@@ -100,7 +116,7 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options inheritable copy", () => {
-    const opts = new InheritableOptions(null, { a: 1 });
+    const opts = new InheritableOptions({ a: 1 });
     const copy = opts.inheritableCopy();
     expect(copy.get("a")).toBe(1);
     (copy as any).b = 2;
@@ -108,29 +124,35 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable option inspect", () => {
-    const opts = new InheritableOptions(null, { x: 1 });
+    const opts = new InheritableOptions({ x: 1 });
     expect(opts.inspect()).toContain("x");
   });
 
   it("inheritable options to h", () => {
-    const opts = new InheritableOptions(null, { a: 1, b: 2 });
+    const opts = new InheritableOptions({ a: 1, b: 2 });
     expect(opts.toH()).toEqual({ a: 1, b: 2 });
   });
 
   it("inheritable options dup", () => {
-    const parent = new OrderedOptions({ x: 1 });
-    const child = new InheritableOptions(parent, { y: 2 });
+    const parent = new OrderedOptions();
+    parent.set("x", 1);
+    const child = new InheritableOptions(parent);
+    child.set("y", 2);
     const copy = child.dup();
+    expect(copy).toBeInstanceOf(InheritableOptions);
     expect(copy.get("y")).toBe(2);
+    expect(copy.get("x")).toBe(1);
   });
 
   it("inheritable options key", () => {
-    const opts = new InheritableOptions(null, { a: 10 });
+    const opts = new InheritableOptions();
+    opts.set("a", 10);
     expect(opts.key(10)).toBe("a");
   });
 
   it("inheritable options overridden", () => {
-    const parent = new OrderedOptions({ val: "parent" });
+    const parent = new OrderedOptions();
+    parent.set("val", "parent");
     const child = new InheritableOptions(parent);
     (child as any).val = "child";
     expect(child.get("val")).toBe("child");
@@ -141,14 +163,15 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options overridden with nil", () => {
-    const parent = new OrderedOptions({ val: "parent" });
+    const parent = new OrderedOptions();
+    parent.set("val", "parent");
     const child = new InheritableOptions(parent);
     (child as any).val = null;
     expect(child.get("val")).toBeNull();
   });
 
   it("inheritable options each", () => {
-    const opts = new InheritableOptions(null, { a: 1, b: 2 });
+    const opts = new InheritableOptions({ a: 1, b: 2 });
     const keys: string[] = [];
     opts.each((k) => keys.push(k));
     expect(keys).toContain("a");
@@ -156,28 +179,28 @@ describe("OrderedOptionsTest", () => {
   });
 
   it("inheritable options to a", () => {
-    const opts = new InheritableOptions(null, { x: 1 });
+    const opts = new InheritableOptions({ x: 1 });
     expect(opts.entries()).toEqual([["x", 1]]);
     expect(opts.toA()).toEqual([["x", 1]]);
   });
 
   it("inheritable options count", () => {
-    const opts = new InheritableOptions(null, { a: 1, b: 2 });
+    const opts = new InheritableOptions({ a: 1, b: 2 });
     expect(opts.count).toBe(2);
   });
 
   it("inheritable options to s", () => {
-    const opts = new InheritableOptions(null, { k: "v" });
+    const opts = new InheritableOptions({ k: "v" });
     expect(opts.toString()).toContain("k");
   });
 
   it("inheritable options pp", () => {
-    const opts = new InheritableOptions(null, { m: 1 });
+    const opts = new InheritableOptions({ m: 1 });
     expect(opts.inspect()).toContain("m");
   });
 
   it("inheritable options with bang", () => {
-    const opts = new InheritableOptions(null, {});
+    const opts = new InheritableOptions();
     expect(() => (opts as any).missing!()).toThrow();
   });
 });

--- a/packages/activesupport/src/ordered-options.ts
+++ b/packages/activesupport/src/ordered-options.ts
@@ -193,10 +193,13 @@ export class OrderedOptions {
 export class InheritableOptions extends OrderedOptions {
   private readonly parent: OrderedOptions | Record<string, unknown>;
 
-  /** Mirrors `initialize(parent = nil)` (ordered_options.rb:89-99). */
+  /**
+   * Mirrors `initialize(parent = nil)` (ordered_options.rb:89-99) — an
+   * `OrderedOptions` parent is read through the faster `_get`, any other hash
+   * through `[]`, and a nil parent leaves an empty hash behind.
+   */
   constructor(parent: OrderedOptions | Record<string, unknown> | null = null) {
     if (parent instanceof OrderedOptions) {
-      // use the faster _get when dealing with OrderedOptions
       super((k) => (parent as unknown as { _get(key: string): unknown })._get(k));
       this.parent = parent;
     } else if (parent != null) {

--- a/packages/activesupport/src/ordered-options.ts
+++ b/packages/activesupport/src/ordered-options.ts
@@ -170,6 +170,12 @@ export class OrderedOptions {
    * `Object#dup` — allocates the receiver's OWN class and copies its ivars, so
    * an `InheritableOptions` dup stays an `InheritableOptions` reading through
    * the same parent (`Hash#dup` carries the default block over too).
+   *
+   * TypeScript has no allocate-without-initialize, so the ivars are replayed
+   * through the constructor: this is only valid for the two classes in this
+   * file, whose sole constructor argument is the parent (`InheritableOptions`)
+   * or the default block (`OrderedOptions`, which has no `parent`). A subclass
+   * with a differently-shaped constructor would need its own `dup`.
    */
   dup(): this {
     const copy = new (this.constructor as new (parent?: unknown) => this)(

--- a/packages/activesupport/src/ordered-options.ts
+++ b/packages/activesupport/src/ordered-options.ts
@@ -28,8 +28,14 @@ export class OrderedOptions {
    */
   protected defaultBlock?: (key: string) => unknown;
 
-  constructor(initial: Record<string, unknown> = {}) {
-    this.data = new Map(Object.entries(initial));
+  /**
+   * `Hash.new` — Rails' `OrderedOptions < Hash` inherits it untouched, so it
+   * takes no entries; a subclass hands it a default block instead
+   * (ordered_options.rb:89-99).
+   */
+  constructor(defaultBlock?: (key: string) => unknown) {
+    this.data = new Map();
+    this.defaultBlock = defaultBlock;
     return new Proxy(this, {
       // Mirrors `method_missing` (ordered_options.rb:49-58) and
       // `respond_to_missing?` (:60-62), which answers true for every name.
@@ -160,9 +166,18 @@ export class OrderedOptions {
     return this.entries().length;
   }
 
-  /** `Object#dup`. */
-  dup(): OrderedOptions {
-    return new OrderedOptions(this.toH());
+  /**
+   * `Object#dup` — allocates the receiver's OWN class and copies its ivars, so
+   * an `InheritableOptions` dup stays an `InheritableOptions` reading through
+   * the same parent (`Hash#dup` carries the default block over too).
+   */
+  dup(): this {
+    const copy = new (this.constructor as new (parent?: unknown) => this)(
+      (this as unknown as { parent?: unknown }).parent,
+    );
+    for (const [key, value] of this.data) copy.set(key, value);
+    if (copy.defaultBlock === undefined) copy.defaultBlock = this.defaultBlock;
+    return copy;
   }
 }
 
@@ -178,15 +193,17 @@ export class OrderedOptions {
 export class InheritableOptions extends OrderedOptions {
   private readonly parent: OrderedOptions | Record<string, unknown>;
 
-  constructor(parent: OrderedOptions | null = null, initial: Record<string, unknown> = {}) {
-    super(initial);
+  /** Mirrors `initialize(parent = nil)` (ordered_options.rb:89-99). */
+  constructor(parent: OrderedOptions | Record<string, unknown> | null = null) {
     if (parent instanceof OrderedOptions) {
+      // use the faster _get when dealing with OrderedOptions
+      super((k) => (parent as unknown as { _get(key: string): unknown })._get(k));
       this.parent = parent;
-      this.defaultBlock = (k) => (parent as any)._get(k);
-    } else if (parent) {
+    } else if (parent != null) {
+      super((k) => parent[k]);
       this.parent = parent;
-      this.defaultBlock = (k) => (parent as Record<string, unknown>)[k];
     } else {
+      super();
       this.parent = {};
     }
   }


### PR DESCRIPTION
Two related convergence stories: both remove trails-only shapes in favour of the Rails body.

## 1. OrderedOptions/InheritableOptions constructors and `dup`

`ordered_options.rb:33` — `OrderedOptions < Hash`, and `Hash.new` takes a default
value/block, never entries, so the entries argument is gone; the constructor now
takes the default block Rails' subclass hands it.

`ordered_options.rb:89-99` — `InheritableOptions#initialize(parent = nil)` takes only
`parent` and installs the parent lookup as the Hash default block, with all three arms
(the `_get` fast path for an `OrderedOptions` parent, the `[]` path for a plain hash,
and the `else` that calls `super()` and sets `@parent = {}`). A plain-hash argument is
the PARENT, exactly as Rails' own tests build it
(`InheritableOptions.new(one: "first value")`, ordered_options_test.rb:149).

`dup` allocated a hardcoded `OrderedOptions`, so an `InheritableOptions` dup came back
as the wrong class with the parent silently dropped. `Object#dup` allocates the
receiver's own class and copies its ivars, so it now allocates `this.constructor` and
carries the parent and the default block over.

Call sites (both `OrderedOptionsTest` files) build through `set`/`method_missing`
instead of an entries argument. Test names are unchanged.

## 2. Inlining the where-family private helpers

`_excludingArgs`, `_patternMatcher`, `_countMatching` and
`_whereMatchesUnscopedBaseline` are decompositions Rails does not have; each is inlined
into its caller at the Rails body:

- `excluding` — `query_methods.rb:1574`, the extract/flatten/compact/validate sequence
  inline.
- `any?` / `one?` / `many?` / `none?` — `relation.rb:391`/`:404`/`:413`/`:373`. Ruby
  passes the pattern straight to `Enumerable`, whose `===` is `instance_of?` for a class
  and a call for anything else; that is now spelled at each call site instead of behind
  a relation-level matcher, and `one?`/`many?`'s counting loop is `Enumerable`'s
  short-circuit-at-2.
- `empty_scope?` — `relation.rb:1299`; the WHERE-half comparison is inline in the getter.

One deviation is deliberate and called out at the call site: Rails writes
`alias :without :excluding` (`query_methods.rb:1585`) and distinguishes the two through
`__callee__`, which the ArgumentError message depends on and both
`excluding_test.rb:105`/`:108` assert. TypeScript has no `__callee__`, and routing
`without` back through a shared helper is precisely the invention this story removes, so
the aliased body is materialized once per callee. Happy to take a different shape here
if a reviewer prefers one.

No behavior change beyond the `dup` fix. `parity:api:calls` and `:args` are green,
`parity:api:extra` for `ordered-options.ts` and `relation.ts` does not grow.

Closes-story: converge-ordered-options-constructor-and-dup
Closes-story: inline-relation-where-family-private-helpers
