### PR TITLE
refactor(activerecord): converge batches :order validation onto Kernel#Array subtraction

### DIFF
--- a/packages/activerecord/src/batches.trails.test.ts
+++ b/packages/activerecord/src/batches.trails.test.ts
@@ -38,7 +38,7 @@ describe("BatchEnumerator (trails)", () => {
     await expect(
       Post.inBatches({ of: 1, order: "invalid" as "asc" }).eachRecord(() => {}),
     ).rejects.toThrow(
-      ':order must be :asc or :desc or an array consisting of :asc or :desc, got "invalid"',
+      ":order must be :asc or :desc or an array consisting of :asc or :desc, got :invalid",
     );
   });
 
@@ -48,7 +48,7 @@ describe("BatchEnumerator (trails)", () => {
         () => {},
       ),
     ).rejects.toThrow(
-      ':order must be :asc or :desc or an array consisting of :asc or :desc, got ["asc", "sideways"]',
+      ":order must be :asc or :desc or an array consisting of :asc or :desc, got [:asc, :sideways]",
     );
   });
 });

--- a/packages/activerecord/src/batches.trails.test.ts
+++ b/packages/activerecord/src/batches.trails.test.ts
@@ -33,4 +33,22 @@ describe("BatchEnumerator (trails)", () => {
     const expected = (await Post.order({ id: "desc" })).map((p) => Number(p.id));
     expect(records.map((p) => Number(p.id))).toEqual(expected);
   });
+
+  it("an invalid order raises the ArgumentError batches.rb:324 raises", async () => {
+    await expect(
+      Post.inBatches({ of: 1, order: "invalid" as "asc" }).eachRecord(() => {}),
+    ).rejects.toThrow(
+      ':order must be :asc or :desc or an array consisting of :asc or :desc, got "invalid"',
+    );
+  });
+
+  it("an invalid order inside an array raises with the array inspected", async () => {
+    await expect(
+      Post.inBatches({ of: 1, cursor: ["id"], order: ["asc", "sideways"] as "asc"[] }).eachRecord(
+        () => {},
+      ),
+    ).rejects.toThrow(
+      ':order must be :asc or :desc or an array consisting of :asc or :desc, got ["asc", "sideways"]',
+    );
+  });
 });

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -3,8 +3,10 @@
  *
  * Mirrors: ActiveRecord::Batches
  */
+import { ArgumentError } from "@blazetrails/activemodel";
 import { kernelArray } from "@blazetrails/activesupport";
 import { WhereClause } from "./where-clause.js";
+import { rubyInspect } from "./ruby-inspect.js";
 import { ActiveRecord } from "../ar-config.js";
 import { stripThenable } from "./thenable.js";
 import { BatchEnumerator } from "./batches/batch-enumerator.js";
@@ -321,11 +323,10 @@ export async function ensureValidOptionsForBatchingBang(
     }
   }
 
-  const orderArr = Array.isArray(order) ? order : [order];
-  for (const o of orderArr) {
-    if (o !== "asc" && o !== "desc") {
-      throw new Error(`:order must be :asc or :desc, got ${String(o)}`);
-    }
+  if (kernelArray(order).filter((o) => o !== "asc" && o !== "desc").length > 0) {
+    throw new ArgumentError(
+      `:order must be :asc or :desc or an array consisting of :asc or :desc, got ${rubyInspect(order)}`,
+    );
   }
 }
 

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -323,7 +323,7 @@ export async function ensureValidOptionsForBatchingBang(
     }
   }
 
-  if (kernelArray(order).filter((o) => o !== "asc" && o !== "desc").length > 0) {
+  if (kernelArray(order).filter((o) => !["asc", "desc"].includes(o)).length > 0) {
     throw new ArgumentError(
       `:order must be :asc or :desc or an array consisting of :asc or :desc, got ${rubyInspect(order)}`,
     );

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -6,7 +6,6 @@
 import { ArgumentError } from "@blazetrails/activemodel";
 import { kernelArray } from "@blazetrails/activesupport";
 import { WhereClause } from "./where-clause.js";
-import { rubyInspect } from "./ruby-inspect.js";
 import { ActiveRecord } from "../ar-config.js";
 import { stripThenable } from "./thenable.js";
 import { BatchEnumerator } from "./batches/batch-enumerator.js";
@@ -324,8 +323,15 @@ export async function ensureValidOptionsForBatchingBang(
   }
 
   if (kernelArray(order).filter((o) => !["asc", "desc"].includes(o)).length > 0) {
+    // `:order` takes Symbols, which trails spells as bare strings (CLAUDE.md,
+    // "A Ruby Symbol is a JS string"), so the colon Ruby's `order.inspect`
+    // prints at batches.rb:324 has to be restored here for the message to read
+    // as it does in Rails.
+    const inspected = Array.isArray(order)
+      ? `[${order.map((o) => `:${o}`).join(", ")}]`
+      : `:${order}`;
     throw new ArgumentError(
-      `:order must be :asc or :desc or an array consisting of :asc or :desc, got ${rubyInspect(order)}`,
+      `:order must be :asc or :desc or an array consisting of :asc or :desc, got ${inspected}`,
     );
   }
 }


### PR DESCRIPTION
Converges `ensure_valid_options_for_batching!`'s `:order` validation onto
`vendor/rails/activerecord/lib/active_record/relation/batches.rb:323-325`:

```ruby
if (Array(order) - [:asc, :desc]).any?
  raise ArgumentError, ":order must be :asc or :desc or an array consisting of :asc or :desc, got #{order.inspect}"
end
```

- normalizes with `kernelArray` (the settled `Kernel#Array` spelling) instead of
  a bespoke `Array.isArray(order) ? order : [order]`;
- one set subtraction instead of a per-element loop, so the branch shape mirrors
  the Ruby;
- the message carries Rails' "or an array consisting of :asc or :desc" clause and
  the `inspect` rendering of the value, and raises `ArgumentError` rather than a
  bare `Error`.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are both clean; no new
rows.

`converge-apply-join-dependency-sync-eager-residue` is NOT in this PR — it has
been released back to the pool. Its only real convergence path is making
`Relation#toSql` (relation.rb:1210-1222) and the synchronous `.where()` /
`PredicateBuilder::RelationHandler#call` path async, since
`distinct_relation_for_primary_key` executes a query. `.where()` returns a
chainable Relation and cannot become async, and `Relation#toSql` has 400+ call
sites in the AR suite alone — the change is far past this PR's 700 LOC ceiling
and needs its own budget.

Closes-story: converge-batches-order-validation-kernel-array
