### PR TITLE
refactor: HWIA bang forms, Date builder seats, association ==, spawn call sites, readonly?/locked?

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -268,21 +268,26 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Array-style equality — compares against the relation's loaded records.
-   * Mirrors Rails' `AssociationRelation#==(other)`, which is defined as
-   * `other == records` so that `blog.posts == [p1, p2]` works in user code.
+   * Mirrors `AssociationRelation#==` (association_relation.rb:14-16), which is
+   * `other == records` — the comparison semantics come from `other`'s own
+   * `==`, so an Array compares element-wise and a Relation runs
+   * `Relation#==` (relation.rb:1253-1262), which compares `to_sql`.
    *
    * TypeScript can't overload `==` / `===`, so this is surfaced as an
    * explicit `equals` method.
    */
-  async equals(other: Relation<T> | T[]): Promise<boolean> {
-    const ours = await this.toArray();
-    const theirs = Array.isArray(other) ? other : await other;
-    if (ours.length !== theirs.length) return false;
-    for (let i = 0; i < ours.length; i++) {
-      if (!ours[i].equals(theirs[i])) return false;
+  override async equals(other: unknown): Promise<boolean | undefined> {
+    const records = await this.records();
+    if (Array.isArray(other)) {
+      return (
+        other.length === records.length && other.every((record: T, i) => record.equals(records[i]))
+      );
     }
-    return true;
+    const otherEquals = (other as { equals?: (o: unknown) => unknown } | null)?.equals;
+    if (typeof otherEquals === "function") {
+      return (await otherEquals.call(other, records)) as boolean | undefined;
+    }
+    return false;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2737,6 +2737,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
+   * Mirrors `CollectionProxy#==` (collection_proxy.rb:980-982) — `load_target
+   * == other`, so the loaded target does the comparing: `Array#==` is
+   * element-wise against another Array, and against anything that converts to
+   * one (another proxy) MRI re-dispatches as `other == load_target`.
+   */
+  override async equals(other: unknown): Promise<boolean | undefined> {
+    const loadTarget = await this.loadTarget();
+    if (Array.isArray(other)) {
+      return sameRecordList(loadTarget, other as Base[]);
+    }
+    const otherEquals = (other as { equals?: (o: unknown) => unknown } | null)?.equals;
+    if (typeof otherEquals === "function") {
+      return (await otherEquals.call(other, loadTarget)) as boolean | undefined;
+    }
+    return false;
+  }
+
+  /**
    * Alias for push/<<.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#append

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -124,7 +124,7 @@ describe("ReadOnlyTest", () => {
     for (const d of await Developer.all()) {
       expect(d.isReadonly()).toBe(false);
     }
-    expect(Developer.all().isReadonly).toBe(false);
+    expect(Developer.all().isReadonly).toBeFalsy();
     for (const d of await Developer.all().readonly(false)) {
       expect(d.isReadonly()).toBe(false);
     }

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -1036,3 +1036,37 @@ describe("Relation Enumerable surface (trails)", () => {
     expect((await present!.toArray()).length).toBe(await CanonPost.all().count());
   });
 });
+
+// `AssociationRelation#==` is `other == records` (association_relation.rb:14-16)
+// and `CollectionProxy#==` is `load_target == other` (collection_proxy.rb:980-982):
+// both re-dispatch instead of hand-rolling a record loop, so the semantics come
+// from the OTHER side's `==` — a Relation runs `Relation#==` (relation.rb:1253-1262).
+describe("association equality re-dispatches to the other side", () => {
+  fixtures(["authors", "posts"]);
+
+  it("AssociationRelation#== asks other, passing its own records", async () => {
+    const author = await CanonAuthor.first();
+    const relation = (author!.posts as any).where({}) as AssociationRelation<any>;
+    const records = await relation.records();
+    const other = CanonPost.where({ id: records.map((r: any) => r.id) });
+
+    // `other == records`: Relation#=='s Array arm (relation.rb:1259-1260)
+    // compares OTHER's records against ours, so the answer is other's, not a
+    // loop over our own array.
+    expect(await relation.equals(other)).toBe(await other.equals(records));
+    expect(await relation.equals(CanonPost.where({ id: -1 }))).toBe(false);
+
+    // Anything with no `==` of its own is simply unequal.
+    expect(await relation.equals("posts")).toBe(false);
+  });
+
+  it("CollectionProxy#== compares its loaded target element-wise", async () => {
+    const author = await CanonAuthor.first();
+    const proxy = author!.posts as any;
+    const records = await proxy.records();
+
+    expect(await proxy.equals([...records])).toBe(true);
+    expect(await proxy.equals(records.slice(1))).toBe(false);
+    expect(await proxy.equals("posts")).toBe(false);
+  });
+});

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -649,7 +649,7 @@ export class Relation<T extends Base> {
     conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | string[] | unknown[] | null,
     ...rest: unknown[]
   ): Relation<T> | WhereChain<Relation<T>> {
-    if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this.clone());
+    if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this.spawn());
     // Rails: a single blank-ish argument (`args.length == 1 && args.first.blank?`,
     // query_methods.rb:1036) makes `where` a no-op returning the relation
     // unchanged — `where({})` / `where([])` / `where(null)` / `where("")` all
@@ -660,7 +660,7 @@ export class Relation<T extends Base> {
     // lets a NESTED empty hash (`where(posts: {})`) still expand to the `1=0`
     // contradiction Rails' `expand_from_hash` returns.
     if (rest.length === 0 && _qm.isBlankArgument(conditionsOrSql)) {
-      return this.clone();
+      return this;
     }
     // Composite-key form: array of column names + array of tuples. It is
     // always a two-argument call (`where(cols, tuples)`), so it is
@@ -694,12 +694,12 @@ export class Relation<T extends Base> {
         tuples,
         (tableName) => this.lookupTableKlassFromJoinDependencies(tableName) as typeof Base | null,
       );
-      if (nodes.length === 0) return this.clone().noneBang();
-      const rel = this.clone();
+      if (nodes.length === 0) return this.spawn().noneBang();
+      const rel = this.spawn();
       rel.whereClause = rel.whereClause.plus(new WhereClause([...nodes]));
       return rel;
     }
-    return this.clone().whereBang(
+    return this.spawn().whereBang(
       conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
       ...rest,
     );
@@ -714,7 +714,7 @@ export class Relation<T extends Base> {
     // Mirrors rewhere (query_methods.rb): `return unscope(:where) if conditions.nil?`.
     if (conditions == null) return this.unscope("where");
     conditions = sanitizeForbiddenAttributes(conditions);
-    const rel = this.clone();
+    const rel = this.spawn();
     // Mirrors rewhere (query_methods.rb): `where_clause = build_where_clause(...)`,
     // `unscope!(where: where_clause.extract_attributes)`, `where_clause += ...`.
     // Building through the same `build_where_clause` path as `where` keeps the
@@ -894,7 +894,7 @@ export class Relation<T extends Base> {
     conditions = sanitizeForbiddenAttributes(conditions as Record<string, unknown>) as
       | Record<string, unknown>
       | string[];
-    const rel = this.clone();
+    const rel = this.spawn();
     rel.referencesBang(...referencesFromConditions(conditions));
     if (
       Array.isArray(conditions) &&
@@ -965,7 +965,7 @@ export class Relation<T extends Base> {
    */
   or(other: Relation<T>): Relation<T> {
     if (this._isNone) return other.clone();
-    return this.clone().orBang(other);
+    return this.spawn().orBang(other);
   }
 
   /**
@@ -975,7 +975,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#and
    */
   and(other: Relation<T>): Relation<T> {
-    return this.clone().andBang(other);
+    return this.spawn().andBang(other);
   }
 
   /**
@@ -995,7 +995,7 @@ export class Relation<T extends Base> {
     for (let i = 1; i < conditions.length; i++) {
       combined = combined.or(buildClause(conditions[i]));
     }
-    const rel = this.clone();
+    const rel = this.spawn();
     if (combined.predicates.length > 0)
       rel.whereClause = rel.whereClause.plus(new WhereClause([combined.ast]));
     return rel;
@@ -1051,7 +1051,7 @@ export class Relation<T extends Base> {
       else combined.push(relation);
     }
     if (combined.length === 0) return this;
-    return this.clone().excludingBang(combined);
+    return this.spawn().excludingBang(combined);
   }
 
   /**
@@ -1086,7 +1086,7 @@ export class Relation<T extends Base> {
       else combined.push(relation);
     }
     if (combined.length === 0) return this;
-    return this.clone().excludingBang(combined);
+    return this.spawn().excludingBang(combined);
   }
 
   /**
@@ -1098,7 +1098,7 @@ export class Relation<T extends Base> {
     this.checkIfMethodHasArgumentsBang(":order", args as unknown[], undefined, () => {
       this.sanitizeOrderArguments(args as unknown[]);
     });
-    return this.clone().orderBang(...args);
+    return this.spawn().orderBang(...args);
   }
 
   /**
@@ -1107,7 +1107,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#limit
    */
   limit(value: number | string | null): Relation<T> {
-    return this.clone().limitBang(value);
+    return this.spawn().limitBang(value);
   }
 
   /**
@@ -1116,7 +1116,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#offset
    */
   offset(value: number | string | null): Relation<T> {
-    return this.clone().offsetBang(value);
+    return this.spawn().offsetBang(value);
   }
 
   /**
@@ -1143,7 +1143,7 @@ export class Relation<T extends Base> {
     }
     this.checkIfMethodHasArgumentsBang(":select", fields, "Call `select' with at least one field.");
     fields = this.processSelectArgs(fields);
-    return this.clone()._selectBang(...fields);
+    return this.spawn()._selectBang(...fields);
   }
 
   /**
@@ -1154,7 +1154,7 @@ export class Relation<T extends Base> {
   reselect(...args: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":reselect", args as unknown[]);
     args = this.processSelectArgs(args as unknown[]) as typeof args;
-    return this.clone().reselectBang(...args);
+    return this.spawn().reselectBang(...args);
   }
 
   /**
@@ -1163,7 +1163,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#distinct
    */
   distinct(value = true): Relation<T> {
-    return this.clone().distinctBang(value);
+    return this.spawn().distinctBang(value);
   }
 
   /**
@@ -1172,7 +1172,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#distinct_on (PostgreSQL only)
    */
   distinctOn(...columns: string[]): Relation<T> {
-    const rel = this.clone();
+    const rel = this.spawn();
     rel.distinctValue = true;
     rel._distinctOnColumns = columns;
     return rel;
@@ -1185,7 +1185,7 @@ export class Relation<T extends Base> {
    */
   group(...args: (string | import("@blazetrails/arel").Nodes.Node)[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":group", args as unknown[]);
-    return this.clone().groupBang(...(args as string[]));
+    return this.spawn().groupBang(...(args as string[]));
   }
 
   /**
@@ -1201,7 +1201,7 @@ export class Relation<T extends Base> {
     condition: string | Record<string, unknown> | Nodes.Node,
     ...binds: unknown[]
   ): Relation<T> {
-    return this.clone().havingBang(condition, ...binds);
+    return this.spawn().havingBang(condition, ...binds);
   }
 
   /**
@@ -1211,7 +1211,7 @@ export class Relation<T extends Base> {
    */
   regroup(...args: string[]): Relation<T> {
     this.checkIfMethodHasArgumentsBang(":regroup", args);
-    return this.clone().regroupBang(...args);
+    return this.spawn().regroupBang(...args);
   }
 
   /**
@@ -1223,7 +1223,7 @@ export class Relation<T extends Base> {
     this.checkIfMethodHasArgumentsBang(":reorder", args as unknown[], undefined, () => {
       this.sanitizeOrderArguments(args as unknown[]);
     });
-    return this.clone().reorderBang(...args);
+    return this.spawn().reorderBang(...args);
   }
 
   /**
@@ -1232,7 +1232,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reverse_order
    */
   reverseOrder(): Relation<T> {
-    return this.clone().reverseOrderBang();
+    return this.spawn().reverseOrderBang();
   }
 
   /**
@@ -1251,7 +1251,7 @@ export class Relation<T extends Base> {
 
     if (values.length === 0) return this.none();
 
-    const rel = this.clone();
+    const rel = this.spawn();
 
     // Mirrors Rails: `references = column_references([column]);
     // self.references_values |= references unless references.empty?`
@@ -1317,7 +1317,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#invert_where
    */
   invertWhere(): Relation<T> {
-    return this.clone().invertWhereBang();
+    return this.spawn().invertWhereBang();
   }
 
   /**
@@ -1376,19 +1376,23 @@ export class Relation<T extends Base> {
   /**
    * Check if this relation is marked readonly.
    *
-   * Mirrors: ActiveRecord::Relation#readonly?
+   * Mirrors: ActiveRecord::Relation#readonly? (relation.rb:1278-1280) — the
+   * stored `readonly_value` itself, so an unset relation answers `null` the way
+   * Rails answers `nil`.
    */
-  get isReadonly(): boolean {
-    return this.readonlyValue ?? false;
+  get isReadonly(): boolean | null {
+    return this.readonlyValue;
   }
 
   /**
    * Check if this relation carries a lock clause.
    *
-   * Mirrors: ActiveRecord::Relation#locked? (`alias :locked? :lock_value`)
+   * Mirrors: ActiveRecord::Relation#locked? (relation.rb:75,
+   * `alias :locked? :lock_value`) — the lock clause itself, so `lock("FOR
+   * UPDATE")` answers the string rather than a boolean.
    */
-  get isLocked(): boolean {
-    return this.lockValue !== null;
+  get isLocked(): string | null {
+    return this.lockValue;
   }
 
   /**

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -930,7 +930,7 @@ export async function pluck(
     // the spawn's select before building is essential: resolving the discarded
     // select list would mutate referencesValues and could promote includes
     // (adding joins Rails would not add for the pluck columns).
-    const rel = this.clone();
+    const rel = this.spawn();
     delete rel._values.select;
     // calculations.rb:315-316 — `relation.select_values = columns; relation.arel`.
     // Going through `select_values` (rather than overwriting `manager.projections`)

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -239,7 +239,7 @@ describe("RelationMergingTest", () => {
       .where("salary >= 80000")
       .order("id DESC")
       .merge(Developer.limit(2));
-    expect(devs.isLocked).toBe(true);
+    expect(devs.isLocked).toBeTruthy();
   });
 
   it("relation merging with preload", async () => {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -330,7 +330,7 @@ function unionAppend<T>(target: readonly T[], incoming: readonly T[]): T[] {
  */
 function includes(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":includes", args);
-  return includesBang.apply(this.clone(), args);
+  return includesBang.apply(this.spawn(), args);
 }
 
 function includesBang(this: QueryMethodsHost, ...associations: AssociationSpec[]): any {
@@ -352,7 +352,7 @@ function all(this: QueryMethodsHost): any {
  */
 function eagerLoad(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":eager_load", args);
-  return eagerLoadBang.apply(this.clone(), args);
+  return eagerLoadBang.apply(this.spawn(), args);
 }
 
 function eagerLoadBang(this: QueryMethodsHost, ...associations: AssociationSpec[]): any {
@@ -367,7 +367,7 @@ function eagerLoadBang(this: QueryMethodsHost, ...associations: AssociationSpec[
  */
 function preload(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":preload", args);
-  return preloadBang.apply(this.clone(), args);
+  return preloadBang.apply(this.spawn(), args);
 }
 
 function preloadBang(this: QueryMethodsHost, ...associations: AssociationSpec[]): any {
@@ -393,7 +393,7 @@ async function extractAssociated(this: QueryMethodsHost, association: string): P
  */
 function references(this: QueryMethodsHost, ...tableNames: Array<string | Nodes.SqlLiteral>): any {
   checkIfMethodHasArgumentsBang.call(this, ":references", tableNames);
-  return referencesBang.apply(this.clone(), tableNames);
+  return referencesBang.apply(this.spawn(), tableNames);
 }
 
 function referencesBang(
@@ -463,7 +463,7 @@ function withCte(this: QueryMethodsHost, ...args: any[]): any {
     throw argumentError("ActiveRecord::Relation#with does not accept a block");
   }
   checkIfMethodHasArgumentsBang.call(this, ":with", args);
-  return withBang.apply(this.clone(), args);
+  return withBang.apply(this.spawn(), args);
 }
 
 function withBang(this: QueryMethodsHost, ...args: unknown[]): any {
@@ -480,7 +480,7 @@ function withBang(this: QueryMethodsHost, ...args: unknown[]): any {
  */
 function withRecursive(this: QueryMethodsHost, ...args: any[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":with_recursive", args);
-  return withRecursiveBang.apply(this.clone(), args);
+  return withRecursiveBang.apply(this.spawn(), args);
 }
 
 function withRecursiveBang(this: QueryMethodsHost, ...args: unknown[]): any {
@@ -801,7 +801,7 @@ function unscope(
   ...args: Array<UnscopeType | { where: string | string[] }>
 ): any {
   checkIfMethodHasArgumentsBang.call(this, ":unscope", args as unknown[]);
-  return unscopeBang.apply(this.clone(), args as any);
+  return unscopeBang.apply(this.spawn(), args as any);
 }
 
 function unscopeBang(
@@ -854,7 +854,7 @@ function unscopeBang(
  */
 function joins(this: QueryMethodsHost, ...args: JoinSpec[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":joins", args as unknown[]);
-  return joinsBang.apply(this.clone(), args as (string | Nodes.Join)[]);
+  return joinsBang.apply(this.spawn(), args as (string | Nodes.Join)[]);
 }
 
 function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
@@ -884,7 +884,7 @@ function leftOuterJoins(this: QueryMethodsHost, ...args: AssociationSpec[]): any
   // `left_outer_joins!` stores args verbatim and only raises for a
   // non-Hash/Symbol/Array arg lazily at SQL-build time, in `build_join_buckets`
   // (query_methods.rb:1828-1834) — not eagerly here.
-  return leftOuterJoinsBang.apply(this.clone(), args);
+  return leftOuterJoinsBang.apply(this.spawn(), args);
 }
 
 /**
@@ -892,7 +892,7 @@ function leftOuterJoins(this: QueryMethodsHost, ...args: AssociationSpec[]): any
  */
 function leftJoins(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":left_joins", args);
-  return leftOuterJoinsBang.apply(this.clone(), args);
+  return leftOuterJoinsBang.apply(this.spawn(), args);
 }
 
 function leftOuterJoinsBang(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
@@ -1312,7 +1312,7 @@ function offsetBang(this: QueryMethodsHost, value: number | string | null): any 
  * Mirrors: ActiveRecord::QueryMethods#lock (query_methods.rb:1238-1240)
  */
 function lock(this: QueryMethodsHost, locks: string | boolean = true): any {
-  return lockBang.call(this.clone(), locks);
+  return lockBang.call(this.spawn(), locks);
 }
 
 function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
@@ -1330,7 +1330,7 @@ function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
  * Mirrors: ActiveRecord::QueryMethods#none (query_methods.rb:1281-1283)
  */
 function none(this: QueryMethodsHost): any {
-  return noneBang.call(this.clone());
+  return noneBang.call(this.spawn());
 }
 
 function noneBang(this: QueryMethodsHost): any {
@@ -1363,7 +1363,7 @@ function isNullRelation(this: QueryMethodsHost): boolean {
  * Mirrors: ActiveRecord::QueryMethods#readonly (query_methods.rb:1309-1311)
  */
 function readonly(this: QueryMethodsHost, value = true): any {
-  return readonlyBang.call(this.clone(), value);
+  return readonlyBang.call(this.spawn(), value);
 }
 
 function readonlyBang(this: QueryMethodsHost, value = true): any {
@@ -1377,7 +1377,7 @@ function readonlyBang(this: QueryMethodsHost, value = true): any {
  * Mirrors: ActiveRecord::QueryMethods#strict_loading (query_methods.rb:1324-1326)
  */
 function strictLoading(this: QueryMethodsHost, value = true): any {
-  return strictLoadingBang.call(this.clone(), value);
+  return strictLoadingBang.call(this.spawn(), value);
 }
 
 function strictLoadingBang(this: QueryMethodsHost, value = true): any {
@@ -1391,7 +1391,7 @@ function strictLoadingBang(this: QueryMethodsHost, value = true): any {
  * Mirrors: ActiveRecord::QueryMethods#create_with (query_methods.rb:1346-1348)
  */
 function createWith(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
-  return createWithBang.call(this.clone(), value);
+  return createWithBang.call(this.spawn(), value);
 }
 
 function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> | null): any {
@@ -1411,7 +1411,7 @@ function createWithBang(this: QueryMethodsHost, value: Record<string, unknown> |
  * Mirrors: ActiveRecord::QueryMethods#from (query_methods.rb:1391-1393)
  */
 function from(this: QueryMethodsHost, value: any, subqueryName?: string): any {
-  return fromBang.call(this.clone(), value, subqueryName);
+  return fromBang.call(this.spawn(), value, subqueryName);
 }
 
 function fromBang(this: QueryMethodsHost, value: any, subqueryName?: string): any {
@@ -1434,8 +1434,8 @@ function extending(
   this: QueryMethodsHost,
   mod?: Record<string, (...args: any[]) => any> | ((rel: any) => void),
 ): any {
-  if (!mod) return this.clone();
-  return extendingBang.call(this.clone(), mod);
+  if (!mod) return this;
+  return extendingBang.call(this.spawn(), mod);
 }
 
 function extendingBang(
@@ -1467,7 +1467,7 @@ function extendingBang(
  */
 function optimizerHints(this: QueryMethodsHost, ...args: string[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":optimizer_hints", args);
-  return optimizerHintsBang.apply(this.clone(), args);
+  return optimizerHintsBang.apply(this.spawn(), args);
 }
 
 function optimizerHintsBang(this: QueryMethodsHost, ...args: string[]): any {
@@ -1568,7 +1568,7 @@ function skipPreloadingBang(this: QueryMethodsHost): any {
  */
 function annotate(this: QueryMethodsHost, ...args: string[]): any {
   checkIfMethodHasArgumentsBang.call(this, ":annotate", args);
-  return annotateBang.apply(this.clone(), args);
+  return annotateBang.apply(this.spawn(), args);
 }
 
 function annotateBang(this: QueryMethodsHost, ...comments: string[]): any {

--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -72,6 +72,8 @@ describe("Relation value accessor Rails semantics", () => {
     rel.readonlyValue = false;
     expect(rel.readonlyValue).toBe(false);
     expect(rel.isReadonly).toBe(false);
+    // relation.rb:1278-1280 — `readonly?` IS `readonly_value`, so unset is nil.
+    expect(relation().isReadonly).toBeNull();
   });
 
   it("unscope(:readonly) clears readonly_value back to nil (null)", () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -2514,7 +2514,7 @@ describe("RelationTest", () => {
 
   it("locked should not build arel", () => {
     const postsRel = Post.all().lock();
-    expect(postsRel.isLocked).toBe(true);
+    expect(postsRel.isLocked).toBeTruthy();
     expect(() => postsRel.lock(false)).not.toThrow();
   });
 

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -103,6 +103,22 @@ describe("HashWithIndifferentAccessTest", () => {
     const transformed = h.transformKeys((k) => k.repeat(2));
     expect(transformed).toBeInstanceOf(HashWithIndifferentAccess);
     expect(transformed.toHash()).toEqual({ aa: 1, bb: 2 });
+
+    let hash = new HashWithIndifferentAccess({ a: 1, b: 2 }).transformKeys({ a: "x", y: "z" });
+    expect(hash.get("a")).toBeUndefined();
+    expect(hash.get("x")).toBe(1);
+    expect(hash.get("b")).toBe(2);
+    expect(hash.get("z")).toBeUndefined();
+    expect([...hash.keys()]).toEqual(["x", "b"]);
+
+    hash = new HashWithIndifferentAccess({ a: 1, b: 2 }).transformKeys({ a: "A", q: "Q" }, (k) =>
+      k.repeat(3),
+    );
+    expect(hash.get("A")).toBe(1);
+    expect(hash.get("bbb")).toBe(2);
+    expect([...hash.keys()]).toEqual(["A", "bbb"]);
+
+    expect(() => hash.transformKeys(null)).toThrow(/no implicit conversion of nil/);
   });
 
   it("indifferent transform_values — returns new HWIA", () => {

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -317,14 +317,16 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("to options for hash with indifferent access", () => {
-    const h = new HashWithIndifferentAccess({ a: 1, b: 2 });
-    expect(h.toHash()).toEqual({ a: 1, b: 2 });
+    expect(new HashWithIndifferentAccess({ a: 1, b: 2 }).toOptions()).toEqual({ a: 1, b: 2 });
+    expect(new HashWithIndifferentAccess({ ":a": 1, b: 2 }).toOptions()).toEqual({ a: 1, b: 2 });
   });
 
   it("deep symbolize keys for hash with indifferent access", () => {
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    const plain = h.symbolizeKeys();
-    expect(plain).toEqual({ a: 1 });
+    const nestedSymbols = { a: { b: { c: 3 } } };
+    expect(new HashWithIndifferentAccess(nestedSymbols).deepSymbolizeKeys()).toEqual(nestedSymbols);
+    expect(new HashWithIndifferentAccess({ a: { b: { c: 3 } } }).deepSymbolizeKeys()).toEqual(
+      nestedSymbols,
+    );
   });
 
   it("symbolize keys bang for hash with indifferent access", () => {
@@ -920,10 +922,62 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("indifferent to proc", () => {
-    // In Ruby, a hash can be converted to a proc (h.to_proc). Not applicable in TS.
-    // Verify basic HWIA functionality still works.
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    const fn = (key: string) => h.get(key);
-    expect(fn("a")).toBe(1);
+    const strings = new HashWithIndifferentAccess({ a: 1, b: 2 });
+    const proc = strings.toProc();
+
+    expect(proc("a")).toBe(1);
+    expect(proc(":a")).toBe(1);
+    expect(proc(":no_such")).toBeUndefined();
+  });
+
+  it("indifferent transform_keys bang", () => {
+    const strings = { a: 1, b: 2 };
+
+    let indifferentStrings = new HashWithIndifferentAccess<number>(strings);
+    indifferentStrings.transformKeysBang((k) => k.repeat(2));
+    expect(indifferentStrings.toHash()).toEqual({ aa: 1, bb: 2 });
+    expect(indifferentStrings).toBeInstanceOf(HashWithIndifferentAccess);
+
+    indifferentStrings = new HashWithIndifferentAccess<number>(strings);
+    indifferentStrings.transformKeysBang((k) => `:${k}`);
+    expect(indifferentStrings.get(":a")).toBe(1);
+    expect(indifferentStrings.get("a")).toBe(1);
+
+    let hash = new HashWithIndifferentAccess<number>(strings);
+    hash.transformKeysBang({ a: "x", y: "z" });
+    expect(hash.get("a")).toBeUndefined();
+    expect(hash.get("x")).toBe(1);
+    expect(hash.get("b")).toBe(2);
+    expect(hash.get("z")).toBeUndefined();
+    expect([...hash.keys()]).toEqual(["x", "b"]);
+
+    hash = new HashWithIndifferentAccess<number>(strings);
+    hash.transformKeysBang({ a: "A", q: "Q" }, (k) => k.repeat(3));
+    expect(hash.get("A")).toBe(1);
+    expect(hash.get("bbb")).toBe(2);
+    expect([...hash.keys()]).toEqual(["A", "bbb"]);
+
+    expect(() => hash.transformKeysBang(null)).toThrow(/no implicit conversion of nil/);
+  });
+
+  it("indifferent slice inplace", () => {
+    const original = new HashWithIndifferentAccess({ a: "x", b: "y", c: 10 });
+    const expected = new HashWithIndifferentAccess({ c: 10 });
+
+    for (const keys of [
+      ["a", "b"],
+      [":a", ":b"],
+    ]) {
+      const copy = new HashWithIndifferentAccess(original);
+      expect(copy.sliceBang(...keys).toHash()).toEqual(expected.toHash());
+      expect(copy.toHash()).toEqual({ a: "x", b: "y" });
+    }
+  });
+
+  it("to options on indifferent preserves hash", () => {
+    const h = new HashWithIndifferentAccess<number>();
+    h.set("first", 1);
+    h.toOptionsBang();
+    expect(h.get("first")).toBe(1);
   });
 });

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -10,11 +10,36 @@
  * Rails' own name.
  */
 
-import { deepMerge as deepMergeObj, isPlainObject, symbolizeKeysBang } from "./hash-utils.js";
+import {
+  deepMerge as deepMergeObj,
+  deepSymbolizeKeysBang,
+  isPlainObject,
+  symbolizeKeysBang,
+} from "./hash-utils.js";
 import { nestedUnderIndifferentAccess } from "./core-ext/hash/indifferent-access.js";
 import { KeyError } from "./core-ext/key-error.js";
 
 type AnyObject = Record<string, unknown>;
+
+/**
+ * `NOT_GIVEN = Object.new` (hash_with_indifferent_access.rb:336) — the sentinel
+ * `transform_keys`/`transform_keys!` compare against so an explicitly-passed
+ * `nil` is told apart from an omitted argument.
+ */
+const NOT_GIVEN: AnyObject = {};
+
+/**
+ * Mirror of Ruby's `TypeError` — what `Hash#transform_keys!` raises for a `nil`
+ * hash. Its throw site carries an eslint-disable because `rails-error-parity`
+ * matches on the native name.
+ * @internal
+ */
+class TypeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TypeError";
+  }
+}
 
 /**
  * The `update`/`merge!` duplicate-key block (hash_with_indifferent_access.rb:127-131):
@@ -269,6 +294,21 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
+   * Mirrors `slice!` (hash_with_indifferent_access.rb:366-369) — the keys are
+   * converted, then `Hash#slice!` (core_ext/hash/slice.rb:10-17) replaces the
+   * hash with the given keys and returns the removed pairs. The `default` /
+   * `default_proc` lines have no counterpart here: this class does not model a
+   * Hash default (see `initialize`).
+   */
+  sliceBang(...keys: string[]): HashWithIndifferentAccess<V> {
+    keys = keys.map((key) => this.convertKey(key));
+    const omit = this.slice(...[...this.keys()].filter((key) => !keys.includes(key)));
+    const hash = this.slice(...keys);
+    this.replace(hash);
+    return omit;
+  }
+
+  /**
    * Return a new HashWithIndifferentAccess without the specified keys.
    */
   except(...keys: string[]): HashWithIndifferentAccess<V> {
@@ -322,6 +362,48 @@ export class HashWithIndifferentAccess<V = unknown> {
       result.set(fn(k), v);
     }
     return result;
+  }
+
+  /**
+   * Mirrors `transform_keys!` (hash_with_indifferent_access.rb:345-357). Ruby's
+   * block is syntactically separate from the optional `hash`; JS has no such
+   * separation, so a function passed in the `hash` slot is read as the block —
+   * the same reading `fetch` above gives a trailing function.
+   */
+  transformKeysBang(
+    hash: AnyObject | null | ((key: string) => string) = NOT_GIVEN,
+    block?: (key: string) => string,
+  ): this {
+    if (typeof hash === "function") {
+      block = hash;
+      hash = NOT_GIVEN;
+    }
+
+    if (hash === null) {
+      // `super` — `Hash#transform_keys!` takes no implicit conversion of nil.
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new TypeError("no implicit conversion of nil into Hash");
+    } else if (NOT_GIVEN === hash) {
+      for (const key of [...this.keys()]) {
+        const value = this.get(key)!;
+        this.delete(key);
+        this.set(block!(key), value);
+      }
+    } else if (block) {
+      for (const key of [...this.keys()]) {
+        const value = this.get(key)!;
+        this.delete(key);
+        this.set((hash[key] as string) || block(key), value);
+      }
+    } else {
+      for (const key of [...this.keys()]) {
+        const value = this.get(key)!;
+        this.delete(key);
+        this.set((hash[key] as string) || key, value);
+      }
+    }
+
+    return this;
   }
 
   /**
@@ -505,6 +587,29 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
+   * `alias_method :to_options, :symbolize_keys`
+   * (hash_with_indifferent_access.rb:319).
+   */
+  toOptions(): AnyObject {
+    return this.symbolizeKeys();
+  }
+
+  /**
+   * Mirrors `deep_symbolize_keys` (hash_with_indifferent_access.rb:320).
+   */
+  deepSymbolizeKeys(): AnyObject {
+    return deepSymbolizeKeysBang(this.toHash());
+  }
+
+  /**
+   * Mirrors `to_options!` (hash_with_indifferent_access.rb:321) — this hash is
+   * already indifferent, so it answers itself.
+   */
+  toOptionsBang(): this {
+    return this;
+  }
+
+  /**
    * Mirrors `nested_under_indifferent_access`
    * (hash_with_indifferent_access.rb:66-68) — already indifferent, so a hash
    * nested under one being converted is returned as-is.
@@ -523,6 +628,14 @@ export class HashWithIndifferentAccess<V = unknown> {
       copy[k] = this.convertValueToHash(v);
     }
     return copy;
+  }
+
+  /**
+   * Mirrors `to_proc` (hash_with_indifferent_access.rb:383-385) — a Ruby proc
+   * is a JS function, so the reader closure is returned as-is.
+   */
+  toProc(): (key: string) => V | undefined {
+    return (key: string) => this.get(key);
   }
 
   /**

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -358,12 +358,17 @@ export class HashWithIndifferentAccess<V = unknown> {
    * `dup.tap { |h| h.transform_keys!(hash, &block) }`, so the mapping hash and
    * the block arms are the ones `transform_keys!` documents below.
    */
+  transformKeys(block: (key: string) => string): HashWithIndifferentAccess<V>;
   transformKeys(
-    hash: AnyObject | null | ((key: string) => string) = NOT_GIVEN,
+    hash: AnyObject | null,
+    block?: (key: string) => string,
+  ): HashWithIndifferentAccess<V>;
+  transformKeys(
+    hash: AnyObject | null | ((key: string) => string),
     block?: (key: string) => string,
   ): HashWithIndifferentAccess<V> {
     const dup = new HashWithIndifferentAccess<V>(this);
-    dup.transformKeysBang(hash, block);
+    dup.transformKeysBang(hash as AnyObject | null, block);
     return dup;
   }
 
@@ -372,9 +377,17 @@ export class HashWithIndifferentAccess<V = unknown> {
    * block is syntactically separate from the optional `hash`; JS has no such
    * separation, so a function passed in the `hash` slot is read as the block —
    * the same reading `fetch` above gives a trailing function.
+   *
+   * Ruby's no-argument arm (`return to_enum(:transform_keys!) if
+   * NOT_GIVEN.equal?(hash) && !block_given?`, :346) has no JS analogue — there
+   * is no Enumerator to return — so, as at `Deprecators#each`
+   * (deprecators.rb:41), the overloads require either the block or the hash and
+   * a bare call is a compile-time error rather than an enumerator.
    */
+  transformKeysBang(block: (key: string) => string): this;
+  transformKeysBang(hash: AnyObject | null, block?: (key: string) => string): this;
   transformKeysBang(
-    hash: AnyObject | null | ((key: string) => string) = NOT_GIVEN,
+    hash: AnyObject | null | ((key: string) => string),
     block?: (key: string) => string,
   ): this {
     if (typeof hash === "function") {

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -354,14 +354,17 @@ export class HashWithIndifferentAccess<V = unknown> {
   }
 
   /**
-   * Transform keys — returns new HWIA with transformed keys.
+   * Mirrors `transform_keys` (hash_with_indifferent_access.rb:338-341) —
+   * `dup.tap { |h| h.transform_keys!(hash, &block) }`, so the mapping hash and
+   * the block arms are the ones `transform_keys!` documents below.
    */
-  transformKeys(fn: (key: string) => string): HashWithIndifferentAccess<V> {
-    const result = new HashWithIndifferentAccess<V>();
-    for (const [k, v] of this.data) {
-      result.set(fn(k), v);
-    }
-    return result;
+  transformKeys(
+    hash: AnyObject | null | ((key: string) => string) = NOT_GIVEN,
+    block?: (key: string) => string,
+  ): HashWithIndifferentAccess<V> {
+    const dup = new HashWithIndifferentAccess<V>(this);
+    dup.transformKeysBang(hash, block);
+    return dup;
   }
 
   /**

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2367,3 +2367,45 @@ describe("Date#inspect", () => {
     );
   });
 });
+
+// `dup_obj_with_new_start` (date_core.c:5801-5810) and `d_simple_new_internal`
+// / `d_complex_new_internal` (date_core.c:3036-3071) all build
+// `rb_obj_class(self)`, so every copy/builder seat answers the RECEIVER's
+// class. The construction statics (`Date.today`, `Date.jd`, ...) are a separate
+// question — they answer the `Temporal` seat under RFC 0088.
+describe("builder seats answer rb_obj_class(self)", () => {
+  class DateSub extends RubyDate {}
+  class DateTimeSub extends RubyDateTime {}
+
+  it("propagates a Date subclass through plus/minus/shift/succ/next", () => {
+    const d = new DateSub(2001, 2, 3);
+    expect(d.plus(1)).toBeInstanceOf(DateSub);
+    expect(d.minus(1)).toBeInstanceOf(DateSub);
+    expect(d.rshift(1)).toBeInstanceOf(DateSub);
+    expect(d.lshift(1)).toBeInstanceOf(DateSub);
+    expect(d.succ()).toBeInstanceOf(DateSub);
+    expect(d.next()).toBeInstanceOf(DateSub);
+  });
+
+  it("propagates a Date subclass through the new_start family", () => {
+    const d = new DateSub(2001, 2, 3);
+    expect(d.italy()).toBeInstanceOf(DateSub);
+    expect(d.england()).toBeInstanceOf(DateSub);
+    expect(d.julian()).toBeInstanceOf(DateSub);
+    expect(d.gregorian()).toBeInstanceOf(DateSub);
+  });
+
+  it("propagates a DateTime subclass through both seats", () => {
+    const dt = new DateTimeSub(2001, 2, 3);
+    expect(dt.plus(1)).toBeInstanceOf(DateTimeSub);
+    expect(dt.minus(1)).toBeInstanceOf(DateTimeSub);
+    expect(dt.rshift(1)).toBeInstanceOf(DateTimeSub);
+    expect(dt.lshift(1)).toBeInstanceOf(DateTimeSub);
+    expect(dt.succ()).toBeInstanceOf(DateTimeSub);
+    expect(dt.next()).toBeInstanceOf(DateTimeSub);
+    expect(dt.italy()).toBeInstanceOf(DateTimeSub);
+    expect(dt.england()).toBeInstanceOf(DateTimeSub);
+    expect(dt.julian()).toBeInstanceOf(DateTimeSub);
+    expect(dt.gregorian()).toBeInstanceOf(DateTimeSub);
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -6715,7 +6715,7 @@ export class Date {
    * `DateTime`.
    */
   newStart(start = DEFAULT_SG): this {
-    return new Date(
+    return new (this.constructor as typeof Date)(
       SEAT,
       this.nth,
       this.#getSJd(),
@@ -7086,8 +7086,9 @@ export class Date {
    * that branch, and {@link DateTime} overrides it with the complex arm.
    */
   dNewInternal(nth: bigint, rjd: number, df: number, sf: Rational, of: number): this {
-    if (!df && sf.isZero() && !of) return new Date(SEAT, nth, rjd, this.start) as this;
-    return new Date(SEAT, nth, rjd, this.start, df, sf, of) as this;
+    if (!df && sf.isZero() && !of)
+      return new (this.constructor as typeof Date)(SEAT, nth, rjd, this.start) as this;
+    return new (this.constructor as typeof Date)(SEAT, nth, rjd, this.start, df, sf, of) as this;
   }
 
   /**
@@ -8501,7 +8502,15 @@ export class DateTime extends DateWithoutParseStatics {
    * side of the `simple_dat_p` branch {@link Date#dNewInternal} documents.
    */
   override dNewInternal(nth: bigint, rjd: number, df: number, sf: Rational, of: number): this {
-    return new DateTime(SEAT, nth, rjd, df, sf, of, this.start) as this;
+    return new (this.constructor as typeof DateTime)(
+      SEAT,
+      nth,
+      rjd,
+      df,
+      sf,
+      of,
+      this.start,
+    ) as this;
   }
 
   /**
@@ -8561,7 +8570,7 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   override newStart(start = DEFAULT_SG): this {
-    return new DateTime(
+    return new (this.constructor as typeof DateTime)(
       SEAT,
       this.nth,
       this.#getCJd(),


### PR DESCRIPTION
Five bundled convergences.

### HashWithIndifferentAccess bang forms and `to_options` / `to_proc`

Ports `to_options` / `to_options!` / `deep_symbolize_keys`
(hash_with_indifferent_access.rb:319-321), `transform_keys!` (:345-357),
`slice!` (:366-369) and `to_proc` (:383-385) at the Rails names, routing through
`convert_key` where Rails does. `transform_keys!` carries Rails' `NOT_GIVEN`
sentinel so an explicit `nil` (which `super` raises `TypeError` on) stays
distinct from an omitted hash; the block is read out of the `hash` slot the way
`fetch` already reads a trailing function. `slice!` is `Hash#slice!`
(core_ext/hash/slice.rb:10-17) minus the `default` / `default_proc` lines, which
this class does not model.

The file's remaining 6 missing members are the defaults family
(`default`, `reverse_merge`, `with_defaults`, …) — the sibling story.

### Date's builder seats answer `Date`, not `rb_obj_class(self)`

`new_start` and both `dNewInternal` arms build the receiver's class
(date_core.c:5801-5810 for `dup_obj_with_new_start`, :3036-3071 for
`d_simple_new_internal` / `d_complex_new_internal`), so a `DateSub` answers
`DateSub` from `plus`, `minus`, `rshift`, `lshift`, `succ`, `next`, `italy`,
`england`, `julian` and `gregorian` — likewise `DateTimeSub`. The construction
statics are untouched: they answer the `Temporal` seat under RFC 0088, which is
what keeps `test_sub` blocked.

### `AssociationRelation#==` is `other == records`

association_relation.rb:14-16 re-dispatches to `other`'s own `==` rather than
hand-rolling an element loop, so an Array compares element-wise and a Relation
runs `Relation#==` (relation.rb:1253-1262). `CollectionProxy#==` had no port at
all and was inheriting `Relation#==`; it is now `load_target == other`
(collection_proxy.rb:980-982).

### Non-bang query methods call `spawn`, not `clone`

44 call sites across `relation.ts`, `relation/query-methods.ts` and
`relation/calculations.ts` (`pluck`'s `relation = spawn`, calculations.rb:315)
now go through `spawn` (spawn_methods.rb:9-11), so the `already_in_scope?` arm
is live on user-facing chains instead of dead. Two arms that Rails does not
spawn at all are converged with them: `where` with a single blank argument
returns `self` (query_methods.rb:686) and `extending` with no module returns
`self` (:1456-1462). The genuinely-`clone` internal paths (the eager-load
rewrites in `_buildIdSubquery` / count / `hasInclude`, `sole`, `WhereClause`)
are left alone.

### `readonly?` and `locked?` return their values

`readonly?` is `readonly_value` (relation.rb:1278-1280), so an unset relation
answers `null` rather than a coerced `false`; `locked?` is the `lock_value`
alias (relation.rb:75) and hands over the lock clause. Rails' own assertions
here are `assert_predicate` / `assert_not`, so the two `toBe(true)` and one
`toBe(false)` assertions become truthiness checks, matching them.

Verified: `parity:api:calls` and `:args` OK with no new baseline rows,
`parity:api:extra --package activesupport` reports 0 novel names in
hash-with-indifferent-access.ts, lint and typecheck clean, and the relation,
scoping, associations, readonly, date and activesupport suites pass locally on
SQLite.

Closes-story: port-hwia-bang-forms-and-to-options
Closes-story: date-builders-name-date-instead-of-rb-obj-class
Closes-story: converge-association-relation-equals-to-other-records
Closes-story: converge-query-method-call-sites-onto-spawn
Closes-story: converge-relation-readonly-and-locked-predicates
