### PR TITLE
refactor(parity): converge Request#method, TimeWithZone#to_fs and Array#first

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Request, PassNotFound } from "../request.js";
 import { MimeType } from "../http/mime-type.js";
 import { X_CASCADE } from "../constants.js";
+import { UnknownHttpMethod } from "../../action-controller/metal/exceptions.js";
 
 describe("RequestUrlFor", () => {
   it("url_for class method", () => {
@@ -203,42 +204,59 @@ describe("RequestMethod", () => {
   });
 
   it("allow request method hacking", () => {
-    const req = new Request({
-      REQUEST_METHOD: "POST",
-      "action_dispatch.request.parameters": { _method: "put" },
-    });
-    expect(req.method).toBe("PUT");
+    const req = new Request({ REQUEST_METHOD: "POST" });
+
+    expect(req.requestMethod).toBe("POST");
+    expect(req.env["REQUEST_METHOD"]).toBe("POST");
+
+    req.requestMethod = "GET";
+
+    expect(req.requestMethod).toBe("GET");
+    expect(req.env["REQUEST_METHOD"]).toBe("GET");
+    expect(req.isGet).toBe(true);
   });
 
   it("method returns original value of environment request method on POST", () => {
-    const req = new Request({
-      REQUEST_METHOD: "POST",
-      HTTP_X_HTTP_METHOD_OVERRIDE: "PATCH",
-    });
-    expect(req.method).toBe("PATCH");
-    expect(req.requestMethod).toBe("POST");
+    const req = new Request({ "rack.methodoverride.original_method": "POST" });
+    expect(req.method).toBe("POST");
   });
 
   it("post masquerading as patch", () => {
     const req = new Request({
-      REQUEST_METHOD: "POST",
-      HTTP_X_HTTP_METHOD_OVERRIDE: "PATCH",
+      REQUEST_METHOD: "PATCH",
+      "rack.methodoverride.original_method": "POST",
     });
-    expect(req.method).toBe("PATCH");
+
+    expect(req.method).toBe("POST");
+    expect(req.requestMethod).toBe("PATCH");
     expect(req.isPatch).toBe(true);
   });
 
   it("post masquerading as put", () => {
     const req = new Request({
-      REQUEST_METHOD: "POST",
-      HTTP_X_HTTP_METHOD_OVERRIDE: "PUT",
+      REQUEST_METHOD: "PUT",
+      "rack.methodoverride.original_method": "POST",
     });
-    expect(req.method).toBe("PUT");
+    expect(req.method).toBe("POST");
+    expect(req.requestMethod).toBe("PUT");
     expect(req.isPut).toBe(true);
   });
 
-  it.skip("invalid http method raises exception", () => {}); // checkMethod not wired into requestMethod getter
-  it.skip("method raises exception on invalid HTTP method", () => {}); // checkMethod not wired into method getter
+  it("invalid http method raises exception", () => {
+    expect(() => new Request({ REQUEST_METHOD: "RANDOM_METHOD" }).requestMethod).toThrow(
+      UnknownHttpMethod,
+    );
+  });
+
+  it("method raises exception on invalid HTTP method", () => {
+    expect(
+      () => new Request({ "rack.methodoverride.original_method": "_RANDOM_METHOD" }).method,
+    ).toThrow(UnknownHttpMethod);
+
+    expect(() => new Request({ REQUEST_METHOD: "_RANDOM_METHOD" }).method).toThrow(
+      UnknownHttpMethod,
+    );
+  });
   it.skip("exception on invalid HTTP method unaffected by I18n settings", () => {}); // no I18n
   it.skip("post uneffected by local inflections", () => {}); // no Inflector integration
   it.skip("delegates to Object#method if an argument is passed", () => {}); // TS getter cannot accept arguments

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -150,9 +150,7 @@ function envName(key: string): string {
 export class Request {
   readonly env: RackEnv;
 
-  /** Rails' `@method` memo (request.rb:214). */
   #method?: string;
-  /** Rails' `@request_method` memo (request.rb:151). */
   #requestMethod?: string;
 
   constructor(env: RackEnv = {}) {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -73,7 +73,7 @@ const ACTION_DISPATCH_REQUEST_ID = "action_dispatch.request_id";
 const FORM_DATA_MEDIA_TYPES = ["application/x-www-form-urlencoded", "multipart/form-data"] as const;
 const LOCALHOST_RE = /^(?:127(?:\.\d{1,3}){3}|::1|0:0:0:0:0:0:0:1(?:%.*)?)$/;
 
-const RFC_METHODS = [
+const HTTP_METHODS = [
   "OPTIONS",
   "GET",
   "HEAD",
@@ -110,7 +110,7 @@ const RFC_METHODS = [
 // prototype-chain lookups into apparent membership in `checkMethod`.
 const HTTP_METHOD_LOOKUP: Record<string, string> = Object.assign(
   Object.create(null) as Record<string, string>,
-  Object.fromEntries(RFC_METHODS.map((m) => [m, m.toLowerCase().replace(/-/g, "_")])),
+  Object.fromEntries(HTTP_METHODS.map((m) => [m, m.toLowerCase().replace(/-/g, "_")])),
 );
 
 const HTTP_HEADER_NAME = /^[A-Za-z0-9-]+$/;
@@ -757,7 +757,7 @@ export class Request {
     if (name != null) {
       if (!Object.hasOwn(HTTP_METHOD_LOOKUP, name)) {
         throw new UnknownHttpMethod(
-          `${name}, accepted HTTP methods are ${toSentence([...RFC_METHODS], { locale: false })}`,
+          `${name}, accepted HTTP methods are ${toSentence([...HTTP_METHODS], { locale: false })}`,
         );
       }
     }

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -5,8 +5,10 @@
  * mirroring the Rails Request API.
  */
 
+import { toSentence } from "@blazetrails/activesupport";
 import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
 import { parseNestedQuery, Request as RackRequest } from "@blazetrails/rack";
+import { UnknownHttpMethod } from "../../action-controller/metal/exceptions.js";
 import { Session } from "../request/session.js";
 import {
   etagMatches as _etagMatches,
@@ -148,6 +150,11 @@ function envName(key: string): string {
 export class Request {
   readonly env: RackEnv;
 
+  /** Rails' `@method` memo (request.rb:214). */
+  #method?: string;
+  /** Rails' `@request_method` memo (request.rb:151). */
+  #requestMethod?: string;
+
   constructor(env: RackEnv = {}) {
     this.env = { ...env };
     // Set defaults
@@ -162,49 +169,59 @@ export class Request {
 
   // --- HTTP method ---
 
-  private _requestMethod?: string;
-
+  /**
+   * Returns the original value of the environment's REQUEST_METHOD, even if it
+   * was overridden by middleware. See {@link requestMethod}. Mirrors
+   * `Request#method` (request.rb:212-221); the `*args` arm delegating to
+   * `Object#method` has no spelling on a TS getter.
+   */
   get method(): string {
-    // Check for method override via _method parameter or X-Http-Method-Override header
-    if (this.requestMethod === "POST") {
-      const override =
-        (this.getHeader("HTTP_X_HTTP_METHOD_OVERRIDE") as string) ?? this.params?.["_method"];
-      if (override) {
-        const upper = String(override).toUpperCase();
-        if (["GET", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS"].includes(upper)) {
-          return upper;
-        }
-      }
-    }
-    return this.requestMethod;
+    this.#method ??= this.checkMethod(
+      this.getHeader("rack.methodoverride.original_method") ?? this.getHeader("REQUEST_METHOD"),
+    );
+    return this.#method as string;
   }
 
+  /**
+   * Returns the HTTP method that the application should see — the overridden
+   * value where a middleware rewrote it. Mirrors `Request#request_method`
+   * (request.rb:145-152).
+   */
   get requestMethod(): string {
-    return (this._requestMethod ??= this.checkMethod(this.getHeader("REQUEST_METHOD"))!);
+    this.#requestMethod ??= this.checkMethod(this.rawRequestMethod);
+    return this.#requestMethod as string;
   }
 
-  /** Mirrors: `alias raw_request_method request_method` (request.rb:145). */
+  /** @internal Mirrors `Request#request_method=` (request.rb:184-188). */
+  set requestMethod(requestMethod: string) {
+    if (this.checkMethod(requestMethod)) {
+      this.#requestMethod = this.setHeader("REQUEST_METHOD", requestMethod) as string;
+    }
+  }
+
+  /** Mirrors: `alias raw_request_method request_method` (request.rb:145) — the
+   * unchecked `Rack::Request::Helpers#request_method`. */
   get rawRequestMethod(): string {
-    return this.requestMethod;
+    return this.getHeader("REQUEST_METHOD") as string;
   }
 
   get isGet(): boolean {
-    return this.method === "GET";
+    return this.requestMethod === "GET";
   }
   get isHead(): boolean {
-    return this.method === "HEAD";
+    return this.requestMethod === "HEAD";
   }
   get isPost(): boolean {
-    return this.method === "POST";
+    return this.requestMethod === "POST";
   }
   get isPut(): boolean {
-    return this.method === "PUT";
+    return this.requestMethod === "PUT";
   }
   get isPatch(): boolean {
-    return this.method === "PATCH";
+    return this.requestMethod === "PATCH";
   }
   get isDelete(): boolean {
-    return this.method === "DELETE";
+    return this.requestMethod === "DELETE";
   }
 
   // --- URL components ---
@@ -737,12 +754,16 @@ export class Request {
     return HTTP_METHOD_LOOKUP[this.requestMethod];
   }
 
-  /** @internal Validates `name` against the RFC methods list. */
+  /** @internal Mirrors `Request#check_method` (request.rb:497-503). */
   protected checkMethod(name: string | undefined): string | undefined {
-    if (!name) return name;
-    if (!Object.hasOwn(HTTP_METHOD_LOOKUP, name)) {
-      throw new Error(`${name}, accepted HTTP methods are ${RFC_METHODS.join(", ")}`);
+    if (name != null) {
+      if (!Object.hasOwn(HTTP_METHOD_LOOKUP, name)) {
+        throw new UnknownHttpMethod(
+          `${name}, accepted HTTP methods are ${toSentence([...RFC_METHODS], { locale: false })}`,
+        );
+      }
     }
+
     return name;
   }
 

--- a/packages/actionpack/src/action-dispatch/testing/test-request.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-request.ts
@@ -31,14 +31,6 @@ export class TestRequest extends Request {
     return new TestRequest(merged);
   }
 
-  get requestMethod(): string {
-    return ((this.env["REQUEST_METHOD"] as string) || "GET").toUpperCase();
-  }
-
-  set requestMethod(method: string) {
-    this.setHeader("REQUEST_METHOD", method.toUpperCase());
-  }
-
   get host(): string {
     return super.host;
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1,6 +1,7 @@
 import { Temporal } from "@blazetrails/date";
 import { except, hexdigest, isBlank, Notifications, toFs } from "@blazetrails/activesupport";
 import { isEmpty } from "./ruby-empty.js";
+import { first } from "./ruby-first.js";
 import { Table, SelectManager, Nodes, sql } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { threadedConnectionFor } from "./connection-handling.js";
@@ -3381,11 +3382,7 @@ export class Relation<T extends Base> {
     return this._cacheVersions.get(timestampColumn)!;
   }
 
-  /**
-   * @internal
-   * @missingRailsCall first — Ruby's `Array#first` on the `select_rows` result; JS
-   *   arrays have no such method and `[0]` is the whole of it.
-   */
+  /** @internal */
   async computeCacheVersion(timestampColumn = "updated_at"): Promise<string> {
     timestampColumn = String(timestampColumn);
 
@@ -3460,7 +3457,7 @@ export class Relation<T extends Base> {
         arel = query.toArel();
       }
 
-      [size, timestamp] = (await c.selectRows(arel, null))[0] ?? [];
+      [size, timestamp] = first(await c.selectRows(arel, null)) ?? [];
 
       if (size != null) {
         const columnType = this.model.typeForAttribute(timestampColumn);

--- a/packages/activerecord/src/ruby-first.ts
+++ b/packages/activerecord/src/ruby-first.ts
@@ -1,0 +1,29 @@
+/**
+ * Ruby `Array#first`, for ports of Ruby collection readers.
+ *
+ * This has no Rails counterpart — `Array#first` is Ruby core, the same way the
+ * sibling `ruby-empty.ts` models `empty?` and `ruby-truthy.ts` models Ruby
+ * truthiness. It lives here rather than in activesupport for the same reason
+ * those do: the call-set comparator resolves a Ruby call name against the
+ * PORTED names of the package the call appears in, so exporting `first` from
+ * activesupport would make every Ruby `first` in an activesupport body
+ * resolvable and surface a pile of unrelated divergences at once. activerecord
+ * already resolves `first` (`ActiveRecord::Relation#first`), so the population
+ * here is unchanged.
+ *
+ * It exists because the faithful spelling — `rows[0]` — is an index read, so a
+ * faithfully ported body emits no call at all and the call-set gate (RFC 0047)
+ * has nothing to credit the Ruby `first` with. Calling it keeps the Ruby method
+ * visible in the TS body, which is what the gate measures and what a Rails dev
+ * reads.
+ *
+ * Only the no-argument Array arm is ported, the way `ruby-empty.ts` limited
+ * itself to its own receivers. Ruby's `first(n)` returns an Array and
+ * `Enumerable#first` also answers on Hash and Range; no trails caller needs
+ * either yet, and porting an unused arm is surface the ports do not read.
+ *
+ * @internal
+ */
+export function first<T>(value: readonly T[]): T | undefined {
+  return value[0];
+}

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -666,12 +666,17 @@ export function secFraction(
 export { secFraction as subsec };
 
 /**
- * The receivers `Time::DATE_FORMATS`' lambdas duck-type: a ruby/date `Time` and
- * the `PlainDateTime | ZonedDateTime` seat a Ruby `DateTime` stands on. Both
- * answer `day`, `strftime`, `formatted_offset`, `rfc2822` and `iso8601`, which
- * is every member those lambdas call.
+ * The receivers `Time::DATE_FORMATS`' lambdas duck-type: a ruby/date `Time`,
+ * the `PlainDateTime | ZonedDateTime` seat a Ruby `DateTime` stands on, and a
+ * `TimeWithZone` — `time_with_zone.rb:212-220` resolves the same hash and
+ * passes `self`. All three answer `day`, `strftime`, `formatted_offset`,
+ * `rfc2822` and `iso8601`, which is every member those lambdas call.
  */
-type DateFormatsReceiver = RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+type DateFormatsReceiver =
+  | RubyTime
+  | TimeWithZone
+  | Temporal.PlainDateTime
+  | Temporal.ZonedDateTime;
 
 /**
  * The named formats `to_fs` resolves, either a `strftime` string or a callable
@@ -713,21 +718,31 @@ export const DATE_FORMATS: Record<string, string | ((time: DateFormatsReceiver) 
   long: "%B %d, %Y %H:%M",
   long_ordinal: (time) => {
     const dayFormat = ordinalize(time.day);
-    return (time instanceof RubyTime ? time : new RubyDateTime(time)).strftime(
-      `%B ${dayFormat}, %Y %H:%M`,
-    );
+    return (
+      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
+    ).strftime(`%B ${dayFormat}, %Y %H:%M`);
   },
   rfc822: (time) => {
     const offsetFormat =
       time instanceof RubyTime
         ? formattedOffset(time, false)
-        : dateTimeFormattedOffset(time, false);
-    return (time instanceof RubyTime ? time : new RubyDateTime(time)).strftime(
-      `%a, %d %b %Y %H:%M:%S ${offsetFormat}`,
-    );
+        : time instanceof TimeWithZone
+          ? time.formattedOffset(false)
+          : dateTimeFormattedOffset(time, false);
+    return (
+      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
+    ).strftime(`%a, %d %b %Y %H:%M:%S ${offsetFormat}`);
   },
-  rfc2822: (time) => (time instanceof RubyTime ? time : new RubyDateTime(time)).rfc2822(),
-  iso8601: (time) => (time instanceof RubyTime ? time : new RubyDateTime(time)).iso8601(),
+  rfc2822: (time) =>
+    (time instanceof RubyTime || time instanceof TimeWithZone
+      ? time
+      : new RubyDateTime(time)
+    ).rfc2822(),
+  iso8601: (time) =>
+    (time instanceof RubyTime || time instanceof TimeWithZone
+      ? time
+      : new RubyDateTime(time)
+    ).iso8601(),
 };
 
 /**

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -4,7 +4,7 @@ import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
 import { Temporal } from "@blazetrails/date";
-import { DATE_FORMATS, inTimeZone } from "./time-ext.js";
+import { inTimeZone } from "./time-ext.js";
 import { setZone, zone as timeZone } from "./time-zone-config.js";
 
 describe("TimeWithZoneTest", () => {
@@ -848,23 +848,6 @@ describe("TimeWithZoneTest", () => {
   it("to fs not existent", () => {
     const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.toFs("not_existent")).toBe("1999-12-31 19:00:00 -0500");
-  });
-
-  // Trails-only: every `Time::DATE_FORMATS` key answers on a TimeWithZone
-  // (time_with_zone.rb:212-220), including one registered after boot.
-  it("to fs resolves through Time::DATE_FORMATS", () => {
-    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
-    expect(twz.toFs("number")).toBe("19991231190000");
-    expect(twz.toFs("usec")).toBe("19991231190000000000");
-    expect(twz.toFs("nsec")).toBe("19991231190000000000000");
-    expect(twz.toFs("time")).toBe("19:00");
-
-    DATE_FORMATS["shouty"] = "%Y!";
-    try {
-      expect(twz.toFs("shouty")).toBe("1999!");
-    } finally {
-      delete DATE_FORMATS["shouty"];
-    }
   });
 
   it("strftime with composite format", () => {

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -4,7 +4,7 @@ import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
 import { Temporal } from "@blazetrails/date";
-import { inTimeZone } from "./time-ext.js";
+import { DATE_FORMATS, inTimeZone } from "./time-ext.js";
 import { setZone, zone as timeZone } from "./time-zone-config.js";
 
 describe("TimeWithZoneTest", () => {
@@ -827,6 +827,44 @@ describe("TimeWithZoneTest", () => {
   it("to fs iso8601", () => {
     const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
     expect(twz.toFs("iso8601")).toBe(twz.xmlschema());
+  });
+
+  it("to fs", () => {
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
+    expect(twz.toFs()).toBe("1999-12-31 19:00:00 -0500");
+  });
+
+  it("to fs db", () => {
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
+    expect(twz.toFs("db")).toBe("2000-01-01 00:00:00");
+    expect(twz.toFormattedS("db")).toBe("2000-01-01 00:00:00");
+  });
+
+  it("to fs inspect", () => {
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
+    expect(twz.toFs("inspect")).toBe("1999-12-31 19:00:00.000000000 -0500");
+  });
+
+  it("to fs not existent", () => {
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
+    expect(twz.toFs("not_existent")).toBe("1999-12-31 19:00:00 -0500");
+  });
+
+  // Trails-only: every `Time::DATE_FORMATS` key answers on a TimeWithZone
+  // (time_with_zone.rb:212-220), including one registered after boot.
+  it("to fs resolves through Time::DATE_FORMATS", () => {
+    const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0, 0, 0))), eastern);
+    expect(twz.toFs("number")).toBe("19991231190000");
+    expect(twz.toFs("usec")).toBe("19991231190000000000");
+    expect(twz.toFs("nsec")).toBe("19991231190000000000000");
+    expect(twz.toFs("time")).toBe("19:00");
+
+    DATE_FORMATS["shouty"] = "%Y!";
+    try {
+      expect(twz.toFs("shouty")).toBe("1999!");
+    } finally {
+      delete DATE_FORMATS["shouty"];
+    }
   });
 
   it("strftime with composite format", () => {

--- a/packages/activesupport/src/time-with-zone.trails.test.ts
+++ b/packages/activesupport/src/time-with-zone.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Temporal } from "@blazetrails/date";
+import { DATE_FORMATS } from "./time-ext.js";
 
 // Ruby's Time carries full nanosecond precision, so %N answers nine significant
 // digits (time_with_zone.rb:223-227 delegates strftime to that Time). These
@@ -37,5 +38,29 @@ describe("TimeWithZone sub-millisecond precision", () => {
     expect(subMs().xmlschema(3)).toBe("1999-12-31T19:00:00.123-05:00");
     expect(subMs().xmlschema(6)).toBe("1999-12-31T19:00:00.123456-05:00");
     expect(subMs().xmlschema(9)).toBe("1999-12-31T19:00:00.123456789-05:00");
+  });
+});
+
+// `to_fs` resolves through `Time::DATE_FORMATS` (time_with_zone.rb:212-220), so
+// every key in that hash answers here — including one an app registers at boot.
+describe("TimeWithZone to_fs over Time::DATE_FORMATS", () => {
+  const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+  const twz = () => new TimeWithZone(Temporal.Instant.from("2000-01-01T00:00:00Z"), eastern);
+
+  it("resolves every built-in key", () => {
+    expect(twz().toFs("number")).toBe("19991231190000");
+    expect(twz().toFs("usec")).toBe("19991231190000000000");
+    expect(twz().toFs("nsec")).toBe("19991231190000000000000");
+    expect(twz().toFs("time")).toBe("19:00");
+    expect(twz().toFs("long_ordinal")).toBe("December 31st, 1999 19:00");
+  });
+
+  it("reaches a format registered after boot", () => {
+    DATE_FORMATS["shouty"] = "%Y!";
+    try {
+      expect(twz().toFs("shouty")).toBe("1999!");
+    } finally {
+      delete DATE_FORMATS["shouty"];
+    }
   });
 });

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -13,6 +13,7 @@ import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { Rational, cCivilToJd, strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
+import { DATE_FORMATS, toFs } from "./time-ext.js";
 import {
   preserveTimezone,
   utcToLocalReturnsUtcOffsetTimes,
@@ -493,41 +494,33 @@ export class TimeWithZone {
     );
   }
 
-  /** Named format strings, matching Rails to_fs / to_formatted_s */
+  /**
+   * Returns a string of the object's date and time.
+   *
+   * Mirrors: `TimeWithZone#to_fs` (`time_with_zone.rb:212-220`). Every key in
+   * `Time::DATE_FORMATS` works here, including one an app registers at boot —
+   * the registry is read at call time, so a late registration is reachable.
+   *
+   * `DATE_FORMATS` comes from `time-ext.ts`, which imports this file back. The
+   * edge is not a TDZ hazard: neither side reads the other at module-eval time
+   * (this read is inside the method, and `time-ext`'s `TimeWithZone` uses are
+   * inside function bodies) and neither declares a `class ... extends` across
+   * it.
+   */
   toFs(format: string = "default"): string {
-    switch (format) {
-      case "db": {
-        const u = this._utc;
-        return (
-          `${u.year}-${pad2(u.month)}-${pad2(u.day)} ` +
-          `${pad2(u.hour)}:${pad2(u.minute)}:${pad2(u.second)}`
-        );
-      }
-      case "long":
-        return this.strftime("%B %d, %Y %H:%M");
-      case "short":
-        return this.strftime("%d %b %H:%M");
-      case "rfc822":
-      case "rfc2822":
-        return this.rfc2822();
-      case "iso8601":
-      case "xmlschema":
-        return this.xmlschema();
-      case "inspect": {
-        const li = this._local();
-        const nsi = String(li.nsec).padStart(9, "0");
-        return (
-          `${li.year}-${pad2(li.month)}-${pad2(li.day)} ` +
-          `${pad2(li.hour)}:${pad2(li.minute)}:${pad2(li.second)}.${nsi} ` +
-          `${this.formattedOffset(false)}`
-        );
-      }
-      default:
+    if (format === "db") {
+      return toFs(this.utc(), format);
+    } else {
+      const formatter = DATE_FORMATS[format];
+      if (formatter != null) {
+        return typeof formatter === "function" ? String(formatter(this)) : this.strftime(formatter);
+      } else {
         return this.toString();
+      }
     }
   }
 
-  /** Alias for toFs */
+  /** `alias_method :to_formatted_s, :to_fs` (time_with_zone.rb:221). */
   toFormattedS(format?: string): string {
     return this.toFs(format);
   }

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/request.json
@@ -44,17 +44,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
-    "rubyName": "method",
-    "call": "get_header",
-    "kind": "args",
-    "rubyArgs": [
-      "str:rack.methodoverride.original_method"
-    ],
-    "reason": "request.rb:212-221 makes `method` the PRE-override HTTP method, read from `rack.methodoverride.original_method` before `REQUEST_METHOD`; trails inverts the pair — `method` applies an override it reads from `HTTP_X_HTTP_METHOD_OVERRIDE`/`_method` inline, and `requestMethod` is the raw value. Converging needs both readers and the override site moved, tracked as story converge-request-method-onto-methodoverride-original-method."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
     "rubyName": "request_parameters_list",
     "call": "get_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-with-zone.json
@@ -65,17 +65,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-with-zone.ts",
-    "rubyName": "to_fs",
-    "call": "strftime",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:formatter"
-    ],
-    "reason": "trails has no `Time::DATE_FORMATS` registry, so `to_fs` switches on the format name and passes that entry's format string literally where Rails passes the looked-up `formatter`. Porting the registry is tracked as its own story (0023-surfaced-deviations/port-time-date-formats-registry)."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-with-zone.ts",
     "rubyName": "to_s",
     "call": "strftime",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Three converge-only stories, no new behavior beyond Rails'.

## `Request#method` reads the wrong env key (and inverts `request_method`)

Rails (`actionpack/lib/action_dispatch/http/request.rb:212-221`): `method` is
the **pre-override** HTTP method — `rack.methodoverride.original_method ||
REQUEST_METHOD`, memoized and run through `check_method` — while
`request_method` (:145-152) is the possibly-overridden one. trails had the two
inverted: `method` applied an `HTTP_X_HTTP_METHOD_OVERRIDE` / `_method`
override inline, which is `Rack::MethodOverride`'s job and is already ported at
`packages/rack/src/method-override.ts`.

- `method` / `request_method` carry Rails' meanings, with Rails' `@method` /
  `@request_method` memos.
- `check_method` raises `ActionController::UnknownHttpMethod` with Rails'
  `to_sentence` message (:497-503) instead of a bare `Error`.
- `request_method=` lands on `Request` where Rails declares it (:184-188), so
  `TestRequest`'s bespoke uppercasing override is deleted.
- `raw_request_method` reads the unchecked env value the alias captures.
- `get?`/`post?`/… read `request_method`, as `Rack::Request::Helpers` does.
- The three formerly-skipped tests are enrolled and the override tests now
  mirror `request_test.rb:735-805` verbatim.

## `TimeWithZone#to_fs` must resolve through `Time::DATE_FORMATS`

`time_with_zone.rb:212-220`, three arms: the `:db` delegation to the UTC
receiver's `to_fs`, the `Time::DATE_FORMATS` lookup with the
callable-vs-`strftime` split, then `to_s`. The hand-rolled switch is gone, so
`:usec`, `:nsec`, `:number` and `:time` render correctly on a `TimeWithZone`
and an app-registered format is reachable. `DATE_FORMATS`' duck-typed receiver
widens to include `TimeWithZone`, which answers `strftime`/`rfc2822`/`iso8601`
itself. The `time-ext` ↔ `time-with-zone` edge is read-at-call-time on both
sides and declares no `class ... extends` across it; verified TDZ-free by
importing the built `dist/` modules as entry modules under plain node.

## Ruby `Array#first` has no TS call spelling

`packages/activerecord/src/ruby-first.ts`, following `ruby-empty.ts` including
its placement rationale (it must live in activerecord, not activesupport).
`Relation#compute_cache_version`'s `select_rows(arel, nil).first`
(`relation.rb:509`) calls it and its `@missingRailsCall first` receipt is
deleted.

The two other `@missingRailsCall first` tags (`internal-metadata.ts`,
`schema-migration.ts`) are **not** converted: their Ruby receiver is a plain
local, so `first(values)` reads as a call-argument mismatch against Ruby's
zero-arg `values.first` and the args ratchet would need a new baseline row —
which this PR will not add. Left as pre-existing debt.

## Gates

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green, three
call-set rows and one call-arg row retired by hand (no reseed).
`parity:api:extra --package activerecord` clean. actionpack, activesupport,
rack and the AR cache-key suites pass locally. The Rails-mirroring test names
land in the Rails-named files; the two trails-only DATE_FORMATS assertions live
in `time-with-zone.trails.test.ts`.

Closes-story: converge-request-method-onto-methodoverride-original-method
Closes-story: ruby-first-has-no-ts-call-spelling
Closes-story: time-with-zone-to-fs-through-date-formats