### PR TITLE
test(date): port the iso8601/xmlschema/jisx0301 parse pairs, converge two STI/schema deviations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ import railsDeprecatedJsdoc from "./eslint/rails-deprecated-jsdoc.mjs";
 import nieRequiresAnnotation from "./eslint/nie-requires-annotation.mjs";
 import noNativeDate from "./eslint/no-native-date.mjs";
 import noGetterCalledAsMethod from "./eslint/no-getter-called-as-method.mjs";
+import schemaMemoReadThroughGuard from "./eslint/schema-memo-read-through-guard.mjs";
 import asyncQueryingEmpty from "./eslint/async-querying-empty.mjs";
 import sqliteDriverAwait from "./eslint/sqlite-driver-await.mjs";
 import preferAwaitRelation from "./eslint/prefer-await-relation.mjs";
@@ -240,6 +241,7 @@ export default defineConfig(
           "rails-deprecated-jsdoc": railsDeprecatedJsdoc,
           "no-native-date": noNativeDate,
           "no-getter-called-as-method": noGetterCalledAsMethod,
+          "schema-memo-read-through-guard": schemaMemoReadThroughGuard,
           "async-querying-empty": asyncQueryingEmpty,
           "sqlite-driver-await": sqliteDriverAwait,
           "prefer-await-relation": preferAwaitRelation,
@@ -325,6 +327,21 @@ export default defineConfig(
     files: ["packages/*/src/**/*.ts"],
     rules: {
       "blazetrails/no-getter-called-as-method": "error",
+    },
+  },
+
+  // ── schema-memo-read-through-guard ──
+  // trails has no `inherited` hook, so `reloadSchemaFromCache`'s Rails-shaped
+  // recursive push reaches only subclasses that happened to call
+  // `registerSubclass`. The rest are covered by `schemaStaleAgainstAncestors`'s
+  // pull fallback, which is only sound while every read of the memoized schema
+  // state goes through `ownSchemaMemo` / `isSchemaLoaded`. This makes that
+  // invariant enforced rather than hand-verified.
+  {
+    files: ["packages/activerecord/src/*.ts"],
+    ignores: ["packages/activerecord/src/*.test.ts"],
+    rules: {
+      "blazetrails/schema-memo-read-through-guard": "error",
     },
   },
 

--- a/eslint/schema-memo-read-through-guard.mjs
+++ b/eslint/schema-memo-read-through-guard.mjs
@@ -1,0 +1,104 @@
+/**
+ * ESLint rule: schema-memo-read-through-guard
+ *
+ * Rails invalidates schema state by pushing DOWN through DescendantsTracker,
+ * whose registry Ruby's `inherited` hook fills the moment a subclass is defined
+ * (`vendor/rails/activerecord/lib/active_record/model_schema.rb:553-568`). JS
+ * has no `inherited` hook: trails registers a subclass only when
+ * `registerSubclass` is explicitly called, so `reloadSchemaFromCache`'s
+ * recursive push (`model-schema.ts`) reaches only the registered ones.
+ *
+ * The gap is covered by a PULL fallback — `schemaStaleAgainstAncestors`
+ * (`model-schema.ts:74`) walks the prototype chain on every schema-memo read and
+ * answers the memo as `undefined` when an ancestor stamped a newer
+ * `_schemaRevision`. That is only sound while EVERY read of the memoized schema
+ * state routes through `ownSchemaMemo` / `isSchemaLoaded`. Nothing enforced it;
+ * a raw `this._columnsHash` read on a subclass silently serves the ancestor's
+ * stale value (JS statics are inherited, Ruby class ivars are not), which is the
+ * defect this rule makes impossible.
+ *
+ * Scoped to the model-class statics: `packages/activerecord/src/*.ts` (the
+ * directory the invariant was hand-verified over). `SchemaCache`'s unrelated
+ * private `_columnsHash` instance field lives a directory down and is untouched.
+ *
+ * Writes are fine — they are how the memo gets filled and reset. Only reads are
+ * flagged.
+ */
+
+const DEFAULT_MEMOS = [
+  "_schemaLoaded",
+  "_columnsHash",
+  "_columns",
+  "_attributesBuilder",
+  "_virtualAttributesReconciled",
+];
+
+/** `x.y = v`, `x.y += v`, `x.y++`, `delete x.y` — a write, not a read. */
+function isWritePosition(node, parent) {
+  if (!parent) return false;
+  if (parent.type === "AssignmentExpression" && parent.left === node) return true;
+  if (parent.type === "UpdateExpression" && parent.argument === node) return true;
+  if (parent.type === "UnaryExpression" && parent.operator === "delete") return true;
+  return false;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require reads of the memoized model schema state to route through `ownSchemaMemo` / `isSchemaLoaded`.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          memos: { type: "array", items: { type: "string" }, minItems: 1 },
+          allowIn: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      rawRead:
+        'Raw read of `{{name}}`: JS statics are inherited where Ruby class ivars are not, so on a subclass this serves the ancestor\'s memo — stale once an ancestor stamped `_schemaRevision`. Read it through `ownSchemaMemo(host, "{{name}}")` (or `isSchemaLoaded`), which applies the `schemaStaleAgainstAncestors` pull fallback.',
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] ?? {};
+    const memos = new Set(options.memos ?? DEFAULT_MEMOS);
+    // `ownSchemaMemo` and `schemaStaleAgainstAncestors` ARE the guard; their own
+    // reads are the sanctioned ones.
+    const allowIn = new Set(options.allowIn ?? ["ownSchemaMemo", "schemaStaleAgainstAncestors"]);
+
+    /** Name of the nearest enclosing function declaration/expression, if any. */
+    function enclosingFunctionNames(node) {
+      const names = [];
+      for (let n = node.parent; n; n = n.parent) {
+        if (n.type === "FunctionDeclaration" && n.id) names.push(n.id.name);
+        else if (
+          (n.type === "FunctionExpression" || n.type === "ArrowFunctionExpression") &&
+          n.parent?.type === "VariableDeclarator" &&
+          n.parent.id.type === "Identifier"
+        )
+          names.push(n.parent.id.name);
+      }
+      return names;
+    }
+
+    return {
+      MemberExpression(node) {
+        if (node.computed || node.property.type !== "Identifier") return;
+        const name = node.property.name;
+        if (!memos.has(name)) return;
+        if (isWritePosition(node, node.parent)) return;
+        if (enclosingFunctionNames(node).some((n) => allowIn.has(n))) return;
+        context.report({ node, messageId: "rawRead", data: { name } });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/schema-memo-read-through-guard.test.mjs
+++ b/eslint/schema-memo-read-through-guard.test.mjs
@@ -1,0 +1,51 @@
+import { RuleTester } from "eslint";
+import rule from "./schema-memo-read-through-guard.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: (await import("typescript-eslint")).parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("schema-memo-read-through-guard", rule, {
+  valid: [
+    // The guarded reads.
+    'const hash = ownSchemaMemo(host, "_columnsHash");',
+    "if (isSchemaLoaded(this)) return;",
+    // Writes fill and reset the memo — that is not the stale-read hazard.
+    "this._virtualAttributesReconciled = false;",
+    "host._columnsHash = hash;",
+    "delete host._schemaLoaded;",
+    // The guard's own raw reads are the sanctioned ones.
+    "function ownSchemaMemo(host, key) { return host._columnsHash; }",
+    "function schemaStaleAgainstAncestors(host) { return current._columns; }",
+    // An unrelated property name.
+    "const cache = this._schemaCache;",
+    // Computed access cannot be resolved statically.
+    "const v = host[key];",
+  ],
+  invalid: [
+    {
+      code: "const hash = this._columnsHash;",
+      errors: [{ messageId: "rawRead", data: { name: "_columnsHash" } }],
+    },
+    {
+      code: "if (this._schemaLoaded) return;",
+      errors: [{ messageId: "rawRead" }],
+    },
+    {
+      code: "const builder = (this as any)._attributesBuilder;",
+      errors: [{ messageId: "rawRead" }],
+    },
+    {
+      code: "function loadSchema(host) { return host._columns.length; }",
+      errors: [{ messageId: "rawRead" }],
+    },
+    {
+      code: "if (!this._virtualAttributesReconciled) reconcile();",
+      errors: [{ messageId: "rawRead" }],
+    },
+  ],
+});

--- a/packages/activerecord/src/inheritance-sti-new-gate.trails.test.ts
+++ b/packages/activerecord/src/inheritance-sti-new-gate.trails.test.ts
@@ -1,0 +1,32 @@
+/**
+ * trails-only regression test for the `new()` STI dispatch gate in
+ * `subclassFromAttributesForNew`. See inheritance.test.ts for the
+ * Rails-mirrored suite.
+ *
+ * The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
+ * which swallowed an STI *leaf* whose `type` column had not reflected yet and
+ * which tracks no descendants of its own: it built as-is (and then failed as an
+ * unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
+ * (`inheritance.rb:55`, `subclass_from_attributes`) reaches `find_sti_class`
+ * and raises.
+ *
+ * This lives in its own file, and calls no `fixtures()`, because the defect only
+ * exists while reflection is COLD: anything that warms the hierarchy's schema —
+ * including a `fixtures()` hook in an earlier describe of the same file — makes
+ * `classHasAttribute(VerySpecialClient, "type")` true, at which point even the
+ * unpatched gate falls through to the raising resolver and the test passes for
+ * the wrong reason. The precondition is asserted below so a future reordering
+ * trips loudly rather than silently going green.
+ */
+import { describe, it, expect } from "vitest";
+import { SubclassNotFound } from "./errors.js";
+import { classHasAttribute } from "./inheritance.js";
+import { VerySpecialClient } from "./test-helpers/models/company.js";
+
+describe("new() STI dispatch gate", () => {
+  it("raises SubclassNotFound for a bad type on a cold STI leaf", () => {
+    expect(classHasAttribute(VerySpecialClient as never, "type")).toBe(false);
+
+    expect(() => VerySpecialClient.new({ type: "InvalidType" })).toThrow(SubclassNotFound);
+  });
+});

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -4,8 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-fixtures.js";
-import { SubclassNotFound } from "./errors.js";
-import { Client, VerySpecialClient } from "./test-helpers/models/company.js";
+import { Client } from "./test-helpers/models/company.js";
 
 describe("_instantiate STI dispatch", () => {
   fixtures([]);
@@ -19,20 +18,5 @@ describe("_instantiate STI dispatch", () => {
     const record = Client._instantiate({ id: "7", name: "Acme" });
 
     expect(record).toBeInstanceOf(Client);
-  });
-});
-
-/**
- * The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
- * which swallowed an STI *leaf* whose `type` column had not reflected yet and
- * which tracks no descendants of its own: it built as-is (and then failed as an
- * unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
- * (`inheritance.rb:55`, `subclass_from_attributes`) reaches `find_sti_class` and
- * raises. No fixtures/schema load in this describe on purpose — the reflection
- * has to be cold for the leaf to be one.
- */
-describe("new() STI dispatch gate", () => {
-  it("raises SubclassNotFound for a bad type on a cold STI leaf", () => {
-    expect(() => VerySpecialClient.new({ type: "InvalidType" })).toThrow(SubclassNotFound);
   });
 });

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -4,7 +4,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-fixtures.js";
-import { Client } from "./test-helpers/models/company.js";
+import { SubclassNotFound } from "./errors.js";
+import { Client, VerySpecialClient } from "./test-helpers/models/company.js";
 
 describe("_instantiate STI dispatch", () => {
   fixtures([]);
@@ -18,5 +19,18 @@ describe("_instantiate STI dispatch", () => {
     const record = Client._instantiate({ id: "7", name: "Acme" });
 
     expect(record).toBeInstanceOf(Client);
+  });
+});
+
+describe("new() STI dispatch gate", () => {
+  // The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
+  // which swallowed an STI *leaf* whose `type` column had not reflected yet and
+  // which tracks no descendants of its own: it built as-is (and then failed as an
+  // unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
+  // (inheritance.rb:55, subclass_from_attributes) reaches find_sti_class and
+  // raises. No fixtures/schema load here on purpose — the reflection has to be
+  // cold for the leaf to be one.
+  it("raises SubclassNotFound for a bad type on a cold STI leaf", () => {
+    expect(() => VerySpecialClient.new({ type: "InvalidType" })).toThrow(SubclassNotFound);
   });
 });

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -22,14 +22,16 @@ describe("_instantiate STI dispatch", () => {
   });
 });
 
+/**
+ * The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
+ * which swallowed an STI *leaf* whose `type` column had not reflected yet and
+ * which tracks no descendants of its own: it built as-is (and then failed as an
+ * unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
+ * (`inheritance.rb:55`, `subclass_from_attributes`) reaches `find_sti_class` and
+ * raises. No fixtures/schema load in this describe on purpose — the reflection
+ * has to be cold for the leaf to be one.
+ */
 describe("new() STI dispatch gate", () => {
-  // The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
-  // which swallowed an STI *leaf* whose `type` column had not reflected yet and
-  // which tracks no descendants of its own: it built as-is (and then failed as an
-  // unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
-  // (inheritance.rb:55, subclass_from_attributes) reaches find_sti_class and
-  // raises. No fixtures/schema load here on purpose — the reflection has to be
-  // cold for the leaf to be one.
   it("raises SubclassNotFound for a bad type on a cold STI leaf", () => {
     expect(() => VerySpecialClient.new({ type: "InvalidType" })).toThrow(SubclassNotFound);
   });

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -1115,8 +1115,14 @@ function findStiClassForRow(baseClass: typeof Base, typeName: string): typeof Ba
  * each through {@link findStiClassInHierarchy} (registry-safe) instead of
  * Rails' constant-lookup `find_sti_class`. `inheritance_column` now always
  * resolves to a name (default `"type"`), and the dispatch is gated on the
- * column-aware `_has_attribute?` ({@link classHasAttribute}). Returns null (no
- * dispatch) when no source names an inheritance value at all.
+ * column-aware `_has_attribute?` ({@link classHasAttribute}) — or, for a
+ * receiver that is explicitly STI-enabled ({@link stiEnabled}), on that
+ * assignment, which is the same structural fact Rails reads off
+ * `_has_attribute?` and, unlike trails' schema reflection, never goes cold.
+ * Without that arm an STI *leaf* whose `type` column had not reflected yet and
+ * which tracks no descendants of its own built as-is where Rails raises.
+ * Returns null (no dispatch) when no source names an inheritance value at
+ * all.
  *
  * Matching Rails' `subclass_from_attributes` → `find_sti_class`: when an
  * explicitly STI-enabled receiver carries a *present* inheritance value that
@@ -1144,18 +1150,12 @@ export function subclassFromAttributesForNew(
   // reflected DB column) is the primary guard. But trails' schema reflection is
   // not always warm at construction — a canonical STI base like `Company` declares
   // no `attribute("type")` and its `type` column only reflects once the schema
-  // loads — so an explicitly STI-enabled hierarchy or a tracked STI subtree stands in as the
-  // trails-reliable signal that `findStiClassInHierarchy` could resolve. A plain
-  // model with none of the three can never
-  // dispatch (it has no in-subtree match), so short-circuit the source probing —
-  // including the non-memoized columnDefaults build — on the hot path.
+  // loads — so an explicit `stiEnabled` assignment or a tracked STI subtree stands
+  // in as the trails-reliable signal that `findStiClassInHierarchy` could resolve.
+  // A plain model with none of the three can never dispatch (it has no in-subtree
+  // match), so short-circuit the source probing — including the non-memoized
+  // columnDefaults build — on the hot path.
   // `inheritance_column = nil` disables STI even when a real `type` column exists.
-  // An explicitly STI-enabled receiver never short-circuits: `inheritanceColumn`
-  // having been assigned on it or an ancestor ({@link stiEnabled}) is the same
-  // structural fact Rails reads off `_has_attribute?(inheritance_column)`, and it
-  // does not go cold. Without that arm an STI leaf whose `type` column has not
-  // reflected yet and which tracks no descendants of its own — `VerySpecialClient` —
-  // built as-is where Rails raises SubclassNotFound.
   const col = modelClass.inheritanceColumn;
   if (col === null) return null;
   if (

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -1144,14 +1144,26 @@ export function subclassFromAttributesForNew(
   // reflected DB column) is the primary guard. But trails' schema reflection is
   // not always warm at construction — a canonical STI base like `Company` declares
   // no `attribute("type")` and its `type` column only reflects once the schema
-  // loads — so a tracked STI subtree stands in as the trails-reliable signal that
-  // `findStiClassInHierarchy` could resolve. A plain model with neither can never
+  // loads — so an explicitly STI-enabled hierarchy or a tracked STI subtree stands in as the
+  // trails-reliable signal that `findStiClassInHierarchy` could resolve. A plain
+  // model with none of the three can never
   // dispatch (it has no in-subtree match), so short-circuit the source probing —
   // including the non-memoized columnDefaults build — on the hot path.
   // `inheritance_column = nil` disables STI even when a real `type` column exists.
+  // An explicitly STI-enabled receiver never short-circuits: `inheritanceColumn`
+  // having been assigned on it or an ancestor ({@link stiEnabled}) is the same
+  // structural fact Rails reads off `_has_attribute?(inheritance_column)`, and it
+  // does not go cold. Without that arm an STI leaf whose `type` column has not
+  // reflected yet and which tracks no descendants of its own — `VerySpecialClient` —
+  // built as-is where Rails raises SubclassNotFound.
   const col = modelClass.inheritanceColumn;
   if (col === null) return null;
-  if (!classHasAttribute(modelClass, col) && descendants(modelClass).length === 0) return null;
+  if (
+    !classHasAttribute(modelClass, col) &&
+    !stiEnabled(modelClass) &&
+    descendants(modelClass).length === 0
+  )
+    return null;
 
   const resolve = (source: unknown, fromScope = false): typeof Base | null => {
     if (!source || typeof source !== "object") return null;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -762,8 +762,9 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
     }
   }
 
-  this._attributesBuilder = new AttributeSetBuilder(attributeTypes, defaults);
-  return this._attributesBuilder;
+  const builder = new AttributeSetBuilder(attributeTypes, defaults);
+  this._attributesBuilder = builder;
+  return builder;
 }
 
 /**
@@ -772,8 +773,9 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
 export function columns(this: SchemaHost): any[] {
   const ownColumns = ownSchemaMemo(this, "_columns");
   if (ownColumns != null) return ownColumns;
-  this._columns = Object.values(columnsHash.call(this as unknown as typeof Base));
-  return this._columns;
+  const built = Object.values(columnsHash.call(this as unknown as typeof Base));
+  this._columns = built;
+  return built;
 }
 
 /**

--- a/packages/date/src/test-date-parse.test.ts
+++ b/packages/date/src/test-date-parse.test.ts
@@ -328,6 +328,120 @@ describe("TestDateParse", () => {
     expect(rescueArgumentError(() => DateTime.parse("")) instanceof Date.Error).toBeTruthy();
   });
 
+  it(" iso8601", () => {
+    let h = Date._iso8601("01-02-03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("2001-02-03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("--02-03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([null, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("---03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([null, null, 3, 4, 5, 6, 0]);
+
+    h = Date._iso8601("2001-02-03T04:05");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, null, null]);
+    h = Date._iso8601("2001-02-03T04:05:06");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("2001-02-03T04:05:06,07");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("2001-02-03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("2001-02-03T04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+    h = Date._iso8601("2001-02");
+    expect(valuesAt(h, "year", "mon")).toEqual([2001, 2]);
+
+    h = Date._iso8601("010203T040506Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("20010203T040506Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("--0203T040506Z");
+    expect(ymdhms(h)).toEqual([null, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("---03T040506Z");
+    expect(ymdhms(h)).toEqual([null, null, 3, 4, 5, 6, 0]);
+
+    h = Date._iso8601("010203T0405");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, null, null]);
+    h = Date._iso8601("20010203T0405");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, null, null]);
+    h = Date._iso8601("20010203T040506");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("20010203T040506,07");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("20010203T040506Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("20010203T040506.07+0100");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._iso8601("200102030405");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, null, null]);
+    h = Date._iso8601("20010203040506");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("20010203040506,07");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._iso8601("20010203040506Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("20010203040506.07+0100");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._iso8601("01-023T04:05:06Z");
+    expect(ydhms(h)).toEqual([2001, 23, 4, 5, 6, 0]);
+    h = Date._iso8601("2001-023T04:05:06Z");
+    expect(ydhms(h)).toEqual([2001, 23, 4, 5, 6, 0]);
+    h = Date._iso8601("-023T04:05:06Z");
+    expect(ydhms(h)).toEqual([null, 23, 4, 5, 6, 0]);
+
+    h = Date._iso8601("01023T040506Z");
+    expect(ydhms(h)).toEqual([2001, 23, 4, 5, 6, 0]);
+    h = Date._iso8601("2001023T040506Z");
+    expect(ydhms(h)).toEqual([2001, 23, 4, 5, 6, 0]);
+    h = Date._iso8601("-023T040506Z");
+    expect(ydhms(h)).toEqual([null, 23, 4, 5, 6, 0]);
+
+    h = Date._iso8601("01-w02-3T04:05:06Z");
+    expect(cwhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("2001-w02-3T04:05:06Z");
+    expect(cwhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("-w02-3T04:05:06Z");
+    expect(cwhms(h)).toEqual([null, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("-w-3T04:05:06Z");
+    expect(cwhms(h)).toEqual([null, null, 3, 4, 5, 6, 0]);
+
+    h = Date._iso8601("01w023T040506Z");
+    expect(cwhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("2001w023T040506Z");
+    expect(cwhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("-w023T040506Z");
+    expect(cwhms(h)).toEqual([null, 2, 3, 4, 5, 6, 0]);
+    h = Date._iso8601("-w-3T040506Z");
+    expect(cwhms(h)).toEqual([null, null, 3, 4, 5, 6, 0]);
+
+    h = Date._iso8601("04:05");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, null, null]);
+    h = Date._iso8601("04:05:06");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, null]);
+    h = Date._iso8601("04:05:06,07");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, null]);
+    h = Date._iso8601("04:05:06Z");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, 0]);
+    h = Date._iso8601("04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, 3600]);
+
+    h = Date._iso8601("040506,07");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, null]);
+    h = Date._iso8601("040506.07+0100");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, 3600]);
+
+    h = Date._iso8601("");
+    expect(h).toEqual({});
+
+    h = Date._iso8601(null as unknown as string);
+    expect(h).toEqual({});
+
+    // See ` rfc2822` below for why the Ruby Symbol is spelled as a non-string.
+    expect(() => Date._iso8601(1 as unknown as string)).toThrow(TypeError);
+  });
+
   it(" rfc3339", () => {
     let h = Date._rfc3339("2001-02-03T04:05:06Z");
     expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
@@ -344,6 +458,71 @@ describe("TestDateParse", () => {
 
     // See ` rfc2822` below for why the Ruby Symbol is spelled as a non-string.
     expect(() => Date._rfc3339(1 as unknown as string)).toThrow(TypeError);
+  });
+
+  it(" xmlschema", () => {
+    let h = Date._xmlschema("2001-02-03");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, null, null, null, null]);
+    h = Date._xmlschema("2001-02-03Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, null, null, null, 0]);
+    h = Date._xmlschema("2001-02-03+01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, null, null, null, 3600]);
+
+    h = Date._xmlschema("2001-02-03T04:05:06");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._xmlschema("2001-02-03T04:05:06.07");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._xmlschema("2001-02-03T04:05:06.07Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._xmlschema("2001-02-03T04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._xmlschema("04:05:06");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, null]);
+    h = Date._xmlschema("04:05:06Z");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, 0]);
+    h = Date._xmlschema("04:05:06+01:00");
+    expect(ymdhms(h)).toEqual([null, null, null, 4, 5, 6, 3600]);
+
+    h = Date._xmlschema("2001-02");
+    expect(ymdhms(h)).toEqual([2001, 2, null, null, null, null, null]);
+    h = Date._xmlschema("2001-02Z");
+    expect(ymdhms(h)).toEqual([2001, 2, null, null, null, null, 0]);
+    h = Date._xmlschema("2001-02+01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, null, null, null, null, 3600]);
+    h = Date._xmlschema("2001-02-01:00");
+    expect(ymdhms(h)).toEqual([2001, 2, null, null, null, null, -3600]);
+
+    h = Date._xmlschema("2001");
+    expect(ymdhms(h)).toEqual([2001, null, null, null, null, null, null]);
+    h = Date._xmlschema("2001Z");
+    expect(ymdhms(h)).toEqual([2001, null, null, null, null, null, 0]);
+    h = Date._xmlschema("2001+01:00");
+    expect(ymdhms(h)).toEqual([2001, null, null, null, null, null, 3600]);
+    h = Date._xmlschema("2001-01:00");
+    expect(ymdhms(h)).toEqual([2001, null, null, null, null, null, -3600]);
+
+    h = Date._xmlschema("--02");
+    expect(ymdhms(h)).toEqual([null, 2, null, null, null, null, null]);
+    h = Date._xmlschema("--02Z");
+    expect(ymdhms(h)).toEqual([null, 2, null, null, null, null, 0]);
+    h = Date._xmlschema("--02+01:00");
+    expect(ymdhms(h)).toEqual([null, 2, null, null, null, null, 3600]);
+
+    h = Date._xmlschema("92001-02-03T04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([92001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._xmlschema("-92001-02-03T04:05:06.07+01:00");
+    expect(ymdhms(h)).toEqual([-92001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._xmlschema("");
+    expect(h).toEqual({});
+
+    h = Date._xmlschema(null as unknown as string);
+    expect(h).toEqual({});
+
+    // See ` rfc2822` below for why the Ruby Symbol is spelled as a non-string.
+    expect(() => Date._xmlschema(1 as unknown as string)).toThrow(TypeError);
   });
 
   it(" rfc2822", () => {
@@ -402,6 +581,79 @@ describe("TestDateParse", () => {
     expect(() => Date._httpdate(1 as unknown as string)).toThrow(TypeError);
   });
 
+  it(" jisx0301", () => {
+    let h = Date._jisx0301("13.02.03");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, null, null, null, null]);
+    h = Date._jisx0301("H13.02.03");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, null, null, null, null]);
+    h = Date._jisx0301("S63.02.03");
+    expect(ymdhms(h)).toEqual([1988, 2, 3, null, null, null, null]);
+    h = Date._jisx0301("H31.04.30");
+    expect(ymdhms(h)).toEqual([2019, 4, 30, null, null, null, null]);
+    h = Date._jisx0301("H31.05.01");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, null, null, null, null]);
+    h = Date._jisx0301("R01.05.01");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, null, null, null, null]);
+
+    h = Date._jisx0301("H13.02.03T04:05:06");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._jisx0301("H13.02.03T04:05:06,07");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, null]);
+    h = Date._jisx0301("H13.02.03T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 0]);
+    h = Date._jisx0301("H13.02.03T04:05:06.07+0100");
+    expect(ymdhms(h)).toEqual([2001, 2, 3, 4, 5, 6, 3600]);
+
+    h = Date._jisx0301("H31.04.30T04:05:06");
+    expect(ymdhms(h)).toEqual([2019, 4, 30, 4, 5, 6, null]);
+    h = Date._jisx0301("H31.04.30T04:05:06,07");
+    expect(ymdhms(h)).toEqual([2019, 4, 30, 4, 5, 6, null]);
+    h = Date._jisx0301("H31.04.30T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2019, 4, 30, 4, 5, 6, 0]);
+    h = Date._jisx0301("H31.04.30T04:05:06.07+0100");
+    expect(ymdhms(h)).toEqual([2019, 4, 30, 4, 5, 6, 3600]);
+
+    h = Date._jisx0301("H31.05.01T04:05:06");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, null]);
+    h = Date._jisx0301("H31.05.01T04:05:06,07");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, null]);
+    h = Date._jisx0301("H31.05.01T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, 0]);
+    h = Date._jisx0301("H31.05.01T04:05:06.07+0100");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, 3600]);
+
+    h = Date._jisx0301("R01.05.01T04:05:06");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, null]);
+    h = Date._jisx0301("R01.05.01T04:05:06,07");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, null]);
+    h = Date._jisx0301("R01.05.01T04:05:06Z");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, 0]);
+    h = Date._jisx0301("R01.05.01T04:05:06.07+0100");
+    expect(ymdhms(h)).toEqual([2019, 5, 1, 4, 5, 6, 3600]);
+
+    h = Date._jisx0301("");
+    expect(h).toEqual({});
+
+    h = Date._jisx0301(null as unknown as string);
+    expect(h).toEqual({});
+
+    // See ` rfc2822` above for why the Ruby Symbol is spelled as a non-string.
+    expect(() => Date._jisx0301(1 as unknown as string)).toThrow(TypeError);
+  });
+
+  it("iso8601", () => {
+    expect(Date.iso8601()).toBeInstanceOf(Temporal.PlainDate);
+    expect(DateTime.iso8601()).toBeInstanceOf(Temporal.PlainDateTime);
+
+    const d = Date.iso8601("2001-02-03", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2001, 2, 3))).toBe(true);
+    expect(startOf(Date._iso8601("2001-02-03"))).toBe(Date.ITALY + 10);
+
+    const dt = DateTime.iso8601("2001-02-03T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._iso8601("2001-02-03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+  });
+
   it("rfc3339", () => {
     expect(Date.rfc3339()).toBeInstanceOf(Temporal.PlainDate);
     expect(DateTime.rfc3339()).toBeInstanceOf(Temporal.PlainDateTime);
@@ -413,6 +665,19 @@ describe("TestDateParse", () => {
     const dt = DateTime.rfc3339("2001-02-03T04:05:06+07:00", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
     expect(dtStartOf(Date._rfc3339("2001-02-03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+  });
+
+  it("xmlschema", () => {
+    expect(Date.xmlschema()).toBeInstanceOf(Temporal.PlainDate);
+    expect(DateTime.xmlschema()).toBeInstanceOf(Temporal.PlainDateTime);
+
+    const d = Date.xmlschema("2001-02-03", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2001, 2, 3))).toBe(true);
+    expect(startOf(Date._xmlschema("2001-02-03"))).toBe(Date.ITALY + 10);
+
+    const dt = DateTime.xmlschema("2001-02-03T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._xmlschema("2001-02-03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
   });
 
   it("rfc2822", () => {
@@ -447,6 +712,92 @@ describe("TestDateParse", () => {
     const dt = DateTime.httpdate("Sat, 03 Feb 2001 04:05:06 GMT", Date.ITALY + 10);
     expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+00:00").toDatetime())).toBe(true);
     expect(dtStartOf(Date._httpdate("Sat, 03 Feb 2001 04:05:06 GMT"))).toBe(Date.ITALY + 10);
+  });
+
+  it("jisx0301", () => {
+    expect(Date.jisx0301()).toBeInstanceOf(Temporal.PlainDate);
+    expect(DateTime.jisx0301()).toBeInstanceOf(Temporal.PlainDateTime);
+
+    let d = Date.jisx0301("H13.02.03", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2001, 2, 3))).toBe(true);
+    expect(startOf(Date._jisx0301("H13.02.03"))).toBe(Date.ITALY + 10);
+
+    d = Date.jisx0301("H31.04.30", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2019, 4, 30))).toBe(true);
+    expect(startOf(Date._jisx0301("H31.04.30"))).toBe(Date.ITALY + 10);
+
+    d = Date.jisx0301("H31.05.01", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2019, 5, 1))).toBe(true);
+    expect(startOf(Date._jisx0301("H31.05.01"))).toBe(Date.ITALY + 10);
+
+    d = Date.jisx0301("R01.05.01", Date.ITALY + 10);
+    expect(d.equals(Date.civil(2019, 5, 1))).toBe(true);
+    expect(startOf(Date._jisx0301("R01.05.01"))).toBe(Date.ITALY + 10);
+
+    let dt = DateTime.jisx0301("H13.02.03T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2001, 2, 3, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._jisx0301("H13.02.03T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+
+    dt = DateTime.jisx0301("H31.04.30T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2019, 4, 30, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._jisx0301("H31.04.30T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+
+    dt = DateTime.jisx0301("H31.05.01T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2019, 5, 1, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._jisx0301("H31.05.01T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+
+    dt = DateTime.jisx0301("R01.05.01T04:05:06+07:00", Date.ITALY + 10);
+    expect(dt.equals(new DateTime(2019, 5, 1, 4, 5, 6, "+07:00").toDatetime())).toBe(true);
+    expect(dtStartOf(Date._jisx0301("R01.05.01T04:05:06+07:00"))).toBe(Date.ITALY + 10);
+  });
+
+  /**
+   * Ruby also asserts the argument came back unmutated (`assert_equal(s0, s)`)
+   * after each parse; a JS string is immutable, so those arms read the same
+   * assertion against the untouched local.
+   */
+  it("given string", () => {
+    let s = "2001-02-03T04:05:06Z";
+    let s0 = s;
+
+    expect(Date._parse(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    expect(Date._iso8601(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    expect(Date._rfc3339(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    expect(Date._xmlschema(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    s = "Sat, 3 Feb 2001 04:05:06 UT";
+    s0 = s;
+    expect(Date._rfc2822(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+    expect(Date._rfc822(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    s = "Sat, 03 Feb 2001 04:05:06 GMT";
+    s0 = s;
+    expect(Date._httpdate(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    s = "H13.02.03T04:05:06,07Z";
+    s0 = s;
+    expect(Date._jisx0301(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    s = "H31.04.30T04:05:06,07Z";
+    s0 = s;
+    expect(Date._jisx0301(s)).not.toEqual({});
+    expect(s).toEqual(s0);
+
+    s = "H31.05.01T04:05:06,07Z";
+    s0 = s;
+    expect(Date._jisx0301(s)).not.toEqual({});
+    expect(s).toEqual(s0);
   });
 
   /**
@@ -523,6 +874,16 @@ function startOf(h: DateParts): number {
 /** {@link startOf}, for the `DateTime` arms. */
 function dtStartOf(h: DateParts): number {
   return dtNewByFrags(h, Date.ITALY + 10).start;
+}
+
+/** Ruby `h.values_at(:year, :yday, :hour, :min, :sec, :offset)`. */
+function ydhms(h: DateParts): unknown[] {
+  return valuesAt(h, "year", "yday", "hour", "min", "sec", "offset");
+}
+
+/** Ruby `h.values_at(:cwyear, :cweek, :cwday, :hour, :min, :sec, :offset)`. */
+function cwhms(h: DateParts): unknown[] {
+  return valuesAt(h, "cwyear", "cweek", "cwday", "hour", "min", "sec", "offset");
 }
 
 /** Ruby `h.values_at(:hour, :min, :sec, :sec_fraction)`. */


### PR DESCRIPTION
Four bundled stories.

### 1. `port-test-date-parse-formats-iso8601-tests`

Ports the remaining format-specific parse tests from
`vendor/date/test/date/test_date_parse.rb` into
`packages/date/src/test-date-parse.test.ts`, in `test__X` / `test_X` **pairs**
so `normPath` pairs each `it` with the right Rails test rather than greedily
matching the 49-assertion `test__iso8601` against the 6-assertion
`it("iso8601")`:

- `test__iso8601` (`:714-871`) / `test_iso8601` (`:1123-1134`)
- `test__xmlschema` (`:893-978`) / `test_xmlschema` (`:1149-1160`)
- `test__jisx0301` (`:1042-1121`) / `test_jisx0301` (`:1196-1231`)
- `test_given_string` (`:1233-1275`)

`test_date_parse.rb` goes 17/26 → **23/26**. The story's "26/26" is not
reachable here: the three still-missing tests are `test__parse`'s table,
`test_parse__comp` (`DateTime.now`) and `test_parse__d_to_s` (`DateTime#to_s`),
each needing a reader this package has not ported — the same three the test
file's header already documents. `pnpm parity:test:assertions --package date`
is green.

Ruby's `assert_raise(TypeError) { Date._iso8601(str.to_sym) }` has no port: a
Ruby Symbol is a JS string (CLAUDE.md), so the non-String argument is spelled as
the ported `rfc2822`/`rfc3339` tests already spell it.

### 2. `sti-new-cold-leaf-gate-raise-subclass-not-found`

`subclassFromAttributesForNew`'s gate short-circuited on
`!classHasAttribute(modelClass, col) && descendants(modelClass).length === 0`,
which swallowed an STI **leaf** whose `type` column had not reflected yet and
which tracks no descendants of its own. Measured on `VerySpecialClient`:
`VerySpecialClient.new({ type: "InvalidType" })` raised
`UnknownAttributeError`, where Rails' `_has_attribute?(inheritance_column)` gate
(`inheritance.rb:55` → `subclass_from_attributes` → `find_sti_class`) reaches
the resolver and raises `SubclassNotFound`.

The gate now also holds out an explicitly STI-enabled receiver: `stiEnabled` —
`inheritanceColumn` having been assigned on the class or an ancestor — is the
same structural fact Rails reads off `_has_attribute?`, and unlike schema
reflection it does not go cold. Non-STI models that merely reflect a `type`
column are untouched and keep degrading to build-as-is (the documented graceful
deviation: trails has no autoloader to tell an unloaded-but-valid subclass from
a bad type).

Regression test in its own file, `inheritance-sti-new-gate.trails.test.ts`,
which calls no `fixtures()`: the defect only exists while reflection is COLD,
and anything that warms the hierarchy's schema — including a `fixtures()` hook
in an earlier describe of the same file — makes `classHasAttribute` true, at
which point even the unpatched gate falls through to the raising resolver and
the test passes for the wrong reason. The cold-schema precondition is asserted
explicitly so a future reordering trips loudly. Verified failing on baseline
`inheritance.ts` in that isolated file (`expected error to be instance of
SubclassNotFound`).

### 3. `sti-schema-stale-invariant-unenforced`

Takes the **enforce** branch of the story's choice. `schemaStaleAgainstAncestors`'s
pull fallback is only sound while every read of `_schemaLoaded` / `_columnsHash`
/ `_columns` / `_attributesBuilder` / `_virtualAttributesReconciled` routes
through `ownSchemaMemo` / `isSchemaLoaded` — verified by hand at PR #5199, with
nothing keeping it true. New eslint rule
`blazetrails/schema-memo-read-through-guard` flags raw reads of those five
across `packages/activerecord/src/*.ts` (the directory the invariant was
verified over; `SchemaCache`'s unrelated private `_columnsHash` instance field
is a directory down and out of scope). Writes are fine — they are how the memo
gets filled and reset.

The eager-registration alternative was not taken: JS has no `inherited` hook, so
eager registration would need a `Base` static-init path that runs per subclass
definition, which nothing in the object model provides without a decorator or an
explicit call — the same reason `registerSubclass` is lazy today.

Turning the rule on surfaced two real read-back-what-was-just-written reads in
`model-schema.ts` (`attributesBuilder`, `columns`); both are now a local, which
is closer to Rails' single-expression `@columns ||= …` anyway.

### 4. `measure-adapter-specific-arm-saving-across-lanes`

Nothing shipped — the honest outcome is the recorded measurement, per the
story's own "Converged shape". Method and full numbers are appended to the story
file in the tasks repo. Taken from **outside** a single boot (a
`performance.now()` pair around the fast-path arm plus a memo-forced-off
comparison run, both reverted); the reverted `3be2d49c7` in-boot-bit shape was
not re-attempted.

| lane          | memo on | memo off | saving/boot | extrapolated/run |
| ------------- | ------- | -------- | ----------- | ---------------- |
| sqlite (file) | 0.0 ms  | 20.5 ms  | 20.5 ms     | ~16 s            |
| `sqlite3_mem` | no boot takes the fast path at all | — | n/a | n/a |
| PostgreSQL 17 | 0.0 ms  | 174.7 ms | 174.7 ms    | ~2.3 min         |
| MariaDB       | not measured — no MariaDB/MySQL server on this host | | | |

- #6121's "sqlite ~0 ms for the arm" is **corrected**: it is ~20 ms per boot,
  ~16 s per full run. Small next to the server lanes, but not zero.
- #6121's "~2.5 min per run" **holds in order of magnitude**, measured on PG
  (~2.3 min) rather than MariaDB.
- New finding: **`sqlite3_mem` has no fast path to save on.** Each worker's
  `:memory:` database is fresh, so `canonicalSchemaUpToDate` is false on every
  boot and the full-load arm runs unconditionally. The memo is structurally
  inapplicable there.

`move-adapter-specific-snapshot-off-ar-internal-metadata`'s AC4 is closed by the
three measured lanes. The MariaDB lane is filed as
`measure-adapter-specific-arm-saving-on-mariadb` (RFC 0051), which carries the
method verbatim so it is a single re-run on a host that has the server.

Closes-story: port-test-date-parse-formats-iso8601-tests
Closes-story: sti-schema-stale-invariant-unenforced
Closes-story: measure-adapter-specific-arm-saving-across-lanes
Closes-story: sti-new-cold-leaf-gate-raise-subclass-not-found