### PR TITLE
fix(parity): compare numeric assertion values by source spelling, not scanner value

### DIFF
--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -22,18 +22,18 @@
     },
     "activemodel": {
       "assertionCount": 415,
-      "kind": 623,
+      "kind": 622,
       "value": 65
     },
     "activerecord": {
-      "assertionCount": 1977,
-      "kind": 4066,
-      "value": 49
+      "assertionCount": 1965,
+      "kind": 4056,
+      "value": 39
     },
     "activesupport": {
-      "assertionCount": 1044,
-      "kind": 1475,
-      "value": 136
+      "assertionCount": 1019,
+      "kind": 1450,
+      "value": 135
     },
     "arel": {
       "assertionCount": 180,
@@ -41,8 +41,8 @@
       "value": 17
     },
     "date": {
-      "assertionCount": 21,
-      "kind": 31,
+      "assertionCount": 20,
+      "kind": 30,
       "value": 1
     },
     "did-you-mean": {

--- a/scripts/test-compare/extract-ts-assertions.test.ts
+++ b/scripts/test-compare/extract-ts-assertions.test.ts
@@ -352,6 +352,17 @@ describe("TS extractor assertion-value collection", () => {
     expect(tsAssertionValues(src)["neg"]).toEqual(["n:-3"]);
   });
 
+  it("keeps a numeric literal's source spelling so a Rails float still matches", () => {
+    const src = `
+      it("nums", () => {
+        expect(a).toEqual(946684800.0);
+        expect(b).toEqual(1_000);
+        expect(c).toEqual(-1.50);
+      });
+    `;
+    expect(tsAssertionValues(src)["nums"]).toEqual(["n:946684800.0", "n:1000", "n:-1.50"]);
+  });
+
   it("folds null and undefined matcher args to the x:nil token", () => {
     const src = `
       it("nils", () => {

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -184,6 +184,19 @@ function expectChainMatcher(call: ts.CallExpression): string | null {
 }
 
 /**
+ * The SOURCE spelling of a numeric literal, underscores stripped — the same
+ * shape extract-ruby-tests.rb's `literal_token` emits from Ripper's `@int` /
+ * `@float` leaves (`node[1].delete('_')`). `NumericLiteral.text` is the
+ * scanner's normalized value (`946684800.0` → `946684800`, `0xff` → `255`), so
+ * reading it would make a faithful port of `assert_equal 946684800.0, …` look
+ * like a value divergence against a Rails float that TypeScript has no separate
+ * literal type for.
+ */
+function numericText(node: ts.NumericLiteral, sourceFile: ts.SourceFile): string {
+  return node.getText(sourceFile).replaceAll("_", "");
+}
+
+/**
  * Normalize a matcher-argument node to a tagged literal token (see
  * assertion-values.ts for the encoding and its Ruby twin), or `null` when the
  * argument is a computed expression/variable we can't statically compare.
@@ -191,9 +204,9 @@ function expectChainMatcher(call: ts.CallExpression): string | null {
  * literal in the AST) and folds `null`/`undefined` to the `x:nil` token so a TS
  * `toBeNull()`/`toBeUndefined()` lines up with a Ruby `nil`.
  */
-function literalToken(node: ts.Node | undefined): string | null {
+function literalToken(node: ts.Node | undefined, sourceFile: ts.SourceFile): string | null {
   if (!node) return null;
-  if (ts.isNumericLiteral(node)) return `n:${node.text}`;
+  if (ts.isNumericLiteral(node)) return `n:${numericText(node, sourceFile)}`;
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return `s:${node.text}`;
   if (node.kind === ts.SyntaxKind.TrueKeyword) return "b:true";
   if (node.kind === ts.SyntaxKind.FalseKeyword) return "b:false";
@@ -204,7 +217,7 @@ function literalToken(node: ts.Node | undefined): string | null {
     node.operator === ts.SyntaxKind.MinusToken &&
     ts.isNumericLiteral(node.operand)
   ) {
-    return `n:-${node.operand.text}`;
+    return `n:-${numericText(node.operand, sourceFile)}`;
   }
   return null;
 }
@@ -218,11 +231,15 @@ function literalToken(node: ts.Node | undefined): string | null {
  * (`includes`/`excludes`) checks its second argument (the member), every other
  * value-bearing kind its first.
  */
-function helperCalleeValue(name: string, args: readonly ts.Expression[]): string | null {
+function helperCalleeValue(
+  name: string,
+  args: readonly ts.Expression[],
+  sourceFile: ts.SourceFile,
+): string | null {
   const kind = normalizeTrailsKind(name);
   if (!kind || !VALUE_BEARING_KINDS.has(kind)) return null;
   const idx = kind === "includes" || kind === "excludes" ? 1 : 0;
-  return literalToken(args[idx]);
+  return literalToken(args[idx], sourceFile);
 }
 
 /** Lockstep assertion-kind tokens and their captured literal expected values. */
@@ -248,6 +265,7 @@ interface AssertionKinds {
 function collectAssertionKinds(
   node: ts.Node,
   helpers: HelperMap,
+  sourceFile: ts.SourceFile,
   depth = 0,
   visiting: Set<string> = new Set(),
 ): AssertionKinds {
@@ -259,7 +277,7 @@ function collectAssertionKinds(
         const matcher = expectChainMatcher(n);
         if (matcher) {
           kinds.push(matcher);
-          values.push(literalToken(n.arguments[0]));
+          values.push(literalToken(n.arguments[0], sourceFile));
         }
       } else if (ts.isIdentifier(n.expression)) {
         const name = n.expression.text;
@@ -268,13 +286,13 @@ function collectAssertionKinds(
           // callee (assertQueriesCount, expectQuotedColumnInSql, …) is its kind.
           if (name !== "expect") {
             kinds.push(name);
-            values.push(helperCalleeValue(name, n.arguments));
+            values.push(helperCalleeValue(name, n.arguments, sourceFile));
           }
         } else if (depth < MAX_HELPER_DEPTH && !visiting.has(name)) {
           const body = resolveHelper(helpers, name, n.pos);
           if (body) {
             visiting.add(name);
-            const sub = collectAssertionKinds(body, helpers, depth + 1, visiting);
+            const sub = collectAssertionKinds(body, helpers, sourceFile, depth + 1, visiting);
             kinds.push(...sub.kinds);
             values.push(...sub.values);
             visiting.delete(name);
@@ -341,7 +359,11 @@ export function extractTestsFromSource(content: string, relativePath: string): T
     let gate = activeGate();
     if (inlineGate) gate = mergeGate(gate, inlineGate);
     const finalGate = gate ? finalizeGate(gate) : undefined;
-    const { kinds: assertionKinds, values: assertionValues } = collectAssertionKinds(node, helpers);
+    const { kinds: assertionKinds, values: assertionValues } = collectAssertionKinds(
+      node,
+      helpers,
+      sourceFile,
+    );
     fileInfo.testCases.push({
       path: [...currentAncestors, title].join(" > "),
       description: title,


### PR DESCRIPTION
## What

`Rails API/Test Comparison` is red on `main` @bc14d32d at the **Assertion-mismatch ratchet** step:

```
activesupport  assertion-value-mismatch: 137 (mark 136, +1)
```

The +1 is `datetimeextcalculationstest > to f`, ported in #6628:

```ts
expect(toF(dt(2000))).toBe(946684800.0);        // Rails: assert_equal 946684800.0, ...
```

That is a verbatim port of the Rails literal, but the extractor read `ts.NumericLiteral.text` — the **scanner's normalized value**, not the source spelling. `946684800.0` arrives as `946684800` (and `0xff` as `255`, `1e3` as `1000`), while the Ruby twin, `extract-ruby-tests.rb`'s `literal_token`, emits the raw Ripper `@int`/`@float` source with underscores stripped:

```ruby
when :@int, :@float
  "n:#{node[1].delete('_')}"
```

So the two sides were never comparing the same thing for a float, and `assertion-values.ts` deliberately does *not* normalize numeric width (`n:5` != `n:5.0`) — a fidelity distinction that is real in Ruby and that TypeScript has no separate literal type for. The only place the distinction survives on the TS side is the source text.

## Change

`literalToken` takes the `SourceFile` and reads the literal's source text with underscores stripped (`numericText`), mirroring the Ruby side exactly. `helperCalleeValue` / `collectAssertionKinds` thread it through; the negative-literal arm goes through the same helper.

No baseline was widened. Value mismatches drop **277 -> 265** overall (activerecord 49 -> 39, activesupport 137 -> 135, activemodel 65 unchanged), and the marks are lowered to the new totals — every counter shrinks, none rises. Matched-test totals are unchanged (15718/22770).

## Verification

- `pnpm exec tsx scripts/test-compare/lint-assertion-mismatches.ts --no-regen` — OK
- `pnpm vitest run scripts/test-compare/{extract-ts-assertions,assertion-values,lint-assertion-mismatches}.test.ts` — 49 passing, plus a new regression covering `946684800.0` / `1_000` / `-1.50`
- `pnpm typecheck`, `pnpm exec eslint` on the touched files — clean

Closes-story: red-bc14d32d