### PR TITLE
fix(parity): converge the accessor-surfaced call-set rows (wave 3)

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -162,6 +162,9 @@ export class Request {
 
   // --- HTTP method ---
 
+  /** Rails' `@request_method` memo (request.rb:153). */
+  private _requestMethod?: string;
+
   get method(): string {
     // Check for method override via _method parameter or X-Http-Method-Override header
     if (this.requestMethod === "POST") {
@@ -178,7 +181,9 @@ export class Request {
   }
 
   get requestMethod(): string {
-    return ((this.getHeader("REQUEST_METHOD") as string) || "GET").toUpperCase();
+    return (this._requestMethod ??= this.checkMethod(
+      ((this.getHeader("REQUEST_METHOD") as string) || "GET").toUpperCase(),
+    )!);
   }
 
   /** Mirrors: `alias raw_request_method request_method` (request.rb:145). */

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -162,7 +162,6 @@ export class Request {
 
   // --- HTTP method ---
 
-  /** Rails' `@request_method` memo (request.rb:153). */
   private _requestMethod?: string;
 
   get method(): string {
@@ -181,9 +180,7 @@ export class Request {
   }
 
   get requestMethod(): string {
-    return (this._requestMethod ??= this.checkMethod(
-      ((this.getHeader("REQUEST_METHOD") as string) || "GET").toUpperCase(),
-    )!);
+    return (this._requestMethod ??= this.checkMethod(this.getHeader("REQUEST_METHOD"))!);
   }
 
   /** Mirrors: `alias raw_request_method request_method` (request.rb:145). */

--- a/packages/actionpack/src/action-dispatch/routing/inspector.ts
+++ b/packages/actionpack/src/action-dispatch/routing/inspector.ts
@@ -131,10 +131,14 @@ export class RouteWrapper {
     return this.route.verb;
   }
   get controller(): string {
-    return this.route.controller;
+    return this.route.pathParamNames.includes("controller")
+      ? ":controller"
+      : (this.requirements.controller as string);
   }
   get action(): string {
-    return this.route.action;
+    return this.route.pathParamNames.includes("action")
+      ? ":action"
+      : (this.requirements.action as string);
   }
 
   get reqs(): string {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -184,6 +184,10 @@ export interface AssociationDefinition {
    * read this.
    */
   macro?: "belongsTo" | "hasOne" | "hasMany" | "hasAndBelongsToMany";
+  /** Rails' `MacroReflection#extensions`. See {@link macro}. */
+  extensions?: () => any[];
+  /** Rails' `AbstractReflection#scope_for`. See {@link macro}. */
+  scopeFor?: (relation: any, owner?: any) => any;
   /** Rails' `AssociationReflection#foreign_key`. See {@link macro}. */
   foreignKey?: string | string[];
   /** Rails' `AssociationReflection#association_primary_key`. See {@link macro}. */

--- a/packages/activerecord/src/associations/association-extensions.trails.test.ts
+++ b/packages/activerecord/src/associations/association-extensions.trails.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Trails-only surface: `Association#extensions`
+ * (activerecord/lib/active_record/associations/association.rb:169-177) has no
+ * live trails caller yet — `CollectionProxy#initialize` reads the macro
+ * record's `extend:` option directly — so nothing else exercises the getter.
+ * Cover it here, because the reflection an `Association` is constructed with is
+ * the lightweight macro record, which carries neither `extensions` nor
+ * `scope_for`: the getter has to resolve the rich reflection the way
+ * `Association#klass` does, and a body reading them off the macro record throws.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
+
+describe("Association#extensions", () => {
+  fixtures(["posts", "comments"]);
+
+  it("unions the class default extensions with the reflection's", async () => {
+    const post = (await Post.first()) as Post;
+    const defaultExtensions = Comment.defaultExtensions();
+
+    expect(post.association("commentsWithExtend").extensions).toEqual([
+      ...defaultExtensions,
+      Post.namedExtension,
+    ]);
+    expect(post.association("commentsWithExtend_2").extensions).toEqual([
+      ...defaultExtensions,
+      Post.namedExtension,
+      Post.namedExtension2,
+    ]);
+  });
+
+  it("picks up the extensions a scoped association's scope extends with", async () => {
+    const post = (await Post.first()) as Post;
+
+    expect(post.association("commentsWithExtending").extensions).toContain(Post.namedExtension);
+  });
+});

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -497,15 +497,25 @@ export class Association {
   }
 
   get extensions(): any[] {
+    // `reflection` here is Rails' rich `MacroReflection`, resolved off the
+    // owner's class exactly as `klass` above does: the definition an
+    // `Association` is constructed with is the lightweight macro record, which
+    // carries neither `extensions` nor `scope_for`.
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => AssociationDefinition | null;
+    };
+    const reflection = (ctor._reflectOnAssociation?.(this.reflection.name) ??
+      this.reflection) as AssociationDefinition;
+
     let extensions = [
-      ...new Set([...this.klass.defaultExtensions(), ...this.reflection.extensions!()]),
+      ...new Set([...this.klass.defaultExtensions(), ...(reflection.extensions?.() ?? [])]),
     ];
 
-    if (this.reflection.scope) {
+    if (reflection.scope) {
       extensions = [
         ...new Set([
           ...extensions,
-          ...this.reflection.scopeFor!(this.klass.unscoped(), this.owner).extensions,
+          ...reflection.scopeFor!(this.klass.unscoped(), this.owner).extensions,
         ]),
       ];
     }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -497,9 +497,25 @@ export class Association {
   }
 
   get extensions(): any[] {
-    const ext = this.reflection.options.extend;
-    if (!ext) return [];
-    return Array.isArray(ext) ? ext : [ext];
+    // Ruby `|` is an order-preserving set union (association.rb:170, :173).
+    let extensions = [
+      ...new Set([
+        ...(this.klass as any).defaultExtensions(),
+        ...(this.reflection as any).extensions(),
+      ]),
+    ];
+
+    if (this.reflection.scope) {
+      extensions = [
+        ...new Set([
+          ...extensions,
+          ...(this.reflection as any).scopeFor((this.klass as any).unscoped(), this.owner)
+            .extensions,
+        ]),
+      ];
+    }
+
+    return extensions;
   }
 
   /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -497,20 +497,15 @@ export class Association {
   }
 
   get extensions(): any[] {
-    // Ruby `|` is an order-preserving set union (association.rb:170, :173).
     let extensions = [
-      ...new Set([
-        ...(this.klass as any).defaultExtensions(),
-        ...(this.reflection as any).extensions(),
-      ]),
+      ...new Set([...this.klass.defaultExtensions(), ...this.reflection.extensions!()]),
     ];
 
     if (this.reflection.scope) {
       extensions = [
         ...new Set([
           ...extensions,
-          ...(this.reflection as any).scopeFor((this.klass as any).unscoped(), this.owner)
-            .extensions,
+          ...this.reflection.scopeFor!(this.klass.unscoped(), this.owner).extensions,
         ]),
       ];
     }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -364,7 +364,8 @@ export class ForeignKeyDefinition {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    return !statelessTest(SchemaDumper.fkIgnorePattern, this.name);
+    // Rails guards the whole body with `if name` (schema_definitions.rb:157-159).
+    return this.name ? !statelessTest(SchemaDumper.fkIgnorePattern, this.name) : false;
   }
 
   isDefinedFor(options: ForeignKeyLookupOptions = {}): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -364,7 +364,7 @@ export class ForeignKeyDefinition {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    return this.name ? !statelessTest(SchemaDumper.fkIgnorePattern, this.name) : false;
+    return this.name != null ? !statelessTest(SchemaDumper.fkIgnorePattern, this.name) : false;
   }
 
   isDefinedFor(options: ForeignKeyLookupOptions = {}): boolean {
@@ -454,7 +454,7 @@ export class CheckConstraintDefinition {
   }
 
   get isExportNameOnSchemaDump(): boolean {
-    return this.name ? !statelessTest(SchemaDumper.chkIgnorePattern, this.name) : false;
+    return this.name != null ? !statelessTest(SchemaDumper.chkIgnorePattern, this.name) : false;
   }
 
   isDefinedFor(options: {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -364,7 +364,6 @@ export class ForeignKeyDefinition {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    // Rails guards the whole body with `if name` (schema_definitions.rb:157-159).
     return this.name ? !statelessTest(SchemaDumper.fkIgnorePattern, this.name) : false;
   }
 

--- a/packages/activerecord/src/encryption/key.ts
+++ b/packages/activerecord/src/encryption/key.ts
@@ -18,7 +18,7 @@ export class Key {
   }
 
   get id(): string {
-    return getCrypto().createHash("sha256").update(this.secret).digest("hex").slice(0, 8);
+    return getCrypto().createHash("sha1").update(this.secret).digest("hex").slice(0, 4);
   }
 
   static deriveFrom(password: string): Key {

--- a/packages/activesupport/src/cache/entry.ts
+++ b/packages/activesupport/src/cache/entry.ts
@@ -46,7 +46,7 @@ export class Entry {
   }
 
   get value(): unknown {
-    return this._compressed ? this.uncompress(this._value as string) : this._value;
+    return this.isCompressed() ? this.uncompress(this._value as string) : this._value;
   }
 
   get expiresAt(): number | null {

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -46,7 +46,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "method",
     "call": "check_method",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `method` still reads `HTTP_X_HTTP_METHOD_OVERRIDE`/`_method` inline instead of Rails' `check_method(get_header(\"rack.methodoverride.original_method\") || get_header(\"REQUEST_METHOD\"))` (request.rb:212-220). Convergence is owned by the wave-2 follow-up story `converge-request-method-onto-methodoverride-original-method`; `check_method` lands with the `original_method` header read, not before it."
   },
   {
     "package": "actiondispatch",
@@ -58,13 +58,6 @@
       "str:rack.methodoverride.original_method"
     ],
     "reason": "request.rb:212-221 makes `method` the PRE-override HTTP method, read from `rack.methodoverride.original_method` before `REQUEST_METHOD`; trails inverts the pair — `method` applies an override it reads from `HTTP_X_HTTP_METHOD_OVERRIDE`/`_method` inline, and `requestMethod` is the raw value. Converging needs both readers and the override site moved, tracked as story converge-request-method-onto-methodoverride-original-method."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "request_method",
-    "call": "check_method",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
   },
   {
     "package": "actiondispatch",
@@ -85,20 +78,20 @@
     "tsFile": "http/request.ts",
     "rubyName": "session=",
     "call": "set",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `Session.set self, session` (request.rb:387) writes `env[\"rack.session\"]`; trails' setter performs that env write directly because there is no ported `Session.set` class method to delegate to."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "session_options=",
     "call": "set",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `Session::Options.set self, options` (request.rb:391) writes `env[\"rack.session.options\"]`; trails' setter performs that env write directly, there being no ported `Session::Options.set`."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "xml_http_request?",
     "call": "match?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `/XMLHttpRequest/i.match?(get_header(\"HTTP_X_REQUESTED_WITH\"))` (request.rb:301) is spelled as a case-insensitive equality on the header value; a `Regexp#match?` against a literal-only pattern has no separate JS call form the gate credits."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -45,13 +45,6 @@
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "method",
-    "call": "check_method",
-    "reason": "Verified per-site (RFC 0106): `method` still reads `HTTP_X_HTTP_METHOD_OVERRIDE`/`_method` inline instead of Rails' `check_method(get_header(\"rack.methodoverride.original_method\") || get_header(\"REQUEST_METHOD\"))` (request.rb:212-220). Convergence is owned by the wave-2 follow-up story `converge-request-method-onto-methodoverride-original-method`; `check_method` lands with the `original_method` header read, not before it."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "method",
     "call": "get_header",
     "kind": "args",
     "rubyArgs": [

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/path/pattern.json
@@ -4,6 +4,6 @@
     "tsFile": "journey/path/pattern.ts",
     "rubyName": "requirements_for_missing_keys_check",
     "call": "transform_values",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `requirements.transform_values { … }` (pattern.rb:178-180) over a Ruby Hash; the TS counterpart is a plain object rebuilt by an `Object.entries` loop — `Hash#transform_values` has no JS call form (RFC 0092 positional-idiom-analogues)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/route.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/journey/route.json
@@ -11,21 +11,21 @@
     "tsFile": "journey/route.ts",
     "rubyName": "required_defaults",
     "call": "delete_if",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@defaults.dup.delete_if { … }` (route.rb:135-137) is spelled as an `Object.entries` loop that skips the rejected keys while building the copy; `Hash#delete_if` has no JS call form."
   },
   {
     "package": "actiondispatch",
     "tsFile": "journey/route.ts",
     "rubyName": "requirements",
     "call": "delete_if",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `delete_if { |_, v| /.+?/m == v }` (route.rb:96-98) is spelled as an `Object.entries` loop with `delete merged[k]`; `Hash#delete_if` has no JS call form."
   },
   {
     "package": "actiondispatch",
     "tsFile": "journey/route.ts",
     "rubyName": "requirements",
     "call": "merge",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@defaults.merge(path.requirements)` (route.rb:96) is object spread `{ ...this.defaults, ...this.path.requirements }`; `Hash#merge` has no JS call form."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/routing/inspector.json
@@ -2,20 +2,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/inspector.ts",
-    "rubyName": "action",
-    "call": "include?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/inspector.ts",
-    "rubyName": "controller",
-    "call": "include?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/inspector.ts",
     "rubyName": "matches_filter?",
     "call": "match",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
@@ -11,7 +11,7 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "cookies",
     "call": "cookie_jar",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `_mock_session.cookie_jar` (integration.rb:114-116) reads the jar off Rack::Test's mock session; trails has no `_mock_session`, so the jar is built from and read through the request (`CookieJar.build` / `testProcessCookies`)."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/test-response.json
@@ -4,7 +4,7 @@
     "tsFile": "testing/test-response.ts",
     "rubyName": "parsed_body",
     "call": "call",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `response_parser.call(body)` (test_response.rb:51) invokes a Proc; the TS parser is a function value invoked directly as `this.responseParser(this.body)` — `Proc#call` has no distinct JS call form."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/errors.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/errors.json
@@ -4,7 +4,7 @@
     "tsFile": "errors.ts",
     "rubyName": "details",
     "call": "transform_values",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `group_by_attribute.transform_values { |errors| errors.map(&:details) }` (errors.rb:277-279) over a Ruby Hash; the TS counterpart builds a `Map` in an `Object.entries` loop — `Hash#transform_values` has no JS call form."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -2,20 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "extensions",
-    "call": "scope_for",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "extensions",
-    "call": "unscoped",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "marshal_dump",
     "call": "map",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails association.rb:206-209 maps over instance_variables to build the ivar list; trails association.ts:529-537 dumps the fixed `{loaded, target}` shape — Marshal introspection has no JS analogue, the shape is explicit."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/association.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
+    "rubyName": "extensions",
+    "call": "order:scopeFor,unscoped",
+    "reason": "Verified per-site (RFC 0106): the body now makes both calls, nested exactly as Rails nests them — `reflection.scope_for(klass.unscoped, owner)` (association.rb:173). The extractor records a nested TS call argument before its enclosing call, so an inner-argument call can never be recorded after its caller; the sequence is unreachable from source, not a control-flow difference."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
     "rubyName": "marshal_dump",
     "call": "map",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails association.rb:206-209 maps over instance_variables to build the ivar list; trails association.ts:529-537 dumps the fixed `{loaded, target}` shape — Marshal introspection has no JS analogue, the shape is explicit."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -11,14 +11,14 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "reader",
     "call": "create",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@proxy ||= CollectionProxy.create(klass, self)` (collection_association.rb:41) — RFC 0022 makes the `CollectionProxy` the canonical has_many store, created and cached by `associationProxy(owner, name)` rather than constructed inside `reader`; `reader` returns the shared target it already owns."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "reader",
     "call": "reload",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `reload` on a stale target (collection_association.rb:37-39) issues the load query, so it is `await`-only in trails while `reader` is a synchronous property read; the stale-reload arm lives in `asyncReader`, which every awaited call site uses."
   },
   {
     "package": "activerecord",
@@ -32,41 +32,41 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
     "call": "count_records",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `count_records` (collection_association.rb:218, :220) issues a COUNT query, so it cannot run inside the synchronous `size` getter; the counted arms live on the awaitable `CollectionProxy#size`."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
     "call": "empty?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `target.empty?` / `association_scope.group_values.empty?` (collection_association.rb:214, :216) are `.length === 0` property reads, which the gate deliberately does not credit as calls (JS_ENUMERABLE_ALIASES, RFC 0092)."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
     "call": "find_target?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `!find_target? || loaded?` (collection_association.rb:210) IS ported — as `findTargetNeeded()`, the trails spelling of `find_target?` — so what the gate misses is the name, not the branch."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
     "call": "select",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `target.select(&:new_record?)` (collection_association.rb:217) belongs to the un-loaded `count_records` arm, which is async in trails and lives on `CollectionProxy#size`; the synchronous getter never reaches it."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "target=",
     "call": "klass",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `reflection.klass.has_many_inversing` (collection_association.rb:286) — the whole `target=` body is the inverse-wiring arm, ported in `inversedFrom` (collection-association.ts), which is where trails' `set_inverse_instance` → `inversed_from` chain lands; the `target` setter itself is only the holder write Rails reaches via `super`."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "target=",
     "call": "replace_on_target",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `replace_on_target(record, true, replace: true, inversing: true)` (collection_association.rb:294) is likewise ported in `inversedFrom`, which routes the inverse record into the canonical `CollectionProxy` store (RFC 0022); the `target` setter is the plain `super` holder write."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -25,7 +25,7 @@
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "reflections",
     "call": "drop",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:82) walks the join tree as an Enumerable; trails' join root exposes the walk as `eachChildren`, so the root-skipping `drop(1)` is the guard inside the callback rather than a separate call."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/association.json
@@ -11,7 +11,7 @@
     "tsFile": "associations/preloader/association.ts",
     "rubyName": "preloaded_records",
     "call": "load_records",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `load_records unless defined?(@preloaded_records)` (preloader/association.rb:155) — `loadRecords` is async in trails (it runs the preload query), so the synchronous getter cannot call it; it is awaited by `load()` (preloader/association.ts) before any reader touches `preloadedRecords`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
@@ -11,6 +11,6 @@
     "tsFile": "encryption/key.ts",
     "rubyName": "id",
     "call": "first",
-    "reason": "Verified per-site (RFC 0106): `Digest::SHA1.hexdigest(secret).first(4)` (`encryption/key.rb:25`) — ActiveSupport's `String#first(n)`, a positional idiom whose JS spelling is `slice(0, n)`. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body. The digest divergence in the same line (SHA-256/8 chars where Rails takes SHA-1/4) is a separate defect, filed as `encryption-key-id-uses-sha256-not-sha1`."
+    "reason": "Verified per-site (RFC 0106): `Digest::SHA1.hexdigest(secret).first(4)` (`encryption/key.rb:25`) — ActiveSupport's `String#first(n)`, a positional idiom whose JS spelling is `slice(0, n)`. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment), so the reason-text route is the sanctioned one; nothing was dropped from the TS body. The digest divergence on the same line (SHA-256/8 chars where Rails takes SHA-1/4) is fixed here, closing `encryption-key-id-uses-sha256-not-sha1`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/entry.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/entry.json
@@ -12,12 +12,5 @@
     "rubyName": "dup_value!",
     "call": "compressed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/entry.ts",
-    "rubyName": "value",
-    "call": "compressed?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/number-converter.json
@@ -11,6 +11,6 @@
     "tsFile": "number-helper/number-converter.ts",
     "rubyName": "options",
     "call": "merge",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `format_options.merge(opts)` (number_converter.rb:142) is object spread `{ ...this.formatOptions(), ...this.opts }`; `Hash#merge` has no JS call form."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogirisax.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogirisax.json
@@ -4,7 +4,7 @@
     "tsFile": "xml-mini/nokogirisax.ts",
     "rubyName": "current_hash",
     "call": "last",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `@hash_stack.last` (nokogirisax.rb:25) is the positional read `this._hashStack[this._hashStack.length - 1]`; `Array#last` has no JS call form (RFC 0092 positional-idiom-analogues)."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/trailties/application.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/application.json
@@ -4,14 +4,14 @@
     "tsFile": "application.ts",
     "rubyName": "config",
     "call": "called_from",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `self.class.called_from` (engine.rb:553) is only read to feed `find_root`, which the synchronous getter cannot await (async fs only); `calledFrom()` is read where the root is resolved instead."
   },
   {
     "package": "trailties",
     "tsFile": "application.ts",
     "rubyName": "config",
     "call": "find_root",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `Engine::Configuration.new(self.class.find_root(self.class.called_from))` (engine.rb:553) — `findRoot` walks the filesystem and is async under the hard rule (async fs only), so the synchronous `config` getter cannot await it; the root is applied through the resolved-root path instead."
   },
   {
     "package": "trailties",

--- a/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
+++ b/scripts/api-compare/call-mismatches-exclude/trailties/engine.json
@@ -4,14 +4,14 @@
     "tsFile": "engine.ts",
     "rubyName": "config",
     "call": "called_from",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `self.class.called_from` (engine.rb:553) is only read to feed `find_root`, which the synchronous getter cannot await (async fs only); `calledFrom()` is read by the resolved-root path (engine.ts:85)."
   },
   {
     "package": "trailties",
     "tsFile": "engine.ts",
     "rubyName": "config",
     "call": "find_root",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
+    "reason": "Verified per-site (RFC 0106): `Engine::Configuration.new(self.class.find_root(self.class.called_from))` (engine.rb:553) — `findRoot` walks the filesystem and is async under the hard rule (async fs only), so the synchronous `config` getter cannot await it; the root is resolved via the engine's resolved-root path (engine.ts:80-85)."
   },
   {
     "package": "trailties",


### PR DESCRIPTION
Finishes the burndown of the rows in `call-mismatches-exclude/` carrying the
RFC 0108 accessor cluster reason ("Cluster-vetted: … not line-diffed
individually"). After the rebase onto #6666 (which took the ActiveRecord half),
what remained here is converged and deleted, or replaced with a per-row
justification citing the Rails `gem/path.rb:LINE` it was read against. No
`grep -rl 0108 scripts/api-compare/call-mismatches-exclude/` hit is left.

## Converged (rows deleted)

- `Association#extensions` — mirrors association.rb:169-177: the
  `klass.default_extensions | reflection.extensions` union, plus the
  `reflection.scope_for(klass.unscoped, owner).extensions` arm the trails body
  never had (it only read `options[:extend]`).
- `PoolManager#shard_names` — `flat_map` + uniq (pool_manager.rb:11).
- `Cache::Entry#value` — calls `compressed?` (entry.rb:34) rather than reading
  the field.
- `Request#request_method` — `@request_method ||= check_method(...)`
  (request.rb:152-154); `method` picks up `check_method` through it.
- `RouteWrapper#controller` / `#action` — `parts.include?(:controller) ?
  ":controller" : requirements[:controller]` (inspector.rb:52-58); trails
  returned `route.controller` unconditionally.
- `ForeignKeyDefinition#export_name_on_schema_dump?` — restores Rails' `if name`
  guard (schema_definitions.rb:157-159).
- `Encryption::Key#id` — SHA1 + first 4 hex chars (key.rb:24); trails computed
  SHA256 + 8. That closes `encryption-key-id-uses-sha256-not-sha1`, filed by
  #6666 against the same line, so its baseline reason is updated in place.

One row is added: `extensions | order:scopeFor,unscoped`. The converged body
nests the two calls exactly as Rails does, but the extractor records a nested
call argument before its enclosing call, so Rails' sequence is unreachable from
any source spelling.

## Justified per row

Ruby idioms with no JS call form, each citing its Rails line: `Array#last` /
`String#first` / `Hash#fetch` positional and default reads (RFC 0092),
`Hash#merge` / `transform_values` / `delete_if` on plain objects, `Proc#call`
on the unported `ConnectionHandling::DEFAULT_ENV`,
`Concurrent::Map#compute_if_absent`, `Regexp#match?` via `statelessTest`; plus
the sites where the Rails call is async in trails and lives on the awaitable
sibling (`CollectionAssociation#reader` / `#size` → `CollectionProxy`,
`Preloader::Association#preloaded_records` → `load()`, `Engine#config` → the
resolved-root path), and the one whose convergence is owned by an already-filed
story (`Request#method` →
`converge-request-method-onto-methodoverride-original-method`).

## Follow-up filed

`converge-exception-wrapper-traces-partition` — `ExceptionWrapper#traces`
returned the raw split backtrace instead of Rails' id-tagged
application/framework/full partition (exception_wrapper.rb:147-172). Filed from
this PR and already shipped by #6669, so its row is gone from the tree.

## On the deleted `method | check_method` row

The `Request#requestMethod` memo makes that row **stale**, so it had to go: with
the row restored, `API_COMPARE_FORCE=1 pnpm parity:api --calls` fails with
`1 STALE baseline entr(ies) that no longer flag — actiondispatch http/request.ts
method check_method`, and the only-shrink baseline cannot carry it. Verified by
running exactly that (row re-added, full forced regeneration, gate red; row
removed, gate OK) rather than reasoned about.

That is a gate-credit effect, not a convergence claim: the extractor credits the
call through the same-file closure `method` → `requestMethod` → `checkMethod`.
`Request#method` (request.rb:212-221) still does not make Rails' own
`check_method(get_header("rack.methodoverride.original_method") ||
get_header("REQUEST_METHOD"))` call. That divergence stays tracked by the
surviving `kind: "args"` row in the same shard and by the wave-2 story
`converge-request-method-onto-methodoverride-original-method`, which owns the
convergence.

## Verification

- `pnpm parity:api:calls` OK (1192 baselined, 881 unreviewed, marks already
  tight — no `--write`, no reseed); `pnpm parity:api:calls:args` OK.
- `pnpm build` / `pnpm lint` green; associations, connection-adapters,
  encryption, actionpack, actionview, rack, trailties, activemodel errors,
  activesupport cache + number-helper suites green locally.

`Association#extensions` resolves the rich reflection off the owner's class the
way `Association#klass` does (association.ts:487-491): the definition an
`Association` is constructed with is sometimes the lightweight macro record
(`findHasManyTarget`, `CollectionProxy` build one inline), which carries neither
`extensions` nor `scope_for`. The getter has no other live caller, so
`association-extensions.trails.test.ts` covers both the default-extension union
and the scope arm.

Closes-story: converge-accessor-surfaced-call-set-rows-wave-3
