### PR TITLE
test(date,activesupport): converge assertion parity for the date gem suite and Date core_ext

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -18,12 +18,13 @@ import {
   toFs,
   xmlschema,
   toDate,
-  isPast,
-  isFuture,
   isToday,
 } from "../time-ext.js";
 import { toFormattedS as dateToFormattedS, toFs as dateToFs, toTime } from "./date/conversions.js";
 import * as DateExt from "./date/calculations.js";
+import { isFuture, isPast } from "./date-and-time/calculations.js";
+import { isBlank } from "./object/blank.js";
+import { assertNothingRaised, assertNotPredicate, assertPredicate } from "../testing/assertions.js";
 import { setZone } from "../time-zone-config.js";
 import { TimeZone } from "../values/time-zone.js";
 
@@ -39,27 +40,45 @@ function asDate(instant: Temporal.Instant): Date {
   return new Date(instant.epochMilliseconds);
 }
 
+function instant(date: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
+}
+
+/** Ruby `Time#to_i`, the seconds an `assert_equal Time.local(...)` compares. */
+function seconds(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+/** The calendar days a Rails `Date` range's two ends name. */
+function range(r: { start: Temporal.Instant; end: Temporal.Instant }): Temporal.PlainDate[] {
+  return [toDate(asDate(r.start)), toDate(asDate(r.end))];
+}
+
 describe("DateExtBehaviorTest", () => {
   it("date acts like date", () => {
-    const date = new Date();
-    expect(date instanceof Date).toBe(true);
+    // Rails sends `acts_like_date?`, the duck-type marker `Date` defines; the
+    // port has no such marker, so the predicate is the class check it stands for.
+    assertPredicate(new Date(), (date) => date instanceof Date);
   });
 
   it("blank?", () => {
-    const date = new Date();
-    expect(date instanceof Date).toBe(true);
+    assertNotPredicate(new Date(), isBlank);
   });
 
-  it("freeze doesnt clobber memoized instance methods", () => {
-    const date = new Date();
-    Object.freeze(date);
-    expect(typeof date.toISOString()).toBe("string");
+  it("freeze doesnt clobber memoized instance methods", async () => {
+    await assertNothingRaised(() => {
+      const date = new Date();
+      Object.freeze(date);
+      return date.toISOString();
+    });
   });
 
-  it("can freeze twice", () => {
-    const date = new Date();
-    Object.freeze(date);
-    expect(() => Object.freeze(date)).not.toThrow();
+  it("can freeze twice", async () => {
+    await assertNothingRaised(() => {
+      const date = new Date();
+      Object.freeze(date);
+      Object.freeze(date);
+    });
   });
 });
 
@@ -113,9 +132,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("compare to time", () => {
-    const ref = d(2023, 6, 15, 12, 0, 0);
-    const before = prevDay(ref);
-    expect(before.epochMilliseconds).toBeLessThan(ref.getTime());
+    expect(Temporal.PlainDate.compare(DateExt.yesterday(), toDate(new Date())) < 0).toBeTruthy();
   });
 
   it("to datetime", () => {
@@ -127,11 +144,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("to date", () => {
-    const date = d(2005, 2, 21, 10, 30);
-    const result = toDate(date);
-    expect(result.year).toBe(2005);
-    expect(result.month).toBe(2);
-    expect(result.day).toBe(21);
+    expect(toDate(d(2005, 2, 21, 10, 30))).toEqual(pd(2005, 2, 21));
   });
 
   it("change", () => {
@@ -143,10 +156,10 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("sunday", () => {
-    const result = asDate(endOfWeek(d(2008, 2, 29)));
-    expect(result.getDay()).toBe(0); // Sunday
-    expect(result.getMonth()).toBe(2); // March
-    expect(result.getDate()).toBe(2);
+    // Rails `Date#sunday` is `end_of_week(:monday)`, which the port spells with
+    // the week-start day number rather than its Symbol.
+    expect(toDate(asDate(endOfWeek(d(2008, 3, 2))))).toEqual(pd(2008, 3, 2));
+    expect(toDate(asDate(endOfWeek(d(2008, 2, 29))))).toEqual(pd(2008, 3, 2));
   });
 
   it("last year in calendar reform", () => {
@@ -163,14 +176,25 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("advance in calendar reform", () => {
-    expect(asDate(advance(d(1582, 10, 4), { days: 1 })).getDate()).toBe(5);
-    expect(asDate(advance(d(1582, 10, 15), { days: -1 })).getDate()).toBe(14);
+    // The port's calendar is proleptic Gregorian throughout — it has no Julian
+    // reform seam — so the day either side of 1582-10-15 is its neighbour, not
+    // the reform's, and the expected dates below are that calendar's.
+    expect(toDate(asDate(advance(d(1582, 10, 4), { days: 1 })))).toEqual(pd(1582, 10, 5));
+    expect(toDate(asDate(advance(d(1582, 10, 15), { days: -1 })))).toEqual(pd(1582, 10, 14));
+    for (let day = 5; day <= 14; day++) {
+      expect(toDate(asDate(advance(d(1582, 9, day), { months: 1 })))).toEqual(pd(1582, 10, day));
+      expect(toDate(asDate(advance(d(1582, 11, day), { months: -1 })))).toEqual(pd(1582, 10, day));
+      expect(toDate(asDate(advance(d(1581, 10, day), { years: 1 })))).toEqual(pd(1582, 10, day));
+      expect(toDate(asDate(advance(d(1583, 10, day), { years: -1 })))).toEqual(pd(1582, 10, day));
+    }
   });
 
   it("last week", () => {
-    const result = asDate(lastWeek(d(2005, 5, 17), "monday"));
-    expect(result.getDate()).toBe(9);
-    expect(result.getMonth()).toBe(4); // May
+    expect(toDate(asDate(lastWeek(d(2005, 5, 17))))).toEqual(pd(2005, 5, 9));
+    expect(toDate(asDate(lastWeek(d(2007, 1, 7))))).toEqual(pd(2006, 12, 25));
+    expect(toDate(asDate(lastWeek(d(2010, 2, 19), "friday")))).toEqual(pd(2010, 2, 12));
+    expect(toDate(asDate(lastWeek(d(2010, 2, 19), "saturday")))).toEqual(pd(2010, 2, 13));
+    expect(toDate(asDate(lastWeek(d(2010, 3, 4), "saturday")))).toEqual(pd(2010, 2, 27));
   });
 
   it("last quarter on 31st", () => {
@@ -181,10 +205,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("yesterday constructor", () => {
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    const today = new Date();
-    expect(yesterday.getDate()).not.toBe(today.getDate());
+    expect(DateExt.yesterday()).toEqual(DateExt.current().subtract({ days: 1 }));
   });
 
   it("yesterday constructor when zone is not set", () => {
@@ -210,9 +231,7 @@ describe("DateExtCalculationsTest", () => {
   it.skip("tomorrow constructor when zone is set");
 
   it("since", () => {
-    const result = DateExt.since(pd(2005, 2, 21), 45);
-    expect(result.sec).toBe(45);
-    expect(result.day).toBe(21);
+    expect(DateExt.since(pd(2005, 2, 21), 45).toI()).toEqual(seconds(d(2005, 2, 21, 0, 0, 45)));
   });
 
   it("since when zone is set", () => {
@@ -229,11 +248,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("ago", () => {
-    const result = DateExt.ago(pd(2005, 2, 21), 45);
-    expect(result.day).toBe(20);
-    expect(result.hour).toBe(23);
-    expect(result.min).toBe(59);
-    expect(result.sec).toBe(15);
+    expect(DateExt.ago(pd(2005, 2, 21), 45).toI()).toEqual(seconds(d(2005, 2, 20, 23, 59, 15)));
   });
 
   it("ago when zone is set", () => {
@@ -250,9 +265,7 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("middle of day", () => {
-    const result = DateExt.middleOfDay(pd(2005, 2, 21));
-    expect(result.hour).toBe(12);
-    expect(result.min).toBe(0);
+    expect(DateExt.middleOfDay(pd(2005, 2, 21)).toI()).toEqual(seconds(d(2005, 2, 21, 12, 0, 0)));
   });
 
   it("beginning of day when zone is set", () => {
@@ -272,53 +285,43 @@ describe("DateExtCalculationsTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     setZone(zone);
     try {
-      const endOfDayInZone = DateExt.endOfDay(pd(2005, 2, 21));
-      expect(endOfDayInZone.hour).toBe(23);
-      expect(endOfDayInZone.min).toBe(59);
-      expect(endOfDayInZone.sec).toBe(59);
-      expect(endOfDayInZone.timeZone).toBe(zone);
+      expect(DateExt.endOfDay(pd(2005, 2, 21)).toI()).toEqual(
+        zone.local(2005, 2, 21, 23, 59, 59).toI(),
+      );
+      expect(DateExt.endOfDay(pd(2005, 2, 21)).timeZone).toBe(zone);
     } finally {
       setZone(null);
     }
   });
 
   it("all day", () => {
-    const { start, end } = allDay(d(2011, 6, 7));
-    expect(asDate(start).getHours()).toBe(0);
-    expect(asDate(end).getHours()).toBe(23);
-    expect(asDate(end).getMinutes()).toBe(59);
+    // Rails' range end carries `Rational(999999999, 1000)` of a second; the
+    // port's `Temporal.Instant` seat holds milliseconds, so it ends at `.999`.
+    const beginningOfDay = d(2011, 6, 7, 0, 0, 0);
+    const endOfDay = d(2011, 6, 7, 23, 59, 59, 999);
+    expect(allDay(d(2011, 6, 7))).toEqual({
+      start: instant(beginningOfDay),
+      end: instant(endOfDay),
+    });
   });
 
   it.skip("all day when zone is set");
 
   it("all week", () => {
-    const { start, end } = allWeek(d(2011, 6, 7));
-    expect(asDate(start).getDay()).toBe(1); // Monday
-    expect(asDate(start).getDate()).toBe(6);
-    expect(asDate(end).getDay()).toBe(0); // Sunday
-    expect(asDate(end).getDate()).toBe(12);
+    expect(range(allWeek(d(2011, 6, 7)))).toEqual([pd(2011, 6, 6), pd(2011, 6, 12)]);
+    expect(range(allWeek(d(2011, 6, 7), 0))).toEqual([pd(2011, 6, 5), pd(2011, 6, 11)]);
   });
 
   it("all month", () => {
-    const { start, end } = allMonth(d(2011, 6, 7));
-    expect(asDate(start).getDate()).toBe(1);
-    expect(asDate(start).getMonth()).toBe(5); // June
-    expect(asDate(end).getDate()).toBe(30);
+    expect(range(allMonth(d(2011, 6, 7)))).toEqual([pd(2011, 6, 1), pd(2011, 6, 30)]);
   });
 
   it("all quarter", () => {
-    const { start, end } = allQuarter(d(2011, 6, 7));
-    expect(asDate(start).getMonth()).toBe(3); // April
-    expect(asDate(end).getMonth()).toBe(5); // June
-    expect(asDate(end).getDate()).toBe(30);
+    expect(range(allQuarter(d(2011, 6, 7)))).toEqual([pd(2011, 4, 1), pd(2011, 6, 30)]);
   });
 
   it("all year", () => {
-    const { start, end } = allYear(d(2011, 6, 7));
-    expect(asDate(start).getMonth()).toBe(0); // January
-    expect(asDate(start).getDate()).toBe(1);
-    expect(asDate(end).getMonth()).toBe(11); // December
-    expect(asDate(end).getDate()).toBe(31);
+    expect(range(allYear(d(2011, 6, 7)))).toEqual([pd(2011, 1, 1), pd(2011, 12, 31)]);
   });
 
   it("xmlschema", () => {
@@ -329,14 +332,19 @@ describe("DateExtCalculationsTest", () => {
 
   it.skip("xmlschema when zone is set");
 
+  // Rails stubs `Date.current` to 2000-01-01 and reads the day before, the day
+  // itself and the day after. The port has no stub seam on `current`, so the
+  // three days are taken relative to the real one instead.
   it("past", () => {
-    expect(isPast(d(1999, 12, 31))).toBe(true);
-    expect(isPast(d(2099, 1, 1))).toBe(false);
+    expect(isPast(DateExt.current().subtract({ days: 1 }))).toBe(true);
+    expect(isPast(DateExt.current())).toBe(false);
+    expect(isPast(DateExt.current().add({ days: 1 }))).toBe(false);
   });
 
   it("future", () => {
-    expect(isFuture(d(2099, 1, 1))).toBe(true);
-    expect(isFuture(d(1999, 12, 31))).toBe(false);
+    expect(isFuture(DateExt.current().subtract({ days: 1 }))).toBe(false);
+    expect(isFuture(DateExt.current())).toBe(false);
+    expect(isFuture(DateExt.current().add({ days: 1 }))).toBe(true);
   });
 
   it("current returns date today when zone not set", () => {
@@ -353,15 +361,15 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("end of year", () => {
-    const result = asDate(endOfYear(d(2005, 6, 15)));
-    expect(result.getMonth()).toBe(11); // December
-    expect(result.getDate()).toBe(31);
+    expect(toDate(asDate(endOfYear(d(2008, 2, 22)))).toString()).toEqual(
+      pd(2008, 12, 31).toString(),
+    );
   });
 
   it("end of month", () => {
-    const result = asDate(endOfMonth(d(2005, 2, 5)));
-    expect(result.getDate()).toBe(28);
-    expect(result.getMonth()).toBe(1);
+    expect(toDate(asDate(endOfMonth(d(2005, 3, 20))))).toEqual(pd(2005, 3, 31));
+    expect(toDate(asDate(endOfMonth(d(2005, 2, 20))))).toEqual(pd(2005, 2, 28));
+    expect(toDate(asDate(endOfMonth(d(2005, 4, 20))))).toEqual(pd(2005, 4, 30));
   });
 
   it("last year in leap years", () => {
@@ -371,20 +379,29 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("advance", () => {
-    expect(asDate(advance(d(2005, 1, 31), { months: 1 }))).toEqual(d(2005, 2, 28));
+    expect(toDate(asDate(advance(d(2005, 2, 28), { years: 1 })))).toEqual(pd(2006, 2, 28));
+    expect(toDate(asDate(advance(d(2005, 2, 28), { months: 4 })))).toEqual(pd(2005, 6, 28));
+    expect(toDate(asDate(advance(d(2005, 2, 28), { weeks: 3 })))).toEqual(pd(2005, 3, 21));
+    expect(toDate(asDate(advance(d(2005, 2, 28), { days: 5 })))).toEqual(pd(2005, 3, 5));
+    expect(toDate(asDate(advance(d(2005, 2, 28), { years: 7, months: 7 })))).toEqual(
+      pd(2012, 9, 28),
+    );
+    expect(toDate(asDate(advance(d(2005, 2, 28), { years: 7, months: 19, days: 5 })))).toEqual(
+      pd(2013, 10, 3),
+    );
+    expect(
+      toDate(asDate(advance(d(2005, 2, 28), { years: 7, months: 19, weeks: 2, days: 5 }))),
+    ).toEqual(pd(2013, 10, 17));
+    expect(toDate(asDate(advance(d(2004, 2, 29), { years: 1 })))).toEqual(pd(2005, 2, 28));
   });
 
   it("beginning of day", () => {
-    const result = DateExt.beginningOfDay(pd(2005, 2, 21));
-    expect(result.hour).toBe(0);
-    expect(result.min).toBe(0);
-    expect(result.sec).toBe(0);
+    expect(DateExt.beginningOfDay(pd(2005, 2, 21)).toI()).toEqual(seconds(d(2005, 2, 21, 0, 0, 0)));
   });
 
   it("end of day", () => {
-    const result = DateExt.endOfDay(pd(2005, 2, 21));
-    expect(result.hour).toBe(23);
-    expect(result.min).toBe(59);
-    expect(result.sec).toBe(59);
+    // Rails' expected `Time` carries `Rational(999999999, 1000)` of a second;
+    // `TimeWithZone#toI` truncates to the second either way.
+    expect(DateExt.endOfDay(pd(2005, 2, 21)).toI()).toEqual(seconds(d(2005, 2, 21, 23, 59, 59)));
   });
 });

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -375,8 +375,11 @@ export function allDay(date: Date): { start: Temporal.Instant; end: Temporal.Ins
   return { start: beginningOfDay(date), end: endOfDay(date) };
 }
 
-export function allWeek(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {
-  return { start: beginningOfWeek(date), end: endOfWeek(date) };
+export function allWeek(
+  date: Date,
+  startDay = 1,
+): { start: Temporal.Instant; end: Temporal.Instant } {
+  return { start: beginningOfWeek(date, startDay), end: endOfWeek(date, startDay) };
 }
 
 export function allMonth(date: Date): { start: Temporal.Instant; end: Temporal.Instant } {

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4957,6 +4957,13 @@ function getLimit(opt: ParseOpt | undefined): number {
  */
 function checkLimit(str: string | null | undefined, opt: ParseOpt | undefined): void {
   if (str == null) return;
+  // `StringValue(str)`: anything that is not a String and has no `to_str` is a
+  // `TypeError` here, before the length is ever measured.
+  if (typeof str !== "string") {
+    throw new TypeError(
+      `no implicit conversion of ${(str as object)?.constructor?.name ?? String(str)} into String`,
+    );
+  }
   const slen = new TextEncoder().encode(str).length;
   const limit = getLimit(opt);
   if (slen > limit) {

--- a/packages/date/src/test-date-arith.test.ts
+++ b/packages/date/src/test-date-arith.test.ts
@@ -273,6 +273,11 @@ describe("TestDateArith", () => {
     p.step(q, o as never, (d) => {
       a.push(d);
     });
-    expect(a).toEqual([]);
+    assertEmpty(a);
   });
 });
+
+/** minitest `assert_empty`, which vitest has no matcher for. */
+function assertEmpty(collection: { length: number }): void {
+  expect(collection.length).toBe(0);
+}

--- a/packages/date/src/test-date-attr.test.ts
+++ b/packages/date/src/test-date-attr.test.ts
@@ -120,7 +120,7 @@ describe("TestDateAttr", () => {
             ] as const
           )[i % 7]
         ],
-      ).toBe(true);
+      ).toBeTruthy();
     }
   });
 

--- a/packages/date/src/test-date-compat.test.ts
+++ b/packages/date/src/test-date-compat.test.ts
@@ -19,9 +19,9 @@ describe("TestDateCompat", () => {
       new DateTime(2002, 3, 19, 0, 0, 0, 0, Date.JULIAN).equals(new Date(2002, 3, 19, Date.JULIAN)),
     ).toBe(true);
 
-    expect(new Date(2002, 3, 19).equals(new DateTime(2002, 3, 19, 12, 0, 0))).toBe(false);
-    expect(new Date(2002, 3, 19).equals(new DateTime(2002, 3, 19, 0, 0, 1))).toBe(false);
-    expect(new Date(2002, 3, 19).caseEquals(new DateTime(2002, 3, 19, 12, 0, 0))).toBe(true);
-    expect(new Date(2002, 3, 19).caseEquals(new DateTime(2002, 3, 19, 0, 0, 1))).toBe(true);
+    expect(!new Date(2002, 3, 19).equals(new DateTime(2002, 3, 19, 12, 0, 0))).toBeTruthy();
+    expect(!new Date(2002, 3, 19).equals(new DateTime(2002, 3, 19, 0, 0, 1))).toBeTruthy();
+    expect(new Date(2002, 3, 19).caseEquals(new DateTime(2002, 3, 19, 12, 0, 0))).toBeTruthy();
+    expect(new Date(2002, 3, 19).caseEquals(new DateTime(2002, 3, 19, 0, 0, 1))).toBeTruthy();
   });
 });

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -27,16 +27,21 @@ import { Temporal, Date, DateTime, Rational, Time } from "./index.js";
 
 describe("TestDateConv", () => {
   it("to class", () => {
-    const subjects = [new Time(2004, 9, 19, 1, 2, 3), new Date(2004, 9, 19)];
-    for (const o of subjects) {
+    // RFC 0088 splits Ruby's one `DateTime` value across two Temporal classes —
+    // a carried offset answers `ZonedDateTime`, a zero offset `PlainDateTime` —
+    // so each subject names the class its own offset selects. The subjects fix
+    // their offsets rather than reading `now`/`today` so that selection does not
+    // depend on the host zone (Ruby's `Date.today` has no gem-shaped twin here).
+    const subjects: [Time | Date | DateTime, new (...args: never[]) => object][] = [
+      [new Time(2004, 9, 19, 1, 2, 3, "+03:00"), Temporal.ZonedDateTime],
+      [new Date(2004, 9, 19), Temporal.PlainDateTime],
+      [new DateTime(2004, 9, 19, 1, 2, 3, new Rational(8, 24)), Temporal.ZonedDateTime],
+    ];
+    for (const [o, datetimeClass] of subjects) {
       expect(o.toTime()).toBeInstanceOf(Temporal.ZonedDateTime);
       expect(o.toDate()).toBeInstanceOf(Temporal.PlainDate);
+      expect(o.toDatetime()).toBeInstanceOf(datetimeClass);
     }
-    const isDatetime = (v: unknown): boolean =>
-      v instanceof Temporal.PlainDateTime || v instanceof Temporal.ZonedDateTime;
-    expect(isDatetime(new DateTime(2004, 9, 19, 1, 2, 3).toDatetime())).toBe(true);
-    expect(isDatetime(new Time(2004, 9, 19, 1, 2, 3).toDatetime())).toBe(true);
-    expect(isDatetime(new Date(2004, 9, 19).toDatetime())).toBe(true);
   });
 
   it("to time  from time", () => {
@@ -93,10 +98,16 @@ describe("TestDateConv", () => {
       new Rational(456789, 86400000000),
     );
     let t = d.toTime();
-    expect([t.year, t.month, t.day, t.hour, t.minute, t.second, usec(t)]).toEqual([
-      2004, 9, 19, 1, 2, 3, 456789,
-    ]);
-    expect(t.offsetNanoseconds / 1_000_000_000).toBe(8 * 60 * 60);
+    expect([
+      t.year,
+      t.month,
+      t.day,
+      t.hour,
+      t.minute,
+      t.second,
+      usec(t),
+      t.offsetNanoseconds / 1_000_000_000,
+    ]).toEqual([2004, 9, 19, 1, 2, 3, 456789, 8 * 60 * 60]);
 
     d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
     t = d.toTime().withTimeZone("UTC");
@@ -142,8 +153,7 @@ describe("TestDateConv", () => {
   it("to date  from date", () => {
     const d = new Date(2004, 9, 19).plus(new Rational(1, 2));
     const d2 = d.toDate();
-    expect([d2.year, d2.month, d2.day]).toEqual([2004, 9, 19]);
-    expect((d.dayFraction as Rational).cmp(new Rational(1, 2))).toBe(0);
+    expect([d2.year, d2.month, d2.day, d.dayFraction]).toEqual([2004, 9, 19, new Rational(1, 2)]);
   });
 
   it("to date  from datetime", () => {
@@ -161,33 +171,43 @@ describe("TestDateConv", () => {
   it("to datetime  from time", () => {
     let t = Time.mktime(2004, 9, 19, 1, 2, 3, 456789);
     let d = t.toDatetime();
-    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
-      2004, 9, 19, 1, 2, 3, 456789,
-    ]);
-    expect(offsetSeconds(d)).toBe(t.utcOffset);
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d), offsetSeconds(d)]).toEqual(
+      [2004, 9, 19, 1, 2, 3, 456789, t.utcOffset],
+    );
 
     t = Time.utc(2004, 9, 19, 1, 2, 3, 456789);
     d = t.toDatetime();
-    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
-      2004, 9, 19, 1, 2, 3, 456789,
-    ]);
-    expect(offsetSeconds(d)).toBe(0);
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d), offsetSeconds(d)]).toEqual(
+      [2004, 9, 19, 1, 2, 3, 456789, 0],
+    );
 
     t = Time.utc(1582, 10, 13, 1, 2, 3, 456789);
     d = t.toDatetime();
-    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d)]).toEqual([
-      1582, 10, 3, 1, 2, 3, 456789,
-    ]);
-    expect(offsetSeconds(d)).toBe(0);
+    expect([d.year, d.month, d.day, d.hour, d.minute, d.second, usec(d), offsetSeconds(d)]).toEqual(
+      [1582, 10, 3, 1, 2, 3, 456789, 0],
+    );
+
+    t = Time.now();
+    d = t.toDatetime();
+    // Ruby asks both sides for `iso8601(10)`. `Temporal` holds nanoseconds, so
+    // its formatter caps `fractionalSecondDigits` at 9 — the tenth digit Ruby
+    // prints there is always a zero — and 9 is the widest both sides can spell.
+    expect(t.iso8601(9)).toEqual(iso8601(d, 9));
   });
 
   it("to datetime  from date", () => {
     const d = new Date(2004, 9, 19).plus(new Rational(1, 2));
     const d2 = d.toDatetime();
-    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
-      2004, 9, 19, 0, 0, 0, 0,
-    ]);
-    expect(offsetSeconds(d2)).toBe(0);
+    expect([
+      d2.year,
+      d2.month,
+      d2.day,
+      d2.hour,
+      d2.minute,
+      d2.second,
+      usec(d2),
+      offsetSeconds(d2),
+    ]).toEqual([2004, 9, 19, 0, 0, 0, 0, 0]);
   });
 
   it("to datetime  from datetime", () => {
@@ -195,17 +215,29 @@ describe("TestDateConv", () => {
       new Rational(456789, 86400000000),
     );
     let d2 = d.toDatetime();
-    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
-      2004, 9, 19, 1, 2, 3, 456789,
-    ]);
-    expect(offsetSeconds(d2)).toBe(9 * 60 * 60);
+    expect([
+      d2.year,
+      d2.month,
+      d2.day,
+      d2.hour,
+      d2.minute,
+      d2.second,
+      usec(d2),
+      offsetSeconds(d2),
+    ]).toEqual([2004, 9, 19, 1, 2, 3, 456789, 9 * 60 * 60]);
 
     d = new DateTime(2004, 9, 19, 1, 2, 3, 0).plus(new Rational(456789, 86400000000));
     d2 = d.toDatetime();
-    expect([d2.year, d2.month, d2.day, d2.hour, d2.minute, d2.second, usec(d2)]).toEqual([
-      2004, 9, 19, 1, 2, 3, 456789,
-    ]);
-    expect(offsetSeconds(d2)).toBe(0);
+    expect([
+      d2.year,
+      d2.month,
+      d2.day,
+      d2.hour,
+      d2.minute,
+      d2.second,
+      usec(d2),
+      offsetSeconds(d2),
+    ]).toEqual([2004, 9, 19, 1, 2, 3, 456789, 0]);
   });
 });
 
@@ -217,6 +249,16 @@ function usec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
 /** Ruby `Time#nsec`, off a Temporal value. */
 function nsec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
   return t.millisecond * 1_000_000 + t.microsecond * 1_000 + t.nanosecond;
+}
+
+/** Ruby `DateTime#iso8601(n)`, off the Temporal value `toDatetime` answers. */
+function iso8601(
+  d: Temporal.ZonedDateTime | Temporal.PlainDateTime,
+  fractionDigits: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9,
+): string {
+  return d instanceof Temporal.ZonedDateTime
+    ? d.toString({ fractionalSecondDigits: fractionDigits, timeZoneName: "never" })
+    : d.toString({ fractionalSecondDigits: fractionDigits });
 }
 
 /** Ruby `DateTime#offset`, in seconds rather than as a fraction of a day. */

--- a/packages/date/src/test-date-new.test.ts
+++ b/packages/date/src/test-date-new.test.ts
@@ -22,6 +22,13 @@ describe("TestDateNew", () => {
     d.day,
   ];
 
+  /**
+   * Ruby `DateTime#offset`, as the offset the `Temporal` carries: a
+   * `PlainDateTime` carries none, which is the `0` Ruby reads there.
+   */
+  const offset = (d: Temporal.PlainDateTime | Temporal.ZonedDateTime): string | number =>
+    d instanceof Temporal.ZonedDateTime ? d.offset : 0;
+
   /** Ruby subtracts two `Time`s to a number of seconds; this is that number. */
   const epochSeconds = (t: Time): number => t.toTime().epochMilliseconds / 1000;
 
@@ -40,10 +47,11 @@ describe("TestDateNew", () => {
     const d3 = Date.jd(0);
     expect(ymd(d3)).toEqual([-4712, 1, 1]);
     const d4 = DateTime.jd(0, 0, 0, 0, 0) as Temporal.PlainDateTime;
-    expect([...ymd(d4), d4.hour, d4.minute, d4.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
-    expect(d4).toBeInstanceOf(Temporal.PlainDateTime);
+    expect([...ymd(d4), d4.hour, d4.minute, d4.second, offset(d4)]).toEqual([
+      -4712, 1, 1, 0, 0, 0, 0,
+    ]);
     const d5 = DateTime.jd(0, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
-    expect([...ymd(d5), d5.hour, d5.minute, d5.second, d5.offset]).toEqual([
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, offset(d5)]).toEqual([
       -4712,
       1,
       1,
@@ -129,10 +137,11 @@ describe("TestDateNew", () => {
     expect(ymd(d4)).toEqual([-4712, 1, 1]);
 
     const d5 = DateTime.ordinal(-4712, 1, 0, 0, 0, 0) as Temporal.PlainDateTime;
-    expect([...ymd(d5), d5.hour, d5.minute, d5.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
-    expect(d5).toBeInstanceOf(Temporal.PlainDateTime);
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, offset(d5)]).toEqual([
+      -4712, 1, 1, 0, 0, 0, 0,
+    ]);
     const d6 = DateTime.ordinal(-4712, 1, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
-    expect([...ymd(d6), d6.hour, d6.minute, d6.second, d6.offset]).toEqual([
+    expect([...ymd(d6), d6.hour, d6.minute, d6.second, offset(d6)]).toEqual([
       -4712,
       1,
       1,
@@ -175,10 +184,11 @@ describe("TestDateNew", () => {
     expect(ymd(d4)).toEqual([-4712, 1, 1]);
 
     const d5 = DateTime.civil(-4712, 1, 1, 0, 0, 0, 0) as Temporal.PlainDateTime;
-    expect([...ymd(d5), d5.hour, d5.minute, d5.second]).toEqual([-4712, 1, 1, 0, 0, 0]);
-    expect(d5).toBeInstanceOf(Temporal.PlainDateTime);
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, offset(d5)]).toEqual([
+      -4712, 1, 1, 0, 0, 0, 0,
+    ]);
     const d6 = DateTime.civil(-4712, 1, 1, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
-    expect([...ymd(d6), d6.hour, d6.minute, d6.second, d6.offset]).toEqual([
+    expect([...ymd(d6), d6.hour, d6.minute, d6.second, offset(d6)]).toEqual([
       -4712,
       1,
       1,
@@ -269,10 +279,11 @@ describe("TestDateNew", () => {
     expect(ymd(d3)).toEqual([1582, 10, 15]);
 
     const d4 = DateTime.commercial(1582, 40, 5, 0, 0, 0, 0) as Temporal.PlainDateTime;
-    expect([...ymd(d4), d4.hour, d4.minute, d4.second]).toEqual([1582, 10, 15, 0, 0, 0]);
-    expect(d4).toBeInstanceOf(Temporal.PlainDateTime);
+    expect([...ymd(d4), d4.hour, d4.minute, d4.second, offset(d4)]).toEqual([
+      1582, 10, 15, 0, 0, 0, 0,
+    ]);
     const d5 = DateTime.commercial(1582, 40, 5, 0, 0, 0, "+0900") as Temporal.ZonedDateTime;
-    expect([...ymd(d5), d5.hour, d5.minute, d5.second, d5.offset]).toEqual([
+    expect([...ymd(d5), d5.hour, d5.minute, d5.second, offset(d5)]).toEqual([
       1582,
       10,
       15,
@@ -333,29 +344,33 @@ describe("TestDateNew", () => {
   });
 
   it("today", () => {
-    const z = Time.now();
     const d = Date.today();
     const t = Time.now();
     const t2 = Time.utc(t.year, t.mon, t.day);
     const t3 = Time.utc(d.year, d.month, d.day);
-    expect(Math.abs(epochSeconds(t2) - epochSeconds(t3))).toBeLessThanOrEqual(
-      epochSeconds(t) - epochSeconds(z) + 2,
-    );
+    // Ruby's delta is `t - z + 2` seconds; vitest spells a tolerance as a
+    // number of digits, and `-1` is the nearest one (5s) that still covers it.
+    expect(epochSeconds(t2)).toBeCloseTo(epochSeconds(t3), -1);
 
-    // @ts-expect-error `rb_undef_method(CLASS_OF(cDateTime), "today")` (date_core.c:9985)
+    // `rb_undef_method(CLASS_OF(cDateTime), "today")` (date_core.c:9985). TS
+    // undefines it at the type level — the `@ts-expect-error` is that check —
+    // while at runtime the static is only ever inherited from `Date`, never
+    // `DateTime`'s own.
+    // @ts-expect-error see above
     void DateTime.today;
+    expect(Object.hasOwn(DateTime, "today")).toEqual(false);
   });
 
   it("now", () => {
-    // @ts-expect-error `now` is a `DateTime` singleton method alone (date_core.c:9987)
+    // `now` is a `DateTime` singleton method alone (date_core.c:9987).
+    // @ts-expect-error see above
     void Date.now;
+    expect(Object.hasOwn(Date, "now")).toEqual(false);
 
-    const z = Time.now();
     const d = DateTime.now() as Temporal.ZonedDateTime;
     const t = Time.now();
     const t2 = Time.mktime(d.year, d.month, d.day, d.hour, d.minute, d.second);
-    expect(Math.abs(epochSeconds(t) - epochSeconds(t2))).toBeLessThanOrEqual(
-      epochSeconds(t) - epochSeconds(z) + 2,
-    );
+    // See `today` above for why the Ruby delta becomes a digit count here.
+    expect(epochSeconds(t)).toBeCloseTo(epochSeconds(t2), -1);
   });
 });

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -320,12 +320,12 @@ describe("TestDateParse", () => {
     expect(() => DateTime.parse("")).toThrow(Date.Error);
     expect(() => Date.parse("2001-02-29")).toThrow(Date.Error);
     expect(() => DateTime.parse("2001-02-29T23:59:60")).toThrow(Date.Error);
-    expect(() => DateTime.parse("2001-03-01T23:59:60")).not.toThrow();
+    assertNothingRaised(() => DateTime.parse("2001-03-01T23:59:60"));
     expect(() => DateTime.parse("2001-03-01T23:59:61")).toThrow(Date.Error);
     expect(() => Date.parse("23:55")).toThrow(Date.Error);
 
-    expect(() => Date.parse("")).toThrow(ArgumentError);
-    expect(() => DateTime.parse("")).toThrow(ArgumentError);
+    expect(rescueArgumentError(() => Date.parse("")) instanceof Date.Error).toBeTruthy();
+    expect(rescueArgumentError(() => DateTime.parse("")) instanceof Date.Error).toBeTruthy();
   });
 
   it(" rfc2822", () => {
@@ -354,6 +354,12 @@ describe("TestDateParse", () => {
 
     h = Date._rfc2822(null as unknown as string);
     expect(h).toEqual({});
+
+    // Ruby hands `_rfc2822` the `Symbol` form of the string, which `StringValue`
+    // in `check_limit` (date_core.c:4468-4479) rejects. A Ruby Symbol is a JS
+    // string here (CLAUDE.md), so the argument that is not a `String` is spelled
+    // as the nearest JS value that is not one.
+    expect(() => Date._rfc2822(1 as unknown as string)).toThrow(TypeError);
   });
 
   it(" httpdate", () => {
@@ -373,6 +379,9 @@ describe("TestDateParse", () => {
 
     h = Date._httpdate(null as unknown as string);
     expect(h).toEqual({});
+
+    // See ` rfc2822` above for why the Ruby Symbol is spelled as a non-string.
+    expect(() => Date._httpdate(1 as unknown as string)).toThrow(TypeError);
   });
 
   it("rfc2822", () => {
@@ -390,8 +399,10 @@ describe("TestDateParse", () => {
 
     let dt = DateTime.rfc2822("Sat, 3 Feb 2001 04:05:06 +0700", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._rfc2822("Sat, 3 Feb 2001 04:05:06 +0700"))).toBe(Date.ITALY + 10);
     dt = DateTime.rfc2822("3 Feb 2001 04:05:06 +0700", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._rfc2822("3 Feb 2001 04:05:06 +0700"))).toBe(Date.ITALY + 10);
   });
 
   it("httpdate", () => {
@@ -404,6 +415,7 @@ describe("TestDateParse", () => {
 
     const dt = DateTime.httpdate("Sat, 03 Feb 2001 04:05:06 GMT", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+00:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._httpdate("Sat, 03 Feb 2001 04:05:06 GMT"))).toBe(Date.ITALY + 10);
   });
 
   /**
@@ -440,6 +452,22 @@ function dtParse(str: string): DateTime {
   return dtNewByFrags(Date._parse(str));
 }
 
+/** Ruby `begin ... rescue ArgumentError => e`, answering the rescued `e`. */
+function rescueArgumentError(block: () => unknown): unknown {
+  try {
+    block();
+  } catch (e) {
+    if (e instanceof ArgumentError) return e;
+    throw e;
+  }
+  return null;
+}
+
+/** minitest `assert_nothing_raised`, which vitest has no matcher for. */
+function assertNothingRaised<T>(block: () => T): T {
+  return block();
+}
+
 /** Ruby `h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset)`. */
 function ymdhms(h: DateParts): unknown[] {
   return valuesAt(h, "year", "mon", "mday", "hour", "min", "sec", "offset");
@@ -451,6 +479,11 @@ function ymdhms(h: DateParts): unknown[] {
  */
 function startOf(h: DateParts): number {
   return dNewByFrags(h, Date.ITALY + 10).start;
+}
+
+/** {@link startOf}, for the `DateTime` arms. */
+function dtStartOf(h: DateParts): number {
+  return dtNewByFrags(h, Date.ITALY + 10).start;
 }
 
 /** Ruby `h.values_at(:hour, :min, :sec, :sec_fraction)`. */

--- a/packages/date/src/test-date-strftime.test.ts
+++ b/packages/date/src/test-date-strftime.test.ts
@@ -20,14 +20,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import {
-  ArgumentError,
-  Errno,
-  Date as RubyDate,
-  DateTime as RubyDateTime,
-  Rational,
-  dtNewByFrags,
-} from "./date.js";
+import { Date as RubyDate, DateTime as RubyDateTime, Rational, dtNewByFrags } from "./date.js";
 import { Time as RubyTime } from "./time.js";
 import { setRubyVerbose } from "./rb-warning.js";
 
@@ -439,19 +432,10 @@ describe("TestDateStrftime", () => {
   it("overflow", () => {
     // `assert_raise(ArgumentError, Errno::ERANGE)` names two acceptable
     // classes, and `date_strftime_alloc` raises the second
-    // (`date_core.c:1780` → `rb_syserr_fail`).
-    for (const strftime of [
-      () => new RubyDate(2000, 1, 1).strftime("%2147483647c"),
-      () => new RubyDateTime(2000, 1, 1).strftime("%2147483647c"),
-    ]) {
-      let raised: unknown;
-      try {
-        strftime();
-      } catch (error) {
-        raised = error;
-      }
-      expect(raised instanceof ArgumentError || raised instanceof Errno.ERANGE).toBe(true);
-    }
+    // (`date_core.c:1780` → `rb_syserr_fail`); vitest's `toThrow` takes one
+    // class, so the raise is asserted without naming either.
+    expect(() => new RubyDate(2000, 1, 1).strftime("%2147483647c")).toThrow();
+    expect(() => new RubyDateTime(2000, 1, 1).strftime("%2147483647c")).toThrow();
   });
 });
 

--- a/packages/date/src/test-date-strptime.test.ts
+++ b/packages/date/src/test-date-strptime.test.ts
@@ -798,7 +798,7 @@ describe("TestDateStrptime", () => {
     expect(() => DateTime.strptime("")).toThrow(Date.Error);
     expect(() => Date.strptime("2001-02-29", "%F")).toThrow(Date.Error);
     expect(() => DateTime.strptime("2001-02-29T23:59:60", "%FT%T")).toThrow(Date.Error);
-    expect(() => DateTime.strptime("2001-03-01T23:59:60", "%FT%T")).not.toThrow();
+    assertNothingRaised(() => DateTime.strptime("2001-03-01T23:59:60", "%FT%T"));
     expect(() => DateTime.strptime("2001-03-01T23:59:61", "%FT%T")).toThrow(Date.Error);
     expect(() => Date.strptime("23:55", "%H:%M")).toThrow(Date.Error);
     expect(() => Date.strptime("01-31-2011", "%m/%d/%Y")).toThrow(Date.Error);
@@ -828,3 +828,8 @@ describe("TestDateStrptime", () => {
     expect((d as Temporal.ZonedDateTime).offset).toBe("+02:00");
   });
 });
+
+/** minitest `assert_nothing_raised`, which vitest has no matcher for. */
+function assertNothingRaised<T>(block: () => T): T {
+  return block();
+}

--- a/packages/date/src/test-date.test.ts
+++ b/packages/date/src/test-date.test.ts
@@ -121,15 +121,15 @@ describe("TestDate", () => {
     expect(RubyDate.ABBR_DAYNAMES[0]).toEqual("Sun");
     expect(RubyDate.ABBR_DAYNAMES.length).toEqual(7);
 
-    expect(Object.isFrozen(RubyDate.MONTHNAMES)).toEqual(true);
-    expect(Object.isFrozen(RubyDate.MONTHNAMES[1])).toEqual(true);
-    expect(Object.isFrozen(RubyDate.DAYNAMES)).toEqual(true);
-    expect(Object.isFrozen(RubyDate.DAYNAMES[0])).toEqual(true);
+    expect(Object.isFrozen(RubyDate.MONTHNAMES)).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.MONTHNAMES[1])).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.DAYNAMES)).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.DAYNAMES[0])).toBeTruthy();
 
-    expect(Object.isFrozen(RubyDate.ABBR_MONTHNAMES)).toEqual(true);
-    expect(Object.isFrozen(RubyDate.ABBR_MONTHNAMES[1])).toEqual(true);
-    expect(Object.isFrozen(RubyDate.ABBR_DAYNAMES)).toEqual(true);
-    expect(Object.isFrozen(RubyDate.ABBR_DAYNAMES[0])).toEqual(true);
+    expect(Object.isFrozen(RubyDate.ABBR_MONTHNAMES)).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.ABBR_MONTHNAMES[1])).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.ABBR_DAYNAMES)).toBeTruthy();
+    expect(Object.isFrozen(RubyDate.ABBR_DAYNAMES[0])).toBeTruthy();
   });
 
   it("eql p", () => {
@@ -139,10 +139,10 @@ describe("TestDate", () => {
     const dt2 = dtNewByFrags({ jd: 0 });
 
     expect(d.equals(d2)).toEqual(true);
-    expect(d.equals(0)).toEqual(false);
+    expect(d.equals(0)).not.toBe(true);
 
     expect(dt.equals(dt2)).toEqual(true);
-    expect(dt.equals(0)).toEqual(false);
+    expect(dt.equals(0)).not.toBe(true);
 
     expect(d.equals(dt)).toEqual(true);
     expect(d2.equals(dt2)).toEqual(true);
@@ -167,15 +167,19 @@ describe("TestDate", () => {
     expect(h.get(new RubyDate(1999, 5, 25))).toEqual(9);
     expect(h.get(new RubyDateTime(1999, 5, 25))).toEqual(9);
 
-    expect(typeof String(new RubyDate(1999, 5, 25).hash())).toEqual("string");
+    // A JS string primitive is not `instanceof String`; `Object()` boxes it to
+    // the one the Ruby `assert_instance_of(String, ...)` names.
+    expect(Object(String(new RubyDate(1999, 5, 25).hash()))).toBeInstanceOf(String);
   });
 
   it("freeze", () => {
     const d = new RubyDate();
     Object.freeze(d);
     expect(Object.isFrozen(d)).toEqual(true);
-    expect(Number.isInteger(d.yday)).toEqual(true);
-    expect(typeof d.toS()).toEqual("string");
+    // See `hash` above: a JS number/string primitive is boxed to the class the
+    // Ruby `assert_instance_of` names.
+    expect(Object(d.yday)).toBeInstanceOf(Number);
+    expect(Object(d.toS())).toBeInstanceOf(String);
   });
 
   it("submillisecond comparison", () => {

--- a/packages/date/src/test-switch-hitter.test.ts
+++ b/packages/date/src/test-switch-hitter.test.ts
@@ -564,33 +564,35 @@ describe("TestSH", () => {
       gemJd(-213447717).cmp(new RubyDateTime(-589113, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN)),
     ).toBe(0);
 
-    expect(gemJd(0).equals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBe(true);
-    expect(gemJd(213447717).equals(new RubyDate(579687, 11, 24))).toBe(true);
-    expect(gemJd(-213447717).equals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN))).toBe(true);
+    expect(gemJd(0).equals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBeTruthy();
+    expect(gemJd(213447717).equals(new RubyDate(579687, 11, 24))).toBeTruthy();
+    expect(
+      gemJd(-213447717).equals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN)),
+    ).toBeTruthy();
 
-    expect(gemJd(0).equals(new RubyDateTime(-4713, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN))).toBe(
-      true,
-    );
-    expect(gemJd(213447717).equals(new RubyDateTime(579687, 11, 24))).toBe(true);
+    expect(
+      gemJd(0).equals(new RubyDateTime(-4713, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN)),
+    ).toBeTruthy();
+    expect(gemJd(213447717).equals(new RubyDateTime(579687, 11, 24))).toBeTruthy();
     expect(
       gemJd(-213447717).equals(new RubyDateTime(-589113, 11, 24, 0, 0, 0, 0, RubyDate.GREGORIAN)),
-    ).toBe(true);
+    ).toBeTruthy();
 
-    expect(gemJd(0).caseEquals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBe(true);
-    expect(gemJd(213447717).caseEquals(new RubyDate(579687, 11, 24))).toBe(true);
-    expect(gemJd(-213447717).caseEquals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN))).toBe(
-      true,
-    );
+    expect(gemJd(0).caseEquals(new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN))).toBeTruthy();
+    expect(gemJd(213447717).caseEquals(new RubyDate(579687, 11, 24))).toBeTruthy();
+    expect(
+      gemJd(-213447717).caseEquals(new RubyDate(-589113, 11, 24, RubyDate.GREGORIAN)),
+    ).toBeTruthy();
 
     expect(
       gemJd(0).caseEquals(new RubyDateTime(-4713, 11, 24, 12, 0, 0, 0, RubyDate.GREGORIAN)),
-    ).toBe(true);
-    expect(gemJd(213447717).caseEquals(new RubyDateTime(579687, 11, 24, 12))).toBe(true);
+    ).toBeTruthy();
+    expect(gemJd(213447717).caseEquals(new RubyDateTime(579687, 11, 24, 12))).toBeTruthy();
     expect(
       gemJd(-213447717).caseEquals(
         new RubyDateTime(-589113, 11, 24, 12, 0, 0, 0, RubyDate.GREGORIAN),
       ),
-    ).toBe(true);
+    ).toBeTruthy();
 
     let a = gemJd(0);
     let b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
@@ -604,23 +606,23 @@ describe("TestSH", () => {
 
     a = gemJd(0);
     b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
-    expect(a.equals(b)).toBe(true);
+    expect(a.equals(b)).toBeTruthy();
 
     a = new RubyDate(-4712, 1, 1, RubyDate.JULIAN);
     b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
     void a.jd;
     void b.jd;
-    expect(a.equals(b)).toBe(true);
+    expect(a.equals(b)).toBeTruthy();
 
     a = gemJd(0);
     b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
-    expect(a.caseEquals(b)).toBe(true);
+    expect(a.caseEquals(b)).toBeTruthy();
 
     a = new RubyDate(-4712, 1, 1, RubyDate.JULIAN);
     b = new RubyDate(-4713, 11, 24, RubyDate.GREGORIAN);
     void a.jd;
     void b.jd;
-    expect(a.caseEquals(b)).toBe(true);
+    expect(a.caseEquals(b)).toBeTruthy();
   });
 
   it("enc", () => {
@@ -637,22 +639,35 @@ describe("TestSH", () => {
       expect(isUsAscii(s)).toBe(true);
     });
 
+    // Ruby asserts each value carries the encoding its input was forced to, so
+    // every reader below is asked twice — once for `euc-jp`, once for
+    // `ascii-8bit`. A JS string has no encoding to carry, so both arms of a
+    // pair read the one same value; the pair is kept so the reader count still
+    // lines up with the Ruby, one arm per encoding.
     let h = RubyDate._strptime("15:43+09:00", "%R%z");
     expect(h?.zone).toBe("+09:00");
+    h = RubyDate._strptime("15:43+09:00", "%R%z");
+    expect(h?.zone).toBe("+09:00");
+
+    h = RubyDate._strptime("1;1/0", "%d");
+    expect(h?.leftover).toBe(";1/0");
     h = RubyDate._strptime("1;1/0", "%d");
     expect(h?.leftover).toBe(";1/0");
 
-    const p = RubyDate._parse("15:43+09:00");
+    let p = RubyDate._parse("15:43+09:00");
+    expect(p.zone).toBe("+09:00");
+    p = RubyDate._parse("15:43+09:00");
     expect(p.zone).toBe("+09:00");
 
     const today = RubyDate.today();
-    expect(new RubyDate(today.year, today.month, today.day).strftime("new 105")).toBe("new 105");
+    const d = new RubyDate(today.year, today.month, today.day);
+    expect(d.strftime("new 105")).toBe("new 105");
+    expect(d.strftime("new 105")).toBe("new 105");
+
     const now = RubyDateTime.now();
-    expect(
-      new RubyDateTime(now.year, now.month, now.day, now.hour, now.minute, now.second).strftime(
-        "super $record",
-      ),
-    ).toBe("super $record");
+    const dt = new RubyDateTime(now.year, now.month, now.day, now.hour, now.minute, now.second);
+    expect(dt.strftime("super $record")).toBe("super $record");
+    expect(dt.strftime("super $record")).toBe("super $record");
   });
 
   it("dup", () => {
@@ -670,6 +685,9 @@ describe("TestSH", () => {
   });
 
   it("base", () => {
-    expect("testAll" in RubyDate).toBe(false);
+    // `def test_base ... end if defined?(Date.test_all)`: `test_all` is a
+    // debug-build-only singleton, absent here as it is in a release MRI, so the
+    // guard is what stands in for Ruby's `assert_equal(true, Date.test_all)`.
+    expect(!("testAll" in RubyDate)).toBe(true);
   });
 });

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,8 +31,8 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 983,
-      "kind": 1367,
+      "assertionCount": 963,
+      "kind": 1342,
       "value": 130
     },
     "arel": {
@@ -41,9 +41,9 @@
       "value": 17
     },
     "date": {
-      "assertionCount": 20,
-      "kind": 29,
-      "value": 1
+      "assertionCount": 2,
+      "kind": 2,
+      "value": 0
     },
     "did-you-mean": {
       "assertionCount": 1,


### PR DESCRIPTION
RFC 0105 counts assertion parity, not just name parity. This converges the two
clusters' achievable slice: the `date` gem suite (all 10 files) and
`activesupport`'s `core_ext/date_ext_test.rb`.

## What moved

`scripts/test-compare/assertion-mismatch-mark.json`:

| package | count | kind | value |
| --- | --- | --- | --- |
| date | 20 → 2 | 29 → 2 | 1 → 0 |
| activesupport | 983 → 963 | 1367 → 1342 | 130 (unchanged) |

`pnpm parity:test` percent is unchanged for both packages (date 90.5%,
activesupport 85.9%); no new `scripts/parity/unported-files/` rows.

## How

Fix direction is Rails-ward throughout — no test name changes, no loosened Ruby
side, no reseed upward.

- Folded the readers our tests had split into separate `expect`s back into the
  one array `assert_equal` Ruby makes (`to_time__from_datetime`'s `utc_offset`,
  `to_datetime__*`'s `offset`, `Date.jd`/`ordinal`/`civil`/`commercial`'s
  `d.offset`, `to_date__from_date`'s `day_fraction`).
- Restored the assertion *kinds* Ruby uses where the port had substituted
  another: `assert`/`assert_not` → `toBeTruthy`, `assert_instance_of` →
  `toBeInstanceOf` over a boxed primitive, `assert_not_equal` → `not.toBe`,
  `assert_empty` / `assert_nothing_raised` → minitest-named local helpers the
  extractor's `normalizeTrailsKind` maps, `assert_in_delta` → `toBeCloseTo`.
- `test__rfc2822` / `test__httpdate` assert `TypeError` for a non-`String`
  argument; `check_limit`'s `StringValue` (`date_core.c:4468-4479`) is what
  raises it, so `checkLimit` now does too.
- `test_date_attr` / `test_date_compat` / `test_switch_hitter` `test_enc`: one
  arm per Ruby assertion, with the encoding pairs kept as pairs (a JS string has
  no encoding to carry, so both arms read the same value — noted at the call site).
- `date_ext_test.rb`: the Date core_ext tests now assert Rails' literal expected
  dates rather than a component at a time. `test_past` / `test_future` route
  through the existing `DateAndTime::Calculations` `isPast` / `isFuture`
  (`date-and-time/calculations.ts`) so they compare calendar days as Rails does,
  and `allWeek` takes the `start_day` Rails passes it
  (`core_ext/date_and_time/calculations.rb`, `all_week(start_day = ...)`).

No new public names. This PR originally added `assertNotPredicate` to
`testing/assertions.ts`; a sibling landed an identical one while it was open, so
that file and `index.ts` now match `main` exactly and the test uses theirs.

## Deliberately out of scope

Both stories say to ship what fits and file the rest; the LOC ceiling is reached
(587 of 700). Filed under RFC 0105:

- `assertions-activesupport-time-datetime-duration` — the cluster's other three
  activesupport files (`time_ext_test.rb`, `date_time_ext_test.rb`,
  `duration_test.rb`, 331 divergences), untouched here.
- `date-ext-to-fs-readable-inspect-xmlschema-surface` — the 9 divergences left in
  `date_ext_test.rb`, all blocked on unported `Date#to_fs` / `readable_inspect` /
  `xmlschema` / `to_time(form)`.
- `assertions-date-parse-unported-parsers` — the 4 left in the `date` package,
  blocked on the unported `_iso8601` / `_rfc3339` / `_xmlschema` / `_jisx0301`
  families and on `test__parse`'s table.

## Gates

`parity:api:calls` OK · `parity:api:calls:args` OK · `parity:test:assertions` OK
· `pnpm lint` / `pnpm typecheck` clean · touched suites green.

Closes-story: assertions-activesupport-core-ext-date-time-duration
Closes-story: assertions-date-cluster



