### PR TITLE
fix(parity): converge loaded_session? onto Session#isLoaded and port Session#inspect

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request/session.trails.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request/session.trails.test.ts
@@ -67,4 +67,25 @@ describe("Session", () => {
     Session.delete(req);
     expect(Session.find(req)).toBeNull();
   });
+
+  it("inspect reports a not yet loaded session without loading it", () => {
+    const req = makeReq();
+    const loadSession = vi.fn(() => [1, {}] as [unknown, Record<string, unknown>]);
+    const store = {
+      loadSession,
+      sessionExists: () => true,
+      deleteSession: () => null,
+      extractSessionId: () => 1,
+    };
+    const session = Session.create(store, req, {});
+
+    expect(session.inspect()).toMatch(
+      /^#<ActionDispatch::Request::Session:0x[0-9a-f]+ not yet loaded>$/,
+    );
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(session.isLoaded()).toBe(false);
+
+    session.get("foo");
+    expect(session.inspect()).toMatch(/^#<ActionDispatch::Request::Session:0x[0-9a-f]+>$/);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
@@ -94,7 +94,7 @@ describe("ActionDispatch::Session::AbstractStore", () => {
         "staleSessionCheckBang",
         "commitSession",
         "prepareSession",
-        "loadedSession",
+        "isLoadedSession",
       ]) {
         expect(typeof proto[name]).toBe("function");
       }
@@ -157,9 +157,9 @@ describe("ActionDispatch::Session::AbstractStore", () => {
     });
   });
 
-  describe("SessionObject.loadedSession", () => {
+  describe("SessionObject.isLoadedSession", () => {
     it("returns true for non-Session inputs", () => {
-      expect(SessionObject.loadedSession.call({}, {})).toBe(true);
+      expect(SessionObject.isLoadedSession.call({}, {})).toBe(true);
     });
   });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
@@ -179,9 +179,8 @@ export const SessionObject = {
     return RequestSession.create(this as any, req, this.defaultOptions);
   },
 
-  loadedSession(this: unknown, session: unknown): boolean {
-    if (!(session instanceof RequestSession)) return true;
-    return (session as unknown as { loaded?: boolean }).loaded === true;
+  isLoadedSession(this: unknown, session: unknown): boolean {
+    return !(session instanceof RequestSession) || session.isLoaded();
   },
 };
 

--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
@@ -43,7 +43,7 @@ describe("ActionDispatch::Session::MemCacheStore", () => {
       "makeRequest", // Compatibility
       "staleSessionCheckBang", // StaleSessionCheck
       "prepareSession", // SessionObject
-      "loadedSession", // SessionObject
+      "isLoadedSession", // SessionObject
       "generateSid", // class-defined override; not the Compatibility hex form
     ];
     for (const name of ownNames) {

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -114,6 +114,24 @@ function classNameOf(value: unknown): string {
   return (value as { constructor?: { name?: string } }).constructor?.name ?? typeof value;
 }
 
+/** Ruby's `self.class` for `Session#inspect`, which prints the Ruby class path. */
+const SESSION_CLASS_NAME = "ActionDispatch::Request::Session";
+
+// Ruby's `object_id` — a per-object identity number JS does not expose, handed
+// out lazily and remembered on a WeakMap. Same shape as `KeyGenerator#inspect`
+// in activesupport, which is the settled trails spelling for `(object_id << 1)`.
+const objectIds = new WeakMap<object, number>();
+let nextObjectId = 1;
+
+function objectIdHex(object: object): string {
+  let id = objectIds.get(object);
+  if (id == null) {
+    id = nextObjectId++;
+    objectIds.set(object, id);
+  }
+  return ((id << 1) >>> 0).toString(16).padStart(14, "0");
+}
+
 export class Session {
   private by: SessionStore | null;
   private req: Req;
@@ -357,6 +375,22 @@ export class Session {
       if (Object.hasOwn(this.delegate, k)) return this.delegate[k];
       if (block) return block(k);
       return defaultValue;
+    }
+  }
+
+  /**
+   * Mirrors: `Session#inspect` (`request/session.rb:222-228`).
+   *
+   * The loaded arm is Ruby's `super`, i.e. `Object#inspect`. JS has no
+   * equivalent that lists instance variables, so it renders the identity form
+   * `#<Class:0x…>` — the same spelling `KeyGenerator#inspect` uses in
+   * activesupport for `(object_id << 1).to_s(16)`.
+   */
+  inspect(): string {
+    if (this.isLoaded()) {
+      return `#<${SESSION_CLASS_NAME}:0x${objectIdHex(this)}>`;
+    } else {
+      return `#<${SESSION_CLASS_NAME}:0x${objectIdHex(this)} not yet loaded>`;
     }
   }
 

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -114,12 +114,12 @@ function classNameOf(value: unknown): string {
   return (value as { constructor?: { name?: string } }).constructor?.name ?? typeof value;
 }
 
-/** Ruby's `self.class` for `Session#inspect`, which prints the Ruby class path. */
-const SESSION_CLASS_NAME = "ActionDispatch::Request::Session";
-
-// Ruby's `object_id` — a per-object identity number JS does not expose, handed
-// out lazily and remembered on a WeakMap. Same shape as `KeyGenerator#inspect`
-// in activesupport, which is the settled trails spelling for `(object_id << 1)`.
+/**
+ * Ruby's `object_id` — a per-object identity number JS does not expose, handed
+ * out lazily and remembered on a WeakMap, shifted and hexed the way
+ * `(object_id << 1).to_s(16)` renders it. Same spelling as
+ * `KeyGenerator#inspect` (`activesupport/src/key-generator.ts:69`).
+ */
 const objectIds = new WeakMap<object, number>();
 let nextObjectId = 1;
 
@@ -388,9 +388,9 @@ export class Session {
    */
   inspect(): string {
     if (this.isLoaded()) {
-      return `#<${SESSION_CLASS_NAME}:0x${objectIdHex(this)}>`;
+      return `#<ActionDispatch::Request::Session:0x${objectIdHex(this)}>`;
     } else {
-      return `#<${SESSION_CLASS_NAME}:0x${objectIdHex(this)} not yet loaded>`;
+      return `#<ActionDispatch::Request::Session:0x${objectIdHex(this)} not yet loaded>`;
     }
   }
 


### PR DESCRIPTION
Two RFC 0106 convergences in the session cluster.

**`SessionObject#loaded_session?`** (`actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:81-83`) was ported as `loadedSession`, reading `Session`'s now-`private` `loaded` field through a cast. It is now `isLoadedSession` (predicate naming per docs/ruby-ts-conventions.md) and calls `session.isLoaded()`, matching `!session.is_a?(Request::Session) || session.loaded?`. Call sites renamed with it.

**`Session#inspect`** (`actionpack/lib/action_dispatch/request/session.rb:222-228`) was the last unported method of the class body after #6695. Both arms ported, at the Rails position between `fetch` and `exists?`. Ruby's `super` (`Object#inspect`) and `(object_id << 1).to_s(16)` have no JS equivalent; the identity form uses the settled trails spelling from `KeyGenerator#inspect` (`packages/activesupport/src/key-generator.ts:69`) — a module-private WeakMap object id. The not-yet-loaded arm is pinned in `session.trails.test.ts` (no counterpart in `session_test.rb`), asserting the store is never loaded.

`parity:api:calls` and `parity:api:calls:args` both OK, no new baseline rows.

Closes-story: converge-abstract-store-loaded-session-predicate
Closes-story: port-request-session-inspect
