### PR TITLE
fix(activerecord): converge schemaUpToDate onto with_temporary_pool

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1408,23 +1408,13 @@ export class DatabaseTasks {
     const fs = getFs();
     if (!fs.existsSync(file)) return true;
 
-    let adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter;
-    try {
-      adapter = await this._migrationAdapter();
-    } catch (error) {
-      if (error instanceof ConnectionNotDefined) return false;
-      throw error;
-    }
+    return await this.withTemporaryPool(dbConfig, async (pool) => {
+      const internalMetadata = pool.internalMetadata;
+      if (internalMetadata.enabled == null || internalMetadata.enabled === false) return false;
+      if (!(await internalMetadata.tableExists())) return false;
 
-    const { InternalMetadata } = await import("../internal-metadata.js");
-    const metadata = new InternalMetadata(adapter.pool);
-    if (!(await metadata.tableExists())) return false;
-
-    const storedSha1 = await metadata.get("schema_sha1");
-    if (!storedSha1) return false;
-
-    const fileSha1 = await this.schemaSha1(file);
-    return storedSha1 === fileSha1;
+      return (await internalMetadata.get("schema_sha1")) === (await this.schemaSha1(file));
+    });
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/tasks/database-tasks.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "schema_up_to_date?",
-    "call": "with_temporary_pool",
-    "reason": "Verified per-site (RFC 0106): `with_temporary_pool(db_config)` (`database_tasks.rb:403`) — the port reads internal_metadata off the already-established migration pool instead. Converging it re-establishes and restores a connection inside the `reconstruct_from_schema` fast path, so it is filed as its own story rather than folded in here."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "target_version",
     "call": "empty?",
     "reason": "Verified per-site (RFC 0106): `ENV[\"VERSION\"].empty?` (database_tasks.rb:324) — `empty?` on a Ruby String, whose faithful JS spelling is `s === \"\"`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."


### PR DESCRIPTION
`DatabaseTasks.schema_up_to_date?` (`tasks/database_tasks.rb:397-411`) wraps its metadata reads in `with_temporary_pool(db_config)` and reads `pool.internal_metadata`. trails read `InternalMetadata` off the already-established migration pool, caught `ConnectionNotDefined` to answer `false` (no Rails analogue), and never consulted `internal_metadata.enabled?`.

Now mirrors Rails' order: `enabled?` → `table_exists?` → `internal_metadata[:schema_sha1] == schema_sha1(file)`. Also drops the extra `if (!storedSha1) return false` guard — Rails compares a possibly-nil value directly.

Deleted the baselined `schema_up_to_date? | with_temporary_pool` row from `call-mismatches-exclude/activerecord/tasks/database-tasks.json` by hand via `serializeBaseline`; there is no unreviewed mark shard for that file, so no tighten was needed. `parity:api:calls` and `parity:api:calls:args` green.

Closes-story: schema-up-to-date-skips-with-temporary-pool