### PR TITLE
fix(parity): inline class_for_adapter's detect and converge the AR accessor call-set rows

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -232,12 +232,14 @@ export class ConnectionHandler {
   }
 
   activeConnectionsQ(role?: string | null): boolean {
-    const pools = this.connectionPoolList(role);
+    // `each_connection_pool(role)` (connection_handler.rb:158) is an Enumerator
+    // when called without a block; the TS overload always takes one, so the
+    // pools are collected before `any?`.
+    const pools: ConnectionPool[] = [];
+    this.eachConnectionPool(role, (pool) => {
+      pools.push(pool);
+    });
     return pools.some((pool) => pool.activeConnection != null);
-  }
-
-  get activeConnections(): boolean {
-    return this.activeConnectionsQ();
   }
 
   clearActiveConnectionsBang(role?: string | null): void {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -231,10 +231,14 @@ export class ConnectionHandler {
     return poolConfig.pool;
   }
 
+  /**
+   * Mirrors: `active_connections?` (`connection_handler.rb:157-159`).
+   *
+   * `each_connection_pool(role)` is an Enumerator when Ruby calls it without a
+   * block; the TS signature always takes one, so the pools are collected before
+   * `any?`.
+   */
   activeConnectionsQ(role?: string | null): boolean {
-    // `each_connection_pool(role)` (connection_handler.rb:158) is an Enumerator
-    // when called without a block; the TS overload always takes one, so the
-    // pools are collected before `any?`.
     const pools: ConnectionPool[] = [];
     this.eachConnectionPool(role, (pool) => {
       pools.push(pool);

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -245,12 +245,12 @@ describe("ConnectionHandlerTest", () => {
   });
 
   it("active connections?", async () => {
-    expect(handler.activeConnections).toBe(false);
+    expect(handler.activeConnectionsQ()).toBe(false);
     const config = new HashConfig("development", "primary", ambientPoolConfiguration());
     handler.establishConnection(config, { ownerName: "primary" });
     const pool = handler.retrieveConnectionPool("primary")!;
     await pool.leaseConnection();
-    expect(handler.activeConnections).toBe(true);
+    expect(handler.activeConnectionsQ()).toBe(true);
     pool.releaseConnection();
   });
 

--- a/packages/activerecord/src/connection-adapters/pool-manager.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.ts
@@ -15,13 +15,11 @@ export class PoolManager {
   }
 
   get shardNames(): string[] {
-    const shards = new Set<string>();
-    for (const shardMap of this._roleToShardMapping.values()) {
-      for (const shard of shardMap.keys()) {
-        shards.add(shard);
-      }
-    }
-    return [...shards];
+    return [
+      ...new Set(
+        [...this._roleToShardMapping.values()].flatMap((shardMap) => [...shardMap.keys()]),
+      ),
+    ];
   }
 
   get roleNames(): string[] {

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -107,7 +107,7 @@ describe("connect", () => {
     const { adapter, envConfig } = await connect();
     expect(adapter).toBe("sqlite");
     expect(envConfig.adapter).toMatch(/sqlite/i);
-    expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
+    expect(DatabaseTasks["classForAdapter"]("sqlite3")).toBeDefined();
   });
 
   it("falls back to the default_connection (sqlite3) when ARCONN is unset", async () => {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { stdout, stderr, setEnv } from "@blazetrails/activesupport";
-import { DatabaseTasks } from "./database-tasks.js";
+import { DatabaseTasks, DatabaseNotSupported } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
@@ -256,11 +256,11 @@ describe("DatabaseTasksRegisterTask", () => {
     };
     DatabaseTasks.registerTask("sqlite", first);
     DatabaseTasks.registerTask("sqlite", second);
-    expect(DatabaseTasks.resolveTask("sqlite3")).toBe(second);
+    expect(DatabaseTasks["classForAdapter"]("sqlite3")).toBe(second);
   });
 
   it("unregistered task", () => {
-    expect(DatabaseTasks.resolveTask("nonexistent")).toBeUndefined();
+    expect(() => DatabaseTasks["classForAdapter"]("nonexistent")).toThrow(DatabaseNotSupported);
   });
 });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -180,23 +180,8 @@ export class DatabaseTasks {
     this._registeredTasks.push({ pattern, handler });
   }
 
-  static resolveTask(adapter: string): DatabaseTaskHandler | undefined {
-    for (let i = this._registeredTasks.length - 1; i >= 0; i--) {
-      const { pattern, handler } = this._registeredTasks[i];
-      if (typeof pattern === "string") {
-        if (adapter.startsWith(pattern)) return handler;
-      } else {
-        pattern.lastIndex = 0;
-        if (pattern.test(adapter)) return handler;
-      }
-    }
-    return undefined;
-  }
-
   /**
    * @internal Mirrors: `class_for_adapter` (`tasks/database_tasks.rb:574-580`).
-   * Ruby's `@tasks.reverse_each.detect { |pattern, _| adapter[pattern] }` is
-   * `resolveTask` above, which walks the same registrations newest-first;
    * `task.is_a?(String) ? task.constantize : task` has no analogue because
    * `registerTask` takes the handler itself, never its name.
    *
@@ -206,7 +191,15 @@ export class DatabaseTasks {
    * error class and message exact.
    */
   private static classForAdapter(adapter: string | undefined): DatabaseTaskHandler {
-    const task = adapter === undefined ? undefined : this.resolveTask(adapter);
+    const task = this._registeredTasks
+      .slice()
+      .reverse()
+      .find(({ pattern }) => {
+        if (adapter === undefined) return false;
+        if (typeof pattern === "string") return adapter.includes(pattern);
+        pattern.lastIndex = 0;
+        return pattern.test(adapter);
+      })?.handler;
     if (!task) {
       throw new DatabaseNotSupported(`Rake tasks not supported by '${adapter}' adapter`);
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -191,15 +191,17 @@ export class DatabaseTasks {
    * error class and message exact.
    */
   private static classForAdapter(adapter: string | undefined): DatabaseTaskHandler {
-    const task = this._registeredTasks
-      .slice()
-      .reverse()
-      .find(({ pattern }) => {
-        if (adapter === undefined) return false;
-        if (typeof pattern === "string") return adapter.includes(pattern);
-        pattern.lastIndex = 0;
-        return pattern.test(adapter);
-      })?.handler;
+    const task =
+      adapter === undefined
+        ? undefined
+        : this._registeredTasks
+            .slice()
+            .reverse()
+            .find(({ pattern }) => {
+              if (typeof pattern === "string") return adapter.includes(pattern);
+              pattern.lastIndex = 0;
+              return pattern.test(adapter);
+            })?.handler;
     if (!task) {
       throw new DatabaseNotSupported(`Rake tasks not supported by '${adapter}' adapter`);
     }

--- a/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.trails.test.ts
@@ -19,7 +19,7 @@ describe("MySQLDatabaseTasks", () => {
   it("test_registers_mysql_and_trilogy_patterns", () => {
     DatabaseTasks.clearRegisteredTasks();
     MySQLDatabaseTasks.register();
-    expect(DatabaseTasks.resolveTask("mysql2")).toBeDefined();
+    expect(DatabaseTasks["classForAdapter"]("mysql2")).toBeDefined();
   });
 
   it("test_purge_preserves_existing_database_charset_and_collation", async () => {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.trails.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.trails.test.ts
@@ -21,7 +21,7 @@ describe("PostgreSQLDatabaseTasks", () => {
   it("test_registers_with_database_tasks", () => {
     DatabaseTasks.clearRegisteredTasks();
     PostgreSQLDatabaseTasks.register();
-    expect(DatabaseTasks.resolveTask("postgresql")).toBeDefined();
+    expect(DatabaseTasks["classForAdapter"]("postgresql")).toBeDefined();
   });
 
   it("test_purge_drops_then_recreates_with_already_connected_flag", async () => {

--- a/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/sqlite-database-tasks.test.ts
@@ -75,7 +75,7 @@ describe("SQLiteDatabaseTasks", () => {
   it("test_registers_with_database_tasks", () => {
     DatabaseTasks.clearRegisteredTasks();
     SQLiteDatabaseTasks.register();
-    expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
+    expect(DatabaseTasks["classForAdapter"]("sqlite3")).toBeDefined();
   });
 
   it("test_structure_dump_and_load_round_trip_via_adapter", async () => {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/asynchronous-queries-tracker.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/asynchronous-queries-tracker.json
@@ -4,6 +4,6 @@
     "tsFile": "asynchronous-queries-tracker.ts",
     "rubyName": "current_session",
     "call": "last",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@stack.last or raise ActiveRecordError` (`asynchronous_queries_tracker.rb:50`) — the TS body reads `this.#stack[this.#stack.length - 1]` and raises the same error with the same message. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -46,6 +46,6 @@
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "type_map",
     "call": "compute_if_absent",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `EXTENDED_TYPE_MAPS.compute_if_absent(key) { ... }` (`connection_adapters/abstract_adapter.rb:1114`) — `Concurrent::Map#compute_if_absent` is an atomic memoize with no JS analogue; the body spells the same memoize as a `get`/`set` pair on a plain `Map`, keyed on the serialized option hash because JS Maps key on reference identity."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "active_connections?",
-    "call": "each_connection_pool",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "connection_pool_list",
     "call": "flat_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -39,7 +39,7 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "export_name_on_schema_dump?",
     "call": "match?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `!ActiveRecord::SchemaDumper.fk_ignore_pattern.match?(name) if name` (`connection_adapters/schema_definitions.rb:158`). Ruby's `Regexp#match?` is stateless; JS `RegExp#test` advances `lastIndex` on a `/g` pattern, and `fk_ignore_pattern` is user-assignable (`schema-definitions.trails.test.ts` pins a `/g` pattern giving two different answers on consecutive reads). The `statelessTest` wrapper is that language shortcoming, and `test` is the only JS analogue the gate credits for `match?`."
   },
   {
     "package": "activerecord",
@@ -102,6 +102,6 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "validate?",
     "call": "fetch",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `options.fetch(:validate, true)` (`connection_adapters/schema_definitions.rb:153`) — `options` is a plain TS object, not a Hash, so the default-substituting read has no `fetch` call spelling; the body is `this.options.validate ?? true`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -32,14 +32,14 @@
     "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "current_transaction",
     "call": "last",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@stack.last || NULL_TRANSACTION` (`connection_adapters/abstract/transaction.rb:662`) — the TS body reads the last stack slot and falls back to the same `NULL_TRANSACTION`. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "open_transactions",
     "call": "size",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@stack.size` (`connection_adapters/abstract/transaction.rb:658`) — the TS body is `this._stack.length`, the whole method. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/pool-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/pool-manager.json
@@ -5,12 +5,5 @@
     "rubyName": "pool_configs",
     "call": "flat_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/pool-manager.ts",
-    "rubyName": "shard_names",
-    "call": "flat_map",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/statement-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/statement-pool.json
@@ -32,7 +32,7 @@
     "tsFile": "connection-adapters/statement-pool.ts",
     "rubyName": "length",
     "call": "cache",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `cache.length` (`connection_adapters/statement_pool.rb:28`), where private `cache` is `@cache[Process.pid]` (`statement_pool.rb:60-62`). trails has no `process.*` access by construction, so the pool holds one un-keyed `Map` and there is no `cache` member for the body to call."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
@@ -32,7 +32,7 @@
     "tsFile": "database-configurations.ts",
     "rubyName": "default_env",
     "call": "call",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s` (`database_configurations.rb:189`) — `DEFAULT_ENV` is an unported Proc constant, so there is no receiver to send `call` to; porting it is filed as `port-connection-handling-default-env-proc`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -11,6 +11,6 @@
     "tsFile": "database-configurations/database-config.ts",
     "rubyName": "for_current_env?",
     "call": "call",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call` (`database_configurations/database_config.rb:92`) — same unported `DEFAULT_ENV` Proc as `default_env`; filed as `port-connection-handling-default-env-proc`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/hash-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/hash-config.json
@@ -32,6 +32,6 @@
     "tsFile": "database-configurations/hash-config.ts",
     "rubyName": "seeds?",
     "call": "fetch",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `configuration_hash.fetch(:seeds, primary?)` (`database_configurations/hash_config.rb:138`) — same Hash#fetch shortcoming as `validate?`: the configuration hash is a plain TS object, so the body spells the stored-key test explicitly and falls back to `isPrimary()`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/contexts.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/contexts.json
@@ -4,6 +4,6 @@
     "tsFile": "encryption/contexts.ts",
     "rubyName": "current_custom_context",
     "call": "last",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `self.custom_contexts&.last` (`encryption/contexts.rb:67`) — the TS body reads the last custom context, returning null when the stack is empty (Ruby's `&.` arm). `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
@@ -11,6 +11,6 @@
     "tsFile": "encryption/key.ts",
     "rubyName": "id",
     "call": "first",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `Digest::SHA1.hexdigest(secret).first(4)` (`encryption/key.rb:25`) — ActiveSupport's `String#first(n)`, a positional idiom whose JS spelling is `slice(0, n)`. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body. The digest divergence in the same line (SHA-256/8 chars where Rails takes SHA-1/4) is a separate defect, filed as `encryption-key-id-uses-sha256-not-sha1`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -46,7 +46,7 @@
     "tsFile": "migration.ts",
     "rubyName": "current_environment",
     "call": "call",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `ActiveRecord::ConnectionHandling::DEFAULT_ENV.call` (`migration.rb:1341`) — same unported `DEFAULT_ENV` Proc as `default_env`; filed as `port-connection-handling-default-env-proc`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "class_for_adapter",
-    "call": "detect",
-    "reason": "Verified per-site (RFC 0106): `@tasks.reverse_each.detect` (`database_tasks.rb:575`) is `resolveTask`, the same newest-first walk over the same registrations, extracted because `registerTask` stores the handler rather than its name so `task.is_a?(String) ? task.constantize : task` has no analogue; inlining it back is filed as its own story."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "dump_schema",
     "call": "open",
     "reason": "Verified per-site (RFC 0106): `File.open(filename, \"w:utf-8\") { |file| ... }` (`database_tasks.rb:439`) — the fs port models no open-file handle, so the dumper writes into a line buffer that `writeFileSync` flushes; there is no TS call spelling for the block form."


### PR DESCRIPTION
## What

Two bundled stories from RFC 0106.

### 1. `class_for_adapter` no longer extracts `resolveTask`

Rails (`activerecord/lib/active_record/tasks/database_tasks.rb:574-580`) is one
method with the lookup inline:

```ruby
_key, task = @tasks.reverse_each.detect { |pattern, _task| adapter[pattern] }
```

trails split it into `DatabaseTasks.resolveTask` + `classForAdapter`, which is
the "no extra abstraction" case CLAUDE.md names and why the comparator saw no
`detect` in `class_for_adapter`. The reverse walk is now inline at the Rails
name, `resolveTask` is gone, and its test callers moved onto `classForAdapter`
(private in Rails too, `database_tasks.rb:541`).

While inlining, the string-pattern arm converged from `adapter.startsWith(pattern)`
to `adapter.includes(pattern)` — Ruby's `adapter[pattern]` is substring
containment, not a prefix test.

### 2. Accessor-surfaced call-set rows, wave 1 (ActiveRecord slice)

The parent story sizes the RFC 0108 cohort at 81 rows across 8 packages and says
explicitly to take it in waves. This wave takes ActiveRecord:

- **Converged.** `ConnectionHandler#activeConnectionsQ` now walks
  `eachConnectionPool` the way `active_connections?` does
  (`connection_handler.rb:157-159`) instead of `connectionPoolList`, and the
  duplicate `get activeConnections` delegate — extra surface, one Rails method
  is one TS method — is deleted along with its row.
- **Converged.** `PoolManager#shardNames` is `flatMap` + uniq
  (`pool_manager.rb:10-12`) instead of a hand-rolled nested loop.
- **Reviewed per-row.** The other 11 ActiveRecord rows carried the cluster
  reason ("not line-diffed individually"). Each was read against the vendored
  Rails body and now carries its own justification citing `gem/path.rb:LINE`.
  They are the outcomes RFC 0092 already routed to reason text — `first` /
  `last` / `size` positional reads with no JS call form, `Hash#fetch` against a
  plain TS object, `Concurrent::Map#compute_if_absent`, `Proc#call` on an
  unported constant — which is the second sanctioned outcome in this story's
  acceptance criteria.

Exclude-tree row count: 1230 → 1228, plus the `class_for_adapter` row.

## Filed rather than folded in

- `encryption-key-id-uses-sha256-not-sha1` (0023) — `Key#id` uses SHA-256/8
  chars where `key.rb:25` uses SHA-1/4. Same line as a row in this wave, but a
  behavioural defect, not a call-set one.
- `port-connection-handling-default-env-proc` (0023) — trails has no
  `ConnectionHandling::DEFAULT_ENV`, so three sites re-derive it three ways and
  each carries a `| call` row. One fix retires all three.
- `converge-accessor-surfaced-call-set-rows-wave-2` (0106) — the rest of the
  cohort: the Rack header-accessor cluster (one decision, ~29 rows), the harder
  ActiveRecord association/relation rows, and the remaining packages.

## Verification

- `pnpm parity:api:calls` — OK (1228 baselined)
- `pnpm parity:api:calls:args` — OK (162 baselined shape rows)
- `pnpm parity:api:extra --package activerecord` — non-growing (one novel name
  removed, none added)
- No `--write` reseed; no mark went stale, so no `tighten` was needed.

Closes-story: class-for-adapter-extracts-resolve-task
Closes-story: converge-accessor-surfaced-call-set-rows
