### PR TITLE
refactor(activerecord,activemodel): one mechanism for Relation's Enumerable surface; faithful model/api test ports

### DIFF
--- a/packages/activemodel/src/api.test.ts
+++ b/packages/activemodel/src/api.test.ts
@@ -1,79 +1,101 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "./index.js";
+import { Model, UnknownAttributeError } from "./index.js";
+
+/**
+ * Port of `vendor/rails/activemodel/test/cases/api_test.rb`. Rails' host is
+ * `include ActiveModel::API`; trails' `API` is an interface (api.ts) whose
+ * implementation is `Model`, so the test classes extend `Model`.
+ *
+ * `module DefaultValue` (api_test.rb:7-17) is a mixin whose `initialize`
+ * seeds `@attr` and whose `included` hook adds `attr_accessor :hello`. Ruby
+ * inserts it into the ancestor chain, so `BasicModel` and
+ * `BasicModelWithReversedMixins` differ only in whether the seeding runs
+ * before or after `ActiveModel::API#initialize` assigns the passed attributes
+ * — an ordering that is unobservable either way, since `||=` never overwrites
+ * an assigned value. JS has one linear constructor chain and `super()` must
+ * run first, so both classes seed after `super`, which is BasicModel's own
+ * ancestry (`API#initialize` assigns, then `super` reaches DefaultValue).
+ */
+class DefaultValueModel extends Model {
+  declare _hello?: string;
+
+  declare _attr?: string;
+
+  // `attr_accessor :hello`, added by DefaultValue's `included` hook.
+  get hello(): string | undefined {
+    return this._hello;
+  }
+
+  set hello(value: string | undefined) {
+    this._hello = value;
+  }
+
+  get attr(): string | undefined {
+    return this._attr;
+  }
+
+  set attr(value: string | undefined) {
+    this._attr = value;
+  }
+
+  constructor(attrs?: Record<string, unknown> | null) {
+    super(attrs ?? {});
+    this._attr ??= "default value";
+  }
+}
+
+class BasicModel extends DefaultValueModel {}
+
+class BasicModelWithReversedMixins extends DefaultValueModel {}
+
+class SimpleModel extends Model {
+  declare _attr?: string;
+
+  get attr(): string | undefined {
+    return this._attr;
+  }
+
+  set attr(value: string | undefined) {
+    this._attr = value;
+  }
+}
 
 describe("APITest", () => {
   it("initialize with params", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 30 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
-  });
-
-  it("initialize with nil or empty hash params does not explode", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(() => new Person({})).not.toThrow();
-    expect(() => new Person()).not.toThrow();
-  });
-
-  it("persisted is always false", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(new Person({ name: "Alice" }).isPersisted()).toBe(false);
+    const object = new BasicModel({ attr: "value" });
+    expect(object.attr).toBe("value");
   });
 
   it("initialize with params and mixins reversed", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 30 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
+    const object = new BasicModelWithReversedMixins({ attr: "value" });
+    expect(object.attr).toBe("value");
   });
 
-  it("mixin initializer when args exist", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+  it("initialize with nil or empty hash params does not explode", () => {
+    expect(() => {
+      new BasicModel();
+      new BasicModel(null);
+      new BasicModel({});
+      new SimpleModel({ attr: "value" });
+    }).not.toThrow();
   });
 
-  it("mixin initializer when args dont exist", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({});
-    expect(p.readAttribute("name")).toBeNull();
+  it("persisted is always false", () => {
+    const object = new BasicModel({ attr: "value" });
+    expect(object.isPersisted()).toBeFalsy();
   });
 
   it("mixin inclusion chain", () => {
-    // Model includes Attributes, Validations, Callbacks, Dirty, Serialization, Naming
-    const p = new Model();
-    expect(typeof p.readAttribute).toBe("function");
-    expect(typeof p.writeAttribute).toBe("function");
-    expect(typeof p.isValid).toBe("function");
-    expect(typeof p.runCallbacks).toBe("function");
-    expect(typeof p.serializableHash).toBe("function");
-    expect(p.modelName).toBeDefined();
-    expect(typeof p.changed).toBe("boolean");
+    const object = new BasicModel();
+    expect(object.attr).toBe("default value");
+  });
+
+  it("mixin initializer when args exist", () => {
+    const object = new BasicModel({ hello: "world" });
+    expect(object.hello).toBe("world");
+  });
+
+  it("mixin initializer when args dont exist", () => {
+    expect(() => new SimpleModel({ hello: "world" })).toThrow(UnknownAttributeError);
   });
 });

--- a/packages/activemodel/src/model.test.ts
+++ b/packages/activemodel/src/model.test.ts
@@ -1,91 +1,110 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "./index.js";
+import { onLoad } from "@blazetrails/activesupport";
+import { Model, UnknownAttributeError } from "./index.js";
+
+/**
+ * Port of `vendor/rails/activemodel/test/cases/model_test.rb`.
+ *
+ * `module DefaultValue` (model_test.rb:7-17) is a mixin whose `initialize`
+ * seeds `@attr` and whose `included` hook adds `attr_accessor :hello`. Ruby
+ * inserts it into the ancestor chain, so `BasicModel` and
+ * `BasicModelWithReversedMixins` differ only in whether the seeding runs
+ * before or after `ActiveModel::API#initialize` assigns the passed attributes
+ * — an ordering that is unobservable either way, since `||=` never overwrites
+ * an assigned value. JS has one linear constructor chain and `super()` must
+ * run first, so both classes seed after `super`, which is BasicModel's own
+ * ancestry (`API#initialize` assigns, then `super` reaches DefaultValue).
+ */
+class DefaultValueModel extends Model {
+  declare _hello?: string;
+
+  declare _attr?: string;
+
+  // `attr_accessor :hello`, added by DefaultValue's `included` hook.
+  get hello(): string | undefined {
+    return this._hello;
+  }
+
+  set hello(value: string | undefined) {
+    this._hello = value;
+  }
+
+  get attr(): string | undefined {
+    return this._attr;
+  }
+
+  set attr(value: string | undefined) {
+    this._attr = value;
+  }
+
+  constructor(attrs?: Record<string, unknown> | null) {
+    super(attrs ?? {});
+    this._attr ??= "default value";
+  }
+}
+
+class BasicModel extends DefaultValueModel {}
+
+class BasicModelWithReversedMixins extends DefaultValueModel {}
+
+class SimpleModel extends Model {
+  declare _attr?: string;
+
+  get attr(): string | undefined {
+    return this._attr;
+  }
+
+  set attr(value: string | undefined) {
+    this._attr = value;
+  }
+}
 
 describe("ModelTest", () => {
   it("initialize with params", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 25 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(25);
-  });
-
-  it("initialize with nil or empty hash params does not explode", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(() => new Person()).not.toThrow();
-    expect(() => new Person({})).not.toThrow();
+    const object = new BasicModel({ attr: "value" });
+    expect(object.attr).toBe("value");
   });
 
   it("initialize with params and mixins reversed", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Bob", age: 25 });
-    expect(p.readAttribute("name")).toBe("Bob");
-    expect(p.readAttribute("age")).toBe(25);
+    const object = new BasicModelWithReversedMixins({ attr: "value" });
+    expect(object.attr).toBe("value");
   });
 
-  it("mixin inclusion chain", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "test" });
-    expect(p).toBeInstanceOf(Model);
-  });
-
-  it("mixin initializer when args exist", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
-  });
-
-  it("mixin initializer when args dont exist", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({});
-    expect(p.readAttribute("name")).toBeNull();
+  it("initialize with nil or empty hash params does not explode", () => {
+    expect(() => {
+      new BasicModel();
+      new BasicModel(null);
+      new BasicModel({});
+      new SimpleModel({ attr: "value" });
+    }).not.toThrow();
   });
 
   it("persisted is always false", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(new Person({ name: "Alice" }).isPersisted()).toBe(false);
+    const object = new BasicModel({ attr: "value" });
+    expect(object.isPersisted()).toBeFalsy();
+  });
+
+  it("mixin inclusion chain", () => {
+    const object = new BasicModel();
+    expect(object.attr).toBe("default value");
+  });
+
+  it("mixin initializer when args exist", () => {
+    const object = new BasicModel({ hello: "world" });
+    expect(object.hello).toBe("world");
+  });
+
+  it("mixin initializer when args dont exist", () => {
+    expect(() => new SimpleModel({ hello: "world" })).toThrow(UnknownAttributeError);
   });
 
   it("load hook is called", () => {
-    const log: string[] = [];
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.afterInitialize((_r: any) => {
-          log.push("initialized");
-        });
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    expect(log).toEqual(["initialized"]);
+    let value = "not loaded";
+
+    onLoad("active_model", () => {
+      value = "loaded";
+    });
+
+    expect(value).toBe("loaded");
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -22,6 +22,7 @@ import {
   resetCallbacks as asResetCallbacks,
   withOptions,
   include,
+  runLoadHooks,
   wrap,
   ToJsonWithActiveSupportEncoder,
   type Included,
@@ -2664,3 +2665,6 @@ function _rejectOnOption(conditions?: CallbackConditions): void {
 }
 
 include(Model, ToJsonWithActiveSupportEncoder);
+
+// model.rb:77 — `ActiveSupport.run_load_hooks(:active_model, Model)`.
+runLoadHooks("active_model", Model);

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -419,34 +419,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this._target.some(fn, thisArg);
   }
 
-  // Mirrors Ruby's Enumerable#detect / #find: returns the first record for
-  // which the block is truthy, else undefined. Named `detect` (not `find`)
-  // because `find` is the AR PK finder on both CollectionProxy and Relation.
-  // Rails reaches detect via Enumerable#detect → Relation#records →
-  // CollectionProxy#load_target (collection_proxy.rb:1024), so an unloaded
-  // proxy loads first — hence async + loadTarget() here (as select/records do).
-  async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
-    const records = await this.loadTarget();
-    return records.find(fn);
-  }
-
-  // Mirrors Ruby's Enumerable#sort_by: a new array sorted ascending by the
-  // block's return key (stable, non-mutating). Like detect above, Rails reaches
-  // sort_by via Enumerable → Relation#records → CollectionProxy#load_target
-  // (collection_proxy.rb:1024), so override Relation#sortBy to load through
-  // loadTarget() — hydrating the target and its loaded-state side effects —
-  // rather than the inherited toArray() path.
-  async sortBy(key: (record: T) => any): Promise<T[]> {
-    const records = await this.loadTarget();
-    return records
-      .map((record, index) => ({ record, index, sortKey: key(record) }))
-      .sort((a, b) => {
-        if (a.sortKey < b.sortKey) return -1;
-        if (a.sortKey > b.sortKey) return 1;
-        return a.index - b.index;
-      })
-      .map((entry) => entry.record);
-  }
+  // Enumerable#detect / #sort_by are NOT overridden here: Rails reaches them
+  // through Relation#records → CollectionProxy#load_target
+  // (collection_proxy.rb:1024), and `toArray()` above IS that path, so the
+  // inherited Relation implementations already load through the target.
 
   // every has the standard type-predicate overload from Array<T>.
   every<S extends T>(

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -419,10 +419,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this._target.some(fn, thisArg);
   }
 
-  // Enumerable#detect / #sort_by are NOT overridden here: Rails reaches them
-  // through Relation#records → CollectionProxy#load_target
-  // (collection_proxy.rb:1024), and `toArray()` above IS that path, so the
-  // inherited Relation implementations already load through the target.
+  // Enumerable#detect / #sort_by are inherited, not overridden: `toArray()`
+  // below is this proxy's `records` → `load_target` (collection_proxy.rb:1024).
 
   // every has the standard type-predicate overload from Array<T>.
   every<S extends T>(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1448,13 +1448,7 @@ export class Relation<T extends Base> {
     return this.structurallyIncompatibleValuesFor(other as never).length === 0;
   }
 
-  // ---- include Enumerable (relation.rb:67) ----
-  // Ruby's core Enumerable works over `each` → `records`; there is no per-method
-  // Rails body to mirror, so each of these applies the shared
-  // `ENUMERABLE_DELEGATES` function to the loaded records — the same table
-  // CollectionProxy applies to `load_target` (collection_proxy.rb:1024). They
-  // load first (`toArray()`) because JS has no blocking IO where Rails reads
-  // `records` inline.
+  // ---- include Enumerable (relation.rb:67) — see ENUMERABLE_DELEGATES ----
 
   /** `Enumerable#detect` / `#find` — `find` on a Relation is the AR PK finder. */
   async length(): Promise<number> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -23,9 +23,9 @@ import {
   isPlainObject as _isPlainObject,
   wrap,
   any,
-  compactBlank as _compactBlank,
-  groupBy as _groupBy,
-  indexBy as _indexBy,
+  compactBlank,
+  groupBy,
+  indexBy,
 } from "@blazetrails/activesupport";
 
 import { Range } from "./connection-adapters/postgresql/oid/range.js";
@@ -420,6 +420,52 @@ export interface ExplainProxy<T extends Base> {
   finally(onfinally?: (() => void) | null): Promise<string>;
 }
 /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
+
+/**
+ * Ruby core `Enumerable`'s methods — `relation.rb:67`'s `include Enumerable`,
+ * which works over `each` → `records` — as pure sync functions on an
+ * already-loaded `records` array. This is the Enumerable half of what
+ * `RECORD_DELEGATES` is for `delegate ... to: :records` (delegation.rb:101):
+ * Ruby's core Enumerable has no `def` in any vendored gem, so there is no
+ * per-method Rails body to mirror and the `include` itself is the only thing
+ * to port — one table, not a bespoke body per method.
+ *
+ * `Relation` applies these to `toArray()`; `CollectionProxy` applies the same
+ * functions to `loadTarget()` (collection_proxy.rb:1024 — `records` →
+ * `load_target`), which is the whole of the difference Rails has between the
+ * two.
+ */
+const ENUMERABLE_DELEGATES = {
+  /** `Enumerable#detect` / `#find` — the first record the block is truthy for. */
+  detect: <T>(records: T[], fn: (record: T, index: number, all: T[]) => unknown): T | undefined =>
+    records.find(fn),
+
+  /** `Enumerable#reject` — the records the block is falsy for. */
+  reject: <T>(records: T[], fn: (record: T) => boolean): T[] => records.filter((r) => !fn(r)),
+
+  /**
+   * `Enumerable#sort_by` — ascending by the block's key, stable (equal keys
+   * keep their relative order) and non-mutating (`sort_by`, not `sort_by!`).
+   */
+  sortBy: <T>(records: T[], key: (record: T) => any): T[] =>
+    records
+      .map((record, index) => ({ record, index, sortKey: key(record) }))
+      .sort((a, b) => {
+        if (a.sortKey < b.sortKey) return -1;
+        if (a.sortKey > b.sortKey) return 1;
+        return a.index - b.index;
+      })
+      .map((entry) => entry.record),
+
+  /** `Enumerable#group_by`. */
+  groupBy,
+
+  /** `Enumerable#index_by` (core_ext/enumerable.rb:52-60) — last wins. */
+  indexBy,
+
+  /** `Enumerable#compact_blank` (core_ext/enumerable.rb:184-186). */
+  compactBlank,
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Relation<T extends Base> {
@@ -1402,78 +1448,47 @@ export class Relation<T extends Base> {
     return this.structurallyIncompatibleValuesFor(other as never).length === 0;
   }
 
-  /**
-   * Return the number of loaded records (alias for toArray().length).
-   *
-   * Mirrors: ActiveRecord::Relation#length
-   */
+  // ---- include Enumerable (relation.rb:67) ----
+  // Ruby's core Enumerable works over `each` → `records`; there is no per-method
+  // Rails body to mirror, so each of these applies the shared
+  // `ENUMERABLE_DELEGATES` function to the loaded records — the same table
+  // CollectionProxy applies to `load_target` (collection_proxy.rb:1024). They
+  // load first (`toArray()`) because JS has no blocking IO where Rails reads
+  // `records` inline.
+
+  /** `Enumerable#detect` / `#find` — `find` on a Relation is the AR PK finder. */
   async length(): Promise<number> {
     const records = await this.toArray();
     return records.length;
   }
 
-  /**
-   * Filter loaded records, removing those that match the predicate.
-   *
-   * Mirrors: ActiveRecord::Relation#reject (Ruby Enumerable)
-   */
-  async reject(fn: (record: T) => boolean): Promise<T[]> {
-    const records = await this.toArray();
-    return records.filter((r) => !fn(r));
-  }
-
-  /**
-   * Return the first loaded record for which the block is truthy, else
-   * undefined. Named `detect` (Ruby's Enumerable#detect) rather than `find`
-   * because `find` on a Relation is the AR PK finder, not a block search.
-   *
-   * Mirrors: Enumerable#detect / #find (via Relation#include Enumerable)
-   *
-   * @noRailsEquivalent PERMANENT
-   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
-   *   `detect` has no `def` in any vendored gem because Ruby's core Enumerable
-   *   supplies it over `each`).
-   */
   async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
-    const records = await this.toArray();
-    return records.find(fn);
+    return ENUMERABLE_DELEGATES.detect(await this.toArray(), fn);
   }
 
-  /**
-   * Return a new array of the records sorted ascending by the block's return
-   * key. The sort is stable (equal keys keep their original relative order)
-   * and non-mutating (Ruby's `sort_by`, not `sort_by!`). Loads first — JS has
-   * no blocking IO, so where Rails reaches `records`/`load_target` lazily we
-   * evaluate the relation up front via `toArray()`.
-   *
-   * Mirrors: Enumerable#sort_by (via Relation#include Enumerable)
-   *
-   * @noRailsEquivalent PERMANENT
-   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
-   *   `sort_by` has no `def` in any vendored gem because Ruby's core Enumerable
-   *   supplies it over `each`).
-   */
+  /** `Enumerable#reject`. */
+  async reject(fn: (record: T) => boolean): Promise<T[]> {
+    return ENUMERABLE_DELEGATES.reject(await this.toArray(), fn);
+  }
+
+  /** `Enumerable#sort_by`. */
   async sortBy(key: (record: T) => any): Promise<T[]> {
-    const records = await this.toArray();
-    return records
-      .map((record, index) => ({ record, index, sortKey: key(record) }))
-      .sort((a, b) => {
-        if (a.sortKey < b.sortKey) return -1;
-        if (a.sortKey > b.sortKey) return 1;
-        return a.index - b.index;
-      })
-      .map((entry) => entry.record);
+    return ENUMERABLE_DELEGATES.sortBy(await this.toArray(), key);
   }
 
-  /**
-   * Return the loaded records with the blank ones rejected. Loads first, for
-   * the same reason {@link sortBy} does.
-   *
-   * Mirrors: Enumerable#compact_blank (core_ext/enumerable.rb:184-186, via
-   * Relation#include Enumerable)
-   */
+  /** `Enumerable#group_by`. */
+  async groupBy<K>(fn: (record: T) => K): Promise<Map<K, T[]>> {
+    return ENUMERABLE_DELEGATES.groupBy(await this.toArray(), fn);
+  }
+
+  /** `Enumerable#index_by`. */
+  async indexBy<K extends string | number>(fn: (record: T) => K): Promise<Record<K, T>> {
+    return ENUMERABLE_DELEGATES.indexBy(await this.toArray(), fn);
+  }
+
+  /** `Enumerable#compact_blank`. */
   async compactBlank(): Promise<T[]> {
-    return _compactBlank(await this.toArray());
+    return ENUMERABLE_DELEGATES.compactBlank(await this.toArray());
   }
 
   // -- Terminal methods --
@@ -2283,33 +2298,6 @@ export class Relation<T extends Base> {
    */
   whereValuesHash(relationTableName: string = this.model.tableName): Record<string, unknown> {
     return this.whereClause.toH(relationTableName);
-  }
-
-  // -- Collection convenience methods --
-
-  /**
-   * Load records and group them by the block's return value.
-   *
-   * Mirrors: Enumerable#group_by (via Relation#include Enumerable)
-   *
-   * @noRailsEquivalent PERMANENT
-   *   (`vendor/rails/activerecord/lib/active_record/relation.rb:67` — `include Enumerable`;
-   *   `group_by` has no `def` in any vendored gem because Ruby's core Enumerable
-   *   supplies it over `each`).
-   */
-  async groupBy<K>(fn: (record: T) => K): Promise<Map<K, T[]>> {
-    return _groupBy(await this.toArray(), fn);
-  }
-
-  /**
-   * Load records and index them by the block's return value (last wins on
-   * collision).
-   *
-   * Mirrors: Enumerable#index_by (core_ext/enumerable.rb:52-60, via
-   * Relation#include Enumerable)
-   */
-  async indexBy<K extends string | number>(fn: (record: T) => K): Promise<Record<K, T>> {
-    return _indexBy(await this.toArray(), fn);
   }
 
   /** @internal */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1448,14 +1448,20 @@ export class Relation<T extends Base> {
     return this.structurallyIncompatibleValuesFor(other as never).length === 0;
   }
 
-  // ---- include Enumerable (relation.rb:67) — see ENUMERABLE_DELEGATES ----
-
-  /** `Enumerable#detect` / `#find` — `find` on a Relation is the AR PK finder. */
+  /**
+   * Return the number of loaded records — `delegate :length, to: :records`
+   * (delegation.rb:101), not an Enumerable member.
+   *
+   * Mirrors: ActiveRecord::Relation#length
+   */
   async length(): Promise<number> {
     const records = await this.toArray();
     return records.length;
   }
 
+  // ---- include Enumerable (relation.rb:67) — see ENUMERABLE_DELEGATES ----
+
+  /** `Enumerable#detect` / `#find` — `find` on a Relation is the AR PK finder. */
   async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
     return ENUMERABLE_DELEGATES.detect(await this.toArray(), fn);
   }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -185,6 +185,94 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes: string[] }> = {
  *     Keyed on one host class since `allowed` is
  *     unioned per-file across every entity in errors.rb.
  */
+/**
+ * Ruby CORE modules a Rails class `include`s, with the method names the core
+ * module supplies. These have no `def` in any vendored gem — they are the
+ * interpreter's — so the include contributes nothing to the allow-set and every
+ * faithful port of one reads as novel TS surface (`ActiveRecord::Relation`
+ * `include Enumerable`, relation.rb:67, is the whole population today: `detect`,
+ * `sort_by`, `group_by` and the rest of the Enumerable surface a Relation
+ * answers over `each` → `records`).
+ *
+ * That is a false read: the port IS the include, and the alternative was one
+ * near-identical `@noRailsEquivalent PERMANENT` tag per method, all citing the
+ * same `include` line. So a core module's methods enter `allowed` exactly like
+ * a vendored mixin's, keeping the allowance scoped to the files whose Ruby
+ * counterpart actually writes the `include` — a `detect` on a class that does
+ * not include Enumerable stays flagged.
+ *
+ * Values are `Enumerable.instance_methods(false)` (Ruby 3.4). An
+ * ActiveSupport core_ext reopening of the same module (`index_by`,
+ * `compact_blank` in `core_ext/enumerable.rb`) is a real `def` in a vendored
+ * gem and already resolves through the normal module walk — this table adds
+ * only what the interpreter supplies.
+ */
+const CORE_MIXIN_METHODS: Record<string, string[]> = {
+  Enumerable: [
+    "all?",
+    "any?",
+    "chain",
+    "chunk",
+    "chunk_while",
+    "collect",
+    "collect_concat",
+    "compact",
+    "count",
+    "cycle",
+    "detect",
+    "drop",
+    "drop_while",
+    "each_cons",
+    "each_entry",
+    "each_slice",
+    "each_with_index",
+    "each_with_object",
+    "entries",
+    "filter",
+    "filter_map",
+    "find",
+    "find_all",
+    "find_index",
+    "first",
+    "flat_map",
+    "grep",
+    "grep_v",
+    "group_by",
+    "include?",
+    "inject",
+    "lazy",
+    "map",
+    "max",
+    "max_by",
+    "member?",
+    "min",
+    "min_by",
+    "minmax",
+    "minmax_by",
+    "none?",
+    "one?",
+    "partition",
+    "reduce",
+    "reject",
+    "reverse_each",
+    "select",
+    "slice_after",
+    "slice_before",
+    "slice_when",
+    "sort",
+    "sort_by",
+    "sum",
+    "take",
+    "take_while",
+    "tally",
+    "to_a",
+    "to_h",
+    "to_set",
+    "uniq",
+    "zip",
+  ],
+};
+
 const PORTED_METHODS_FROM_UNPORTED_MIXINS: Record<string, string[]> = {
   "ActiveRecord::Railtie": ["process_action", "cleanup_view_runtime", "append_info_to_payload"],
   "ActiveRecord::AssociationNotFoundError": ["detailed_message"],
@@ -1072,6 +1160,11 @@ function collectAllowedNames(
     const fqn = resolveModuleName(incName, contextFqn, moduleFqnByShort);
     if (visited.has(fqn)) return;
     visited.add(fqn);
+    // A Ruby core module (`include Enumerable`) supplies methods no vendored
+    // gem `def`s — see CORE_MIXIN_METHODS. Added before the module lookup
+    // because the same name can ALSO be a vendored core_ext reopening, which
+    // contributes its own `def`s through the walk below.
+    for (const name of CORE_MIXIN_METHODS[fqn] ?? []) addRubyName(name);
     // Fall back to the cross-package map: a railtie-injected mixin (see
     // AMBIENT_RAILTIE_MIXINS) or a fully-qualified cross-gem include lives
     // in another package's modules, not this package's.

--- a/scripts/test-compare/assertion-kinds.test.ts
+++ b/scripts/test-compare/assertion-kinds.test.ts
@@ -46,6 +46,11 @@ describe("normalizeTrailsKind", () => {
     expect(normalizeTrailsKind("not:toBeTruthy")).toBe("falsy");
   });
 
+  it("folds not.toThrow onto assert_nothing_raised", () => {
+    expect(normalizeTrailsKind("not:toThrow")).toBe("nothingRaised");
+    expect(normalizeTrailsKind("not:toThrow")).toBe(normalizeRailsKind("assert_nothing_raised"));
+  });
+
   it("maps helper callees that mirror a Rails name via snake-case", () => {
     expect(normalizeTrailsKind("refuteEqual")).toBe("notEqual");
     expect(normalizeTrailsKind("mustEqual")).toBe("equal");

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -60,6 +60,10 @@ const NEGATION: Partial<Record<CanonicalKind, CanonicalKind>> = {
   notSame: "same",
   predicate: "notPredicate",
   notPredicate: "predicate",
+  // `expect(() => …).not.toThrow()` is the port of `assert_nothing_raised`,
+  // which minitest spells as its own assertion rather than as `refute_raises`.
+  raises: "nothingRaised",
+  nothingRaised: "raises",
 };
 
 // Rails minitest assertion method name → canonical kind. `refute_*` is minitest's

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,19 +21,19 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 400,
-      "kind": 604,
-      "value": 65
+      "assertionCount": 393,
+      "kind": 592,
+      "value": 63
     },
     "activerecord": {
       "assertionCount": 1965,
-      "kind": 4056,
+      "kind": 4008,
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 1018,
-      "kind": 1449,
-      "value": 135
+      "assertionCount": 1016,
+      "kind": 1435,
+      "value": 131
     },
     "arel": {
       "assertionCount": 180,
@@ -42,7 +42,7 @@
     },
     "date": {
       "assertionCount": 20,
-      "kind": 30,
+      "kind": 29,
       "value": 1
     },
     "did-you-mean": {
@@ -57,8 +57,8 @@
     },
     "i18n": {
       "assertionCount": 18,
-      "kind": 32,
-      "value": 6
+      "kind": 23,
+      "value": 4
     },
     "rack": {
       "assertionCount": 0,

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -13,6 +13,18 @@ describe("assertionValueMismatch", () => {
     expect(deltas).toEqual([{ kind: "equal", rails: ["n:5"], trails: ["n:4"] }]);
   });
 
+  it("folds trails' colon-prefixed symbol spelling onto the Ruby symbol token", () => {
+    // Ruby `assert_equal :short, …` extracts as `s:short`; trails spells the
+    // same Symbol VALUE as the string `":short"`, which extracts as `s::short`.
+    expect(
+      assertionValueMismatch(["assert_equal"], ["s:short"], ["toBe"], ["s::short"], false),
+    ).toBeNull();
+    // A genuinely different symbol still diverges.
+    expect(
+      assertionValueMismatch(["assert_equal"], ["s:short"], ["toBe"], ["s::long"], false),
+    ).toEqual([{ kind: "equal", rails: ["s:short"], trails: ["s:long"] }]);
+  });
+
   it("compares as an order-independent multiset per kind", () => {
     // Same two equality values, asserted in a different order → no divergence.
     expect(

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -97,9 +97,22 @@ function collectSide(
     }
     entry.total++;
     const value = values?.[i];
-    if (value != null) entry.captured.push(value);
+    if (value != null) entry.captured.push(foldSymbolToken(value));
   }
   return map;
+}
+
+/**
+ * Fold a string token's leading `:` — trails spells a Ruby Symbol VALUE as the
+ * colon-prefixed string (`:short` is `":short"`, CLAUDE.md "A Ruby Symbol is a
+ * JS string, never a JS `Symbol`"), while the Ruby extractor renders `:short`
+ * as the bare `s:short`. Applied to BOTH sides so every spelling of the pair —
+ * Ruby symbol, Ruby string, trails colon-string, trails bare string — folds
+ * onto one token, which is the same "symbol-vs-string is not a fidelity
+ * divergence" rule the encoding comment already states.
+ */
+function foldSymbolToken(token: string): string {
+  return token.startsWith("s::") ? `s:${token.slice(3)}` : token;
 }
 
 /**


### PR DESCRIPTION
Bundle of two RFC stories.

## give-relation-enumerable-surface-one-mechanism (RFC 0107)

`relation.rb:67`'s `include Enumerable` had no counterpart mechanism: `detect`,
`sortBy` and `groupBy` each carried a bespoke body plus a `@noRailsEquivalent
PERMANENT` tag citing the same include line, with `reject` / `compactBlank` /
`indexBy` the same shape untagged.

- `ENUMERABLE_DELEGATES` in `relation.ts` — one table of the Enumerable methods
  a Relation answers, backed by the activesupport free functions where they
  exist. Each `Relation` member is a one-liner over it, exactly as
  `DelegationMethods` is over `RECORD_DELEGATES`.
- `CollectionProxy`'s `detect` / `sortBy` overrides are gone: its `toArray()`
  IS the `records` → `load_target` path (`collection_proxy.rb:1024`), so the
  inherited implementations already load through the target.
- `extra-surface.ts` `CORE_MIXIN_METHODS`: a Ruby CORE module a Rails class
  `include`s now contributes its methods to the allow-set, scoped to the files
  whose `.rb` actually writes the include. That retires the three tags at the
  source rather than restating them — `relation.ts` novel surface stays at 7
  and its `moved` count drops 4 → 3.

Not moved: `Relation#length`, which IS on `delegation.rb:101`'s `to: :records`
list. Relocating it to `DelegationMethods` turned three unrelated `relation.ts`
bodies (`to_sql`, `create_or_find_by`, `apply_join_dependency`) red on
`parity:api:calls` for a `with_connection` credit they had been getting —
a comparator behaviour keyed on relation.ts's class-body membership, not on
those bodies. Left where main has it rather than baselining four rows.

## assertions-activemodel-remainder-second-pass (RFC 0105)

`model.test.ts` and `api.test.ts` asserted entirely invented values against
invented `Person` models. Both are now ported from
`vendor/rails/activemodel/test/cases/{model,api}_test.rb` — the `DefaultValue`
mixin, `BasicModel` / `BasicModelWithReversedMixins` / `SimpleModel`, the
`UnknownAttributeError` raise, and model_test's load-hook test, which needed
`model.rb:77`'s `ActiveSupport.run_load_hooks(:active_model, Model)` — missing
from `model.ts`. Both files now report 0/0/0.

Two comparator convergences the ports surfaced:

- `assertion-kinds.ts` `NEGATION` folds `raises`/`nothingRaised`, so a
  `expect(() => …).not.toThrow()` port of `assert_nothing_raised` matches.
- `assertion-values.ts` folds a leading `:` on a string token, so trails'
  Symbol spelling (`":default"`) lines up with Ruby `:default` — the same
  symbol-vs-string rule that file's encoding comment already documents.

**Both folds are global comparator behaviour, not scoped to the two files this
PR ports.** Neither has any effect inside this diff — model.test.ts/api.test.ts
contain no colon-symbol token — so their entire measured effect is on
pre-existing tests in packages this PR does not touch. That is deliberate: they
are corrections to how the comparator reads two spellings the repo already
mandates (`.not.toThrow()` for `assert_nothing_raised`; a colon-prefixed string
for a Ruby Symbol VALUE, per CLAUDE.md), so scoping them to one package would
be the wrong shape. Both carry a regression test that fails on the prior
baseline.

`assertion-mismatch-mark.json` lowered for every package they improve
(activemodel 415/623/65 → 408/610/63; also activerecord, activesupport, date,
i18n). Note the activesupport **value** counter was already at 137 against a
mark of 136 on `main` before this branch — the symbol-token fold takes it to
133, so this PR incidentally un-reds that gate.

Remainder of the activemodel cluster filed as
`0105-ar-deps-test-parity-100/assertions-activemodel-remainder-third-pass`,
including the `Rational` arm `type/decimal_test.rb` needs in `DecimalType`
(`decimal.rb:64-66`).

Closes-story: assertions-activemodel-remainder-second-pass
Closes-story: give-relation-enumerable-surface-one-mechanism

