### PR TITLE
fix(activerecord): converge the ignored-columns reload test onto the canonical Developer

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1603,17 +1603,12 @@ describe("BasicsTest", () => {
     expect(User.ignoredColumns).toEqual(["col1", "col2"]);
   });
   it("when #reload called, ignored columns' attribute methods are not defined", async () => {
-    class User extends Base {
-      static {
-        this.attribute("name", "string");
-        this.attribute("secret", "string");
-        this.ignoredColumns = ["secret"];
-      }
-    }
-    const u = await User.create({ name: "test" });
-    await u.reload();
-    expect(User.columnNames()).not.toContain("secret");
-    expect("secret" in u).toBe(false);
+    const developer = await CanonicalDeveloper.create({ name: "Developer" });
+    expect("first_name" in developer).toBe(false);
+
+    await developer.reload();
+
+    expect("first_name" in developer).toBe(false);
   });
   it("when ignored attribute is loaded, cast type should be preferred over DB type", async () => {
     const developer = await AttributedDeveloper.create();

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -416,10 +416,10 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     await dev.updateColumn("name", "name");
     await dev.reload();
     // A declared attribute IS in `types`, so an unprojected slot takes
-    // `default_attribute`'s `types.key?` arm and dups the initialized default
-    // (attribute_set/builder.rb:82-87, `Attribute::Null#with_type` →
-    // `with_cast_value`, attribute.rb:231-233) rather than landing on
-    // `Attribute.null`. Only a plain ignored column (the case above) drops out.
+    // `default_attribute`'s `types.key?` arm, which ASSIGNS `@attributes[name]`
+    // (attribute_set/builder.rb:82-87) — the `else` arm's `Attribute.null` is
+    // returned but never assigned, which is why only a plain ignored column
+    // (the case above) drops out of the set.
     expect("name" in dev).toBe(true);
   });
 });

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -410,13 +410,16 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     );
   });
 
-  it("a declared-then-ignored column not projected does not respond after reload", async () => {
+  it("a declared-then-ignored column not projected keeps its declared slot after reload", async () => {
     const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
     const dev = await AttributedDeveloper.create();
     await dev.updateColumn("name", "name");
     await dev.reload();
-    // reload's default select omits the ignored column, so its declared slot
-    // narrows to uninitialized — Rails' key? is false, no accessor responds.
-    expect("name" in dev).toBe(false);
+    // A declared attribute IS in `types`, so an unprojected slot takes
+    // `default_attribute`'s `types.key?` arm and dups the initialized default
+    // (attribute_set/builder.rb:82-87, `Attribute::Null#with_type` →
+    // `with_cast_value`, attribute.rb:231-233) rather than landing on
+    // `Attribute.null`. Only a plain ignored column (the case above) drops out.
+    expect("name" in dev).toBe(true);
   });
 });

--- a/packages/activerecord/src/dynamic-matchers.ts
+++ b/packages/activerecord/src/dynamic-matchers.ts
@@ -5,7 +5,7 @@
 
 /** Host shape `respondToMissing` reads off the model class. */
 interface DynamicMatchersHost {
-  _attributeDefinitions: Map<string, unknown>;
+  columnsHash(): Record<string, unknown>;
   _attributeAliases?: Record<string, string>;
 }
 
@@ -27,8 +27,9 @@ export function respondToMissing(this: DynamicMatchersHost, methodName: string):
   // Split on "_and_" like Rails' Method#attribute_names
   const attributeNames = snakePart.split("_and_");
   const aliases = this._attributeAliases;
+  const columnsHash = this.columnsHash();
   return attributeNames.every((name) => {
     const resolved = aliases?.[name] ?? name;
-    return this._attributeDefinitions.has(resolved);
+    return columnsHash[resolved] != null;
   });
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -567,25 +567,6 @@ export function narrowToProjectedColumns(
   const pkSet = new Set(Array.isArray(pk) ? pk : pk != null ? [pk] : []);
   const rowKeys = new Set(Object.keys(row));
   const narrowable = klass.columnNames().filter((c) => !pkSet.has(c) && !rowKeys.has(c));
-  // An ignored column is dropped from columnNames(), so a `new` record's seeded
-  // default for a still-declared-and-ignored attribute (Rails' AttributedDeveloper
-  // `name`) would otherwise survive narrowing as an initialized value.
-  //
-  // Rails does NOT leave such a slot uninitialized, contrary to what this
-  // comment used to claim: a defaultless `attribute` records only a PendingType,
-  // and `Attribute::Null#with_type` → `with_cast_value(name, nil, type)`
-  // (attribute.rb:231-233) is initialized; a load that skips the column then
-  // dups that default via `default_attribute`'s `types.key?` arm
-  // (attribute_set/builder.rb:81-85). Rails' own test is narrower — an ignored
-  // REAL column (`Developer#first_name`, base_test.rb:1825-1834) is not in
-  // `types`, lands on `Attribute.null`, and stays out of `@attributes`. The
-  // narrowing is kept for the trails-only shape base.test.ts pins (a column both
-  // declared and ignored); an ignored column present in a raw `SELECT *` row (in
-  // rowKeys) is untouched and keeps its loaded value.
-  const ignoredColumns = (klass as unknown as { _ignoredColumns?: string[] })._ignoredColumns ?? [];
-  for (const c of ignoredColumns) {
-    if (!pkSet.has(c) && !rowKeys.has(c)) narrowable.push(c);
-  }
   // Hot path: a full SELECT projects every column, so there is nothing to
   // narrow — skip the attribute-set scan entirely.
   if (narrowable.length === 0) return;

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -127,10 +127,11 @@ export class ClassMethods {
     (this as any)._lockingColumn = column == null ? "" : String(column);
   }
 
-  /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled? */
+  /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled? (optimistic.rb:160-162)
+   *  — `lock_optimistically && columns_hash[locking_column]`. */
   static get lockingEnabled(): boolean {
     const self = this as unknown as typeof Base;
-    return self.lockOptimistically && self._attributeDefinitions.has(self.lockingColumn);
+    return self.lockOptimistically && self.columnsHash()[self.lockingColumn] != null;
   }
 
   /** Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically */


### PR DESCRIPTION
Ports `base_test.rb:1825-1834` faithfully: the trails test declared a bespoke
local `class User extends Base` with a column both `attribute()`-declared and
`ignoredColumns`-ignored — a shape Rails' test never exercises. It now uses the
canonical `Developer` and its real ignored columns (`first_name`, `last_name`),
which is what Rails asserts against.

With no test depending on the declared-and-ignored shape, the trails-only
`_ignoredColumns` narrowing loop in `narrowToProjectedColumns`
(`inheritance.ts`) and its comment are deleted; the `columnNames()`-derived
`narrowable` list is what Rails' behaviour needs.

Also converges two leaf `_attributeDefinitions` membership readers onto the
Rails spelling, both `columns_hash` lookups in Ruby:

- `locking_enabled?` → `lock_optimistically && columns_hash[locking_column]`
  (`locking/optimistic.rb:160-162`)
- `DynamicMatchers::Method#valid?` → `model.columns_hash[name]`
  (`dynamic_matchers.rb:57-59`)

## Bundle disposition

- `converge-ignored-columns-reload-test-onto-canonical-developer` — closed here.
- `sweep-includes-preload-call-sites-onto-the-colon-symbol-spelling` — **blocked**
  on PR #6704 (the joins sweep), still open. The `joinedIncludesValues`
  colon-stripping normalization this story deletes exists only on that branch,
  and sweeping the ~470 `includes`/`preload` call sites here would conflict with
  it wholesale.
- `converge-attribute-definitions-onto-default-attributes` — **released**. The
  reader inventory is 132 non-test references across 26 source files, plus 48
  references to the `_schemaRevision` / `ownSchemaMemo` machinery that hangs off
  it; it does not fit one PR. The leaf-reader slice is filed as
  `converge-attribute-definitions-leaf-membership-readers` (RFC 0078), which
  records what landed here and the two readers left, including the measured
  reason a naive `attributeTypes()` swap in `pluckCastTypeForKnownColumn` reds
  `calculations.test.ts`.

Local: `base.test.ts`, `inheritance*.test.ts`, `attributes.test.ts`,
`model-schema.test.ts`, `normalized-attribute.trails.test.ts`, `locking*`,
`finder*`, `calculations.test.ts`, `relations.test.ts` green.
`parity:api:calls` and `:args` OK; `parity:test` unchanged.

Closes-story: converge-ignored-columns-reload-test-onto-canonical-developer

## Review follow-up

**Assertion count (Rails asserts `:first_name` and `:first_name=`, the port
checks `"first_name" in developer`).** The pairing invariant the reviewer asked
to see confirmed holds by construction: `defineAttributeMethod`
(`attribute-methods.ts:440-467`) builds ONE `PropertyDescriptor` for the
attribute name and installs its `get` and `set` halves in a single
`Object.defineProperty(proto, name, newDesc)` — the setter cannot exist without
the getter because they are two halves of the same JS property, and the alias
path (`:325-340`) does the same. A Ruby writer `first_name=` is that property's
`set` half, not a separately-named member, so there is no second name to probe:
`"first_name" in developer` is exactly the conjunction of Rails'
`assert_not_respond_to :first_name` and `assert_not_respond_to :first_name=`.
Spelling it as two identical `in` checks would add an assertion without adding
coverage.
