### PR TITLE
refactor(activesupport,activerecord): HWIA#delete returns the removed value; order/projection query methods move to query-methods.ts

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -72,7 +72,6 @@ import { FinderMethods } from "./relation/finder-methods.js";
 import { SpawnMethods } from "./relation/spawn-methods.js";
 import { FromClause } from "./relation/from-clause.js";
 import { TableMetadata } from "./table-metadata.js";
-import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { WhereClause } from "./relation/where-clause.js";
 import type { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import {
@@ -1090,83 +1089,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Add ORDER BY. Accepts column name or { column: "asc"|"desc" }.
-   *
-   * Mirrors: ActiveRecord::Relation#order
-   */
-  order(...args: OrderArg[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":order", args as unknown[], undefined, () => {
-      this.sanitizeOrderArguments(args as unknown[]);
-    });
-    return this.spawn().orderBang(...args);
-  }
-
-  /**
-   * Set LIMIT.
-   *
-   * Mirrors: ActiveRecord::Relation#limit
-   */
-  limit(value: number | string | null): Relation<T> {
-    return this.spawn().limitBang(value);
-  }
-
-  /**
-   * Set OFFSET.
-   *
-   * Mirrors: ActiveRecord::Relation#offset
-   */
-  offset(value: number | string | null): Relation<T> {
-    return this.spawn().offsetBang(value);
-  }
-
-  /**
-   * Select specific columns, or filter loaded records with a block.
-   *
-   * Mirrors: ActiveRecord::Relation#select
-   *
-   * Examples:
-   *   select("name", "email")          // column projection
-   *   select("COUNT(*) as total")       // raw SQL expression
-   *   select(record => record.active)   // block form (returns array)
-   */
-  select(fn: (record: T) => boolean): Promise<T[]>;
-  select(...fields: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T>;
-  select(...fields: any[]): Relation<T> | Promise<T[]> {
-    // Block form first — mirrors Rails' `if block_given?` guard before
-    // check_if_method_has_arguments!. A trailing function argument is the TS
-    // equivalent of a Ruby block.
-    if (fields.length >= 1 && typeof fields[fields.length - 1] === "function") {
-      if (fields.length > 1) {
-        throw new ArgumentError("`select' with block doesn't take arguments.");
-      }
-      return this.toArray().then((records) => records.filter(fields[0]));
-    }
-    this.checkIfMethodHasArgumentsBang(":select", fields, "Call `select' with at least one field.");
-    fields = this.processSelectArgs(fields);
-    return this.spawn()._selectBang(...fields);
-  }
-
-  /**
-   * Replace existing select columns.
-   *
-   * Mirrors: ActiveRecord::Relation#reselect
-   */
-  reselect(...args: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":reselect", args as unknown[]);
-    args = this.processSelectArgs(args as unknown[]) as typeof args;
-    return this.spawn().reselectBang(...args);
-  }
-
-  /**
-   * Make the query DISTINCT.
-   *
-   * Mirrors: ActiveRecord::Relation#distinct
-   */
-  distinct(value = true): Relation<T> {
-    return this.spawn().distinctBang(value);
-  }
-
-  /**
    * PostgreSQL DISTINCT ON — select distinct rows based on specific columns.
    *
    * Mirrors: ActiveRecord::Relation#distinct_on (PostgreSQL only)
@@ -1175,138 +1097,6 @@ export class Relation<T extends Base> {
     const rel = this.spawn();
     rel.distinctValue = true;
     rel._distinctOnColumns = columns;
-    return rel;
-  }
-
-  /**
-   * Add GROUP BY.
-   *
-   * Mirrors: ActiveRecord::Relation#group
-   */
-  group(...args: (string | import("@blazetrails/arel").Nodes.Node)[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":group", args as unknown[]);
-    return this.spawn().groupBang(...(args as string[]));
-  }
-
-  /**
-   * Add HAVING clause. Accepts raw SQL string (with optional bind values),
-   * a hash of column/value pairs, or an Arel node.
-   *
-   * Mirrors: ActiveRecord::Relation#having
-   */
-  having(condition: string, ...binds: unknown[]): Relation<T>;
-  having(condition: Record<string, unknown>): Relation<T>;
-  having(condition: Nodes.Node): Relation<T>;
-  having(
-    condition: string | Record<string, unknown> | Nodes.Node,
-    ...binds: unknown[]
-  ): Relation<T> {
-    return this.spawn().havingBang(condition, ...binds);
-  }
-
-  /**
-   * Replace GROUP BY columns.
-   *
-   * Mirrors: ActiveRecord::Relation#regroup
-   */
-  regroup(...args: string[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":regroup", args);
-    return this.spawn().regroupBang(...args);
-  }
-
-  /**
-   * Replace ordering.
-   *
-   * Mirrors: ActiveRecord::Relation#reorder
-   */
-  reorder(...args: OrderArg[]): Relation<T> {
-    this.checkIfMethodHasArgumentsBang(":reorder", args as unknown[], undefined, () => {
-      this.sanitizeOrderArguments(args as unknown[]);
-    });
-    return this.spawn().reorderBang(...args);
-  }
-
-  /**
-   * Reverse the existing order.
-   *
-   * Mirrors: ActiveRecord::Relation#reverse_order
-   */
-  reverseOrder(): Relation<T> {
-    return this.spawn().reverseOrderBang();
-  }
-
-  /**
-   * Order by specific values of a column.
-   *
-   * Mirrors: ActiveRecord::Relation#in_order_of (query_methods.rb:718) — the
-   * permit matcher comes off `model.adapter_class`, a class-level lookup that
-   * leases no connection.
-   */
-  inOrderOf(column: string | Nodes.Node, values: unknown[], filter = true): Relation<T> {
-    this.model.disallowRawSqlBang([column], {
-      permit: (
-        this.model.adapterClassSync() as unknown as { columnNameWithOrderMatcher(): RegExp }
-      ).columnNameWithOrderMatcher(),
-    });
-
-    if (values.length === 0) return this.none();
-
-    const rel = this.spawn();
-
-    // Mirrors Rails: `references = column_references([column]);
-    // self.references_values |= references unless references.empty?`
-    // (query_methods.rb:721-722) — recorded on the spawn, which trails clones
-    // up-front rather than at Rails' `spawn.order!`.
-    const references = _qm.columnReferences([column]);
-    if (references.length > 0) rel.referencesBang(...references);
-
-    // Mirrors Rails: `values.map { |v| model.type_caster.type_cast_for_database(column, v) }`.
-    // Cast each value to its database form so the CASE/IN predicates match a typed
-    // column (e.g. enum integer mappings, date/time serialization) instead of the
-    // JS-native string/number form. An Arel node finds no attribute type and falls
-    // through to ValueType (no-op cast).
-    const typeCaster = new TypeCasterMap(this.model);
-    // Normalize undefined → null so eq(null) emits IS NULL (not the invalid = NULL).
-    const normalized = values.map((value) => {
-      if (value === undefined || value === null) return null;
-      return typeCaster.typeCastForDatabase(column, value);
-    });
-
-    // Mirrors Rails: `column.is_a?(Arel::Nodes::SqlLiteral) ? column : order_column(column.to_s)`.
-    // An Arel expression (e.g. `Arel.sql("id * 2")`) is used verbatim; a string/symbol
-    // resolves through orderColumn, which handles `"table.column"` for joined associations
-    // (and records the reference on the cloned relation).
-    const arelCol =
-      column instanceof Nodes.SqlLiteral
-        ? column
-        : (_qm.orderColumn.call(rel as any, String(column)) as any);
-
-    // Mirrors Rails: `scope = spawn.order!(build_case_for_value_position(arel_column,
-    // values, filter: filter))` (query_methods.rb:727). The Arel CASE node is
-    // pushed as a node (not pre-rendered SQL) so its embedded bind values thread
-    // through the outer collector when the statement is compiled.
-    const caseNode = _qm.buildCaseForValuePosition.call(rel as any, arelCol, normalized, {
-      filter,
-    });
-    QueryMethodBangs.orderBang.call(rel as any, caseNode as any);
-
-    // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
-    // The values were already database-cast above via type_cast_for_database, and `in`
-    // wraps each in Casted, which casts again on value_for_database. That double-cast is
-    // faithful because Rails does the identical one (query_methods.rb:724 then :735,
-    // casted.rb:19-20) — not because the second cast is inert; a non-idempotent
-    // serialize would run twice here exactly as it does in Rails.
-    if (filter) {
-      const hasNull = normalized.includes(null);
-      const nonNull = normalized.filter((v) => v !== null);
-      // Mirrors Rails: `arel_column.in(values.compact).or(arel_column.eq(nil))`
-      // (query_methods.rb:732) — Arel's `or` wraps the pair in a Grouping itself.
-      const whereNode: Nodes.Node = hasNull
-        ? (arelCol.in(nonNull) as Nodes.Node).or(arelCol.eq(null))
-        : arelCol.in(nonNull);
-      rel.whereClause = rel.whereClause.plus(new WhereClause([whereNode]));
-    }
-
     return rel;
   }
 
@@ -4948,6 +4738,28 @@ export interface Relation<T extends Base>
   arelColumns(columns: ReadonlyArray<unknown>): unknown[];
   /** @internal */
   arelColumnsFromHash(fields: Record<PropertyKey, unknown>): unknown[];
+  // QueryMethods' ordering and projection families (query-methods.ts), whose
+  // mixin signatures return `any` — declared here with the relation's own
+  // element type, in query_methods.rb source order.
+  select(fn: (record: T) => boolean): Promise<T[]>;
+  select(...fields: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T>;
+  reselect(...args: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T>;
+  group(...args: (string | Nodes.Node)[]): Relation<T>;
+  regroup(...args: string[]): Relation<T>;
+  order(...args: OrderArg[]): Relation<T>;
+  inOrderOf(column: string | Nodes.Node, values: unknown[], filter?: boolean): Relation<T>;
+  reorder(...args: OrderArg[]): Relation<T>;
+  having(condition: string, ...binds: unknown[]): Relation<T>;
+  having(condition: Record<string, unknown>): Relation<T>;
+  having(condition: Nodes.Node): Relation<T>;
+  having(
+    condition: string | Record<string, unknown> | Nodes.Node,
+    ...binds: unknown[]
+  ): Relation<T>;
+  limit(value: number | string | null): Relation<T>;
+  offset(value: number | string | null): Relation<T>;
+  distinct(value?: boolean): Relation<T>;
+  reverseOrder(): Relation<T>;
   spawn(): Relation<T>;
   merge<U extends Base>(other: Relation<U>): Relation<T>;
   mergeBang(other: any): Relation<T>;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1420,10 +1420,14 @@ function orBang(this: QueryMethodsHost, other: any): any {
  */
 function having(
   this: QueryMethodsHost,
-  condition: string | Record<string, unknown> | Nodes.Node,
-  ...binds: unknown[]
+  opts: string | Record<string, unknown> | Nodes.Node,
+  ...rest: unknown[]
 ): any {
-  return havingBang.call(this.spawn(), condition, ...binds);
+  // `opts.blank? ? self : spawn.having!(opts, *rest)` (query_methods.rb:1198) —
+  // a blank condition (an empty hash included) is a no-op on the receiver, so it
+  // never reaches PredicateBuilder, which expands `{}` to the `1=0` contradiction.
+  if (opts == null || isBlankArgument(opts)) return this;
+  return havingBang.call(this.spawn(), opts, ...rest);
 }
 
 function havingBang(
@@ -1431,31 +1435,8 @@ function havingBang(
   opts: string | Record<string, unknown> | Nodes.Node,
   ...rest: unknown[]
 ): any {
-  // Rails' `having` no-ops on a blank condition (`opts.blank? ? self : …`,
-  // query_methods.rb:1198) — including an empty hash. Guard it here (mirroring
-  // the same check `where` applies) so `having({})` stays a no-op rather than
-  // routing an empty hash through PredicateBuilder, which now expands it to the
-  // `1=0` contradiction.
-  if (opts == null || isBlankArgument(opts)) return this;
-
-  if (typeof opts === "string") {
-    const sql = rest.length > 0 ? this._model.sanitizeSqlArray(opts, ...rest) : opts;
-    this.havingClause = this.havingClause.plus(new WhereClause([new Nodes.SqlLiteral(sql)]));
-    return this;
-  }
-
-  if (opts instanceof Nodes.Node) {
-    this.havingClause = this.havingClause.plus(new WhereClause([opts]));
-    return this;
-  }
-
-  if (typeof opts !== "object" || Array.isArray(opts)) {
-    throw argumentError(`Unsupported argument type for having: ${typeof opts} (${String(opts)})`);
-  }
-
-  this.havingClause = this.havingClause.plus(
-    new WhereClause([...this.predicateBuilder.buildFromHash(opts)]),
-  );
+  // `self.having_clause += build_having_clause(opts, rest)` (query_methods.rb:1202).
+  this.havingClause = this.havingClause.plus(buildWhereClause.call(this, opts, rest));
   return this;
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -7,6 +7,7 @@
 import * as Arel from "@blazetrails/arel";
 import { Nodes, SelectManager, Table as ArelTable, relationName } from "@blazetrails/arel";
 import {
+  ArgumentError,
   Attribute,
   ValueType,
   sanitizeForMassAssignment as sanitizeForbiddenAttributes,
@@ -21,6 +22,7 @@ import {
   UnmodifiableRelation,
 } from "../errors.js";
 import { FromClause } from "./from-clause.js";
+import { Map as TypeCasterMap } from "../type-caster/map.js";
 import { WhereClause } from "./where-clause.js";
 import { sanitizeLimit } from "../connection-adapters/abstract/database-statements.js";
 import { JoinDependency } from "../associations/join-dependency.js";
@@ -490,6 +492,47 @@ function withRecursiveBang(this: QueryMethodsHost, ...args: unknown[]): any {
   return this;
 }
 
+/**
+ * Select specific columns, or filter loaded records with a block.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#select (query_methods.rb:413-424)
+ *
+ * Examples:
+ *   select("name", "email")          // column projection
+ *   select("COUNT(*) as total")       // raw SQL expression
+ *   select(record => record.active)   // block form (returns array)
+ */
+function select(this: QueryMethodsHost, ...fields: any[]): any {
+  // Block form first — mirrors Rails' `if block_given?` guard before
+  // check_if_method_has_arguments!. A trailing function argument is the TS
+  // equivalent of a Ruby block.
+  if (fields.length >= 1 && typeof fields[fields.length - 1] === "function") {
+    if (fields.length > 1) {
+      throw new ArgumentError("`select' with block doesn't take arguments.");
+    }
+    return (this as any).toArray().then((records: any[]) => records.filter(fields[0]));
+  }
+  checkIfMethodHasArgumentsBang.call(
+    this,
+    ":select",
+    fields,
+    "Call `select' with at least one field.",
+  );
+  fields = processSelectArgs.call(this, fields);
+  return _selectBang.apply(this.spawn(), fields);
+}
+
+/**
+ * Replace existing select columns.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#reselect (query_methods.rb:541-545)
+ */
+function reselect(this: QueryMethodsHost, ...args: any[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":reselect", args);
+  args = processSelectArgs.call(this, args);
+  return reselectBang.apply(this.spawn(), args);
+}
+
 function reselectBang(this: QueryMethodsHost, ...columns: any[]): any {
   this.selectValues = columns.map((c: any) => {
     if (c instanceof Nodes.Node) return c;
@@ -566,12 +609,32 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   return this;
 }
 
+/**
+ * Add GROUP BY.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#group (query_methods.rb:573-576)
+ */
+function group(this: QueryMethodsHost, ...args: (string | Nodes.Node)[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":group", args as unknown[]);
+  return groupBang.apply(this.spawn(), args);
+}
+
 function groupBang(
   this: QueryMethodsHost,
   ...columns: (string | import("@blazetrails/arel").Nodes.Node)[]
 ): any {
   this.groupValues = [...this.groupValues, ...(columns as string[])];
   return this;
+}
+
+/**
+ * Replace GROUP BY columns.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#regroup (query_methods.rb:593-596)
+ */
+function regroup(this: QueryMethodsHost, ...args: string[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":regroup", args);
+  return regroupBang.apply(this.spawn(), args);
 }
 
 function regroupBang(
@@ -582,6 +645,18 @@ function regroupBang(
   return this;
 }
 
+/**
+ * Add ORDER BY. Accepts column name or { column: "asc"|"desc" }.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#order (query_methods.rb:656-662)
+ */
+function order(this: QueryMethodsHost, ...args: OrderArg[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":order", args as unknown[], undefined, () => {
+    sanitizeOrderArguments.call(this, args as unknown[]);
+  });
+  return orderBang.apply(this.spawn(), args);
+}
+
 function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
   if (args.length > 0) preprocessOrderArgs.call(this, args as unknown[]);
   // Mirrors Rails' `self.order_values |= args`: union dedupes repeated terms.
@@ -590,6 +665,84 @@ function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
     ...(args as unknown[]),
   ]) as typeof this.orderValues;
   return this;
+}
+
+/**
+ * Order by specific values of a column.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#in_order_of (query_methods.rb:717-741) —
+ * the permit matcher comes off `model.adapter_class`, a class-level lookup that
+ * leases no connection.
+ */
+function inOrderOf(
+  this: QueryMethodsHost,
+  column: string | Nodes.Node,
+  values: unknown[],
+  filter = true,
+): any {
+  (this.model as any).disallowRawSqlBang([column], {
+    permit: (
+      this.model.adapterClassSync() as unknown as { columnNameWithOrderMatcher(): RegExp }
+    ).columnNameWithOrderMatcher(),
+  });
+  if (values.length === 0) return noneBang.call(this.spawn());
+
+  const references = columnReferences([column]);
+  if (references.length > 0) referencesBang.call(this, ...references);
+
+  // Mirrors Rails: `values.map { |v| model.type_caster.type_cast_for_database(column, v) }`.
+  // Cast each value to its database form so the CASE/IN predicates match a typed
+  // column (e.g. enum integer mappings, date/time serialization) instead of the
+  // JS-native string/number form. An Arel node finds no attribute type and falls
+  // through to ValueType (no-op cast). `undefined` is normalized to `null` so
+  // `eq(null)` emits IS NULL rather than the invalid `= NULL`.
+  const typeCaster = new TypeCasterMap(this.model);
+  values = values.map((value) => {
+    if (value === undefined || value === null) return null;
+    return typeCaster.typeCastForDatabase(column, value);
+  });
+
+  // Mirrors Rails: `column.is_a?(Arel::Nodes::SqlLiteral) ? column : order_column(column.to_s)`.
+  // An Arel expression (e.g. `Arel.sql("id * 2")`) is used verbatim; a string/symbol
+  // resolves through orderColumn, which handles `"table.column"` for joined associations.
+  const arelColumn: any =
+    column instanceof Nodes.SqlLiteral ? column : orderColumn.call(this, String(column));
+
+  // The Arel CASE node is pushed as a node (not pre-rendered SQL) so its embedded
+  // bind values thread through the outer collector when the statement is compiled.
+  let scope = orderBang.call(
+    this.spawn(),
+    buildCaseForValuePosition.call(this, arelColumn, values, { filter }) as any,
+  );
+
+  // The values were already database-cast above via type_cast_for_database, and `in`
+  // wraps each in Casted, which casts again on value_for_database. That double-cast is
+  // faithful because Rails does the identical one (query_methods.rb:724 then :735,
+  // casted.rb:19-20) — not because the second cast is inert; a non-idempotent
+  // serialize would run twice here exactly as it does in Rails.
+  if (filter) {
+    // Mirrors Rails: `arel_column.in(values.compact).or(arel_column.eq(nil))`
+    // (query_methods.rb:732) — Arel's `or` wraps the pair in a Grouping itself.
+    const whereClause: Nodes.Node = values.includes(null)
+      ? (arelColumn.in(values.filter((v) => v !== null)) as Nodes.Node).or(arelColumn.eq(null))
+      : arelColumn.in(values);
+
+    scope = whereBang.call(scope, whereClause);
+  }
+
+  return scope;
+}
+
+/**
+ * Replace ordering.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#reorder (query_methods.rb:752-757)
+ */
+function reorder(this: QueryMethodsHost, ...args: OrderArg[]): any {
+  checkIfMethodHasArgumentsBang.call(this, ":reorder", args as unknown[], undefined, () => {
+    sanitizeOrderArguments.call(this, args as unknown[]);
+  });
+  return reorderBang.apply(this.spawn(), args);
 }
 
 function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
@@ -1259,6 +1412,20 @@ function orBang(this: QueryMethodsHost, other: any): any {
   return this;
 }
 
+/**
+ * Add HAVING clause. Accepts raw SQL string (with optional bind values),
+ * a hash of column/value pairs, or an Arel node.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#having (query_methods.rb:1197-1199)
+ */
+function having(
+  this: QueryMethodsHost,
+  condition: string | Record<string, unknown> | Nodes.Node,
+  ...binds: unknown[]
+): any {
+  return havingBang.call(this.spawn(), condition, ...binds);
+}
+
 function havingBang(
   this: QueryMethodsHost,
   opts: string | Record<string, unknown> | Nodes.Node,
@@ -1292,11 +1459,29 @@ function havingBang(
   return this;
 }
 
+/**
+ * Set LIMIT.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#limit (query_methods.rb:1211-1213)
+ */
+function limit(this: QueryMethodsHost, value: number | string | null): any {
+  return limitBang.call(this.spawn(), value);
+}
+
 function limitBang(this: QueryMethodsHost, value: number | string | null): any {
   // Mirrors `limit!` (query_methods.rb:1215-1218): the raw value is stored and
   // sanitized later, by `build_arel`'s `connection.sanitize_limit` (:1757).
   this.limitValue = value;
   return this;
+}
+
+/**
+ * Set OFFSET.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#offset (query_methods.rb:1227-1229)
+ */
+function offset(this: QueryMethodsHost, value: number | string | null): any {
+  return offsetBang.call(this.spawn(), value);
 }
 
 function offsetBang(this: QueryMethodsHost, value: number | string | null): any {
@@ -1419,6 +1604,15 @@ function fromBang(this: QueryMethodsHost, value: any, subqueryName?: string): an
   return this;
 }
 
+/**
+ * Make the query DISTINCT.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#distinct (query_methods.rb:1410-1412)
+ */
+function distinct(this: QueryMethodsHost, value = true): any {
+  return distinctBang.call(this.spawn(), value);
+}
+
 function distinctBang(this: QueryMethodsHost, value = true): any {
   this.distinctValue = value;
   return this;
@@ -1475,6 +1669,15 @@ function optimizerHintsBang(this: QueryMethodsHost, ...args: string[]): any {
   // union, so a hint already present is not repeated.
   this.optimizerHintsValues = [...new Set([...this.optimizerHintsValues, ...args])];
   return this;
+}
+
+/**
+ * Reverse the existing order.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#reverse_order (query_methods.rb:1498-1500)
+ */
+function reverseOrder(this: QueryMethodsHost): any {
+  return reverseOrderBang.call(this.spawn());
 }
 
 function reverseOrderBang(this: QueryMethodsHost): any {
@@ -2201,11 +2404,18 @@ export const QueryMethodBangs = {
   referencesBang,
   withBang,
   withRecursiveBang,
+  select,
+  reselect,
   reselectBang,
   _selectBang,
+  group,
   groupBang,
+  regroup,
   regroupBang,
+  order,
   orderBang,
+  inOrderOf,
+  reorder,
   reorderBang,
   unscope,
   unscopeBang,
@@ -2215,8 +2425,11 @@ export const QueryMethodBangs = {
   invertWhereBang,
   andBang,
   orBang,
+  having,
   havingBang,
+  limit,
   limitBang,
+  offset,
   offsetBang,
   lock,
   lockBang,
@@ -2231,11 +2444,13 @@ export const QueryMethodBangs = {
   createWithBang,
   from,
   fromBang,
+  distinct,
   distinctBang,
   extending,
   extendingBang,
   optimizerHints,
   optimizerHintsBang,
+  reverseOrder,
   reverseOrderBang,
   skipQueryCacheBang,
   skipPreloadingBang,

--- a/packages/activesupport/src/hash-with-indifferent-access.test.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.test.ts
@@ -28,9 +28,9 @@ describe("HashWithIndifferentAccessTest", () => {
 
   it("delete — removes key", () => {
     const h = new HashWithIndifferentAccess({ a: 1 });
-    expect(h.delete("a")).toBe(true);
+    expect(h.delete("a")).toBe(1);
     expect(h.hasKey("a")).toBe(false);
-    expect(h.delete("a")).toBe(false);
+    expect(h.delete("a")).toBeUndefined();
   });
 
   it("size — reports entry count", () => {
@@ -544,10 +544,13 @@ describe("HashWithIndifferentAccessTest", () => {
   });
 
   it("indifferent deleting", () => {
-    const h = new HashWithIndifferentAccess({ a: 1 });
-    expect(h.delete("a")).toBe(true);
-    expect(h.hasKey("a")).toBe(false);
-    expect(h.delete("a")).toBe(false);
+    const getHash = () => new HashWithIndifferentAccess({ a: "foo" });
+    let hash = getHash();
+    expect(hash.delete("a")).toBe("foo");
+    expect(hash.delete("a")).toBeUndefined();
+    hash = getHash();
+    expect(hash.delete("a")).toBe("foo");
+    expect(hash.delete("a")).toBeUndefined();
   });
 
   it("indifferent select", () => {

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -115,8 +115,16 @@ export class HashWithIndifferentAccess<V = unknown> {
     return this;
   }
 
-  delete(key: string): boolean {
-    return this.data.delete(this.convertKey(key));
+  /**
+   * Mirrors `delete` (hash_with_indifferent_access.rb:303-305) — `Hash#delete`
+   * through `convert_key`, so the removed value comes back (`undefined` when
+   * the key was absent), not `Map#delete`'s boolean.
+   */
+  delete(key: string): V | undefined {
+    const convertedKey = this.convertKey(key);
+    const value = this.data.get(convertedKey);
+    this.data.delete(convertedKey);
+    return value;
   }
 
   /**
@@ -400,23 +408,13 @@ export class HashWithIndifferentAccess<V = unknown> {
       // eslint-disable-next-line blazetrails/rails-error-parity
       throw new TypeError("no implicit conversion of nil into Hash");
     } else if (NOT_GIVEN === hash) {
-      for (const key of [...this.keys()]) {
-        const value = this.get(key)!;
-        this.delete(key);
-        this.set(block!(key), value);
-      }
+      for (const key of [...this.keys()]) this.set(block!(key), this.delete(key)!);
     } else if (block) {
       for (const key of [...this.keys()]) {
-        const value = this.get(key)!;
-        this.delete(key);
-        this.set((hash[key] as string) || block(key), value);
+        this.set((hash[key] as string) || block(key), this.delete(key)!);
       }
     } else {
-      for (const key of [...this.keys()]) {
-        const value = this.get(key)!;
-        this.delete(key);
-        this.set((hash[key] as string) || key, value);
-      }
+      for (const key of [...this.keys()]) this.set((hash[key] as string) || key, this.delete(key)!);
     }
 
     return this;


### PR DESCRIPTION
## HashWithIndifferentAccess#delete

`delete(key)` now returns the removed value (`undefined` when the key was
absent) instead of `Map#delete`'s boolean, matching
`hash_with_indifferent_access.rb:303-305` (`super(convert_key(key))` over
`Hash#delete`).

That lets `transformKeysBang` collapse back to Rails' one line per arm
(`:348-355`): `keys.each { |key| self[yield(key)] = delete(key) }`. All three
arms were carrying a `get` + `delete` + `set` triple purely because the return
value was unavailable.

Call-site audit: no production caller consumed the boolean — the only
consumers were assertions in `hash-with-indifferent-access.test.ts`, whose
`indifferent deleting` case is now the verbatim port of
`hash_with_indifferent_access_test.rb:378-386` (`assert_equal "foo"` /
`assert_nil`). Strong-params `delete` is its own method and already returned a
value.

## relation.ts → relation/query-methods.ts (RFC 0107 split 2/4)

Moves the ordering and projection families into `query-methods.ts`, mixed in
through `QueryMethodBangs` / `Included<>`, each non-bang sitting next to the
bang form it spawns into: `select` (`:413`), `reselect` (`:541`), `group`
(`:573`), `regroup` (`:593`), `order` (`:656`), `inOrderOf` (`:717`),
`reorder` (`:752`), `having` (`:1197`), `limit` (`:1211`), `offset` (`:1227`),
`distinct` (`:1410`), `reverseOrder` (`:1498`). Their `Relation<T>`-typed
signatures are declared on the `Relation` interface alongside the existing
joins/CTE block, since the mixin signatures return `any`.

`select` keeps both arms — the block form (Rails' `Enumerable#select` through
`include Enumerable`) and the column-projection form.

### `in_order_of` (query_methods.rb:717-741)

Diffed line-by-line rather than moved verbatim; four divergences converged:

- empty `values` returns `spawn.none!`, not `self.none` (`:719`);
- `references` unions onto **self** via `self.references_values |= references`
  (`:722`), not onto the spawn;
- `arel_column` resolves through `order_column` on self (`:725`);
- the `filter:` arm applies through `where!` (`:737`) instead of splicing
  `whereClause` by hand.

The `undefined → null` normalization before `type_cast_for_database` stays: it
is the TS-side spelling of Ruby's single `nil`.

### `having` / `having!` (query_methods.rb:1197-1204)

The blank guard moves to the non-bang, which is where Rails has it
(`opts.blank? ? self : spawn.having!(opts, *rest)`), so `having({})` returns
the receiver rather than a spawn. `having!` drops its hand-rolled
string/node/hash dispatch for Rails' single
`self.having_clause += build_having_clause(opts, rest)` — which is the
`build_where_clause` alias already mixed in, so a HAVING fragment now gets the
same named/positional bound-literal handling and the same hash reference
promotion that WHERE gets.

## Verification

No behavior change beyond the convergences above. `src/relation/**` (61 files,
1426 tests), `relations.test.ts`, `calculations.test.ts`,
`calculations.trails.test.ts`, `relation.trails.test.ts`,
`has-many-through-associations.test.ts`, the strong-params suite and the
ActiveSupport hash suites all pass.

`pnpm parity:api:calls`, `parity:api:calls:args`, `pnpm lint`, `pnpm typecheck`
clean; `parity:api` / `parity:test` deltas non-negative.

Closes-story: converge-hwia-delete-returns-the-removed-value
Closes-story: fan-out-query-methods-order-and-projection
