### PR TITLE
fix(parity): converge Request#session onto Rack's fetch_header … default_session

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Request, PassNotFound } from "../request.js";
+import { Session } from "../request/session.js";
 import { MimeType } from "../http/mime-type.js";
 import { X_CASCADE } from "../constants.js";
 import { UnknownHttpMethod } from "../../action-controller/metal/exceptions.js";
@@ -699,13 +700,11 @@ describe("RequestInspectTest", () => {
 
 describe("RequestSession", () => {
   it("#session", () => {
-    const req = new Request({ "rack.session": { user_id: 1 } });
-    expect(req.session).toEqual({ user_id: 1 });
-  });
-
-  it("#session returns empty hash when not set", () => {
     const req = new Request({});
-    expect(req.session).toEqual({});
+    void req.session;
+
+    expect(Session.find(req)!.isEnabled()).toBe(false);
+    expect(Session.Options.find(req)).toBeInstanceOf(Session.Options);
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/request/session.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request/session.test.ts
@@ -195,9 +195,9 @@ describe("Request", () => {
 
 // ==========================================================================
 // No Rails counterpart: `Session::Options` (request/session.rb:47-73) has no
-// test of its own in session_test.rb — request_test.rb's `RequestSession#session`
-// only asserts `Options.find(req)` is an Options instance, through a
-// `Request#session` reader trails has not converged yet.
+// test of its own in session_test.rb. request_test.rb's `RequestSession#session`
+// covers `Options.find(req)` being an `Options` instance; what is left here is
+// the reader behaviour it does not reach.
 // ==========================================================================
 describe("Options", () => {
   it("create stores an Options instance", () => {
@@ -212,9 +212,7 @@ describe("Options", () => {
   it("disabled stores an Options instance whose id is nil", () => {
     const req = makeReq();
     Session.disabled(req);
-    const options = Options.find(req) as Options;
-    expect(options).toBeInstanceOf(Options);
-    expect(options.id(req)).toBeNull();
+    expect((Options.find(req) as Options).id(req)).toBeNull();
   });
 
   it("id falls back to the store when no id is stored", () => {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -7,8 +7,7 @@
 
 import { toSentence } from "@blazetrails/activesupport";
 import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
-import { RACK_SESSION } from "@blazetrails/rack";
-import { parseNestedQuery, Request as RackRequest } from "@blazetrails/rack";
+import { parseNestedQuery, RACK_SESSION, Request as RackRequest } from "@blazetrails/rack";
 import { UnknownHttpMethod } from "../../action-controller/metal/exceptions.js";
 import { Session } from "../request/session.js";
 import {
@@ -893,7 +892,7 @@ export class Request {
 
   // --- Session ---
 
-  /** Rails: `reset_session` — destroys session and resets CSRF token. */
+  /** Rails: `reset_session` (request.rb:381-384) — `session.destroy; reset_csrf_token`. */
   resetSession(): void {
     this.session.destroy();
     this.resetCsrfToken();

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -7,6 +7,7 @@
 
 import { toSentence } from "@blazetrails/activesupport";
 import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
+import { RACK_SESSION } from "@blazetrails/rack";
 import { parseNestedQuery, Request as RackRequest } from "@blazetrails/rack";
 import { UnknownHttpMethod } from "../../action-controller/metal/exceptions.js";
 import { Session } from "../request/session.js";
@@ -676,8 +677,17 @@ export class Request {
 
   // --- Session ---
 
-  get session(): Record<string, unknown> {
-    return (this.env["rack.session"] as Record<string, unknown>) || {};
+  /**
+   * Mirrors: `Rack::Request::Helpers#session` (`rack/request.rb:207-211`) —
+   * `fetch_header(RACK_SESSION) { |k| set_header RACK_SESSION, default_session }`.
+   * ActionDispatch supplies `default_session` (`request.rb:505-507`) as
+   * `Session.disabled(self)`, so a request with no session middleware answers a
+   * disabled `Session` and seeds `Session::Options` as a side effect.
+   */
+  get session(): Session {
+    return this.fetchHeader(RACK_SESSION, (k) =>
+      this.setHeader(k, this.defaultSession()),
+    ) as Session;
   }
 
   // --- Flash ---
@@ -885,14 +895,12 @@ export class Request {
 
   /** Rails: `reset_session` — destroys session and resets CSRF token. */
   resetSession(): void {
-    const session = this.env["rack.session"] as { destroy?: () => void } | undefined;
-    if (session && typeof session.destroy === "function") session.destroy();
-    else this.env["rack.session"] = {};
+    this.session.destroy();
     this.resetCsrfToken();
   }
 
   /** Rails: `session=` (request.rb:385-387) — `Session.set self, session`. */
-  set session(session: Record<string, unknown>) {
+  set session(session: Session) {
     Session.set(this, session);
   }
 

--- a/packages/rack/src/index.ts
+++ b/packages/rack/src/index.ts
@@ -63,4 +63,4 @@ export {
 } from "./utils.js";
 export { BodyProxy } from "./body-proxy.js";
 export { Request } from "./request.js";
-export { CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";
+export { CONTENT_TYPE, CONTENT_LENGTH, RACK_SESSION, RACK_SESSION_OPTIONS } from "./constants.js";

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -454,12 +454,14 @@ export class Request {
     return undefined;
   }
 
+  /** Mirrors: `Rack::Request::Helpers#session` (`rack/request.rb:207-211`). */
   get session(): Record<string, any> {
-    return this.env[RACK_SESSION] || (this.env[RACK_SESSION] = {});
+    return this.fetchHeader(RACK_SESSION, (k) => this.setHeader(k, this.defaultSession()));
   }
 
+  /** Mirrors: `Rack::Request::Helpers#session_options` (`rack/request.rb:213-217`). */
   get sessionOptions(): Record<string, any> {
-    return this.env[RACK_SESSION_OPTIONS] || (this.env[RACK_SESSION_OPTIONS] = {});
+    return this.fetchHeader(RACK_SESSION_OPTIONS, (k) => this.setHeader(k, {}));
   }
 
   get ip(): string {
@@ -664,6 +666,11 @@ export class Request {
     const err = new Error(`key not found: "${name}"`);
     err.name = "KeyError";
     throw err;
+  }
+
+  /** Mirrors: `Rack::Request::Env#set_header` (`rack/request.rb:116-118`). */
+  setHeader(name: string, v: any): any {
+    return (this.env[name] = v);
   }
 
   eachHeader(callback: (key: string, value: any) => void): void {


### PR DESCRIPTION
`ActionDispatch::Request#session` was `env["rack.session"] || {}` — it never
called the already-ported `defaultSession()`, answered a plain object rather
than a `Session`, and never seeded the env.

- `Request#session` now reads through `fetchHeader(RACK_SESSION, k => setHeader(k, defaultSession()))`, per Rack's `Request#session` (`rack/request.rb:207-211`) with ActionDispatch's `default_session = Session.disabled(self)` (`actionpack .../http/request.rb:505-507`). A request with no session middleware answers a disabled `Session` and seeds `Session::Options` as a side effect.
- `reset_session` is now `session.destroy; reset_csrf_token` (`request.rb:381-384`), which the converged reader makes possible.
- Rack's own `Request#session` / `#session_options` get the same `fetch_header … set_header` body, plus the missing `Rack::Request::Env#set_header` (`rack/request.rb:116-118`).
- `RequestSession#session` now asserts what `request_test.rb:1441-1446` asserts; the trails-only `#session returns empty hash when not set` test is retired, and the `Options` block from #6687 is trimmed to what the Rails test does not cover.

`parity:api:calls` and `parity:api:calls:args` both OK; `parity:api:extra --package rack` shows no new novel surface.

Closes-story: converge-request-session-onto-default-session