### PR TITLE
refactor(parity): admit index_by and compact_blank to RECEIVER_AS_FIRST_ARG

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -5,14 +5,5 @@
     "rubyName": "ids_reader",
     "call": "empty?",
     "reason": "Verified per-site (RFC 0106): `target.empty?` (collection_association.rb:54) — `empty?` on a Ruby Array, whose faithful JS spelling is `xs.length === 0`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_writer",
-    "call": "index_by",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby calling convention, not a divergence: `records.index_by { … }` is a receiver call with a block (collection_association.rb:68-75), and ActiveSupport's TS `indexBy` is a free function, so the receiver and the block become its two arguments — same call, same key function, arity shifted by the language."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -16,15 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "columns_for_distinct",
-    "call": "compact_blank",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Verified per-site (RFC 0106): Ruby's `orders.compact_blank` (abstract_mysql_adapter.rb:620,625) is Enumerable#compact_blank, a receiver method. trails does not monkey-patch Array, so ActiveSupport's `compactBlank(collection)` takes the receiver as its only argument — the zero-vs-one arg delta is the standalone-function spelling, not a dropped argument."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "dbconsole",
     "call": "empty?",
     "reason": "Verified per-site (RFC 0106): `mysql_config[:password].to_s.empty?` (abstract_mysql_adapter.rb:76) — `empty?` on a Ruby String, whose faithful JS spelling is `s === \"\"`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."

--- a/scripts/api-compare/receiver-as-first-arg.ts
+++ b/scripts/api-compare/receiver-as-first-arg.ts
@@ -85,4 +85,12 @@ export const RECEIVER_AS_FIRST_ARG = new Set([
   // Ruby's Hash does not), so @blazetrails/activesupport exports it as
   // `groupBy(collection, block)` and the receiver is TS argument 1.
   "group_by",
+  // active_support/core_ext/enumerable.rb:52-60 — `people.index_by { … }`,
+  // exported by @blazetrails/activesupport as `indexBy(collection, block)` for
+  // the same reason `group_by` is: the Hash is keyed by VALUE, not by string
+  // coercion, so no `Array.prototype` analogue exists.
+  "index_by",
+  // active_support/core_ext/enumerable.rb:184-186 — `values.compact_blank`,
+  // exported by @blazetrails/activesupport as `compactBlank(collection)`.
+  "compact_blank",
 ]);


### PR DESCRIPTION
## What

`index_by` and `compact_blank` join `group_by` in `RECEIVER_AS_FIRST_ARG`
(`scripts/api-compare/receiver-as-first-arg.ts`). Both satisfy the table's
stated admission rule verbatim — an ActiveSupport core-ext on Enumerable that
trails necessarily exports as a free function, so the Ruby receiver is TS
argument 1:

- `index_by` — `activesupport/lib/active_support/core_ext/enumerable.rb:52-60`,
  exported as `indexBy(collection, block)`.
- `compact_blank` — `.../enumerable.rb:184-186`, exported as
  `compactBlank(collection)`.

Adding a name can only shrink the mismatch set, so the two rows it covered went
stale and are deleted by hand (only-shrink, no reseed):

- `activerecord associations/collection-association.ts ids_writer index_by()`
- `activerecord connection-adapters/abstract-mysql-adapter.ts columns_for_distinct compact_blank()`

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are both green; no mark
shard went stale, so nothing was tightened.

## The other two bundled stories

Both were measured and handed back with findings rather than half-converged.

**`converge-parameter-filter-joined-regexp-unicode-flag-argument`** — blocked on
a genuine language shortcoming, verified on Node v24.16.0:

- `\p{...}` is a Unicode property escape only under a `u`/`v`-flagged Regexp.
  `new RegExp("\\p{Lu}").test("A")` is `false`; the pattern matches the literal
  text `p{Lu}` instead.
- JS has no way to carry the flag in the source. Ruby's `Regexp#to_s` embeds
  each member's flags inline as `(?-mix:…)`, which is exactly why
  `Regexp.new(patterns.join("|"))` needs no second argument. V8 rejects
  `(?u:…)` with `Invalid group`, and the ES2025 modifiers proposal it does ship
  covers `i`/`m`/`s` only — `(?i:a)` works, `(?u:…)` never will.
- The story's candidate 1 (rewrite `\p{...}` u-free during the case-flag
  expansion) does not close it: a u-free equivalent of an arbitrary Unicode
  property is its full code-point range table, which JS exposes no API to
  obtain, and the flag is needed for a verbatim non-`ignoreCase` member just as
  much as for an expanded one.
- Criterion 3 is coupled to the same fact: `\-` is `Invalid escape` under both
  `u` and `v`, so `escapeRegexp` cannot escape `-` while any joined group can
  carry the flag.

**`assertions-activemodel-length-numericality-comparison-refile`** — closed as
superseded by one story per file, each carrying its measurement and the port
recipe: `assertions-activemodel-comparison-validation`,
`assertions-activemodel-length-validation`,
`assertions-activemodel-numericality-validation`,
`assertions-activemodel-validations-test`,
`assertions-activemodel-validates-test`.

Each of the five trails files matches Rails by test name only — every body is an
invented scenario over an ad-hoc inline model — so convergence is a re-port of
the Rails file, not an assertion edit. The smallest (`comparison-validation.test.ts`,
567 lines to delete plus ~200 to add) already exceeds the 700-LOC ceiling on its
own, and `validations.test.ts` is 2,474 lines with 146 trails-only extras.

The measurement also surfaced two implementation blockers sitting under the
ports, both filed:

- `Model.validates` (model.ts:561) is a hardcoded per-validator chain where
  Rails' `validates` (validates.rb:105-124) resolves
  `"#{key.to_s.camelize}Validator"` by constant lookup, raises
  `ArgumentError, "Unknown validator: …"`, and honours
  `_validates_default_keys` / `_parse_validates_options`. That strands 15 of the
  21 `validates_test.rb` tests → `converge-model-validates-onto-rails-generic-lookup`
  (RFC 0023), on which the validates test story now depends.
- `ComparisonValidator#compare` (comparison.ts) throws for a
  `PlainDate`/`PlainDateTime` pair that Ruby compares through `Comparable`, and
  `checkValidity()` still raises the pre-Rails-7 message; both are noted in the
  comparison story.

Closes-story: admit-index-by-and-compact-blank-to-receiver-as-first-arg
