### PR TITLE
refactor(parity,activesupport,activerecord): Regexp flag equivalence, total ParameterFilter case-flag expansion, Relation Enumerable surface

### DIFF
--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -1,3 +1,4 @@
+import { groupBy } from "@blazetrails/activesupport";
 import type { Base } from "../../base.js";
 import type { Preloader } from "../preloader.js";
 import type { Association } from "./association.js";
@@ -19,16 +20,10 @@ export class Batch {
     // Empty preloaders are rejected in `call()` — `isEmpty()` is async because
     // it may materialize a Relation, mirroring Rails' `records.length`.
     this._preloaders = preloaders;
-    this._availableRecords = new Map();
-    for (const record of availableRecords.flat()) {
-      const klass = (record.constructor as typeof Base).baseClass;
-      const existing = this._availableRecords.get(klass);
-      if (existing) {
-        existing.push(record);
-      } else {
-        this._availableRecords.set(klass, [record]);
-      }
-    }
+    this._availableRecords = groupBy(
+      availableRecords.flat(),
+      (r) => (r.constructor as typeof Base).baseClass,
+    );
   }
 
   async call(): Promise<void> {

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Encryption::KeyProvider
  */
 
+import { groupBy } from "@blazetrails/activesupport";
 import { Key } from "./key.js";
 import { headerString } from "./encoding-helpers.js";
 import { Configurable } from "./configurable-slot.js";
@@ -40,14 +41,6 @@ export class KeyProvider {
 
   /** @internal */
   private keysGroupedById(): Map<string, Key[]> {
-    if (!this._keysGroupedById) {
-      this._keysGroupedById = new Map();
-      for (const key of this._keys) {
-        const group = this._keysGroupedById.get(key.id) ?? [];
-        group.push(key);
-        this._keysGroupedById.set(key.id, group);
-      }
-    }
-    return this._keysGroupedById;
+    return (this._keysGroupedById ??= groupBy(this._keys, (key) => key.id));
   }
 }

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -1021,7 +1021,12 @@ describe("Relation Enumerable surface (trails)", () => {
     const first = (await posts)[0] as any;
     expect((indexed[first.id] as any).id).toBe(first.id);
 
-    expect((await posts.compactBlank()).length).toBe(await posts.count());
+    // `reject(&:blank?)` over records (enumerable.rb:184-186): no persisted
+    // record is blank, so the identity of the survivors is what this pins —
+    // the same instances, in load order, not merely the same count.
+    const loaded = await posts;
+    expect(await posts.compactBlank()).toEqual(loaded);
+    expect((await CanonPost.where({ id: -1 }).compactBlank()).length).toBe(0);
   });
 
   it("presence returns the relation when records exist and null when none do", async () => {

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -999,3 +999,35 @@ describe("relation.rb:68 mixin ancestry", () => {
     expect(collisions.map(({ name, key }) => `${name}#${key}`)).toEqual([]);
   });
 });
+
+describe("Relation Enumerable surface (trails)", () => {
+  fixtures(["authors", "posts"]);
+
+  beforeAll(() => {
+    registerModel(CanonAuthor);
+    registerModel(CanonPost);
+  });
+
+  it("groups, indexes and compacts the loaded records the way Enumerable does", async () => {
+    const posts = CanonPost.where({ type: "Post" }).order("id");
+
+    const grouped = await posts.groupBy((post: any) => post.authorId);
+    expect([...grouped.keys()].sort()).toEqual(
+      [...new Set((await posts).map((post: any) => post.authorId))].sort(),
+    );
+    expect([...grouped.values()].flat().length).toBe(await posts.count());
+
+    const indexed = await posts.indexBy((post: any) => post.id as number);
+    const first = (await posts)[0] as any;
+    expect((indexed[first.id] as any).id).toBe(first.id);
+
+    expect((await posts.compactBlank()).length).toBe(await posts.count());
+  });
+
+  it("presence returns the relation when records exist and null when none do", async () => {
+    expect(await CanonPost.where({ id: -1 }).presence()).toBeNull();
+    const present = await CanonPost.all().presence();
+    expect(present).not.toBeNull();
+    expect((await present!.toArray()).length).toBe(await CanonPost.all().count());
+  });
+});

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -29,6 +29,9 @@ import {
   isPlainObject as _isPlainObject,
   wrap,
   any,
+  compactBlank as _compactBlank,
+  groupBy as _groupBy,
+  indexBy as _indexBy,
 } from "@blazetrails/activesupport";
 
 import { Range } from "./connection-adapters/postgresql/oid/range.js";
@@ -2218,10 +2221,11 @@ export class Relation<T extends Base> {
   /**
    * Return self if any records exist, null otherwise.
    *
-   * Mirrors: ActiveRecord::Relation#presence
+   * Mirrors: Object#presence (core_ext/object/blank.rb:45-47) — `present? ?
+   * self : nil`, reached on a Relation through `Relation#blank?`.
    */
   async presence(): Promise<LoadedRelation<Relation<T>> | null> {
-    return (await this.isAny()) ? stripThenable(this as Relation<T>) : null;
+    return (await this.isPresent()) ? stripThenable(this as Relation<T>) : null;
   }
 
   /**
@@ -2260,6 +2264,11 @@ export class Relation<T extends Base> {
    * because `find` on a Relation is the AR PK finder, not a block search.
    *
    * Mirrors: Enumerable#detect / #find (via Relation#include Enumerable)
+   *
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
+   *   `detect` has no `def` in any vendored gem because Ruby's core Enumerable
+   *   supplies it over `each`).
    */
   async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
     const records = await this.toArray();
@@ -2274,6 +2283,11 @@ export class Relation<T extends Base> {
    * evaluate the relation up front via `toArray()`.
    *
    * Mirrors: Enumerable#sort_by (via Relation#include Enumerable)
+   *
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
+   *   `sort_by` has no `def` in any vendored gem because Ruby's core Enumerable
+   *   supplies it over `each`).
    */
   async sortBy(key: (record: T) => any): Promise<T[]> {
     const records = await this.toArray();
@@ -2288,16 +2302,14 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Filter to only records where the given column is not null/undefined.
+   * Return the loaded records with the blank ones rejected. Loads first, for
+   * the same reason {@link sortBy} does.
    *
-   * Mirrors: Rails where.not(column: nil) pattern
+   * Mirrors: Enumerable#compact_blank (core_ext/enumerable.rb:184-186, via
+   * Relation#include Enumerable)
    */
-  compactBlank(...columns: string[]): Relation<T> {
-    let rel: Relation<T> = this;
-    for (const col of columns) {
-      rel = rel.whereNot({ [col]: null });
-    }
-    return rel;
+  async compactBlank(): Promise<T[]> {
+    return _compactBlank(await this.toArray());
   }
 
   // -- Terminal methods --
@@ -3149,40 +3161,28 @@ export class Relation<T extends Base> {
   // -- Collection convenience methods --
 
   /**
-   * Load records and group them by the value of a column or function.
+   * Load records and group them by the block's return value.
    *
-   * Mirrors: Enumerable#group_by (used on ActiveRecord::Relation)
+   * Mirrors: Enumerable#group_by (via Relation#include Enumerable)
+   *
+   * @noRailsEquivalent PERMANENT
+   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
+   *   `group_by` has no `def` in any vendored gem because Ruby's core Enumerable
+   *   supplies it over `each`).
    */
-  async groupByColumn(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T[]>> {
-    const records = await this.toArray();
-    const result: Record<string, T[]> = {};
-    for (const record of records) {
-      const key =
-        typeof keyOrFn === "string"
-          ? String(record.readAttribute(keyOrFn))
-          : String(keyOrFn(record));
-      if (!result[key]) result[key] = [];
-      result[key].push(record);
-    }
-    return result;
+  async groupBy<K>(fn: (record: T) => K): Promise<Map<K, T[]>> {
+    return _groupBy(await this.toArray(), fn);
   }
 
   /**
-   * Load records and index them by a column value (last wins on collision).
+   * Load records and index them by the block's return value (last wins on
+   * collision).
    *
-   * Mirrors: Enumerable#index_by (used on ActiveRecord::Relation)
+   * Mirrors: Enumerable#index_by (core_ext/enumerable.rb:52-60, via
+   * Relation#include Enumerable)
    */
-  async indexBy(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T>> {
-    const records = await this.toArray();
-    const result: Record<string, T> = {};
-    for (const record of records) {
-      const key =
-        typeof keyOrFn === "string"
-          ? String(record.readAttribute(keyOrFn))
-          : String(keyOrFn(record));
-      result[key] = record;
-    }
-    return result;
+  async indexBy<K extends string | number>(fn: (record: T) => K): Promise<Record<K, T>> {
+    return _indexBy(await this.toArray(), fn);
   }
 
   /** @internal */

--- a/packages/activesupport/src/parameter-filter.trails.test.ts
+++ b/packages/activesupport/src/parameter-filter.trails.test.ts
@@ -32,33 +32,38 @@ describe("ParameterFilter (trails)", () => {
     expect(seen).toEqual(["secret", "other"]);
   });
 
-  it("keeps a case-insensitive pattern the flag expansion cannot rewrite as its own Regexp", () => {
+  it("folds a case-insensitive pattern the flag expansion must rewrite into the one group Regexp", () => {
     // Ruby folds every pattern of a group into ONE Regexp with an inline
     // `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag
-    // group, so the port expands each cased character to `[aA]` — which is
-    // unsafe for a source carrying a character class, a Unicode property
-    // escape or a named group. Those keep their own `i`-flagged Regexp
-    // instead of being folded in, which is the one case where a group ends
-    // up with more than one Regexp.
-    const unexpandable = [/[xy]z/i, /\p{L}q/iu, /(?<tail>vw)/i];
-    for (const pattern of unexpandable) {
+    // group, so the port expands each cased character to `[aA]` — inside a
+    // character class in place, and widening `\p{Lu}` / `\p{Ll}` to `\p{L}`,
+    // since `(?i:)` scopes the flag to any sub-pattern.
+    for (const pattern of [/[xy]z/i, /\p{Lu}q/iu, /(?<tail>vw)/i, /[a-c]z/i]) {
       const precompiled = ParameterFilter.precompileFilters([/plain/, pattern]);
-      expect(precompiled).toContain(pattern);
-      expect(precompiled.length).toBe(2);
-      expect((precompiled[0] as RegExp).source).toBe("plain");
+      expect(precompiled.length).toBe(1);
+      expect(precompiled[0]).not.toBe(pattern);
     }
 
-    // Riding along as its own Regexp keeps the `i` flag, so `new
-    // ParameterFilter(precompiled)` still matches case-insensitively.
-    const filter = new ParameterFilter(ParameterFilter.precompileFilters([/[xy]z/i, "ccC"]));
+    const filter = new ParameterFilter(
+      ParameterFilter.precompileFilters([/[xy]z/i, /(?<tail>vw)/i, /[a-c]q/i, "ccC"]),
+    );
     expect(filter.filterParam("XZ", "v")).toBe("[FILTERED]");
+    expect(filter.filterParam("VW", "v")).toBe("[FILTERED]");
+    expect(filter.filterParam("BQ", "v")).toBe("[FILTERED]");
     expect(filter.filterParam("cCc", "v")).toBe("[FILTERED]");
     expect(filter.filterParam("zzz", "v")).toBe("v");
+    expect(filter.filterParam("dq", "v")).toBe("v");
+
+    // The property escape only means a property under `u`, so the joined
+    // Regexp carries the flag its members were written with.
+    const unicode = new ParameterFilter(ParameterFilter.precompileFilters([/\p{Lu}q/iu]));
+    expect(unicode.filterParam("aQ", "v")).toBe("[FILTERED]");
+    expect(unicode.filterParam("1q", "v")).toBe("v");
   });
 
-  it("keeps a deep case-insensitive pattern the flag expansion cannot rewrite as its own Regexp", () => {
+  it("folds a deep case-insensitive pattern the flag expansion must rewrite into the one group Regexp", () => {
     const precompiled = ParameterFilter.precompileFilters([/a\.a/, /[xy]\.z/i]);
-    expect(precompiled.length).toBe(2);
+    expect(precompiled.length).toBe(1);
     const filter = new ParameterFilter(precompiled);
     expect(filter.filter({ X: { Z: "v" } }).X).toEqual({ Z: "[FILTERED]" });
     expect(filter.filter({ a: { a: "v" } }).a).toEqual({ a: "[FILTERED]" });

--- a/packages/activesupport/src/parameter-filter.ts
+++ b/packages/activesupport/src/parameter-filter.ts
@@ -60,22 +60,34 @@ export class ParameterFilter {
    * `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag group,
    * so {@link ignoreCaseSource} spells the same matching case-sensitively —
    * each cased character expanded to a `[aA]` class — and the group is joined
-   * into ONE Regexp exactly as Rails'. A source that expansion cannot rewrite
-   * safely (a character class, a Unicode property escape, a named group or
-   * backreference) rides on as the caller's own Regexp after the joined one,
-   * rather than being folded into it.
+   * into ONE Regexp exactly as Rails'.
    */
   static precompileFilters(filters: Filter[]): Array<FilterProc | RegExp> {
-    const patterns: Array<{ source: string; ignoreCase: boolean; regexp?: RegExp }> = [];
+    const patterns: Array<{
+      source: string;
+      ignoreCase: boolean;
+      unicode: boolean;
+      unicodeSets: boolean;
+    }> = [];
     const compiled: Array<FilterProc | RegExp> = [];
 
     for (const filter of filters) {
       if (typeof filter === "function") {
         compiled.push(filter);
       } else if (filter instanceof RegExp) {
-        patterns.push({ source: filter.source, ignoreCase: filter.ignoreCase, regexp: filter });
+        patterns.push({
+          source: filter.source,
+          ignoreCase: filter.ignoreCase,
+          unicode: filter.flags.includes("u"),
+          unicodeSets: filter.flags.includes("v"),
+        });
       } else {
-        patterns.push({ source: escapeRegexp(String(filter)), ignoreCase: true });
+        patterns.push({
+          source: escapeRegexp(String(filter)),
+          ignoreCase: true,
+          unicode: false,
+          unicodeSets: false,
+        });
       }
     }
 
@@ -85,15 +97,18 @@ export class ParameterFilter {
     }
 
     for (const group of [patterns, deepPatterns]) {
-      const sources: string[] = [];
-      const unexpandable: RegExp[] = [];
-      for (const pattern of group) {
-        const source = pattern.ignoreCase ? ignoreCaseSource(pattern.source) : pattern.source;
-        if (source === null) unexpandable.push(pattern.regexp!);
-        else sources.push(source);
+      const sources = group.map((pattern) =>
+        pattern.ignoreCase
+          ? ignoreCaseSource(pattern.source, pattern.unicode || pattern.unicodeSets)
+          : pattern.source,
+      );
+      // A `\p{...}` escape only means a Unicode property under `u`/`v`; without
+      // it the escape is the letter `p`, which Ruby has no spelling for. Ruby's
+      // Regexp is always Unicode-aware, so the joined Regexp carries `u`
+      // whenever any member of the group was written with it.
+      if (sources.length > 0) {
+        compiled.push(new RegExp(sources.join("|"), unicodeFlag(group)));
       }
-      if (sources.length > 0) compiled.push(new RegExp(sources.join("|")));
-      compiled.push(...unexpandable);
     }
 
     return compiled;
@@ -219,42 +234,160 @@ export class ParameterFilter {
   }
 }
 
+/** The Unicode flag the joined Regexp of a group must carry: the widest one any
+ *  member was written with, since a `v` source is not always legal under `u`. */
+function unicodeFlag(group: Array<{ unicode: boolean; unicodeSets: boolean }>): string {
+  if (group.some((pattern) => pattern.unicodeSets)) return "v";
+  return group.some((pattern) => pattern.unicode) ? "u" : "";
+}
+
+/** A cased character spelled as the class matching both of its cases, or the
+ *  character unchanged when it has no other case. */
+function bothCases(char: string): string {
+  const lower = char.toLowerCase();
+  const upper = char.toUpperCase();
+  return lower === upper || lower.length !== 1 || upper.length !== 1 ? char : `[${lower}${upper}]`;
+}
+
+/**
+ * A Unicode property escape as `(?i:...)` matches it: Ruby case-folds the
+ * subject, so `\p{Lu}` matches a lowercase letter and `\p{Ll}` an uppercase one
+ * — both are `\p{L}` — while the negated `\P{Lu}` is the complement of that,
+ * `\P{L}`. Any other property is case-blind and passes through.
+ */
+function ignoreCaseProperty(property: string): string {
+  return property === "Lu" || property === "Ll" ? "L" : property;
+}
+
+/** The index of the `]` closing the character class open at `start`, or the end
+ *  of the source when it is unterminated. A `]` in the first member position is
+ *  a literal, as is one preceded by a backslash. */
+function classEnd(source: string, start: number): number {
+  let i = start + 1;
+  if (source[i] === "^") i++;
+  if (source[i] === "]") i++;
+  for (; i < source.length; i++) {
+    if (source[i] === "\\") i++;
+    else if (source[i] === "]") return i;
+  }
+  return source.length - 1;
+}
+
+/**
+ * A character class as `(?i:...)` matches it: each cased member gains its other
+ * case, in place, so `[xy]` is `[xXyY]` and a cased range gains the range of
+ * its folded endpoints, `[a-c]` → `[a-cA-C]`. Nesting `[aA]` is not an option
+ * here, which is why the member expansion is written out rather than reusing
+ * {@link bothCases}.
+ */
+function ignoreCaseClass(klass: string, unicode: boolean): string {
+  const negated = klass.startsWith("[^");
+  const body = klass.slice(negated ? 2 : 1, -1);
+  let out = "";
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === "\\") {
+      const next = body[i + 1];
+      if (unicode && (next === "p" || next === "P") && body[i + 2] === "{") {
+        const end = body.indexOf("}", i + 3);
+        if (end !== -1) {
+          out += `\\${next}{${ignoreCaseProperty(body.slice(i + 3, end))}}`;
+          i = end;
+          continue;
+        }
+      }
+      out += char + (next ?? "");
+      i++;
+      continue;
+    }
+    const to = body[i + 1] === "-" && i + 2 < body.length ? body[i + 2] : undefined;
+    if (to !== undefined) {
+      out += `${char}-${to}`;
+      const folded = `${swapCase(char)}-${swapCase(to)}`;
+      if (folded !== `${char}-${to}`) out += folded;
+      i += 2;
+      continue;
+    }
+    out += char;
+    const other = swapCase(char);
+    if (other !== char) out += other;
+  }
+  return `[${negated ? "^" : ""}${out}]`;
+}
+
+/** The character's other case, or the character itself when it has none. */
+function swapCase(char: string): string {
+  const lower = char.toLowerCase();
+  const upper = char.toUpperCase();
+  if (lower.length !== 1 || upper.length !== 1) return char;
+  return char === lower ? upper : lower;
+}
+
 /**
  * Ruby spells a case-insensitive alternative inline as `(?i:...)`
  * (parameter_filter.rb:59) so one Regexp can carry both case-sensitive and
  * case-insensitive parts. JS has no inline flag group, so the same matching is
  * spelled case-sensitively by expanding each cased character to a `[aA]` class.
  *
- * Returns null for a source whose letters are not all literal — a character
- * class (where `[aA]` cannot be nested and a range must not be expanded), a
- * Unicode property escape, a named group or a named backreference — where the
- * expansion would silently corrupt the pattern. `Regexp.escape`d strings, the
- * only sources Rails itself wraps in `(?i:...)`, never contain any of them.
+ * Total, so `precompileFilters` emits one Regexp per group for every input
+ * exactly as `Regexp.new(patterns.join("|"))` does (parameter_filter.rb:64-65).
+ * The spans where a letter is not a pattern letter are copied verbatim: the
+ * `<name>` of a named group (`(?<name>`, but not the lookbehinds `(?<=` /
+ * `(?<!`) or of a named backreference (`\k<name>`). A character class and a
+ * Unicode property escape expand under their own rules
+ * ({@link ignoreCaseClass}, {@link ignoreCaseProperty}).
  */
-function ignoreCaseSource(source: string): string | null {
+function ignoreCaseSource(source: string, unicode: boolean): string {
   let out = "";
   for (let i = 0; i < source.length; i++) {
     const char = source[i];
     if (char === "\\") {
       const next = source[i + 1];
-      if (next === "p" || next === "P" || next === "k") return null;
+      if (unicode && (next === "p" || next === "P") && source[i + 2] === "{") {
+        const end = source.indexOf("}", i + 3);
+        if (end !== -1) {
+          out += `\\${next}{${ignoreCaseProperty(source.slice(i + 3, end))}}`;
+          i = end;
+          continue;
+        }
+      }
+      if (next === "k" && source[i + 2] === "<") {
+        const end = source.indexOf(">", i + 3);
+        if (end !== -1) {
+          out += source.slice(i, end + 1);
+          i = end;
+          continue;
+        }
+      }
       out += char + (next ?? "");
       i++;
       continue;
     }
-    if (char === "[") return null;
-    if (source.startsWith("(?<", i) && source[i + 3] !== "=" && source[i + 3] !== "!") return null;
-    const lower = char.toLowerCase();
-    const upper = char.toUpperCase();
-    out +=
-      lower === upper || lower.length !== 1 || upper.length !== 1 ? char : `[${lower}${upper}]`;
+    if (char === "[") {
+      const end = classEnd(source, i);
+      out += ignoreCaseClass(source.slice(i, end + 1), unicode);
+      i = end;
+      continue;
+    }
+    if (source.startsWith("(?<", i) && source[i + 3] !== "=" && source[i + 3] !== "!") {
+      const end = source.indexOf(">", i + 3);
+      if (end !== -1) {
+        out += source.slice(i, end + 1);
+        i = end;
+        continue;
+      }
+    }
+    out += bothCases(char);
   }
   return out;
 }
 
-/** Mirrors Ruby's `Regexp.escape`, which JS has no built-in for. */
+/** Mirrors Ruby's `Regexp.escape`, which JS has no built-in for. `-` is left
+ *  alone: it is literal outside a character class in both languages, and `\-`
+ *  is not a legal identity escape under a `u`-flagged JS Regexp, which
+ *  {@link ParameterFilter.precompileFilters} can join an escaped string into. */
 function escapeRegexp(source: string): string {
-  return source.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Ruby's `value.is_a?(Hash)` — a plain object, not a class instance. */

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -330,6 +330,18 @@ describe("compareCallArgs Regexp flag argument", () => {
     expect(result.class).toBe("shape");
   });
 
+  it("skips a site whose flag argument is an OR of option constants", () => {
+    // extract-ruby-api.rb:2580 describes `Regexp::IGNORECASE | Regexp::MULTILINE`
+    // as the bare `binop:|`, an OPAQUE descriptor — the operands are gone, so
+    // the site is uncomparable rather than a mismatch.
+    const result = compareCallArgs(
+      regexpNew(["id:source", "binop:|"]),
+      site("constructor", ["id:source", "str:is"]),
+    );
+    expect(result.verdict).toBe("skip");
+    expect(result.reason).toBe("opaqueRubyArg");
+  });
+
   it("scopes the equivalence to the flag position", () => {
     expect(compareCallArgs(regexpNew(["bool:true"]), site("constructor", ["str:i"])).verdict).toBe(
       "mismatch",

--- a/scripts/api-compare/call-args.test.ts
+++ b/scripts/api-compare/call-args.test.ts
@@ -264,6 +264,79 @@ describe("compareCallArgs built-in receiver as argument 1", () => {
   });
 });
 
+describe("compareCallArgs Regexp flag argument", () => {
+  // parameter_filter.rb:121 `Regexp.new(strings.join("|"), true)`, ported as
+  // `new RegExp(strings.join("|"), "i")`.
+  const regexpNew = (args: string[]): CallSite => ({
+    ...site("new", args),
+    recv: "const:Regexp",
+  });
+
+  it("reads Ruby's ignore-case boolean as the JS i flag", () => {
+    expect(
+      compareCallArgs(
+        regexpNew(["call:join", "bool:true"]),
+        site("constructor", ["call:join", "str:i"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("reads Regexp::IGNORECASE the same way", () => {
+    expect(
+      compareCallArgs(
+        regexpNew(["id:source", "const:Regexp::IGNORECASE"]),
+        site("constructor", ["id:source", "str:i"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("reads Regexp::MULTILINE as the JS s flag", () => {
+    expect(
+      compareCallArgs(
+        regexpNew(["id:source", "const:Regexp::MULTILINE"]),
+        site("constructor", ["id:source", "str:s"]),
+      ).verdict,
+    ).toBe("match");
+    expect(
+      compareCallArgs(
+        regexpNew(["id:source", "const:Regexp::MULTILINE"]),
+        site("constructor", ["id:source", "str:m"]),
+      ).verdict,
+    ).toBe("mismatch");
+  });
+
+  it("compares flag strings letter-set-wise", () => {
+    expect(
+      compareCallArgs(
+        regexpNew(["id:source", "str:im"]),
+        site("constructor", ["id:source", "str:mi"]),
+      ).verdict,
+    ).toBe("match");
+  });
+
+  it("still flags a dropped flag argument", () => {
+    expect(
+      compareCallArgs(regexpNew(["call:join", "bool:true"]), site("constructor", ["call:join"]))
+        .verdict,
+    ).toBe("mismatch");
+  });
+
+  it("scopes the equivalence to Regexp construction", () => {
+    const result = compareCallArgs(
+      site("match_filter", ["id:source", "bool:true"]),
+      site("matchFilter", ["id:source", "str:i"]),
+    );
+    expect(result.verdict).toBe("mismatch");
+    expect(result.class).toBe("shape");
+  });
+
+  it("scopes the equivalence to the flag position", () => {
+    expect(compareCallArgs(regexpNew(["bool:true"]), site("constructor", ["str:i"])).verdict).toBe(
+      "mismatch",
+    );
+  });
+});
+
 describe("compareCallArgs ported-private receiver argument", () => {
   const required = (name: string, type?: string): ParamInfo => ({ name, kind: "required", type });
 

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -763,6 +763,14 @@ const RUBY_REGEXP_OPTIONS: Record<string, string> = {
  * `Regexp::IGNORECASE`. JS spells the same argument as a flag string, so the
  * faithful port passes `"i"`. Same argument, same meaning, one letter of
  * language punctuation between them.
+ *
+ * An OR of two option constants is out of reach here, and structurally rather
+ * than by omission: extract-ruby-api.rb:2580 describes any `|` expression as
+ * the bare operator (`binop:|`) with its operands discarded, and `binop:` is an
+ * OPAQUE descriptor, so such a site is SKIPPED as uncomparable long before this
+ * function sees it. Recovering it would mean widening the extractor's
+ * descriptor grammar for every consumer; no vendored Rails call site spells the
+ * flag that way.
  */
 function regexpFlagKey(key: string): string | undefined {
   if (key === "bool:true") return "reflags:i";

--- a/scripts/api-compare/call-args.ts
+++ b/scripts/api-compare/call-args.ts
@@ -737,6 +737,63 @@ function keptSymbolColon(rubyKey: string, tsKey: string): boolean {
   return rubyKey.startsWith("str:") && tsKey === `str::${rubyKey.slice("str:".length)}`;
 }
 
+/** The Ruby `Regexp.new` receiver, in `CallSite.recv` spelling. `Regexp.new`
+ *  is the ONLY call whose flag argument the two languages spell differently,
+ *  so the equivalence below is scoped to it. */
+const REGEXP_RECEIVER = "const:Regexp";
+
+/** Ruby's Regexp option constants, and the JS flag letter each one means.
+ *  Ruby `MULTILINE` is dot-matches-newline, which JS spells `s` — JS `m` is
+ *  Ruby's default anchor behaviour and has no Ruby constant. `EXTENDED` has no
+ *  JS equivalent at all and is deliberately absent, so a site passing it keeps
+ *  reporting rather than comparing equal to some other flag string. */
+const RUBY_REGEXP_OPTIONS: Record<string, string> = {
+  "Regexp::IGNORECASE": "i",
+  "Regexp::MULTILINE": "s",
+};
+
+/**
+ * The canonical flag descriptor for one `Regexp.new` / `new RegExp` flag
+ * argument, or undefined when the argument is not a flag spelling either
+ * language sanctions.
+ *
+ * Ruby's second `Regexp.new` argument is the option argument, and any truthy
+ * value means IGNORECASE — `Regexp.new(strings.join("|"), true)`
+ * (activesupport/lib/active_support/parameter_filter.rb:121-122) is exactly
+ * `Regexp::IGNORECASE`. JS spells the same argument as a flag string, so the
+ * faithful port passes `"i"`. Same argument, same meaning, one letter of
+ * language punctuation between them.
+ */
+function regexpFlagKey(key: string): string | undefined {
+  if (key === "bool:true") return "reflags:i";
+  if (key === "bool:false" || key === "nil") return "reflags:";
+  if (key.startsWith("const:")) {
+    const flag = RUBY_REGEXP_OPTIONS[key.slice("const:".length)];
+    return flag === undefined ? undefined : `reflags:${flag}`;
+  }
+  if (key.startsWith("str:")) {
+    const flags = key.slice("str:".length);
+    return /^[dgimsuvy]*$/.test(flags) ? `reflags:${[...flags].sort().join("")}` : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * An argument list with a Regexp construction's flag argument rewritten to its
+ * canonical descriptor, so Ruby's flag boolean and JS's flag string compare
+ * equal (RFC 0106).
+ *
+ * Scoped to `Regexp.new` — the equivalence is a property of that constructor's
+ * second argument, not of `true` and `"i"`, and a global one would mask a
+ * genuine changed-literal defect anywhere else. A flag spelling neither side
+ * sanctions is left alone and still reports.
+ */
+function withRegexpFlagKeys(ruby: CallSite, args: string[]): string[] {
+  if (ruby.name !== "new" || ruby.recv !== REGEXP_RECEIVER || args.length < 2) return args;
+  const flag = regexpFlagKey(args[1]);
+  return flag === undefined ? args : [args[0], flag, ...args.slice(2)];
+}
+
 function argsEqual(rubyArgs: string[], tsArgs: string[]): boolean {
   return (
     rubyArgs.length === tsArgs.length && rubyArgs.every((arg, i) => argKeysEqual(arg, tsArgs[i]))
@@ -1113,8 +1170,9 @@ export function compareCallArgs(
   }
   const tsArgs = stripBlockTailPadding(ruby, ts, rubyArgs, normalizedTs, calleeSigs);
 
-  const compared = resolveCalleeRefs(rubyArgs, enclosingRubyName);
-  if (argsEqual(compared, tsArgs)) {
+  const compared = withRegexpFlagKeys(ruby, resolveCalleeRefs(rubyArgs, enclosingRubyName));
+  const comparedTs = withRegexpFlagKeys(ruby, tsArgs);
+  if (argsEqual(compared, comparedTs)) {
     const alignedRuby = aligned.rubyArgs === ruby.args ? aligned.rubyArgs : undefined;
     if (
       alignedRuby === undefined ||
@@ -1124,5 +1182,5 @@ export function compareCallArgs(
     }
     return { verdict: "mismatch", class: "shape", rubyArgs, tsArgs };
   }
-  return { verdict: "mismatch", class: classify(compared, tsArgs), rubyArgs, tsArgs };
+  return { verdict: "mismatch", class: classify(compared, comparedTs), rubyArgs, tsArgs };
 }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/parameter-filter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/parameter-filter.json
@@ -2,13 +2,12 @@
   {
     "package": "activesupport",
     "tsFile": "parameter-filter.ts",
-    "rubyName": "compile_filters!",
+    "rubyName": "precompile_filters",
     "call": "new",
     "kind": "args",
     "rubyArgs": [
-      "ref:join",
-      "bool:true"
+      "ref:join"
     ],
-    "reason": "`Regexp.new(strings.join(\"|\"), true)` (parameter_filter.rb:121-122) — Ruby's second Regexp argument is the ignore-case boolean; the JS constructor's second argument is a flag string, so `\"i\"` is the same argument spelled the way the language spells it. Irreducible language shortcoming, demonstrated under burn-down-parameter-filter-regexp-and-block-deviations (RFC 0098): the flag is whole-pattern in both languages here, so there is no closer spelling."
+    "reason": "`Regexp.new(patterns.join(\"|\"))` (parameter_filter.rb:64-65) — a Ruby Regexp is Unicode-aware with no flag to say so, while a JS Regexp only reads `\\p{...}` as a property escape under an explicit `u`/`v` flag. The port's second argument spells the property Ruby's constructor has implicitly, so the joined group Regexp keeps the semantics of the members it folds in; there is no one-argument JS spelling of it."
   }
 ]

--- a/scripts/api-compare/receiver-as-first-arg.ts
+++ b/scripts/api-compare/receiver-as-first-arg.ts
@@ -80,4 +80,9 @@ export const RECEIVER_AS_FIRST_ARG = new Set([
   // active_support/core_ext/hash/indifferent_access.rb — `hash.with_indifferent_access`,
   // exported by @blazetrails/activesupport as `withIndifferentAccess(obj)`.
   "with_indifferent_access",
+  // Ruby core `Enumerable#group_by` — `records.group_by { … }`. JS has no
+  // `Array.prototype` analogue (`Object.groupBy` keys by string coercion, which
+  // Ruby's Hash does not), so @blazetrails/activesupport exports it as
+  // `groupBy(collection, block)` and the receiver is TS argument 1.
+  "group_by",
 ]);


### PR DESCRIPTION
Three bundled stories.

## teach-call-args-regexp-flag-equivalence (RFC 0106)

`compareCallArgs` now canonicalizes the flag argument of a Regexp construction,
so Ruby's `Regexp.new(strings.join("|"), true)` (parameter_filter.rb:121-122)
and the port's `new RegExp(strings.join("|"), "i")` compare equal. The
equivalence is scoped to `Regexp.new` (`recv` is `const:Regexp`) and to the flag
position — `bool:true` vs `str:i` on any other call, or in any other slot, still
reports a `shape` row. `Regexp::IGNORECASE` maps to `i` and `Regexp::MULTILINE`
to JS's `s` (dot-matches-newline; JS `m` is a different flag, verified against
MRI); `EXTENDED` has no JS spelling and deliberately does not compare equal.
Covered by seven cases in `scripts/api-compare/call-args.test.ts`; the
`compile_filters!` row is gone from the baseline.

## make-parameter-filter-case-flag-expansion-total (RFC 0098)

`ignoreCaseSource` is total, so `precompileFilters` emits exactly ONE Regexp per
group for every input, as `Regexp.new(patterns.join("|"))` does
(parameter_filter.rb:64-65), and the `unexpandable` array is gone:

- character class: cased members expand in place (`[xy]` → `[xXyY]`), a cased
  range endpoint-wise (`[a-c]` → `[a-cA-C]`), negation preserved;
- `\p{Lu}` / `\p{Ll}` widen to `\p{L}` — and `\P{Lu}` to `\P{L}`, which is what
  MRI actually does (`/\P{Lu}/i.match?("A") == false`);
- a named group's / backreference's `<name>` span copies verbatim.

A property escape only means a property under `u`/`v`, so the joined group
Regexp carries the widest Unicode flag its members were written with. That is
the second argument the one remaining baseline row in
`call-mismatches-exclude/activesupport/parameter-filter.json` covers: Ruby's
Regexp is Unicode-aware with no flag to say so, and there is no one-argument JS
spelling of it. `escapeRegexp` no longer escapes `-` (literal outside a class in
both languages, and `\-` is not a legal identity escape under `u`).

## resolve-relation-enumerable-delegation-surface (RFC 0107)

- `groupByColumn` → `groupBy`, the Ruby name, delegating to activesupport's
  `groupBy`; the invented string-column arm is gone (it had no callers).
- `indexBy` and `compactBlank` route through the activesupport Enumerable
  functions. `compactBlank`'s old body was `where.not(col: nil)` under an
  Enumerable name — it is now `Enumerable#compact_blank` over the loaded
  records (also callerless before).
- `presence` reads `present?`, as `Object#presence` does.
- `detect` / `sortBy` / `groupBy` have no `def` in any vendored gem (core
  Enumerable over `each`), so they carry `@noRailsEquivalent PERMANENT` with the
  `relation.rb:67 include Enumerable` citation. `relation.ts` novel surface:
  10 → 7.
- `sample` / `rindex` / `shuffle` / `toFormattedS` are on Rails' actual
  `delegate ... to: :records` list (delegation.rb:99-102) and are unchanged.

Adding `Relation#groupBy` enrolled Ruby `group_by` into the call-gate
population, surfacing two pre-existing divergences: `Preloader::Batch#initialize`
and `KeyProvider#keys_grouped_by_id` both hand-rolled the grouping. Both now
call `groupBy`, and `group_by` joins `RECEIVER_AS_FIRST_ARG` (Ruby core
Enumerable, exported as a free function because JS has no `Array.prototype`
analogue).

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api` /
`parity:test` unchanged, lint and typecheck clean, `relation/` + preloader +
collection-proxy + encryption + parameter-filter suites pass.

Closes-story: teach-call-args-regexp-flag-equivalence
Closes-story: make-parameter-filter-case-flag-expansion-total
Closes-story: resolve-relation-enumerable-delegation-surface