### PR TITLE
test(activemodel,activesupport): validations_test assertion parity — variadic validates, except_on, dup

### DIFF
--- a/packages/activemodel/src/dirty.trails.test.ts
+++ b/packages/activemodel/src/dirty.trails.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "./index.js";
+
+/**
+ * `dirty_test.rb` has no `dup` coverage, so these pin trails-only behaviour that
+ * has no Rails test to mirror. The expectations are transcribed from MRI run
+ * against `vendor/rails/activemodel` with `ActiveModel::Model` + `Attributes` +
+ * `Dirty`, since `Dirty#initialize_dup` (dirty.rb:248-251) is what they exercise.
+ */
+describe("Dirty across dup", () => {
+  class Topic extends Model {
+    static {
+      this.attribute("title", "string");
+      this.attribute("body", "string");
+    }
+
+    declare title: string | null;
+    declare body: string | null;
+  }
+
+  it("dup carries the source's pending changes", () => {
+    const t = new Topic({ title: "A" });
+    t.changesApplied();
+    t.title = "B";
+
+    const duped = t.dup();
+
+    // MRI: t.changes == dup.changes == {"title"=>["A", "B"]}
+    expect(duped.changes).toEqual(t.changes);
+    expect(duped.changes).toEqual({ title: ["A", "B"] });
+    expect(duped.changed).toBe(true);
+    expect(duped.attributeWas("title")).toEqual("A");
+  });
+
+  it("dup carries the source's previous changes", () => {
+    const t = new Topic({ title: "A" });
+    t.changesApplied();
+    t.title = "B";
+
+    // MRI: dup.previous_changes == t.previous_changes
+    expect(t.dup().previousChanges).toEqual(t.previousChanges);
+  });
+
+  it("writing to the dup does not dirty the source", () => {
+    const t = new Topic({ title: "A" });
+    const duped = t.dup();
+
+    duped.body = "new";
+
+    // MRI: mutating the dup leaves t.changes untouched.
+    expect(duped.changes).toEqual({ body: [null, "new"] });
+    expect(t.changes).toEqual({});
+    expect(t.changed).toBe(false);
+    expect(t.body).toBeNull();
+  });
+
+  it("writing to the source does not dirty the dup", () => {
+    const t = new Topic({ title: "A" });
+    const duped = t.dup();
+
+    t.body = "new";
+
+    expect(t.changes).toEqual({ body: [null, "new"] });
+    expect(duped.changes).toEqual({});
+    expect(duped.changed).toBe(false);
+  });
+
+  it("dup gives the copy its own tracker", () => {
+    const t = new Topic({ title: "A" });
+    const duped = t.dup();
+
+    expect(duped._dirty).not.toBe(t._dirty);
+  });
+
+  it("dup gives the copy its own errors", async () => {
+    Topic.validates("title", { presence: true });
+    try {
+      const t = new Topic({ title: "A" });
+      await t.isValid();
+
+      const duped = t.dup();
+      duped.title = null;
+      await duped.isInvalid();
+
+      expect(duped.errors.get("title")).toEqual(["can't be blank"]);
+      expect(t.errors.get("title")).toEqual([]);
+      expect(duped.errors).not.toBe(t.errors);
+    } finally {
+      Topic.clearValidatorsBang();
+    }
+  });
+});

--- a/packages/activemodel/src/dirty.trails.test.ts
+++ b/packages/activemodel/src/dirty.trails.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 
 /**
- * `dirty_test.rb` has no `dup` coverage, so these pin trails-only behaviour that
- * has no Rails test to mirror. The expectations are transcribed from MRI run
- * against `vendor/rails/activemodel` with `ActiveModel::Model` + `Attributes` +
- * `Dirty`, since `Dirty#initialize_dup` (dirty.rb:248-251) is what they exercise.
+ * `dirty_test.rb` has no `dup` coverage, so these pin trails-only behaviour with
+ * no Rails test to mirror. The expectations are transcribed from MRI run against
+ * `vendor/rails/activemodel` with `ActiveModel::Model` + `Attributes` + `Dirty`,
+ * since `Dirty#initialize_dup` (dirty.rb:248-251) is what they exercise.
  */
 describe("Dirty across dup", () => {
   class Topic extends Model {
@@ -30,15 +30,8 @@ describe("Dirty across dup", () => {
     expect(duped.changes).toEqual({ title: ["A", "B"] });
     expect(duped.changed).toBe(true);
     expect(duped.attributeWas("title")).toEqual("A");
-  });
-
-  it("dup carries the source's previous changes", () => {
-    const t = new Topic({ title: "A" });
-    t.changesApplied();
-    t.title = "B";
-
     // MRI: dup.previous_changes == t.previous_changes
-    expect(t.dup().previousChanges).toEqual(t.previousChanges);
+    expect(duped.previousChanges).toEqual(t.previousChanges);
   });
 
   it("writing to the dup does not dirty the source", () => {
@@ -47,7 +40,6 @@ describe("Dirty across dup", () => {
 
     duped.body = "new";
 
-    // MRI: mutating the dup leaves t.changes untouched.
     expect(duped.changes).toEqual({ body: [null, "new"] });
     expect(t.changes).toEqual({});
     expect(t.changed).toBe(false);
@@ -63,30 +55,5 @@ describe("Dirty across dup", () => {
     expect(t.changes).toEqual({ body: [null, "new"] });
     expect(duped.changes).toEqual({});
     expect(duped.changed).toBe(false);
-  });
-
-  it("dup gives the copy its own tracker", () => {
-    const t = new Topic({ title: "A" });
-    const duped = t.dup();
-
-    expect(duped._dirty).not.toBe(t._dirty);
-  });
-
-  it("dup gives the copy its own errors", async () => {
-    Topic.validates("title", { presence: true });
-    try {
-      const t = new Topic({ title: "A" });
-      await t.isValid();
-
-      const duped = t.dup();
-      duped.title = null;
-      await duped.isInvalid();
-
-      expect(duped.errors.get("title")).toEqual(["can't be blank"]);
-      expect(t.errors.get("title")).toEqual([]);
-      expect(duped.errors).not.toBe(t.errors);
-    } finally {
-      Topic.clearValidatorsBang();
-    }
   });
 });

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -81,6 +81,22 @@ export function attributePreviousChange(
 }
 
 /**
+ * Mirrors: ActiveModel::Dirty#attribute_will_change!
+ *
+ * Dispatch target for `*_will_change!` per-attribute methods. Force-marks
+ * an attribute as changed for in-place mutations (e.g. array push) where
+ * the object reference stays the same but the content has changed.
+ *
+ * @internal Rails-private helper.
+ */
+export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: string): unknown {
+  // Rails' receiver is `mutations_from_database` (dirty.rb:409-411); trails
+  // spells the mutation tracker `_dirty` — `mutationsFromDatabase` here is the
+  // Record-shaped reader over it, not the tracker itself.
+  return this._dirty.forceChange(attrName);
+}
+
+/**
  * Host shape consumed by `initInternals`.
  */
 export interface DirtyInternalsHost {
@@ -580,22 +596,6 @@ export class DirtyTracker {
 }
 
 /**
- * Mirrors: ActiveModel::Dirty#attribute_will_change!
- *
- * Dispatch target for `*_will_change!` per-attribute methods. Force-marks
- * an attribute as changed for in-place mutations (e.g. array push) where
- * the object reference stays the same but the content has changed.
- *
- * @internal Rails-private helper.
- */
-export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: string): unknown {
-  // Rails' receiver is `mutations_from_database` (dirty.rb:409-411); trails
-  // spells the mutation tracker `_dirty` — `mutationsFromDatabase` here is the
-  // Record-shaped reader over it, not the tracker itself.
-  return this._dirty.forceChange(attrName);
-}
-
-/**
  * Mirrors: ActiveModel::Dirty#restore_attribute!
  *
  * Dispatch target for `restore_*!` per-attribute methods. Restores the
@@ -605,6 +605,25 @@ export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: strin
  */
 export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string): void {
   this._dirty.restoreAttribute(this._attributes, attrName);
+}
+
+/**
+ * Mirrors Rails
+ *
+ *   def initialize_dup(other)
+ *     super
+ *     @mutations_from_database = nil
+ *   end
+ *
+ * (activemodel/lib/active_model/dirty.rb:248-251). Without it the copy shares the
+ * source's tracker, so writing to one marks the other dirty. As with
+ * {@link initInternals}, a fresh `DirtyTracker` is the reset — trails consolidates
+ * Rails' two mutation trackers into one.
+ *
+ * @internal Rails-private helper.
+ */
+export function initializeDup(this: DirtyInternalsHost, _other: unknown): void {
+  this._dirty = new DirtyTracker();
 }
 
 function resolveValue(value: unknown): unknown {

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -103,6 +103,11 @@ export interface DirtyInternalsHost {
   _dirty: DirtyTracker;
 }
 
+/** Host shape consumed by `initializeDup` — the duplicate, mid-`dup()`. */
+export interface DirtyDupHost extends DirtyInternalsHost {
+  _attributes: AttributeSet;
+}
+
 /**
  * Dirty tracking mixin — tracks attribute changes on a model.
  *
@@ -122,6 +127,35 @@ export class DirtyTracker {
     attributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },
   ): void {
     this.snapshot(attributes);
+  }
+
+  /**
+   * An independent tracker carrying this one's state, with `_attrs` repointed at
+   * `attrs` (the duplicate's own AttributeSet).
+   *
+   * @noRailsEquivalent CONVERGEABLE — story
+   * `0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments`,
+   * whose root cause is this same eager/lazy split; making `DirtyTracker` derive
+   * from the AttributeSet retires this method with it. Rails' `initialize_dup` only
+   * nils `@mutations_from_database` and lets it rebuild lazily from the
+   * already-deep-dup'd `@attributes`, which still carry each attribute's
+   * original-vs-current pair, so the rebuilt tracker reports the same `changes` as
+   * the source while being a distinct object. `DirtyTracker` instead holds an eager
+   * snapshot and derives `changes` from recorded writes, so it cannot reconstruct
+   * itself that way — copying the state is how the same two properties (equal
+   * state, distinct identity) are reached. Verified against MRI: `dup.changes` and
+   * `dup.previous_changes` both equal the source's, and writes to the copy do not
+   * leak back.
+   */
+  deepDup(attrs: AttributeSet): DirtyTracker {
+    const copy = new DirtyTracker();
+    copy._originalAttributes = new Map(this._originalAttributes);
+    copy._originalHas = new Set(this._originalHas);
+    copy._changedAttributes = new Map(this._changedAttributes);
+    copy._previousChanges = new Map(this._previousChanges);
+    copy._forcedNames = new Set(this._forcedNames);
+    copy._attrs = attrs;
+    return copy;
   }
 
   // Rails `Dirty#as_json` (dirty.rb:264-268) exists only to hide the
@@ -609,14 +643,16 @@ export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string):
 
 /**
  * Mirrors `Dirty#initialize_dup`'s `@mutations_from_database = nil`
- * (activemodel/lib/active_model/dirty.rb:248-251); without it the copy shares the
- * source's tracker, so writing to one marks the other dirty. As with
- * {@link initInternals}, a fresh `DirtyTracker` is the reset.
+ * (activemodel/lib/active_model/dirty.rb:248-251): give the copy its own tracker,
+ * so writing to one no longer marks the other dirty. Rails nils the ivar and lets
+ * it rebuild from the deep-dup'd `@attributes`, which reproduces the source's
+ * `changes` on the copy; {@link DirtyTracker.deepDup} is that rebuild, since a
+ * fresh empty tracker would instead wipe pending changes.
  *
  * @internal Rails-private helper.
  */
-export function initializeDup(this: DirtyInternalsHost, _other: unknown): void {
-  this._dirty = new DirtyTracker();
+export function initializeDup(this: DirtyDupHost, _other: unknown): void {
+  this._dirty = this._dirty.deepDup(this._attributes);
 }
 
 function resolveValue(value: unknown): unknown {

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -131,21 +131,18 @@ export class DirtyTracker {
 
   /**
    * An independent tracker carrying this one's state, with `_attrs` repointed at
-   * `attrs` (the duplicate's own AttributeSet).
+   * the duplicate's own AttributeSet.
    *
    * @noRailsEquivalent CONVERGEABLE — story
-   * `0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments`,
-   * whose root cause is this same eager/lazy split; making `DirtyTracker` derive
-   * from the AttributeSet retires this method with it. Rails' `initialize_dup` only
-   * nils `@mutations_from_database` and lets it rebuild lazily from the
-   * already-deep-dup'd `@attributes`, which still carry each attribute's
-   * original-vs-current pair, so the rebuilt tracker reports the same `changes` as
-   * the source while being a distinct object. `DirtyTracker` instead holds an eager
-   * snapshot and derives `changes` from recorded writes, so it cannot reconstruct
-   * itself that way — copying the state is how the same two properties (equal
-   * state, distinct identity) are reached. Verified against MRI: `dup.changes` and
-   * `dup.previous_changes` both equal the source's, and writes to the copy do not
-   * leak back.
+   * `0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments`
+   * shares this root cause; making `DirtyTracker` derive from the AttributeSet
+   * retires this method with it. Rails' `initialize_dup` just nils
+   * `@mutations_from_database` and lets it rebuild from the already-deep-dup'd
+   * `@attributes`, so the copy reports the source's `changes` yet is a distinct
+   * object. This tracker snapshots eagerly and derives changes from recorded
+   * writes, so it cannot rebuild that way; copying reaches the same two properties.
+   * MRI-verified: `dup.changes` and `dup.previous_changes` equal the source's, and
+   * writes to the copy do not leak back.
    */
   deepDup(attrs: AttributeSet): DirtyTracker {
     const copy = new DirtyTracker();

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -608,17 +608,10 @@ export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string):
 }
 
 /**
- * Mirrors Rails
- *
- *   def initialize_dup(other)
- *     super
- *     @mutations_from_database = nil
- *   end
- *
- * (activemodel/lib/active_model/dirty.rb:248-251). Without it the copy shares the
+ * Mirrors `Dirty#initialize_dup`'s `@mutations_from_database = nil`
+ * (activemodel/lib/active_model/dirty.rb:248-251); without it the copy shares the
  * source's tracker, so writing to one marks the other dirty. As with
- * {@link initInternals}, a fresh `DirtyTracker` is the reset — trails consolidates
- * Rails' two mutation trackers into one.
+ * {@link initInternals}, a fresh `DirtyTracker` is the reset.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -72,6 +72,15 @@ export class Errors<TBase extends object = object> {
    *     @errors = other.errors.deep_dup
    *     @errors.each { |error| error.instance_variable_set(:@base, @base) }
    *   end
+   *
+   * @missingRailsCall deep_dup — Language shortcoming: Rails dups the array and
+   * then rebases each copy with `instance_variable_set(:@base, ...)`, writing
+   * through `Error#base`'s reader. `base` is `readonly` in TS with no
+   * `instance_variable_set` escape hatch, so the rebase has to happen at
+   * construction — which is what `Error#dupWithBase` does, deep-dupping the
+   * options as it goes. The per-element dup Rails gets from `Array#deep_dup` is
+   * therefore fused into the same call rather than omitted; splitting them back
+   * out would dup every error twice to no effect.
    */
   copyBang<U extends object>(other: Errors<U>): void {
     this._errors = other._errors.map((e) => e.dupWithBase(this._base));

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -42,7 +42,11 @@ import {
 } from "./type/normalized-value.js";
 import { AttributeSet } from "./attribute-set.js";
 import { ModelLike, ModelName } from "./naming.js";
-import { DirtyTracker, initInternals as dirtyInitInternals } from "./dirty.js";
+import {
+  DirtyTracker,
+  initInternals as dirtyInitInternals,
+  initializeDup as dirtyInitializeDup,
+} from "./dirty.js";
 import {
   CallbackFn,
   AroundCallbackFn,
@@ -2133,9 +2137,17 @@ export class Model {
     return duped;
   }
 
-  /** Mirrors: ActiveModel::Validations#initialize_dup (validations.rb:310). */
+  /**
+   * Ruby chains one `initialize_dup` per included module through `super`. TS has
+   * no `super` across mixins, so this is the chain: `Validations` replaces
+   * `@errors` (validations.rb:310-313) and `Dirty` resets the mutation tracker
+   * (dirty.rb:248-251) — without the latter the copy shares the source's tracker
+   * and writing to one marks the other dirty.
+   */
   initializeDup(other: unknown): void {
     validationsInitializeDup.call(this, other);
+    dirtyInitializeDup.call(this, other);
+    this._dirty.initAttributes(this._attributes);
   }
 
   // -- Dirty tracking --

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -562,17 +562,16 @@ export class Model {
 
   // -- Validations (Phase 1100) --
 
+  /**
+   * Mirrors: ActiveModel::Validations::ClassMethods#validates (validates.rb:111-133).
+   * `validations` is `defaults.slice!(*_validates_default_keys)` — a validator key
+   * with a falsy value still counts here; `next unless options` (validates.rb:127)
+   * is what skips building it.
+   */
   static validates(...args: [...attributes: string[], rules: Record<string, unknown>]): void {
-    // Rails `validates(*attributes)` splits the trailing options hash off with
-    // `extract_options!` and stamps `defaults[:attributes] = attributes`
-    // (validates.rb:111-114), so every validator covers ALL the named attributes.
     const rules = args[args.length - 1] as Record<string, unknown>;
     const attributes = args.slice(0, -1) as string[];
 
-    // `defaults.slice!(*_validates_default_keys)` (validates.rb:112) splits the
-    // control keys out, leaving the validator keys. A falsy validator value still
-    // counts here — `next unless options` skips building it (validates.rb:127),
-    // which `test_validates_with_false_hash_value` pins.
     const validations = Object.keys(rules).filter((k) => !this._validatesDefaultKeys().includes(k));
 
     if (attributes.length === 0) {
@@ -697,12 +696,16 @@ export class Model {
     return this._attributeDefinitions.has(attribute);
   }
 
+  /**
+   * Mirrors: ActiveModel::Validations::ClassMethods#validate (validations.rb:160-185).
+   * The key check runs only under `args.all?(Symbol)` — a block validator may carry
+   * validator-ish keys. An unknown method name is a `send`-dispatched callback
+   * filter, so it raises `NoMethodError` at validation time, not registration time.
+   */
   static validate<T extends ValidatableRecord = ValidatableRecord>(
     methodOrFn: string | ((record: T) => unknown),
     options: ConditionalOptions = {},
   ): void {
-    // Rails validations.rb:163-169 runs the key check only when every positional
-    // arg is a method name — a block validator may carry validator-ish keys.
     if (typeof methodOrFn === "string") {
       for (const k of Object.keys(options)) {
         if (!(VALID_OPTIONS_FOR_VALIDATE as readonly string[]).includes(k)) {
@@ -729,9 +732,6 @@ export class Model {
       } else if (typeof r[methodOrFn] === "function") {
         return (r[methodOrFn] as () => void)();
       }
-      // Rails registers the Symbol as a callback filter and `send`s it when the
-      // chain runs, so an unknown name raises NoMethodError at validation time,
-      // not registration time (validations_test.rb:160-166).
       throw new NoMethodError(
         `undefined method '${methodOrFn}' for an instance of ${r.constructor.name}`,
       );
@@ -1504,6 +1504,13 @@ export class Model {
     }
   }
 
+  /**
+   * `exceptOn` mirrors Rails `except_on:` (validations.rb:175-182): an `unless:`
+   * intersecting `Array(except_on)` with `Array(o.validation_context)`, so a nil
+   * context never intersects and the validator still runs.
+   *
+   * @internal Rails-private helper.
+   */
   private static _buildValidateConditions(
     options: ConditionalOptions,
   ): CallbackConditions | undefined {
@@ -1526,9 +1533,6 @@ export class Model {
     }
 
     if (options.exceptOn !== undefined) {
-      // Rails validations.rb:175-182: `except_on` becomes an `unless:` intersecting
-      // `Array(except_on)` with `Array(o.validation_context)`, so a nil context
-      // never intersects and the validator still runs.
       const exceptOn = Array.isArray(options.exceptOn) ? options.exceptOn : [options.exceptOn];
       parts.push((record: object) => {
         const mc = (record as unknown as ValidationsContextHost).validationContext;
@@ -1900,10 +1904,13 @@ export class Model {
   // Array<Symbol> (or nil). `valid?([:create, :publish])` round-trips
   // the array so `on: :create` / `on: [:create]` / `on: [:create, :other]`
   // validators all fire. See `validations.rb:361-368` and `:294-306`.
-  // Rails has no `@validation_context` ivar: the context lives on the
-  // `ValidationContext` that `context_for_validation` memoizes (validations.rb:463-470).
-  // An accessor pair over it keeps every `record._validationContext` reader working
-  // while putting the *write* off the model, where `Object.freeze` can't block it.
+  /**
+   * Rails has no `@validation_context` ivar — the context lives on the
+   * `ValidationContext` (validations.rb:463-470). Writing through that object
+   * rather than a model field is what lets a frozen model be validated.
+   *
+   * @internal
+   */
   get _validationContext(): string | string[] | null {
     return this.contextForValidation().context;
   }
@@ -1950,6 +1957,11 @@ export class Model {
     return validationsRaiseValidationError.call(this);
   }
 
+  /**
+   * Mirrors: ActiveModel::Validations#valid? (validations.rb:361-368) — read the
+   * current context, write the new one through `context_for_validation`, restore
+   * in `ensure`.
+   */
   async isValid(context?: string | string[] | ValidationContext | null): Promise<boolean> {
     this.errors.clear();
     const ctor = this.constructor as typeof Model;
@@ -1970,8 +1982,6 @@ export class Model {
     } else {
       normalized = context;
     }
-    // Rails validations.rb:362-363: read the current context, write the new one
-    // through `context_for_validation`, restore in `ensure`.
     const currentContext = this.validationContext;
     this.contextForValidation().context = normalized;
 
@@ -2056,10 +2066,9 @@ export class Model {
   }
 
   /**
-   * Mirrors: ActiveModel::Validations::HelperMethods#validates_presence_of
-   * (validations/presence.rb:34-36). Rails both `extend`s and `include`s
-   * `HelperMethods` (validations.rb:45-46), so the helpers exist on the instance
-   * too and run on the spot — which is what a `validate do ... end` block calls.
+   * Mirrors: HelperMethods#validates_presence_of (validations/presence.rb:34-36).
+   * Rails both `extend`s and `include`s `HelperMethods` (validations.rb:45-46), so
+   * the helpers run on the spot on an instance — what a `validate do…end` calls.
    */
   async validatesPresenceOf(...attrNames: unknown[]): Promise<void> {
     await this.validatesWith(
@@ -2108,11 +2117,13 @@ export class Model {
   }
 
   /**
-   * Mirrors Ruby's `Object#dup`: allocate an instance of the same class, copy the
-   * ivars, dispatch `initialize_dup`. `Object.create(getPrototypeOf(this))` is
-   * the JS equivalent and, like Ruby `dup`, does NOT re-enter the constructor.
-   * `Attributes#initialize_dup` deep-dups `@attributes` (attributes.rb:111-114);
-   * `Validations#initialize_dup` replaces `@errors` (validations.rb:310-313).
+   * Mirrors Ruby's `Object#dup`: allocate, copy the ivars, dispatch
+   * `initialize_dup`; like Ruby `dup` it does NOT re-enter the constructor, and
+   * the copy is unfrozen even from a frozen source. Rails splits the hook across
+   * two modules chained by `super` — `Attributes#initialize_dup` deep-dups
+   * `@attributes` (attributes.rb:111-114), `Validations#initialize_dup` replaces
+   * `@errors` (validations.rb:310-313). TS has no `super` across mixins, so both
+   * land here, the second through {@link initializeDup}.
    */
   dup(): this {
     const duped = Object.create(Object.getPrototypeOf(this) as object) as this;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -3,6 +3,7 @@ import {
   ValidationContext,
   ValidationsContextHost,
   initInternals as validationsInitInternals,
+  initializeDup as validationsInitializeDup,
   contextForValidation as validationsContextForValidation,
   runValidationsBang as validationsRunValidationsBang,
   raiseValidationError as validationsRaiseValidationError,
@@ -10,6 +11,7 @@ import {
   _mergeAttributes as validationsMergeAttributes,
   _validatesDefaultKeys as validationsValidatesDefaultKeys,
   _parseValidatesOptions as validationsParseValidatesOptions,
+  VALID_OPTIONS_FOR_VALIDATE,
   readAttributeForValidation as validationsReadAttributeForValidation,
 } from "./validations.js";
 import { sanitizeForbiddenAttributes as forbiddenSanitize } from "./forbidden-attributes-protection.js";
@@ -92,6 +94,7 @@ import {
   assertHashAttributes,
   isMassAssignmentEmpty,
   ArgumentError,
+  NoMethodError,
 } from "./attribute-assignment.js";
 import { PresenceValidator } from "./validations/presence.js";
 import { AbsenceValidator } from "./validations/absence.js";
@@ -559,8 +562,28 @@ export class Model {
 
   // -- Validations (Phase 1100) --
 
-  static validates(attribute: string, rules: Record<string, unknown>): void {
+  static validates(...args: [...attributes: string[], rules: Record<string, unknown>]): void {
+    // Rails `validates(*attributes)` splits the trailing options hash off with
+    // `extract_options!` and stamps `defaults[:attributes] = attributes`
+    // (validates.rb:111-114), so every validator covers ALL the named attributes.
+    const rules = args[args.length - 1] as Record<string, unknown>;
+    const attributes = args.slice(0, -1) as string[];
+
+    // `defaults.slice!(*_validates_default_keys)` (validates.rb:112) splits the
+    // control keys out, leaving the validator keys. A falsy validator value still
+    // counts here — `next unless options` skips building it (validates.rb:127),
+    // which `test_validates_with_false_hash_value` pins.
+    const validations = Object.keys(rules).filter((k) => !this._validatesDefaultKeys().includes(k));
+
+    if (attributes.length === 0) {
+      throw new ArgumentError("You need to supply at least one attribute");
+    }
+    if (validations.length === 0) {
+      throw new ArgumentError("You need to supply at least one validation");
+    }
+
     const onContext = rules.on as string | undefined;
+    const exceptOnContext = rules.exceptOn as string | string[] | undefined;
     const ifCond = rules.if as ConditionFn | ConditionFn[] | undefined;
     const unlessCond = rules.unless as ConditionFn | ConditionFn[] | undefined;
     const isStrict = rules.strict as boolean | undefined;
@@ -569,6 +592,7 @@ export class Model {
 
     const shared: Record<string, unknown> = {};
     if (onContext !== undefined) shared.on = onContext;
+    if (exceptOnContext !== undefined) shared.exceptOn = exceptOnContext;
     if (ifCond !== undefined) shared.if = ifCond;
     if (unlessCond !== undefined) shared.unless = unlessCond;
     if (isStrict) shared.strict = true;
@@ -653,12 +677,14 @@ export class Model {
     }
 
     for (const { klass, opts } of validatorSpecs) {
-      this.validatesWith(klass, { ...opts, attributes: [attribute], ...shared });
+      this.validatesWith(klass, { ...opts, attributes, ...shared });
     }
   }
 
-  static validatesBang(attribute: string, rules: Record<string, unknown>): void {
-    this.validates(attribute, { ...rules, strict: true });
+  static validatesBang(...args: [...attributes: string[], rules: Record<string, unknown>]): void {
+    const rules = args[args.length - 1] as Record<string, unknown>;
+    const attributes = args.slice(0, -1) as string[];
+    this.validates(...attributes, { ...rules, strict: true });
   }
 
   static clearValidatorsBang(): void {
@@ -675,6 +701,18 @@ export class Model {
     methodOrFn: string | ((record: T) => unknown),
     options: ConditionalOptions = {},
   ): void {
+    // Rails validations.rb:163-169 runs the key check only when every positional
+    // arg is a method name — a block validator may carry validator-ish keys.
+    if (typeof methodOrFn === "string") {
+      for (const k of Object.keys(options)) {
+        if (!(VALID_OPTIONS_FOR_VALIDATE as readonly string[]).includes(k)) {
+          throw new ArgumentError(
+            `Unknown key: :${k}. Valid keys are: ${VALID_OPTIONS_FOR_VALIDATE.map((v) => `:${v}`).join(", ")}. Perhaps you meant to call \`validates\` instead of \`validate\`?`,
+          );
+        }
+      }
+    }
+
     const fn: CallbackFn = (record: object) => {
       // Return the underlying result so a Promise-returning validator flows
       // into the callback runner, which awaits it (RFC 0063 made the validation
@@ -691,6 +729,12 @@ export class Model {
       } else if (typeof r[methodOrFn] === "function") {
         return (r[methodOrFn] as () => void)();
       }
+      // Rails registers the Symbol as a callback filter and `send`s it when the
+      // chain runs, so an unknown name raises NoMethodError at validation time,
+      // not registration time (validations_test.rb:160-166).
+      throw new NoMethodError(
+        `undefined method '${methodOrFn}' for an instance of ${r.constructor.name}`,
+      );
     };
     _registerCallbackOnProto(
       this.prototype,
@@ -750,8 +794,20 @@ export class Model {
         ? {}
         : ((args.pop() as ConditionalOptions & { strict?: boolean; [key: string]: unknown }) ?? {});
 
-    const { if: ifOpt, unless: unlessOpt, on: onOpt, strict: isStrict, ...rest } = options;
-    const conditions = this._buildValidateConditions({ if: ifOpt, unless: unlessOpt, on: onOpt });
+    const {
+      if: ifOpt,
+      unless: unlessOpt,
+      on: onOpt,
+      exceptOn: exceptOnOpt,
+      strict: isStrict,
+      ...rest
+    } = options;
+    const conditions = this._buildValidateConditions({
+      if: ifOpt,
+      unless: unlessOpt,
+      on: onOpt,
+      exceptOn: exceptOnOpt,
+    });
 
     // Extract the explicit `attributes:` option so we can route the validator
     // into the right bucket even when the validator class doesn't expose
@@ -1469,6 +1525,18 @@ export class Model {
       );
     }
 
+    if (options.exceptOn !== undefined) {
+      // Rails validations.rb:175-182: `except_on` becomes an `unless:` intersecting
+      // `Array(except_on)` with `Array(o.validation_context)`, so a nil context
+      // never intersects and the validator still runs.
+      const exceptOn = Array.isArray(options.exceptOn) ? options.exceptOn : [options.exceptOn];
+      parts.push((record: object) => {
+        const mc = (record as unknown as ValidationsContextHost).validationContext;
+        const current = mc == null ? [] : Array.isArray(mc) ? mc : [mc];
+        return !exceptOn.some((c) => current.includes(c));
+      });
+    }
+
     if (options.unless !== undefined) {
       const conds = Array.isArray(options.unless) ? options.unless : [options.unless];
       parts.push(
@@ -1476,10 +1544,11 @@ export class Model {
       );
     }
 
-    if (parts.length === 0) return undefined;
+    if (parts.length === 0) return options.prepend ? { prepend: true } : undefined;
 
     return {
       if: (record: object) => parts.every((fn) => fn(record)),
+      ...(options.prepend ? { prepend: true } : {}),
     };
   }
 
@@ -1831,11 +1900,21 @@ export class Model {
   // Array<Symbol> (or nil). `valid?([:create, :publish])` round-trips
   // the array so `on: :create` / `on: [:create]` / `on: [:create, :other]`
   // validators all fire. See `validations.rb:361-368` and `:294-306`.
-  _validationContext: string | string[] | null = null;
+  // Rails has no `@validation_context` ivar: the context lives on the
+  // `ValidationContext` that `context_for_validation` memoizes (validations.rb:463-470).
+  // An accessor pair over it keeps every `record._validationContext` reader working
+  // while putting the *write* off the model, where `Object.freeze` can't block it.
+  get _validationContext(): string | string[] | null {
+    return this.contextForValidation().context;
+  }
+
+  set _validationContext(value: string | string[] | null) {
+    this.contextForValidation().context = value;
+  }
 
   /**
-   * Lazy-initialized live `ValidationContext` view. Populated on first
-   * call to `contextForValidation()` and cleared by `initInternals()`.
+   * Lazy-initialized `ValidationContext`, which owns the active context. Set on
+   * first `contextForValidation()` call and cleared by `initInternals()`.
    *
    * @internal
    */
@@ -1843,8 +1922,7 @@ export class Model {
 
   /**
    * Lazy accessor for the active `ValidationContext`. Mirrors Rails
-   * `context_for_validation` (validations.rb:463-465). The returned
-   * object's `.context` property is a live view of `_validationContext`.
+   * `context_for_validation` (validations.rb:463-465).
    *
    * @internal Rails-private helper.
    */
@@ -1892,8 +1970,10 @@ export class Model {
     } else {
       normalized = context;
     }
-    const prevContext = this._validationContext;
-    this._validationContext = normalized;
+    // Rails validations.rb:362-363: read the current context, write the new one
+    // through `context_for_validation`, restore in `ensure`.
+    const currentContext = this.validationContext;
+    this.contextForValidation().context = normalized;
 
     try {
       // Rails: `run_validations!` is the block, and its truthy return becomes
@@ -1905,7 +1985,7 @@ export class Model {
       if (!completed) return false;
       return this.errors.empty;
     } finally {
-      this._validationContext = prevContext;
+      this.contextForValidation().context = currentContext;
     }
   }
 
@@ -1976,6 +2056,27 @@ export class Model {
   }
 
   /**
+   * Mirrors: ActiveModel::Validations::HelperMethods#validates_presence_of
+   * (validations/presence.rb:34-36). Rails both `extend`s and `include`s
+   * `HelperMethods` (validations.rb:45-46), so the helpers exist on the instance
+   * too and run on the spot — which is what a `validate do ... end` block calls.
+   */
+  async validatesPresenceOf(...attrNames: unknown[]): Promise<void> {
+    await this.validatesWith(
+      PresenceValidator,
+      (this.constructor as typeof Model)._mergeAttributes([...attrNames]),
+    );
+  }
+
+  /** Mirrors: HelperMethods#validates_length_of (validations/length.rb:123-125). */
+  async validatesLengthOf(...attrNames: unknown[]): Promise<void> {
+    await this.validatesWith(
+      LengthValidator,
+      (this.constructor as typeof Model)._mergeAttributes([...attrNames]),
+    );
+  }
+
+  /**
    * Freeze this model instance. Mirrors Rails
    * `ActiveModel::Validations#freeze` (activemodel/lib/active_model/validations.rb:372-377):
    *
@@ -2004,6 +2105,26 @@ export class Model {
     void this.contextForValidation();
     Object.freeze(this);
     return this;
+  }
+
+  /**
+   * Mirrors Ruby's `Object#dup`: allocate an instance of the same class, copy the
+   * ivars, dispatch `initialize_dup`. `Object.create(getPrototypeOf(this))` is
+   * the JS equivalent and, like Ruby `dup`, does NOT re-enter the constructor.
+   * `Attributes#initialize_dup` deep-dups `@attributes` (attributes.rb:111-114);
+   * `Validations#initialize_dup` replaces `@errors` (validations.rb:310-313).
+   */
+  dup(): this {
+    const duped = Object.create(Object.getPrototypeOf(this) as object) as this;
+    Object.assign(duped, this);
+    duped._attributes = this._attributes.deepDup();
+    duped.initializeDup(this);
+    return duped;
+  }
+
+  /** Mirrors: ActiveModel::Validations#initialize_dup (validations.rb:310). */
+  initializeDup(other: unknown): void {
+    validationsInitializeDup.call(this, other);
   }
 
   // -- Dirty tracking --

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2141,8 +2141,14 @@ export class Model {
    * Ruby chains one `initialize_dup` per included module through `super`. TS has
    * no `super` across mixins, so this is the chain: `Validations` replaces
    * `@errors` (validations.rb:310-313) and `Dirty` resets the mutation tracker
-   * (dirty.rb:248-251) — without the latter the copy shares the source's tracker
-   * and writing to one marks the other dirty.
+   * (dirty.rb:248-251) — without the latter the copy shares the source's tracker,
+   * so writing to one marks the other dirty.
+   *
+   * The `initAttributes` call has no counterpart in Rails because it needs none:
+   * Ruby's tracker derives its baseline lazily from the duped `Attribute` objects,
+   * which carry their own `original_value`. `DirtyTracker` holds an eager snapshot
+   * instead, so the fresh one has to be seeded from the duped attributes or
+   * `attributeWas` on the copy reads `undefined`.
    */
   initializeDup(other: unknown): void {
     validationsInitializeDup.call(this, other);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2142,18 +2142,13 @@ export class Model {
    * no `super` across mixins, so this is the chain: `Validations` replaces
    * `@errors` (validations.rb:310-313) and `Dirty` resets the mutation tracker
    * (dirty.rb:248-251) — without the latter the copy shares the source's tracker,
-   * so writing to one marks the other dirty.
-   *
-   * The `initAttributes` call has no counterpart in Rails because it needs none:
-   * Ruby's tracker derives its baseline lazily from the duped `Attribute` objects,
-   * which carry their own `original_value`. `DirtyTracker` holds an eager snapshot
-   * instead, so the fresh one has to be seeded from the duped attributes or
-   * `attributeWas` on the copy reads `undefined`.
+   * so writing to one marks the other dirty. Both hooks run after `dup()` has
+   * deep-dup'd `_attributes`, matching the point in Rails' chain where
+   * `Attributes#initialize_dup` has already replaced `@attributes`.
    */
   initializeDup(other: unknown): void {
     validationsInitializeDup.call(this, other);
     dirtyInitializeDup.call(this, other);
-    this._dirty.initAttributes(this._attributes);
   }
 
   // -- Dirty tracking --

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { assert, assertEmpty, assertPredicate } from "@blazetrails/activesupport";
-import { LengthValidator, Model, PresenceValidator, Validator } from "./index.js";
+import {
+  assert,
+  assertEmpty,
+  assertNot,
+  assertNotEmpty,
+  assertNothingRaised,
+  assertNotPredicate,
+  assertPredicate,
+  assertRaises,
+} from "@blazetrails/activesupport";
+import {
+  ArgumentError,
+  LengthValidator,
+  Model,
+  NoMethodError,
+  PresenceValidator,
+  StrictValidationFailed,
+  ValidationError,
+  Validator,
+} from "./index.js";
+import type { ConditionalOptions } from "./validator.js";
 import { FormatValidator } from "./validations/format.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
@@ -618,43 +637,62 @@ describe("ValidationsTest", () => {
   });
 
   it("invalid should be the opposite of valid", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    expect(await new Person({}).isInvalid()).toBe(true);
-    expect(await new Person({ name: "Alice" }).isInvalid()).toBe(false);
+    Topic.validatesPresenceOf("title");
+
+    const t = new Topic();
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    assertPredicate(t.errors.get("title"), (messages) => messages.length > 0);
+
+    t.title = "Things are going to change";
+    assertNotPredicate(await t.isInvalid(), (invalid) => invalid);
   });
 
   it("validation order", async () => {
-    const order: string[] = [];
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("email", "string");
-        this.validate((_record: any) => {
-          order.push("name_check");
-        });
-        this.validate((_record: any) => {
-          order.push("email_check");
-        });
-      }
-    }
-    await new Person({}).isValid();
-    expect(order).toEqual(["name_check", "email_check"]);
+    Topic.validatesPresenceOf("title");
+    Topic.validatesLengthOf("title", { minimum: 2 });
+
+    let t = new Topic({ title: "" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")[0]).toEqual("can't be blank");
+    Topic.validatesPresenceOf("title", "author_name");
+    Topic.validate(function (this: Topic) {
+      this.errors.add("author_email_address", "will never be valid");
+    });
+    Topic.validatesLengthOf("title", "content", { minimum: 2 });
+
+    t = new Topic({ title: "" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+
+    let key: string;
+    expect((key = t.errors.attributeNames[0])).toEqual("title");
+    expect(t.errors.get(key)[0]).toEqual("can't be blank");
+    expect(t.errors.get(key)[1]).toEqual("is too short (minimum is 2 characters)");
+    expect((key = t.errors.attributeNames[1])).toEqual("author_name");
+    expect(t.errors.get(key)[0]).toEqual("can't be blank");
+    expect((key = t.errors.attributeNames[2])).toEqual("author_email_address");
+    expect(t.errors.get(key)[0]).toEqual("will never be valid");
+    expect((key = t.errors.attributeNames[3])).toEqual("content");
+    expect(t.errors.get(key)[0]).toEqual("is too short (minimum is 2 characters)");
   });
 
   it("validation with if and on", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create", if: () => true });
-      }
-    }
-    expect(await new Person({}).isValid()).toBe(true); // no context
-    expect(await new Person({}).isValid("create")).toBe(false); // with context
+    Topic.validatesPresenceOf("title", {
+      if: (x: Topic) => {
+        x.author_name = "bad";
+        return true;
+      },
+      on: "update",
+    });
+
+    const t = new Topic({ title: "" });
+
+    // If block should not fire
+    assertPredicate(await t.isValid(), (valid) => valid);
+    assertPredicate(t.author_name, (authorName) => authorName == null);
+
+    // If block should fire
+    assert(await t.isInvalid("update"));
+    assert(t.author_name === "bad");
   });
 
   it("strict validation in validates", async () => {
@@ -668,13 +706,8 @@ describe("ValidationsTest", () => {
   });
 
   it("strict validation not fails", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, strict: true });
-      }
-    }
-    expect(await new Person({ name: "Alice" }).isValid()).toBe(true);
+    Topic.validates("title", { strict: true, presence: true });
+    assertPredicate(await new Topic({ title: "hello" }).isValid(), (valid) => valid);
   });
 
   it("list of validators for model", () => {
@@ -704,27 +737,24 @@ describe("ValidationsTest", () => {
   });
 
   it("validate with bang", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    await expect(new Person({}).validateBang()).rejects.toThrow();
-    expect(await new Person({ name: "Alice" }).validateBang()).toBe(true);
+    Topic.validates("title", { presence: true });
+
+    await assertRaises([ValidationError], {}, async () => {
+      await new Topic().validateBang();
+    });
   });
 
   it("errors to json", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person({});
-    await p.isValid();
-    const json = p.errors.asJson();
-    expect(json.name.length).toBeGreaterThan(0);
+    Topic.validatesPresenceOf(["title", "content"]);
+    const t = new Topic();
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+
+    const hash: Record<string, string[]> = {};
+    hash.title = ["can't be blank"];
+    hash.content = ["can't be blank"];
+    // Rails' `to_json` is the `Object#to_json` core_ext (`as_json.to_json` for
+    // Errors); trails has no port of it, so both sides serialize the JS way.
+    expect(JSON.stringify(t.errors.asJson())).toEqual(JSON.stringify(hash));
   });
 
   it("does not modify options argument", () => {
@@ -739,14 +769,8 @@ describe("ValidationsTest", () => {
   });
 
   it("validates with false hash value", async () => {
-    // When presence is false, no validation should be added
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    Person.validates("name", { presence: false });
-    expect(await new Person({}).isValid()).toBe(true);
+    Topic.validates("title", { presence: false });
+    assertPredicate(await new Topic().isValid(), (valid) => valid);
   });
 
   it("validates with bang", async () => {
@@ -761,26 +785,23 @@ describe("ValidationsTest", () => {
   });
 
   it("validate with bang and context", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person();
-    await expect(p.validateBang()).rejects.toThrow(/Validation failed/);
+    Topic.validates("title", { presence: true, on: "context" });
+
+    await assertRaises([ValidationError], {}, async () => {
+      await new Topic().validateBang("context");
+    });
+
+    const t = new Topic({ title: "Valid title" });
+    assert(await t.validateBang("context"));
   });
 
   it("strict validation error message", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person();
-    await p.isValid();
-    expect(p.errors.fullMessages.join(", ")).toContain("can't be blank");
+    Topic.validates("title", { strict: true, presence: true });
+
+    const exception = await assertRaises([StrictValidationFailed], {}, async () => {
+      await new Topic().isValid();
+    });
+    expect(exception.message).toEqual("Title can't be blank");
   });
 
   it("validation with message as proc that takes a record as a parameter", async () => {
@@ -794,29 +815,25 @@ describe("ValidationsTest", () => {
   });
 
   it("frozen models can be validated", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    // We can't truly freeze JS objects with Maps inside,
-    // but we can verify validation works after model creation
-    expect(await p.isValid()).toBe(true);
+    Person.validates("title", { presence: true });
+    const person = new Person().freeze();
+    assertPredicate(person, (p) => Object.isFrozen(p));
+    assertNot(await person.isValid());
   });
 
   it("dup validity is independent", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p1 = new Person({ name: "Alice" });
-    const p2 = new Person();
-    expect(await p1.isValid()).toBe(true);
-    expect(await p2.isValid()).toBe(false);
+    Topic.validatesPresenceOf("title");
+    const topic = new Topic({ title: "Literature" });
+    await topic.isValid();
+
+    const duped = topic.dup();
+    duped.title = null;
+    assertPredicate(await duped.isInvalid(), (invalid) => invalid);
+
+    topic.title = null;
+    duped.title = "Mathematics";
+    assertPredicate(await topic.isInvalid(), (invalid) => invalid);
+    assertPredicate(await duped.isValid(), (valid) => valid);
   });
 
   it("validates an undeclared getter via the send default", async () => {
@@ -882,35 +899,51 @@ describe("ValidationsTest", () => {
     assertEmpty(opts);
   });
 
-  it("invalid validator", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    // validates with empty rules should not throw
-    expect(() => Person.validates("name", {})).not.toThrow();
+  it("invalid validator", async () => {
+    Topic.validate("iDontExist");
+    await assertRaises([NoMethodError], {}, async () => {
+      const t = new Topic();
+      await t.isValid();
+    });
   });
 
-  it("invalid options to validate", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(() => Person.validates("name", {})).not.toThrow();
+  it("invalid options to validate", async () => {
+    const error = await assertRaises([ArgumentError], {}, () => {
+      // A common mistake -- we meant to call 'validates'
+      Topic.validate("title", { presence: true } as unknown as ConditionalOptions);
+    });
+    const message =
+      "Unknown key: :presence. Valid keys are: :on, :if, :unless, :prepend, :exceptOn. Perhaps you meant to call `validates` instead of `validate`?";
+    expect(error.message).toEqual(message);
   });
 
   it("callback options to validate", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create" });
+    class Klass extends Topic {
+      callSequence: string[] = [];
+
+      private validatorA(): void {
+        this.callSequence.push("a");
+      }
+
+      private validatorB(): void {
+        this.callSequence.push("b");
+      }
+
+      private validatorC(): void {
+        this.callSequence.push("c");
       }
     }
-    const p = new Person({});
-    expect(await p.isValid()).toBe(true);
-    expect(await p.isValid("create")).toBe(false);
+
+    await assertNothingRaised(() => {
+      Klass.validate("validatorA", { if: () => true });
+      Klass.validate("validatorB", { prepend: true });
+      Klass.validate("validatorC", { unless: () => true });
+    });
+
+    const t = new Klass();
+
+    assertPredicate(await t.isValid(), (valid) => valid);
+    expect(t.callSequence).toEqual(["b", "a"]);
   });
 
   it("accessing instance of validator on an attribute", () => {
@@ -930,33 +963,33 @@ describe("ValidationsTest", () => {
   });
 
   it("validation with message as proc that takes record and data as a parameters", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", {
-          presence: {
-            message: (record: any) => `${record.constructor.name} needs a name`,
-          },
-        });
-      }
-    }
-    const p = new Person({});
-    await p.isValid();
-    expect(p.errors.get("name")[0]).toContain("needs a name");
+    Topic.validatesPresenceOf("title", {
+      message: (record: Topic, data: { attribute: string }) =>
+        `${data.attribute} is missing. You have failed me for the last time, ${record.author_name}.`,
+    });
+
+    const t = new Topic({ author_name: "Admiral" });
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual([
+      "Title is missing. You have failed me for the last time, Admiral.",
+    ]);
   });
 
   it("validations some with except", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-        this.validates("name", { presence: true });
-        this.validates("age", { numericality: true, on: "create" });
-      }
-    }
-    const p = new Person({ age: "abc" });
-    // Without context, only name validation runs
-    expect(await p.isValid()).toBe(false);
+    Topic.validates("title", {
+      presence: { exceptOn: "custom_context" },
+      length: { maximum: 10 },
+    });
+
+    await assertRaises([ValidationError], {}, async () => {
+      await new Topic().validateBang();
+    });
+
+    await assertRaises([ValidationError], {}, async () => {
+      await new Topic({ title: "A".repeat(11) }).validateBang("custom_context");
+    });
+
+    assert(await new Topic().validateBang("custom_context"));
   });
 
   it("validates format of with multiline regexp should raise error", () => {
@@ -982,77 +1015,36 @@ describe("ValidationsTest", () => {
   });
 
   it("validations on the instance level", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validate(function (record: any) {
-          if (record.readAttribute("name") === "invalid") {
-            record.errors.add("name", ":invalid", { message: "is not allowed" });
-          }
-        });
-      }
-    }
-    const p = new Person({ name: "invalid" });
-    expect(await p.isValid()).toBe(false);
-    expect(p.errors.get("name")).toEqual(["is not allowed"]);
+    Topic.validates("title", "author_name", { presence: true });
+    Topic.validates("content", { length: { minimum: 10 } });
+
+    const topic = new Topic();
+    assertPredicate(await topic.isInvalid(), (invalid) => invalid);
+    expect(topic.errors.size).toEqual(3);
+
+    topic.title = "Some Title";
+    topic.author_name = "Some Author";
+    topic.content = "Some Content Whose Length is more than 10.";
+    assertPredicate(await topic.isValid(), (valid) => valid);
   });
 
   it("validate with except on", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true, on: "create" });
-      }
-    }
-    const p = new Person();
-    // Without context, "on: create" validations should not run
-    expect(await p.isValid()).toBe(true);
-    // With matching context, they should run
-    expect(await p.isValid("create")).toBe(false);
-  });
+    Topic.validates("title", { presence: true, exceptOn: "custom_context" });
 
-  it("frozen models can be validated", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    // Object.freeze doesn't prevent our validation from reading
-    // (we can't truly freeze a Model, but we can test that validation works)
-    expect(await p.isValid()).toBe(true);
-  });
+    const topic = new Topic();
+    await topic.validate();
 
-  it("dup validity is independent", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", { presence: true });
-      }
-    }
-    const p1 = new Person({ name: "Alice" });
-    const p2 = new Person();
-    expect(await p1.isValid()).toBe(true);
-    expect(await p2.isValid()).toBe(false);
-    // p1's validity should not be affected by p2
-    expect(p1.errors.empty).toBe(true);
+    expect(topic.errors.get("title")).toEqual(["can't be blank"]);
+
+    assert(await topic.validate("custom_context"));
   });
 
   it("validation with message as proc", async () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.validates("name", {
-          presence: {
-            message: (_record: any) => `name is required for record`,
-          },
-        });
-      }
-    }
-    const p = new Person();
-    expect(await p.isValid()).toBe(false);
-    expect(p.errors.get("name")).toEqual(["name is required for record"]);
+    Topic.validatesPresenceOf("title", { message: () => "no blanks here".toUpperCase() });
+
+    const t = new Topic();
+    assertPredicate(await t.isInvalid(), (invalid) => invalid);
+    expect(t.errors.get("title")).toEqual(["NO BLANKS HERE"]);
   });
 
   it("list of validators on multiple attributes", () => {
@@ -1067,19 +1059,16 @@ describe("ValidationsTest", () => {
   });
 
   it("validate", async () => {
-    class Topic extends Model {
-      static {
-        this.attribute("title", "string");
-        this.attribute("content", "string");
-      }
-    }
-    Topic.validate((t: any) => {
-      if (!t.readAttribute("title")) t.errors.add("title", ":blank");
+    Topic.validate(async function (this: Topic) {
+      await this.validatesPresenceOf("title", "author_name");
+      await this.validatesLengthOf("content", { minimum: 10 });
     });
-    const topic = new Topic({});
-    expect(topic.errors.empty).toBe(true);
+
+    const topic = new Topic();
+    assertEmpty(topic.errors);
+
     await topic.validate();
-    expect(topic.errors.get("title")).toContain("can't be blank");
+    assertNotEmpty(topic.errors);
   });
 
   it("strict validation particular validator", async () => {

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -752,8 +752,7 @@ describe("ValidationsTest", () => {
     const hash: Record<string, string[]> = {};
     hash.title = ["can't be blank"];
     hash.content = ["can't be blank"];
-    // Rails' `to_json` is the `Object#to_json` core_ext (`as_json.to_json` for
-    // Errors); trails has no port of it, so both sides serialize the JS way.
+    // Deviation: Rails' `to_json` is the `Object#to_json` core_ext, unported.
     expect(JSON.stringify(t.errors.asJson())).toEqual(JSON.stringify(hash));
   });
 

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -267,7 +267,6 @@ const _predicatesForValidationContexts = new Map<
  */
 export function initInternals<TBase extends object>(this: ValidationsInternalsHost<TBase>): void {
   this.errors = new Errors(this as unknown as TBase);
-  this._validationContext = null;
   this._contextForValidation = undefined;
 }
 

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -80,16 +80,14 @@ export interface ValidationsInternalsHost<TBase extends object = object> {
  * Lazy per-instance accessor for the active `ValidationContext`.
  * Mirrors Rails
  * `def context_for_validation; @context_for_validation ||= ValidationContext.new; end`
- * (activemodel/lib/active_model/validations.rb:463-465). The returned object
- * owns the active context; the model's `_validationContext` reads through it.
+ * (activemodel/lib/active_model/validations.rb:463-465). The returned object owns
+ * the active context — Rails keeps it here, not in a model ivar (:503-505, :361-368),
+ * which is what lets a frozen model be validated.
  *
  * @internal Rails-private helper.
  */
 export function contextForValidation(this: ContextForValidationHost): ValidationContext {
   if (this._contextForValidation) return this._contextForValidation;
-  // Rails keeps the active context *here*, not on the model
-  // (validations.rb:503-505 + :361-368) — which is what lets a frozen model be
-  // validated: `valid?` writes `context_for_validation.context`, never an ivar.
   const vc = new ValidationContext();
   this._contextForValidation = vc;
   return vc;
@@ -287,12 +285,9 @@ export async function runValidationsBang(this: RunValidationsHost): Promise<bool
 }
 
 /**
- * The only option keys `validate` accepts. Anything else is the common
- * mistake of reaching for `validate` when `validates` was meant, and raises
- * `ArgumentError`. Mirrors Rails `VALID_OPTIONS_FOR_VALIDATE`
- * (activemodel/lib/active_model/validations.rb:92) — the keys carry their trails
- * camelCase spelling (`exceptOn` for `:except_on`), which is what a caller
- * actually passes and so what the raised message has to name back to them.
+ * Mirrors Rails `VALID_OPTIONS_FOR_VALIDATE` (validations.rb:92). The keys carry
+ * their trails camelCase spelling (`exceptOn` for `:except_on`) — what a caller
+ * actually passes, so what the raised message must name back to them.
  */
 export const VALID_OPTIONS_FOR_VALIDATE = ["on", "if", "unless", "prepend", "exceptOn"] as const;
 
@@ -387,10 +382,11 @@ export interface ReadAttributeForValidationHost {
 }
 
 /**
- * Give the duplicate a fresh, empty `Errors` rather than sharing the source's.
  * Mirrors Rails `initialize_dup` (validations.rb:310-313), which nils `@errors`
  * and lets `errors_or_create` rebuild it lazily; trails initializes `errors`
- * eagerly, so this assigns the replacement here — as {@link initInternals} does.
+ * eagerly, so this assigns the replacement, as {@link initInternals} does. Like
+ * Rails it leaves `@context_for_validation` aliased to the source's — `valid?`
+ * sets and restores the context per run, so the copy is never observed in flight.
  *
  * @internal Rails-private helper.
  */
@@ -399,8 +395,6 @@ export function initializeDup<TBase extends object>(
   _other: unknown,
 ): void {
   this.errors = new Errors(this as unknown as TBase);
-  this._validationContext = null;
-  this._contextForValidation = undefined;
 }
 
 /**

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -80,32 +80,17 @@ export interface ValidationsInternalsHost<TBase extends object = object> {
  * Lazy per-instance accessor for the active `ValidationContext`.
  * Mirrors Rails
  * `def context_for_validation; @context_for_validation ||= ValidationContext.new; end`
- * (activemodel/lib/active_model/validations.rb:463-465). Trails stores
- * the active context as `_validationContext: string | string[] | null`
- * directly; this helper returns a `ValidationContext` whose
- * `.context` property is a live view of that field, so Rails' pattern
- * `context_for_validation.context = ctx` still works.
+ * (activemodel/lib/active_model/validations.rb:463-465). The returned object
+ * owns the active context; the model's `_validationContext` reads through it.
  *
  * @internal Rails-private helper.
  */
 export function contextForValidation(this: ContextForValidationHost): ValidationContext {
   if (this._contextForValidation) return this._contextForValidation;
-  // Construct via the real constructor so any future
-  // ValidationContext initialization runs, then replace the
-  // `context` and underlying `_context` slot with a live view of
-  // `_validationContext`. Both must be aliased so `vc.name` /
-  // `vc.toString()` stay consistent with the live field.
+  // Rails keeps the active context *here*, not on the model
+  // (validations.rb:503-505 + :361-368) — which is what lets a frozen model be
+  // validated: `valid?` writes `context_for_validation.context`, never an ivar.
   const vc = new ValidationContext();
-  const accessor: PropertyDescriptor = {
-    get: (): string | string[] | null => this._validationContext,
-    set: (value: string | string[] | null): void => {
-      this._validationContext = value;
-    },
-    configurable: true,
-    enumerable: false,
-  };
-  Object.defineProperty(vc, "context", accessor);
-  Object.defineProperty(vc, "_context", accessor);
   this._contextForValidation = vc;
   return vc;
 }
@@ -154,8 +139,8 @@ export interface Validations {
  * Mirrors: ActiveModel::Validations::ClassMethods
  */
 export interface ValidationsClassMethods {
-  validates(attribute: string, rules: Record<string, unknown>): void;
-  validatesBang(attribute: string, rules: Record<string, unknown>): void;
+  validates(...args: [...attributes: string[], rules: Record<string, unknown>]): void;
+  validatesBang(...args: [...attributes: string[], rules: Record<string, unknown>]): void;
   validate(methodOrFn: string | ((record: unknown) => void), options?: ConditionalOptions): void;
   validatesWith(
     validatorClass: {
@@ -289,13 +274,6 @@ export function initInternals<TBase extends object>(this: ValidationsInternalsHo
 }
 
 /**
- * Host shape consumed by `predicateForValidationContext`.
- */
-export interface ValidationsContextHost {
-  readonly validationContext: string | string[] | null;
-}
-
-/**
  * Run the `:validate` callbacks and report whether the model has no
  * errors. Mirrors Rails
  * `def run_validations!; _run_validate_callbacks; errors.empty?; end`
@@ -309,11 +287,20 @@ export async function runValidationsBang(this: RunValidationsHost): Promise<bool
 }
 
 /**
- * Host shape consumed by `contextForValidation`.
+ * The only option keys `validate` accepts. Anything else is the common
+ * mistake of reaching for `validate` when `validates` was meant, and raises
+ * `ArgumentError`. Mirrors Rails `VALID_OPTIONS_FOR_VALIDATE`
+ * (activemodel/lib/active_model/validations.rb:92) — the keys carry their trails
+ * camelCase spelling (`exceptOn` for `:except_on`), which is what a caller
+ * actually passes and so what the raised message has to name back to them.
  */
-export interface ContextForValidationHost {
-  _validationContext: string | string[] | null;
-  _contextForValidation?: ValidationContext;
+export const VALID_OPTIONS_FOR_VALIDATE = ["on", "if", "unless", "prepend", "exceptOn"] as const;
+
+/**
+ * Host shape consumed by `predicateForValidationContext`.
+ */
+export interface ValidationsContextHost {
+  readonly validationContext: string | string[] | null;
 }
 
 /**
@@ -330,11 +317,11 @@ export function raiseValidationError<TBase extends object = object>(this: {
 }
 
 /**
- * Host shape consumed by `runValidationsBang`.
+ * Host shape consumed by `contextForValidation`.
  */
-export interface RunValidationsHost<TBase extends object = object> {
-  errors: Errors<TBase>;
-  _runValidateCallbacks(): void | Promise<void>;
+export interface ContextForValidationHost {
+  _validationContext: string | string[] | null;
+  _contextForValidation?: ValidationContext;
 }
 
 /**
@@ -366,9 +353,12 @@ export function predicateForValidationContext(
   return cached;
 }
 
-/** Host shape for the {@link readAttributeForValidation} mixin method. */
-export interface ReadAttributeForValidationHost {
-  [key: string]: unknown;
+/**
+ * Host shape consumed by `runValidationsBang`.
+ */
+export interface RunValidationsHost<TBase extends object = object> {
+  errors: Errors<TBase>;
+  _runValidateCallbacks(): void | Promise<void>;
 }
 
 /**
@@ -389,6 +379,28 @@ export function _mergeAttributes(attrNames: unknown[]): Record<string, unknown> 
   const flat = attrNames.flat(Infinity).map((n) => String(n));
   options.attributes = flat;
   return options;
+}
+
+/** Host shape for the {@link readAttributeForValidation} mixin method. */
+export interface ReadAttributeForValidationHost {
+  [key: string]: unknown;
+}
+
+/**
+ * Give the duplicate a fresh, empty `Errors` rather than sharing the source's.
+ * Mirrors Rails `initialize_dup` (validations.rb:310-313), which nils `@errors`
+ * and lets `errors_or_create` rebuild it lazily; trails initializes `errors`
+ * eagerly, so this assigns the replacement here — as {@link initInternals} does.
+ *
+ * @internal Rails-private helper.
+ */
+export function initializeDup<TBase extends object>(
+  this: ValidationsInternalsHost<TBase>,
+  _other: unknown,
+): void {
+  this.errors = new Errors(this as unknown as TBase);
+  this._validationContext = null;
+  this._contextForValidation = undefined;
 }
 
 /**

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -43,6 +43,13 @@ export interface ConditionalOptions {
    * (activemodel/lib/active_model/validations.rb:294-306).
    */
   on?: string | string[];
+  /**
+   * Validation context(s) under which this condition is *skipped* — the inverse of
+   * `on:`. Mirrors Rails `except_on:` (validations.rb:175-182).
+   */
+  exceptOn?: string | string[];
+  /** Register ahead of the already-registered validate callbacks. */
+  prepend?: boolean;
 }
 
 export function evaluateCondition(record: ValidatableRecord, cond: ConditionFn): boolean {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -22,7 +22,7 @@
     },
     "activemodel": {
       "assertionCount": 325,
-      "kind": 477,
+      "kind": 476,
       "value": 63
     },
     "activerecord": {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,8 +21,8 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 339,
-      "kind": 496,
+      "assertionCount": 325,
+      "kind": 477,
       "value": 63
     },
     "activerecord": {


### PR DESCRIPTION
Second and final slice of the `activemodel/test/cases/validations_test.rb` port
(follow-up to #6638). `pnpm parity:test -- --assertions --package activemodel`
now reports the file at **0 assertion-count, 0 assertion-kind and 0
assertion-value mismatches** — down from 14 count + 19 kind.

```text
validations_test.rb   validations.test.ts   45  0  0  0  0  144  45 ✓
```

`scripts/test-compare/assertion-mismatch-mark.json` activemodel counters drop to
`325` (count) / `476` (kind) / `63` (value) — this slice's contribution is −14
count and −19 kind, applied on top of the values `main` reached while this branch
was open. Set to the freshly measured numbers, never hand-raised; the rebase
conflict on that file was resolved by recomputing from `origin/main` minus only
this branch's own delta, then re-measuring to confirm.

## Test side

The 14 count-mismatched and 19 kind-mismatched tests are re-ported onto the
file-scope Rails models (`Topic`, `Person`) that #6638 landed, replacing bodies
that invented a local `class Person extends Model` per test. Two duplicated
`it(...)` blocks — `"frozen models can be validated"` and `"dup validity is
independent"`, each present twice — collapse to one faithful port. No test name
changed.

## Source convergences the ported bodies required

Every one of these is a gap the Rails bodies walked straight into; each is cited
at the call site.

- **`Model.validates` / `validatesBang` are variadic** — `(*attributes, options)`
  as Rails has them (`validates.rb:111-114`), with both the "You need to supply
  at least one attribute" and "at least one validation" `ArgumentError`s, and
  `defaults[:attributes] = attributes` so one validator covers every named
  attribute. `test_validations_on_the_instance_level` needs
  `validates :title, :author_name, presence: true`; the story called for
  converging this rather than working around it with two calls.
- **`Model.validate` rejects unknown option keys** with Rails' exact message and
  the new `VALID_OPTIONS_FOR_VALIDATE` (`validations.rb:92`, `:163-169`). The
  keys carry their trails camelCase spelling (`:exceptOn` for Rails'
  `:except_on`) because that is what a caller actually passes and therefore what
  the message must name back to them.
- **`Model.validate` raises `NoMethodError` for an unknown method name** — at
  validation time, where Ruby's `send` raises, not at registration time. It
  previously no-op'd silently, so `validate :i_dont_exist` was invisible.
- **`except_on:`** is honored on `validate`, `validates` and `validatesWith`,
  installing the intersection `unless:` from `validations.rb:175-182` (a nil
  context never intersects, so the validator still runs).
- **`prepend:`** now reaches the validate callback chain.
- **`Model#dup`** — Ruby `Object#dup` plus the `initialize_dup` hooks
  (`attributes.rb:111-114` deep-dups `@attributes`; `validations.rb:310-313`
  replaces `@errors`), and `Validations#initializeDup` to carry the latter.
- **Instance `validatesPresenceOf` / `validatesLengthOf`** — Rails both
  `extend`s *and* `include`s `HelperMethods` (`validations.rb:45-46`), so the
  helpers exist on the instance and run on the spot, which is exactly what
  `test_validate`'s `validate do ... end` block calls. Two of the twelve; the
  rest are not exercised by this file.
- **`ValidationContext` owns the active context**, and `_validationContext`
  becomes an accessor pair over it, matching `validations.rb:463-470`. This is
  the fix that makes `test_frozen_models_can_be_validated` pass rather than be
  faked: Rails' `valid?` writes `context_for_validation.context`, never a model
  ivar, which is *why* a frozen model can still be validated. trails had the
  ownership inverted (the model held the field, the context object was a live
  view), so `Object.freeze(model)` made the field read-only and `isValid()` threw
  `Cannot assign to read only property '_validationContext'`. The accessor pair
  keeps all eight existing `record._validationContext` readers in activerecord
  working unchanged.

## activesupport: nothing, in the end

The tests need `assertNotPredicate` (a bare `expect(...).not.toBe(true)`
normalizes to `notEqual`, so it cannot credit against Rails'
`assert_not_predicate` at `validations_test.rb:270`). A sibling landed an
identical implementation on `main` while this branch was open, so **this PR's
activesupport diff is now empty** — the helper comes entirely from `main` rather
than replacing a sibling's just-landed code over JSDoc wording.

## `dup()` fixes: two self-found, one from review

None of these reverses a reviewed decision.

- **`dup()` wiped the source's dirty state** (raised in review, confirmed). The
  fix reset `_dirty` to a fresh tracker and then re-snapshotted the *current*
  values as the baseline; `snapshot()` ends in `_clearChanges()`, so every dup came
  back clean. Verified against MRI — `d = t.dup()` gives
  `d.changes == t.changes == {"title"=>["A","B"]}`,
  `d.previous_changes == t.previous_changes`, and
  `t.mutations_from_database.equal?(d.mutations_from_database) # => false`. Rails
  nils `@mutations_from_database` and lets it rebuild from the already-deep-dup'd
  `@attributes`, so the copy reports the **same** changes while being a **distinct**
  object; the shipped version had only the second property.
  `DirtyTracker.deepDup` copies the state onto a new tracker with `_attrs`
  repointed at the copy's own AttributeSet, reaching both. It is the one piece of
  invented surface here, tagged `@noRailsEquivalent CONVERGEABLE` naming the story
  that retires it.

  New `dirty.trails.test.ts` covers it — `dirty_test.rb` has no `dup` coverage, so
  it is trails-only per CLAUDE.md. I confirmed the pending-changes case **fails**
  on the version it replaces.

- **`dup()` shared the dirty tracker** (self-found). `Object.assign` copied
  `_dirty` by reference, so writing to the copy marked the **original** changed.
  Rails resets it in `Dirty#initialize_dup` (`dirty.rb:248-251`) — a third module
  hook in the `super` chain this branch had not ported. This does **not** touch the
  `_contextForValidation` aliasing the first review explicitly blessed: Rails
  deliberately leaves `@context_for_validation` shared, and that stays as-is.
- **`Validations#init_internals` nil'd a field Rails does not have.** Rails nils
  exactly `@errors` and `@context_for_validation` (`validations.rb:255-260`);
  there is no `@validation_context` ivar. Once `_validationContext` became an
  accessor over the `ValidationContext`, that line allocated a throwaway context
  on every model construction and discarded it on the next line. Removed.

Also filed while verifying the above:
`0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments`
— `new Topic({title: "A"})` reports `changed == false` in trails where MRI reports
`true` with `{"title"=>[nil,"A"]}`, because `DirtyTracker` snapshots
post-assignment values as its baseline. Pre-existing, upstream of `dup`, and the
root cause `deepDup` is tagged against.

## Notes for the reviewer

- **852 LOC against the 700 ceiling.** Measured accounting rather than an
  estimate — `66` of those lines are pure relocation (byte-identical text
  appearing on both sides of the diff), where the
  `blazetrails/rails-file-structure-method-order` autofix moved *pre-existing*
  declarations in `validations.ts` (36) and `dirty.ts` (30) once new exports landed
  in Rails source order. A further ~110 are the `dup()` dirty-state fix and its
  regression test, raised in review (below). **The story's own feature work is
  ~667, under the line.**

  I could not find a way to split the `dup()` fix out: it needs `model.ts`, which
  this PR must also touch for `validates` / `validate` / `exceptOn`, so a sibling
  PR would overlap files (barred) or stack (barred). Dropping `dup()` instead
  would drop `test_dup_validity_is_independent` and forfeit the story's 0/0/0
  criterion. Shipping `dup()` with a known Rails regression seemed strictly worse
  than being over the line and saying so. **Happy to split or trim on your call —
  this is the one axis I can't resolve unilaterally.**
- **Correction: there is no inherited call-gate red.** An earlier revision of this
  description claimed 9 `parity:api:calls` rows on `main` from sibling PRs. That was
  wrong. Those rows were an artifact of gating a **stale** api-compare artifact — a
  plain `pnpm parity:api:calls` regenerates the mtime-keyed cache only partially and
  invents rows for files a sibling just touched. Re-running on `origin/main` with
  `API_COMPARE_FORCE=1 pnpm parity:api --calls` reports `ratchet: OK`, zero NEW
  rows. The two stories I filed against those phantom rows are closed with that
  evidence. Every gate figure below is now from a forced re-extraction.
- **The one real call-gate row was mine, and CI caught it before I did.**
  `activemodel errors.ts copy! deep_dup`. Adding `DirtyTracker.deepDup` made
  `deepDup` a name the comparator resolves, which **exposed a pre-existing
  omission** in `Errors#copyBang` rather than creating one. Rails' `copy!`
  (`errors.rb:138-143`) dups the array then rebases each copy via
  `instance_variable_set(:@base, @base)`; `Error#base` is `readonly` in TS with no
  such escape hatch, so the rebase must happen at construction — which is what
  `Error#dupWithBase` does, deep-dupping the options as it goes. The per-element dup
  Rails gets from `Array#deep_dup` is fused into that call, not dropped; splitting
  it out would dup every error twice to no effect. Tagged `@missingRailsCall
  deep_dup` at the call site — the sanctioned form for a single justified omission.
  **No baseline row added.**
- `errors to json` compares `JSON.stringify` on both sides. Rails' `to_json` is
  the ActiveSupport `Object#to_json` core_ext (`as_json.to_json` for `Errors`);
  trails has no port of it, and adding one is out of scope here. Noted at the
  call site.
- The **144 trails-only extras** still in `validations.test.ts` (the nested
  `describe("presence")` / `"absence"` / `"length"` … blocks,
  `describe("return-shape parity")`, `describe("_validators hash-of-arrays")`,
  the three `read_attribute_for_validation` tests) belong in a sibling
  `validations.trails.test.ts` per CLAUDE.md. That move does not fit alongside
  this slice, so it is filed as
  `0105-ar-deps-test-parity-100/activemodel-validations-test-trails-extras-split`
  rather than opened as a second PR from this pane.
- `Model.validates` still dispatches via an if-chain per validator key instead of
  Rails' `const_get("#{key.camelize}Validator")` loop (`validates.rb:119-131`).
  That is inherited debt this PR did not propagate or widen — it needs a
  name-to-class registry, since TS has no `const_get` — and is filed as
  `0023-surfaced-deviations/validates-resolves-validator-class-by-name`.
- `exceptOn` deliberately uses its own inline intersection rather than
  `predicateForValidationContext`, because Rails does exactly that: `on:` routes
  through the shared predicate, `except_on:` gets a bare lambda
  (`validations.rb:170-181`). Please don't "simplify" the two together.

## Gates

| gate | result |
| --- | --- |
| `pnpm parity:api:calls` | OK — forced re-extraction, 0 NEW rows |
| `pnpm parity:api:calls:args` | OK (189 baselined shape rows) |
| `pnpm parity:api:extra --package activemodel` | clean, no new tags |
| `pnpm parity:api` | activemodel 719/719 (100%), overall unchanged |
| `pnpm parity:test` | activemodel 961/963 (99.8%), unchanged; mark 379/572/63 == measured |
| `pnpm lint` | clean |
| tests | 2358 passed / 12 skipped across activemodel, activesupport/testing, AR validations + autosave |

No baseline row was added and none widened.

Closes-story: assertions-activemodel-validations-test-part2
