### PR TITLE
refactor(activerecord): move the where/or/and/excluding family into query-methods.ts

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -630,130 +630,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Add WHERE conditions. Accepts:
-   *  - a hash of column/value pairs
-   *  - a raw SQL string with optional bind values
-   *  - an Arel `Nodes.Node`
-   *  - composite-key positional form: `where(['c1','c2'], [[v1a,v1b], ...])`
-   *    (the JS analog of Rails' `where({[c1, c2] => [tuples]})` —
-   *    JS object keys can't be arrays, so columns become a leading
-   *    positional argument)
-   *
-   * Mirrors: ActiveRecord::Relation#where
-   *
-   * Examples:
-   *   where({ name: "dean" })
-   *   where("age > ?", 18)
-   *   where("name LIKE ?", "%dean%")
-   *   where(['shop_id', 'order_number'], [[1, 100], [2, 200]])
-   */
-  where(): WhereChain<Relation<T>>;
-  where(conditions: undefined): WhereChain<Relation<T>>;
-  where(conditions: Record<string, unknown> | null): Relation<T>;
-  where(sql: string, ...binds: unknown[]): Relation<T>;
-  where(node: Nodes.Node): Relation<T>;
-  /**
-   * Sanitized-conditions array form: `where(["name = ?", x])` /
-   * `where(["name = :name", { name: x }])` / `where(["name = '%s'", x])`.
-   * A single array argument routes through `buildWhereClause`, matching Rails'
-   * `sanitize_sql(array)`; the two-argument composite form below is distinct.
-   */
-  where(conditions: unknown[]): Relation<T>;
-  /**
-   * Composite-key form: `where(['c1', 'c2'], [[v11, v12], [v21, v22]])`
-   * compiles to `(c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22)`.
-   * The Rails analog is `where({['c1', 'c2'] => [[v11, v12], ...]})` —
-   * JS object keys can't be arrays, so columns become a leading
-   * positional argument. Tuples containing null/undefined are
-   * filtered (SQL tuple-equality treats any null component as a
-   * non-match); after filtering, an empty list short-circuits via
-   * `none()`.
-   */
-  where(cols: string[], tuples: unknown[][]): Relation<T>;
-  where(
-    conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | string[] | unknown[] | null,
-    ...rest: unknown[]
-  ): Relation<T> | WhereChain<Relation<T>> {
-    if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this.spawn());
-    // Rails: a single blank-ish argument (`args.length == 1 && args.first.blank?`,
-    // query_methods.rb:1036) makes `where` a no-op returning the relation
-    // unchanged — `where({})` / `where([])` / `where(null)` / `where("")` all
-    // match every row. This applies ONLY to the single-argument call:
-    // `where([], tuples)` (a 2-arg composite) must fall through so the empty
-    // column list raises rather than silently no-opping. Short-circuiting the
-    // empty top-level hash here (rather than in the predicate builder) is what
-    // lets a NESTED empty hash (`where(posts: {})`) still expand to the `1=0`
-    // contradiction Rails' `expand_from_hash` returns.
-    if (rest.length === 0 && _qm.isBlankArgument(conditionsOrSql)) {
-      return this;
-    }
-    // Composite-key form: array of column names + array of tuples. It is
-    // always a two-argument call (`where(cols, tuples)`), so it is
-    // disambiguated from Rails' sanitized-array conditions form
-    // (`where(["name = ?", x])`, a single array argument) by the presence of
-    // the extra `tuples` argument. A single all-strings array falls through
-    // to `buildWhereClause`, which unwraps `[head, ...tail]` and sanitizes.
-    if (
-      Array.isArray(conditionsOrSql) &&
-      rest.length > 0 &&
-      conditionsOrSql.every((c) => typeof c === "string")
-    ) {
-      if (rest.length !== 1 || !Array.isArray(rest[0])) {
-        throw argumentError(
-          "Relation#where(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
-        );
-      }
-      const cols = conditionsOrSql as string[];
-      const tuples = rest[0] as unknown[][];
-      // buildComposite returns the WhereClause predicates directly (the native
-      // PredicateBuilder currency); spread them into the clause exactly as
-      // buildWhereClause spreads buildFromHash's result, so a single tuple stays
-      // flat (`WHERE c1 = ? AND c2 = ?`, no wrapping Grouping) like Rails.
-      //
-      // Rails passes `lookup_table_klass_from_join_dependencies` as the block to
-      // `predicate_builder.build_from_hash` (query_methods.rb:1643-1645) so a
-      // qualified col naming a manual-join table binds through the joined
-      // model's column type.
-      const nodes = this.predicateBuilder.buildComposite(
-        cols,
-        tuples,
-        (tableName) => this.lookupTableKlassFromJoinDependencies(tableName) as typeof Base | null,
-      );
-      if (nodes.length === 0) return this.spawn().noneBang();
-      const rel = this.spawn();
-      rel.whereClause = rel.whereClause.plus(new WhereClause([...nodes]));
-      return rel;
-    }
-    return this.spawn().whereBang(
-      conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
-      ...rest,
-    );
-  }
-
-  /**
-   * Replace all existing WHERE conditions with new ones.
-   *
-   * Mirrors: ActiveRecord::Relation#rewhere
-   */
-  rewhere(conditions: Record<string, unknown> | null): Relation<T> {
-    // Mirrors rewhere (query_methods.rb): `return unscope(:where) if conditions.nil?`.
-    if (conditions == null) return this.unscope("where");
-    conditions = sanitizeForbiddenAttributes(conditions);
-    const rel = this.spawn();
-    // Mirrors rewhere (query_methods.rb): `where_clause = build_where_clause(...)`,
-    // `unscope!(where: where_clause.extract_attributes)`, `where_clause += ...`.
-    // Building through the same `build_where_clause` path as `where` keeps the
-    // predicates separate (so a polymorphic `belongs_to` key like `writer`
-    // expands to distinct `writer_type`/`writer_id` predicates), and excepting by
-    // the *columns the new predicates reference* — not the hash keys — drops both
-    // of those columns before re-adding them.
-    const newClause = rel.buildWhereClause(conditions);
-    rel.whereClause = rel.whereClause.except(...newClause.extractAttributes());
-    rel.whereClause = rel.whereClause.plus(newClause);
-    return rel;
-  }
-
-  /**
    * Filter for records WHERE the association IS present.
    *
    * Mirrors: ActiveRecord::QueryMethods::WhereChain#associated
@@ -914,81 +790,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Combine this relation with another using OR.
-   *
-   * Mirrors: ActiveRecord::Relation#or
-   */
-  or(other: Relation<T>): Relation<T> {
-    if (this._isNone) return other.clone();
-    return this.spawn().orBang(other);
-  }
-
-  /**
-   * Combine this relation with another using AND — merges all WHERE
-   * conditions from the other relation into this one.
-   *
-   * Mirrors: ActiveRecord::Relation#and
-   */
-  and(other: Relation<T>): Relation<T> {
-    return this.spawn().andBang(other);
-  }
-
-  /**
-   * WHERE ANY of the given conditions match (OR logic).
-   * Accepts an array of condition hashes.
-   *
-   * Mirrors: ActiveRecord::Relation#where.any (Rails 7.1)
-   */
-  whereAny(...conditions: Record<string, unknown>[]): Relation<T> {
-    if (conditions.length === 0) return this;
-    if (conditions.length === 1) return this.where(conditions[0]);
-
-    const buildClause = (cond: Record<string, unknown>): WhereClause =>
-      new WhereClause(this.predicateBuilder.buildFromHash(cond));
-
-    let combined = buildClause(conditions[0]);
-    for (let i = 1; i < conditions.length; i++) {
-      combined = combined.or(buildClause(conditions[i]));
-    }
-    const rel = this.spawn();
-    if (combined.predicates.length > 0)
-      rel.whereClause = rel.whereClause.plus(new WhereClause([combined.ast]));
-    return rel;
-  }
-
-  /**
-   * WHERE ALL of the given conditions match (AND logic).
-   * Accepts an array of condition hashes.
-   *
-   * Mirrors: ActiveRecord::Relation#where.all (Rails 7.1)
-   */
-  whereAll(...conditions: Record<string, unknown>[]): Relation<T> {
-    let rel: Relation<T> = this;
-    for (const cond of conditions) {
-      rel = rel.where(cond);
-    }
-    return rel;
-  }
-
-  /**
-   * Exclude specific records from the result.
-   *
-   * Mirrors: ActiveRecord::QueryMethods#excluding (query_methods.rb:1574-1584)
-   * and `alias :without :excluding` (query_methods.rb:1585). Ruby writes ONE
-   * body and lets `__callee__` (:1580) name whichever alias was invoked;
-   * TypeScript has no `__callee__` and a shared prototype function cannot
-   * recover the name it was reached under, so the one authored body lives in
-   * {@link excludingWithCallee} and each name is bound to a copy of it
-   * generated with its own callee — the ArgumentError then names `#excluding`
-   * or `#without` exactly as `excluding_test.rb:103-110`
-   * (`test_raises_on_record_from_different_class`) asserts, with no shared
-   * helper Rails does not have.
-   */
-  declare excluding: (...records: unknown[]) => Relation<T>;
-
-  declare without: (...records: unknown[]) => Relation<T>;
-
-  /**
    * PostgreSQL DISTINCT ON — select distinct rows based on specific columns.
    *
    * Mirrors: ActiveRecord::Relation#distinct_on (PostgreSQL only)
@@ -998,16 +799,6 @@ export class Relation<T extends Base> {
     rel.distinctValue = true;
     rel._distinctOnColumns = columns;
     return rel;
-  }
-
-  /**
-   * Invert all existing WHERE conditions.
-   * Swaps where ↔ whereNot clauses.
-   *
-   * Mirrors: ActiveRecord::Relation#invert_where
-   */
-  invertWhere(): Relation<T> {
-    return this.spawn().invertWhereBang();
   }
 
   /**
@@ -1412,16 +1203,6 @@ export class Relation<T extends Base> {
    */
   async presence(): Promise<LoadedRelation<Relation<T>> | null> {
     return (await this.isPresent()) ? stripThenable(this as Relation<T>) : null;
-  }
-
-  /**
-   * Check if another relation is structurally compatible for use with or().
-   *
-   * Mirrors: ActiveRecord::Relation#structurally_compatible?
-   */
-  structurallyCompatible(other: Relation<T>): boolean {
-    if (this._model !== other._model) return false;
-    return isEmpty(this.structurallyIncompatibleValuesFor(other as never));
   }
 
   /**
@@ -3895,6 +3676,36 @@ export interface Relation<T extends Base>
   order(...args: OrderArg[]): Relation<T>;
   inOrderOf(column: string | Nodes.Node, values: unknown[], filter?: boolean): Relation<T>;
   reorder(...args: OrderArg[]): Relation<T>;
+  where(): WhereChain<Relation<T>>;
+  where(conditions: undefined): WhereChain<Relation<T>>;
+  where(conditions: Record<string, unknown> | null): Relation<T>;
+  where(sql: string, ...binds: unknown[]): Relation<T>;
+  where(node: Nodes.Node): Relation<T>;
+  /**
+   * Sanitized-conditions array form: `where(["name = ?", x])` /
+   * `where(["name = :name", { name: x }])` / `where(["name = '%s'", x])`.
+   * A single array argument routes through `buildWhereClause`, matching Rails'
+   * `sanitize_sql(array)`; the two-argument composite form below is distinct.
+   */
+  where(conditions: unknown[]): Relation<T>;
+  /**
+   * Composite-key form: `where(['c1', 'c2'], [[v11, v12], [v21, v22]])`
+   * compiles to `(c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22)`.
+   * The Rails analog is `where({['c1', 'c2'] => [[v11, v12], ...]})` —
+   * JS object keys can't be arrays, so columns become a leading
+   * positional argument. Tuples containing null/undefined are
+   * filtered (SQL tuple-equality treats any null component as a
+   * non-match); after filtering, an empty list short-circuits via
+   * `none()`.
+   */
+  where(cols: string[], tuples: unknown[][]): Relation<T>;
+  rewhere(conditions: Record<string, unknown> | null): Relation<T>;
+  invertWhere(): Relation<T>;
+  structurallyCompatible(other: Relation<T>): boolean;
+  and(other: Relation<T>): Relation<T>;
+  or(other: Relation<T>): Relation<T>;
+  excluding(...records: unknown[]): Relation<T>;
+  without(...records: unknown[]): Relation<T>;
   having(condition: string, ...binds: unknown[]): Relation<T>;
   having(condition: Record<string, unknown>): Relation<T>;
   having(condition: Nodes.Node): Relation<T>;
@@ -4052,46 +3863,3 @@ async function computeCacheVersion(
 ): Promise<string> {
   return rel.computeCacheVersion(timestampColumn);
 }
-
-/**
- * The one authored `excluding` body (query_methods.rb:1574-1584), generated per
- * callee so `alias :without :excluding` (:1585) keeps its own `__callee__` in
- * the ArgumentError. See {@link Relation.excluding}.
- */
-function excludingWithCallee(callee: "excluding" | "without") {
-  return function (this: Relation<Base>, ...records: unknown[]): Relation<Base> {
-    const relations = records.filter((r) => r instanceof Relation) as Relation<Base>[];
-    records = records
-      .filter((r) => !(r instanceof Relation))
-      .flat(1)
-      .filter((r) => r != null);
-
-    const model = this.model;
-    if (
-      !records.every((r) => r instanceof model) ||
-      !relations.every((relation) => relation.model === model)
-    ) {
-      throw new ArgumentError(
-        `You must only pass a single or collection of ${model.name} objects to #${callee}.`,
-      );
-    }
-
-    // Rails `records + relations.flat_map(&:ids)`. `Relation#ids` returns the
-    // cached `records.map(&:id)` when the relation is loaded (calculations.rb:371)
-    // and re-queries otherwise. A loaded relation's records are already in
-    // memory, so spread them into the literal `records` collection to match
-    // Rails exactly (no extra query). An unloaded relation is deferred:
-    // `excludingBang` records a marker that the load pipeline materializes into a
-    // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
-    // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
-    const combined: unknown[] = [...records];
-    for (const relation of relations) {
-      if (relation.isLoaded) combined.push(...(relation as any)._records);
-      else combined.push(relation);
-    }
-    return this.spawn().excludingBang(combined);
-  };
-}
-
-Relation.prototype.excluding = excludingWithCallee("excluding");
-Relation.prototype.without = excludingWithCallee("without");

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1515,7 +1515,6 @@ export function areStructurallyCompatible(self: unknown, other: unknown): boolea
  * (query_methods.rb:1121-1123)
  */
 function structurallyCompatible(this: QueryMethodsHost, other: any): boolean {
-  if (this._model !== other._model) return false;
   return structurallyIncompatibleValuesFor.call(this, other).length === 0;
 }
 
@@ -1547,7 +1546,10 @@ function andBang(this: QueryMethodsHost, other: any): any {
  * Mirrors: ActiveRecord::QueryMethods#or (query_methods.rb:1167-1177)
  */
 function or(this: QueryMethodsHost, other: any): any {
-  if (this._isNone) return other.clone();
+  // query_methods.rb:1168 — the `other.is_a?(Relation)` guard wraps BOTH arms,
+  // so `none.or(garbage)` raises rather than reaching `other.spawn`.
+  assertRelationForCombining(other, "or");
+  if (this._isNone) return other.spawn();
   return orBang.call(this.spawn(), other);
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1126,11 +1126,117 @@ export function buildWhereClause(
   throw argumentError(`Unsupported argument type: ${String(opts)} (${typeof opts})`);
 }
 
+/**
+ * Add WHERE conditions. Accepts:
+ *  - a hash of column/value pairs
+ *  - a raw SQL string with optional bind values
+ *  - an Arel `Nodes.Node`
+ *  - composite-key positional form: `where(['c1','c2'], [[v1a,v1b], ...])`
+ *    (the JS analog of Rails' `where({[c1, c2] => [tuples]})` —
+ *    JS object keys can't be arrays, so columns become a leading
+ *    positional argument)
+ *
+ * Mirrors: ActiveRecord::QueryMethods#where (query_methods.rb:1033-1041)
+ *
+ * Examples:
+ *   where({ name: "dean" })
+ *   where("age > ?", 18)
+ *   where("name LIKE ?", "%dean%")
+ *   where(['shop_id', 'order_number'], [[1, 100], [2, 200]])
+ */
+function where(
+  this: QueryMethodsHost,
+  conditionsOrSql?: Record<string, unknown> | string | Nodes.Node | string[] | unknown[] | null,
+  ...rest: unknown[]
+): any {
+  if (conditionsOrSql === undefined) return new WhereChain(this.spawn());
+  // Rails: a single blank-ish argument (`args.length == 1 && args.first.blank?`,
+  // query_methods.rb:1036) makes `where` a no-op returning the relation
+  // unchanged — `where({})` / `where([])` / `where(null)` / `where("")` all
+  // match every row. This applies ONLY to the single-argument call:
+  // `where([], tuples)` (a 2-arg composite) must fall through so the empty
+  // column list raises rather than silently no-opping. Short-circuiting the
+  // empty top-level hash here (rather than in the predicate builder) is what
+  // lets a NESTED empty hash (`where(posts: {})`) still expand to the `1=0`
+  // contradiction Rails' `expand_from_hash` returns.
+  if (rest.length === 0 && isBlankArgument(conditionsOrSql)) {
+    return this;
+  }
+  // Composite-key form: array of column names + array of tuples. It is
+  // always a two-argument call (`where(cols, tuples)`), so it is
+  // disambiguated from Rails' sanitized-array conditions form
+  // (`where(["name = ?", x])`, a single array argument) by the presence of
+  // the extra `tuples` argument. A single all-strings array falls through
+  // to `buildWhereClause`, which unwraps `[head, ...tail]` and sanitizes.
+  if (
+    Array.isArray(conditionsOrSql) &&
+    rest.length > 0 &&
+    conditionsOrSql.every((c) => typeof c === "string")
+  ) {
+    if (rest.length !== 1 || !Array.isArray(rest[0])) {
+      throw argumentError(
+        "Relation#where(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
+      );
+    }
+    const cols = conditionsOrSql as string[];
+    const tuples = rest[0] as unknown[][];
+    // buildComposite returns the WhereClause predicates directly (the native
+    // PredicateBuilder currency); spread them into the clause exactly as
+    // buildWhereClause spreads buildFromHash's result, so a single tuple stays
+    // flat (`WHERE c1 = ? AND c2 = ?`, no wrapping Grouping) like Rails.
+    //
+    // Rails passes `lookup_table_klass_from_join_dependencies` as the block to
+    // `predicate_builder.build_from_hash` (query_methods.rb:1643-1645) so a
+    // qualified col naming a manual-join table binds through the joined
+    // model's column type.
+    const nodes = this.predicateBuilder.buildComposite(
+      cols,
+      tuples,
+      (tableName) =>
+        lookupTableKlassFromJoinDependencies.call(this, tableName) as
+          | QueryMethodsHost["_model"]
+          | null,
+    );
+    if (nodes.length === 0) return noneBang.call(this.spawn());
+    const rel = this.spawn();
+    rel.whereClause = rel.whereClause.plus(new WhereClause([...nodes]));
+    return rel;
+  }
+  return whereBang.call(
+    this.spawn(),
+    conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
+    ...rest,
+  );
+}
+
 function whereBang(this: QueryMethodsHost, opts: any, ...rest: unknown[]): any {
   if (opts == null) return this;
   const clause = buildWhereClause.call(this, opts, rest);
   this.whereClause = this.whereClause.plus(clause);
   return this;
+}
+
+/**
+ * Replace all existing WHERE conditions with new ones.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#rewhere (query_methods.rb:1061-1071)
+ */
+function rewhere(this: QueryMethodsHost, conditions: Record<string, unknown> | null): any {
+  // Mirrors rewhere (query_methods.rb): `return unscope(:where) if conditions.nil?`.
+  if (conditions == null) return unscope.call(this, "where");
+  conditions = sanitizeForbiddenAttributes(conditions);
+  const rel = this.spawn();
+  // Mirrors rewhere (query_methods.rb): `where_clause = build_where_clause(...)`,
+  // `unscope!(where: where_clause.extract_attributes)`, `where_clause += ...`.
+  // Building through the same `build_where_clause` path as `where` keeps the
+  // predicates separate (so a polymorphic `belongs_to` key like `writer`
+  // expands to distinct `writer_type`/`writer_id` predicates), and excepting by
+  // the *columns the new predicates reference* — not the hash keys — drops both
+  // of those columns before re-adding them.
+  const newClause = buildWhereClause.call(rel, conditions);
+  rel.whereClause = rel.whereClause.except(...newClause.extractAttributes());
+  rel.whereClause = rel.whereClause.plus(newClause);
+  return rel;
 }
 
 /**
@@ -1146,6 +1252,16 @@ function isRelationLike(value: unknown): boolean {
     "_model" in value &&
     typeof (value as { toArel?: unknown }).toArel === "function"
   );
+}
+
+/**
+ * Invert all existing WHERE conditions.
+ * Swaps where ↔ whereNot clauses.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#invert_where (query_methods.rb:1101-1103)
+ */
+function invertWhere(this: QueryMethodsHost): any {
+  return invertWhereBang.call(this.spawn());
 }
 
 function invertWhereBang(this: QueryMethodsHost): any {
@@ -1392,6 +1508,27 @@ export function areStructurallyCompatible(self: unknown, other: unknown): boolea
   return structurallyIncompatibleValuesFor.call(self, other).length === 0;
 }
 
+/**
+ * Check if another relation is structurally compatible for use with and()/or().
+ *
+ * Mirrors: ActiveRecord::QueryMethods#structurally_compatible?
+ * (query_methods.rb:1121-1123)
+ */
+function structurallyCompatible(this: QueryMethodsHost, other: any): boolean {
+  if (this._model !== other._model) return false;
+  return structurallyIncompatibleValuesFor.call(this, other).length === 0;
+}
+
+/**
+ * Combine this relation with another using AND — merges all WHERE
+ * conditions from the other relation into this one.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#and (query_methods.rb:1135-1141)
+ */
+function and(this: QueryMethodsHost, other: any): any {
+  return andBang.call(this.spawn(), other);
+}
+
 function andBang(this: QueryMethodsHost, other: any): any {
   assertRelationForCombining(other, "and");
   assertStructurallyCompatible(this, other, "and");
@@ -1402,6 +1539,16 @@ function andBang(this: QueryMethodsHost, other: any): any {
   this.havingClause = this.havingClause.union(other.havingClause);
   this.referencesValues = unionReferences(this.referencesValues, other.referencesValues);
   return this;
+}
+
+/**
+ * Combine this relation with another using OR.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#or (query_methods.rb:1167-1177)
+ */
+function or(this: QueryMethodsHost, other: any): any {
+  if (this._isNone) return other.clone();
+  return orBang.call(this.spawn(), other);
 }
 
 function orBang(this: QueryMethodsHost, other: any): any {
@@ -1781,6 +1928,65 @@ function uniqBang(this: QueryMethodsHost, name?: string): any {
   }
   return this;
 }
+
+/**
+ * Exclude specific records from the result.
+ *
+ * Mirrors: ActiveRecord::QueryMethods#excluding (query_methods.rb:1574-1584)
+ * and `alias :without :excluding` (query_methods.rb:1585). Ruby writes ONE
+ * body and lets `__callee__` (:1580) name whichever alias was invoked;
+ * TypeScript has no `__callee__` and a shared prototype function cannot
+ * recover the name it was reached under, so the one authored body lives in
+ * {@link excludingWithCallee} and each name is bound to a copy of it
+ * generated with its own callee — the ArgumentError then names `#excluding`
+ * or `#without` exactly as `excluding_test.rb:103-110`
+ * (`test_raises_on_record_from_different_class`) asserts, with no shared
+ * helper Rails does not have.
+ */
+function excludingWithCallee(callee: "excluding" | "without") {
+  return function (this: QueryMethodsHost, ...records: unknown[]): any {
+    // Rails `records.extract! { |element| element.is_a?(Relation) }`. The
+    // `Relation` constant itself is unreachable from here — importing it would
+    // close the relation.ts ↔ query-methods.ts cycle — so the same partition
+    // runs off the structural relation check this file already uses for
+    // `#and` / `#or`.
+    const relations = records.filter((r) => isRelationForCombining(r)) as any[];
+    records = records
+      .filter((r) => !isRelationForCombining(r))
+      .flat(1)
+      .filter((r) => r != null);
+
+    const model = this.model;
+    if (
+      !records.every((r) => r instanceof (model as any)) ||
+      !relations.every((relation) => relation.model === model)
+    ) {
+      throw new ArgumentError(
+        `You must only pass a single or collection of ${model.name} objects to #${callee}.`,
+      );
+    }
+
+    // Rails `records + relations.flat_map(&:ids)`. `Relation#ids` returns the
+    // cached `records.map(&:id)` when the relation is loaded (calculations.rb:371)
+    // and re-queries otherwise. A loaded relation's records are already in
+    // memory, so spread them into the literal `records` collection to match
+    // Rails exactly (no extra query). An unloaded relation is deferred:
+    // `excludingBang` records a marker that the load pipeline materializes into a
+    // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
+    // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
+    const combined: unknown[] = [...records];
+    for (const relation of relations) {
+      if (relation.isLoaded) combined.push(...relation._records);
+      else combined.push(relation);
+    }
+    return excludingBang.call(this.spawn(), combined);
+  };
+}
+
+const excluding = excludingWithCallee("excluding");
+
+/** Mirrors `alias :without :excluding` (query_methods.rb:1585). */
+const without = excludingWithCallee("without");
 
 function excludingBang(this: QueryMethodsHost, records: any[]): any {
   const primaryKey = this.primaryKey;
@@ -2411,9 +2617,15 @@ export const QueryMethodBangs = {
   unscopeBang,
   joinsBang,
   leftOuterJoinsBang,
+  where,
   whereBang,
+  rewhere,
+  invertWhere,
   invertWhereBang,
+  structurallyCompatible,
+  and,
   andBang,
+  or,
   orBang,
   having,
   havingBang,
@@ -2447,6 +2659,8 @@ export const QueryMethodBangs = {
   annotate,
   annotateBang,
   uniqBang,
+  excluding,
+  without,
   excludingBang,
   constructJoinDependency,
   asyncBang,

--- a/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
+++ b/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
@@ -1,6 +1,6 @@
 /**
  * trails-specific regression guard (no Rails counterpart): `Relation#where` /
- * `whereNot` / `whereAny` / `having` hand hash values RAW to PredicateBuilder,
+ * `whereNot` / `or` / `having` hand hash values RAW to PredicateBuilder,
  * like Rails' build_where_clause (query_methods.rb) — the QueryAttribute bind
  * owns casting/serialization at compile time (predicate_builder.rb:57-69 →
  * build_bind_attribute → value_for_database). An earlier trails invention
@@ -31,8 +31,8 @@ describe("where value defer-to-bind casting", () => {
     expect(await rel).toHaveLength(0);
   });
 
-  it("whereAny with an un-castable string binds it instead of IS NULL", async () => {
-    const rel = Topic.all().whereAny({ parent_id: "not-a-number" }, { written_on: "" });
+  it("or with an un-castable string binds it instead of IS NULL", async () => {
+    const rel = Topic.where({ parent_id: "not-a-number" }).or(Topic.where({ written_on: "" }));
     expect(rel.toSql()).not.toMatch(/IS NULL/i);
     expect(await rel).toHaveLength(0);
   });


### PR DESCRIPTION
Split 1 of 4 of the `relation.ts` decomposition (RFC 0107). Moves the where
family out of `relation.ts` into `packages/activerecord/src/relation/query-methods.ts`,
whose Rails counterpart `active_record/relation/query_methods.rb` defines it.

| member                    | `query_methods.rb`             |
| ------------------------- | ------------------------------ |
| `where`                   | `:1033` (`where!` `:1043`)     |
| `rewhere`                 | `:1061`                        |
| `invertWhere`             | `:1101` (`invert_where!` `:1105`) |
| `structurallyCompatible`  | `:1121`                        |
| `and`                     | `:1135` (`and!` `:1143`)       |
| `or`                      | `:1167` (`or!` `:1179`)        |
| `excluding` / `without`   | `:1574` / `:1585`              |

Each is now a `this`-typed function mixed in through `QueryMethodBangs`, placed
in `query_methods.rb` source order next to the `*Bang` it spawns into. Bodies
are unchanged apart from the mechanical `this.foo()` → `foo.call(this)` rewrite
the mixin shape requires, and one substitution in `excluding`: `r instanceof
Relation` becomes the file's existing `isRelationForCombining` structural check,
since importing `Relation` here would close the `relation.ts` ↔
`query-methods.ts` cycle. `_excludingArgs` stays in `relation.ts` (owned by the
where-family-privates story).

Two deviations found sitting in the moved bodies are converged rather than
carried over. `structurally_compatible?` (`:1121-1123`) is
`structurally_incompatible_values_for(other).empty?` and nothing else — the
model identity check trails had in front of it has no counterpart
(`structurally_incompatible_values_for`, `:2266-2277`, compares only
`STRUCTURAL_VALUE_METHODS`). And `or` (`:1167-1177`) wraps *both* arms in the
`other.is_a?(Relation)` guard, so `none.or(garbage)` raises the ArgumentError
instead of reaching the `@none` arm; that arm is `other.spawn`, not
`other.clone`.

`whereAny` / `whereAll` are deleted. Rails has no `where.any` / `where.all` —
the "Rails 7.1" claim in their doc comments was wrong. `whereAll` had no
callers; `whereAny`'s only caller was `where-raw-bind-defer.trails.test.ts`,
whose OR-path bind coverage moves onto `#or` (same predicate shape, same
assertion). `pnpm parity:api:extra` drops both rows.

Not in this PR: the WhereChain trio inversion (`WhereChain#not` / `#associated`
/ `#missing` carrying the bodies instead of delegating outward to
`Relation#whereNot` / `#whereAssociated` / `#whereMissing`). It is ~266 LOC of
move plus ~40 call sites, which does not fit under the ceiling alongside this;
filed unchanged as `0107-relation-ts-decomposition/invert-where-chain-trio-onto-wherechain`.

Verification: `relation/where.test.ts`, `where-chain.test.ts`, `or.test.ts`,
`composite-where.test.ts`, `merging.test.ts`, `where-raw-bind-defer.trails.test.ts`,
`excluding.test.ts`, `excluding.trails.test.ts`, `relations.test.ts` all pass.
`pnpm parity:api` / `parity:test` deltas non-negative; `parity:api:calls` and
`parity:api:calls:args` clean, no new baseline rows.

Closes-story: fan-out-query-methods-where-family
