### PR TITLE
feat(date): port test__different_format and the instance formatters it needs

### DIFF
--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -72,9 +72,6 @@ export const FactoryMethods: FactoryMethodsModule = {
   },
 
   createStringJoin(to: string | Node): StringJoin {
-    // Ruby's StringJoin visitor renders a bare String `to` directly; TS needs
-    // the SqlLiteral wrapper for the node to reach the visitor at all.
-    if (typeof to === "string") to = new SqlLiteral(to);
     return this.createJoin(to, null, StringJoin) as StringJoin;
   },
 

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4420,6 +4420,16 @@ function encodeYear(nth: bigint, y: number, style: number): number | bigint {
  * MRI narrows it. Ruby's `RangeError` is JS's, and the message is MRI's own
  * (`bignum too big to convert into 'long'`, `numeric.c`).
  */
+/**
+ * @internal MRI's `NUM2LONG` where `dt_lite_iso8601` (`date_core.c:8754-8766`)
+ * and `dt_lite_jisx0301` (`:8794-8805`) apply it to the fractional-digit
+ * argument: a Float converts by truncating toward zero, which is why Ruby's
+ * `iso8601(3.5)` renders three digits, not four.
+ */
+function num2long(n: number): number {
+  return Math.trunc(n);
+}
+
 function realYearToLong(year: number | bigint): number {
   if (typeof year === "number") return year;
   if (year < BigInt(Number.MIN_SAFE_INTEGER) || year > BigInt(Number.MAX_SAFE_INTEGER)) {
@@ -4663,6 +4673,53 @@ function plainDateFromJd(jd: number | bigint, sg = DEFAULT_SG): Temporal.PlainDa
  * Symbol — nothing reads it as a value.
  */
 export const SEAT: unique symbol = Symbol("d_simple_new_internal");
+
+/**
+ * @internal `date_core.c` `dup_obj_with_new_offset` (`date_core.c:5899-5908`),
+ * which promotes the receiver to a ComplexDateData and runs `set_of` on the
+ * copy. TS has no `dup_obj_as_complex`: a `::Date` already reads `of == 0`, so
+ * the promotion changes nothing a formatter can see, and a `::DateTime` is
+ * complex already and reaches `set_of` through
+ * {@link DateTime#newOffset} — the reader `Init_date_core` gives to
+ * `::DateTime` alone (`:10018`).
+ */
+function dupObjWithNewOffset(obj: Date, of: number): Date {
+  return obj instanceof DateTime ? obj.newOffset(of) : obj;
+}
+
+/**
+ * @internal `date_core.c` `jisx0301_date_format` (`date_core.c:7358-7381`),
+ * which picks the era letter and the year offset off the Julian day and writes
+ * `"%c%02ld.%%m.%%d"` into the caller's buffer. A day outside a Fixnum — a
+ * `nth` away from zero — takes the C's non-`FIXNUM_P` arm and renders plain
+ * ISO, as does any day before Meiji 6 (jd 2405160, 1873-01-01).
+ */
+function jisx0301DateFormat(jd: number | bigint, y: number | bigint): string {
+  if (typeof jd === "number") {
+    const d = jd;
+    let s: number;
+    let c: string;
+    if (d < 2405160) return "%Y-%m-%d";
+    if (d < 2419614) {
+      c = "M";
+      s = 1867;
+    } else if (d < 2424875) {
+      c = "T";
+      s = 1911;
+    } else if (d < 2447535) {
+      c = "S";
+      s = 1925;
+    } else if (d < 2458605) {
+      c = "H";
+      s = 1988;
+    } else {
+      c = "R";
+      s = 2018;
+    }
+    return `${c}${String(Number(y) - s).padStart(2, "0")}.%m.%d`;
+  }
+  return "%Y-%m-%d";
+}
 
 /**
  * @internal `date_core.c` `c_valid_time_p` (`date_core.c:870-886`), which folds
@@ -8024,6 +8081,23 @@ export class Date {
   }
 
   /**
+   * Ruby `Date#asctime` (ruby/date, `date_core.c` `d_lite_asctime`,
+   * `date_core.c:7281-7285`) — `strftimev("%a %b %e %H:%M:%S %Y", self,
+   * set_tmx)`.
+   */
+  asctime(): string {
+    return this.strftime("%a %b %e %H:%M:%S %Y");
+  }
+
+  /**
+   * Ruby `Date#ctime`, which `date_core.c:9808` binds to the same
+   * `d_lite_asctime` as `asctime` (`:9807`).
+   */
+  ctime(): string {
+    return this.asctime();
+  }
+
+  /**
    * Ruby `Date#iso8601` (ruby/date, `date_core.c` `d_lite_iso8601`,
    * `date_core.c:7298-7302`) — `strftimev("%Y-%m-%d", self, set_tmx)`.
    */
@@ -8037,6 +8111,16 @@ export class Date {
    */
   xmlschema(): string {
     return this.iso8601();
+  }
+
+  /**
+   * Ruby `Date#rfc3339` (ruby/date, `date_core.c` `d_lite_rfc3339`,
+   * `date_core.c:7314-7318`) — `strftimev("%Y-%m-%dT%H:%M:%S%:z", self,
+   * set_tmx)`. `::DateTime` overrides it (`date_core.c:10026`) only to take
+   * the fractional-second `n`; see {@link DateTime#rfc3339}.
+   */
+  rfc3339(): string {
+    return this.strftime("%Y-%m-%dT%H:%M:%S%:z");
   }
 
   /**
@@ -8057,6 +8141,29 @@ export class Date {
    */
   rfc822(): string {
     return this.rfc2822();
+  }
+
+  /**
+   * Ruby `Date#httpdate` (ruby/date, `date_core.c` `d_lite_httpdate`,
+   * `date_core.c:7346-7351`) — the receiver is first moved to a zero offset by
+   * `dup_obj_with_new_offset`, so a `DateTime` in another zone still renders
+   * `GMT`. `::DateTime` does not override it (`date_core.c:10004` defines only
+   * the singleton), so it reaches this body.
+   */
+  httpdate(): string {
+    const dup = dupObjWithNewOffset(this, 0);
+    return dup.strftime("%a, %d %b %Y %T GMT");
+  }
+
+  /**
+   * Ruby `Date#jisx0301` (ruby/date, `date_core.c` `d_lite_jisx0301`,
+   * `date_core.c:7403-7414`), which picks the format with
+   * {@link jisx0301DateFormat} off the real local Julian day and the real year
+   * before handing it to `strftimev`.
+   */
+  jisx0301(): string {
+    const fmt = jisx0301DateFormat(encodeJd(this.nth, this.mLocalJd()), this.year);
+    return this.strftime(fmt);
   }
 
   /**
@@ -9416,6 +9523,7 @@ export class DateTime extends DateWithoutParseStatics {
    * digits of fractional seconds.
    */
   iso8601(n = 0): string {
+    n = num2long(n);
     return this.strftime("%Y-%m-%d") + this.#iso8601Timediv(n);
   }
 
@@ -9425,6 +9533,24 @@ export class DateTime extends DateWithoutParseStatics {
    */
   xmlschema(n = 0): string {
     return this.iso8601(n);
+  }
+
+  /**
+   * Ruby `DateTime#rfc3339(n = 0)`, whose C body `dt_lite_rfc3339`
+   * (`date_core.c:8778-8782`) forwards straight to `dt_lite_iso8601`.
+   */
+  override rfc3339(n = 0): string {
+    return this.iso8601(n);
+  }
+
+  /**
+   * Ruby `DateTime#jisx0301(n = 0)` (ruby/date, `date_core.c`
+   * `dt_lite_jisx0301`, `date_core.c:8794-8805`) — `d_lite_jisx0301(self)`,
+   * which is `super` here, appended with {@link DateTime.#iso8601Timediv}.
+   */
+  override jisx0301(n = 0): string {
+    n = num2long(n);
+    return super.jisx0301() + this.#iso8601Timediv(n);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -4420,6 +4420,14 @@ function encodeYear(nth: bigint, y: number, style: number): number | bigint {
  * MRI narrows it. Ruby's `RangeError` is JS's, and the message is MRI's own
  * (`bignum too big to convert into 'long'`, `numeric.c`).
  */
+function realYearToLong(year: number | bigint): number {
+  if (typeof year === "number") return year;
+  if (year < BigInt(Number.MIN_SAFE_INTEGER) || year > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new RangeError("bignum too big to convert into `long'");
+  }
+  return Number(year);
+}
+
 /**
  * @internal MRI's `NUM2LONG` where `dt_lite_iso8601` (`date_core.c:8754-8766`)
  * and `dt_lite_jisx0301` (`:8794-8805`) apply it to the fractional-digit
@@ -4428,14 +4436,6 @@ function encodeYear(nth: bigint, y: number, style: number): number | bigint {
  */
 function num2long(n: number): number {
   return Math.trunc(n);
-}
-
-function realYearToLong(year: number | bigint): number {
-  if (typeof year === "number") return year;
-  if (year < BigInt(Number.MIN_SAFE_INTEGER) || year > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new RangeError("bignum too big to convert into `long'");
-  }
-  return Number(year);
 }
 
 /**

--- a/packages/date/src/test-date-strftime.test.ts
+++ b/packages/date/src/test-date-strftime.test.ts
@@ -1,12 +1,8 @@
 /**
  * Port of ruby/date's `test/date/test_date_strftime.rb`, the standard
- * directive set (`:70-215`, through `test_strftime__minus`) and the GNU
- * coreutils extensions (`:216-356`, through `test_strftime__gnuext_complex`)
- * plus `test_overflow` (`:445-452`).
- *
- * `test__different_format` (`:359-443`) is not here: it exercises the instance
- * formatters (`ctime`/`asctime`/`iso8601`/`xmlschema`/`rfc3339`/`jisx0301`)
- * and the `limit:` kwarg, none of which are ported yet.
+ * directive set (`:70-215`, through `test_strftime__minus`), the GNU
+ * coreutils extensions (`:216-356`, through `test_strftime__gnuext_complex`),
+ * `test__different_format` (`:359-443`) and `test_overflow` (`:445-452`).
  *
  * The gem's statics answer `Temporal` under RFC 0088, so where Ruby writes
  * `DateTime.parse(s)` and then calls `#strftime` on the result, this file goes
@@ -20,7 +16,13 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { Date as RubyDate, DateTime as RubyDateTime, Rational, dtNewByFrags } from "./date.js";
+import {
+  Date as RubyDate,
+  DateTime as RubyDateTime,
+  Rational,
+  dNewByFrags,
+  dtNewByFrags,
+} from "./date.js";
 import { Time as RubyTime } from "./time.js";
 import { setRubyVerbose } from "./rb-warning.js";
 
@@ -44,6 +46,7 @@ function assertWarning(pattern: RegExp, block: () => void): void {
   expect(output).toMatch(pattern);
 }
 
+const gemDateParse = (str: string) => dNewByFrags(RubyDate._parse(str));
 const gemDateTimeParse = (str: string) => dtNewByFrags(RubyDate._parse(str));
 const gemDateTimeStrptime = (str: string, fmt: string) =>
   dtNewByFrags(RubyDateTime._strptime(str, fmt));
@@ -427,6 +430,103 @@ describe("TestDateStrftime", () => {
     expect(d.strftime("%_100+")).toEqual("Sat Feb  3 04:05:06 +09:00 2001".padStart(100));
     expect(d.strftime("%0100+")).toEqual("Sat Feb  3 04:05:06 +09:00 2001".padStart(100, "0"));
     expect(d.strftime("%^+")).toEqual("SAT FEB  3 04:05:06 +09:00 2001");
+  });
+
+  it("different format", () => {
+    let d: RubyDate = new RubyDate(2001, 2, 3);
+
+    expect(d.ctime()).toEqual("Sat Feb  3 00:00:00 2001");
+    expect(d.asctime()).toEqual(d.ctime());
+
+    expect(d.iso8601()).toEqual("2001-02-03");
+    expect(d.iso8601()).toEqual(d.xmlschema());
+    expect(d.rfc3339()).toEqual("2001-02-03T00:00:00+00:00");
+    expect(d.rfc2822()).toEqual("Sat, 3 Feb 2001 00:00:00 +0000");
+    expect(d.rfc2822()).toEqual(d.rfc822());
+    expect(d.httpdate()).toEqual("Sat, 03 Feb 2001 00:00:00 GMT");
+    expect(d.jisx0301()).toEqual("H13.02.03");
+
+    d = new RubyDateTime(2001, 2, 3);
+
+    expect(d.ctime()).toEqual("Sat Feb  3 00:00:00 2001");
+    expect(d.asctime()).toEqual(d.ctime());
+
+    expect(d.iso8601()).toEqual("2001-02-03T00:00:00+00:00");
+    expect(d.iso8601()).toEqual(d.rfc3339());
+    expect(d.iso8601()).toEqual(d.xmlschema());
+    expect(d.rfc2822()).toEqual("Sat, 3 Feb 2001 00:00:00 +0000");
+    expect(d.rfc2822()).toEqual(d.rfc822());
+    expect(d.httpdate()).toEqual("Sat, 03 Feb 2001 00:00:00 GMT");
+    expect(d.jisx0301()).toEqual("H13.02.03T00:00:00+00:00");
+
+    const d2 = gemDateTimeParse("2001-02-03T04:05:06.123456");
+    expect(d2.iso8601(3)).toEqual("2001-02-03T04:05:06.123+00:00");
+    expect(d2.rfc3339(3)).toEqual("2001-02-03T04:05:06.123+00:00");
+    expect(d2.jisx0301(3)).toEqual("H13.02.03T04:05:06.123+00:00");
+    expect(d2.iso8601(3.5)).toEqual("2001-02-03T04:05:06.123+00:00");
+    expect(d2.rfc3339(3.5)).toEqual("2001-02-03T04:05:06.123+00:00");
+    expect(d2.jisx0301(3.5)).toEqual("H13.02.03T04:05:06.123+00:00");
+    expect(d2.iso8601(9)).toEqual("2001-02-03T04:05:06.123456000+00:00");
+    expect(d2.rfc3339(9)).toEqual("2001-02-03T04:05:06.123456000+00:00");
+    expect(d2.jisx0301(9)).toEqual("H13.02.03T04:05:06.123456000+00:00");
+    expect(d2.iso8601(9.9)).toEqual("2001-02-03T04:05:06.123456000+00:00");
+    expect(d2.rfc3339(9.9)).toEqual("2001-02-03T04:05:06.123456000+00:00");
+    expect(d2.jisx0301(9.9)).toEqual("H13.02.03T04:05:06.123456000+00:00");
+
+    expect(new RubyDateTime(1800).jisx0301()).toEqual("1800-01-01T00:00:00+00:00");
+
+    expect(gemDateParse("1868-01-25").jisx0301()).toEqual("1868-01-25");
+    expect(gemDateParse("1872-12-31").jisx0301()).toEqual("1872-12-31");
+
+    expect(gemDateParse("1873-01-01").jisx0301()).toEqual("M06.01.01");
+    expect(gemDateParse("1912-07-29").jisx0301()).toEqual("M45.07.29");
+    expect(gemDateParse("1912-07-30").jisx0301()).toEqual("T01.07.30");
+    expect(gemDateParse("1926-12-24").jisx0301()).toEqual("T15.12.24");
+    expect(gemDateParse("1926-12-25").jisx0301()).toEqual("S01.12.25");
+    expect(gemDateParse("1989-01-07").jisx0301()).toEqual("S64.01.07");
+    expect(gemDateParse("1989-01-08").jisx0301()).toEqual("H01.01.08");
+    expect(gemDateParse("2006-09-01").jisx0301()).toEqual("H18.09.01");
+    expect(gemDateParse("2019-04-30").jisx0301()).toEqual("H31.04.30");
+    expect(gemDateParse("2019-05-01").jisx0301()).toEqual("R01.05.01");
+
+    // The gem's statics answer `Temporal` under RFC 0088 (see this file's
+    // header), so where Ruby compares the parsed `DateTime` to `d2` directly
+    // this compares the seat each side names.
+    expect(
+      RubyDateTime.iso8601("2001-02-03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 64 }),
+    ).toEqual(d2.toDatetime());
+    expect(
+      RubyDateTime.rfc3339("2001-02-03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 64 }),
+    ).toEqual(d2.toDatetime());
+    expect(
+      RubyDateTime.jisx0301("H13.02.03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 64 }),
+    ).toEqual(d2.toDatetime());
+
+    const exceeds = /string length \(\d+\) exceeds/;
+    expect(() =>
+      RubyDateTime.iso8601("2001-02-03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 1 }),
+    ).toThrow(exceeds);
+    expect(() =>
+      RubyDateTime.rfc3339("2001-02-03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 1 }),
+    ).toThrow(exceeds);
+    expect(() =>
+      RubyDateTime.jisx0301("H13.02.03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 1 }),
+    ).toThrow(exceeds);
+
+    for (const s of [
+      "M06.01.01",
+      "M45.07.29",
+      "T01.07.30",
+      "T15.12.24",
+      "S01.12.25",
+      "S64.01.07",
+      "H01.01.08",
+      "H18.09.01",
+      "H31.04.30",
+      "R01.05.01",
+    ]) {
+      expect(gemDateParse(s).jisx0301()).toEqual(s);
+    }
   });
 
   it("overflow", () => {

--- a/packages/date/src/test-date-strftime.test.ts
+++ b/packages/date/src/test-date-strftime.test.ts
@@ -9,6 +9,10 @@
  * through the exported `dtNewByFrags`/`dNewByFrags` builders those statics
  * themselves call — the gem-shaped object that carries `strftime`.
  *
+ * `test__different_format`'s `limit:` arms go through the statics, which answer
+ * `Temporal` under RFC 0088, so where Ruby compares the parsed `DateTime` to
+ * `d2` directly this file compares the seat each side names.
+ *
  * `test_strftime__offset`'s `assert_warning(/invalid offset/)` arm goes through
  * {@link assertWarning}, which sets `$VERBOSE` for the block the way Ruby's
  * does — `rb_warning("invalid offset is ignored")` (`date_core.c:8304`) is
@@ -489,9 +493,6 @@ describe("TestDateStrftime", () => {
     expect(gemDateParse("2019-04-30").jisx0301()).toEqual("H31.04.30");
     expect(gemDateParse("2019-05-01").jisx0301()).toEqual("R01.05.01");
 
-    // The gem's statics answer `Temporal` under RFC 0088 (see this file's
-    // header), so where Ruby compares the parsed `DateTime` to `d2` directly
-    // this compares the seat each side names.
     expect(
       RubyDateTime.iso8601("2001-02-03T04:05:06.123456+00:00", RubyDate.ITALY, { limit: 64 }),
     ).toEqual(d2.toDatetime());

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -93,6 +93,8 @@ const RAILS_MAP: Record<string, CanonicalKind> = {
   refute_match: "noMatch",
   assert_raises: "raises",
   assert_raise: "raises",
+  // ruby/test-unit's core_assertions.rb: `assert_raise` plus a message match.
+  assert_raise_with_message: "raises",
   assert_nothing_raised: "nothingRaised",
   assert_same: "same",
   assert_not_same: "notSame",

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -93,7 +93,6 @@ const RAILS_MAP: Record<string, CanonicalKind> = {
   refute_match: "noMatch",
   assert_raises: "raises",
   assert_raise: "raises",
-  // ruby/test-unit's core_assertions.rb: `assert_raise` plus a message match.
   assert_raise_with_message: "raises",
   assert_nothing_raised: "nothingRaised",
   assert_same: "same",


### PR DESCRIPTION
Ports ruby/date's `test__different_format` (`vendor/date/test/date/test_date_strftime.rb:359-443`) into `packages/date/src/test-date-strftime.test.ts` along with the `date_core.c` formatters it exercises, and converges Arel's `createStringJoin` onto its Rails body.

## date

New on `Date`, each at the C name with the `date_core.c` line:

- `#asctime` / `#ctime` — `d_lite_asctime` (`:7281-7285`), aliased at `:9807-9808`
- `#rfc3339` — `d_lite_rfc3339` (`:7314-7318`)
- `#httpdate` — `d_lite_httpdate` (`:7346-7351`), which moves the receiver to a zero offset through `dup_obj_with_new_offset` (`:5899-5908`) so an inheriting `DateTime` still renders `GMT`
- `#jisx0301` — `d_lite_jisx0301` (`:7403-7414`) over the era table in `jisx0301_date_format` (`:7358-7381`)

New on `DateTime`:

- `#rfc3339(n)` — `dt_lite_rfc3339` (`:8778-8782`), which forwards to `dt_lite_iso8601`
- `#jisx0301(n)` — `dt_lite_jisx0301` (`:8794-8805`), the `Date` body appended with `iso8601_timediv`

`DateTime#iso8601` and `#jisx0301` also gain the `NUM2LONG` their C bodies apply to the fractional-digit argument — that truncation is what makes Ruby's `iso8601(3.5)` render three digits, and the test asserts it.

The statics' `limit:` kwarg and its `string length (N) exceeds` raise already worked; the test exercises them. Where Ruby compares the parsed `DateTime` to `d2` directly, the port compares the `Temporal` seat each side names, per RFC 0088.

`assert_raise_with_message` joins `scripts/test-compare/assertion-kinds.ts` as a `raises` kind — ruby/date's strftime test is the only file in the vendored corpora that uses it, and without the mapping the ported raises read as three unmatched assertions.

`parity:test --package date`: 132/137 → 133/137, `test_date_strftime.rb` now 14/14, assertion-mismatch counts unchanged from baseline.

## arel

`FactoryMethods#createStringJoin` passes `to` straight through to `createJoin`, matching `arel/factory_methods.rb:23-25`. The call-site `SqlLiteral` wrapping had no Rails counterpart: `Nodes::StringJoin` (`string_join.rb:5-9`) stores `left` as given, and trails' `visitArelNodesStringJoin` visits `o.left` exactly as `to_sql.rb:528-530` does. The `factory-methods.ts` `naming` call-argument row (`ref:node` vs Ruby's `ref:to`) is retired with no new `shape` row. `Table#join` / `SelectManager#join` are untouched — they promote the klass on their own Rails lines.

## Not in this PR

Two bundled stories are blocked rather than shipped, each with the specific blocker recorded on the story:

- `temporal-seat-loses-the-absolute-day-for-week-readers` — the decided `plainDateFromJd` raise reds 30 ported gem tests across 6 files, not just `test_commercial`/`test_fractional`: `Date.jd()` / `.ordinal()` / `.commercial()` all default to jd 0 = `-4712-01-01`, Julian-side under the default ITALY `sg`, so it is the base case of most of the ported suite. Converting those to `toThrow` takes `parity:test` assertion deltas negative. Needs an RFC 0088 owner call on the wider blast radius.
- `converge-schema-invalidation-onto-push-only-eager-registration` — `class X extends Y {}` exposes no hook on `Y` that receives `X` (it reads `Y.prototype` before the class object exists, and `[[SetPrototypeOf]]` fires on `X`), so eager registration is not reachable without the decorator or explicit call the acceptance criteria forbid, and the pull apparatus cannot be deleted.

Closes-story: port-test-date-strftime-different-format
Closes-story: arel-create-string-join-callsite-conversion