### PR TITLE
refactor(activesupport): port date_time/calculations.rb onto its own DateTime receiver

### DIFF
--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./date-time/calculations.js";
 import { setFrozenTime } from "../time-travel.js";
 import { setZone } from "../time-zone-config.js";
+import { ArgumentError } from "../hash-utils.js";
 import {
   advance as timeAdvance,
   civilFromFormat,
@@ -179,6 +180,17 @@ describe("DateTimeExtCalculationsTest", () => {
     expect(change(dt(2005, 2, 22, 15, 15, 10.7), { day: 1 }).toString()).toBe(
       dt(2005, 2, 1, 15, 15, 10.7).toString(),
     );
+    expect(change(dt(2005, 1, 2, 11, 22, 33), { usec: 8 }).toString()).toBe(
+      dt(2005, 1, 2, 11, 22, new Rational(33000008, 1000000)).toString(),
+    );
+    expect(change(dt(2005, 1, 2, 11, 22, 33), { nsec: 8000 }).toString()).toBe(
+      dt(2005, 1, 2, 11, 22, new Rational(33000008, 1000000)).toString(),
+    );
+    expect(() => change(dt(2005, 1, 2, 11, 22, 0), { usec: 1, nsec: 1 })).toThrow(ArgumentError);
+    expect(() => change(dt(2005, 1, 2, 11, 22, 0), { usec: 1000000 })).toThrow(ArgumentError);
+    expect(() => change(dt(2005, 1, 2, 11, 22, 0), { nsec: 1000000000 })).toThrow(ArgumentError);
+    expect(() => change(dt(2005, 1, 2, 11, 22, 0), { usec: 999999 })).not.toThrow();
+    expect(() => change(dt(2005, 1, 2, 11, 22, 0), { nsec: 999999999 })).not.toThrow();
   });
 
   it("advance partial days", () => {
@@ -562,5 +574,22 @@ describe("DateTimeExtCalculationsTest", () => {
     expect(advance(receiver(), { seconds: 9 }).toString()).toBe(
       dt(2005, 2, 28, 15, 15, 19).toString(),
     );
+    expect(advance(receiver(), { hours: 5, minutes: 7, seconds: 9 }).toString()).toBe(
+      dt(2005, 2, 28, 20, 22, 19).toString(),
+    );
+    expect(advance(receiver(), { hours: -5, minutes: -7, seconds: -9 }).toString()).toBe(
+      dt(2005, 2, 28, 10, 8, 1).toString(),
+    );
+    expect(
+      advance(receiver(), {
+        years: 7,
+        months: 19,
+        weeks: 2,
+        days: 5,
+        hours: 5,
+        minutes: 7,
+        seconds: 9,
+      }).toString(),
+    ).toBe(dt(2013, 10, 17, 20, 22, 19).toString());
   });
 });

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -1,20 +1,28 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { Temporal } from "@blazetrails/date";
-import { current } from "./date-time/calculations.js";
-import { setFrozenTime } from "../time-travel.js";
-import { setZone } from "../time-zone-config.js";
+import { DateTime, Rational, Temporal } from "@blazetrails/date";
 import {
   advance,
-  civilFromFormat,
   ago,
   beginningOfDay,
   beginningOfHour,
   beginningOfMinute,
-  beginningOfQuarter,
   change,
+  current,
   endOfDay,
   endOfHour,
   endOfMinute,
+  middleOfDay,
+  secondsSinceMidnight,
+  secondsUntilEndOfDay,
+  since,
+  subsec,
+} from "./date-time/calculations.js";
+import { setFrozenTime } from "../time-travel.js";
+import { setZone } from "../time-zone-config.js";
+import {
+  advance as timeAdvance,
+  civilFromFormat,
+  beginningOfQuarter,
   endOfMonth,
   formattedOffset,
   isFuture,
@@ -23,13 +31,9 @@ import {
   isTomorrow,
   isYesterday,
   lastWeek,
-  middleOfDay,
   nextDay,
   nsec,
   prevDay,
-  secondsSinceMidnight,
-  secondsUntilEndOfDay,
-  since,
   toDate,
   toFs,
   toTime,
@@ -49,6 +53,21 @@ function asDate(instant: Temporal.Instant): Date {
 function d(year: number, month: number, day: number, hour = 0, min = 0, sec = 0, ms = 0): Date {
   return new Date(year, month - 1, day, hour, min, sec, ms);
 }
+
+/** `DateTime.civil`, the receiver every `date_time/calculations.rb` member takes. */
+function dt(
+  year: number,
+  month = 1,
+  day = 1,
+  hour = 0,
+  min = 0,
+  sec: number | Rational = 0,
+): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+  return DateTime.civil(year, month, day, hour, min, sec);
+}
+
+/** The end-of-period second `Rational(999999999, 1000)` usec lands on. */
+const END_OF_PERIOD_SEC = new Rational(59999999999, 1000000000);
 
 describe("DateTimeExtCalculationsTest", () => {
   it("to fs", () => {
@@ -113,22 +132,21 @@ describe("DateTimeExtCalculationsTest", () => {
   });
 
   it("middle of day", () => {
-    const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = asDate(middleOfDay(dt));
-    expect(result.getHours()).toBe(12);
-    expect(result.getMinutes()).toBe(0);
+    expect(middleOfDay(dt(2005, 2, 4, 10, 10, 10)).toString()).toBe(
+      dt(2005, 2, 4, 12, 0, 0).toString(),
+    );
   });
 
   it("beginning of minute", () => {
-    const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = asDate(beginningOfMinute(dt));
-    expect(result.getSeconds()).toBe(0);
+    expect(beginningOfMinute(dt(2005, 2, 4, 19, 30, 10)).toString()).toBe(
+      dt(2005, 2, 4, 19, 30, 0).toString(),
+    );
   });
 
   it("end of minute", () => {
-    const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = asDate(endOfMinute(dt));
-    expect(result.getSeconds()).toBe(59);
+    expect(endOfMinute(dt(2005, 2, 4, 19, 30, 10)).toString()).toBe(
+      dt(2005, 2, 4, 19, 30, END_OF_PERIOD_SEC).toString(),
+    );
   });
 
   it("end of month", () => {
@@ -138,23 +156,63 @@ describe("DateTimeExtCalculationsTest", () => {
   });
 
   it("change", () => {
-    const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(change(dt, { year: 2006 }));
-    expect(result.getFullYear()).toBe(2006);
+    const receiver = dt(2005, 2, 22, 15, 15, 10);
+    expect(change(receiver, { year: 2006 }).toString()).toBe(
+      dt(2006, 2, 22, 15, 15, 10).toString(),
+    );
+    expect(change(receiver, { month: 6 }).toString()).toBe(dt(2005, 6, 22, 15, 15, 10).toString());
+    expect(change(receiver, { year: 2012, month: 9 }).toString()).toBe(
+      dt(2012, 9, 22, 15, 15, 10).toString(),
+    );
+    expect(change(receiver, { hour: 16 }).toString()).toBe(dt(2005, 2, 22, 16).toString());
+    expect(change(receiver, { hour: 16, min: 45 }).toString()).toBe(
+      dt(2005, 2, 22, 16, 45).toString(),
+    );
+    expect(change(receiver, { min: 45 }).toString()).toBe(dt(2005, 2, 22, 15, 45).toString());
+
+    // datetime with non-zero offset
+    expect(change(dt(2005, 2, 22, 15, 15, 10), { offset: new Rational(-5, 24) }).toString()).toBe(
+      DateTime.civil(2005, 2, 22, 15, 15, 10, new Rational(-5, 24)).toString(),
+    );
+
+    // datetime with fractions of a second
+    expect(change(dt(2005, 2, 22, 15, 15, 10.7), { day: 1 }).toString()).toBe(
+      dt(2005, 2, 1, 15, 15, 10.7).toString(),
+    );
   });
 
   it("advance partial days", () => {
-    const dt = d(2005, 2, 22, 15, 15, 10);
-    const result = asDate(advance(dt, { hours: 12 }));
-    expect(result.getDate()).toBe(23);
-    expect(result.getHours()).toBe(3);
+    expect(advance(dt(2012, 9, 28, 1, 15, 10), { days: 1.5 }).toString()).toBe(
+      dt(2012, 9, 29, 13, 15, 10).toString(),
+    );
+    expect(advance(dt(2012, 9, 28, 1, 15, 10), { days: 0.5 }).toString()).toBe(
+      dt(2012, 9, 28, 13, 15, 10).toString(),
+    );
+    expect(advance(dt(2012, 9, 28, 1, 15, 10), { days: 1.5, months: 1 }).toString()).toBe(
+      dt(2012, 10, 29, 13, 15, 10).toString(),
+    );
   });
 
   it("advanced processes first the date deltas and then the time deltas", () => {
-    const dt = d(2005, 2, 28, 15, 15, 10);
-    const result = asDate(advance(dt, { months: 1, days: 1 }));
-    expect(result.getMonth()).toBe(2); // March
-    expect(result.getDate()).toBe(29);
+    // If the time deltas were processed first, the following datetimes would be
+    // advanced to 2010/04/01 instead.
+    expect(advance(dt(2010, 2, 28, 23, 59, 59), { months: 1, seconds: 1 }).toString()).toBe(
+      dt(2010, 3, 29).toString(),
+    );
+    expect(advance(dt(2010, 2, 28, 23, 59), { months: 1, minutes: 1 }).toString()).toBe(
+      dt(2010, 3, 29).toString(),
+    );
+    expect(advance(dt(2010, 2, 28, 23), { months: 1, hours: 1 }).toString()).toBe(
+      dt(2010, 3, 29).toString(),
+    );
+    expect(
+      advance(dt(2010, 2, 28, 22, 58, 59), {
+        months: 1,
+        hours: 1,
+        minutes: 1,
+        seconds: 1,
+      }).toString(),
+    ).toBe(dt(2010, 3, 29).toString());
   });
 
   it("last week", () => {
@@ -174,7 +232,7 @@ describe("DateTimeExtCalculationsTest", () => {
   it("last quarter on 31st", () => {
     const dt = d(2005, 10, 31, 10, 10, 10);
     const quarterStart = beginningOfQuarter(dt);
-    const lastQuarterStart = asDate(advance(asDate(quarterStart), { months: -3 }));
+    const lastQuarterStart = asDate(timeAdvance(asDate(quarterStart), { months: -3 }));
     expect(lastQuarterStart.getMonth()).toBe(6); // July
   });
 
@@ -388,33 +446,35 @@ describe("DateTimeExtCalculationsTest", () => {
   });
 
   it("subsec", () => {
-    const dt = new Date(2005, 1, 22, 10, 10, 10, 500);
-    const subsec = dt.getMilliseconds() / 1000;
-    expect(subsec).toBeCloseTo(0.5);
+    expect(subsec(dt(2000))).toBe(0);
+    expect(subsec(dt(2000, 1, 1, 0, 0, new Rational(1, 2)))).toBe(0.5);
   });
 
   it("seconds since midnight", () => {
-    const dt = d(2005, 2, 4, 1, 30, 0);
-    expect(secondsSinceMidnight(dt)).toBe(5400);
+    expect(secondsSinceMidnight(dt(2005, 1, 1, 0, 0, 1))).toBe(1);
+    expect(secondsSinceMidnight(dt(2005, 1, 1, 0, 1, 0))).toBe(60);
+    expect(secondsSinceMidnight(dt(2005, 1, 1, 1, 1, 0))).toBe(3660);
+    expect(secondsSinceMidnight(dt(2005, 1, 1, 23, 59, 59))).toBe(86399);
   });
 
   it("seconds until end of day", () => {
-    const dt = d(2005, 2, 4, 23, 59, 59);
-    expect(secondsUntilEndOfDay(dt)).toBe(0);
+    expect(secondsUntilEndOfDay(dt(2005, 1, 1, 23, 59, 59))).toBe(0);
+    expect(secondsUntilEndOfDay(dt(2005, 1, 1, 23, 59, 58))).toBe(1);
+    expect(secondsUntilEndOfDay(dt(2005, 1, 1, 23, 58, 59))).toBe(60);
+    expect(secondsUntilEndOfDay(dt(2005, 1, 1, 22, 58, 59))).toBe(3660);
+    expect(secondsUntilEndOfDay(dt(2005, 1, 1, 0, 0, 0))).toBe(86399);
   });
 
   it("beginning of hour", () => {
-    const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = asDate(beginningOfHour(dt));
-    expect(result.getHours()).toBe(19);
-    expect(result.getMinutes()).toBe(0);
+    expect(beginningOfHour(dt(2005, 2, 4, 19, 30, 10)).toString()).toBe(
+      dt(2005, 2, 4, 19, 0, 0).toString(),
+    );
   });
 
   it("end of hour", () => {
-    const dt = d(2005, 2, 4, 19, 30, 10);
-    const result = asDate(endOfHour(dt));
-    expect(result.getHours()).toBe(19);
-    expect(result.getMinutes()).toBe(59);
+    expect(endOfHour(dt(2005, 2, 4, 19, 30, 10)).toString()).toBe(
+      dt(2005, 2, 4, 19, 59, END_OF_PERIOD_SEC).toString(),
+    );
   });
 
   it("prev day with offset", () => {
@@ -432,30 +492,75 @@ describe("DateTimeExtCalculationsTest", () => {
   });
 
   it("beginning of day", () => {
-    const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = asDate(beginningOfDay(dt));
-    expect(result.getHours()).toBe(0);
+    expect(beginningOfDay(dt(2005, 2, 4, 10, 10, 10)).toString()).toBe(
+      dt(2005, 2, 4, 0, 0, 0).toString(),
+    );
   });
 
   it("end of day", () => {
-    const dt = d(2005, 2, 4, 10, 10, 10);
-    const result = asDate(endOfDay(dt));
-    expect(result.getHours()).toBe(23);
-    expect(result.getMinutes()).toBe(59);
+    expect(endOfDay(dt(2005, 2, 4, 10, 10, 10)).toString()).toBe(
+      dt(2005, 2, 4, 23, 59, END_OF_PERIOD_SEC).toString(),
+    );
   });
 
   it("ago", () => {
-    const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(asDate(ago(dt, 1))).toEqual(d(2005, 2, 22, 10, 10, 9));
+    const receiver = dt(2005, 2, 22, 10, 10, 10);
+    expect(ago(receiver, 1).toString()).toBe(dt(2005, 2, 22, 10, 10, 9).toString());
+    expect(ago(receiver, 3600).toString()).toBe(dt(2005, 2, 22, 9, 10, 10).toString());
+    expect(ago(receiver, 86400 * 2).toString()).toBe(dt(2005, 2, 20, 10, 10, 10).toString());
+    expect(ago(receiver, 86400 * 2 + 3600 + 25).toString()).toBe(
+      dt(2005, 2, 20, 9, 9, 45).toString(),
+    );
   });
 
   it("since", () => {
-    const dt = d(2005, 2, 22, 10, 10, 10);
-    expect(asDate(since(dt, 1))).toEqual(d(2005, 2, 22, 10, 10, 11));
+    const receiver = dt(2005, 2, 22, 10, 10, 10);
+    expect(since(receiver, 1).toString()).toBe(dt(2005, 2, 22, 10, 10, 11).toString());
+    expect(since(receiver, 3600).toString()).toBe(dt(2005, 2, 22, 11, 10, 10).toString());
+    expect(since(receiver, 86400 * 2).toString()).toBe(dt(2005, 2, 24, 10, 10, 10).toString());
+    expect(since(receiver, 86400 * 2 + 3600 + 25).toString()).toBe(
+      dt(2005, 2, 24, 11, 10, 35).toString(),
+    );
+    expect(since(receiver, 1.333).toString()).not.toBe(dt(2005, 2, 22, 10, 10, 11).toString());
+    expect(since(receiver, 1.667).toString()).not.toBe(dt(2005, 2, 22, 10, 10, 12).toString());
   });
 
   it("advance", () => {
-    const dt = d(2005, 2, 22, 15, 15, 10);
-    expect(asDate(advance(dt, { years: 1 }))).toEqual(d(2006, 2, 22, 15, 15, 10));
+    const receiver = () => dt(2005, 2, 28, 15, 15, 10);
+    expect(advance(receiver(), { years: 1 }).toString()).toBe(
+      dt(2006, 2, 28, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { months: 4 }).toString()).toBe(
+      dt(2005, 6, 28, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { weeks: 3 }).toString()).toBe(
+      dt(2005, 3, 21, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { days: 5 }).toString()).toBe(dt(2005, 3, 5, 15, 15, 10).toString());
+    expect(advance(receiver(), { years: 7, months: 7 }).toString()).toBe(
+      dt(2012, 9, 28, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { years: 7, months: 19, days: 5 }).toString()).toBe(
+      dt(2013, 10, 3, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { years: 7, months: 19, weeks: 2, days: 5 }).toString()).toBe(
+      dt(2013, 10, 17, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { years: -3, months: -2, days: -1 }).toString()).toBe(
+      dt(2001, 12, 27, 15, 15, 10).toString(),
+    );
+    // leap day plus one year
+    expect(advance(dt(2004, 2, 29, 15, 15, 10), { years: 1 }).toString()).toBe(
+      dt(2005, 2, 28, 15, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { hours: 5 }).toString()).toBe(
+      dt(2005, 2, 28, 20, 15, 10).toString(),
+    );
+    expect(advance(receiver(), { minutes: 7 }).toString()).toBe(
+      dt(2005, 2, 28, 15, 22, 10).toString(),
+    );
+    expect(advance(receiver(), { seconds: 9 }).toString()).toBe(
+      dt(2005, 2, 28, 15, 15, 19).toString(),
+    );
   });
 });

--- a/packages/activesupport/src/core-ext/date-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-time/calculations.ts
@@ -3,20 +3,35 @@
  * (`core_ext/date_time/calculations.rb`). Rails keeps `Time`, `Date` and
  * `DateTime` as three separate receivers, and the members whose bodies differ
  * only by the receiver's class live on `time-ext.ts` (the instant arm) or
- * `core-ext/date/calculations.ts` (the calendar-day arm). This file is for the
- * DateTime members a single TS function cannot stand in for, because their
- * return type is a DateTime rather than a Time — `DateTime.current` is the
- * first: `Time.current` (`time/calculations.rb:39-41`) is the same expression
- * without the `to_datetime` tail, and one function cannot answer both.
+ * `core-ext/date/calculations.ts` (the calendar-day arm). This file is the
+ * DateTime one, keyed on the `Temporal.PlainDateTime | Temporal.ZonedDateTime`
+ * seat `@blazetrails/date`'s `DateTime#toDatetime` answers — a civil date plus
+ * a time of day, carrying an offset only where it is not UTC, which is what a
+ * Ruby `DateTime` is. Every member here returns a DateTime rather than the
+ * `Temporal.Instant` the `Time` arm returns, so one function could not answer
+ * both: `Time.current` (`time/calculations.rb:39-41`) is `DateTime.current`
+ * (`:10-12`) without the `to_datetime` tail, and `Time#change`
+ * (`time/calculations.rb:130-176`) rebuilds a zoned instant where
+ * `DateTime#change` (`:51-71`) rebuilds a civil date at an offset.
  *
  * Mirrors: `class DateTime` (`core_ext/date_time/calculations.rb`)
  */
 
-import { Temporal, Time } from "@blazetrails/date";
+import { DateTime as RubyDateTime, Rational, Temporal, Time } from "@blazetrails/date";
+import { ArgumentError } from "../../hash-utils.js";
 import { instantFrom } from "../../temporal.js";
 import { currentTime } from "../../time-travel.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { zone as timeZone } from "../../time-zone-config.js";
+import { nsec, secFraction, secondsSinceUnixEpoch } from "../../time-ext.js";
+import * as date from "../date/calculations.js";
+
+/**
+ * The receiver of this file's instance members: the seat
+ * `@blazetrails/date`'s `DateTime#toDatetime` answers, where a `PlainDateTime`
+ * is the offset-0 case a Ruby `DateTime` defaults to.
+ */
+type DateTime = Temporal.PlainDateTime | Temporal.ZonedDateTime;
 
 /**
  * Mirrors: `DateTime.current` (`date_time/calculations.rb:10-12`) —
@@ -42,3 +57,256 @@ export function current(): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     now.getSeconds() + now.getMilliseconds() / 1000,
   ).toDatetime();
 }
+
+/**
+ * Mirrors: `DateTime#seconds_since_midnight` (`date_time/calculations.rb:20-22`)
+ * — `sec + (min * 60) + (hour * 3600)`, a whole-second count with none of the
+ * sub-second arithmetic `Time#seconds_since_midnight`
+ * (`time/calculations.rb:64-66`) does.
+ */
+export function secondsSinceMidnight(datetime: DateTime): number {
+  const self = new RubyDateTime(datetime);
+  return self.sec + self.min * 60 + self.hour * 3600;
+}
+
+/**
+ * Mirrors: `DateTime#seconds_until_end_of_day`
+ * (`date_time/calculations.rb:29-31`) — `end_of_day.to_i - to_i`, where
+ * `DateTime#to_i` is `seconds_since_unix_epoch.to_i`
+ * (`date_time/conversions.rb:84-86`).
+ */
+export function secondsUntilEndOfDay(datetime: DateTime): number {
+  return (
+    Math.trunc(secondsSinceUnixEpoch(endOfDay(datetime))) -
+    Math.trunc(secondsSinceUnixEpoch(datetime))
+  );
+}
+
+/** Mirrors: `DateTime#subsec` (`date_time/calculations.rb:36-38`) — `sec_fraction`. */
+export function subsec(datetime: DateTime): number {
+  return secFraction(datetime);
+}
+
+/** The keys `DateTime#change` reads (`date_time/calculations.rb:51-71`). */
+interface ChangeOptions {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  min?: number;
+  sec?: number;
+  usec?: number | Rational;
+  nsec?: number;
+  /** Ruby's `:offset` is a day fraction, a seconds Integer or a `"+09:00"` String. */
+  offset?: number | Rational | string;
+  start?: number;
+}
+
+/**
+ * Mirrors: `DateTime#change` (`date_time/calculations.rb:51-71`).
+ *
+ * `nsec` and `sec_fraction` are `DateTime`'s own readers
+ * (`date_time/conversions.rb:94-96`, ruby/date `d_lite_sec_fraction`), and
+ * `offset` / `start` are read off the ruby/date receiver the seat widens into,
+ * which is where `DateTime.civil` takes them back.
+ *
+ * `options.fetch` yields the stored value whenever the key is present — a zero
+ * included — and Ruby's `options[:hour] || options[:min] || options[:sec]` is
+ * false only for a missing key, never for a `0`, so both read presence rather
+ * than truthiness here.
+ */
+export function change(datetime: DateTime, options: ChangeOptions): DateTime {
+  const self = new RubyDateTime(datetime);
+
+  let newFraction: Rational;
+  const newNsec = options.nsec;
+  if (newNsec != null) {
+    if (options.usec != null) {
+      throw new ArgumentError(
+        `Can't change both :nsec and :usec at the same time: ${inspect(options)}`,
+      );
+    }
+    newFraction = new Rational(newNsec, 1000000000);
+  } else {
+    const newUsec =
+      "usec" in options
+        ? options.usec!
+        : options.hour != null || options.min != null || options.sec != null
+          ? 0
+          : new Rational(nsec(datetime), 1000);
+    newFraction =
+      newUsec instanceof Rational ? newUsec.quo(1000000) : new Rational(newUsec, 1000000);
+  }
+
+  if (newFraction.cmp(1) >= 0) throw new ArgumentError("argument out of range");
+
+  return RubyDateTime.civil(
+    "year" in options ? options.year! : Number(self.year),
+    "month" in options ? options.month! : self.month,
+    "day" in options ? options.day! : self.day,
+    "hour" in options ? options.hour! : self.hour,
+    "min" in options ? options.min! : options.hour != null ? 0 : self.min,
+    newFraction.add(
+      "sec" in options ? options.sec! : options.hour != null || options.min != null ? 0 : self.sec,
+    ),
+    "offset" in options ? options.offset! : self.offset,
+    "start" in options ? options.start! : self.start,
+  );
+}
+
+/**
+ * `Hash#inspect` over the options `change` raises with — Ruby 3.4 spells a
+ * Symbol key `nsec: 1`.
+ * @internal
+ */
+function inspect(options: ChangeOptions): string {
+  return `{${Object.entries(options)
+    .map(([key, value]) => `${key}: ${typeof value === "string" ? `"${value}"` : String(value)}`)
+    .join(", ")}}`;
+}
+
+/** The keys `DateTime#advance` reads (`date_time/calculations.rb:82-105`). */
+interface AdvanceOptions {
+  years?: number;
+  months?: number;
+  weeks?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}
+
+/**
+ * Mirrors: `DateTime#advance` (`date_time/calculations.rb:82-105`). Rails
+ * normalises the fractional `:weeks` / `:days` back into the caller's hash —
+ * `Date#advance` (`date/calculations.rb:127-136`) reads it only — so the
+ * writes below land on the passed object, as the Ruby's do. `divmod(1)` floors
+ * and answers the non-negative remainder, which is what the two splits below
+ * spell out.
+ */
+export function advance(datetime: DateTime, options: AdvanceOptions): DateTime {
+  if (options.weeks != null) {
+    const partialWeeks = options.weeks - Math.floor(options.weeks);
+    options.weeks = Math.floor(options.weeks);
+    options.days = (options.days ?? 0) + 7 * partialWeeks;
+  }
+
+  if (options.days != null) {
+    const partialDays = options.days - Math.floor(options.days);
+    options.days = Math.floor(options.days);
+    options.hours = (options.hours ?? 0) + 24 * partialDays;
+  }
+
+  const d = date.advance(new RubyDateTime(datetime).toDate(), options);
+  const datetimeAdvancedByDate = change(datetime, { year: d.year, month: d.month, day: d.day });
+  const secondsToAdvance =
+    (options.seconds ?? 0) + (options.minutes ?? 0) * 60 + (options.hours ?? 0) * 3600;
+
+  if (secondsToAdvance === 0) {
+    return datetimeAdvancedByDate;
+  } else {
+    return since(datetimeAdvancedByDate, secondsToAdvance);
+  }
+}
+
+/** Mirrors: `DateTime#ago` (`date_time/calculations.rb:109-111`) — `since(-seconds)`. */
+export function ago(datetime: DateTime, seconds: number): DateTime {
+  return since(datetime, -seconds);
+}
+
+/**
+ * Mirrors: `DateTime#since` (`date_time/calculations.rb:116-118`) —
+ * `self + Rational(seconds, 86400)`.
+ *
+ * Ruby's `Rational()` takes a Float numerator; this constructor takes Integers
+ * only, so a fractional `seconds` is carried as its nanosecond count over the
+ * matching denominator — the same value, at the sub-second precision the
+ * receiver's `sf` holds. An Integer `seconds` cancels back to
+ * `Rational(seconds, 86400)` through the constructor's own gcd.
+ */
+export function since(datetime: DateTime, seconds: number): DateTime {
+  return new RubyDateTime(datetime)
+    .plus(new Rational(Math.round(seconds * 1_000_000_000), 86_400_000_000_000))
+    .toDatetime();
+}
+
+/**
+ * Mirrors: `alias :in :since` (`date_time/calculations.rb:119`). `in` is a
+ * reserved word, so it cannot be a binding name; the export name can be one,
+ * and that is the name importers and the comparator see.
+ */
+export { since as in };
+
+/** Mirrors: `DateTime#beginning_of_day` (`date_time/calculations.rb:122-124`) */
+export function beginningOfDay(datetime: DateTime): DateTime {
+  return change(datetime, { hour: 0 });
+}
+
+/** Mirrors: `alias :midnight :beginning_of_day` (`date_time/calculations.rb:125`) */
+export const midnight = beginningOfDay;
+
+/** Mirrors: `alias :at_midnight :beginning_of_day` (`date_time/calculations.rb:126`) */
+export const atMidnight = beginningOfDay;
+
+/** Mirrors: `alias :at_beginning_of_day :beginning_of_day` (`date_time/calculations.rb:127`) */
+export const atBeginningOfDay = beginningOfDay;
+
+/** Mirrors: `DateTime#middle_of_day` (`date_time/calculations.rb:130-132`) */
+export function middleOfDay(datetime: DateTime): DateTime {
+  return change(datetime, { hour: 12 });
+}
+
+/** Mirrors: `alias :midday :middle_of_day` (`date_time/calculations.rb:133`) */
+export const midday = middleOfDay;
+
+/** Mirrors: `alias :noon :middle_of_day` (`date_time/calculations.rb:134`) */
+export const noon = middleOfDay;
+
+/** Mirrors: `alias :at_midday :middle_of_day` (`date_time/calculations.rb:135`) */
+export const atMidday = middleOfDay;
+
+/** Mirrors: `alias :at_noon :middle_of_day` (`date_time/calculations.rb:136`) */
+export const atNoon = middleOfDay;
+
+/** Mirrors: `alias :at_middle_of_day :middle_of_day` (`date_time/calculations.rb:137`) */
+export const atMiddleOfDay = middleOfDay;
+
+/** Mirrors: `DateTime#end_of_day` (`date_time/calculations.rb:140-142`) */
+export function endOfDay(datetime: DateTime): DateTime {
+  return change(datetime, { hour: 23, min: 59, sec: 59, usec: new Rational(999999999, 1000) });
+}
+
+/** Mirrors: `alias :at_end_of_day :end_of_day` (`date_time/calculations.rb:143`) */
+export const atEndOfDay = endOfDay;
+
+/** Mirrors: `DateTime#beginning_of_hour` (`date_time/calculations.rb:146-148`) */
+export function beginningOfHour(datetime: DateTime): DateTime {
+  return change(datetime, { min: 0 });
+}
+
+/** Mirrors: `alias :at_beginning_of_hour :beginning_of_hour` (`date_time/calculations.rb:149`) */
+export const atBeginningOfHour = beginningOfHour;
+
+/** Mirrors: `DateTime#end_of_hour` (`date_time/calculations.rb:152-154`) */
+export function endOfHour(datetime: DateTime): DateTime {
+  return change(datetime, { min: 59, sec: 59, usec: new Rational(999999999, 1000) });
+}
+
+/** Mirrors: `alias :at_end_of_hour :end_of_hour` (`date_time/calculations.rb:155`) */
+export const atEndOfHour = endOfHour;
+
+/** Mirrors: `DateTime#beginning_of_minute` (`date_time/calculations.rb:158-160`) */
+export function beginningOfMinute(datetime: DateTime): DateTime {
+  return change(datetime, { sec: 0 });
+}
+
+/** Mirrors: `alias :at_beginning_of_minute :beginning_of_minute` (`date_time/calculations.rb:161`) */
+export const atBeginningOfMinute = beginningOfMinute;
+
+/** Mirrors: `DateTime#end_of_minute` (`date_time/calculations.rb:164-166`) */
+export function endOfMinute(datetime: DateTime): DateTime {
+  return change(datetime, { sec: 59, usec: new Rational(999999999, 1000) });
+}
+
+/** Mirrors: `alias :at_end_of_minute :end_of_minute` (`date_time/calculations.rb:167`) */
+export const atEndOfMinute = endOfMinute;

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -18,6 +18,7 @@ import { TimeZone } from "./values/time-zone.js";
 import { toTime as stringToTime } from "./core-ext/string/conversions.js";
 import { preserveTimezone as compatibilityPreserveTimezone } from "./core-ext/date-and-time/compatibility.js";
 import { currentTime } from "./time-travel.js";
+import { secondsSinceMidnight as dateTimeSecondsSinceMidnight } from "./core-ext/date-time/calculations.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
@@ -62,8 +63,9 @@ export function endOfDay(date: Date): Temporal.Instant {
   return change(date, { hour: 23, min: 59, sec: 59, usec: 999999999 / 1000 });
 }
 
-// Rails' `alias`es on the day boundaries — time/calculations.rb:241-243, 250-254,
-// 264 and the identical set on DateTime (date_time/calculations.rb:126-137).
+// Rails' `alias`es on the day boundaries — time/calculations.rb:241-243,
+// 250-254, 264. DateTime's identical set is on its own receiver
+// (core-ext/date-time/calculations.ts).
 export { beginningOfDay as midnight };
 export { beginningOfDay as atMidnight };
 export { beginningOfDay as atBeginningOfDay };
@@ -86,7 +88,7 @@ export function endOfHour(date: Date): Temporal.Instant {
   return change(date, { min: 59, sec: 59, usec: 999999999 / 1000 });
 }
 
-// time/calculations.rb:270, 281; date_time/calculations.rb:148, 155.
+// time/calculations.rb:270, 281.
 export { beginningOfHour as atBeginningOfHour };
 export { endOfHour as atEndOfHour };
 
@@ -102,7 +104,7 @@ export function endOfMinute(date: Date): Temporal.Instant {
   return change(date, { sec: 59, usec: 999999999 / 1000 });
 }
 
-// time/calculations.rb:286, 295; date_time/calculations.rb:162, 168.
+// time/calculations.rb:286, 295.
 export { beginningOfMinute as atBeginningOfMinute };
 export { endOfMinute as atEndOfMinute };
 
@@ -329,22 +331,13 @@ export function advance(
 // ---------------------------------------------------------------------------
 
 /**
- * `DateTime#seconds_since_midnight` (`core_ext/date_time/calculations.rb:20-22`)
+ * `Time#seconds_since_midnight` (`core_ext/time/calculations.rb:64-66`). The
+ * `DateTime` arm of the same name (`core_ext/date_time/calculations.rb:20-22`)
  * is `sec + (min * 60) + (hour * 3600)` — a whole-second count, with none of
- * the sub-second arithmetic `Time#seconds_since_midnight`
- * (`core_ext/time/calculations.rb:64-66`) does.
+ * this sub-second arithmetic — and lives on its own receiver in
+ * `core-ext/date-time/calculations.ts`.
  */
-export function secondsSinceMidnight(
-  datetime: Temporal.PlainDateTime | Temporal.ZonedDateTime,
-): number;
-export function secondsSinceMidnight(date: Date): number;
-export function secondsSinceMidnight(
-  receiver: Date | Temporal.PlainDateTime | Temporal.ZonedDateTime,
-): number {
-  if (!(receiver instanceof Date)) {
-    return receiver.second + receiver.minute * 60 + receiver.hour * 3600;
-  }
-  const date = receiver;
+export function secondsSinceMidnight(date: Date): number {
   return (
     Math.floor(date.getTime() / 1000) -
     Math.floor(change(date, { hour: 0 }).epochMilliseconds / 1000) +
@@ -844,7 +837,9 @@ export function secondsSinceUnixEpoch(
   datetime: Temporal.PlainDateTime | Temporal.ZonedDateTime,
 ): number {
   const jd = cCivilToJd(datetime.year, datetime.month, datetime.day);
-  return (jd - 2440588) * 86400 - offsetInSeconds(datetime) + secondsSinceMidnight(datetime);
+  return (
+    (jd - 2440588) * 86400 - offsetInSeconds(datetime) + dateTimeSecondsSinceMidnight(datetime)
+  );
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -9,13 +9,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "current",
-    "call": "to_datetime",
-    "reason": "Homonym across two Ruby receivers: `Time.current` (time/calculations.rb:39-41) has no `to_datetime`, `DateTime.current` (date_time/calculations.rb:10-12) is that same expression plus `.to_datetime`, and trails has one `current()` here serving both — one function cannot return both a Time and a DateTime. `DateTime.current` now has that receiver — `core-ext/date-time/calculations.ts` — but RUBY_FILE_TS_OVERRIDES maps one Ruby file to ONE TS file, so `date_time/calculations.rb` still points at `time-ext.ts` (where its other 28 members live) and its `current` is still charged here. The row dies when those 28 bodies move too: 0098-activesupport-ar-closure-port/port-date-time-calculations-onto-its-own-receiver."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "sec_fraction",
     "call": "subsec",
     "reason": "`Time#sec_fraction` is `subsec` (time/calculations.rb:107-109) and `DateTime#subsec` is `sec_fraction` (date_time/calculations.rb:36-38) — the two are each other's body in Ruby only because the receivers differ. trails has one `secFraction` function exported under both names, so neither call site exists."

--- a/scripts/parity/conventions.test.ts
+++ b/scripts/parity/conventions.test.ts
@@ -378,14 +378,18 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     // without these the 129 methods the calculations.rb files add are measured
     // against files that define none of them. `Date` is its own receiver: its
     // calculations widen through `in_time_zone` (date/calculations.rb:55-87)
-    // rather than operating on an instant. Its file sits at the Rails path the
-    // default rule already produces; the entry is what splits the bucket off
-    // `date/acts_like.rb`, Date's first reopening.
+    // rather than operating on an instant. `DateTime` is its own receiver too:
+    // its calculations answer a civil date at an offset rather than an instant.
+    // Both files sit at the Rails path the default rule already produces; the
+    // entries are what split the buckets off `date/acts_like.rb` and
+    // `date_time/acts_like.rb`, those two classes' first reopenings.
     expect(rubyFileToTs("core_ext/time/calculations.rb", "activesupport")).toBe("time-ext.ts");
     expect(rubyFileToTs("core_ext/date/calculations.rb", "activesupport")).toBe(
       "core-ext/date/calculations.ts",
     );
-    expect(rubyFileToTs("core_ext/date_time/calculations.rb", "activesupport")).toBe("time-ext.ts");
+    expect(rubyFileToTs("core_ext/date_time/calculations.rb", "activesupport")).toBe(
+      "core-ext/date-time/calculations.ts",
+    );
   });
 
   it("gives core_ext/object/json.rb its own bucket", () => {

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -196,7 +196,13 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // bucket off `date/acts_like.rb` (Date's first reopening); the path it names
   // is the one the default rule would produce anyway.
   "activesupport:core_ext/date/calculations.rb": "core-ext/date/calculations.ts",
-  "activesupport:core_ext/date_time/calculations.rb": "time-ext.ts",
+  // The `DateTime` arm answers a DateTime — a civil date at an offset — where
+  // the `Time` arm answers an instant, so it has its own receiver
+  // (`Temporal.PlainDateTime | Temporal.ZonedDateTime`) and its own file. As
+  // with the `Date` entry above, the path it names is the one the default rule
+  // would produce anyway; the entry is what splits the bucket off
+  // `date_time/acts_like.rb` (DateTime's first reopening).
+  "activesupport:core_ext/date_time/calculations.rb": "core-ext/date-time/calculations.ts",
   // The activesupport `core_ext/*` reopenings. Ruby splits one class's extensions
   // across a file per concern and reopens the class in each; the extractor stamps
   // the entity with whichever reopening came first (`object/blank.rb` for String,


### PR DESCRIPTION
The 28 remaining members of `core_ext/date_time/calculations.rb` still lived on
`time-ext.ts`, where one TS function served both the `Time` and the `DateTime`
receiver. They move onto the DateTime receiver in
`core-ext/date-time/calculations.ts` (which `DateTime.current` already had),
keyed on the `Temporal.PlainDateTime | Temporal.ZonedDateTime` seat
`@blazetrails/date`'s `DateTime#toDatetime` answers:

- `seconds_since_midnight`, `seconds_until_end_of_day`, `subsec`
- `change` — Rails' body, `DateTime.civil(...)` with the `:offset` / `:start`
  the receiver carries, not the `Time` arm's zoned rebuild
- `advance`, `ago`, `since` (+ `in`)
- `beginning_of_day` / `middle_of_day` / `end_of_day` / `beginning_of_hour` /
  `end_of_hour` / `beginning_of_minute` / `end_of_minute`, with their full
  alias sets

`RUBY_FILE_TS_OVERRIDES` follows them, so `date_time/calculations.rb` now
measures against that file: **29/29** (was 1/29), with `time/calculations.rb`
unchanged at 38/38. `time-ext.ts` keeps only the `Time` arm —
`secondsSinceMidnight` loses its DateTime overload, and
`secondsSinceUnixEpoch` (a `date_time/conversions.rb` member) reads the new
file's.

The `current` -> `to_datetime` row in
`call-mismatches-exclude/activesupport/time-ext.json` is deleted: it existed
only because `DateTime.current`'s call set was charged to `Time.current` while
the override still named `time-ext.ts`. No new rows; marks were already tight,
so no `:tighten` was needed.

The DateTime tests in `core-ext/date-time-ext.test.ts` are re-pointed at the
new receiver and now carry the Rails assertions verbatim
(`date_time_ext_test.rb:100-217`, `:507-510`) instead of the one-line `Date`
stand-ins they had. Names unchanged.

`parity:api` +28 methods, `parity:test` unchanged (11 fewer assertion
mismatches), `parity:api:calls` / `:args` clean.

The bundled `retire-relation-parallel-join-resolver` story was released rather
than shipped here: at ~500 LOC of AR join-resolver surgery it does not fit
under the ceiling alongside this one.

Closes-story: port-date-time-calculations-onto-its-own-receiver