### PR TITLE
feat(activesupport,activemodel): HashWithIndifferentAccess defaults family; comparison_validation_test port

### DIFF
--- a/packages/activemodel/src/validations/comparison-validation.test.ts
+++ b/packages/activemodel/src/validations/comparison-validation.test.ts
@@ -1,567 +1,437 @@
-import { describe, it, expect } from "vitest";
-import { instant, plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
+import { describe, it, expect, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
+import {
+  instant,
+  plainDate,
+  plainDateTime,
+} from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Model } from "../index.js";
+import { ArgumentError } from "../attribute-assignment.js";
+
+// Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
+// Rails' Topic declares `attr_accessor :approved` with no type, which is the
+// untyped ValueType here (type/registry.ts:47).
+class Topic extends Model {
+  static {
+    this.attribute("title", "string");
+    this.attribute("content", "string");
+    this.attribute("approved", "value");
+  }
+}
+
+/**
+ * Mirrors the `Struct.new(:amount) { include Comparable; def <=> ... }` of
+ * `test_validates_comparison_with_custom_compare`. `compareTo` is trails'
+ * spelling of Ruby's `<=>` (date/src/date.ts:5147).
+ */
+class Custom {
+  constructor(readonly amount: number) {}
+
+  compareTo(other: Custom): number {
+    return (this.amount % 100) - (other.amount % 100);
+  }
+}
 
 describe("ComparisonValidationTest", () => {
-  it("validates comparison with less than or equal to using date", async () => {
-    class Event extends Model {
-      static {
-        this.attribute("startDate", "string");
-      }
-    }
-    // Use numbers for comparison since dates need special handling
-    Event.validates("startDate", { comparison: { lessThanOrEqualTo: "2025-12-31" } });
-    const e = new Event({ startDate: "2025-01-01" });
-    expect(await e.isValid()).toBe(true);
-  });
-
-  it("validates comparison with other than using string", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("status", "string");
-        this.validates("status", { comparison: { otherThan: "banned" } });
-      }
-    }
-    expect(await new Person({ status: "active" }).isValid()).toBe(true);
-    expect(await new Person({ status: "banned" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with blank allowed", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("age", "integer");
-        this.validates("age", { comparison: { greaterThan: 0, allowBlank: true } });
-      }
-    }
-    const p = new Person();
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates comparison with less than or equal to using time", () => {
-    class Event extends Model {
-      static {
-        this.attribute("start_time", "datetime");
-        this.attribute("end_time", "datetime");
-      }
-    }
-    const e = new Event({});
-    expect(e.readAttribute("start_time")).toBeNull();
-  });
-
-  it("validates comparison with less than or equal to using string", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { lessThanOrEqualTo: "zzz" } });
-      }
-    }
-    const p = new Person({ code: "abc" });
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates comparison with other than using date", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { otherThan: 0 } });
-      }
-    }
-    const p = new Person({ score: 5 });
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates comparison with other than using time", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { otherThan: 0 } });
-      }
-    }
-    const p = new Person({ score: 1 });
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates comparison with custom compare", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { greaterThan: 0 } });
-      }
-    }
-    const p = new Person({ score: 5 });
-    expect(await p.isValid()).toBe(true);
-  });
-
-  it("validates comparison of incomparables", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { greaterThan: 0 } });
-      }
-    }
-    const p = new Person({ score: -1 });
-    await p.isValid();
-    expect(p.errors.count).toBeGreaterThan(0);
-  });
-
-  it("validates comparison non-ArgumentError propagates", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", {
-          comparison: {
-            greaterThan: () => {
-              throw new TypeError("unexpected");
-            },
-          },
-        });
-      }
-    }
-    const p = new Person({ score: 5 });
-    await expect(p.isValid()).rejects.toThrow(TypeError);
-  });
-
-  it("validates comparison of no options", () => {
-    expect(() => {
-      class Person extends Model {
-        static {
-          this.attribute("score", "integer");
-          this.validates("score", { comparison: {} });
-        }
-      }
-      return Person;
-    }).toThrow();
+  afterEach(() => {
+    Topic.clearValidatorsBang();
   });
 
   it("validates comparison with greater than using numeric", async () => {
-    class Order extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThan: 0 } });
-      }
-    }
-    expect(await new Order({ quantity: 1 }).isValid()).toBe(true);
-    expect(await new Order({ quantity: 0 }).isValid()).toBe(false);
-    expect(await new Order({ quantity: -1 }).isValid()).toBe(false);
+    Topic.validatesComparisonOf("approved", { greaterThan: 10 });
+
+    await assertInvalidValues([-12, 10], "must be greater than 10");
+    await assertValidValues([11]);
   });
 
   it("validates comparison with greater than using date", async () => {
-    const fixedDate = plainDate("2024-01-01");
-    class Event extends Model {
-      static {
-        this.attribute("date", "date");
-        this.validates("date", { comparison: { greaterThan: fixedDate } });
-      }
-    }
-    expect(await new Event({ date: "2024-01-02" }).isValid()).toBe(true);
-    expect(await new Event({ date: "2023-12-31" }).isValid()).toBe(false);
-  });
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { greaterThan: dateValue });
 
-  it("validates comparison with greater than using string", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { greaterThan: "A" } });
-      }
-    }
-    expect(await new Item({ code: "B" }).isValid()).toBe(true);
-    expect(await new Item({ code: "A" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with greater than or equal to using numeric", async () => {
-    class Order extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThanOrEqualTo: 1 } });
-      }
-    }
-    expect(await new Order({ quantity: 1 }).isValid()).toBe(true);
-    expect(await new Order({ quantity: 0 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with equal to using numeric", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("value", "integer");
-        this.validates("value", { comparison: { equalTo: 42 } });
-      }
-    }
-    expect(await new Item({ value: 42 }).isValid()).toBe(true);
-    expect(await new Item({ value: 43 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with less than using numeric", async () => {
-    class Rating extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { lessThan: 10 } });
-      }
-    }
-    expect(await new Rating({ score: 9 }).isValid()).toBe(true);
-    expect(await new Rating({ score: 10 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with less than or equal to using numeric", async () => {
-    class Rating extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { lessThanOrEqualTo: 10 } });
-      }
-    }
-    expect(await new Rating({ score: 10 }).isValid()).toBe(true);
-    expect(await new Rating({ score: 11 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with other than using numeric", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("status", "integer");
-        this.validates("status", { comparison: { otherThan: 0 } });
-      }
-    }
-    expect(await new Item({ status: 1 }).isValid()).toBe(true);
-    expect(await new Item({ status: 0 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with proc", async () => {
-    class Event extends Model {
-      static {
-        this.attribute("startDate", "date");
-        this.attribute("endDate", "date");
-        this.validates("endDate", {
-          comparison: { greaterThan: (record: any) => record.readAttribute("startDate") },
-        });
-      }
-    }
-    expect(await new Event({ startDate: "2024-01-01", endDate: "2024-01-02" }).isValid()).toBe(
-      true,
+    await assertInvalidValues(
+      [
+        plainDate("2019-08-03"),
+        plainDate("2020-07-03"),
+        plainDate("2020-08-01"),
+        plainDate("2020-08-02"),
+        plainDateTime("2020-08-01T12:34:00"),
+      ],
+      "must be greater than 2020-08-02",
     );
-    expect(await new Event({ startDate: "2024-01-02", endDate: "2024-01-01" }).isValid()).toBe(
-      false,
-    );
-  });
-
-  it("validates comparison with nil allowed", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThan: 0, allowNil: true } });
-      }
-    }
-    expect(await new Item({}).isValid()).toBe(true);
+    await assertValidValues([plainDate("2020-08-03"), plainDateTime("2020-08-02T12:34:00")]);
   });
 
   it("validates comparison with greater than using time", async () => {
-    const baseTime = instant("2024-01-01T12:00:00Z");
-    class Event extends Model {
-      static {
-        this.attribute("startTime", "datetime");
-        this.validates("startTime", { comparison: { greaterThan: baseTime } });
-      }
-    }
-    expect(await new Event({ startTime: "2024-01-01T13:00:00Z" }).isValid()).toBe(true);
-    expect(await new Event({ startTime: "2024-01-01T11:00:00Z" }).isValid()).toBe(false);
-  });
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { greaterThan: timeValue });
 
-  it("validates comparison with greater than or equal to using date", async () => {
-    const baseDate = plainDate("2024-06-01");
-    class Event extends Model {
-      static {
-        this.attribute("date", "date");
-        this.validates("date", { comparison: { greaterThanOrEqualTo: baseDate } });
-      }
-    }
-    expect(await new Event({ date: "2024-06-01" }).isValid()).toBe(true);
-    expect(await new Event({ date: "2024-05-31" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with greater than or equal to using time", async () => {
-    const baseTime = instant("2024-01-01T12:00:00Z");
-    class Event extends Model {
-      static {
-        this.attribute("time", "datetime");
-        this.validates("time", { comparison: { greaterThanOrEqualTo: baseTime } });
-      }
-    }
-    expect(await new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(true);
-    expect(await new Event({ time: "2024-01-01T11:59:59Z" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with greater than or equal to using string", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { greaterThanOrEqualTo: "B" } });
-      }
-    }
-    expect(await new Item({ code: "B" }).isValid()).toBe(true);
-    expect(await new Item({ code: "C" }).isValid()).toBe(true);
-    expect(await new Item({ code: "A" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with equal to using date", async () => {
-    const target = plainDate("2024-06-15");
-    class Event extends Model {
-      static {
-        this.attribute("date", "date");
-        this.validates("date", { comparison: { equalTo: target } });
-      }
-    }
-    expect(await new Event({ date: "2024-06-15" }).isValid()).toBe(true);
-    expect(await new Event({ date: "2024-06-16" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with equal to using time", async () => {
-    const target = instant("2024-01-01T12:00:00Z");
-    class Event extends Model {
-      static {
-        this.attribute("time", "datetime");
-        this.validates("time", { comparison: { equalTo: target } });
-      }
-    }
-    expect(await new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(true);
-    expect(await new Event({ time: "2024-01-01T12:00:01Z" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with equal to using string", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { equalTo: "ABC" } });
-      }
-    }
-    expect(await new Item({ code: "ABC" }).isValid()).toBe(true);
-    expect(await new Item({ code: "ABD" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with less than using date", async () => {
-    const limit = plainDate("2025-01-01");
-    class Event extends Model {
-      static {
-        this.attribute("date", "date");
-        this.validates("date", { comparison: { lessThan: limit } });
-      }
-    }
-    expect(await new Event({ date: "2024-12-31" }).isValid()).toBe(true);
-    expect(await new Event({ date: "2025-01-01" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with less than using time", async () => {
-    const limit = instant("2024-01-01T12:00:00Z");
-    class Event extends Model {
-      static {
-        this.attribute("time", "datetime");
-        this.validates("time", { comparison: { lessThan: limit } });
-      }
-    }
-    expect(await new Event({ time: "2024-01-01T11:59:59Z" }).isValid()).toBe(true);
-    expect(await new Event({ time: "2024-01-01T12:00:00Z" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with less than using string", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { lessThan: "Z" } });
-      }
-    }
-    expect(await new Item({ code: "A" }).isValid()).toBe(true);
-    expect(await new Item({ code: "Z" }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with lambda", async () => {
-    class Event extends Model {
-      static {
-        this.attribute("startDate", "date");
-        this.attribute("endDate", "date");
-        this.validates("endDate", {
-          comparison: { greaterThan: (r: any) => r.readAttribute("startDate") },
-        });
-      }
-    }
-    expect(await new Event({ startDate: "2024-01-01", endDate: "2024-02-01" }).isValid()).toBe(
-      true,
+    await assertInvalidValues(
+      [instant("2020-08-01T12:34:00Z"), instant("2020-07-02T18:30:00Z")],
+      `must be greater than ${timeValue}`,
     );
-    expect(await new Event({ startDate: "2024-02-01", endDate: "2024-01-01" }).isValid()).toBe(
-      false,
-    );
-  });
-
-  it("validates comparison with method", async () => {
-    class Event extends Model {
-      static {
-        this.attribute("startDate", "date");
-        this.attribute("endDate", "date");
-        this.validates("endDate", {
-          comparison: { greaterThan: (r: any) => r.getStartDate() },
-        });
-      }
-      getStartDate() {
-        return this.readAttribute("startDate");
-      }
-    }
-    expect(await new Event({ startDate: "2024-01-01", endDate: "2024-02-01" }).isValid()).toBe(
-      true,
-    );
-  });
-
-  it("validates comparison of multiple values", async () => {
-    class Score extends Model {
-      static {
-        this.attribute("value", "integer");
-        this.validates("value", {
-          comparison: { greaterThanOrEqualTo: 0, lessThanOrEqualTo: 100 },
-        });
-      }
-    }
-    expect(await new Score({ value: 50 }).isValid()).toBe(true);
-    expect(await new Score({ value: -1 }).isValid()).toBe(false);
-    expect(await new Score({ value: 101 }).isValid()).toBe(false);
-  });
-});
-describe("ComparisonValidator", () => {
-  it("validates greaterThan", async () => {
-    class Order extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThan: 0 } });
-      }
-    }
-    expect(await new Order({ quantity: 5 }).isValid()).toBe(true);
-    expect(await new Order({ quantity: 0 }).isValid()).toBe(false);
-    expect(await new Order({ quantity: -1 }).isValid()).toBe(false);
-  });
-
-  it("validates greaterThanOrEqualTo", async () => {
-    class Order extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThanOrEqualTo: 1 } });
-      }
-    }
-    expect(await new Order({ quantity: 1 }).isValid()).toBe(true);
-    expect(await new Order({ quantity: 0 }).isValid()).toBe(false);
-  });
-
-  it("validates lessThan", async () => {
-    class Rating extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { lessThan: 10 } });
-      }
-    }
-    expect(await new Rating({ score: 9 }).isValid()).toBe(true);
-    expect(await new Rating({ score: 10 }).isValid()).toBe(false);
-  });
-
-  it("validates lessThanOrEqualTo", async () => {
-    class Rating extends Model {
-      static {
-        this.attribute("score", "integer");
-        this.validates("score", { comparison: { lessThanOrEqualTo: 10 } });
-      }
-    }
-    expect(await new Rating({ score: 10 }).isValid()).toBe(true);
-    expect(await new Rating({ score: 11 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with equal to using numeric", async () => {
-    class Confirmation extends Model {
-      static {
-        this.attribute("value", "integer");
-        this.validates("value", { comparison: { equalTo: 42 } });
-      }
-    }
-    expect(await new Confirmation({ value: 42 }).isValid()).toBe(true);
-    expect(await new Confirmation({ value: 43 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with other than using numeric", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("status", "integer");
-        this.validates("status", { comparison: { otherThan: 0 } });
-      }
-    }
-    expect(await new Item({ status: 1 }).isValid()).toBe(true);
-    expect(await new Item({ status: 0 }).isValid()).toBe(false);
-  });
-
-  it("validates comparison with proc", async () => {
-    class Event extends Model {
-      static {
-        this.attribute("startDate", "date");
-        this.attribute("endDate", "date");
-        this.validates("endDate", {
-          comparison: { greaterThan: (record: any) => record.readAttribute("startDate") },
-        });
-      }
-    }
-    const valid = new Event({ startDate: "2024-01-01", endDate: "2024-01-02" });
-    expect(await valid.isValid()).toBe(true);
-
-    const invalid = new Event({ startDate: "2024-01-02", endDate: "2024-01-01" });
-    expect(await invalid.isValid()).toBe(false);
-  });
-
-  it("validates comparison with greater than using date", async () => {
-    const tomorrow = plainDate("2024-06-02");
-    class Booking extends Model {
-      static {
-        this.attribute("checkIn", "date");
-        this.validates("checkIn", { comparison: { greaterThanOrEqualTo: tomorrow } });
-      }
-    }
-    expect(await new Booking({ checkIn: "2024-06-02" }).isValid()).toBe(true);
-    expect(await new Booking({ checkIn: "2024-06-01" }).isValid()).toBe(false);
+    await assertValidValues([instant("2020-08-02T12:34:00Z"), instant("2020-08-02T18:30:00Z")]);
   });
 
   it("validates comparison with greater than using string", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("code", "string");
-        this.validates("code", { comparison: { greaterThan: "A" } });
-      }
+    Topic.validatesComparisonOf("approved", { greaterThan: "cat" });
+
+    await assertInvalidValues(["ant", "cat"], "must be greater than cat");
+    await assertValidValues(["dog", "whale"]);
+  });
+
+  it("validates comparison with greater than or equal to using numeric", async () => {
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: 10 });
+
+    await assertInvalidValues([-12, 5], "must be greater than or equal to 10");
+    await assertValidValues([11, 10]);
+  });
+
+  it("validates comparison with greater than or equal to using date", async () => {
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: dateValue });
+
+    await assertInvalidValues(
+      [
+        plainDate("2019-08-03"),
+        plainDate("2020-07-03"),
+        plainDate("2020-08-01"),
+        plainDateTime("2020-08-01T12:34:00"),
+      ],
+      "must be greater than or equal to 2020-08-02",
+    );
+    await assertValidValues([
+      plainDate("2020-08-03"),
+      plainDateTime("2020-08-02T12:34:00"),
+      plainDate("2020-08-02"),
+    ]);
+  });
+
+  it("validates comparison with greater than or equal to using time", async () => {
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: timeValue });
+
+    await assertInvalidValues(
+      [instant("2019-08-01T12:34:00Z"), instant("2020-08-01T12:33:50Z")],
+      `must be greater than or equal to ${timeValue}`,
+    );
+    await assertValidValues([instant("2020-08-01T12:34:00Z"), instant("2020-08-01T12:34:01Z")]);
+  });
+
+  it("validates comparison with greater than or equal to using string", async () => {
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: "cat" });
+
+    await assertInvalidValues(["ant"], "must be greater than or equal to cat");
+    await assertValidValues(["cat", "dog", "whale"]);
+  });
+
+  it("validates comparison with equal to using numeric", async () => {
+    Topic.validatesComparisonOf("approved", { equalTo: 10 });
+
+    await assertInvalidValues([-12, 5, 11], "must be equal to 10");
+    await assertValidValues([10]);
+  });
+
+  it("validates comparison with equal to using date", async () => {
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { equalTo: dateValue });
+
+    await assertInvalidValues(
+      [
+        plainDate("2019-08-03"),
+        plainDate("2020-07-03"),
+        plainDate("2020-08-01"),
+        plainDateTime("2020-08-01T12:34:00"),
+        plainDate("2020-08-03"),
+        plainDateTime("2020-08-02T12:34:00"),
+      ],
+      "must be equal to 2020-08-02",
+    );
+    await assertValidValues([plainDate("2020-08-02"), plainDateTime("2020-08-02T00:00:00")]);
+  });
+
+  it("validates comparison with equal to using time", async () => {
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { equalTo: timeValue });
+
+    await assertInvalidValues(
+      [instant("2019-08-01T12:34:00Z"), instant("2020-08-01T12:33:50Z")],
+      `must be equal to ${timeValue}`,
+    );
+    await assertValidValues([instant("2020-08-01T12:34:00Z")]);
+  });
+
+  it("validates comparison with equal to using string", async () => {
+    Topic.validatesComparisonOf("approved", { equalTo: "cat" });
+
+    await assertInvalidValues(["dog", "whale"], "must be equal to cat");
+    await assertValidValues(["cat"]);
+  });
+
+  it("validates comparison with less than using numeric", async () => {
+    Topic.validatesComparisonOf("approved", { lessThan: 10 });
+
+    await assertInvalidValues([11, 10], "must be less than 10");
+    await assertValidValues([-12, -5, 5]);
+  });
+
+  it("validates comparison with less than using date", async () => {
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { lessThan: dateValue });
+
+    await assertInvalidValues(
+      [plainDate("2020-08-02"), plainDate("2020-08-03"), plainDateTime("2020-08-02T12:34:00")],
+      "must be less than 2020-08-02",
+    );
+    await assertValidValues([
+      plainDate("2019-08-03"),
+      plainDate("2020-07-03"),
+      plainDate("2020-08-01"),
+      plainDateTime("2020-08-01T12:34:00"),
+    ]);
+  });
+
+  it("validates comparison with less than using time", async () => {
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { lessThan: timeValue });
+
+    await assertInvalidValues(
+      [instant("2020-08-02T12:34:00Z"), instant("2020-08-02T18:30:00Z")],
+      `must be less than ${timeValue}`,
+    );
+    await assertValidValues([instant("2020-08-01T12:33:59Z"), instant("2020-07-02T18:30:00Z")]);
+  });
+
+  it("validates comparison with less than using string", async () => {
+    Topic.validatesComparisonOf("approved", { lessThan: "dog" });
+
+    await assertInvalidValues(["whale"], "must be less than dog");
+    await assertValidValues(["ant", "cat"]);
+  });
+
+  it("validates comparison with less than or equal to using numeric", async () => {
+    Topic.validatesComparisonOf("approved", { lessThanOrEqualTo: 10 });
+
+    await assertInvalidValues([12], "must be less than or equal to 10");
+    await assertValidValues([-11, 5, 10]);
+  });
+
+  it("validates comparison with less than or equal to using date", async () => {
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { lessThanOrEqualTo: dateValue });
+
+    await assertInvalidValues(
+      [plainDate("2020-08-03"), plainDateTime("2020-08-02T12:34:00")],
+      "must be less than or equal to 2020-08-02",
+    );
+    await assertValidValues([
+      plainDate("2019-08-03"),
+      plainDate("2020-07-03"),
+      plainDate("2020-08-01"),
+      plainDate("2020-08-02"),
+      plainDateTime("2020-08-01T12:34:00"),
+    ]);
+  });
+
+  it("validates comparison with less than or equal to using time", async () => {
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { lessThanOrEqualTo: timeValue });
+
+    await assertInvalidValues(
+      [instant("2020-09-01T12:34:00Z"), instant("2020-08-01T12:34:01Z")],
+      `must be less than or equal to ${timeValue}`,
+    );
+    await assertValidValues([instant("2020-08-01T12:34:00Z"), instant("2020-08-01T12:33:50Z")]);
+  });
+
+  it("validates comparison with less than or equal to using string", async () => {
+    Topic.validatesComparisonOf("approved", { lessThanOrEqualTo: "dog" });
+
+    await assertInvalidValues(["whale"], "must be less than or equal to dog");
+    await assertValidValues(["ant", "cat", "dog"]);
+  });
+
+  it("validates comparison with other than using numeric", async () => {
+    Topic.validatesComparisonOf("approved", { otherThan: 10 });
+
+    await assertInvalidValues([10], "must be other than 10");
+    await assertValidValues([-12, 5, 11]);
+  });
+
+  it("validates comparison with other than using date", async () => {
+    const dateValue = plainDate("2020-08-02");
+    Topic.validatesComparisonOf("approved", { otherThan: dateValue });
+
+    await assertInvalidValues(
+      [plainDate("2020-08-02"), plainDateTime("2020-08-02T00:00:00")],
+      "must be other than 2020-08-02",
+    );
+    await assertValidValues([
+      plainDate("2019-08-03"),
+      plainDate("2020-07-03"),
+      plainDate("2020-08-01"),
+      plainDateTime("2020-08-01T12:34:00"),
+      plainDate("2020-08-03"),
+      plainDateTime("2020-08-02T12:34:00"),
+    ]);
+  });
+
+  it("validates comparison with other than using time", async () => {
+    const timeValue = instant("2020-08-01T12:34:00Z");
+    Topic.validatesComparisonOf("approved", { otherThan: timeValue });
+
+    await assertInvalidValues([instant("2020-08-01T12:34:00Z")], `must be other than ${timeValue}`);
+    await assertValidValues([instant("2019-08-01T12:34:00Z"), instant("2020-08-01T12:33:50Z")]);
+  });
+
+  it("validates comparison with other than using string", async () => {
+    Topic.validatesComparisonOf("approved", { otherThan: "whale" });
+
+    await assertInvalidValues(["whale"], "must be other than whale");
+    await assertValidValues(["ant", "cat", "dog"]);
+  });
+
+  it("validates comparison with proc", async () => {
+    defineRequested();
+    Topic.validatesComparisonOf("approved", {
+      greaterThanOrEqualTo: (topic: Topic) => (topic as unknown as Requested).requested(),
+    });
+
+    try {
+      await assertInvalidValues(
+        [plainDate("2020-07-01"), plainDate("2019-07-01"), plainDateTime("2020-07-01T22:34:00")],
+        "must be greater than or equal to 2020-08-01",
+      );
+      await assertValidValues([plainDate("2020-08-02"), plainDateTime("2021-08-01T00:00:00")]);
+    } finally {
+      removeRequested();
     }
-    expect(await new Item({ code: "B" }).isValid()).toBe(true);
-    expect(await new Item({ code: "A" }).isValid()).toBe(false);
+  });
+
+  it("validates comparison with lambda", async () => {
+    Topic.validatesComparisonOf("approved", {
+      greaterThanOrEqualTo: () => plainDate("2020-08-01"),
+    });
+
+    await assertInvalidValues(
+      [plainDate("2020-07-01"), plainDate("2019-07-01"), plainDateTime("2020-07-01T22:34:00")],
+      "must be greater than or equal to 2020-08-01",
+    );
+    await assertValidValues([plainDate("2020-08-02"), plainDateTime("2021-08-01T00:00:00")]);
+  });
+
+  it("validates comparison with method", async () => {
+    defineRequested();
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: "requested" });
+
+    try {
+      await assertInvalidValues(
+        [plainDate("2020-07-01"), plainDate("2019-07-01"), plainDateTime("2020-07-01T22:34:00")],
+        "must be greater than or equal to 2020-08-01",
+      );
+      await assertValidValues([plainDate("2020-08-02"), plainDateTime("2021-08-01T00:00:00")]);
+    } finally {
+      removeRequested();
+    }
+  });
+
+  it("validates comparison with custom compare", async () => {
+    Topic.validatesComparisonOf("approved", { greaterThanOrEqualTo: new Custom(1150) });
+
+    await assertInvalidValues([new Custom(530), new Custom(2325)]);
+    await assertValidValues([new Custom(575), new Custom(250), new Custom(1999)]);
+  });
+
+  it("validates comparison with blank allowed", async () => {
+    Topic.validatesComparisonOf("approved", { greaterThan: "cat", allowBlank: true });
+
+    await assertInvalidValues(["ant"]);
+    await assertValidValues([null, ""]);
   });
 
   it("validates comparison with nil allowed", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("quantity", "integer");
-        this.validates("quantity", { comparison: { greaterThan: 0, allowNil: true } });
-      }
-    }
-    expect(await new Item({}).isValid()).toBe(true);
+    Topic.validatesComparisonOf("approved", { lessThan: 100, allowNil: true });
+
+    await assertInvalidValues([200]);
+    await assertValidValues([null, 50]);
   });
 
-  it("supports custom message", async () => {
-    class Item extends Model {
-      static {
-        this.attribute("qty", "integer");
-        this.validates("qty", {
-          comparison: { greaterThan: 0, message: "must be positive" },
-        });
-      }
-    }
-    const item = new Item({ qty: 0 });
-    expect(await item.isValid()).toBe(false);
-    expect(item.errors.fullMessages).toContain("Qty must be positive");
+  it("validates comparison of incomparables", async () => {
+    Topic.validatesComparisonOf("approved", { lessThan: "cat" });
+
+    await assertInvalidValues([12], "comparison of Integer with String failed");
+    await assertInvalidValues([null]);
+    await assertValidValues([]);
   });
 
   it("validates comparison of multiple values", async () => {
-    class Score extends Model {
-      static {
-        this.attribute("value", "integer");
-        this.validates("value", {
-          comparison: { greaterThanOrEqualTo: 0, lessThanOrEqualTo: 100 },
-        });
-      }
-    }
-    expect(await new Score({ value: 50 }).isValid()).toBe(true);
-    expect(await new Score({ value: -1 }).isValid()).toBe(false);
-    expect(await new Score({ value: 101 }).isValid()).toBe(false);
+    Topic.validatesComparisonOf("approved", { otherThan: 17, greaterThan: 13 });
+
+    await assertInvalidValues([12, null, 17]);
+    await assertValidValues([15]);
   });
+
+  it("validates comparison of no options", () => {
+    let error: Error | undefined;
+    expect(() => {
+      try {
+        Topic.validatesComparisonOf("approved");
+      } catch (e) {
+        error = e as Error;
+        throw e;
+      }
+    }).toThrow(ArgumentError);
+    expect(error?.message).toEqual(
+      "Expected one of :greater_than, :greater_than_or_equal_to," +
+        " :equal_to, :less_than, :less_than_or_equal_to, or :other_than option to be supplied.",
+    );
+  });
+
+  // -- private --
+
+  async function assertInvalidValues(values: unknown[], error?: string): Promise<void> {
+    await withEachTopicApprovedValue(values, async (topic, value) => {
+      assertPredicate(await topic.isInvalid(), (invalid) => invalid, `${value} failed comparison`);
+      assertPredicate(
+        topic.errors.get("approved"),
+        (errors) => errors.length > 0,
+        `FAILED for ${value}`,
+      );
+      if (error) expect(topic.errors.get("approved")[0]).toEqual(error);
+    });
+  }
+
+  async function assertValidValues(values: unknown[]): Promise<void> {
+    await withEachTopicApprovedValue(values, async (topic, value) => {
+      assertPredicate(
+        await topic.isValid(),
+        (valid) => valid,
+        `${value} failed comparison with validation error: ${topic.errors.get("approved")[0]}`,
+      );
+    });
+  }
+
+  async function withEachTopicApprovedValue(
+    values: unknown[],
+    block: (topic: Topic, value: unknown) => Promise<void>,
+  ): Promise<void> {
+    const topic = new Topic({ title: "comparison test", content: "whatever" });
+    for (const value of values) {
+      topic.approved = value;
+      await block(topic, value);
+    }
+  }
 });
+
+interface Requested {
+  requested(): unknown;
+}
+
+/** Rails' `Topic.define_method(:requested) { Date.new(2020, 8, 1) }`. */
+function defineRequested(): void {
+  (Topic.prototype as unknown as Requested).requested = () => plainDate("2020-08-01");
+}
+
+/** Rails' `ensure Topic.remove_method :requested`. */
+function removeRequested(): void {
+  delete (Topic.prototype as unknown as Partial<Requested>).requested;
+}

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -7,6 +7,21 @@ import { COMPARE_CHECKS, compareOperator, errorOptions } from "./comparability.j
 import type { CompareKey } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
 
+/** Ruby `Comparable`'s `<=>`, spelled `compareTo` in trails. */
+function hasCompareTo(value: unknown): value is { compareTo(other: unknown): number | null } {
+  return value != null && typeof (value as { compareTo?: unknown }).compareTo === "function";
+}
+
+/** The `rb_cmperr` message from `value.public_send(op, other)`: "comparison of Integer with String failed". */
+function comparisonFailed(a: unknown, b: unknown): string {
+  const nameOf = (x: unknown) => {
+    if (x === null || x === undefined) return "NilClass";
+    if (typeof x === "number") return Number.isInteger(x) ? "Integer" : "Float";
+    return (x as object).constructor?.name ?? typeof x;
+  };
+  return `comparison of ${nameOf(a)} with ${nameOf(b)} failed`;
+}
+
 export class ComparisonValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
@@ -41,6 +56,20 @@ export class ComparisonValidator extends EachValidator {
   }
 
   private compare(a: unknown, b: unknown): number {
+    // Ruby dispatches the operator off the value, so any object that
+    // `include Comparable` and defines `<=>` compares. `compareTo` is trails'
+    // spelling of `<=>` (see date/src/date.ts:5147).
+    if (hasCompareTo(a)) {
+      const cmp = a.compareTo(b);
+      if (cmp === null || cmp === undefined) throw new ArgumentError(comparisonFailed(a, b));
+      return cmp;
+    }
+    // Ruby's Date and DateTime compare against each other through the same
+    // astronomical Julian day; a Date is that day at midnight.
+    if (a instanceof Temporal.PlainDate && b instanceof Temporal.PlainDateTime)
+      return Temporal.PlainDateTime.compare(a.toPlainDateTime(), b);
+    if (a instanceof Temporal.PlainDateTime && b instanceof Temporal.PlainDate)
+      return Temporal.PlainDateTime.compare(a, b.toPlainDateTime());
     if (a instanceof Temporal.Instant && b instanceof Temporal.Instant)
       return Temporal.Instant.compare(a, b);
     if (a instanceof Temporal.PlainDateTime && b instanceof Temporal.PlainDateTime)
@@ -55,21 +84,14 @@ export class ComparisonValidator extends EachValidator {
     if (typeof a === "string" && typeof b === "string") return a < b ? -1 : a > b ? 1 : 0;
     // boundary: comparison validator accepts Date pairs by Rails parity.
     if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
-    // Match Rails ArgumentError format from value.public_send(op, other):
-    //   "comparison of Integer with String failed"
-    const nameOf = (x: unknown) =>
-      x === null
-        ? "NilClass"
-        : x === undefined
-          ? "NilClass"
-          : ((x as object).constructor?.name ?? typeof x);
-    throw new ArgumentError(`comparison of ${nameOf(a)} with ${nameOf(b)} failed`);
+    throw new ArgumentError(comparisonFailed(a, b));
   }
 
   override checkValidity(): void {
     if (!Object.keys(COMPARE_CHECKS).some((k) => this.options[k] !== undefined)) {
       throw new ArgumentError(
-        "One of :greater_than, :greater_than_or_equal_to, :less_than, :less_than_or_equal_to, :equal_to, or :other_than must be supplied",
+        "Expected one of :greater_than, :greater_than_or_equal_to, " +
+          ":equal_to, :less_than, :less_than_or_equal_to, or :other_than option to be supplied.",
       );
     }
   }

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -60,7 +60,8 @@ export class ComparisonValidator extends EachValidator {
    * (comparison.rb:27). Ruby dispatches the operator off the value, so any
    * object that `include Comparable` and defines `<=>` compares — `compareTo`
    * is trails' spelling of `<=>` (date/src/date.ts:5147) and is tried first.
-   * A Date and a DateTime compare through the same astronomical Julian day,
+   * A Date and a DateTime compare through the same astronomical Julian day
+   * (`Date#<=>` is `d_lite_cmp` over `ajd` in the date gem's `date_core.c`),
    * a Date being that day at midnight.
    */
   private compare(a: unknown, b: unknown): number {

--- a/packages/activemodel/src/validations/comparison.ts
+++ b/packages/activemodel/src/validations/comparison.ts
@@ -55,17 +55,20 @@ export class ComparisonValidator extends EachValidator {
     }
   }
 
+  /**
+   * The `<=>` behind `value.public_send(COMPARE_CHECKS[option], option_value)`
+   * (comparison.rb:27). Ruby dispatches the operator off the value, so any
+   * object that `include Comparable` and defines `<=>` compares — `compareTo`
+   * is trails' spelling of `<=>` (date/src/date.ts:5147) and is tried first.
+   * A Date and a DateTime compare through the same astronomical Julian day,
+   * a Date being that day at midnight.
+   */
   private compare(a: unknown, b: unknown): number {
-    // Ruby dispatches the operator off the value, so any object that
-    // `include Comparable` and defines `<=>` compares. `compareTo` is trails'
-    // spelling of `<=>` (see date/src/date.ts:5147).
     if (hasCompareTo(a)) {
       const cmp = a.compareTo(b);
       if (cmp === null || cmp === undefined) throw new ArgumentError(comparisonFailed(a, b));
       return cmp;
     }
-    // Ruby's Date and DateTime compare against each other through the same
-    // astronomical Julian day; a Date is that day at midnight.
     if (a instanceof Temporal.PlainDate && b instanceof Temporal.PlainDateTime)
       return Temporal.PlainDateTime.compare(a.toPlainDateTime(), b);
     if (a instanceof Temporal.PlainDateTime && b instanceof Temporal.PlainDate)

--- a/packages/activesupport/src/core-ext/hash/slice.ts
+++ b/packages/activesupport/src/core-ext/hash/slice.ts
@@ -11,6 +11,8 @@ type AnyObject = Record<string, unknown>;
  * `replace(hash)` (slice.rb:15) is the own-key clear plus `Object.assign` —
  * JS objects carry no `replace`.
  *
+ * @missingRailsCall default — `hash.default = default` (slice.rb:13) reads a
+ * seat a plain JS object does not have.
  * @missingRailsCall replace — Ruby's `Hash#replace` (slice.rb:15) has no JS
  * analogue; the own-key delete loop plus `Object.assign` IS that call.
  */

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -508,21 +508,24 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("indifferent reverse merging", () => {
-    // reverse_merge: other's keys only if not already present
-    const h = new HashWithIndifferentAccess<unknown>({ a: 1 });
-    const other = new HashWithIndifferentAccess({ a: 99, b: 2 });
-    // Simulate reverse merge: other merged with h overriding
-    const reversed = other.merge(h);
-    expect(reversed.get("a")).toBe(1);
-    expect(reversed.get("b")).toBe(2);
+    let hash = new HashWithIndifferentAccess<unknown>({ key: ":old_value" });
+    hash.reverseMergeBang({ key: ":new_value" });
+    expect(hash.get(":key")).toBe(":old_value");
+
+    hash = new HashWithIndifferentAccess<unknown>({ some: "value", other: "value" });
+    hash.reverseMergeBang({ some: "noclobber", another: "clobber" });
+    expect(hash.get(":some")).toBe("value");
+    expect(hash.get(":another")).toBe("clobber");
   });
 
   it("indifferent with defaults aliases reverse merge", () => {
-    const h = new HashWithIndifferentAccess<unknown>({ a: 1 });
-    const defaults = new HashWithIndifferentAccess({ a: 99, b: 2 });
-    const merged = defaults.merge(h);
-    expect(merged.get("a")).toBe(1);
-    expect(merged.get("b")).toBe(2);
+    let hash = new HashWithIndifferentAccess<unknown>({ key: ":old_value" });
+    const actual = hash.withDefaults({ key: ":new_value" });
+    expect(actual.get(":key")).toBe(":old_value");
+
+    hash = new HashWithIndifferentAccess<unknown>({ key: ":old_value" });
+    hash.withDefaultsBang({ key: ":new_value" });
+    expect(hash.get(":key")).toBe(":old_value");
   });
 
   it("indifferent deleting", () => {
@@ -711,20 +714,23 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("argless default with existing nil key", () => {
-    const h = new HashWithIndifferentAccess<unknown>({ a: null });
-    expect(h.get("a")).toBeNull();
-    expect(h.hasKey("a")).toBe(true);
+    const h = new HashWithIndifferentAccess<unknown>(":default").merge({ a: "defined" });
+
+    expect(h.default()).toBe(":default");
   });
 
   it("default with argument", () => {
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    expect(h.get("missing")).toBeUndefined();
+    const h = new HashWithIndifferentAccess<unknown>(() => 5).merge({ "1": 2 });
+
+    expect(h.default("1")).toBe(5);
   });
 
   it("default proc", () => {
-    // We don't support default procs; verify missing key returns undefined
-    const h = new HashWithIndifferentAccess<unknown>({ a: 1 });
-    expect(h.get("nonexistent")).toBeUndefined();
+    const h = new HashWithIndifferentAccess<unknown>((_hash: unknown, key: string) => key);
+
+    expect(h.default()).toBeUndefined();
+    expect(h.default("foo")).toBe("foo");
+    expect(h.default(":foo")).toBe("foo");
   });
 
   it("double conversion with nil key", () => {
@@ -817,21 +823,31 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("dup with default proc", () => {
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    const dup = h.withIndifferentAccess();
-    expect(dup.get("a")).toBe(1);
+    const hash = new HashWithIndifferentAccess<unknown>();
+    hash.setDefaultProc(() => {
+      throw new Error("walrus");
+    });
+    expect(() => hash.dup()).not.toThrow();
   });
 
   it("dup with default proc sets proc", () => {
-    // We don't support default procs; verify dup works
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    const dup = h.withIndifferentAccess();
-    expect(dup).toBeInstanceOf(HashWithIndifferentAccess);
+    const hash = new HashWithIndifferentAccess<unknown>();
+    hash.setDefaultProc((_h: unknown, k: string) => Number(k) + 1);
+    const newHash = hash.dup();
+
+    expect(newHash.get("2")).toBe(3);
+
+    newHash.setDefault(2);
+    expect(newHash.get(":non_existent")).toBe(2);
   });
 
   it("to hash with raising default proc", () => {
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    expect(h.toHash()).toEqual({ a: 1 });
+    const hash = new HashWithIndifferentAccess<unknown>();
+    hash.setDefaultProc(() => {
+      throw new Error("walrus");
+    });
+
+    expect(() => hash.toHash()).not.toThrow();
   });
 
   it("new with to hash conversion copies default", () => {

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -714,7 +714,11 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("argless default with existing nil key", () => {
-    const h = new HashWithIndifferentAccess<unknown>(":default").merge({ a: "defined" });
+    // Rails builds the source as `Hash.new(:default).merge(nil => "defined")`.
+    // A plain JS object has no default seat and no nil key — every key is a
+    // string — so the default comes from the HWIA constructor and the nil key
+    // is JS's own spelling of it.
+    const h = new HashWithIndifferentAccess<unknown>(":default").merge({ null: "defined" });
 
     expect(h.default()).toBe(":default");
   });

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -45,23 +45,34 @@ export class HashWithIndifferentAccess<V = unknown> {
    * Mirrors `initialize` (hash_with_indifferent_access.rb:70-83). The
    * `respond_to?(:to_hash)` arm goes through `update`, so every key gets
    * `convert_key` and every value `convert_value`, then carries the source
-   * hash's `default` / `default_proc` over; the `else` arm is `Hash.new(obj)`,
-   * which sets the default value.
+   * hash's `default` / `default_proc` over — both under Ruby truthiness, so a
+   * stored `false` default is left behind exactly as `if hash.default` does;
+   * the `else` arm is `Hash.new(obj)`, which sets the default value.
+   *
+   * `Hash.new { |hash, key| ... }` takes its default_proc as a block. A block
+   * is a single trailing function argument here, the same spelling `fetch`
+   * uses (:195).
    */
-  constructor(constructor?: AnyObject | HashWithIndifferentAccess<V> | NoInfer<V>) {
+  constructor(
+    constructor?: AnyObject | HashWithIndifferentAccess<V> | DefaultProc<V> | NoInfer<V>,
+  ) {
     this.data = new Map();
     if (constructor instanceof HashWithIndifferentAccess || isPlainObject(constructor)) {
       this.update(constructor);
 
       const hash = constructor;
       if (hash instanceof HashWithIndifferentAccess) {
-        if (hash._default != null) this._default = hash._default;
-        if (hash._defaultProc != null) this._defaultProc = hash._defaultProc;
+        if (hash.default() != null && (hash.default() as unknown) !== false) {
+          this.setDefault(hash.default());
+        }
+        if (hash.defaultProc()) this.setDefaultProc(hash.defaultProc());
       }
     } else if (constructor == null) {
       // super()
+    } else if (typeof constructor === "function") {
+      this.setDefaultProc(constructor as DefaultProc<V>);
     } else {
-      this._default = constructor as V;
+      this.setDefault(constructor as V);
     }
   }
 
@@ -96,6 +107,40 @@ export class HashWithIndifferentAccess<V = unknown> {
       const key = this.convertKey(args[0]);
       return this._defaultProc ? this._defaultProc(this, key) : this._default;
     }
+  }
+
+  /**
+   * `Hash#default=`, which `initialize` (:76) and `set_defaults` (:420) write
+   * through. A TS `set` accessor cannot share a name with the `default()`
+   * reader, so it takes the conventions' `setX()` spelling. MRI clears
+   * default_proc on this write, and `test_dup_with_default_proc_sets_proc`
+   * (hash_with_indifferent_access_test.rb:837-838) depends on it.
+   */
+  setDefault(value: V | undefined): void {
+    this._default = value;
+    this._defaultProc = undefined;
+  }
+
+  /**
+   * `Hash#default_proc`, read by `set_defaults` (:417-418).
+   *
+   * @noRailsEquivalent inherited from Ruby's Hash, which this class subclasses;
+   * core Ruby has no file in the mapped Rails source to match against
+   */
+  defaultProc(): DefaultProc<V> | undefined {
+    return this._defaultProc;
+  }
+
+  /**
+   * `Hash#default_proc=`, which `initialize` (:77) and `set_defaults` (:418)
+   * write through. MRI clears the default value on this write.
+   *
+   * @noRailsEquivalent inherited from Ruby's Hash, which this class subclasses;
+   * core Ruby has no file in the mapped Rails source to match against
+   */
+  setDefaultProc(proc: DefaultProc<V> | undefined): void {
+    this._defaultProc = proc;
+    this._default = undefined;
   }
 
   /**
@@ -226,7 +271,7 @@ export class HashWithIndifferentAccess<V = unknown> {
   merge(
     ...hashes: (AnyObject | HashWithIndifferentAccess<V> | BlockFn<V>)[]
   ): HashWithIndifferentAccess<V> {
-    return new HashWithIndifferentAccess<V>(this).update(...hashes);
+    return this.dup().update(...hashes);
   }
 
   /**
@@ -644,10 +689,10 @@ export class HashWithIndifferentAccess<V = unknown> {
    * (`dup`) reach it.
    */
   private setDefaults(target: HashWithIndifferentAccess<V>): void {
-    if (this._defaultProc) {
-      target._defaultProc = this._defaultProc;
+    if (this.defaultProc()) {
+      target.setDefaultProc(this.defaultProc());
     } else {
-      target._default = this.default();
+      target.setDefault(this.default());
     }
   }
 

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -124,8 +124,8 @@ export class HashWithIndifferentAccess<V = unknown> {
   /**
    * `Hash#default_proc`, read by `set_defaults` (:417-418).
    *
-   * @noRailsEquivalent inherited from Ruby's Hash, which this class subclasses;
-   * core Ruby has no file in the mapped Rails source to match against
+   * @noRailsEquivalent PERMANENT — inherited from Ruby's Hash, which this class
+   * subclasses; core Ruby has no file in the mapped Rails source to match against
    */
   defaultProc(): DefaultProc<V> | undefined {
     return this._defaultProc;
@@ -135,8 +135,8 @@ export class HashWithIndifferentAccess<V = unknown> {
    * `Hash#default_proc=`, which `initialize` (:77) and `set_defaults` (:418)
    * write through. MRI clears the default value on this write.
    *
-   * @noRailsEquivalent inherited from Ruby's Hash, which this class subclasses;
-   * core Ruby has no file in the mapped Rails source to match against
+   * @noRailsEquivalent PERMANENT — inherited from Ruby's Hash, which this class
+   * subclasses; core Ruby has no file in the mapped Rails source to match against
    */
   setDefaultProc(proc: DefaultProc<V> | undefined): void {
     this._defaultProc = proc;

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -41,13 +41,16 @@ export class HashWithIndifferentAccess<V = unknown> {
   private _default?: V;
   private _defaultProc?: DefaultProc<V>;
 
+  /**
+   * Mirrors `initialize` (hash_with_indifferent_access.rb:70-83). The
+   * `respond_to?(:to_hash)` arm goes through `update`, so every key gets
+   * `convert_key` and every value `convert_value`, then carries the source
+   * hash's `default` / `default_proc` over; the `else` arm is `Hash.new(obj)`,
+   * which sets the default value.
+   */
   constructor(constructor?: AnyObject | HashWithIndifferentAccess<V> | NoInfer<V>) {
     this.data = new Map();
-    // Mirrors `initialize` (hash_with_indifferent_access.rb:70-83).
     if (constructor instanceof HashWithIndifferentAccess || isPlainObject(constructor)) {
-      // The `respond_to?(:to_hash)` arm: the populated hash goes through
-      // `update`, so every key gets `convert_key` and every value
-      // `convert_value`, then the source hash's defaults are carried over.
       this.update(constructor);
 
       const hash = constructor;
@@ -58,7 +61,6 @@ export class HashWithIndifferentAccess<V = unknown> {
     } else if (constructor == null) {
       // super()
     } else {
-      // `super(constructor)` — `Hash.new(obj)` sets the default value.
       this._default = constructor as V;
     }
   }
@@ -73,12 +75,12 @@ export class HashWithIndifferentAccess<V = unknown> {
 
   /**
    * Mirrors `[]` (hash_with_indifferent_access.rb:166-168) — the reader that
-   * takes either spelling of the key.
+   * takes either spelling of the key. On a miss `Hash#[]` yields to the
+   * default_proc, else returns the default.
    */
   get(key: string): V | undefined {
     const convertedKey = this.convertKey(key);
     if (this.data.has(convertedKey)) return this.data.get(convertedKey);
-    // `Hash#[]` on a miss yields to the default_proc, else returns the default.
     return this.default(convertedKey);
   }
 

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -28,17 +28,38 @@ type BlockFn<V> = (key: string, oldValue: V, newValue: V) => V;
  */
 type DefaultBlock<V> = (key: string) => V;
 
+/**
+ * A `Hash#default_proc` (hash_with_indifferent_access.rb:77): yielded the hash
+ * itself and the missing key.
+ */
+type DefaultProc<V> = (hash: HashWithIndifferentAccess<V>, key: string) => V;
+
 export class HashWithIndifferentAccess<V = unknown> {
   private data: Map<string, V>;
 
-  constructor(constructor?: AnyObject | HashWithIndifferentAccess<V>) {
+  /** `Hash#default` / `Hash#default_proc` storage — Rails inherits both. */
+  private _default?: V;
+  private _defaultProc?: DefaultProc<V>;
+
+  constructor(constructor?: AnyObject | HashWithIndifferentAccess<V> | NoInfer<V>) {
     this.data = new Map();
-    // Mirrors `initialize` (hash_with_indifferent_access.rb:70-83): the
-    // populated arm goes through `update`, so every key gets `convert_key` and
-    // every value `convert_value`. Rails' `else super(constructor)` arm sets a
-    // Hash default value, which this class does not model.
-    if (constructor != null) {
+    // Mirrors `initialize` (hash_with_indifferent_access.rb:70-83).
+    if (constructor instanceof HashWithIndifferentAccess || isPlainObject(constructor)) {
+      // The `respond_to?(:to_hash)` arm: the populated hash goes through
+      // `update`, so every key gets `convert_key` and every value
+      // `convert_value`, then the source hash's defaults are carried over.
       this.update(constructor);
+
+      const hash = constructor;
+      if (hash instanceof HashWithIndifferentAccess) {
+        if (hash._default != null) this._default = hash._default;
+        if (hash._defaultProc != null) this._defaultProc = hash._defaultProc;
+      }
+    } else if (constructor == null) {
+      // super()
+    } else {
+      // `super(constructor)` — `Hash.new(obj)` sets the default value.
+      this._default = constructor as V;
     }
   }
 
@@ -55,7 +76,24 @@ export class HashWithIndifferentAccess<V = unknown> {
    * takes either spelling of the key.
    */
   get(key: string): V | undefined {
-    return this.data.get(this.convertKey(key));
+    const convertedKey = this.convertKey(key);
+    if (this.data.has(convertedKey)) return this.data.get(convertedKey);
+    // `Hash#[]` on a miss yields to the default_proc, else returns the default.
+    return this.default(convertedKey);
+  }
+
+  /**
+   * Mirrors `default` (hash_with_indifferent_access.rb:223-229) — with no
+   * argument it is `Hash#default`, the plain default value; with one it is
+   * `Hash#default(key)` over the converted key, which runs the default_proc.
+   */
+  default(...args: string[]): V | undefined {
+    if (args.length === 0) {
+      return this._default;
+    } else {
+      const key = this.convertKey(args[0]);
+      return this._defaultProc ? this._defaultProc(this, key) : this._default;
+    }
   }
 
   /**
@@ -233,6 +271,43 @@ export class HashWithIndifferentAccess<V = unknown> {
         this.regularWriter(this.convertKey(key), this.convertValue(v));
       }
     }
+  }
+
+  /**
+   * Mirrors `dup` (hash_with_indifferent_access.rb:264-268) — a shallow copy
+   * that carries the receiver's defaults over.
+   */
+  dup(): HashWithIndifferentAccess<V> {
+    const newHash = new HashWithIndifferentAccess<V>(this);
+    this.setDefaults(newHash);
+    return newHash;
+  }
+
+  /**
+   * Mirrors `reverse_merge` (hash_with_indifferent_access.rb:283-285) — like
+   * `merge` but the other way around: merges the receiver into the argument
+   * and returns a new hash with indifferent access as result.
+   */
+  reverseMerge(otherHash: AnyObject | HashWithIndifferentAccess<V>): HashWithIndifferentAccess<V> {
+    return new HashWithIndifferentAccess<V>(otherHash).merge(this);
+  }
+
+  /** `alias_method :with_defaults, :reverse_merge` (hash_with_indifferent_access.rb:286). */
+  withDefaults(otherHash: AnyObject | HashWithIndifferentAccess<V>): HashWithIndifferentAccess<V> {
+    return this.reverseMerge(otherHash);
+  }
+
+  /**
+   * Mirrors `reverse_merge!` (hash_with_indifferent_access.rb:288-290) — same
+   * semantics as `reverseMerge` but modifies the receiver in-place.
+   */
+  reverseMergeBang(otherHash: AnyObject | HashWithIndifferentAccess<V>): this {
+    return this.replace(this.reverseMerge(new HashWithIndifferentAccess<V>(otherHash)));
+  }
+
+  /** `alias_method :with_defaults!, :reverse_merge!` (hash_with_indifferent_access.rb:291). */
+  withDefaultsBang(otherHash: AnyObject | HashWithIndifferentAccess<V>): this {
+    return this.reverseMergeBang(otherHash);
   }
 
   /**
@@ -485,7 +560,7 @@ export class HashWithIndifferentAccess<V = unknown> {
    * withIndifferentAccess — returns a dup of self (already HWIA).
    */
   withIndifferentAccess(): HashWithIndifferentAccess<V> {
-    return new HashWithIndifferentAccess<V>(this);
+    return this.dup();
   }
 
   /**
@@ -555,6 +630,22 @@ export class HashWithIndifferentAccess<V = unknown> {
       return array as V;
     } else {
       return value;
+    }
+  }
+
+  /**
+   * Mirrors `set_defaults` (hash_with_indifferent_access.rb:416-422) — copies
+   * the receiver's default_proc, else its default value, onto `target`.
+   *
+   * Rails' other caller is `to_hash`, whose target is a plain `Hash`; a TS
+   * object has nowhere to keep a default, so only the hash-valued targets
+   * (`dup`) reach it.
+   */
+  private setDefaults(target: HashWithIndifferentAccess<V>): void {
+    if (this._defaultProc) {
+      target._defaultProc = this._defaultProc;
+    } else {
+      target._default = this.default();
     }
   }
 

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,8 +21,8 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 429,
-      "kind": 656,
+      "assertionCount": 415,
+      "kind": 623,
       "value": 65
     },
     "activerecord": {


### PR DESCRIPTION
Two bundled stories.

## 1. `port-hwia-defaults-family` (RFC 0098)

`HashWithIndifferentAccess` had no default seat at all, which is why the
defaults family was deferred by the converters/readers PR. It now has one,
populated by all three arms of `initialize`
(`hash_with_indifferent_access.rb:70-83`), and the six remaining members of the
group are ported at the Rails names:

- `default(key = (no_key = true))` (:223-229) — both arms; with a key it runs
  the default_proc, exactly as MRI's `Hash#default(key)` does (verified against
  `ruby -e`).
- `reverse_merge` / `with_defaults` (:283-286), `reverse_merge!` /
  `with_defaults!` (:288-291), each through `self.class.new(other_hash)` and
  the `Hash#reverse_merge` body it supers into (`core_ext/hash/reverse_merge.rb:14-22`).
- private `set_defaults(target)` (:416-422).
- `dup` (:264-268) came with it, since it is `set_defaults`' caller and is what
  `with_indifferent_access` (:62) returns.

`get()` (Rails `[]`) now falls back to the default on a miss, which is what
`Hash#[]` does; with no default configured that is `undefined` as before.

`parity:api` for `hash_with_indifferent_access.rb`: 12 missing → 6 missing
(the remainder is the `to_options` / `transform_keys!` / `slice!` / `to_proc`
group, out of scope here).

Rails' other `set_defaults` caller is `to_hash`, whose target is a plain
`Hash`; a TS object has no default seat, so only `dup` reaches it. The same
shortcoming already existed in `core-ext/hash/slice.ts`, which now carries the
`@missingRailsCall default` receipt it was missing — it surfaced as a new
call-gate row only because `default` became a resolvable ported name.

## 2. `assertions-activemodel-comparison-validation` (RFC 0105)

`comparison_validation_test.rb` (336 lines) ported over the top of the trails
file, which matched Rails only by `it(...)` name. One file-scope `Topic` with
`attribute("approved", "value")` (the untyped `ValueType`, `type/registry.ts:47`,
standing in for Rails' bare `attr_accessor :approved`), the three private
helpers at their Rails names and call sites, and `assertPredicate` wherever
Rails writes `assert_predicate`.

Measured before: 14 assertion-count + 33 assertion-kind + 0 assertion-value
mismatches over 33 matched tests, 13 trails-only extras (all invented
scenarios, none worth keeping). After: `0 0 0`, 33/33, 0 extra;
`assertion-mismatch-mark.json` lowered for activemodel by exactly that
(429/656 → 415/623). The activemodel test percent is unchanged.

Both implementation blockers named in the story are fixed in
`validations/comparison.ts`:

- `checkValidity()` raises Rails' message (`comparison.rb:13-17`), which
  `test_validates_comparison_of_no_options` asserts verbatim.
- `compare()` compares a `Date` against a `DateTime` — Ruby compares both
  through the same astronomical Julian day, a Date being that day at midnight
  — which nine of the tests depend on.

`test_validates_comparison_with_custom_compare` did not need its own story:
Ruby's `<=>` already has a trails spelling, `compareTo` (`date/src/date.ts:5147`,
where `DateInfinity` derives the `Comparable` operators from it). `compare()`
dispatches through it first, which is what Rails' `value.public_send(op, other)`
does for any `include Comparable` object, so the `Struct` ports as a small
class with `compareTo`.

The `ArgumentError` message for incomparables also reports Ruby class names
(`Integer`, not `Number`), as `test_validates_comparison_of_incomparables`
asserts.

## Review round 1

- The constructor's `default` copy now follows Ruby truthiness (`if hash.default`
  is false for `false` too), so a `false` default is left behind as Rails leaves
  it. Both writers also reproduce MRI's mutual clearing (`default=` clears
  default_proc and vice versa), which
  `test_dup_with_default_proc_sets_proc` (:837-838) depends on — verified with
  `ruby -e`.
- The six stale simulations in `hash-with-indifferent-access.test.ts` are now
  the Rails bodies: `test_indifferent_reverse_merging` (:357-366) and
  `test_indifferent_with_defaults_aliases_reverse_merge` (:368-376) call
  `reverseMergeBang` / `withDefaults` / `withDefaultsBang`; `test_default_proc`
  (:712-718), `test_dup_with_default_proc` (:824-828),
  `test_dup_with_default_proc_sets_proc` (:830-839) and
  `test_to_hash_with_raising_default_proc` (:841-846) exercise default_proc
  end to end, including `set_defaults` carrying it onto the dup.
  `Hash.new { |hash, key| ... }` passes its default_proc as a block, spelled as
  a single trailing function argument — the same convention `fetch` (:195)
  already uses in this file.
- `merge` now calls `dup()` (:274-276), as Rails' body does.
- `Date#<=>` is cited at the call site (`d_lite_cmp` over `ajd`, date gem
  `date_core.c`).
- `defaultProc` / `setDefaultProc` are `Hash` members this class inherits by
  subclassing; core Ruby has no file in the mapped source, so they carry a
  `@noRailsEquivalent` receipt. `parity:api:extra` is back to 0 novel for the
  file.


## Review round 2

`test_argless_default_with_existing_nil_key` keeps its nil-key entry: Rails
builds the source as `Hash.new(:default).merge(nil => "defined")`, and the port
notes at the call site why neither half has a literal JS spelling — a plain
object has no default seat, and every JS key is a string.

## Size

1112 LOC (582+/530-), over the 700 ceiling. It is one file's 1:1 test rewrite:
567 lines of ad-hoc tests replaced by the 336-line Rails file's port, and the
deletions are the same file's old body. There is no split that does not leave
the file half-converged.

Closes-story: port-hwia-defaults-family
Closes-story: assertions-activemodel-comparison-validation


