### PR TITLE
fix(parity): resolve one-body-two-declaration TS owners in the call gate

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
@@ -11,6 +11,6 @@
     "tsFile": "array-utils.ts",
     "rubyName": "in_groups",
     "call": "div",
-    "reason": "Ruby core Integer#div (core_ext/array/grouping.rb:66), not a ported trails method — the gate matched Date#div/Duration#div; the port uses Math.floor."
+    "reason": "Ruby core Integer#div (core_ext/array/grouping.rb:66), not a ported trails method — the port uses Math.floor."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/array-utils.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "array-utils.ts",
+    "rubyName": "extract!",
+    "call": "reject!",
+    "reason": "Ruby core Array#reject! (core_ext/array/extract.rb:15), not a ported trails method — the gate matched DescendantsTracker.rejectBang; the port splices in place."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "array-utils.ts",
+    "rubyName": "in_groups",
+    "call": "div",
+    "reason": "Ruby core Integer#div (core_ext/array/grouping.rb:66), not a ported trails method — the gate matched Date#div/Duration#div; the port uses Math.floor."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
@@ -11,6 +11,6 @@
     "tsFile": "core-ext/digest/uuid.ts",
     "rubyName": "uuid_from_hash",
     "call": "unpack",
-    "reason": "Ruby core String#unpack of the digest bytes (core_ext/digest/uuid.rb:19-38), not a ported trails method — the gate matched Cache::Entry.unpack."
+    "reason": "Ruby core String#unpack of the digest bytes (core_ext/digest/uuid.rb:19-38), not a ported trails method."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/digest/uuid.ts",
+    "rubyName": "pack_uuid_namespace",
+    "call": "map",
+    "reason": "Ruby core Array#map over the packed namespace (core_ext/digest/uuid.rb:52-58), not a ported trails method."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/digest/uuid.ts",
+    "rubyName": "uuid_from_hash",
+    "call": "unpack",
+    "reason": "Ruby core String#unpack of the digest bytes (core_ext/digest/uuid.rb:19-38), not a ported trails method — the gate matched Cache::Entry.unpack."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
@@ -18,13 +18,13 @@
     "tsFile": "core-ext/file/atomic.ts",
     "rubyName": "atomic_write",
     "call": "stat",
-    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:21-52), not a ported trails method — the gate matched ConnectionPool#stat."
+    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:21-52), not a ported trails method — the port asks fs/promises."
   },
   {
     "package": "activesupport",
     "tsFile": "core-ext/file/atomic.ts",
     "rubyName": "probe_stat_in",
     "call": "stat",
-    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:56-64), not a ported trails method — the gate matched ConnectionPool#stat."
+    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:56-64), not a ported trails method — the port asks fs/promises."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/file/atomic.json
@@ -1,0 +1,30 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "exist?",
+    "reason": "Ruby stdlib File.exist? (core_ext/file/atomic.rb:21-52), not a ported trails method — the port asks fs/promises."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "rename",
+    "reason": "Ruby stdlib File.rename (core_ext/file/atomic.rb:21-52), not a ported trails method — the port calls fs/promises rename."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "atomic_write",
+    "call": "stat",
+    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:21-52), not a ported trails method — the gate matched ConnectionPool#stat."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/file/atomic.ts",
+    "rubyName": "probe_stat_in",
+    "call": "stat",
+    "reason": "Ruby stdlib File.stat (core_ext/file/atomic.rb:56-64), not a ported trails method — the gate matched ConnectionPool#stat."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/deprecation/method-wrappers.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/deprecation/method-wrappers.json
@@ -1,0 +1,23 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "deprecation/method-wrappers.ts",
+    "rubyName": "deprecate_methods",
+    "call": "define_method",
+    "reason": "Module#define_method inside module_eval (deprecation/method_wrappers.rb:35-49), Ruby metaprogramming — the port assigns the wrapper onto the object."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "deprecation/method-wrappers.ts",
+    "rubyName": "deprecate_methods",
+    "call": "new",
+    "reason": "Module.new for the prepended shim module (deprecation/method_wrappers.rb:35-49), a Ruby prepend shape TS has no counterpart for."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "deprecation/method-wrappers.ts",
+    "rubyName": "deprecate_methods",
+    "call": "redefine_method",
+    "reason": "Module#redefine_method inside module_eval (deprecation/method_wrappers.rb:35-49), Ruby metaprogramming — the port assigns the wrapper onto the object."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
@@ -1,0 +1,44 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "in_order_of",
+    "call": "compact",
+    "reason": "Ruby core Array#compact on the receiver (core_ext/enumerable.rb:197-207), not a ported trails method — the gate matched Relation#compact."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "many?",
+    "call": "any?",
+    "reason": "Ruby core Enumerable#any? on the receiver (core_ext/enumerable.rb:93-99), not a ported trails method — the gate matched Querying.isAny."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "sole",
+    "call": "count",
+    "reason": "Ruby core Enumerable#count on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method — the gate matched Querying.count."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "sole",
+    "call": "first",
+    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method — the gate matched Relation#first."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "sum",
+    "call": "first",
+    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method — the gate matched Relation#first."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "enumerable-utils.ts",
+    "rubyName": "sum",
+    "call": "last",
+    "reason": "Ruby core Enumerable#last on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method — the gate matched Querying.last."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/enumerable-utils.json
@@ -4,41 +4,41 @@
     "tsFile": "enumerable-utils.ts",
     "rubyName": "in_order_of",
     "call": "compact",
-    "reason": "Ruby core Array#compact on the receiver (core_ext/enumerable.rb:197-207), not a ported trails method — the gate matched Relation#compact."
+    "reason": "Ruby core Array#compact on the receiver (core_ext/enumerable.rb:197-207), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
     "rubyName": "many?",
     "call": "any?",
-    "reason": "Ruby core Enumerable#any? on the receiver (core_ext/enumerable.rb:93-99), not a ported trails method — the gate matched Querying.isAny."
+    "reason": "Ruby core Enumerable#any? on the receiver (core_ext/enumerable.rb:93-99), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
     "rubyName": "sole",
     "call": "count",
-    "reason": "Ruby core Enumerable#count on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method — the gate matched Querying.count."
+    "reason": "Ruby core Enumerable#count on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
     "rubyName": "sole",
     "call": "first",
-    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method — the gate matched Relation#first."
+    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:211-217), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
     "rubyName": "sum",
     "call": "first",
-    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method — the gate matched Relation#first."
+    "reason": "Ruby core Enumerable#first on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "enumerable-utils.ts",
     "rubyName": "sum",
     "call": "last",
-    "reason": "Ruby core Enumerable#last on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method — the gate matched Querying.last."
+    "reason": "Ruby core Enumerable#last on the receiver (core_ext/enumerable.rb:241-247), not a ported trails method."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -11,7 +11,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "change",
     "call": "utc?",
-    "reason": "Ruby core Time#utc? read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — the gate matched DateTime#isUtc."
+    "reason": "Ruby core Time#utc? read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — Temporal carries the zone on the value."
   },
   {
     "package": "activesupport",
@@ -25,7 +25,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "sec_fraction",
     "call": "subsec",
-    "reason": "Ruby core Time#subsec on the receiver (core_ext/time/calculations.rb:107-109), not a ported trails method — the gate matched DateTime#subsec."
+    "reason": "Ruby core Time#subsec on the receiver (core_ext/time/calculations.rb:107-109), not a ported trails method — the port reads Temporal's sub-second fields."
   },
   {
     "package": "activesupport",
@@ -46,21 +46,21 @@
     "tsFile": "time-ext.ts",
     "rubyName": "to_time",
     "call": "day",
-    "reason": "Ruby core Date#day read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.day."
+    "reason": "Ruby core Date#day read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "to_time",
     "call": "getlocal",
-    "reason": "Ruby core Time#getlocal on the receiver (core_ext/time/compatibility.rb:13-15), not a ported trails method — the gate matched TimeWithZone#getlocal."
+    "reason": "Ruby core Time#getlocal on the receiver (core_ext/time/compatibility.rb:13-15), not a ported trails method — the port reads the zone off the Temporal value."
   },
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "to_time",
     "call": "month",
-    "reason": "Ruby core Date#month read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.month."
+    "reason": "Ruby core Date#month read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method."
   },
   {
     "package": "activesupport",
@@ -74,7 +74,7 @@
     "tsFile": "time-ext.ts",
     "rubyName": "to_time",
     "call": "year",
-    "reason": "Ruby core Date#year read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.year."
+    "reason": "Ruby core Date#year read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -1,0 +1,86 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "active_support_local_zone",
+    "call": "new",
+    "reason": "Ruby core Time.new to read the system zone (core_ext/time/compatibility.rb:32-40), not a ported trails constructor."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "utc?",
+    "reason": "Ruby core Time#utc? read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — the gate matched DateTime#isUtc."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "utc_offset",
+    "reason": "Ruby core Time#utc_offset read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — Temporal carries the offset on the value."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "sec_fraction",
+    "call": "subsec",
+    "reason": "Ruby core Time#subsec on the receiver (core_ext/time/calculations.rb:107-109), not a ported trails method — the gate matched DateTime#subsec."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "since",
+    "call": "to_datetime",
+    "reason": "Ruby core Time#to_datetime in the TypeError rescue arm (core_ext/time/calculations.rb:225-233); TS has no TypeError arm to enter."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "since",
+    "call": "warn",
+    "reason": "ActiveSupport.deprecator.warn in the same TypeError rescue arm (core_ext/time/calculations.rb:228-232), unreachable in the port."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "day",
+    "reason": "Ruby core Date#day read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.day."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "getlocal",
+    "reason": "Ruby core Time#getlocal on the receiver (core_ext/time/compatibility.rb:13-15), not a ported trails method — the gate matched TimeWithZone#getlocal."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "month",
+    "reason": "Ruby core Date#month read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.month."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "utc_offset",
+    "reason": "Ruby core Time#utc_offset read off the receiver (core_ext/date_time/compatibility.rb:15-17), not a ported trails method — Temporal carries the offset on the value."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "year",
+    "reason": "Ruby core Date#year read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method — the gate matched Duration.year."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "xmlschema",
+    "call": "in_time_zone",
+    "reason": "Date#xmlschema (core_ext/date/conversions.rb:95-97) reaches in_time_zone through to_time; the port formats the date directly."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "transliterate.ts",
+    "rubyName": "transliterate",
+    "call": "include?",
+    "reason": "Ruby core Array#include? over ALLOWED_ENCODINGS_FOR_TRANSLITERATE (inflector/transliterate.rb:66), not a ported trails method — JS strings carry no encoding."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
@@ -4,6 +4,6 @@
     "tsFile": "xml-mini/nokogiri.ts",
     "rubyName": "parse",
     "call": "first",
-    "reason": "Ruby core Enumerable#first on the parsed document (xml_mini/nokogiri.rb:19-30), not a ported trails method — the gate matched Relation#first."
+    "reason": "Ruby core Enumerable#first on the parsed document (xml_mini/nokogiri.rb:19-30), not a ported trails method."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "xml-mini/nokogiri.ts",
+    "rubyName": "parse",
+    "call": "first",
+    "reason": "Ruby core Enumerable#first on the parsed document (xml_mini/nokogiri.rb:19-30), not a ported trails method — the gate matched Relation#first."
+  }
+]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1944,6 +1944,36 @@ describe("resolveTsOwner — include graph and seats", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("resolves one body declared twice — the free export and the grouping", () => {
+    // The trails mixin convention: `export function toTime()` beside
+    // `export const TimeExt = { toTime }`, so both owners record the SAME
+    // call-set and the comparison is identical whichever is picked.
+    const calls = { "": [["getlocal"]], TimeExt: [["getlocal"]] };
+    expect(
+      resolveTsOwner(new Set(["", "TimeExt"]), "Date", {
+        callSetOf: (o: string) => calls[o as keyof typeof calls],
+      }),
+    ).toBe("");
+  });
+
+  it("refuses two owners whose call-sets differ", () => {
+    // relation.ts's `ExplainProxy#first` next to the `Relation` overload: two
+    // bodies, so picking one is the mispairing the resolution exists to avoid.
+    const calls = { Relation: [["findNth"]], ExplainProxy: [["execExplain"]] };
+    expect(
+      resolveTsOwner(new Set(["Relation", "ExplainProxy"]), "ActiveRecord::FinderMethods", {
+        callSetOf: (o: string) => calls[o as keyof typeof calls],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("refuses when an owner records no call-set at all", () => {
+    const calls: Record<string, string[][]> = { TimeExt: [["getlocal"]] };
+    expect(
+      resolveTsOwner(new Set(["", "TimeExt"]), "Date", { callSetOf: (o: string) => calls[o] }),
+    ).toBeUndefined();
+  });
 });
 
 describe("tsOwnerSeat", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -963,11 +963,20 @@ export function callTagKey(tsFile: string, tsClass: string, tsName: string): str
  * picking one by seat is the mispairing this resolution exists to avoid:
  * time-ext.ts's single `toTime` body answers `Time#to_time`, `Date#to_time` and
  * `DateTime#to_time` alike (RFC 0108).
+ *
+ *  4. one BODY declared twice. The trails mixin convention (CLAUDE.md "Module
+ *     mixins") exports a top-level function and re-exports the very same
+ *     function through a grouping object — `export function toTime()` beside
+ *     `export const TimeExt = { toTime }` — so the file's owners are `""` and
+ *     `TimeExt` for one body. Where every owner declaring the name records the
+ *     SAME call-set the comparison is identical whichever is picked, so pick
+ *     one (`callSetOf`; the sorted first, which is the free export). Owners
+ *     whose call-sets differ are two bodies and stay unresolved.
  */
 export function resolveTsOwner(
   owners: ReadonlySet<string> | undefined,
   rubyModule: string,
-  { hosts, seatOf, rubySeat, rubySeats = new Set() }: TsOwnerResolution = {},
+  { hosts, seatOf, rubySeat, rubySeats = new Set(), callSetOf }: TsOwnerResolution = {},
 ): string | undefined {
   if (!owners || owners.size === 0) return undefined;
   if (owners.size === 1) return [...owners][0];
@@ -982,6 +991,14 @@ export function resolveTsOwner(
     if (exact.length === 1) return exact[0];
     const compatible = [...owners].filter((o) => (seatOf(o) ?? rubySeat) === rubySeat);
     if (compatible.length === 1) return compatible[0];
+  }
+  if (callSetOf) {
+    const sorted = [...owners].sort();
+    const keys = sorted.map((o) => {
+      const sets = callSetOf(o);
+      return sets === undefined ? undefined : JSON.stringify(sets);
+    });
+    if (keys[0] !== undefined && keys.every((k) => k === keys[0])) return sorted[0];
   }
   return undefined;
 }
@@ -1005,6 +1022,9 @@ export interface TsOwnerResolution {
   /** The seats of EVERY Ruby owner declaring the name in this Ruby file. The
    *  seat arm runs only when they differ — see resolveTsOwner. */
   rubySeats?: ReadonlySet<OwnerSeat>;
+  /** The call-sets the file records for each TS owner declaring the name, for
+   *  the one-body-two-declarations arm — see resolveTsOwner step 4. */
+  callSetOf?: (tsOwner: string) => readonly string[][] | undefined;
 }
 
 /** The seat a Ruby owner FQN states, if any: `ActiveRecord::Persistence::ClassMethods`
@@ -2959,6 +2979,7 @@ export function main() {
           seatOf,
           rubySeat,
           rubySeats,
+          callSetOf: (tsOwner) => tsCallsByFileNameOwner.get(tsFile)?.get(tsName)?.get(tsOwner),
         });
         const tsSeat = tsClass === undefined ? undefined : seatOf(tsClass);
         const ambiguous =

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -971,7 +971,12 @@ export function callTagKey(tsFile: string, tsClass: string, tsName: string): str
  *     `TimeExt` for one body. Where every owner declaring the name records the
  *     SAME call-set the comparison is identical whichever is picked, so pick
  *     one (`callSetOf`; the sorted first, which is the free export). Owners
- *     whose call-sets differ are two bodies and stay unresolved.
+ *     whose call-sets differ are two bodies and stay unresolved. Equality of
+ *     the recorded sets is the whole test, so two genuinely different bodies
+ *     recording the same set (both empty, say) also resolve — harmless while
+ *     the resolved owner only gates `ambiguousTsOwner` / `ownerRecordsNothing`
+ *     and the comparison itself unions the file's declarations (checkCalls),
+ *     but a reader that consumed the owner's OWN set would need more here.
  */
 export function resolveTsOwner(
   owners: ReadonlySet<string> | undefined,


### PR DESCRIPTION
## What

`resolveTsOwner` (RFC 0108) could not name an owner when a file declares one
name on several classes and neither the Ruby short name, the include graph, nor
the class/instance seat picks one. Most of that population is not two
declarations at all: it is ONE body declared twice — the trails mixin
convention of a top-level `export function` re-exported through a grouping
object (`export function toTime()` beside `export const TimeExt = { toTime }`),
so `tsOwnersByFileName` holds `{"", "TimeExt"}` for a single body.

A fourth arm resolves exactly that: where every owner declaring the name in the
file records the SAME call-set, the comparison is identical whichever owner is
picked, so it picks the sorted-first (the free export). Owners whose call-sets
differ are two bodies and stay unresolved — that is the mispairing the arm must
refuse, and `time-ext.ts`'s single `toTime` answering `Time#to_time`,
`Date#to_time` and `DateTime#to_time` alike is why.

## Measured

- call-set comparisons: 5583 → **5761** (+178 matched pairs)
- call-argument sites: 5556 → 5556 (unmoved — that gate additionally requires a
  single recorded site per file+name, which a twice-declared body never has)
- new mismatch records: 21 (33 individual calls), all activesupport

## The rows

All 33 are pre-existing name collisions between a Ruby core/stdlib receiver
call and an unrelated ported trails name — `Integer#div`, `Array#reject!`,
`Enumerable#first/last/count/compact/any?`, `String#unpack`, `File.exist?/stat/
rename`, `Time#getlocal/utc?/utc_offset/subsec`, `Module#define_method` — plus
two rescue-arm calls in `Time#since` (`core_ext/time/calculations.rb:225-233`)
that the port has no `TypeError` arm to enter. Each is baselined with its own
one-line reason carrying the Rails `file:line`; none is a dropped delegation.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` are both green.

Closes-story: resolve-duplicate-declaration-owners-one-body-two-seats