### PR TITLE
refactor(activesupport): route Time#to_fs through DATE_FORMATS; port Date::DATE_FORMATS

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/date";
+import { Date as RubyDate, Temporal } from "@blazetrails/date";
 import {
   endOfMonth,
   endOfYear,
@@ -22,7 +22,7 @@ import {
   isFuture,
   isToday,
 } from "../time-ext.js";
-import { toTime } from "./date/conversions.js";
+import { toFormattedS as dateToFormattedS, toFs as dateToFs, toTime } from "./date/conversions.js";
 import * as DateExt from "./date/calculations.js";
 import { setZone } from "../time-zone-config.js";
 import { TimeZone } from "../values/time-zone.js";
@@ -75,15 +75,28 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("to fs", () => {
-    const date = d(2005, 2, 21);
-    const result = toFs(date, "db");
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    const date = pd(2005, 2, 21);
+    expect(dateToFs(date, "short")).toBe("21 Feb");
+    expect(dateToFs(date, "long")).toBe("February 21, 2005");
+    expect(dateToFs(date, "long_ordinal")).toBe("February 21st, 2005");
+    expect(dateToFs(date, "db")).toBe("2005-02-21");
+    expect(dateToFs(date, "inspect")).toBe("2005-02-21");
+    expect(dateToFs(date, "rfc822")).toBe("21 Feb 2005");
+    expect(dateToFs(date, "rfc2822")).toBe("21 Feb 2005");
+    expect(dateToFs(date, "iso8601")).toBe("2005-02-21");
+    expect(dateToFs(date, "doesnt_exist")).toBe(new RubyDate(date).toS());
+    expect(dateToFormattedS(date, "short")).toBe("21 Feb");
   });
 
   it("to fs with single digit day", () => {
-    const date = d(2005, 2, 1);
-    const result = toFs(date, "db");
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    const date = pd(2005, 2, 1);
+    expect(dateToFs(date, "short")).toBe("01 Feb");
+    expect(dateToFs(date, "long")).toBe("February 01, 2005");
+    expect(dateToFs(date, "long_ordinal")).toBe("February 1st, 2005");
+    expect(dateToFs(date, "db")).toBe("2005-02-01");
+    expect(dateToFs(date, "inspect")).toBe("2005-02-01");
+    expect(dateToFs(date, "rfc822")).toBe("01 Feb 2005");
+    expect(dateToFs(date, "iso8601")).toBe("2005-02-01");
   });
 
   it("readable inspect", () => {

--- a/packages/activesupport/src/core-ext/date/conversions.ts
+++ b/packages/activesupport/src/core-ext/date/conversions.ts
@@ -6,10 +6,63 @@
  * Mirrors: `class Date` (`core_ext/date/conversions.rb`)
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Date as RubyDate, Temporal } from "@blazetrails/date";
+import { ordinalize } from "../../inflector.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { ArgumentError } from "../../time-zone-config.js";
+
+/**
+ * The named formats `Date#to_fs` resolves, either a `strftime` string or a
+ * callable taking the receiver.
+ *
+ * Mirrors: `Date::DATE_FORMATS` (`core_ext/date/conversions.rb:8-21`). It is a
+ * hash of its own, distinct from `Time::DATE_FORMATS` (`time-ext.ts`) — the
+ * same keys carry date-only formats here, and `rfc822`/`rfc2822` are plain
+ * `strftime` strings rather than lambdas.
+ */
+export const DATE_FORMATS: Record<string, string | ((date: Temporal.PlainDate) => string)> = {
+  short: "%d %b",
+  long: "%B %d, %Y",
+  db: "%Y-%m-%d",
+  inspect: "%Y-%m-%d",
+  number: "%Y%m%d",
+  long_ordinal: (date) => {
+    const dayFormat = ordinalize(date.day);
+    return new RubyDate(date).strftime(`%B ${dayFormat}, %Y`);
+  },
+  rfc822: "%d %b %Y",
+  rfc2822: "%d %b %Y",
+  iso8601: (date) => new RubyDate(date).iso8601(),
+};
+
+/**
+ * Convert to a formatted string. See {@link DATE_FORMATS} for predefined
+ * formats.
+ *
+ *     toFs(date, "db")            // => "2007-11-10"
+ *     toFs(date, "short")         // => "10 Nov"
+ *     toFs(date, "long_ordinal")  // => "November 10th, 2007"
+ *
+ * Mirrors: `Date#to_fs` (`core_ext/date/conversions.rb:49-59`) —
+ * `formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)`,
+ * else `to_s`, which is ruby/date's own `Date#to_s` (`date_core.c`
+ * `d_lite_to_s`) — not `readable_inspect`, which reopens `inspect` alone.
+ */
+export function toFs(date: Temporal.PlainDate, format: string = "default"): string {
+  const formatter = DATE_FORMATS[format];
+  if (formatter != null) {
+    if (typeof formatter === "function") {
+      return String(formatter(date));
+    } else {
+      return new RubyDate(date).strftime(formatter);
+    }
+  }
+  return new RubyDate(date).toS();
+}
+
+/** Mirrors: `alias_method :to_formatted_s, :to_fs` (`core_ext/date/conversions.rb:60`). */
+export { toFs as toFormattedS };
 
 /**
  * Mirrors: `Date#to_time` (`core_ext/date/conversions.rb:83-86`) —

--- a/packages/activesupport/src/core-ext/range/conversions.ts
+++ b/packages/activesupport/src/core-ext/range/conversions.ts
@@ -2,6 +2,7 @@ import { Temporal } from "@blazetrails/date";
 
 import { Range } from "../../range-ext.js";
 import { toFs as timeToFs } from "../../time-ext.js";
+import { toFs as dateToFs } from "../date/conversions.js";
 
 /**
  * `ActiveSupport::RangeWithFormat`
@@ -25,7 +26,7 @@ declare module "../../range-ext.js" {
  * for `Date`, `Date`/`Temporal.Instant` for `Time`, everything else `to_s`.
  */
 function toFsDb(value: unknown): string {
-  if (value instanceof Temporal.PlainDate) return value.toString();
+  if (value instanceof Temporal.PlainDate) return dateToFs(value, "db");
   // boundary: `time-ext.ts`'s `toFs` — the ported `Time#to_fs` — takes a JS Date.
   if (value instanceof Date) return timeToFs(value, "db");
   // boundary: as above, an Instant is bridged to the Date `toFs` accepts.

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -14,6 +14,7 @@ import {
   ceil,
   change,
   toFs,
+  DATE_FORMATS,
   xmlschema,
   lastWeek,
   toDate,
@@ -479,15 +480,31 @@ describe("TimeExtCalculationsTest", () => {
   });
 
   it("to fs", () => {
-    const t = d(2005, 2, 21, 17, 44, 30);
-    const result = toFs(t, "db");
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    // boundary: a JS `Date` is Rails' `Time.utc` receiver here, and carries
+    // milliseconds where Ruby's `30.12345678901` carries nanoseconds.
+    const time = utc(2005, 2, 21, 17, 44, 30, 123);
+    expect(toFs(time, "doesnt_exist")).toBe("2005-02-21 17:44:30 UTC");
+    expect(toFs(time, "db")).toBe("2005-02-21 17:44:30");
+    expect(toFs(time, "short")).toBe("21 Feb 17:44");
+    expect(toFs(time, "time")).toBe("17:44");
+    expect(toFs(time, "number")).toBe("20050221174430");
+    expect(toFs(time, "nsec")).toBe("20050221174430123000000");
+    expect(toFs(time, "usec")).toBe("20050221174430123000");
+    expect(toFs(time, "long")).toBe("February 21, 2005 17:44");
+    expect(toFs(time, "long_ordinal")).toBe("February 21st, 2005 17:44");
+    expect(toFs(time, "rfc822")).toBe("Mon, 21 Feb 2005 17:44:30 +0000");
+    expect(toFs(time, "rfc2822")).toBe("Mon, 21 Feb 2005 17:44:30 -0000");
+    expect(toFs(time, "inspect")).toBe("2005-02-21 17:44:30.123000000 +0000");
+    expect(toFs(time, "iso8601")).toBe("2005-02-21T17:44:30Z");
   });
 
   it("to fs custom date format", () => {
-    const t = d(2005, 2, 21, 14, 30, 0);
-    const result = toFs(t, "db");
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    DATE_FORMATS.custom = "%Y%m%d%H%M%S";
+    try {
+      expect(toFs(utc(2005, 2, 21, 14, 30, 0), "custom")).toBe("20050221143000");
+    } finally {
+      delete DATE_FORMATS.custom;
+    }
   });
 
   it("rfc3339 with fractional seconds", () => {

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -761,6 +761,9 @@ export function toFs(date: Date, format: string = "default"): string {
   return time.toS();
 }
 
+/** Mirrors: `alias_method :to_formatted_s, :to_fs` (`core_ext/time/conversions.rb:62`). */
+export { toFs as toFormattedS };
+
 /**
  * Creates a Time instance from an RFC 3339 string — time/calculations.rb:68-81.
  *

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -663,6 +663,14 @@ export function secFraction(
 export { secFraction as subsec };
 
 /**
+ * The receivers `Time::DATE_FORMATS`' lambdas duck-type: a ruby/date `Time` and
+ * the `PlainDateTime | ZonedDateTime` seat a Ruby `DateTime` stands on. Both
+ * answer `day`, `strftime`, `formatted_offset`, `rfc2822` and `iso8601`, which
+ * is every member those lambdas call.
+ */
+type DateFormatsReceiver = RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+
+/**
  * The named formats `to_fs` resolves, either a `strftime` string or a callable
  * taking the receiver.
  *
@@ -670,15 +678,16 @@ export { secFraction as subsec };
  * Ruby keys are Symbols and the four lambdas duck-type their argument — a
  * `Time`, a `Date` or a `DateTime` all answer `day`, `strftime`,
  * `formatted_offset`, `rfc2822` and `iso8601` — so the hash is shared by every
- * `to_fs` in ActiveSupport. Its only caller in trails today is
- * `core-ext/date-time/conversions.ts`'s `toFs`, so the callables are typed over
- * that receiver; `time-ext.ts`'s own `toFs` below still answers a JS `Date`
- * through a hand-rolled `switch` and is converged separately.
+ * `to_fs` in ActiveSupport. TS has no open classes, so the duck typing is the
+ * `DateFormatsReceiver` union below and an explicit dispatch inside each
+ * lambda: a ruby/date `Time` — the receiver `toFs` bridges a JS `Date` onto —
+ * answers `strftime`/`rfc2822`/`iso8601` itself, and the `DateTime` seat
+ * reaches the same names through `RubyDateTime`.
  *
- * `rfc822`'s `time.formatted_offset(false)` is imported as
- * `dateTimeFormattedOffset` because this file declares its own
- * `formattedOffset` over a JS `Date` — `core_ext/time/conversions.rb`'s arm of
- * the same Rails name — and a `DateTime` receiver reaches the other one.
+ * `rfc822`'s `time.formatted_offset(false)` is the `Time` arm this file
+ * declares for a `Time` receiver and `dateTimeFormattedOffset`
+ * (`core_ext/date_time/conversions.rb`'s arm of the same Rails name) for the
+ * `DateTime` one.
  *
  * That import closes a cycle with `core-ext/date-time/conversions.ts`, which
  * reads `DATE_FORMATS` back for its `to_fs`. Neither side touches the other at
@@ -690,10 +699,7 @@ export { secFraction as subsec };
  * call-time-constant section; a vitest run enters through a funnel module and
  * would mask it.
  */
-export const DATE_FORMATS: Record<
-  string,
-  string | ((time: Temporal.PlainDateTime | Temporal.ZonedDateTime) => string)
-> = {
+export const DATE_FORMATS: Record<string, string | ((time: DateFormatsReceiver) => string)> = {
   db: "%Y-%m-%d %H:%M:%S",
   inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
   number: "%Y%m%d%H%M%S",
@@ -704,53 +710,55 @@ export const DATE_FORMATS: Record<
   long: "%B %d, %Y %H:%M",
   long_ordinal: (time) => {
     const dayFormat = ordinalize(time.day);
-    return new RubyDateTime(time).strftime(`%B ${dayFormat}, %Y %H:%M`);
+    return (time instanceof RubyTime ? time : new RubyDateTime(time)).strftime(
+      `%B ${dayFormat}, %Y %H:%M`,
+    );
   },
   rfc822: (time) => {
-    const offsetFormat = dateTimeFormattedOffset(time, false);
-    return new RubyDateTime(time).strftime(`%a, %d %b %Y %H:%M:%S ${offsetFormat}`);
+    const offsetFormat =
+      time instanceof RubyTime
+        ? formattedOffset(time, false)
+        : dateTimeFormattedOffset(time, false);
+    return (time instanceof RubyTime ? time : new RubyDateTime(time)).strftime(
+      `%a, %d %b %Y %H:%M:%S ${offsetFormat}`,
+    );
   },
-  rfc2822: (time) => new RubyDateTime(time).rfc2822(),
-  iso8601: (time) => new RubyDateTime(time).iso8601(),
+  rfc2822: (time) => (time instanceof RubyTime ? time : new RubyDateTime(time)).rfc2822(),
+  iso8601: (time) => (time instanceof RubyTime ? time : new RubyDateTime(time)).iso8601(),
 };
 
 /**
- * toFs — formats a Date as a string using various named formats.
+ * Converts to a formatted string. See {@link DATE_FORMATS} for built-in
+ * formats.
+ *
+ *     toFs(time, "time")   // => "06:10"
+ *     toFs(time, "db")     // => "2007-01-18 06:10:17"
+ *     toFs(time, "short")  // => "18 Jan 06:10"
+ *
+ * Mirrors: `Time#to_fs` (`core_ext/time/conversions.rb:55-61`) —
+ * `formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)`,
+ * else `to_s`, which for a `Time` is ruby/time.c's `time_to_s`.
+ *
+ * A JS `Date` is an instant with no zone of its own, so it is bridged onto the
+ * ruby/date `Time` the Rails body formats as a `Time.utc` — the reading
+ * `Date#toISOString` answers, and the receiver Rails' own tests of this
+ * method's callers build (`range_ext_test.rb`'s `Time.utc` endpoints).
  */
 export function toFs(date: Date, format: string = "default"): string {
-  switch (format) {
-    case "db":
-      return date
-        .toISOString()
-        .replace("T", " ")
-        .replace(/\.\d+Z$/, "");
-    case "long":
-      return (
-        date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" }) +
-        " " +
-        date.toTimeString().slice(0, 8)
-      );
-    case "short":
-      return (
-        date.toLocaleDateString("en-US", { month: "short", day: "numeric" }) +
-        " " +
-        date.toTimeString().slice(0, 5)
-      );
-    case "rfc822":
-    case "rfc2822":
-      return date.toUTCString();
-    case "iso8601":
-    case "xmlschema":
-      return date.toISOString();
-    case "inspect":
-      return date.toISOString();
-    default:
-      return (
-        date.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" }) +
-        " " +
-        date.toTimeString().slice(0, 8)
-      );
+  const time = new RubyTime(
+    date.getUTCFullYear(),
+    date.getUTCMonth() + 1,
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds() + date.getUTCMilliseconds() / 1000,
+    "UTC",
+  );
+  const formatter = DATE_FORMATS[format];
+  if (formatter != null) {
+    return typeof formatter === "function" ? String(formatter(time)) : time.strftime(formatter);
   }
+  return time.toS();
 }
 
 /**
@@ -909,16 +917,19 @@ export function instantToS(instant: Temporal.Instant): string {
  * Mirrors: `Time#formatted_offset` (`core_ext/time/conversions.rb:69-71`) —
  * `utc? && alternate_utc_string || ActiveSupport::TimeZone.seconds_to_utc_offset(utc_offset, colon)`.
  * A `Date` is an instant read in the system zone, so `utc?` is that zone's
- * offset being zero and `utc_offset` is the offset itself, in seconds.
+ * offset being zero and `utc_offset` is the offset itself, in seconds; a
+ * ruby/date `Time` — the receiver `Time::DATE_FORMATS`' `rfc822` lambda hands
+ * over — answers both readers itself.
  * Ruby's `alternate_utc_string` is any non-nil String — `""` included — so the
  * arm is chosen on presence rather than on truthiness.
  */
 export function formattedOffset(
-  date: Date,
+  date: Date | RubyTime,
   colon = true,
   alternateUtcString: string | null = null,
 ): string {
-  const utcOffset = -date.getTimezoneOffset() * 60;
-  if (utcOffset === 0 && alternateUtcString != null) return alternateUtcString;
+  const isUtc = date instanceof RubyTime ? date.isUtc() : -date.getTimezoneOffset() * 60 === 0;
+  if (isUtc && alternateUtcString != null) return alternateUtcString;
+  const utcOffset = date instanceof RubyTime ? date.utcOffset : -date.getTimezoneOffset() * 60;
   return TimeZone.secondsToUtcOffset(utcOffset, colon);
 }

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -76,20 +76,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "formatted_offset",
-    "call": "utc?",
-    "reason": "`utc?` and `utc_offset` are Ruby core `Time` readers — no Rails definition to port — and this file's `Time` arm is a JS `Date`, an instant that carries no offset of its own, so every body Ruby writes through them reads `getTimezoneOffset()` instead. Surfaced, not introduced, by taking `utc?`/`utc_offset` off the date_time/calculations.rb skip group: both are now ported on the DateTime receiver in core-ext/date-time/calculations.ts."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "formatted_offset",
-    "call": "utc_offset",
-    "reason": "`utc?` and `utc_offset` are Ruby core `Time` readers — no Rails definition to port — and this file's `Time` arm is a JS `Date`, an instant that carries no offset of its own, so every body Ruby writes through them reads `getTimezoneOffset()` instead. Surfaced, not introduced, by taking `utc?`/`utc_offset` off the date_time/calculations.rb skip group: both are now ported on the DateTime receiver in core-ext/date-time/calculations.ts."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "preserve_timezone",
     "call": "system_local_time?",
     "kind": "args",
@@ -116,13 +102,6 @@
     "rubyName": "since",
     "call": "warn",
     "reason": "Time#since's `warn` is reached only from its `rescue TypeError` arm, which deprecates passing a non-numeric (time/calculations.rb:126-133). time-ext.ts's `since` takes `seconds: number`, so the deprecated call shape is unrepresentable and the arm has nothing to warn about."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "to_fs",
-    "call": "strftime",
-    "reason": "`strftime` is Ruby's C-level time formatter. JS has no strftime; each named DATE_FORMATS entry is expanded with `Intl`/`toISOString` in `toFs`."
   },
   {
     "package": "activesupport",


### PR DESCRIPTION
`Time#to_fs` (`core_ext/time/conversions.rb:55-61`) still answered a JS `Date`
through a hand-rolled `switch` whose format strings disagreed with the
`Time::DATE_FORMATS` registry #6635 ported (`long`/`short`/`rfc822` went through
`toLocaleDateString`/`toUTCString`), so the two spellings of the same Rails
method could disagree.

- `time-ext.ts`'s `toFs` is now the Rails body over `DATE_FORMATS` — resolve the
  formatter, call it or `strftime` it, else `to_s`. The JS `Date` receiver is
  bridged onto the ruby/date `Time` the body formats as a `Time.utc`: the
  reading `Date#toISOString` already answered, and the receiver Rails' own tests
  of this method's callers build.
- The registry's callables take the receiver union Rails' lambdas duck-type
  (`RubyTime | PlainDateTime | ZonedDateTime`) rather than the DateTime seat
  alone, with `Time#formatted_offset` (`conversions.rb:69-71`) widened to the
  same receiver.
- `Date::DATE_FORMATS` (`core_ext/date/conversions.rb:8-21`) — a separate hash
  from `Time`'s — is ported at its own spelling next to `Date#to_fs` /
  `#to_formatted_s` (`:49-60`), and `range/conversions.ts`'s `toFsDb` reaches it
  for a `Date` endpoint the way Rails' `start.to_fs(:db)` does.
- `date_ext_test.rb`'s `test_to_fs` / `test_to_fs_with_single_digit_day` and
  `time_ext_test.rb`'s `test_to_fs` / `test_to_fs_custom_date_format` were
  asserting the switch's output through loose regexes; they now carry Rails'
  literal expectations. `parity:test` assertion mismatches drop
  (count 3653 → 3651, kind 6832 → 6829) with matched tests unchanged.
- Three baseline rows converged and deleted (`formatted_offset`'s `utc?` /
  `utc_offset`, `to_fs`'s `strftime`); `parity:api:calls` and `:args` clean.

Closes-story: route-time-and-date-to-fs-through-date-formats
