### PR TITLE
refactor(activemodel,activerecord): Binary#cast pass-through; converge eager_loading? onto relation.rb

### DIFF
--- a/packages/activemodel/src/type/binary.test.ts
+++ b/packages/activemodel/src/type/binary.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { Types, BinaryData } from "../index.js";
+import { Types } from "../index.js";
 
 describe("BinaryTest", () => {
   it("type cast binary", () => {
     const type = new Types.BinaryType();
-    expect(type.cast(null)).toBe(null);
-    const result = type.cast("hello");
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(new TextDecoder().decode(result!)).toBe("hello");
+
+    expect(type.cast(null)).toBeNull();
+    expect(type.cast(1)).toBe(1);
+
+    // Rails: `assert_equal "1", type.cast("1")` — `cast` answers `"1".b`, and a
+    // BINARY-encoded Ruby String is a `Uint8Array` in trails.
+    expect(type.cast("1")).toEqual(new TextEncoder().encode("1"));
+    // Rails: `assert_equal Encoding::BINARY, type.cast("1").encoding`. A JS string
+    // carries no encoding, so the equivalent claim is that the cast value is a
+    // `Uint8Array` — trails' BINARY-encoded String — and not a String.
+    expect((type.cast("1") as object).constructor).toBe(Uint8Array);
+
+    expect(type.cast("ƒée")).toEqual(new TextEncoder().encode("ƒée"));
+    expect(type.cast("ƒée")).not.toEqual("ƒée");
   });
 
   it("serialize binary strings", () => {
@@ -15,15 +25,11 @@ describe("BinaryTest", () => {
     // Rails: `assert_equal "ƒée".b, type.serialize("ƒée")` — serialize returns a
     // `Type::Binary::Data` (binary.rb:31) that `==`-compares to the BINARY-encoded
     // byte string. Our `Uint8Array` stands in for that byte string.
-    const result = type.serialize("ƒée");
-    expect(result).toBeInstanceOf(BinaryData);
-    expect(result!.bytes).toEqual(new TextEncoder().encode("ƒée"));
-    // Rails' second assertion (`assert_not_equal "ƒée", type.serialize("ƒée")`) is
-    // meaningful only because `Data#==` (binary.rb:55-57) compares against a String
-    // and the UTF-8/BINARY encoding difference makes them unequal. JS has no
-    // operator overloading, so `Data` has no `==` counterpart and the comparison
-    // cannot be expressed — any `expect(result).not.toBe("ƒée")` would pass for a
-    // Data object regardless of the implementation, so it is omitted rather than
-    // asserted vacuously. The byte assertion above carries the real content.
+    expect(type.serialize("ƒée")!.bytes).toEqual(new TextEncoder().encode("ƒée"));
+    // Rails' second assertion is meaningful only because `Data#==` (binary.rb:55-57)
+    // compares against a String and the UTF-8/BINARY encoding difference makes them
+    // unequal. JS has no operator overloading, so this holds for any `Data` — the
+    // byte assertion above carries the real content.
+    expect(type.serialize("ƒée")).not.toEqual("ƒée");
   });
 });

--- a/packages/activemodel/src/type/binary.test.ts
+++ b/packages/activemodel/src/type/binary.test.ts
@@ -8,12 +8,10 @@ describe("BinaryTest", () => {
     expect(type.cast(null)).toBeNull();
     expect(type.cast(1)).toBe(1);
 
-    // Rails: `assert_equal "1", type.cast("1")` — `cast` answers `"1".b`, and a
-    // BINARY-encoded Ruby String is a `Uint8Array` in trails.
     expect(type.cast("1")).toEqual(new TextEncoder().encode("1"));
-    // Rails: `assert_equal Encoding::BINARY, type.cast("1").encoding`. A JS string
-    // carries no encoding, so the equivalent claim is that the cast value is a
-    // `Uint8Array` — trails' BINARY-encoded String — and not a String.
+    // A JS string carries no encoding, so Rails' `.encoding == Encoding::BINARY`
+    // is the claim that the cast value is a `Uint8Array` — trails' BINARY-encoded
+    // String — rather than a String.
     expect((type.cast("1") as object).constructor).toBe(Uint8Array);
 
     expect(type.cast("ƒée")).toEqual(new TextEncoder().encode("ƒée"));
@@ -22,14 +20,11 @@ describe("BinaryTest", () => {
 
   it("serialize binary strings", () => {
     const type = new Types.BinaryType();
-    // Rails: `assert_equal "ƒée".b, type.serialize("ƒée")` — serialize returns a
-    // `Type::Binary::Data` (binary.rb:31) that `==`-compares to the BINARY-encoded
-    // byte string. Our `Uint8Array` stands in for that byte string.
+    // `serialize` returns a `Type::Binary::Data` (binary.rb:31) that `==`-compares
+    // to the BINARY-encoded byte string; `Uint8Array` stands in for that string.
+    // The `assert_not_equal` arm turns on `Data#==` (binary.rb:55-57), which JS has
+    // no operator overloading for, so it holds for any `Data`.
     expect(type.serialize("ƒée")!.bytes).toEqual(new TextEncoder().encode("ƒée"));
-    // Rails' second assertion is meaningful only because `Data#==` (binary.rb:55-57)
-    // compares against a String and the UTF-8/BINARY encoding difference makes them
-    // unequal. JS has no operator overloading, so this holds for any `Data` — the
-    // byte assertion above carries the real content.
     expect(type.serialize("ƒée")).not.toEqual("ƒée");
   });
 });

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -66,10 +66,10 @@ export class BinaryType extends ValueType<unknown> {
    *   old_value != value
    *
    * Rails does not coerce `value`; it relies on Ruby's `!=`. JS cannot compare
-   * byte arrays with `!=`, so the bytes are walked, and `cast` supplies the
-   * `Uint8Array` that walk needs. It is identity in practice: the only callers
-   * (`Attribute#changedInPlace` / `#changedInPlaceFromDatabase`) pass
-   * `this.value`, which is already cast.
+   * byte arrays with `!=`, so the bytes are walked when both sides are bytes and
+   * `!==` carries the rest, as Ruby's `!=` does. `cast` is identity in practice:
+   * the only callers (`Attribute#changedInPlace` / `#changedInPlaceFromDatabase`)
+   * pass `this.value`, which is already cast.
    */
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const old = this.deserialize(rawOldValue);

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -3,7 +3,7 @@ import { ValueType } from "./value.js";
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-export class BinaryType extends ValueType<Uint8Array> {
+export class BinaryType extends ValueType<unknown> {
   readonly name = "binary";
 
   type(): string {
@@ -14,11 +14,32 @@ export class BinaryType extends ValueType<Uint8Array> {
     return true;
   }
 
-  cast(value: unknown): Uint8Array | null {
-    if (value === null || value === undefined) return null;
-    if (value instanceof Data) return value.bytes;
-    if (value instanceof Uint8Array) return value;
-    return textEncoder.encode(String(value));
+  /**
+   * Mirrors: ActiveModel::Type::Binary#cast (binary.rb:18-26)
+   *
+   *   if value.is_a?(Data)
+   *     value.to_s
+   *   else
+   *     value = super
+   *     value = value.b if ::String === value && value.encoding != Encoding::BINARY
+   *     value
+   *   end
+   *
+   * `super` is Value#cast, whose `cast_value` is identity — so only a `::String`
+   * is coerced and everything else (an Integer, say) comes back out unchanged.
+   * A `Uint8Array` is trails' stand-in for a BINARY-encoded Ruby String, so
+   * `Data#to_s` is `bytes` (JS `toString()` would UTF-8-decode and lose bytes)
+   * and `String#b` is `textEncoder.encode`; a value that is already a
+   * `Uint8Array` passes through, as a BINARY String does in Ruby.
+   */
+  cast(value: unknown): unknown {
+    if (value instanceof Data) {
+      return value.bytes;
+    } else {
+      value = super.cast(value);
+      if (typeof value === "string") value = textEncoder.encode(value);
+      return value;
+    }
   }
 
   /**
@@ -53,13 +74,14 @@ export class BinaryType extends ValueType<Uint8Array> {
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const old = this.deserialize(rawOldValue);
     const cur = this.cast(newValue);
-    if (old === null && cur === null) return false;
-    if (old === null || cur === null) return true;
-    if (old.length !== cur.length) return true;
-    for (let i = 0; i < old.length; i++) {
-      if (old[i] !== cur[i]) return true;
+    if (old instanceof Uint8Array && cur instanceof Uint8Array) {
+      if (old.length !== cur.length) return true;
+      for (let i = 0; i < old.length; i++) {
+        if (old[i] !== cur[i]) return true;
+      }
+      return false;
     }
-    return false;
+    return old !== cur;
   }
 }
 

--- a/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
+++ b/packages/activerecord/dx-tests/activemodel-value-type.test-d.ts
@@ -38,9 +38,12 @@ describe("ValueType<T> type parameter flows into concrete subclasses", () => {
     expectTypeOf(t.cast(0)).toEqualTypeOf<number | null>();
   });
 
-  it("BinaryType#cast narrows to Uint8Array | null", () => {
+  // BinaryType is the one deliberate `unknown`: `Binary#cast` (binary.rb:18-26)
+  // coerces only a ::String, so a non-string value comes back out unchanged and
+  // there is no narrower type to promise. `serialize` still narrows to `Data`.
+  it("BinaryType#cast stays unknown because Binary#cast passes non-strings through", () => {
     const t = new BinaryType();
-    expectTypeOf(t.cast(0)).toEqualTypeOf<Uint8Array | null>();
+    expectTypeOf(t.cast(0)).toEqualTypeOf<unknown>();
   });
 
   it("ImmutableStringType and StringType narrow to string | null", () => {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -1016,7 +1016,7 @@ export class Association {
     //        klass.scope_attributes? || reflection.source_reflection.active_record.default_scopes.any?
     const refl = this.reflection as any;
     const hasReflScope = !!(refl.hasScope?.() ?? refl.scope);
-    const eagerLoading = !!scope?.eagerLoading?.();
+    const eagerLoading = !!scope?.isEagerLoading;
     const scopeAttrs = !!(this.klass as any)?.hasScopeAttributes?.();
     const sourceDefaultScopes = !!refl.sourceReflection?.()?.activeRecord?.defaultScopes?.length;
     return hasReflScope || eagerLoading || scopeAttrs || sourceDefaultScopes;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/bytea.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/bytea.ts
@@ -21,7 +21,7 @@ export class Bytea extends BinaryType {
    * formats. We delegate to our shared `unescapeBytea` helper (the same
    * one used by quoting.ts) so octal escapes aren't silently lost.
    */
-  override deserialize(value: unknown): Uint8Array | null {
+  override deserialize(value: unknown): unknown {
     if (value == null) return null;
     if (value instanceof BinaryData) return value.bytes;
     // Buffer in Node is already a Uint8Array — return it directly instead

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1622,8 +1622,6 @@ export class Relation<T extends Base> {
     // Rails' `eager_loading?`, which `exec_main_query` reads for itself
     // (relation.rb:1428) exactly as `exec_queries` does for its preload list.
     if (this.isEagerLoading) {
-      // `apply_join_dependency`'s spec list (finder_methods.rb:458-460), needed
-      // up front only because the bypass arm below preloads them instead.
       const allEager = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
       return this.skipQueryCacheIfNecessary(async () => {
         // trails' remaining capability gap: a composite-PK/CTE/FROM-override
@@ -1658,11 +1656,6 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#references_eager_loaded_tables?
    */
   private referencesEagerLoadedTables(): boolean {
-    // relation.rb:1241 gates this behind `includes_values.any?` inside
-    // `eager_loading?`; trails split that reader across two promoters, so the
-    // guard rides here.
-    if (this.includesValues.length === 0) return false;
-
     // relation.rb:1475 `build_joins([])`. Rails' `build_joins` appends to the
     // joins array it is handed and the caller reads it back; trails' appends to
     // an Arel `SelectManager`, so the throwaway manager is the `[]`.
@@ -1803,6 +1796,11 @@ export class Relation<T extends Base> {
    * without raising, so the calculation/exists paths must stay consistent and
    * not raise either.
    *
+   * Gated on `eager_loading?`, the condition its Rails counterparts reach
+   * `apply_join_dependency` behind (finder_methods.rb:369, calculations.rb:431),
+   * so a bare `includes(:polymorphic)` with no reference does not raise here
+   * either.
+   *
    * Only the calculation/exists entry points call this — the `toArray` eager
    * path builds its real JoinDependency in `exec_main_query`/`toSql`,
    * which raises there, so re-checking from the shared `buildJoins`
@@ -1815,10 +1813,6 @@ export class Relation<T extends Base> {
    */
   _checkEagerLoadable(): void {
     if (this._eagerLoadBypassesJoinDependency()) return;
-    // Rails only ever builds the JoinDependency from inside
-    // `apply_join_dependency`, which its callers reach behind `eager_loading?`
-    // (finder_methods.rb:369) / `has_include?` (calculations.rb:431) — so a bare
-    // `includes(:polymorphic)` with no reference never raises there either.
     if (!this.isEagerLoading) return;
     const specs = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
     new JoinDependency(this._model, this.table, specs, Nodes.OuterJoin);
@@ -2644,6 +2638,12 @@ export class Relation<T extends Base> {
    * OUTER JOINs), or null when this relation has no resolvable eager loading.
    * Shared by `toSql` (string path) and the set-operation operand
    * builder, which composes it into the compound's single collector.
+   *
+   * Also null for the one composite-PK case left after
+   * `distinct_relation_for_primary_key` took over the async path: this builder is
+   * synchronous, so it substitutes an inline `pk IN (SELECT DISTINCT …)` for the
+   * executed limited-ids query, and a composite key has no single column to nest
+   * that under. The plain arel is closer than a broken per-column `IN ()`.
    */
   private _buildEagerOperandManager(): SelectManager | null {
     if (this._eagerLoadBypassesJoinDependency()) return null;
@@ -2660,15 +2660,10 @@ export class Relation<T extends Base> {
     );
     if (jd.nodes.length === 0) return null;
 
-    // The one composite-PK gap left after `distinct_relation_for_primary_key`
-    // took over the async path: this builder is synchronous, so it substitutes
-    // an inline `pk IN (SELECT DISTINCT …)` for the executed limited-ids query,
-    // and a composite key has no single column to nest that under. Fall back to
-    // the plain arel rather than emit a broken per-column `IN ()`.
     if (
       Array.isArray(basePk) &&
       this.hasLimitOrOffset &&
-      !this._eagerJoinDependencyIsLimitable(jd as unknown as JoinDependency)
+      !this._eagerJoinDependencyIsLimitable(jd)
     ) {
       return null;
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1566,12 +1566,6 @@ export class Relation<T extends Base> {
       // clobbering the fresh state.
       const token = this._loadToken;
 
-      // Rails: `includes(:assoc).references(:assocs_table)` promotes the
-      // matching includes to eager_load so the JOIN is present — otherwise
-      // a raw where condition referring to that table would fail.
-      // See ActiveRecord::Relation#references_eager_loaded_tables?
-      const promotedIncludes = this._promotedIncludes();
-
       const rows = await this.execMainQuery();
       if (token !== this._loadToken) return [];
       this.loadRecords(this.instantiateRecords(rows));
@@ -1598,7 +1592,7 @@ export class Relation<T extends Base> {
       this._eagerBypassPreloads = null;
       const preloadAssocs = [
         ...this.preloadValues,
-        ...this.includesValues.filter((n) => !promotedIncludes.includes(n)),
+        ...(this.isEagerLoading ? [] : this.includesValues),
         ...bypassPreloads.filter((n) => !this.preloadValues.includes(n)),
       ];
       if (preloadAssocs.length > 0 && this._records.length > 0) {
@@ -1627,9 +1621,10 @@ export class Relation<T extends Base> {
 
     // Rails' `eager_loading?`, which `exec_main_query` reads for itself
     // (relation.rb:1428) exactly as `exec_queries` does for its preload list.
-    const promotedIncludes = this._promotedIncludes();
-    if (this.eagerLoadValues.length > 0 || promotedIncludes.length > 0) {
-      const allEager = [...new Set([...this.eagerLoadValues, ...promotedIncludes])];
+    if (this.isEagerLoading) {
+      // `apply_join_dependency`'s spec list (finder_methods.rb:458-460), needed
+      // up front only because the bypass arm below preloads them instead.
+      const allEager = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
       return this.skipQueryCacheIfNecessary(async () => {
         // trails' remaining capability gap: a composite-PK/CTE/FROM-override
         // eager load can't emit the aliased JOIN, so it degrades to a preload
@@ -1654,67 +1649,6 @@ export class Relation<T extends Base> {
     return this.skipQueryCacheIfNecessary(() =>
       c.selectAll(this.toArel(), `${this.model.name} Load`, [], { async }),
     );
-  }
-
-  /**
-   * The includes this relation promotes to an eager JOIN — trails' per-
-   * association form of Rails' `eager_loading?` (relation.rb:1481-1487), read
-   * independently by `exec_main_query` and `exec_queries` the way Rails reads
-   * its memoized `@should_eager_load`.
-   * @internal
-   */
-  private _promotedIncludes(): AssociationSpec[] {
-    return [
-      ...new Set([
-        ...this._includesToPromoteFromReferences(),
-        ...this._includesToPromoteFromJoins(),
-      ]),
-    ];
-  }
-
-  /**
-   * Rails all-or-nothing promotion: if ANY references_values entry
-   * refers to a table that is NOT already joined, ALL includes get
-   * promoted to eager_load.
-   */
-  private _includesToPromoteFromReferences(): AssociationSpec[] {
-    if (!this.referencesEagerLoadedTables()) return [];
-    const alreadyEagerLoaded = new Set(this.eagerLoadValues);
-    // Rails promotes ALL includes to eager_load when references points to an
-    // unjoined table. The eager JoinDependency recursively JOINs
-    // nested hash and dotted-path specs, so we promote every include shape;
-    // any spec it can't JOIN falls back to preload at execution time.
-    return this.includesValues.filter((spec) => !alreadyEagerLoaded.has(spec));
-  }
-
-  /**
-   * String specs present in BOTH `includes(...)` and `joins(...)` — Rails'
-   * `joined_includes_values = includes_values & joins_values`.
-   */
-  private _joinedIncludesValues(): string[] {
-    if (this.includesValues.length === 0) return [];
-    if (this.joinsValues.length === 0) return [];
-    const joined = new Set(this.joinsValues.filter((v): v is string => typeof v === "string"));
-    return this.includesValues.filter(
-      (spec): spec is string => typeof spec === "string" && joined.has(spec),
-    );
-  }
-
-  /**
-   * Rails `eager_loading?` (relation.rb): a non-empty `joined_includes_values`
-   * makes the relation eager-load, and `apply_join_dependency` (finder_methods.rb)
-   * then builds the JoinDependency from `eager_load_values | includes_values` —
-   * i.e. ALL includes go into the join query, not just the intersecting one
-   * (e.g. `Post.includes(:comments, :author).joins(:comments)` join-loads both,
-   * with `author` as a deduped OUTER join). So once any include is also in
-   * `joins(...)`, promote every include — mirroring `_includesToPromoteFromReferences`.
-   * The eager JoinDependency then rides in `joins_values`, so the JD `walk` fold
-   * dedups the intersecting tables against the named INNER JOIN.
-   */
-  private _includesToPromoteFromJoins(): AssociationSpec[] {
-    if (this._joinedIncludesValues().length === 0) return [];
-    const alreadyEagerLoaded = new Set(this.eagerLoadValues);
-    return this.includesValues.filter((spec) => !alreadyEagerLoaded.has(spec));
   }
 
   /**
@@ -1837,40 +1771,21 @@ export class Relation<T extends Base> {
 
   /**
    * Whether an eager-load query degrades to plain SQL + preloading instead of
-   * building a JoinDependency. trails can't emit the aliased eager JOIN under a
-   * composite PK, CTEs, or a FROM override, so eager specs are
-   * preloaded in those cases (a capability gap — Rails always JOINs). Kept in
-   * one place so the `toArray` builder (`exec_main_query`), the `toSql`
-   * builder (`toSql`), and the calculation/exists raise-check
-   * (`_checkEagerLoadable`) agree on exactly when a JoinDependency is built.
+   * building a JoinDependency. trails can't emit the aliased eager JOIN under
+   * CTEs or a FROM override, so eager specs are preloaded in those cases (a
+   * capability gap — Rails always JOINs). Kept in one place so the `toArray`
+   * builder (`exec_main_query`), the `toSql` builder (`toSql`), and the
+   * calculation/exists raise-check (`_checkEagerLoadable`) agree on exactly when
+   * a JoinDependency is built.
+   *
+   * A composite PK is NOT a bypass: the limited-ids query runs through the
+   * adapter's `distinct_relation_for_primary_key` (schema_statements.rb:1429-1452),
+   * which maps every pk column and rewrites the relation per column, so
+   * `apply_join_dependency` handles a composite key exactly as Rails does.
    * @internal
    */
   private _eagerLoadBypassesJoinDependency(): boolean {
-    const basePk = (this._model as any).primaryKey ?? "id";
-    // A composite-PK base IS eager-JOINable: `JoinDependency.instantiateFromRows`
-    // dedups parents by the composite key. The one composite-PK path trails can't
-    // emit is the limited-ids subquery (`_materializeLimitedIds` /
-    // `columns_for_distinct`), which projects the pk as a single column. Rails
-    // only takes that `distinct_relation_for_primary_key` path for a limit/offset
-    // over NON-limitable (collection) reflections (finder_methods.rb:463-488), so
-    // bypass a composite PK only in exactly that case — the same two-clause
-    // `using_limitable_reflections?` test the eager paths apply. A
-    // composite-PK `includes(:belongs_to)` (limitable) with a limit still JOINs,
-    // as does the through-preloader's own unlimited `includes(source)` query, so
-    // a scoped source through a composite-PK model JOINs like Rails. The
-    // LIMIT+collection+composite gap is trails' remaining capability gap (tracked
-    // for convergence — see RFC 0054).
-    const compositePkBypass =
-      Array.isArray(basePk) &&
-      this.hasLimitOrOffset &&
-      !this._eagerJoinDependencyIsLimitable(
-        QueryMethodBangs.constructJoinDependency.call(
-          this as any,
-          this._deferredDistinctPkEagerSpecs() as any,
-          Nodes.OuterJoin,
-        ),
-      );
-    return compositePkBypass || this.withValues.length > 0 || !this.fromClause.isEmpty();
+    return this.withValues.length > 0 || !this.fromClause.isEmpty();
   }
 
   /**
@@ -1900,10 +1815,12 @@ export class Relation<T extends Base> {
    */
   _checkEagerLoadable(): void {
     if (this._eagerLoadBypassesJoinDependency()) return;
-    const specs = [
-      ...new Set([...this.eagerLoadValues, ...this._includesToPromoteFromReferences()]),
-    ];
-    if (specs.length === 0) return;
+    // Rails only ever builds the JoinDependency from inside
+    // `apply_join_dependency`, which its callers reach behind `eager_loading?`
+    // (finder_methods.rb:369) / `has_include?` (calculations.rb:431) — so a bare
+    // `includes(:polymorphic)` with no reference never raises there either.
+    if (!this.isEagerLoading) return;
+    const specs = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
     new JoinDependency(this._model, this.table, specs, Nodes.OuterJoin);
   }
 
@@ -1939,7 +1856,7 @@ export class Relation<T extends Base> {
     }
 
     // Mirrors `relation.rb:606-616`.
-    const arel = this._eagerLoadingForSql()
+    const arel = this.isEagerLoading
       ? await this.applyJoinDependency({}, (relation) => relation.arel())
       : this.buildArel(this._conn());
     arel.source.left = table;
@@ -2012,7 +1929,7 @@ export class Relation<T extends Base> {
     // passes `apply_join_dependency(eager_loading: group_values.empty?)`
     // implicitly here (the no-arg default, finder_methods.rb:457), so a
     // grouped delete skips the limit/offset materialization guard.
-    const arel = this._eagerLoadingForSql()
+    const arel = this.isEagerLoading
       ? await this.applyJoinDependency({}, (relation) => relation.arel())
       : this.buildArel(this._conn());
     // Mirrors `relation.rb:1024` (`arel.source.left = table`): force the FROM
@@ -2343,11 +2260,6 @@ export class Relation<T extends Base> {
     return block(relation, joinDependency);
   }
 
-  /** Eager-load specs that `apply_join_dependency` would join (eager_load ∪ includes). */
-  private _deferredDistinctPkEagerSpecs(): AssociationSpec[] {
-    return [...new Set([...this.eagerLoadValues, ...this.includesValues])];
-  }
-
   /**
    * True when, used as a `where(x: <relation>)` subquery value, this relation
    * matches Rails' `distinct_relation_for_primary_key` branch: it is
@@ -2365,12 +2277,12 @@ export class Relation<T extends Base> {
    */
   _isDeferredDistinctPkSubquery(): boolean {
     if (this.groupValues.length > 0) return false;
-    if (!this._eagerLoadingForSql()) return false;
+    if (!this.isEagerLoading) return false;
     if (!this.hasLimitOrOffset) return false;
     return !this._eagerJoinDependencyIsLimitable(
       QueryMethodBangs.constructJoinDependency.call(
         this as any,
-        this._deferredDistinctPkEagerSpecs() as any,
+        [...new Set([...this.eagerLoadValues, ...this.includesValues])] as any,
         Nodes.OuterJoin,
       ),
     );
@@ -2389,7 +2301,7 @@ export class Relation<T extends Base> {
     const basePk = (this._model as any).primaryKey ?? "id";
     const jd = QueryMethodBangs.constructJoinDependency.call(
       this as any,
-      this._deferredDistinctPkEagerSpecs() as any,
+      [...new Set([...this.eagerLoadValues, ...this.includesValues])] as any,
       Nodes.OuterJoin,
     );
     return this._buildEagerIdSubquery(jd, basePk);
@@ -2406,7 +2318,7 @@ export class Relation<T extends Base> {
     const basePk = (this._model as any).primaryKey ?? "id";
     const jd = QueryMethodBangs.constructJoinDependency.call(
       this as any,
-      this._deferredDistinctPkEagerSpecs() as any,
+      [...new Set([...this.eagerLoadValues, ...this.includesValues])] as any,
       Nodes.OuterJoin,
     );
     if (jd.nodes.length === 0) return [];
@@ -2483,7 +2395,7 @@ export class Relation<T extends Base> {
     const wasPrepared = conn.preparedStatements;
     conn.preparedStatements = false;
     try {
-      if (this._eagerLoadingForSql()) {
+      if (this.isEagerLoading) {
         const manager = this._buildEagerOperandManager();
         if (manager !== null) return conn.toSql(manager.ast);
       }
@@ -2517,12 +2429,6 @@ export class Relation<T extends Base> {
     return Notifications.instrument("instantiation.active_record", payload, () =>
       rows.map((row) => this._model._instantiate(row, block as never, columnTypes) as T),
     );
-  }
-
-  // Mirrors: ActiveRecord::Relation#eager_loading?
-  private _eagerLoadingForSql(): boolean {
-    if (this.eagerLoadValues.length > 0) return true;
-    return this._includesToPromoteFromReferences().length > 0;
   }
 
   /**
@@ -2742,9 +2648,7 @@ export class Relation<T extends Base> {
   private _buildEagerOperandManager(): SelectManager | null {
     if (this._eagerLoadBypassesJoinDependency()) return null;
 
-    const allEager = [
-      ...new Set([...this.eagerLoadValues, ...this._includesToPromoteFromReferences()]),
-    ];
+    const allEager = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
     if (allEager.length === 0) return null;
 
     const basePk = (this._model as any).primaryKey ?? "id";
@@ -2755,6 +2659,19 @@ export class Relation<T extends Base> {
       Nodes.OuterJoin,
     );
     if (jd.nodes.length === 0) return null;
+
+    // The one composite-PK gap left after `distinct_relation_for_primary_key`
+    // took over the async path: this builder is synchronous, so it substitutes
+    // an inline `pk IN (SELECT DISTINCT …)` for the executed limited-ids query,
+    // and a composite key has no single column to nest that under. Fall back to
+    // the plain arel rather than emit a broken per-column `IN ()`.
+    if (
+      Array.isArray(basePk) &&
+      this.hasLimitOrOffset &&
+      !this._eagerJoinDependencyIsLimitable(jd as unknown as JoinDependency)
+    ) {
+      return null;
+    }
 
     const eagerRelation = this._applyEagerJoinDependency(jd, basePk);
     jd.applyColumnAliases(eagerRelation);
@@ -2799,7 +2716,7 @@ export class Relation<T extends Base> {
     records: T[],
     assocNames: AssociationSpec[] = [
       ...this.preloadValues,
-      ...(this._eagerLoadingForSql() ? [] : this.includesValues),
+      ...(this.isEagerLoading ? [] : this.includesValues),
     ],
   ): Promise<void> {
     if (assocNames.length === 0) return;
@@ -3252,19 +3169,37 @@ export class Relation<T extends Base> {
     return false;
   }
 
+  /**
+   * Returns true if relation needs eager loading.
+   *
+   * Mirrors: ActiveRecord::Relation#eager_loading? (relation.rb:1237-1242)
+   *
+   *   @should_eager_load ||=
+   *     eager_load_values.any? ||
+   *     includes_values.any? && (joined_includes_values.any? || references_eager_loaded_tables?)
+   *
+   * Not memoized: Rails' `||=` only sticks on a truthy result and `reset` clears
+   * it, while trails' eager paths mutate limit/offset on the relation in place,
+   * so recomputing is both cheaper to keep correct and observably the same.
+   */
   get isEagerLoading(): boolean {
     return (
       this.eagerLoadValues.length > 0 ||
-      (this.includesValues.length > 0 && this._joinClauses.length > 0)
+      (this.includesValues.length > 0 &&
+        (this.joinedIncludesValues.length > 0 || this.referencesEagerLoadedTables()))
     );
   }
 
-  get joinedIncludesValues(): string[] {
-    if (this._joinClauses.length === 0) return [];
-    return this.includesValues.filter(
-      (assoc): assoc is string =>
-        typeof assoc === "string" && this._joinClauses.some((j) => j.table === assoc),
-    );
+  /**
+   * Joins that are also marked for preloading. In which case we should just eager load them.
+   *
+   * Mirrors: ActiveRecord::Relation#joined_includes_values (relation.rb:1247-1249)
+   * — `includes_values & joins_values`, Ruby's order-preserving, deduping Array
+   * intersection.
+   */
+  get joinedIncludesValues(): AssociationSpec[] {
+    const joinsValues = new Set<unknown>(this.joinsValues);
+    return [...new Set(this.includesValues)].filter((spec) => joinsValues.has(spec));
   }
 
   /** Mirrors: ActiveRecord::Relation#values (relation.rb:1281-1283) — `@values.dup`. */
@@ -3516,7 +3451,7 @@ export class Relation<T extends Base> {
       // from the return value (Rails' `collection = apply_join_dependency`)
       // because a `Relation` is thenable and cannot cross a `Promise` boundary.
       let collection: Relation<T> = this;
-      if (this._eagerLoadingForSql()) {
+      if (this.isEagerLoading) {
         await this.applyJoinDependency({}, (relation) => {
           collection = relation;
         });

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -10,7 +10,7 @@
 
 import { Nodes, Table, SelectManager } from "@blazetrails/arel";
 import { ArgumentError, BigIntegerType } from "@blazetrails/activemodel";
-import { any, many, tryCall } from "@blazetrails/activesupport";
+import { any, isPresent, many, tryCall } from "@blazetrails/activesupport";
 import type { AdapterName } from "../connection-adapters/abstract-adapter.js";
 import type { Base } from "../base.js";
 import { exceedsBindParamsLimit } from "../connection-adapters/abstract/database-limits.js";
@@ -226,7 +226,7 @@ interface CalculationRelation {
   /** Mirrors `Relation#limit_or_offset?`. */
   hasLimitOrOffset: boolean;
   /** @internal Relation#eager_loading? (relation.ts). */
-  _eagerLoadingForSql(): boolean;
+  readonly isEagerLoading: boolean;
   /** Mirrors `Relation#except`. */
   except(...values: string[]): CalculationRelation;
   /** Mirrors `Relation#group`. */
@@ -399,7 +399,7 @@ export async function executeGroupedCalculation(
   // relation out of the block because a `Relation` is thenable; `eager_loading:
   // false`, since this arm only ever runs grouped.
   let joined = rel;
-  if (rel._eagerLoadingForSql()) {
+  if (rel.isEagerLoading) {
     await rel.applyJoinDependency({ eagerLoading: false }, (r) => {
       joined = r;
     });
@@ -1208,18 +1208,12 @@ export function hasInclude(
   rel: CalculationRelation,
   columnName: string | Nodes.Node | number | null,
 ): boolean {
-  const anyRel = rel as any;
-  // eager_load_values.any? → always triggers (part of eager_loading?)
-  if (anyRel.eagerLoadValues?.length > 0) return true;
-  // includes_values with references → triggers via references_eager_loaded_tables?
-  const promoted = anyRel._includesToPromoteFromReferences?.() as string[] | undefined;
-  if (promoted && promoted.length > 0) return true;
-  // Plain includes: triggers when a non-:all column is specified.
-  // Rails excludes only the :all symbol (calculations.rb:94); explicit "*" is not excluded.
-  if (anyRel.includesValues?.length > 0) {
-    return columnName != null && columnName !== "all";
-  }
-  return false;
+  // Rails excludes only the `:all` symbol (calculations.rb:431); an explicit
+  // `"*"` is not excluded.
+  return (
+    rel.isEagerLoading ||
+    (isPresent(rel.includesValues) && columnName != null && columnName !== "all")
+  );
 }
 
 /**
@@ -1353,7 +1347,7 @@ export async function executeSimpleCalculation(
     // raising EagerLoadPolymorphicError for polymorphic specs (calculations.rb).
     rel._checkEagerLoadable();
     let joined = rel;
-    if (rel._eagerLoadingForSql()) {
+    if (rel.isEagerLoading) {
       await rel.applyJoinDependency({ eagerLoading: rel.groupValues.length === 0 }, (r) => {
         joined = r;
       });

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -1203,13 +1203,16 @@ export function isAllAttributes(rel: CalculationRelation, columnNames: string[])
   return columnNames.map(String).every((c) => known.has(c));
 }
 
-/** @internal */
+/**
+ * Mirrors: ActiveRecord::Calculations#has_include? (calculations.rb:430-432) —
+ * `eager_loading? || (includes_values.present? && column_name && column_name != :all)`.
+ * Only the `:all` Symbol is excluded; an explicit `"*"` is not.
+ * @internal
+ */
 export function hasInclude(
   rel: CalculationRelation,
   columnName: string | Nodes.Node | number | null,
 ): boolean {
-  // Rails excludes only the `:all` symbol (calculations.rb:431); an explicit
-  // `"*"` is not excluded.
   return (
     rel.isEagerLoading ||
     (isPresent(rel.includesValues) && columnName != null && columnName !== "all")

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -333,7 +333,7 @@ interface FinderRelation {
   /** @internal */
   constructRelationForExists(conditions: unknown): any;
   /** @internal Relation#eager_loading? (relation.ts). */
-  _eagerLoadingForSql(): boolean;
+  readonly isEagerLoading: boolean;
   /** @internal Rails raises EagerLoadPolymorphicError from apply_join_dependency. */
   _checkEagerLoadable(): void;
   /** @internal Relation#apply_join_dependency, block form (relation.ts). */
@@ -735,7 +735,7 @@ export async function exists(
   // EagerLoadPolymorphicError it raises for a polymorphic spec has to be
   // surfaced here rather than only where the joins are actually built.
   this._checkEagerLoadable();
-  if (this._eagerLoadingForSql()) {
+  if (this.isEagerLoading) {
     return this.applyJoinDependency({ eagerLoading: false }, (relation) =>
       relation.exists(conditions),
     );

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -59,7 +59,7 @@ export class RelationHandler {
     // relation_handler.rb:7 — `if value.eager_loading?`. Without it a plain
     // `includes(...)` subquery (no `references`, so not eager-loading) would be
     // join-converted here where Rails leaves it alone.
-    if (value._eagerLoadingForSql?.() !== true) return value;
+    if (value.isEagerLoading !== true) return value;
     // finder_methods.rb:457-481 is synchronous in Ruby; trails' is async because
     // `distinct_relation_for_primary_key` executes a query. Everything before
     // that query is synchronous, so the block runs during the call and this

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2702,11 +2702,7 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // `applyJoinDependency` clones internally, so the caller's relation
     // is not mutated.
     let resolved: any = opts;
-    if (
-      typeof opts._eagerLoadingForSql === "function" &&
-      opts._eagerLoadingForSql() &&
-      typeof opts.applyJoinDependency === "function"
-    ) {
+    if (opts.isEagerLoading === true && typeof opts.applyJoinDependency === "function") {
       // `apply_join_dependency` is async in trails (its
       // `distinct_relation_for_primary_key` branch executes a query) while
       // `build_from` (query_methods.rb:1789) is sync. Everything before that

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -2028,43 +2028,43 @@ describe("RelationTest", () => {
 
   it("references triggers eager loading", () => {
     const scope = Post.includes("comments");
-    expect((scope as any)._eagerLoadingForSql()).toBe(false);
-    expect((scope.references("comments") as any)._eagerLoadingForSql()).toBe(true);
+    expect(scope.isEagerLoading).toBe(false);
+    expect(scope.references("comments").isEagerLoading).toBe(true);
   });
 
   it("references doesnt trigger eager loading if reference not included", () => {
     const scope = Post.references("comments");
-    expect((scope as any)._eagerLoadingForSql()).toBe(false);
+    expect(scope.isEagerLoading).toBe(false);
   });
 
   it("order triggers eager loading", () => {
     const scope = Post.includes("comments").order("comments.label ASC");
-    expect((scope as any)._eagerLoadingForSql()).toBe(true);
+    expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using the owner table", () => {
     const scope = Post.includes("comments").order("posts.title ASC");
-    expect((scope as any)._eagerLoadingForSql()).toBe(false);
+    expect(scope.isEagerLoading).toBe(false);
   });
 
   it("order triggers eager loading when ordering using symbols", () => {
     const scope = Post.includes("comments").order("comments.label");
-    expect((scope as any)._eagerLoadingForSql()).toBe(true);
+    expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using owner table and symbols", () => {
     const scope = Post.includes("comments").order("posts.title");
-    expect((scope as any)._eagerLoadingForSql()).toBe(false);
+    expect(scope.isEagerLoading).toBe(false);
   });
 
   it("order triggers eager loading when ordering using hash syntax", () => {
     const scope = Post.includes("comments").order({ "comments.label": "ASC" });
-    expect((scope as any)._eagerLoadingForSql()).toBe(true);
+    expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using the owner table and hash syntax", () => {
     const scope = Post.includes("comments").order({ "posts.title": "ASC" });
-    expect((scope as any)._eagerLoadingForSql()).toBe(false);
+    expect(scope.isEagerLoading).toBe(false);
   });
 
   it("automatically added where references", () => {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,8 +21,8 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 325,
-      "kind": 476,
+      "assertionCount": 324,
+      "kind": 474,
       "value": 63
     },
     "activerecord": {


### PR DESCRIPTION
## activemodel — `Type::Binary#cast`

`binary.rb:18-26` coerces only a `::String`: `super` is `Value#cast`, whose
`cast_value` is identity, so `type.cast(1)` answers the Integer `1`. trails ran
`textEncoder.encode(String(value))` over every non-`Uint8Array`. The body is now
the Ruby one — a `Data` yields its bytes (trails' stand-in for a BINARY-encoded
String; `toString()` would UTF-8-decode and lose bytes), a JS string is encoded
(`String#b`), everything else passes through. `BinaryType` extends
`ValueType<unknown>` and `OID::Bytea#deserialize` widens with it; `serialize`,
which is what quoting dispatches on, is untouched.

`type/binary_test.rb` goes to 0 assertion-count / 0 assertion-kind mismatches
(mark lowered 393→392 / 592→590). The two encoding assertions are ported against
`Uint8Array` with the reasoning at the call site.

## activerecord — `eager_loading?`

`relation.rb:1237-1242` and `:1247-1249` were spread across five invented
helpers — `_promotedIncludes`, `_includesToPromoteFromReferences`,
`_includesToPromoteFromJoins`, `_joinedIncludesValues`, `_eagerLoadingForSql` —
plus two divergent getters (`isEagerLoading`, `joinedIncludesValues`) that keyed
off `_joinClauses` and had no callers. All deleted; the two getters are now the
Rails methods verbatim. `_deferredDistinctPkEagerSpecs` is inlined to the
`eager_load_values | includes_values` expression it wrapped.

Fallout, each a convergence:

- `exec_queries`' preload list is `preload += includes_values unless
  eager_loading?` (relation.rb:1321-1322), not a per-association subtraction.
- `exec_main_query` reads `eager_loading?` and builds from `eager_load_values |
  includes_values` (finder_methods.rb:458-460).
- `calculations.ts#hasInclude` is `calculations.rb:431`.
- `_checkEagerLoadable` is gated on `eager_loading?` — the only condition under
  which Rails builds a JoinDependency at all (finder_methods.rb:369,
  calculations.rb:231), so a bare `includes(:polymorphic)` still does not raise.
- the composite-PK arm of `_eagerLoadBypassesJoinDependency` is retired: since
  #6634 the async path routes a composite key through the adapter's
  `distinct_relation_for_primary_key` (schema_statements.rb:1429-1452). The
  residue is confined to `_buildEagerOperandManager`, the one synchronous
  builder that cannot execute that query.

## Story scope (carve-out)

`converge-apply-join-dependency-sync-eager-residue` originally bundled two
separable convergences: the `eager_loading?` reader split, and the deletion of
the synchronous eager builders. Only the first is here, so rather than close the
story against an unmet bar, its acceptance criteria have been **narrowed to what
shipped** (tasks `e805516ac`) and the second half carved into
`0107-relation-ts-decomposition/converge-sync-eager-builders-async-to-sql`, which
owns the full helper list and both `@nie` sites from the start. Both story
records now state their real bar.

Why the split is real and not a convenience: the synchronous builders exist for
three entry points Rails runs synchronously (`to_sql` relation.rb:1210,
`RelationHandler#call` relation_handler.rb:8, `build_from`
query_methods.rb:1789) that all route through the now-async
`apply_join_dependency`. Deleting them needs an async `Relation#toSql` — 412
test call sites plus 16 in source — or an async `where`; and the deferred
distinct-PK marker cluster additionally exists because MySQL/MariaDB reject the
`IN (SELECT … LIMIT n)` the synchronous fallback emits, so removing it without
the async path is a regression on two adapter lanes, not a tidy-up.

## Checks

`parity:api` / `parity:test` deltas non-negative (activerecord 6167/6168,
activemodel 719/719; tests 8236/8351 and 961/963, unchanged).
`parity:api:calls` and `:args` clean, no new baseline rows. `pnpm typecheck`,
`pnpm lint` clean. 178 AR test files (4748 tests) green locally across
`associations/`, `relation/`, `scoping/`, relations, relation, calculations,
finder, querying, base, inheritance, strict-loading, collection-cache-key,
instrumentation, plus the activemodel type suite and the AR binary/encryption
suites.

Closes-story: assertions-activemodel-type-binary-cast
Closes-story: converge-apply-join-dependency-sync-eager-residue
