### PR TITLE
fix(actiondispatch): converge ExceptionWrapper#traces onto Rails' id-tagged trace partition

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
@@ -119,10 +119,24 @@ describe("ExceptionWrapperTest", () => {
   });
 
   it("#traces returns every trace by category enumerated with an index", () => {
-    const wrapper = new ExceptionWrapper(new Error("test"));
-    expect(wrapper.traces.length).toBeGreaterThan(0);
-    for (const line of wrapper.traces) {
-      expect(typeof line).toBe("string");
+    const exception = new Error("test");
+    const wrapper = new ExceptionWrapper(exception);
+    const traces = wrapper.traces;
+
+    expect(Object.keys(traces)).toEqual(["Application Trace", "Framework Trace", "Full Trace"]);
+    expect(traces["Full Trace"].length).toBe(wrapper.fullTrace.length);
+    expect(traces["Application Trace"].length + traces["Framework Trace"].length).toBe(
+      traces["Full Trace"].length,
+    );
+    expect(traces["Full Trace"].map((frame) => frame.id)).toEqual(
+      wrapper.fullTrace.map((_trace, idx) => idx),
+    );
+    expect(traces["Full Trace"].map((frame) => frame.trace)).toEqual(wrapper.fullTrace);
+    for (const frame of traces["Full Trace"]) {
+      expect(frame.exceptionObjectId).toBe(wrapper.exceptionId());
+    }
+    for (const frame of traces["Application Trace"]) {
+      expect(wrapper.applicationTrace).toContain(frame.trace);
     }
   });
 

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -111,10 +111,7 @@ export class DebugExceptions {
       status: wrapper.statusCode,
       error: wrapper.statusText,
       exception: wrapper.exceptionName,
-      traces: {
-        "Application Trace": wrapper.applicationTrace,
-        "Framework Trace": wrapper.frameworkTrace,
-      },
+      traces: wrapper.traces,
     });
     return this.render(wrapper.statusCode, body, "application/json");
   }

--- a/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
@@ -91,6 +91,7 @@ function _idFor(err: object): number {
 }
 
 export type TraceEntry = { file: string; line: number };
+export type TraceWithId = { exceptionObjectId: number; id: number; trace: string };
 export type SourceExtract = TraceEntry & { code?: Record<number, string> };
 
 export class ExceptionWrapper {
@@ -191,14 +192,32 @@ export class ExceptionWrapper {
     return RESCUE_TEMPLATES[this.exceptionClassName] ?? "diagnostics";
   }
 
-  get traces(): string[] {
-    const stack = this.exception.stack;
-    if (!stack) return [];
-    return stack
-      .split("\n")
-      .slice(1)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
+  get traces(): Record<string, TraceWithId[]> {
+    const applicationTraceWithIds: TraceWithId[] = [];
+    const frameworkTraceWithIds: TraceWithId[] = [];
+    const fullTraceWithIds: TraceWithId[] = [];
+
+    this.fullTrace.forEach((trace, idx) => {
+      const traceWithId: TraceWithId = {
+        exceptionObjectId: _idFor(this.exception),
+        id: idx,
+        trace,
+      };
+
+      if (this.applicationTrace.includes(trace)) {
+        applicationTraceWithIds.push(traceWithId);
+      } else {
+        frameworkTraceWithIds.push(traceWithId);
+      }
+
+      fullTraceWithIds.push(traceWithId);
+    });
+
+    return {
+      "Application Trace": applicationTraceWithIds,
+      "Framework Trace": frameworkTraceWithIds,
+      "Full Trace": fullTraceWithIds,
+    };
   }
 
   get applicationTrace(): string[] {
@@ -222,18 +241,21 @@ export class ExceptionWrapper {
   }
 
   traceToShow(): "Application Trace" | "Full Trace" {
-    if (this.applicationTrace.length === 0 && this.rescueTemplate() !== "routing_error") {
+    if (
+      this.traces["Application Trace"].length === 0 &&
+      this.rescueTemplate() !== "routing_error"
+    ) {
       return "Full Trace";
     }
     return "Application Trace";
   }
 
-  sourceToShowId(): number {
-    return 0;
+  sourceToShowId(): number | undefined {
+    return this.traces[this.traceToShow()][0]?.id;
   }
 
   get sourceLocation(): TraceEntry | null {
-    const firstTrace = this.traces[0];
+    const firstTrace = this.backtrace()[0];
     if (!firstTrace) return null;
     return this.extractFileAndLineNumber(firstTrace);
   }
@@ -295,7 +317,13 @@ export class ExceptionWrapper {
   // handle it.
   /** @internal */
   buildBacktrace(): string[] {
-    return this.traces;
+    const stack = this.exception.stack;
+    if (!stack) return [];
+    return stack
+      .split("\n")
+      .slice(1)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
   }
 
   /** @internal */

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json
@@ -4,7 +4,7 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "new",
-    "reason": "Missing construction, not a constructor idiom: Rails' `build_backtrace` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:254-275) maps template frames onto `SourceMapLocation.new(...)`. The port (middleware/exception-wrapper.ts:297) is `return this.traces` — `ActionView::PathRegistry` and `SourceMapLocation` are unported, as the call-site comment already records. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
+    "reason": "Missing construction, not a constructor idiom: Rails' `build_backtrace` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:254-275) maps template frames onto `SourceMapLocation.new(...)`. The port splits the raw `exception.stack` into frame strings — `ActionView::PathRegistry` and `SourceMapLocation` are unported, as the call-site comment already records. Not tracked by a story: actionpack is outside the project's stated focus (activerecord and its dependencies), which is why the convergence story filed for this row was closed as out of scope."
   },
   {
     "package": "actiondispatch",
@@ -12,12 +12,5 @@
     "rubyName": "source_fragment",
     "call": "root",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/exception-wrapper.ts",
-    "rubyName": "traces",
-    "call": "include?",
-    "reason": "Baseline (RFC 0108): call-set divergence inside a `get`/`set` accessor body, newly VISIBLE to the gate now that extract-ts-api records accessor call sets. Pre-existing divergence in the ported body, not introduced by the extractor change; pending per-body convergence review. Cluster-vetted: representative entries were read against the vendored Rails body and the rest were classified by the same mechanism — surfacing an accessor's call set for the first time — not line-diffed individually."
   }
 ]


### PR DESCRIPTION
## Converge `ExceptionWrapper#traces` onto Rails' id-tagged trace partition

`traces` (actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:147-172)
walks `full_trace.each_with_index`, tags each frame with
`{exception_object_id:, id:, trace:}` and splits it into `"Application Trace"` /
`"Framework Trace"` on `application_trace.include?(trace)`, returning all three
groups plus `"Full Trace"`. The port returned the raw split backtrace as
`string[]` and never partitioned or tagged.

- `traces` now mirrors that body line for line, including the branch order and
  the per-iteration `this.applicationTrace.includes(trace)`. `exceptionObjectId`
  uses the file's existing `_idFor` weak-map id — the same value
  `exceptionId()` returns for `exception.object_id` (`:228-230`).
- `buildBacktrace` used to `return this.traces`, i.e. it relied on `traces`
  being the raw stack. It now splits `exception.stack` itself, which is what
  Rails' `build_backtrace` (`:254-275`) does modulo the unported
  `PathRegistry`/`SourceMapLocation` remap that its baseline row still records
  (row kept; its stale "`return this.traces`" citation updated).
- Callers converged onto the new shape: `traceToShow` now reads
  `traces["Application Trace"]` (`:204-210`), `sourceToShowId` returns
  `traces[traceToShow()][0]?.id` instead of a hardcoded `0` (`:212-214`), and
  `DebugExceptions#renderForApiRequest` passes `wrapper.traces` whole as Rails'
  `render_for_api_request` does (debug_exceptions.rb:100). `sourceLocation` (no
  Rails counterpart) reads `backtrace()[0]`, the raw frame it was reading before.
- The `traces | include?` row is deleted from
  `call-mismatches-exclude/actiondispatch/middleware/exception-wrapper.json`;
  `parity:api:calls`, `parity:api:calls:args` and `parity:api:calls:tighten` are
  all clean (nothing stale to tighten).

`exception_wrapper_test.rb`'s `#traces returns every trace by category
enumerated with an index` is ported to assert the three keys, the id
enumeration, the frame ids, and the application/framework split.

### Second story in the bundle: already landed

`resolve-owner-by-static-and-include-graph-instead-of-skipping` is implemented
in `main` by #6665 — `resolveTsOwner` already carries the include-graph `hosts`
arm and the `OwnerSeat` arm, `ambiguousRubyOwner` already resolves via
`rubyOwnersOnTsSeat`, and `compare.test.ts`'s `resolveTsOwner — include graph
and seats` covers both resolutions. Marked done against #6665; no code here.

Closes-story: converge-exception-wrapper-traces-partition
