### PR TITLE
feat(activesupport,date): DateTime#to_fs over Time::DATE_FORMATS; Rational canonicalizes a negative denominator

### DIFF
--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -19,11 +19,22 @@ import {
   subsec,
   utcOffset,
 } from "./date-time/calculations.js";
-import { civilFromFormat, formattedOffset, nsec, toF, toI, usec } from "./date-time/conversions.js";
+import {
+  civilFromFormat,
+  formattedOffset,
+  nsec,
+  readableInspect,
+  toF,
+  toFormattedS,
+  toFs,
+  toI,
+  usec,
+} from "./date-time/conversions.js";
 import { setFrozenTime } from "../time-travel.js";
 import { setZone } from "../time-zone-config.js";
 import { ArgumentError } from "../hash-utils.js";
 import {
+  DATE_FORMATS,
   advance as timeAdvance,
   beginningOfQuarter,
   endOfMonth,
@@ -36,7 +47,6 @@ import {
   nextDay,
   prevDay,
   toDate,
-  toFs,
   toTime,
   xmlschema,
 } from "../time-ext.js";
@@ -71,21 +81,49 @@ const END_OF_PERIOD_SEC = new Rational(59999999999, 1000000000);
 
 describe("DateTimeExtCalculationsTest", () => {
   it("to fs", () => {
-    const dt = d(2005, 2, 22, 10, 10, 10);
-    const result = toFs(dt);
-    expect(result).toContain("2005");
+    const datetime = dt(2005, 2, 21, 14, 30, 0);
+    expect(toFs(datetime, "db")).toBe("2005-02-21 14:30:00");
+    expect(toFs(datetime, "inspect")).toBe("2005-02-21 14:30:00.000000000 +0000");
+    expect(toFs(datetime, "time")).toBe("14:30");
+    expect(toFs(datetime, "short")).toBe("21 Feb 14:30");
+    expect(toFs(datetime, "long")).toBe("February 21, 2005 14:30");
+    expect(toFs(datetime, "rfc822")).toBe("Mon, 21 Feb 2005 14:30:00 +0000");
+    expect(toFs(datetime, "rfc2822")).toBe("Mon, 21 Feb 2005 14:30:00 +0000");
+    expect(toFs(datetime, "long_ordinal")).toBe("February 21st, 2005 14:30");
+    expect(toFs(datetime)).toMatch(/^2005-02-21T14:30:00(Z|\+00:00)$/);
+    expect(toFs(datetime, "not_existent")).toMatch(/^2005-02-21T14:30:00(Z|\+00:00)$/);
+
+    // Rails wraps these three in `with_env_tz "US/Central"`; a `DateTime`
+    // carries its own offset, so the ambient zone never reaches `:iso8601`.
+    expect(
+      toFs(DateTime.civil(2009, 2, 5, 14, 30, 5, new Rational(-21600, 86400)), "iso8601"),
+    ).toBe("2009-02-05T14:30:05-06:00");
+    expect(toFs(DateTime.civil(2008, 6, 9, 4, 5, 1, new Rational(-18000, 86400)), "iso8601")).toBe(
+      "2008-06-09T04:05:01-05:00",
+    );
+    expect(toFs(DateTime.civil(2009, 2, 5, 14, 30, 5), "iso8601")).toBe(
+      "2009-02-05T14:30:05+00:00",
+    );
+
+    expect(toFormattedS(datetime, "db")).toBe("2005-02-21 14:30:00");
   });
 
   it("readable inspect", () => {
-    const dt = d(2005, 2, 22, 10, 10, 10);
-    const result = toFs(dt);
-    expect(typeof result).toBe("string");
+    const datetime = dt(2005, 2, 21, 14, 30, 0);
+    expect(readableInspect(datetime)).toBe("Mon, 21 Feb 2005 14:30:00 +0000");
+    // Rails asserts `datetime.readable_inspect == datetime.inspect`, the alias
+    // its `alias_method :inspect, :readable_inspect` installs; trails reopens
+    // no `::DateTime`, so the alias target is compared directly.
+    expect(readableInspect(datetime)).toBe(toFs(datetime, "rfc822"));
   });
 
   it("to fs with custom date format", () => {
-    const dt = d(2005, 2, 22, 10, 10, 10);
-    const result = toFs(dt, "db");
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    DATE_FORMATS.custom = "%Y%m%d%H%M%S";
+    try {
+      expect(toFs(dt(2005, 2, 21, 14, 30, 0), "custom")).toBe("20050221143000");
+    } finally {
+      delete DATE_FORMATS.custom;
+    }
   });
 
   it("localtime", () => {

--- a/packages/activesupport/src/core-ext/date-time/conversions.ts
+++ b/packages/activesupport/src/core-ext/date-time/conversions.ts
@@ -12,7 +12,7 @@
  */
 
 import { DateTime as RubyDateTime, Temporal, Time, cCivilToJd } from "@blazetrails/date";
-import { secFraction } from "../../time-ext.js";
+import { DATE_FORMATS, secFraction } from "../../time-ext.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { isUtc, secondsSinceMidnight, utcOffset } from "./calculations.js";
 
@@ -22,6 +22,34 @@ import { isUtc, secondsSinceMidnight, utcOffset } from "./calculations.js";
  * is the offset-0 case a Ruby `DateTime` defaults to.
  */
 type DateTime = Temporal.PlainDateTime | Temporal.ZonedDateTime;
+
+/**
+ * Convert to a formatted string. See `Time::DATE_FORMATS` for predefined
+ * formats.
+ *
+ * This method is aliased to {@link toFormattedS}.
+ *
+ *     toFs(datetime, "db")            // => "2007-12-04 00:00:00"
+ *     toFs(datetime, "long_ordinal")  // => "December 4th, 2007 00:00"
+ *     toFs(datetime, "rfc822")        // => "Tue, 04 Dec 2007 00:00:00 +0000"
+ *
+ * Mirrors: `DateTime#to_fs` (`core_ext/date_time/conversions.rb:35-40`) —
+ * `formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)`,
+ * else `to_s`. The unknown-format arm falls through to ruby/date's own
+ * `DateTime#to_s` (`date_core.c` `dt_lite_to_s`), not to a format string.
+ */
+export function toFs(datetime: DateTime, format = "default"): string {
+  const formatter = DATE_FORMATS[format];
+  if (formatter != null) {
+    return typeof formatter === "function"
+      ? String(formatter(datetime))
+      : new RubyDateTime(datetime).strftime(formatter);
+  }
+  return new RubyDateTime(datetime).toS();
+}
+
+/** Mirrors: `alias_method :to_formatted_s, :to_fs` (`core_ext/date_time/conversions.rb:42`). */
+export const toFormattedS = toFs;
 
 /**
  * Returns a formatted string of the offset from UTC, or an alternative string
@@ -39,6 +67,30 @@ export function formattedOffset(
 ): string {
   if (isUtc(datetime) && alternateUtcString != null) return alternateUtcString;
   return TimeZone.secondsToUtcOffset(utcOffset(datetime), colon);
+}
+
+/**
+ * Overrides the default inspect method with a human readable one, e.g.,
+ * "Mon, 21 Feb 2005 14:30:00 +0000".
+ *
+ * Mirrors: `DateTime#readable_inspect`
+ * (`core_ext/date_time/conversions.rb:56-58`) — `to_fs(:rfc822)`. Rails then
+ * runs `alias_method :inspect, :readable_inspect`, reopening `::DateTime`
+ * itself; trails has no receiver to reopen, so callers reach this name
+ * directly.
+ */
+export function readableInspect(datetime: DateTime): string {
+  return toFs(datetime, "rfc822");
+}
+
+/**
+ * Mirrors: `alias_method :default_inspect, :inspect`
+ * (`core_ext/date_time/conversions.rb:59`), which captures the ORIGINAL
+ * `::DateTime#inspect` — ruby/date's `d_lite_inspect` — before the line below
+ * it replaces `inspect` with {@link readableInspect}.
+ */
+export function defaultInspect(datetime: DateTime): string {
+  return new RubyDateTime(datetime).inspect();
 }
 
 /**

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -426,14 +426,14 @@ export class HashWithIndifferentAccess<V = unknown> {
   /**
    * Mirrors `slice!` (hash_with_indifferent_access.rb:366-369) — the keys are
    * converted, then `Hash#slice!` (core_ext/hash/slice.rb:10-17) replaces the
-   * hash with the given keys and returns the removed pairs. The `default` /
-   * `default_proc` lines have no counterpart here: this class does not model a
-   * Hash default (see `initialize`).
+   * hash with the given keys and returns the removed pairs.
    */
   sliceBang(...keys: string[]): HashWithIndifferentAccess<V> {
     keys = keys.map((key) => this.convertKey(key));
     const omit = this.slice(...[...this.keys()].filter((key) => !keys.includes(key)));
     const hash = this.slice(...keys);
+    hash.setDefault(this.default());
+    if (this.defaultProc()) hash.setDefaultProc(this.defaultProc());
     this.replace(hash);
     return omit;
   }

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -679,6 +679,16 @@ export { secFraction as subsec };
  * `dateTimeFormattedOffset` because this file declares its own
  * `formattedOffset` over a JS `Date` — `core_ext/time/conversions.rb`'s arm of
  * the same Rails name — and a `DateTime` receiver reaches the other one.
+ *
+ * That import closes a cycle with `core-ext/date-time/conversions.ts`, which
+ * reads `DATE_FORMATS` back for its `to_fs`. Neither side touches the other at
+ * module-eval time — the read is inside a lambda here and inside `toFs` there,
+ * and neither file declares a `class ... extends` across the edge — so no
+ * binding is in TDZ when either module body runs. Verified by importing the
+ * built `dist/time-ext.js`, `dist/core-ext/date-time/conversions.js` and
+ * `dist/index.js` as entry modules under plain node, per CLAUDE.md's
+ * call-time-constant section; a vitest run enters through a funnel module and
+ * would mask it.
  */
 export const DATE_FORMATS: Record<
   string,

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -9,8 +9,14 @@
  *   `toDate`). Predicates (`isPast`, `isFuture`) accept `Date | Temporal.Instant`.
  */
 
-import { Temporal, Time as RubyTime } from "@blazetrails/date";
+import { DateTime as RubyDateTime, Temporal, Time as RubyTime } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
+import { ordinalize } from "./inflector.js";
+// `time-ext.ts` declares its own `formattedOffset` over a JS `Date`
+// (`core_ext/time/conversions.rb`'s arm), so the DateTime arm — the one
+// `Time::DATE_FORMATS[:rfc822]`'s `time.formatted_offset(false)` reaches on a
+// `DateTime` receiver — comes in under an alias.
+import { formattedOffset as dateTimeFormattedOffset } from "./core-ext/date-time/conversions.js";
 import { ArgumentError } from "./hash-utils.js";
 import { findZoneBang, zone as timeZone } from "./time-zone-config.js";
 import { TimeWithZone } from "./time-with-zone.js";
@@ -659,6 +665,43 @@ export function secFraction(
 // Time direction is the mirror image (`Time#sec_fraction` is `subsec`,
 // time/calculations.rb:107-109), so one function answers both names.
 export { secFraction as subsec };
+
+/**
+ * The named formats `to_fs` resolves, either a `strftime` string or a callable
+ * taking the receiver.
+ *
+ * Mirrors: `Time::DATE_FORMATS` (`core_ext/time/conversions.rb:8-27`). The
+ * Ruby keys are Symbols and the four lambdas duck-type their argument — a
+ * `Time`, a `Date` or a `DateTime` all answer `day`, `strftime`,
+ * `formatted_offset`, `rfc2822` and `iso8601` — so the hash is shared by every
+ * `to_fs` in ActiveSupport. Its only caller in trails today is
+ * `core-ext/date-time/conversions.ts`'s `toFs`, so the callables are typed over
+ * that receiver; `time-ext.ts`'s own `toFs` below still answers a JS `Date`
+ * through a hand-rolled `switch` and is converged separately.
+ */
+export const DATE_FORMATS: Record<
+  string,
+  string | ((time: Temporal.PlainDateTime | Temporal.ZonedDateTime) => string)
+> = {
+  db: "%Y-%m-%d %H:%M:%S",
+  inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
+  number: "%Y%m%d%H%M%S",
+  nsec: "%Y%m%d%H%M%S%9N",
+  usec: "%Y%m%d%H%M%S%6N",
+  time: "%H:%M",
+  short: "%d %b %H:%M",
+  long: "%B %d, %Y %H:%M",
+  long_ordinal: (time) => {
+    const dayFormat = ordinalize(time.day);
+    return new RubyDateTime(time).strftime(`%B ${dayFormat}, %Y %H:%M`);
+  },
+  rfc822: (time) => {
+    const offsetFormat = dateTimeFormattedOffset(time, false);
+    return new RubyDateTime(time).strftime(`%a, %d %b %Y %H:%M:%S ${offsetFormat}`);
+  },
+  rfc2822: (time) => new RubyDateTime(time).rfc2822(),
+  iso8601: (time) => new RubyDateTime(time).iso8601(),
+};
 
 /**
  * toFs — formats a Date as a string using various named formats.

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -12,10 +12,6 @@
 import { DateTime as RubyDateTime, Temporal, Time as RubyTime } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { ordinalize } from "./inflector.js";
-// `time-ext.ts` declares its own `formattedOffset` over a JS `Date`
-// (`core_ext/time/conversions.rb`'s arm), so the DateTime arm — the one
-// `Time::DATE_FORMATS[:rfc822]`'s `time.formatted_offset(false)` reaches on a
-// `DateTime` receiver — comes in under an alias.
 import { formattedOffset as dateTimeFormattedOffset } from "./core-ext/date-time/conversions.js";
 import { ArgumentError } from "./hash-utils.js";
 import { findZoneBang, zone as timeZone } from "./time-zone-config.js";
@@ -678,6 +674,11 @@ export { secFraction as subsec };
  * `core-ext/date-time/conversions.ts`'s `toFs`, so the callables are typed over
  * that receiver; `time-ext.ts`'s own `toFs` below still answers a JS `Date`
  * through a hand-rolled `switch` and is converged separately.
+ *
+ * `rfc822`'s `time.formatted_offset(false)` is imported as
+ * `dateTimeFormattedOffset` because this file declares its own
+ * `formattedOffset` over a JS `Date` — `core_ext/time/conversions.rb`'s arm of
+ * the same Rails name — and a `DateTime` receiver reaches the other one.
  */
 export const DATE_FORMATS: Record<
   string,

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2415,9 +2415,13 @@ describe("the instance formatters", () => {
     // ruby 3.3.11:
     //   Date.new(2001,2,3).iso8601  #=> "2001-02-03"
     //   Date.new(2001,2,3).rfc2822  #=> "Sat, 3 Feb 2001 00:00:00 +0000"
+    //   Date.new(2001,2,3).xmlschema #=> "2001-02-03"
+    //   Date.new(2001,2,3).rfc822    #=> "Sat, 3 Feb 2001 00:00:00 +0000"
     const d = new RubyDate(2001, 2, 3);
     expect(d.iso8601()).toBe("2001-02-03");
     expect(d.rfc2822()).toBe("Sat, 3 Feb 2001 00:00:00 +0000");
+    expect(d.xmlschema()).toBe(d.iso8601());
+    expect(d.rfc822()).toBe(d.rfc2822());
   });
 
   it("carries the time of day and the offset into a DateTime's, as dt_lite_iso8601 does", () => {
@@ -2429,6 +2433,7 @@ describe("the instance formatters", () => {
     expect(dt.iso8601()).toBe("2001-02-03T00:00:00+00:00");
     expect(dt.xmlschema()).toBe("2001-02-03T00:00:00+00:00");
     expect(dt.rfc2822()).toBe("Sat, 3 Feb 2001 00:00:00 +0000");
+    expect(dt.rfc822()).toBe(dt.rfc2822());
   });
 
   it("takes n digits of fractional seconds through iso8601_timediv", () => {

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2427,4 +2427,16 @@ describe("Rational", () => {
     expect(() => new Rational(Infinity, 1)).toThrow("Infinity");
     expect(() => new Rational(NaN, 1)).toThrow("NaN");
   });
+
+  it("canonicalizes the sign onto the numerator, as nurat_s_canonicalize_internal does", () => {
+    // ruby 3.3.11:
+    //   Rational(3, -4)   #=> (-3/4)
+    //   Rational(-3, -4)  #=> (3/4)
+    //   Rational(1, -0.5) #=> (-2/1)
+    expect(new Rational(3, -4).numerator).toBe(-3n);
+    expect(new Rational(3, -4).denominator).toBe(4n);
+    expect(new Rational(3, -4).inspect()).toBe("(-3/4)");
+    expect(new Rational(-3, -4).inspect()).toBe("(3/4)");
+    expect(new Rational(1, -0.5).inspect()).toBe("(-2/1)");
+  });
 });

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2410,6 +2410,39 @@ describe("builder seats answer rb_obj_class(self)", () => {
   });
 });
 
+describe("the instance formatters", () => {
+  it("answers iso8601 and rfc2822 off the date, as d_lite_iso8601 and d_lite_rfc2822 do", () => {
+    // ruby 3.3.11:
+    //   Date.new(2001,2,3).iso8601  #=> "2001-02-03"
+    //   Date.new(2001,2,3).rfc2822  #=> "Sat, 3 Feb 2001 00:00:00 +0000"
+    const d = new RubyDate(2001, 2, 3);
+    expect(d.iso8601()).toBe("2001-02-03");
+    expect(d.rfc2822()).toBe("Sat, 3 Feb 2001 00:00:00 +0000");
+  });
+
+  it("carries the time of day and the offset into a DateTime's, as dt_lite_iso8601 does", () => {
+    // ruby 3.3.11:
+    //   DateTime.new(2001,2,3).iso8601   #=> "2001-02-03T00:00:00+00:00"
+    //   DateTime.new(2001,2,3).xmlschema #=> "2001-02-03T00:00:00+00:00"
+    //   DateTime.new(2001,2,3).rfc2822   #=> "Sat, 3 Feb 2001 00:00:00 +0000"
+    const dt = new RubyDateTime(2001, 2, 3);
+    expect(dt.iso8601()).toBe("2001-02-03T00:00:00+00:00");
+    expect(dt.xmlschema()).toBe("2001-02-03T00:00:00+00:00");
+    expect(dt.rfc2822()).toBe("Sat, 3 Feb 2001 00:00:00 +0000");
+  });
+
+  it("takes n digits of fractional seconds through iso8601_timediv", () => {
+    // ruby 3.3.11:
+    //   DateTime.parse("2001-02-03T04:05:06.123456").iso8601(3)
+    //     #=> "2001-02-03T04:05:06.123+00:00"
+    //   ...iso8601(9) #=> "2001-02-03T04:05:06.123456000+00:00"
+    const d2 = new RubyDateTime(RubyDateTime.parse("2001-02-03T04:05:06.123456"));
+    expect(d2.iso8601(3)).toBe("2001-02-03T04:05:06.123+00:00");
+    expect(d2.iso8601(9)).toBe("2001-02-03T04:05:06.123456000+00:00");
+    expect(d2.xmlschema(3)).toBe("2001-02-03T04:05:06.123+00:00");
+  });
+});
+
 describe("Rational", () => {
   it("takes a Float on either side, as nurat_s_convert does", () => {
     // ruby 3.3.11:

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -8851,9 +8851,6 @@ export class DateTime extends DateWithoutParseStatics {
    * @internal ruby/date's `iso8601_timediv(self, n)` (`date_core.c:8728-8742`),
    * which builds `"T%H:%M:%S"`, appends `".%<n>N"` only when `n > 0`, then
    * `"%:z"`, and runs the result through `strftimev`.
-   *
-   * @noRailsEquivalent PERMANENT — a file-static C helper with no Ruby name,
-   * extracted here exactly as the C extracts it.
    */
   #iso8601Timediv(n: number): string {
     let fmt = "T%H:%M:%S";

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -1259,12 +1259,21 @@ export class Rational {
    * `float_to_r` ({@link floatToR}) — `Rational(0.5, 86400)` is `(1/172800)` on
    * ruby 3.3.11 — and an Integer one is itself over one, which is the
    * `BigInt(num) / BigInt(den)` this constructor used to be limited to.
+   *
+   * `nurat_s_canonicalize_internal` (`rational.c`) then canonicalizes the SIGN
+   * onto the numerator before it cancels: its `switch (FIX2INT(f_cmp(den,
+   * ZERO)))` negates BOTH parts on a negative denominator, which is why
+   * `Rational(3, -4)` is `(-3/4)` on ruby 3.3.11 and not `(3/-4)`.
    */
   constructor(num: number | bigint, den: number | bigint) {
     const a = floatToR(num);
     const b = floatToR(den);
-    const n = a.numerator * b.denominator;
-    const d = a.denominator * b.numerator;
+    let n = a.numerator * b.denominator;
+    let d = a.denominator * b.numerator;
+    if (d < 0n) {
+      n = -n;
+      d = -d;
+    }
     const g = iGcd(n, d);
     this.numerator = n / g;
     this.denominator = d / g;
@@ -7538,6 +7547,26 @@ export class Date {
   }
 
   /**
+   * Ruby `Date#iso8601` (ruby/date, `date_core.c` `d_lite_iso8601`,
+   * `date_core.c:7298-7302`) — `strftimev("%Y-%m-%d", self, set_tmx)`.
+   */
+  iso8601(): string {
+    return this.strftime("%Y-%m-%d");
+  }
+
+  /**
+   * Ruby `Date#rfc2822` (ruby/date, `date_core.c` `d_lite_rfc2822`,
+   * `date_core.c:7330-7334`) — `strftimev("%a, %-d %b %Y %T %z", self,
+   * set_tmx)`. `::DateTime` does not override it (`date_core.c:10020-10025`
+   * defines `to_s`, `iso8601` and `xmlschema` on `cDateTime` but not this), so
+   * a `DateTime` receiver reaches it and `set_tmx` carries its own time and
+   * offset into `%T`/`%z`.
+   */
+  rfc2822(): string {
+    return this.strftime("%a, %-d %b %Y %T %z");
+  }
+
+  /**
    * Ruby `Date#deconstruct_keys(array_of_names_or_nil)` (ruby/date,
    * `date_core.c` `d_lite_deconstruct_keys`, `date_core.c:7500-7504`), the
    * pattern-matching reader. The key names are Ruby Symbols and stay in the
@@ -8816,6 +8845,39 @@ export class DateTime extends DateWithoutParseStatics {
    */
   override toS(): string {
     return this.strftime("%Y-%m-%dT%H:%M:%S%:z");
+  }
+
+  /**
+   * @internal ruby/date's `iso8601_timediv(self, n)` (`date_core.c:8728-8742`),
+   * which builds `"T%H:%M:%S"`, appends `".%<n>N"` only when `n > 0`, then
+   * `"%:z"`, and runs the result through `strftimev`.
+   *
+   * @noRailsEquivalent PERMANENT — a file-static C helper with no Ruby name,
+   * extracted here exactly as the C extracts it.
+   */
+  #iso8601Timediv(n: number): string {
+    let fmt = "T%H:%M:%S";
+    if (n > 0) fmt += `.%${n}N`;
+    fmt += "%:z";
+    return this.strftime(fmt);
+  }
+
+  /**
+   * Ruby `DateTime#iso8601(n = 0)` (ruby/date, `date_core.c`
+   * `dt_lite_iso8601`, `date_core.c:8755-8766`) — `strftimev("%Y-%m-%d")`
+   * appended with {@link DateTime.#iso8601Timediv}. `n` is the number of
+   * digits of fractional seconds.
+   */
+  iso8601(n = 0): string {
+    return this.strftime("%Y-%m-%d") + this.#iso8601Timediv(n);
+  }
+
+  /**
+   * Ruby `DateTime#xmlschema(n = 0)`, which `date_core.c:10025` binds to the
+   * same `dt_lite_iso8601`.
+   */
+  xmlschema(n = 0): string {
+    return this.iso8601(n);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -7555,6 +7555,14 @@ export class Date {
   }
 
   /**
+   * Ruby `Date#xmlschema`, which `date_core.c:9810` binds to the same
+   * `d_lite_iso8601` as `iso8601` (`:9809`).
+   */
+  xmlschema(): string {
+    return this.iso8601();
+  }
+
+  /**
    * Ruby `Date#rfc2822` (ruby/date, `date_core.c` `d_lite_rfc2822`,
    * `date_core.c:7330-7334`) — `strftimev("%a, %-d %b %Y %T %z", self,
    * set_tmx)`. `::DateTime` does not override it (`date_core.c:10020-10025`
@@ -7564,6 +7572,14 @@ export class Date {
    */
   rfc2822(): string {
     return this.strftime("%a, %-d %b %Y %T %z");
+  }
+
+  /**
+   * Ruby `Date#rfc822`, which `date_core.c:9813` binds to the same
+   * `d_lite_rfc2822` as `rfc2822` (`:9812`). `::DateTime` inherits both.
+   */
+  rfc822(): string {
+    return this.rfc2822();
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -10,6 +10,13 @@
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "change",
+    "call": "order:local,isInteger",
+    "reason": "`change`'s TS body runs the `elsif zone` arm (time/calculations.rb:172-173) BEFORE the `elsif zone.respond_to?(:utc_to_local)` one (:150-171), so `Time.local` is reached ahead of the `utc_offset.integer?` guard. This file's `Time` arm is a JS `Date`, which carries no zone OBJECT — only the system zone — so it can never take the `utc_to_local` arm and is dispatched by receiver type up front; the ZonedDateTime receiver still falls through to the `utc_to_local` body in Rails' order. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
     "call": "utc?",
     "reason": "`utc?` and `utc_offset` are Ruby core `Time` readers — no Rails definition to port — and this file's `Time` arm is a JS `Date`, an instant that carries no offset of its own, so every body Ruby writes through them reads `getTimezoneOffset()` instead. Surfaced, not introduced, by taking `utc?`/`utc_offset` off the date_time/calculations.rb skip group: both are now ported on the DateTime receiver in core-ext/date-time/calculations.ts."
   },
@@ -103,5 +110,69 @@
     "rubyName": "xmlschema",
     "call": "in_time_zone",
     "reason": "Rails' `Date#xmlschema` goes through `in_time_zone.xmlschema` to pick up `Time.zone`; trails' is the zoneless arm, and `TimeWithZone#xmlschema` is the zone-aware one."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "integer?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "local",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newSec",
+      "ref:newMin",
+      "ref:newHour",
+      "ref:newDay",
+      "ref:newMonth",
+      "ref:newYear",
+      "nil",
+      "nil",
+      "ref:isdst",
+      "nil"
+    ],
+    "reason": "`::Time.local`'s ten-argument form (time/calculations.rb:172) passes `usec`, `yday`, `isdst` and `tz` positionally; this file's `local` helper is the six-field civil form, and the receiver it builds from is a JS `Date` with no `isdst` of its own — the system zone resolves DST for it. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newYear",
+      "ref:newMonth",
+      "ref:newDay",
+      "ref:newHour",
+      "ref:newMin",
+      "ref:newSec",
+      "ref:zone"
+    ],
+    "reason": "The `new` the extractor pairs here is `new ArgumentError(\"argument out of range\")` (time/calculations.rb:139), not the `::Time.new` of :148 — a JS `new` expression and Ruby's `.new` send share one call name. The `::Time.new` arms are spelled `Temporal.ZonedDateTime.from`, which carries no `new`. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "preserve_timezone",
+    "call": "system_local_time?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "preserve_timezone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -10,6 +10,52 @@
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "change",
+    "call": "integer?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "local",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newSec",
+      "ref:newMin",
+      "ref:newHour",
+      "ref:newDay",
+      "ref:newMonth",
+      "ref:newYear",
+      "nil",
+      "nil",
+      "ref:isdst",
+      "nil"
+    ],
+    "reason": "`::Time.local`'s ten-argument form (time/calculations.rb:172) passes `usec`, `yday`, `isdst` and `tz` positionally; this file's `local` helper is the six-field civil form, and the receiver it builds from is a JS `Date` with no `isdst` of its own — the system zone resolves DST for it. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newYear",
+      "ref:newMonth",
+      "ref:newDay",
+      "ref:newHour",
+      "ref:newMin",
+      "ref:newSec",
+      "ref:zone"
+    ],
+    "reason": "The `new` the extractor pairs here is `new ArgumentError(\"argument out of range\")` (time/calculations.rb:139), not the `::Time.new` of :148 — a JS `new` expression and Ruby's `.new` send share one call name. The `::Time.new` arms are spelled `Temporal.ZonedDateTime.from`, which carries no `new`. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
     "call": "order:local,isInteger",
     "reason": "`change`'s TS body runs the `elsif zone` arm (time/calculations.rb:172-173) BEFORE the `elsif zone.respond_to?(:utc_to_local)` one (:150-171), so `Time.local` is reached ahead of the `utc_offset.integer?` guard. This file's `Time` arm is a JS `Date`, which carries no zone OBJECT — only the system zone — so it can never take the `utc_to_local` arm and is dispatched by receiver type up front; the ZonedDateTime receiver still falls through to the `utc_to_local` body in Rails' order. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
   },
@@ -40,6 +86,15 @@
     "rubyName": "formatted_offset",
     "call": "utc_offset",
     "reason": "`utc?` and `utc_offset` are Ruby core `Time` readers — no Rails definition to port — and this file's `Time` arm is a JS `Date`, an instant that carries no offset of its own, so every body Ruby writes through them reads `getTimezoneOffset()` instead. Surfaced, not introduced, by taking `utc?`/`utc_offset` off the date_time/calculations.rb skip group: both are now ported on the DateTime receiver in core-ext/date-time/calculations.ts."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "preserve_timezone",
+    "call": "system_local_time?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
   },
   {
     "package": "activesupport",
@@ -94,6 +149,15 @@
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "to_time",
+    "call": "preserve_timezone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
     "call": "utc_offset",
     "reason": "`utc?` and `utc_offset` are Ruby core `Time` readers — no Rails definition to port — and this file's `Time` arm is a JS `Date`, an instant that carries no offset of its own, so every body Ruby writes through them reads `getTimezoneOffset()` instead. Surfaced, not introduced, by taking `utc?`/`utc_offset` off the date_time/calculations.rb skip group: both are now ported on the DateTime receiver in core-ext/date-time/calculations.ts."
   },
@@ -110,69 +174,5 @@
     "rubyName": "xmlschema",
     "call": "in_time_zone",
     "reason": "Rails' `Date#xmlschema` goes through `in_time_zone.xmlschema` to pick up `Time.zone`; trails' is the zoneless arm, and `TimeWithZone#xmlschema` is the zone-aware one."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "change",
-    "call": "integer?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "change",
-    "call": "local",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:newSec",
-      "ref:newMin",
-      "ref:newHour",
-      "ref:newDay",
-      "ref:newMonth",
-      "ref:newYear",
-      "nil",
-      "nil",
-      "ref:isdst",
-      "nil"
-    ],
-    "reason": "`::Time.local`'s ten-argument form (time/calculations.rb:172) passes `usec`, `yday`, `isdst` and `tz` positionally; this file's `local` helper is the six-field civil form, and the receiver it builds from is a JS `Date` with no `isdst` of its own — the system zone resolves DST for it. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "change",
-    "call": "new",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:newYear",
-      "ref:newMonth",
-      "ref:newDay",
-      "ref:newHour",
-      "ref:newMin",
-      "ref:newSec",
-      "ref:zone"
-    ],
-    "reason": "The `new` the extractor pairs here is `new ArgumentError(\"argument out of range\")` (time/calculations.rb:139), not the `::Time.new` of :148 — a JS `new` expression and Ruby's `.new` send share one call name. The `::Time.new` arms are spelled `Temporal.ZonedDateTime.from`, which carries no `new`. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "preserve_timezone",
-    "call": "system_local_time?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "to_time",
-    "call": "preserve_timezone",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "Ruby sends this to the receiver; `time-ext.ts`'s `Time` arm is a JS `Date`, which cannot carry a method, so every member here is a free function and the receiver is its first argument. Surfaced — not introduced — by this file gaining `Time::DATE_FORMATS`, which brings `core_ext/time/conversions.rb` into the compared population alongside the Ruby files already mapped here."
   }
 ]


### PR DESCRIPTION
Bundle of four stories. Two ship here, one was already implemented on `main`,
one is blocked on a prerequisite.

## `port-date-time-to-fs-onto-the-datetime-receiver`

`core_ext/date_time/conversions.rb` goes 6/10 → **10/10**.

The story's first blocker — `DateTime#strftime` over the receiver's own
hour/min/sec/sec_fraction/offset — turned out to be already ported (#6628,
`date.ts` `override strftime`, `dt_lite_strftime`). What was missing:

- **`packages/date`**: `Date#iso8601` (`date_core.c` `d_lite_iso8601`,
  `:7298-7302`), `Date#rfc2822` (`d_lite_rfc2822`, `:7330-7334`, which
  `::DateTime` inherits — `date_core.c:10020-10025` does not override it), and
  `DateTime#iso8601(n = 0)` / `#xmlschema` over the file-static
  `iso8601_timediv` (`dt_lite_iso8601`, `:8755-8766`).
- **`Time::DATE_FORMATS`** (`core_ext/time/conversions.rb:8-27`) at that
  file's bucket, `time-ext.ts`, lambdas included. Its callables are typed over
  the DateTime seat because that is its only caller today; `time-ext.ts`'s own
  `toFs(date: Date)` still answers through a hand-rolled `switch` and converges
  separately.
- **`to_fs` / `to_formatted_s` / `readable_inspect` / `default_inspect`**
  (`conversions.rb:35-42`, `:56-59`) on `core-ext/date-time/conversions.ts`.

The three placeholder tests now carry Rails' assertions from
`date_time_ext_test.rb:16-46` verbatim. Rails' `with_env_tz "US/Central"`
wrapper is dropped with a comment: a `DateTime` carries its own offset, so the
ambient zone never reaches `:iso8601`, and the assertions are unchanged.

Every expected string was checked against ruby 3.3.11.

## `rational-canonicalizes-a-negative-denominator`

`Rational`'s constructor now negates both parts on a negative denominator
before the gcd cancel, as `rational.c` `nurat_s_canonicalize_internal`'s
`switch (FIX2INT(f_cmp(den, ZERO)))` does. `new Rational(3, -4)` answers
numerator `-3n` / denominator `4n` and inspects as `(-3/4)`; the Float arm
(`Rational(1, -0.5)` → `(-2/1)`) canonicalizes identically. `iGcd` already
returned a positive gcd, so no reader was compensating; the `den < 0n` guards
in `div` / `round` mirror the C's generic form and stay. The `packages/date`
and `packages/activesupport` suites are unchanged.

## `port-hwia-to-options-slice-bang-to-proc` — already on `main`

All six members (`to_options`, `to_options!`, `deep_symbolize_keys`,
`transform_keys!`, `slice!`, `to_proc`) landed in #6624 / #6626 / #6629;
`parity:api` reports `hash_with_indifferent_access.rb` at 46/46. One real gap
was left behind, and is converged here: `slice!` skipped
`core_ext/hash/slice.rb:10-17`'s `default` / `default_proc` lines with a
comment saying the class models no Hash default — true when it was written,
false since #6626 landed the defaults family.

## `retire-relation-is-named-join-value-discriminator` — blocked

Not in this PR. The Rails discriminator (`query_methods.rb:1852`
`String === join`, `:1814` `when Hash, Symbol, Array`) reads Symbol-ness,
which in trails is the leading colon — but **286 of 389** `.joins()` call
sites in `packages/activerecord/src` still pass a bare association-name
string (`.joins("comments")`). Flipping the discriminator before those are
swept turns each into an `Arel::Nodes::StringJoin` over a bare table word:
wrong SQL on all three adapters. Sweeping them is ~400 changed lines on its
own.

Filed `sweep-joins-call-sites-onto-the-colon-symbol-spelling` under RFC 0107
with the measurement and acceptance criteria, set it as a dep, and blocked the
retire story on it.

## Baseline rows

`time-ext.ts` gaining `DATE_FORMATS` brings `core_ext/time/conversions.rb`
into that file's compared population, which surfaces **pre-existing**
divergences in bodies this PR does not touch — six call-arg rows and one
order row across `change`, `preserve_timezone` and `to_time`. Each is
baselined with its own reason rather than a seed string:

- four are the same class — Ruby sends `integer?` / `preserve_timezone` /
  `system_local_time?` to the receiver, and this file's `Time` arm is a JS
  `Date` that cannot carry a method, so the receiver is the first argument;
- `change`'s `local` is Rails' ten-argument `::Time.local` against this file's
  six-field civil helper;
- `change`'s `new` is a false pairing — the TS `new` is
  `new ArgumentError("argument out of range")` (`:139`), not `::Time.new`
  (`:148`), which is spelled `Temporal.ZonedDateTime.from`;
- the order row is `change`'s `elsif zone` arm running ahead of the
  `utc_to_local` one, because a JS `Date` carries no zone object and is
  dispatched by receiver type up front.

## Gates

`pnpm typecheck`, `pnpm lint`, `parity:api:calls`, `parity:api:calls:args`,
`extra-surface` all green. `parity:api` deltas non-negative
(`date_time/conversions.rb` 6→10, `time/conversions.rb` +1,
`hash_with_indifferent_access.rb` 46/46); `parity:test` non-negative
(`date_time_ext_test.rb` 66/68). `packages/date` and the full
`packages/activesupport` suite pass locally.

## Review round 1

**`Date#xmlschema` / `Date#rfc822` (finding 1)** — fixed. `date_core.c:9809-9813`
binds four names to two C functions on `cDate`: `iso8601` and `xmlschema` to
`d_lite_iso8601`, `rfc2822` and `rfc822` to `d_lite_rfc2822`. Both aliases are
now ported, and `::DateTime` inherits the rfc2822 pair — `date_core.c:10024-10025`
overrides only `iso8601`/`xmlschema`. Asserted against ruby 3.3.11
(`Date.new(2001,2,3).xmlschema` → `"2001-02-03"`, `.rfc822` → `"Sat, 3 Feb 2001
00:00:00 +0000"`, and `DateTime#rfc822` reaching the inherited one).

**The `time-ext.ts` ↔ `date-time/conversions.ts` cycle (finding 2)** — verified
the way CLAUDE.md's call-time-constant section prescribes, not under vitest.
Built `dist`, then imported each side as a plain-node ESM **entry** module:
`dist/time-ext.js`, `dist/core-ext/date-time/conversions.js` and
`dist/index.js`. All three load and evaluate the formats end to end
(`DATE_FORMATS.rfc822`, `DATE_FORMATS.long_ordinal`, `toFs(dt, "rfc822"/"db")`,
`readableInspect`). Neither side touches the other at module-eval time — the
read is inside a lambda on one side and inside `toFs` on the other — and
neither file declares a `class ... extends` across the edge, so the TDZ trap
has nothing to bite. That reasoning and the verification are now recorded in
the `DATE_FORMATS` JSDoc so the next reader does not have to re-derive it.

**Baseline row ordering** — the reviewer's "worth a final sanity check" was a
real failure: the rows were sorted on a key that included `kind`, which is not
part of `keyOf` (`package tsFile rubyName call`), and CI's reseed-drift gate
caught it. Re-sorted with `compareKeys` from `call-mismatch-baseline.ts`; a
`lint-call-mismatches.ts --write` reseed now leaves the file byte-identical.

## Rebased onto `origin/main` @ `1637d7944`

The `Rails API/Test Comparison` red this PR was carrying is gone: it was the
assertion-mismatch ratchet failing on `main` itself
(`activesupport assertion-value-mismatch: 137 (mark 136, +1)`, the
`datetimeextcalculationstest > to f` literal `946684800.0` vs `946684800`), and
#6631 fixed the extractor to compare numeric assertion values by source
spelling. Rebasing picked it up — activesupport is now 135 against a mark of
135, and `lint-assertion-mismatches.ts` reports
`OK (no counter exceeds its high-water mark)`.

Clean rebase, no conflicts: #6631 touched only `scripts/test-compare/**` and
this branch touches none of those files. Re-verified after the rebase rather
than assumed — `pnpm build`, `typecheck`, `eslint` on the touched files,
`parity:api:calls`, `parity:api:calls:args`, `extra-surface`,
`lint-assertion-mismatches.ts --no-regen`, `closure-cli.ts --check`, a
`lint-call-mismatches.ts --write` reseed (leaves this branch's baseline
byte-identical), and the `packages/date` + activesupport date/HWIA suites
(818 passed).

Closes-story: port-date-time-to-fs-onto-the-datetime-receiver
Closes-story: port-hwia-to-options-slice-bang-to-proc
Closes-story: rational-canonicalizes-a-negative-denominator



