### PR TITLE
fix(parity): one @target seat for CollectionAssociation, isEmpty in activesupport

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -24,6 +24,7 @@
       "@blazetrails/activesupport/core-ext/string/inflections": [
         "../../activesupport/src/core-ext/string/inflections.ts"
       ],
+      "@blazetrails/activesupport/ruby-empty": ["../../activesupport/src/ruby-empty.ts"],
       "@blazetrails/activesupport/gzip": ["../../activesupport/src/gzip.ts"],
       "@blazetrails/activesupport/yaml": ["../../activesupport/src/yaml.ts"],
       "@blazetrails/activesupport/process-adapter": ["../../activesupport/src/process-adapter.ts"],

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1849,14 +1849,7 @@ export function association<T extends Base = Base>(
     }
   )._create(record, assocName, assocDef) as CollectionProxy<T> & {
     _hydrateFromPreload: (records: T[]) => void;
-    _adoptSharedTarget: (records: Base[], loaded: boolean) => void;
   };
-
-  const instance = record._associationInstances.get(assocName);
-  if (instance?.isCollection?.()) {
-    const raw = instance._rawTarget;
-    proxy._adoptSharedTarget(Array.isArray(raw) ? raw : [], instance._rawLoaded);
-  }
 
   const preloaded = _preloadedHolderTarget(record, assocName)?.value;
   if (preloaded != null) {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -32,10 +32,15 @@ export class Association {
   owner: Base;
   readonly reflection: AssociationDefinition;
   readonly disableJoins: boolean;
-  /** @internal */
-  protected _targetStore: Base | Base[] | null = null;
-  /** @internal */
-  protected _loadedStore = false;
+  /**
+   * Ruby's `@target` ivar. Public-but-`@internal` rather than `protected`
+   * because `CollectionProxy` is Rails' `@association.target` reader/writer
+   * (collection_proxy.rb:53) and holds no seat of its own.
+   * @internal
+   */
+  _targetStore: Base | Base[] | null = null;
+  /** Ruby's `@loaded` ivar; see `_targetStore`. @internal */
+  _loadedStore = false;
 
   get loaded(): boolean {
     return this._loadedStore;

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -86,6 +86,10 @@ export class CollectionAssociation extends Association {
   /** @internal */
   callbacksFor = callbacksFor;
 
+  // Rails has no `CollectionAssociation#initialize`: `Association#initialize`
+  // runs `reset` (association.rb:46), which seeds `@target = []`
+  // (collection_association.rb:89). trails' base constructor does not call
+  // `reset`, so the collection seat is opened here instead.
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
     this._targetStore = [];

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1,6 +1,5 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
-import { association as associationProxy } from "../associations.js";
 import {
   underscore,
   isAbortSignal,
@@ -35,13 +34,6 @@ export interface ReplacePlan {
    * which Rails deletes in a transaction (`delete_or_destroy`, :393-397).
    */
   pending?: Promise<unknown>;
-}
-
-/** @internal */
-interface SharedTargetStore {
-  _sharedTarget: Base[];
-  _sharedLoaded: boolean;
-  _sharedReplacedOrAddedTargets: Set<Base>;
 }
 
 /**
@@ -80,8 +72,6 @@ export class CollectionAssociation extends Association {
   // `CollectionProxy`.
   _namedScopeRelations?: Map<string, unknown>;
 
-  private _sharedTargetEnabled = false;
-
   /**
    * Mirrors: `CollectionAssociation#callback` / `#callbacks_for`
    * (collection_association.rb:492-505) — instance methods on the association,
@@ -98,110 +88,47 @@ export class CollectionAssociation extends Association {
 
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
-    this._writeTargetStore([]);
-    this._sharedTargetEnabled = true;
+    this._targetStore = [];
   }
 
   /**
-   * A cache *lookup*, never a build: constructing a proxy here would be
-   * re-entrant (its constructor resolves through-scopes that read back through
-   * this association). Until one exists there is no second store to keep
-   * coherent, and `association()` hands the proxy this very array
-   * (`_adoptSharedTarget`), so no reference already handed out goes stale.
-   */
-  private _sharedStore(): SharedTargetStore | null {
-    if (!this._sharedTargetEnabled) return null;
-    return (
-      (this.owner._collectionProxies.get(this.reflection.name) as SharedTargetStore | undefined) ??
-      null
-    );
-  }
-
-  /**
-   * Rails' `CollectionProxy` forwards `target`/`loaded` to its `@association`;
-   * trails inverts the ownership (RFC 0022 makes the proxy the canonical
-   * has_many store) so the association forwards the other way. Either
-   * direction gives the one invariant that matters: ONE in-memory target.
+   * Ruby's `@target` for a collection is always an Array (`reset` seeds it with
+   * `[]`, collection_association.rb:89); the override only narrows the
+   * singular-shaped base type.
    */
   override get target(): Base[] {
-    const store = this._sharedStore();
-    return store ? store._sharedTarget : (this._targetStore as Base[]);
+    return this._targetStore as Base[];
   }
 
   /**
    * Mirrors: ActiveRecord::Associations::CollectionAssociation#target=
-   * (`collection_association.rb:285-296`). Without `has_many_inversing` this is
+   * (`collection_association.rb:284-295`). Without `has_many_inversing` this is
    * the plain holder write (`super`); with it, a single inverse record folds
    * into the collection via `replace_on_target(record, true, replace: true,
    * inversing: true)` and a `nil` is a no-op — it cannot be removed from the
    * inverse.
-   *
-   * `associationProxy` materializes the `CollectionProxy` first because RFC
-   * 0022 makes the proxy the canonical has_many store — the trails analog of
-   * Rails' `@target` — so the `replace_on_target` write lands where readers
-   * (`size()`/`load()`) look. The `super` arms keep the pre-existing coercion
-   * of a lone record and of `null` to an array, which Rails leaves to Ruby's
-   * untyped `@target`.
    */
   override set target(records: Base | Base[] | null) {
     if (!this.reflection.klass?.hasManyInversing) {
-      this._writeTargetStore(records == null ? [] : Array.isArray(records) ? records : [records]);
+      super.target = records;
       return;
     }
 
     if (records === null) {
       // It's not possible to remove the record from the inverse association.
     } else if (Array.isArray(records)) {
-      this._writeTargetStore(records);
+      super.target = records;
     } else {
-      associationProxy(this.owner, this.reflection.name);
       void this.replaceOnTarget(records, true, { replace: true, inversing: true });
     }
   }
 
   /**
-   * Ruby's `@target = …` ivar write — Rails' `super` inside `target=`, and the
-   * direct writes `reset`/`load_target`/`replace` make without going through
-   * `target=`. RFC 0022 puts the canonical has_many target on the
-   * `CollectionProxy`, so the write has to pick the shared store when one
-   * exists.
-   *
-   * @internal
-   */
-  private _writeTargetStore(value: Base[]): void {
-    const store = this._sharedStore();
-    if (store) store._sharedTarget = value;
-    else this._targetStore = value;
-  }
-
-  override get loaded(): boolean {
-    const store = this._sharedStore();
-    return store ? store._sharedLoaded : this._loadedStore;
-  }
-
-  override set loaded(value: boolean) {
-    const store = this._sharedStore();
-    if (store) store._sharedLoaded = value;
-    else this._loadedStore = value;
-  }
-
-  /**
    * Rails' `@replaced_or_added_targets`, the other half of
-   * `replace_on_target`'s state — it has to travel with the target, since two
-   * sets over one array double-append.
+   * `replace_on_target`'s state.
    * @internal
    */
-  get _replacedOrAddedTargets(): Set<Base> {
-    return this._sharedStore()?._sharedReplacedOrAddedTargets ?? this._replacedOrAddedTargetsStore;
-  }
-
-  set _replacedOrAddedTargets(value: Set<Base>) {
-    const store = this._sharedStore();
-    if (store) store._sharedReplacedOrAddedTargets = value;
-    else this._replacedOrAddedTargetsStore = value;
-  }
-
-  private _replacedOrAddedTargetsStore = new Set<Base>();
+  _replacedOrAddedTargets = new Set<Base>();
 
   /**
    * Rails' `@_was_loaded` (collection_association.rb:468-489): `loaded?` as of
@@ -419,7 +346,7 @@ export class CollectionAssociation extends Association {
 
   override reset(): void {
     super.reset();
-    this._writeTargetStore([]);
+    this._targetStore = [];
     // Rails' `Set.new.compare_by_identity`: a JS Set already compares object
     // members by identity.
     this._replacedOrAddedTargets = new Set<Base>();
@@ -862,11 +789,11 @@ export class CollectionAssociation extends Association {
     await this.transaction(async () => {
       // replaceRecords diffs against assoc.target; restore originalTarget so
       // it sees the real DB state rather than the already-updated in-memory target
-      this._writeTargetStore([...pending.originalTarget]);
+      this._targetStore = [...pending.originalTarget];
       try {
         await replaceRecords(this, pending.newTarget, pending.originalTarget);
       } finally {
-        this._writeTargetStore(currentTarget);
+        this._targetStore = currentTarget;
       }
     });
   }
@@ -903,7 +830,7 @@ export class CollectionAssociation extends Association {
       // Every collection subclass overrides `findTarget` to return `Base[]`;
       // the cast only narrows the singular-shaped base signature.
       return Promise.resolve(this.findTarget()).then((findTarget) => {
-        this._writeTargetStore(this.mergeTargetLists(findTarget as Base[], this.target));
+        this._targetStore = this.mergeTargetLists(findTarget as Base[], this.target);
         return loaded();
       });
     }
@@ -1254,7 +1181,7 @@ export class CollectionAssociation extends Association {
     this._lastRemoveAborted = false;
     // Rails' tail after `delete_records` (collection_association.rb:404-409).
     const pruned = (): boolean => {
-      this._writeTargetStore(this.target.filter((r) => !includesRecord(records, r)));
+      this._targetStore = this.target.filter((r) => !includesRecord(records, r));
       for (const record of records) {
         // A `dependent: :destroy` record is frozen once destroyed, so clearing its
         // inverse foreign key would raise FrozenError. Rails leaves the destroyed
@@ -1383,7 +1310,7 @@ export class CollectionAssociation extends Association {
    * @internal
    */
   _mergeLoaderResults(rows: Base[]): void {
-    this._writeTargetStore(this.mergeTargetLists(rows, this.target));
+    this._targetStore = this.mergeTargetLists(rows, this.target);
     this.loadedBang();
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -172,8 +172,55 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
   private _assocName: string;
   private _assocDef: AssociationDefinition;
-  private _target: T[] = [];
-  private _targetLoaded = false;
+  // Rails' `CollectionProxy` holds no target of its own — `target`, `loaded?`
+  // and `@replaced_or_added_targets` all read `@association`
+  // (collection_proxy.rb:33, 53). trails keeps that direction: these accessors
+  // are the association's `@target` / `@loaded` ivars, so association and proxy
+  // are one seat rather than two stores to keep coherent.
+  private get _target(): T[] {
+    return this._seat()._targetStore as T[];
+  }
+
+  private set _target(records: T[]) {
+    this._seat()._targetStore = records;
+  }
+
+  private get _targetLoaded(): boolean {
+    return this._seat()._loadedStore;
+  }
+
+  private set _targetLoaded(value: boolean) {
+    this._seat()._loadedStore = value;
+  }
+
+  /**
+   * The association object holding the seat. Deliberately a raw
+   * `@association_cache` read rather than `_collectionAssociation()`:
+   * `Base#association` re-syncs the cache, which reads loadedness back off
+   * this proxy, so resolving a seat through it would recurse.
+   */
+  private _seat(): CollectionAssociation {
+    const instance = this._record._associationInstances.get(this._assocName) as
+      | (CollectionAssociation & { isCollection?(): boolean })
+      | undefined;
+    if (instance?.isCollection?.() === true) return instance;
+    // The cache slot holds one of the minimal ad-hoc holders an undeclared
+    // inverse seeds (`associations.ts`, `seed-association-cache.ts`), which has
+    // no `@target` seat of its own. Build the real association object for the
+    // reflection and carry that holder's target onto it — `Base#association`
+    // would hand the ad-hoc holder straight back.
+    const built = _buildAssociationInstance.call(
+      this._record,
+      this._assocDef as never,
+    ) as unknown as CollectionAssociation;
+    if (instance) {
+      const seeded = (instance as unknown as { target?: Base | Base[] | null }).target;
+      built._targetStore = Array.isArray(seeded) ? seeded : seeded ? [seeded] : [];
+      built._loadedStore = instance.isLoaded?.() === true;
+    }
+    this._record._associationInstances.set(this._assocName, built as never);
+    return built;
+  }
   // Rails' `CollectionProxy#@scope` memo (collection_proxy.rb:949-951), cleared
   // by `reset_scope` (collection_proxy.rb:1112-1116).
   private _scope: unknown;
@@ -181,7 +228,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // `Set.new.compare_by_identity`): records that have been added to or
   // replaced on the in-memory target. `replace_on_target` consults it to
   // dedup by identity rather than appending the same record twice.
-  private _replacedOrAddedTargets = new Set<T>();
+  private get _replacedOrAddedTargets(): Set<T> {
+    return this._seat()._replacedOrAddedTargets as Set<T>;
+  }
+
+  private set _replacedOrAddedTargets(value: Set<T>) {
+    this._seat()._replacedOrAddedTargets = value as unknown as Set<Base>;
+  }
   // The JS Proxy wrapper returned by association() — methods that return
   // `self` (push / concat / append) hand this back so callers get the same
   // object they hold, since `this` is the raw target, not the wrapper.
@@ -215,39 +268,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   get target(): T[] {
     return this._target;
-  }
-
-  /** @internal */
-  get _sharedTarget(): T[] {
-    return this._target;
-  }
-
-  set _sharedTarget(records: T[]) {
-    this._target = records;
-  }
-
-  /** @internal */
-  get _sharedReplacedOrAddedTargets(): Set<T> {
-    return this._replacedOrAddedTargets;
-  }
-
-  set _sharedReplacedOrAddedTargets(value: Set<T>) {
-    this._replacedOrAddedTargets = value;
-  }
-
-  /** @internal */
-  get _sharedLoaded(): boolean {
-    return this._targetLoaded;
-  }
-
-  set _sharedLoaded(value: boolean) {
-    this._targetLoaded = value;
-  }
-
-  /** @internal */
-  _adoptSharedTarget(records: T[], loaded: boolean): void {
-    this._target = records;
-    this._targetLoaded = loaded;
   }
 
   /**
@@ -1211,7 +1231,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (collection_association.rb:439-446), and `concat` owns both halves Rails
    * puts there — the new-record-owner `load_target` and the persisted-owner
    * `transaction { concat_records }`. The proxy and the association object
-   * share ONE in-memory target (`_sharedTarget`), so the appended records,
+   * share ONE in-memory target (the association's `@target`), so the appended records,
    * loaded-ness, `@replaced_or_added_targets` dedup and before/after_add
    * callbacks all land on this proxy too.
    */
@@ -1379,7 +1399,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * join-row decision lives on `HasManyThroughAssociation#concat_records` /
    * `#insert_record` (has_many_through_association.rb:24-49). This is that
    * delegation. The proxy and the association object share ONE in-memory target
-   * (`_sharedTarget`, `collection-association.ts:96`), so routing the write onto
+   * (the association's `@target`), so routing the write onto
    * the association keeps membership, loaded-ness, `@replaced_or_added_targets`
    * dedup, and the before/after_add callbacks coherent across both handles.
    *

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -170,6 +170,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   static override _railsClassName = "ActiveRecord::Associations::CollectionProxy";
 
   private _record: Base;
+  // Seat of last resort — see `_seat()`. Never used once the association cache
+  // holds the real `CollectionAssociation`.
+  private _ownSeat?: CollectionAssociation;
   private _assocName: string;
   private _assocDef: AssociationDefinition;
   // Rails' `CollectionProxy` holds no target of its own — `target`, `loaded?`
@@ -204,22 +207,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       | (CollectionAssociation & { isCollection?(): boolean })
       | undefined;
     if (instance?.isCollection?.() === true) return instance;
-    // The cache slot holds one of the minimal ad-hoc holders an undeclared
-    // inverse seeds (`associations.ts`, `seed-association-cache.ts`), which has
-    // no `@target` seat of its own. Build the real association object for the
-    // reflection and carry that holder's target onto it — `Base#association`
-    // would hand the ad-hoc holder straight back.
-    const built = _buildAssociationInstance.call(
-      this._record,
-      this._assocDef as never,
-    ) as unknown as CollectionAssociation;
-    if (instance) {
-      const seeded = (instance as unknown as { target?: Base | Base[] | null }).target;
-      built._targetStore = Array.isArray(seeded) ? seeded : seeded ? [seeded] : [];
-      built._loadedStore = instance.isLoaded?.() === true;
-    }
-    this._record._associationInstances.set(this._assocName, built as never);
-    return built;
+    // The cache slot is empty, or holds one of the minimal ad-hoc holders an
+    // undeclared inverse seeds (`associations.ts`, `seed-association-cache.ts`)
+    // — those are singular by construction and have no `@target` seat to share,
+    // and `Base#association` would hand one straight back. Keep the seat here
+    // until a real collection association claims the slot.
+    return (this._ownSeat ??= {
+      _targetStore: [],
+      _loadedStore: false,
+      _replacedOrAddedTargets: new Set<Base>(),
+    } as unknown as CollectionAssociation);
   }
   // Rails' `CollectionProxy#@scope` memo (collection_proxy.rb:949-951), cleared
   // by `reset_scope` (collection_proxy.rb:1112-1116).

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -201,6 +201,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `@association_cache` read rather than `_collectionAssociation()`:
    * `Base#association` re-syncs the cache, which reads loadedness back off
    * this proxy, so resolving a seat through it would recurse.
+   *
+   * Invariant for anything that writes `_target` / `_targetLoaded`: the real
+   * `CollectionAssociation` must already be registered, so the write lands on
+   * the shared seat. Every current writer satisfies it — the mutation paths
+   * reach `_collectionAssociation()` / `_staleWrapper()` first, and the
+   * preloader calls `owner.association(name)` before `_hydrateFromPreload`
+   * (`preloader/association.ts`, `preloader/batch.ts`). A new writer that runs
+   * before the association exists would strand its records on `_ownSeat`.
    */
   private _seat(): CollectionAssociation {
     const instance = this._record._associationInstances.get(this._assocName) as

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -158,6 +158,18 @@ interface ThroughAssociationHandle {
   transaction<R>(block: () => Promise<R>): Promise<R | undefined>;
 }
 
+/**
+ * The three ivars a `CollectionProxy` reads through its association: Ruby's
+ * `@target`, `@loaded` and `@replaced_or_added_targets`. `CollectionAssociation`
+ * satisfies it structurally; see `_seat()`.
+ * @internal
+ */
+interface TargetSeat {
+  _targetStore: Base | Base[] | null;
+  _loadedStore: boolean;
+  _replacedOrAddedTargets: Set<Base>;
+}
+
 interface StaleWrapper {
   isStaleTarget?: () => boolean;
   resetScope?: () => void;
@@ -172,7 +184,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _record: Base;
   // Seat of last resort — see `_seat()`. Never used once the association cache
   // holds the real `CollectionAssociation`.
-  private _ownSeat?: CollectionAssociation;
+  private _ownSeat?: TargetSeat;
   private _assocName: string;
   private _assocDef: AssociationDefinition;
   // Rails' `CollectionProxy` holds no target of its own — `target`, `loaded?`
@@ -210,9 +222,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (`preloader/association.ts`, `preloader/batch.ts`). A new writer that runs
    * before the association exists would strand its records on `_ownSeat`.
    */
-  private _seat(): CollectionAssociation {
+  private _seat(): TargetSeat {
     const instance = this._record._associationInstances.get(this._assocName) as
-      | (CollectionAssociation & { isCollection?(): boolean })
+      | (TargetSeat & { isCollection?(): boolean })
       | undefined;
     if (instance?.isCollection?.() === true) return instance;
     // The cache slot is empty, or holds one of the minimal ad-hoc holders an
@@ -224,7 +236,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       _targetStore: [],
       _loadedStore: false,
       _replacedOrAddedTargets: new Set<Base>(),
-    } as unknown as CollectionAssociation);
+    });
   }
   // Rails' `CollectionProxy#@scope` memo (collection_proxy.rb:949-951), cleared
   // by `reset_scope` (collection_proxy.rb:1112-1116).
@@ -238,7 +250,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   private set _replacedOrAddedTargets(value: Set<T>) {
-    this._seat()._replacedOrAddedTargets = value as unknown as Set<Base>;
+    this._seat()._replacedOrAddedTargets = value as Set<Base>;
   }
   // The JS Proxy wrapper returned by association() — methods that return
   // `self` (push / concat / append) hand this back so callers get the same

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -56,8 +56,10 @@ function syncAssociationInstance(this: Base, name: string, instance: Association
   // that implement only `target` / `isLoaded` / `setTarget`. Those are singular
   // by construction, so falling through is right.
   if ((instance as { isCollection?(): boolean }).isCollection?.()) {
-    const proxy = this._collectionProxies.get(name) as { loaded?: boolean } | undefined;
-    if (proxy?.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
+    // One seat since RFC 0022's fold: the proxy writes `@loaded` on this very
+    // instance, so read it here rather than back off the proxy (which resolves
+    // its seat through this function).
+    if (instance.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
     return;
   }
   // Reads the loaded target through the association cache

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -11,7 +11,7 @@ import type { ExplainOption } from "../abstract/database-statements.js";
 import { ActiveSupport } from "@blazetrails/activesupport";
 import { PreparedStatementCacheExpired, type SQLWarning } from "../../errors.js";
 import { Result } from "../../result.js";
-import { isEmpty } from "../../ruby-empty.js";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
 // Mirrors Rails' build_read_query_regexp which combines the default read list

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -8,7 +8,7 @@ import type { Base } from "./base.js";
 import { isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import { Result } from "./result.js";
-import { isEmpty } from "./ruby-empty.js";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { withConnection } from "./connection-handling.js";
 
 type ModelClass = typeof Base;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@blazetrails/date";
 import { except, hexdigest, isBlank, Notifications, toFs } from "@blazetrails/activesupport";
-import { isEmpty } from "./ruby-empty.js";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { first } from "./ruby-first.js";
 import { Table, SelectManager, Nodes, sql } from "@blazetrails/arel";
 import type { Base } from "./base.js";

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -5,7 +5,7 @@
  */
 import { ArgumentError } from "@blazetrails/activemodel";
 import { kernelArray } from "@blazetrails/activesupport";
-import { isEmpty } from "../ruby-empty.js";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { WhereClause } from "./where-clause.js";
 import { ActiveRecord } from "../ar-config.js";
 import { stripThenable } from "./thenable.js";

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -11,7 +11,7 @@
 import { Nodes, Table, SelectManager } from "@blazetrails/arel";
 import { ArgumentError, BigIntegerType } from "@blazetrails/activemodel";
 import { any, isPresent, many, tryCall } from "@blazetrails/activesupport";
-import { isEmpty } from "../ruby-empty.js";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import type { AdapterName } from "../connection-adapters/abstract-adapter.js";
 import type { Base } from "../base.js";
 import { exceedsBindParamsLimit } from "../connection-adapters/abstract/database-limits.js";

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -24,6 +24,7 @@
       "@blazetrails/activesupport/core-ext/string/inflections": [
         "../../activesupport/src/core-ext/string/inflections.ts"
       ],
+      "@blazetrails/activesupport/ruby-empty": ["../../activesupport/src/ruby-empty.ts"],
       "@blazetrails/activesupport/gzip": ["../../activesupport/src/gzip.ts"],
       "@blazetrails/activesupport/yaml": ["../../activesupport/src/yaml.ts"],
       "@blazetrails/globalid/signed-global-id": ["../../globalid/src/signed-global-id.ts"]

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -6,6 +6,7 @@ import { ArgumentError, assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
 import { camelize } from "./inflector.js";
 import { inspect, toS } from "./core-ext/object/inspect.js";
+import { isEmpty } from "./ruby-empty.js";
 
 /**
  * Wraps its argument in an array unless it is already an array (or array-like).
@@ -217,7 +218,7 @@ export function extractBang<T>(array: T[], predicate: (item: T) => boolean): T[]
 export function toFs(self: unknown[], format = "default"): string {
   switch (format) {
     case "db":
-      if (self.length === 0) {
+      if (isEmpty(self)) {
         return "null";
       } else {
         return self.map((e) => (e as { id: unknown }).id).join(",");

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -280,13 +280,14 @@ export class FileStore extends Store implements CacheStore {
     } catch {
       return;
     }
-    if (!isEmpty(children)) return;
-    // Rails: `Dir.delete(dir) rescue nil` — a failed delete is swallowed and we
-    // still recurse toward the parent (file_store.rb:193-195).
-    try {
-      getFs().rmdirSync(dir);
-    } catch {}
-    this.deleteEmptyDirectories(getPath().dirname(dir));
+    if (isEmpty(children)) {
+      // Rails: `Dir.delete(dir) rescue nil` — a failed delete is swallowed and
+      // we still recurse toward the parent (file_store.rb:197-199).
+      try {
+        getFs().rmdirSync(dir);
+      } catch {}
+      this.deleteEmptyDirectories(getPath().dirname(dir));
+    }
   }
 
   // Resolve symlinks like Ruby File.realpath. Adapters without symlink support

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -6,6 +6,7 @@ import { atomicWrite } from "../core-ext/file/atomic.js";
 import { Integer } from "./integer.js";
 import { hexdigest } from "../hexdigest.js";
 import { registerStoreClass } from "./store-registry.js";
+import { isEmpty } from "../ruby-empty.js";
 
 // max filename size on file system is 255, minus room for timestamp, pid, and
 // random characters appended by Tempfile (file_store.rb:16)
@@ -279,7 +280,7 @@ export class FileStore extends Store implements CacheStore {
     } catch {
       return;
     }
-    if (children.length > 0) return;
+    if (!isEmpty(children)) return;
     // Rails: `Dir.delete(dir) rescue nil` — a failed delete is swallowed and we
     // still recurse toward the parent (file_store.rb:193-195).
     try {

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -7,6 +7,7 @@ import { DeserializationError } from "./deserialization-error.js";
 import { Notifications } from "../notifications.js";
 import { toParam } from "../hash-utils.js";
 import type { EventPayload } from "../notifications/instrumenter.js";
+import { isEmpty } from "../ruby-empty.js";
 
 /** Mirrors Rails `Cache::DEFAULT_COMPRESS_LIMIT` (cache.rb:45). */
 const DEFAULT_COMPRESS_LIMIT = 1024;
@@ -710,7 +711,11 @@ export abstract class Store {
       );
     }
 
-    return { ...this.options, ...call };
+    if (isEmpty(this.options)) {
+      return call;
+    } else {
+      return { ...this.options, ...call };
+    }
   }
 
   /** Mirrors Rails `Cache::Store#normalize_options` (cache.rb:905–911). */

--- a/packages/activesupport/src/core-ext/tse/util.ts
+++ b/packages/activesupport/src/core-ext/tse/util.ts
@@ -5,6 +5,7 @@
 
 import { SafeBuffer, htmlSafe } from "../string/output-safety.js";
 import { NotImplementedError } from "../../cache/store.js";
+import { isEmpty } from "../../ruby-empty.js";
 
 const HTML_ESCAPE: Record<string, string> = {
   "&": "&amp;",
@@ -207,7 +208,7 @@ export function tokenize(source: string): [string, string][] {
       if (len > 0) tokens.push([":TEXT", scanner.string.slice(pos, pos + len)]);
       tokens.push([":OPEN", scanner.matched]);
       if (scanner.scan(CODE_RE) !== null) {
-        if (scanner.matched !== "") tokens.push([":CODE", scanner.matched]);
+        if (!isEmpty(scanner.matched)) tokens.push([":CODE", scanner.matched]);
         if (!scanner.isEos()) tokens.push([":CLOSE", scanner.scan(FINISH_RE)!]);
       } else {
         // @nie disposition=TODO

--- a/packages/activesupport/src/inflector/inflections.ts
+++ b/packages/activesupport/src/inflector/inflections.ts
@@ -4,6 +4,7 @@
  */
 
 import { I18n } from "../i18n.js";
+import { isEmpty } from "../ruby-empty.js";
 
 export interface InflectionRule {
   rule: RegExp;
@@ -151,7 +152,7 @@ export class Inflections {
   }
 
   private defineAcronymRegexPatterns(): void {
-    if (this.acronyms.size === 0) {
+    if (isEmpty(this.acronyms)) {
       this.acronymRegex = /(?=a)b/;
       this.acronymsCamelizeRegex = /^\w/;
       this.acronymsUnderscoreRegex = /(?=a)b/;

--- a/packages/activesupport/src/json/encoding.ts
+++ b/packages/activesupport/src/json/encoding.ts
@@ -1,4 +1,5 @@
 import { asJson, Float, isPlainObject } from "../core-ext/object/json.js";
+import { isEmpty } from "../ruby-empty.js";
 
 /**
  * Serialization options threaded through `as_json` — only the subset Rails'
@@ -37,7 +38,7 @@ export class JSONGemEncoder {
    *   `??`.
    */
   encode(value: unknown): string {
-    if (Object.keys(this.options).length !== 0) {
+    if (!isEmpty(this.options)) {
       value = asJson(value, this.options);
     }
     let json = this.stringify(this.jsonify(value));

--- a/packages/activesupport/src/ruby-empty.ts
+++ b/packages/activesupport/src/ruby-empty.ts
@@ -2,17 +2,10 @@
  * Ruby `empty?`, for ports of Ruby collection predicates.
  *
  * This has no Rails counterpart — `Array#empty?`, `Hash#empty?` and
- * `String#empty?` are Ruby core, the same way the sibling `ruby-truthy.ts`
- * models Ruby truthiness. It lives here rather than in activesupport for the
- * same reason that one does: the call-set comparator resolves a Ruby call name
- * against the PORTED names of the package it appears in, so exporting `isEmpty`
- * from activesupport would make every Ruby `empty?` in an activesupport body
- * resolvable and surface eight unrelated divergences at once. activerecord
- * already resolves `empty?` (`ActiveRecord::Result#empty`), so the population
- * here is unchanged. Those eight are real, pre-existing divergences and want
- * their own story; surfacing them as a side effect of this helper's placement
- * would have baselined them, which is the one thing the exclude tree must never
- * grow for.
+ * `String#empty?` are Ruby core, the same way `activerecord`'s sibling
+ * `ruby-truthy.ts` models Ruby truthiness. It lives in activesupport, the
+ * lowest package every port can reach, so an `empty?` in an activesupport body
+ * spells the same call an activerecord one does.
  *
  * It exists because the obvious
  * spellings — `xs.length === 0`, `Object.keys(h).length === 0` — are property

--- a/packages/activesupport/src/tagged-logging.ts
+++ b/packages/activesupport/src/tagged-logging.ts
@@ -6,6 +6,7 @@
 import { Logger, taggedLogging as _taggedLogging } from "./logger.js";
 import type { TaggedLogger } from "./logger.js";
 import type { Temporal } from "@blazetrails/date";
+import { isEmpty } from "./ruby-empty.js";
 
 export class TagStack {
   private _tags: string[] = [];
@@ -39,7 +40,7 @@ export class TagStack {
   }
 
   formatMessage(message: string): string {
-    if (this._tags.length === 0) {
+    if (isEmpty(this._tags)) {
       return message;
     } else if (this._tags.length === 1) {
       return `[${this._tags[0]}] ${message}`;

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -7,6 +7,7 @@ import { Duration } from "../duration.js";
 import { clock, currentTimeInstant } from "../time-travel.js";
 import { zone as timeZone } from "../time-zone-config.js";
 import { midnight } from "../core-ext/date/calculations.js";
+import { isEmpty } from "../ruby-empty.js";
 
 /** Mirrors Ruby's `RuntimeError` — what a bare `raise "message"` raises. */
 class RuntimeError extends Error {
@@ -80,7 +81,7 @@ export class SimpleStubs {
 
   /** Returns true if any stubs are set, false if there are none */
   isStubbed(): boolean {
-    return this.stubs.size !== 0;
+    return !isEmpty(this.stubs);
   }
 
   /** Restores the original object.method described by the Stub */

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -10,15 +10,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
-    "call": "first",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "relation.rb:472 reads `.first` off the fetched row; the port calls a `first(selectRows)` free function over the driver rows, threading the receiver as argument 1."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
     "call": "to_fs",
     "kind": "args",
     "rubyArgs": [

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
@@ -67,5 +67,12 @@
     "rubyName": "since",
     "call": "sum",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
+    "rubyName": "sum",
+    "call": "empty?",
+    "reason": "Name collision, not an omission: Ruby's `sum` here is the private instance method `sum(sign, time)` (duration.rb:486-510) whose `@parts.empty?` arm trails ports inside `applyDuration`; the TS owner the comparator pairs it with is the unrelated `static sum(durations)` Enumerable helper. The two `since`/`ago` rows above record the same unported private `sum`."
   }
 ]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -133,6 +133,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/digest.ts",
   ),
+  "@blazetrails/activesupport/ruby-empty": path.resolve(
+    __dirname,
+    "packages/activesupport/src/ruby-empty.ts",
+  ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
   "@blazetrails/activesupport/message-pack": path.resolve(
     __dirname,


### PR DESCRIPTION
## One `@target` seat, and `isEmpty` in activesupport

### `CollectionAssociation` — one target seat (RFC 0106)

`CollectionProxy` no longer holds a target of its own. Rails' proxy reads
`@association.target` / `@association.loaded?` (collection_proxy.rb:33, 53), and
trails now keeps that direction: the proxy's `_target` / `_targetLoaded` /
`_replacedOrAddedTargets` are accessors onto the association's `@target` /
`@loaded` ivars. With one seat:

- `_writeTargetStore` is gone; its 7 call sites are Ruby's bare `@target = …`
  (`this._targetStore = x`), matching collection_association.rb:89, :274, :422.
- `_sharedStore` / `_sharedTarget` / `_sharedLoaded` /
  `_sharedReplacedOrAddedTargets` / `_adoptSharedTarget` are gone.
- `target=` is collection_association.rb:284-295 verbatim — the
  `has_many_inversing` guard, then `nil` / `Array` / else with `super` and
  `replace_on_target`. No array coercion (Ruby's `@target = record` stores what
  it is given), and no `associationProxy(...)` materialization: with one seat
  there is no second store for `replace_on_target` to miss.

The proxy resolves its seat with a raw `@association_cache` read rather than
`Base#association`, which re-syncs the cache off the proxy and would recurse.
An ad-hoc holder (the minimal object an undeclared inverse seeds) is upgraded to
the real association object, carrying its seeded target over.

### `isEmpty` moved to activesupport

`ruby-empty.ts` moves from activerecord to activesupport, so activesupport
bodies can spell Ruby `empty?` as a call. The eight sites that surfaced are
converged against their Rails lines:

| TS | Rails |
| --- | --- |
| `cache/store.ts` `mergedOptions` | cache.rb:880 (also restores the `options.empty?` branch, which was collapsed into one spread) |
| `cache/file-store.ts` `deleteEmptyDirectories` | file_store.rb:192 |
| `core-ext/tse/util.ts` `tokenize` | core_ext/erb/util.rb:180 |
| `inflector/inflections.ts` `defineAcronymRegexPatterns` | inflector/inflections.rb:251 |
| `json/encoding.ts` `encode` | json/encoding.rb:56 |
| `tagged-logging.ts` `formatMessage` | tagged_logging.rb:97 |
| `testing/time-helpers.ts` `isStubbed` | testing/time_helpers.rb:54 |
| `array-utils.ts` `toFs` | core_ext/array/conversions.rb:97 |

One new baseline row (`duration.ts` `sum` `empty?`): a name collision, not an
omission — Ruby's `sum` there is the private `sum(sign, time)`
(duration.rb:486-510), and the comparator pairs it with the unrelated
`static sum(durations)` helper. Two sibling rows (`since`/`ago` → `sum`) already
record the same unported private method.

One stale call-args row deleted by hand (`relation.ts` `compute_cache_version`
`first()`), which the rebase onto #6679 surfaced.

### Filed, not folded: `Association#target=` does not call `loaded!`

Rails' base setter is two statements (`association.rb:100-103`):
`@target = target; loaded!`. trails' `association.ts:57-59` writes the ivar only,
so every `self.target = record` path leaves `@loaded` false where Rails leaves it
true. `CollectionAssociation#target=`'s `super` arms now land on that setter, so
the gap sits in this convergence's path — but it predates this PR (the retired
`_writeTargetStore` had it too) and it is not baselined either: there is no
`association.ts | target= | loaded!` row in the exclude tree or in
`output/call-mismatches.json`.

It is **not** folded in here because `loaded!` also snapshots `stale_state`
(`association.rb:86-89`), so making the base setter call it changes loadedness
*and* staleness on every `self.target = record` path across singular
associations (`has_one_association.rb:69, 84`; `inversed_from` at
`association.rb:132`) — a behavioural change beyond a call-set convergence,
needing its own three-lane run.

Tracked as story `association-target-setter-must-call-loaded-bang` under RFC
0106, at
`rfcs/0106-wide-call-set-direct-burndown/stories/association-target-setter-must-call-loaded-bang.md`
in the tasks repo (commit `ccbd84008`, on its `origin/main`). Its acceptance
criteria require auditing every caller that relies on the setter *not* marking
loaded, and the `stale_state` re-snapshot interaction with
`syncAssociationInstance`.

### Not in this PR

`wave-4e-schema-dumper-migration-residue` (38 rows) and
`converge-execute-grouped-calculation-body-to-rails-source-order` (a
`with_connection` re-wrap plus a `type_for` block signature change) do not fit
under the LOC ceiling alongside the above; both have been released back to the
queue unclaimed.

Closes-story: converge-collection-target-setter-coercion-and-proxy
Closes-story: retire-collection-association-write-target-store
Closes-story: activesupport-empty-predicate-call-rows
