### PR TITLE
fix(parity): converge the mime-negotiation fetch_header call-arg rows

### DIFF
--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -287,6 +287,16 @@ describe("P20b/P20c smoke", () => {
     expect(requestAuthenticityTokens(c)).toEqual(["p", "x"]);
   });
 
+  it("Exception raises InvalidAuthenticityToken with its warningMessage", () => {
+    const strategy = new Exception({} as never);
+    expect(() => strategy.handleUnverifiedRequest()).toThrow(InvalidAuthenticityToken);
+
+    strategy.warningMessage = "HTTP Origin header didn't match request.base_url";
+    expect(() => strategy.handleUnverifiedRequest()).toThrow(
+      "HTTP Origin header didn't match request.base_url",
+    );
+  });
+
   it("protectionMethodClass maps names + passes class through", () => {
     expect(protectionMethodClass("null_session")).toBe(NullSession);
     expect(protectionMethodClass("reset_session")).toBe(ResetSession);

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -113,9 +113,11 @@ export class ResetSession implements ProtectionMethods {
 }
 
 export class Exception implements ProtectionMethods {
+  /** Mirrors `attr_accessor :warning_message` (request_forgery_protection.rb:307). */
+  warningMessage?: string;
   constructor(_controller: Controller) {}
   handleUnverifiedRequest(): void {
-    throw new InvalidAuthenticityToken();
+    throw new InvalidAuthenticityToken(this.warningMessage);
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/http/mime-negotiation.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-negotiation.test.ts
@@ -51,7 +51,35 @@ describe("MimeNegotiation.paramsReadable", () => {
   });
 });
 
+describe("MimeNegotiation.contentMimeType", () => {
+  it("caches through fetchHeader so a second read does not reparse", () => {
+    const req = new Request({ CONTENT_TYPE: "application/xml" });
+    expect(req.contentMimeType?.toString()).toBe("application/xml");
+    expect(req.getHeader("action_dispatch.request.content_type")).toBe(req.contentMimeType);
+  });
+
+  it("looks up the empty media type when CONTENT_TYPE is blank", () => {
+    const req = new Request({ CONTENT_TYPE: "" });
+    expect(req.contentMimeType?.toString()).toBe("");
+  });
+});
+
+describe("MimeNegotiation.accepts", () => {
+  it("caches through fetchHeader so a second read does not reparse", () => {
+    const req = new Request({ HTTP_ACCEPT: "application/xml,text/html" });
+    expect(req.accepts.map((m) => m.toString())).toEqual(["application/xml", "text/html"]);
+    expect(req.getHeader("action_dispatch.request.accepts")).toBe(req.accepts);
+  });
+});
+
 describe("MimeNegotiation writers", () => {
+  it("variant= raises ArgumentError for a non-Symbol", () => {
+    const req = new Request({});
+    expect(() => {
+      (req as unknown as { variant: unknown }).variant = [1];
+    }).toThrow("request.variant must be set to a Symbol or an Array of Symbols.");
+  });
+
   it("format= forces the format regardless of the path extension", () => {
     const req = new Request({ PATH_INFO: "/posts/5.html" });
     req.format = "xml";

--- a/packages/actionpack/src/action-dispatch/http/mime-negotiation.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-negotiation.ts
@@ -25,6 +25,13 @@ import { ParseError } from "./parameters.js";
  */
 const RESCUABLE_MIME_FORMAT_ERRORS = [BadRequest, ParseError] as const;
 
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
 /**
  * Raised when a `Content-Type` or `Accept` header cannot be parsed as a
  * valid MIME type. Mirrors `ActionDispatch::Http::MimeNegotiation::InvalidType`,
@@ -122,7 +129,7 @@ export class MimeNegotiation {
   set variant(value: string | string[] | null | undefined) {
     const arr = Array.isArray(value) ? value : value == null ? [] : [value];
     if (!arr.every((v) => typeof v === "string")) {
-      throw new Error("request.variant must be set to a Symbol or an Array of Symbols.");
+      throw new ArgumentError("request.variant must be set to a Symbol or an Array of Symbols.");
     }
     this._variant = new ArrayInquirer<string>(...arr) as ArrayInquirer<string> &
       Record<string, () => boolean>;
@@ -171,8 +178,8 @@ export function hasContentType(this: MimeNegotiationHost): boolean {
 /** Accepted MIME types parsed from `HTTP_ACCEPT`. */
 export function accepts(this: MimeNegotiationHost): MimeType[] {
   return this.fetchHeader("action_dispatch.request.accepts", (k) => {
-    const header = String(this.getHeader("HTTP_ACCEPT") ?? "").trim();
     try {
+      const header = String(this.getHeader("HTTP_ACCEPT") ?? "").trim();
       // Rails: `[content_mime_type]` — array of one element even when nil. The
       // subsequent `validAcceptHeader` gate prevents `accepts` from being used in
       // the all-blank branch, so a `[null]` payload never reaches the formats

--- a/packages/actionpack/src/action-dispatch/http/mime-negotiation.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-negotiation.ts
@@ -153,8 +153,8 @@ const BROWSER_LIKE_ACCEPTS = /,\s*\*\/\*|\*\/\*\s*,/;
 /** The MIME type of the HTTP request (parsed from `CONTENT_TYPE`). */
 export function contentMimeType(this: MimeNegotiationHost): MimeType | null {
   return this.fetchHeader("action_dispatch.request.content_type", (k) => {
-    const match = (this.getHeader("CONTENT_TYPE") as string | undefined)?.match(/^([^,;]*)/);
     try {
+      const match = (this.getHeader("CONTENT_TYPE") as string | undefined)?.match(/^([^,;]*)/);
       const v = match ? MimeType.lookup(match[1].trim().toLowerCase()) : null;
       return this.setHeader(k, v);
     } catch (e) {


### PR DESCRIPTION
> **Rebased onto main.** A sibling PR landed the same `mime-negotiation`
> `fetch_header` convergence and the same four baseline-row deletions
> independently, so that half of this PR is now redundant and has been dropped
> in the rebase — including the two rewritten baseline reasons, where main's
> wording (reached independently, and identical in substance: extractor residue
> from Ruby's reader/writer name collision) is kept over mine. What remains is
> the part no sibling covered.

## Rails fidelity fixes

**`variant=` raises `ArgumentError`.** `mime_negotiation.rb:96` is
`raise ArgumentError, "request.variant must be set to a Symbol or an Array of Symbols."`;
the port threw a plain `Error`, so no caller could distinguish it. Uses the
module-local `ArgumentError` the rest of actionpack already declares
(`permissions-policy.ts:167`).

**The `rescue` in both readers now covers the span Ruby's does.**
`mime_negotiation.rb:24-33` and `:39-53` put the `rescue ::Mime::Type::InvalidMimeType`
inline on the `fetch_header` **block**, so it covers the `get_header` read as well
as the parse. Main's version computes `match` / `header` *before* the `try`, which
leaves that read outside the rescue: a `Mime::Type::InvalidMimeType` raised from
`get_header` would escape as itself instead of being re-raised as `InvalidType`.
Both reads move inside the `try`.

**`ProtectionMethods::Exception` regains `warning_message`.**
`request_forgery_protection.rb:307,314` is `attr_accessor :warning_message` plus
`raise ActionController::InvalidAuthenticityToken, warning_message`; the port
threw a bare `InvalidAuthenticityToken()`, discarding the explanation.

> **Not yet wired to a caller.** The write side is the module-level dispatcher
> `handle_unverified_request` (`request_forgery_protection.rb:401-409`), which does
> `protection_strategy.warning_message = unverified_request_warning_message` before
> dispatching. That method is not ported anywhere in this file — nothing calls the
> three strategies' `handleUnverifiedRequest`, and `unverifiedRequestWarningMessage`
> (`request-forgery-protection.ts:307`) is a free function with no caller into a
> strategy. So `warningMessage` has no production writer yet: this restores the
> Rails accessor and raise site, not an end-to-end fix. The dispatcher is a module
> instance method on implicit `self`, so porting it here would mean spelling it as
> one more free function threading the controller as argument 1 — adding a row of
> exactly the class the follow-up story exists to delete. It has been added to that
> story's scope and acceptance criteria instead.

## Tests

Four added, all in trails-only test files (the Rails-named
`raised exception message explains why it occurred` already exists at
`controller/request-forgery-protection.test.ts:427` and is untouched): the
`fetch_header` caching on both readers, the empty-`CONTENT_TYPE` lookup,
`variant=`'s `ArgumentError`, and `Exception#warning_message` reaching the raised
`InvalidAuthenticityToken`.

## Disposition of the rest of the bundle

Most of what the two stories enumerated has landed already — partly before I
claimed the bundle (siblings #6688, #6691, #6697), partly during it. Of what is
left:

- **Owned by a sibling story.** `relation.ts` (2), `reflection.ts`,
  `test-databases.ts` are the receiver-threading class the story text itself
  hands to `converge-date-time-receiver-threaded-call-args`.
- **Genuinely language-forced, each with a reviewed reason already in place.**
  `digest/uuid.ts` (Ruby passes the digest CLASS; `createHash` selects by OpenSSL
  name), `transliterate.ts` (Ruby skips a middle positional; TS cannot),
  `cache/coder.ts` (`Float::INFINITY` vs `Infinity`), `testing/deprecation.ts` and
  `rack/multipart/parser.ts` (Ruby's `raise Class, msg` and frozen-string `dup`
  have no JS spelling), `i18n/interpolate/ruby.ts` (no `Proc#call`),
  `date-time/calculations.ts` (3 — `Rational()` is a Kernel function, the port's
  is a class).
- **Filed rather than fanned out into sibling PRs**, each with the Rails
  `file:line` and call sites in hand:
  - `0108/request-forgery-protection-this-typed-mixin` — 12 seeded rows. The
    module is ported as ~30 free functions threading the controller as argument 1;
    converging means moving it onto the CLAUDE.md `this`-typed mixin idiom across
    ~63 call sites and two test files, and porting the missing
    `handle_unverified_request` dispatcher.
  - `0108/request-env-by-reference` — `host_authorization.rb:163,167` pass the
    `request` and mutate its env; trails' `Request` COPIES the env it is
    constructed from (`http/request.ts:157`), so a `set_header` on it never reaches
    the app. (RFC 0023's `converge-actiondispatch-request-env-clone-to-rack-shared-env`
    was closed as a duplicate of this one.)

## Verification

- `pnpm parity:api:calls` — OK (1109 baselined, 814 unreviewed, tight)
- `pnpm parity:api:calls:args` — OK (167 baselined shape rows)
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm vitest run packages/actionpack/src/` — 178 files, 3638 passed

Closes-story: converge-remaining-call-arg-shape-rows
Closes-story: converge-surfaced-call-arg-shape-rows
