### PR TITLE
fix(activerecord): converge lock_value, create_or_find_by's with_connection, and excluding's spawn

### DIFF
--- a/packages/activerecord/src/excluding.trails.test.ts
+++ b/packages/activerecord/src/excluding.trails.test.ts
@@ -28,4 +28,16 @@ describe("excluding deferred arm (trails)", () => {
     expect(attribute.relation).toBeInstanceOf(Nodes.TableAlias);
     expect((attribute.relation as Nodes.TableAlias).name).toBe("p");
   });
+
+  // `spawn.excluding!(...)` (query_methods.rb:1580) has no empty-argument
+  // short circuit: the result is always a distinct relation carrying the
+  // (vacuously true) inverted predicate.
+  it("spawns and appends the inverted predicate with no arguments", () => {
+    const all = Post.all();
+    const excluded = all.excluding();
+
+    expect(excluded).not.toBe(all);
+    expect(excluded.whereClause.predicates.length).toBe(all.whereClause.predicates.length + 1);
+    expect(excluded.toSql()).not.toBe(all.toSql());
+  });
 });

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -1087,3 +1087,30 @@ describe("Relation#empty_scope? STI type_condition (trails)", () => {
     expect((CanonCompany.all() as any).isEmptyScope).toBe(true);
   });
 });
+
+// `lock!` (query_methods.rb:1242-1249) stores the ARGUMENT — `locks || true`
+// for String/true/nil, `false` otherwise. The `FOR UPDATE` default belongs to
+// Arel's `SelectManager#lock` (select_manager.rb:52-59), so the stored value
+// and the emitted SQL are two different things. Rails' relation_mutation_test
+// only pins the String arm.
+describe("lock_value stores the argument", () => {
+  fixtures([]);
+
+  it("stores true for a bare lock and false for lock(false)", () => {
+    expect(CanonPost.all().lock().lockValue).toBe(true);
+    expect(CanonPost.all().lock(null).lockValue).toBe(true);
+    expect(CanonPost.all().lock(false).lockValue).toBe(false);
+    expect(CanonPost.all().lock("FOR SHARE").lockValue).toBe("FOR SHARE");
+  });
+
+  // The SQLite visitor drops the LOCK node entirely (arel/visitors/sqlite.rb),
+  // so assert against the AST rather than the rendered SQL.
+  it("builds the Arel default clause for a bare lock", () => {
+    expect((CanonPost.all().toArel() as any).ast.lock).toBe(null);
+    expect(String((CanonPost.all().lock().toArel() as any).ast.lock.expr)).toBe("FOR UPDATE");
+    expect((CanonPost.all().lock(false).toArel() as any).ast.lock).toBe(null);
+    expect(String((CanonPost.all().lock("FOR SHARE").toArel() as any).ast.lock.expr)).toBe(
+      "FOR SHARE",
+    );
+  });
+});

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1077,10 +1077,10 @@ export class Relation<T extends Base> {
    * Check if this relation carries a lock clause.
    *
    * Mirrors: ActiveRecord::Relation#locked? (relation.rb:75,
-   * `alias :locked? :lock_value`) — the lock clause itself, so `lock("FOR
-   * UPDATE")` answers the string rather than a boolean.
+   * `alias :locked? :lock_value`) — the stored `lock_value` itself, so `lock`
+   * answers `true` and `lock("FOR UPDATE")` answers the string.
    */
-  get isLocked(): string | null {
+  get isLocked(): string | boolean | null {
     return this.lockValue;
   }
 
@@ -1987,49 +1987,53 @@ export class Relation<T extends Base> {
   /**
    * Try to create first; if uniqueness violation, find the existing record.
    *
-   * Mirrors: ActiveRecord::Relation#create_or_find_by
+   * Mirrors: ActiveRecord::Relation#create_or_find_by (relation.rb:273-283) —
+   * the whole body runs inside `with_connection do |connection|`, and the
+   * rescue's `transaction_open?` branch asks that yielded connection.
    */
   async createOrFindBy(
     attributes: Record<string, unknown>,
     extra?: Record<string, unknown>,
   ): Promise<T> {
-    // Rails:
-    //   transaction(requires_new: true) { create(attributes, &block) }
-    //   rescue ActiveRecord::RecordNotUnique
-    //     where(attributes).lock.find_by!(attributes)
-    // Nested transaction so the failed INSERT rolls back cleanly
-    // before the retry; `.lock` + `find_by!` so the concurrent winner
-    // is materialized + row-locked inside the caller's txn.
-    try {
-      const result = await this._model.transaction(
-        () =>
-          this._model.create({
-            ...this.scopeForCreate(),
-            ...attributes,
-            ...extra,
-          }) as Promise<T>,
-        { requiresNew: true },
-      );
-      // transaction() returns undefined when the block raises Rollback.
-      // Don't silently yield undefined — raise so callers see the abort.
-      if (result === undefined) {
-        // `RecordNotSaved.record` is conventionally the model instance that
-        // failed to persist — which doesn't exist here, since the inner
-        // create rolled back. Leave record undefined rather than passing
-        // the Relation.
-        throw new RecordNotSaved(`${this._model.name}.createOrFindBy rolled back before persist`);
+    return this.withConnection(async (connection) => {
+      // Rails:
+      //   transaction(requires_new: true) { create(attributes, &block) }
+      //   rescue ActiveRecord::RecordNotUnique
+      //     where(attributes).lock.find_by!(attributes)
+      // Nested transaction so the failed INSERT rolls back cleanly
+      // before the retry; `.lock` + `find_by!` so the concurrent winner
+      // is materialized + row-locked inside the caller's txn.
+      try {
+        const result = await this._model.transaction(
+          () =>
+            this._model.create({
+              ...this.scopeForCreate(),
+              ...attributes,
+              ...extra,
+            }) as Promise<T>,
+          { requiresNew: true },
+        );
+        // transaction() returns undefined when the block raises Rollback.
+        // Don't silently yield undefined — raise so callers see the abort.
+        if (result === undefined) {
+          // `RecordNotSaved.record` is conventionally the model instance that
+          // failed to persist — which doesn't exist here, since the inner
+          // create rolled back. Leave record undefined rather than passing
+          // the Relation.
+          throw new RecordNotSaved(`${this._model.name}.createOrFindBy rolled back before persist`);
+        }
+        return result;
+      } catch (e) {
+        if (!(e instanceof RecordNotUnique)) throw e;
+        // Rails (relation.rb:277-281): with a transaction still open the winner
+        // is materialized + row-locked inside it; otherwise plain find_by!, no
+        // lock.
+        if (connection.isTransactionOpen()) {
+          return this.where(attributes).lock().findByBang(attributes);
+        }
+        return this.findByBang(attributes);
       }
-      return result;
-    } catch (e) {
-      if (!(e instanceof RecordNotUnique)) throw e;
-      // Rails (relation.rb:277-281): with a transaction still open the winner
-      // is materialized + row-locked inside it; otherwise plain find_by!, no
-      // lock.
-      if (this._conn().isTransactionOpen()) {
-        return this.where(attributes).lock().findByBang(attributes);
-      }
-      return this.findByBang(attributes);
-    }
+    });
   }
 
   /**
@@ -2360,6 +2364,15 @@ export class Relation<T extends Base> {
    * — `_buildEagerOperandManager` is that block, and its manager is rendered
    * through the same connection path (a null manager, e.g. an unresolvable
    * association, falls through to the plain arel).
+   *
+   * @missingRailsCall with_connection — Rails' non-eager arm is
+   * `model.with_connection { |conn| conn.unprepared_statement { conn.to_sql(arel) } }`
+   * (relation.rb:1217-1219). `withConnection` is a `Promise`-returning checkout
+   * in TypeScript, and `to_sql` renders a string with no `await` in it, so
+   * taking one would make `toSql` async — 412 test and 16 source call sites
+   * treat it as synchronous. The checkout is instead the caller's, read through
+   * `_conn()`, and `unprepared_statement` is applied by hand around the render.
+   * Convergence tracked by RFC 0107 (`converge-sync-eager-builders-async-to-sql`).
    */
   toSql(): string {
     // `unprepared_statement` applied synchronously: `to_sql` is sync here, so
@@ -3742,7 +3755,7 @@ export interface Relation<T extends Base> {
   /** Mirrors: ActiveRecord::Relation#offset_value */
   offsetValue: number | null;
   /** Mirrors: ActiveRecord::Relation#lock_value */
-  lockValue: string | null;
+  lockValue: string | boolean | null;
   /** Mirrors: ActiveRecord::Relation#readonly_value */
   readonlyValue: boolean | null;
   /** Mirrors: ActiveRecord::Relation#reordering_value */
@@ -3825,7 +3838,7 @@ export interface Relation<T extends Base>
   // whose mixin signatures return `any` — declared here with the relation's own
   // element type.
   unscope(...args: Array<UnscopeType | { where: string | string[] }>): Relation<T>;
-  lock(locks?: string | boolean): Relation<T>;
+  lock(locks?: string | boolean | null): Relation<T>;
   none(): Relation<T>;
   readonly(value?: boolean): Relation<T>;
   strictLoading(value?: boolean): Relation<T>;
@@ -4079,7 +4092,6 @@ function excludingWithCallee(callee: "excluding" | "without") {
       if (relation.isLoaded) combined.push(...(relation as any)._records);
       else combined.push(relation);
     }
-    if (combined.length === 0) return this;
     return this.spawn().excludingBang(combined);
   };
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -257,7 +257,7 @@ interface QueryMethodsHost {
   _withIsRecursive: boolean;
   limitValue: number | string | null;
   offsetValue: number | string | null;
-  lockValue: string | null;
+  lockValue: string | boolean | null;
   readonlyValue: boolean | null;
   reorderingValue: boolean | null;
   strictLoadingValue: boolean | null;
@@ -1478,15 +1478,23 @@ function offsetBang(this: QueryMethodsHost, value: number | string | null): any 
  *
  * Mirrors: ActiveRecord::QueryMethods#lock (query_methods.rb:1238-1240)
  */
-function lock(this: QueryMethodsHost, locks: string | boolean = true): any {
+function lock(this: QueryMethodsHost, locks: string | boolean | null = true): any {
   return lockBang.call(this.spawn(), locks);
 }
 
-function lockBang(this: QueryMethodsHost, locks: string | boolean = true): any {
-  if (typeof locks === "string") {
-    this.lockValue = locks;
+/**
+ * Mirrors: ActiveRecord::QueryMethods#lock! (query_methods.rb:1242-1249) — the
+ * argument itself is stored, so a bare `lock` leaves `lockValue === true` and
+ * `lock(false)` leaves it `false`. The `FOR UPDATE` default is Arel's, applied
+ * by `SelectManager#lock` (select_manager.rb:52-59), not by this writer.
+ */
+function lockBang(this: QueryMethodsHost, locks: string | boolean | null = true): any {
+  if (typeof locks === "string" || locks === true || locks == null) {
+    // Ruby `locks || true`: only `nil` falls through to `true` here, since
+    // `false` never reaches this arm.
+    this.lockValue = locks ?? true;
   } else {
-    this.lockValue = locks ? "FOR UPDATE" : null;
+    this.lockValue = false;
   }
   return this;
 }
@@ -2924,7 +2932,7 @@ export function buildArel(
 
   if (!this.fromClause.isEmpty()) arel.from(buildFrom.call(this) as any);
 
-  if (this.lockValue) arel.lock(this.lockValue);
+  if (this.lockValue != null && this.lockValue !== false) arel.lock(this.lockValue);
 
   if (this.annotateValues.length > 0) {
     const annotates =

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "create_or_find_by",
-    "call": "with_connection",
-    "reason": "Surfaced by RFC 0108's closure fix: the same-file call closure used to bridge relation.ts bodies through the `xs.length` property read into `Relation#length` and on to `toArray`'s `withConnection`, crediting a call neither body makes. Rails wraps both in `with_connection` (relation.rb:274, :291); trails' `toSql` is synchronous and `createOrFindBy` runs inside the caller's checkout, so neither can take one. Convergence tracked by RFC 0107."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "exec_main_query",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
@@ -65,12 +58,5 @@
     "rubyName": "to_sql",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "to_sql",
-    "call": "with_connection",
-    "reason": "Surfaced by RFC 0108's closure fix: the same-file call closure used to bridge relation.ts bodies through the `xs.length` property read into `Relation#length` and on to `toArray`'s `withConnection`, crediting a call neither body makes. Rails wraps both in `with_connection` (relation.rb:274, :291); trails' `toSql` is synchronous and `createOrFindBy` runs inside the caller's checkout, so neither can take one. Convergence tracked by RFC 0107."
   }
 ]


### PR DESCRIPTION
Three convergences in `relation.ts` / `relation/query-methods.ts`, plus a blocked fourth story.

### `lock_value` stores the argument, not the clause string

Rails' `lock!` (query_methods.rb:1242-1249) stores what it was handed:

```ruby
case locks
when String, TrueClass, NilClass then self.lock_value = locks || true
else                                  self.lock_value = false
end
```

trails normalized to `"FOR UPDATE"` / `null` at the writer, so `lock_value` could
never be `true` and `locked?` (relation.rb:75) could not answer the way Rails does.
`lockBang` now mirrors the case statement; `lockValue` widens to
`string | boolean | null`; `isLocked` answers it unchanged. The `FOR UPDATE`
default is Arel's — `SelectManager#lock` (select_manager.rb:52-59) already maps
`true` to it — so `buildArel`'s `arel.lock(lockValue)` emits the same SQL. The
`if lock_value` guard is ported as `!= null && !== false` rather than a bare
truthiness test, so `lock("")` behaves as it does in Ruby.

### `create_or_find_by` takes a `with_connection`

Rails wraps the whole body in `with_connection do |connection| … end` and asks the
yielded connection for `transaction_open?` (relation.rb:274-283); trails read
`this._conn()` directly. Now routed through `withConnection`, using the yielded
connection for the branch.

### `to_sql`'s omission moves to the call site

`to_sql` (relation.rb:1210-1222) renders through `with_connection`. trails' `toSql`
is synchronous by construction — it renders a string with no `await`, and 412 test
plus 16 source call sites treat it as sync — so it cannot take a `Promise`-returning
checkout. Per the story, that omission is now stated at the call site as a
`@missingRailsCall` tag instead of a baseline row. Both `with_connection` rows are
deleted from `call-mismatches-exclude/activerecord/relation.json` (only-shrink, no
reseed).

### `excluding` / `without` always spawn

`spawn.excluding!(records + relations.flat_map(&:ids))` (query_methods.rb:1580) has
no empty-argument guard. trails returned the receiver, so `Post.excluding()` was
`Post.all`-identical and missing the inverted predicate Rails appends. The short
circuit is gone; `excluding.trails.test.ts` pins the spawn identity and the extra
predicate on the empty-argument path.

### Blocked

`converge-sync-eager-builders-async-to-sql` is `tasks block`ed. Deleting the invented
synchronous eager builders requires an async `toSql` (or an async `where`), because
Rails' `apply_join_dependency`'s `distinct_relation_for_primary_key` branch executes
a query (schema_statements.rb:1429-1452). That is far past this RFC's LOC ceiling,
and the marker cluster additionally covers a real MySQL/MariaDB regression — MySQL
rejects `IN (SELECT … LIMIT n)` — so it needs its own PR and its own three-lane run.

### Verification

`pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK, `parity:api:extra` shows
no new surface, `pnpm typecheck` clean. `relations.test.ts`, `relation.test.ts`,
`relation.trails.test.ts`, `relation/merging.test.ts`, `relation/delegation.test.ts`,
`relation/mutation.test.ts`, `locking.test.ts`, `excluding.test.ts` and
`excluding.trails.test.ts` green locally on SQLite.

Closes-story: converge-lock-value-stores-locks-not-clause-string
Closes-story: converge-relation-with-connection-on-create-or-find-by-and-to-sql
Closes-story: excluding-always-spawns-no-empty-short-circuit
