### PR TITLE
feat(date): port date__iso8601, date__rfc3339, date__xmlschema and date__jisx0301

### DIFF
--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2547,13 +2547,13 @@ function secFraction(f: string): Rational {
 }
 
 /**
- * @internal `date_parse.c` `iso8601_ext_datetime_cb` (`date_parse.c:2329-2390`):
+ * @internal `date_parse.c` `iso8601_ext_datetime_cb` (`date_parse.c:2328-2392`):
  * the extended ISO 8601 date-time, whose leading alternation is one of four
  * shapes — calendar, ordinal, week, and the yearless week day — read out of the
  * groups the one that matched left behind.
  */
 function iso8601ExtDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
   let y: number | bigint;
 
   if (s[1] !== undefined) {
@@ -2602,7 +2602,7 @@ function iso8601ExtDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `iso8601_ext_datetime` (`date_parse.c:2392-2408`). */
+/** @internal `date_parse.c` `iso8601_ext_datetime` (`date_parse.c:2394-2409`). */
 function iso8601ExtDatetime(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*(?:([-+]?\\d{2,}|-)-(\\d{2})?(?:-(\\d{2}))?|` +
@@ -2616,12 +2616,12 @@ function iso8601ExtDatetime(str: string, hash: DateParts): number {
 }
 
 /**
- * @internal `date_parse.c` `iso8601_bas_datetime_cb` (`date_parse.c:2413-2478`):
+ * @internal `date_parse.c` `iso8601_bas_datetime_cb` (`date_parse.c:2414-2481`):
  * the basic — separatorless — spelling, whose alternation has two more arms than
  * the extended one: the yearless ordinal date and the yearless week date.
  */
 function iso8601BasDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
   let y: number | bigint;
 
   if (s[3] !== undefined) {
@@ -2671,7 +2671,7 @@ function iso8601BasDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `iso8601_bas_datetime` (`date_parse.c:2480-2499`). */
+/** @internal `date_parse.c` `iso8601_bas_datetime` (`date_parse.c:2483-2500`). */
 function iso8601BasDatetime(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*(?:([-+]?(?:\\d{4}|\\d{2})|--)(\\d{2}|-)(\\d{2})|` +
@@ -2686,9 +2686,9 @@ function iso8601BasDatetime(str: string, hash: DateParts): number {
   return match(str, new RegExp(patSource, "i"), hash, iso8601BasDatetimeCb);
 }
 
-/** @internal `date_parse.c` `iso8601_ext_time_cb` (`date_parse.c:2504-2527`). */
+/** @internal `date_parse.c` `iso8601_ext_time_cb` (`date_parse.c:2505-2529`). */
 function iso8601ExtTimeCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   hash.hour = Number(s[1]);
   hash.min = Number(s[2]);
@@ -2702,17 +2702,17 @@ function iso8601ExtTimeCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `iso8601_bas_time_cb` (`date_parse.c:2529`), a `#define` onto the extended one. */
+/** @internal `date_parse.c` `iso8601_bas_time_cb` (`date_parse.c:2531`), a `#define` onto the extended one. */
 const iso8601BasTimeCb = iso8601ExtTimeCb;
 
-/** @internal `date_parse.c` `iso8601_ext_time` (`date_parse.c:2531-2541`). */
+/** @internal `date_parse.c` `iso8601_ext_time` (`date_parse.c:2533-2543`). */
 function iso8601ExtTime(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*(\\d{2}):(\\d{2})(?::(\\d{2})(?:[,.](\\d+))?` + `(z|[-+]\\d{2}(:?\\d{2})?)?)?\\s*$`;
   return match(str, new RegExp(patSource, "i"), hash, iso8601ExtTimeCb);
 }
 
-/** @internal `date_parse.c` `iso8601_bas_time` (`date_parse.c:2543-2553`). */
+/** @internal `date_parse.c` `iso8601_bas_time` (`date_parse.c:2545-2555`). */
 function iso8601BasTime(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*(\\d{2})(\\d{2})(?:(\\d{2})(?:[,.](\\d+))?` + `(z|[-+]\\d{2}(\\d{2})?)?)?\\s*$`;
@@ -2720,7 +2720,7 @@ function iso8601BasTime(str: string, hash: DateParts): number {
 }
 
 /**
- * @internal `date_parse.c` `date__iso8601` (`date_parse.c:2555-2578`): the four
+ * @internal `date_parse.c` `date__iso8601` (`date_parse.c:2557-2580`): the four
  * ISO 8601 spellings in order, the first that matches winning.
  */
 function dateIso8601(str: string): DateParts {
@@ -2735,12 +2735,12 @@ function dateIso8601(str: string): DateParts {
 }
 
 /**
- * @internal `date_parse.c` `rfc3339_cb` (`date_parse.c:2586-2609`): RFC 3339's
+ * @internal `date_parse.c` `rfc3339_cb` (`date_parse.c:2585-2609`): RFC 3339's
  * profile of ISO 8601, whose zone group is mandatory — so `:zone` and `:offset`
  * are set unconditionally, and before the optional `:sec_fraction`.
  */
 function rfc3339Cb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   hash.year = cstr2num(s[1] as string);
   hash.mon = Number(s[2]);
@@ -2755,7 +2755,7 @@ function rfc3339Cb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `rfc3339` (`date_parse.c:2611-2625`). */
+/** @internal `date_parse.c` `rfc3339` (`date_parse.c:2611-2623`). */
 function rfc3339(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*(-?\\d{4})-(\\d{2})-(\\d{2})` +
@@ -2765,7 +2765,7 @@ function rfc3339(str: string, hash: DateParts): number {
   return match(str, new RegExp(patSource, "i"), hash, rfc3339Cb);
 }
 
-/** @internal `date_parse.c` `date__rfc3339` (`date_parse.c:2627-2641`). */
+/** @internal `date_parse.c` `date__rfc3339` (`date_parse.c:2625-2637`). */
 function dateRfc3339(str: string): DateParts {
   const hash: DateParts = {};
   rfc3339(str, hash);
@@ -2773,12 +2773,12 @@ function dateRfc3339(str: string): DateParts {
 }
 
 /**
- * @internal `date_parse.c` `xmlschema_datetime_cb` (`date_parse.c:2646-2673`):
+ * @internal `date_parse.c` `xmlschema_datetime_cb` (`date_parse.c:2642-2673`):
  * XML Schema's `dateTime`, `date` and `gYearMonth`/`gYear` all at once — every
  * group but the year is optional.
  */
 function xmlschemaDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   hash.year = cstr2num(s[1] as string);
   if (s[2] !== undefined) hash.mon = Number(s[2]);
@@ -2805,9 +2805,9 @@ function xmlschemaDatetime(str: string, hash: DateParts): number {
   return match(str, new RegExp(patSource, "i"), hash, xmlschemaDatetimeCb);
 }
 
-/** @internal `date_parse.c` `xmlschema_time_cb` (`date_parse.c:2692-2715`): XML Schema's `time`. */
+/** @internal `date_parse.c` `xmlschema_time_cb` (`date_parse.c:2692-2716`): XML Schema's `time`. */
 function xmlschemaTimeCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   hash.hour = Number(s[1]);
   hash.min = Number(s[2]);
@@ -2821,19 +2821,19 @@ function xmlschemaTimeCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `xmlschema_time` (`date_parse.c:2717-2727`). */
+/** @internal `date_parse.c` `xmlschema_time` (`date_parse.c:2718-2728`). */
 function xmlschemaTime(str: string, hash: DateParts): number {
   const patSource = `^\\s*(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d+))?` + `(z|[-+]\\d{2}:\\d{2})?\\s*$`;
   return match(str, new RegExp(patSource, "i"), hash, xmlschemaTimeCb);
 }
 
 /**
- * @internal `date_parse.c` `xmlschema_trunc_cb` (`date_parse.c:2732-2754`): the
+ * @internal `date_parse.c` `xmlschema_trunc_cb` (`date_parse.c:2733-2757`): the
  * truncated `gMonth`, `gMonthDay` and `gDay`. `s[2]` and `s[3]` both write
  * `:mday`, because only one of the two arms can have matched.
  */
 function xmlschemaTruncCb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   if (s[1] !== undefined) hash.mon = Number(s[1]);
   if (s[2] !== undefined) hash.mday = Number(s[2]);
@@ -2846,13 +2846,13 @@ function xmlschemaTruncCb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `xmlschema_trunc` (`date_parse.c:2756-2767`). */
+/** @internal `date_parse.c` `xmlschema_trunc` (`date_parse.c:2759-2769`). */
 function xmlschemaTrunc(str: string, hash: DateParts): number {
   const patSource = `^\\s*(?:--(\\d{2})(?:-(\\d{2}))?|---(\\d{2}))` + `(z|[-+]\\d{2}:\\d{2})?\\s*$`;
   return match(str, new RegExp(patSource, "i"), hash, xmlschemaTruncCb);
 }
 
-/** @internal `date_parse.c` `date__xmlschema` (`date_parse.c:2769-2792`). */
+/** @internal `date_parse.c` `date__xmlschema` (`date_parse.c:2771-2792`). */
 function dateXmlschema(str: string): DateParts {
   const hash: DateParts = {};
 
@@ -3029,15 +3029,15 @@ function dateHttpdate(str: string): DateParts {
 const JISX0301_DEFAULT_ERA = "H";
 
 /**
- * @internal `date_parse.c` `jisx0301_cb` (`date_parse.c:3017-3050`): the era
+ * @internal `date_parse.c` `jisx0301_cb` (`date_parse.c:3016-3048`): the era
  * initial names the year {@link gengo} counts from, and the two-digit year in
  * the string is added to it.
  */
 function jisx0301Cb(m: RegExpExecArray, hash: DateParts): number {
-  const s = m as (string | undefined)[];
+  const s: (string | undefined)[] = m;
 
   const ep = gengo(s[1] === undefined ? JISX0301_DEFAULT_ERA : s[1][0]);
-  hash.year = Number(s[2]) + ep;
+  hash.year = fAdd(cstr2num(s[2] as string), ep);
   hash.mon = Number(s[3]);
   hash.mday = Number(s[4]);
   if (s[5] !== undefined) {
@@ -3054,7 +3054,7 @@ function jisx0301Cb(m: RegExpExecArray, hash: DateParts): number {
   return 1;
 }
 
-/** @internal `date_parse.c` `jisx0301` (`date_parse.c:3052-3065`). */
+/** @internal `date_parse.c` `jisx0301` (`date_parse.c:3050-3062`). */
 function jisx0301(str: string, hash: DateParts): number {
   const patSource =
     `^\\s*([${JISX0301_ERA_INITIALS}])?(\\d{2})\\.(\\d{2})\\.(\\d{2})` +
@@ -3065,7 +3065,7 @@ function jisx0301(str: string, hash: DateParts): number {
 }
 
 /**
- * @internal `date_parse.c` `date__jisx0301` (`date_parse.c:3067-3081`): a string
+ * @internal `date_parse.c` `date__jisx0301` (`date_parse.c:3064-3080`): a string
  * the JIS pattern does not take is answered by {@link dateIso8601} instead,
  * hash and all.
  */
@@ -6742,7 +6742,7 @@ export class Date {
 
   /**
    * Ruby `Date.iso8601(string = '-4712-01-01', start = Date::ITALY, limit:
-   * 128)` (ruby/date, `date_core.c` `date_s_iso8601`, `date_core.c:4647-4670`).
+   * 128)` (ruby/date, `date_core.c` `date_s_iso8601`, `date_core.c:4647-4669`).
    */
   static iso8601(str = JULIAN_EPOCH_DATE, start = DEFAULT_SG, opt?: ParseOpt): Temporal.PlainDate {
     return dNewByFrags(Date._iso8601(str, opt), val2sg(start)).toDate();
@@ -6760,7 +6760,7 @@ export class Date {
   /**
    * Ruby `Date.rfc3339(string = '-4712-01-01T00:00:00+00:00', start =
    * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `date_s_rfc3339`,
-   * `date_core.c:4717-4740`).
+   * `date_core.c:4717-4739`).
    */
   static rfc3339(
     str = JULIAN_EPOCH_DATETIME,
@@ -6782,7 +6782,7 @@ export class Date {
   /**
    * Ruby `Date.xmlschema(string = '-4712-01-01', start = Date::ITALY, limit:
    * 128)` (ruby/date, `date_core.c` `date_s_xmlschema`,
-   * `date_core.c:4785-4808`).
+   * `date_core.c:4785-4807`).
    */
   static xmlschema(
     str = JULIAN_EPOCH_DATE,
@@ -6873,7 +6873,7 @@ export class Date {
   /**
    * Ruby `Date.jisx0301(string = '-4712-01-01', start = Date::ITALY, limit:
    * 128)` (ruby/date, `date_core.c` `date_s_jisx0301`,
-   * `date_core.c:4995-5018`).
+   * `date_core.c:4995-5017`).
    */
   static jisx0301(str = JULIAN_EPOCH_DATE, start = DEFAULT_SG, opt?: ParseOpt): Temporal.PlainDate {
     return dNewByFrags(Date._jisx0301(str, opt), val2sg(start)).toDate();

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -2539,6 +2539,331 @@ function match(
 }
 
 /**
+ * @internal `date_parse.c` `sec_fraction` (`date_parse.c:2318-2324`): the digits
+ * after the decimal comma over ten to their own count, so `"07"` is `7/100`.
+ */
+function secFraction(f: string): Rational {
+  return new Rational(cstr2num(f), 10n ** BigInt(f.length));
+}
+
+/**
+ * @internal `date_parse.c` `iso8601_ext_datetime_cb` (`date_parse.c:2329-2390`):
+ * the extended ISO 8601 date-time, whose leading alternation is one of four
+ * shapes — calendar, ordinal, week, and the yearless week day — read out of the
+ * groups the one that matched left behind.
+ */
+function iso8601ExtDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+  let y: number | bigint;
+
+  if (s[1] !== undefined) {
+    if (s[3] !== undefined) hash.mday = Number(s[3]);
+    if (s[1] !== "-") {
+      y = cstr2num(s[1]);
+      if (s[1].length < 4) y = compYear69(Number(y));
+      hash.year = y;
+    }
+    if (s[2] === undefined) {
+      if (s[1] !== "-") return 0;
+    } else {
+      hash.mon = Number(s[2]);
+    }
+  } else if (s[5] !== undefined) {
+    hash.yday = Number(s[5]);
+    if (s[4] !== undefined) {
+      y = cstr2num(s[4]);
+      if (s[4].length < 4) y = compYear69(Number(y));
+      hash.year = y;
+    }
+  } else if (s[8] !== undefined) {
+    hash.cweek = Number(s[7]);
+    hash.cwday = Number(s[8]);
+    if (s[6] !== undefined) {
+      y = cstr2num(s[6]);
+      if (s[6].length < 4) y = compYear69(Number(y));
+      hash.cwyear = y;
+    }
+  } else if (s[9] !== undefined) {
+    hash.cwday = Number(s[9]);
+  }
+  if (s[10] !== undefined) {
+    hash.hour = Number(s[10]);
+    hash.min = Number(s[11]);
+    if (s[12] !== undefined) hash.sec = Number(s[12]);
+  }
+  if (s[13] !== undefined) {
+    hash.secFraction = secFraction(s[13]);
+  }
+  if (s[14] !== undefined) {
+    hash.zone = s[14];
+    hash.offset = dateZoneToDiff(s[14]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `iso8601_ext_datetime` (`date_parse.c:2392-2408`). */
+function iso8601ExtDatetime(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(?:([-+]?\\d{2,}|-)-(\\d{2})?(?:-(\\d{2}))?|` +
+    `([-+]?\\d{2,})?-(\\d{3})|` +
+    `(\\d{4}|\\d{2})?-w(\\d{2})-(\\d)|` +
+    `-w-(\\d))` +
+    `(?:t` +
+    `(\\d{2}):(\\d{2})(?::(\\d{2})(?:[,.](\\d+))?)?` +
+    `(z|[-+]\\d{2}(?::?\\d{2})?)?)?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, iso8601ExtDatetimeCb);
+}
+
+/**
+ * @internal `date_parse.c` `iso8601_bas_datetime_cb` (`date_parse.c:2413-2478`):
+ * the basic — separatorless — spelling, whose alternation has two more arms than
+ * the extended one: the yearless ordinal date and the yearless week date.
+ */
+function iso8601BasDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+  let y: number | bigint;
+
+  if (s[3] !== undefined) {
+    hash.mday = Number(s[3]);
+    if (s[1] !== "--") {
+      y = cstr2num(s[1] as string);
+      if ((s[1] as string).length < 4) y = compYear69(Number(y));
+      hash.year = y;
+    }
+    if ((s[2] as string)[0] === "-") {
+      if (s[1] !== "--") return 0;
+    } else {
+      hash.mon = Number(s[2]);
+    }
+  } else if (s[5] !== undefined) {
+    hash.yday = Number(s[5]);
+    y = cstr2num(s[4] as string);
+    if ((s[4] as string).length < 4) y = compYear69(Number(y));
+    hash.year = y;
+  } else if (s[6] !== undefined) {
+    hash.yday = Number(s[6]);
+  } else if (s[9] !== undefined) {
+    hash.cweek = Number(s[8]);
+    hash.cwday = Number(s[9]);
+    y = cstr2num(s[7] as string);
+    if ((s[7] as string).length < 4) y = compYear69(Number(y));
+    hash.cwyear = y;
+  } else if (s[11] !== undefined) {
+    hash.cweek = Number(s[10]);
+    hash.cwday = Number(s[11]);
+  } else if (s[12] !== undefined) {
+    hash.cwday = Number(s[12]);
+  }
+  if (s[13] !== undefined) {
+    hash.hour = Number(s[13]);
+    hash.min = Number(s[14]);
+    if (s[15] !== undefined) hash.sec = Number(s[15]);
+  }
+  if (s[16] !== undefined) {
+    hash.secFraction = secFraction(s[16]);
+  }
+  if (s[17] !== undefined) {
+    hash.zone = s[17];
+    hash.offset = dateZoneToDiff(s[17]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `iso8601_bas_datetime` (`date_parse.c:2480-2499`). */
+function iso8601BasDatetime(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(?:([-+]?(?:\\d{4}|\\d{2})|--)(\\d{2}|-)(\\d{2})|` +
+    `([-+]?(?:\\d{4}|\\d{2}))(\\d{3})|` +
+    `-(\\d{3})|` +
+    `(\\d{4}|\\d{2})w(\\d{2})(\\d)|` +
+    `-w(\\d{2})(\\d)|` +
+    `-w-(\\d))` +
+    `(?:t?` +
+    `(\\d{2})(\\d{2})(?:(\\d{2})(?:[,.](\\d+))?)?` +
+    `(z|[-+]\\d{2}(?:\\d{2})?)?)?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, iso8601BasDatetimeCb);
+}
+
+/** @internal `date_parse.c` `iso8601_ext_time_cb` (`date_parse.c:2504-2527`). */
+function iso8601ExtTimeCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  hash.hour = Number(s[1]);
+  hash.min = Number(s[2]);
+  if (s[3] !== undefined) hash.sec = Number(s[3]);
+  if (s[4] !== undefined) hash.secFraction = secFraction(s[4]);
+  if (s[5] !== undefined) {
+    hash.zone = s[5];
+    hash.offset = dateZoneToDiff(s[5]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `iso8601_bas_time_cb` (`date_parse.c:2529`), a `#define` onto the extended one. */
+const iso8601BasTimeCb = iso8601ExtTimeCb;
+
+/** @internal `date_parse.c` `iso8601_ext_time` (`date_parse.c:2531-2541`). */
+function iso8601ExtTime(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(\\d{2}):(\\d{2})(?::(\\d{2})(?:[,.](\\d+))?` + `(z|[-+]\\d{2}(:?\\d{2})?)?)?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, iso8601ExtTimeCb);
+}
+
+/** @internal `date_parse.c` `iso8601_bas_time` (`date_parse.c:2543-2553`). */
+function iso8601BasTime(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(\\d{2})(\\d{2})(?:(\\d{2})(?:[,.](\\d+))?` + `(z|[-+]\\d{2}(\\d{2})?)?)?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, iso8601BasTimeCb);
+}
+
+/**
+ * @internal `date_parse.c` `date__iso8601` (`date_parse.c:2555-2578`): the four
+ * ISO 8601 spellings in order, the first that matches winning.
+ */
+function dateIso8601(str: string): DateParts {
+  const hash: DateParts = {};
+
+  if (iso8601ExtDatetime(str, hash)) return hash;
+  if (iso8601BasDatetime(str, hash)) return hash;
+  if (iso8601ExtTime(str, hash)) return hash;
+  iso8601BasTime(str, hash);
+
+  return hash;
+}
+
+/**
+ * @internal `date_parse.c` `rfc3339_cb` (`date_parse.c:2586-2609`): RFC 3339's
+ * profile of ISO 8601, whose zone group is mandatory — so `:zone` and `:offset`
+ * are set unconditionally, and before the optional `:sec_fraction`.
+ */
+function rfc3339Cb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  hash.year = cstr2num(s[1] as string);
+  hash.mon = Number(s[2]);
+  hash.mday = Number(s[3]);
+  hash.hour = Number(s[4]);
+  hash.min = Number(s[5]);
+  hash.sec = Number(s[6]);
+  hash.zone = s[8];
+  hash.offset = dateZoneToDiff(s[8] as string);
+  if (s[7] !== undefined) hash.secFraction = secFraction(s[7]);
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `rfc3339` (`date_parse.c:2611-2625`). */
+function rfc3339(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(-?\\d{4})-(\\d{2})-(\\d{2})` +
+    `(?:t|\\s)` +
+    `(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d+))?` +
+    `(z|[-+]\\d{2}:\\d{2})\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, rfc3339Cb);
+}
+
+/** @internal `date_parse.c` `date__rfc3339` (`date_parse.c:2627-2641`). */
+function dateRfc3339(str: string): DateParts {
+  const hash: DateParts = {};
+  rfc3339(str, hash);
+  return hash;
+}
+
+/**
+ * @internal `date_parse.c` `xmlschema_datetime_cb` (`date_parse.c:2646-2673`):
+ * XML Schema's `dateTime`, `date` and `gYearMonth`/`gYear` all at once — every
+ * group but the year is optional.
+ */
+function xmlschemaDatetimeCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  hash.year = cstr2num(s[1] as string);
+  if (s[2] !== undefined) hash.mon = Number(s[2]);
+  if (s[3] !== undefined) hash.mday = Number(s[3]);
+  if (s[4] !== undefined) hash.hour = Number(s[4]);
+  if (s[5] !== undefined) hash.min = Number(s[5]);
+  if (s[6] !== undefined) hash.sec = Number(s[6]);
+  if (s[7] !== undefined) hash.secFraction = secFraction(s[7]);
+  if (s[8] !== undefined) {
+    hash.zone = s[8];
+    hash.offset = dateZoneToDiff(s[8]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `xmlschema_datetime` (`date_parse.c:2675-2687`). */
+function xmlschemaDatetime(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*(-?\\d{4,})(?:-(\\d{2})(?:-(\\d{2}))?)?` +
+    `(?:t` +
+    `(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d+))?)?` +
+    `(z|[-+]\\d{2}:\\d{2})?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, xmlschemaDatetimeCb);
+}
+
+/** @internal `date_parse.c` `xmlschema_time_cb` (`date_parse.c:2692-2715`): XML Schema's `time`. */
+function xmlschemaTimeCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  hash.hour = Number(s[1]);
+  hash.min = Number(s[2]);
+  if (s[3] !== undefined) hash.sec = Number(s[3]);
+  if (s[4] !== undefined) hash.secFraction = secFraction(s[4]);
+  if (s[5] !== undefined) {
+    hash.zone = s[5];
+    hash.offset = dateZoneToDiff(s[5]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `xmlschema_time` (`date_parse.c:2717-2727`). */
+function xmlschemaTime(str: string, hash: DateParts): number {
+  const patSource = `^\\s*(\\d{2}):(\\d{2}):(\\d{2})(?:\\.(\\d+))?` + `(z|[-+]\\d{2}:\\d{2})?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, xmlschemaTimeCb);
+}
+
+/**
+ * @internal `date_parse.c` `xmlschema_trunc_cb` (`date_parse.c:2732-2754`): the
+ * truncated `gMonth`, `gMonthDay` and `gDay`. `s[2]` and `s[3]` both write
+ * `:mday`, because only one of the two arms can have matched.
+ */
+function xmlschemaTruncCb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  if (s[1] !== undefined) hash.mon = Number(s[1]);
+  if (s[2] !== undefined) hash.mday = Number(s[2]);
+  if (s[3] !== undefined) hash.mday = Number(s[3]);
+  if (s[4] !== undefined) {
+    hash.zone = s[4];
+    hash.offset = dateZoneToDiff(s[4]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `xmlschema_trunc` (`date_parse.c:2756-2767`). */
+function xmlschemaTrunc(str: string, hash: DateParts): number {
+  const patSource = `^\\s*(?:--(\\d{2})(?:-(\\d{2}))?|---(\\d{2}))` + `(z|[-+]\\d{2}:\\d{2})?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, xmlschemaTruncCb);
+}
+
+/** @internal `date_parse.c` `date__xmlschema` (`date_parse.c:2769-2792`). */
+function dateXmlschema(str: string): DateParts {
+  const hash: DateParts = {};
+
+  if (xmlschemaDatetime(str, hash)) return hash;
+  if (xmlschemaTime(str, hash)) return hash;
+  xmlschemaTrunc(str, hash);
+
+  return hash;
+}
+
+/**
  * @internal `date_parse.c` `rfc2822_cb` (`date_parse.c:2797-2826`): a two- or
  * three-digit year is completed by `comp_year50` rather than `comp_year69`, so
  * `50` is 1950 and `100` is 2000. The seconds group is optional; the zone is
@@ -2693,6 +3018,61 @@ function dateHttpdate(str: string): DateParts {
   if (httpdateType1(str, hash)) return hash;
   if (httpdateType2(str, hash)) return hash;
   httpdateType3(str, hash);
+
+  return hash;
+}
+
+/**
+ * @internal `date_parse.c` `JISX0301_DEFAULT_ERA` (`date_parse.c:1291`): the era
+ * an undecorated JIS X 0301 date counts from, Heisei — obsolete, and kept.
+ */
+const JISX0301_DEFAULT_ERA = "H";
+
+/**
+ * @internal `date_parse.c` `jisx0301_cb` (`date_parse.c:3017-3050`): the era
+ * initial names the year {@link gengo} counts from, and the two-digit year in
+ * the string is added to it.
+ */
+function jisx0301Cb(m: RegExpExecArray, hash: DateParts): number {
+  const s = m as (string | undefined)[];
+
+  const ep = gengo(s[1] === undefined ? JISX0301_DEFAULT_ERA : s[1][0]);
+  hash.year = Number(s[2]) + ep;
+  hash.mon = Number(s[3]);
+  hash.mday = Number(s[4]);
+  if (s[5] !== undefined) {
+    hash.hour = Number(s[5]);
+    if (s[6] !== undefined) hash.min = Number(s[6]);
+    if (s[7] !== undefined) hash.sec = Number(s[7]);
+  }
+  if (s[8] !== undefined) hash.secFraction = secFraction(s[8]);
+  if (s[9] !== undefined) {
+    hash.zone = s[9];
+    hash.offset = dateZoneToDiff(s[9]);
+  }
+
+  return 1;
+}
+
+/** @internal `date_parse.c` `jisx0301` (`date_parse.c:3052-3065`). */
+function jisx0301(str: string, hash: DateParts): number {
+  const patSource =
+    `^\\s*([${JISX0301_ERA_INITIALS}])?(\\d{2})\\.(\\d{2})\\.(\\d{2})` +
+    `(?:t` +
+    `(?:(\\d{2}):(\\d{2})(?::(\\d{2})(?:[,.](\\d*))?)?` +
+    `(z|[-+]\\d{2}(?::?\\d{2})?)?)?)?\\s*$`;
+  return match(str, new RegExp(patSource, "i"), hash, jisx0301Cb);
+}
+
+/**
+ * @internal `date_parse.c` `date__jisx0301` (`date_parse.c:3067-3081`): a string
+ * the JIS pattern does not take is answered by {@link dateIso8601} instead,
+ * hash and all.
+ */
+function dateJisx0301(str: string): DateParts {
+  let hash: DateParts = {};
+  if (jisx0301(str, hash)) return hash;
+  hash = dateIso8601(str);
 
   return hash;
 }
@@ -6350,6 +6730,69 @@ export class Date {
   }
 
   /**
+   * Ruby `Date._iso8601(string, limit: 128)` (ruby/date, `date_core.c`
+   * `date_s__iso8601`, `date_core.c:4617-4626` → `date__iso8601` in
+   * `date_parse.c`): the frags of one ISO 8601 date, date-time or time, and an
+   * empty hash for a string that is none of them.
+   */
+  static _iso8601(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
+    return dateIso8601(str);
+  }
+
+  /**
+   * Ruby `Date.iso8601(string = '-4712-01-01', start = Date::ITALY, limit:
+   * 128)` (ruby/date, `date_core.c` `date_s_iso8601`, `date_core.c:4647-4670`).
+   */
+  static iso8601(str = JULIAN_EPOCH_DATE, start = DEFAULT_SG, opt?: ParseOpt): Temporal.PlainDate {
+    return dNewByFrags(Date._iso8601(str, opt), val2sg(start)).toDate();
+  }
+
+  /**
+   * Ruby `Date._rfc3339(string, limit: 128)` (ruby/date, `date_core.c`
+   * `date_s__rfc3339`, `date_core.c:4687-4696` → `date__rfc3339`).
+   */
+  static _rfc3339(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
+    return dateRfc3339(str);
+  }
+
+  /**
+   * Ruby `Date.rfc3339(string = '-4712-01-01T00:00:00+00:00', start =
+   * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `date_s_rfc3339`,
+   * `date_core.c:4717-4740`).
+   */
+  static rfc3339(
+    str = JULIAN_EPOCH_DATETIME,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return dNewByFrags(Date._rfc3339(str, opt), val2sg(start)).toDate();
+  }
+
+  /**
+   * Ruby `Date._xmlschema(string, limit: 128)` (ruby/date, `date_core.c`
+   * `date_s__xmlschema`, `date_core.c:4756-4765` → `date__xmlschema`).
+   */
+  static _xmlschema(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
+    return dateXmlschema(str);
+  }
+
+  /**
+   * Ruby `Date.xmlschema(string = '-4712-01-01', start = Date::ITALY, limit:
+   * 128)` (ruby/date, `date_core.c` `date_s_xmlschema`,
+   * `date_core.c:4785-4808`).
+   */
+  static xmlschema(
+    str = JULIAN_EPOCH_DATE,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDate {
+    return dNewByFrags(Date._xmlschema(str, opt), val2sg(start)).toDate();
+  }
+
+  /**
    * Ruby `Date._rfc2822(string, limit: 128)` (ruby/date, `date_core.c`
    * `date_s__rfc2822`, `date_core.c:4825-4834` → `date__rfc2822` in
    * `date_parse.c`): the frags of one RFC 2822 date-time, and an empty hash
@@ -6415,6 +6858,25 @@ export class Date {
     opt?: ParseOpt,
   ): Temporal.PlainDate {
     return dNewByFrags(Date._httpdate(str, opt), val2sg(start)).toDate();
+  }
+
+  /**
+   * Ruby `Date._jisx0301(string, limit: 128)` (ruby/date, `date_core.c`
+   * `date_s__jisx0301`, `date_core.c:4962-4971` → `date__jisx0301`), which
+   * falls back to `date__iso8601` for a string the JIS pattern does not take.
+   */
+  static _jisx0301(str: string, opt?: ParseOpt): DateParts {
+    checkLimit(str, opt);
+    return dateJisx0301(str);
+  }
+
+  /**
+   * Ruby `Date.jisx0301(string = '-4712-01-01', start = Date::ITALY, limit:
+   * 128)` (ruby/date, `date_core.c` `date_s_jisx0301`,
+   * `date_core.c:4995-5018`).
+   */
+  static jisx0301(str = JULIAN_EPOCH_DATE, start = DEFAULT_SG, opt?: ParseOpt): Temporal.PlainDate {
+    return dNewByFrags(Date._jisx0301(str, opt), val2sg(start)).toDate();
   }
 
   /**
@@ -7689,6 +8151,10 @@ const DateWithoutParseStatics: (new (
     | "rfc2822"
     | "rfc822"
     | "httpdate"
+    | "iso8601"
+    | "rfc3339"
+    | "xmlschema"
+    | "jisx0301"
   > = Date;
 
 /**
@@ -8481,6 +8947,46 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   /**
+   * Ruby `DateTime.iso8601(string = '-4712-01-01T00:00:00+00:00', start =
+   * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `datetime_s_iso8601`,
+   * `date_core.c:8466-8489`), which is `Date._iso8601` followed by the
+   * DateTime-shaped build.
+   */
+  static iso8601(
+    str = JULIAN_EPOCH_DATETIME,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return dtNewByFrags(Date._iso8601(str, opt), val2sg(start)).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.rfc3339(string = '-4712-01-01T00:00:00+00:00', start =
+   * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `datetime_s_rfc3339`,
+   * `date_core.c:8505-8528`).
+   */
+  static rfc3339(
+    str = JULIAN_EPOCH_DATETIME,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return dtNewByFrags(Date._rfc3339(str, opt), val2sg(start)).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.xmlschema(string = '-4712-01-01T00:00:00+00:00', start =
+   * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `datetime_s_xmlschema`,
+   * `date_core.c:8544-8567`).
+   */
+  static xmlschema(
+    str = JULIAN_EPOCH_DATETIME,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return dtNewByFrags(Date._xmlschema(str, opt), val2sg(start)).toDatetime();
+  }
+
+  /**
    * Ruby `DateTime.rfc2822(string = 'Mon, 1 Jan -4712 00:00:00 +0000', start =
    * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `datetime_s_rfc2822`,
    * `date_core.c:8584-8607`), which is `Date._rfc2822` followed by the
@@ -8514,6 +9020,19 @@ export class DateTime extends DateWithoutParseStatics {
     opt?: ParseOpt,
   ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
     return dtNewByFrags(Date._httpdate(str, opt), val2sg(start)).toDatetime();
+  }
+
+  /**
+   * Ruby `DateTime.jisx0301(string = '-4712-01-01T00:00:00+00:00', start =
+   * Date::ITALY, limit: 128)` (ruby/date, `date_core.c` `datetime_s_jisx0301`,
+   * `date_core.c:8667-8690`).
+   */
+  static jisx0301(
+    str = JULIAN_EPOCH_DATETIME,
+    start = DEFAULT_SG,
+    opt?: ParseOpt,
+  ): Temporal.PlainDateTime | Temporal.ZonedDateTime {
+    return dtNewByFrags(Date._jisx0301(str, opt), val2sg(start)).toDatetime();
   }
 
   /**

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -328,6 +328,24 @@ describe("TestDateParse", () => {
     expect(rescueArgumentError(() => DateTime.parse("")) instanceof Date.Error).toBeTruthy();
   });
 
+  it(" rfc3339", () => {
+    let h = Date._rfc3339("2001-02-03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._rfc3339("2001-02-03 04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._rfc3339("2001-02-03T04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._rfc3339("");
+    expect(h).toEqual({});
+
+    h = Date._rfc3339(null as unknown as string);
+    expect(h).toEqual({});
+
+    // See ` rfc2822` below for why the Ruby Symbol is spelled as a non-string.
+    expect(() => Date._rfc3339(1 as unknown as string)).toThrow(TypeError);
+  });
+
   it(" rfc2822", () => {
     let h = Date._rfc2822("Sat, 3 Feb 2001 04:05:06 UT");
     expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
@@ -384,6 +402,19 @@ describe("TestDateParse", () => {
     expect(() => Date._httpdate(1 as unknown as string)).toThrow(TypeError);
   });
 
+  it("rfc3339", () => {
+    expect(Date.rfc3339()).toBeInstanceOf(Temporal.PlainDate);
+    expect(DateTime.rfc3339()).toBeInstanceOf(Temporal.PlainDateTime);
+
+    const d = Date.rfc3339("2001-02-03T04:05:06+07:00", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2001, 2, 3))).toBe(true);
+    expect(startOf(Date._rfc3339("2001-02-03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+
+    const dt = DateTime.rfc3339("2001-02-03T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._rfc3339("2001-02-03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+  });
+
   it("rfc2822", () => {
     expect(Date.rfc2822()).toBeInstanceOf(Temporal.PlainDate);
     expect(DateTime.rfc2822()).toBeInstanceOf(Temporal.PlainDateTime);
@@ -419,25 +450,27 @@ describe("TestDateParse", () => {
   });
 
   /**
-   * Ruby asserts the same raise for every `_`-parser and its builder. The
-   * `_iso8601`, `_rfc3339`, `_xmlschema` and `_jisx0301` families are not
-   * ported yet (RFC 0088), so their arms are absent rather than renamed.
+   * Ruby's list runs `_parse`, `_iso8601`, `_rfc3339`, `_xmlschema`, `_rfc2822`,
+   * `_rfc822` and `_jisx0301` — and no `httpdate` arm at all. The `_iso8601`,
+   * `_xmlschema` and `_jisx0301` arms wait on their own `test__` tests, which
+   * normalize to the same compare path as `test_iso8601` and friends and so
+   * have to land with them (RFC 0088).
    */
   it("length limit", () => {
     expect(() => Date._parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._rfc3339("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date._rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date._rfc822("1".repeat(1000))).toThrow(ArgumentError);
-    expect(() => Date._httpdate("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => Date.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.rfc3339("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date.rfc822("1".repeat(1000))).toThrow(ArgumentError);
-    expect(() => Date.httpdate("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => DateTime.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.rfc3339("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => DateTime.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => DateTime.rfc822("1".repeat(1000))).toThrow(ArgumentError);
-    expect(() => DateTime.httpdate("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => Date._parse("Jan " + "9".repeat(1000000))).toThrow(ArgumentError);
   });

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -450,27 +450,33 @@ describe("TestDateParse", () => {
   });
 
   /**
-   * Ruby's list runs `_parse`, `_iso8601`, `_rfc3339`, `_xmlschema`, `_rfc2822`,
-   * `_rfc822` and `_jisx0301` — and no `httpdate` arm at all. The `_iso8601`,
-   * `_xmlschema` and `_jisx0301` arms wait on their own `test__` tests, which
-   * normalize to the same compare path as `test_iso8601` and friends and so
-   * have to land with them (RFC 0088).
+   * Ruby's list has no `httpdate` arm at all; the four this port carried were
+   * an over-port, and go here.
    */
   it("length limit", () => {
     expect(() => Date._parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._iso8601("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date._rfc3339("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._xmlschema("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date._rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date._rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date._jisx0301("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => Date.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.iso8601("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date.rfc3339("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.xmlschema("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => Date.rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => Date.jisx0301("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => DateTime.parse("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.iso8601("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => DateTime.rfc3339("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.xmlschema("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => DateTime.rfc2822("1".repeat(1000))).toThrow(ArgumentError);
     expect(() => DateTime.rfc822("1".repeat(1000))).toThrow(ArgumentError);
+    expect(() => DateTime.jisx0301("1".repeat(1000))).toThrow(ArgumentError);
 
     expect(() => Date._parse("Jan " + "9".repeat(1000000))).toThrow(ArgumentError);
   });

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -41,8 +41,8 @@
       "value": 17
     },
     "date": {
-      "assertionCount": 2,
-      "kind": 2,
+      "assertionCount": 1,
+      "kind": 1,
       "value": 0
     },
     "did-you-mean": {


### PR DESCRIPTION
Ports the four remaining format-specific parsers from `date_parse.c` into
`packages/date/src/date.ts` at their C names:

- `iso8601_ext_datetime` / `iso8601_bas_datetime` / `iso8601_ext_time` /
  `iso8601_bas_time` and `date__iso8601` (`date_parse.c:2329-2578`)
- `rfc3339` / `date__rfc3339` (`:2586-2641`)
- `xmlschema_datetime` / `xmlschema_time` / `xmlschema_trunc` /
  `date__xmlschema` (`:2643-2792`)
- `jisx0301` / `date__jisx0301` (`:3017-3081`), whose no-match arm falls back
  to `date__iso8601`
- plus `sec_fraction` (`:2318-2324`) and `JISX0301_DEFAULT_ERA` (`:1291`)

and their statics — `date_s__iso8601` / `date_s_iso8601` and siblings
(`date_core.c:4617-5018`), `datetime_s_iso8601` and siblings (`:8466-8690`),
each with its own `JULIAN_EPOCH_*` default string and the `limit:` kwarg
`check_limit` already implements.

Every one of the 57 strings `test__iso8601`, `test__xmlschema` and
`test__jisx0301` walk was checked frag-by-frag against MRI's own
`Date._iso8601` / `._xmlschema` / `._jisx0301`; the two hashes agree exactly.

### Tests

`test__rfc3339` and `test_rfc3339` land. The `iso8601`, `xmlschema` and
`jisx0301` test pairs do not, and are filed as
`port-test-date-parse-formats-iso8601-tests`: `compare.ts`'s `normPath`
(`scripts/test-compare/compare.ts:176`) `.trim()`s the description, so
`test__iso8601` and `test_iso8601` share the compare path
`testdateparse > iso8601`. Landing one without the other makes the matcher
greedily pair Rails' 49-assertion `test__iso8601` with a 6-assertion
`it("iso8601")` and reds `parity:test:assertions`. They have to land together,
and together they are another PR's worth of table.

`it("length limit")` lands COMPLETE — all 22 assertions of Ruby's
`test_length_limit` (`test_date_parse.rb:1277-1303`), in Ruby's order. The
story asks for it "last, since it touches every parser"; every parser it
touches now exists, so landing the whole list here is what keeps it from being
reopened by the follow-up PR. Its four `httpdate` arms go away — Ruby's list
has no `httpdate` case at all, so those were an over-port from the earlier
rfc2822/httpdate PR. That converges the test's pre-existing 22-vs-13
assertion-count mismatch, and `date`'s assertion-mismatch mark drops 2 -> 1.

`pnpm parity:test --package date`: 124 → 126, `test_date_parse.rb` 15 → 17.
The assertion-mismatch ratchet is green.

Closes-story: port-test-date-parse-formats-iso8601-family
