### PR TITLE
fix(parity): retire the converged compute_cache_version first() call-args row

### DIFF
--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -10,15 +10,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
-    "call": "first",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "relation.rb:472 reads `.first` off the fetched row; the port calls a `first(selectRows)` free function over the driver rows, threading the receiver as argument 1."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
     "call": "to_fs",
     "kind": "args",
     "rubyArgs": [


### PR DESCRIPTION
The `Rails API/Test Comparison` job is red on main @334744a0 with:

```
call-args ratchet: 1 STALE baseline entr(ies) that no longer flag.
  - activerecord  relation.ts  compute_cache_version  first()
```

#6679 converged `Relation#computeCacheVersion`'s `first()` call site, which made its `kind: "args"` row in `call-mismatches-exclude/activerecord/relation.json` stale. The baseline is only-shrink, so the row is deleted by hand (via `serializeBaseline`, no reseed).

Verified locally after a full build: `parity:api:calls:args` OK (253 baselined shape rows), `parity:api:calls` OK (1205 baselined, 878 unreviewed).

Closes-story: red-334744a0