### PR TITLE
fix(parity): teach isReceiverParam DateOrTime and drop whereBang's nil guard

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1210,7 +1210,6 @@ function where(
 }
 
 function whereBang(this: QueryMethodsHost, opts: any, ...rest: unknown[]): any {
-  if (opts == null) return this;
   const clause = buildWhereClause.call(this, opts, rest);
   this.whereClause = this.whereClause.plus(clause);
   return this;

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -202,6 +202,11 @@ describe("arityMatches", () => {
     expect(arityMatches([], [req("date", "Date")]).ok).toBe(true);
   });
 
+  it("strips a leading core-extension receiver by type (dateOrTime: DateOrTime)", () => {
+    // ruby DateAndTime::Calculations#next_weekday  vs  nextWeekday(dateOrTime: DateOrTime)
+    expect(arityMatches([], [req("dateOrTime", "DateOrTime")]).ok).toBe(true);
+  });
+
   it("strips a leading `validator` receiver", () => {
     // ruby UniquenessValidator#covered_by_unique_index?(klass, record, attribute, scope)
     // vs isCoveredByUniqueIndex(validator, klass, record, attribute, scope)

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -64,6 +64,7 @@ const HOST_PARAM_TYPES = new Set([
   "Date",
   "Time",
   "DateTime",
+  "DateOrTime",
   "Numeric",
   "Duration",
   "PlainDate",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/calculations.json
@@ -2,35 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "all_day",
-    "call": "beginning_of_day",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "core_ext/date_and_time/calculations.rb:310 calls `beginning_of_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "all_day",
-    "call": "end_of_day",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "core_ext/date_and_time/calculations.rb:310 calls `end_of_day` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "beginning_of_month",
-    "call": "change",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{day=num:1}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:125 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
     "rubyName": "beginning_of_week",
     "call": "acts_like?",
     "kind": "args",
@@ -38,17 +9,6 @@
       "str:time"
     ],
     "reason": "core_ext/date_and_time/calculations.rb:267 calls `acts_like?` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "beginning_of_week",
-    "call": "days_to_week_start",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:startDay"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:267 calls `days_to_week_start` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   },
   {
     "package": "activesupport",
@@ -62,28 +22,6 @@
   {
     "package": "activesupport",
     "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "beginning_of_year",
-    "call": "change",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{month=num:1}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:179 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "days_since",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{days=ref:days}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:82 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
     "rubyName": "end_of_quarter",
     "call": "end_of_month",
     "kind": "args",
@@ -93,55 +31,11 @@
   {
     "package": "activesupport",
     "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "end_of_week",
-    "call": "days_to_week_start",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:startDay"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:283 calls `days_to_week_start` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "end_of_year",
-    "call": "change",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{month=num:12}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:304 calls `change` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
     "rubyName": "end_of_year",
     "call": "end_of_month",
     "kind": "args",
     "rubyArgs": [],
     "reason": "core_ext/date_and_time/calculations.rb:304 calls `end_of_month` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "months_since",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{months=ref:months}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:102 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "next_occurring",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{days=ref:fromNow}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:340 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   },
   {
     "package": "activesupport",
@@ -219,44 +113,11 @@
   {
     "package": "activesupport",
     "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "tomorrow",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{days=num:1}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:25 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
     "rubyName": "tomorrow?",
     "call": "tomorrow",
     "kind": "args",
     "rubyArgs": [],
     "reason": "core_ext/date_and_time/calculations.rb:35 calls `tomorrow` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "weeks_since",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{weeks=ref:weeks}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:92 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/calculations.ts",
-    "rubyName": "years_since",
-    "call": "advance",
-    "kind": "args",
-    "rubyArgs": [
-      "kwargs{years=ref:years}"
-    ],
-    "reason": "core_ext/date_and_time/calculations.rb:112 calls `advance` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/zones.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-and-time/zones.json
@@ -5,17 +5,5 @@
     "rubyName": "in_time_zone",
     "call": "acts_like?",
     "reason": "Preserving the call inverts the branch for every receiver: `Object.actsLike` (core-ext/object/acts-like.ts:38-44) discovers a duck-type by looking for the marker METHOD on the value, and no trails receiver carries one — `actsLikeDate` appears in no production file, and `actsLikeTime` only on TimeWithZone. Measured against the built dist: `DateTime.parse(...)` returns a `Temporal.PlainDateTime`, for which `actsLike(v, \"date\")` and `actsLike(v, \"time\")` are both false, so `acts_like?(:time)` would send every Date AND every Time down the wrong arm. Installing the markers needs `core_ext/{time,date,date_time}/acts_like.rb`, which reopen classes `@blazetrails/date` and the Temporal polyfill own; that is filed as 0098/time-with-zone-residue-structural-blockers section D. Delete this row when it lands."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "core-ext/date-and-time/zones.ts",
-    "rubyName": "in_time_zone",
-    "call": "time_with_zone",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:time",
-      "ref:timeZone"
-    ],
-    "reason": "core_ext/date_and_time/zones.rb:20 calls `time_with_zone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
   }
 ]


### PR DESCRIPTION
Two small convergences.

## `DateOrTime` is a receiver type (`scripts/api-compare/arity.ts`)

`DateAndTime::Calculations` (`vendor/rails/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb`) is a module mixed into `Date`/`Time`/`DateTime`, so every internal call is receiverless. The port (`packages/activesupport/src/core-ext/date-and-time/calculations.ts`) threads the receiver as an explicit `dateOrTime: DateOrTime` first parameter, so `stripCalleeReceiverArg` / `stripHostParam` need `isReceiverParam` to recognise it — exactly like the `Date`, `Time`, `DateTime` entries already sitting in the same core-ext block of `HOST_PARAM_TYPES`.

Measured: arity 8320/8419 → 8324/8419. `parity:api:calls` and `parity:api:calls:args` both stay green with no stale baseline rows (the 93 `kind: "args"` rows the story cites are surfaced by the owner-scoped `checkCallArgs` fix, which is not on `main` yet; this lands the receiver half so those sites compare rather than baseline when it does).

## `whereBang` loses its nil short-circuit

`query_methods.rb:1043-1046` is three lines with no guard:

```ruby
def where!(opts, *rest) # :nodoc:
  self.where_clause += build_where_clause(opts, rest)
  self
end
```

trails' `whereBang` opened with `if (opts == null) return this;`. Rails puts the blank handling in `where` (`:1036`, `args.length == 1 && args.first.blank?`) — as trails' `where` also does via `isBlankArgument` — so the guard was dead for everything arriving through `where`, and for a direct call it silently no-opped what Rails routes into `build_where_clause` (which raises `ArgumentError`). Checked the direct callers (`query-methods.ts:731` passes an Arel node, `:1205` is post-`isBlankArgument`, `schema-statements.ts:1803` passes a conditions hash); none passes null.

Tests: `where`, `where-chain`, `composite-where`, `merging`, `relations`, plus `scripts/api-compare/{arity,call-args}.test.ts` all pass.

Closes-story: converge-date-time-receiver-threaded-call-args
Closes-story: drop-where-bang-nil-short-circuit