### PR TITLE
test(activesupport): converge inquirer and parameter-filter assertion parity

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -612,8 +612,8 @@ describe("RequestVariant", () => {
   it("setting variant to a symbol", () => {
     const req = new Request({});
     req.variant = "phone";
-    expect(req.variant.phone()).toBe(true);
-    expect(req.variant.tablet()).toBe(false);
+    expect(req.variant["phone?"]()).toBe(true);
+    expect(req.variant["tablet?"]()).toBe(false);
     expect(req.variant.any("phone", "tablet")).toBe(true);
     expect(req.variant.any("tablet", "desktop")).toBe(false);
   });
@@ -621,9 +621,9 @@ describe("RequestVariant", () => {
   it("setting variant to an array of symbols", () => {
     const req = new Request({});
     req.variant = ["phone", "tablet"];
-    expect(req.variant.phone()).toBe(true);
-    expect(req.variant.tablet()).toBe(true);
-    expect(req.variant.desktop()).toBe(false);
+    expect(req.variant["phone?"]()).toBe(true);
+    expect(req.variant["tablet?"]()).toBe(true);
+    expect(req.variant["desktop?"]()).toBe(false);
     expect(req.variant.any("tablet", "desktop")).toBe(true);
     expect(req.variant.any("desktop", "watch")).toBe(false);
   });
@@ -632,7 +632,7 @@ describe("RequestVariant", () => {
     const req = new Request({});
     req.variant = null;
     expect(req.variant.length).toBe(0);
-    expect(req.variant.phone()).toBe(false);
+    expect(req.variant["phone?"]()).toBe(false);
     expect(req.variant.any("phone", "tablet")).toBe(false);
   });
 

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -102,10 +102,10 @@ describe("DelegatedTypeTest", () => {
     // `entryable_name.message?` works in addition to string equality.
     expect(String((entryWithMessage as any).entryableName)).toBe("message");
     expect((entryWithMessage as any).entryableName).toBeInstanceOf(StringInquirer);
-    expect((entryWithMessage as any).entryableName.message()).toBe(true);
+    expect((entryWithMessage as any).entryableName["message?"]()).toBe(true);
 
     expect(String((entryWithComment as any).entryableName)).toBe("comment");
-    expect((entryWithComment as any).entryableName.comment()).toBe(true);
+    expect((entryWithComment as any).entryableName["comment?"]()).toBe(true);
   });
 
   it("delegated type predicates", () => {

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -15,7 +15,7 @@
  * contract) have no Rails analog but ride the same canonical tables.
  */
 import { describe, it, expect } from "vitest";
-import { ActiveSupportJSON } from "@blazetrails/activesupport";
+import { ActiveSupportJSON, assertNotRespondTo } from "@blazetrails/activesupport";
 import { Base, registerModel } from "./index.js";
 
 import { Contact, ContactSti } from "./test-helpers/models/contact.js";
@@ -310,6 +310,7 @@ describe("DatabaseConnectedJsonEncodingTest", () => {
       await david.asJson({ include: "posts", methods: ["favoriteQuote"] }),
     );
 
+    assertNotRespondTo((await david.posts.first())!, "favoriteQuote");
     expect(json).toMatch(/"favoriteQuote":"Constraints are liberating"/);
     expect(json.match(/"favoriteQuote":/g)!.length).toBe(1);
   });

--- a/packages/activesupport/src/array-inquirer.test.ts
+++ b/packages/activesupport/src/array-inquirer.test.ts
@@ -1,57 +1,74 @@
-import { describe, it, expect } from "vitest";
-import { ArrayInquirer, arrayInquiry } from "./array-inquirer.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { ArrayInquirer, inquiry } from "./array-inquirer.js";
+import {
+  assert,
+  assertNot,
+  assertNotPredicate,
+  assertNotRespondTo,
+  assertPredicate,
+  assertRespondTo,
+} from "./testing/assertions.js";
 
 describe("ArrayInquirerTest", () => {
+  // Ruby `[:mobile, :tablet, "api"]` — a Symbol is a JS string, so all three
+  // elements are plain strings here.
+  let arrayInquirer: ArrayInquirer<string>;
+
+  beforeEach(() => {
+    arrayInquirer = new ArrayInquirer("mobile", "tablet", "api");
+  });
+
   it("individual", () => {
-    const kinds = arrayInquiry(["phone", "tablet"]);
-    expect((kinds as any).phone()).toBe(true);
-    expect((kinds as any).laptop()).toBe(false);
+    assertPredicate(arrayInquirer, (a) => (a as any)["mobile?"]());
+    assertPredicate(arrayInquirer, (a) => (a as any)["tablet?"]());
+    assertNotPredicate(arrayInquirer, (a) => (a as any)["desktop?"]());
   });
 
   it("any", () => {
-    const kinds = arrayInquiry(["phone", "tablet"]);
-    expect(kinds.any("phone", "laptop")).toBe(true);
-    expect(kinds.any("laptop", "desktop")).toBe(false);
+    assert(arrayInquirer.any("mobile", "desktop"));
+    assert(arrayInquirer.any("watch", "tablet"));
+    assertNot(arrayInquirer.any("desktop", "watch"));
   });
 
   it("any string symbol mismatch", () => {
-    const kinds = arrayInquiry(["phone"]);
-    // "phone" vs "Phone" — case sensitive
-    expect(kinds.any("Phone")).toBe(false);
-    expect(kinds.any("phone")).toBe(true);
+    assert(arrayInquirer.any("mobile"));
+    assert(arrayInquirer.any("api"));
   });
 
   it("any with block", () => {
-    const kinds = arrayInquiry(["phone", "tablet"]);
-    expect(kinds.any((k) => k.startsWith("ph"))).toBe(true);
-    expect(kinds.any((k) => k.startsWith("x"))).toBe(false);
+    assert(arrayInquirer.any((v) => v === "mobile"));
+    assertNot(arrayInquirer.any((v) => v === "desktop"));
   });
 
   it("respond to", () => {
-    const kinds = arrayInquiry(["phone"]);
-    expect(typeof (kinds as any).phone).toBe("function");
+    assertRespondTo(arrayInquirer, "development?");
   });
 
   it("inquiry", () => {
-    const arr = arrayInquiry(["a", "b"]);
-    expect(arr.inquiry()).toBe(arr);
+    const result = inquiry.call(["mobile", "tablet", "api"]);
+
+    expect(result).toBeInstanceOf(ArrayInquirer);
+    expect(result).toEqual(arrayInquirer);
   });
 
   it("respond to fallback to array respond to", () => {
-    const kinds = arrayInquiry(["phone"]);
-    // Standard array methods still work
-    expect(kinds.length).toBe(1);
-    expect(Array.isArray(kinds)).toBe(true);
+    // Rails reopens `Array` with a `respond_to_missing?` that answers `:foo`.
+    // The `super` arm of the inquirer's `has` trap is the prototype chain, so
+    // teaching `Array` one more name is `Array.prototype`.
+    Object.defineProperty(Array.prototype, "foo", { value: () => true, configurable: true });
+    const arr = new ArrayInquirer("x");
+
+    try {
+      assertRespondTo(arr, "can_you_hear_me?");
+      assertRespondTo(arr, "foo");
+      assertNotRespondTo(arr, "nope");
+    } finally {
+      delete (Array.prototype as any).foo;
+    }
   });
 });
 
 describe("ArrayInquirer", () => {
-  it("can be created directly", () => {
-    const ai = new ArrayInquirer("foo", "bar");
-    expect((ai as any).foo()).toBe(true);
-    expect((ai as any).baz()).toBe(false);
-  });
-
   it("any() with no args returns true when non-empty", () => {
     const ai = new ArrayInquirer("a", "b");
     expect(ai.any()).toBe(true);
@@ -60,5 +77,10 @@ describe("ArrayInquirer", () => {
   it("any() with no args returns false when empty", () => {
     const ai = new ArrayInquirer();
     expect(ai.any()).toBe(false);
+  });
+
+  it("a name without a question mark raises NoMethodError", () => {
+    const ai = new ArrayInquirer("a");
+    expect(() => (ai as any).mobile()).toThrow(/undefined method 'mobile'/);
   });
 });

--- a/packages/activesupport/src/array-inquirer.ts
+++ b/packages/activesupport/src/array-inquirer.ts
@@ -2,59 +2,88 @@
  * ActiveSupport::ArrayInquirer
  *
  * An array that makes membership checks more expressive via method-like access.
- * In Rails: kinds = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
- *           kinds.phone?  # => true
- *           kinds.laptop? # => false
- *           kinds.any?(:phone, :tablet) # => true
+ * In Rails: variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
+ *           variants.phone?  # => true
+ *           variants.desktop? # => false
+ *           variants.any?(:phone, :tablet) # => true
+ *
+ * Ruby resolves the predicates through `method_missing` / `respond_to_missing?`
+ * (array_inquirer.rb:36-46). TS has no such hook, so the class returns a `Proxy`
+ * whose `has` trap is `respond_to_missing?` and whose `get` trap is
+ * `method_missing` — the shape `methodMissingProxy` establishes. The Ruby method
+ * name keeps its question mark, so callers write `variants["phone?"]()`.
  */
 
-export class ArrayInquirer<T extends string | symbol> extends Array<T> {
-  private _proxy!: this;
+import { NameError } from "./core-ext/name-error.js";
 
+/** Ruby's `NoMethodError`, raised by `method_missing`'s `else super` arm. */
+class NoMethodError extends NameError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+export class ArrayInquirer<T extends string | symbol> extends Array<T> {
   constructor(...items: T[]) {
     super(...items);
-    const proxy = new Proxy(this, {
-      get(target, prop: string | symbol) {
-        if (prop in target || typeof prop === "symbol") {
-          const val = (target as any)[prop];
-          if (typeof val === "function") {
-            return function (this: unknown, ...args: unknown[]) {
-              return val.apply(target, args);
-            };
-          }
-          return val;
+    return new Proxy(this, {
+      get(target, prop: string | symbol, receiver) {
+        if (typeof prop === "symbol" || Reflect.has(target, prop)) {
+          return Reflect.get(target, prop, receiver);
         }
-        if (typeof prop === "string") {
-          const name = (prop.endsWith("?") ? prop.slice(0, -1) : prop) as unknown as T;
-          return () => (target as unknown as T[]).includes(name);
+        // `any?(name[0..-2])` when the name ends in `?`.
+        if (prop.endsWith("?")) {
+          const methodName = prop;
+          return () => target.any(methodName.slice(0, -1));
         }
-        return undefined;
+        // `else super` — see StringInquirer for why the raise is at the call.
+        return () => {
+          throw new NoMethodError(
+            `undefined method '${prop}' for an instance of ${target.constructor.name}`,
+          );
+        };
+      },
+      // `respond_to_missing?`: `name.end_with?("?") || super`.
+      has(target, prop) {
+        return (typeof prop === "string" && prop.endsWith("?")) || Reflect.has(target, prop);
       },
     });
-    this._proxy = proxy;
-    return proxy;
   }
 
-  /** any?(*values) — true if any of the given values are in the array. */
-  any(...values: (string | symbol | ((item: T) => boolean))[]): boolean {
-    if (values.length === 0) return this.length > 0;
-    return values.some((v) => {
-      if (typeof v === "function") return (this as unknown as T[]).some(v as (item: T) => boolean);
-      return (this as unknown as T[]).includes(v as T);
-    });
-  }
+  /**
+   * Mirrors: ActiveSupport::ArrayInquirer#any? (array_inquirer.rb:27-35).
+   *
+   * A trails `candidate` is always a string — a Ruby Symbol is a JS string — so
+   * the `to_sym`/`to_s` pair collapses to one `include?`. Ruby's block arrives
+   * as a trailing function argument, which is what leaves `candidates` empty and
+   * takes the `super` arm (`Enumerable#any?`) just as `any? { … }` does.
+   */
+  any(...candidates: (string | ((element: T) => boolean))[]): boolean {
+    const block = typeof candidates[0] === "function" ? candidates[0] : undefined;
+    if (block !== undefined) candidates = [];
 
-  /** inquiry — alias that returns self (matches Rails API) */
-  inquiry(): this {
-    return this._proxy;
+    if (candidates.length === 0) {
+      // `super` — `Enumerable#any?`, which is "matches the block" with one and
+      // "not empty" without.
+      const elements = this as unknown as T[];
+      return block !== undefined ? elements.some(block) : elements.length > 0;
+    }
+    return (candidates as string[]).some((candidate) =>
+      (this as unknown as T[]).includes(candidate as T),
+    );
   }
 }
 
 /**
- * Factory — mirrors Rails' Array#inquiry core ext.
+ * `Array#inquiry` (core_ext/array/inquiry.rb:15-17). Ruby reopens Array, so the
+ * receiver is `self`; TS spells that with the `this`-typed mixin idiom
+ * (CLAUDE.md, _Module mixins_) and callers write `inquiry.call(arr)`. The package
+ * index re-exports it as `arrayInquiry`, since `String#inquiry` already holds
+ * the bare name there.
  */
-export function arrayInquiry<T extends string | symbol>(
-  items: T[],
+export function inquiry<T extends string | symbol>(
+  this: T[],
 ): ArrayInquirer<T> & Record<string, () => boolean> {
-  return new ArrayInquirer<T>(...items) as any;
+  return new ArrayInquirer<T>(...this) as any;
 }

--- a/packages/activesupport/src/core-ext/string-ext.test.ts
+++ b/packages/activesupport/src/core-ext/string-ext.test.ts
@@ -636,8 +636,8 @@ describe("StringInflectionsTest", () => {
 
   it("string inquiry", () => {
     const env = new StringInquirer("production") as any;
-    expect(env.isProduction()).toBe(true);
-    expect(env.isDevelopment()).toBe(false);
+    expect(env["production?"]()).toBe(true);
+    expect(env["development?"]()).toBe(false);
   });
 
   it("truncate", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -546,7 +546,7 @@ export { Executor } from "./executor.js";
 export { objectWith } from "./core-ext/object/with.js";
 export { withOptions } from "./core-ext/object/with-options.js";
 export { OptionMerger } from "./option-merger.js";
-export { ArrayInquirer, arrayInquiry } from "./array-inquirer.js";
+export { ArrayInquirer, inquiry as arrayInquiry } from "./array-inquirer.js";
 export { tryCall, tryWith, tryBang } from "./try.js";
 export { OrderedOptions, InheritableOptions } from "./ordered-options.js";
 // Digest/SecurityUtils/ConfigurationFile use adapter pattern — kept as subpath imports:
@@ -616,6 +616,8 @@ export {
   assertNot,
   assertPredicate,
   assertNotPredicate,
+  assertRespondTo,
+  assertNotRespondTo,
   assertEmpty,
   assertNotEmpty,
   assertSame,

--- a/packages/activesupport/src/parameter-filter.test.ts
+++ b/packages/activesupport/src/parameter-filter.test.ts
@@ -1,148 +1,198 @@
 import { describe, it, expect } from "vitest";
-import { ParameterFilter } from "./parameter-filter.js";
+import { ParameterFilter, type Filter } from "./parameter-filter.js";
+import { HashWithIndifferentAccess } from "./hash-with-indifferent-access.js";
+import { withIndifferentAccess } from "./core-ext/hash/indifferent-access.js";
 
 /** Ruby's `String#swapcase`, which JS has no built-in for. */
 function swapcase(str: string): string {
   return str.replace(/\p{L}/gu, (c) => (c === c.toLowerCase() ? c.toUpperCase() : c.toLowerCase()));
 }
 
+type Params = Record<string, unknown>;
+
 describe("ParameterFilterTest", () => {
   it("process parameter filter", () => {
-    const f = new ParameterFilter(["password", "credit_card"]);
-    const result = f.filter({
-      username: "alice",
-      password: "secret",
-      credit_card: "4111111111111111",
-    });
-    expect(result.username).toBe("alice");
-    expect(result.password).toBe("[FILTERED]");
-    expect(result.credit_card).toBe("[FILTERED]");
+    const testHashes: [Params, Params, Filter[]][] = [
+      [{ foo: "bar" }, { foo: "bar" }, ["food"]],
+      [{ foo: "bar" }, { foo: "[FILTERED]" }, ["foo"]],
+      [{ foo: "bar", bar: "foo" }, { foo: "[FILTERED]", bar: "foo" }, ["foo", "baz"]],
+      [{ foo: "bar", baz: "foo" }, { foo: "[FILTERED]", baz: "[FILTERED]" }, ["foo", "baz"]],
+      [{ bar: { foo: "bar", bar: "foo" } }, { bar: { foo: "[FILTERED]", bar: "foo" } }, ["fo"]],
+      [{ foo: { foo: "bar", bar: "foo" } }, { foo: "[FILTERED]" }, ["f", "banana"]],
+      [
+        { deep: { cc: { code: "bar", bar: "foo" }, ss: { code: "bar" } } },
+        { deep: { cc: { code: "[FILTERED]", bar: "foo" }, ss: { code: "bar" } } },
+        ["deep.cc.code"],
+      ],
+      [{ baz: [{ foo: "baz" }, "1"] }, { baz: [{ foo: "[FILTERED]" }, "1"] }, [/foo/]],
+    ];
+
+    for (const [beforeFilter, afterFilter, filterWords] of testHashes) {
+      let parameterFilter = new ParameterFilter(filterWords);
+      expect(parameterFilter.filter(beforeFilter)).toEqual(afterFilter);
+
+      filterWords.push("blah");
+      filterWords.push((key, value) => {
+        if (/bargain/.test(key)) return [...String(value)].reverse().join("");
+      });
+      filterWords.push((key, value, originalParams) => {
+        if ((originalParams!["barg"] as Params)["blah"] === "bar" && key === "hello") {
+          return "world!";
+        }
+      });
+
+      filterWords.push((key, value) => {
+        if (key === "array_elements") return String(value).toUpperCase();
+      });
+
+      parameterFilter = new ParameterFilter(filterWords);
+      beforeFilter["barg"] = {
+        bargain: "gain",
+        blah: "bar",
+        bar: { bargain: { blah: "foo", hello: "world" } },
+      };
+      afterFilter["barg"] = {
+        bargain: "niag",
+        blah: "[FILTERED]",
+        bar: { bargain: { blah: "[FILTERED]", hello: "world!" } },
+      };
+
+      beforeFilter["array_elements"] = ["element1", "element2"];
+      afterFilter["array_elements"] = ["ELEMENT1", "ELEMENT2"];
+
+      expect(parameterFilter.filter(beforeFilter)).toEqual(afterFilter);
+    }
   });
 
   it("filter should return mask option when value is filtered", () => {
-    const f = new ParameterFilter(["secret"], { mask: "[REDACTED]" });
-    const result = f.filter({ secret: "mySecret", name: "bob" });
-    expect(result.secret).toBe("[REDACTED]");
-    expect(result.name).toBe("bob");
+    const mask = Object.freeze({});
+    const testHashes: [Params, Params, Filter[]][] = [
+      [{ foo: "bar" }, { foo: "bar" }, ["food"]],
+      [{ foo: "bar" }, { foo: mask }, ["foo"]],
+      [{ foo: "bar", bar: "foo" }, { foo: mask, bar: "foo" }, ["foo", "baz"]],
+      [{ foo: "bar", baz: "foo" }, { foo: mask, baz: mask }, ["foo", "baz"]],
+      [{ bar: { foo: "bar", bar: "foo" } }, { bar: { foo: mask, bar: "foo" } }, ["fo"]],
+      [{ foo: { foo: "bar", bar: "foo" } }, { foo: mask }, ["f", "banana"]],
+      [
+        { deep: { cc: { code: "bar", bar: "foo" }, ss: { code: "bar" } } },
+        { deep: { cc: { code: mask, bar: "foo" }, ss: { code: "bar" } } },
+        ["deep.cc.code"],
+      ],
+      [{ baz: [{ foo: "baz" }, "1"] }, { baz: [{ foo: mask }, "1"] }, [/foo/]],
+    ];
+
+    for (const [beforeFilter, afterFilter, filterWords] of testHashes) {
+      let parameterFilter = new ParameterFilter(filterWords, { mask });
+      expect(parameterFilter.filter(beforeFilter)).toEqual(afterFilter);
+
+      filterWords.push("blah");
+      filterWords.push((key, value) => {
+        if (/bargain/.test(key)) return [...String(value)].reverse().join("");
+      });
+      filterWords.push((key, value, originalParams) => {
+        if ((originalParams!["barg"] as Params)["blah"] === "bar" && key === "hello") {
+          return "world!";
+        }
+      });
+
+      parameterFilter = new ParameterFilter(filterWords, { mask });
+      beforeFilter["barg"] = {
+        bargain: "gain",
+        blah: "bar",
+        bar: { bargain: { blah: "foo", hello: "world" } },
+      };
+      afterFilter["barg"] = {
+        bargain: "niag",
+        blah: mask,
+        bar: { bargain: { blah: mask, hello: "world!" } },
+      };
+
+      expect(parameterFilter.filter(beforeFilter)).toEqual(afterFilter);
+    }
   });
 
   it("filter_param", () => {
-    const f = new ParameterFilter(["password"]);
-    expect(f.filterParam("password", "hunter2")).toBe("[FILTERED]");
-    expect(f.filterParam("username", "alice")).toBe("alice");
+    const parameterFilter = new ParameterFilter(["foo", /bar/]);
+    expect(parameterFilter.filterParam("food", "secret value")).toBe("[FILTERED]");
+    expect(parameterFilter.filterParam("baz.foo", "secret value")).toBe("[FILTERED]");
+    expect(parameterFilter.filterParam("barbar", "secret value")).toBe("[FILTERED]");
+    expect(parameterFilter.filterParam("baz", "non secret value")).toBe("non secret value");
   });
 
   it("filter_param can work with empty filters", () => {
-    const f = new ParameterFilter([]);
-    expect(f.filterParam("password", "hunter2")).toBe("hunter2");
-    expect(f.filterParam("anything", "value")).toBe("value");
+    const parameterFilter = new ParameterFilter();
+    expect(parameterFilter.filterParam("foo", "bar")).toBe("bar");
   });
 
   it("parameter filter should maintain hash with indifferent access", () => {
-    const f = new ParameterFilter(["token"]);
-    const result = f.filter({ token: "abc123", data: "visible" });
-    expect(result["token"]).toBe("[FILTERED]");
-    expect(result["data"]).toBe("visible");
+    const testHashes: [HashWithIndifferentAccess<unknown>, Filter[]][] = [
+      [withIndifferentAccess({ foo: "bar" }), ["blah"]],
+      [withIndifferentAccess({ foo: "bar" }), []],
+    ];
+
+    for (const [beforeFilter, filterWords] of testHashes) {
+      const parameterFilter = new ParameterFilter(filterWords);
+      expect(parameterFilter.filter(beforeFilter as unknown as Params)).toBeInstanceOf(
+        HashWithIndifferentAccess,
+      );
+    }
   });
 
   it("filter_param should return mask option when value is filtered", () => {
-    const f = new ParameterFilter(["key"], { mask: "[HIDDEN]" });
-    expect(f.filterParam("key", "value")).toBe("[HIDDEN]");
+    const mask = Object.freeze({});
+    const parameterFilter = new ParameterFilter(["foo", /bar/], { mask });
+    expect(parameterFilter.filterParam("food", "secret value")).toEqual(mask);
+    expect(parameterFilter.filterParam("baz.foo", "secret value")).toEqual(mask);
+    expect(parameterFilter.filterParam("barbar", "secret value")).toEqual(mask);
+    expect(parameterFilter.filterParam("baz", "non secret value")).toEqual("non secret value");
   });
 
   it("process parameter filter with hash having integer keys", () => {
-    const f = new ParameterFilter(["secret"]);
-    const params: Record<string, unknown> = { "0": "public", secret: "hidden" };
-    const result = f.filter(params);
-    expect(result["0"]).toBe("public");
-    expect(result["secret"]).toBe("[FILTERED]");
+    const testHashes: [Params, Params, Filter[]][] = [
+      [{ 13: "bar" }, { 13: "[FILTERED]" }, ["13"]],
+      [{ 20: "bar" }, { 20: "bar" }, ["13"]],
+    ];
+
+    for (const [beforeFilter, afterFilter, filterWords] of testHashes) {
+      const parameterFilter = new ParameterFilter(filterWords);
+      expect(parameterFilter.filter(beforeFilter)).toEqual(afterFilter);
+    }
   });
 
   it("precompile_filters", () => {
-    const patterns = [/A.a/, /b.B/i, "ccC", "ddD"];
+    const patterns: (RegExp | string)[] = [/A.a/, /b.B/i, "ccC", "ddD"];
     const keys = ["Aaa", "Bbb", "Ccc", "Ddd"];
-    const deepPatterns = [/A\.a/, /b\.B/i, "c.C", "d.D"];
+    const deepPatterns: (RegExp | string)[] = [/A\.a/, /b\.B/i, "c.C", "d.D"];
     const deepKeys = ["A.a", "B.b", "C.c", "D.d"];
     const procs = [() => {}, () => {}];
 
     const precompiled = ParameterFilter.precompileFilters([...patterns, ...deepPatterns, ...procs]);
 
-    const regexps = precompiled.filter((f): f is RegExp => f instanceof RegExp);
-    expect(regexps.length).toBe(2);
+    expect(precompiled.filter((filter) => filter instanceof RegExp).length).toBe(2);
     expect(precompiled.length).toBe(2 + procs.length);
 
-    const regexp = regexps.find((r) => r.source.includes((patterns[0] as RegExp).source))!;
-    for (const key of keys) expect(regexp.test(key)).toBe(true);
-    expect(regexp.test(swapcase(keys[0]))).toBe(false);
+    // Ruby matches on `filter.to_s`, whose embeddable form (`(?-mix:A.a)`) is what
+    // the joined Regexp carries; JS joins `source`, so `source` is the analogue.
+    const regexp = precompiled.find(
+      (filter) =>
+        filter instanceof RegExp && filter.source.includes((patterns[0] as RegExp).source),
+    ) as RegExp;
+    for (const key of keys) expect(key).toMatch(regexp);
+    expect(swapcase(keys[0])).not.toMatch(regexp);
 
-    const deepRegexp = regexps.find((r) => r.source.includes((deepPatterns[0] as RegExp).source))!;
-    for (const deepKey of deepKeys) expect(deepRegexp.test(deepKey)).toBe(true);
-    expect(deepRegexp.test(swapcase(deepKeys[0]))).toBe(false);
+    const deepRegexp = precompiled.find(
+      (filter) =>
+        filter instanceof RegExp && filter.source.includes((deepPatterns[0] as RegExp).source),
+    ) as RegExp;
+    for (const deepKey of deepKeys) expect(deepKey).toMatch(deepRegexp);
+    expect(swapcase(deepKeys[0])).not.toMatch(deepRegexp);
 
     expect(regexp).not.toEqual(deepRegexp);
-    expect(precompiled.filter((f) => procs.includes(f as () => void))).toEqual(procs);
-
-    const filter = new ParameterFilter(precompiled);
-    for (const key of keys) expect(filter.filterParam(key, "x")).toBe("[FILTERED]");
-    for (const deepKey of deepKeys) {
-      expect(filter.filter({ [deepKey]: "x" })[deepKey]).toBe("[FILTERED]");
-    }
-    expect(filter.filterParam("zzz", "x")).toBe("x");
+    expect(precompiled.filter((filter) => procs.includes(filter as () => void))).toEqual(procs);
   });
 });
 
-describe("ParameterFilterTest", () => {
-  it("process parameter filter", () => {
-    const filter = new ParameterFilter(["password"]);
-    const result = filter.filter({ user: "alice", password: "secret" });
-    expect(result.user).toBe("alice");
-    expect(result.password).toBe("[FILTERED]");
-  });
-
-  it("filter should return mask option when value is filtered", () => {
-    const filter = new ParameterFilter(["token"], { mask: "REDACTED" });
-    const result = filter.filter({ token: "abc123" });
-    expect(result.token).toBe("REDACTED");
-  });
-
-  it("filter_param", () => {
-    const filter = new ParameterFilter(["secret"]);
-    expect(filter.filterParam("secret", "my_secret")).toBe("[FILTERED]");
-    expect(filter.filterParam("name", "alice")).toBe("alice");
-  });
-
-  it("filter_param can work with empty filters", () => {
-    const filter = new ParameterFilter([]);
-    expect(filter.filterParam("password", "value")).toBe("value");
-  });
-
-  it("parameter filter should maintain hash with indifferent access", () => {
-    const filter = new ParameterFilter(["password"]);
-    const result = filter.filter({ password: "secret", username: "admin" });
-    expect(result.password).toBe("[FILTERED]");
-    expect(result.username).toBe("admin");
-  });
-
-  it("filter_param should return mask option when value is filtered", () => {
-    const filter = new ParameterFilter(["key"], { mask: "***" });
-    expect(filter.filterParam("key", "value")).toBe("***");
-  });
-
-  it("process parameter filter with hash having integer keys", () => {
-    const filter = new ParameterFilter(["password"]);
-    const result = filter.filter({ 1: "one", password: "secret" } as Record<string, unknown>);
-    expect(result.password).toBe("[FILTERED]");
-    expect(result["1"]).toBe("one");
-  });
-
-  it("precompile_filters", () => {
-    // Verify filter works with regex patterns
-    const filter = new ParameterFilter([/password/i]);
-    const result = filter.filter({ Password: "secret", name: "alice" });
-    expect(result.Password).toBe("[FILTERED]");
-    expect(result.name).toBe("alice");
-  });
-
+describe("ParameterFilter", () => {
   it("recurses into nested plain objects", () => {
     const filter = new ParameterFilter(["secret"]);
     const result = filter.filter({ outer: { secret: "hidden", public: "visible" } });
@@ -179,5 +229,14 @@ describe("ParameterFilterTest", () => {
     const result = filter.filter(params as Record<string, unknown>);
     expect(result.secret).toBe("[FILTERED]");
     expect(result.name).toBe("alice");
+  });
+
+  it("filters a nested HashWithIndifferentAccess in place", () => {
+    const filter = new ParameterFilter(["secret"]);
+    const params = withIndifferentAccess({ outer: withIndifferentAccess({ secret: "hidden" }) });
+    const result = filter.filter(params as unknown as Record<string, unknown>);
+    expect((result as unknown as HashWithIndifferentAccess<any>).get("outer").get("secret")).toBe(
+      "[FILTERED]",
+    );
   });
 });

--- a/packages/activesupport/src/parameter-filter.ts
+++ b/packages/activesupport/src/parameter-filter.ts
@@ -1,3 +1,5 @@
+import { HashWithIndifferentAccess } from "./hash-with-indifferent-access.js";
+
 /**
  * = Active Support Parameter Filter
  *
@@ -132,7 +134,14 @@ export class ParameterFilter {
 
   /** Mask value of `params` if key matches one of filters. */
   filter(params: Record<string, unknown>): Record<string, unknown> {
-    return this.noFilters ? { ...params } : this.call(params);
+    if (!this.noFilters) return this.call(params);
+    // `params.dup` (parameter_filter.rb:85) — a shallow copy of the SAME class,
+    // so a HashWithIndifferentAccess in stays one on the way out. An object
+    // spread would flatten it to a plain object, whose keys are not indifferent.
+    if (params instanceof HashWithIndifferentAccess) {
+      return params.dup() as unknown as Record<string, unknown>;
+    }
+    return { ...params };
   }
 
   /**
@@ -181,9 +190,21 @@ export class ParameterFilter {
     fullParentKey: string | null = null,
     originalParams: Record<string, unknown> | null = params,
   ): Record<string, unknown> {
-    // `params.class.new` (parameter_filter.rb:126). A null-prototype hash has
-    // no constructor — no class, in Ruby's terms — so it allocates a plain
-    // Object, the nearest thing JS has to its class.
+    // `params.class.new` (parameter_filter.rb:126), then `params.each` and
+    // `filtered_params[key] = …`. A HashWithIndifferentAccess keeps its keys in
+    // a private Map, so `Object.entries` sees nothing on it and index
+    // assignment writes past it — its own iteration and writer are the `each`
+    // and `[]=` Ruby dispatches to.
+    if (params instanceof HashWithIndifferentAccess) {
+      const filteredParams = new HashWithIndifferentAccess<unknown>();
+      (params as HashWithIndifferentAccess<unknown>).forEach((value, key) => {
+        filteredParams.set(key, this.valueForKey(key, value, fullParentKey, originalParams));
+      });
+      return filteredParams as unknown as Record<string, unknown>;
+    }
+
+    // A null-prototype hash has no constructor — no class, in Ruby's terms —
+    // so it allocates a plain Object, the nearest thing JS has to its class.
     const filteredParams = new ((params.constructor ?? Object) as ObjectConstructor)() as Record<
       string,
       unknown
@@ -241,8 +262,13 @@ function escapeRegexp(source: string): string {
   return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Ruby's `value.is_a?(Hash)` — a plain object, not a class instance. */
+/**
+ * Ruby's `value.is_a?(Hash)` — a plain object, not a class instance. A
+ * HashWithIndifferentAccess is a `Hash` in Ruby (`class HashWithIndifferentAccess
+ * < Hash`), so a nested one recurses like any other hash.
+ */
 function isHash(value: unknown): value is Record<string, unknown> {
+  if (value instanceof HashWithIndifferentAccess) return true;
   if (value === null || typeof value !== "object") return false;
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;

--- a/packages/activesupport/src/string-inquirer.test.ts
+++ b/packages/activesupport/src/string-inquirer.test.ts
@@ -1,45 +1,58 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { StringInquirer, inquiry } from "./string-inquirer.js";
+import {
+  assertNotPredicate,
+  assertNotRespondTo,
+  assertPredicate,
+  assertRespondTo,
+} from "./testing/assertions.js";
 
 describe("StringInquirerTest", () => {
+  let stringInquirer: StringInquirer;
+
+  beforeEach(() => {
+    stringInquirer = new StringInquirer("production");
+  });
+
   it("match", () => {
-    const env = inquiry.call("production");
-    expect((env as any).production()).toBe(true);
+    assertPredicate(stringInquirer, (s) => (s as any)["production?"]());
   });
 
   it("miss", () => {
-    const env = inquiry.call("production");
-    expect((env as any).development()).toBe(false);
+    assertNotPredicate(stringInquirer, (s) => (s as any)["development?"]());
   });
 
   it("missing question mark", () => {
-    const env = inquiry.call("test");
-    // Without ? still returns a callable function (TS adaptation)
-    expect(typeof (env as any).test).toBe("function");
+    expect(() => (stringInquirer as any).production()).toThrow(/undefined method 'production'/);
   });
 
   it("respond to", () => {
-    const env = inquiry.call("production");
-    expect(typeof (env as any).production).toBe("function");
+    assertRespondTo(stringInquirer, "development?");
   });
 
   it("respond to fallback to string respond to", () => {
-    const env = inquiry.call("production");
-    expect(env.toString()).toBe("production");
+    // Rails reopens `String` with a `respond_to_missing?` that answers `:bar`.
+    // The `super` arm of the inquirer's `has` trap is the prototype chain, so
+    // teaching `String` one more name is `String.prototype`.
+    Object.defineProperty(String.prototype, "bar", { value: () => true, configurable: true });
+    const str = new StringInquirer("hello");
+
+    try {
+      assertRespondTo(str, "are_you_ready?");
+      assertRespondTo(str, "bar");
+      assertNotRespondTo(str, "nope");
+    } finally {
+      delete (String.prototype as any).bar;
+    }
   });
 });
 
 describe("StringInquirer", () => {
-  it("inquiry factory creates inquirer from string", () => {
+  it("inquiry factory wraps the receiver", () => {
     const env = inquiry.call("test");
-    expect(env.is("test")).toBe(true);
-    expect(env.is("production")).toBe(false);
-  });
-
-  it("is() method checks equality", () => {
-    const s = new StringInquirer("staging");
-    expect(s.is("staging")).toBe(true);
-    expect(s.is("production")).toBe(false);
+    expect(env).toBeInstanceOf(StringInquirer);
+    expect((env as any)["test?"]()).toBe(true);
+    expect((env as any)["production?"]()).toBe(false);
   });
 
   it("toString returns original string", () => {
@@ -51,12 +64,5 @@ describe("StringInquirer", () => {
   it("valueOf returns original string", () => {
     const s = inquiry.call("test");
     expect(s.valueOf()).toBe("test");
-  });
-
-  it("question mark methods return true/false", () => {
-    const env = inquiry.call("production");
-    expect((env as any).production()).toBe(true);
-    expect((env as any).staging()).toBe(false);
-    expect((env as any).development()).toBe(false);
   });
 });

--- a/packages/activesupport/src/string-inquirer.ts
+++ b/packages/activesupport/src/string-inquirer.ts
@@ -6,8 +6,23 @@
  *           env.production? # => true
  *           env.development? # => false
  *
- * In TypeScript we use a Proxy to intercept property access.
+ * Ruby resolves those through `method_missing` / `respond_to_missing?`
+ * (string_inquirer.rb:22-32). TS has no such hook, so the class returns a
+ * `Proxy` whose `has` trap is `respond_to_missing?` and whose `get` trap is
+ * `method_missing` — the shape `methodMissingProxy` establishes, and for the
+ * same reason. The Ruby method name keeps its question mark, so callers write
+ * `env["production?"]()`.
  */
+
+import { NameError } from "./core-ext/name-error.js";
+
+/** Ruby's `NoMethodError`, raised by `method_missing`'s `else super` arm. */
+class NoMethodError extends NameError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
 
 export class StringInquirer {
   private readonly _value: string;
@@ -15,14 +30,38 @@ export class StringInquirer {
   constructor(value: string) {
     this._value = value;
     return new Proxy(this, {
-      get(target, prop: string | symbol) {
-        if (typeof prop === "symbol" || prop in target) {
-          return (target as any)[prop];
+      get(target, prop: string | symbol, receiver) {
+        if (typeof prop === "symbol" || Reflect.has(target, prop)) {
+          return Reflect.get(target, prop, receiver);
         }
-        let name = prop;
-        if (name.endsWith("?")) name = name.slice(0, -1);
-        if (/^is[A-Z]/.test(name)) name = name[2].toLowerCase() + name.slice(3);
-        return () => target._value === name;
+        // `class StringInquirer < String` (string_inquirer.rb:21): a String
+        // method resolves before `method_missing` does. TS cannot subclass the
+        // String primitive, so the superclass is the wrapped string itself.
+        const stringSelf = Object(target._value) as Record<string, unknown>;
+        if (prop in stringSelf) {
+          const value = stringSelf[prop];
+          return typeof value === "function" ? value.bind(target._value) : value;
+        }
+        // `self == method_name[0..-2]` when the name ends in `?`.
+        if (prop.endsWith("?")) {
+          const methodName = prop;
+          return () => target._value === methodName.slice(0, -1);
+        }
+        // `else super`. A `get` trap cannot raise — `"foo" in x` and
+        // `typeof x.foo` both route through it — so the raise moves to the
+        // call, which is where Ruby's `method_missing` raises.
+        return () => {
+          throw new NoMethodError(
+            `undefined method '${prop}' for an instance of ${target.constructor.name}`,
+          );
+        };
+      },
+      // `respond_to_missing?`: `method_name.end_with?("?") || super`.
+      has(target, prop) {
+        if (typeof prop === "string" && (prop.endsWith("?") || prop in Object(target._value))) {
+          return true;
+        }
+        return Reflect.has(target, prop);
       },
     });
   }
@@ -38,11 +77,6 @@ export class StringInquirer {
    */
   valueOf(): string {
     return this._value;
-  }
-
-  /** Programmatic inquiry — mirrors Ruby's respond_to? pattern. */
-  is(name: string): boolean {
-    return this._value === name;
   }
 }
 

--- a/packages/activesupport/src/testing/assertions.ts
+++ b/packages/activesupport/src/testing/assertions.ts
@@ -555,6 +555,28 @@ export function assertNotPredicate<T>(
 }
 
 /**
+ * @noRailsEquivalent PERMANENT — Minitest's `assert_respond_to`
+ * (minitest/assertions.rb), which sends `respond_to?(name)`. Rails inherits it
+ * from Minitest, so there is no Ruby counterpart in a mapped file.
+ *
+ * JS has no `respond_to?`; the analogue of Ruby's method lookup (own members,
+ * ancestors, and `respond_to_missing?`) is the `in` operator, which walks the
+ * prototype chain and routes through a `Proxy`'s `has` trap — the trap
+ * `methodMissingProxy` and the inquirers implement `respond_to_missing?` with.
+ */
+export function assertRespondTo(actual: unknown, name: string, message?: string): void {
+  assert(name in Object(actual), message ?? `Expected ${inspect(actual)} to respond to ${name}`);
+}
+
+/** @noRailsEquivalent PERMANENT — Minitest's `assert_not_respond_to` / `refute_respond_to`. */
+export function assertNotRespondTo(actual: unknown, name: string, message?: string): void {
+  assert(
+    !(name in Object(actual)),
+    message ?? `Expected ${inspect(actual)} to not respond to ${name}`,
+  );
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Minitest's `assert_empty` (minitest/assertions.rb),
  * which sends `empty?` to the collection. Rails inherits it from Minitest, so
  * there is no Ruby counterpart in a mapped file. JS has no `empty?` protocol, so

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -108,7 +108,7 @@ Finisher.initializer("setup_main_autoloader", async function (this: FinisherHost
 });
 
 Finisher.initializer("add_internal_routes", function (this: FinisherHost) {
-  if (!(Trails.env as unknown as { isDevelopment(): boolean }).isDevelopment()) return;
+  if (!(Trails.env as unknown as Record<string, () => boolean>)["development?"]()) return;
   this.routes().prepend((mapper) => {
     mapper.get("/rails/info/properties", { to: "rails/info#properties", internal: true });
     mapper.get("/rails/info/routes", { to: "rails/info#routes", internal: true });

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -79,7 +79,7 @@ describe("Trails", () => {
 
   it("Trails.env= accepts a string and wraps it in EnvironmentInquirer", () => {
     Trails.env = "test";
-    expect(Trails.env.is("test")).toBe(true);
+    expect((Trails.env as any)["test?"]()).toBe(true);
     expect(Trails.env.toString()).toBe("test");
   });
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-inquirer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-inquirer.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "array-inquirer.ts",
-    "rubyName": "inquiry",
-    "call": "new",
-    "reason": "Rails' `Array#inquiry` is `ArrayInquirer.new(self)`; trails' `arrayInquiry` does construct one (`new ArrayInquirer<T>(...items)`, array-inquirer.ts:58) — the spread makes it a different arity, so the matcher does not pair the two."
-  }
-]

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -36,6 +36,7 @@ export type CanonicalKind =
   | "notPredicate"
   | "instanceOf"
   | "respondTo"
+  | "notRespondTo"
   | "operator"
   | "length"
   | "inDelta";
@@ -60,6 +61,8 @@ const NEGATION: Partial<Record<CanonicalKind, CanonicalKind>> = {
   notSame: "same",
   predicate: "notPredicate",
   notPredicate: "predicate",
+  respondTo: "notRespondTo",
+  notRespondTo: "respondTo",
   // `expect(() => …).not.toThrow()` is the port of `assert_nothing_raised`,
   // which minitest spells as its own assertion rather than as `refute_raises`.
   raises: "nothingRaised",
@@ -100,6 +103,8 @@ const RAILS_MAP: Record<string, CanonicalKind> = {
   assert_instance_of: "instanceOf",
   assert_kind_of: "instanceOf",
   assert_respond_to: "respondTo",
+  assert_not_respond_to: "notRespondTo",
+  refute_respond_to: "notRespondTo",
   assert_operator: "operator",
   assert_in_delta: "inDelta",
 };

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,8 +31,8 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 963,
-      "kind": 1342,
+      "assertionCount": 951,
+      "kind": 1327,
       "value": 130
     },
     "arel": {


### PR DESCRIPTION
Converges `array_inquirer_test.rb`, `string_inquirer_test.rb` and
`parameter_filter_test.rb` to **0 assertion-count / 0 kind / 0 value**
mismatches, re-ported against the vendored Ruby.

## Inquirers — `respond_to_missing?` / `method_missing`

`ArrayInquirer` and `StringInquirer` previously resolved *every* name through
their `Proxy`, so `assert_respond_to` / `assert_not_respond_to` were
untestable and `test_missing_question_mark`'s `NoMethodError` had nowhere to
come from.

They now mirror array_inquirer.rb:36-46 / string_inquirer.rb:22-32 with the
settled trails shape (`method-missing-proxy.ts`): the `has` trap **is**
`respond_to_missing?` (`name.end_with?("?") || super`) and the `get` trap
**is** `method_missing`, whose `else super` arm raises `NoMethodError` — at
call time, since a `get` trap cannot raise without blowing up every
`typeof`/`in` probe.

So a predicate keeps the Ruby method name, question mark included:

```ts
variants["phone?"]()      // was variants.phone()
```

Callers updated: `request.test.ts`, `delegated-type.test.ts`,
`string-ext.test.ts`, `rails.test.ts`, and `finisher.ts` (whose
`Rails.env.development?`, finisher.rb:141, was spelled `isDevelopment()`).

Also here: `StringInquirer` resolves String's own methods — read through the
wrapped string, so `length` is the string's length — before `method_missing`
runs, per `class StringInquirer < String`; `ArrayInquirer#any?` follows
array_inquirer.rb:27-35's single `candidates.none?` branch, with Ruby's block
arriving as the trailing function argument that empties `candidates` and routes
to the `super` arm; and
`Array#inquiry` is the top-level `inquiry` (core_ext/array/inquiry.rb:15-17),
which **retires** the `activesupport/array-inquirer.json` call-mismatch
baseline row (the old instance-method `inquiry` returned a memoized proxy
instead of constructing one).

## ParameterFilter — HashWithIndifferentAccess

`filter`'s no-filters arm is `params.dup` (parameter_filter.rb:85) and `call`
uses `params.class.new` / `params.each` / `filtered_params[key] =`
(:124-131). Trails used an object spread and `Object.entries` + index
assignment, which see *nothing* on a `HashWithIndifferentAccess` — its keys
live in a private `Map` — so `test_parameter_filter_should_maintain_hash_with_indifferent_access`
could not pass. Both arms now dispatch to the hash's own class, writer and
iterator, and `isHash` treats one as a `Hash` (which in Ruby it is), so a
nested HWIA recurses.

The duplicate `describe("ParameterFilterTest")` block is deleted; its
genuinely TS-only cases (Date/class-instance passthrough, null-prototype
objects) move under `describe("ParameterFilter")`.

## Comparator

`assert_not_respond_to` / `refute_respond_to` were **unmapped** in
`scripts/test-compare/assertion-kinds.ts`, so they never counted. Mapping them
(canonical kind `notRespondTo`, negation-paired with `respondTo`) surfaced one
pre-existing gap in `json_serialization_test.rb › should not call methods on
associations that dont respond`, missing its `assert_not_respond_to` — converged
here rather than left to red the ratchet. New `assertRespondTo` /
`assertNotRespondTo` helpers check `name in Object(actual)`, the JS analogue of
Ruby's method lookup (own members, ancestors, `respond_to_missing?`) and the
operator that routes through the `has` trap.

## Gates

- `pnpm parity:test -- --assertions --package activesupport`: 983/1367/130 →
  **971/1352/130** (measured on the rebased base); mark lowered to match.
  Percent unchanged at 85.9%. activerecord's counters are unmoved: the
  `notRespondTo` mapping and the `json_serialization_test.rb` fix cancel out.
- `pnpm parity:api:calls` green with **one baseline row deleted, none added**;
  `pnpm parity:api:calls:args`, `pnpm parity:api:extra`, `pnpm lint`,
  `pnpm typecheck` green.

## Scope

At the LOC ceiling, so the remaining 12 files in the cluster are filed as
`assertions-activesupport-cluster-tail-3` (0105), with the measured
count/kind/value table and a note that `notRespondTo` now counts.

`converge-relation-length-onto-records-delegation` was **not** shipped. Re-verified
the move (`RECORD_DELEGATES.length` + `DelegationMethods.length` + the
`Relation` declare): typecheck and the relation / delegation / collection-proxy
suites all pass, but `pnpm parity:api:calls` still reds with two spurious rows
in *unrelated* `relation.ts` methods — `create_or_find_by with_connection` and
`to_sql with_connection`, neither of which those TS bodies ever called.
Baselining them would ratify pre-existing divergence in methods the story does
not touch, so the story is `pnpm tasks block`ed on
`call-credit-leaks-across-sibling-methods-in-a-class` (0025) with that finding
recorded.

Closes-story: assertions-activesupport-cluster-tail-2
