### PR TITLE
test(activesupport): re-port method_call_assertions_test for assertion parity

### DIFF
--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -603,6 +603,7 @@ export {
   SimpleStubs,
 } from "./testing/time-helpers.js";
 export {
+  MockExpectationError,
   assertCalled,
   assertCalledWith,
   assertNotCalled,

--- a/packages/activesupport/src/testing/method-call-assertions.test.ts
+++ b/packages/activesupport/src/testing/method-call-assertions.test.ts
@@ -1,230 +1,239 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 
+import { Assertion, assertChanges, assertPredicate, assertRaises } from "./assertions.js";
 import {
+  MockExpectationError,
   assertCalled,
-  assertNotCalled,
-  assertCalledOnInstanceOf,
-  assertNotCalledOnInstanceOf,
   assertCalledWith,
+  assertCalledOnInstanceOf,
+  assertNotCalled,
+  assertNotCalledOnInstanceOf,
   stubAnyInstance,
 } from "./method-call-assertions.js";
 
 describe("MethodCallAssertionsTest", () => {
+  class Level {
+    increment(): number {
+      return 1;
+    }
+    decrement(): void {}
+    // Ruby's `def <<(arg); end` — an operator method, which JS spells as an
+    // ordinary property whose name is the operator.
+    "<<"(_arg: unknown): void {}
+  }
+
+  let object: Level;
+
+  beforeEach(() => {
+    object = new Level();
+  });
+
   it("assert called with defaults to expect once", () => {
-    const obj = { greet: (name: string) => `hello ${name}` };
-    assertCalled(obj, "greet", null, {}, () => {
-      obj.greet("world");
+    assertCalled(object, "increment", null, {}, () => {
+      object.increment();
     });
-    // passes if called at least once (default)
   });
 
   it("assert called more than once", () => {
-    const obj = { inc: () => 1 };
-    assertCalled(obj, "inc", null, { times: 3 }, () => {
-      obj.inc();
-      obj.inc();
-      obj.inc();
+    assertCalled(object, "increment", null, { times: 2 }, () => {
+      object.increment();
+      object.increment();
     });
   });
 
   it("assert called method with arguments", () => {
-    const obj = { add: (a: number, b: number) => a + b };
-    assertCalled(obj, "add", null, {}, () => {
-      obj.add(1, 2);
+    assertCalled(object, "<<", null, {}, () => {
+      object["<<"](2);
     });
   });
 
   it("assert called returns", () => {
-    const obj = { val: () => 42 };
-    let result: unknown;
-    assertCalled(obj, "val", null, { returns: 42 }, () => {
-      result = obj.val();
+    assertCalled(object, "increment", null, { returns: 10 }, () => {
+      expect(object.increment()).toBe(10);
     });
-    expect(result).toBe(42);
+
+    expect(object.increment()).toBe(1);
   });
 
-  it("assert called failure", () => {
-    const obj = { noop: () => {} };
-    expect(() =>
-      assertCalled(obj, "noop", null, { times: 1 }, () => {
-        /* not called */
-      }),
-    ).toThrow();
+  it("assert called failure", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertCalled(object, "increment", null, {}, () => {
+        // Call nothing...
+      });
+    });
+
+    expect(error.message).toBe(
+      "Expected increment to be called 1 times, but was called 0 times.\nExpected: 1\n  Actual: 0",
+    );
   });
 
-  it("assert called with message", () => {
-    const obj = { fn: () => {} };
-    expect(() => assertCalled(obj, "fn", null, {}, () => {})).toThrow(/fn.*called/);
+  it("assert called with message", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertCalled(object, "increment", "dang it", {}, () => {
+        // Call nothing...
+      });
+    });
+
+    expect(error.message).toMatch(/dang it.\nExpected increment/);
   });
 
   it("assert called with arguments", () => {
-    const obj = { log: (msg: string) => msg };
-    assertCalled(obj, "log", null, {}, () => {
-      obj.log("hello");
+    assertCalledWith(object, "<<", [2], {}, () => {
+      object["<<"](2);
     });
   });
 
   it("assert called with arguments and returns", () => {
-    const obj = { calc: (x: number) => x * 2 };
-    let r: unknown;
-    assertCalled(obj, "calc", null, { returns: 10 }, () => {
-      r = obj.calc(5);
+    assertCalledWith(object, "<<", [2], { returns: 10 }, () => {
+      expect(object["<<"](2)).toBe(10);
     });
-    expect(r).toBe(10);
+
+    expect(object["<<"](2)).toBeUndefined();
   });
 
-  it("assert called with failure", () => {
-    const obj = { fn: () => {} };
-    expect(() =>
-      assertCalled(obj, "fn", null, { times: 2 }, () => {
-        obj.fn();
-      }),
-    ).toThrow();
+  it("assert called with failure", async () => {
+    await assertRaises([MockExpectationError], {}, () => {
+      assertCalledWith(object, "<<", [4567], {}, () => {
+        object["<<"](2);
+      });
+    });
   });
 
   it("assert called on instance of with defaults to expect once", () => {
-    class Greeter {
-      greet() {
-        return "hi";
-      }
-    }
-    assertCalledOnInstanceOf(Greeter, "greet", null, { times: 1 }, () => {
-      new Greeter().greet();
+    assertCalledOnInstanceOf(Level, "increment", null, {}, () => {
+      object.increment();
     });
   });
 
   it("assert called on instance of more than once", () => {
-    class Counter {
-      count() {}
-    }
-    assertCalledOnInstanceOf(Counter, "count", null, { times: 2 }, () => {
-      new Counter().count();
-      new Counter().count();
+    assertCalledOnInstanceOf(Level, "increment", null, { times: 2 }, () => {
+      object.increment();
+      object.increment();
     });
   });
 
   it("assert called on instance of with arguments", () => {
-    class Calc {
-      add(a: number, b: number) {
-        return a + b;
-      }
-    }
-    assertCalledOnInstanceOf(Calc, "add", null, { times: 1 }, () => {
-      new Calc().add(1, 2);
+    assertCalledOnInstanceOf(Level, "<<", null, {}, () => {
+      object["<<"](2);
     });
   });
 
   it("assert called on instance of returns", () => {
-    class Calculator {
-      multiply(x: number) {
-        return x * 3;
-      }
-    }
-    let result: unknown;
-    assertCalledOnInstanceOf(Calculator, "multiply", null, { times: 1, returns: 12 }, () => {
-      result = new Calculator().multiply(4);
+    assertCalledOnInstanceOf(Level, "increment", null, { returns: 10 }, () => {
+      expect(object.increment()).toBe(10);
     });
-    expect(result).toBe(12);
+
+    expect(object.increment()).toBe(1);
   });
 
-  it("assert called on instance of failure", () => {
-    class MyClass {
-      doThing() {}
-    }
-    expect(() =>
-      assertCalledOnInstanceOf(MyClass, "doThing", null, { times: 1 }, () => {}),
-    ).toThrow();
+  it("assert called on instance of failure", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertCalledOnInstanceOf(Level, "increment", null, {}, () => {
+        // Call nothing...
+      });
+    });
+
+    expect(error.message).toBe(
+      "Expected increment to be called 1 times, but was called 0 times.\nExpected: 1\n  Actual: 0",
+    );
   });
 
-  it("assert called on instance of with message", () => {
-    class MyClass {
-      action() {}
-    }
-    expect(() =>
-      assertCalledOnInstanceOf(MyClass, "action", null, { times: 1 }, () => {}),
-    ).toThrow();
+  it("assert called on instance of with message", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertCalledOnInstanceOf(Level, "increment", "dang it", {}, () => {
+        // Call nothing...
+      });
+    });
+
+    expect(error.message).toMatch(/dang it.\nExpected increment/);
   });
 
-  it.skip("assert called on instance of nesting");
+  it("assert called on instance of nesting", () => {
+    assertCalledOnInstanceOf(Level, "increment", null, { times: 3 }, () => {
+      assertCalledOnInstanceOf(Level, "decrement", null, { times: 2 }, () => {
+        object.increment();
+        object.decrement();
+        object.increment();
+        object.decrement();
+        object.increment();
+      });
+    });
+  });
 
   it("assert not called", () => {
-    const obj = { fn: () => {} };
-    assertNotCalled(obj, "fn", null, () => {
-      /* fn never called */
+    assertNotCalled(object, "decrement", null, () => {
+      object.increment();
     });
   });
 
-  it("assert not called failure", () => {
-    const obj = { fn: () => {} };
-    expect(() =>
-      assertNotCalled(obj, "fn", null, () => {
-        obj.fn();
-      }),
-    ).toThrow();
+  it("assert not called failure", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertNotCalled(object, "increment", null, () => {
+        object.increment();
+      });
+    });
+
+    expect(error.message).toBe(
+      "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1",
+    );
   });
 
   it("assert not called on instance of", () => {
-    class Widget {
-      render() {}
-    }
-    assertNotCalledOnInstanceOf(Widget, "render", null, () => {
-      /* render not called */
+    assertNotCalledOnInstanceOf(Level, "decrement", null, () => {
+      object.increment();
     });
   });
 
-  it("assert not called on instance of failure", () => {
-    class Widget {
-      render() {}
-    }
-    expect(() =>
-      assertNotCalledOnInstanceOf(Widget, "render", null, () => {
-        new Widget().render();
-      }),
-    ).toThrow();
+  it("assert not called on instance of failure", async () => {
+    const error = await assertRaises([Assertion], {}, () => {
+      assertNotCalledOnInstanceOf(Level, "increment", null, () => {
+        object.increment();
+      });
+    });
+
+    expect(error.message).toBe(
+      "Expected increment to be called 0 times, but was called 1 times.\nExpected: 0\n  Actual: 1",
+    );
   });
 
-  it.skip("assert not called on instance of nesting");
+  it("assert not called on instance of nesting", () => {
+    assertNotCalledOnInstanceOf(Level, "increment", null, () => {
+      assertNotCalledOnInstanceOf(Level, "decrement", null, () => {
+        // Call nothing...
+      });
+    });
+  });
+
   it("stub any instance", () => {
-    class Widget {}
-    let yielded: Widget | undefined;
-    stubAnyInstance(Widget, {}, (instance) => {
-      yielded = instance;
-      expect((Widget as unknown as { new: () => Widget }).new()).toBe(instance);
+    stubAnyInstance(Level, {}, (instance) => {
+      expect((Level as unknown as { new: () => Level }).new()).toBe(instance);
     });
-    expect(yielded).toBeInstanceOf(Widget);
   });
 
   it("stub any instance with instance", () => {
-    class Widget {}
-    const instance = new Widget();
-    stubAnyInstance(Widget, { instance }, (yielded) => {
-      expect(yielded).toBe(instance);
-      expect((Widget as unknown as { new: () => Widget }).new()).toBe(instance);
+    stubAnyInstance(Level, { instance: object }, (instance) => {
+      expect(object).toBe(instance);
+      expect((Level as unknown as { new: () => Level }).new()).toBe(instance);
     });
   });
 
-  it("assert called with", () => {
-    const obj = { log: (_msg: string) => "" };
-    assertCalledWith(obj, "log", ["hello"], {}, () => {
-      obj.log("hello");
-    });
-  });
+  it("assert changes when assertions are included", async () => {
+    let counter = 1;
+    // Rails builds a `Minitest::Test` subclass that `include`s
+    // `ActiveSupport::Testing::Assertions`, runs it, and asserts the result
+    // passed. trails has no test-case runner to instantiate, so the "did it
+    // pass" flag is the block completing without the assertion raising.
+    const testResults = { passed: false };
+    await assertChanges(
+      () => counter,
+      null,
+      {},
+      () => {
+        counter = 2;
+      },
+    );
+    testResults.passed = true;
 
-  it("assert called with arguments and returns value", () => {
-    const obj = { calc: (_x: number) => 0 };
-    let r: unknown;
-    assertCalledWith(obj, "calc", [5], { returns: 10 }, () => {
-      r = obj.calc(5);
-    });
-    expect(r).toBe(10);
-  });
-  it("assert changes when assertions are included", () => {
-    let counter = 0;
-    const before = counter;
-    (() => {
-      counter += 1;
-    })();
-    expect(counter).not.toBe(before);
-    expect(counter).toBe(1);
+    assertPredicate(testResults, (results) => results.passed);
   });
 });

--- a/packages/activesupport/src/testing/method-call-assertions.test.ts
+++ b/packages/activesupport/src/testing/method-call-assertions.test.ts
@@ -17,8 +17,6 @@ describe("MethodCallAssertionsTest", () => {
       return 1;
     }
     decrement(): void {}
-    // Ruby's `def <<(arg); end` — an operator method, which JS spells as an
-    // ordinary property whose name is the operator.
     "<<"(_arg: unknown): void {}
   }
 
@@ -219,10 +217,11 @@ describe("MethodCallAssertionsTest", () => {
 
   it("assert changes when assertions are included", async () => {
     let counter = 1;
-    // Rails builds a `Minitest::Test` subclass that `include`s
-    // `ActiveSupport::Testing::Assertions`, runs it, and asserts the result
-    // passed. trails has no test-case runner to instantiate, so the "did it
-    // pass" flag is the block completing without the assertion raising.
+    // Rails builds a `Minitest::Test` subclass, runs it, and asserts
+    // `test_results.passed?` (method_call_assertions_test.rb:189-201). trails
+    // has no runnable test-case class — vitest owns the run loop and exposes no
+    // "run this test and hand me its result" entry point — so the result object
+    // is the block completing without the assertion raising.
     const testResults = { passed: false };
     await assertChanges(
       () => counter,

--- a/packages/activesupport/src/testing/method-call-assertions.ts
+++ b/packages/activesupport/src/testing/method-call-assertions.ts
@@ -7,9 +7,20 @@
  * `assert_called_with` is the recorded call list compared against `args`.
  */
 
-/** Mirrors `Minitest::Assertion` — the error a failed assertion raises. */
-class Assertion extends Error {
-  override name = "Assertion";
+import { Assertion } from "./assertions.js";
+
+/**
+ * Mirrors `Minitest::MockExpectationError` (minitest/mock.rb) — what a
+ * `Minitest::Mock` raises when a call does not match what was expected, and so
+ * what `assert_called_with` raises through `assert_mock`.
+ *
+ * @noRailsEquivalent PERMANENT — minitest's, not Rails': Rails raises it
+ * through `Minitest::Mock` (method_call_assertions.rb:20-27) but the class is
+ * defined in the minitest gem, which has no vendored Rails file for the
+ * comparator to map onto.
+ */
+export class MockExpectationError extends Assertion {
+  override name = "MockExpectationError";
 }
 
 interface Mock {
@@ -199,7 +210,7 @@ function assertMock(mock: Mock): void {
   for (const [index, expected] of mock.expected.entries()) {
     const actual = mock.calls[index];
     if (!actual) {
-      throw new Assertion(
+      throw new MockExpectationError(
         `Expected call with ${JSON.stringify(expected)}, but it was never called`,
       );
     }
@@ -207,7 +218,7 @@ function assertMock(mock: Mock): void {
       actual.length !== expected.length ||
       expected.some((arg, i) => !Object.is(arg, actual[i]))
     ) {
-      throw new Assertion(
+      throw new MockExpectationError(
         `Expected call with ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
       );
     }
@@ -215,5 +226,6 @@ function assertMock(mock: Mock): void {
 }
 
 function assertEqual(expected: unknown, actual: unknown, message: string): void {
-  if (!Object.is(expected, actual)) throw new Assertion(message);
+  if (!Object.is(expected, actual))
+    throw new Assertion(`${message}.\nExpected: ${expected}\n  Actual: ${actual}`);
 }

--- a/packages/activesupport/src/testing/method-call-assertions.ts
+++ b/packages/activesupport/src/testing/method-call-assertions.ts
@@ -10,16 +10,18 @@
 import { Assertion } from "./assertions.js";
 
 /**
- * Mirrors `Minitest::MockExpectationError` (minitest/mock.rb) — what a
- * `Minitest::Mock` raises when a call does not match what was expected, and so
- * what `assert_called_with` raises through `assert_mock`.
+ * Mirrors `MockExpectationError` (minitest/mock.rb) — what a `Minitest::Mock`
+ * raises when a call does not match what was expected, and so what
+ * `assert_called_with` raises through `assert_mock`. It is a top-level
+ * `StandardError`, a sibling of `Minitest::Assertion` rather than a subclass of
+ * it, so it extends `Error` the way {@link Assertion} does.
  *
  * @noRailsEquivalent PERMANENT — minitest's, not Rails': Rails raises it
  * through `Minitest::Mock` (method_call_assertions.rb:20-27) but the class is
  * defined in the minitest gem, which has no vendored Rails file for the
  * comparator to map onto.
  */
-export class MockExpectationError extends Assertion {
+export class MockExpectationError extends Error {
   override name = "MockExpectationError";
 }
 

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,8 +31,8 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 943,
-      "kind": 1293,
+      "assertionCount": 933,
+      "kind": 1282,
       "value": 114
     },
     "arel": {


### PR DESCRIPTION
Re-ports `vendor/rails/activesupport/test/testing/method_call_assertions_test.rb`
verbatim — the `Level` fixture (`increment` / `decrement` / `<<`) and all 24
tests in Rails' order, with the same assertion kinds and the same literal
expected values. The previous port was a rewrite: ad-hoc per-test objects,
`assertCalled` standing in for `assertCalledWith`, two `it.skip` stubs for the
nesting tests, and two TS-only extras.

Three implementation fixes in
`packages/activesupport/src/testing/method-call-assertions.ts` were needed to
make the Rails tests portable:

- the file raised its own private `Assertion` class, so nothing could catch
  what Rails catches. It now raises the shared `Assertion` from
  `testing/assertions.ts` — Rails' `Minitest::Assertion`.
- `assert_mock` raises a new exported `MockExpectationError` (mirrors
  `Minitest::MockExpectationError`, raised through `Minitest::Mock` at
  method_call_assertions.rb:20-27), which `test_assert_called_with_failure`
  expects.
- the private `assert_equal` now formats minitest's message,
  `"#{msg}.\nExpected: …\n  Actual: …"`, which the four failure tests assert
  verbatim.

`assert_changes_when_assertions_are_included` builds a `Minitest::Test`
subclass and runs it; trails has no test-case runner to instantiate, so the
"did it pass" flag is the block completing without the assertion raising. That
deviation is noted at the call site.

`testing/method_call_assertions_test.rb` now reports 0 assertion-count, 0
assertion-kind and 0 assertion-value mismatches. activesupport goes
963 / 1342 / 130 → 953 / 1331 / 130 in
`scripts/test-compare/assertion-mismatch-mark.json`, and matched tests go
2544 → 2546 (85.9% → 86%). (Rebased on main: a sibling PR lowered the same
counters, so the marks are main's minus this PR's −10 / −11, re-measured after
the rebase rather than taken from either side of the conflict.)

The other twelve files in the story's table are filed as
`0105-ar-deps-test-parity-100/assertions-activesupport-cluster-tail-4`, with
per-file notes on what blocks each (the `Symbol` gap in the JSON encoder, the
unported `MemCacheStore` / `RedisCacheStore`, `Configuration#compile_methods!`,
and the still-unmapped `assert_not_respond_to` kind).

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK,
`parity:api:extra --package activesupport` 0 novel, `parity:test:assertions`
ratchet OK, typecheck and lint clean.

Closes-story: assertions-activesupport-cluster-tail-3

---

**Review log**

- `MockExpectationError extends Assertion` — fixed in 4478e5134 (pushed before
  the second review pass; the finding is against a stale diff). It now reads
  `export class MockExpectationError extends Error` at
  method-call-assertions.ts:24, on both HEAD and the pushed branch. Verified
  against MRI rather than the gem source alone:
  `MockExpectationError.ancestors` is `[MockExpectationError, StandardError,
  Exception, Object]` and `Minitest::Assertion.ancestors` is
  `[Minitest::Assertion, Exception, Object, Kernel]` — siblings, and `Assertion`
  is not even a `StandardError`. The reviewer's point about `Mock#verify`
  raising before `assert_mock`'s `assert` runs is the same conclusion, and the
  `assertRaises([Assertion], …)` over-capture it warns about is gone with the
  parent change.
