### PR TITLE
refactor(activesupport): require the predicate for Array#extract!

### DIFF
--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -192,10 +192,13 @@ export function split<T>(array: T[], valueOrFn: T | ((item: T) => boolean)): T[]
 
 /**
  * Remove elements from `array` that match `predicate`, returning the removed elements.
- * Mirrors Rails' `Array#extract!`.
+ *
+ * Mirrors: `Array#extract!` (core_ext/array/extract.rb:10-20). Ruby's no-block
+ * arm (`return to_enum(:extract!) { size } unless block_given?`, line 11) has
+ * no JS analogue — there is no Enumerator to return, as at `Enumerable#index_with`
+ * and `Deprecators#each` — so the predicate is required.
  */
-export function extractBang<T>(array: T[], predicate?: (item: T) => boolean): T[] {
-  if (!predicate) return array.splice(0, array.length);
+export function extractBang<T>(array: T[], predicate: (item: T) => boolean): T[] {
   const extracted: T[] = [];
   for (let i = array.length - 1; i >= 0; i--) {
     if (predicate(array[i])) {

--- a/packages/activesupport/src/core-ext/array/extract.test.ts
+++ b/packages/activesupport/src/core-ext/array/extract.test.ts
@@ -16,10 +16,28 @@ describe("ExtractTest", () => {
   });
 
   it("extract without block", () => {
-    const arr = [1, 2, 3];
-    const extracted = extractBang(arr);
-    expect(extracted).toEqual([1, 2, 3]);
-    expect(arr).toEqual([]);
+    const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const arrayId = numbers;
+
+    // Ruby returns `to_enum(:extract!) { size }` when no block is given
+    // (extract.rb:11); there is no JS Enumerator to return, so the predicate is
+    // required and the no-block call is a TypeError rather than an enumerator
+    // whose `size` is the receiver's.
+    let error: unknown;
+    try {
+      (extractBang as (array: number[]) => number[])(numbers);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(numbers.length).toBe(10);
+
+    const oddNumbers = extractBang(numbers, (n) => n % 2 !== 0);
+
+    expect(oddNumbers).toEqual([1, 3, 5, 7, 9]);
+    expect(numbers).toEqual([0, 2, 4, 6, 8]);
+    expect(numbers).toBe(arrayId);
   });
 
   it("extract on empty array", () => {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,8 +31,8 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 1019,
-      "kind": 1450,
+      "assertionCount": 1018,
+      "kind": 1449,
       "value": 135
     },
     "arel": {


### PR DESCRIPTION
Rails `Array#extract!` (`activesupport/lib/active_support/core_ext/array/extract.rb:10-20`) returns `to_enum(:extract!) { size }` when no block is given. There is no JS Enumerator to return, so — following the settled precedent at `Enumerable#index_with` (`enumerable-utils.ts`) and `Deprecators#each` — the predicate is now required, documented at the call site with the Rails `file:line`. The previous no-predicate arm (splice the whole array and return it) was a trails invention with no Rails counterpart and no production callers.

`core_ext/array/extract_test.rb`'s `test_extract_without_block` is converged to the same assertion count and kinds as Rails, asserting the documented no-block behavior instead of the Enumerator. `assertion-mismatch-mark.json` lowered for activesupport: count 1019 → 1018, kind 1450 → 1449 (`value` untouched at 135).

Structural note on the converged test: Rails drives the enumerator returned by the no-block `extract!` with `.each(&:odd?)`, so its one call both yields the enumerator and performs the extraction. With the predicate required, the port asserts the no-predicate call raises, then performs the extraction with a second, predicate-carrying call — the closest analogue available under the documented divergence.

Closes-story: assertions-activesupport-array-extract-enumerator-arm