### PR TITLE
test(activesupport,activemodel): converge Array/Integer and ValidationsContext assertion parity

### DIFF
--- a/packages/activemodel/src/validations/validations-context.test.ts
+++ b/packages/activemodel/src/validations/validations-context.test.ts
@@ -43,13 +43,19 @@ describe("ValidationsContextTest", () => {
   it("with a class that adds errors on update and validating a new model", async () => {
     Topic.validatesWith(ValidatorThatAddsErrors, { on: "update" });
     const topic = new Topic();
-    expect(await topic.isValid("create")).toBeTruthy(); // Validation doesn't run on create if 'on' is set to update
+    expect(
+      await topic.isValid("create"),
+      "Validation doesn't run on create if 'on' is set to update",
+    ).toBeTruthy();
   });
 
   it("with a class that adds errors on create and validating a new model", async () => {
     Topic.validatesWith(ValidatorThatAddsErrors, { on: "create" });
     const topic = new Topic();
-    expect(await topic.isInvalid("create")).toBeTruthy(); // Validation does run on create if 'on' is set to create
+    expect(
+      await topic.isInvalid("create"),
+      "Validation does run on create if 'on' is set to create",
+    ).toBeTruthy();
     expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
   });
 
@@ -63,10 +69,16 @@ describe("ValidationsContextTest", () => {
       "Validation ran with no context given when 'on' is set to context1 and context2",
     );
 
-    expect(await topic.isInvalid("context1")).toBeTruthy(); // Validation did not run on context1
+    expect(
+      await topic.isInvalid("context1"),
+      "Validation did not run on context1 when 'on' is set to context1 and context2",
+    ).toBeTruthy();
     expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
 
-    expect(await topic.isInvalid("context2")).toBeTruthy(); // Validation did not run on context2
+    expect(
+      await topic.isInvalid("context2"),
+      "Validation did not run on context2 when 'on' is set to context1 and context2",
+    ).toBeTruthy();
     expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
   });
 
@@ -81,7 +93,10 @@ describe("ValidationsContextTest", () => {
       "Validation ran with no context given when 'on' is set to context1 and context2",
     );
 
-    expect(await topic.isInvalid(["context1", "context2"])).toBeTruthy();
+    expect(
+      await topic.isInvalid(["context1", "context2"]),
+      "Validation did not run on context1 when 'on' is set to context1 and context2",
+    ).toBeTruthy();
     expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
     expect(topic.errors.get("base")).toContain(ANOTHER_ERROR_MESSAGE);
   });

--- a/packages/activemodel/src/validations/validations-context.test.ts
+++ b/packages/activemodel/src/validations/validations-context.test.ts
@@ -1,69 +1,88 @@
-import { describe, it, expect } from "vitest";
-import { Model } from "../index.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
+import { Model, Validator } from "../index.js";
+import type { ValidatableRecord } from "../validator.js";
+
+// Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+  }
+}
 
 describe("ValidationsContextTest", () => {
-  it("with a class that adds errors on create and validating a new model with no arguments", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create" });
-      }
-    }
-    // No context specified, so validation with on: "create" is skipped
-    expect(await new Person({}).isValid()).toBe(true);
+  afterEach(() => {
+    Topic.clearValidatorsBang();
   });
 
-  it("with a class that adds errors on create and validating a new model", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create" });
-      }
+  const ERROR_MESSAGE = "Validation error from validator";
+  const ANOTHER_ERROR_MESSAGE = "Another validation error from validator";
+
+  class ValidatorThatAddsErrors extends Validator {
+    validate(record: ValidatableRecord): void {
+      record.errors.add("base", ERROR_MESSAGE);
     }
-    expect(await new Person({}).isValid("create")).toBe(false);
+  }
+
+  class AnotherValidatorThatAddsErrors extends Validator {
+    validate(record: ValidatableRecord): void {
+      record.errors.add("base", ANOTHER_ERROR_MESSAGE);
+    }
+  }
+
+  it("with a class that adds errors on create and validating a new model with no arguments", async () => {
+    Topic.validatesWith(ValidatorThatAddsErrors, { on: "create" });
+    const topic = new Topic();
+    assertPredicate(
+      await topic.isValid(),
+      (valid) => valid,
+      "Validation doesn't run on valid? if 'on' is set to create",
+    );
   });
 
   it("with a class that adds errors on update and validating a new model", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "update" });
-      }
-    }
-    expect(await new Person({}).isValid("create")).toBe(true);
-    expect(await new Person({}).isValid("update")).toBe(false);
+    Topic.validatesWith(ValidatorThatAddsErrors, { on: "update" });
+    const topic = new Topic();
+    expect(await topic.isValid("create")).toBeTruthy(); // Validation doesn't run on create if 'on' is set to update
+  });
+
+  it("with a class that adds errors on create and validating a new model", async () => {
+    Topic.validatesWith(ValidatorThatAddsErrors, { on: "create" });
+    const topic = new Topic();
+    expect(await topic.isInvalid("create")).toBeTruthy(); // Validation does run on create if 'on' is set to create
+    expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
   });
 
   it("with a class that adds errors on multiple contexts and validating a new model", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("email", "string");
-        this.validates("name", { presence: true, on: "create" });
-        this.validates("email", { presence: true, on: "update" });
-      }
-    }
-    // On create: only name validation fires
-    const p1 = new Person({});
-    expect(await p1.isValid("create")).toBe(false);
-    expect(p1.errors.get("name").length).toBeGreaterThan(0);
+    Topic.validatesWith(ValidatorThatAddsErrors, { on: ["context1", "context2"] });
 
-    const p2 = new Person({ name: "Alice" });
-    expect(await p2.isValid("create")).toBe(true);
+    const topic = new Topic();
+    assertPredicate(
+      await topic.isValid(),
+      (valid) => valid,
+      "Validation ran with no context given when 'on' is set to context1 and context2",
+    );
+
+    expect(await topic.isInvalid("context1")).toBeTruthy(); // Validation did not run on context1
+    expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
+
+    expect(await topic.isInvalid("context2")).toBeTruthy(); // Validation did not run on context2
+    expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
   });
 
   it("with a class that validating a model for a multiple contexts", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create" });
-      }
-    }
-    // Without context, validation is skipped
-    expect(await new Person({}).isValid()).toBe(true);
-    // With matching context, validation runs
-    expect(await new Person({}).isValid("create")).toBe(false);
-    // With non-matching context, validation is skipped
-    expect(await new Person({}).isValid("update")).toBe(true);
+    Topic.validatesWith(ValidatorThatAddsErrors, { on: "context1" });
+    Topic.validatesWith(AnotherValidatorThatAddsErrors, { on: "context2" });
+
+    const topic = new Topic();
+    assertPredicate(
+      await topic.isValid(),
+      (valid) => valid,
+      "Validation ran with no context given when 'on' is set to context1 and context2",
+    );
+
+    expect(await topic.isInvalid(["context1", "context2"])).toBeTruthy();
+    expect(topic.errors.get("base")).toContain(ERROR_MESSAGE);
+    expect(topic.errors.get("base")).toContain(ANOTHER_ERROR_MESSAGE);
   });
 });

--- a/packages/activesupport/src/array-utils.trails.test.ts
+++ b/packages/activesupport/src/array-utils.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { kernelArray, toFs } from "./array-utils.js";
+import { inGroupsOf, kernelArray, toFs } from "./array-utils.js";
 
 describe("KernelArrayTest (trails)", () => {
   it("returns an empty array for nil", () => {
@@ -51,5 +51,28 @@ describe("ToFsTest (trails)", () => {
 
   it("default format is the empty brackets for an empty array", () => {
     expect(toFs([])).toBe("[]");
+  });
+});
+
+describe("GroupingTest (trails)", () => {
+  // `grouping_test.rb` only guards 0, -1 and nil. Ruby reaches the same verdict
+  // for a fractional group size through `number.to_i`, which truncates — and
+  // reports it unrounded, because the message interpolates `number.inspect`.
+  // Verified against the vendored `grouping.rb` under MRI.
+  it("truncates a fractional group size the way Integer#to_i does", () => {
+    expect(() => inGroupsOf([1, 2, 3, 4, 5], 0.7)).toThrow(
+      "Group size must be a positive integer, was 0.7",
+    );
+    expect(inGroupsOf([1, 2, 3, 4, 5], 2.7)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("does not mutate the receiver when padding", () => {
+    const array = [1, 2, 3, 4, 5];
+    expect(inGroupsOf(array, 2)).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, null],
+    ]);
+    expect(array).toEqual([1, 2, 3, 4, 5]);
   });
 });

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -50,9 +50,11 @@ export function kernelArray<T>(value: T | T[] | null | undefined): T[] {
  * Splits or iterates over the array in groups of size +number+, padding any
  * remaining slots with +fill_with+ unless it is +false+.
  *
- * Mirrors: `Array#in_groups_of` (`core_ext/array/grouping.rb:21-49`). The guard
- * is Ruby's `number.to_i <= 0`, whose `to_i` answers 0 for nil and for anything
- * non-numeric.
+ * Mirrors: `Array#in_groups_of` (`core_ext/array/grouping.rb:21-49`). Ruby's
+ * `to_i` and `Array.new` both TRUNCATE, and `each_slice` truncates through
+ * `to_int`, so a fractional +number+ is floored at three separate points while
+ * the error message reports it unrounded via `inspect` — `in_groups_of(0.7)`
+ * raises where `0.7 > 0` would have passed.
  */
 export function inGroupsOf<T>(
   array: T[],
@@ -60,19 +62,24 @@ export function inGroupsOf<T>(
   fillWith: T | null | false = null,
   block?: (group: (T | null | false)[]) => void,
 ): (T | null | false)[][] {
-  const numberToI = Number(number) || 0;
+  const numberToI = Math.trunc(Number(number)) || 0;
   if (numberToI <= 0) {
     throw new ArgumentError(`Group size must be a positive integer, was ${inspect(number)}`);
   }
+
+  let collection: (T | null | false)[];
+  if (fillWith === false) {
+    collection = array;
+  } else {
+    const padding = Math.trunc((number - (array.length % number)) % number) || 0;
+    collection = (array as (T | null | false)[]).concat(
+      globalThis.Array<T | null | false>(padding).fill(fillWith),
+    );
+  }
+
   const result: (T | null | false)[][] = [];
-  for (let i = 0; i < array.length; i += number) {
-    const group: (T | null | false)[] = array.slice(i, i + number);
-    if (fillWith !== false) {
-      while (group.length < number) {
-        group.push(fillWith);
-      }
-    }
-    result.push(group);
+  for (let i = 0; i < collection.length; i += numberToI) {
+    result.push(collection.slice(i, i + numberToI));
   }
   if (block) result.forEach(block);
   return result;

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -2,19 +2,24 @@
  * Array utilities mirroring Rails ActiveSupport array extensions.
  */
 
-import { assertValidKeys } from "./hash-utils.js";
+import { ArgumentError, assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
 import { camelize } from "./inflector.js";
-import { toS } from "./core-ext/object/inspect.js";
+import { inspect, toS } from "./core-ext/object/inspect.js";
 
 /**
  * Wraps a value in an array. `null`/`undefined` → `[]`, arrays pass through,
  * scalars become `[value]`.
  */
-export function wrap<T>(value: T | T[] | null | undefined): T[] {
-  if (value === null || value === undefined) return [];
-  if (Array.isArray(value)) return value;
-  return [value] as T[];
+export function wrap<T>(object: T | T[] | null | undefined): T[] {
+  if (object === null || object === undefined) return [];
+  if (Array.isArray(object)) return object;
+  // Ruby's `object.respond_to?(:to_ary)` arm: `to_ary || [object]`, so a
+  // `to_ary` answering nil still wraps, and one answering a non-array is
+  // returned as-is.
+  const toAry = (object as { toAry?: () => T[] | null }).toAry;
+  if (typeof toAry === "function") return toAry.call(object) ?? ([object] as T[]);
+  return [object] as T[];
 }
 
 /**
@@ -46,19 +51,24 @@ export function kernelArray<T>(value: T | T[] | null | undefined): T[] {
  */
 export function inGroupsOf<T>(
   array: T[],
-  n: number,
+  number: number,
   fillWith: T | null | false = null,
+  block?: (group: (T | null | false)[]) => void,
 ): (T | null | false)[][] {
+  if (!(Number(number) > 0)) {
+    throw new ArgumentError(`Group size must be a positive integer, was ${inspect(number)}`);
+  }
   const result: (T | null | false)[][] = [];
-  for (let i = 0; i < array.length; i += n) {
-    const group: (T | null | false)[] = array.slice(i, i + n);
+  for (let i = 0; i < array.length; i += number) {
+    const group: (T | null | false)[] = array.slice(i, i + number);
     if (fillWith !== false) {
-      while (group.length < n) {
+      while (group.length < number) {
         group.push(fillWith);
       }
     }
     result.push(group);
   }
+  if (block) result.forEach(block);
   return result;
 }
 
@@ -115,6 +125,7 @@ export function inGroups<T>(
   array: T[],
   n: number,
   fillWith: T | null | false = null,
+  block?: (group: (T | null | false)[]) => void,
 ): (T | null | false)[][] {
   const quotient = Math.floor(array.length / n);
   const remainder = array.length % n;
@@ -131,6 +142,7 @@ export function inGroups<T>(
     groups.push(group);
     start += size;
   }
+  if (block) groups.forEach(block);
   return groups;
 }
 

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -8,15 +8,15 @@ import { camelize } from "./inflector.js";
 import { inspect, toS } from "./core-ext/object/inspect.js";
 
 /**
- * Wraps a value in an array. `null`/`undefined` → `[]`, arrays pass through,
- * scalars become `[value]`.
+ * Wraps its argument in an array unless it is already an array (or array-like).
+ *
+ * Mirrors: `Array.wrap` (`core_ext/array/wrap.rb:39-46`) — the
+ * `respond_to?(:to_ary)` arm is `object.to_ary || [object]`, so a `to_ary`
+ * answering nil still wraps and one answering a non-array is returned as-is.
  */
 export function wrap<T>(object: T | T[] | null | undefined): T[] {
   if (object === null || object === undefined) return [];
   if (Array.isArray(object)) return object;
-  // Ruby's `object.respond_to?(:to_ary)` arm: `to_ary || [object]`, so a
-  // `to_ary` answering nil still wraps, and one answering a non-array is
-  // returned as-is.
   const toAry = (object as { toAry?: () => T[] | null }).toAry;
   if (typeof toAry === "function") return toAry.call(object) ?? ([object] as T[]);
   return [object] as T[];
@@ -47,7 +47,12 @@ export function kernelArray<T>(value: T | T[] | null | undefined): T[] {
 }
 
 /**
- * Split an array into groups of `n`, padding the last group with `fillWith`.
+ * Splits or iterates over the array in groups of size +number+, padding any
+ * remaining slots with +fill_with+ unless it is +false+.
+ *
+ * Mirrors: `Array#in_groups_of` (`core_ext/array/grouping.rb:21-49`). The guard
+ * is Ruby's `number.to_i <= 0`, whose `to_i` answers 0 for nil and for anything
+ * non-numeric.
  */
 export function inGroupsOf<T>(
   array: T[],
@@ -55,7 +60,8 @@ export function inGroupsOf<T>(
   fillWith: T | null | false = null,
   block?: (group: (T | null | false)[]) => void,
 ): (T | null | false)[][] {
-  if (!(Number(number) > 0)) {
+  const numberToI = Number(number) || 0;
+  if (numberToI <= 0) {
     throw new ArgumentError(`Group size must be a positive integer, was ${inspect(number)}`);
   }
   const result: (T | null | false)[][] = [];
@@ -118,30 +124,37 @@ export function toSentence(
 }
 
 /**
- * Split an array into `n` groups of roughly equal size, padding with `fillWith`.
- * Mirrors Rails' `Array#in_groups`.
+ * Splits or iterates over the array in +number+ of groups, padding any
+ * remaining slots with +fill_with+ unless it is +false+.
+ *
+ * Mirrors: `Array#in_groups` (`core_ext/array/grouping.rb:57-84`). `division`
+ * is Ruby's `size.div number`, floor division as a method — JS has only the
+ * operator, so it is `Math.floor` here.
  */
 export function inGroups<T>(
   array: T[],
-  n: number,
+  number: number,
   fillWith: T | null | false = null,
   block?: (group: (T | null | false)[]) => void,
 ): (T | null | false)[][] {
-  const quotient = Math.floor(array.length / n);
-  const remainder = array.length % n;
+  // size.div number gives minor group size;
+  // size % number gives how many objects need extra accommodation;
+  // each group hold either division or division + 1 items.
+  const division = Math.floor(array.length / number);
+  const modulo = array.length % number;
+
+  // create a new array avoiding dup
   const groups: (T | null | false)[][] = [];
   let start = 0;
-  for (let i = 0; i < n; i++) {
-    const size = i < remainder ? quotient + 1 : quotient;
-    const group: (T | null | false)[] = array.slice(start, start + size);
-    if (fillWith !== false) {
-      while (group.length < quotient + (remainder > 0 ? 1 : 0)) {
-        group.push(fillWith);
-      }
-    }
-    groups.push(group);
-    start += size;
+
+  for (let index = 0; index < number; index++) {
+    const length = division + (modulo > 0 && modulo > index ? 1 : 0);
+    const lastGroup: (T | null | false)[] = array.slice(start, start + length);
+    groups.push(lastGroup);
+    if (fillWith !== false && modulo > 0 && length === division) lastGroup.push(fillWith);
+    start += length;
   }
+
   if (block) groups.forEach(block);
   return groups;
 }

--- a/packages/activesupport/src/core-ext/array/access.test.ts
+++ b/packages/activesupport/src/core-ext/array/access.test.ts
@@ -30,7 +30,8 @@ describe("AccessTest", () => {
   });
 
   it("including", () => {
-    expect(ArrayExt.including([1, 2, 3], 4, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(ArrayExt.including([1, 2, 4], 3, 5).sort()).toEqual([1, 2, 3, 4, 5]);
+    expect(ArrayExt.including([1, 2, 4], [3, 5]).sort()).toEqual([1, 2, 3, 4, 5]);
     expect(ArrayExt.including([[0, 1]], [[1, 0]])).toEqual([
       [0, 1],
       [1, 0],
@@ -38,7 +39,17 @@ describe("AccessTest", () => {
   });
 
   it("excluding", () => {
-    expect(ArrayExt.excluding([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
+    expect(ArrayExt.excluding([1, 2, 3, 4, 5], 3, 5)).toEqual([1, 2, 4]);
+    expect(ArrayExt.excluding([1, 2, 3, 4, 5], [3, 5])).toEqual([1, 2, 4]);
+    expect(
+      ArrayExt.excluding(
+        [
+          [0, 1],
+          [1, 0],
+        ],
+        [[1, 0]],
+      ),
+    ).toEqual([[0, 1]]);
   });
 
   it("without", () => {

--- a/packages/activesupport/src/core-ext/array/access.ts
+++ b/packages/activesupport/src/core-ext/array/access.ts
@@ -71,7 +71,9 @@ export class Array {
    */
   static excluding<T>(self: T[], ...elements: (T | T[])[]): T[] {
     const removed = elements.flat(1) as T[];
-    return self.filter((element) => !removed.includes(element));
+    // Ruby's `Array#-` compares with `eql?`/`hash`, so a nested array is removed
+    // by value; `Array#includes` is identity-only and would keep it.
+    return self.filter((element) => !removed.some((other) => eql(element, other)));
   }
 
   /** Alias of {@link Array.excluding}. */
@@ -155,4 +157,17 @@ export class Array {
     }
     return self;
   }
+}
+
+/**
+ * Ruby's `eql?` for the values `Array#-` compares: identity, or element-wise
+ * equality for nested arrays.
+ *
+ * @noRailsEquivalent Ruby gets value equality on nested arrays from `Array#eql?`;
+ * JS `===` is identity-only, so `Array#-` has to spell it out.
+ */
+function eql(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (!globalThis.Array.isArray(a) || !globalThis.Array.isArray(b)) return false;
+  return a.length === b.length && a.every((element, i) => eql(element, b[i]));
 }

--- a/packages/activesupport/src/core-ext/array/access.ts
+++ b/packages/activesupport/src/core-ext/array/access.ts
@@ -71,8 +71,6 @@ export class Array {
    */
   static excluding<T>(self: T[], ...elements: (T | T[])[]): T[] {
     const removed = elements.flat(1) as T[];
-    // Ruby's `Array#-` compares with `eql?`/`hash`, so a nested array is removed
-    // by value; `Array#includes` is identity-only and would keep it.
     return self.filter((element) => !removed.some((other) => eql(element, other)));
   }
 
@@ -160,11 +158,9 @@ export class Array {
 }
 
 /**
- * Ruby's `eql?` for the values `Array#-` compares: identity, or element-wise
- * equality for nested arrays.
- *
- * @noRailsEquivalent Ruby gets value equality on nested arrays from `Array#eql?`;
- * JS `===` is identity-only, so `Array#-` has to spell it out.
+ * The comparison Ruby's `Array#-` makes — `eql?`/`hash`, which is element-wise
+ * on a nested array. `Array#includes` is identity-only and would keep a nested
+ * array that `self - elements` removes.
  */
 function eql(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;

--- a/packages/activesupport/src/core-ext/array/extract-options.test.ts
+++ b/packages/activesupport/src/core-ext/array/extract-options.test.ts
@@ -1,35 +1,54 @@
 import { describe, expect, it } from "vitest";
-import { extractOptionsBang } from "../../index.js";
+import { extractOptionsBang, HashWithIndifferentAccess, OrderedOptions } from "../../index.js";
 
 describe("ExtractOptionsTest", () => {
+  // Ruby's `class HashSubclass < Hash`; a class instance is not a plain object,
+  // so it is the TS shape of a Hash subclass that does not opt in.
+  class HashSubclass {
+    foo?: number;
+  }
+
+  class ExtractableHashSubclass {
+    foo?: number;
+    isExtractableOptions(): boolean {
+      return true;
+    }
+  }
+
   it("extract options", () => {
-    const [args, opts] = extractOptionsBang(["a", "b", { limit: 10 }]);
-    expect(args).toEqual(["a", "b"]);
-    expect(opts).toEqual({ limit: 10 });
+    expect(extractOptionsBang([])[1]).toEqual({});
+    expect(extractOptionsBang([1])[1]).toEqual({});
+    expect(extractOptionsBang([{ a: ":b" }])[1]).toEqual({ a: ":b" });
+    expect(extractOptionsBang([1, { a: ":b" }])[1]).toEqual({ a: ":b" });
   });
 
   it("extract options doesnt extract hash subclasses", () => {
-    // Non-object trailing args are not extracted
-    const [args, opts] = extractOptionsBang(["a", "b"]);
-    expect(args).toEqual(["a", "b"]);
-    expect(opts).toEqual({});
+    const hash = new HashSubclass();
+    hash.foo = 1;
+    const [array, options] = extractOptionsBang([hash]);
+    expect(options).toEqual({});
+    expect(array).toEqual([hash]);
   });
 
   it("extract options extracts extractable subclass", () => {
-    const [args, opts] = extractOptionsBang([{ extractable: true }]);
-    expect(args).toEqual([]);
-    expect(opts).toEqual({ extractable: true });
+    const hash = new ExtractableHashSubclass();
+    hash.foo = 1;
+    const [array, options] = extractOptionsBang([hash]);
+    expect(options).toBe(hash);
+    expect(array).toEqual([]);
   });
 
   it("extract options extracts hash with indifferent access", () => {
-    const [args, opts] = extractOptionsBang(["a", { key: "value" }]);
-    expect(args).toEqual(["a"]);
-    expect(opts.key).toBe("value");
+    const array = [new HashWithIndifferentAccess({ foo: 1 })];
+    const [, options] = extractOptionsBang(array);
+    expect((options as unknown as HashWithIndifferentAccess).get("foo")).toBe(1);
   });
 
   it("extract options extracts ordered options", () => {
-    const [args, opts] = extractOptionsBang([{ z: 1, a: 2 }]);
-    expect(args).toEqual([]);
-    expect(opts).toEqual({ z: 1, a: 2 });
+    const hash = new OrderedOptions();
+    hash.set("foo", 1);
+    const [array, options] = extractOptionsBang([hash]);
+    expect(options).toBe(hash);
+    expect(array).toEqual([]);
   });
 });

--- a/packages/activesupport/src/core-ext/array/extract.test.ts
+++ b/packages/activesupport/src/core-ext/array/extract.test.ts
@@ -3,10 +3,16 @@ import { extractBang } from "../../index.js";
 
 describe("ExtractTest", () => {
   it("extract", () => {
-    const numbers = [1, 2, 3, 4, 5];
-    const odds = extractBang(numbers, (n) => n % 2 !== 0);
-    expect(odds).toEqual([1, 3, 5]);
-    expect(numbers).toEqual([2, 4]);
+    const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    // Ruby's `object_id`, held to assert `extract!` mutated the receiver in
+    // place rather than returning a new array.
+    const arrayId = numbers;
+
+    const oddNumbers = extractBang(numbers, (n) => n % 2 !== 0);
+
+    expect(oddNumbers).toEqual([1, 3, 5, 7, 9]);
+    expect(numbers).toEqual([0, 2, 4, 6, 8]);
+    expect(numbers).toBe(arrayId);
   });
 
   it("extract without block", () => {
@@ -17,9 +23,13 @@ describe("ExtractTest", () => {
   });
 
   it("extract on empty array", () => {
-    const arr: number[] = [];
-    const extracted = extractBang(arr, (n) => n > 0);
-    expect(extracted).toEqual([]);
-    expect(arr).toEqual([]);
+    const emptyArray: number[] = [];
+    const arrayId = emptyArray;
+
+    const newEmptyArray = extractBang(emptyArray, () => undefined as unknown as boolean);
+
+    expect(newEmptyArray).toEqual([]);
+    expect(emptyArray).toEqual([]);
+    expect(emptyArray).toBe(arrayId);
   });
 });

--- a/packages/activesupport/src/core-ext/array/extract.test.ts
+++ b/packages/activesupport/src/core-ext/array/extract.test.ts
@@ -26,7 +26,7 @@ describe("ExtractTest", () => {
     const emptyArray: number[] = [];
     const arrayId = emptyArray;
 
-    const newEmptyArray = extractBang(emptyArray, () => undefined as unknown as boolean);
+    const newEmptyArray = extractBang(emptyArray, () => false);
 
     expect(newEmptyArray).toEqual([]);
     expect(emptyArray).toEqual([]);

--- a/packages/activesupport/src/core-ext/array/grouping.test.ts
+++ b/packages/activesupport/src/core-ext/array/grouping.test.ts
@@ -1,36 +1,84 @@
 import { describe, expect, it } from "vitest";
 import { inGroups, inGroupsOf, split } from "../../index.js";
 
+// Ruby's `("a".."i").to_a` / `(1..9).to_a`.
+function toA(first: string, last: string): string[];
+function toA(first: number, last: number): number[];
+function toA(first: string | number, last: string | number): (string | number)[] {
+  if (typeof first === "string" && typeof last === "string") {
+    const result: string[] = [];
+    for (let c = first.charCodeAt(0); c <= last.charCodeAt(0); c++) {
+      result.push(String.fromCharCode(c));
+    }
+    return result;
+  }
+  const result: number[] = [];
+  for (let i = first as number; i <= (last as number); i++) result.push(i);
+  return result;
+}
+
 describe("GroupingTest", () => {
   it("in groups of with perfect fit", () => {
-    expect(inGroupsOf([1, 2, 3, 4, 5, 6], 3)).toEqual([
-      [1, 2, 3],
-      [4, 5, 6],
+    const groups: unknown[] = [];
+    inGroupsOf(toA("a", "i"), 3, null, (group) => {
+      groups.push(group);
+    });
+
+    expect(groups).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+      ["g", "h", "i"],
+    ]);
+    expect(inGroupsOf(toA("a", "i"), 3)).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+      ["g", "h", "i"],
     ]);
   });
 
   it("in groups of with padding", () => {
-    expect(inGroupsOf([1, 2, 3, 4, 5], 3)).toEqual([
-      [1, 2, 3],
-      [4, 5, null],
+    const groups: unknown[] = [];
+    inGroupsOf(toA("a", "g"), 3, null, (group) => {
+      groups.push(group);
+    });
+
+    expect(groups).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+      ["g", null, null],
     ]);
   });
 
   it("in groups of pads with specified values", () => {
-    expect(inGroupsOf([1, 2, 3, 4, 5], 3, 0)).toEqual([
-      [1, 2, 3],
-      [4, 5, 0],
+    const groups: unknown[] = [];
+
+    inGroupsOf(toA("a", "g"), 3, "foo", (group) => {
+      groups.push(group);
+    });
+
+    expect(groups).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+      ["g", "foo", "foo"],
     ]);
   });
 
   it("in groups of without padding", () => {
-    const result = inGroupsOf([1, 2, 3, 4, 5], 3, false);
-    expect(result[0]).toEqual([1, 2, 3]);
-    expect(result[1]).toEqual([4, 5]);
+    const groups: unknown[] = [];
+
+    inGroupsOf(toA("a", "g"), 3, false, (group) => {
+      groups.push(group);
+    });
+
+    expect(groups).toEqual([["a", "b", "c"], ["d", "e", "f"], ["g"]]);
   });
 
   it("in groups returned array size", () => {
-    expect(inGroupsOf([1, 2, 3, 4, 5], 3).length).toBe(2);
+    const array = toA(1, 7);
+
+    for (let number = 1; number <= array.length + 1; number++) {
+      expect(inGroups(array, number).length).toBe(number);
+    }
   });
 
   it("in groups with empty array", () => {
@@ -38,60 +86,97 @@ describe("GroupingTest", () => {
   });
 
   it("in groups with block", () => {
-    const groups = inGroups([1, 2, 3, 4, 5, 6, 7], 3);
-    expect(groups.length).toBe(3);
+    const array = toA(1, 9);
+    const groups: unknown[] = [];
+
+    inGroups(array, 3, null, (group) => {
+      groups.push(group);
+    });
+
+    expect(inGroups(array, 3)).toEqual(groups);
   });
 
   it("in groups with perfect fit", () => {
-    expect(inGroups([1, 2, 3, 4, 5, 6], 3)).toEqual([
-      [1, 2],
-      [3, 4],
-      [5, 6],
+    expect(inGroups(toA(1, 9), 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
     ]);
   });
 
   it("in groups with padding", () => {
-    expect(inGroups([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([
+    const array = toA(1, 7);
+
+    expect(inGroups(array, 3)).toEqual([
       [1, 2, 3],
       [4, 5, null],
       [6, 7, null],
     ]);
+    expect(inGroups(array, 3, "foo" as unknown as number)).toEqual([
+      [1, 2, 3],
+      [4, 5, "foo"],
+      [6, 7, "foo"],
+    ]);
   });
 
   it("in groups without padding", () => {
-    const result = inGroups([1, 2, 3, 4, 5, 6, 7], 3, false);
-    expect(result[0]).toEqual([1, 2, 3]);
-    expect(result[1]).toEqual([4, 5]);
-    expect(result[2]).toEqual([6, 7]);
+    expect(inGroups(toA(1, 7), 3, false)).toEqual([
+      [1, 2, 3],
+      [4, 5],
+      [6, 7],
+    ]);
   });
 
   it("in groups invalid argument", () => {
-    expect(() => inGroups([1, 2, 3], 0)).not.toThrow();
+    expect(() => inGroupsOf([], 0)).toThrow(/Group size must be a positive integer/);
+    expect(() => inGroupsOf([], -1)).toThrow(/Group size must be a positive integer/);
+    expect(() => inGroupsOf([], null as unknown as number)).toThrow(
+      /Group size must be a positive integer/,
+    );
   });
 });
 
 describe("SplitTest", () => {
   it("split with empty array", () => {
-    expect(split([], 1)).toEqual([[]]);
+    expect(split([], 0)).toEqual([[]]);
   });
 
   it("split with argument", () => {
-    expect(split([1, 2, 3, 4, 5], 3)).toEqual([
+    const a = [1, 2, 3, 4, 5];
+    expect(split(a, 3)).toEqual([
       [1, 2],
       [4, 5],
     ]);
+    expect(split(a, 0)).toEqual([[1, 2, 3, 4, 5]]);
+    expect(a).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("split with block", () => {
-    expect(split([1, 2, 3, 4, 5], (x: number) => x % 2 === 0)).toEqual([[1], [3], [5]]);
+    const a = toA(1, 10);
+    expect(split(a, (i: number) => i % 3 === 0)).toEqual([[1, 2], [4, 5], [7, 8], [10]]);
+    expect(a).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
   it("split with edge values", () => {
-    expect(split([1, 2, 3], 1)).toEqual([[], [2, 3]]);
-    expect(split([1, 2, 3], 3)).toEqual([[1, 2], []]);
+    const a = [1, 2, 3, 4, 5];
+    expect(split(a, 1)).toEqual([[], [2, 3, 4, 5]]);
+    expect(split(a, 5)).toEqual([[1, 2, 3, 4], []]);
+    expect(split(a, (i: number) => i === 1 || i === 5)).toEqual([[], [2, 3, 4], []]);
+    expect(a).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("split with repeated values", () => {
-    expect(split([1, 2, 1, 3, 1], 1)).toEqual([[], [2], [3], []]);
+    const a = [1, 2, 3, 5, 5, 3, 4, 6, 2, 1, 3];
+    expect(split(a, 3)).toEqual([[1, 2], [5, 5], [4, 6, 2, 1], []]);
+    expect(split(a, 5)).toEqual([[1, 2, 3], [], [3, 4, 6, 2, 1, 3]]);
+    expect(split(a, (i: number) => i === 3 || i === 5)).toEqual([
+      [1, 2],
+      [],
+      [],
+      [],
+      [4, 6, 2, 1],
+      [],
+    ]);
+    expect(a).toEqual([1, 2, 3, 5, 5, 3, 4, 6, 2, 1, 3]);
   });
 });

--- a/packages/activesupport/src/core-ext/array/wrap.test.ts
+++ b/packages/activesupport/src/core-ext/array/wrap.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { wrap } from "../../index.js";
+import { assertSame } from "../../testing/assertions.js";
 
 describe("WrapTest", () => {
+  class FakeCollection {
+    toAry(): string[] {
+      return ["foo", "bar"];
+    }
+  }
+
+  // Ruby forwards every call through `method_missing`, which — the point of
+  // `test_proxy_object` — leaves `respond_to?(:to_ary)` false. A plain class
+  // holding the target has the same property here: no `toAry` of its own.
+  class Proxy {
+    constructor(readonly target: unknown) {}
+  }
+
+  class DoubtfulToAry {
+    toAry(): string[] {
+      return ":not_an_array" as unknown as string[];
+    }
+  }
+
+  class NilToAry {
+    toAry(): string[] | null {
+      return null;
+    }
+  }
+
   it("array", () => {
-    const arr = [1, 2, 3];
-    expect(wrap(arr)).toBe(arr);
+    const ary = ["foo", "bar"];
+    assertSame(ary, wrap(ary));
   });
 
   it("nil", () => {
@@ -12,46 +38,43 @@ describe("WrapTest", () => {
   });
 
   it("object", () => {
-    expect(wrap(42)).toEqual([42]);
+    const o = {};
+    expect(wrap(o)).toEqual([o]);
   });
 
   it("string", () => {
-    expect(wrap("hello")).toEqual(["hello"]);
+    expect(wrap("foo")).toEqual(["foo"]);
   });
 
   it("string with newline", () => {
-    expect(wrap("hello\nworld")).toEqual(["hello\nworld"]);
+    expect(wrap("foo\nbar")).toEqual(["foo\nbar"]);
   });
 
   it("object with to ary", () => {
-    // Objects that are arrays pass through
-    const arr = [1, 2];
-    expect(wrap(arr)).toBe(arr);
+    expect(wrap(new FakeCollection())).toEqual(["foo", "bar"]);
   });
 
   it("proxy object", () => {
-    // A regular object gets wrapped
-    const obj = { x: 1 };
-    expect(wrap(obj as any)).toEqual([obj]);
+    const p = new Proxy({});
+    expect(wrap(p)).toEqual([p]);
   });
 
   it("proxy to object with to ary", () => {
-    const arr = [1, 2, 3];
-    expect(wrap(arr)).toBe(arr);
+    const p = new Proxy(new FakeCollection());
+    expect(wrap(p)).toEqual([p]);
   });
 
   it("struct", () => {
-    // Non-array object gets wrapped
-    const struct = { name: "alice" };
-    expect(wrap(struct as any)).toEqual([struct]);
+    const o = { foo: 123 };
+    expect(wrap(o)).toEqual([o]);
   });
 
   it("wrap returns wrapped if to ary returns nil", () => {
-    // undefined/null → empty array
-    expect(wrap(undefined)).toEqual([]);
+    const o = new NilToAry();
+    expect(wrap(o)).toEqual([o]);
   });
 
   it("wrap does not complain if to ary does not return an array", () => {
-    expect(() => wrap(42)).not.toThrow();
+    expect(wrap(new DoubtfulToAry())).toEqual(new DoubtfulToAry().toAry());
   });
 });

--- a/packages/activesupport/src/core-ext/integer-ext.test.ts
+++ b/packages/activesupport/src/core-ext/integer-ext.test.ts
@@ -1,38 +1,31 @@
 import { describe, expect, it } from "vitest";
+import { Integer } from "./integer/multiple.js";
 import { ordinal, ordinalize } from "../inflector.js";
 
 describe("IntegerExtTest", () => {
+  const PRIME = 22953686867719691230002707821868552601124472329079n;
+
   it("multiple of", () => {
-    expect(4 % 4).toBe(0); // 4 is multiple of 4
-    expect(3 % 4).not.toBe(0); // 3 is not multiple of 4
-    expect(12 % 3).toBe(0); // 12 is multiple of 3
-    expect(13 % 3).not.toBe(0); // 13 is not multiple of 3
+    expect([-7, 0, 7, 14].every((i) => Integer.isMultipleOf(i, 7))).toBeTruthy();
+    expect([-7, 7, 14].some((i) => Integer.isMultipleOf(i, 6))).toBeFalsy();
+
+    // test the 0 edge case
+    expect(Integer.isMultipleOf(0, 0)).toBeTruthy();
+    expect(Integer.isMultipleOf(5, 0)).toBeFalsy();
+
+    // test with a prime
+    expect([2, 3, 5, 7].some((i) => Integer.isMultipleOf(PRIME, i))).toBeFalsy();
   });
 
   it("ordinalize", () => {
+    // These tests are mostly just to ensure that the ordinalize method exists.
+    // Its results are tested comprehensively in the inflector test cases.
     expect(ordinalize(1)).toBe("1st");
-    expect(ordinalize(2)).toBe("2nd");
-    expect(ordinalize(3)).toBe("3rd");
-    expect(ordinalize(4)).toBe("4th");
-    expect(ordinalize(11)).toBe("11th");
-    expect(ordinalize(12)).toBe("12th");
-    expect(ordinalize(13)).toBe("13th");
-    expect(ordinalize(21)).toBe("21st");
-    expect(ordinalize(1002)).toBe("1002nd");
-    expect(ordinalize(1003)).toBe("1003rd");
-    expect(ordinalize(-11)).toBe("-11th");
-    expect(ordinalize(-1)).toBe("-1st");
+    expect(ordinalize(8)).toBe("8th");
   });
 
   it("ordinal", () => {
     expect(ordinal(1)).toBe("st");
-    expect(ordinal(2)).toBe("nd");
-    expect(ordinal(3)).toBe("rd");
-    expect(ordinal(4)).toBe("th");
-    expect(ordinal(11)).toBe("th");
-    expect(ordinal(12)).toBe("th");
-    expect(ordinal(13)).toBe("th");
-    expect(ordinal(21)).toBe("st");
-    expect(ordinal(-1)).toBe("st");
+    expect(ordinal(8)).toBe("th");
   });
 });

--- a/packages/activesupport/src/core-ext/integer/multiple.ts
+++ b/packages/activesupport/src/core-ext/integer/multiple.ts
@@ -1,0 +1,31 @@
+/**
+ * Mirrors: active_support/core_ext/integer/multiple.rb
+ *
+ * Ruby reopens `Integer`; TypeScript cannot, so the reopening is a class of the
+ * Ruby name whose members take the receiver as the first parameter — the same
+ * idiom `core-ext/numeric/bytes.ts` uses for `Numeric`.
+ */
+
+export class Integer {
+  /**
+   * Check whether the integer is evenly divisible by the argument.
+   *
+   *   0.multiple_of?(0)  # => true
+   *   6.multiple_of?(5)  # => false
+   *   10.multiple_of?(2) # => true
+   *
+   * Ruby's `Integer` is arbitrary-precision, so the receiver can exceed
+   * `Number.MAX_SAFE_INTEGER` — where a `number` `%` would answer from a
+   * rounded double. `bigint` is that arm.
+   */
+  static isMultipleOf(self: number, number: number): boolean;
+  static isMultipleOf(self: bigint, number: bigint | number): boolean;
+  static isMultipleOf(self: number | bigint, number: number | bigint): boolean {
+    if (typeof self === "bigint" || typeof number === "bigint") {
+      const selfBig = BigInt(self);
+      const numberBig = BigInt(number);
+      return numberBig === 0n ? selfBig === 0n : selfBig % numberBig === 0n;
+    }
+    return number === 0 ? self === 0 : self % number === 0;
+  }
+}

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -2,7 +2,6 @@
  * Hash/object utilities mirroring Rails ActiveSupport hash extensions.
  */
 
-import { HashWithIndifferentAccess } from "./hash-with-indifferent-access.js";
 import { isBlank } from "./core-ext/object/blank.js";
 
 type AnyObject = Record<string, unknown>;
@@ -179,7 +178,11 @@ export function isExtractableOptions(self: unknown): boolean {
  */
 export function extractOptionsBang<T>(args: T[]): [T[], AnyObject] {
   const last = args[args.length - 1];
-  const isHash = isPlainObject(last) || last instanceof HashWithIndifferentAccess;
+  // Ruby's `last.is_a?(Hash)`: a plain object, or any Hash subclass — which in
+  // TS is an object declaring the `extractable_options?` override.
+  const isHash =
+    isPlainObject(last) ||
+    (last !== null && typeof last === "object" && "isExtractableOptions" in last);
   if (args.length > 0 && isHash && isExtractableOptions(last)) {
     return [args.slice(0, -1), last as unknown as AnyObject];
   }

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -175,11 +175,13 @@ export function isExtractableOptions(self: unknown): boolean {
  * Ruby's `extract_options!` mutates the receiver and returns only the options;
  * the args array is returned alongside it here because a TS caller has no
  * `pop`-in-place idiom for a rest parameter.
+ *
+ * Ruby's `last.is_a?(Hash)` guard (`core_ext/array/extract_options.rb:26`)
+ * admits every Hash subclass, which in TS is an object declaring the
+ * `extractable_options?` override.
  */
 export function extractOptionsBang<T>(args: T[]): [T[], AnyObject] {
   const last = args[args.length - 1];
-  // Ruby's `last.is_a?(Hash)`: a plain object, or any Hash subclass — which in
-  // TS is an object declaring the `extractable_options?` override.
   const isHash =
     isPlainObject(last) ||
     (last !== null && typeof last === "object" && "isExtractableOptions" in last);

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
@@ -12,12 +12,5 @@
     "rubyName": "in_groups",
     "call": "div",
     "reason": "Ruby `size.div number` is Integer#div, floor division as a METHOD (grouping.rb:66). JS has no method form for it — `Math.floor(array.length / n)` (array-utils.ts:94) is the whole of it — so the call cannot survive the port."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "array-utils.ts",
-    "rubyName": "in_groups_of",
-    "call": "new",
-    "reason": "Ruby's `Array.new(padding, fill_with)` (grouping.rb:38) builds the pad run; JS spells the same allocation as an array literal/`fill`, with no constructor call to match."
   }
 ]

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,8 +21,8 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 433,
-      "kind": 661,
+      "assertionCount": 429,
+      "kind": 656,
       "value": 65
     },
     "activerecord": {
@@ -31,9 +31,9 @@
       "value": 49
     },
     "activesupport": {
-      "assertionCount": 1090,
-      "kind": 1505,
-      "value": 139
+      "assertionCount": 1044,
+      "kind": 1475,
+      "value": 136
     },
     "arel": {
       "assertionCount": 180,


### PR DESCRIPTION
RFC 0105 assertion parity: rewrite the ported tests to assert what the Rails test asserts — same assertion kinds, in the same order, with the same literal expected values.

## Converged to 0 count/kind/value mismatches

- activesupport `core_ext/array/access_test.rb`, `array/extract_options_test.rb`, `array/grouping_test.rb`, `array/wrap_test.rb`, `integer_ext_test.rb`
- activemodel `validations/validations_context_test.rb`
- `core_ext/array/extract_test.rb` except `test_extract_without_block` — filed as `assertions-activesupport-array-extract-enumerator-arm`, since its `assert_instance_of Enumerator` has no counterpart until `extract!`'s `to_enum(:extract!) { size }` arm (`array/extract.rb:20`) is ported

`scripts/test-compare/assertion-mismatch-mark.json` lowered for activesupport (1090/1505/139 → 1044/1475/136) and activemodel (433/661 → 429/656). Only the two packages this PR touched were lowered.

## Port divergences the Rails assertions surfaced

Mirroring Rails' assertions turned up five real bugs, fixed here:

| trails | Rails |
| --- | --- |
| `Array#excluding` used `Array#includes` (identity), so `[[0,1],[1,0]].excluding([[1,0]])` kept both rows | `Array#-` compares with `eql?` (`array/access.rb:46`) |
| `Array#extract_options!` gated on `isPlainObject \|\| HashWithIndifferentAccess`, so an `OrderedOptions` (or any extractable Hash subclass) was never extracted | `last.is_a?(Hash) && last.extractable_options?` (`array/extract_options.rb:26`) |
| `Array.wrap` ignored the `to_ary` arm entirely | `object.to_ary \|\| [object]` (`array/wrap.rb:39-46`) |
| `Array#in_groups_of` did not raise on a non-positive group size | `raise ArgumentError` (`grouping.rb:22-25`) — converges a call-mismatch baseline row, deleted here |
| `in_groups_of` / `in_groups` took no block, which every Rails grouping test uses | `grouping.rb:34`, `:78`; the group-size parameter also regains its Rails name `number` |

`Integer#multiple_of?` (`integer/multiple.rb:9-11`) had no port at all — added at `core-ext/integer/multiple.ts`. It carries a `bigint` arm because the Rails test exercises it with a 50-digit prime, which a `number` `%` would answer from a rounded double.

## Scope

This is a partial burn-down of two of the four bundled stories, so it carries no `Closes-story` trailers — `assertions-activesupport-array-enumerable-and-numeric` still has `range_ext`, `enumerable`, `numeric_ext` and `array/conversions` open, and `assertions-activemodel-remaining-validations-second-pass` has seven files left. Both stay open. `assertions-activemodel-length-numericality-comparison` and `assertions-activemodel-remainder-second-pass` were not started and are released.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args`, `pnpm parity:api:extra --package activesupport` and the assertion ratchet are all green; activesupport, activemodel, actionpack, actionview and trailties suites pass locally (11,522 tests).