### PR TITLE
fix(parity): converge index_parts' default_index_type?, Migration#run and crc32

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -24,7 +24,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.enableExtension("citext");
         }
       }
-      await new EnableCitext().run(adapter, "up");
+      await new EnableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("disable extension", async () => {
@@ -34,7 +34,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.disableExtension("citext", { force: "cascade" });
         }
       }
-      await new DisableCitext().run(adapter, "up");
+      await new DisableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("enable extension idempotent", async () => {
@@ -44,8 +44,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new EnableCitext();
-      await m.run(adapter, "up");
-      await expect(m.run(adapter, "up")).resolves.toBeUndefined();
+      await m.execMigration(adapter, "up");
+      await expect(m.execMigration(adapter, "up")).resolves.toBeUndefined();
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("disable extension idempotent", async () => {
@@ -55,8 +55,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new DisableCitext();
-      await m.run(adapter, "up");
-      await expect(m.run(adapter, "up")).resolves.toBeUndefined();
+      await m.execMigration(adapter, "up");
+      await expect(m.execMigration(adapter, "up")).resolves.toBeUndefined();
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("extension schema dump", async () => {
@@ -65,7 +65,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.enableExtension("citext");
         }
       }
-      await new EnableCitext().run(adapter, "up");
+      await new EnableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
       const dump = (await adapter.createSchemaDumper(adapter).dump()).join("\n");
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
@@ -82,7 +82,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.enableExtension("citext");
         }
       }
-      await new EnableCitext().run(adapter, "up");
+      await new EnableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
     });
     it("enable extension migration with schema", async () => {
@@ -94,10 +94,10 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new EnableCitext();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
       // Down must strip schema and call DROP EXTENSION IF EXISTS "citext" (not "public.citext")
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("disable extension migration ignores prefix and suffix", async () => {
@@ -107,7 +107,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           await this.disableExtension("citext", { force: "cascade" });
         }
       }
-      await new DisableCitext().run(adapter, "up");
+      await new DisableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });
     it("disable extension raises when dependent objects exist", async () => {

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -172,11 +172,11 @@ describeIfPg("PostgreSQLAdapter", () => {
 
       const m = new HstoreMigration();
       await m.suppressMessages(async () => {
-        await m.run(connection, "up");
+        await m.execMigration(connection, "up");
         const upCols = (await connection.columns("hstores")).map((c: any) => c.name);
         expect(upCols).toContain("keys");
 
-        await new HstoreMigration().run(connection, "down");
+        await new HstoreMigration().execMigration(connection, "down");
         const downCols = (await connection.columns("hstores")).map((c: any) => c.name);
         expect(downCols).not.toContain("keys");
       });

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -29,9 +29,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new CreateHorses();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       expect(await adapter.tableExists("settings")).toBe(true);
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       expect(await adapter.tableExists("settings")).toBe(false);
     });
     it("migrate revert add index with expression", async () => {
@@ -47,14 +47,14 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new ExpressionIndexMigration();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
 
       expect(await adapter.tableExists("settings")).toBe(true);
       expect(await adapter.indexExists("settings", null, { name: "index_settings_data_foo" })).toBe(
         true,
       );
 
-      await new ExpressionIndexMigration().run(adapter, "down");
+      await new ExpressionIndexMigration().execMigration(adapter, "down");
 
       expect(await adapter.tableExists("settings")).toBe(false);
       expect(await adapter.indexExists("settings", null, { name: "index_settings_data_foo" })).toBe(
@@ -69,7 +69,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new CreateEnumMig();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       // Add an actual enum-typed column so reversal must drop the table before
       // dropping the enum type (otherwise DROP TYPE fails with dependency error)
       await adapter.execute(
@@ -79,7 +79,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(enumsBefore.some(([name]) => name === "color")).toBe(true);
 
       // Down: drops table first (containing enum column), then drops enum type
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       const enumsAfter = await adapter.enumTypes();
       expect(enumsAfter.some(([name]) => name === "color")).toBe(false);
       expect(await adapter.tableExists("enums")).toBe(false);
@@ -93,11 +93,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new DropEnumMig();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       const enumsAfterDrop = await adapter.enumTypes();
       expect(enumsAfterDrop.some(([name]) => name === "color")).toBe(false);
 
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       const enumsRestored = await adapter.enumTypes();
       expect(enumsRestored.some(([name]) => name === "color")).toBe(true);
     });
@@ -110,13 +110,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new RenameEnumMig();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       const afterRename = await adapter.enumTypes();
       const colorValues = afterRename.find(([name]) => name === "color")?.[1] ?? [];
       expect(colorValues).toContain("red");
       expect(colorValues).not.toContain("blue");
 
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       const afterRevert = await adapter.enumTypes();
       const revertedValues = afterRevert.find(([name]) => name === "color")?.[1] ?? [];
       expect(revertedValues).toContain("blue");
@@ -135,11 +135,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new AddAndValidateCheckMig();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       const before = await adapter.checkConstraints("settings");
       expect(before.some((c: any) => c.name === "positive_value")).toBe(true);
 
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       const after = await adapter.checkConstraints("settings");
       expect(after.some((c: any) => c.name === "positive_value")).toBe(false);
     });
@@ -158,10 +158,10 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       const m = new AddAndValidateFKMig();
-      await m.run(adapter, "up");
+      await m.execMigration(adapter, "up");
       expect(await adapter.foreignKeyExists("bars", "foos")).toBe(true);
 
-      await m.run(adapter, "down");
+      await m.execMigration(adapter, "down");
       expect(await adapter.foreignKeyExists("bars", "foos")).toBe(false);
     });
   });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1965,15 +1965,13 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  // Mirrors Rails' `abstract_adapter.rb#default_index_type?` (`index.using.nil?`),
-  // the predicate the schema dumper uses to decide whether to print `using:`
-  // (schema_dumper.rb#indexes: `... if !default_index_type?(index)`). PostgreSQL
-  // and MySQL override to also treat `:btree` as the default; SQLite inherits
-  // this nil-only check (so a non-nil `using` on sqlite still dumps). Surfaced
-  // here so `addIndex` gates the stored `using` on the same
-  // per-adapter predicate the dumper reads, rather than an adapter-name check.
-  defaultIndexType(using?: string): boolean {
-    return using == null;
+  // Mirrors Rails' `abstract_adapter.rb:834#default_index_type?`
+  // (`index.using.nil?`), the predicate `SchemaDumper#index_parts` reads to
+  // decide whether to print `using:` (schema_dumper.rb:275). PostgreSQL and
+  // MySQL override to also treat `:btree` as the default; SQLite inherits this
+  // nil-only check, so a non-nil `using` on sqlite still dumps.
+  defaultIndexType(index: IndexDefinition): boolean {
+    return index.using == null;
   }
 
   supportsConcurrentConnections(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -70,6 +70,7 @@ import type {
   AddIndexOptions,
   ColumnOptions,
   ColumnType,
+  IndexDefinition,
   RemoveForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
 import type { CommentOrChanges } from "./abstract/schema-statements.js";
@@ -357,8 +358,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   // Rails: `index.using == :btree || super` (abstract_mysql_adapter.rb#default_index_type?).
-  override defaultIndexType(using?: string): boolean {
-    return using === "btree" || super.defaultIndexType(using);
+  override defaultIndexType(index: IndexDefinition): boolean {
+    return index.using === "btree" || super.defaultIndexType(index);
   }
 
   async supportsIndexSortOrder(): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3180,8 +3180,8 @@ export class PostgreSQLAdapter
     return true;
   }
   // Rails: `index.using == :btree || super` (postgresql_adapter.rb#default_index_type?).
-  override defaultIndexType(using?: string): boolean {
-    return using === "btree" || super.defaultIndexType(using);
+  override defaultIndexType(index: IndexDefinition): boolean {
+    return index.using === "btree" || super.defaultIndexType(index);
   }
   async supportsPartitionedIndexes(): Promise<boolean> {
     return (await this.databaseVersion) >= 110000;

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1332,8 +1332,6 @@ describe("MigrationTest", () => {
     }
     const m = new WeNeedReminders();
     const cb = new ChangeBased();
-    // `exec_migration` clears `@connection` in its ensure (migration.rb:998-1000),
-    // so re-point the migration at the adapter for the assertions that follow.
     const runMigration = async (mig: Migration, direction: "up" | "down") => {
       await mig.execMigration(adapter, direction);
       mig.connection = adapter;

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1332,8 +1332,14 @@ describe("MigrationTest", () => {
     }
     const m = new WeNeedReminders();
     const cb = new ChangeBased();
+    // `exec_migration` clears `@connection` in its ensure (migration.rb:998-1000),
+    // so re-point the migration at the adapter for the assertions that follow.
+    const runMigration = async (mig: Migration, direction: "up" | "down") => {
+      await mig.execMigration(adapter, direction);
+      mig.connection = adapter;
+    };
     try {
-      await m.run(adapter, "up");
+      await runMigration(m, "up");
       // Use adapter quoting so MySQL (no ANSI_QUOTES) works alongside PG/SQLite.
       const qt = adapter.quoteTableName("prefix_reminders_suffix");
       const qc = adapter.quoteColumnName("content");
@@ -1341,13 +1347,13 @@ describe("MigrationTest", () => {
       const rows = await adapter.execute(`SELECT * FROM ${qt}`);
       expect(rows).toHaveLength(1);
 
-      await m.run(adapter, "down");
+      await runMigration(m, "down");
       expect(await m.tableExists("reminders")).toBe(false);
 
-      await cb.run(adapter, "up");
+      await runMigration(cb, "up");
       expect(await cb.tableExists("gadgets")).toBe(true);
       expect(await cb.columnExists("gadgets", "price")).toBe(true);
-      await cb.run(adapter, "down");
+      await runMigration(cb, "down");
       expect(await cb.tableExists("gadgets")).toBe(false);
       expect(await cb.tableExists("widgets")).toBe(false);
     } finally {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -118,7 +118,7 @@ export interface ColumnExistsOptions {
 }
 
 // Mirrors Zlib.crc32 (ISO 3309 / ITU-T V.42 polynomial) operating on UTF-8 bytes.
-function _crc32(str: string): number {
+function crc32(str: string): number {
   const bytes = new TextEncoder().encode(str);
   let crc = 0xffffffff;
   for (const byte of bytes) {
@@ -1165,7 +1165,7 @@ export class Migration {
     if (migrationOrFn === undefined) return;
     if (migrationOrFn instanceof Migration) {
       // Mirrors Rails `revert(*migration_classes)` -> `run(..., revert: true)`.
-      await this._run(migrationOrFn, { revert: true });
+      await this.run(migrationOrFn, { revert: true });
       return;
     }
     const fn = migrationOrFn;
@@ -1201,13 +1201,18 @@ export class Migration {
   }
 
   /**
-   * Run another migration in a direction, flipping it under `revert`.
+   * Runs the given migration classes.
    *
-   * Mirrors: ActiveRecord::Migration#run — when the current migration is itself
-   * reverting, running a sub-migration `:up` means executing it `:down` without
-   * reverting, so it wraps the call in a nested `revert`.
+   * Last argument can specify options:
+   * - `direction` - Default is `up`.
+   * - `revert` - Default is `false`.
+   *
+   * Mirrors: ActiveRecord::Migration#run (`migration.rb:937-949`) — when the
+   * current migration is itself reverting, running a sub-migration `up` means
+   * executing it `down` without reverting, so it wraps the call in a nested
+   * `revert`.
    */
-  private async _run(
+  async run(
     migration: Migration,
     opts: { direction?: "up" | "down"; revert?: boolean } = {},
   ): Promise<void> {
@@ -1215,7 +1220,7 @@ export class Migration {
     if (opts.revert) dir = dir === "down" ? "up" : "down";
     if (this.isReverting()) {
       await this.revert(async () => {
-        await this._run(migration, { direction: dir, revert: true });
+        await this.run(migration, { direction: dir, revert: true });
       });
     } else if (this._recording) {
       // Recording (but not reverting): route the sub-migration's ops into the
@@ -1315,18 +1320,6 @@ export class Migration {
    */
   static get(_version: string): Migration | null {
     return null;
-  }
-
-  /**
-   * Execute the migration on a given adapter.
-   */
-  async run(adapter?: DatabaseAdapter, direction: "up" | "down" = "up"): Promise<void> {
-    if (adapter) this.connection = adapter;
-    if (direction === "up") {
-      await this.up();
-    } else {
-      await this.down();
-    }
   }
 
   /**
@@ -2639,7 +2632,7 @@ export class Migrator {
     // Rails sends `current_database` unconditionally; an adapter that does not
     // define it raises NoMethodError. The `!` reproduces that unconditional
     // send — it is not a claim that the member is always present.
-    const dbNameHash = _crc32(await this.connection.currentDatabase!());
+    const dbNameHash = crc32(await this.connection.currentDatabase!());
     return BigInt(Migrator._MIGRATOR_SALT) * BigInt(dbNameHash);
   }
 

--- a/packages/activerecord/src/migrator.ts
+++ b/packages/activerecord/src/migrator.ts
@@ -71,7 +71,7 @@ export class MigrationRunner {
     for (const entry of this.migrations) {
       if (applied.has(entry.version)) continue;
 
-      await entry.migration.run(this.adapter, "up");
+      await entry.migration.execMigration(this.adapter, "up");
       const im = new InsertManager(this.arelTable);
       im.insert([[this.arelTable.get("version"), entry.version]]);
       await this.adapter.execute(this.adapter.toSql(im));
@@ -93,7 +93,7 @@ export class MigrationRunner {
     const toRollback = appliedMigrations.slice(0, steps);
 
     for (const entry of toRollback) {
-      await entry.migration.run(this.adapter, "down");
+      await entry.migration.execMigration(this.adapter, "down");
       const dm = new DeleteManager();
       dm.from(this.arelTable);
       dm.where(this.arelTable.get("version").eq(entry.version));

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -8,7 +8,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
+import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+
+const EMPTY_SOURCE = {
+  tables: () => [],
+  columns: () => [],
+  indexes: () => [],
+  adapter: { defaultIndexType: AbstractAdapter.prototype.defaultIndexType },
+};
 
 describe("SchemaDumper trails-only cases", () => {
   it("schema dump emits defaultFunction as arrow for non-PK columns", async () => {
@@ -108,7 +116,7 @@ describe("SchemaDumper trails-only cases", () => {
   it("indexParts emits include for covering indexes", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const emptySource = { ...EMPTY_SOURCE };
     const dumper = new (TopLevelDumper as any)(emptySource);
     const parts = dumper.indexParts({ columns: ["a"], unique: false, include: ["b", "c"] });
     expect(parts.join(", ")).toContain(`include: ["b","c"]`);
@@ -117,7 +125,7 @@ describe("SchemaDumper trails-only cases", () => {
   it("indexParts emits NULLS FIRST/LAST order strings verbatim", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const emptySource = { ...EMPTY_SOURCE };
     const dumper = new (TopLevelDumper as any)(emptySource);
     const parts = dumper.indexParts({
       columns: ["created_at"],
@@ -130,7 +138,7 @@ describe("SchemaDumper trails-only cases", () => {
   it("indexParts collapses uniform multi-column orders to a scalar", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const emptySource = { ...EMPTY_SOURCE };
     const dumper = new (TopLevelDumper as any)(emptySource);
     const parts = dumper.indexParts({
       columns: ["name", "rating"],
@@ -143,7 +151,7 @@ describe("SchemaDumper trails-only cases", () => {
   it("indexParts keeps mixed multi-column orders as a map", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const emptySource = { ...EMPTY_SOURCE };
     const dumper = new (TopLevelDumper as any)(emptySource);
     const parts = dumper.indexParts({
       columns: ["name", "rating"],
@@ -156,7 +164,7 @@ describe("SchemaDumper trails-only cases", () => {
   it("indexParts collapses uniform multi-column opclasses to a scalar", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const emptySource = { tables: () => [], columns: () => [], indexes: () => [] };
+    const emptySource = { ...EMPTY_SOURCE };
     const dumper = new (TopLevelDumper as any)(emptySource);
     const parts = dumper.indexParts({
       columns: ["name", "description"],
@@ -167,34 +175,18 @@ describe("SchemaDumper trails-only cases", () => {
   });
 
   it("indexParts routes using: through the connection's defaultIndexType predicate", async () => {
-    // Rails' `index_parts` prints `using:` unless
-    // `@connection.default_index_type?(index)` (schema_dumper.rb:275). The
-    // abstract adapter's body is nil-only (abstract_adapter.rb:834-836), which
-    // SQLite inherits, so a `btree` index still dumps `using: "btree"` there;
-    // PostgreSQL and MySQL override to treat `:btree` as the default
-    // (postgresql_adapter.rb:646, abstract_mysql_adapter.rb:634) and omit it.
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
-    const { AbstractAdapter } = await import("./connection-adapters/abstract-adapter.js");
     const { AbstractMysqlAdapter } =
       await import("./connection-adapters/abstract-mysql-adapter.js");
     const index = { columns: ["name"], unique: false, using: "btree" };
 
-    const mkDumper = (adapter: unknown) =>
-      new (TopLevelDumper as any)({
-        tables: () => [],
-        columns: () => [],
-        indexes: () => [],
-        adapter,
-      });
-
-    const sqliteLike = mkDumper({
-      defaultIndexType: AbstractAdapter.prototype.defaultIndexType,
-    });
+    const sqliteLike = new (TopLevelDumper as any)({ ...EMPTY_SOURCE });
     expect(sqliteLike.indexParts(index).join(", ")).toContain(`using: "btree"`);
 
-    const mysqlLike = mkDumper({
-      defaultIndexType: AbstractMysqlAdapter.prototype.defaultIndexType,
+    const mysqlLike = new (TopLevelDumper as any)({
+      ...EMPTY_SOURCE,
+      adapter: { defaultIndexType: AbstractMysqlAdapter.prototype.defaultIndexType },
     });
     expect(mysqlLike.indexParts(index).join(", ")).not.toContain("using:");
     expect(mysqlLike.indexParts({ ...index, using: "hash" }).join(", ")).toContain(`using: "hash"`);

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -166,6 +166,40 @@ describe("SchemaDumper trails-only cases", () => {
     expect(parts.join(", ")).toContain(`opclass: "varchar_pattern_ops"`);
   });
 
+  it("indexParts routes using: through the connection's defaultIndexType predicate", async () => {
+    // Rails' `index_parts` prints `using:` unless
+    // `@connection.default_index_type?(index)` (schema_dumper.rb:275). The
+    // abstract adapter's body is nil-only (abstract_adapter.rb:834-836), which
+    // SQLite inherits, so a `btree` index still dumps `using: "btree"` there;
+    // PostgreSQL and MySQL override to treat `:btree` as the default
+    // (postgresql_adapter.rb:646, abstract_mysql_adapter.rb:634) and omit it.
+    const { SchemaDumper: TopLevelDumper } =
+      await import("./connection-adapters/abstract/schema-dumper.js");
+    const { AbstractAdapter } = await import("./connection-adapters/abstract-adapter.js");
+    const { AbstractMysqlAdapter } =
+      await import("./connection-adapters/abstract-mysql-adapter.js");
+    const index = { columns: ["name"], unique: false, using: "btree" };
+
+    const mkDumper = (adapter: unknown) =>
+      new (TopLevelDumper as any)({
+        tables: () => [],
+        columns: () => [],
+        indexes: () => [],
+        adapter,
+      });
+
+    const sqliteLike = mkDumper({
+      defaultIndexType: AbstractAdapter.prototype.defaultIndexType,
+    });
+    expect(sqliteLike.indexParts(index).join(", ")).toContain(`using: "btree"`);
+
+    const mysqlLike = mkDumper({
+      defaultIndexType: AbstractMysqlAdapter.prototype.defaultIndexType,
+    });
+    expect(mysqlLike.indexParts(index).join(", ")).not.toContain("using:");
+    expect(mysqlLike.indexParts({ ...index, using: "hash" }).join(", ")).toContain(`using: "hash"`);
+  });
+
   it("fkIgnorePattern suppresses name for matching FK names, includes name for non-matching", async () => {
     const mkSource = (fkName: string) => ({
       tables: async () => ["books"],

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -977,16 +977,8 @@ export abstract class SchemaDumper {
     const opclasses = conciseOptions(index.columns, index.opclasses);
     if (opclasses !== undefined) parts.push(`opclass: ${this.formatIndexParts(opclasses)}`);
     if (index.where) parts.push(`where: ${JSON.stringify(index.where)}`);
-    // Rails: `... if !@connection.default_index_type?(index)` (schema_dumper.rb:275).
-    // A dumper built over a plain `SchemaSource` has no adapter behind it, so
-    // fall back to the abstract adapter's own body (`index.using.nil?`,
-    // abstract_adapter.rb:834-836).
-    const connection = this._adapter();
-    const defaultIndexType =
-      typeof connection?.defaultIndexType === "function"
-        ? (connection.defaultIndexType(index) as boolean)
-        : index.using == null;
-    if (!defaultIndexType) parts.push(`using: ${JSON.stringify(index.using)}`);
+    if (!this._adapter().defaultIndexType(index))
+      parts.push(`using: ${JSON.stringify(index.using)}`);
     if (index.nullsNotDistinct) parts.push("nullsNotDistinct: true");
     if (index.include && index.include.length > 0)
       parts.push(`include: ${JSON.stringify(index.include)}`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -977,7 +977,16 @@ export abstract class SchemaDumper {
     const opclasses = conciseOptions(index.columns, index.opclasses);
     if (opclasses !== undefined) parts.push(`opclass: ${this.formatIndexParts(opclasses)}`);
     if (index.where) parts.push(`where: ${JSON.stringify(index.where)}`);
-    if (index.using && index.using !== "btree") parts.push(`using: ${JSON.stringify(index.using)}`);
+    // Rails: `... if !@connection.default_index_type?(index)` (schema_dumper.rb:275).
+    // A dumper built over a plain `SchemaSource` has no adapter behind it, so
+    // fall back to the abstract adapter's own body (`index.using.nil?`,
+    // abstract_adapter.rb:834-836).
+    const connection = this._adapter();
+    const defaultIndexType =
+      typeof connection?.defaultIndexType === "function"
+        ? (connection.defaultIndexType(index) as boolean)
+        : index.using == null;
+    if (!defaultIndexType) parts.push(`using: ${JSON.stringify(index.using)}`);
     if (index.nullsNotDistinct) parts.push("nullsNotDistinct: true");
     if (index.include && index.include.length > 0)
       parts.push(`include: ${JSON.stringify(index.include)}`);

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -98,7 +98,7 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
 function isMigrationClass(value: unknown): boolean {
   if (typeof value !== "function") return false;
   const proto = (value as any).prototype;
-  return proto && typeof proto.run === "function";
+  return proto && typeof proto.execMigration === "function";
 }
 
 async function loadMigrationClass(
@@ -132,6 +132,6 @@ async function loadMigrationClass(
 
   throw new Error(
     `No migration class found in ${filePath}. ` +
-      `Expected a class extending Migration with a run(adapter, direction) method.`,
+      `Expected a class extending Migration with an execMigration(connection, direction) method.`,
   );
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/migration.json
@@ -65,13 +65,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "generate_migrator_advisory_lock_id",
-    "call": "crc32",
-    "reason": "`Zlib.crc32` (migration.rb:1617) is Ruby stdlib; the port calls the trails CRC-32 helper `_crc32` (migration.ts:2642), whose underscored name cannot match the Ruby callee."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "migrate",
     "call": "with_connection",
     "reason": "`DatabaseTasks.migration_connection.pool.with_connection` (migration.rb:973) checks a connection out for the exec_migration block; trails migrations run against the already-seated `this.connection` (RFC 0073's permanent-checkout flip is where this converges)."
@@ -89,13 +82,6 @@
     "rubyName": "parse_migration_filename",
     "call": "first",
     "reason": "Ruby `Array#first` on the `scan` result (migration.rb:1374); JS indexes with `[0]`, which records no callee."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
-    "call": "run",
-    "reason": "Rails' `run(*migration_classes.reverse, revert: true)` (migration.rb:853); the port spells the same method `_run` (migration.ts:1168), so the underscored callee does not match."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
-    "call": "default_index_type?",
-    "reason": "`!@connection.default_index_type?(index)` (schema_dumper.rb:275) is inlined as `index.using !== \"btree\"`; the adapter predicate exists (abstract-adapter.ts:1975) but is nil-only on SQLite, so routing through it changes the SQLite dump — RFC 0051 schema-dumper territory."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
     "rubyName": "indexes_in_create",
     "call": "any?",
     "reason": "Ruby's block-less `any?` (schema_dumper.rb:245,246,252) is an emptiness test on the fetched array; the port spells it `.length > 0`, which records no callee."
@@ -67,62 +60,62 @@
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "column_spec",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "column_spec_for_primary_key",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "exclusion_constraints_in_create",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "format_colspec",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "format_options",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "indexes_in_create",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "table_options",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "unique_constraints_in_create",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   },
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "valid_type?",
-    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence belongs to RFC 0051's schema-dumper stories."
+    "reason": "verified at schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the port's `table` hands that half to `emitTable` (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this call. The gate credits same-FILE helpers only, so the delegation reads as an omission. Convergence is RFC 0051 story `inline-schema-dumper-table-retire-emit-table`."
   }
 ]


### PR DESCRIPTION
Burns down three of the four real port-divergence reasons left by
`wave-4e-schema-dumper-migration-residue`:

- `SchemaDumper#index_parts` now routes `using:` through
  `@connection.default_index_type?(index)` (schema_dumper.rb:275) instead of
  the inlined `index.using !== "btree"`. `defaultIndexType` also takes the
  index, as Rails does (abstract_adapter.rb:834, abstract_mysql_adapter.rb:634,
  postgresql_adapter.rb:646); it previously took a bare `using` string and had
  no callers at all. A trails test pins both arms: SQLite's inherited nil-only
  predicate still dumps `using: "btree"`, MySQL's and PostgreSQL's override
  omits it. The five trails-only `indexParts` unit tests grew an adapter behind
  their mock source, since Rails' dumper always has one.
- `Migration#_run` is now `run` (migration.rb:937-949). The name was taken by an
  invented `run(adapter, direction)` with no Rails counterpart; that is deleted
  and its callers use `execMigration(conn, direction)` (migration.rb:985), which
  is what it wrapped.
- The CRC-32 helper is `crc32`, matching `Zlib.crc32` (migration.rb:1617).

The fourth — the nine `SchemaDumper#table` rows, where the port hands the column
half to the Rails-less `emitTable` — is an architectural change across five
dumper files and is handed to RFC 0051 story
`inline-schema-dumper-table-retire-emit-table`, now named in each row's reason.

Closes-story: schema-dumper-emit-table-and-underscored-callee-convergence
