### PR TITLE
fix(parity): converge the time-ext call-arg shape rows, sharpen the activesupport/rack/i18n reasons

### DIFF
--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -848,17 +848,16 @@ export function toDate(date: Date): Temporal.PlainDate {
  * `getlocal(utc_offset)` in the receiver's own offset.
  */
 export function toTime(
-  receiver: RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+  time: RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime,
 ): Temporal.ZonedDateTime {
-  if (receiver instanceof RubyTime) {
-    const self = receiver.toTime();
-    return preserveTimezone(receiver) ? self : self.withTimeZone(Temporal.Now.timeZoneId());
+  if (time instanceof RubyTime) {
+    const self = time.toTime();
+    return preserveTimezone(time) ? self : self.withTimeZone(Temporal.Now.timeZoneId());
   }
 
   // A Ruby `DateTime` without an explicit offset is `+00:00` (date.rb's
   // `civil`), which is the offset a `PlainDateTime` stands in for here.
-  const zoned =
-    receiver instanceof Temporal.PlainDateTime ? receiver.toZonedDateTime("UTC") : receiver;
+  const zoned = time instanceof Temporal.PlainDateTime ? time.toZonedDateTime("UTC") : time;
   return compatibilityPreserveTimezone()
     ? zoned.withTimeZone(zoned.offset)
     : zoned.withTimeZone(Temporal.Now.timeZoneId());

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -202,6 +202,11 @@ describe("arityMatches", () => {
     expect(arityMatches([], [req("date", "Date")]).ok).toBe(true);
   });
 
+  it("strips a leading core-extension receiver under its import alias (time: RubyTime)", () => {
+    // ruby Time#system_local_time?  vs  isSystemLocalTime(time: RubyTime)
+    expect(arityMatches([], [req("time", "RubyTime")]).ok).toBe(true);
+  });
+
   it("strips a leading core-extension receiver by type (dateOrTime: DateOrTime)", () => {
     // ruby DateAndTime::Calculations#next_weekday  vs  nextWeekday(dateOrTime: DateOrTime)
     expect(arityMatches([], [req("dateOrTime", "DateOrTime")]).ok).toBe(true);

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -65,12 +65,10 @@ const HOST_PARAM_TYPES = new Set([
   "Time",
   "DateTime",
   "DateOrTime",
-  // Local import aliases the core_ext ports use for the date gem's classes
-  // (`import { Time as RubyTime }`) — the same receivers under the spelling the
-  // importing file declares.
+  // The alias `core_ext/time` ports declare for the date gem's `Time`
+  // (`import { Time as RubyTime }`) — the same receiver under the spelling the
+  // importing file gives it.
   "RubyTime",
-  "RubyDate",
-  "RubyDateTime",
   "Numeric",
   "Duration",
   "PlainDate",

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -65,6 +65,12 @@ const HOST_PARAM_TYPES = new Set([
   "Time",
   "DateTime",
   "DateOrTime",
+  // Local import aliases the core_ext ports use for the date gem's classes
+  // (`import { Time as RubyTime }`) — the same receivers under the spelling the
+  // importing file declares.
+  "RubyTime",
+  "RubyDate",
+  "RubyDateTime",
   "Numeric",
   "Duration",
   "PlainDate",

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-time/calculations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date-time/calculations.json
@@ -8,7 +8,7 @@
     "rubyArgs": [
       "kwargs{hour=num:23,min=num:59,sec=num:59,usec=ref:Rational}"
     ],
-    "reason": "date_time/calculations.rb:140 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+    "reason": "date_time/calculations.rb:140 passes `usec: Rational(999999999, 1000)`. `Rational()` is a Kernel FUNCTION in Ruby; the port's Rational is a class (`@blazetrails/date` date.ts:1241) and JS has no way to construct one without `new`, so the kwarg value is `new Rational(999999999, 1000)` — the same value under the only spelling the language has. (A Kernel-style `Rational()` factory would additionally have to canonicalize `Rational(n, 1)` to an Integer, which `new Rational` deliberately does not.)"
   },
   {
     "package": "activesupport",
@@ -19,7 +19,7 @@
     "rubyArgs": [
       "kwargs{min=num:59,sec=num:59,usec=ref:Rational}"
     ],
-    "reason": "date_time/calculations.rb:152 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+    "reason": "date_time/calculations.rb:152 passes `usec: Rational(999999999, 1000)`. `Rational()` is a Kernel FUNCTION in Ruby; the port's Rational is a class (`@blazetrails/date` date.ts:1241) and JS has no way to construct one without `new`, so the kwarg value is `new Rational(999999999, 1000)` — the same value under the only spelling the language has. (A Kernel-style `Rational()` factory would additionally have to canonicalize `Rational(n, 1)` to an Integer, which `new Rational` deliberately does not.)"
   },
   {
     "package": "activesupport",
@@ -30,6 +30,6 @@
     "rubyArgs": [
       "kwargs{sec=num:59,usec=ref:Rational}"
     ],
-    "reason": "date_time/calculations.rb:164 passes `usec: Rational(999999999, 1000)`; the port builds the sub-second remainder through its own Rational constructor reference, so the kwarg value spells differently."
+    "reason": "date_time/calculations.rb:164 passes `usec: Rational(999999999, 1000)`. `Rational()` is a Kernel FUNCTION in Ruby; the port's Rational is a class (`@blazetrails/date` date.ts:1241) and JS has no way to construct one without `new`, so the kwarg value is `new Rational(999999999, 1000)` — the same value under the only spelling the language has. (A Kernel-style `Rational()` factory would additionally have to canonicalize `Rational(n, 1)` to an Integer, which `new Rational` deliberately does not.)"
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/digest/uuid.json
@@ -10,7 +10,7 @@
       "ref:uuidNamespace",
       "ref:name"
     ],
-    "reason": "digest/uuid.rb:42 names the digest class `::Digest::MD5`; the port selects it by the string `\"md5\"` the Web Crypto/Node digest API takes."
+    "reason": "digest/uuid.rb:42 passes the digest CLASS `OpenSSL::Digest::MD5`. TypeScript has no such class to pass: the port's digest comes from Web Crypto / node:crypto, whose `createHash` selects the algorithm by its OpenSSL NAME, so the only value that exists at this call site is the string `\"md5\"`. `uuidFromHash` switches on it exactly where Rails switches on the class (uuid.rb:20-26)."
   },
   {
     "package": "activesupport",
@@ -23,6 +23,6 @@
       "ref:uuidNamespace",
       "ref:name"
     ],
-    "reason": "digest/uuid.rb:47 names the digest class `::Digest::SHA1`; the port selects it by the string `\"sha1\"` the Web Crypto/Node digest API takes."
+    "reason": "digest/uuid.rb:47 passes the digest CLASS `OpenSSL::Digest::SHA1`. TypeScript has no such class to pass: the port's digest comes from Web Crypto / node:crypto, whose `createHash` selects the algorithm by its OpenSSL NAME, so the only value that exists at this call site is the string `\"sha1\"`. `uuidFromHash` switches on it exactly where Rails switches on the class (uuid.rb:20-26)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
@@ -52,6 +52,6 @@
       "kwargs{seconds=ref:value}",
       "bool:false"
     ],
-    "reason": "duration.rb:155 is `new(value, { seconds: value }, false)`; the port drops the leading raw value and passes ({ seconds: n }, false) — Duration carries its value off the parts."
+    "reason": "duration.rb:155 is `new(value, { seconds: value }, false)`: Rails' Duration constructor carries the total seconds in its own seat (`initialize(value, parts, variable)`, duration.rb:280). trails' constructor is `(parts, variable)` and derives the total from the parts, so no factory can pass the leading value. Converging is the ctor seat itself, tracked by story `converge-duration-constructor-value-seat` (RFC 0106)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/duration.json
@@ -52,6 +52,6 @@
       "kwargs{seconds=ref:value}",
       "bool:false"
     ],
-    "reason": "duration.rb:155 is `new(value, { seconds: value }, false)`: Rails' Duration constructor carries the total seconds in its own seat (`initialize(value, parts, variable)`, duration.rb:280). trails' constructor is `(parts, variable)` and derives the total from the parts, so no factory can pass the leading value. Converging is the ctor seat itself, tracked by story `converge-duration-constructor-value-seat` (RFC 0106)."
+    "reason": "duration.rb:155 is `new(value, { seconds: value }, false)`: Rails' Duration constructor carries the total seconds in its own seat (`initialize(value, parts, variable = nil)`, duration.rb:226). trails' constructor is `(parts, variable)` and derives the total from the parts, so no factory can pass the leading value. Converging is the ctor seat itself, tracked by story `converge-duration-constructor-value-seat` (RFC 0106)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/deprecation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/deprecation.json
@@ -8,6 +8,6 @@
     "rubyArgs": [
       "ref:escape"
     ],
-    "reason": "testing/deprecation.rb:30 builds the matcher from `escape`; the port's `new` at this site constructs the \"No deprecator given\" error the same guard raises."
+    "reason": "testing/deprecation.rb:34 is `raise ArgumentError, \"No deprecator given\"` — Ruby's `raise` CONSTRUCTS the error from the class and message, emitting no `new` of its own. JavaScript has no such form: `throw new ArgumentError(\"No deprecator given\")` is the only spelling, so the port carries one `new` site more than the Ruby body and the pairing lands on it rather than on the `new RegExp(...)` that mirrors `Regexp.new` (deprecation.rb:40)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -2,24 +2,6 @@
   {
     "package": "activesupport",
     "tsFile": "time-ext.ts",
-    "rubyName": "preserve_timezone",
-    "call": "system_local_time?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "core_ext/time/compatibility.rb:17 calls `system_local_time?` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "to_time",
-    "call": "preserve_timezone",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "core_ext/date_time/compatibility.rb:15 calls `preserve_timezone` on implicit self; DateAndTime::Calculations is a module mixed into Date/Time/DateTime, receivers TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
     "rubyName": "xmlschema",
     "call": "in_time_zone",
     "reason": "Date#xmlschema (core_ext/date/conversions.rb:95-97) reaches in_time_zone through to_time; the port formats the date directly."

--- a/scripts/api-compare/call-mismatches-exclude/i18n/interpolate/ruby.json
+++ b/scripts/api-compare/call-mismatches-exclude/i18n/interpolate/ruby.json
@@ -6,6 +6,6 @@
     "call": "missing_interpolation_argument_handler",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "i18n interpolate/ruby.rb:34 reads the handler with no arguments and calls the returned proc; the port folds both into one call taking (key, values, string)."
+    "reason": "interpolate/ruby.rb:43 READS the handler (`config.missing_interpolation_argument_handler`, no arguments) and then invokes the returned Proc with `.call(key, values, string)`. JS has no `Proc#call`: invoking the function a getter returns is spelled by calling the getter's result directly, so the read and the invocation collapse into the one call site — the same shortcoming the file's `@missingRailsCall call` tag already records for `value.call(values)`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
+++ b/scripts/api-compare/call-mismatches-exclude/rack/multipart/parser.json
@@ -36,7 +36,7 @@
     "rubyArgs": [
       "ref:dup"
     ],
-    "reason": "rack multipart/parser.rb:49 builds the buffer from `dup`; the port seeds it with the empty string."
+    "reason": "multipart/parser.rb:209 is `StringScanner.new(\"\".dup)` — the `dup` exists only to hand the scanner an UNFROZEN copy of the frozen string literal (the file is `# frozen_string_literal: true`). JS strings are immutable and have no frozen/unfrozen distinction, so there is no `dup` to call and `new SBuf(\"\")` is the same value."
   },
   {
     "package": "rack",
@@ -59,7 +59,7 @@
     "call": "new",
     "kind": "args",
     "rubyArgs": [],
-    "reason": "Baseline (RFC 0095): call-ARGUMENT shape divergence seeded when the argument ratchet landed — the port makes the call Rails makes with a different argument count, order, literal value or kwarg key; pending per-body convergence review."
+    "reason": "multipart/parser.rb:161 is `body = String.new` — the empty body of a BufferPart, built before `klass.new(body, head, filename, content_type, name)` at parser.rb:164. The port has one `Part` class instead of MimePart/BufferPart/TempfilePart and constructs it up-front with an empty body (parser.ts:197), so the argumentless `String.new` pairs against that construction. Converging is the Collector class hierarchy, tracked by story `converge-rack-multipart-collector-mimepart-hierarchy` (RFC 0106)."
   },
   {
     "package": "rack",


### PR DESCRIPTION
RFC 0106's non-ActiveRecord call-ARGUMENT shape burndown, activesupport / rack / i18n half.

## Converged (rows deleted)

`activesupport/time-ext.ts` — both rows were gate residue (RFC 0108), not port debt:

- `arity.ts` now recognises the date-gem import aliases the core_ext ports declare (`import { Time as RubyTime }`) as receiver types, alongside the already-listed `Time` / `Date` / `DateTime` / `DateOrTime`, so `preserveTimezone(time)` reads as `system_local_time?` on implicit self (`core_ext/time/compatibility.rb:17`).
- `toTime`'s receiver parameter is spelled `time`, as its callees `preserveTimezone(time: RubyTime)` and `isSystemLocalTime(time: RubyTime)` already spell theirs, so the receiver strip can see it.

Verified against a before/after `call-arg-mismatches.json` diff: exactly those two rows removed, none added.

## Left, each with a reason naming the specific language shortcoming

- `core-ext/digest/uuid.ts` (2) — Rails passes the digest CLASS (`OpenSSL::Digest::MD5`, `uuid.rb:42/47`); the port's digest comes from Web Crypto / node:crypto, which selects the algorithm by its OpenSSL NAME string.
- `core-ext/date-time/calculations.ts` (3) — `Rational()` is a Kernel function in Ruby (`date_time/calculations.rb:140/152/164`); the port's `Rational` is a class, and JS cannot construct one without `new`.
- `testing/deprecation.ts` — `raise ArgumentError, "No deprecator given"` (`deprecation.rb:34`) emits no `new`; JS has only `throw new ArgumentError(...)`, so the port carries one construction site more and the pairing lands on it.
- `rack/multipart/parser.ts` `initialize` — `StringScanner.new("".dup)` (`parser.rb:209`): the `dup` only unfreezes a frozen literal, a distinction JS strings do not have.
- `i18n/interpolate/ruby.ts` — `config.missing_interpolation_argument_handler.call(key, values, string)` (`interpolate/ruby.rb:43`): JS has no `Proc#call`, so the getter read and the invocation collapse into one site (same shortcoming as the file's existing `@missingRailsCall call`).

## Structural port debt — filed as its own story, row kept and re-pointed

- `activesupport/duration.ts` `seconds -> new` — Rails' Duration ctor has a `value` seat (`duration.rb:280`), trails' derives the total. Story: `converge-duration-constructor-value-seat`.
- `rack/multipart/parser.ts` `on_mime_head -> new` — Rails branches over `BufferPart` / `TempfilePart` with `String.new` (`parser.rb:153-165`); the port has one `Part`. Story: `converge-rack-multipart-collector-mimepart-hierarchy`.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both green.

Closes-story: converge-remaining-call-arg-shape-rows-activesupport-rack-i18n