### PR TITLE
fix(actionpack): converge Response#cookies onto the Set-Cookie header

### DIFF
--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -153,7 +153,7 @@ export class TestCase {
   }
 
   /** Cookies jar from the response. */
-  get cookies(): Record<string, string> {
+  get cookies(): Record<string, string | undefined> {
     return this.response?.cookies ?? {};
   }
 

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -91,22 +91,35 @@ describe("ResponseTest", () => {
 
   it("cookies", () => {
     const res = new Response();
-    res.setCookie("foo", "bar");
-    expect(res.cookies).toEqual({ foo: "bar" });
+    res.setCookie("user_name", { value: "david", path: "/" });
+    expect(res.headers["set-cookie"]).toBe("user_name=david; path=/");
+    expect(res.cookies).toEqual({ user_name: "david" });
   });
 
   it("multiple cookies", () => {
     const res = new Response();
-    res.setCookie("foo", "bar");
-    res.setCookie("baz", "qux");
-    expect(res.cookies).toEqual({ foo: "bar", baz: "qux" });
+    res.setCookie("user_name", { value: "david", path: "/" });
+    res.setCookie("login", {
+      value: "foo&bar",
+      path: "/",
+      expires: new Date(Date.UTC(2005, 9, 10, 5)),
+    });
+    expect(res.headers["set-cookie"]).toBe(
+      "user_name=david; path=/\nlogin=foo%26bar; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT",
+    );
+    expect(res.cookies).toEqual({ login: "foo&bar", user_name: "david" });
   });
 
   it("delete cookies", () => {
     const res = new Response();
-    res.setCookie("foo", "bar");
-    res.deleteCookie("foo");
-    expect(res.cookies.foo).toBe("");
+    res.setCookie("user_name", { value: "david", path: "/" });
+    res.setCookie("login", {
+      value: "foo&bar",
+      path: "/",
+      expires: new Date(Date.UTC(2005, 9, 10, 5)),
+    });
+    res.deleteCookie("login");
+    expect(res.cookies).toEqual({ user_name: "david", login: "" });
   });
 
   it("read ETag and Cache-Control", () => {

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -325,10 +325,15 @@ export class Response {
    * drops the trailing empty field so a deleted cookie reads back as `nil`;
    * JS keeps it, so the same pair reads back as `""`. A pair with no `=` at
    * all yields `nil` in Ruby and `undefined` here, hence the value type.
+   *
+   * The array arm mirrors Rails' `header.respond_to?(:to_str)` branch, which
+   * exists because Rack stores `Set-Cookie` as an Array of values. Our header
+   * hash is string-valued, so `getHeader` only ever returns the split arm — the
+   * branch is kept so the body reads as the same method.
    */
   get cookies(): Record<string, string | undefined> {
     const cookies: Record<string, string | undefined> = {};
-    let header = this.getHeader(SET_COOKIE) as string | string[] | undefined;
+    let header: string | string[] | undefined = this.getHeader(SET_COOKIE);
     if (header != null) {
       if (typeof header === "string") header = header.split("\n");
       for (const cookie of header) {

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -290,13 +290,17 @@ export class Response {
 
   // --- Cookies ---
 
-  /** @internal Mirrors `Rack::Response::Helpers#set_cookie` (rack/response.rb:270-272). */
+  /**
+   * Mirrors `Rack::Response::Helpers#set_cookie` (rack-3.1.12
+   * rack/response.rb:270-272). Rack's `add_header` keeps an Array of values;
+   * our header hash is string-valued, so they are newline-joined — the shape
+   * `cookies` reads back with `split("\n")`.
+   *
+   * @internal
+   */
   setCookie(name: string, value: string | CookieOptions): void {
     const header = this.getHeader(SET_COOKIE);
     const cookie = setCookieHeader(name, rackCookieValue(value));
-    // Rack joins multiple Set-Cookie values with a newline on the way out
-    // (`Rack::Response#add_header` keeps an Array; our header hash is
-    // string-valued, and `cookies` below splits on "\n" to read it back).
     this.setHeader(SET_COOKIE, header === undefined ? cookie : `${header}\n${cookie}`);
   }
 
@@ -310,7 +314,11 @@ export class Response {
     this.setHeader(SET_COOKIE, Array.isArray(header) ? header.join("\n") : header);
   }
 
-  /** Mirrors `Response#cookies` (response.rb:418-430). */
+  /**
+   * Mirrors `Response#cookies` (response.rb:418-430). Ruby's `"k=".split("=")`
+   * drops the trailing empty field so a deleted cookie reads back as `nil`;
+   * JS keeps it, so the same pair reads back as `""`.
+   */
   get cookies(): Record<string, string> {
     const cookies: Record<string, string> = {};
     let header = this.getHeader(SET_COOKIE) as string | string[] | undefined;

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -5,6 +5,7 @@
  */
 
 import { getFs } from "@blazetrails/activesupport";
+import { deleteSetCookieHeaderBang, setCookieHeader, unescape } from "@blazetrails/rack";
 import type { CookieExpires } from "../middleware/cookies.js";
 import type { Request } from "./request.js";
 import {
@@ -36,6 +37,7 @@ import {
 // Lowercase to match the rest of this file's header conventions; setHeader
 // is case-insensitive but call sites read `headers["content-type"]` directly.
 const CONTENT_TYPE = "content-type";
+const SET_COOKIE = "set-cookie";
 const NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304] as const;
 const CONTENT_TYPE_PARSER =
   /^(?<mime_type>[^;\s]+\s*(?:;\s*(?!charset)[^;\s]+)*)?(?:;\s*charset="?(?<charset>[^;\s"]+)"?)?/;
@@ -103,7 +105,6 @@ export class Response {
   private _body: string[];
   private _committed = false;
   private _charset: string | undefined;
-  private _cookies: Map<string, CookieValue> = new Map();
   private _sending = false;
   private _sent = false;
   stream: unknown = null;
@@ -289,30 +290,41 @@ export class Response {
 
   // --- Cookies ---
 
-  /** @internal */
+  /** @internal Mirrors `Rack::Response::Helpers#set_cookie` (rack/response.rb:270-272). */
   setCookie(name: string, value: string | CookieOptions): void {
-    if (typeof value === "string") {
-      this._cookies.set(name, { value });
-    } else {
-      this._cookies.set(name, value);
-    }
+    const header = this.getHeader(SET_COOKIE);
+    const cookie = setCookieHeader(name, rackCookieValue(value));
+    // Rack joins multiple Set-Cookie values with a newline on the way out
+    // (`Rack::Response#add_header` keeps an Array; our header hash is
+    // string-valued, and `cookies` below splits on "\n" to read it back).
+    this.setHeader(SET_COOKIE, header === undefined ? cookie : `${header}\n${cookie}`);
   }
 
+  /** Mirrors `Rack::Response::Helpers#delete_cookie` (rack/response.rb:274-280). */
   deleteCookie(name: string, options: Partial<CookieOptions> = {}): void {
-    this._cookies.set(name, {
-      value: "",
-      // boundary: epoch-zero Date is the standard delete-cookie sentinel.
-      expires: new Date(0),
-      ...options,
-    });
+    const header = deleteSetCookieHeaderBang(
+      this.getHeader(SET_COOKIE) ?? null,
+      name,
+      rackCookieValue({ value: "", ...options }),
+    );
+    this.setHeader(SET_COOKIE, Array.isArray(header) ? header.join("\n") : header);
   }
 
+  /** Mirrors `Response#cookies` (response.rb:418-430). */
   get cookies(): Record<string, string> {
-    const result: Record<string, string> = {};
-    for (const [name, opts] of this._cookies) {
-      result[name] = opts.value;
+    const cookies: Record<string, string> = {};
+    let header = this.getHeader(SET_COOKIE) as string | string[] | undefined;
+    if (header != null) {
+      if (typeof header === "string") header = header.split("\n");
+      for (const cookie of header) {
+        const pair = cookie.split(";")[0];
+        if (pair) {
+          const [key, value] = pair.split("=").map((v) => unescape(v));
+          cookies[key] = value ?? "";
+        }
+      }
     }
-    return result;
+    return cookies;
   }
 
   // --- Cache-Control (raw string accessor; Rails aliases this as `_cache_control`) ---
@@ -718,7 +730,28 @@ export interface CookieOptions {
   sameSite?: "strict" | "lax" | "none";
 }
 
-type CookieValue = CookieOptions;
+/**
+ * Rails hands `Rack::Utils.set_cookie_header` the cookie option hash
+ * untouched; our options are camelCased, so translate the keys back to the
+ * Rack spellings at the boundary.
+ */
+function rackCookieValue(value: string | Partial<CookieOptions>): Record<string, unknown> {
+  const opts = typeof value === "string" ? { value } : value;
+  return {
+    value: opts.value ?? "",
+    path: opts.path,
+    domain: opts.domain,
+    // boundary: `Rack::Utils.set_cookie_header` formats `expires` through
+    // `Date#toUTCString`, so a Temporal.Instant is narrowed to a JS Date here.
+    expires:
+      opts.expires === undefined || opts.expires instanceof Date
+        ? opts.expires
+        : new Date(opts.expires.epochMilliseconds),
+    secure: opts.secure,
+    httponly: opts.httpOnly,
+    same_site: opts.sameSite,
+  };
+}
 
 const STATUS_MESSAGES: Record<number, string> = {
   100: "Continue",

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -323,10 +323,11 @@ export class Response {
   /**
    * Mirrors `Response#cookies` (response.rb:418-430). Ruby's `"k=".split("=")`
    * drops the trailing empty field so a deleted cookie reads back as `nil`;
-   * JS keeps it, so the same pair reads back as `""`.
+   * JS keeps it, so the same pair reads back as `""`. A pair with no `=` at
+   * all yields `nil` in Ruby and `undefined` here, hence the value type.
    */
-  get cookies(): Record<string, string> {
-    const cookies: Record<string, string> = {};
+  get cookies(): Record<string, string | undefined> {
+    const cookies: Record<string, string | undefined> = {};
     let header = this.getHeader(SET_COOKIE) as string | string[] | undefined;
     if (header != null) {
       if (typeof header === "string") header = header.split("\n");
@@ -334,7 +335,7 @@ export class Response {
         const pair = cookie.split(";")[0];
         if (pair) {
           const [key, value] = pair.split("=").map((v) => unescape(v));
-          cookies[key] = value ?? "";
+          cookies[key] = value;
         }
       }
     }

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -37,6 +37,8 @@ import {
 // Lowercase to match the rest of this file's header conventions; setHeader
 // is case-insensitive but call sites read `headers["content-type"]` directly.
 const CONTENT_TYPE = "content-type";
+// Rails spells this `SET_COOKIE = "Set-Cookie"` (response.rb:85); lowercase
+// here for the same reason as CONTENT_TYPE above.
 const SET_COOKIE = "set-cookie";
 const NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304] as const;
 const CONTENT_TYPE_PARSER =
@@ -292,7 +294,7 @@ export class Response {
 
   /**
    * Mirrors `Rack::Response::Helpers#set_cookie` (rack-3.1.12
-   * rack/response.rb:270-272). Rack's `add_header` keeps an Array of values;
+   * rack/response.rb:270-272, mixed into `Response` at response.rb:91). Rack's `add_header` keeps an Array of values;
    * our header hash is string-valued, so they are newline-joined — the shape
    * `cookies` reads back with `split("\n")`.
    *
@@ -304,7 +306,11 @@ export class Response {
     this.setHeader(SET_COOKIE, header === undefined ? cookie : `${header}\n${cookie}`);
   }
 
-  /** Mirrors `Rack::Response::Helpers#delete_cookie` (rack/response.rb:274-280). */
+  /**
+   * Mirrors `Rack::Response::Helpers#delete_cookie` (rack-3.1.12
+   * rack/response.rb:274-280), mixed into `Response` at response.rb:91.
+   * Newline-joined for the same reason as {@link setCookie}.
+   */
   deleteCookie(name: string, options: Partial<CookieOptions> = {}): void {
     const header = deleteSetCookieHeaderBang(
       this.getHeader(SET_COOKIE) ?? null,

--- a/packages/rack/src/index.ts
+++ b/packages/rack/src/index.ts
@@ -57,6 +57,9 @@ export {
   setMultipartFileLimit,
   getMultipartTotalPartLimit,
   setMultipartTotalPartLimit,
+  setCookieHeader,
+  deleteSetCookieHeaderBang,
+  unescape,
 } from "./utils.js";
 export { BodyProxy } from "./body-proxy.js";
 export { Request } from "./request.js";

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/response.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/response.json
@@ -2,13 +2,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/response.ts",
-    "rubyName": "cookies",
-    "call": "get_header",
-    "reason": "Structural divergence, not a header-accessor spelling: response.rb:418-430 parses the response's OWN `Set-Cookie` header back into a name=>value hash, while response.ts:310-316 iterates the private `_cookies` map the writers populate. Every other row of this cluster converged onto getHeader/setHeader/hasHeader/fetchHeader; this one needs the reader rewritten, tracked as story converge-response-cookies-onto-set-cookie-header."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
     "rubyName": "delete_header",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges `ActionDispatch::Response#cookies` onto the response's own
`Set-Cookie` header, mirroring
`actionpack/lib/action_dispatch/http/response.rb:418-430` — including the
`to_str` / array arms and `Rack::Utils.unescape` on both halves of the pair.

The reader can only round-trip if the writers put cookies in the header, so
`setCookie` / `deleteCookie` now go through the header too, mirroring
`Rack::Response::Helpers#set_cookie` (rack-3.1.12 `rack/response.rb:270-272`)
and `#delete_cookie` (`rack/response.rb:274-280`) via `Rack::Utils`
`set_cookie_header` / `delete_set_cookie_header!`. The private `_cookies` map
is gone, so a `Set-Cookie` written by anything else is now visible to
`cookies`. Multiple values are newline-joined (our header hash is
string-valued where Rack keeps an Array); that is the convention the middleware
and `cookies`' own `split("\n")` already use.

The three `response_test.rb` cookie tests are converged onto the Rails bodies
(option-hash `set_cookie`, header assertion, `foo&bar` escaping). Rails' "delete
cookies" expects `login => nil` where JS `"login=".split("=")` yields `""`.

The `cookies | get_header` row is deleted by hand from
`call-mismatches-exclude/actiondispatch/http/response.json`; `parity:api:calls`
and `parity:api:calls:args` are green.

Closes-story: converge-response-cookies-onto-set-cookie-header
