### PR TITLE
test(activesupport): converge assertion parity for xml-mini, file-store and the cache-store behavior

### DIFF
--- a/packages/activesupport/src/cache/behaviors/cache-store-behavior.ts
+++ b/packages/activesupport/src/cache/behaviors/cache-store-behavior.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, it, vi } from "vitest";
 import { ArgumentError, type Store, type StoreOptions } from "../store.js";
+import { assert, assertNot, assertSame } from "../../testing/assertions.js";
 
 // Mirrors Rails `CacheStoreBehavior`
 // (activesupport/test/cache/behaviors/cache_store_behavior.rb) — "the base
@@ -192,6 +193,8 @@ export function cacheStoreBehavior(host: CacheStoreBehaviorHost): void {
     );
 
     expect(values).toEqual({ [key]: key + key, [otherKey]: otherKey + otherKey });
+    expect(cache.read(key)).toEqual(key + key);
+    expect(cache.read(otherKey)).toEqual(otherKey + otherKey);
   });
 
   it("exist", () => {
@@ -204,32 +207,32 @@ export function cacheStoreBehavior(host: CacheStoreBehaviorHost): void {
   it("nil exist", () => {
     const key = crypto.randomUUID();
     cache.write(key, null);
-    expect(cache.exist(key)).toBe(true);
+    assert(cache.exist(key));
   });
 
   it("delete", () => {
     const key = crypto.randomUUID();
     cache.write(key, "bar");
-    expect(cache.exist(key)).toBe(true);
-    expect(cache.delete(key)).toBe(true);
-    expect(cache.exist(key)).toBe(false);
+    assert(cache.exist(key));
+    assertSame(true, cache.delete(key));
+    assertNot(cache.exist(key));
   });
 
   it("delete returns false if not exist", () => {
     const key = crypto.randomUUID();
-    expect(cache.delete(key)).toBe(false);
+    assertSame(false, cache.delete(key));
   });
 
   it("delete multi", () => {
     const key = crypto.randomUUID();
     cache.write(key, "bar");
-    expect(cache.exist(key)).toBe(true);
+    assert(cache.exist(key));
     const otherKey = crypto.randomUUID();
     cache.write(otherKey, "world");
-    expect(cache.exist(otherKey)).toBe(true);
-    expect(cache.deleteMulti([key, crypto.randomUUID(), otherKey])).toBe(2);
-    expect(cache.exist(key)).toBe(false);
-    expect(cache.exist(otherKey)).toBe(false);
+    assert(cache.exist(otherKey));
+    expect(cache.deleteMulti([key, crypto.randomUUID(), otherKey])).toEqual(2);
+    assertNot(cache.exist(key));
+    assertNot(cache.exist(otherKey));
   });
 
   it("delete multi empty list", () => {

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -9,7 +9,7 @@ import { registerStoreClass } from "./store-registry.js";
 
 // max filename size on file system is 255, minus room for timestamp, pid, and
 // random characters appended by Tempfile (file_store.rb:16)
-const FILENAME_MAX_SIZE = 226;
+export const FILENAME_MAX_SIZE = 226;
 // max is 1024, plus some room (file_store.rb:17)
 const FILEPATH_MAX_SIZE = 900;
 const GITKEEP_FILES = [".gitkeep", ".keep"];

--- a/packages/activesupport/src/cache/stores/file-store.test.ts
+++ b/packages/activesupport/src/cache/stores/file-store.test.ts
@@ -1,8 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, symlinkSync, realpathSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  symlinkSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { FileStore } from "../file-store.js";
+import { basename, dirname, join } from "node:path";
+import { FileStore, FILENAME_MAX_SIZE } from "../file-store.js";
+import { assert, assertEmpty, assertNot, assertPredicate } from "../../testing/assertions.js";
+import { Store } from "../store.js";
+import { getFs } from "../../fs-adapter.js";
+import { isPresent } from "../../core-ext/object/blank.js";
 import { cacheInstrumentationBehavior } from "../behaviors/cache-instrumentation-behavior.js";
 import { cacheStoreBehavior } from "../behaviors/cache-store-behavior.js";
 import { cacheDeleteMatchedBehavior } from "../behaviors/cache-delete-matched-behavior.js";
@@ -15,6 +28,12 @@ import type { StoreOptions } from "../store.js";
 // (file_store_test.rb:63).
 function pathFor(store: FileStore, key: string): string {
   return (store as unknown as { normalizeKey(k: string, o: object): string }).normalizeKey(key, {});
+}
+
+// Rails reaches the private key helper with `@cache.send(:file_path_key, key)`
+// (file_store_test.rb:64).
+function filePathKey(store: FileStore, path: string): string {
+  return (store as unknown as { filePathKey(p: string): string }).filePathKey(path);
 }
 
 describe("FileStoreTest", () => {
@@ -36,38 +55,61 @@ describe("FileStoreTest", () => {
   });
 
   it("long uri encoded keys", () => {
-    const longKey = "a".repeat(300);
-    store.write(longKey, "value");
-    expect(store.read(longKey)).toBe("value");
+    store.write("%".repeat(870), 1);
+    expect(store.read("%".repeat(870))).toEqual(1);
   });
 
   it("key transformation", () => {
-    store.write("my/key", "val");
-    expect(store.read("my/key")).toBe("val");
+    const key = pathFor(store, "views/index?id=1");
+    expect(filePathKey(store, key)).toEqual("views/index?id=1");
   });
 
+  // Rails builds `@cache_with_pathname` from `Pathname.new(cache_dir)`
+  // (file_store_test.rb:21); Ruby's Pathname is stdlib with no trails
+  // counterpart, so the store is built from the same directory as a String and
+  // the round-trip through `file_path_key` is what the test pins.
   it("key transformation with pathname", () => {
-    store.write("path/to/key", "value");
-    expect(store.read("path/to/key")).toBe("value");
+    writeFileSync(join(cacheDir, "foo"), "");
+    const cacheWithPathname = new FileStore(cacheDir, { expiresIn: 60 });
+    const key = pathFor(cacheWithPathname, "views/index?id=1");
+    expect(filePathKey(cacheWithPathname, key)).toEqual("views/index?id=1");
   });
 
+  // Test that generated cache keys are short enough to have Tempfile stuff added to them and
+  // remain valid
   it("filename max size", () => {
-    // Keys with 228+ char segments should be stored without throwing
-    const bigSegment = "x".repeat(250);
-    expect(() => store.write(bigSegment, "v")).not.toThrow();
+    const key = "A".repeat(FILENAME_MAX_SIZE);
+    const path = pathFor(store, key);
+    // Ruby wraps the assertion in `Dir::Tmpname.create(basename, …)`
+    // (file_store_test.rb:80), which appends the timestamp/pid/random suffix
+    // `atomic_write`'s Tempfile would; trails' atomicWrite spells that suffix
+    // itself, so the budget is measured against the same worst case.
+    const tmpname = `${basename(path)}.20260817-123456-abcdef`;
+    assert(
+      basename(`${tmpname}.lock`).length <= 255,
+      `Temp filename too long: ${basename(`${tmpname}.lock`).length}`,
+    );
   });
 
+  // Because file systems have a maximum filename size, filenames > max size should be split in to directories
+  // If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   it("key transformation max filename size", () => {
-    const bigKey = "x".repeat(500);
-    store.write(bigKey, "v");
-    expect(store.read(bigKey)).toBe("v");
+    const key = `${"A".repeat(FILENAME_MAX_SIZE)}B`;
+    const path = pathFor(store, key);
+    assert(path.split("/").every((dirName) => dirName.length <= FILENAME_MAX_SIZE));
+    expect(basename(path)).toEqual("B");
   });
 
   it("delete matched when key exceeds max filename size", () => {
-    const bigKey = "x".repeat(500);
-    store.write(bigKey, "v");
-    store.deleteMatched(/x{10}/);
-    expect(store.read(bigKey)).toBeNull();
+    const submaximalKey = "_".repeat(FILENAME_MAX_SIZE - 1);
+
+    store.write(submaximalKey + "AB", "value");
+    store.deleteMatched(/AB/);
+    assertNot(store.exist(submaximalKey + "AB"));
+
+    store.write(submaximalKey + "/A", "value");
+    store.deleteMatched(/A/);
+    assertNot(store.exist(submaximalKey + "/A"));
   });
 
   it("delete matched when cache directory does not exist", () => {
@@ -76,9 +118,15 @@ describe("FileStoreTest", () => {
   });
 
   it("delete does not delete empty parent dir", () => {
-    store.write("a/b", "val");
-    store.delete("a/b");
-    expect(existsSync(cacheDir)).toBe(true);
+    const subCacheDir = join(cacheDir, "subdir/");
+    const subCacheStore = new FileStore(subCacheDir);
+    expect(() => {
+      assert(subCacheStore.write("foo", "bar"));
+      assert(subCacheStore.delete("foo"));
+    }).not.toThrow();
+    assert(existsSync(cacheDir), "Parent of top level cache dir was deleted!");
+    assert(existsSync(subCacheDir), "Top level cache dir was deleted!");
+    assertEmpty(readdirSync(subCacheDir));
   });
 
   it("delete prunes empty parent directories", () => {
@@ -115,39 +163,69 @@ describe("FileStoreTest", () => {
   });
 
   it("log exception when cache read fails", () => {
-    // Corrupted cache files should return null gracefully
-    expect(store.read("nonexistent_key")).toBeNull();
+    // Rails' `@buffer = StringIO.new` + `@cache.logger = Logger.new(@buffer)`
+    // (file_store_test.rb:23-24); the logger is class-level in trails.
+    const buffer = { string: "" };
+    const previousLogger = Store.logger;
+    Store.logger = {
+      warn: (message: string) => (buffer.string += message),
+      error: (message: string) => (buffer.string += message),
+    };
+    // Rails' `File.stub(:exist?, -> { raise StandardError.new("failed") })`
+    // (file_store_test.rb:127).
+    const existsSync = vi.spyOn(getFs(), "existsSync").mockImplementation(() => {
+      throw new Error("failed");
+    });
+    try {
+      (store as unknown as { readEntry(k: string, o: object): unknown }).readEntry("winston", {});
+      assertPredicate(buffer.string, isPresent);
+    } finally {
+      existsSync.mockRestore();
+      Store.logger = previousLogger;
+    }
   });
 
-  it("cleanup removes all expired entries", async () => {
-    store.write("foo", "bar", { expiresIn: 0.01 });
+  it("cleanup removes all expired entries", () => {
+    const time = Date.now();
+    store.write("foo", "bar", { expiresIn: 10 });
     store.write("baz", "qux");
-    await new Promise((r) => setTimeout(r, 20));
-    store.cleanup();
-    expect(store.exist("foo")).toBe(false);
-    expect(store.exist("baz")).toBe(true);
+    store.write("quux", "corge", { expiresIn: 20 });
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(time + 15_000);
+      store.cleanup();
+      assertNot(store.exist("foo"));
+      assert(store.exist("baz"));
+      assert(store.exist("quux"));
+      expect(readdirSync(cacheDir).length).toEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("cleanup when non active support cache file exists", () => {
-    // Non-JSON files in cache dir should not cause errors during cleanup
-    writeFileSync(join(cacheDir, "not_a_cache_file.txt"), "plain text");
+    const cacheFilePath = pathFor(store, "foo");
+    mkdirSync(dirname(cacheFilePath), { recursive: true });
+    writeFileSync(cacheFilePath, cacheDir);
     expect(() => store.cleanup()).not.toThrow();
+    expect(readdirSync(cacheDir).length).toEqual(1);
   });
 
   it("write with unless exist", () => {
-    store.write("1", "aaaaaaaaaa");
-    expect(store.write("1", "aaaaaaaaaa", { unlessExist: true })).toBe(false);
-    expect(store.write("new_k", "val", { unlessExist: true })).toBe(true);
+    expect(store.write("1", "aaaaaaaaaa")).toEqual(true);
+    expect(store.write("1", "aaaaaaaaaa", { unlessExist: true })).toEqual(false);
+    store.write("1", null);
+    expect(store.write("1", "aaaaaaaaaa", { unlessExist: true })).toEqual(false);
   });
 
   it("clear", () => {
-    writeFileSync(join(cacheDir, ".gitkeep"), "");
-    writeFileSync(join(cacheDir, ".keep"), "");
-    store.write("foo", "bar");
+    const gitkeep = join(cacheDir, ".gitkeep");
+    const keep = join(cacheDir, ".keep");
+    writeFileSync(gitkeep, "");
+    writeFileSync(keep, "");
     store.clear();
-    expect(existsSync(join(cacheDir, ".gitkeep"))).toBe(true);
-    expect(existsSync(join(cacheDir, ".keep"))).toBe(true);
-    expect(store.read("foo")).toBeNull();
+    assert(existsSync(gitkeep));
+    assert(existsSync(keep));
   });
 
   // Inherited Store#fetch_multi routes through the readEntry hook, which must

--- a/packages/activesupport/src/cache/stores/file-store.test.ts
+++ b/packages/activesupport/src/cache/stores/file-store.test.ts
@@ -79,12 +79,17 @@ describe("FileStoreTest", () => {
   // remain valid
   it("filename max size", () => {
     const key = "A".repeat(FILENAME_MAX_SIZE);
-    const path = pathFor(store, key);
-    // Ruby wraps the assertion in `Dir::Tmpname.create(basename, …)`
-    // (file_store_test.rb:80), which appends the timestamp/pid/random suffix
-    // `atomic_write`'s Tempfile would; trails' atomicWrite spells that suffix
-    // itself, so the budget is measured against the same worst case.
-    const tmpname = `${basename(path)}.20260817-123456-abcdef`;
+    // Ruby reads the name Tempfile would pick out of `Dir::Tmpname.create`
+    // (file_store_test.rb:80); trails' atomicWrite picks its own, so the name
+    // under test is the one the real write hands to writeFileSync.
+    const writeFileSync = vi.spyOn(getFs(), "writeFileSync");
+    let tmpname: string;
+    try {
+      store.write(key, "v");
+      tmpname = basename(String(writeFileSync.mock.calls[0][0]));
+    } finally {
+      writeFileSync.mockRestore();
+    }
     assert(
       basename(`${tmpname}.lock`).length <= 255,
       `Temp filename too long: ${basename(`${tmpname}.lock`).length}`,

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -92,11 +92,11 @@ describe("ParsingTest", () => {
   it("boolean", () => {
     const parser = parsing["boolean"];
     for (const value of [1, true, "1"]) {
-      expect(parser(value)).toBe(true);
+      expect(parser(value)).toBeTruthy();
     }
 
     for (const value of [0, false, "0"]) {
-      expect(parser(value)).toBe(false);
+      expect(parser(value)).toBeFalsy();
     }
   });
 
@@ -163,57 +163,62 @@ describe("ParsingTest", () => {
 
 describe("RenameKeyTest", () => {
   it("rename key dasherizes by default", () => {
-    expect(renameKey("hello_world")).toBe("hello-world");
+    expect(renameKey("my_key")).toBe("my-key");
   });
 
   it("rename key dasherizes with dasherize true", () => {
-    expect(renameKey("hello_world", { dasherize: true })).toBe("hello-world");
+    expect(renameKey("my_key", { dasherize: true })).toBe("my-key");
   });
 
   it("rename key does nothing with dasherize false", () => {
-    expect(renameKey("hello_world", { dasherize: false })).toBe("hello_world");
+    expect(renameKey("my_key", { dasherize: false })).toBe("my_key");
   });
 
   it("rename key camelizes with camelize true", () => {
-    expect(renameKey("hello_world", { camelize: true })).toBe("HelloWorld");
+    expect(renameKey("my_key", { camelize: true })).toBe("MyKey");
   });
 
   it("rename key lower camelizes with camelize lower", () => {
-    expect(renameKey("hello_world", { camelize: "lower" })).toBe("helloWorld");
+    expect(renameKey("my_key", { camelize: "lower" })).toBe("myKey");
   });
 
   it("rename key lower camelizes with camelize upper", () => {
-    expect(renameKey("hello_world", { camelize: "upper" })).toBe("HelloWorld");
+    expect(renameKey("my_key", { camelize: "upper" })).toBe("MyKey");
   });
 
   it("rename key does not dasherize leading underscores", () => {
-    expect(renameKey("__hello_world")).toBe("__hello-world");
+    expect(renameKey("_id")).toBe("_id");
   });
 
   it("rename key with leading underscore dasherizes interior underscores", () => {
-    expect(renameKey("_hello_world")).toBe("_hello-world");
+    expect(renameKey("_my_key")).toBe("_my-key");
   });
 
   it("rename key does not dasherize trailing underscores", () => {
-    expect(renameKey("hello_world__")).toBe("hello-world__");
+    expect(renameKey("id_")).toBe("id_");
   });
 
   it("rename key with trailing underscore dasherizes interior underscores", () => {
-    expect(renameKey("hello_world_")).toBe("hello-world_");
+    expect(renameKey("my_key_")).toBe("my-key_");
   });
 
   it("rename key does not dasherize multiple leading underscores", () => {
-    expect(renameKey("___hello_world")).toBe("___hello-world");
+    expect(renameKey("__id")).toBe("__id");
   });
 
   it("rename key does not dasherize multiple trailing underscores", () => {
-    expect(renameKey("hello_world___")).toBe("hello-world___");
+    expect(renameKey("id__")).toBe("id__");
   });
 });
 
 describe("ToTagTest", () => {
   let builder: XmlStringBuilder;
   let options: ToTagOptions;
+
+  /** Mirrors `assert_xml` (xml_mini_test.rb:64-66). */
+  function assertXml(xml: string): void {
+    expect(builder.target()).toBe(xml);
+  }
 
   beforeEach(() => {
     builder = new XmlStringBuilder();
@@ -222,12 +227,12 @@ describe("ToTagTest", () => {
 
   it("#to_tag accepts a callable object and passes options with the builder", () => {
     toTag("some_tag", (o: ToTagOptions) => o.builder.tag("br"), options);
-    expect(builder.target()).toBe("<br/>");
+    assertXml("<br/>");
   });
 
   it("#to_tag accepts a callable object and passes options and tag name", () => {
     toTag("tag", (o: ToTagOptions, t: string) => o.builder.tag("b", t), options);
-    expect(builder.target()).toBe("<b>tag</b>");
+    assertXml("<b>tag</b>");
   });
 
   it("#to_tag accepts an object responding to #to_xml and passes the options, where :root is key", () => {
@@ -237,52 +242,52 @@ describe("ToTagTest", () => {
       },
     };
     toTag("tag", obj, options);
-    expect(builder.target()).toBe("<yo>tag</yo>");
+    assertXml("<yo>tag</yo>");
   });
 
   it("#to_tag accepts arbitrary objects responding to #to_str", () => {
     toTag("b", "Howdy", options);
-    expect(builder.target()).toBe("<b>Howdy</b>");
+    assertXml("<b>Howdy</b>");
   });
 
   it("#to_tag should use the type value in the options hash", () => {
     toTag("b", "blue", { ...options, type: "color" });
-    expect(builder.target()).toBe('<b type="color">blue</b>');
+    assertXml('<b type="color">blue</b>');
   });
 
   it("#to_tag accepts symbol types", () => {
     toTag("b", Symbol("name"), options);
-    expect(builder.target()).toBe('<b type="symbol">name</b>');
+    assertXml('<b type="symbol">name</b>');
   });
 
   it("#to_tag accepts boolean types", () => {
     toTag("b", true, options);
-    expect(builder.target()).toBe('<b type="boolean">true</b>');
+    assertXml('<b type="boolean">true</b>');
   });
 
   it("#to_tag accepts float types", () => {
     toTag("b", 3.14, options);
-    expect(builder.target()).toBe('<b type="float">3.14</b>');
+    assertXml('<b type="float">3.14</b>');
   });
 
   it("#to_tag accepts decimal types", () => {
     toTag("b", new BigDecimal("1.2"), options);
-    expect(builder.target()).toBe('<b type="decimal">1.2</b>');
+    assertXml('<b type="decimal">1.2</b>');
   });
 
   it("#to_tag accepts date types", () => {
     toTag("b", Temporal.PlainDate.from("2001-02-03"), options);
-    expect(builder.target()).toBe('<b type="date">2001-02-03</b>');
+    assertXml('<b type="date">2001-02-03</b>');
   });
 
   it("#to_tag accepts datetime types", () => {
     toTag("b", Temporal.ZonedDateTime.from("2001-02-03T04:05:06+07:00[+07:00]"), options);
-    expect(builder.target()).toBe('<b type="dateTime">2001-02-03T04:05:06+07:00</b>');
+    assertXml('<b type="dateTime">2001-02-03T04:05:06+07:00</b>');
   });
 
   it("#to_tag accepts time types", () => {
     toTag("b", Temporal.ZonedDateTime.from("1993-02-24T12:00:00+09:00[+09:00]"), options);
-    expect(builder.target()).toBe('<b type="dateTime">1993-02-24T12:00:00+09:00</b>');
+    assertXml('<b type="dateTime">1993-02-24T12:00:00+09:00</b>');
   });
 
   it("#to_tag accepts ActiveSupport::TimeWithZone types", () => {
@@ -295,7 +300,7 @@ describe("ToTagTest", () => {
       }
     }
     toTag("b", new TimeWithZone(), options);
-    expect(builder.target()).toBe('<b type="dateTime">1993-02-24T13:00:00+01:00</b>');
+    assertXml('<b type="dateTime">1993-02-24T13:00:00+01:00</b>');
   });
 
   it("#to_tag accepts duration types", () => {
@@ -304,46 +309,44 @@ describe("ToTagTest", () => {
       Temporal.Duration.from({ years: 3, months: 6, days: 4, hours: 12, minutes: 30, seconds: 5 }),
       options,
     );
-    expect(builder.target()).toBe('<b type="duration">P3Y6M4DT12H30M5S</b>');
+    assertXml('<b type="duration">P3Y6M4DT12H30M5S</b>');
   });
 
   it("#to_tag accepts array types", () => {
     toTag("b", ["first_name", "last_name"], options);
-    expect(builder.target()).toBe('<b type="array"><b>first_name</b><b>last_name</b></b>');
+    assertXml('<b type="array"><b>first_name</b><b>last_name</b></b>');
   });
 
   it("#to_tag accepts hash types", () => {
     toTag("b", { first_name: "Bob", last_name: "Marley" }, options);
-    expect(builder.target()).toBe(
-      "<b><first-name>Bob</first-name><last-name>Marley</last-name></b>",
-    );
+    assertXml("<b><first-name>Bob</first-name><last-name>Marley</last-name></b>");
   });
 
   it("#to_tag should not add type when skip types option is set", () => {
     toTag("b", "Bob", { ...options, skipTypes: 1 });
-    expect(builder.target()).toBe("<b>Bob</b>");
+    assertXml("<b>Bob</b>");
   });
 
   it("#to_tag should dasherize the space when passed a string with spaces as a key", () => {
     toTag("New   York", 33, options);
-    expect(builder.target()).toBe('<New---York type="integer">33</New---York>');
+    assertXml('<New---York type="integer">33</New---York>');
   });
 
   it("#to_tag should dasherize the space when passed a symbol with spaces as a key", () => {
     toTag(Symbol("New   York"), 33, options);
-    expect(builder.target()).toBe('<New---York type="integer">33</New---York>');
+    assertXml('<New---York type="integer">33</New---York>');
   });
 
   // trails coverage beyond Rails' ToTagTest, exercising the XmlMini `binary`
   // formatter/encoding and the empty-array self-closing form.
   it("#to_tag base64-encodes binary types and sets the encoding attribute", () => {
     toTag("b", "hello", { ...options, type: "binary" });
-    expect(builder.target()).toBe('<b type="binary" encoding="base64">aGVsbG8=\n</b>');
+    assertXml('<b type="binary" encoding="base64">aGVsbG8=\n</b>');
   });
 
   it("#to_tag emits an empty array as a self-closing tag", () => {
     toTag("b", [], options);
-    expect(builder.target()).toBe('<b type="array"/>');
+    assertXml('<b type="array"/>');
   });
 });
 

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,9 +31,9 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 951,
-      "kind": 1327,
-      "value": 130
+      "assertionCount": 943,
+      "kind": 1293,
+      "value": 114
     },
     "arel": {
       "assertionCount": 180,


### PR DESCRIPTION
Ports the Rails assertions verbatim for three activesupport test files whose trails ports had drifted into paraphrase. All three now report 0 assertion-count / 0 assertion-kind / 0 assertion-value mismatches.

## `xml_mini_test.rb`

- **RenameKeyTest** asserts on Rails' own literals (`my_key`, `_id`, `id_`, `__id`, `id__`, …) instead of a `hello_world` stand-in — xml_mini_test.rb:13-61. All twelve pass unchanged against the existing `renameKey`.
- **ToTagTest** routes every assertion through an `assertXml` helper, the twin of Rails' `assert_xml` (xml_mini_test.rb:64-66). Both extractors count a helper whose name starts with `assert` as one assertion with an unmapped kind, so the twenty `to_tag` tests now line up on both sides.
- The `boolean` parser asserts truthiness, matching Rails' `assert` / `assert_not` (xml_mini_test.rb:317-326), not `toBe(true)` / `toBe(false)`.

`xml_mini_test.rb` keeps 5 count / 5 kind rows: `symbol`, `integer`, `float`, `decimal` and `string` each close with `assert_raises(ArgumentError) { parser.call(Date.new(2013, 11, 12, 02, 11)) }`, which MRI raises from `Date.new`'s arity before the parser runs. trails' `Date.civil` takes four parameters and silently ignores a fifth argument at runtime (verified in this worktree), so the assertion has no faithful counterpart — the pre-existing note at xml-mini.test.ts:22-31 stands unchanged.

## `cache/behaviors/cache_store_behavior.rb`

- `fetch multi with forced cache miss` reads both keys back (cache_store_behavior.rb:248-258).
- `nil exist`, `delete`, `delete returns false if not exist` and `delete multi` use `assert` / `assertNot` / `assertSame` from `testing/assertions.ts`, matching Rails' `assert`, `assert_not` and `assert_same true` / `assert_same false` (cache_store_behavior.rb:421-450) rather than collapsing all five kinds onto `toBe`.

## `cache/stores/file_store_test.rb`

All eleven drifted tests re-ported assertion for assertion against file_store_test.rb:43-160: `clear`, `long uri encoded keys`, `key transformation`, `key transformation with pathname`, `filename max size`, `key transformation max filename size`, `delete matched when key exceeds max filename size`, `delete does not delete empty parent dir`, `log exception when cache read fails`, `cleanup removes all expired entries`, `cleanup when non active support cache file exists` and `write with unless exist`.

Two supporting changes:

- `FILENAME_MAX_SIZE` is exported from `cache/file-store.ts` — Rails' `FileStore::FILENAME_MAX_SIZE` is a public class constant (file_store.rb:16), and the max-filename tests are written against it rather than a hand-picked 500.
- The test reaches `normalize_key` and `file_path_key` through the same two casts Rails reaches them through `send` (file_store_test.rb:63-64).

Two Rails details have no trails counterpart and are noted at the call site instead of restated against a stand-in: `Pathname` (Ruby stdlib, so `@cache_with_pathname` is built from the same directory as a String) and `Dir::Tmpname.create` (trails' `atomicWrite` spells its own suffix, so the 255-byte budget is measured against the same worst case).

## Measurement

`pnpm parity:test -- --assertions --package activesupport`, activesupport marks:

    951 / 1327 / 130  ->  943 / 1293 / 114

`scripts/test-compare/assertion-mismatch-mark.json` lowered to match. (The starting point moved from 963 / 1342 / 130 to 951 / 1327 / 130 when #6649 landed; the rebase conflict on that file was resolved by recomputing `origin/main` minus this branch's own -8 / -34 / -16, then confirmed against a fresh measurement rather than by taking either side.) No test names changed; the activesupport matched percent is unchanged at 85.9%.

Gates run: `parity:test:assertions`, `parity:api:calls`, `parity:api:calls:args`, `parity:api:extra --package activesupport`, `pnpm lint`, `pnpm typecheck`, and the three touched test files (90 + 96 + 49 tests, all green).

The remainder of the story — `test_case_test.rb`, `callbacks_test.rb`, `number_helper_test.rb`, `current_attributes_test.rb`, `json/encoding_test.rb`, `configurable_test.rb`, `cache/cache_store_setting_test.rb`, `json/decoding_test.rb` and `null_store_test.rb`, each of which needs implementation work or a several-hundred-line fixture re-port before its assertions can converge — is filed as `0105-ar-deps-test-parity-100/assertions-activesupport-cluster-tail-5` with the per-file measurements and blockers.

Closes-story: assertions-activesupport-cluster-tail-4
