### PR TITLE
fix(parity): converge collection reader, join-dependency reflections, and Hash#fetch option readers

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -682,7 +682,7 @@ export class Association {
     return false;
   }
 
-  get reader(): Base | Base[] | null | Promise<Base | null> {
+  get reader(): Base | Base[] | null | Promise<Base | Base[] | null> {
     return this.target;
   }
 

--- a/packages/activerecord/src/associations/collection-association-reader-proxy.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-reader-proxy.trails.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Trails-only: pins `CollectionAssociation#reader`
+ * (collection_association.rb:33-42) to Rails' four lines — `ensure_klass_exists!`,
+ * the stale-target `reload`, `@proxy ||= CollectionProxy.create(klass, self)`,
+ * and `@proxy.reset_scope`. Rails reaches `reader` through the generated
+ * accessor, so it has no test of its own; these reach the OO association
+ * directly because that is where the port had drifted — the stale-reload arm
+ * lived in a callerless `asyncReader` and `reader` returned the bare target.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+
+interface CollectionAssociationLike {
+  reader: Promise<Post[]>;
+  isStaleTarget(): boolean;
+  reload(): Promise<unknown>;
+  resetScope?(): void;
+}
+
+const postsAssociation = (author: Author): CollectionAssociationLike =>
+  (author as unknown as { association(name: string): CollectionAssociationLike }).association(
+    "posts",
+  );
+
+describe("CollectionAssociation#reader", () => {
+  const { authors } = fixtures(["authors", "posts"]);
+
+  it("reloads a stale target before answering", async () => {
+    const author = await authors("david");
+    const association = postsAssociation(author);
+    await association.reader;
+
+    vi.spyOn(association, "isStaleTarget").mockReturnValue(true);
+    const reload = vi.spyOn(association, "reload");
+
+    await association.reader;
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload a fresh target", async () => {
+    const author = await authors("david");
+    const association = postsAssociation(author);
+    await association.reader;
+
+    const reload = vi.spyOn(association, "reload");
+    await association.reader;
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("memoizes the proxy and resets its scope on every read", async () => {
+    const author = await authors("david");
+    const association = postsAssociation(author);
+
+    const proxy = author.posts;
+    await association.reader;
+
+    const resetScope = vi.spyOn(proxy, "resetScope");
+    await association.reader;
+
+    expect(resetScope).toHaveBeenCalledTimes(1);
+    expect(author.posts).toBe(proxy);
+  });
+});

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -996,7 +996,8 @@ export class CollectionAssociation extends Association {
    * (it resolves to its records), so awaiting this promise hands back the
    * records the proxy holds rather than the proxy object. Callers that need the
    * proxy object take it from `record.<name>` (the generated accessor), which is
-   * the same cached instance this returns.
+   * the same cached instance this returns. `reset_scope` is likewise called for
+   * effect: it returns the raw proxy, not the JS Proxy wrapper callers hold.
    */
   override get reader(): Promise<Base[]> {
     this.ensureKlassExists();
@@ -1010,9 +1011,6 @@ export class CollectionAssociation extends Association {
         create(klass: typeof Base, association: CollectionAssociation): AssociationProxy;
       };
       this._proxy ??= CollectionProxy.create(this.klass, this);
-      // `@proxy.reset_scope` returns the proxy itself; here it is called for
-      // effect because `this` inside it is the raw proxy, not the JS Proxy
-      // wrapper every caller must keep holding.
       this._proxy.resetScope();
       return this._proxy;
     })();

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -10,6 +10,8 @@ import {
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Association } from "./association.js";
+import type { AssociationProxy } from "./collection-proxy.js";
+import { _CollectionProxyCtor } from "./collection-proxy-slot.js";
 import { foreignKeyPresentFor, ownerForeignKeyColumns } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import type { AssociationReflection } from "../reflection.js";
@@ -56,6 +58,8 @@ export class CollectionAssociation extends Association {
   // 1:1 ordering with the assigned attributes collection (Rails
   // nested_attributes.rb:487-547).
   nestedAttributesTarget: (Base | null)[] | null = null;
+  /** Mirrors `@proxy` (collection_association.rb:41). */
+  protected _proxy?: AssociationProxy;
   protected _associationIds: unknown[] | null = null;
   // Whether the most recent `removeRecords` was halted by a `before_remove`
   // abort. Rails leaves `@target` untouched on abort (remove_records exits
@@ -983,19 +987,35 @@ export class CollectionAssociation extends Association {
     proxy._wireInverseTarget(record);
   }
 
-  override get reader(): Base[] {
+  /**
+   * Mirrors: CollectionAssociation#reader (collection_association.rb:33-42).
+   *
+   * The reload arm issues the load query, so the body after `ensure_klass_exists!`
+   * is a promise — Rails' four lines in Rails' order, awaited by the caller.
+   * Rails' return value is `@proxy` itself; trails' CollectionProxy is thenable
+   * (it resolves to its records), so awaiting this promise hands back the
+   * records the proxy holds rather than the proxy object. Callers that need the
+   * proxy object take it from `record.<name>` (the generated accessor), which is
+   * the same cached instance this returns.
+   */
+  override get reader(): Promise<Base[]> {
     this.ensureKlassExists();
-    return this.target;
-  }
 
-  async asyncReader(): Promise<Base[]> {
-    this.ensureKlassExists();
+    return (async () => {
+      if (this.isStaleTarget()) {
+        await this.reload();
+      }
 
-    if (this.isStaleTarget()) {
-      await this.reload();
-    }
-
-    return this.target;
+      const CollectionProxy = _CollectionProxyCtor as unknown as {
+        create(klass: typeof Base, association: CollectionAssociation): AssociationProxy;
+      };
+      this._proxy ??= CollectionProxy.create(this.klass, this);
+      // `@proxy.reset_scope` returns the proxy itself; here it is called for
+      // effect because `this` inside it is the raw proxy, not the JS Proxy
+      // wrapper every caller must keep holding.
+      this._proxy.resetScope();
+      return this._proxy;
+    })();
   }
 
   private ensureKlassExists(): void {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -998,6 +998,12 @@ export class CollectionAssociation extends Association {
    * proxy object take it from `record.<name>` (the generated accessor), which is
    * the same cached instance this returns. `reset_scope` is likewise called for
    * effect: it returns the raw proxy, not the JS Proxy wrapper callers hold.
+   *
+   * It is called here, not left to `association()`: that factory resets only on
+   * its own cache-hit path (the trails generated accessor's reader, RFC 0022),
+   * so without this line a second `reader` would skip Rails' fourth line. The
+   * cost is one redundant reset on the read that first builds the proxy;
+   * `reset_scope` is idempotent.
    */
   override get reader(): Promise<Base[]> {
     this.ensureKlassExists();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -57,6 +57,7 @@ import {
   autoloadModel,
   resolveAssocClass,
   _routeThroughViaAssociationScope,
+  association as associationProxy,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 import { multisetDifference, multisetIntersection } from "./has-many-through-association.js";
@@ -521,6 +522,24 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (richKlass) return richKlass;
     autoloadModel(className);
     return constantize(className) as typeof Base;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Delegation::ClassMethods#create
+   * (relation/delegation.rb:138-140) — `relation_class_for(model).new(model, ...)`
+   * — as reached by `CollectionProxy.create(klass, self)`
+   * (collection_association.rb:41).
+   *
+   * RFC 0022 makes the wrapped proxy the canonical has_many store, keyed on the
+   * owner by association name, so the create-or-fetch of that store is the
+   * `association()` factory: it routes through the same `collectionProxyClassFor`
+   * carrier `_create` uses and then hydrates and wraps the instance.
+   */
+  static create<T extends Base = Base>(
+    _klass: typeof Base,
+    association: { owner: Base; reflection: { name: string } },
+  ): AssociationProxy<T> {
+    return associationProxy<T>(association.owner, association.reflection.name);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -533,10 +533,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * RFC 0022 makes the wrapped proxy the canonical has_many store, keyed on the
    * owner by association name, so the create-or-fetch of that store is the
    * `association()` factory: it routes through the same `collectionProxyClassFor`
-   * carrier `_create` uses and then hydrates and wraps the instance.
+   * carrier `_create` uses and then hydrates and wraps the instance — resolving
+   * `model` from the association itself, so the argument is accepted and unused.
    */
   static create<T extends Base = Base>(
-    _klass: typeof Base,
+    _model: typeof Base,
     association: { owner: Base; reflection: { name: string } },
   ): AssociationProxy<T> {
     return associationProxy<T>(association.owner, association.reflection.name);

--- a/packages/activerecord/src/associations/join-dependency-reflections.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-reflections.trails.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Trails-only: pins `JoinDependency#reflections`
+ * (join_dependency.rb:81-83, `join_root.drop(1).map!(&:reflection)`) to the
+ * reflection each tree node carries, in the depth-first order Ruby's
+ * `Enumerable` gives `join_root` (join_part.rb:13, 31-34), with the root
+ * dropped. Rails covers this indirectly through
+ * `FinderMethods#using_limitable_reflections?`; the walk itself has no Rails
+ * test of its own, so the port is pinned here.
+ */
+import { describe, it, expect } from "vitest";
+import { Nodes } from "@blazetrails/arel";
+import { fixtures } from "../test-fixtures.js";
+import { JoinDependency } from "./join-dependency.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
+
+describe("JoinDependency#reflections", () => {
+  fixtures(["authors", "posts", "comments"]);
+
+  it("drops the join root and reads each node's own reflection", () => {
+    const jd = new JoinDependency(Author, null, "posts.comments", Nodes.OuterJoin);
+
+    expect(jd.reflections).toEqual([
+      Author.reflectOnAssociation("posts"),
+      Post.reflectOnAssociation("comments"),
+    ]);
+    expect(jd.reflections).not.toContain(undefined);
+  });
+
+  it("lists a through association once, not once per chain hop", () => {
+    const jd = new JoinDependency(Author, null, "comments", Nodes.OuterJoin);
+
+    expect(jd.reflections).toEqual([Author.reflectOnAssociation("comments")]);
+    expect(jd.reflections[0].klass).toBe(Comment);
+  });
+});

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -396,14 +396,17 @@ export class JoinDependency {
     return this._baseModel;
   }
 
+  // Mirrors: `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:81-83) —
+  // the Enumerable walk of the join tree, root dropped, reading the reflection
+  // each node already carries.
   get reflections(): any[] {
-    const result: any[] = [];
-    this._joinRoot.eachChildren((parent, child) => {
-      if (child.tableIndex < 0) return;
-      const reflection = _reflectOnAssociation(parent.baseKlass as any, child.immediateAssocName);
-      if (reflection) result.push(reflection);
-    });
-    return result;
+    // `_through_` hops are trails-only tree nodes (`JoinLeaf`): Rails keeps a
+    // through association's whole chain inside the one JoinAssociation, so the
+    // hops carry no reflection of their own and Rails never lists one here.
+    return this.joinRoot
+      .drop(1)
+      .map((node) => (node as any).reflection)
+      .filter((reflection) => reflection != null);
   }
 
   /**

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -401,7 +401,8 @@ export class JoinDependency {
    * the Enumerable walk of the join tree, root dropped, reading the reflection
    * each node already carries.
    *
-   * `_through_` hops are trails-only tree nodes (`JoinLeaf`): Rails keeps a
+   * `_through_` hops are trails-only tree nodes (`JoinLeaf`, declared below in
+   * this file): Rails keeps a
    * through association's whole chain inside the one JoinAssociation, so the
    * hops carry no reflection of their own and Rails never lists one here.
    */

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -396,13 +396,16 @@ export class JoinDependency {
     return this._baseModel;
   }
 
-  // Mirrors: `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:81-83) —
-  // the Enumerable walk of the join tree, root dropped, reading the reflection
-  // each node already carries.
+  /**
+   * Mirrors: `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:81-83) —
+   * the Enumerable walk of the join tree, root dropped, reading the reflection
+   * each node already carries.
+   *
+   * `_through_` hops are trails-only tree nodes (`JoinLeaf`): Rails keeps a
+   * through association's whole chain inside the one JoinAssociation, so the
+   * hops carry no reflection of their own and Rails never lists one here.
+   */
   get reflections(): any[] {
-    // `_through_` hops are trails-only tree nodes (`JoinLeaf`): Rails keeps a
-    // through association's whole chain inside the one JoinAssociation, so the
-    // hops carry no reflection of their own and Rails never lists one here.
     return this.joinRoot
       .drop(1)
       .map((node) => (node as any).reflection)

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -108,6 +108,34 @@ export abstract class JoinPart {
     }
   }
 
+  /**
+   * Mirrors `include Enumerable` (join_part.rb:13) over `each`
+   * (join_part.rb:31-34): Ruby derives every Enumerable method — `drop`, `map!`,
+   * … — from `each`, and JS derives them from `Symbol.iterator` the same way, so
+   * `[...node]` is the depth-first, self-first node list `join_root.drop(1)`
+   * reads.
+   *
+   * @noRailsEquivalent PERMANENT — JS has no module to `include`, so the
+   * Enumerable contract Ruby gets from `each` (join_part.rb:13, 31-34) is
+   * spelled `Symbol.iterator`. No port can remove the spelling difference.
+   */
+  *[Symbol.iterator](): IterableIterator<JoinPart> {
+    yield this;
+    for (const child of this.children) {
+      yield* child;
+    }
+  }
+
+  /**
+   * `Enumerable#drop` (join_part.rb:13 `include Enumerable`), the walk
+   * `JoinDependency#reflections` reads. JS has no Enumerable module to mix in,
+   * so the one method Rails actually calls on a JoinPart-as-Enumerable is
+   * spelled out over the same `each`/iterator.
+   */
+  drop(n: number): JoinPart[] {
+    return [...this].slice(n);
+  }
+
   eachChildren(fn: (parent: JoinPart, child: JoinPart) => void): void {
     for (const child of this.children) {
       fn(this, child);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -62,6 +62,17 @@ describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {
   });
 });
 
+describe("CheckConstraintDefinition#validate?", () => {
+  it("returns the stored value when :validate is present, including nil", () => {
+    // `options.fetch(:validate, true)` (schema_definitions.rb:180-183) returns
+    // the STORED value whenever the key is present, so a stored nil is not
+    // replaced by the `true` default.
+    expect(new CheckConstraintDefinition("t", "e", {}).validate).toBe(true);
+    expect(new CheckConstraintDefinition("t", "e", { validate: false }).validate).toBe(false);
+    expect(new CheckConstraintDefinition("t", "e", { validate: null }).validate).toBe(null);
+  });
+});
+
 describe("TableDefinition#remove_column", () => {
   const td = (): TableDefinition => {
     const t = new TableDefinition("astronauts", { adapter: conn });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -64,9 +64,6 @@ describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {
 
 describe("CheckConstraintDefinition#validate?", () => {
   it("returns the stored value when :validate is present, including nil", () => {
-    // `options.fetch(:validate, true)` (schema_definitions.rb:180-183) returns
-    // the STORED value whenever the key is present, so a stored nil is not
-    // replaced by the `true` default.
     expect(new CheckConstraintDefinition("t", "e", {}).validate).toBe(true);
     expect(new CheckConstraintDefinition("t", "e", { validate: false }).validate).toBe(false);
     expect(new CheckConstraintDefinition("t", "e", { validate: null }).validate).toBe(null);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -68,6 +68,19 @@ describe("CheckConstraintDefinition#validate?", () => {
     expect(new CheckConstraintDefinition("t", "e", { validate: false }).validate).toBe(false);
     expect(new CheckConstraintDefinition("t", "e", { validate: null }).validate).toBe(null);
   });
+
+  it("ignores a validate lookup when the definition stores no :validate", () => {
+    const definition = new CheckConstraintDefinition("t", "e", { name: "chk" });
+
+    expect(definition.isDefinedFor({ name: "chk", validate: false })).toBe(true);
+    expect(definition.isDefinedFor({ name: "chk", validate: true })).toBe(true);
+    expect(
+      new CheckConstraintDefinition("t", "e", { name: "chk", validate: false }).isDefinedFor({
+        name: "chk",
+        validate: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("TableDefinition#remove_column", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -324,13 +324,12 @@ export class ForeignKeyDefinition {
     this.onDelete = onDelete;
     this.onUpdate = onUpdate;
     this.deferrable = deferrable;
-    // Rails reads `validate?` off `options.fetch(:validate, true)`, so the value
-    // defaults to true; storesValidate records whether `:validate` was actually
+    // Rails reads `validate?` off `options.fetch(:validate, true)`, so a stored
+    // value — nil included — survives and the `true` default applies only when
+    // the key is absent; storesValidate records whether `:validate` was actually
     // on the options hash (PG introspection sets it; mysql/sqlite/DSL-without-it
     // leave it absent), driving the fetch-fallback in isDefinedFor.
     this.storesValidate = validate !== undefined;
-    // `options.fetch(:validate, true)`: a stored nil survives as nil; the
-    // default applies only when `:validate` was never stored.
     this.validate = this.storesValidate ? (validate as boolean | null) : true;
     // Default: every generic key is stored, matching the DB-introspection paths
     // (pg/mysql/sqlite `foreignKeys`) whose options hash always carries
@@ -444,10 +443,11 @@ export class CheckConstraintDefinition {
     return this.options.name as string;
   }
 
-  /** Mirrors: `validate?` (schema_definitions.rb:180-183). */
+  /**
+   * Mirrors: `validate?` (schema_definitions.rb:180-183). `options.fetch` returns
+   * a stored nil as nil; the `true` default applies only when the key is absent.
+   */
   get validate(): boolean | null {
-    // `options.fetch(:validate, true)` returns a stored nil as nil; the default
-    // applies only when the key is absent.
     return "validate" in this.options ? (this.options.validate as boolean | null) : true;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -189,7 +189,7 @@ export interface AddForeignKeyOptions {
   onDelete?: ReferentialAction;
   onUpdate?: ReferentialAction;
   deferrable?: "immediate" | "deferred" | false;
-  validate?: boolean;
+  validate?: boolean | null;
   ifNotExists?: boolean;
 }
 
@@ -235,7 +235,7 @@ export interface ForeignKeyLookupOptions {
   toTable?: string;
   column?: string | string[];
   name?: string;
-  validate?: boolean;
+  validate?: boolean | null;
   primaryKey?: string | string[];
   onDelete?: ReferentialAction;
   onUpdate?: ReferentialAction;
@@ -284,7 +284,7 @@ export class ForeignKeyDefinition {
   readonly onDelete?: ReferentialAction;
   readonly onUpdate?: ReferentialAction;
   readonly deferrable?: "immediate" | "deferred" | false;
-  readonly validate: boolean;
+  readonly validate: boolean | null;
   /**
    * Whether `:validate` was stored on the options hash (Rails introspection
    * sets it only on PostgreSQL; mysql/sqlite leave it absent). Mirrors the
@@ -313,7 +313,7 @@ export class ForeignKeyDefinition {
     onDelete?: ReferentialAction,
     onUpdate?: ReferentialAction,
     deferrable?: "immediate" | "deferred" | false,
-    validate?: boolean,
+    validate?: boolean | null,
     storedOptionKeys?: Iterable<ForeignKeyStoredOptionKey>,
   ) {
     this.fromTable = fromTable;
@@ -329,7 +329,9 @@ export class ForeignKeyDefinition {
     // on the options hash (PG introspection sets it; mysql/sqlite/DSL-without-it
     // leave it absent), driving the fetch-fallback in isDefinedFor.
     this.storesValidate = validate !== undefined;
-    this.validate = validate ?? true;
+    // `options.fetch(:validate, true)`: a stored nil survives as nil; the
+    // default applies only when `:validate` was never stored.
+    this.validate = this.storesValidate ? (validate as boolean | null) : true;
     // Default: every generic key is stored, matching the DB-introspection paths
     // (pg/mysql/sqlite `foreignKeys`) whose options hash always carries
     // column/name/primaryKey/onDelete/onUpdate/deferrable — present even when
@@ -353,12 +355,12 @@ export class ForeignKeyDefinition {
     return "id";
   }
 
-  get isValidate(): boolean {
+  get isValidate(): boolean | null {
     return this.validate;
   }
 
   /** Alias of isValidate (Rails: `alias validated? validate?`). */
-  get isValidated(): boolean {
+  get isValidated(): boolean | null {
     return this.isValidate;
   }
 
@@ -389,9 +391,7 @@ export class ForeignKeyDefinition {
       // when `:validate` was not stored on the definition (mysql/sqlite
       // introspection, or an add/DSL path that didn't pass it), the fetch falls
       // back to the lookup value, so the comparison is trivially true.
-      (options.validate === undefined ||
-        !this.storesValidate ||
-        options.validate === this.validate) &&
+      (options.validate == null || !this.storesValidate || options.validate === this.validate) &&
       // Generic key compare, mirroring defined_for?'s `options.all?` over the
       // remaining stored option keys (column, name, primary_key, on_delete, …).
       (options.column === undefined ||
@@ -428,12 +428,12 @@ export class PrimaryKeyDefinition {
 export class CheckConstraintDefinition {
   readonly tableName: string;
   readonly expression: string;
-  readonly options: { name?: string; validate?: boolean };
+  readonly options: { name?: string; validate?: boolean | null };
 
   constructor(
     tableName: string,
     expression: string,
-    options: { name?: string; validate?: boolean } = {},
+    options: { name?: string; validate?: boolean | null } = {},
   ) {
     this.tableName = tableName;
     this.expression = expression;
@@ -445,11 +445,13 @@ export class CheckConstraintDefinition {
   }
 
   /** Mirrors: `validate?` (schema_definitions.rb:180-183). */
-  get validate(): boolean {
-    return this.options.validate ?? true;
+  get validate(): boolean | null {
+    // `options.fetch(:validate, true)` returns a stored nil as nil; the default
+    // applies only when the key is absent.
+    return "validate" in this.options ? (this.options.validate as boolean | null) : true;
   }
 
-  get isValidate(): boolean {
+  get isValidate(): boolean | null {
     return this.validate;
   }
 
@@ -460,7 +462,7 @@ export class CheckConstraintDefinition {
   isDefinedFor(options: {
     name: string | null | undefined;
     expression?: string;
-    validate?: boolean;
+    validate?: boolean | null;
   }): boolean {
     // Mirrors Rails CheckConstraintDefinition#defined_for?(name:, expression: nil,
     // ...): it matches on name (and validate) only — the expression is accepted
@@ -469,7 +471,7 @@ export class CheckConstraintDefinition {
     // form (e.g. PostgreSQL's `pg_get_constraintdef`).
     return (
       this.name === (options.name == null ? "" : options.name.toString()) &&
-      (options.validate === undefined || options.validate === this.validate)
+      (options.validate == null || options.validate === this.validate)
     );
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -468,10 +468,16 @@ export class CheckConstraintDefinition {
     // ...): it matches on name (and validate) only — the expression is accepted
     // but never compared (it is used upstream to derive the name). A raw-string
     // expression compare would spuriously fail against the adapter's normalized
-    // form (e.g. PostgreSQL's `pg_get_constraintdef`).
+    // form (e.g. PostgreSQL's `pg_get_constraintdef`). The validate arm mirrors
+    // `validate.nil? || validate == self.options.fetch(:validate, validate)`
+    // (schema_definitions.rb:193): with `:validate` unstored the fetch falls back
+    // to the lookup value, so the comparison is trivially true — the getter's
+    // `true` default must not stand in for it.
     return (
       this.name === (options.name == null ? "" : options.name.toString()) &&
-      (options.validate == null || options.validate === this.validate)
+      (options.validate == null ||
+        !("validate" in this.options) ||
+        options.validate === this.validate)
     );
   }
 }

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -26,7 +26,7 @@ export interface DatabaseConfigOptions {
   schemaDump?: string | false | null;
   databaseTasks?: boolean;
   useMetadataTable?: boolean;
-  seeds?: boolean;
+  seeds?: boolean | null;
   url?: string;
   replicaOf?: string;
   replica?: boolean;
@@ -172,7 +172,7 @@ export class DatabaseConfig {
    *
    * Abstract on DatabaseConfig — HashConfig overrides with real logic.
    */
-  get seeds(): boolean {
+  get seeds(): boolean | null {
     return false;
   }
 

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -270,6 +270,11 @@ describe("DatabaseConfigurations", () => {
       config = new HashConfig("default_env", "secondary", { adapter: "abstract", seeds: true });
       vi.spyOn(config, "isPrimary").mockReturnValue(false);
       expect(config.seeds).toBe(true);
+
+      // `configuration_hash.fetch(:seeds, primary?)` returns the STORED value
+      // whenever the key is present — a stored nil is not the default.
+      config = new HashConfig("default_env", "primary", { adapter: "abstract", seeds: null });
+      expect(config.seeds).toBe(null);
     });
 
     it("_database= does not mutate the hash passed to the constructor", () => {

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -271,8 +271,6 @@ describe("DatabaseConfigurations", () => {
       vi.spyOn(config, "isPrimary").mockReturnValue(false);
       expect(config.seeds).toBe(true);
 
-      // `configuration_hash.fetch(:seeds, primary?)` returns the STORED value
-      // whenever the key is present — a stored nil is not the default.
       config = new HashConfig("default_env", "primary", { adapter: "abstract", seeds: null });
       expect(config.seeds).toBe(null);
     });

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -41,10 +41,13 @@ export class HashConfig extends DatabaseConfig {
    * If the `seeds` key is present, returns its value. Otherwise returns
    * true for the primary database and false for others.
    */
-  get seeds(): boolean {
-    const raw = this.configuration.seeds;
-    if (raw !== undefined) return !!raw;
-    return this.isPrimary();
+  get seeds(): boolean | null {
+    // `Hash#fetch` returns the STORED value whenever the key is present —
+    // including a stored nil — and substitutes the default only when the key is
+    // absent, so this reads by key presence rather than `??`.
+    return "seeds" in this.configuration
+      ? (this.configuration.seeds as boolean | null)
+      : this.isPrimary();
   }
 
   /**

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -38,13 +38,12 @@ export class HashConfig extends DatabaseConfig {
   /**
    * Mirrors: HashConfig#seeds?
    *
-   * If the `seeds` key is present, returns its value. Otherwise returns
-   * true for the primary database and false for others.
+   * `Hash#fetch` returns the stored value whenever the key is present — a stored
+   * nil included — so this reads by key presence: if `seeds` is present it
+   * returns its value, otherwise true for the primary database and false for
+   * others.
    */
   get seeds(): boolean | null {
-    // `Hash#fetch` returns the STORED value whenever the key is present —
-    // including a stored nil — and substitutes the default only when the key is
-    // absent, so this reads by key presence rather than `??`.
     return "seeds" in this.configuration
       ? (this.configuration.seeds as boolean | null)
       : this.isPrimary();

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -9,20 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "reader",
-    "call": "create",
-    "reason": "Verified per-site (RFC 0106): `@proxy ||= CollectionProxy.create(klass, self)` (collection_association.rb:41) — RFC 0022 makes the `CollectionProxy` the canonical has_many store, created and cached by `associationProxy(owner, name)` rather than constructed inside `reader`; `reader` returns the shared target it already owns."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "reader",
-    "call": "reload",
-    "reason": "Verified per-site (RFC 0106): `reload` on a stale target (collection_association.rb:37-39) issues the load query, so it is `await`-only in trails while `reader` is a synchronous property read; the stale-reload arm lives in `asyncReader`, which every awaited call site uses."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "replace",
     "call": "transaction",
     "reason": "Rails wraps `replace_records` in `transaction` (collection_association.rb:251); the synchronous writer path returns a ReplacePlan and opens the transaction in `persistReplacePlan` (collection-association.ts:775-791)."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/join-dependency.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
-    "rubyName": "reflections",
-    "call": "drop",
-    "reason": "Verified per-site (RFC 0106): `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:82) walks the join tree as an Enumerable; trails' join root exposes the walk as `eachChildren`, so the root-skipping `drop(1)` is the guard inside the callback rather than a separate call."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
     "rubyName": "walk",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
RFC 0106 wave-3 burndown: three call-set/semantics rows converged, no new baseline rows.

## `CollectionAssociation#reader` (collection_association.rb:33-42)

`reader` now runs Rails' four lines in Rails' order — `ensure_klass_exists!`,
the stale-target `reload`, `@proxy ||= CollectionProxy.create(klass, self)`,
`@proxy.reset_scope` — collapsing the `reader` / `asyncReader` split (the
latter had no callers). `@proxy` is mirrored as a `_proxy` field; the create
side goes through `CollectionProxy.create`, added as the trails spelling of
`Delegation::ClassMethods#create` (relation/delegation.rb:138-140), which
routes to the RFC 0022 owner-keyed proxy store the same `collectionProxyClassFor`
carrier `_create` uses.

Because the reload issues a query, the body after `ensure_klass_exists!` is a
promise. trails' `CollectionProxy` is thenable, so awaiting the result hands
back the records rather than the proxy object — noted at the call site.

## `JoinDependency#reflections` (join_dependency.rb:81-83)

`join_root.drop(1).map!(&:reflection)` — `JoinPart` gets the `Symbol.iterator`
that stands in for `include Enumerable` over `each` (join_part.rb:13, 31-34)
plus `drop`, and `reflections` reads the reflection each node already carries
instead of re-resolving it through `_reflectOnAssociation` per node.
`_through_` hops are trails-only `JoinLeaf` nodes (Rails keeps a through
chain inside its one JoinAssociation) and carry no reflection, so they are
filtered out — same set as before.

## `Hash#fetch` semantics (the CLAUDE.md `fetch` vs `??` trap)

`ForeignKeyDefinition#validate?` / `CheckConstraintDefinition#validate?`
(schema_definitions.rb:152-153, 180-181) and `HashConfig#seeds?`
(hash_config.rb:137-139) now read by key presence, so an explicitly stored
`null` survives the way Ruby's `fetch` returns it instead of being replaced by
the default. `defined_for?`'s `validate.nil?` guards widened to `== null` to
match. Covered by a stored-null case in `hash-config.test.ts` and a new
`CheckConstraintDefinition#validate?` case.

## Baselines

`reader | create`, `reader | reload`, and `reflections | drop` deleted by hand
via `serializeBaseline` (no `--write`). Gate: 1189 → 1186 baselined rows,
unreviewed count unchanged, no stale marks. `parity:api:calls:args` OK,
`parity:api:extra` OK (the iterator carries a PERMANENT `@noRailsEquivalent`),
`parity:api` totals unchanged.

Closes-story: converge-collection-association-reader-reload-and-proxy
Closes-story: converge-join-dependency-reflections-drop-walk
Closes-story: port-hash-fetch-semantics-validate-and-seeds
