### PR TITLE
test(globalid): converge assertion parity for four globalid test files

### DIFF
--- a/packages/globalid/src/global-id.test.ts
+++ b/packages/globalid/src/global-id.test.ts
@@ -9,29 +9,62 @@ import { type LocatorModel } from "./locator.js";
 // GlobalIDModel's `readonly constructor: { readonly name: string }`.
 const fakeModel = (id: unknown, name = "Person") => ({ id, constructor: { name } });
 
-// ─── Fixture models for find / model_class tests ───────────────────────────
+// ─── Fixture models — vendor/globalid/test/models/*.rb ─────────────────────
 
 class Person {
-  static primaryKey = "id";
-  id: string;
-  constructor(id: string) {
+  static HARDCODED_ID_FOR_MISSING_PERSON = "1000";
+  static primaryKey: string | string[] = "id";
+  id: unknown;
+  constructor(id: unknown = 1) {
     this.id = id;
   }
-  static async find(id: unknown): Promise<Person> {
-    return new this(String(id));
+  static find(idOrIds: unknown): unknown {
+    if (Array.isArray(idOrIds)) return idOrIds.map((id) => this.find(id));
+    if (idOrIds === Person.HARDCODED_ID_FOR_MISSING_PERSON) throw new Error("Person missing");
+    return new this(idOrIds);
   }
 }
-class PersonUuid extends Person {}
+class PersonUuid extends Person {
+  static primaryKey = "uuid";
+}
+// Rails' `Person::Child`. A TS class name can't contain `::`, so the Rails
+// spelling is stamped on `name` — that is what GlobalID#model_name renders
+// and what the constant registry resolves.
 class PersonChild extends Person {}
-class PersonModel extends Person {}
-class CompositePrimaryKeyModel {
-  static primaryKey: string[] = ["tenant", "key"];
-  id: string[];
-  constructor(id: string[]) {
-    this.id = id;
+Object.defineProperty(PersonChild, "name", { value: "Person::Child" });
+
+class PersonModel {
+  static primaryKey = "id";
+  id: unknown;
+  constructor(attrs: { id: unknown }) {
+    this.id = attrs.id;
   }
-  static async find(id: unknown): Promise<CompositePrimaryKeyModel> {
-    return new CompositePrimaryKeyModel((id as unknown[]).map(String));
+  static find(id: unknown): PersonModel {
+    return new PersonModel({ id });
+  }
+}
+
+class CompositePrimaryKeyModel {
+  static primaryKey: string[] = ["tenant_key", "id"];
+  id: unknown;
+  constructor(attrs: { id: unknown }) {
+    this.id = attrs.id;
+  }
+  static find(idOrIds: unknown[]): unknown {
+    if (!Array.isArray(idOrIds)) throw new Error("id is not composite");
+    const multiRecordFetch = Array.isArray(idOrIds[0]);
+    if (multiRecordFetch) {
+      return idOrIds.map((id) => {
+        if ((id as unknown[]).length !== CompositePrimaryKeyModel.primaryKey.length) {
+          throw new Error("id doesn't match primary key");
+        }
+        return new CompositePrimaryKeyModel({ id });
+      });
+    }
+    if (idOrIds.length !== CompositePrimaryKeyModel.primaryKey.length) {
+      throw new Error("id doesn't match primary key");
+    }
+    return new CompositePrimaryKeyModel({ id: idOrIds });
   }
 }
 
@@ -44,19 +77,27 @@ function registerConstants(registry: Record<string, LocatorModel>): void {
 const FIXTURE_REGISTRY: Record<string, LocatorModel> = {
   Person: Person as unknown as LocatorModel,
   PersonUuid: PersonUuid as unknown as LocatorModel,
-  // Rails 'Person::Child' — TS class can't have :: in its name, so the
-  // registered name uses the namespaced spelling that GlobalID.modelName
-  // round-trips, mapped to a flat PersonChild class.
   "Person::Child": PersonChild as unknown as LocatorModel,
   PersonModel: PersonModel as unknown as LocatorModel,
   CompositePrimaryKeyModel: CompositePrimaryKeyModel as unknown as LocatorModel,
 };
 
+// Ruby's `Array#uniq` folds on the hash/eql? protocol; a JS Set folds on
+// identity. This mirrors GlobalID#hash / #eql?
+// (vendor/globalid/lib/global_id/global_id.rb:88-94): same class, same URI.
+function uniq<T>(items: T[]): T[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${(item as object).constructor.name}:${String(item)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 describe("GlobalIDTest", () => {
   it("value equality", () => {
-    const a = GlobalID.parse("gid://app/Person/5")!;
-    const b = GlobalID.parse("gid://app/Person/5")!;
-    expect(a.equals(b)).toBe(true);
+    expect(new GlobalID("gid://app/Person/5")).toEqual(new GlobalID("gid://app/Person/5"));
   });
 
   it("invalid app name", () => {
@@ -78,9 +119,7 @@ describe("GlobalIDParamEncodedTest", () => {
 
   it("parsing", () => {
     const gid = GlobalID.create(fakeModel("id"));
-    const parsed = GlobalID.parse(gid.toParam());
-    expect(parsed).not.toBeNull();
-    expect(parsed!.equals(gid)).toBe(true);
+    expect(GlobalID.parse(gid.toParam())).toEqual(gid);
   });
 
   it("finding", async () => {
@@ -97,174 +136,244 @@ describe("GlobalIDParamEncodedTest", () => {
 
 describe("GlobalIDCreationTest", () => {
   const uuid = "7ef9b614-353c-43a1-a203-ab2307851990";
+  let personGid: GlobalID;
+  let personUuidGid: GlobalID;
+  let personNamespacedGid: GlobalID;
+  let personModelGid: GlobalID;
+  let cpkModelGid: GlobalID;
 
   beforeEach(() => {
     setApp("bcx");
     registerConstants(FIXTURE_REGISTRY);
+    personGid = GlobalID.create(new Person(5));
+    personUuidGid = GlobalID.create(new PersonUuid(uuid));
+    personNamespacedGid = GlobalID.create(new PersonChild(4));
+    personModelGid = GlobalID.create(new PersonModel({ id: 1 }));
+    cpkModelGid = GlobalID.create(
+      new CompositePrimaryKeyModel({ id: ["tenant-key-value", "id-value"] }),
+    );
   });
   afterEach(() => {
     _resetApp();
     _resetConstants();
   });
 
-  it("as string", () => {
-    expect(GlobalID.create(fakeModel(5)).toString()).toBe("gid://bcx/Person/5");
-    expect(GlobalID.create(fakeModel(uuid, "PersonUuid")).toString()).toBe(
-      `gid://bcx/PersonUuid/${uuid}`,
+  it("find", async () => {
+    expect(Person.find(personGid.modelId)).toEqual(await personGid.find());
+    expect(Person.find(personUuidGid.modelId)).toEqual(await personUuidGid.find());
+    expect(PersonChild.find(personNamespacedGid.modelId)).toEqual(await personNamespacedGid.find());
+    expect(PersonModel.find(personModelGid.modelId)).toEqual(await personModelGid.find());
+    expect(CompositePrimaryKeyModel.find(cpkModelGid.modelId as unknown[])).toEqual(
+      await cpkModelGid.find(),
     );
-    expect(GlobalID.create(fakeModel(4, "Person::Child")).toString()).toBe(
-      "gid://bcx/Person::Child/4",
+  });
+
+  it("find with class", async () => {
+    expect(Person.find(personGid.modelId)).toEqual(
+      await personGid.find({ only: Person as unknown as LocatorModel }),
     );
-    expect(GlobalID.create(fakeModel(1, "PersonModel")).toString()).toBe("gid://bcx/PersonModel/1");
+    expect(Person.find(personUuidGid.modelId)).toEqual(
+      await personUuidGid.find({ only: Person as unknown as LocatorModel }),
+    );
+    expect(PersonModel.find(personModelGid.modelId)).toEqual(
+      await personModelGid.find({ only: PersonModel as unknown as LocatorModel }),
+    );
+    expect(CompositePrimaryKeyModel.find(cpkModelGid.modelId as unknown[])).toEqual(
+      await cpkModelGid.find({ only: CompositePrimaryKeyModel as unknown as LocatorModel }),
+    );
+  });
+
+  it("find with class no match", async () => {
+    // Rails' Hash is `Map` here, not `Object`: every JS class extends Object,
+    // so `only: Object` would match where Ruby's Hash rejects. Ruby's Integer /
+    // Float / Numeric all collapse onto `Number`, which JS has only one of.
+    expect(await personGid.find({ only: Map as unknown as LocatorModel })).toBeNull();
+    expect(await personUuidGid.find({ only: Array as unknown as LocatorModel })).toBeNull();
+    expect(await personNamespacedGid.find({ only: String as unknown as LocatorModel })).toBeNull();
+    expect(await personModelGid.find({ only: Number as unknown as LocatorModel })).toBeNull();
+    expect(await cpkModelGid.find({ only: Map as unknown as LocatorModel })).toBeNull();
+  });
+
+  it("find with subclass", async () => {
+    expect(PersonChild.find(personNamespacedGid.modelId)).toEqual(
+      await personNamespacedGid.find({ only: Person as unknown as LocatorModel }),
+    );
+  });
+
+  it("find with subclass no match", async () => {
+    expect(await personNamespacedGid.find({ only: String as unknown as LocatorModel })).toBeNull();
+  });
+
+  it("find with multiple class", async () => {
+    expect(Person.find(personGid.modelId)).toEqual(
+      await personGid.find({
+        only: [Number as unknown as LocatorModel, Person as unknown as LocatorModel],
+      }),
+    );
+    expect(Person.find(personUuidGid.modelId)).toEqual(
+      await personUuidGid.find({
+        only: [Number as unknown as LocatorModel, Person as unknown as LocatorModel],
+      }),
+    );
+    expect(PersonModel.find(personModelGid.modelId)).toEqual(
+      await personModelGid.find({
+        only: [Number as unknown as LocatorModel, PersonModel as unknown as LocatorModel],
+      }),
+    );
+    expect(PersonChild.find(personNamespacedGid.modelId)).toEqual(
+      await personNamespacedGid.find({
+        only: [Person as unknown as LocatorModel, PersonChild as unknown as LocatorModel],
+      }),
+    );
+  });
+
+  it("find with multiple class no match", async () => {
     expect(
-      GlobalID.create(
-        fakeModel(["tenant-key-value", "id-value"], "CompositePrimaryKeyModel"),
-      ).toString(),
-    ).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
+      await personGid.find({
+        only: [Number as unknown as LocatorModel, Number as unknown as LocatorModel],
+      }),
+    ).toBeNull();
+    expect(
+      await personUuidGid.find({
+        only: [Number as unknown as LocatorModel, String as unknown as LocatorModel],
+      }),
+    ).toBeNull();
+    expect(
+      await personModelGid.find({
+        only: [Array as unknown as LocatorModel, Map as unknown as LocatorModel],
+      }),
+    ).toBeNull();
+    expect(
+      await personNamespacedGid.find({
+        only: [String as unknown as LocatorModel, Set as unknown as LocatorModel],
+      }),
+    ).toBeNull();
+  });
+
+  it("as string", () => {
+    expect(personGid.toString()).toBe("gid://bcx/Person/5");
+    expect(personUuidGid.toString()).toBe(`gid://bcx/PersonUuid/${uuid}`);
+    expect(personNamespacedGid.toString()).toBe("gid://bcx/Person::Child/4");
+    expect(personModelGid.toString()).toBe("gid://bcx/PersonModel/1");
+    expect(cpkModelGid.toString()).toBe(
+      "gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value",
+    );
   });
 
   it("as param", () => {
-    const gid = GlobalID.create(fakeModel(5));
-    expect(gid.toParam()).toBe("Z2lkOi8vYmN4L1BlcnNvbi81");
-    expect(GlobalID.parse("Z2lkOi8vYmN4L1BlcnNvbi81")!.equals(gid)).toBe(true);
+    expect(personGid.toParam()).toBe("Z2lkOi8vYmN4L1BlcnNvbi81");
+    expect(GlobalID.parse("Z2lkOi8vYmN4L1BlcnNvbi81")).toEqual(personGid);
 
-    const uuidGid = GlobalID.create(fakeModel(uuid, "PersonUuid"));
-    expect(GlobalID.parse(uuidGid.toParam())!.equals(uuidGid)).toBe(true);
-
-    const cpkGid = GlobalID.create(
-      fakeModel(["tenant-key-value", "id-value"], "CompositePrimaryKeyModel"),
+    expect(personUuidGid.toParam()).toBe(
+      "Z2lkOi8vYmN4L1BlcnNvblV1aWQvN2VmOWI2MTQtMzUzYy00M2ExLWEyMDMtYWIyMzA3ODUxOTkw",
     );
-    expect(GlobalID.parse(cpkGid.toParam())!.equals(cpkGid)).toBe(true);
+    expect(
+      GlobalID.parse(
+        "Z2lkOi8vYmN4L1BlcnNvblV1aWQvN2VmOWI2MTQtMzUzYy00M2ExLWEyMDMtYWIyMzA3ODUxOTkw",
+      ),
+    ).toEqual(personUuidGid);
+
+    expect(personNamespacedGid.toParam()).toBe("Z2lkOi8vYmN4L1BlcnNvbjo6Q2hpbGQvNA");
+    expect(GlobalID.parse("Z2lkOi8vYmN4L1BlcnNvbjo6Q2hpbGQvNA")).toEqual(personNamespacedGid);
+
+    expect(personModelGid.toParam()).toBe("Z2lkOi8vYmN4L1BlcnNvbk1vZGVsLzE");
+    expect(GlobalID.parse("Z2lkOi8vYmN4L1BlcnNvbk1vZGVsLzE")).toEqual(personModelGid);
+
+    const expectedEncoded =
+      "Z2lkOi8vYmN4L0NvbXBvc2l0ZVByaW1hcnlLZXlNb2RlbC90ZW5hbnQta2V5LXZhbHVlL2lkLXZhbHVl";
+    expect(cpkModelGid.toParam()).toBe(expectedEncoded);
+    expect(GlobalID.parse(expectedEncoded)).toEqual(cpkModelGid);
   });
 
   it("as URI", () => {
-    expect(GlobalID.create(fakeModel(5)).uri).toBe("gid://bcx/Person/5");
-    expect(GlobalID.create(fakeModel(4, "Person::Child")).uri).toBe("gid://bcx/Person::Child/4");
+    // Rails compares URI objects; GlobalID#uri is its string form here.
+    expect(personGid.uri).toBe("gid://bcx/Person/5");
+    expect(personUuidGid.uri).toBe(`gid://bcx/PersonUuid/${uuid}`);
+    expect(personNamespacedGid.uri).toBe("gid://bcx/Person::Child/4");
+    expect(personModelGid.uri).toBe("gid://bcx/PersonModel/1");
+    expect(cpkModelGid.uri).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
   });
 
   it("as JSON", () => {
-    const gid = GlobalID.create(fakeModel(5));
-    expect(gid.asJson()).toBe("gid://bcx/Person/5");
-    // Rails' `to_json`; here JSON.stringify(gid) routes through toJSON().
-    expect(JSON.stringify(gid)).toBe('"gid://bcx/Person/5"');
+    // Rails' `to_json`; here JSON.stringify routes through toJSON().
+    expect(personGid.asJson()).toBe("gid://bcx/Person/5");
+    expect(JSON.stringify(personGid)).toBe('"gid://bcx/Person/5"');
 
-    const uuidGid = GlobalID.create(fakeModel(uuid, "PersonUuid"));
-    expect(uuidGid.asJson()).toBe(`gid://bcx/PersonUuid/${uuid}`);
-    expect(JSON.stringify(uuidGid)).toBe(`"gid://bcx/PersonUuid/${uuid}"`);
+    expect(personUuidGid.asJson()).toBe(`gid://bcx/PersonUuid/${uuid}`);
+    expect(JSON.stringify(personUuidGid)).toBe(`"gid://bcx/PersonUuid/${uuid}"`);
 
-    const namespacedGid = GlobalID.create(fakeModel(4, "Person::Child"));
-    expect(namespacedGid.asJson()).toBe("gid://bcx/Person::Child/4");
-    expect(JSON.stringify(namespacedGid)).toBe('"gid://bcx/Person::Child/4"');
+    expect(personNamespacedGid.asJson()).toBe("gid://bcx/Person::Child/4");
+    expect(JSON.stringify(personNamespacedGid)).toBe('"gid://bcx/Person::Child/4"');
 
-    const cpkGid = GlobalID.create(
-      fakeModel(["tenant-key-value", "id-value"], "CompositePrimaryKeyModel"),
+    expect(personModelGid.asJson()).toBe("gid://bcx/PersonModel/1");
+    expect(JSON.stringify(personModelGid)).toBe('"gid://bcx/PersonModel/1"');
+
+    expect(cpkModelGid.asJson()).toBe(
+      "gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value",
     );
-    expect(cpkGid.asJson()).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
-    expect(JSON.stringify(cpkGid)).toBe(
+    expect(JSON.stringify(cpkModelGid)).toBe(
       '"gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value"',
     );
   });
 
   it("model id", () => {
-    expect(GlobalID.create(fakeModel(5)).modelId).toBe("5");
-    expect(GlobalID.create(fakeModel(uuid, "PersonUuid")).modelId).toBe(uuid);
-    expect(GlobalID.create(fakeModel(4, "Person::Child")).modelId).toBe("4");
-    expect(
-      GlobalID.create(fakeModel(["tenant-key-value", "id-value"], "CompositePrimaryKeyModel"))
-        .modelId,
-    ).toEqual(["tenant-key-value", "id-value"]);
+    expect(personGid.modelId).toBe("5");
+    expect(personUuidGid.modelId).toBe(uuid);
+    expect(personNamespacedGid.modelId).toBe("4");
+    expect(personModelGid.modelId).toBe("1");
+    expect(cpkModelGid.modelId).toEqual(["tenant-key-value", "id-value"]);
   });
 
   it("model name", () => {
-    expect(GlobalID.create(fakeModel(5)).modelName).toBe("Person");
-    expect(GlobalID.create(fakeModel(uuid, "PersonUuid")).modelName).toBe("PersonUuid");
-    expect(GlobalID.create(fakeModel(4, "Person::Child")).modelName).toBe("Person::Child");
-    expect(GlobalID.create(fakeModel(["t", "i"], "CompositePrimaryKeyModel")).modelName).toBe(
-      "CompositePrimaryKeyModel",
-    );
-  });
-
-  it(":app option", () => {
-    expect(GlobalID.create(fakeModel(5)).toString()).toBe("gid://bcx/Person/5");
-    expect(GlobalID.create(fakeModel(5), { app: "foo" }).toString()).toBe("gid://foo/Person/5");
-    _resetApp();
-    expect(() => GlobalID.create(fakeModel(5), { app: null as unknown as string })).toThrow();
-  });
-
-  it("equality", () => {
-    const gid1 = GlobalID.create(fakeModel(5));
-    const gid2 = GlobalID.create(fakeModel(5));
-    const gid3 = GlobalID.create(fakeModel(10));
-    expect(gid1.equals(gid2)).toBe(true);
-    expect(gid1.equals(gid3)).toBe(false);
+    expect(personGid.modelName).toBe("Person");
+    expect(personUuidGid.modelName).toBe("PersonUuid");
+    expect(personNamespacedGid.modelName).toBe("Person::Child");
+    expect(personModelGid.modelName).toBe("PersonModel");
+    expect(cpkModelGid.modelName).toBe("CompositePrimaryKeyModel");
   });
 
   it("model class", () => {
-    expect(GlobalID.create(new Person("5")).modelClass).toBe(Person);
-    expect(GlobalID.create(new PersonUuid(uuid)).modelClass).toBe(PersonUuid);
-    expect(GlobalID.create(fakeModel(1, "PersonModel")).modelClass).toBe(PersonModel);
-    expect(GlobalID.create(fakeModel(["t", "i"], "CompositePrimaryKeyModel")).modelClass).toBe(
-      CompositePrimaryKeyModel,
-    );
+    expect(personGid.modelClass).toBe(Person);
+    expect(personUuidGid.modelClass).toBe(PersonUuid);
+    expect(personNamespacedGid.modelClass).toBe(PersonChild);
+    expect(personModelGid.modelClass).toBe(PersonModel);
+    expect(cpkModelGid.modelClass).toBe(CompositePrimaryKeyModel);
+    // Rails: `GlobalID.find 'gid://bcx/SignedGlobalID/5'` — the raise comes
+    // from #model_class, which trails reaches through the parsed GID.
+    expect(() => GlobalID.parse("gid://bcx/SignedGlobalID/5")!.modelClass).toThrow();
   });
 
-  it("find", async () => {
-    const personGid = GlobalID.create(new Person("5"));
-    const found = (await personGid.find()) as Person;
-    expect(found).toBeInstanceOf(Person);
-    expect(found.id).toBe("5");
+  it(":app option", () => {
+    expect(GlobalID.create(new Person(5)).toString()).toBe("gid://bcx/Person/5");
+    expect(GlobalID.create(new Person(5), { app: "foo" }).toString()).toBe("gid://foo/Person/5");
+    _resetApp();
+    expect(() => GlobalID.create(new Person(5), { app: null as unknown as string })).toThrow();
   });
 
-  it("find with class", async () => {
-    const personGid = GlobalID.create(new Person("5"));
-    const found = (await personGid.find({ only: Person as unknown as LocatorModel })) as Person;
-    expect(found).toBeInstanceOf(Person);
-    expect(found.id).toBe("5");
-  });
+  it("equality", () => {
+    const p1 = new Person(5);
+    const p2 = new Person(5);
+    const p3 = new Person(10);
+    expect(p1).toEqual(p2);
+    expect(p2).not.toEqual(p3);
 
-  it("find with class no match", async () => {
-    const personGid = GlobalID.create(new Person("5"));
-    class Unrelated {}
-    expect(await personGid.find({ only: Unrelated as unknown as LocatorModel })).toBeNull();
-  });
+    const gid1 = GlobalID.create(p1);
+    const gid2 = GlobalID.create(p2);
+    const gid3 = GlobalID.create(p3);
+    expect(gid1).toEqual(gid2);
+    expect(gid2).not.toEqual(gid3);
 
-  it("find with subclass", async () => {
-    // Rails: a PersonChild GID with only: Person succeeds because
-    // PersonChild < Person. findAllowed uses `instanceof prototype`.
-    // Use the namespaced 'Person::Child' GID directly — that's how
-    // GlobalID.create(new PersonChild(...)) renders the modelName when
-    // the class is registered under the Rails namespaced spelling.
-    const namespacedGid = GlobalID.parse(`gid://bcx/Person::Child/4`)!;
-    const found = (await namespacedGid.find({
-      only: Person as unknown as LocatorModel,
-    })) as PersonChild;
-    expect(found).toBeInstanceOf(PersonChild);
-  });
+    // hash and eql? to match for two GlobalID's pointing to the same object
+    expect([gid1]).toEqual(uniq([gid1, gid2]));
+    expect([gid1, gid3]).toEqual(uniq([gid1, gid2, gid3]));
 
-  it("find with subclass no match", async () => {
-    const namespacedGid = GlobalID.parse(`gid://bcx/Person::Child/4`)!;
-    class Unrelated {}
-    expect(await namespacedGid.find({ only: Unrelated as unknown as LocatorModel })).toBeNull();
-  });
+    // Rails asserts GlobalID#hash differs from its URI's hash. JS has no hash
+    // protocol, so assert what that difference encodes: a GlobalID is never
+    // equal to its bare URI.
+    expect(gid1).not.toEqual(gid1.uri);
 
-  it("find with multiple class", async () => {
-    const personGid = GlobalID.create(new Person("5"));
-    class Other {}
-    const found = (await personGid.find({
-      only: [Other as unknown as LocatorModel, Person as unknown as LocatorModel],
-    })) as Person;
-    expect(found).toBeInstanceOf(Person);
-  });
-
-  it("find with multiple class no match", async () => {
-    const personGid = GlobalID.create(new Person("5"));
-    class A {}
-    class B {}
-    expect(
-      await personGid.find({
-        only: [A as unknown as LocatorModel, B as unknown as LocatorModel],
-      }),
-    ).toBeNull();
+    // verify that URI and GlobalID do not pass the uniq test
+    expect([gid1, gid1.uri]).toEqual(uniq([gid1, gid1.uri]));
   });
 });
 

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -32,9 +32,12 @@ class Person {
 }
 
 describe("GlobalIdentificationTest", () => {
+  let model: Person;
+
   beforeEach(() => {
     setApp("bcx");
     registerConstant("Person", Person);
+    model = new Person("1");
   });
   afterEach(() => {
     _resetApp();
@@ -42,59 +45,67 @@ describe("GlobalIdentificationTest", () => {
   });
 
   it("creates a Global ID from self", () => {
-    const p = new Person("1");
-    expect(toGlobalId.call(p).uri).toBe(GlobalID.create(p).uri);
-    expect(toGid.call(p).uri).toBe(GlobalID.create(p).uri);
-    expect(toGlobalId.call(p)).toBeInstanceOf(GlobalID);
+    expect(GlobalID.create(model)).toEqual(toGlobalId.call(model));
+    expect(GlobalID.create(model)).toEqual(toGid.call(model));
   });
 
   it("creates a Global ID with custom params", () => {
-    const p = new Person("1");
-    const a = toGlobalId.call(p, { some: "param" });
-    expect(a.params).toEqual({ some: "param" });
+    expect(GlobalID.create(model, { some: "param" })).toEqual(
+      toGlobalId.call(model, { some: "param" }),
+    );
+    expect(GlobalID.create(model, { some: "param" })).toEqual(toGid.call(model, { some: "param" }));
   });
 
+  // Rails compares SignedGlobalIDs with `assert_equal`, which routes through
+  // SignedGlobalID#== (uri + purpose). Vitest's `toEqual` is structural and
+  // would also compare the per-instance inspect id, so the ported assertions
+  // go through the same `equals` Rails' `==` is.
   it("creates a signed Global ID from self", () => {
     const verifier = makeVerifier();
-    const a = toSignedGlobalId.call(new Person("1"), { verifier });
-    const b = toSgid.call(new Person("1"), { verifier });
-    expect(a).toBeInstanceOf(SignedGlobalID);
-    expect(a.uri).toBe("gid://bcx/Person/1");
-    expect(b.uri).toBe(a.uri);
+    expect(
+      SignedGlobalID.create(model, { verifier }).equals(toSignedGlobalId.call(model, { verifier })),
+    ).toBe(true);
+    expect(
+      SignedGlobalID.create(model, { verifier }).equals(toSgid.call(model, { verifier })),
+    ).toBe(true);
   });
 
   it("creates a signed Global ID with purpose", () => {
     const verifier = makeVerifier();
-    const a = toSignedGlobalId.call(new Person("1"), { verifier, for: "login" });
-    expect(a.purpose).toBe("login");
-    // Round-trip verifies the purpose only when caller passes matching for:.
-    const token = a.toString();
-    expect(SignedGlobalID.parse(token, { verifier, for: "login" })).not.toBeNull();
-    expect(SignedGlobalID.parse(token, { verifier, for: "other" })).toBeNull();
+    expect(
+      SignedGlobalID.create(model, { verifier, for: "login" }).equals(
+        toSignedGlobalId.call(model, { verifier, for: "login" }),
+      ),
+    ).toBe(true);
+    expect(
+      SignedGlobalID.create(model, { verifier, for: "login" }).equals(
+        toSgid.call(model, { verifier, for: "login" }),
+      ),
+    ).toBe(true);
   });
 
   it("creates a signed Global ID with custom params", () => {
     const verifier = makeVerifier();
-    const sgid = toSignedGlobalId.call(new Person("1"), { verifier, db: "primary" });
-    expect(sgid.uri).toContain("?db=primary");
-    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
-    expect(parsed!.uri).toContain("?db=primary");
+    expect(
+      SignedGlobalID.create(model, { verifier, some: "param" }).equals(
+        toSignedGlobalId.call(model, { verifier, some: "param" }),
+      ),
+    ).toBe(true);
+    expect(
+      SignedGlobalID.create(model, { verifier, some: "param" }).equals(
+        toSgid.call(model, { verifier, some: "param" }),
+      ),
+    ).toBe(true);
   });
 
   it("dup should clear memoized to_global_id", () => {
-    // Rails calls model.dup (which clears @global_id memoization) and
-    // mutates the dup's id. The test verifies the resulting GID reflects
-    // the new id, not a stale memoized one. Trails doesn't memoize
-    // toGlobalId, so the same invariant holds without dup: mutating id
-    // on the original instance and re-calling toGlobalId must return a
-    // fresh GID for the new id. Mutating in-place is the stricter check —
-    // if memoization ever creeps in, this test catches it.
-    const model = new Person("1");
-    const before = toGlobalId.call(model);
-    model.id = "2";
-    const after = toGlobalId.call(model);
-    expect(after.uri).not.toBe(before.uri);
-    expect(after.modelId).toBe("2");
+    // Rails calls model.dup (which clears the @global_id memoization) before
+    // bumping the id. Trails doesn't memoize toGlobalId, so the dup is a plain
+    // structural copy and the same invariant holds.
+    const globalId = toGlobalId.call(model);
+    const dupModel = new Person(String(Number(model.id) + 1));
+    const dupGlobalId = toGlobalId.call(dupModel);
+    expect(globalId).not.toEqual(dupGlobalId);
   });
 
   it("toGidParam round-trips through GlobalID.parse", () => {

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -40,11 +40,10 @@ describe("SignedGlobalIDTest", () => {
   it("as string", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(person(), { verifier });
-    const s = sgid.toString();
-    expect(typeof s).toBe("string");
-    expect(s.length).toBeGreaterThan(0);
-    // Round-trip — verify the produced token parses back to the same SGID.
-    expect(SignedGlobalID.parse(s, { verifier })!.uri).toBe(sgid.uri);
+    // Rails asserts the exact signed token produced by the vendored test
+    // verifier secret. Trails builds a verifier per test, so the token bytes
+    // differ; assert the round-trip instead.
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })!.uri).toBe(sgid.uri);
   });
 
   it("model id", () => {
@@ -76,11 +75,6 @@ describe("SignedGlobalIDTest", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(person(5), { verifier });
     expect(sgid.inspect()).toMatch(/^#<SignedGlobalID:0x[0-9a-f]+>$/);
-    // Stable per instance — Ruby's object_id doesn't change between calls.
-    expect(sgid.inspect()).toBe(sgid.inspect());
-    // Distinct instances get distinct ids.
-    const other = SignedGlobalID.create(person(5), { verifier });
-    expect(sgid.inspect()).not.toBe(other.inspect());
   });
 });
 
@@ -92,7 +86,12 @@ describe("SignedGlobalIDPurposeTest", () => {
     const verifier = makeVerifier();
     const loginSgid = SignedGlobalID.create(person(5), { verifier, for: "login" });
     const likeSgid = SignedGlobalID.create(person(5), { verifier, for: "like-button" });
-    expect(loginSgid.equals(likeSgid)).toBe(false);
+    // Rails asserts the exact signed token; trails' per-test verifier secret
+    // differs, so assert the round-trip URI instead.
+    expect(SignedGlobalID.parse(loginSgid.toString(), { verifier, for: "login" })!.uri).toBe(
+      loginSgid.uri,
+    );
+    expect(loginSgid.equals(likeSgid)).not.toBe(true);
   });
 
   it("sign with default purpose when no :for is provided", () => {
@@ -120,7 +119,6 @@ describe("SignedGlobalIDPurposeTest", () => {
     const a = SignedGlobalID.create(person(5), { verifier, for: "login" });
     const b = SignedGlobalID.create(person(5), { verifier, for: "login" });
     expect(a.equals(b)).toBe(true);
-    expect(a.purpose).toBe("login");
   });
 
   it("parse returns nil when purpose mismatch", () => {
@@ -138,8 +136,8 @@ describe("SignedGlobalIDPurposeTest", () => {
     const likeSgid = SignedGlobalID.create(person(5), { verifier, for: "like_button" });
     const noPurposeSgid = SignedGlobalID.create(person(5), { verifier });
     expect(loginSgid.equals(expected)).toBe(true);
-    expect(loginSgid.equals(likeSgid)).toBe(false);
-    expect(loginSgid.equals(noPurposeSgid)).toBe(false);
+    expect(loginSgid.equals(likeSgid)).not.toBe(true);
+    expect(loginSgid.equals(noPurposeSgid)).not.toBe(true);
   });
 });
 
@@ -167,48 +165,72 @@ describe("SignedGlobalIDExpirationTest", () => {
   });
 
   it("passing expires_in nil turns off expiration checking", () => {
-    const verifier = makeVerifier();
-    // Explicitly pass null (not undefined / omitted) to verify Rails parity:
-    // `expires_in: nil` means "no expiration", NOT "expire in 0ms".
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: null });
-    expect(sgid.expiresAt).toBeUndefined();
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      SignedGlobalID.expiresIn = 3600;
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: null });
+
+      vi.setSystemTime(new Date("2024-01-01T01:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+
+      vi.setSystemTime(new Date("2024-01-01T02:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      _resetSignedGlobalIDClassConfig();
+    }
   });
 
   it("passing expires_at sets expiration date", () => {
-    const verifier = makeVerifier();
-    // Use a millisecond-precision instant so the round-trip is exact
-    // (serialization uses smallestUnit: "millisecond" so sub-ms precision
-    // is intentionally lost).
-    const future = Temporal.Instant.fromEpochMilliseconds(
-      Math.floor(Temporal.Now.instant().epochMilliseconds + 3_600_000),
-    );
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: future });
-    expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
-    // Round-trip: the expiresAt survives serialization/parsing.
-    const parsed = SignedGlobalID.parse(sgid.toString(), { verifier });
-    expect(parsed!.expiresAt).toBeDefined();
-    expect(parsed!.expiresAt!.epochMilliseconds).toBe(future.epochMilliseconds);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      const date = Temporal.Instant.from("2024-01-01T23:59:59.999Z");
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: date });
+      expect(sgid.expiresAt!.epochMilliseconds).toBe(date.epochMilliseconds);
+
+      vi.setSystemTime(new Date("2024-01-02T00:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passing nil expires_at turns off expiration checking", () => {
-    const verifier = makeVerifier();
-    // Explicitly null (Rails parity, as with expires_in).
-    const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: null });
-    expect(sgid.expiresAt).toBeUndefined();
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      SignedGlobalID.expiresIn = 3600;
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: null });
+
+      vi.setSystemTime(new Date("2024-01-01T04:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      _resetSignedGlobalIDClassConfig();
+    }
   });
 
   it("favor expires_at over expires_in", () => {
-    const verifier = makeVerifier();
-    const future = Temporal.Now.instant().add({ seconds: 3600 });
-    // Both supplied — expiresAt wins (Rails parity: pick_expiration prefers
-    // expiresAt over expiresIn).
-    const sgid = SignedGlobalID.create(person(5), {
-      verifier,
-      expiresAt: future,
-      expiresIn: 1,
-    });
-    expect(Temporal.Instant.compare(sgid.expiresAt!, future)).toBe(0);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      const verifier = makeVerifier();
+      const sgid = SignedGlobalID.create(person(5), {
+        verifier,
+        expiresAt: Temporal.Instant.from("2024-01-02T23:59:59.999Z"),
+        expiresIn: 3600,
+      });
+
+      vi.setSystemTime(new Date("2024-01-01T01:00:00.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("expires_at: undefined falls through to expires_in (spread-defaults case)", () => {
@@ -281,8 +303,8 @@ describe("SignedGlobalIDExpirationTest", () => {
       const sgid = SignedGlobalID.create(person(5), { verifier, expiresIn: 7200 });
       vi.setSystemTime(new Date("2024-01-01T01:00:00.000Z"));
       expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
-      vi.setSystemTime(new Date("2024-01-01T01:00:03.000Z"));
-      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
+      vi.setSystemTime(new Date("2024-01-01T02:00:03.000Z"));
+      expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
     } finally {
       vi.useRealTimers();
       _resetSignedGlobalIDClassConfig();
@@ -296,8 +318,10 @@ describe("SignedGlobalIDExpirationTest", () => {
       const verifier = makeVerifier();
       SignedGlobalID.expiresIn = 3600;
       // Per-call expiresAt: tomorrow wins over class-level 1 hour
-      const tomorrow = Temporal.Instant.from("2024-01-02T00:00:00.000Z");
-      const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: tomorrow });
+      const date = Temporal.Instant.from("2024-01-02T23:59:59.999Z");
+      const sgid = SignedGlobalID.create(person(5), { verifier, expiresAt: date });
+      expect(sgid.expiresAt!.epochMilliseconds).toBe(date.epochMilliseconds);
+
       vi.setSystemTime(new Date("2024-01-01T02:00:00.000Z"));
       expect(SignedGlobalID.parse(sgid.toString(), { verifier })).not.toBeNull();
     } finally {

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -7,6 +7,33 @@ import {
   BadURIError,
 } from "./uri/gid.js";
 
+// Mirrors the private assertion helpers on URI::GIDValidationTest /
+// URI::GIDAppValidationTest (vendor/globalid/test/cases/uri_gid_test.rb:143-171).
+// Mirrors minitest's `assert_raise(Klass) { ... }`, which returns the raised
+// error so a following `assert_match` can read its message. Vitest's
+// `toThrow` doesn't hand the error back.
+function assertRaise(klass: new (...args: never[]) => Error, block: () => unknown): Error {
+  try {
+    block();
+  } catch (e) {
+    expect(e).toBeInstanceOf(klass);
+    return e as Error;
+  }
+  throw new Error(`expected ${klass.name} to be raised`);
+}
+
+function assertInvalidComponent(uri: string): void {
+  expect(() => GID.parse(uri)).toThrow(InvalidComponentError);
+}
+
+function assertBadUri(uri: string): void {
+  expect(() => GID.parse(uri)).toThrow(BadURIError);
+}
+
+function assertInvalidApp(value: string | null): void {
+  expect(() => validateApp(value)).toThrow();
+}
+
 describe("URI::GIDTest", () => {
   it("parsed", () => {
     const gid = GID.parse("gid://bcx/Person/5");
@@ -74,22 +101,18 @@ describe("URI::GIDTest", () => {
   });
 
   it("equal", () => {
-    const a = GID.parse("gid://bcx/Person/5");
-    const b = GID.parse("gid://bcx/Person/5");
-    expect(a.app).toBe(b.app);
-    expect(a.modelName).toBe(b.modelName);
-    expect(a.modelId).toBe(b.modelId);
-    const c = GID.parse("gid://bcxxx/Persona/1");
-    expect(a.app).not.toBe(c.app);
+    const gid = GID.parse("gid://bcx/Person/5");
+    expect(gid).toEqual(GID.parse("gid://bcx/Person/5"));
+    expect(gid).not.toEqual(GID.parse("gid://bcxxx/Persona/1"));
   });
 
   it("build with wrong ordered array creates a wrong ordered gid", () => {
     // Rails: URI::GID.build(['Person', '5', 'bcx', nil]) misorders the
     // positional (app, modelName, modelId, params) tuple. The resulting
     // URI is not equal to the canonical gid://bcx/Person/5.
-    const wrong = GID.build({ app: "Person", modelName: "5", modelId: "bcx" }).toString();
-    expect(wrong).toBe("gid://Person/5/bcx");
-    expect(wrong).not.toBe("gid://bcx/Person/5");
+    expect(GID.build({ app: "Person", modelName: "5", modelId: "bcx" }).toString()).not.toBe(
+      "gid://bcx/Person/5",
+    );
   });
 
   it("new returns invalid gid when not checking", () => {
@@ -104,7 +127,6 @@ describe("URI::GIDTest", () => {
       params: {},
     });
     expect(synthetic).toBeTruthy();
-    expect(synthetic.toString()).toBe("gid:///");
   });
 });
 
@@ -152,46 +174,46 @@ describe("URI::GIDModelIDDecodingTest", () => {
 
 describe("URI::GIDValidationTest", () => {
   it("missing app", () => {
-    expect(() => GID.parse("gid:///Person/1")).toThrow(InvalidComponentError);
+    assertInvalidComponent("gid:///Person/1");
   });
 
   it("missing path", () => {
-    expect(() => GID.parse("gid://bcx/")).toThrow();
+    assertInvalidComponent("gid://bcx/");
   });
 
   it("missing model id", () => {
-    expect(() => GID.parse("gid://bcx/Person")).toThrow(MissingModelIdError);
-    expect(() => GID.parse("gid://bcx/Person")).toThrow(/Unable to create a Global ID for Person/);
+    const err = assertRaise(MissingModelIdError, () => GID.parse("gid://bcx/Person"));
+    expect(err.message).toMatch(/Unable to create a Global ID for Person/);
   });
 
   it("missing model composite id", () => {
-    expect(() => GID.parse("gid://bcx/CompositePrimaryKeyModel")).toThrow(MissingModelIdError);
-    expect(() => GID.parse("gid://bcx/CompositePrimaryKeyModel")).toThrow(
-      /Unable to create a Global ID for CompositePrimaryKeyModel/,
+    const err = assertRaise(MissingModelIdError, () =>
+      GID.parse("gid://bcx/CompositePrimaryKeyModel"),
     );
+    expect(err.message).toMatch(/Unable to create a Global ID for CompositePrimaryKeyModel/);
   });
 
   it("empty", () => {
-    expect(() => GID.parse("gid:///")).toThrow();
+    assertInvalidComponent("gid:///");
   });
 
   it("invalid schemes", () => {
-    expect(() => GID.parse("http://bcx/Person/5")).toThrow(BadURIError);
-    expect(() => GID.parse("gyd://bcx/Person/5")).toThrow(BadURIError);
-    expect(() => GID.parse("//bcx/Person/5")).toThrow(BadURIError);
+    assertBadUri("http://bcx/Person/5");
+    assertBadUri("gyd://bcx/Person/5");
+    assertBadUri("//bcx/Person/5");
   });
 });
 
 describe("URI::GIDAppValidationTest", () => {
   it("nil or blank apps are invalid", () => {
-    expect(() => validateApp(null)).toThrow();
-    expect(() => validateApp("")).toThrow();
+    assertInvalidApp(null);
+    assertInvalidApp("");
   });
 
   it("apps containing non alphanumeric characters are invalid", () => {
-    expect(() => validateApp("foo&bar")).toThrow();
-    expect(() => validateApp("foo:bar")).toThrow();
-    expect(() => validateApp("foo_bar")).toThrow();
+    assertInvalidApp("foo&bar");
+    assertInvalidApp("foo:bar");
+    assertInvalidApp("foo_bar");
   });
 
   it("app with hyphen is allowed", () => {
@@ -208,6 +230,9 @@ describe("URI::GIDParamsTest", () => {
       params: { hello: "world" },
     }).toString();
     const gid = GID.parse(uri);
+    // Rails asserts both `params[:hello]` and `params['hello']` — a Ruby
+    // Symbol key is a plain JS string here, so both arms read the same key.
+    expect(gid.params["hello"]).toBe("world");
     expect(gid.params["hello"]).toBe("world");
   });
 
@@ -245,7 +270,6 @@ describe("URI::GIDParamsTest", () => {
     const gid = GID.parse("gid://bcx/Person/5?hello=world");
     gid.params["param"] = "value";
     expect(gid.toString()).not.toBe("gid://bcx/Person/5?hello=world&param=value");
-    expect(gid.toString()).toBe("gid://bcx/Person/5?hello=world");
   });
 });
 

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -51,9 +51,9 @@
       "value": 0
     },
     "globalid": {
-      "assertionCount": 53,
-      "kind": 71,
-      "value": 2
+      "assertionCount": 24,
+      "kind": 27,
+      "value": 1
     },
     "i18n": {
       "assertionCount": 18,


### PR DESCRIPTION
Burns down the RFC 0105 assertion-parity debt for four of the five `globalid`
files: they now assert what the Rails tests assert — same assertion kinds, same
order, same literal expected values.

**Measured (`pnpm parity:test -- --assertions --package globalid`)**

| | before | after |
| --- | ---: | ---: |
| assertion-count mismatches | 53 | 24 |
| assertion-kind mismatches | 71 | 27 |
| assertion-value mismatches | 2 | 1 |

Every remaining row is `global_locator_test.rb`, split out to stay under the
LOC ceiling (see **Scope** below). `scripts/test-compare/assertion-mismatch-mark.json`
is lowered to `{24, 27, 1}` for `globalid`. Test names are unchanged;
`parity:test` stays at 131/131 (100%), 6/6 files.

## What changed

- **`global_id_test.rb`** — the port used synthetic `{ id, constructor: { name } }`
  literals and asserted a narrowed subset of each Rails test. It now carries real
  `Person` / `PersonUuid` / `Person::Child` / `PersonModel` /
  `CompositePrimaryKeyModel` fixtures mirroring `vendor/globalid/test/models/*.rb`
  (including `Person::HARDCODED_ID_FOR_MISSING_PERSON` and
  `CompositePrimaryKeyModel.find`'s multi-record branch), plus a Rails-shaped
  `setup` block. `find` and its `with class` / `subclass` / `multiple class`
  variants and no-match arms, `model class`, `as param`, `as URI`, `as JSON`,
  `model id`, `model name` and `equality` now assert every Rails line, with the
  same expression on each side (`Person.find(@person_uuid_gid.model_id)`, not
  `PersonUuid.find`).
- **`uri_gid_test.rb`** — mirrors the private helpers Rails defines on
  `URI::GIDValidationTest` / `URI::GIDAppValidationTest`
  (`assert_invalid_component`, `assert_bad_uri`, `assert_invalid_app`,
  uri_gid_test.rb:143-171), so the unmapped-kind slots line up on both sides,
  and adds `assertRaise` for minitest's error-returning `assert_raise` so
  `missing model id` can `assert_match` on the message.
- **`signed_global_id_test.rb`** — the expiration tests travel the clock the way
  Rails does (`passing expires_at sets expiration date` now checks the date
  *and* that the token is expired a day later; `passing in expires_in overrides
  class level expiration` actually expires at the far end), and the purpose
  tests use the `assert_not_equal` arm Rails uses.
- **`global_identification_test.rb`** — each test asserts both the
  `to_global_id`/`to_gid` (and `to_signed_global_id`/`to_sgid`) arms Rails
  asserts, against a `model` built in `setup`.

## Deviations, each cited at the call site

- Rails asserts literal signed tokens produced by the vendored test verifier
  secret (`test/helper.rb:20`); trails builds a verifier per test, so those
  assertions check the round-trip instead.
- Ruby's `Array#uniq` folds on `hash`/`eql?`; a local `uniq` mirrors
  `GlobalID#hash` / `#eql?` (same class + same URI) for the `equality` test, and
  the `gid1.hash != gid1.uri.hash` assertion becomes the invariant that
  difference encodes.
- `only: Hash` maps to `Map`, not `Object` — every JS class extends `Object`, so
  `Object` would match where Ruby's `Hash` rejects.
- `Person::Child` is a TS class with the Rails spelling stamped on `name`, which
  is what `GlobalID#model_name` renders and the constant registry resolves.
- `SignedGlobalID` comparisons route through `equals` (the port of `#==`) rather
  than `toEqual`, which would also compare the per-instance `inspect` id.

## Scope

Two follow-ups filed under RFC 0105 rather than grown into this PR:

- **`assertions-globalid-locator`** — `global_locator_test.rb`'s 24/27/1. It was
  converged and green locally, but including it put the PR at ~908 LOC against
  the 700 ceiling, so it ships separately. The story body carries the per-test
  shapes and Rails `file:line` for each, so no re-derivation is needed.
- **`globalid-locator-single-argument-deprecation`** — `Locator.locate` doesn't
  port the `locator.method(:locate).arity == 1` deprecation branch
  (`vendor/globalid/lib/global_id/locator.rb:30-34`), because JS
  `Function.length` stops at the first defaulted parameter and so reports `1`
  for `locate(gid, options = {})` too. That is the one assertion in
  `global_locator_test.rb` that cannot be ported as written.

The bundled story `assertions-activesupport-hash-and-ordered-options` was
**released untouched** — its 295 divergences had no room here.

Closes-story: assertions-globalid-cluster
