### PR TITLE
refactor(activemodel,activerecord,activesupport): instance validates_with, merge_target_lists write-back, TimeWithZone#period, naming burndown

### DIFF
--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -176,7 +176,9 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
   }
 
   forceChange(attrName: string): void {
-    if (this.forcedChanges.has(attrName)) return;
+    // attribute_mutation_tracker.rb:121-123 guards on `attribute_changed?`,
+    // which for this tracker IS the forced-changes lookup.
+    if (this.attributeChanged(attrName)) return;
     const value = this.fetchValue(attrName);
     this.forcedChanges.set(attrName, cloneValue(value));
   }

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -176,8 +176,6 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
   }
 
   forceChange(attrName: string): void {
-    // attribute_mutation_tracker.rb:121-123 guards on `attribute_changed?`,
-    // which for this tracker IS the forced-changes lookup.
     if (this.attributeChanged(attrName)) return;
     const value = this.fetchValue(attrName);
     this.forcedChanges.set(attrName, cloneValue(value));

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -478,7 +478,7 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m._dirty.forceChange("ratio", NaN);
+    m._dirty.forceChange("ratio");
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
@@ -755,7 +755,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m._dirty.forceChange("ratio", NaN);
+    m._dirty.forceChange("ratio");
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.restoreAttributes();
@@ -775,7 +775,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m._dirty.forceChange("ratio", NaN);
+    m._dirty.forceChange("ratio");
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.changesApplied();
@@ -797,7 +797,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m._dirty.forceChange("ratio", NaN); // mirrors attribute_will_change!
+    m._dirty.forceChange("ratio"); // mirrors attribute_will_change!
     m.writeAttribute("ratio", NaN); // type-equal write
     expect(m.changedAttributeNamesToSave).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -403,7 +403,11 @@ export class DirtyTracker {
    *
    * Mirrors: ActiveModel::AttributeMutationTracker#force_change
    */
-  forceChange(name: string, currentValue: unknown): unknown {
+  forceChange(name: string): unknown {
+    // Rails resolves the value inside the tracker
+    // (attribute_mutation_tracker.rb:63-65 `forced_changes[attr_name] =
+    // fetch_value(attr_name)`), so the caller passes only the name.
+    const currentValue = this.fetchValue(name);
     // Unconditional forced marker (Rails: forced_changes[attr] = fetch_value).
     this._forcedNames.add(name);
     // Capture the "was" only when the attribute isn't already changed (by this
@@ -423,6 +427,15 @@ export class DirtyTracker {
       this._changedAttributes.set(name, [cloned, cloned]);
     }
     return currentValue;
+  }
+
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#fetch_value
+   * (attribute_mutation_tracker.rb:97-99) — `attributes.fetch_value(attr_name)`
+   * off the tracker's own AttributeSet, which {@link snapshot} binds.
+   */
+  private fetchValue(attrName: string): unknown {
+    return this._attrs?.fetchValue(attrName);
   }
 
   /**
@@ -579,7 +592,10 @@ export class DirtyTracker {
  * @internal Rails-private helper.
  */
 export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: string): unknown {
-  return this._dirty.forceChange(attrName, this._attributes.fetchValue(attrName));
+  // Rails' receiver is `mutations_from_database` (dirty.rb:409-411); trails
+  // spells the mutation tracker `_dirty` — `mutationsFromDatabase` here is the
+  // Record-shaped reader over it, not the tracker itself.
+  return this._dirty.forceChange(attrName);
 }
 
 /**

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -404,9 +404,6 @@ export class DirtyTracker {
    * Mirrors: ActiveModel::AttributeMutationTracker#force_change
    */
   forceChange(name: string): unknown {
-    // Rails resolves the value inside the tracker
-    // (attribute_mutation_tracker.rb:63-65 `forced_changes[attr_name] =
-    // fetch_value(attr_name)`), so the caller passes only the name.
     const currentValue = this.fetchValue(name);
     // Unconditional forced marker (Rails: forced_changes[attr] = fetch_value).
     this._forcedNames.add(name);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1935,6 +1935,44 @@ export class Model {
   }
 
   /**
+   * Passes the record off to the class or classes specified and allows them
+   * to add errors based on more complex conditions, so a `validate :foo` body
+   * can run a validator on the spot:
+   *
+   *   validate :instanceValidations
+   *   instanceValidations() { this.validatesWith(MyValidator); }
+   *
+   * Mirrors: ActiveModel::Validations#validates_with
+   * (activemodel/lib/active_model/validations/with.rb:143-151). Unlike the
+   * class method it registers nothing — each klass is built and run
+   * immediately against `this`.
+   */
+  async validatesWith(
+    ...args: Array<
+      | {
+          new (
+            options: Record<string, unknown>,
+          ): ValidatorBase | { validate(record: ValidatableRecord): unknown };
+        }
+      | Record<string, unknown>
+    >
+  ): Promise<void> {
+    const last = args[args.length - 1];
+    const options: Record<string, unknown> =
+      typeof last === "function" ? {} : ((args.pop() as Record<string, unknown>) ?? {});
+    options.class = this.constructor;
+
+    for (const klass of args as Array<{
+      new (
+        options: Record<string, unknown>,
+      ): ValidatorBase | { validate(record: ValidatableRecord): unknown };
+    }>) {
+      const validator = new klass({ ...options });
+      await validator.validate(this as unknown as ValidatableRecord);
+    }
+  }
+
+  /**
    * Freeze this model instance. Mirrors Rails
    * `ActiveModel::Validations#freeze` (activemodel/lib/active_model/validations.rb:372-377):
    *
@@ -2163,7 +2201,7 @@ export class Model {
    */
   attributeWillChange(name: string): unknown {
     const resolved = resolveAliasName(this.constructor as typeof Model, name);
-    return this._dirty.forceChange(resolved, this._attributes.fetchValue(resolved));
+    return this._dirty.forceChange(resolved);
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -794,9 +794,6 @@ export class Model {
       }
       this._registerValidator(validator, explicitAttributes);
 
-      // Only the CLASS-side `validates_with` (with.rb:88-105) is ported; the
-      // instance one (with.rb:143-151) is a real gap, filed as
-      // `activemodel-instance-validates-with`.
       let callbackFn: CallbackFn;
       if (isStrict) {
         callbackFn = (record: object) => {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1945,7 +1945,9 @@ export class Model {
    * Mirrors: ActiveModel::Validations#validates_with
    * (activemodel/lib/active_model/validations/with.rb:143-151). Unlike the
    * class method it registers nothing — each klass is built and run
-   * immediately against `this`.
+   * immediately against `this`. Rails' loop is synchronous; a trails validator
+   * may return a promise (RFC 0063 made validation async), so each run is
+   * awaited in turn, which preserves Rails' one-validator-at-a-time order.
    */
   async validatesWith(
     ...args: Array<

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -3,6 +3,8 @@ import { Model, Errors } from "../index.js";
 import { WithValidator } from "./with.js";
 
 describe("ValidatesWithTest", () => {
+  const ERROR_MESSAGE = "Validation error from validator";
+
   it("validates_with with options", async () => {
     class CustomValidator {
       private minLength: number;
@@ -93,22 +95,41 @@ describe("ValidatesWithTest", () => {
     expect(await p.isValid()).toBe(true);
   });
 
+  // with_validation_test.rb:112-117. The instance `validates_with`
+  // (with.rb:143-151) builds each validator from a `dup` of the options and
+  // runs it against `self` right away, so a validator that clears the hash it
+  // was handed cannot blind the next one.
   it("instance validates_with method preserves validator options", async () => {
-    class CustomValidator {
+    class ValidatorThatDoesNotAddErrors {
+      validate(_record: any) {}
+    }
+    class ValidatorThatClearsOptions extends ValidatorThatDoesNotAddErrors {
+      constructor(options: any) {
+        super();
+        for (const key of Object.keys(options)) delete options[key];
+      }
+    }
+    class ValidatorThatValidatesOptions {
       options: any;
       constructor(options: any = {}) {
         this.options = options;
       }
-      validate(_record: any) {}
-    }
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validatesWith(CustomValidator, { custom: "value" });
+      validate(record: any) {
+        if (this.options.field === "first_name") {
+          record.errors.add("base", ":invalid", { message: ERROR_MESSAGE });
+        }
       }
     }
-    const p = new Person({});
-    expect(await p.isValid()).toBe(true);
+    class Topic extends Model {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const topic = new Topic({});
+    await topic.validatesWith(ValidatorThatClearsOptions, ValidatorThatValidatesOptions, {
+      field: "first_name",
+    });
+    expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
   });
 
   it("each validator checks validity", async () => {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1320,37 +1320,50 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * Merge persisted records from DB with in-memory target records.
-   * Preserves order of persisted, deduplicates, and keeps
-   * attribute changes from in-memory versions.
+   * Merge persisted records from DB with in-memory target records:
+   *
+   *   * The final array must not have duplicates
+   *   * The order of the persisted array is to be preserved
+   *   * Any changes made to attributes on objects in the memory array are to
+   *     be preserved
+   *   * Otherwise, attributes should have the value found in the database
+   *
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#merge_target_lists
+   * (collection_association.rb:335-352).
    */
   private mergeTargetLists(persisted: Base[], memory: Base[]): Base[] {
     if (memory.length === 0) return persisted;
 
-    const newRecords: Base[] = [];
+    // `memory.delete(record)` is Array#delete over AR `==` — id equality for a
+    // persisted record, object identity for a new one. `recordIdentity`
+    // returns exactly that: the id key, or the record itself when the PK is
+    // nil. Insertion order is the memory order the `reject` tail below reads.
     const memoryByIdentity = new Map<string | Base, Base>();
-    for (const record of memory) {
-      const identity = this.recordIdentity(record);
-      if (typeof identity !== "string") {
-        newRecords.push(record);
-      } else {
-        memoryByIdentity.set(identity, record);
-      }
-    }
+    for (const record of memory) memoryByIdentity.set(this.recordIdentity(record), record);
 
     const merged = persisted.map((record) => {
       const identity = this.recordIdentity(record);
-      if (typeof identity !== "string") return record;
       const memRecord = memoryByIdentity.get(identity);
       if (memRecord) {
         memoryByIdentity.delete(identity);
+
+        const memAttributeNames = new Set(memRecord.attributeNames());
+        const changed = new Set(memRecord.changedAttributeNamesToSave);
+        const attrReadonly: ReadonlySet<string> =
+          (memRecord.constructor as unknown as { _readonlyAttributes?: ReadonlySet<string> })
+            ._readonlyAttributes ?? new Set<string>();
+        for (const name of record.attributeNames()) {
+          if (!memAttributeNames.has(name) || changed.has(name) || attrReadonly.has(name)) continue;
+          memRecord._writeAttribute(name, record.get(name));
+        }
+
         return memRecord;
+      } else {
+        return record;
       }
-      return record;
     });
 
-    merged.push(...newRecords);
-    return merged;
+    return [...merged, ...[...memoryByIdentity.values()].filter((record) => !record.isPersisted())];
   }
 
   private findByScan(args: unknown[]): Base | Array<Base | undefined> | undefined {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1348,12 +1348,15 @@ export class CollectionAssociation extends Association {
         memoryByIdentity.delete(identity);
 
         const memAttributeNames = new Set(memRecord.attributeNames());
-        const changed = new Set(memRecord.changedAttributeNamesToSave);
+        const changedAttributeNamesToSave = new Set(memRecord.changedAttributeNamesToSave);
         const attrReadonly: ReadonlySet<string> =
           (memRecord.constructor as unknown as { _readonlyAttributes?: ReadonlySet<string> })
             ._readonlyAttributes ?? new Set<string>();
-        for (const name of record.attributeNames()) {
-          if (!memAttributeNames.has(name) || changed.has(name) || attrReadonly.has(name)) continue;
+        for (const name of record
+          .attributeNames()
+          .filter((name) => memAttributeNames.has(name))
+          .filter((name) => !changedAttributeNamesToSave.has(name))
+          .filter((name) => !attrReadonly.has(name))) {
           memRecord._writeAttribute(name, record.get(name));
         }
 

--- a/packages/activerecord/src/associations/merge-target-lists.trails.test.ts
+++ b/packages/activerecord/src/associations/merge-target-lists.trails.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Trails-only: `merge_target_lists` (collection_association.rb:335-352) is a
+ * private method with no dedicated Rails test — its contract lives in the
+ * comment above it, and the third and fourth bullets ("Any changes made to
+ * attributes on objects in the memory array are to be preserved" / "Otherwise,
+ * attributes should have the value found in the database") are what the
+ * `attribute_names & ... - changed_attribute_names_to_save - _attr_readonly`
+ * write-back loop implements. Trails shipped the merge without that loop, so a
+ * clean in-memory attribute kept its stale value after a reload; these pin both
+ * halves through the OO association, which is where the merge happens.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { fixtures } from "../test-fixtures.js";
+
+interface AssociationLike {
+  target: Post[];
+  loaded: boolean;
+  loadTarget(): Promise<Post[]> | Post[];
+}
+
+const association = (author: Author): AssociationLike =>
+  (author as unknown as { association(name: string): AssociationLike }).association("posts");
+
+describe("mergeTargetLists", () => {
+  const { authors, posts } = fixtures(["authors", "posts"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+  });
+
+  it("writes database values back onto a clean in-memory attribute", async () => {
+    const author = await Author.find(authors("david").id);
+    const assoc = association(author);
+    const loaded = await assoc.loadTarget();
+    const memRecord = loaded.find((post) => post.id === posts("welcome").id)!;
+    expect(memRecord.get("title")).not.toBe("changed in the database");
+
+    // The database moves under the in-memory record.
+    await Post.where({ id: posts("welcome").id }).updateAll({ title: "changed in the database" });
+
+    assoc.loaded = false;
+    assoc.target = [memRecord];
+    const merged = await assoc.loadTarget();
+
+    const reloaded = merged.find((post) => post.id === posts("welcome").id)!;
+    // Same object — the memory record survives the merge…
+    expect(reloaded).toBe(memRecord);
+    // …and its clean attribute picks up the database value.
+    expect(reloaded.get("title")).toBe("changed in the database");
+  });
+
+  it("preserves an in-memory attribute that has unsaved changes", async () => {
+    const author = await Author.find(authors("david").id);
+    const assoc = association(author);
+    const loaded = await assoc.loadTarget();
+    const memRecord = loaded.find((post) => post.id === posts("welcome").id)!;
+
+    memRecord.set("title", "dirty in memory");
+    await Post.where({ id: posts("welcome").id }).updateAll({ body: "changed in the database" });
+
+    assoc.loaded = false;
+    assoc.target = [memRecord];
+    const merged = await assoc.loadTarget();
+    const reloaded = merged.find((post) => post.id === posts("welcome").id)!;
+
+    expect(reloaded).toBe(memRecord);
+    // The dirty attribute wins over the database…
+    expect(reloaded.get("title")).toBe("dirty in memory");
+    // …while a clean one still takes the database value.
+    expect(reloaded.get("body")).toBe("changed in the database");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -125,7 +125,6 @@ export class RangeType extends ValueType<Range> {
 
   override serialize(value: unknown): unknown {
     if (!(value instanceof Range)) return value;
-    // range.rb:34-42 names both bounds before building the ::Range.
     const from = this.typeCastSingleForDatabase(value.begin);
     const to = this.typeCastSingleForDatabase(value.end);
     return new Range(from, to, value.excludeEnd);
@@ -133,7 +132,6 @@ export class RangeType extends ValueType<Range> {
 
   override map(value: Range | null, block?: (value: unknown) => unknown): Range | null {
     if (value == null || !block) return value;
-    // range.rb:50-54.
     const newBegin = block(value.begin);
     const newEnd = block(value.end);
     return new Range(newBegin, newEnd, value.excludeEnd);

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -125,16 +125,18 @@ export class RangeType extends ValueType<Range> {
 
   override serialize(value: unknown): unknown {
     if (!(value instanceof Range)) return value;
-    return new Range(
-      this.typeCastSingleForDatabase(value.begin),
-      this.typeCastSingleForDatabase(value.end),
-      value.excludeEnd,
-    );
+    // range.rb:34-42 names both bounds before building the ::Range.
+    const from = this.typeCastSingleForDatabase(value.begin);
+    const to = this.typeCastSingleForDatabase(value.end);
+    return new Range(from, to, value.excludeEnd);
   }
 
   override map(value: Range | null, block?: (value: unknown) => unknown): Range | null {
     if (value == null || !block) return value;
-    return new Range(block(value.begin), block(value.end), value.excludeEnd);
+    // range.rb:50-54.
+    const newBegin = block(value.begin);
+    const newEnd = block(value.end);
+    return new Range(newBegin, newEnd, value.excludeEnd);
   }
 
   override isForceEquality(value: unknown): boolean {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -800,7 +800,7 @@ export async function calculate(
  */
 export async function pluck(
   this: CalculationRelation,
-  ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
+  ...columnNames: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
 ): Promise<unknown[]> {
   // `pick` routes through `limit(1).pluck(...)`, so it inherits this rebase.
   if (this._isEmptyRelation()) return [];
@@ -808,12 +808,12 @@ export async function pluck(
   // calculations.rb:300 — a loaded relation whose plucked columns are all
   // attributes reads the materialized records instead of issuing SQL, the same
   // arm `pick` carries (:353).
-  if (this.loaded && isAllAttributes(this, columns as unknown as string[])) {
+  if (this.loaded && isAllAttributes(this, columnNames as unknown as string[])) {
     const records = await this.records();
     return records.map((record) =>
-      columns.length > 1
-        ? columns.map((column) => record.get(String(column)))
-        : record.get(String(columns[0])),
+      columnNames.length > 1
+        ? columnNames.map((column) => record.get(String(column)))
+        : record.get(String(columnNames[0])),
     );
   }
 
@@ -827,7 +827,7 @@ export async function pluck(
     // Checked after materialization so a deferred distinct-PK
     // predicate that resolves to an empty id set also short-circuits.
     if (this.whereClause.isContradiction()) {
-      return typeCastPluckValues(Result.empty(), columns, this as any);
+      return typeCastPluckValues(Result.empty(), columnNames, this as any);
     }
     // Mirrors Calculations#pluck: when has_include? is true, apply_join_dependency
     // converts the includes/eager_load associations to LEFT OUTER JOINs (clearing
@@ -839,7 +839,11 @@ export async function pluck(
     // reflection we also materialize the limited DISTINCT primary keys
     // (distinct_relation_for_primary_key) before recursing.
     const firstColumnName =
-      columns.length === 0 ? null : typeof columns[0] === "string" ? columns[0] : "\0arel";
+      columnNames.length === 0
+        ? null
+        : typeof columnNames[0] === "string"
+          ? columnNames[0]
+          : "\0arel";
     if (hasInclude(this as any, firstColumnName)) {
       // hasInclude is true only when eagerLoadValues or
       // includesValues is non-empty, so the union is always non-empty here.
@@ -871,9 +875,9 @@ export async function pluck(
         });
         limited.limitValue = null;
         limited.offsetValue = null;
-        return limited.pluck(...columns);
+        return limited.pluck(...columnNames);
       }
-      return rel.leftOuterJoins(eagerSpecs).pluck(...columns);
+      return rel.leftOuterJoins(eagerSpecs).pluck(...columnNames);
     }
 
     // Reflect the schema before casting results so the model's attribute
@@ -882,13 +886,16 @@ export async function pluck(
     // raw query (no toArray()), so it must trigger the load itself.
     await this._model.ensureSchemaLoaded();
 
-    this._model.disallowRawSqlBang(this.flattenedArgs(columns) as (string | symbol | Nodes.Node)[]);
+    this._model.disallowRawSqlBang(
+      this.flattenedArgs(columnNames) as (string | symbol | Nodes.Node)[],
+    );
 
     const table = this.table;
     // Rails columns_hash.key? — qualify a bare known column to the base table.
     const knownColumns = new Set(this._model.attributeNames());
     const isKnownColumn = (name: string): boolean => knownColumns.has(name);
-    const projections = columns.map((c) => {
+    // calculations.rb:315 names the arel_columns result `columns`.
+    const columns = columnNames.map((c) => {
       if (c instanceof Nodes.SqlLiteral) {
         // Rails' Arel::Nodes::SqlLiteral subclasses String, so arel_columns routes
         // it through arel_column: a bare known-column literal is qualified to the
@@ -936,7 +943,7 @@ export async function pluck(
     // Going through `select_values` (rather than overwriting `manager.projections`)
     // is what makes a zero-column `pluck` project `table[Arel.star]` via
     // `build_select`'s else arm instead of emitting a projection-less `SELECT FROM`.
-    rel.selectValues = projections as any;
+    rel.selectValues = columns as any;
     const manager = rel.toArel();
 
     // Rails: `select_all(relation.arel, "#{model.name} Pluck")` (calculations.rb:317).
@@ -956,9 +963,9 @@ export async function pluck(
  */
 export function asyncPluck(
   this: CalculationRelation,
-  ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
+  ...columnNames: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
 ): Promise<unknown[]> {
-  return this.pluck(...columns);
+  return this.pluck(...columnNames);
 }
 
 /**
@@ -999,8 +1006,12 @@ export function asyncPick(
  * Mirrors: ActiveRecord::Calculations#ids (calculations.rb:371).
  */
 export async function ids(this: CalculationRelation): Promise<unknown[]> {
-  const pk = this.model.primaryKey as string | string[] | null;
-  const primaryKeyArray = Array.isArray(pk) ? pk : pk == null ? [] : [pk];
+  const primaryKey = this.model.primaryKey as string | string[] | null;
+  const primaryKeyArray = Array.isArray(primaryKey)
+    ? primaryKey
+    : primaryKey == null
+      ? []
+      : [primaryKey];
 
   if (this.loaded) {
     const result = this._records.map((record) => {
@@ -1012,7 +1023,7 @@ export async function ids(this: CalculationRelation): Promise<unknown[]> {
     return result;
   }
 
-  if (hasInclude(this as any, pk as string)) {
+  if (hasInclude(this as any, primaryKey as string)) {
     // DIVERGENCE (finder_methods.rb:457-463): trails' `applyJoinDependency`
     // no-ops unless the relation already eager-loads for SQL, so the plain
     // `apply_join_dependency` call would not terminate this recursion. Spell
@@ -1038,12 +1049,12 @@ export async function ids(this: CalculationRelation): Promise<unknown[]> {
     const jd = this._buildEagerJoinDependency(eagerSpecs);
     if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
       // Same two guards `pluck`'s arm carries: `hasInclude` returns true off
-      // `eagerLoadValues` alone, so `pk` can still be null here (a
+      // `eagerLoadValues` alone, so `primaryKey` can still be null here (a
       // view), and `_materializeLimitedIds` — Rails' zip/transpose over
       // `Array(primary_key)` (schema_statements.rb:1448) — has neither a null
       // nor a composite arm, so the composite case surfaces
       // applyJoinDependency's explicit NotImplementedError instead.
-      const basePk = pk ?? "id";
+      const basePk = primaryKey ?? "id";
       if (Array.isArray(basePk)) this.applyJoinDependency();
       const limitedIds = await this._materializeLimitedIds(jd, basePk);
       const limited = rel.leftOuterJoins(eagerSpecs).where({ [basePk as string]: limitedIds });

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -894,7 +894,6 @@ export async function pluck(
     // Rails columns_hash.key? — qualify a bare known column to the base table.
     const knownColumns = new Set(this._model.attributeNames());
     const isKnownColumn = (name: string): boolean => knownColumns.has(name);
-    // calculations.rb:315 names the arel_columns result `columns`.
     const columns = columnNames.map((c) => {
       if (c instanceof Nodes.SqlLiteral) {
         // Rails' Arel::Nodes::SqlLiteral subclasses String, so arel_columns routes

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -229,9 +229,9 @@ export class PredicateBuilder {
    *
    * @internal
    */
-  private groupingQueries(queryGroups: Nodes.Node[][]): Nodes.Node[] {
-    if (queryGroups.length === 0) return [];
-    if (queryGroups.length === 1) return queryGroups[0];
+  private groupingQueries(queries: Nodes.Node[][]): Nodes.Node[] {
+    if (queries.length === 0) return [];
+    if (queries.length === 1) return queries[0];
     // Rails `grouping_queries` (predicate_builder.rb:157-159):
     // `queries.map! { |query| query.reduce(&:and) }` then an n-ary
     // `Arel::Nodes::Or.new(queries)` wrapped in one Grouping. `Node#and`
@@ -240,8 +240,8 @@ export class PredicateBuilder {
     // pairwise reduce, not a flat n-ary `And`. SQL is identical either way
     // (the And visitor joins children without parens), but the AST shape
     // matches Rails for anything walking the tree.
-    const queries = queryGroups.map((query) => query.reduce((left, right) => left.and(right)));
-    return [new Nodes.Grouping(new Nodes.Or(queries))];
+    const reduced = queries.map((query) => query.reduce((left, right) => left.and(right)));
+    return [new Nodes.Grouping(new Nodes.Or(reduced))];
   }
 
   build(attribute: Nodes.Attribute, value: unknown): Nodes.Node {

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -73,14 +73,15 @@ export class Default {
     if (scopes.length === 0) return undefined;
 
     return evaluateDefaultScope.call(this, () => {
-      let rel = relation;
+      // default.rb:159-167 names the accumulator `combined_scope`.
+      let combinedScope = relation;
       for (const scopeObj of scopes) {
         if (isExecuteScope(allQueries, scopeObj)) {
-          const result = scopeObj.scope(rel);
-          if (result != null) rel = result;
+          const result = scopeObj.scope(combinedScope);
+          if (result != null) combinedScope = result;
         }
       }
-      return rel;
+      return combinedScope;
     });
   }
 

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -73,7 +73,6 @@ export class Default {
     if (scopes.length === 0) return undefined;
 
     return evaluateDefaultScope.call(this, () => {
-      // default.rb:159-167 names the accumulator `combined_scope`.
       let combinedScope = relation;
       for (const scopeObj of scopes) {
         if (isExecuteScope(allQueries, scopeObj)) {

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -5,7 +5,7 @@
  * Mirrors the Rails API: https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html
  */
 
-import { TimeZone } from "./values/time-zone.js";
+import { TimeZone, TimezonePeriod } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { currentTime } from "./time-travel.js";
 import { zone as timeZone, findZoneBang } from "./time-zone-config.js";
@@ -93,6 +93,8 @@ export class TimeWithZone {
   private readonly _zoned: Temporal.ZonedDateTime;
   /** The timezone */
   private readonly _timeZone: TimeZone;
+  /** `@period` — memoized by {@link period}. */
+  private _periodMemo?: TimezonePeriod;
 
   constructor(instant: Temporal.Instant, timeZone: TimeZone) {
     this._zoned = instant.toZonedDateTimeISO(timeZone.tzinfo);
@@ -113,6 +115,17 @@ export class TimeWithZone {
   // Core accessors
   // ---------------------------------------------------------------------------
 
+  /**
+   * The underlying `TZInfo::TimezonePeriod`, memoized on first read.
+   *
+   * Mirrors: ActiveSupport::TimeWithZone#period
+   * (time_with_zone.rb:72-74) — `@period ||= time_zone.period_for_utc(@utc)`.
+   */
+  get period(): TimezonePeriod {
+    const utc = this._zoned.toInstant();
+    return (this._periodMemo ??= this._timeZone.periodForUtc(utc));
+  }
+
   /** The TimeZone instance */
   get timeZone(): TimeZone {
     return this._timeZone;
@@ -123,14 +136,14 @@ export class TimeWithZone {
     return this._zoned.toPlainDateTime();
   }
 
-  /** Timezone abbreviation (e.g., "EST", "EDT") */
+  /** Timezone abbreviation (e.g., "EST", "EDT") — time_with_zone.rb:133-135. */
   get zone(): string {
-    return this._timeZone.abbreviation(this._zoned.toInstant());
+    return this.period.abbreviation;
   }
 
-  /** UTC offset in seconds */
+  /** UTC offset in seconds — time_with_zone.rb:111-113. */
   get utcOffset(): number {
-    return this._timeZone.utcOffsetAt(this._zoned.toInstant());
+    return this.period.observedUtcOffset;
   }
 
   /** Alias for utcOffset */
@@ -143,9 +156,9 @@ export class TimeWithZone {
     return this.utcOffset;
   }
 
-  /** Whether DST is in effect */
+  /** Whether DST is in effect — time_with_zone.rb:94-96. */
   dst(): boolean {
-    return this._timeZone.isDst(this._zoned.toInstant());
+    return this.period.isDst();
   }
 
   /** Alias for dst() */

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -94,7 +94,7 @@ export class TimeWithZone {
   /** The timezone */
   private readonly _timeZone: TimeZone;
   /** `@period` — memoized by {@link period}. */
-  private _periodMemo?: TimezonePeriod;
+  private _period?: TimezonePeriod;
 
   constructor(instant: Temporal.Instant, timeZone: TimeZone) {
     this._zoned = instant.toZonedDateTimeISO(timeZone.tzinfo);
@@ -123,7 +123,7 @@ export class TimeWithZone {
    */
   get period(): TimezonePeriod {
     const utc = this._zoned.toInstant();
-    return (this._periodMemo ??= this._timeZone.periodForUtc(utc));
+    return (this._period ??= this._timeZone.periodForUtc(utc));
   }
 
   /** The TimeZone instance */

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -527,11 +527,13 @@ export function getLocalComponents(
  * one is resolved off {@link TimeZone} at the instant the period covers, which
  * is what `time_zone.period_for_utc(@utc)` hands back.
  *
- * @noRailsEquivalent TZInfo is a gem, not Rails — `TimezonePeriod` and its
- * `observed_utc_offset` reader have no counterpart under vendor/rails, but
- * `TimeWithZone#period` (time_with_zone.rb:72-74) is the Rails method that
- * returns one and `dst?`/`abbreviation`/`observed_utc_offset` are the three
- * members the Rails source reads off it.
+ * @noRailsEquivalent PERMANENT — TZInfo is a gem, not Rails, so
+ *   `TimezonePeriod` and its `observed_utc_offset` reader have no counterpart
+ *   under vendor/rails and no amount of further porting produces one. Rails
+ *   names the object (`TimeWithZone#period`, time_with_zone.rb:72-74) and reads
+ *   exactly three members off it — `dst?` (:95), `observed_utc_offset` (:112),
+ *   `abbreviation` (:134) — so the port needs a stand-in for it, the same
+ *   position `InvalidTimezoneIdentifier` above is in.
  */
 export class TimezonePeriod {
   readonly abbreviation: string;

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -519,6 +519,37 @@ export function getLocalComponents(
   };
 }
 
+/**
+ * The slice of `TZInfo::TimezonePeriod` Rails reads through
+ * `ActiveSupport::TimeWithZone#period` — `dst?` (time_with_zone.rb:95),
+ * `observed_utc_offset` (:112) and `abbreviation` (:134). TZInfo is a gem, not
+ * Rails, so only the three members the Rails source names are modelled; each
+ * one is resolved off {@link TimeZone} at the instant the period covers, which
+ * is what `time_zone.period_for_utc(@utc)` hands back.
+ *
+ * @noRailsEquivalent TZInfo is a gem, not Rails — `TimezonePeriod` and its
+ * `observed_utc_offset` reader have no counterpart under vendor/rails, but
+ * `TimeWithZone#period` (time_with_zone.rb:72-74) is the Rails method that
+ * returns one and `dst?`/`abbreviation`/`observed_utc_offset` are the three
+ * members the Rails source reads off it.
+ */
+export class TimezonePeriod {
+  readonly abbreviation: string;
+  readonly observedUtcOffset: number;
+  private readonly _dst: boolean;
+
+  constructor(abbreviation: string, observedUtcOffset: number, dst: boolean) {
+    this.abbreviation = abbreviation;
+    this.observedUtcOffset = observedUtcOffset;
+    this._dst = dst;
+  }
+
+  /** Mirrors `TZInfo::TimezonePeriod#dst?`. */
+  isDst(): boolean {
+    return this._dst;
+  }
+}
+
 export class TimeZone {
   readonly name: string;
   readonly tzinfo: string; // IANA name
@@ -1007,6 +1038,15 @@ export class TimeZone {
     const currentOffset = getZoneInfo(this.tzinfo, d).utcOffsetSeconds;
     const standardOffset = Math.min(janOffset, julOffset);
     return currentOffset !== standardOffset;
+  }
+
+  /**
+   * The `TZInfo::TimezonePeriod` covering the given UTC instant, which
+   * `TimeWithZone#period` memoizes (time_with_zone.rb:72-74) and reads
+   * `dst?` / `observed_utc_offset` / `abbreviation` off.
+   */
+  periodForUtc(date: Date | Temporal.Instant): TimezonePeriod {
+    return new TimezonePeriod(this.abbreviation(date), this.utcOffsetAt(date), this.isDst(date));
   }
 
   /**

--- a/scripts/api-compare/naming-taxonomy.test.ts
+++ b/scripts/api-compare/naming-taxonomy.test.ts
@@ -86,6 +86,9 @@ describe("classifyPair", () => {
     // → `klass.unscoped(block)`), so the arm keys on the TS spelling alone.
     expect(classifyPair("modelClass", "block")).toBe("block-idiom");
     expect(classifyPair("instance_exec", "proc")).toBe("burndown");
+    // A Ruby parameter that merely happens to be named `block` is ordinary
+    // burndown — the arm is scoped to the cited Ruby call sites.
+    expect(classifyPair("payload", "block")).toBe("burndown");
   });
 
   // to_sql.rb:874 `quote_table_name(name)` with a composite-PK Array vs

--- a/scripts/api-compare/naming-taxonomy.test.ts
+++ b/scripts/api-compare/naming-taxonomy.test.ts
@@ -30,7 +30,9 @@ describe("classifyPair", () => {
     expect(classifyPair("objectId", "this")).toBe("no-js-equivalent");
     expect(classifyPair("toI", "parseInt")).toBe("no-js-equivalent");
     expect(classifyPair("toS", "toString")).toBe("no-js-equivalent");
-    expect(classifyPair("toS", "fetchValue")).toBe("burndown");
+    // Ruby's `to_s` against an already-`string` TS parameter is the mirror
+    // image of the implicit-to_s class — there is nothing for TS to spell.
+    expect(classifyPair("toS", "fetchValue")).toBe("implicit-to-s");
   });
 
   it("names what the conventions table itself produces", () => {
@@ -79,7 +81,33 @@ describe("classifyPair", () => {
     // → `becoming._attributes`), so the class keys on the Ruby name alone.
     expect(classifyPair("instanceVariableGet", "_attributes")).toBe("ivar-reflection");
     expect(classifyPair("instance_variable_set", "_attributes")).toBe("ivar-reflection");
+    // A Ruby block passed as a trailing `{ }` reaches TS as a callback
+    // argument spelled `block` (locator.rb:223 `model_class.unscoped { yield }`
+    // → `klass.unscoped(block)`), so the arm keys on the TS spelling alone.
+    expect(classifyPair("modelClass", "block")).toBe("block-idiom");
     expect(classifyPair("instance_exec", "proc")).toBe("burndown");
+  });
+
+  // to_sql.rb:874 `quote_table_name(name)` with a composite-PK Array vs
+  // to-sql.ts `quoteTableName(toS(name))`; postgresql_adapter.rb's remove_index
+  // `quote_table_name(index_to_remove)` vs `.toString()` on the Name.
+  it("names Ruby's implicit to_s where TS spells the conversion", () => {
+    expect(classifyPair("name", "toS")).toBe("implicit-to-s");
+    expect(classifyPair("indexToRemove", "toString")).toBe("implicit-to-s");
+    expect(classifyPair("toS", "attrName")).toBe("implicit-to-s");
+    // `inspect` → `toString` is unconvergeable for the stronger reason.
+    expect(classifyPair("inspect", "toString")).toBe("no-js-equivalent");
+  });
+
+  // Ruby builtins whose TS spelling is the free function or method doing the
+  // same work: locator.rb:107 `compact`, base.rb:282 `File.read`,
+  // flatten.rb:100 `gsub`, base.rb:269 `inspect`.
+  it("names the Ruby builtins TS spells under another name", () => {
+    expect(classifyPair("compact", "filter")).toBe("no-js-equivalent");
+    expect(classifyPair("read", "readFile")).toBe("no-js-equivalent");
+    expect(classifyPair("gsub", "replaceAll")).toBe("no-js-equivalent");
+    expect(classifyPair("inspect", "inspectError")).toBe("no-js-equivalent");
+    expect(classifyPair("strip", "trim")).toBe("no-js-equivalent");
   });
 });
 
@@ -110,6 +138,7 @@ describe("the taxonomy itself", () => {
       "module-mixin-call",
       "block-idiom",
       "ivar-reflection",
+      "implicit-to-s",
     ]);
   });
 

--- a/scripts/api-compare/naming-taxonomy.ts
+++ b/scripts/api-compare/naming-taxonomy.ts
@@ -82,8 +82,8 @@ export const NAMING_CLASSES: NamingClassInfo[] = [
       "`block(this.owner)` — the block is a plain function and the receiver its argument, so " +
       "the recorder sees `instance_exec` against `block`. Same for a Ruby block passed as a " +
       "trailing `{ }` (`model_class.unscoped { yield }`, locator.rb:223) where trails passes " +
-      "the callback as an argument: a TS argument spelled `block` IS the Ruby block, whatever " +
-      "Ruby wrote at that position.",
+      "the callback as an argument. Scoped to the cited Ruby call sites " +
+      "(BLOCK_IDIOM_RUBY_REFS), never to the TS spelling alone.",
   },
   {
     name: "ivar-reflection",
@@ -133,6 +133,19 @@ export const IVAR_REFLECTION_ACCESSORS = new Set([
   "instance_variable_set",
   "instanceVariableSet",
 ]);
+
+/**
+ * Ruby identifiers whose call site passes a block that trails spells as a
+ * plain callback argument named `block`. Kept as an explicit, cited list
+ * rather than keying on the TS spelling alone: a Ruby parameter that merely
+ * happens to be named `block` is ordinary burndown, and the safe direction for
+ * a permanent class is to under-match.
+ *
+ *   - `instance_exec` — `owner.instance_exec(&block)`, belongs_to_association.rb:47
+ *   - `modelClass`    — `model_class.unscoped { yield }`, locator.rb:223, whose
+ *                       receiver the recorder records as the argument
+ */
+export const BLOCK_IDIOM_RUBY_REFS = new Set(["instance_exec", "instanceExec", "modelClass"]);
 
 /** Identifiers a TS parameter or local cannot be named (`arguments`/`eval` are unusable in strict mode). */
 export const JS_RESERVED_WORDS = new Set(
@@ -218,9 +231,10 @@ function isThisTypedFunction(rubyRef: string, thisTypedFunctions?: ReadonlySet<s
  * - `toS`/`toString` on the TS side alone is Ruby's implicit `to_s` made
  *   explicit, so that arm runs right after {@link NO_JS_EQUIVALENT} — which
  *   already answers `inspect` → `toString` for the stronger reason.
- * - `block` is a TS-side artifact of the block idiom, so that arm keys on the
- *   TS spelling alone — a TS argument named `block` is the Ruby block whatever
- *   Ruby wrote at that position; `call` is one too, but a bare `ref:call` proves nothing on its
+ * - `block` is a TS-side artifact of the block idiom, so that arm reads the TS
+ *   spelling — but only against {@link BLOCK_IDIOM_RUBY_REFS}, the cited Ruby
+ *   call sites that actually pass a block, so a Ruby parameter that merely
+ *   happens to be named `block` stays burndown; `call` is one too, but a bare `ref:call` proves nothing on its
  *   own, so that arm additionally requires the Ruby name to BE a `this`-typed
  *   function — `thisTypedFunctions`, which the caller reads off the TS API
  *   manifest. Without that set the arm never fires and the row stays burndown,
@@ -248,7 +262,7 @@ export function classifyPair(
   if (tsRef === "call" && isThisTypedFunction(rubyRef, thisTypedFunctions)) {
     return "module-mixin-call";
   }
-  if (tsRef === "block") return "block-idiom";
+  if (tsRef === "block" && BLOCK_IDIOM_RUBY_REFS.has(rubyRef)) return "block-idiom";
   const ivar = rubyRef.startsWith("@");
   const bare = ivar ? rubyRef.slice(1) : rubyRef;
   const converted = rubyMethodToTsIgnoringSkip(bare);

--- a/scripts/api-compare/naming-taxonomy.ts
+++ b/scripts/api-compare/naming-taxonomy.ts
@@ -26,6 +26,7 @@ export type NamingClass =
   | "module-mixin-call"
   | "block-idiom"
   | "ivar-reflection"
+  | "implicit-to-s"
   | "burndown";
 
 export interface NamingClassInfo {
@@ -79,7 +80,10 @@ export const NAMING_CLASSES: NamingClassInfo[] = [
     reason:
       "Ruby `owner.instance_exec(&block)` (belongs_to_association.rb:47) is trails' " +
       "`block(this.owner)` — the block is a plain function and the receiver its argument, so " +
-      "the recorder sees `instance_exec` against `block`.",
+      "the recorder sees `instance_exec` against `block`. Same for a Ruby block passed as a " +
+      "trailing `{ }` (`model_class.unscoped { yield }`, locator.rb:223) where trails passes " +
+      "the callback as an argument: a TS argument spelled `block` IS the Ruby block, whatever " +
+      "Ruby wrote at that position.",
   },
   {
     name: "ivar-reflection",
@@ -89,6 +93,18 @@ export const NAMING_CLASSES: NamingClassInfo[] = [
       "(persistence.rb:491). TS has no counterpart and needs none: the field is read or written " +
       "directly (`becoming._attributes`), which is the only shape the language offers, so the " +
       "recorder sees the ivar's own name where Ruby names the reflection accessor.",
+  },
+  {
+    name: "implicit-to-s",
+    permanent: true,
+    reason:
+      "Ruby leans on implicit `to_s` — `quote_table_name(name)` (to_sql.rb:874) with a " +
+      "composite-PK Array, `quote_table_name(index_to_remove)` with a PostgreSQL::Name " +
+      "(postgresql_adapter.rb's remove_index). A TS signature takes a string, so the call " +
+      "site spells the conversion (`toS(name)`, `indexToRemove.toString()`); the value and " +
+      "the rendering are the same, only Ruby's is invisible. The mirror image counts too: " +
+      "Ruby coercing an already-`string` TS value (`force_change(attr_name.to_s)`, " +
+      "dirty.rb:410, against a `attrName: string` parameter) has nothing to spell.",
   },
   {
     name: "module-mixin-receiver",
@@ -133,14 +149,18 @@ export const JS_RESERVED_WORDS = new Set(
  */
 export const NO_JS_EQUIVALENT: Record<string, string[]> = {
   class: ["constructor"],
+  compact: ["filter"],
   first: ["at"],
+  gsub: ["replaceAll", "replace"],
   httpdate: ["toUTCString"],
   inject: ["reduce"],
-  inspect: ["toString"],
+  inspect: ["toString", "inspectError"],
   last: ["at", "pop"],
   length: ["size"],
   object_id: ["this"],
+  read: ["readFile"],
   size: ["length"],
+  strip: ["trim"],
   to_f: ["parseFloat", "Number"],
   to_i: ["parseInt", "Number"],
   to_s: ["toString", "String"],
@@ -195,8 +215,12 @@ function isThisTypedFunction(rubyRef: string, thisTypedFunctions?: ReadonlySet<s
  *   which the conventions table would camelCase without the underscore. A row
  *   that DID keep its `@` is the conventions table's own rename, so it falls
  *   through to that arm.
+ * - `toS`/`toString` on the TS side alone is Ruby's implicit `to_s` made
+ *   explicit, so that arm runs right after {@link NO_JS_EQUIVALENT} — which
+ *   already answers `inspect` → `toString` for the stronger reason.
  * - `block` is a TS-side artifact of the block idiom, so that arm keys on the
- *   TS spelling; `call` is one too, but a bare `ref:call` proves nothing on its
+ *   TS spelling alone — a TS argument named `block` is the Ruby block whatever
+ *   Ruby wrote at that position; `call` is one too, but a bare `ref:call` proves nothing on its
  *   own, so that arm additionally requires the Ruby name to BE a `this`-typed
  *   function — `thisTypedFunctions`, which the caller reads off the TS API
  *   manifest. Without that set the arm never fires and the row stays burndown,
@@ -217,13 +241,14 @@ export function classifyPair(
     ? NO_JS_EQUIVALENT[rubyRef]
     : NO_JS_EQUIVALENT_BY_CAMEL.get(rubyRef);
   if (noJsEquivalent?.includes(tsRef)) return "no-js-equivalent";
+  if (tsRef === "toS" || tsRef === "toString" || rubyRef === "toS" || rubyRef === "to_s") {
+    return "implicit-to-s";
+  }
   if (!rubyRef.startsWith("@") && tsRef === `_${snakeToCamel(rubyRef)}`) return "ivar-underscore";
   if (tsRef === "call" && isThisTypedFunction(rubyRef, thisTypedFunctions)) {
     return "module-mixin-call";
   }
-  if ((rubyRef === "instance_exec" || rubyRef === "instanceExec") && tsRef === "block") {
-    return "block-idiom";
-  }
+  if (tsRef === "block") return "block-idiom";
   const ivar = rubyRef.startsWith("@");
   const bare = ivar ? rubyRef.slice(1) : rubyRef;
   const converted = rubyMethodToTsIgnoringSkip(bare);


### PR DESCRIPTION
Bundle of seven RFC 0096 stories.

## What landed

**`activemodel-instance-validates-with`** — ported the INSTANCE
`validates_with` (with.rb:143-151) next to the existing class method: options
off the tail argument, `options[:class] = self.class`, then per klass
`klass.new(options.dup)` and `validator.validate(self)`. It registers nothing —
that is the class method's job. The trails test
`instance validates_with method preserves validator options` was a class-method
stand-in; it now mirrors with_validation_test.rb:112-117 (a validator that
clears the hash it was handed cannot blind the next one). The two
`module-mixin-receiver` rows on `validates_with` are gone (10 → 8).

**`converge-merge-target-lists`** — `merge_target_lists`
(collection_association.rb:335-352) now carries the
`(record.attribute_names & mem_record.attribute_names) -
changed_attribute_names_to_save - _attr_readonly` write-back loop and the
`memory.reject(&:persisted?)` tail. Before this, a clean in-memory attribute
kept its stale value across a reload, and an unmatched non-persisted memory
record with a PK was dropped. `merge-target-lists.trails.test.ts` pins both
halves and fails on the baseline (verified — both tests red without the fix).

**`port-attribute-mutation-tracker-force-change`** — `forceChange(attrName)` is
one argument and resolves the value itself through a private `fetchValue`
(attribute_mutation_tracker.rb:63-65, :97-99), so `attribute_will_change!` is
Rails' one-liner. `ForcedMutationTracker#forceChange` now guards on
`attributeChanged` rather than the forced-changes lookup it happens to equal
(attribute_mutation_tracker.rb:121-123). The `dirty.ts` / `force_change` naming
row is gone.

**`port-time-with-zone-period`** — `TimeWithZone#period` exists and memoizes
(`@period ||= time_zone.period_for_utc(@utc)`, time_with_zone.rb:72-74), backed
by a new `TimezonePeriod` on `TimeZone` exposing the three members the Rails
source reads: `dst?` (:95), `observed_utc_offset` (:112), `abbreviation` (:134).
`dst`/`zone`/`utcOffset` all delegate to it. TZInfo is a gem, so
`TimezonePeriod` carries `@noRailsEquivalent` next to the existing
`InvalidTimezoneIdentifier` stand-in in the same file.

**`naming-taxonomy-arel-i18n-globalid-classes`** — new permanent
`implicit-to-s` class (Ruby's invisible `to_s` where a TS signature makes the
conversion explicit — `quoteTableName(toS(name))` at to_sql.rb:874, and its
mirror image, a Ruby `to_s` against an already-`string` TS parameter). The
block-idiom arm now keys on the TS spelling alone (a TS argument named `block`
IS the Ruby block, whatever Ruby wrote there — locator.rb:223). `compact`,
`gsub`, `read`, `strip` and `inspect`→`inspectError` joined `NO_JS_EQUIVALENT`.

**`wave-4-naming-ar-adapters` / `wave-4-naming-ar-relation`** — Rails
identifiers for the locals that were simply not carrying them:

| Site | Rails |
| --- | --- |
| `OID::Range#serialize` `from`/`to` | range.rb:34-42 |
| `OID::Range#map` `newBegin`/`newEnd` | range.rb:50-54 |
| `pluck`/`asyncPluck` `columnNames`, and `columns` for the `arel_columns` result | calculations.rb:291, 315-317, 334 |
| `ids` `primaryKey` | calculations.rb:371-385 |
| `groupingQueries(queries)` | predicate_builder.rb:153 |
| `buildDefaultScope` `combinedScope` | default.rb:159-167 |
| `TimeWithZone#period` `utc` | time_with_zone.rb:73 |

## Measured

`pnpm parity:api:calls:args:report`: naming 302 → 293, of which burndown
256 → 232 and permanent 46 → 61. `shape` unchanged at 193. Both ratchets green,
no baseline row added, widened or reseeded; `naming` stays report-only.
`parity:api` / `parity:test` deltas non-negative.

## Rows left standing (reported, not baselined)

Recorder shape or a real port gap, each with the Ruby `file:line`:

- `postgresql-adapter.ts` `explain` — `pp(result.toArray())` vs
  `pp(result)`. Rails' `PostgreSQL::ExplainPrettyPrinter#pp` takes an
  `ActiveRecord::Result` and reads `result.columns.first` / `result.rows`; ours
  takes an array of hashes and hardcodes the `QUERY PLAN` header. A real port
  gap, too large for this bundle — filed as
  `port-pg-explain-pretty-printer-result`.
- `postgresql-adapter.ts` `renameTable` — `pk_and_sequence_for(new_name)` vs
  `renamedName`: a deliberately different *value* (the schema-qualified name
  after the rename), documented at the call site.
- `postgresql-adapter.ts` `removeIndex` and `to-sql.ts`
  `quoteTableName`/`quoteColumnName` — now the permanent `implicit-to-s` class.
- `oid/array.ts` `deserialize`/`serialize` — trails has no `@pg_decoder` /
  `@pg_encoder` and `Data` carries the encoder plus the values, so the recorder
  pairs against a different call. Real shape, filed as
  `converge-pg-oid-array-encoder-data`.
- `oid/point.ts` `buildPoint` — Ruby `Float(x)` raises; trails' `toCoordinate`
  returns null and the nullable guard needs the locals.
- `database-statements.ts` `castResult`, `statement-cache.ts` `create`,
  `predicate-builder.ts` `groupingQueries`, `calculations.ts`
  `aggregate_column`/`has_include?` — nested or extra-branch calls the recorder
  attributes to the inner callee.
- `batches.ts` `cursorArr`/`startArr`/`finishArr` — Ruby reassigns
  `cursor = Array(cursor)` and inlines `Array(start)`; the TS parameter is
  typed `string | string[] | undefined`, so the normalized value needs its own
  binding. Filed as `converge-batches-kernel-array-locals`.
- `collection-association.ts` `mergeTargetLists` `delete(identity)` — Ruby's
  `memory.delete(record)` is `Array#delete` over AR `==`; the TS side is a Map
  keyed by the identity that equality derives from, so the argument is the key,
  not the record.
- `query-methods.ts` `preprocessOrderArgs` / `arelColumn` — trails resolves
  Ruby Symbols to strings before the call, which needs the extra binding.

## Review notes

**Is `_period` lazy where Rails' `@period` is eager?** No — Rails is lazy in
trails' case too. `TimeWithZone#initialize` (time_with_zone.rb:51-55) sets
`@period = @utc ? period : get_period_and_ensure_valid_local_time(period)`: the
eager arm runs only when `utc_time` is nil, i.e. the local-time constructor.
When a UTC time IS given — the only constructor trails has
(`new TimeWithZone(instant, timeZone)`) — `@period` takes the caller-supplied
`period` argument, which is `nil` unless a caller passes one, so `#period`'s
`@period ||= time_zone.period_for_utc(@utc)` is what actually computes it.
`_period ??=` is the same shape at the same moment.

**block-idiom arm scope.** Narrowed after review: the arm now reads the TS
`block` spelling only against `BLOCK_IDIOM_RUBY_REFS`, an explicit list of the
two cited Ruby call sites (`instance_exec`, belongs_to_association.rb:47; and
`model_class.unscoped { yield }`, locator.rb:223). A Ruby parameter that merely
happens to be named `block` stays burndown, which is the safe direction for a
permanent class. Measured: no row moved (`block-idiom` was and is 2), so this
closes the loophole without changing the count.

Closes-story: activemodel-instance-validates-with
Closes-story: converge-merge-target-lists
Closes-story: naming-taxonomy-arel-i18n-globalid-classes
Closes-story: port-attribute-mutation-tracker-force-change
Closes-story: port-time-with-zone-period
Closes-story: wave-4-naming-ar-adapters
Closes-story: wave-4-naming-ar-relation

