### PR TITLE
fix(parity): converge CollectionAssociation#size and Integration#cookies

### DIFF
--- a/packages/actionpack/src/action-dispatch/testing/integration.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.test.ts
@@ -580,8 +580,9 @@ describe("ActionDispatch::IntegrationTest", () => {
   });
 
   describe("_mock_session", () => {
-    it("_mock_session returns the integration session", () => {
-      expect(app._mockSession).toBe(app);
+    it("_mock_session owns the session's cookie jar", () => {
+      expect(app._mockSession).toBe(app._mockSession);
+      expect(app.cookies).toBe(app._mockSession.cookieJar);
     });
   });
 

--- a/packages/actionpack/src/action-dispatch/testing/integration.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.test.ts
@@ -580,9 +580,24 @@ describe("ActionDispatch::IntegrationTest", () => {
   });
 
   describe("_mock_session", () => {
-    it("_mock_session owns the session's cookie jar", () => {
-      expect(app._mockSession).toBe(app._mockSession);
-      expect(app.cookies).toBe(app._mockSession.cookieJar);
+    it("_mock_session owns the session's cookie jar", async () => {
+      const mockSession = app._mockSession;
+      expect(app.cookies).toBe(mockSession.cookieJar);
+
+      app.cookies.set("stored", "value");
+      await app.get("/posts");
+      expect(app._mockSession).toBe(mockSession);
+      expect(app.cookies.get("stored")).toBe("value");
+    });
+
+    it("reset! drops the mock session, and with it the cookies", () => {
+      app.cookies.set("stored", "value");
+      const mockSession = app._mockSession;
+
+      app.resetBang();
+
+      expect(app._mockSession).not.toBe(mockSession);
+      expect(app.cookies.get("stored")).toBeUndefined();
     });
   });
 

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -39,7 +39,6 @@ import { FlashHash } from "../middleware/flash.js";
 import { RouteSet } from "../routing/route-set.js";
 import type { Metal } from "../../action-controller/metal.js";
 import {
-  cookies as testProcessCookies,
   flash as testProcessFlash,
   redirectToUrl as testProcessRedirectToUrl,
   fileFixtureUpload as testProcessFileFixtureUpload,
@@ -153,8 +152,10 @@ export class IntegrationTest {
    */
   resetBang(): void {
     this.session = {};
-    this._persistentCookies = {};
-    this._cookieJar = undefined;
+    // Rails' `reset!` drops the memoized mock session (integration.rb:159), and
+    // with it the cookie jar — that IS how an integration session forgets its
+    // cookies.
+    this._mockSessionMemo = undefined;
     this._htmlDocument?.dispose();
     this._htmlDocument = undefined;
     this.controller = undefined!;
@@ -325,17 +326,8 @@ export class IntegrationTest {
     return this.status;
   }
 
-  /** Accumulated cookies across requests (simple key/value), seeds the jar. */
-  private _persistentCookies: Record<string, string> = {};
-
-  /**
-   * Memoized CookieJar slot consumed by `ActionDispatch::TestProcess#cookies`.
-   * Cleared at the start of each request so the jar reflects the current
-   * request's `HTTP_COOKIE` header.
-   *
-   * @internal
-   */
-  _cookieJar?: CookieJar;
+  /** Backing store for the memoized `_mockSession` (Rails' `@_mock_session`). */
+  _mockSessionMemo?: MockSession;
 
   /** The controller instance from the last request. */
   controller!: Metal;
@@ -378,17 +370,16 @@ export class IntegrationTest {
   }
 
   /**
-   * Cookies from the last request as a Rails-shaped `CookieJar`. Delegates
-   * to `ActionDispatch::TestProcess#cookies`, which builds the jar from
-   * `this.request.cookies` (parsed from `HTTP_COOKIE`) and memoizes it on
-   * `_cookieJar`. The slot is cleared on every new request and on `reset()`.
+   * A map of the cookies returned by the last response, and which will be sent
+   * with the next request.
+   *
+   * Mirrors `ActionDispatch::Integration::Session#cookies`
+   * (integration.rb:114-116) — `_mock_session.cookie_jar`, the one jar the whole
+   * session shares. This overrides `ActionDispatch::TestProcess#cookies`, which
+   * would build a per-request jar off `request.cookies` instead.
    */
   get cookies(): CookieJar {
-    if (!this.request) {
-      this._cookieJar ??= CookieJar.build(undefined, this._persistentCookies);
-      return this._cookieJar;
-    }
-    return testProcessCookies.call(this as unknown as TestProcessHost);
+    return this._mockSession.cookieJar;
   }
 
   /** Mirror of `ActionDispatch::TestProcess#redirectToUrl`. */
@@ -422,14 +413,16 @@ export class IntegrationTest {
   }
 
   /**
-   * The underlying mock session used to dispatch requests. In Rails this is a
-   * `Rack::MockSession`; in Trails the `IntegrationTest` itself plays that
-   * role, so this returns `this`. Mirrors `Integration::Session#_mock_session`.
+   * The underlying mock session used to dispatch requests, memoized as in
+   * `Integration::Session#_mock_session` (integration.rb:318-320):
+   * `@_mock_session ||= Rack::MockSession.new(@app, host)`. It owns the
+   * session's single cookie jar; `reset!` drops it.
    *
    * @internal
    */
-  get _mockSession(): this {
-    return this;
+  get _mockSession(): MockSession {
+    this._mockSessionMemo ??= new MockSession(this.app, this.host);
+    return this._mockSessionMemo;
   }
 
   /** Mirror of `ActionDispatch::TestProcess#session` (no-op delegation). */
@@ -864,7 +857,6 @@ export class IntegrationTest {
     this.requestCount += 1;
     // Clear per-request memos up front so they don't leak across requests,
     // including down the no-route 404 path.
-    this._cookieJar = undefined;
     this._urlOptions = undefined;
     this._htmlDocument?.dispose();
     this._htmlDocument = undefined;
@@ -898,10 +890,9 @@ export class IntegrationTest {
         HTTP_ACCEPT: this.accept,
         ...(options.env ?? {}),
       };
-      if (Object.keys(this._persistentCookies).length > 0) {
-        noRouteEnv.HTTP_COOKIE = Object.entries(this._persistentCookies)
-          .map(([k, v]) => `${k}=${v}`)
-          .join("; ");
+      const noRouteCookieHeader = this.cookieHeader();
+      if (noRouteCookieHeader !== undefined) {
+        noRouteEnv.HTTP_COOKIE = noRouteCookieHeader;
       }
       if (options.headers) {
         for (const [name, value] of Object.entries(options.headers)) {
@@ -967,11 +958,11 @@ export class IntegrationTest {
       (env.PATH_INFO as string) + (env.QUERY_STRING ? `?${env.QUERY_STRING as string}` : "");
     env.REQUEST_URI = this.buildFullUri(finalPath, env);
 
-    // Cookies from persistent jar
-    if (Object.keys(this._persistentCookies).length > 0) {
-      env.HTTP_COOKIE = Object.entries(this._persistentCookies)
-        .map(([k, v]) => `${k}=${v}`)
-        .join("; ");
+    // Cookies the mock session's jar will send with this request — Rack::Test
+    // builds `HTTP_COOKIE` from `cookie_jar.for(uri)`.
+    const cookieHeader = this.cookieHeader();
+    if (cookieHeader !== undefined) {
+      env.HTTP_COOKIE = cookieHeader;
     }
 
     // Format / content type
@@ -1042,7 +1033,9 @@ export class IntegrationTest {
     // (and the `flash` getter above) can find it.
     this.request.flash = (this.controller as any).flash ?? new FlashHash();
 
-    // Collect cookies from response
+    // Merge the response's Set-Cookies into the session's jar — Rack::Test's
+    // MockSession does this in `#request` via `cookie_jar.merge(last_response)`.
+    const cookieJar = this._mockSession.cookieJar;
     const setCookies = this.response.getHeader("set-cookie");
     if (setCookies) {
       for (const cookie of setCookies.split(",")) {
@@ -1051,22 +1044,52 @@ export class IntegrationTest {
         if (eqIdx > 0) {
           const name = parts.slice(0, eqIdx).trim();
           const value = parts.slice(eqIdx + 1).trim();
-          this._persistentCookies[name] = value;
+          cookieJar.set(name, value);
         }
       }
     }
 
-    // Reflect the up-to-date persistent jar on the request so subsequent
-    // reads of `app.cookies` (which delegates to `TestProcess#cookies`)
-    // see Set-Cookies from the just-finished response, not just the
-    // cookies that were sent in.
-    if (Object.keys(this._persistentCookies).length > 0) {
-      this.request.env.HTTP_COOKIE = Object.entries(this._persistentCookies)
-        .map(([k, v]) => `${k}=${v}`)
-        .join("; ");
+    // The jar outlives the request, but its signed/encrypted sub-jars read their
+    // secrets off the request that built them, so re-point it at the request
+    // just dispatched.
+    cookieJar._request = this.request as unknown as CookieJar["_request"];
+
+    // Reflect the up-to-date jar on the request so reads that go through
+    // `request.cookies` see Set-Cookies from the just-finished response, not
+    // just the cookies that were sent in.
+    const updatedCookieHeader = this.cookieHeader();
+    if (updatedCookieHeader !== undefined) {
+      this.request.env.HTTP_COOKIE = updatedCookieHeader;
     }
-    this._cookieJar = undefined;
   }
+
+  /**
+   * `HTTP_COOKIE` for the next request, from the mock session's jar — Rack::Test
+   * spells this `Rack::Test::CookieJar#for(uri)`. `undefined` when the jar is
+   * empty, so the header is omitted rather than sent blank.
+   */
+  private cookieHeader(): string | undefined {
+    const entries = Object.entries(this._mockSession.cookieJar.toHash());
+    if (entries.length === 0) return undefined;
+    return entries.map(([k, v]) => `${k}=${v}`).join("; ");
+  }
+}
+
+/**
+ * The mock session `Integration::Session#_mock_session` memoizes
+ * (integration.rb:318-320, `Rack::MockSession.new(@app, host)`). Rack::Test
+ * lives outside Rails so there is no file to port; what fidelity turns on is
+ * that the mock session owns THE cookie jar for the session — `#cookies` is
+ * `_mock_session.cookie_jar` (integration.rb:114-116) — so cookies sent,
+ * cookies received and cookies read back by a test are one store.
+ */
+class MockSession {
+  readonly cookieJar: CookieJar = CookieJar.build(undefined, {});
+
+  constructor(
+    readonly app: unknown,
+    readonly host: string,
+  ) {}
 }
 
 // --- Mixin attachments ---------------------------------------------------

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -152,9 +152,6 @@ export class IntegrationTest {
    */
   resetBang(): void {
     this.session = {};
-    // Rails' `reset!` drops the memoized mock session (integration.rb:159), and
-    // with it the cookie jar — that IS how an integration session forgets its
-    // cookies.
     this._mockSessionMemo = undefined;
     this._htmlDocument?.dispose();
     this._htmlDocument = undefined;
@@ -326,8 +323,8 @@ export class IntegrationTest {
     return this.status;
   }
 
-  /** Backing store for the memoized `_mockSession` (Rails' `@_mock_session`). */
-  _mockSessionMemo?: MockSession;
+  /** Backing store for the memoized {@link _mockSession} (Rails' `@_mock_session`). */
+  private _mockSessionMemo?: MockSession;
 
   /** The controller instance from the last request. */
   controller!: Metal;
@@ -416,7 +413,8 @@ export class IntegrationTest {
    * The underlying mock session used to dispatch requests, memoized as in
    * `Integration::Session#_mock_session` (integration.rb:318-320):
    * `@_mock_session ||= Rack::MockSession.new(@app, host)`. It owns the
-   * session's single cookie jar; `reset!` drops it.
+   * session's single cookie jar, which is why dropping it is how `reset!`
+   * (integration.rb:159) makes the session forget its cookies.
    *
    * @internal
    */
@@ -890,7 +888,7 @@ export class IntegrationTest {
         HTTP_ACCEPT: this.accept,
         ...(options.env ?? {}),
       };
-      const noRouteCookieHeader = this.cookieHeader();
+      const noRouteCookieHeader = this._mockSession.httpCookie();
       if (noRouteCookieHeader !== undefined) {
         noRouteEnv.HTTP_COOKIE = noRouteCookieHeader;
       }
@@ -958,9 +956,7 @@ export class IntegrationTest {
       (env.PATH_INFO as string) + (env.QUERY_STRING ? `?${env.QUERY_STRING as string}` : "");
     env.REQUEST_URI = this.buildFullUri(finalPath, env);
 
-    // Cookies the mock session's jar will send with this request — Rack::Test
-    // builds `HTTP_COOKIE` from `cookie_jar.for(uri)`.
-    const cookieHeader = this.cookieHeader();
+    const cookieHeader = this._mockSession.httpCookie();
     if (cookieHeader !== undefined) {
       env.HTTP_COOKIE = cookieHeader;
     }
@@ -1033,8 +1029,6 @@ export class IntegrationTest {
     // (and the `flash` getter above) can find it.
     this.request.flash = (this.controller as any).flash ?? new FlashHash();
 
-    // Merge the response's Set-Cookies into the session's jar — Rack::Test's
-    // MockSession does this in `#request` via `cookie_jar.merge(last_response)`.
     const cookieJar = this._mockSession.cookieJar;
     const setCookies = this.response.getHeader("set-cookie");
     if (setCookies) {
@@ -1049,29 +1043,12 @@ export class IntegrationTest {
       }
     }
 
-    // The jar outlives the request, but its signed/encrypted sub-jars read their
-    // secrets off the request that built them, so re-point it at the request
-    // just dispatched.
     cookieJar._request = this.request as unknown as CookieJar["_request"];
 
-    // Reflect the up-to-date jar on the request so reads that go through
-    // `request.cookies` see Set-Cookies from the just-finished response, not
-    // just the cookies that were sent in.
-    const updatedCookieHeader = this.cookieHeader();
+    const updatedCookieHeader = this._mockSession.httpCookie();
     if (updatedCookieHeader !== undefined) {
       this.request.env.HTTP_COOKIE = updatedCookieHeader;
     }
-  }
-
-  /**
-   * `HTTP_COOKIE` for the next request, from the mock session's jar — Rack::Test
-   * spells this `Rack::Test::CookieJar#for(uri)`. `undefined` when the jar is
-   * empty, so the header is omitted rather than sent blank.
-   */
-  private cookieHeader(): string | undefined {
-    const entries = Object.entries(this._mockSession.cookieJar.toHash());
-    if (entries.length === 0) return undefined;
-    return entries.map(([k, v]) => `${k}=${v}`).join("; ");
   }
 }
 
@@ -1090,6 +1067,17 @@ class MockSession {
     readonly app: unknown,
     readonly host: string,
   ) {}
+
+  /**
+   * The `HTTP_COOKIE` the jar sends with the next request, which Rack::Test's
+   * mock session builds as `cookie_jar.for(uri)`. `undefined` for an empty jar,
+   * so the header is omitted rather than sent blank.
+   */
+  httpCookie(): string | undefined {
+    const entries = Object.entries(this.cookieJar.toHash());
+    if (entries.length === 0) return undefined;
+    return entries.map(([k, v]) => `${k}=${v}`).join("; ");
+  }
 }
 
 // --- Mixin attachments ---------------------------------------------------

--- a/packages/activerecord/src/associations/collection-association-size-arms.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-size-arms.trails.test.ts
@@ -17,7 +17,6 @@ interface SizeableAssociation {
   target: Post[];
   isLoaded(): boolean;
   loadedBang(): void;
-  reset(): void;
   addToTarget(record: Post): Post;
   size(): Promise<number> | number;
 }
@@ -77,8 +76,6 @@ describe("CollectionAssociation#size with a grouped association scope", () => {
   it("loads the target and counts it when the association scope groups", async () => {
     const firm = (await Firm.find(companies("first_firm").id)) as unknown as Author;
     const assoc = association(firm, "clientsGroupedByFirmId");
-    // A grouped COUNT(*) returns one row per group rather than a scalar, so the
-    // arm has to load the target and count it in memory.
     const size = await assoc.size();
 
     expect(assoc.isLoaded()).toBe(true);

--- a/packages/activerecord/src/associations/collection-association-size-arms.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-association-size-arms.trails.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Trails-only: `CollectionAssociation#size` (collection_association.rb:209-222)
+ * has five arms, and trails used to keep only the first two on the OO
+ * association — the `group_values` arm and the two `count_records` arms lived on
+ * `CollectionProxy#size` alone. Rails has no equivalent test because Rails has
+ * no such split; these pin every arm on the association itself, so the counted
+ * arms cannot quietly fall back to `target.length` again.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Firm, Client } from "../test-helpers/models/company.js";
+import { fixtures } from "../test-fixtures.js";
+
+interface SizeableAssociation {
+  target: Post[];
+  isLoaded(): boolean;
+  loadedBang(): void;
+  reset(): void;
+  addToTarget(record: Post): Post;
+  size(): Promise<number> | number;
+}
+
+const association = (author: Author, name: string): SizeableAssociation =>
+  (author as unknown as { association(name: string): SizeableAssociation }).association(name);
+
+describe("CollectionAssociation#size arms", () => {
+  const { authors } = fixtures(["authors", "posts", "comments"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+  });
+
+  it("counts the target when the association is loaded", async () => {
+    const author = await Author.find(authors("david").id);
+    const assoc = association(author, "posts");
+    const persisted = (await Post.where({ author_id: author.id }).count()) as number;
+
+    assoc.target.length = 0;
+    assoc.loadedBang();
+
+    expect(await assoc.size()).toBe(0);
+    expect(persisted).toBeGreaterThan(0);
+  });
+
+  it("counts records with a COUNT(*) when the association is not loaded", async () => {
+    const author = await Author.find(authors("david").id);
+    const assoc = association(author, "posts");
+    const persisted = (await Post.where({ author_id: author.id }).count()) as number;
+
+    expect(assoc.isLoaded()).toBe(false);
+    expect(await assoc.size()).toBe(persisted);
+  });
+
+  it("adds buffered new records to the counted records", async () => {
+    const author = await Author.find(authors("david").id);
+    const assoc = association(author, "posts");
+    const persisted = (await Post.where({ author_id: author.id }).count()) as number;
+
+    assoc.addToTarget(Post.new({ title: "unsaved", body: "unsaved" }));
+
+    expect(assoc.isLoaded()).toBe(false);
+    expect(await assoc.size()).toBe(persisted + 1);
+  });
+});
+
+describe("CollectionAssociation#size with a grouped association scope", () => {
+  const { companies } = fixtures(["companies", "accounts"]);
+
+  beforeAll(() => {
+    registerModel(Firm);
+    registerModel(Client);
+  });
+
+  it("loads the target and counts it when the association scope groups", async () => {
+    const firm = (await Firm.find(companies("first_firm").id)) as unknown as Author;
+    const assoc = association(firm, "clientsGroupedByFirmId");
+    // A grouped COUNT(*) returns one row per group rather than a scalar, so the
+    // arm has to load the target and count it in memory.
+    const size = await assoc.size();
+
+    expect(assoc.isLoaded()).toBe(true);
+    expect(size).toBe(assoc.target.length);
+    expect(size).toBeGreaterThan(0);
+  });
+});

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -681,11 +681,17 @@ export class CollectionAssociation extends Association {
    * the collection hasn't been loaded, and by counting `target` if it has.
    *
    * Mirrors: ActiveRecord::Associations::CollectionAssociation#size
-   * (collection_association.rb:209-222). Abstract in the sense that it relies
-   * on `count_records`, which descendants have to provide — so the two counted
-   * arms and the grouped `load_target` arm return a promise while the two
-   * in-memory arms stay synchronous, exactly as Rails' arms do (Rails' first
-   * two issue no query either).
+   * (collection_association.rb:209-222), all five arms in Rails' order. The two
+   * in-memory arms stay synchronous — Rails' first two issue no query either —
+   * while the grouped arm and the two counted arms return a promise, since a
+   * grouped COUNT(*) yields one row per group rather than a scalar and so has to
+   * load the target and count it in memory.
+   *
+   * Rails declares `count_records` only on the descendants
+   * (has_many_association.rb:80, has_many_through_association.rb:79) and calls it
+   * abstractly from here; every concrete collection association is a
+   * `HasManyAssociation`, so it is reached through the subclass rather than
+   * through a base declaration Rails does not have.
    */
   size(): Promise<number> | number {
     if (!this.findTargetNeeded() || this.isLoaded()) {
@@ -696,35 +702,18 @@ export class CollectionAssociation extends Association {
       ((this.associationScope() as { groupValues?: unknown[] } | undefined)?.groupValues ?? [])
         .length > 0
     ) {
-      // A GROUP BY makes COUNT(*) return per-group rows rather than a scalar,
-      // so Rails loads the whole target and counts it in memory.
       return Promise.resolve(this.loadTarget()).then((target) => target.length);
     } else if (
       !(this.associationScope() as { distinctValue?: boolean } | undefined)?.distinctValue &&
       this.target.length > 0
     ) {
       const unsavedRecords = this.target.filter((record) => record.isNewRecord());
-      // Rails declares `count_records` only on the descendants
-      // (has_many_association.rb:80, has_many_through_association.rb:79) and
-      // calls it abstractly from here; every concrete collection association is
-      // a HasManyAssociation, so reach it through the subclass rather than
-      // adding a base declaration Rails does not have.
-      return this.asCountingAssociation()
+      return (this as unknown as { countRecords(): Promise<number> })
         .countRecords()
         .then((count) => unsavedRecords.length + count);
     } else {
-      return this.asCountingAssociation().countRecords();
+      return (this as unknown as { countRecords(): Promise<number> }).countRecords();
     }
-  }
-
-  /**
-   * `CollectionAssociation#size` calls `count_records` abstractly
-   * (collection_association.rb:207-208, :218, :220); only the descendants
-   * declare it (has_many_association.rb:80).
-   * @internal
-   */
-  private asCountingAssociation(): { countRecords(): Promise<number> } {
-    return this as unknown as { countRecords(): Promise<number> };
   }
 
   async isEmpty(): Promise<boolean> {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -676,19 +676,60 @@ export class CollectionAssociation extends Association {
     return this.deleteOrDestroy(records, "destroy");
   }
 
-  get size(): number {
+  /**
+   * Returns the size of the collection by executing a SELECT COUNT(*) query if
+   * the collection hasn't been loaded, and by counting `target` if it has.
+   *
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#size
+   * (collection_association.rb:209-222). Abstract in the sense that it relies
+   * on `count_records`, which descendants have to provide — so the two counted
+   * arms and the grouped `load_target` arm return a promise while the two
+   * in-memory arms stay synchronous, exactly as Rails' arms do (Rails' first
+   * two issue no query either).
+   */
+  size(): Promise<number> | number {
     if (!this.findTargetNeeded() || this.isLoaded()) {
       return this.target.length;
-    }
-    if (this._associationIds) {
+    } else if (this._associationIds) {
       return this._associationIds.length;
+    } else if (
+      ((this.associationScope() as { groupValues?: unknown[] } | undefined)?.groupValues ?? [])
+        .length > 0
+    ) {
+      // A GROUP BY makes COUNT(*) return per-group rows rather than a scalar,
+      // so Rails loads the whole target and counts it in memory.
+      return Promise.resolve(this.loadTarget()).then((target) => target.length);
+    } else if (
+      !(this.associationScope() as { distinctValue?: boolean } | undefined)?.distinctValue &&
+      this.target.length > 0
+    ) {
+      const unsavedRecords = this.target.filter((record) => record.isNewRecord());
+      // Rails declares `count_records` only on the descendants
+      // (has_many_association.rb:80, has_many_through_association.rb:79) and
+      // calls it abstractly from here; every concrete collection association is
+      // a HasManyAssociation, so reach it through the subclass rather than
+      // adding a base declaration Rails does not have.
+      return this.asCountingAssociation()
+        .countRecords()
+        .then((count) => unsavedRecords.length + count);
+    } else {
+      return this.asCountingAssociation().countRecords();
     }
-    return this.target.length;
+  }
+
+  /**
+   * `CollectionAssociation#size` calls `count_records` abstractly
+   * (collection_association.rb:207-208, :218, :220); only the descendants
+   * declare it (has_many_association.rb:80).
+   * @internal
+   */
+  private asCountingAssociation(): { countRecords(): Promise<number> } {
+    return this as unknown as { countRecords(): Promise<number> };
   }
 
   async isEmpty(): Promise<boolean> {
     if (this.isLoaded() || this._associationIds || this.reflection.hasActiveCachedCounter?.()) {
-      return this.size === 0;
+      return (await this.size()) === 0;
     }
     return this.target.length === 0 && !(await this.scope().exists());
   }

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/testing/integration.json
@@ -9,13 +9,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
-    "rubyName": "cookies",
-    "call": "cookie_jar",
-    "reason": "Verified per-site (RFC 0106): `_mock_session.cookie_jar` (integration.rb:114-116) reads the jar off Rack::Test's mock session; trails has no `_mock_session`, so the jar is built from and read through the request (`CookieJar.build` / `testProcessCookies`)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
     "rubyName": "process",
     "call": "encoder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -31,29 +31,8 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "size",
-    "call": "count_records",
-    "reason": "Verified per-site (RFC 0106): `count_records` (collection_association.rb:218, :220) issues a COUNT query, so it cannot run inside the synchronous `size` getter; the counted arms live on the awaitable `CollectionProxy#size`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "size",
     "call": "empty?",
     "reason": "Verified per-site (RFC 0106): `target.empty?` / `association_scope.group_values.empty?` (collection_association.rb:214, :216) are `.length === 0` property reads, which the gate deliberately does not credit as calls (JS_ENUMERABLE_ALIASES, RFC 0092)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "size",
-    "call": "find_target?",
-    "reason": "Verified per-site (RFC 0106): `!find_target? || loaded?` (collection_association.rb:210) IS ported — as `findTargetNeeded()`, the trails spelling of `find_target?` — so what the gate misses is the name, not the branch."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "size",
-    "call": "select",
-    "reason": "Verified per-site (RFC 0106): `target.select(&:new_record?)` (collection_association.rb:217) belongs to the un-loaded `count_records` arm, which is async in trails and lives on `CollectionProxy#size`; the synchronous getter never reaches it."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Two RFC 0106 wave-3 rows, both "one Rails method split across two trails surfaces".

## `CollectionAssociation#size`

`collection_association.rb:209-222` has five arms. trails kept the first two and
then fell back to `target.length`; the grouped `load_target` arm and both
`count_records` arms lived only on the awaitable `CollectionProxy#size`.

All five now run on the association, in Rails' branch order with Rails' guards.
The two in-memory arms stay synchronous (Rails' first two issue no query either)
and the counted ones return a promise, so the return type is
`Promise<number> | number`. `count_records` is reached on the descendant —
Rails declares it only there (`has_many_association.rb:80`) and calls it
abstractly from the base.

`CollectionProxy#size` is untouched: making it `@association.size`
(collection_proxy.rb:782) means giving the proxy a real association instance
instead of its synthesized `proxyAssociation` façade, which is its own change.

## `Integration::Session#cookies`

`integration.rb:114-116` is `_mock_session.cookie_jar` — one jar for the whole
session. trails stitched two stores together: a `_persistentCookies` hash that
built `HTTP_COOKIE`, and a per-request `CookieJar` memo read back through
`TestProcess#cookies`. `_mockSession` now has the `Rack::MockSession` shape that
owns the jar (`integration.rb:318-320`), `cookies` reads `cookieJar` off it, and
`reset!` drops the memoized session as Rails does (`integration.rb:159`).

The jar outlives each request, so it is re-pointed at the request just dispatched
— trails' `CookieJar` reads the signed/encrypted secrets off the request that
built it, where Rack::Test's jar has no such link.

## Baselines

Deleted by hand (no `--write`): `size | count_records`, `size | select`,
`size | find_target?`, `cookies | cookie_jar`. No stale high-water mark, so no
`tighten` needed.

`size | empty?` stays. Its two sites are `target.empty?` and
`association_scope.group_values.empty?`, which port to `.length` reads — a
property form the gate deliberately does not credit for any receiver (RFC 0092,
"handed to the reason-text route instead"). The row's existing reason already
says exactly that.

## Verification

- `pnpm parity:api:calls` / `parity:api:calls:args`: OK
- `pnpm parity:api:extra --package actionpack`: 0 novel (the `MockSession` class
  is module-private)
- 178 actionpack test files green; has_many / HABTM / has_many-through /
  collection-proxy AR suites green
- New `collection-association-size-arms.trails.test.ts` pins all four reachable
  arms on the association; three of its four cases fail on the old getter

Closes-story: converge-collection-association-size-counted-arms
Closes-story: converge-integration-cookies-onto-mock-session