### PR TITLE
refactor(activesupport,activerecord): inline (?i:) filter group, values-based empty_scope?, single excluding body

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -24,6 +24,7 @@ import { AssociationRelation } from "./association-relation.js";
 import { AliasTracker } from "./associations/alias-tracker.js";
 
 import { fixtures } from "./test-fixtures.js";
+import { Company as CanonCompany, Firm as CanonFirm } from "./test-helpers/models/company.js";
 import { Post as CanonPost } from "./test-helpers/models/post.js";
 import {
   Comment as CanonComment,
@@ -1068,5 +1069,21 @@ describe("association equality re-dispatches to the other side", () => {
     expect(await proxy.equals([...records])).toBe(true);
     expect(await proxy.equals(records.slice(1))).toBe(false);
     expect(await proxy.equals("posts")).toBe(false);
+  });
+});
+
+describe("Relation#empty_scope? STI type_condition (trails)", () => {
+  fixtures(["companies"]);
+
+  beforeAll(() => {
+    registerModel(CanonCompany);
+    registerModel(CanonFirm);
+  });
+
+  it("reports an empty scope for an unscoped subclass relation carrying the type_condition", () => {
+    expect((CanonFirm as any).isFinderNeedsTypeCondition()).toBe(true);
+    expect((CanonFirm.all() as any).isEmptyScope).toBe(true);
+    expect((CanonFirm.where({ name: "x" }) as any).isEmptyScope).toBe(false);
+    expect((CanonCompany.all() as any).isEmptyScope).toBe(true);
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -148,21 +148,34 @@ function formatCacheTimestamp(ts: Temporal.Instant, format: "usec" | "number" | 
 }
 
 /**
- * Inline a WhereClause's predicates to SQL. Rails' WhereClause has no `to_sql`
- * — inline where-SQL is produced at the Relation level via
- * `conn.unprepared_statement { conn.to_sql(arel) }` — so this glue lives here,
- * routing the Arel AND/SqlLiteral-wrapped AST through the connection visitor.
- * Consumed by `isEmptyScope` to compare a relation's predicate SQL against the
- * unscoped baseline.
+ * Ruby's `Hash#==` — the comparison `empty_scope?` (relation.rb:1299) makes
+ * between two values hashes. JS has no value equality for objects at all, so
+ * the recursive walk Ruby gets from `==` is spelled out: each value is compared
+ * with its own `==` (`WhereClause#==` / `FromClause#==`, spelled `equals` in the
+ * port; an Arel node's `eql?`, spelled `eql`), arrays element by element, and
+ * anything else by identity.
  */
-function _whereClauseToSql(
-  whereClause: WhereClause,
-  connection: { toSql(arel: unknown): string },
-): string {
-  const wrapped = whereClause.predicatesWithWrappedSqlLiterals();
-  if (wrapped.length === 0) return "";
-  const node = wrapped.length === 1 ? wrapped[0] : new Nodes.And(wrapped);
-  return connection.toSql(node);
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((element, i) => valuesEqual(element, b[i]))
+    );
+  }
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  for (const method of ["equals", "eql"] as const) {
+    if (typeof (a as any)[method] === "function") return Boolean((a as any)[method](b));
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(b, key) && valuesEqual((a as any)[key], (b as any)[key]),
+  );
 }
 
 /**
@@ -1018,76 +1031,20 @@ export class Relation<T extends Base> {
   /**
    * Exclude specific records from the result.
    *
-   * Mirrors: ActiveRecord::QueryMethods#excluding (query_methods.rb:1574-1584).
+   * Mirrors: ActiveRecord::QueryMethods#excluding (query_methods.rb:1574-1584)
+   * and `alias :without :excluding` (query_methods.rb:1585). Ruby writes ONE
+   * body and lets `__callee__` (:1580) name whichever alias was invoked;
+   * TypeScript has no `__callee__` and a shared prototype function cannot
+   * recover the name it was reached under, so the one authored body lives in
+   * {@link excludingWithCallee} and each name is bound to a copy of it
+   * generated with its own callee — the ArgumentError then names `#excluding`
+   * or `#without` exactly as `excluding_test.rb:103-110`
+   * (`test_raises_on_record_from_different_class`) asserts, with no shared
+   * helper Rails does not have.
    */
-  excluding(...records: unknown[]): Relation<T> {
-    const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];
-    records = records
-      .filter((r) => !(r instanceof Relation))
-      .flat(1)
-      .filter((r) => r != null);
+  declare excluding: (...records: unknown[]) => Relation<T>;
 
-    const model = this.model;
-    if (
-      !records.every((r) => r instanceof model) ||
-      !relations.every((relation) => relation.model === model)
-    ) {
-      throw new ArgumentError(
-        `You must only pass a single or collection of ${model.name} objects to #excluding.`,
-      );
-    }
-
-    // Rails `records + relations.flat_map(&:ids)`. `Relation#ids` returns the
-    // cached `records.map(&:id)` when the relation is loaded (calculations.rb:371)
-    // and re-queries otherwise. A loaded relation's records are already in
-    // memory, so spread them into the literal `records` collection to match
-    // Rails exactly (no extra query). An unloaded relation is deferred:
-    // `excludingBang` records a marker that the load pipeline materializes into a
-    // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
-    // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
-    const combined: unknown[] = [...records];
-    for (const relation of relations) {
-      if (relation.isLoaded) combined.push(...relation._records);
-      else combined.push(relation);
-    }
-    if (combined.length === 0) return this;
-    return this.spawn().excludingBang(combined);
-  }
-
-  /**
-   * Mirrors `alias :without :excluding` (query_methods.rb:1585). Ruby's alias
-   * shares one body and lets `__callee__` name whichever alias was called;
-   * TypeScript has no `__callee__`, so the body is materialized once per callee
-   * rather than routed through a helper Rails does not have — the ArgumentError
-   * has to name `#without` here, exactly as
-   * `excluding_test.rb:103-110` (`test_raises_on_record_from_different_class`)
-   * asserts.
-   */
-  without(...records: unknown[]): Relation<T> {
-    const relations = records.filter((r) => r instanceof Relation) as Relation<T>[];
-    records = records
-      .filter((r) => !(r instanceof Relation))
-      .flat(1)
-      .filter((r) => r != null);
-
-    const model = this.model;
-    if (
-      !records.every((r) => r instanceof model) ||
-      !relations.every((relation) => relation.model === model)
-    ) {
-      throw new ArgumentError(
-        `You must only pass a single or collection of ${model.name} objects to #without.`,
-      );
-    }
-
-    const combined: unknown[] = [...records];
-    for (const relation of relations) {
-      if (relation.isLoaded) combined.push(...relation._records);
-      else combined.push(relation);
-    }
-    if (combined.length === 0) return this;
-    return this.spawn().excludingBang(combined);
-  }
+  declare without: (...records: unknown[]) => Relation<T>;
 
   /**
    * Add ORDER BY. Accepts column name or { column: "asc"|"desc" }.
@@ -4127,73 +4084,13 @@ export class Relation<T extends Base> {
 
   /**
    * Mirrors: ActiveRecord::Relation#empty_scope? (relation.rb:1299) —
-   * `@values == model.unscoped.values`, compared value by value.
-   *
-   * In the WHERE half, the unscoped baseline may carry the STI
-   * `type_condition`, so a relation whose WHERE matches that baseline (rather
-   * than being literally empty) is still an empty scope. Only a
-   * finder-type-condition class has such a baseline — for anything else a
-   * non-empty WHERE means a real, non-empty scope — and the baseline is built
-   * against this relation's own table so an alias-qualified relation compares
-   * its type_condition against an identically-qualified one rather than the
-   * default arel_table.
+   * `@values == model.unscoped.values`. The STI `type_condition` needs no
+   * special case: a finder-type-condition class carries it in its own
+   * `unscoped` values too, so it compares equal (see {@link valuesEqual} for
+   * the `Hash#==` JS lacks).
    */
   get isEmptyScope(): boolean {
-    let whereMatchesUnscopedBaseline: boolean;
-    if (this.whereClause.isEmpty()) {
-      whereMatchesUnscopedBaseline = true;
-    } else {
-      const klass = this._model as any;
-      const connection = klass.isFinderNeedsTypeCondition?.() ? this._conn() : undefined;
-      const baseline = connection?.toSql
-        ? klass._buildUnscopedRelation?.(this._table ?? undefined)
-        : undefined;
-      if (!connection?.toSql || !baseline) {
-        whereMatchesUnscopedBaseline = false;
-      } else {
-        try {
-          whereMatchesUnscopedBaseline =
-            _whereClauseToSql(this.whereClause, connection) ===
-            _whereClauseToSql(baseline.whereClause, connection);
-        } catch {
-          whereMatchesUnscopedBaseline = false;
-        }
-      }
-    }
-
-    return (
-      whereMatchesUnscopedBaseline &&
-      this.orderValues.length === 0 &&
-      this.limitValue === null &&
-      this.offsetValue === null &&
-      this.selectValues.length === 0 &&
-      // Rails' `empty_scope?` compares `@values` to the unscoped baseline, and a
-      // `readonly` relation carries `@values[:readonly]`, so it is NOT empty.
-      // Omitting this dropped a `readonly()` reflection scope on the preload
-      // through/HABTM source path (build_scope skips merging an empty scope).
-      this.readonlyValue !== true &&
-      // Rails' `empty_scope?` compares `@values` to the unscoped baseline, and
-      // `unscope_values` is a VALUE_METHOD, so a relation carrying only
-      // `unscope(where: ...)` is NOT empty. Omitting this dropped an
-      // `unscope(...)` reflection scope on the preload through/HABTM source path
-      // (build_scope skips merging an empty scope), so a target `default_scope`
-      // the association meant to unscope survived the eager load.
-      this.unscopeValues.length === 0 &&
-      !this.distinctValue &&
-      this.groupValues.length === 0 &&
-      this.havingClause.isEmpty() &&
-      this._joinClauses.length === 0 &&
-      this.joinsValues.length === 0 &&
-      this.leftOuterJoinsValues.length === 0 &&
-      this.includesValues.length === 0 &&
-      this.eagerLoadValues.length === 0 &&
-      this.preloadValues.length === 0 &&
-      this.lockValue === null &&
-      this.fromClause.isEmpty() &&
-      this.withValues.length === 0 &&
-      this.annotateValues.length === 0 &&
-      this.optimizerHintsValues.length === 0
-    );
+    return valuesEqual(this.values(), (this.model as any).unscoped().values());
   }
 
   get hasLimitOrOffset(): boolean {
@@ -5094,3 +4991,47 @@ async function computeCacheVersion(
 ): Promise<string> {
   return rel.computeCacheVersion(timestampColumn);
 }
+
+/**
+ * The one authored `excluding` body (query_methods.rb:1574-1584), generated per
+ * callee so `alias :without :excluding` (:1585) keeps its own `__callee__` in
+ * the ArgumentError. See {@link Relation.excluding}.
+ */
+function excludingWithCallee(callee: "excluding" | "without") {
+  return function (this: Relation<Base>, ...records: unknown[]): Relation<Base> {
+    const relations = records.filter((r) => r instanceof Relation) as Relation<Base>[];
+    records = records
+      .filter((r) => !(r instanceof Relation))
+      .flat(1)
+      .filter((r) => r != null);
+
+    const model = this.model;
+    if (
+      !records.every((r) => r instanceof model) ||
+      !relations.every((relation) => relation.model === model)
+    ) {
+      throw new ArgumentError(
+        `You must only pass a single or collection of ${model.name} objects to #${callee}.`,
+      );
+    }
+
+    // Rails `records + relations.flat_map(&:ids)`. `Relation#ids` returns the
+    // cached `records.map(&:id)` when the relation is loaded (calculations.rb:371)
+    // and re-queries otherwise. A loaded relation's records are already in
+    // memory, so spread them into the literal `records` collection to match
+    // Rails exactly (no extra query). An unloaded relation is deferred:
+    // `excludingBang` records a marker that the load pipeline materializes into a
+    // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
+    // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
+    const combined: unknown[] = [...records];
+    for (const relation of relations) {
+      if (relation.isLoaded) combined.push(...(relation as any)._records);
+      else combined.push(relation);
+    }
+    if (combined.length === 0) return this;
+    return this.spawn().excludingBang(combined);
+  };
+}
+
+Relation.prototype.excluding = excludingWithCallee("excluding");
+Relation.prototype.without = excludingWithCallee("without");

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -166,9 +166,8 @@ function valuesEqual(a: unknown, b: unknown): boolean {
     );
   }
   if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
-  for (const method of ["equals", "eql"] as const) {
-    if (typeof (a as any)[method] === "function") return Boolean((a as any)[method](b));
-  }
+  if (typeof (a as any).equals === "function") return Boolean((a as any).equals(b));
+  if (typeof (a as any).eql === "function") return Boolean((a as any).eql(b));
   if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
   const keys = Object.keys(a);
   if (keys.length !== Object.keys(b).length) return false;

--- a/packages/activesupport/src/parameter-filter.trails.test.ts
+++ b/packages/activesupport/src/parameter-filter.trails.test.ts
@@ -34,10 +34,9 @@ describe("ParameterFilter (trails)", () => {
 
   it("folds a case-insensitive pattern the flag expansion must rewrite into the one group Regexp", () => {
     // Ruby folds every pattern of a group into ONE Regexp with an inline
-    // `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag
-    // group, so the port expands each cased character to `[aA]` — inside a
-    // character class in place, and widening `\p{Lu}` / `\p{Ll}` to `\p{L}`,
-    // since `(?i:)` scopes the flag to any sub-pattern.
+    // `(?i:...)` group (parameter_filter.rb:58-65), which V8 also spells — so a
+    // case-insensitive member keeps its own flag inside the joined Regexp, down
+    // to case-folding a `\p{Lu}` property escape.
     for (const pattern of [/[xy]z/i, /\p{Lu}q/iu, /(?<tail>vw)/i, /[a-c]z/i]) {
       const precompiled = ParameterFilter.precompileFilters([/plain/, pattern]);
       expect(precompiled.length).toBe(1);

--- a/packages/activesupport/src/parameter-filter.ts
+++ b/packages/activesupport/src/parameter-filter.ts
@@ -57,15 +57,13 @@ export class ParameterFilter {
    *
    * Ruby joins the escaped string patterns and the given Regexps into a single
    * Regexp per group, spelling each case-insensitive part with the inline
-   * `(?i:...)` group (parameter_filter.rb:58-65). JS has no inline flag group,
-   * so {@link ignoreCaseSource} spells the same matching case-sensitively —
-   * each cased character expanded to a `[aA]` class — and the group is joined
-   * into ONE Regexp exactly as Rails'.
+   * `(?i:...)` group (parameter_filter.rb:58-65). V8 ships the same inline
+   * modifier group, so each member is spelled exactly as Ruby spells it and the
+   * group is joined into ONE Regexp.
    */
   static precompileFilters(filters: Filter[]): Array<FilterProc | RegExp> {
     const patterns: Array<{
       source: string;
-      ignoreCase: boolean;
       unicode: boolean;
       unicodeSets: boolean;
     }> = [];
@@ -76,15 +74,13 @@ export class ParameterFilter {
         compiled.push(filter);
       } else if (filter instanceof RegExp) {
         patterns.push({
-          source: filter.source,
-          ignoreCase: filter.ignoreCase,
+          source: filter.ignoreCase ? `(?i:${filter.source})` : filter.source,
           unicode: filter.flags.includes("u"),
           unicodeSets: filter.flags.includes("v"),
         });
       } else {
         patterns.push({
-          source: escapeRegexp(String(filter)),
-          ignoreCase: true,
+          source: `(?i:${escapeRegexp(String(filter))})`,
           unicode: false,
           unicodeSets: false,
         });
@@ -97,11 +93,7 @@ export class ParameterFilter {
     }
 
     for (const group of [patterns, deepPatterns]) {
-      const sources = group.map((pattern) =>
-        pattern.ignoreCase
-          ? ignoreCaseSource(pattern.source, pattern.unicode || pattern.unicodeSets)
-          : pattern.source,
-      );
+      const sources = group.map((pattern) => pattern.source);
       // A `\p{...}` escape only means a Unicode property under `u`/`v`; without
       // it the escape is the letter `p`, which Ruby has no spelling for. Ruby's
       // Regexp is always Unicode-aware, so the joined Regexp carries `u`
@@ -239,147 +231,6 @@ export class ParameterFilter {
 function unicodeFlag(group: Array<{ unicode: boolean; unicodeSets: boolean }>): string {
   if (group.some((pattern) => pattern.unicodeSets)) return "v";
   return group.some((pattern) => pattern.unicode) ? "u" : "";
-}
-
-/** A cased character spelled as the class matching both of its cases, or the
- *  character unchanged when it has no other case. */
-function bothCases(char: string): string {
-  const lower = char.toLowerCase();
-  const upper = char.toUpperCase();
-  return lower === upper || lower.length !== 1 || upper.length !== 1 ? char : `[${lower}${upper}]`;
-}
-
-/**
- * A Unicode property escape as `(?i:...)` matches it: Ruby case-folds the
- * subject, so `\p{Lu}` matches a lowercase letter and `\p{Ll}` an uppercase one
- * — both are `\p{L}` — while the negated `\P{Lu}` is the complement of that,
- * `\P{L}`. Any other property is case-blind and passes through.
- */
-function ignoreCaseProperty(property: string): string {
-  return property === "Lu" || property === "Ll" ? "L" : property;
-}
-
-/** The index of the `]` closing the character class open at `start`, or the end
- *  of the source when it is unterminated. A `]` in the first member position is
- *  a literal, as is one preceded by a backslash. */
-function classEnd(source: string, start: number): number {
-  let i = start + 1;
-  if (source[i] === "^") i++;
-  if (source[i] === "]") i++;
-  for (; i < source.length; i++) {
-    if (source[i] === "\\") i++;
-    else if (source[i] === "]") return i;
-  }
-  return source.length - 1;
-}
-
-/**
- * A character class as `(?i:...)` matches it: each cased member gains its other
- * case, in place, so `[xy]` is `[xXyY]` and a cased range gains the range of
- * its folded endpoints, `[a-c]` → `[a-cA-C]`. Nesting `[aA]` is not an option
- * here, which is why the member expansion is written out rather than reusing
- * {@link bothCases}.
- */
-function ignoreCaseClass(klass: string, unicode: boolean): string {
-  const negated = klass.startsWith("[^");
-  const body = klass.slice(negated ? 2 : 1, -1);
-  let out = "";
-  for (let i = 0; i < body.length; i++) {
-    const char = body[i];
-    if (char === "\\") {
-      const next = body[i + 1];
-      if (unicode && (next === "p" || next === "P") && body[i + 2] === "{") {
-        const end = body.indexOf("}", i + 3);
-        if (end !== -1) {
-          out += `\\${next}{${ignoreCaseProperty(body.slice(i + 3, end))}}`;
-          i = end;
-          continue;
-        }
-      }
-      out += char + (next ?? "");
-      i++;
-      continue;
-    }
-    const to = body[i + 1] === "-" && i + 2 < body.length ? body[i + 2] : undefined;
-    if (to !== undefined) {
-      out += `${char}-${to}`;
-      const folded = `${swapCase(char)}-${swapCase(to)}`;
-      if (folded !== `${char}-${to}`) out += folded;
-      i += 2;
-      continue;
-    }
-    out += char;
-    const other = swapCase(char);
-    if (other !== char) out += other;
-  }
-  return `[${negated ? "^" : ""}${out}]`;
-}
-
-/** The character's other case, or the character itself when it has none. */
-function swapCase(char: string): string {
-  const lower = char.toLowerCase();
-  const upper = char.toUpperCase();
-  if (lower.length !== 1 || upper.length !== 1) return char;
-  return char === lower ? upper : lower;
-}
-
-/**
- * Ruby spells a case-insensitive alternative inline as `(?i:...)`
- * (parameter_filter.rb:59) so one Regexp can carry both case-sensitive and
- * case-insensitive parts. JS has no inline flag group, so the same matching is
- * spelled case-sensitively by expanding each cased character to a `[aA]` class.
- *
- * Total, so `precompileFilters` emits one Regexp per group for every input
- * exactly as `Regexp.new(patterns.join("|"))` does (parameter_filter.rb:64-65).
- * The spans where a letter is not a pattern letter are copied verbatim: the
- * `<name>` of a named group (`(?<name>`, but not the lookbehinds `(?<=` /
- * `(?<!`) or of a named backreference (`\k<name>`). A character class and a
- * Unicode property escape expand under their own rules
- * ({@link ignoreCaseClass}, {@link ignoreCaseProperty}).
- */
-function ignoreCaseSource(source: string, unicode: boolean): string {
-  let out = "";
-  for (let i = 0; i < source.length; i++) {
-    const char = source[i];
-    if (char === "\\") {
-      const next = source[i + 1];
-      if (unicode && (next === "p" || next === "P") && source[i + 2] === "{") {
-        const end = source.indexOf("}", i + 3);
-        if (end !== -1) {
-          out += `\\${next}{${ignoreCaseProperty(source.slice(i + 3, end))}}`;
-          i = end;
-          continue;
-        }
-      }
-      if (next === "k" && source[i + 2] === "<") {
-        const end = source.indexOf(">", i + 3);
-        if (end !== -1) {
-          out += source.slice(i, end + 1);
-          i = end;
-          continue;
-        }
-      }
-      out += char + (next ?? "");
-      i++;
-      continue;
-    }
-    if (char === "[") {
-      const end = classEnd(source, i);
-      out += ignoreCaseClass(source.slice(i, end + 1), unicode);
-      i = end;
-      continue;
-    }
-    if (source.startsWith("(?<", i) && source[i + 3] !== "=" && source[i + 3] !== "!") {
-      const end = source.indexOf(">", i + 3);
-      if (end !== -1) {
-        out += source.slice(i, end + 1);
-        i = end;
-        continue;
-      }
-    }
-    out += bothCases(char);
-  }
-  return out;
 }
 
 /** Mirrors Ruby's `Regexp.escape`, which JS has no built-in for. `-` is left


### PR DESCRIPTION
Three convergence stories, all in `parameter-filter.ts` / `relation.ts`.

## `ParameterFilter.precompileFilters` → Ruby's inline `(?i:...)` group

`parameter_filter.rb:58-59` spells a case-insensitive alternative inline so one
joined Regexp carries both case-sensitive and case-insensitive parts. V8 now
ships the ES2025 regexp modifiers proposal — verified on Node v24.16.0, where
`new RegExp("(?i:a)").test("A")` and `new RegExp("(?i:\\p{Lu})","u").test("a")`
are both `true` — so the port spells the member exactly as Ruby does and the
~150-line hand-rolled substitute (`ignoreCaseSource`, `ignoreCaseClass`,
`ignoreCaseProperty`, `bothCases`, `swapCase`, `classEnd`) is deleted.

This does not unblock the sibling Unicode-flag story: `(?u:…)` is still
`Invalid group` in V8, so the joined Regexp's `u`/`v` flag stays a constructor
argument.

## `Relation#isEmptyScope` → `@values == model.unscoped.values`

`relation.rb:1299` is one line. The port hand-enumerated ~20 value slots plus a
bespoke WHERE-vs-unscoped-baseline SQL comparison for the STI `type_condition`
case; every slot Rails gains or trails adds was a slot that chain could silently
miss (its comment history records two such misses already). It is now the
relation.rb:1299 comparison. The STI case needs no special case — a
finder-type-condition class carries the `type_condition` in its own `unscoped`
values, which is exactly why Rails' comparison handles it. `_whereClauseToSql`
is deleted; `valuesEqual` replaces it, spelling Ruby's `Hash#==` (dispatching to
`WhereClause#==` / `FromClause#==` / an Arel node's `eql?`), which JS has no
operator for.

The full association suite (100 files, 2153 tests) plus `scoping/`,
`relation/`, `relation.test.ts` and `finder-methods.test.ts` are green, which
covers the preload through/HABTM `readonly` / `unscope` regressions the old
chain guarded against, and `relation.trails.test.ts` gains a direct guard that a
finder-type-condition subclass relation still reports an empty scope.

## `excluding` / `without` → one authored body

`query_methods.rb:1585` is `alias :without :excluding`, with `__callee__`
(:1580) naming whichever alias was invoked in the ArgumentError. TypeScript has
no `__callee__`, and a shared prototype function cannot recover the name it was
reached under, so the two hand-maintained copies collapse into one authored
body in `excludingWithCallee`, from which each name is bound to a copy
generated with its own callee. No shared private helper is reintroduced;
`excluding_test.rb:105`/`:108` both still assert their own message.

## Gates

- `pnpm parity:api:calls` — OK
- `pnpm parity:api:calls:args` — OK
- `pnpm lint`, `pnpm typecheck` — clean
- 98 insertions, 306 deletions

Closes-story: converge-parameter-filter-ignore-case-onto-inline-group
Closes-story: converge-empty-scope-to-values-comparison
Closes-story: excluding-without-callee-single-body