### PR TITLE
chore(tasks): delegate `pnpm tasks` to the tasks repo's CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
           TSE_COMPILER_PKGS_RE='^packages/tse-compiler/'
           RACK_PKGS_RE='^packages/(rack|activesupport|date)/'
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|date|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references|non-transactional-row-writes|generate-canonical-zone-identifiers)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|date|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|tasks-shim|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references|non-transactional-row-writes|generate-canonical-zone-identifiers)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|date|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
           GUIDES_EXCL_RE='(/src/test-helpers(/|\.ts$)|/test-fixtures?(/|\.ts$)|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
           WEBSITE_PKGS_RE='^packages/website/'
@@ -599,6 +599,7 @@ jobs:
           scripts/parity
           eslint/
           scripts/strip-asany.test.ts
+          scripts/tasks-shim.test.ts
           scripts/rails-file-structure-mixins.test.ts
           scripts/deprecated-manifest-diff.test.ts
           scripts/ci-suite-coverage.test.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,13 @@ tasks repo enumerates these as convergence classes.
   CI's `Docs ActiveRecord Freeze` job fails any PR that adds or modifies a
   file there (allowlist: `docs/activerecord/parity-verification.md`). Other
   `docs/` trees are not policed and stay live until their own cutover.
+- **The `tasks` CLI itself lives in the tasks repo** (`scripts/cli.ts`, entered
+  through its `bin/tasks`). trails' `pnpm tasks` is a shim,
+  `scripts/tasks/tasks.sh`, that finds a tasks checkout and hands off; it does
+  not set `$TASKS_DIR`, so the CLI still resolves the working tree it acts on
+  from your cwd — your worktree's own `tasks/` symlink. `tasks` is also on the
+  `PATH` (installed by `start-worktree.sh`) and works from any cwd. Fix CLI
+  bugs in the tasks repo, not here.
 - Do NOT add "Co-Authored-By" lines to commits or "Generated with Claude
   Code" lines to PR descriptions.
 - After opening a PR, run the `/link` skill with the PR number so webhook

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@11.5.1",
   "scripts": {
     "build": "tsc --build",
-    "tasks": "tsx scripts/tasks/cli.ts",
+    "tasks": "scripts/tasks/tasks.sh",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",

--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -256,6 +256,15 @@ TASKS_WT="$TASKS_WORKTREES_ROOT/$NAME"
   ln -s "$TASKS_WT" "$TARGET/tasks"
   echo "    linked tasks -> $TASKS_WT"
 ) || echo "    warning: tasks worktree provisioning failed — falling back to canonical $TASKS_CANONICAL" >&2
+
+# Put `tasks` on the PATH. The installer lives in the tasks repo and points
+# ~/.local/bin/tasks at the CANONICAL checkout's bin/tasks — never a
+# worktree's, which would dangle once the worktree is removed. bin/tasks
+# resolves the checkout to run from the caller's cwd, so the canonical target
+# still runs this worktree's tasks/ CLI when invoked from here.
+if [[ -x "$TASKS_CANONICAL/scripts/install-bin.sh" ]]; then
+  "$TASKS_CANONICAL/scripts/install-bin.sh" || true
+fi
 # Cleanup note: removing this trails worktree does not automatically remove
 # the tasks worktree at $TASKS_WT. Remove it manually with:
 #   git -C "$TASKS_CANONICAL" worktree remove "$TASKS_WT"

--- a/scripts/start-worktree.sh
+++ b/scripts/start-worktree.sh
@@ -257,11 +257,9 @@ TASKS_WT="$TASKS_WORKTREES_ROOT/$NAME"
   echo "    linked tasks -> $TASKS_WT"
 ) || echo "    warning: tasks worktree provisioning failed — falling back to canonical $TASKS_CANONICAL" >&2
 
-# Put `tasks` on the PATH. The installer lives in the tasks repo and points
-# ~/.local/bin/tasks at the CANONICAL checkout's bin/tasks — never a
-# worktree's, which would dangle once the worktree is removed. bin/tasks
-# resolves the checkout to run from the caller's cwd, so the canonical target
-# still runs this worktree's tasks/ CLI when invoked from here.
+# Put `tasks` on the PATH. The installer targets the CANONICAL checkout's
+# bin/tasks — a worktree's would dangle once the worktree is removed — and
+# bin/tasks still resolves which checkout to run from the caller's cwd.
 if [[ -x "$TASKS_CANONICAL/scripts/install-bin.sh" ]]; then
   "$TASKS_CANONICAL/scripts/install-bin.sh" || true
 fi

--- a/scripts/tasks-shim.test.ts
+++ b/scripts/tasks-shim.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from "node:child_process";
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SHIM = join(REPO_ROOT, "scripts", "tasks", "tasks.sh");
+
+const scratch: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+// Stands in for a tasks checkout's bin/tasks, recording what the shim handed it.
+function recordingCheckout(root: string): string {
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  const log = join(root, "handoff.txt");
+  writeFileSync(
+    join(bin, "tasks"),
+    "#!/usr/bin/env bash\n" +
+      `printf 'TASKS_DIR=[%s]\\nRFCS_DIR=[%s]\\nargs=[%s]\\n' ` +
+      `"\${TASKS_DIR-<unset>}" "\${RFCS_DIR-<unset>}" "$*" > ${JSON.stringify(log)}\n`,
+  );
+  chmodSync(join(bin, "tasks"), 0o755);
+  return log;
+}
+
+function runShim(args: string[], cwd: string, env: Record<string, string | undefined> = {}) {
+  return spawnSync(SHIM, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, TASKS_DIR: undefined, RFCS_DIR: undefined, ...env },
+  });
+}
+
+afterEach(() => {
+  for (const dir of scratch.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("pnpm tasks shim", () => {
+  it("is the package.json tasks script and is executable", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.tasks).toBe("scripts/tasks/tasks.sh");
+    expect(() => accessSync(SHIM, constants.X_OK)).not.toThrow();
+  });
+
+  it("delegates to bin/tasks in the cwd's tasks checkout, forwarding arguments", () => {
+    const cwd = tempDir("tasks-shim-");
+    const log = recordingCheckout(join(cwd, "tasks"));
+
+    const run = runShim(["claim", "some-story", "--pr", "1"], cwd);
+
+    expect(run.status).toBe(0);
+    expect(readFileSync(log, "utf8")).toContain("args=[claim some-story --pr 1]");
+  });
+
+  it("leaves TASKS_DIR and RFCS_DIR unset so the CLI resolves the working tree from cwd", () => {
+    const cwd = tempDir("tasks-shim-");
+    const log = recordingCheckout(join(cwd, "tasks"));
+
+    expect(runShim(["ready"], cwd).status).toBe(0);
+
+    const handoff = readFileSync(log, "utf8");
+    expect(handoff).toContain("TASKS_DIR=[<unset>]");
+    expect(handoff).toContain("RFCS_DIR=[<unset>]");
+  });
+
+  it("prefers an explicit TASKS_DIR over the cwd's tasks checkout", () => {
+    const cwd = tempDir("tasks-shim-");
+    const localLog = recordingCheckout(join(cwd, "tasks"));
+    const explicit = tempDir("tasks-shim-explicit-");
+    const explicitLog = recordingCheckout(explicit);
+
+    expect(runShim(["ready"], cwd, { TASKS_DIR: explicit }).status).toBe(0);
+
+    expect(readFileSync(explicitLog, "utf8")).toContain("args=[ready]");
+    expect(() => readFileSync(localLog, "utf8")).toThrow();
+  });
+
+  it("fails loudly when no reachable checkout carries bin/tasks", () => {
+    const cwd = tempDir("tasks-shim-empty-");
+
+    const run = runShim(["ready"], cwd, { HOME: cwd });
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain("no tasks checkout with bin/tasks found");
+  });
+});

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1,4 +1,12 @@
 #!/usr/bin/env tsx
+// SUPERSEDED — the live CLI is `scripts/cli.ts` in the tasks repo, entered
+// through its `bin/tasks`. `pnpm tasks` here runs `scripts/tasks/tasks.sh`,
+// which delegates there; nothing invokes this file. It is kept only until the
+// tasks-repo copy has some mileage, then deleted along with its test file, the
+// `scripts/tasks/*.test.ts` entry in vitest.config.ts, and the `scripts/tasks`
+// argument in ci.yml's unit-tests `pnpm vitest run`. Do not fix bugs here —
+// fix them in the tasks repo, or the two silently diverge.
+//
 // trails-side CLI for the sibling blazetrailsdev/tasks repo.
 //
 // All state lives in $TASKS_DIR (default ~/github/blazetrailsdev/tasks).

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1,11 +1,7 @@
 #!/usr/bin/env tsx
-// SUPERSEDED — the live CLI is `scripts/cli.ts` in the tasks repo, entered
-// through its `bin/tasks`. `pnpm tasks` here runs `scripts/tasks/tasks.sh`,
-// which delegates there; nothing invokes this file. It is kept only until the
-// tasks-repo copy has some mileage, then deleted along with its test file, the
-// `scripts/tasks/*.test.ts` entry in vitest.config.ts, and the `scripts/tasks`
-// argument in ci.yml's unit-tests `pnpm vitest run`. Do not fix bugs here —
-// fix them in the tasks repo, or the two silently diverge.
+// SUPERSEDED — nothing invokes this file. The live CLI is `scripts/cli.ts` in
+// the tasks repo; fix bugs there, or the two silently diverge. Deleted by story
+// `delete-trails-copy-of-tasks-cli`.
 //
 // trails-side CLI for the sibling blazetrailsdev/tasks repo.
 //

--- a/scripts/tasks/tasks.sh
+++ b/scripts/tasks/tasks.sh
@@ -6,11 +6,6 @@
 # NOT set $TASKS_DIR — which working tree the CLI acts on is resolved by
 # resolveTasksDir() in the CLI from the caller's cwd, and setting the env var
 # here would suppress the per-worktree branch that pushes `HEAD:main`.
-#
-# Resolution order mirrors bin/tasks:
-#   1. $TASKS_DIR / $RFCS_DIR
-#   2. <cwd>/tasks — the per-worktree symlink start-worktree.sh creates
-#   3. ~/github/blazetrailsdev/tasks
 set -euo pipefail
 
 has_bin() { [[ -n "${1:-}" && -x "$1/bin/tasks" ]]; }

--- a/scripts/tasks/tasks.sh
+++ b/scripts/tasks/tasks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# tasks.sh — trails' `pnpm tasks` shim.
+#
+# The CLI itself lives in the tasks repo (scripts/cli.ts, entered through
+# bin/tasks); this script only finds a tasks checkout and hands off. It does
+# NOT set $TASKS_DIR — which working tree the CLI acts on is resolved by
+# resolveTasksDir() in the CLI from the caller's cwd, and setting the env var
+# here would suppress the per-worktree branch that pushes `HEAD:main`.
+#
+# Resolution order mirrors bin/tasks:
+#   1. $TASKS_DIR / $RFCS_DIR
+#   2. <cwd>/tasks — the per-worktree symlink start-worktree.sh creates
+#   3. ~/github/blazetrailsdev/tasks
+set -euo pipefail
+
+has_bin() { [[ -n "${1:-}" && -x "$1/bin/tasks" ]]; }
+
+DIR=""
+for candidate in "${TASKS_DIR:-}" "${RFCS_DIR:-}" "$PWD/tasks" "$HOME/github/blazetrailsdev/tasks"; do
+  if has_bin "$candidate"; then DIR="$candidate"; break; fi
+done
+
+if [[ -z "$DIR" ]]; then
+  echo "tasks: no tasks checkout with bin/tasks found." >&2
+  echo "       Re-run scripts/start-worktree.sh, set \$TASKS_DIR, or clone" >&2
+  echo "       blazetrailsdev/tasks to ~/github/blazetrailsdev/tasks." >&2
+  exit 1
+fi
+
+exec "$DIR/bin/tasks" "$@"


### PR DESCRIPTION
> **Depends on [tasks#63](https://github.com/blazetrailsdev/tasks/pull/63) — do
> not merge before it.** Until that lands, a trails worktree's `tasks/` checkout
> (and the canonical one) has no `bin/tasks`, and this shim has nothing to
> delegate to.

Part 2 of the CLI extraction. The CLI itself now lives in the tasks repo
(3737 LOC of `cli.ts` + 4378 LOC / 336 tests of `cli.test.ts`, moved intact);
this switches trails over to it, **without yet deleting the trails copy** — the
tasks-repo CLI gets mileage in real use first.

## What changes

- `package.json`: `"tasks"` goes from `tsx scripts/tasks/cli.ts` to
  `scripts/tasks/tasks.sh`.
- `scripts/tasks/tasks.sh` (new): resolves a tasks checkout
  (`$TASKS_DIR` / `$RFCS_DIR` → `<cwd>/tasks` → canonical) and `exec`s its
  `bin/tasks`.
- `scripts/tasks-shim.test.ts` (new): 5 tests over the shim.
- `scripts/start-worktree.sh`: runs the tasks repo's `install-bin.sh` after
  provisioning, putting `tasks` on the `PATH` via `~/.local/bin` (pointed at
  the canonical checkout, so it never dangles when a worktree is removed).
- `CLAUDE.md`: records where the CLI lives and that bugs get fixed there.
- `scripts/tasks/cli.ts`: header marks it superseded and unreachable.

## Why the shim doesn't set `$TASKS_DIR`

Tempting, and wrong. `resolveTasksDir()` in the CLI answers "which tasks
working tree am I acting on" from the caller's cwd, and a sibling flag
(`TASKS_DIR_IS_SYMLINK`) keys off `$TASKS_DIR` being *unset* to decide that a
per-worktree checkout pushes `HEAD:main` instead of `main`. Exporting the
variable from the shim would silently break trunk-only pushes from every agent
worktree. Code location and data location stay separate concerns, and the
unset-env contract now has a test.

Note the deliberate fall-through: an explicit `$TASKS_DIR` that has no
`bin/tasks` does **not** error — the shim keeps looking for *code*, while the
CLI still reads `$TASKS_DIR` for *data*. Old checkout, current CLI.

Verified from this worktree: `TASKS_DIR` resolves to
`<trails-worktree>/tasks`, and `pnpm tasks ready` / `next-bundle` are
byte-identical to the old entrypoint's output.

## CI registration

`scripts/tasks-shim.test.ts` is added to **both** the unit-tests
`pnpm vitest run` argument list and `UNIT_TESTS_PKGS_RE`.
`ci-suite-coverage.test.ts` enforces neither for root-level
`scripts/*.test.ts` (it passed before I registered the file), so an
unregistered test would have collected locally and never run in CI.

## Still here, on purpose

`scripts/tasks/cli.ts` and `scripts/tasks/cli.test.ts` are unchanged (bar the
header) and still run in CI. Their deletion — plus the `scripts/tasks/*.test.ts`
entry in `vitest.config.ts` and the `scripts/tasks` argument in ci.yml — is
filed as story `delete-trails-copy-of-tasks-cli` (RFC 0091), `blocked` on this
PR and tasks#63.

`scripts/tasks/refine-done.sh` is unrelated to the CLI (btwhooks pane teardown
for refine agents) and stays in trails permanently, so `scripts/tasks/` and the
ci.yml path filter naming it both survive.
