### PR TITLE
fix(parity): mirror Rails flat_map in Preloader::Branch#loaders

### DIFF
--- a/packages/activerecord/src/associations/preloader/branch.ts
+++ b/packages/activerecord/src/associations/preloader/branch.ts
@@ -256,10 +256,9 @@ export class Branch {
 
   get loaders(): Association[] {
     if (this._loaders !== null) return this._loaders;
-    this._loaders = [];
-    for (const [reflection, reflectionRecords] of this.groupedRecords()) {
-      this._loaders.push(...this.preloadersForReflection(reflection, reflectionRecords));
-    }
+    this._loaders = [...this.groupedRecords()].flatMap(([reflection, reflectionRecords]) =>
+      this.preloadersForReflection(reflection, reflectionRecords),
+    );
     return this._loaders;
   }
 


### PR DESCRIPTION
Ratchet red on main @61f0c6d7: `activerecord associations/preloader/branch.ts loaders flat_map`.

Rails' `Preloader::Branch#loaders` (activerecord/lib/active_record/associations/preloader/branch.rb:118) is `grouped_records.flat_map { ... }`; the TS body built the array with a for-loop and `push(...)`. Converged to `flatMap`.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` green; preloader tests pass.

Closes-story: red-61f0c6d7
