### PR TITLE
refactor(activerecord): spell Kernel#Array as Array in batches.ts, enroll number_to_human

### DIFF
--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::Batches
  */
 import { ArgumentError } from "@blazetrails/activemodel";
-import { kernelArray } from "@blazetrails/activesupport";
+import { kernelArray as Array } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { WhereClause } from "./where-clause.js";
 import { ActiveRecord } from "../ar-config.js";
@@ -58,7 +58,7 @@ export class Batches {
     // Rails' `enum_for(:find_each, ...) { ... }` size block (batches.rb:90-95);
     // see findInBatches below for why it lives on the iterator.
     enumerator.size = async (): Promise<number> => {
-      cursor = kernelArray(cursor);
+      cursor = Array(cursor);
       return applyLimits(relation, cursor, start, finish, buildBatchOrders(cursor, order)).size();
     };
     return enumerator;
@@ -93,7 +93,7 @@ export class Batches {
     // block hangs off the returned iterator under the same name; `size` is
     // async here only because the count reaches the database.
     const size = async (): Promise<number> => {
-      cursor = kernelArray(cursor);
+      cursor = Array(cursor);
       const total = await applyLimits(
         relation,
         cursor,
@@ -153,7 +153,7 @@ export class Batches {
     block?: (relation: LoadedRelation<Relation<T>>) => void | Promise<void>,
   ): BatchEnumerator<LoadedRelation<Relation<T>>> | Promise<void> {
     const self = this;
-    const cursor = kernelArray(cursorOption ?? this.primaryKey).map(String);
+    const cursor = Array(cursorOption ?? this.primaryKey).map(String);
     // `ensure_valid_options_for_batching!` reaches the schema cache, which is
     // async here, so the validation runs when the batches are first pulled
     // rather than at `in_batches` call time.
@@ -299,12 +299,12 @@ export async function ensureValidOptionsForBatchingBang(
   order: "asc" | "desc" | ("asc" | "desc")[],
 ): Promise<void> {
   if (start !== undefined && start !== null) {
-    if (kernelArray(start).length !== cursor.length) {
+    if (Array(start).length !== cursor.length) {
       throw new Error(":start must contain one value per cursor column");
     }
   }
   if (finish !== undefined && finish !== null) {
-    if (kernelArray(finish).length !== cursor.length) {
+    if (Array(finish).length !== cursor.length) {
       throw new Error(":finish must contain one value per cursor column");
     }
   }
@@ -315,30 +315,30 @@ export async function ensureValidOptionsForBatchingBang(
   // whole check (and so this method) is a promise.
   // Ruby `Array(nil)` is `[]`, so a model with no primary key subtracts to an
   // empty set and skips the check entirely (batches.rb:314).
-  if (kernelArray<string>(relation.primaryKey).some((key) => !cursor.includes(key))) {
+  if (Array<string>(relation.primaryKey).some((key) => !cursor.includes(key))) {
     const model = relation.model;
-    const indexes = (await model.schemaCache().indexes(relation.tableName)) as Array<{
+    const indexes = (await model.schemaCache().indexes(relation.tableName)) as {
       unique: boolean;
       where?: string | null;
       columns: string[];
-    }>;
+    }[];
     const uniqueIndex = indexes.find(
       (index) =>
         index.unique &&
         !index.where &&
-        isEmpty(kernelArray(index.columns).filter((c) => !cursor.includes(c))),
+        isEmpty(Array(index.columns).filter((c) => !cursor.includes(c))),
     );
     if (!uniqueIndex) {
       throw new Error(":cursor must include a primary key or other unique column(s)");
     }
   }
 
-  if (kernelArray(order).filter((o) => !["asc", "desc"].includes(o)).length > 0) {
+  if (Array(order).filter((o) => !["asc", "desc"].includes(o)).length > 0) {
     // `:order` takes Symbols, which trails spells as bare strings (CLAUDE.md,
     // "A Ruby Symbol is a JS string"), so the colon Ruby's `order.inspect`
     // prints at batches.rb:324 has to be restored here for the message to read
     // as it does in Rails.
-    const inspected = Array.isArray(order)
+    const inspected = globalThis.Array.isArray(order)
       ? `[${order.map((o) => `:${o}`).join(", ")}]`
       : `:${order}`;
     throw new ArgumentError(
@@ -400,7 +400,7 @@ export function batchCondition(
   // Multi-column: (col1 STRICT_OP val1) OR (col1 = val1 AND <rest>)
   // where STRICT_OP is the strict variant of OP (lteq→lt, gteq→gt).
   const cursorPositions = cursor.map(
-    (column, i) => [column, kernelArray(values)[i], operators[i]] as const,
+    (column, i) => [column, Array(values)[i], operators[i]] as const,
   );
   const [firstCol, firstVal, firstOp] = cursorPositions[cursorPositions.length - 1];
   let whereClause: any = table.get(firstCol)[firstOp](firstVal);
@@ -420,7 +420,7 @@ export function buildBatchOrders(
   cursor: string[],
   order: "asc" | "desc" | ("asc" | "desc")[] | undefined,
 ): [string, "asc" | "desc"][] {
-  return cursor.map((column, i) => [column, kernelArray(order)[i] ?? "asc"]);
+  return cursor.map((column, i) => [column, Array(order)[i] ?? "asc"]);
 }
 
 /** @internal */
@@ -434,16 +434,15 @@ export function batchOnLoadedRelation(opts: {
 }): any[] {
   const { relation, cursor, batchLimit } = opts;
   // relation.records() is async in this codebase; loaded records live on _records.
-  let records: any[] = Array.isArray(relation._records) ? relation._records : [];
+  let records: any[] = globalThis.Array.isArray(relation._records) ? relation._records : [];
   const order = buildBatchOrders(cursor, opts.order as any).map(([, second]) => second);
 
   if (opts.start != null || opts.finish != null) {
     records = records.filter((record) => {
       const values = recordCursorValues(record, cursor);
       return (
-        (opts.start == null ||
-          compareValuesForOrder(values, kernelArray(opts.start), order) >= 0) &&
-        (opts.finish == null || compareValuesForOrder(values, kernelArray(opts.finish), order) <= 0)
+        (opts.start == null || compareValuesForOrder(values, Array(opts.start), order) >= 0) &&
+        (opts.finish == null || compareValuesForOrder(values, Array(opts.finish), order) <= 0)
       );
     });
   }

--- a/packages/activesupport/src/number-helper.test.ts
+++ b/packages/activesupport/src/number-helper.test.ts
@@ -237,6 +237,41 @@ describe("NumberHelperTest", () => {
     expect(numberToHumanSize(1_073_741_824, { delimiter: ".", separator: "," })).toBe("1 GB");
   });
 
+  it("number to human", () => {
+    expect(numberToHuman(-123)).toBe("-123");
+    expect(numberToHuman(-0.5)).toBe("-0.5");
+    expect(numberToHuman(0)).toBe("0");
+    expect(numberToHuman(0.5)).toBe("0.5");
+    expect(numberToHuman(123)).toBe("123");
+    expect(numberToHuman(1234)).toBe("1.23 Thousand");
+    expect(numberToHuman(12345)).toBe("12.3 Thousand");
+    expect(numberToHuman(1234567)).toBe("1.23 Million");
+    expect(numberToHuman(1234567890)).toBe("1.23 Billion");
+    expect(numberToHuman(1234567890123)).toBe("1.23 Trillion");
+    expect(numberToHuman(1234567890123456)).toBe("1.23 Quadrillion");
+    // Rails' literal exceeds Number.MAX_SAFE_INTEGER; the nearest double still
+    // rounds to the same significant digits, so the assertion holds verbatim.
+    // eslint-disable-next-line no-loss-of-precision
+    expect(numberToHuman(1234567890123456789)).toBe("1230 Quadrillion");
+    expect(numberToHuman(489939, { precision: 2 })).toBe("490 Thousand");
+    expect(numberToHuman(489939, { precision: 4 })).toBe("489.9 Thousand");
+    expect(numberToHuman(489000, { precision: 4 })).toBe("489 Thousand");
+    expect(numberToHuman(489939, { precision: 2, roundMode: ":down" })).toBe("480 Thousand");
+    expect(numberToHuman(489000, { precision: 4, stripInsignificantZeros: false })).toBe(
+      "489.0 Thousand",
+    );
+    expect(numberToHuman(1234567, { precision: 4, significant: false })).toBe("1.2346 Million");
+    expect(numberToHuman(1234567, { precision: 1, significant: false, separator: "," })).toBe(
+      "1,2 Million",
+    );
+    // significant forced to false
+    expect(numberToHuman(1234567, { precision: 0, significant: true, separator: "," })).toBe(
+      "1 Million",
+    );
+    expect(numberToHuman(999999)).toBe("1 Million");
+    expect(numberToHuman(999999999)).toBe("1 Billion");
+  });
+
   it("number to human with custom units that are missing the needed key", () => {
     const units = { million: "M" };
     // Thousand is missing, falls through to smaller unit


### PR DESCRIPTION
Ships the two small stories from the bundle; the two large ones were released back unstarted (see below).

## `converge-batches-kernel-array-import-alias`

`relation/batches.rb` calls `Kernel#Array` at `:93`, `:165`, `:260`, `:306`, `:310`, `:323` and `:387-388`. Those sites were on `kernelArray`, leaving two report-only `naming` rows in `pnpm parity:api:calls:args:report`. `batches.ts` now imports `kernelArray as Array` — the settled spelling already used at `encryption/cipher.ts:9` — so each body reads `Array(...)` exactly as the Ruby does.

The file's two reads of the JS global move to `globalThis.Array.isArray`, as `oid/array.ts` already does throughout. The one `Array<{...}>` type annotation becomes `{...}[]` (a value-position alias cannot serve in type position).

Both `batches.ts` naming rows clear; no new `shape` rows.

## `number-to-human-test-enrollment`

Enrolls `number_helper_test.rb`'s `test_number_to_human` as `it("number to human")` under `describe("NumberHelperTest")`, assertions verbatim — including the `round_mode: :down` one at `:341` that previously had no test to attach to. Rails' `1234567890123456789` literal exceeds `Number.MAX_SAFE_INTEGER`; the nearest double still rounds to the same significant digits, so the assertion holds as written and carries a one-line `no-loss-of-precision` disable with that reason.

## Released, not attempted

`sweep-includes-preload-call-sites-onto-the-colon-symbol-spelling` and `converge-attribute-definitions-onto-default-attributes` each exceed the 700 LOC ceiling on their own — ~800 literal `includes`/`preload`/`eagerLoad`/`references` call sites across 131 files, and 101 non-test `_attributeDefinitions` readers respectively. Both story files already flag that they need splitting first. Released for rescheduling rather than half-swept: the sweep's headline criterion (deleting the `joinedIncludesValues` colon normalization) is only safe once every call site has moved.

Closes-story: converge-batches-kernel-array-import-alias
Closes-story: number-to-human-test-enrollment
