### PR TITLE
fix(parity): mark foreign-receiver calls, drop empty baseline shards, resolve call-gate owners by seat

### DIFF
--- a/scripts/api-compare/baseline-json.test.ts
+++ b/scripts/api-compare/baseline-json.test.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import {
+  findEmptyBaselines,
   findNonCanonicalBaselines,
   reportNonCanonicalBaselines,
   serializeBaseline,
@@ -74,6 +75,31 @@ describe("findNonCanonicalBaselines", () => {
   });
 });
 
+describe("findEmptyBaselines", () => {
+  async function withFile<T>(text: string, fn: (file: string) => Promise<T>): Promise<T> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "empty-baseline-"));
+    const file = path.join(dir, "a.json");
+    await fs.writeFile(file, text);
+    try {
+      return await fn(file);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("flags a shard holding no rows", async () => {
+    await withFile(serializeBaseline([]), async (file) => {
+      expect(await findEmptyBaselines([file])).toEqual([file]);
+    });
+  });
+
+  it("passes a shard holding a row", async () => {
+    await withFile(serializeBaseline([{ reason: "plain" }]), async (file) => {
+      expect(await findEmptyBaselines([file])).toEqual([]);
+    });
+  });
+});
+
 describe("reportNonCanonicalBaselines", () => {
   it("reports nothing for canonical files", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "canon-report-"));
@@ -110,5 +136,15 @@ describe("committed api-compare baselines", () => {
       ...(await jsonFilesUnder(path.join(HERE, "call-mismatches-unreviewed"))),
     ];
     expect(await findNonCanonicalBaselines(files)).toEqual([]);
+  });
+
+  // An empty shard is deleted by every reseed, so committing one makes the
+  // mandatory reseed-drift check report a diff its caller did not cause.
+  it("hold no empty shards", async () => {
+    const files = [
+      ...(await jsonFilesUnder(path.join(HERE, "call-mismatches-exclude"))),
+      ...(await jsonFilesUnder(path.join(HERE, "call-mismatches-unreviewed"))),
+    ];
+    expect(await findEmptyBaselines(files)).toEqual([]);
   });
 });

--- a/scripts/api-compare/baseline-json.ts
+++ b/scripts/api-compare/baseline-json.ts
@@ -87,6 +87,38 @@ export async function findNonCanonicalBaselines(files: string[]): Promise<string
   return out;
 }
 
+/**
+ * Baseline files that hold no rows at all (`[]`). The split writers never emit
+ * one — `writeSplitBaseline` DELETES a shard whose entries all converged — so a
+ * committed empty shard makes the mandatory reseed-drift check report a diff
+ * that has nothing to do with the caller's change, and CI's
+ * `Ratchet baseline drift` step fails on it (RFC 0108;
+ * `call-mismatches-exclude/activerecord/explain.json` was the instance).
+ */
+export async function findEmptyBaselines(files: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const f of files) {
+    const value = JSON.parse(await fs.readFile(f, "utf-8")) as unknown;
+    if (Array.isArray(value) && value.length === 0) out.push(f);
+  }
+  return out;
+}
+
+// Shared gate arm: fails when any baseline file holds no rows. Returns whether
+// the caller should fail.
+export async function reportEmptyBaselines(files: string[], label: string): Promise<boolean> {
+  const empty = await findEmptyBaselines(files);
+  if (empty.length === 0) return false;
+  console.error(
+    `\n${label}: ${empty.length} baseline file(s) hold no rows. The reseed ` +
+      "deletes such a file, so a clean-tree `--write` reports a diff the " +
+      "author did not cause — and the drift check is the one tool that says " +
+      "whether a new row landed in the right shard. Delete them:\n",
+  );
+  for (const f of [...empty].sort()) console.error(`  ! ${path.relative(ROOT_DIR, f)}`);
+  return true;
+}
+
 // Shared gate arm: fails when any baseline file is non-canonical, so escaped
 // non-ASCII (or stray indentation) cannot re-enter and re-arm the churn trap.
 // Returns whether the caller should fail.

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/strong-parameters.json
@@ -154,6 +154,13 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/strong-parameters.ts",
+    "rubyName": "hash_filter",
+    "call": "slice",
+    "reason": "Rails slices the params down to the filter's keys first (strong_parameters.rb:1353); the port walks the filter's own entries and guards each with `k in this._data` (strong-parameters.ts:704-705), covering the same key set without a `slice` call."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/strong-parameters.ts",
     "rubyName": "merge",
     "call": "new_instance_with_inherited_permitted_status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/cookies.json
@@ -24,6 +24,13 @@
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
     "rubyName": "parse",
+    "call": "load",
+    "reason": "Rails' `SerializedCookieJars#parse` deserializes with `serializer.load` (cookies.rb:597); the TS `parse` it pairs with is `CookieJar.parse`, the static Cookie-header splitter (cookies.ts:264-273), which deserializes nothing."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/cookies.ts",
+    "rubyName": "parse",
     "call": "reserialize?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/actionview/renderer/streaming-template-renderer.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/renderer/streaming-template-renderer.json
@@ -3,6 +3,13 @@
     "package": "actionview",
     "tsFile": "renderer/streaming-template-renderer.ts",
     "rubyName": "delayed_render",
+    "call": "new",
+    "reason": "Rails instantiates `StreamingBuffer` and `Fiber` (streaming_template_renderer.rb:61,71); the port splits the layout at a sentinel inside an async generator (streaming-template-renderer.ts:87-110) and constructs neither."
+  },
+  {
+    "package": "actionview",
+    "tsFile": "renderer/streaming-template-renderer.ts",
+    "rubyName": "delayed_render",
     "call": "set",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -23,6 +23,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
+    "rubyName": "replace",
+    "call": "transaction",
+    "reason": "Rails wraps `replace_records` in `transaction` (collection_association.rb:251); the synchronous writer path returns a ReplacePlan and opens the transaction in `persistReplacePlan` (collection-association.ts:775-791)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
     "call": "count_records",
     "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters.ts",
+    "rubyName": "resolve",
+    "call": "join",
+    "reason": "Rails builds the AdapterNotFound message inline (connection_adapters.rb:34-39); the port extracts it into the private `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(\", \")` (connection-adapters.ts:75) is outside the published call-set."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-handling.json
@@ -3,6 +3,13 @@
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
     "rubyName": "establish_connection",
+    "call": "call",
+    "reason": "Rails defaults the argument through `DEFAULT_ENV.call` (connection_handling.rb:51); the port's `configOrEnv === undefined` arm routes to `autoConnect` (connection-handling.ts:770), which resolves the environment itself."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "establish_connection",
     "call": "connection_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -38,6 +38,13 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
+    "call": "inheritance_column",
+    "reason": "Rails casts through `base_class.type_for_attribute(inheritance_column)` (inheritance.rb:312); the port delegates the whole resolution to `stiClassFor` (inheritance.ts:533), same divergence as the `cast` / `type_for_attribute` rows beside it."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "find_sti_class",
     "call": "type_for_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -10,6 +10,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
+    "call": "empty?",
+    "reason": "`collection.select_values.empty?` (relation.rb:489) is spelled `collection.selectValues.length === 0` (relation.ts:3472) — the property form of an Array emptiness test, which the gate deliberately does not credit as a call (JS_ENUMERABLE_ALIASES, RFC 0092)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "compute_cache_version",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
@@ -58,6 +58,13 @@
   {
     "package": "activerecord",
     "tsFile": "relation/delegation.ts",
+    "rubyName": "initialize_relation_delegate_cache",
+    "call": "new",
+    "reason": "Rails mints a subclass per delegated class with `Class.new(klass)` (relation/delegation.rb:35); the port hands each class to `_delegateCache.initialize` (relation/delegation.ts:319) and constructs nothing here."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/delegation.ts",
     "rubyName": "uncacheable_methods",
     "call": "flat_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/rack/builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/builder.json
@@ -16,6 +16,13 @@
   {
     "package": "rack",
     "tsFile": "builder.ts",
+    "rubyName": "new_from_string",
+    "call": "call",
+    "reason": "Rails evaluates the script through `BUILDER_TOPLEVEL_BINDING.call(builder)` (builder.rb:107); the port compiles it with `new Function` and invokes the result directly (builder.ts:59-65), so no `call` dispatch exists."
+  },
+  {
+    "package": "rack",
+    "tsFile": "builder.ts",
     "rubyName": "parse_file",
     "call": "load_file",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
@@ -23,6 +23,13 @@
   {
     "package": "rack",
     "tsFile": "multipart/parser.ts",
+    "rubyName": "handle_mime_head",
+    "call": "new",
+    "reason": "Rails accumulates the quoted parameter value into a `String.new` (multipart/parser.rb:334); the port extracts that loop into `parseDispositionParams` (parser.ts:366) and accumulates into a plain JS string — as for the `find_encoding` row beside it."
+  },
+  {
+    "package": "rack",
+    "tsFile": "multipart/parser.ts",
     "rubyName": "normalize_filename",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -41,6 +41,8 @@ import {
   resolveTsOwner,
   ambiguousTsOwner,
   ambiguousRubyOwner,
+  rubyOwnerSeat,
+  tsOwnerSeat,
   writerPairedWithReader,
   staleCallTags,
   suppressTaggedCalls,
@@ -1881,6 +1883,101 @@ describe("ambiguousTsOwner", () => {
   });
 });
 
+describe("resolveTsOwner — include graph and seats", () => {
+  // relation.ts declares `first` on `Relation` and on the nested `ExplainProxy`
+  // (relation.rb:24-26); `FinderMethods` names neither, but `Relation` is the
+  // class the module is mixed onto (relation.rb's include chain).
+  it("resolves a Ruby module flattened onto a TS host through the include graph", () => {
+    const owners = new Set(["Relation", "ExplainProxy"]);
+    expect(
+      resolveTsOwner(owners, "ActiveRecord::FinderMethods", { hosts: new Set(["Relation"]) }),
+    ).toBe("Relation");
+  });
+
+  it("stays ambiguous when several owners mix the module in", () => {
+    const owners = new Set(["Relation", "ExplainProxy"]);
+    expect(
+      resolveTsOwner(owners, "ActiveRecord::FinderMethods", {
+        hosts: new Set(["Relation", "ExplainProxy"]),
+      }),
+    ).toBeUndefined();
+  });
+
+  // persistence.rb declares `_update_record` on `ClassMethods` (:687-692) and on
+  // the instance (:900-916); persistence.ts spells the class half as the free
+  // export and the instance half as the `InstanceMethods` grouping.
+  const persistence = {
+    owners: new Set(["", "InstanceMethods"]),
+    seatOf: (o: string) => (o === "InstanceMethods" ? ("instance" as const) : undefined),
+    rubySeats: new Set(["class", "instance"] as const),
+  };
+
+  it("pairs a Ruby ClassMethods owner with the seatless top-level export", () => {
+    expect(
+      resolveTsOwner(persistence.owners, "ActiveRecord::Persistence::ClassMethods", {
+        seatOf: persistence.seatOf,
+        rubySeat: "class",
+        rubySeats: persistence.rubySeats,
+      }),
+    ).toBe("");
+  });
+
+  it("pairs the bare Ruby owner with the prototype member", () => {
+    expect(
+      resolveTsOwner(persistence.owners, "ActiveRecord::Persistence", {
+        seatOf: persistence.seatOf,
+        rubySeat: "instance",
+        rubySeats: persistence.rubySeats,
+      }),
+    ).toBe("InstanceMethods");
+  });
+
+  it("leaves the seats alone when the Ruby file poses no seat question", () => {
+    // time-ext.ts declares `toTime` as a free export AND on the `TimeExt`
+    // grouping, but `Date#to_time` is the only Ruby owner: the seat cannot say
+    // which class the module ported to, so picking one would be a mispairing.
+    expect(
+      resolveTsOwner(new Set(["", "TimeExt"]), "Date", {
+        seatOf: (o: string) => (o === "TimeExt" ? ("instance" as const) : undefined),
+        rubySeat: "instance",
+        rubySeats: new Set(["instance"] as const),
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("tsOwnerSeat", () => {
+  it("reads the trails grouping names before staticness", () => {
+    // An object literal's members are prototype members of the grouping, so
+    // `isStatic` would call `ClassMethods` the instance seat.
+    expect(tsOwnerSeat("ClassMethods", undefined, new Set(["ClassMethods"]))).toBe("class");
+    expect(tsOwnerSeat("InstanceMethods", undefined, new Set(["InstanceMethods"]))).toBe(
+      "instance",
+    );
+  });
+
+  it("reads a class declaration's staticness", () => {
+    expect(tsOwnerSeat("Base", new Set(["Base"]), undefined)).toBe("class");
+    expect(tsOwnerSeat("Base", undefined, new Set(["Base"]))).toBe("instance");
+  });
+
+  it("states no seat for a declaration that is both, or for neither", () => {
+    expect(tsOwnerSeat("Base", new Set(["Base"]), new Set(["Base"]))).toBeUndefined();
+    expect(tsOwnerSeat("", undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("rubyOwnerSeat", () => {
+  it("reads the ClassMethods suffix as the singleton seat", () => {
+    expect(rubyOwnerSeat("ActiveRecord::Persistence::ClassMethods", false)).toBe("class");
+    expect(rubyOwnerSeat("ActiveRecord::Persistence", false)).toBe("instance");
+  });
+
+  it("reads a `def self.` method as the singleton seat wherever it lives", () => {
+    expect(rubyOwnerSeat("ActiveRecord::Base", true)).toBe("class");
+  });
+});
+
 describe("ambiguousRubyOwner", () => {
   it("records nothing when two Ruby owners share one TS member", () => {
     // persistence.rb defines `_update_record` on both `Persistence` (:900) and
@@ -1903,6 +2000,36 @@ describe("ambiguousRubyOwner", () => {
 
   it("compares when only one Ruby owner declares the name", () => {
     expect(ambiguousRubyOwner(new Set(["ActiveRecord::Persistence"]), new Set([""]))).toBe(false);
+  });
+
+  it("compares the arm whose seat the single TS member is declared on", () => {
+    const rubyOwners = new Set([
+      "ActiveRecord::Persistence",
+      "ActiveRecord::Persistence::ClassMethods",
+    ]);
+    const resolution = { tsSeat: "class" as const, rubyOwnersOnTsSeat: 1 };
+    expect(
+      ambiguousRubyOwner(rubyOwners, new Set(["Base"]), { ...resolution, rubySeat: "class" }),
+    ).toBe(false);
+    expect(
+      ambiguousRubyOwner(rubyOwners, new Set(["Base"]), { ...resolution, rubySeat: "instance" }),
+    ).toBe(true);
+  });
+
+  it("still records nothing when several Ruby owners share the TS member's seat", () => {
+    // routing/mapper.rb declares `add_route` on `Base`, `Resources` and
+    // `Scoping`, all instance: the seat answers nothing the count did not.
+    const rubyOwners = new Set([
+      "ActionDispatch::Routing::Mapper::Base",
+      "ActionDispatch::Routing::Mapper::Resources",
+    ]);
+    expect(
+      ambiguousRubyOwner(rubyOwners, new Set(["Mapper"]), {
+        rubySeat: "instance",
+        tsSeat: "instance",
+        rubyOwnersOnTsSeat: 2,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -141,6 +141,7 @@ import {
   buildIncludeGraph,
   includeGraphCallSets,
   includeGraphEntities,
+  includeGraphHosts,
   type GraphEntity,
 } from "./include-graph.js";
 import {
@@ -704,11 +705,12 @@ const SYNTHETIC_CALL_NAMES: ReadonlySet<string> = new Set(["constructor"]);
  * set, so self-recursion and longer cycles terminate. Names in
  * SYNTHETIC_CALL_NAMES are never resolved or expanded.
  *
- * Neither are the names a body recorded ONLY as a property read off another
- * object (FOREIGN_READ_PREFIX): `details.locale` names a member of `details`,
- * not the same-file method `locale`, so resolving it would union an unrelated
- * method's call-set — and everything it reaches — into a body that read a plain
- * property, making this body's `missing` set move when that method is edited
+ * Neither are the names a body recorded ONLY off another object
+ * (FOREIGN_READ_PREFIX) — read or invoked: `details.locale` and
+ * `details.digest(x)` name members of `details`, not the same-file methods
+ * `locale` / `digest`, so resolving one would union an unrelated
+ * method's call-set — and everything it reaches — into a body that never
+ * called it, making this body's `missing` set move when that method is edited
  * (RFC 0108; the constructor half of the same receiver-blindness is
  * SYNTHETIC_CALL_NAMES). `foreignReads` answers that population per OWNER —
  * the body itself is `tsName` — because a name foreign to this body may well
@@ -943,11 +945,91 @@ export function callTagKey(tsFile: string, tsClass: string, tsName: string): str
 export function resolveTsOwner(
   owners: ReadonlySet<string> | undefined,
   rubyModule: string,
+  { hosts, seatOf, rubySeat, rubySeats = new Set() }: TsOwnerResolution = {},
 ): string | undefined {
   if (!owners || owners.size === 0) return undefined;
   if (owners.size === 1) return [...owners][0];
   const short = rubyModule.split("::").at(-1) ?? rubyModule;
-  return owners.has(short) ? short : undefined;
+  if (owners.has(short)) return short;
+  // Ruby flattens a mixin's methods onto the INCLUDING class, so the Ruby
+  // module never names the TS owner: `FinderMethods#first` lands in relation.ts,
+  // whose `Relation` records `extends: ["FinderMethods"]` (RFC 0108). One host
+  // is a resolution; several is the same ambiguity as before.
+  if (hosts) {
+    const via = [...owners].filter((o) => hosts.has(o));
+    if (via.length === 1) return via[0];
+  }
+  // The seat arm answers a seat question only where the RUBY file poses one —
+  // the same name on both the singleton and the instance half
+  // (`persistence.rb:687-692` and `:900-916`). Where every Ruby owner sits on
+  // one seat, the several TS declarations are not the two halves of anything
+  // and the seat cannot say which class the module ported to: picking one is
+  // the mispairing this resolution exists to avoid (time-ext.ts's one `toTime`
+  // body answers `Time#to_time`, `Date#to_time` and `DateTime#to_time` alike).
+  if (seatOf && rubySeats.size > 1) {
+    const exact = [...owners].filter((o) => seatOf(o) === rubySeat);
+    if (exact.length === 1) return exact[0];
+    // A seat the file states for no other declaration: persistence.ts ports
+    // `Persistence::ClassMethods#_update_record` (persistence.rb:687-692) as the
+    // free export and the instance half (`:900-916`) as `InstanceMethods`, so
+    // the class seat is "the one that is not the instance seat".
+    const compatible = [...owners].filter((o) => (seatOf(o) ?? rubySeat) === rubySeat);
+    if (compatible.length === 1) return compatible[0];
+  }
+  return undefined;
+}
+
+/**
+ * Which half of its host a member sits on: Ruby's singleton/instance split,
+ * which TS spells as `static` vs prototype and Rails spells as an `X::ClassMethods`
+ * module beside the bare `X` (`persistence.rb:687-692` vs `:900-916`).
+ */
+export type OwnerSeat = "class" | "instance";
+
+/** What `resolveTsOwner` needs to pick one of a file's several declarations of
+ *  a name: the include-graph hosts of the Ruby module (see includeGraphHosts),
+ *  the seat each TS owner declares the name on, and the seat the Ruby method
+ *  itself sits on. All optional — absent, the resolution is name-only, as it
+ *  was before RFC 0108. */
+export interface TsOwnerResolution {
+  hosts?: ReadonlySet<string>;
+  seatOf?: (tsOwner: string) => OwnerSeat | undefined;
+  rubySeat?: OwnerSeat;
+  /** The seats of EVERY Ruby owner declaring the name in this Ruby file. The
+   *  seat arm runs only when they differ — see resolveTsOwner. */
+  rubySeats?: ReadonlySet<OwnerSeat>;
+}
+
+/** The seat a Ruby owner FQN states, if any: `ActiveRecord::Persistence::ClassMethods`
+ *  is the singleton half of `ActiveRecord::Persistence`. A method the extractor
+ *  bucketed as a class method (`def self.foo`) is the class seat wherever it
+ *  lives, which is what `klass` carries. */
+export function rubyOwnerSeat(rubyModule: string, klass: boolean): OwnerSeat {
+  if (klass) return "class";
+  return (rubyModule.split("::").at(-1) ?? rubyModule) === "ClassMethods" ? "class" : "instance";
+}
+
+/**
+ * The seat a TS owner declares `tsName` on. The trails grouping names come
+ * first: an object literal named `ClassMethods` / `InstanceMethods` holds the
+ * halves that could not both be free exports (persistence.ts), and its members
+ * are prototype members of the grouping either way, so `isStatic` would read
+ * every one of them as the instance seat.
+ *
+ * `undefined` for a top-level function (`""`), which is neither — the port
+ * spells both a `ClassMethods` body and an instance mixin body that way.
+ */
+export function tsOwnerSeat(
+  tsOwner: string,
+  staticOwners: ReadonlySet<string> | undefined,
+  instanceOwners: ReadonlySet<string> | undefined,
+): OwnerSeat | undefined {
+  if (tsOwner === "ClassMethods") return "class";
+  if (tsOwner === "InstanceMethods") return "instance";
+  const isStatic = staticOwners?.has(tsOwner) ?? false;
+  const isInstance = instanceOwners?.has(tsOwner) ?? false;
+  if (isStatic === isInstance) return undefined;
+  return isStatic ? "class" : "instance";
 }
 
 /** True when a file declares `tsName` on several owners and the one this pair
@@ -1002,8 +1084,26 @@ export function ambiguousTsOwner(
 export function ambiguousRubyOwner(
   rubyOwners: ReadonlySet<string> | undefined,
   tsOwners: ReadonlySet<string> | undefined,
+  { rubySeat, tsSeat, rubyOwnersOnTsSeat }: RubyOwnerResolution = {},
 ): boolean {
-  return (rubyOwners?.size ?? 0) > 1 && (tsOwners?.size ?? 0) <= 1;
+  if ((rubyOwners?.size ?? 0) <= 1 || (tsOwners?.size ?? 0) > 1) return false;
+  // The seats resolve the pairing only when exactly ONE of the Ruby owners sits
+  // on the TS member's seat: it is then that member's counterpart, and every
+  // other owner's is elsewhere (or nowhere), so this arm compares and the others
+  // record nothing. Several owners sharing that seat — routing/mapper.rb
+  // declares `add_route` on `Base`, `Resources` and `Scoping`, all instance —
+  // says no more than the bare count did (RFC 0108).
+  if (tsSeat !== undefined && rubyOwnersOnTsSeat === 1) return rubySeat !== tsSeat;
+  return true;
+}
+
+/** The seat data `ambiguousRubyOwner` resolves a many-to-one pairing with: the
+ *  seat of the Ruby method under comparison, the seat the single TS member is
+ *  declared on, and how many of the file's Ruby owners of that name sit on it. */
+export interface RubyOwnerResolution {
+  rubySeat?: OwnerSeat;
+  tsSeat?: OwnerSeat;
+  rubyOwnersOnTsSeat?: number;
 }
 
 /**
@@ -2249,6 +2349,12 @@ export function main() {
     const tsMissingCallTagsByFileName = new Map<string, Map<string, Map<string, Set<string>>>>();
     // (file → name → every class declaring it), `resolveTsOwner`'s population.
     const tsOwnersByFileName = new Map<string, Map<string, Set<string>>>();
+    // The same population split by the SEAT each owner declares the name on
+    // (file → name → owners), so `resolveTsOwner` can pair a Ruby
+    // `X::ClassMethods` owner with the static declaration and the bare `X`
+    // owner with the prototype one (RFC 0108).
+    const tsStaticOwnersByFileName = new Map<string, Map<string, Set<string>>>();
+    const tsInstanceOwnersByFileName = new Map<string, Map<string, Set<string>>>();
     // Same call-sets unioned by NAME across this package and its deps (the same
     // scope tsParamsByName uses). Consulted ONLY by the delegation-transparency
     // gate (see effectiveTsCalls), never as the primary population — the
@@ -2293,6 +2399,20 @@ export function main() {
       }
       return includeGraphCallSets(entities, tsName, includeGraph);
     };
+    // (file → Ruby module short name → the file's owners that mix it in),
+    // memoized: `resolveTsOwner` asks once per matched pair.
+    const graphHosts = new Map<string, Map<string, Set<string>>>();
+    const includeHosts = (tsFile: string, rubyModule: string): ReadonlySet<string> => {
+      const short = rubyModule.split("::").at(-1) ?? rubyModule;
+      const byModule = graphHosts.get(tsFile) ?? new Map<string, Set<string>>();
+      let hosts = byModule.get(short);
+      if (!hosts) {
+        hosts = includeGraphHosts(tsFile, short, includeGraph);
+        byModule.set(short, hosts);
+        graphHosts.set(tsFile, byModule);
+      }
+      return hosts;
+    };
     const recordTsParams = (
       m: MethodInfo,
       file = m.file ?? "",
@@ -2303,6 +2423,15 @@ export function main() {
         const owners = tsOwnersByFileName.get(file) ?? new Map<string, Set<string>>();
         owners.set(m.name, (owners.get(m.name) ?? new Set<string>()).add(owner));
         tsOwnersByFileName.set(file, owners);
+        // A top-level function (`owner === ""`) states no seat: the port spells
+        // a `ClassMethods` body and an instance mixin body the same way.
+        if (owner !== "") {
+          const bySeat =
+            m.isStatic === true ? tsStaticOwnersByFileName : tsInstanceOwnersByFileName;
+          const seatOwners = bySeat.get(file) ?? new Map<string, Set<string>>();
+          seatOwners.set(m.name, (seatOwners.get(m.name) ?? new Set<string>()).add(owner));
+          bySeat.set(file, seatOwners);
+        }
       }
       const sigs = tsParamsByName.get(m.name) ?? [];
       sigs.push(m.params);
@@ -2704,10 +2833,15 @@ export function main() {
       const rubyCallsByOwnerName = new Map<string, { calls: string[]; weak: string[] }>();
       const rubyCallArgsByOwnerName = new Map<string, CallSite[]>();
       const rubyReaderNames = new Set<string>();
+      // (owner, name) pairs the extractor bucketed as CLASS methods — the
+      // singleton seat wherever the owner FQN does not already say so (see
+      // rubyOwnerSeat).
+      const rubyKlassOwnerNames = new Set<string>();
       const ownerKey = (owner: string, name: string) => `${owner}\u0000${name}`;
       for (const item of items) {
         const f = flattenIncludedMethodInfos(item.info, item.fqn, rubyPkg, moduleFqnByShort, pkg);
         const rubyMethods = [...f.instance, ...f.klass];
+        const klassNames = new Set(f.klass.map((rm) => rm.name));
         for (const rm of rubyMethods) {
           // Collected ahead of the mode filter: a Rails `attr_reader` is
           // usually private while the bodies reading it are public, so a
@@ -2726,6 +2860,7 @@ export function main() {
             rm.name,
             (rubyOwnersByName.get(rm.name) ?? new Set<string>()).add(item.fqn),
           );
+          if (klassNames.has(rm.name)) rubyKlassOwnerNames.add(ownerKey(item.fqn, rm.name));
           if (rm.calls && !rubyCallsByName.has(rm.name)) {
             rubyCallsByName.set(rm.name, rm.calls);
             rubyWeakCallsByName.set(rm.name, rm.weakCalls ?? []);
@@ -2789,6 +2924,47 @@ export function main() {
         }
       };
 
+      // The one TS member a matched pair should be held to, or `undefined` when
+      // the pairing stays ambiguous and the gates must record nothing (RFC
+      // 0108). Resolution is by include-graph host and by SEAT — the two
+      // dimensions the extractors already carry — before falling back to the
+      // `ambiguousTsOwner` / `ambiguousRubyOwner` skips.
+      const resolveOwner = (
+        rubyName: string,
+        tsName: string,
+        tsFile: string,
+        rubyModule: string,
+      ): { tsClass: string | undefined; ambiguous: boolean } => {
+        const tsOwners = tsOwnersByFileName.get(tsFile)?.get(tsName);
+        const rubySeatOf = (rubyOwner: string) =>
+          rubyOwnerSeat(rubyOwner, rubyKlassOwnerNames.has(ownerKey(rubyOwner, rubyName)));
+        const rubySeat = rubySeatOf(rubyModule);
+        const seatOf = (tsOwner: string) =>
+          tsOwnerSeat(
+            tsOwner,
+            tsStaticOwnersByFileName.get(tsFile)?.get(tsName),
+            tsInstanceOwnersByFileName.get(tsFile)?.get(tsName),
+          );
+        const rubyOwners = rubyOwnersByName.get(rubyName);
+        const rubySeats = new Set([...(rubyOwners ?? [])].map(rubySeatOf));
+        const tsClass = resolveTsOwner(tsOwners, rubyModule, {
+          hosts: includeHosts(tsFile, rubyModule),
+          seatOf,
+          rubySeat,
+          rubySeats,
+        });
+        const tsSeat = tsClass === undefined ? undefined : seatOf(tsClass);
+        const ambiguous =
+          ambiguousTsOwner(tsOwners, tsClass) ||
+          ambiguousRubyOwner(rubyOwners, tsOwners, {
+            rubySeat,
+            tsSeat,
+            rubyOwnersOnTsSeat: [...(rubyOwners ?? [])].filter((o) => rubySeatOf(o) === tsSeat)
+              .length,
+          });
+        return { tsClass, ambiguous };
+      };
+
       // Advisory calls-parity check: for a name-matched pair, flag Ruby body
       // calls that (a) map by naming convention to a method we ported and
       // (b) are absent from the TS body's call-set. A coarse body-fidelity
@@ -2808,9 +2984,8 @@ export function main() {
         const rubyCalls = dropWeakCalls(rubyOwned?.calls, rubyOwned?.weak);
         if (rubyCalls.length === 0) return;
         const tsOwners = tsOwnersByFileName.get(tsFile)?.get(tsName);
-        const tsClass = resolveTsOwner(tsOwners, rubyModule);
-        if (ambiguousTsOwner(tsOwners, tsClass)) return;
-        if (ambiguousRubyOwner(rubyOwnersByName.get(rubyName), tsOwners)) return;
+        const { tsClass, ambiguous } = resolveOwner(rubyName, tsName, tsFile, rubyModule);
+        if (ambiguous) return;
         if (ownerRecordsNothing(tsCallsByFileNameOwner, tsFile, tsName, tsClass, tsOwners)) return;
         const tsCandidateSets = tsCallsByFileName.get(tsFile)?.get(tsName);
         if (!tsCandidateSets || tsCandidateSets.length === 0) return;
@@ -2947,9 +3122,8 @@ export function main() {
         // choosing whose call sites the Ruby ones pair against — as for a
         // skeleton record, only an unambiguous TS body compares.
         const tsOwners = tsOwnersByFileName.get(tsFile)?.get(tsName);
-        const tsClass = resolveTsOwner(tsOwners, rubyModule);
-        if (ambiguousTsOwner(tsOwners, tsClass)) return;
-        if (ambiguousRubyOwner(rubyOwnersByName.get(rubyName), tsOwners)) return;
+        const { tsClass, ambiguous } = resolveOwner(rubyName, tsName, tsFile, rubyModule);
+        if (ambiguous) return;
         if (ownerRecordsNothing(tsCallArgsByFileNameOwner, tsFile, tsName, tsClass, tsOwners)) {
           return;
         }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -936,12 +936,34 @@ export function callTagKey(tsFile: string, tsClass: string, tsName: string): str
   return `${tsFile}\u0000${tsClass}\u0000${tsName}`;
 }
 
-/** The TS class that owns `tsName` in the file a pair matched, given every
- *  class in that file declaring the name and the Ruby entity the pair came
- *  from. One declaration needs no disambiguation; several are resolved by the
- *  Ruby class's own short name (`ActiveRecord::ConnectionAdapters::NullPool` →
- *  `NullPool`), which the naming rules make the TS class name too. Unresolved
- *  (`undefined`) keeps the whole-file behaviour it replaced. */
+/**
+ * The TS class that owns `tsName` in the file a pair matched, given every
+ * class in that file declaring the name and the Ruby entity the pair came
+ * from. One declaration needs no disambiguation; several are resolved in three
+ * steps, each of which must name exactly ONE owner or fall through — an
+ * unresolved (`undefined`) result records nothing rather than pairing wrongly
+ * (see ambiguousTsOwner):
+ *
+ *  1. the Ruby class's own short name
+ *     (`ActiveRecord::ConnectionAdapters::NullPool` → `NullPool`), which the
+ *     naming rules make the TS class name too;
+ *  2. the include graph: Ruby flattens a mixin's methods onto the INCLUDING
+ *     class, so the Ruby module never names the TS owner — `FinderMethods#first`
+ *     lands in relation.ts, whose `Relation` records `extends: ["FinderMethods"]`
+ *     and whose sibling `ExplainProxy` does not (`hosts`, see includeGraphHosts);
+ *  3. the SEAT (`OwnerSeat`), for the file that ports both halves of one name:
+ *     persistence.ts spells `Persistence::ClassMethods#_update_record`
+ *     (persistence.rb:687-692) as the free export and the instance half
+ *     (`:900-916`) as `InstanceMethods`, so the class seat is the one owner
+ *     that is not the instance seat.
+ *
+ * Step 3 runs only where the RUBY file poses a seat question — the same name on
+ * both the singleton and the instance half. Where every Ruby owner sits on one
+ * seat the several TS declarations are not the two halves of anything, and
+ * picking one by seat is the mispairing this resolution exists to avoid:
+ * time-ext.ts's single `toTime` body answers `Time#to_time`, `Date#to_time` and
+ * `DateTime#to_time` alike (RFC 0108).
+ */
 export function resolveTsOwner(
   owners: ReadonlySet<string> | undefined,
   rubyModule: string,
@@ -951,28 +973,13 @@ export function resolveTsOwner(
   if (owners.size === 1) return [...owners][0];
   const short = rubyModule.split("::").at(-1) ?? rubyModule;
   if (owners.has(short)) return short;
-  // Ruby flattens a mixin's methods onto the INCLUDING class, so the Ruby
-  // module never names the TS owner: `FinderMethods#first` lands in relation.ts,
-  // whose `Relation` records `extends: ["FinderMethods"]` (RFC 0108). One host
-  // is a resolution; several is the same ambiguity as before.
   if (hosts) {
     const via = [...owners].filter((o) => hosts.has(o));
     if (via.length === 1) return via[0];
   }
-  // The seat arm answers a seat question only where the RUBY file poses one —
-  // the same name on both the singleton and the instance half
-  // (`persistence.rb:687-692` and `:900-916`). Where every Ruby owner sits on
-  // one seat, the several TS declarations are not the two halves of anything
-  // and the seat cannot say which class the module ported to: picking one is
-  // the mispairing this resolution exists to avoid (time-ext.ts's one `toTime`
-  // body answers `Time#to_time`, `Date#to_time` and `DateTime#to_time` alike).
   if (seatOf && rubySeats.size > 1) {
     const exact = [...owners].filter((o) => seatOf(o) === rubySeat);
     if (exact.length === 1) return exact[0];
-    // A seat the file states for no other declaration: persistence.ts ports
-    // `Persistence::ClassMethods#_update_record` (persistence.rb:687-692) as the
-    // free export and the instance half (`:900-916`) as `InstanceMethods`, so
-    // the class seat is "the one that is not the instance seat".
     const compatible = [...owners].filter((o) => (seatOf(o) ?? rubySeat) === rubySeat);
     if (compatible.length === 1) return compatible[0];
   }
@@ -1080,6 +1087,14 @@ export function ambiguousTsOwner(
  * call `attributesForUpdate` exactly as `persistence.rb:901` does could not
  * retire the row. Bidirectional too: a genuine omission in either body is
  * masked by the other.
+ *
+ * Resolved, and so NOT ambiguous, when exactly one of the Ruby owners sits on
+ * the seat the single TS member is declared on (`RubyOwnerResolution`): it is
+ * then that member's counterpart, and every other owner's counterpart is
+ * elsewhere or nowhere, so this arm compares and the others record nothing.
+ * Several owners sharing that seat says no more than the bare count did —
+ * routing/mapper.rb declares `add_route` on `Base`, `Resources` and `Scoping`,
+ * all instance (RFC 0108).
  */
 export function ambiguousRubyOwner(
   rubyOwners: ReadonlySet<string> | undefined,
@@ -1087,12 +1102,6 @@ export function ambiguousRubyOwner(
   { rubySeat, tsSeat, rubyOwnersOnTsSeat }: RubyOwnerResolution = {},
 ): boolean {
   if ((rubyOwners?.size ?? 0) <= 1 || (tsOwners?.size ?? 0) > 1) return false;
-  // The seats resolve the pairing only when exactly ONE of the Ruby owners sits
-  // on the TS member's seat: it is then that member's counterpart, and every
-  // other owner's is elsewhere (or nowhere), so this arm compares and the others
-  // record nothing. Several owners sharing that seat — routing/mapper.rb
-  // declares `add_route` on `Base`, `Resources` and `Scoping`, all instance —
-  // says no more than the bare count did (RFC 0108).
   if (tsSeat !== undefined && rubyOwnersOnTsSeat === 1) return rubySeat !== tsSeat;
   return true;
 }
@@ -2423,8 +2432,7 @@ export function main() {
         const owners = tsOwnersByFileName.get(file) ?? new Map<string, Set<string>>();
         owners.set(m.name, (owners.get(m.name) ?? new Set<string>()).add(owner));
         tsOwnersByFileName.set(file, owners);
-        // A top-level function (`owner === ""`) states no seat: the port spells
-        // a `ClassMethods` body and an instance mixin body the same way.
+        // A top-level function (`owner === ""`) states no seat — see tsOwnerSeat.
         if (owner !== "") {
           const bySeat =
             m.isStatic === true ? tsStaticOwnersByFileName : tsInstanceOwnersByFileName;
@@ -2924,11 +2932,10 @@ export function main() {
         }
       };
 
-      // The one TS member a matched pair should be held to, or `undefined` when
-      // the pairing stays ambiguous and the gates must record nothing (RFC
-      // 0108). Resolution is by include-graph host and by SEAT — the two
-      // dimensions the extractors already carry — before falling back to the
-      // `ambiguousTsOwner` / `ambiguousRubyOwner` skips.
+      // The one TS member a matched pair is held to (see resolveTsOwner), and
+      // whether the pairing stayed ambiguous — in which case the gates record
+      // nothing rather than compare against a member this Ruby body did not
+      // port to.
       const resolveOwner = (
         rubyName: string,
         tsName: string,

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -101,16 +101,17 @@ export const NEGATED_ALIASES = new Map<string, Set<string>>([
 export const NEGATED_CALL_PREFIX = "!";
 
 /**
- * Prefix the TS extractor uses to mark a name it only ever saw as a property
- * READ off a receiver that is not `this`/`super` (`details.locale` → `.locale`).
+ * Prefix the TS extractor uses to mark a name it only ever saw as a member of a
+ * receiver that is not `this`/`super` — a property READ (`details.locale` →
+ * `.locale`) or an INVOCATION (`details.digest(x)` → `.digest`).
  * Ruby has no field access, so such a read still counts as a call — the plain
  * name is recorded exactly as before — but it names a member of ANOTHER object,
  * so the same-file closure must not resolve it against a same-file method that
  * happens to carry the name (RFC 0108; see reachedSameFileMethods).
  *
  * Marked IN ADDITION to the plain name, and only when EVERY occurrence in the
- * body was such a read: one `this.locale()` in the same body makes the name the
- * body's own again.
+ * body was off such a receiver: one `this.locale()` in the same body makes the
+ * name the body's own again.
  */
 export const FOREIGN_READ_PREFIX = ".";
 
@@ -122,7 +123,7 @@ export function requiresNegatedAlias(rubyCall: string, tsCall: string): boolean 
 /**
  * Split a raw TS call-set into the plain call names, the names the extractor
  * saw in a NEGATED position (`!includes` → `includes`) and the ones it only saw
- * as a foreign property read (`.locale` → `locale`). Both marked populations are
+ * as a foreign member — read or call (`.locale` → `locale`). Both marked populations are
  * kept OUT of the plain set: they are a second record of a call already in it,
  * so leaving them in would double-count against DELEGATION_MAX_CALLS in
  * `isDelegatingWrapper` (compare.ts) and make wrapper detection body-shape dependent.

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -196,7 +196,7 @@ describe("body call capture", () => {
     // sorted + de-duped (runCallbacks appears twice, recorded once). The
     // intermediate read `obj.nested` in `obj.nested.touch()` is credited as
     // `nested` — a non-callee property read mirrors a Ruby method send.
-    expect(save.calls).toEqual([".nested", "helper", "nested", "runCallbacks", "touch"]);
+    expect(save.calls).toEqual([".nested", ".touch", "helper", "nested", "runCallbacks", "touch"]);
   });
 
   it("records the call-set of a get accessor body, as it does for a method", () => {
@@ -455,7 +455,16 @@ describe("body call capture", () => {
       }`,
     );
     const check = cls.instanceMethods.find((m) => m.name === "check")!;
-    expect(check.calls).toEqual(["!has", "!includes", "!loaded", "has", "includes", "loaded"]);
+    expect(check.calls).toEqual([
+      "!has",
+      "!includes",
+      "!loaded",
+      ".has",
+      ".includes",
+      "has",
+      "includes",
+      "loaded",
+    ]);
   });
 
   it("marks a read off another object with the foreign-read prefix", () => {
@@ -474,6 +483,46 @@ describe("body call capture", () => {
     expect(m.calls).toEqual([".locale", "defaults", "formats", "locale"]);
   });
 
+  it("marks a call INVOKED on another object with the foreign-read prefix", () => {
+    // `details.digest(x)` runs a member of `details`, not the same-file method
+    // `digest` — the closure must not union that one's call-set (RFC 0108).
+    const cls = extractFromSource(
+      `class Foo {
+        cacheKey(details: { digest(x: string): string }) {
+          return details.digest(this.name) + Registry.defaults();
+        }
+      }`,
+    );
+    const m = cls.instanceMethods.find((m) => m.name === "cacheKey")!;
+    // `defaults` is called on a class reference, whose static of that name may
+    // genuinely be a same-file member, so it stays resolvable.
+    expect(m.calls).toEqual([".digest", "defaults", "digest", "name"]);
+  });
+
+  it("keeps a name resolvable when the same body also calls it on this", () => {
+    const cls = extractFromSource(
+      `class Foo {
+        cacheKey(details: { digest(x: string): string }) {
+          return details.digest("a") + this.digest("b");
+        }
+      }`,
+    );
+    const m = cls.instanceMethods.find((m) => m.name === "cacheKey")!;
+    expect(m.calls).toEqual(["digest"]);
+  });
+
+  it("does not mark the identifier an X.call(...) dispatch credits", () => {
+    // The `this`-typed mixin convention (CLAUDE.md): `emitJoinPlan` really is a
+    // same-file body, so it must stay resolvable by the closure.
+    const cls = extractFromSource(
+      `class Foo {
+        build() { return emitJoinPlan.call(this, 1); }
+      }`,
+    );
+    const m = cls.instanceMethods.find((m) => m.name === "build")!;
+    expect(m.calls).toEqual([".call", "call", "emitJoinPlan"]);
+  });
+
   it("does not mark a call the ! does not actually negate", () => {
     // `!a &&` binds the negation to `a`; `!!` is a truthiness cast, not a
     // negation — crediting either would be the same false positive the marker
@@ -487,7 +536,7 @@ describe("body call capture", () => {
       }`,
     );
     const check = cls.instanceMethods.find((m) => m.name === "check")!;
-    expect(check.calls).toEqual(["includes"]);
+    expect(check.calls).toEqual([".includes", "includes"]);
   });
 
   it("omits calls entirely for a body that invokes nothing", () => {
@@ -536,7 +585,15 @@ describe("body call capture", () => {
     const m = cls.instanceMethods.find((m) => m.name === "withLock")!;
     // Additive: the dispatched identifier is credited alongside the literal
     // call/apply name (so a Ruby `Proc#call` match is never lost).
-    expect(m.calls).toEqual(["apply", "call", "helper", "lockBang", "transaction"]);
+    expect(m.calls).toEqual([
+      ".apply",
+      ".call",
+      "apply",
+      "call",
+      "helper",
+      "lockBang",
+      "transaction",
+    ]);
   });
 
   it('records `new Foo(...)` as a "constructor" call (Ruby `Foo.new`)', () => {
@@ -659,6 +716,7 @@ describe("body call capture", () => {
        class Foo { buildJoins(arel) { _qm.emitJoinPlan.call(this, arel); } }`,
     );
     expect(cls.instanceMethods.find((m) => m.name === "buildJoins")!.calls).toEqual([
+      ".call",
       ".emitJoinPlan",
       "call",
       "emitJoinPlan",
@@ -750,6 +808,7 @@ describe("body call capture", () => {
     );
     expect(cls.instanceMethods.find((m) => m.name === "buildJoins")!.calls).toEqual([
       ".buildJoins",
+      ".call",
       "buildJoins",
       "call",
     ]);
@@ -787,7 +846,14 @@ describe("body call capture", () => {
     );
     const unpin = cls.instanceMethods.find((m) => m.name === "unpin")!;
     expect(unpin.callSeq).toEqual(["connection", "lock", "synchronize"]);
-    expect(unpin.calls).toEqual([".lock", "checkin", "connection", "lock", "synchronize"]);
+    expect(unpin.calls).toEqual([
+      ".lock",
+      ".synchronize",
+      "checkin",
+      "connection",
+      "lock",
+      "synchronize",
+    ]);
   });
 
   it("drops a hoisted closure's name even when the enclosing body calls it too", () => {
@@ -867,7 +933,7 @@ describe("body call capture", () => {
       }`,
     );
     const m = cls.instanceMethods.find((m) => m.name === "buildJoins")!;
-    expect(m.calls).toEqual(["concat", "joinsValues", "leftOuterJoinsValues"]);
+    expect(m.calls).toEqual([".concat", "concat", "joinsValues", "leftOuterJoinsValues"]);
   });
 
   it("does not double-record a call's callee property as a value read", () => {
@@ -903,7 +969,7 @@ describe("body call capture", () => {
       }`,
     );
     const m = cls.instanceMethods.find((m) => m.name === "reset")!;
-    expect(m.calls).toEqual(["build", "pop"]);
+    expect(m.calls).toEqual([".build", ".pop", "build", "pop"]);
   });
 });
 
@@ -927,7 +993,7 @@ describe("body call capture — renamed-import aliases", () => {
     const m = cls.instanceMethods.find((m) => m.name === "touchDeferredAttributes")!;
     // `touch` (resolved from `timestampTouch` via both the aliased direct call
     // and the `.call` dispatch) plus the retained literal `call`.
-    expect(m.calls).toEqual(["call", "timestampTouch", "touch"]);
+    expect(m.calls).toEqual([".call", "call", "timestampTouch", "touch"]);
   });
 
   it("does not leak one file's aliases into another", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -3055,12 +3055,10 @@ function collectCalls(
         const prop = callee.name.text;
         called.push(prop);
         negated.push(prop);
-        // `obj.someMethod()` invokes a member of ANOTHER object, exactly as
-        // `obj.someMethod` reads one, so it gets the same foreign tally: the
-        // same-file closure must not resolve the bare name against a same-file
-        // method of that name (RFC 0108). The `X.call(...)` identifier credited
-        // below is NOT tallied — that dispatch really does run a same-file body
-        // (the `this`-typed mixin convention, CLAUDE.md).
+        // An invocation off another object gets the same foreign tally as a read
+        // off one (see FOREIGN_READ_PREFIX). The `X.call(...)` identifier
+        // credited below is deliberately NOT tallied: that dispatch really does
+        // run a same-file body — the `this`-typed mixin convention (CLAUDE.md).
         if (isForeignReadReceiver(callee.expression)) tally(foreignReadOccurrences, prop);
         // `X.call(...)` / `X.apply(...)` also dispatch the function bound to
         // `X` (the project's `this`-typed mixin convention, plus Ruby's

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -3055,6 +3055,13 @@ function collectCalls(
         const prop = callee.name.text;
         called.push(prop);
         negated.push(prop);
+        // `obj.someMethod()` invokes a member of ANOTHER object, exactly as
+        // `obj.someMethod` reads one, so it gets the same foreign tally: the
+        // same-file closure must not resolve the bare name against a same-file
+        // method of that name (RFC 0108). The `X.call(...)` identifier credited
+        // below is NOT tallied — that dispatch really does run a same-file body
+        // (the `this`-typed mixin convention, CLAUDE.md).
+        if (isForeignReadReceiver(callee.expression)) tally(foreignReadOccurrences, prop);
         // `X.call(...)` / `X.apply(...)` also dispatch the function bound to
         // `X` (the project's `this`-typed mixin convention, plus Ruby's
         // `meth.call`/`send` indirection). Additionally credit the dispatched

--- a/scripts/api-compare/include-graph.test.ts
+++ b/scripts/api-compare/include-graph.test.ts
@@ -4,6 +4,7 @@ import {
   buildIncludeGraph,
   includeGraphCallSets,
   includeGraphEntities,
+  includeGraphHosts,
   type GraphEntity,
 } from "./include-graph.js";
 import type { ClassInfo, MethodInfo } from "@blazetrails/parity/types";
@@ -197,5 +198,35 @@ describe("includeGraphCallSets", () => {
     const sets = includeGraphCallSets(includeGraphEntities("a.ts", graph), "run", graph);
     expect([...sets.calls]).toEqual(["map"]);
     expect([...sets.negated]).toEqual(["includes"]);
+  });
+});
+
+describe("includeGraphHosts", () => {
+  it("names the file's owner that mixes the Ruby module in", () => {
+    // relation.rb's `FinderMethods#first` is attributed to relation.ts, where
+    // `Relation` records the edge and the sibling `ExplainProxy` does not.
+    const graph = buildIncludeGraph([
+      entity("Relation", "relation.ts", { extends: ["FinderMethods"] }),
+      entity("ExplainProxy", "relation.ts"),
+      entity("FinderMethods", "relation/finder-methods.ts"),
+    ]);
+    expect([...includeGraphHosts("relation.ts", "FinderMethods", graph)]).toEqual(["Relation"]);
+  });
+
+  it("reaches a module through a transitive edge", () => {
+    const graph = buildIncludeGraph([
+      entity("Relation", "relation.ts", { extends: ["QueryMethods"] }),
+      entity("QueryMethods", "relation/query-methods.ts", { includes: ["FinderMethods"] }),
+      entity("FinderMethods", "relation/finder-methods.ts"),
+    ]);
+    expect([...includeGraphHosts("relation.ts", "FinderMethods", graph)]).toEqual(["Relation"]);
+  });
+
+  it("names nobody when no edge reaches the module", () => {
+    const graph = buildIncludeGraph([
+      entity("Relation", "relation.ts"),
+      entity("FinderMethods", "relation/finder-methods.ts"),
+    ]);
+    expect([...includeGraphHosts("relation.ts", "FinderMethods", graph)]).toEqual([]);
   });
 });

--- a/scripts/api-compare/include-graph.ts
+++ b/scripts/api-compare/include-graph.ts
@@ -147,6 +147,39 @@ export function includeGraphEntities(
 }
 
 /**
+ * The entities declared in `tsFile` whose own recorded `includes` / `extends`
+ * closure reaches an entity named `moduleName` — i.e. the TS hosts a Ruby
+ * module of that name was flattened onto.
+ *
+ * Per-ENTITY, unlike `includeGraphEntities`: `resolveTsOwner` asks which of a
+ * file's several declarations of one member name ported a given Ruby module, so
+ * a file-wide closure would answer "all of them". The edge rules are the same —
+ * recorded names only, and an edge naming more than one entity is dropped.
+ */
+export function includeGraphHosts(
+  tsFile: string,
+  moduleName: string,
+  graph: IncludeGraph,
+): Set<string> {
+  const hosts = new Set<string>();
+  for (const entity of graph.entitiesByFile.get(tsFile) ?? []) {
+    const seenEdges = new Set<string>();
+    const queue = [entity];
+    while (queue.length > 0) {
+      const current = queue.pop()!;
+      for (const name of [...current.includes, ...current.extends]) {
+        if (name === moduleName) hosts.add(entity.name);
+        if (seenEdges.has(name)) continue;
+        seenEdges.add(name);
+        const targets = graph.entitiesByName.get(name) ?? [];
+        if (targets.length === 1) queue.push(targets[0]);
+      }
+    }
+  }
+  return hosts;
+}
+
+/**
  * The call-sets of `tsName` bodies on `entities` (the output of
  * `includeGraphEntities`), partitioned into plain, negated and foreign-read calls.
  *

--- a/scripts/api-compare/lint-call-args.ts
+++ b/scripts/api-compare/lint-call-args.ts
@@ -58,7 +58,11 @@ import {
   missingScope,
   rowsOfKind,
 } from "./call-mismatch-baseline.js";
-import { listJsonFiles, reportNonCanonicalBaselines } from "./baseline-json.js";
+import {
+  listJsonFiles,
+  reportEmptyBaselines,
+  reportNonCanonicalBaselines,
+} from "./baseline-json.js";
 import {
   NO_REGEN_FLAG,
   artifactIsStale,
@@ -153,6 +157,7 @@ export async function main(write: boolean): Promise<number> {
 
   const files = await listJsonFiles(BASELINE_DIR);
   if (await reportNonCanonicalBaselines(files, "call-args ratchet")) return 1;
+  if (await reportEmptyBaselines(files, "call-args ratchet")) return 1;
 
   const { added, stale } = diffAgainstBaseline(current, baseline);
   if (added.length === 0 && stale.length === 0) {

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -142,6 +142,7 @@ import {
 import {
   listJsonFiles,
   pruneEmptyDirs,
+  reportEmptyBaselines,
   reportNonCanonicalBaselines,
   serializeBaseline,
 } from "./baseline-json.js";
@@ -685,6 +686,7 @@ async function main(write: boolean, showSeededKeys: boolean): Promise<number> {
   // files, so they are held to the same canonical form.
   const files = [...(await listJsonFiles(BASELINE_DIR)), ...(await listJsonFiles(MARK_DIR))];
   if (await reportNonCanonicalBaselines(files, "call-mismatches ratchet")) return 1;
+  if (await reportEmptyBaselines(files, "call-mismatches ratchet")) return 1;
 
   const { added, stale } = diffAgainstBaseline(current, baseline);
   const staleTags = artifact.staleTags ?? [];


### PR DESCRIPTION
Three RFC 0108 stories.

## 1. Same-file closure resolves calls on a foreign receiver as same-file methods

`extract-ts-api.ts#collectCalls` now applies the `FOREIGN_READ_PREFIX` tally to
CallExpression sites whose callee is a property access on a foreign receiver,
reusing `isForeignReadReceiver` unchanged — the other half of what PR #6657 did
for property reads. A body that calls `obj.foo()` no longer inherits the
call-set of a same-file `foo`; one `this.foo()` anywhere in the same body keeps
the name resolvable, and `X.call(...)` / `X.apply(...)` still credits the
dispatched identifier as the body's own (the `this`-typed mixin convention).

12 rows surfaced. One converged — `Preloader::Branch#loaders` now spells
`grouped_records.flat_map` (branch.rb:120) as `flatMap` instead of a push loop.
The other 11 are baselined with a Rails `file:line` each; every one is a body
whose port makes the call somewhere the published call-set cannot see, or does
not make it at all (`BUILDER_TOPLEVEL_BINDING.call`, `String.new`, `Fiber.new`,
`DEFAULT_ENV.call`, `select_values.empty?` spelled `.length === 0`, …).

## 2. An empty committed shard makes the reseed-drift check lie

`call-mismatches-exclude/activerecord/explain.json` and
`activesupport/key-generator.json` were both committed as `[]`. The reseed
deletes such a shard, so a clean-tree `--write` produced a diff its caller did
not cause — and CI's `Ratchet baseline drift` step fails on any diff, which is
how a genuinely misplaced row gets waved through. This PR deleted both; #6660
landed the same two deletions first, so after the rebase they are gone from
main and what remains here is the invariant that keeps them gone.
`findEmptyBaselines` /
`reportEmptyBaselines` (baseline-json.ts) now hold the invariant in both call
gates, with a plain-vitest guard over the committed trees.

Verified: `lint-call-mismatches.ts --write` on this branch rewrites nothing
beyond the 11 rows added above, i.e. they landed in the right shards.

## 3. Resolve owner by static and include graph instead of skipping

- `includeGraphHosts` (include-graph.ts) walks the recorded `includes`/`extends`
  edges PER ENTITY, so `resolveTsOwner` can name the TS host a Ruby module was
  flattened onto (`FinderMethods` → `Relation`, not the sibling `ExplainProxy`).
- `rubyOwnerSeat` / `tsOwnerSeat` give both sides the singleton/instance
  distinction — Ruby's `X::ClassMethods` (persistence.rb:687-692 vs :900-916)
  and a `def self.` bucket; TS's `isStatic` and the `ClassMethods` /
  `InstanceMethods` grouping names, which come first because a grouping's
  members are prototype members of the grouping either way.
- `resolveTsOwner` pairs the `::ClassMethods` owner with the class-seat member
  and the bare owner with the prototype one; `ambiguousRubyOwner` does the same
  where exactly one Ruby owner sits on the single TS member's seat.

Both resolutions are gated so they cannot mispair. The seat arm runs only where
the RUBY file poses a seat question (the same name on both halves): where every
Ruby owner shares one seat — `routing/mapper.rb` declares `add_route` on `Base`,
`Resources` and `Scoping` — the seat says nothing about which class ported
what, and picking one is the mispairing the resolution exists to avoid. An
earlier revision without that gate paired `Date#to_time` with `TimeExt#toTime`
and produced 196 gate rows.

**Measured recovery: +1 comparison (5583 → 5584), not the 107 the story cites.**
Most of that 107 is not two declarations at all but ONE body declared twice —
a top-level export plus the grouping object that re-exports it (`export const
TimeExt = { toTime }`) — where both owners carry an identical call-set and the
ambiguity is nominal. Resolving that shape is worth **+245 comparisons and +25
call-argument sites**, at the cost of **40 new mismatch rows across 12 files**
(activesupport 29, activerecord 6 incl. the story's own `_update_record` →
`attributes_for_update`, activemodel 1, rack 2, actioncontroller/actiondispatch
2). That burndown is a PR of its own, filed as
`0108-call-gate-false-positives/resolve-duplicate-declaration-owners-one-body-two-seats`
with the measurements and the mispairing it must refuse. Story 3 is therefore
NOT closed by this PR.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are green; parity
totals unchanged (13363/15341, 8313/8412 arity).

Closes-story: closure-resolves-foreign-receiver-calls-as-same-file-methods
Closes-story: empty-baseline-shard-makes-reseed-drift-check-lie
