### PR TITLE
fix(parity): converge CollectionProxy#size/#empty? and unblock the call-args gate

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1396,7 +1396,8 @@ export function syncToAssociationInstance(record: Base, assocName: string, resul
  * violation, matching `find_target?` / `null_scope?`.
  *
  * `foreign_key_present?` has the same two-branch dispatch used by the OO
- * association and `CollectionProxy._foreignKeyPresent`: a belongs_to reads the
+ * association (`CollectionAssociation#foreignKeyPresent`, which the proxy's
+ * `null_scope?` delegates to): a belongs_to reads the
  * owner-side FK columns; a `:through` routes through its belongs_to
  * (`ThroughAssociation#foreign_key_present?`); a vanilla has_one/has_many/habtm
  * requires the owner's `active_record_primary_key`

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -938,8 +938,10 @@ export class CollectionAssociation extends Association {
    * routes through a belongs_to (`ThroughAssociation#foreign_key_present?`,
    * through_association.rb:90); a vanilla has_many requires the owner's
    * `active_record_primary_key` to be present (`ForeignAssociation#foreign_key_present?`,
-   * foreign_association.rb:5). Mirrors the same dispatch in
-   * `CollectionProxy#_foreignKeyPresent` so the two never disagree.
+   * foreign_association.rb:5). This is the only copy of the dispatch:
+   * `CollectionProxy#null_scope?` (collection_proxy.rb:1150-1152) delegates
+   * here through `isNullScope`, so the proxy and the association cannot
+   * disagree.
    */
   protected override foreignKeyPresent(): boolean {
     if (this.reflection.options.through) {

--- a/packages/activerecord/src/associations/collection-proxy-count.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.test.ts
@@ -259,16 +259,18 @@ describe("CollectionProxy#count — non-through fast path", () => {
 
   it("foreignKeyPresent on the proxy agrees with the OO association (owner PK present)", async () => {
     // ForeignAssociation#foreign_key_present? — a new-record owner whose primary
-    // key is already assigned is fetchable; the proxy and the OO association must
-    // not disagree.
+    // key is already assigned is fetchable. The proxy no longer carries its own
+    // copy of the check: `null_scope?` (collection_proxy.rb:1150) delegates to
+    // `@association.null_scope?`, which is `owner.new_record? &&
+    // !foreign_key_present?`, so the two cannot disagree.
     const newWithPk = CpcAuthor.new({ name: "withpk" });
     (newWithPk as any)._writeAttribute("id", 999);
     const newWithoutPk = CpcAuthor.new({ name: "nopk" });
 
     const withPkProxy = association(newWithPk, "cpcPosts") as any;
     const withoutPkProxy = association(newWithoutPk, "cpcPosts") as any;
-    expect(withPkProxy._foreignKeyPresent()).toBe(true);
-    expect(withoutPkProxy._foreignKeyPresent()).toBe(false);
+    expect(withPkProxy.isNullScope()).toBe(false);
+    expect(withoutPkProxy.isNullScope()).toBe(true);
   });
 
   it("count_records reads the active counter cache instead of querying", async () => {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1165,7 +1165,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Alias for count.
+   * Returns the size of the collection, executing a SELECT COUNT(*) query if
+   * the collection hasn't been loaded.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#size
    * (collection_proxy.rb:782-784) — `@association.size`. Every arm of
@@ -1177,7 +1178,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Check if the collection is empty.
+   * Returns true if the collection is empty.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#empty?
    * (collection_proxy.rb:831-833) — `@association.empty?`.

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -61,15 +61,7 @@ import {
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 import { multisetDifference, multisetIntersection } from "./has-many-through-association.js";
-import {
-  countRecords,
-  scope as hasManyScope,
-  setDifference,
-  setIntersection,
-} from "./has-many-association.js";
-import { throughForeignKeyPresent } from "./through-association.js";
-import { foreignKeyPresentFor } from "./foreign-association.js";
-import type { AssociationReflection } from "../reflection.js";
+import { scope as hasManyScope, setDifference, setIntersection } from "./has-many-association.js";
 
 // Declaration merging with `class CollectionProxy extends Relation`
 // propagates Relation's method types into this interface. `load()`
@@ -750,12 +742,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // which for a through association means re-traversing the in-memory chain
     // (`post.author.books` …) on each read rather than caching a scoped subset.
     //
-    // The `!_targetLoaded` guard is essential: `_findTarget()` short-circuits to
-    // `false` once loaded (mirroring Rails `find_target?` = `!loaded? && …`), so
-    // OR-ing on a bare `!_findTarget()` would send *every* post-load `toArray()`
-    // back down the re-query path and defeat caching entirely. `load()` is the
-    // hydrate/cache chokepoint for the already-loaded case (including staleness).
-    if (!this._targetLoaded && !this._findTarget()) {
+    // The `!_targetLoaded` guard is essential: on an unloaded target
+    // `null_scope?` is exactly `!find_target?` (`owner.new_record? &&
+    // !foreign_key_present?`), so OR-ing on a bare `null_scope?` would send
+    // *every* post-load `toArray()` back down the re-query path and defeat
+    // caching entirely. `load()` is the hydrate/cache chokepoint for the
+    // already-loaded case (including staleness).
+    if (!this._targetLoaded && this.isNullScope()) {
       const results = await this._execLoad();
       return this._mergeTargetLists(results);
     }
@@ -1175,149 +1168,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Alias for count.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#size
+   * (collection_proxy.rb:782-784) — `@association.size`. Every arm of
+   * `CollectionAssociation#size` (collection_association.rb:209-222) lives on
+   * the association; the proxy counts nothing itself.
    */
   async size(): Promise<number> {
-    // Mirrors CollectionAssociation#size (collection_association.rb) branch
-    // ordering exactly.
-    //
-    // `!find_target? || loaded?` → return the in-memory target size. A loaded
-    // target is authoritative; an unloaded one is only authoritative when the
-    // target can't be fetched (new-record owner without a foreign key).
-    if (this._targetLoaded || !this._findTarget()) {
-      return this._target.length;
-    }
-    // `@association_ids` cached by a prior ids_reader → its length, no query.
-    const cachedIds = this._cachedAssociationIds();
-    if (cachedIds) {
-      return cachedIds.length;
-    }
-    // GROUP BY present → a grouped COUNT(*) returns per-group rows rather than
-    // a scalar, so Rails loads the full target and counts it in memory.
-    if (this.groupValues.length > 0) {
-      return (await this.loadTarget()).length;
-    }
-    // No DISTINCT and unsaved records buffered → add them to the persisted
-    // COUNT(*) rather than ignoring them.
-    if (!this.distinctValue && this._target.length > 0) {
-      const unsaved = this._target.filter((r) => r.isNewRecord()).length;
-      return unsaved + (await this._countRecords());
-    }
-    return this._countRecords();
-  }
-
-  /**
-   * Mirrors ActiveRecord::Associations::HasManyAssociation#count_records
-   * (has_many_association.rb): prefer an active counter cache, otherwise issue
-   * a `COUNT(*)`; purge non-new records and mark the target loaded when the DB
-   * is empty (a documented side-effect that can avoid an extra SELECT); finally
-   * clamp the result to the association scope's `limit_value`.
-   * @internal
-   */
-  private _countRecords(): Promise<number> {
-    const reflection = this.reflection;
-    return countRecords({
-      hasActiveCachedCounter: () => reflection.hasActiveCachedCounter?.() ?? false,
-      counterCacheColumn: () => reflection.counterCacheColumn?.() ?? null,
-      readCounterAttribute: (col) => this._record.readAttribute(col),
-      // has_many_association.rb:84 `scope.count(:all)`: the `:all` keeps a
-      // `select` declared on the association off the COUNT.
-      countViaScope: () => this.count("all") as Promise<number>,
-      // Rails clamps by `association_scope.limit_value` — the association's own
-      // scope, not any in-place proxy (`whereBang`/`limitBang`) mutation. So we
-      // read the limit from the rebuilt scope even on the diverged count path,
-      // matching count_records rather than the ad-hoc query limit.
-      limitValue: () =>
-        (this.scope() as { limitValue?: number | null } | undefined)?.limitValue ?? null,
-      retainOnlyNewRecords: () => {
-        this._target = this._target.filter((r) => r.isNewRecord());
-      },
-      markLoaded: () => {
-        this._targetLoaded = true;
-      },
-    });
-  }
-
-  /**
-   * Mirrors Association#find_target? — whether the target can be fetched.
-   * False when loaded (the caller short-circuits on `_targetLoaded`) or when
-   * the owner is a new record lacking the foreign key needed to query.
-   * @internal
-   */
-  private _findTarget(): boolean {
-    if (this._targetLoaded) return false;
-    return !this._record.isNewRecord() || this._foreignKeyPresent();
-  }
-
-  /**
-   * Whether the target can be fetched for a new-record owner. A has_many :through
-   * routes through a belongs_to (`ThroughAssociation#foreign_key_present?`,
-   * through_association.rb:90); a vanilla has_many requires the owner's
-   * `active_record_primary_key` to be present (`ForeignAssociation#foreign_key_present?`,
-   * foreign_association.rb:5). The same two-branch dispatch runs in
-   * `CollectionAssociation#foreignKeyPresent`, so the proxy and the OO
-   * association agree on both the through and non-through paths.
-   * @internal
-   */
-  private _foreignKeyPresent(): boolean {
-    const reflection = this.reflection;
-    // No registered reflection: the fallback carries none of the key readers below.
-    if (reflection.klass == null) return false;
-    if (this._assocDef.options.through) {
-      return throughForeignKeyPresent({ owner: this._record, reflection });
-    }
-    return foreignKeyPresentFor(reflection as AssociationReflection, this._record);
-  }
-
-  /**
-   * Mirrors the `@association_ids` ivar read in CollectionAssociation#size —
-   * the ids cache lives on the owner's association instance (populated by a
-   * prior `collectionIds` reader), not on the proxy. Returns null when unset.
-   * @internal
-   */
-  private _cachedAssociationIds(): unknown[] | null {
-    const assocInstance = (this._record as any)._associationInstances?.get(this._assocName);
-    const ids = assocInstance?._associationIds;
-    return Array.isArray(ids) ? ids : null;
+    return this._collectionAssociation().size();
   }
 
   /**
    * Check if the collection is empty.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#empty?
+   * (collection_proxy.rb:831-833) — `@association.empty?`.
    */
   async isEmpty(): Promise<boolean> {
-    if (this._targetLoaded) return this._target.length === 0;
-    if (this._target.length > 0) return false;
-    // Through associations: #exists always loads the full target, so prefer
-    // count() which routes through AssociationScope as a SQL COUNT for the
-    // common shapes (findTarget fallback still loads for the rest).
-    if (this._isThrough) return (await this.count()) === 0;
-    // Mirrors Rails collection_association.rb#empty?:
-    //   if loaded? || @association_ids || reflection.has_active_cached_counter?
-    //     size.zero?  → count_records (reads counter cache; marks loaded when 0)
-    //   else
-    //     target.empty? && !scope.exists?  (no side effects, never marks loaded)
-    // Using _countRecords unconditionally was a regression: when count=0 it calls
-    // markLoaded(), so a later isEmpty() reads a stale empty cache instead of
-    // querying the DB again after records were created.
-    let activeCachedCounter = false;
-    try {
-      activeCachedCounter = this.reflection.hasActiveCachedCounter?.() ?? false;
-    } catch {
-      // hasActiveCachedCounter can throw when referenced models are not yet
-      // registered (e.g. inverseWhichUpdatesCounterCache calls c.klass).
-    }
-    // Rails empty? → size.zero?, and size returns @association_ids.length when
-    // a prior ids_reader cached them (no query). Only fall back to count_records
-    // when the size comes from a counter cache rather than cached ids.
-    const cachedIds = this._cachedAssociationIds();
-    if (cachedIds !== null) {
-      return cachedIds.length === 0;
-    }
-    if (activeCachedCounter) {
-      return (await this._countRecords()) === 0;
-    }
-    return !(await this.exists());
+    return this._collectionAssociation().isEmpty();
   }
 
   /**
@@ -2522,17 +2388,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `CollectionProxy#null_scope?` (collection_proxy.rb:1150-1152), a one-line
    * delegation to `@association.null_scope?`.
    *
-   * The body is re-expressed rather than borrowed from
-   * `CollectionAssociation.prototype.isNullScope` because the proxy's
-   * `_foreignKeyPresent` is the through-aware one (a `has_many :through` routes
-   * the check through the `belongs_to`), and — as with `isFindFromTarget` — the
-   * proxy must not resolve through `owner.association(name)`, whose state is a
-   * secondary copy.
-   *
    * @internal
    */
   isNullScope(): boolean {
-    return this._record.isNewRecord() && !this._foreignKeyPresent();
+    return this._collectionAssociation().isNullScope();
   }
 
   /**
@@ -2696,29 +2555,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#proxy_association
    */
-  get proxyAssociation(): {
-    readonly owner: Base;
-    readonly reflection: any;
-    readonly target: Base[];
-    readonly loaded: boolean;
-    reset: () => void;
-  } {
-    const proxy = this;
-    return {
-      owner: this._record,
-      reflection: this._assocDef,
-      get target() {
-        return proxy._target;
-      },
-      get loaded() {
-        return proxy._targetLoaded;
-      },
-      // reset() returns `this` (a thenable Relation); the contract here is a
-      // plain void reset, so discard the proxy return rather than leak it.
-      reset: () => {
-        this.reset();
-      },
-    };
+  get proxyAssociation(): CollectionAssociation {
+    return this._collectionAssociation();
   }
 
   /**

--- a/packages/activerecord/src/associations/foreign-association.ts
+++ b/packages/activerecord/src/associations/foreign-association.ts
@@ -59,9 +59,9 @@ export function ownerReflectionForeignKey(
  * (foreign_association.rb:5): the owner's `active_record_primary_key` columns
  * must be present for children — which carry the FK referencing them — to be
  * fetchable, so a new-record owner with its PK assigned can still load. Returns
- * false when the associated class has no primary key. Shared by has_many's proxy
- * (`CollectionProxy#_foreignKeyPresent`) and the OO `CollectionAssociation`
- * so the two never disagree.
+ * false when the associated class has no primary key. Read by the OO
+ * `CollectionAssociation`, which has_many's proxy delegates to through
+ * `null_scope?` (collection_proxy.rb:1150-1152), so there is one copy.
  *
  * @internal
  */

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/basic-implicit-render.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/basic-implicit-render.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/basic-implicit-render.ts",
+    "rubyName": "default_render",
+    "call": "head",
+    "kind": "args",
+    "rubyArgs": [
+      "str:noContent"
+    ],
+    "reason": "basic_implicit_render.rb:14 is `head :no_content`; the port passes the numeric status 204 instead of the Symbol."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/etag-with-template-digest.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/etag-with-template-digest.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/etag-with-template-digest.ts",
+    "rubyName": "determine_template_etag",
+    "call": "lookup_and_digest_template",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:template"
+    ],
+    "reason": "etag_with_template_digest.rb:39 passes only the template; the port also threads the lookup context, which the ported digest helper takes explicitly."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/implicit-render.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/implicit-render.json
@@ -3,7 +3,44 @@
     "package": "actioncontroller",
     "tsFile": "metal/implicit-render.ts",
     "rubyName": "default_render",
+    "call": "any_templates?",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:toS",
+      "ref:_prefixes"
+    ],
+    "reason": "implicit_render.rb:40 passes (action_name.to_s, _prefixes); the port passes the action name alone."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/implicit-render.ts",
+    "rubyName": "default_render",
+    "call": "template_exists?",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:toS",
+      "ref:_prefixes",
+      "kwargs{variants=ref:variant}"
+    ],
+    "reason": "implicit_render.rb:38 passes (action_name.to_s, _prefixes, variants: request.variant); the port passes the action name alone."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/implicit-render.ts",
+    "rubyName": "default_render",
     "call": "variant",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/implicit-render.ts",
+    "rubyName": "method_for_action",
+    "call": "template_exists?",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:toS",
+      "ref:_prefixes"
+    ],
+    "reason": "implicit_render.rb:57 passes (action_name.to_s, _prefixes); the port passes the action name alone."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -45,6 +45,17 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
+    "rubyName": "handle_unverified_request",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:request"
+    ],
+    "reason": "request_forgery_protection.rb:262 raises `InvalidAuthenticityToken.new(request)`; the port constructs it with no arguments."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "mark_for_same_origin_verification!",
     "call": "get?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/http/mime-negotiation.json
@@ -36,5 +36,26 @@
       "ref:v"
     ],
     "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "formats",
+    "call": "set_header",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:k",
+      "ref:v"
+    ],
+    "reason": "mime_negotiation.rb:67 forwards the (k, v) pair; the port names the header constant and the computed map directly."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "variant",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "mime_negotiation.rb:90 constructs the variant collection with no arguments; the port's `new` at this site builds the ArgumentError the same guard raises."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/host-authorization.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/host-authorization.json
@@ -2,6 +2,17 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/host-authorization.ts",
+    "rubyName": "call",
+    "call": "mark_as_authorized",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:request"
+    ],
+    "reason": "host_authorization.rb:91 calls `mark_as_authorized(request)`; the port also threads the raw env it holds separately."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/host-authorization.ts",
     "rubyName": "excluded?",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
+++ b/scripts/api-compare/call-mismatches-exclude/actiondispatch/middleware/static.json
@@ -45,6 +45,18 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/static.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:path",
+      "kwargs{headers=ref:headers,index=ref:index}"
+    ],
+    "reason": "middleware/static.rb:21 builds `::Rack::Files.new(path, headers:, index:)`; the port passes (root, rest) — the options object it forwards unsplit."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/static.ts",
     "rubyName": "serve",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/actionview/helpers/javascript-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/actionview/helpers/javascript-helper.json
@@ -1,0 +1,15 @@
+[
+  {
+    "package": "actionview",
+    "tsFile": "helpers/javascript-helper.ts",
+    "rubyName": "javascript_tag",
+    "call": "content_tag",
+    "kind": "args",
+    "rubyArgs": [
+      "str:script",
+      "ref:javascriptCdataSection",
+      "ref:htmlOptions"
+    ],
+    "reason": "javascript_helper.rb:75-84 calls `content_tag(\"script\", javascript_cdata_section(content), html_options)`; the port passes a fourth `true` (the escape flag Ruby leaves to the default)."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/aggregations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/aggregations.json
@@ -19,5 +19,20 @@
     "rubyName": "composed_of",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "aggregations.ts",
+    "rubyName": "composed_of",
+    "call": "writer_method",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:name",
+      "ref:className",
+      "ref:mapping",
+      "ref:allowNil",
+      "ref:converter"
+    ],
+    "reason": "aggregations.rb:225 passes (name, class_name, mapping, allow_nil, converter); the ported writerMethod declares (name, mapping, className, converter, allowNil) — a parameter-ORDER divergence in the helper, not at the site."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/through-association.json
@@ -1,0 +1,14 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "associations/through-association.ts",
+    "rubyName": "ensure_not_nested",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:owner",
+      "ref:reflection"
+    ],
+    "reason": "through_association.rb:106 raises HasManyThroughNestedAssociationsAreReadonly.new(owner, reflection); the ported error takes the rendered message instead of the (owner, reflection) pair."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-statements.json
@@ -2,6 +2,18 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
+    "rubyName": "data_source_sql",
+    "call": "quoted_scope",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:name",
+      "kwargs{type=ref:type}"
+    ],
+    "reason": "sqlite3/schema_statements.rb:181 passes `type:` as a kwarg to quoted_scope; the port takes it positionally."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
     "rubyName": "indexes",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26,5 +38,17 @@
     "rubyName": "virtual_table_exists?",
     "call": "any?",
     "reason": "Per-entry verified (RFC 0072 sqlite3 introspection cluster): Rails schema_statements.rb:88 ends the query_values probe with a block-less `.any?`; the port spells that emptiness test as `.length > 0` (JS arrays have no `any?`), same as the other `#any?` -> `.length > 0` entries in this baseline."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/schema-statements.ts",
+    "rubyName": "virtual_table_exists?",
+    "call": "data_source_sql",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:tableName",
+      "kwargs{type=str:VIRTUAL TABLE}"
+    ],
+    "reason": "sqlite3/schema_statements.rb:87 passes `type:` as a kwarg to data_source_sql; the port takes it positionally."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptor.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptor.json
@@ -5,5 +5,17 @@
     "rubyName": "build_encrypted_message",
     "call": "add",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptor.ts",
+    "rubyName": "encrypt",
+    "call": "build_encrypted_message",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:clearText",
+      "kwargs{cipherOptions=ref:cipherOptions,keyProvider=ref:keyProvider}"
+    ],
+    "reason": "encryptor.rb:49 passes (clear_text, key_provider:, cipher_options:); the port passes (text, keyProvider, { deterministic }) — a positional/kwarg regrouping of buildEncryptedMessage."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -47,5 +47,14 @@
     "rubyName": "inverse_name",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "reflection.ts",
+    "rubyName": "join_scopes",
+    "call": "scope",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "reflection.rb:227 calls `scope` on implicit self; the ported scope helper takes its relation host explicitly (`scope(rel)`)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -9,6 +9,26 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "compute_cache_version",
+    "call": "first",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "relation.rb:472 reads `.first` off the fetched row; the port calls a `first(selectRows)` free function over the driver rows, threading the receiver as argument 1."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "compute_cache_version",
+    "call": "to_fs",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:cacheTimestampFormat"
+    ],
+    "reason": "relation.rb:472 calls `to_fs(cache_timestamp_format)` on the timestamp; the ported toFs is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "create",
     "call": "relation_class_for",
     "reason": "Verified per-site (RFC 0106): homonym. `relation_class_for` is called by `Relation::ClassMethods.create(model, ...)` (delegation.rb:139-141), the relation-class constructor; relation.ts's `create` ports the unrelated `Relation#create(attributes, &block)` (relation.rb:154-161), which makes no such call."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/test-databases.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/test-databases.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "test-databases.ts",
+    "rubyName": "create_and_load_schema",
+    "call": "establish_connection",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "test_databases.rb:20 calls `ActiveRecord::Base.establish_connection` with no arguments; the port spells the receiver as argument 1 (`establishConnection(Base)`)."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/coder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/coder.json
@@ -1,0 +1,14 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "cache/coder.ts",
+    "rubyName": "dump",
+    "call": "dump_compressed",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:entry",
+      "const:INFINITY"
+    ],
+    "reason": "cache/coder.rb:17 passes `Float::INFINITY`; the port passes JS `Infinity` — the same value under a different constant spelling."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/calculations.json
@@ -1,0 +1,496 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "all_day",
+    "call": "beginning_of_day",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:310 calls `beginning_of_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "all_day",
+    "call": "end_of_day",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:310 calls `end_of_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_month",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{day=num:1}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:125 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_quarter",
+    "call": "month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:139 calls `month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_week",
+    "call": "acts_like?",
+    "kind": "args",
+    "rubyArgs": [
+      "str:time"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:267 calls `acts_like?` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_week",
+    "call": "days_to_week_start",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:startDay"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:267 calls `days_to_week_start` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_year",
+    "call": "beginning_of_month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:179 calls `beginning_of_month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "beginning_of_year",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{month=num:1}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:179 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "copy_time_to",
+    "call": "hour",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:370 calls `hour` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "copy_time_to",
+    "call": "min",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:370 calls `min` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "copy_time_to",
+    "call": "sec",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:370 calls `sec` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "days_since",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{days=ref:days}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:82 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "days_span",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:beginningOfWeek"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:366 calls `fetch` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "days_span",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:day"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:366 calls `fetch` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "days_to_week_start",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:startDay"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:258 calls `fetch` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "days_to_week_start",
+    "call": "wday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:258 calls `wday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_month",
+    "call": "day",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:296 calls `day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_month",
+    "call": "month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:296 calls `month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_month",
+    "call": "year",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:296 calls `year` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_quarter",
+    "call": "end_of_month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:154 calls `end_of_month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_quarter",
+    "call": "month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:154 calls `month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_week",
+    "call": "days_to_week_start",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:startDay"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:283 calls `days_to_week_start` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_year",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{month=num:12}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:304 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "end_of_year",
+    "call": "end_of_month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:304 calls `end_of_month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "months_since",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{months=ref:months}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:102 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_occurring",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{days=ref:fromNow}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:340 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_occurring",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:dayOfWeek"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:340 calls `fetch` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_occurring",
+    "call": "wday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:340 calls `wday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_week",
+    "call": "beginning_of_week",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:200 calls `beginning_of_week` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_week",
+    "call": "copy_time_to",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:result"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:200 calls `copy_time_to` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_week",
+    "call": "days_since",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:daysSpan"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:200 calls `days_since` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "next_weekday",
+    "call": "next_day",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:206 calls `next_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "on_weekday?",
+    "call": "wday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:62 calls `wday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "on_weekend?",
+    "call": "wday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:57 calls `wday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_occurring",
+    "call": "fetch",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:dayOfWeek"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:351 calls `fetch` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_occurring",
+    "call": "wday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:351 calls `wday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_week",
+    "call": "beginning_of_week",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:223 calls `beginning_of_week` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_week",
+    "call": "copy_time_to",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:result"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:223 calls `copy_time_to` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_week",
+    "call": "days_since",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:daysSpan"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:223 calls `days_since` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_weekday",
+    "call": "copy_time_to",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:beginningOfWeek"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:230 calls `copy_time_to` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "prev_weekday",
+    "call": "prev_day",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:230 calls `prev_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "quarter",
+    "call": "month",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:166 calls `month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "today?",
+    "call": "to_date",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:30 calls `to_date` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "tomorrow",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{days=num:1}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:25 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "tomorrow?",
+    "call": "to_date",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:35 calls `to_date` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "tomorrow?",
+    "call": "tomorrow",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:35 calls `tomorrow` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "weeks_since",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{weeks=ref:weeks}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:92 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "years_since",
+    "call": "advance",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{years=ref:years}"
+    ],
+    "reason": "core_ext/date_and_time/calculations.rb:112 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "yesterday?",
+    "call": "to_date",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:41 calls `to_date` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/calculations.ts",
+    "rubyName": "yesterday?",
+    "call": "yesterday",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/calculations.rb:41 calls `yesterday` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/zones.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/zones.json
@@ -5,5 +5,26 @@
     "rubyName": "in_time_zone",
     "call": "acts_like?",
     "reason": "Preserving the call inverts the branch for every receiver: `Object.actsLike` (core-ext/object/acts-like.ts:38-44) discovers a duck-type by looking for the marker METHOD on the value, and no trails receiver carries one — `actsLikeDate` appears in no production file, and `actsLikeTime` only on TimeWithZone. Measured against the built dist: `DateTime.parse(...)` returns a `Temporal.PlainDateTime`, for which `actsLike(v, \"date\")` and `actsLike(v, \"time\")` are both false, so `acts_like?(:time)` would send every Date AND every Time down the wrong arm. Installing the markers needs `core_ext/{time,date,date_time}/acts_like.rb`, which reopen classes `@blazetrails/date` and the Temporal polyfill own; that is filed as 0098/time-with-zone-residue-structural-blockers section D. Delete this row when it lands."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/zones.ts",
+    "rubyName": "in_time_zone",
+    "call": "time_with_zone",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:time",
+      "ref:timeZone"
+    ],
+    "reason": "core_ext/date_and_time/zones.rb:20 calls `time_with_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-and-time/zones.ts",
+    "rubyName": "in_time_zone",
+    "call": "to_time",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_and_time/zones.rb:20 calls `to_time` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-time/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-time/calculations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-time/calculations.ts",
+    "rubyName": "end_of_day",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{hour=num:23,min=num:59,sec=num:59,usec=ref:Rational}"
+    ],
+    "reason": "date_time/calculations.rb:140 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-time/calculations.ts",
+    "rubyName": "end_of_hour",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{min=num:59,sec=num:59,usec=ref:Rational}"
+    ],
+    "reason": "date_time/calculations.rb:152 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date-time/calculations.ts",
+    "rubyName": "end_of_minute",
+    "call": "change",
+    "kind": "args",
+    "rubyArgs": [
+      "kwargs{sec=num:59,usec=ref:Rational}"
+    ],
+    "reason": "date_time/calculations.rb:164 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/calculations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/calculations.ts",
+    "rubyName": "ago",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/calculations.rb:55 calls `in_time_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/calculations.ts",
+    "rubyName": "beginning_of_day",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/calculations.rb:67 calls `in_time_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/calculations.ts",
+    "rubyName": "end_of_day",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/calculations.rb:85 calls `in_time_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/calculations.ts",
+    "rubyName": "middle_of_day",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/calculations.rb:75 calls `in_time_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/calculations.ts",
+    "rubyName": "since",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/calculations.rb:61 calls `in_time_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
@@ -12,5 +12,31 @@
     "rubyName": "uuid_from_hash",
     "call": "unpack",
     "reason": "Ruby core String#unpack of the digest bytes (core_ext/digest/uuid.rb:19-38), not a ported trails method."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/digest/uuid.ts",
+    "rubyName": "uuid_v3",
+    "call": "uuid_from_hash",
+    "kind": "args",
+    "rubyArgs": [
+      "const:MD5",
+      "ref:uuidNamespace",
+      "ref:name"
+    ],
+    "reason": "digest/uuid.rb:42 names the digest class `::Digest::MD5`; the port selects it by the string `\"md5\"` the Web Crypto/Node digest API takes."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/digest/uuid.ts",
+    "rubyName": "uuid_v5",
+    "call": "uuid_from_hash",
+    "kind": "args",
+    "rubyArgs": [
+      "const:SHA1",
+      "ref:uuidNamespace",
+      "ref:name"
+    ],
+    "reason": "digest/uuid.rb:47 names the digest class `::Digest::SHA1`; the port selects it by the string `\"sha1\"` the Web Crypto/Node digest API takes."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
@@ -51,6 +51,19 @@
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
+    "rubyName": "seconds",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:value",
+      "kwargs{seconds=ref:value}",
+      "bool:false"
+    ],
+    "reason": "duration.rb:155 is `new(value, { seconds: value }, false)`; the port drops the leading raw value and passes ({ seconds: n }, false) — Duration carries its value off the parts."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
     "rubyName": "since",
     "call": "sum",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/deprecation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/deprecation.json
@@ -1,0 +1,13 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "testing/deprecation.ts",
+    "rubyName": "assert_deprecated",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:escape"
+    ],
+    "reason": "testing/deprecation.rb:30 builds the matcher from `escape`; the port's `new` at this site constructs the \"No deprecator given\" error the same guard raises."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -10,6 +10,52 @@
     "package": "activesupport",
     "tsFile": "time-ext.ts",
     "rubyName": "change",
+    "call": "integer?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/time/calculations.rb:123 calls `integer?` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "local",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newSec",
+      "ref:newMin",
+      "ref:newHour",
+      "ref:newDay",
+      "ref:newMonth",
+      "ref:newYear",
+      "nil",
+      "nil",
+      "ref:isdst",
+      "nil"
+    ],
+    "reason": "time/calculations.rb:123-155 calls `::Time.local(sec, min, hour, day, month, year, nil, nil, isdst, nil)`; the port passes only the six date/time components, the trailing four having no Temporal analogue."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:newYear",
+      "ref:newMonth",
+      "ref:newDay",
+      "ref:newHour",
+      "ref:newMin",
+      "ref:newSec",
+      "ref:zone"
+    ],
+    "reason": "time/calculations.rb:123-155 builds the changed value with `::Time.new(year, month, day, hour, min, sec, zone)`; the port's `new` at this site constructs the ArgumentError Ruby raises from the same guard."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "change",
     "call": "utc?",
     "reason": "Ruby core Time#utc? read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — Temporal carries the zone on the value."
   },
@@ -19,6 +65,15 @@
     "rubyName": "change",
     "call": "utc_offset",
     "reason": "Ruby core Time#utc_offset read off the receiver (core_ext/time/calculations.rb:123-155), not a ported trails method — Temporal carries the offset on the value."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "preserve_timezone",
+    "call": "system_local_time?",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/time/compatibility.rb:17 calls `system_local_time?` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   },
   {
     "package": "activesupport",
@@ -61,6 +116,15 @@
     "rubyName": "to_time",
     "call": "month",
     "reason": "Ruby core Date#month read off the receiver (core_ext/date/conversions.rb:83-85), not a ported trails method."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "time-ext.ts",
+    "rubyName": "to_time",
+    "call": "preserve_timezone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date_time/compatibility.rb:15 calls `preserve_timezone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/transliterate.json
@@ -2,6 +2,18 @@
   {
     "package": "activesupport",
     "tsFile": "transliterate.ts",
+    "rubyName": "parameterize",
+    "call": "transliterate",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:string",
+      "kwargs{locale=ref:locale}"
+    ],
+    "reason": "inflector/transliterate.rb:123 calls `transliterate(string, locale: locale)`; the port passes the replacement `\"?\"` positionally between them."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "transliterate.ts",
     "rubyName": "transliterate",
     "call": "include?",
     "reason": "Ruby core Array#include? over ALLOWED_ENCODINGS_FOR_TRANSLITERATE (inflector/transliterate.rb:66), not a ported trails method — JS strings carry no encoding."

--- a/scripts/api-compare/call-mismatches-exclude/i18n/interpolate/ruby.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/interpolate/ruby.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "i18n",
+    "tsFile": "interpolate/ruby.ts",
+    "rubyName": "interpolate_hash",
+    "call": "missing_interpolation_argument_handler",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "i18n interpolate/ruby.rb:34 reads the handler with no arguments and calls the returned proc; the port folds both into one call taking (key, values, string)."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
@@ -30,6 +30,17 @@
   {
     "package": "rack",
     "tsFile": "multipart/parser.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "kind": "args",
+    "rubyArgs": [
+      "ref:dup"
+    ],
+    "reason": "rack multipart/parser.rb:49 builds the buffer from `dup`; the port seeds it with the empty string."
+  },
+  {
+    "package": "rack",
+    "tsFile": "multipart/parser.ts",
     "rubyName": "normalize_filename",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -39,6 +39,7 @@ import {
   callTagKey,
   splitOverriddenFileBuckets,
   resolveTsOwner,
+  ownerCallArgSites,
   ambiguousTsOwner,
   ambiguousRubyOwner,
   rubyOwnerSeat,
@@ -1880,6 +1881,68 @@ describe("ambiguousTsOwner", () => {
     expect(ambiguousTsOwner(owners, resolveTsOwner(owners, "ActiveRecord::FinderMethods"))).toBe(
       false,
     );
+  });
+});
+
+describe("ownerCallArgSites", () => {
+  // The trails mixin convention (CLAUDE.md "Module mixins"): ONE body exported
+  // free and re-exported through a grouping object, so the file records the
+  // same sites twice — under `""` and under `TimeExt`.
+  const sites = [{ name: "toTime", args: [] }];
+  const twiceDeclared = new Map([
+    [
+      "time-ext.ts",
+      new Map([
+        [
+          "toTime",
+          new Map([
+            ["", [sites]],
+            ["TimeExt", [sites]],
+          ]),
+        ],
+      ]),
+    ],
+  ]);
+  const twiceDeclaredByFile = new Map([["time-ext.ts", new Map([["toTime", [sites, sites]]])]]);
+
+  it("compares a twice-declared single body under its resolved owner", () => {
+    const owners = new Set(["", "TimeExt"]);
+    const tsClass = resolveTsOwner(owners, "Time", {
+      callSetOf: (o) => (o === "" || o === "TimeExt" ? [["toTime"]] : undefined),
+    });
+    expect(tsClass).toBe("");
+    expect(
+      ownerCallArgSites(twiceDeclared, twiceDeclaredByFile, "time-ext.ts", "toTime", tsClass),
+    ).toBe(sites);
+  });
+
+  it("still bails when the owner is ambiguous and the file declares the name twice", () => {
+    // relation.ts's `Relation#first` beside `ExplainProxy#first`: two genuinely
+    // different bodies, so `resolveTsOwner` returns undefined and there is no
+    // ground for pairing the Ruby sites against either.
+    const first = [{ name: "findNth", args: [] }];
+    const second = [{ name: "execExplain", args: [] }];
+    const byOwner = new Map([
+      [
+        "relation.ts",
+        new Map([
+          [
+            "first",
+            new Map([
+              ["Relation", [first]],
+              ["ExplainProxy", [second]],
+            ]),
+          ],
+        ]),
+      ],
+    ]);
+    const byFile = new Map([["relation.ts", new Map([["first", [first, second]]])]]);
+    expect(ownerCallArgSites(byOwner, byFile, "relation.ts", "first", undefined)).toBeUndefined();
+  });
+
+  it("compares the single whole-file entry when the file declares the name once", () => {
+    const byFile = new Map([["relation.ts", new Map([["first", [sites]]])]]);
+    expect(ownerCallArgSites(new Map(), byFile, "relation.ts", "first", "Relation")).toBe(sites);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1079,6 +1079,36 @@ export function ownerRecordsNothing(
 }
 
 /**
+ * The ONE TS call-site list `checkCallArgs` compares a Ruby body against, or
+ * `undefined` when the file gives no unambiguous answer.
+ *
+ * The whole-file map holds one entry per DECLARATION, so the trails mixin
+ * convention (CLAUDE.md "Module mixins") — `export function toTime()` beside
+ * `export const TimeExt = { toTime }`, one body declared twice — always records
+ * two entries and used to be dropped by a bare `length !== 1` guard, before the
+ * resolved owner was ever consulted (RFC 0108). Prefer the owner-scoped list
+ * under the resolved owner: a single body re-exported through a grouping object
+ * records the same sites under each owner, so either is the body's own.
+ *
+ * Unresolved owner, or an owner declaring the name more than once, is the
+ * guard's original case and still records nothing.
+ */
+export function ownerCallArgSites<T>(
+  byFileNameOwner: ReadonlyMap<string, ReadonlyMap<string, ReadonlyMap<string, readonly T[][]>>>,
+  byFileName: ReadonlyMap<string, ReadonlyMap<string, readonly T[][]>>,
+  tsFile: string,
+  tsName: string,
+  tsClass: string | undefined,
+): readonly T[] | undefined {
+  if (tsClass !== undefined) {
+    const owned = byFileNameOwner.get(tsFile)?.get(tsName)?.get(tsClass);
+    if (owned !== undefined) return owned.length === 1 ? owned[0] : undefined;
+  }
+  const sites = byFileName.get(tsFile)?.get(tsName);
+  return sites?.length === 1 ? sites[0] : undefined;
+}
+
+/**
  * True when the TS file declares `tsName` on SEVERAL owners and
  * `resolveTsOwner` could not say which one this Ruby entity ported to.
  *
@@ -3160,15 +3190,21 @@ export function main() {
         if (ownerRecordsNothing(tsCallArgsByFileNameOwner, tsFile, tsName, tsClass, tsOwners)) {
           return;
         }
-        const tsSites = tsCallArgsByFileName.get(tsFile)?.get(tsName);
-        if (tsSites?.length !== 1) return;
+        const tsSites = ownerCallArgSites(
+          tsCallArgsByFileNameOwner,
+          tsCallArgsByFileName,
+          tsFile,
+          tsName,
+          tsClass,
+        );
+        if (tsSites === undefined) return;
         // `rubyOwnersByName` is built per Ruby FILE, a few lines up: its keys are
         // the names THIS file (with its included modules flattened in) declares.
-        const rubySites = comparableRubySites(rubyReadableSites, tsSites[0], (name) =>
+        const rubySites = comparableRubySites(rubyReadableSites, tsSites, (name) =>
           rubyOwnersByName.has(name),
         );
         if (rubySites.length === 0) return;
-        for (const { ruby, ts } of pairCallSites(rubySites, tsSites[0])) {
+        for (const { ruby, ts } of pairCallSites(rubySites, tsSites)) {
           const result = compareCallArgs(
             ruby,
             ts,


### PR DESCRIPTION
## Story 1 — Converge `CollectionProxy#size` / `#empty?` onto the association

Rails' proxy counts nothing itself:

```ruby
def size   = @association.size    # collection_proxy.rb:782-784
def empty? = @association.empty?  # collection_proxy.rb:831-833
```

trails re-implemented both against the proxy's own state: `size()` replayed all
five arms of `CollectionAssociation#size` (collection_association.rb:209-222) a
second time and `isEmpty()` replayed `empty?` (:233-237) with an extra
through-association arm. #6674 put every Rails arm on the association, so those
copies were a straight second body.

- `size()` → `this._collectionAssociation().size()`;
  `isEmpty()` → `.isEmpty()`.
- `isNullScope()` → `@association.null_scope?` (collection_proxy.rb:1150-1152).
  On an unloaded target `null_scope?` is exactly `!find_target?`
  (`owner.new_record? && !foreign_key_present?`), so `toArray()`'s
  re-query guard reads the same as before.
- Deleted `_countRecords`, `_findTarget`, `_foreignKeyPresent` and
  `_cachedAssociationIds` — the last of which reached into
  `record._associationInstances` for the association's `@association_ids`.
- `proxyAssociation` (collection_proxy.rb:944) returns the real
  `CollectionAssociation` instead of the synthesized
  `{ owner, reflection, target, loaded, reset }` façade.

The two flagged risks both resolved in favour of Rails. The proxy's in-place
`whereBang`/`limitBang` mutations were only ever read for `groupValues` /
`distinctValue`, where Rails reads `association_scope` — so the association's
scope is the correct source. The through arm routing `empty?` through `count()`
has no Rails counterpart; `CollectionAssociation#empty?` falls to
`target.empty? && !scope.exists?` and the HMT suite is green on it. Target and
loaded state are already shared both ways (`_sharedTarget` /
`_sharedLoaded`, collection-association.ts:120-145), so the delegation reads
one store.

`packages/activerecord/src/associations/` — 104 files, 2019 tests, green.

## Story 2 — Call-argument gate drops a twice-declared body

`checkCallArgs` bailed on

```ts
const tsSites = tsCallArgsByFileName.get(tsFile)?.get(tsName);
if (tsSites?.length !== 1) return;
```

before the resolved owner was ever consulted. That map holds one entry per
DECLARATION, so the trails mixin convention (CLAUDE.md "Module mixins") — one
body exported free and re-exported through a grouping object, `export function
toTime()` beside `export const TimeExt = { toTime }` — always records
`length === 2` and was always dropped. That is why #6676's owner-resolution arm
recovered +178 call-set pairs and **zero** argument sites.

New `ownerCallArgSites` prefers the owner-scoped list under the owner
`resolveOwner` already computes, falling back to the single whole-file entry;
an unresolved owner still records nothing, which is the guard's original
purpose.

**Measured: `Call args (advisory)` 5556 → 6216 call sites compared (+660)**,
well past the ~25 the surfacing story predicted.

### Baselined rows

The 660 newly-compared sites surfaced **93 pre-existing** `kind: "args"` shape
divergences (582 total flagged, up from 548). None are introduced by this PR;
all are ports that already passed something other than what Rails passes and
were simply never compared. Each is baselined with its own reason naming the
Rails `file:line` and the exact divergence, and both classes are filed:

- 65 rows are one class — `DateAndTime::Calculations` is a module mixed into
  `Date`/`Time`/`DateTime`, which TS cannot monkey-patch, so the port is free
  functions taking the receiver as argument 1 and every internal receiverless
  call reads as a shape diff. The comparator already has
  `stripCalleeReceiverArg` for this; it does not fire because neither
  `DateOrTime` nor `dateOrTime` is a receiver by `arity.ts`' `isReceiverParam`.
  Measured on this branch: adding `"DateOrTime"` to `HOST_PARAM_TYPES` alone
  takes the surfaced rows 98 → 64 and arity 8318 → 8322/8417 with no stale
  rows. Left out here because `HOST_PARAM_TYPES` also drives the arity gate —
  filed as `converge-date-time-receiver-threaded-call-args`.
- 28 are genuine per-body argument divergences across 20 files (parameter
  order in `composed_of`'s `writer_method`, `type:` kwarg → positional in the
  SQLite3 schema statements, `head :no_content` → `head(204)`, …) — filed as
  `converge-surfaced-call-arg-shape-rows` with every Rails cite.

Rows were hand-added sorted into their existing shards (no `--write`, no
reseed). `pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green.

## Checks

- `pnpm typecheck`, `pnpm lint --fix` clean.
- `pnpm parity:api:calls` OK (1213 baselined, unchanged);
  `pnpm parity:api:calls:args` OK (253 shape rows).
- `pnpm parity:api:extra --package activerecord` — no new surface.
- `scripts/api-compare/` 38 files, 1233 tests green (3 new covering a
  twice-declared body that now compares and an ambiguous owner that must
  still bail).
- Size: 287 LOC of code (`git diff --shortstat` excluding the generated
  parity baseline fixtures, which carry the other ~820).

Closes-story: converge-collection-proxy-size-onto-association
Closes-story: call-args-gate-skips-twice-declared-bodies
