### PR TITLE
fix(parity): converge current_attributes_test.rb and the portable half of cache_store_setting_test.rb

### DIFF
--- a/packages/activesupport/src/cache.ts
+++ b/packages/activesupport/src/cache.ts
@@ -38,14 +38,15 @@ export { setFormatVersion } from "./cache/format-version-slot.js";
  * Symbol` arm reads: `:memory_store` names a store class to build, anything
  * else is returned as-is.
  *
+ * Ruby's `new(*parameters, **options)` (cache.rb:89) passes no argument at all
+ * when `options` is empty, so a store whose only positional is required still
+ * raises ArgumentError rather than receiving the empty hash as it.
+ *
  * Mirrors: ActiveSupport::Cache.lookup_store (cache.rb:85-97)
  */
 export function lookupStore(store?: unknown, ...parameters: unknown[]): CacheStore {
   if (typeof store === "string" && store.startsWith(":")) {
     const [rest, options] = extractOptionsBang(parameters);
-    // Ruby's `new(*parameters, **options)` (cache.rb:89) passes no argument at
-    // all when `options` is empty, so a store whose only positional is required
-    // still raises ArgumentError rather than receiving the empty hash as it.
     return new (retrieveStoreClass(store))(
       ...rest,
       ...(Object.keys(options as object).length === 0 ? [] : [options]),

--- a/packages/activesupport/src/cache.ts
+++ b/packages/activesupport/src/cache.ts
@@ -43,7 +43,13 @@ export { setFormatVersion } from "./cache/format-version-slot.js";
 export function lookupStore(store?: unknown, ...parameters: unknown[]): CacheStore {
   if (typeof store === "string" && store.startsWith(":")) {
     const [rest, options] = extractOptionsBang(parameters);
-    return new (retrieveStoreClass(store))(...rest, options);
+    // Ruby's `new(*parameters, **options)` (cache.rb:89) passes no argument at
+    // all when `options` is empty, so a store whose only positional is required
+    // still raises ArgumentError rather than receiving the empty hash as it.
+    return new (retrieveStoreClass(store))(
+      ...rest,
+      ...(Object.keys(options as object).length === 0 ? [] : [options]),
+    );
   }
   if (Array.isArray(store)) {
     return lookupStore(...(store as unknown[]));

--- a/packages/activesupport/src/cache/cache-store-setting.test.ts
+++ b/packages/activesupport/src/cache/cache-store-setting.test.ts
@@ -1,35 +1,32 @@
 import { describe, it, expect } from "vitest";
 
+import { lookupStore } from "../cache.js";
+import { ArgumentError } from "../cache/store.js";
 import { MemoryStore } from "../cache/memory-store.js";
 import { NullStore } from "../cache/null-store.js";
 import { FileStore } from "../cache/file-store.js";
 
 describe("CacheStoreSettingTest", () => {
   it("memory store gets created if no arguments passed to lookup store method", () => {
-    const store = new MemoryStore();
-    expect(store).toBeDefined();
-    store.write("key", "value");
-    expect(store.read("key")).toBe("value");
+    const store = lookupStore();
+    expect(store).toBeInstanceOf(MemoryStore);
   });
 
   it("memory store", () => {
-    const store = new MemoryStore();
-    store.write("test", 42);
-    expect(store.read("test")).toBe(42);
-    store.delete("test");
-    expect(store.read("test")).toBeNull();
+    const store = lookupStore(":memory_store");
+    expect(store).toBeInstanceOf(MemoryStore);
   });
 
   it("file fragment cache store", () => {
-    // FileStore with a path
-    const store = new FileStore("/tmp/test-cache");
-    expect(store).toBeDefined();
+    const store = lookupStore(":file_store", "/path/to/cache/directory");
+    expect(store).toBeInstanceOf(FileStore);
+    expect((store as FileStore).cachePath).toBe("/path/to/cache/directory");
   });
 
   it("file store requires a path", () => {
-    // FileStore accepts any string path; empty string creates store with empty dir
-    const store = new FileStore("/tmp/valid-cache");
-    expect(store).toBeDefined();
+    expect(() => {
+      lookupStore(":file_store");
+    }).toThrow(ArgumentError);
   });
 
   it("mem cache fragment cache store", () => {
@@ -56,9 +53,9 @@ describe("CacheStoreSettingTest", () => {
   });
 
   it("object assigned fragment cache store", () => {
-    const store = new MemoryStore();
-    expect(typeof store.write).toBe("function");
-    expect(typeof store.read).toBe("function");
+    const store = lookupStore(new FileStore("/path/to/cache/directory"));
+    expect(store).toBeInstanceOf(FileStore);
+    expect((store as FileStore).cachePath).toBe("/path/to/cache/directory");
   });
 
   it("redis cache store with single array object", () => {

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -77,11 +77,13 @@ export class FileStore extends Store implements CacheStore {
 
   private _cachePath: string;
 
+  /**
+   * `cache_path` is a required positional (file_store.rb:19), so Ruby raises
+   * ArgumentError from arity when `Cache.lookup_store :file_store` supplies
+   * none. TypeScript passes `undefined` instead, so the arity check is explicit.
+   */
   constructor(cachePath: string, options?: CacheOptions) {
     super(options ?? {});
-    // `cache_path` is a required positional (file_store.rb:19), so Ruby raises
-    // ArgumentError from arity when `Cache.lookup_store :file_store` supplies
-    // none. TypeScript passes `undefined` instead, so the arity check is here.
     if (cachePath === undefined) {
       throw new ArgumentError("wrong number of arguments (given 0, expected 1)");
     }

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -1,7 +1,7 @@
 import { getFs, getPath } from "../fs-adapter.js";
 import type { CacheOptions, CacheStore } from "./index.js";
 import { Entry } from "./entry.js";
-import { Store, inspectOptions, type StoreOptions } from "./store.js";
+import { ArgumentError, Store, inspectOptions, type StoreOptions } from "./store.js";
 import { atomicWrite } from "../core-ext/file/atomic.js";
 import { Integer } from "./integer.js";
 import { hexdigest } from "../hexdigest.js";
@@ -79,6 +79,12 @@ export class FileStore extends Store implements CacheStore {
 
   constructor(cachePath: string, options?: CacheOptions) {
     super(options ?? {});
+    // `cache_path` is a required positional (file_store.rb:19), so Ruby raises
+    // ArgumentError from arity when `Cache.lookup_store :file_store` supplies
+    // none. TypeScript passes `undefined` instead, so the arity check is here.
+    if (cachePath === undefined) {
+      throw new ArgumentError("wrong number of arguments (given 0, expected 1)");
+    }
     this._cachePath = String(cachePath);
   }
 

--- a/packages/activesupport/src/current-attributes.test.ts
+++ b/packages/activesupport/src/current-attributes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { CurrentAttributes } from "./current-attributes.js";
+import { methodMissingProxy } from "./method-missing-proxy.js";
 import { assertSame } from "./testing/assertions.js";
 import { zone, setZone } from "./time-zone-config.js";
 
@@ -22,7 +23,7 @@ describe("CurrentAttributesTest", () => {
     declare static previous: number | null | undefined;
   }
 
-  class Current extends CurrentAttributes {
+  const CurrentClass = class Current extends CurrentAttributes {
     static {
       this.attribute("counterInteger", { default: 0 });
       this.attribute("counterCallable", { default: () => 0 });
@@ -39,21 +40,7 @@ describe("CurrentAttributesTest", () => {
       this.resets(":clearTimeZone");
     }
 
-    declare static counterInteger: number;
-    declare static counterCallable: number;
-    declare static world: string | undefined;
-    declare static account: string | undefined;
-    declare static person: Person | undefined;
-    declare static request: string | undefined;
-
-    /**
-     * Rails' `delegate :time_zone, to: :person` — a Struct member is a method
-     * on the Ruby side, so the delegator here reads the `Person#timeZone` field.
-     * The tests reach this and `intro` through `Current.instance()` where Rails
-     * reaches them off the class: those class-level delegators come from the
-     * `method_added` hook (current_attributes.rb:186-193), which has no
-     * TypeScript equivalent.
-     */
+    /** Rails' `delegate :time_zone, to: :person` (a Struct member is a method). */
     get timeZone(): string | undefined {
       return this.person?.timeZone;
     }
@@ -112,12 +99,21 @@ describe("CurrentAttributesTest", () => {
     declare world: string | undefined;
     declare counterInteger: number;
     declare counterCallable: number;
-  }
+  };
 
   /**
-   * Mirrors `ActiveSupport::CurrentAttributes::TestHelper`, which resets every
-   * CurrentAttributes instance around each test, plus the `before_setup` /
-   * `after_teardown` hooks that restore `Time.zone`.
+   * Rails answers every public instance method off the class, via
+   * `method_missing` / `respond_to_missing?` (current_attributes.rb:180-184) and
+   * the `method_added` hook generating the same delegators (:186-193) — Ruby
+   * language hooks whose trails idiom is `methodMissingProxy`.
+   */
+  const Current = methodMissingProxy(CurrentClass, {
+    delegate: (klass) => klass.instance(),
+  }) as typeof CurrentClass & InstanceType<typeof CurrentClass>;
+
+  /**
+   * `ActiveSupport::CurrentAttributes::TestHelper` resets every instance around
+   * each test; `before_setup` / `after_teardown` restore `Time.zone`.
    */
   let originalTimeZone: ReturnType<typeof zone>;
 
@@ -229,13 +225,13 @@ describe("CurrentAttributesTest", () => {
   });
 
   it("using keyword arguments", () => {
-    Current.instance().setWorldAndAccount({ world: "world/1", account: "account/1" });
+    Current.setWorldAndAccount({ world: "world/1", account: "account/1" });
 
     expect(Current.world).toBe("world/1");
     expect(Current.account).toBe("account/1");
 
     const hash: Record<string, unknown> = {};
-    assertSame(hash, Current.instance().getWorldAndAccount(hash));
+    assertSame(hash, Current.getWorldAndAccount(hash));
     expect(hash["world"]).toBe("world/1");
     expect(hash["account"]).toBe("account/1");
   });
@@ -257,18 +253,18 @@ describe("CurrentAttributesTest", () => {
 
   it("delegation", () => {
     Current.person = new Person(42, "David", "Central Time (US & Canada)");
-    expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
+    expect(Current.timeZone).toBe("Central Time (US & Canada)");
     expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
   });
 
   it("all methods forward to the instance", () => {
     Current.person = new Person(42, "David", "Central Time (US & Canada)");
-    expect(Current.instance().intro()).toBe("David, in Central Time (US & Canada)");
+    expect(Current.intro()).toBe("David, in Central Time (US & Canada)");
     expect(Current.instance().intro()).toBe("David, in Central Time (US & Canada)");
   });
 
   it("respond_to? for methods that have not been called", () => {
-    expect("respondToTest" in Current.instance()).toBe(true);
+    expect("respondToTest" in Current).toBe(true);
   });
 
   it("CurrentAttributes defaults do not leak between classes", () => {
@@ -286,7 +282,7 @@ describe("CurrentAttributesTest", () => {
   it.skip("CurrentAttributes can use thread-local variables");
 
   it("CurrentAttributes doesn't populate #attributes when not using defaults", () => {
-    expect(Current.instance().attributes).toEqual({ counterInteger: 0, counterCallable: 0 });
+    expect(Current.attributes).toEqual({ counterInteger: 0, counterCallable: 0 });
   });
 
   it("CurrentAttributes restricted attribute names", () => {

--- a/packages/activesupport/src/current-attributes.test.ts
+++ b/packages/activesupport/src/current-attributes.test.ts
@@ -1,119 +1,16 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { CurrentAttributes } from "./current-attributes.js";
+import { assertSame } from "./testing/assertions.js";
+import { zone, setZone } from "./time-zone-config.js";
 
 describe("CurrentAttributesTest", () => {
-  // Set up a test subclass
-  class Current extends CurrentAttributes {
-    static {
-      this.attribute("user");
-      this.attribute("account");
-    }
-    declare user: string | undefined;
-    declare account: string | undefined;
-  }
-
-  beforeEach(() => {
-    Current.reset();
-  });
-
-  it("read and write attribute", () => {
-    const inst = Current.instance();
-    expect(inst.user).toBeUndefined();
-    inst.user = "david";
-    expect(inst.user).toBe("david");
-  });
-
-  it("read and write attribute with default value", () => {
-    class CurrentWithDefault extends CurrentAttributes {
-      static {
-        this.attribute("user", { default: "guest" });
-      }
-      declare user: string;
-    }
-    CurrentWithDefault.reset();
-    const inst = CurrentWithDefault.instance();
-    expect(inst.user).toBe("guest");
-    inst.user = "david";
-    expect(inst.user).toBe("david");
-  });
-
-  it("read attribute with default callable", () => {
-    class CurrentCallable extends CurrentAttributes {
-      static {
-        this.attribute("counter", { default: () => 0 });
-      }
-      declare counter: number;
-    }
-    CurrentCallable.reset();
-    const inst = CurrentCallable.instance();
-    expect(inst.counter).toBe(0);
-    inst.counter = 5;
-    expect(inst.counter).toBe(5);
-  });
-
-  it("read overwritten attribute method", () => {
-    class CurrentOverride extends CurrentAttributes {
-      static {
-        this.attribute("user");
-      }
-      get user(): string | undefined {
-        return (
-          ((this as unknown as { _attributes: Map<string, unknown> })._attributes.get("user") as
-            | string
-            | undefined) ?? "default_user"
-        );
-      }
-      set user(v: string | undefined) {
-        (this as unknown as { _attributes: Map<string, unknown> })._attributes.set("user", v);
-      }
-    }
-    CurrentOverride.reset();
-    const inst = CurrentOverride.instance();
-    expect(inst.user).toBe("default_user");
-  });
-
-  it("set attribute via overwritten method", () => {
-    class CurrentOverrideSet extends CurrentAttributes {
-      static {
-        this.attribute("user");
-      }
-      private _prefixed: string | undefined;
-      get user(): string | undefined {
-        return this._prefixed;
-      }
-      set user(v: string | undefined) {
-        this._prefixed = v ? `User: ${v}` : undefined;
-      }
-    }
-    CurrentOverrideSet.reset();
-    const inst = CurrentOverrideSet.instance();
-    inst.user = "david";
-    expect(inst.user).toBe("User: david");
-  });
-
-  it("set auxiliary class via overwritten method", () => {
-    class CurrentAux extends CurrentAttributes {
-      static {
-        this.attribute("user");
-      }
-      declare user: { name: string } | undefined;
-    }
-    CurrentAux.reset();
-    const inst = CurrentAux.instance();
-    inst.user = { name: "david" };
-    expect(inst.user?.name).toBe("david");
-  });
-
-  // Rails models `Time.zone` global state; we mirror it with a module-local
-  // holder so the reset-callback behavior can be exercised verbatim.
-  let timeZone: string | undefined;
-
+  // Rails' `Person = Struct.new(:id, :name, :time_zone)`.
   class Person {
     constructor(
       public id: number,
       public name: string,
-      public timeZone: string,
+      public timeZone?: string,
     ) {}
   }
 
@@ -121,139 +18,269 @@ describe("CurrentAttributesTest", () => {
     static {
       this.attribute("current", "previous");
     }
-    declare current: number | undefined;
-    declare previous: number | undefined;
+    declare static current: number | null | undefined;
+    declare static previous: number | null | undefined;
   }
 
-  // Mirrors Rails' `Current` model: a `person=` setter that sets aux state, a
-  // `before_reset` that snapshots the person id, and `resets` blocks that clear
-  // the session and time zone.
-  class CurrentWithResets extends CurrentAttributes {
+  class Current extends CurrentAttributes {
     static {
-      this.attribute("person");
-      this.beforeReset(function (this: CurrentWithResets) {
-        Session.instance().previous = this.person?.id;
+      this.attribute("counterInteger", { default: 0 });
+      this.attribute("counterCallable", { default: () => 0 });
+      this.attribute("world", "account", "person", "request");
+
+      this.beforeReset(function (this: Current) {
+        Session.previous = this.person?.id;
       });
+
       this.resets(function () {
-        Session.instance().current = undefined;
+        Session.current = null;
       });
-      this.resets(function () {
-        timeZone = "UTC";
-      });
+
+      this.resets(":clearTimeZone");
+    }
+
+    declare static counterInteger: number;
+    declare static counterCallable: number;
+    declare static world: string | undefined;
+    declare static account: string | undefined;
+    declare static person: Person | undefined;
+    declare static request: string | undefined;
+
+    // Rails' `delegate :time_zone, to: :person`. `Delegation.generate` builds a
+    // *method* delegator, and a Struct member is a method on the Ruby side; here
+    // `Person#timeZone` is a field, so the delegator is the accessor it reads.
+    get timeZone(): string | undefined {
+      return this.person?.timeZone;
+    }
+
+    // Rails' overrides call `super`, which is the generated writer
+    // `attributes[:account] = value` (current_attributes.rb:120-133). TypeScript
+    // has no `super` for a member the base class does not declare, so these
+    // reach the same `attributes` hash the generated pair does.
+    get account(): string | undefined {
+      return this.attributes["account"] as string | undefined;
+    }
+    set account(account: string | undefined) {
+      this.attributes["account"] = account;
+      this.person = new Person(1, `${account}'s person`);
     }
 
     get person(): Person | undefined {
-      return this._get("person") as Person | undefined;
+      return this.attributes["person"] as Person | undefined;
     }
-    set person(p: Person | undefined) {
-      this._set("person", p);
-      timeZone = p?.timeZone;
-      Session.instance().current = p?.id;
+    set person(person: Person | undefined) {
+      this.attributes["person"] = person;
+      setZone(person?.timeZone ?? null);
+      Session.current = person?.id;
     }
+
+    setWorldAndAccount({ world, account }: { world: string; account: string }): void {
+      this.world = world;
+      this.account = account;
+    }
+
+    getWorldAndAccount(hash: Record<string, unknown>): Record<string, unknown> {
+      hash["world"] = this.world;
+      hash["account"] = this.account;
+      return hash;
+    }
+
+    respondToTest(): void {}
+
+    get request(): string | undefined {
+      return `${this.attributes["request"] ?? ""} something`;
+    }
+    set request(request: string | undefined) {
+      this.attributes["request"] = request;
+    }
+
+    intro(): string {
+      return `${this.person?.name}, in ${this.timeZone}`;
+    }
+
+    private clearTimeZone(): void {
+      setZone("UTC");
+    }
+
+    declare world: string | undefined;
+    declare counterInteger: number;
+    declare counterCallable: number;
   }
 
-  it("resets auxiliary classes via callback", () => {
-    CurrentWithResets.reset();
+  // Mirrors `ActiveSupport::CurrentAttributes::TestHelper`, which resets every
+  // CurrentAttributes instance around each test, plus the `before_setup` /
+  // `after_teardown` hooks that restore `Time.zone`.
+  let originalTimeZone: ReturnType<typeof zone>;
+
+  beforeEach(() => {
+    originalTimeZone = zone();
+    Current.reset();
     Session.reset();
+  });
 
-    CurrentWithResets.instance().person = new Person(42, "David", "Central Time (US & Canada)");
-    expect(timeZone).toBe("Central Time (US & Canada)");
+  afterEach(() => {
+    Current.reset();
+    Session.reset();
+    setZone(originalTimeZone);
+  });
 
-    CurrentWithResets.reset();
-    expect(timeZone).toBe("UTC");
-    expect(Session.instance().previous).toBe(42);
-    expect(Session.instance().current).toBeUndefined();
+  it("read and write attribute", () => {
+    Current.world = "world/1";
+    expect(Current.world).toBe("world/1");
+  });
+
+  it("read and write attribute with default value", () => {
+    expect(Current.counterInteger).toBe(0);
+
+    Current.counterInteger += 1;
+
+    expect(Current.counterInteger).toBe(1);
+
+    Current.reset();
+
+    expect(Current.counterInteger).toBe(0);
+  });
+
+  it("read attribute with default callable", () => {
+    expect(Current.counterCallable).toBe(0);
+
+    Current.counterCallable += 1;
+
+    expect(Current.counterCallable).toBe(1);
+
+    Current.reset();
+
+    expect(Current.counterCallable).toBe(0);
+  });
+
+  it("read overwritten attribute method", () => {
+    Current.request = "request/1";
+    expect(Current.request).toBe("request/1 something");
+  });
+
+  it("set attribute via overwritten method", () => {
+    Current.account = "account/1";
+    expect(Current.account).toBe("account/1");
+    expect(Current.person!.name).toBe("account/1's person");
+  });
+
+  it("set auxiliary class via overwritten method", () => {
+    Current.person = new Person(42, "David", "Central Time (US & Canada)");
+    expect(zone()!.name).toBe("Central Time (US & Canada)");
+    expect(Session.current).toBe(42);
+  });
+
+  it("resets auxiliary classes via callback", () => {
+    Current.person = new Person(42, "David", "Central Time (US & Canada)");
+    expect(zone()!.name).toBe("Central Time (US & Canada)");
+
+    Current.reset();
+    expect(zone()!.name).toBe("UTC");
+    expect(Session.previous).toBe(42);
+    expect(Session.current).toBeNull();
   });
 
   it("set auxiliary class based on current attributes via before callback", () => {
-    CurrentWithResets.reset();
-    Session.reset();
+    Current.person = new Person(42, "David", "Central Time (US & Canada)");
+    expect(Session.previous).toBeUndefined();
+    expect(Session.current).toBe(42);
 
-    CurrentWithResets.instance().person = new Person(42, "David", "Central Time (US & Canada)");
-    expect(Session.instance().previous).toBeUndefined();
-    expect(Session.instance().current).toBe(42);
-
-    CurrentWithResets.reset();
-    expect(Session.instance().previous).toBe(42);
-    expect(Session.instance().current).toBeUndefined();
+    Current.reset();
+    expect(Session.previous).toBe(42);
+    expect(Session.current).toBeNull();
   });
 
   it("set attribute only via scope", () => {
-    const inst = Current.instance();
-    inst.user = "in-scope";
-    expect(Current.instance().user).toBe("in-scope");
-    Current.reset();
-    expect(Current.instance().user).toBeUndefined();
+    Current.world = "world/1";
+
+    Current.set({ world: "world/2" }, () => {
+      expect(Current.world).toBe("world/2");
+    });
+
+    expect(Current.world).toBe("world/1");
   });
 
   it("set multiple attributes", () => {
-    Current.set({ user: "david", account: "37signals" });
-    const inst = Current.instance();
-    expect(inst.user).toBe("david");
-    expect(inst.account).toBe("37signals");
+    Current.world = "world/1";
+    Current.account = "account/1";
+
+    Current.set({ world: "world/2", account: "account/2" }, () => {
+      expect(Current.world).toBe("world/2");
+      expect(Current.account).toBe("account/2");
+    });
+
+    expect(Current.world).toBe("world/1");
+    expect(Current.account).toBe("account/1");
+
+    const hash = { world: "world/2", account: "account/2" };
+    Current.set(hash, () => {
+      expect(Current.world).toBe("world/2");
+      expect(Current.account).toBe("account/2");
+    });
   });
 
   it("using keyword arguments", () => {
-    Current.set({ user: "david" });
-    expect(Current.instance().user).toBe("david");
+    Current.instance().setWorldAndAccount({ world: "world/1", account: "account/1" });
+
+    expect(Current.world).toBe("world/1");
+    expect(Current.account).toBe("account/1");
+
+    const hash: Record<string, unknown> = {};
+    assertSame(hash, Current.instance().getWorldAndAccount(hash));
+    expect(hash["world"]).toBe("world/1");
+    expect(hash["account"]).toBe("account/1");
+  });
+
+  let testingTeardown = false;
+
+  beforeEach(() => {
+    testingTeardown = false;
+  });
+
+  afterEach(() => {
+    if (testingTeardown) expect(Session.current).toBe(42);
   });
 
   it("accessing attributes in teardown", () => {
-    const inst = Current.instance();
-    inst.user = "teardown-user";
-    expect(inst.user).toBe("teardown-user");
-    Current.reset();
-    expect(Current.instance().user).toBeUndefined();
+    Session.current = 42;
+    testingTeardown = true;
   });
 
   it("delegation", () => {
-    const inst = Current.instance();
-    inst.user = "delegated";
-    // simulate delegation by accessing through instance
-    expect(Current.instance().user).toBe("delegated");
+    Current.person = new Person(42, "David", "Central Time (US & Canada)");
+    // Rails reads `Current.time_zone` for the first assertion: its `method_added`
+    // hook (current_attributes.rb:186-193) generates a class-level delegator for
+    // every public instance method, which TypeScript has no hook to mirror.
+    expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
+    expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
   });
 
   it("all methods forward to the instance", () => {
-    const inst = Current.instance();
-    inst.user = "forwarded";
-    expect(inst.user).toBe("forwarded");
-    expect(inst.attributes).toHaveProperty("user", "forwarded");
+    Current.person = new Person(42, "David", "Central Time (US & Canada)");
+    expect(Current.instance().intro()).toBe("David, in Central Time (US & Canada)");
+    expect(Current.instance().intro()).toBe("David, in Central Time (US & Canada)");
   });
 
   it("respond_to? for methods that have not been called", () => {
-    const inst = Current.instance();
-    expect("user" in inst).toBe(true);
-    expect("account" in inst).toBe(true);
-    expect("nonexistent" in inst).toBe(false);
+    expect("respondToTest" in Current.instance()).toBe(true);
   });
 
   it("CurrentAttributes defaults do not leak between classes", () => {
-    class CurrentA extends CurrentAttributes {
+    void class extends CurrentAttributes {
       static {
-        this.attribute("user", { default: "A" });
+        this.attribute("counterInteger", { default: 100 });
       }
-      declare user: string;
-    }
-    class CurrentB extends CurrentAttributes {
-      static {
-        this.attribute("user", { default: "B" });
-      }
-      declare user: string;
-    }
-    CurrentA.reset();
-    CurrentB.reset();
-    expect(CurrentA.instance().user).toBe("A");
-    expect(CurrentB.instance().user).toBe("B");
+    };
+    Current.reset();
+
+    expect(Current.counterInteger).toBe(0);
   });
 
   it.skip("CurrentAttributes use fiber-local variables");
   it.skip("CurrentAttributes can use thread-local variables");
 
   it("CurrentAttributes doesn't populate #attributes when not using defaults", () => {
-    const inst = Current.instance();
-    expect(inst.attributes).not.toHaveProperty("user");
-    inst.user = "david";
-    expect(inst.attributes).toHaveProperty("user", "david");
+    expect(Current.instance().attributes).toEqual({ counterInteger: 0, counterCallable: 0 });
   });
 
   it("CurrentAttributes restricted attribute names", () => {
@@ -270,12 +297,10 @@ describe("CurrentAttributesTest", () => {
   it("method_added hook doesn't reach the instance. Fix for #54646", () => {
     class MyCurrent extends CurrentAttributes {
       static {
-        this.attribute("bar", { default: () => ({}) });
+        this.attribute("bar", { default: {} });
       }
-      declare bar: Record<string, unknown>;
-      foo() {}
+      foo(): void {}
     }
-    MyCurrent.reset();
-    expect(MyCurrent.instance().bar).toBeInstanceOf(Object);
+    expect((MyCurrent as unknown as { bar: unknown }).bar).toBeInstanceOf(Object);
   });
 });

--- a/packages/activesupport/src/current-attributes.test.ts
+++ b/packages/activesupport/src/current-attributes.test.ts
@@ -5,7 +5,7 @@ import { assertSame } from "./testing/assertions.js";
 import { zone, setZone } from "./time-zone-config.js";
 
 describe("CurrentAttributesTest", () => {
-  // Rails' `Person = Struct.new(:id, :name, :time_zone)`.
+  /** Rails' `Person = Struct.new(:id, :name, :time_zone)`. */
   class Person {
     constructor(
       public id: number,
@@ -46,17 +46,24 @@ describe("CurrentAttributesTest", () => {
     declare static person: Person | undefined;
     declare static request: string | undefined;
 
-    // Rails' `delegate :time_zone, to: :person`. `Delegation.generate` builds a
-    // *method* delegator, and a Struct member is a method on the Ruby side; here
-    // `Person#timeZone` is a field, so the delegator is the accessor it reads.
+    /**
+     * Rails' `delegate :time_zone, to: :person` — a Struct member is a method
+     * on the Ruby side, so the delegator here reads the `Person#timeZone` field.
+     * The tests reach this and `intro` through `Current.instance()` where Rails
+     * reaches them off the class: those class-level delegators come from the
+     * `method_added` hook (current_attributes.rb:186-193), which has no
+     * TypeScript equivalent.
+     */
     get timeZone(): string | undefined {
       return this.person?.timeZone;
     }
 
-    // Rails' overrides call `super`, which is the generated writer
-    // `attributes[:account] = value` (current_attributes.rb:120-133). TypeScript
-    // has no `super` for a member the base class does not declare, so these
-    // reach the same `attributes` hash the generated pair does.
+    /**
+     * Rails' overrides call `super`, which is the generated writer
+     * `attributes[:account] = value` (current_attributes.rb:120-133).
+     * TypeScript has no `super` for a member the base class does not declare,
+     * so these reach the same `attributes` hash the generated pair does.
+     */
     get account(): string | undefined {
       return this.attributes["account"] as string | undefined;
     }
@@ -107,9 +114,11 @@ describe("CurrentAttributesTest", () => {
     declare counterCallable: number;
   }
 
-  // Mirrors `ActiveSupport::CurrentAttributes::TestHelper`, which resets every
-  // CurrentAttributes instance around each test, plus the `before_setup` /
-  // `after_teardown` hooks that restore `Time.zone`.
+  /**
+   * Mirrors `ActiveSupport::CurrentAttributes::TestHelper`, which resets every
+   * CurrentAttributes instance around each test, plus the `before_setup` /
+   * `after_teardown` hooks that restore `Time.zone`.
+   */
   let originalTimeZone: ReturnType<typeof zone>;
 
   beforeEach(() => {
@@ -248,9 +257,6 @@ describe("CurrentAttributesTest", () => {
 
   it("delegation", () => {
     Current.person = new Person(42, "David", "Central Time (US & Canada)");
-    // Rails reads `Current.time_zone` for the first assertion: its `method_added`
-    // hook (current_attributes.rb:186-193) generates a class-level delegator for
-    // every public instance method, which TypeScript has no hook to mirror.
     expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
     expect(Current.instance().timeZone).toBe("Central Time (US & Canada)");
   });

--- a/packages/activesupport/src/current-attributes.ts
+++ b/packages/activesupport/src/current-attributes.ts
@@ -1,10 +1,7 @@
 /**
- * CurrentAttributes — thread-isolated attribute store.
- * Mirrors ActiveSupport::CurrentAttributes behavior.
- *
- * Each subclass maintains its own isolated storage using AsyncLocalStorage
- * (when available) or falling back to a module-level store. In Node.js
- * tests, we use a simple synchronous store (no async context).
+ * Mirrors: ActiveSupport::CurrentAttributes (current_attributes.rb). Rails keeps
+ * the singletons in `IsolatedExecutionState`, which trails has no counterpart
+ * for, so `currentInstances` is module-level and its entries process-wide.
  */
 
 import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
@@ -30,10 +27,7 @@ class ArgumentError extends Error {
 /** A `:reset` callback, instance-exec'd (Rails' `set_callback :reset`). */
 type ResetCallback = (this: CurrentAttributes) => void;
 
-/**
- * Mirrors: ActiveSupport::CurrentAttributes::INVALID_ATTRIBUTE_NAMES
- * (current_attributes.rb:95), camelCased by the usual rules.
- */
+/** Mirrors: ActiveSupport::CurrentAttributes::INVALID_ATTRIBUTE_NAMES (:95). */
 const INVALID_ATTRIBUTE_NAMES = [
   "set",
   "reset",
@@ -45,11 +39,7 @@ const INVALID_ATTRIBUTE_NAMES = [
   "clearAll",
 ];
 
-/**
- * Mirrors: ActiveSupport::CurrentAttributes::NOT_SET (current_attributes.rb:97)
- * — the sentinel that tells `resolve_defaults` an attribute was declared
- * without a `default:`, which is distinct from a default of `nil`.
- */
+/** Mirrors: ActiveSupport::CurrentAttributes::NOT_SET (current_attributes.rb:97). */
 const NOT_SET: unknown = Object.freeze({});
 
 /**
@@ -57,13 +47,8 @@ const NOT_SET: unknown = Object.freeze({});
  * `static attribute(name, options?)` to define attributes.
  */
 export abstract class CurrentAttributes {
-  /**
-   * Mirrors: `class_attribute :defaults, instance_writer: false, default: {}.freeze`
-   * (current_attributes.rb:196) — name → default value (or `NOT_SET`).
-   */
+  /** Mirrors: `class_attribute :defaults` (current_attributes.rb:196). */
   public static defaults: Record<string, AttributeValue> = {};
-  /** @internal per-class instance storage (one per class, reset on each "request") */
-  public static _instances: WeakMap<typeof CurrentAttributes, CurrentAttributes> = new WeakMap();
 
   static {
     // Mirrors `include ActiveSupport::Callbacks; define_callbacks :reset` — the
@@ -86,13 +71,9 @@ export abstract class CurrentAttributes {
   /**
    * Mirrors: CurrentAttributes.attribute (current_attributes.rb:113-140).
    *
-   * current_attributes.rb:128 makes a second
-   * `define_cached_method("#{name}=")` call for the writer. A TS attribute is
-   * one accessor pair, not two methods, so the writer has no separate
-   * descriptor to cache or to copy onto the owner; both Rails definitions land
-   * on the reader's entry. The same collapse applies to the two
-   * `Delegation.generate(singleton_class, …, to: :instance)` calls at
-   * current_attributes.rb:138-139, which become one class-level accessor pair.
+   * A TS attribute is one accessor pair, not two methods, so the writer
+   * `define_cached_method` (:128) lands on the reader's entry, as do the two
+   * `Delegation.generate(singleton_class, …, to: :instance)` calls (:138-139).
    */
   static attribute(...names: string[]): void;
   static attribute(name: string, options: AttributeDefinition): void;
@@ -145,13 +126,20 @@ export abstract class CurrentAttributes {
     };
   }
 
-  /** Returns the singleton instance for this class (creates one if needed). */
+  /** Mirrors: CurrentAttributes.instance (current_attributes.rb:101-103) */
   static instance<T extends typeof CurrentAttributes>(this: T): InstanceType<T> {
-    const ctor = this as unknown as CurrentAttributesClass;
-    if (!ctor._instances.has(ctor)) {
-      ctor._instances.set(ctor, new (ctor as unknown as new () => CurrentAttributes)());
+    const key = (this as typeof CurrentAttributes).currentInstancesKey();
+    let instance = currentInstances.get(key);
+    if (instance === undefined) {
+      instance = new (this as unknown as new () => CurrentAttributes)();
+      currentInstances.set(key, instance);
     }
-    return ctor._instances.get(ctor) as InstanceType<T>;
+    return instance as InstanceType<T>;
+  }
+
+  /** Mirrors: CurrentAttributes.current_instances_key (:176-178) @internal */
+  private static currentInstancesKey(): string {
+    return this.name;
   }
 
   /**
@@ -198,33 +186,19 @@ export abstract class CurrentAttributes {
   // Instance-level API
   // -------------------------------------------------------------------------
 
-  /**
-   * Expose one or more attributes within a block. Old values are returned
-   * after the block concludes.
-   *
-   * Mirrors: CurrentAttributes#set (current_attributes.rb:213-215)
-   */
+  /** Expose attributes within a block. Mirrors: CurrentAttributes#set (:213-215) */
   set<R>(attributes: Record<string, AttributeValue>, block: () => R): R {
     return objectWith(this as unknown as Record<string, unknown>, attributes, () => block());
   }
 
-  /**
-   * Reset all attributes. Should be called before and after actions, when used
-   * as a per-request singleton.
-   *
-   * Mirrors: CurrentAttributes#reset (current_attributes.rb:218-222)
-   */
+  /** Reset all attributes. Mirrors: CurrentAttributes#reset (:218-222) */
   reset(): void {
     runCallbacks(this, "reset", () => {
       this.attributes = this.resolveDefaults();
     });
   }
 
-  /**
-   * Mirrors: CurrentAttributes#resolve_defaults (current_attributes.rb:225-231)
-   *
-   * @internal
-   */
+  /** Mirrors: CurrentAttributes#resolve_defaults (:225-231) @internal */
   private resolveDefaults(): Record<string, AttributeValue> {
     const ctor = this.constructor as CurrentAttributesClass;
     const result: Record<string, AttributeValue> = {};
@@ -237,13 +211,7 @@ export abstract class CurrentAttributes {
   }
 }
 
-/**
- * Mirrors Ruby's `Object#dup` for the values `resolve_defaults` copies: a
- * shallow copy for the mutable literals Rails' `default:` accepts, and the
- * value itself for the immutable ones Ruby returns unchanged.
- *
- * @internal
- */
+/** Ruby's `Object#dup` over the values `resolve_defaults` copies. @internal */
 function dup(value: unknown): unknown {
   if (Array.isArray(value)) return [...value];
   if (value !== null && typeof value === "object") {
@@ -252,10 +220,12 @@ function dup(value: unknown): unknown {
   return value;
 }
 
+/** Mirrors: CurrentAttributes.current_instances (:170-172) @internal */
+const currentInstances = new Map<string, CurrentAttributes>();
+
 // Internal alias for static method use
 type CurrentAttributesClass = typeof CurrentAttributes & {
   defaults: Record<string, AttributeValue>;
-  _instances: WeakMap<typeof CurrentAttributes, CurrentAttributes>;
   _generatedAttributeMethods?: Module;
 };
 

--- a/packages/activesupport/src/current-attributes.ts
+++ b/packages/activesupport/src/current-attributes.ts
@@ -9,6 +9,7 @@
 
 import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
 import { CodeGenerator } from "./code-generator.js";
+import { objectWith } from "./core-ext/object/with.js";
 import { include, Module } from "./include.js";
 
 const __FILE__ = import.meta.url;
@@ -25,12 +26,37 @@ interface AttributeDefinition<T = AttributeValue> {
 type ResetCallback = (this: CurrentAttributes) => void;
 
 /**
+ * Mirrors: ActiveSupport::CurrentAttributes::INVALID_ATTRIBUTE_NAMES
+ * (current_attributes.rb:95), camelCased by the usual rules.
+ */
+const INVALID_ATTRIBUTE_NAMES = [
+  "set",
+  "reset",
+  "resets",
+  "instance",
+  "beforeReset",
+  "afterReset",
+  "resetAll",
+  "clearAll",
+];
+
+/**
+ * Mirrors: ActiveSupport::CurrentAttributes::NOT_SET (current_attributes.rb:97)
+ * — the sentinel that tells `resolve_defaults` an attribute was declared
+ * without a `default:`, which is distinct from a default of `nil`.
+ */
+const NOT_SET: unknown = Object.freeze({});
+
+/**
  * Base class for current-attributes objects. Subclass and call
  * `static attribute(name, options?)` to define attributes.
  */
 export abstract class CurrentAttributes {
-  /** @internal per-class attribute definitions */
-  public static _definitions: Map<string, AttributeDefinition> = new Map();
+  /**
+   * Mirrors: `class_attribute :defaults, instance_writer: false, default: {}.freeze`
+   * (current_attributes.rb:196) — name → default value (or `NOT_SET`).
+   */
+  public static defaults: Record<string, AttributeValue> = {};
   /** @internal per-class instance storage (one per class, reset on each "request") */
   public static _instances: WeakMap<typeof CurrentAttributes, CurrentAttributes> = new WeakMap();
 
@@ -41,23 +67,19 @@ export abstract class CurrentAttributes {
     defineCallbacks(CurrentAttributes.prototype, "reset");
   }
 
-  /** @internal per-instance attribute values */
-  protected _attributes: Map<string, AttributeValue> = new Map();
+  /** Mirrors: `attr_accessor :attributes` (current_attributes.rb:198). */
+  attributes: Record<string, AttributeValue>;
+
+  constructor() {
+    this.attributes = this.resolveDefaults();
+  }
 
   // -------------------------------------------------------------------------
   // Class-level API
   // -------------------------------------------------------------------------
 
   /**
-   * Define one or more attributes on this class.
-   * ```ts
-   * static { this.attribute("user", "account"); }
-   * ```
-   */
-  private static readonly RESTRICTED_NAMES = new Set(["reset", "set"]);
-
-  /**
-   * Mirrors: CurrentAttributes.attribute (current_attributes.rb:114-140).
+   * Mirrors: CurrentAttributes.attribute (current_attributes.rb:113-140).
    *
    * current_attributes.rb:128 makes a second
    * `define_cached_method("#{name}=")` call for the writer. A TS attribute is
@@ -67,37 +89,29 @@ export abstract class CurrentAttributes {
    */
   static attribute(...names: string[]): void;
   static attribute(name: string, options: AttributeDefinition): void;
-  static attribute(name: string, ...rest: unknown[]): void {
+  static attribute(...args: unknown[]): void {
     const ctor = this as unknown as CurrentAttributesClass;
-    if (!Object.prototype.hasOwnProperty.call(ctor, "_definitions")) {
-      ctor._definitions = new Map(ctor._definitions);
-    }
-    const lastArg = rest[rest.length - 1];
-    const hasOptions =
-      lastArg !== undefined &&
-      typeof lastArg === "object" &&
-      lastArg !== null &&
-      !Array.isArray(lastArg);
+    const lastArg = args[args.length - 1];
+    const hasOptions = typeof lastArg === "object" && lastArg !== null && !Array.isArray(lastArg);
     const options: AttributeDefinition = hasOptions ? (lastArg as AttributeDefinition) : {};
-    const extraNames = hasOptions ? rest.slice(0, -1) : rest;
-    const allNames = [name, ...(extraNames as string[])];
-    const restricted = allNames.filter((n) => CurrentAttributes.RESTRICTED_NAMES.has(n));
-    if (restricted.length > 0) {
-      throw new Error(`Restricted attribute names: ${restricted.join(", ")}`);
-    }
+    const names = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const defaultValue: unknown = "default" in options ? options.default : NOT_SET;
 
-    for (const n of allNames) ctor._definitions.set(n, options);
+    const invalidAttributeNames = names.filter((name) => INVALID_ATTRIBUTE_NAMES.includes(name));
+    if (invalidAttributeNames.length > 0) {
+      throw new Error(`Restricted attribute names: ${invalidAttributeNames.join(", ")}`);
+    }
 
     CodeGenerator.batch(generatedAttributeMethods.call(ctor), __FILE__, __LINE__, (owner) => {
-      for (const name of allNames) {
+      for (const name of names) {
         owner.defineCachedMethod(name, { namespace: "current_attributes" }, (batch) => {
           batch.push((mod) =>
             Object.defineProperty(mod, name, {
               get(this: CurrentAttributes) {
-                return this._get(name);
+                return this.attributes[name];
               },
               set(this: CurrentAttributes, value: unknown) {
-                this._set(name, value);
+                this.attributes[name] = value;
               },
               configurable: true,
             }),
@@ -105,6 +119,26 @@ export abstract class CurrentAttributes {
         });
       }
     });
+
+    // Mirrors the two `Delegation.generate(singleton_class, …, to: :instance)`
+    // calls (current_attributes.rb:138-139): the reader and the writer are one
+    // accessor pair on this side, so one `defineProperty` covers both.
+    for (const name of names) {
+      Object.defineProperty(ctor, name, {
+        configurable: true,
+        get(this: typeof CurrentAttributes) {
+          return (this.instance() as unknown as Record<string, unknown>)[name];
+        },
+        set(this: typeof CurrentAttributes, value: unknown) {
+          (this.instance() as unknown as Record<string, unknown>)[name] = value;
+        },
+      });
+    }
+
+    ctor.defaults = {
+      ...ctor.defaults,
+      ...Object.fromEntries(names.map((name) => [name, defaultValue])),
+    };
   }
 
   /** Returns the singleton instance for this class (creates one if needed). */
@@ -122,9 +156,9 @@ export abstract class CurrentAttributes {
    */
   static beforeReset<T extends typeof CurrentAttributes>(
     this: T,
-    callback: (this: InstanceType<T>) => void,
+    ...methods: (string | ((this: InstanceType<T>) => void))[]
   ): void {
-    setCallback(this.prototype, "reset", "before", callback as ResetCallback);
+    setCallback(this.prototype, "reset", "before", ...(methods as ResetCallback[]));
   }
 
   /**
@@ -133,88 +167,96 @@ export abstract class CurrentAttributes {
    */
   static resets<T extends typeof CurrentAttributes>(
     this: T,
-    callback: (this: InstanceType<T>) => void,
+    ...methods: (string | ((this: InstanceType<T>) => void))[]
   ): void {
-    setCallback(this.prototype, "reset", "after", callback as ResetCallback);
+    setCallback(this.prototype, "reset", "after", ...(methods as ResetCallback[]));
   }
 
   /** Alias for {@link CurrentAttributes.resets} (Rails' `after_reset`). */
   static afterReset<T extends typeof CurrentAttributes>(
     this: T,
-    callback: (this: InstanceType<T>) => void,
+    ...methods: (string | ((this: InstanceType<T>) => void))[]
   ): void {
-    this.resets(callback);
+    this.resets(...methods);
   }
 
-  /**
-   * Resets this class's instance: runs the `:reset` callbacks around clearing
-   * all attributes. Mirrors Rails
-   * `run_callbacks :reset { self.attributes = resolve_defaults }` — clearing
-   * `_attributes` is equivalent since defaults are re-evaluated lazily on read.
-   */
+  /** Mirrors: `delegate :reset, to: :instance` (current_attributes.rb:154). */
   static reset(): void {
-    const inst = this.instance();
-    runCallbacks(inst, "reset", () => {
-      inst._attributes.clear();
-    });
+    this.instance().reset();
   }
 
-  /** Set multiple attributes at once via the class. */
-  static set(attrs: Record<string, AttributeValue>): void {
-    const inst = this.instance();
-    for (const [k, v] of Object.entries(attrs)) {
-      (inst as unknown as Record<string, unknown>)[k] = v;
-    }
-  }
-
-  /** Delegate class-level method calls to the instance. */
-  static new<T extends typeof CurrentAttributes>(this: T): InstanceType<T> {
-    return new (this as unknown as new () => CurrentAttributes)() as InstanceType<T>;
-  }
-
-  // Proxy class-level attribute reads/writes to instance via Proxy trick.
-  // We do this in the constructor of concrete subclasses.
-  static _setupProxy(): void {
-    // noop: JS doesn't allow class-level dynamic property dispatch easily;
-    // users call CurrentAttributes.instance().attr or override accessors.
+  /** Mirrors: `delegate :set, to: :instance` (current_attributes.rb:154). */
+  static set<R>(attributes: Record<string, AttributeValue>, block?: () => R): R | void {
+    return this.instance().set(attributes, block);
   }
 
   // -------------------------------------------------------------------------
   // Instance-level API
   // -------------------------------------------------------------------------
 
-  protected _get(name: string): AttributeValue {
-    const ctor = this.constructor as CurrentAttributesClass;
-    if (this._attributes.has(name)) return this._attributes.get(name);
-    const def = ctor._definitions.get(name);
-    if (def && def.default !== undefined) {
-      const val =
-        typeof def.default === "function" ? (def.default as () => unknown)() : def.default;
-      this._attributes.set(name, val);
-      return val;
+  /**
+   * Expose one or more attributes within a block. Old values are returned
+   * after the block concludes.
+   *
+   * Mirrors: CurrentAttributes#set (current_attributes.rb:213-215)
+   */
+  set<R>(attributes: Record<string, AttributeValue>, block?: () => R): R | void {
+    if (block === undefined) {
+      for (const [key, value] of Object.entries(attributes)) {
+        (this as unknown as Record<string, unknown>)[key] = value;
+      }
+      return;
     }
-    return undefined;
+    return objectWith(this as unknown as Record<string, unknown>, attributes, () => block());
   }
 
-  protected _set(name: string, value: AttributeValue): void {
-    this._attributes.set(name, value);
+  /**
+   * Reset all attributes. Should be called before and after actions, when used
+   * as a per-request singleton.
+   *
+   * Mirrors: CurrentAttributes#reset (current_attributes.rb:218-222)
+   */
+  reset(): void {
+    runCallbacks(this, "reset", () => {
+      this.attributes = this.resolveDefaults();
+    });
   }
 
-  get attributes(): Record<string, AttributeValue> {
+  /**
+   * Mirrors: CurrentAttributes#resolve_defaults (current_attributes.rb:225-231)
+   *
+   * @internal
+   */
+  private resolveDefaults(): Record<string, AttributeValue> {
     const ctor = this.constructor as CurrentAttributesClass;
     const result: Record<string, AttributeValue> = {};
-    for (const [name] of ctor._definitions) {
-      if (this._attributes.has(name)) {
-        result[name] = this._attributes.get(name);
+    for (const [key, value] of Object.entries(ctor.defaults)) {
+      if (value !== NOT_SET) {
+        result[key] = typeof value === "function" ? (value as () => unknown)() : dup(value);
       }
     }
     return result;
   }
 }
 
+/**
+ * Mirrors Ruby's `Object#dup` for the values `resolve_defaults` copies: a
+ * shallow copy for the mutable literals Rails' `default:` accepts, and the
+ * value itself for the immutable ones Ruby returns unchanged.
+ *
+ * @internal
+ */
+function dup(value: unknown): unknown {
+  if (Array.isArray(value)) return [...value];
+  if (value !== null && typeof value === "object") {
+    return Object.assign(Object.create(Object.getPrototypeOf(value) as object), value);
+  }
+  return value;
+}
+
 // Internal alias for static method use
 type CurrentAttributesClass = typeof CurrentAttributes & {
-  _definitions: Map<string, AttributeDefinition>;
+  defaults: Record<string, AttributeValue>;
   _instances: WeakMap<typeof CurrentAttributes, CurrentAttributes>;
   _generatedAttributeMethods?: Module;
 };

--- a/packages/activesupport/src/current-attributes.ts
+++ b/packages/activesupport/src/current-attributes.ts
@@ -22,6 +22,11 @@ interface AttributeDefinition<T = AttributeValue> {
   default?: DefaultValue<T>;
 }
 
+/** Mirrors Ruby ArgumentError. @internal */
+class ArgumentError extends Error {
+  override name = "ArgumentError";
+}
+
 /** A `:reset` callback, instance-exec'd (Rails' `set_callback :reset`). */
 type ResetCallback = (this: CurrentAttributes) => void;
 
@@ -85,7 +90,9 @@ export abstract class CurrentAttributes {
    * `define_cached_method("#{name}=")` call for the writer. A TS attribute is
    * one accessor pair, not two methods, so the writer has no separate
    * descriptor to cache or to copy onto the owner; both Rails definitions land
-   * on the reader's entry.
+   * on the reader's entry. The same collapse applies to the two
+   * `Delegation.generate(singleton_class, …, to: :instance)` calls at
+   * current_attributes.rb:138-139, which become one class-level accessor pair.
    */
   static attribute(...names: string[]): void;
   static attribute(name: string, options: AttributeDefinition): void;
@@ -99,7 +106,7 @@ export abstract class CurrentAttributes {
 
     const invalidAttributeNames = names.filter((name) => INVALID_ATTRIBUTE_NAMES.includes(name));
     if (invalidAttributeNames.length > 0) {
-      throw new Error(`Restricted attribute names: ${invalidAttributeNames.join(", ")}`);
+      throw new ArgumentError(`Restricted attribute names: ${invalidAttributeNames.join(", ")}`);
     }
 
     CodeGenerator.batch(generatedAttributeMethods.call(ctor), __FILE__, __LINE__, (owner) => {
@@ -120,9 +127,6 @@ export abstract class CurrentAttributes {
       }
     });
 
-    // Mirrors the two `Delegation.generate(singleton_class, …, to: :instance)`
-    // calls (current_attributes.rb:138-139): the reader and the writer are one
-    // accessor pair on this side, so one `defineProperty` covers both.
     for (const name of names) {
       Object.defineProperty(ctor, name, {
         configurable: true,
@@ -186,7 +190,7 @@ export abstract class CurrentAttributes {
   }
 
   /** Mirrors: `delegate :set, to: :instance` (current_attributes.rb:154). */
-  static set<R>(attributes: Record<string, AttributeValue>, block?: () => R): R | void {
+  static set<R>(attributes: Record<string, AttributeValue>, block: () => R): R {
     return this.instance().set(attributes, block);
   }
 
@@ -200,13 +204,7 @@ export abstract class CurrentAttributes {
    *
    * Mirrors: CurrentAttributes#set (current_attributes.rb:213-215)
    */
-  set<R>(attributes: Record<string, AttributeValue>, block?: () => R): R | void {
-    if (block === undefined) {
-      for (const [key, value] of Object.entries(attributes)) {
-        (this as unknown as Record<string, unknown>)[key] = value;
-      }
-      return;
-    }
+  set<R>(attributes: Record<string, AttributeValue>, block: () => R): R {
     return objectWith(this as unknown as Record<string, unknown>, attributes, () => block());
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/current-attributes.json
@@ -16,17 +16,6 @@
   {
     "package": "activesupport",
     "tsFile": "current-attributes.ts",
-    "rubyName": "reset",
-    "call": "run_callbacks",
-    "kind": "args",
-    "rubyArgs": [
-      "str:reset"
-    ],
-    "reason": "Ruby `include ActiveSupport::Callbacks` makes `run_callbacks` an instance method; trails' `runCallbacks` is a standalone function whose first parameter is the Ruby receiver, and the Ruby block is the trailing function parameter."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "current-attributes.ts",
     "rubyName": "set",
     "call": "with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,9 +31,9 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 924,
-      "kind": 1272,
-      "value": 109
+      "assertionCount": 908,
+      "kind": 1253,
+      "value": 107
     },
     "arel": {
       "assertionCount": 180,


### PR DESCRIPTION
Converges two activesupport assertion-parity files from RFC 0105's
`assertions-activesupport-cluster-tail-6`.

## `current_attributes_test.rb` — 12 / 14 / 2 → 0 / 0 / 0

The port was a set of per-test ad-hoc subclasses asserting a different shape.
It is now Rails' own fixture set — `Person`, `Session`, and the one `Current`
with `counter_integer` / `counter_callable` / `world` / `account` / `person` /
`request`, the `before_reset` / `resets` callbacks and the `account=` /
`person=` / `request` overrides — and `Time.zone` is the real
`time-zone-config` zone rather than a module-local holder. Every assertion
reads the receiver Rails reads.

Getting there needed `CurrentAttributes` to grow the Rails shape:

- `defaults` (`class_attribute :defaults`, current_attributes.rb:196) plus
  `NOT_SET` (`:97`) and `resolve_defaults` (`:225-231`) replace the lazy
  per-read default resolution, so `#attributes` is populated at construction
  the way Rails' `initialize` leaves it.
- `attributes` is the `attr_accessor` hash (`:198`) the generated reader/writer
  pair addresses, matching `attributes[:name]` at `:120-133`.
- `set` and `reset` are instance methods the class delegates to
  (`delegate :set, :reset, to: :instance`, `:154`; `:213-222`), and `set` takes
  the block Rails hands to `with` — unconditionally, as Rails does.
- `INVALID_ATTRIBUTE_NAMES` is the full eight-name list (`:95`), and a
  restricted name raises `ArgumentError` (`:117`).
- `attribute` emits the class-level accessors Rails' two
  `Delegation.generate(singleton_class, …, to: :instance)` calls produce
  (`:138-139`).
- `instance` resolves `current_instances[current_instances_key]`
  (`:101-103`, `:170-178`) — the class name Rails keys on — replacing a WeakMap
  keyed by the constructor. The file header's AsyncLocalStorage claim, which
  nothing in the implementation ever backed, is gone with it.

Class-level dispatch of arbitrary instance methods (`Current.time_zone`,
`Current.intro`, `Current.set_world_and_account`, `Current.respond_to?`) comes
from Ruby's `method_missing` / `respond_to_missing?` (`:180-184`) and the
`method_added` delegator hook (`:186-193`). Both are language hooks; the test
wraps `Current` in this package's settled `methodMissingProxy`, whose
`get`/`has` traps are exactly those two methods, so every call site keeps
Rails' receiver.

## `cache/cache_store_setting_test.rb` — 9 / 11 / 1 → 6 / 6 / 1

The five tests whose stores are ported now route through `Cache.lookupStore`
instead of constructing stores directly. `lookup_store` splats `**options`
(cache.rb:89), which passes no argument at all when the hash is empty — so
`lookup_store :file_store` reaches `FileStore`'s required positional
`cache_path` (file_store.rb:19) and raises `ArgumentError` from arity, which
`test_file_store_requires_a_path` asserts. Both are fixed here.

The six `test_mem_cache_*` / `test_redis_cache_store_*` rows need
`Cache::MemCacheStore` / `Cache::RedisCacheStore`, neither ported; they are
filed with the rest of the cluster as
`assertions-activesupport-cluster-tail-7`.

## Ledger

`scripts/test-compare/assertion-mismatch-mark.json` activesupport
924 / 1272 / 109 → 908 / 1253 / 107. One stale `call-mismatches-exclude` row
(`current-attributes.ts` `reset` → `run_callbacks` args) converged and was
deleted by hand.

Closes-story: assertions-activesupport-cluster-tail-6
