### PR TITLE
feat(date,activesupport): port test_sub with Date marshal hooks, CallbackChain#compile type arm

### DIFF
--- a/packages/activesupport/src/callbacks.trails.test.ts
+++ b/packages/activesupport/src/callbacks.trails.test.ts
@@ -96,3 +96,45 @@ describe("setCallback type-omitted form (trails)", () => {
     expect(ran).toEqual(["block"]);
   });
 });
+
+// trails-only coverage: `run_callbacks(kind, type)` (callbacks.rb:96-104)
+// forwards `type` into `CallbackChain#compile(type)` (callbacks.rb:614-630),
+// whose type arm folds only the callbacks of that one kind and memoizes them in
+// @single_callbacks. Rails has no test for it, so it is pinned here.
+describe("runCallbacks type argument (trails)", () => {
+  class Target {}
+
+  const build = (ran: string[]): Target => {
+    const target = new Target();
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "before", () => {
+      ran.push("before");
+    });
+    setCallback(target, "save", "after", () => {
+      ran.push("after");
+    });
+    return target;
+  };
+
+  it("runs only the callbacks of the given type", () => {
+    const ran: string[] = [];
+    const target = build(ran);
+    runCallbacks(target, "save", () => ran.push("block"), undefined, "before");
+    expect(ran).toEqual(["before", "block"]);
+  });
+
+  it("runs the whole chain when no type is given", () => {
+    const ran: string[] = [];
+    const target = build(ran);
+    runCallbacks(target, "save", () => ran.push("block"));
+    expect(ran).toEqual(["before", "block", "after"]);
+  });
+
+  it("memoizes each type separately from the unfiltered sequence", () => {
+    const ran: string[] = [];
+    const target = build(ran);
+    runCallbacks(target, "save", () => ran.push("block"), undefined, "after");
+    runCallbacks(target, "save", () => ran.push("block"), undefined, "after");
+    expect(ran).toEqual(["block", "after", "block", "after"]);
+  });
+});

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -1082,6 +1082,11 @@ export class CallbackChain {
   // with @mutex.synchronize for thread safety, but JS is single-threaded so
   // runCallbacks never re-enters compile() concurrently — the lock is moot.
   private _allCallbacks: CallbackSequence | undefined;
+  // Rails' @single_callbacks (callbacks.rb:580), the per-type memo beside
+  // @all_callbacks: compile(type) folds only the callbacks of that one kind, so
+  // its sequence cannot be shared with the unfiltered one. Every site that
+  // clears @all_callbacks clears this alongside it.
+  private _singleCallbacks: Map<CallbackKind, CallbackSequence> = new Map();
 
   constructor(name: string, config: DefineCallbacksOptions = {}) {
     this.name = name;
@@ -1106,11 +1111,13 @@ export class CallbackChain {
 
   insert(idx: number, cb: Callback): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.chain.splice(idx, 0, cb);
   }
 
   delete(cb: Callback): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     const i = this.chain.indexOf(cb);
     if (i !== -1) this.chain.splice(i, 1);
   }
@@ -1125,43 +1132,68 @@ export class CallbackChain {
 
   private appendOne(callback: Callback): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.removeDuplicates(callback);
     this.chain.push(callback);
   }
 
   private prependOne(callback: Callback): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.removeDuplicates(callback);
     this.chain.unshift(callback);
   }
 
   private removeDuplicates(callback: Callback): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.chain = this.chain.filter((c) => !callback.isDuplicates(c));
   }
 
   remove(kind: CallbackKind, filter?: AnyCallback | string | symbol | CallbackObject): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.chain = this.chain.filter((cb) => !cb.matches(kind, filter));
   }
 
   clear(): void {
     this._allCallbacks = undefined;
+    this._singleCallbacks.clear();
     this.chain = [];
   }
 
-  compile(): CallbackSequence {
-    if (this._allCallbacks) return this._allCallbacks;
-    // Mirrors Rails CallbackChain#compile: fold the chain in reverse, applying
-    // each callback's compiled filter onto the sequence. before/after mutate the
-    // (single) final sequence's lists; around wraps it in a new nested sequence.
+  /**
+   * Mirrors: ActiveSupport::Callbacks::CallbackChain#compile (callbacks.rb:614-630).
+   *
+   * `type` nil folds the whole chain into `@all_callbacks`; a `type` folds only
+   * the callbacks whose `kind` it is — the rest pass the sequence through
+   * untouched — and memoizes per type in `@single_callbacks`. No mutex: Rails
+   * guards both rebuilds with @mutex.synchronize for thread safety, but JS is
+   * single-threaded so runCallbacks never re-enters compile() concurrently.
+   */
+  compile(type?: CallbackKind): CallbackSequence {
+    if (type == null) {
+      if (this._allCallbacks) return this._allCallbacks;
+      const finalSequence = new CallbackSequence();
+      let callbackSequence = finalSequence;
+      for (let i = this.chain.length - 1; i >= 0; i--) {
+        callbackSequence = this.chain[i].compiled.apply(callbackSequence);
+      }
+      callbackSequence._callbackChain = this;
+      this._allCallbacks = callbackSequence;
+      return callbackSequence;
+    }
+
+    const memo = this._singleCallbacks.get(type);
+    if (memo) return memo;
     const finalSequence = new CallbackSequence();
     let callbackSequence = finalSequence;
     for (let i = this.chain.length - 1; i >= 0; i--) {
-      callbackSequence = this.chain[i].compiled.apply(callbackSequence);
+      const callback = this.chain[i];
+      if (type === callback.kind) callbackSequence = callback.compiled.apply(callbackSequence);
     }
     callbackSequence._callbackChain = this;
-    this._allCallbacks = callbackSequence;
+    this._singleCallbacks.set(type, callbackSequence);
     return callbackSequence;
   }
 
@@ -1441,11 +1473,21 @@ export namespace Callbacks {
     if (chain) chain.clear();
   }
 
+  /**
+   * Mirrors: ActiveSupport::Callbacks#run_callbacks (callbacks.rb:96-104).
+   *
+   * Ruby's `run_callbacks(kind, type = nil)` takes the block as a block; TS has
+   * to spell it positionally, and `opts` is trails' async-strictness argument,
+   * so Ruby's second positional lands after both rather than after `name`.
+   * It is forwarded straight into `chain.compile(type)` as it is there: a
+   * `type` runs only that kind's callbacks.
+   */
   export function runCallbacks(
     target: object,
     name: string,
     block?: () => unknown,
     opts?: RunCallbacksOptions,
+    type?: CallbackKind,
   ): unknown {
     const chains = getCallbackChains(target);
     const chain = chains.get(name);
@@ -1459,7 +1501,7 @@ export namespace Callbacks {
       }
       return r;
     }
-    const sequence = chain.compile();
+    const sequence = chain.compile(type);
     return sequence.invoke(target, block, opts);
   }
 }
@@ -1497,8 +1539,9 @@ export function runCallbacks(
   name: string,
   block?: () => unknown,
   opts?: RunCallbacksOptions,
+  type?: CallbackKind,
 ): unknown {
-  return Callbacks.runCallbacks(target, name, block, opts);
+  return Callbacks.runCallbacks(target, name, block, opts, type);
 }
 
 export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Base?: TBase) {
@@ -1552,8 +1595,13 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
       resetCallbacks(this.prototype, name);
     }
 
-    runCallbacks(name: string, block?: () => unknown, opts?: RunCallbacksOptions): unknown {
-      return runCallbacks(this, name, block, opts);
+    runCallbacks(
+      name: string,
+      block?: () => unknown,
+      opts?: RunCallbacksOptions,
+      type?: CallbackKind,
+    ): unknown {
+      return runCallbacks(this, name, block, opts, type);
     }
 
     // A hook invoked every time a before callback is halted. Overridable in

--- a/packages/date/src/date.trails.test.ts
+++ b/packages/date/src/date.trails.test.ts
@@ -2478,3 +2478,28 @@ describe("Rational", () => {
     expect(new Rational(1, -0.5).inspect()).toBe("(-2/1)");
   });
 });
+
+// `d_lite_marshal_load`'s `case 2` (1.6.x) and `case 3` (1.8.x, 1.9.2) arms
+// (`date_core.c:7570-7588`) over `old_to_new` (`:3105-3137`). ruby/date's own
+// suite only round-trips the 6-element dump `marshal_dump` writes, so the two
+// legacy arms are covered here; the expectations are what MRI 3.3 answers for
+// the same arrays.
+describe("Date#marshalLoad legacy dumps", () => {
+  it("loads the 3-element 1.8.x dump", () => {
+    const d = new RubyDate(2001, 2, 3);
+    const d2 = new RubyDate().marshalLoad([d.ajd, new Rational(0, 1), RubyDate.ITALY]);
+    expect(d2.toS()).toBe("2001-02-03");
+    expect(d2.equals(d)).toBe(true);
+  });
+
+  it("loads the 2-element 1.6.x dump, whose reform is a boolean", () => {
+    const d = new RubyDate(2001, 2, 3);
+    const d2 = new RubyDate().marshalLoad([d.ajd.add(new Rational(1, 2)), true]);
+    expect(d2.toS()).toBe("2001-02-03");
+    expect(d2.isGregorian).toBe(true);
+  });
+
+  it("raises TypeError on any other size", () => {
+    expect(() => new RubyDate().marshalLoad([1, 2, 3, 4])).toThrow(TypeError);
+  });
+});

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -7214,7 +7214,9 @@ export class Date {
    * nothing forces `get_c_jd`/`get_c_df` or clears the civil seat.
    */
   dup(): this {
-    return (new Date(SEAT, 0n, 0, DEFAULT_SG) as this).initializeCopy(this);
+    return (new (this.constructor as typeof Date)(SEAT, 0n, 0, DEFAULT_SG) as this).initializeCopy(
+      this,
+    );
   }
 
   /**
@@ -8068,6 +8070,74 @@ export class Date {
    */
   deconstructKeys(keys: string[] | null): Record<string, unknown> {
     return deconstructKeys(this, keys, false);
+  }
+
+  /**
+   * Ruby `Date#marshal_dump` (ruby/date, `date_core.c` `d_lite_marshal_dump`,
+   * `date_core.c:7529-7550`, registered at `:9822`), the six-element Array
+   * `Marshal.dump` writes: `m_nth`, `m_jd`, `m_df`, `m_sf`, `m_of` and `m_sg`,
+   * in that order. The readers are the STORED ones — `m_jd`, not
+   * `m_local_jd` — so a `DateTime`'s day and day-fraction go out in UTC and
+   * come back beside the offset that names their zone.
+   *
+   * `rb_copy_generic_ivar` (`:7544-7547`) carries the receiver's generic ivars
+   * onto the Array; a TS instance has no such side table, so there is nothing
+   * to copy.
+   */
+  marshalDump(): [bigint, number, number, Rational, number, number] {
+    return [this.nth, this.mJd(), this.mDf(), this.mSf(), this.mOf(), this.sg];
+  }
+
+  /**
+   * Ruby `Date#marshal_load(a)` (ruby/date, `date_core.c`
+   * `d_lite_marshal_load`, `date_core.c:7553-7625`, registered at `:9823`),
+   * which writes the dumped Array back into the receiver `Marshal.load`
+   * allocated — so it is the receiver's own class that comes back out, which is
+   * what `test_sub` asserts.
+   *
+   * The C's `case 2` / `case 3` arms load the 1.6.x and 1.8.x/1.9.2 dumps
+   * through `old_to_new` (`:3105-3137`); `decode_day` and its `div_day` /
+   * `div_df` are not ported, so those two arms are not here yet — story
+   * `port-date-marshal-legacy-dump-arms` (RFC 0088) carries them. `case 6` and
+   * the `default:` raise are.
+   *
+   * `simple_dat_p`'s promotion (`:7603-7612`) — a fractional dump reallocating
+   * the receiver's `SimpleDateData` into a `ComplexDateData` — is a field write
+   * here, as it is at {@link Date#initializeCopy}: `Date` declares the complex
+   * fields and {@link DateTime} overrides this method for its own.
+   */
+  marshalLoad(a: unknown[]): this {
+    if (Object.isFrozen(this)) {
+      throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
+    }
+    if (!Array.isArray(a)) throw new TypeError("expected an array");
+    if (a.length !== 6) throw new TypeError("invalid size");
+
+    const nth = a[0] as bigint;
+    const jd = Number(a[1]);
+    const df = Number(a[2]);
+    const sf = a[3] as Rational;
+    const of = Number(a[4]);
+    const sg = Number(a[5]);
+
+    this.nth = nth;
+    this.#jd = jd;
+    this.sg = sg;
+    this.#civil = undefined;
+    if (df || !sf.isZero() || of) {
+      this.#df = df;
+      this.#sf = sf;
+      this.#of = of;
+    } else {
+      // `set_to_simple` (`:7613`) with `HAVE_JD`: the simple struct has no
+      // `df`/`sf`/`of` at all, and here their absence IS `simple_dat_p`
+      // ({@link Date#complexDatP}), so a non-fractional dump must clear them
+      // rather than write zeroes a complex receiver would be read off.
+      this.#df = undefined;
+      this.#sf = undefined;
+      this.#of = undefined;
+    }
+    return this;
   }
 
   /**
@@ -9248,13 +9318,47 @@ export class DateTime extends DateWithoutParseStatics {
   }
 
   /**
+   * The complex receiver's half of `d_lite_marshal_load` (`:7602-7615`): a
+   * `DateTime` is always complex, so it takes `set_to_complex` (`:7614`)
+   * whatever the dump held and the promotion branch cannot be reached. One C
+   * function, but the two arms write different data and TS class fields are
+   * private to the class that declares them, so the write is spelled where the
+   * fields live — as at {@link DateTime#initializeCopy}.
+   */
+  override marshalLoad(a: unknown[]): this {
+    if (Object.isFrozen(this)) {
+      throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
+    }
+    if (!Array.isArray(a)) throw new TypeError("expected an array");
+    if (a.length !== 6) throw new TypeError("invalid size");
+
+    this.nth = a[0] as bigint;
+    this.#jd = Number(a[1]);
+    this.#df = Number(a[2]);
+    this.#sf = a[3] as Rational;
+    this.#of = Number(a[4]);
+    this.sg = Number(a[5]);
+    this.#civil = undefined;
+    this.#time = undefined;
+    return this;
+  }
+
+  /**
    * `::DateTime`'s allocator is `d_lite_s_alloc_complex` (`date_core.c:9969`),
    * where `::Date`'s is the simple one; see {@link Date#dup}.
    */
   override dup(): this {
-    return (new DateTime(SEAT, 0n, 0, 0, new Rational(0, 1), 0, DEFAULT_SG) as this).initializeCopy(
-      this,
-    );
+    return (
+      new (this.constructor as typeof DateTime)(
+        SEAT,
+        0n,
+        0,
+        0,
+        new Rational(0, 1),
+        0,
+        DEFAULT_SG,
+      ) as this
+    ).initializeCopy(this);
   }
 
   /**

--- a/packages/date/src/date.ts
+++ b/packages/date/src/date.ts
@@ -3957,6 +3957,38 @@ function secToNs(s: number | bigint | Rational): number | bigint | Rational {
 }
 
 /**
+ * @internal `date_core.c` `div_day` (`date_core.c:1070-1076`), the whole days
+ * in a day count and the fraction left over: `f_floor` and `f_mod` of one, both
+ * of which `Rational` already answers ({@link Rational#div} floors, as Ruby's
+ * `Rational#div` does). The C writes the remainder through an out-parameter,
+ * which is the tuple here.
+ */
+function divDay(d: Rational): [number, Rational] {
+  return [d.div(1), d.mod(1)];
+}
+
+/**
+ * @internal `date_core.c` `div_df` (`date_core.c:1078-1086`), the same split
+ * one unit down: the fraction of a day as whole seconds and the fraction of a
+ * second left over.
+ */
+function divDf(d: Rational): [number, Rational] {
+  const s = dayToSec(d);
+  return [s.div(1), s.mod(1)];
+}
+
+/**
+ * @internal `date_core.c` `decode_day` (`date_core.c:1101-1109`), a day count
+ * split into the stored triple — Julian day, day fraction in seconds, and
+ * sub-second in nanoseconds.
+ */
+function decodeDay(d: Rational): [jd: number, df: number, sf: Rational] {
+  const [jd, f1] = divDay(d);
+  const [df, f] = divDf(f1);
+  return [jd, df, secToNs(f) as Rational];
+}
+
+/**
  * @internal `date_core.c` `ns_to_sec` (`date_core.c:993-998`), the inverse:
  * `rb_rational_new2(n, INT2FIX(SECOND_IN_NANOSECONDS))`, which answers a
  * Rational unconditionally, whatever it is handed.
@@ -3971,6 +4003,13 @@ function nsToSec(n: Rational): Rational {
  * — 8.64e13, well inside `Number.MAX_SAFE_INTEGER`.
  */
 const DAY_IN_NANOSECONDS = DAY_IN_SECONDS * SECOND_IN_NANOSECONDS;
+
+/**
+ * @internal `date_core.c` `half_days_in_day` (`date_core.c:27`, initialized to
+ * `Rational(1, 2)` at `date_core.c:9496`), the half day `old_to_new` shifts an
+ * astronomical Julian day by to reach the chronological one.
+ */
+const HALF_DAYS_IN_DAY = new Rational(1, 2);
 
 /** @internal `date_core.c` `HALF_DAYS_IN_SECONDS` (`date_core.c:1592`). */
 const HALF_DAYS_IN_SECONDS = DAY_IN_SECONDS / 2;
@@ -4443,6 +4482,48 @@ function decodeJd(jd: number | bigint): [nth: bigint, rjd: number] {
   const nth = div(jd, CM_PERIOD);
   if (nth === 0) return [0n, jd];
   return [BigInt(nth), mod(jd, CM_PERIOD)];
+}
+
+/**
+ * @internal `date_core.c` `old_to_new` (`date_core.c:3105-3137`), which reads a
+ * 1.6.x / 1.8.x `Marshal` dump — an astronomical Julian day, an offset as a day
+ * fraction and a reform — into the six fields {@link Date#marshalLoad} stores.
+ * The C writes them through out-parameters; they are the tuple here.
+ */
+function oldToNew(
+  ajd: Rational,
+  vof: Rational,
+  vsg: number,
+): [nth: bigint, jd: number, df: number, sf: Rational, of: number, sg: number] {
+  const [jd, df, sf] = decodeDay(ajd.add(HALF_DAYS_IN_DAY));
+  const t = dayToSec(vof);
+  const of2 = t.round();
+
+  if (t.cmp(of2) !== 0) rbWarning("fraction of offset is ignored");
+
+  const [nth, rjd] = decodeJd(jd);
+
+  let of = of2;
+  let sg = vsg;
+
+  if (df < 0 || df >= DAY_IN_SECONDS) throw new DateError("invalid day fraction");
+
+  // `date_core.c:3130-3136` verbatim: the sub-second range test has NO body
+  // upstream, so it GATES the offset clamp below rather than raising — an
+  // out-of-range `sf` is what lets an out-of-range `of` be zeroed. Ported as
+  // written; a raise here would be a behaviour trails invented.
+  if (sf.cmp(0) < 0 || sf.cmp(SECOND_IN_NANOSECONDS) >= 0)
+    if (of < -DAY_IN_SECONDS || of > DAY_IN_SECONDS) {
+      of = 0;
+      rbWarning("invalid offset is ignored");
+    }
+
+  if (!cValidStartP(sg)) {
+    sg = DEFAULT_SG;
+    rbWarning("invalid start is ignored");
+  }
+
+  return [nth, rjd, df, sf, of, sg];
 }
 
 /** @internal `date_core.c` `encode_jd` (`date_core.c:1404-1412`). */
@@ -7209,7 +7290,9 @@ export class Date {
    * `d_lite_s_alloc_complex` for `::DateTime` (`:9969`) — and calls
    * {@link Date#initializeCopy} on it. TS cannot allocate an instance whose
    * private fields exist without running a constructor, so the two allocators
-   * are the {@link SEAT} construction each class already has, and the copy is
+   * are the {@link SEAT} construction each class already has, under the
+   * `rb_obj_class(obj)` the allocator is picked off — which is why a subclass
+   * of either answers itself. The copy is
    * `initialize_copy`'s, not `dup_obj_with_new_start`'s: no `set_sg`, so
    * nothing forces `get_c_jd`/`get_c_df` or clears the civil seat.
    */
@@ -8095,30 +8178,65 @@ export class Date {
    * allocated — so it is the receiver's own class that comes back out, which is
    * what `test_sub` asserts.
    *
-   * The C's `case 2` / `case 3` arms load the 1.6.x and 1.8.x/1.9.2 dumps
-   * through `old_to_new` (`:3105-3137`); `decode_day` and its `div_day` /
-   * `div_df` are not ported, so those two arms are not here yet — story
-   * `port-date-marshal-legacy-dump-arms` (RFC 0088) carries them. `case 6` and
-   * the `default:` raise are.
+   * The `case 2` / `case 3` arms load the 1.6.x and 1.8.x/1.9.2 dumps through
+   * {@link oldToNew} (`:3105-3137`), as they do there.
    *
    * `simple_dat_p`'s promotion (`:7603-7612`) — a fractional dump reallocating
    * the receiver's `SimpleDateData` into a `ComplexDateData` — is a field write
    * here, as it is at {@link Date#initializeCopy}: `Date` declares the complex
-   * fields and {@link DateTime} overrides this method for its own.
+   * fields and {@link DateTime} overrides this method for its own. The C's
+   * `switch` is duplicated into that override for the same reason the guard and
+   * dispatch of `d_lite_initialize_copy` are — one C function whose two arms
+   * write fields TS keeps private to the class that declares them.
    */
   marshalLoad(a: unknown[]): this {
     if (Object.isFrozen(this)) {
       throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
     }
     if (!Array.isArray(a)) throw new TypeError("expected an array");
-    if (a.length !== 6) throw new TypeError("invalid size");
 
-    const nth = a[0] as bigint;
-    const jd = Number(a[1]);
-    const df = Number(a[2]);
-    const sf = a[3] as Rational;
-    const of = Number(a[4]);
-    const sg = Number(a[5]);
+    let nth: bigint;
+    let jd: number;
+    let df: number;
+    let sf: Rational;
+    let of: number;
+    let sg: number;
+
+    switch (a.length) {
+      case 2: /* 1.6.x */
+      case 3 /* 1.8.x, 1.9.2 */:
+        {
+          let ajd: Rational;
+          let vof: Rational;
+          let vsg: unknown;
+
+          if (a.length === 2) {
+            ajd = (a[0] as Rational).add(HALF_DAYS_IN_DAY.mul(-1));
+            vof = new Rational(0, 1);
+            vsg = a[1];
+            if (!kNumericP(vsg)) vsg = vsg != null && vsg !== false ? GREGORIAN : JULIAN;
+          } else {
+            ajd = a[0] as Rational;
+            vof = a[1] as Rational;
+            vsg = a[2];
+          }
+
+          [nth, jd, df, sf, of, sg] = oldToNew(ajd, vof, Number(vsg));
+        }
+        break;
+      case 6:
+        {
+          nth = a[0] as bigint;
+          jd = Number(a[1]);
+          df = Number(a[2]);
+          sf = a[3] as Rational;
+          of = Number(a[4]);
+          sg = Number(a[5]);
+        }
+        break;
+      default:
+        throw new TypeError("invalid size");
+    }
 
     this.nth = nth;
     this.#jd = jd;
@@ -9330,14 +9448,56 @@ export class DateTime extends DateWithoutParseStatics {
       throw new FrozenError(`can't modify frozen ${objClassName(this)}: ${this.inspect()}`);
     }
     if (!Array.isArray(a)) throw new TypeError("expected an array");
-    if (a.length !== 6) throw new TypeError("invalid size");
 
-    this.nth = a[0] as bigint;
-    this.#jd = Number(a[1]);
-    this.#df = Number(a[2]);
-    this.#sf = a[3] as Rational;
-    this.#of = Number(a[4]);
-    this.sg = Number(a[5]);
+    let nth: bigint;
+    let jd: number;
+    let df: number;
+    let sf: Rational;
+    let of: number;
+    let sg: number;
+
+    switch (a.length) {
+      case 2: /* 1.6.x */
+      case 3 /* 1.8.x, 1.9.2 */:
+        {
+          let ajd: Rational;
+          let vof: Rational;
+          let vsg: unknown;
+
+          if (a.length === 2) {
+            ajd = (a[0] as Rational).add(HALF_DAYS_IN_DAY.mul(-1));
+            vof = new Rational(0, 1);
+            vsg = a[1];
+            if (!kNumericP(vsg)) vsg = vsg != null && vsg !== false ? GREGORIAN : JULIAN;
+          } else {
+            ajd = a[0] as Rational;
+            vof = a[1] as Rational;
+            vsg = a[2];
+          }
+
+          [nth, jd, df, sf, of, sg] = oldToNew(ajd, vof, Number(vsg));
+        }
+        break;
+      case 6:
+        {
+          nth = a[0] as bigint;
+          jd = Number(a[1]);
+          df = Number(a[2]);
+          sf = a[3] as Rational;
+          of = Number(a[4]);
+          sg = Number(a[5]);
+        }
+        break;
+      default:
+        throw new TypeError("invalid size");
+    }
+
+    this.nth = nth;
+    this.#jd = jd;
+    this.#df = df;
+    this.#sf = sf;
+    this.#of = of;
+    this.sg = sg;
     this.#civil = undefined;
     this.#time = undefined;
     return this;

--- a/packages/date/src/test-date.test.ts
+++ b/packages/date/src/test-date.test.ts
@@ -1,14 +1,9 @@
 /**
  * Port of ruby/date's `test/date/test_date.rb`.
- *
- * `test_sub` is not here yet: it asserts that `#+`, `#-`, `#>>`, `#<<`,
- * `#succ`, the four calendar readers and `Marshal.load` all answer the
- * RECEIVER's class — `d_lite_plus` and friends build through
- * `rb_obj_class(self)` — where the port's builders name `Date` outright, and it
- * needs `Marshal` besides. It is filed against RFC 0088.
  */
 
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@js-temporal/polyfill";
 import {
   Date as RubyDate,
   DateTime as RubyDateTime,
@@ -93,7 +88,107 @@ class RubyHash {
   }
 }
 
+/**
+ * Ruby's `Marshal.dump` / `Marshal.load` over the two `Date#marshal_dump` /
+ * `Date#marshal_load` (`date_core.c:7529-7625`) hooks `test_sub` round-trips a
+ * date through. JS has no `Marshal`, so the two calls the test makes are
+ * spelled here: `dump` is the hook's Array under the receiver's class, and
+ * `load` is what `Marshal` does with it — allocate an instance of that class
+ * and send it `marshal_load`. Ruby's allocator does not run `initialize`;
+ * TS cannot allocate without a constructor, so the no-argument one runs and
+ * `marshalLoad` overwrites every field it set.
+ */
+const Marshal = {
+  dump(d: RubyDate): { klass: new () => RubyDate; a: unknown[] } {
+    return { klass: d.constructor as new () => RubyDate, a: d.marshalDump() };
+  },
+  load(s: { klass: new () => RubyDate; a: unknown[] }): RubyDate {
+    return new s.klass().marshalLoad(s.a);
+  },
+};
+
+/** ruby/date `test/date/test_date.rb:8`. */
+class DateSub extends RubyDate {}
+
+/** ruby/date `test/date/test_date.rb:11`. */
+class DateTimeSub extends RubyDateTime {}
+
 describe("TestDate", () => {
+  /**
+   * ruby/date `test/date/test_date.rb:46-107`.
+   *
+   * `assert_instance_of(DateSub, DateSub.today)` and its `DateTimeSub.now`
+   * sibling (`:53-54`) assert the class the port cannot answer there: RFC
+   * 0088's mapping table has the two statics answer a `Temporal.PlainDate` /
+   * `Temporal.ZonedDateTime` rather than a gem-shaped instance, so there is no
+   * receiver class for them to carry and the two lines assert what the port
+   * does answer instead. Story `port-date-sub-today-now-receiver-class`
+   * (RFC 0088) converges them; every other assertion is here verbatim.
+   */
+  it("sub", () => {
+    const d = new DateSub();
+    const dt = new DateTimeSub();
+
+    expect(d).toBeInstanceOf(DateSub);
+    expect(dt).toBeInstanceOf(DateTimeSub);
+
+    expect(DateSub.today()).toBeInstanceOf(Temporal.PlainDate);
+    expect(DateTimeSub.now()).toBeInstanceOf(Temporal.ZonedDateTime);
+
+    expect(d.toS()).toEqual("-4712-01-01");
+    expect(dt.toS()).toEqual("-4712-01-01T00:00:00+00:00");
+
+    let d2 = d.plus(1);
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.minus(1) as DateSub;
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.rshift(1);
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.lshift(1);
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.succ();
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.next();
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.italy();
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.england();
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.julian();
+    expect(d2).toBeInstanceOf(DateSub);
+    d2 = d.gregorian();
+    expect(d2).toBeInstanceOf(DateSub);
+    let s = Marshal.dump(d);
+    d2 = Marshal.load(s) as DateSub;
+    expect(d2.equals(d)).toEqual(true);
+    expect(d2).toBeInstanceOf(DateSub);
+
+    let dt2 = dt.plus(1);
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.minus(1) as DateTimeSub;
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.rshift(1);
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.lshift(1);
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.succ();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.next();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.italy();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.england();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.julian();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    dt2 = dt.gregorian();
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+    s = Marshal.dump(dt);
+    dt2 = Marshal.load(s) as DateTimeSub;
+    expect(dt2.equals(dt)).toEqual(true);
+    expect(dt2).toBeInstanceOf(DateTimeSub);
+  });
+
   it("range infinite float", () => {
     const today = new RubyDate(RubyDate.today());
     let r = new RubyRange(today, Number.POSITIVE_INFINITY, true);


### PR DESCRIPTION
Three of the four bundled stories. `bare-attribute-method-pattern-generates-reader`
was released back unstarted — see the bottom of this description.

## `port-test-date-sub-class-propagation`

`test_sub` (`vendor/date/test/date/test_date.rb:46-107`) is ported, taking
`test_date.rb` to **9/9**.

The class propagation the story lists as blocker 1 was mostly already in place:
`Date#dNewInternal` and `Date#newStart` (and `DateTime`'s overrides of both)
already build through `this.constructor`, which is `d_simple_new_internal`'s
`rb_obj_class(self)` / `dup_obj`'s (`date_core.c:3036-3050`, `:5801-5810`), and
`#+`, `#-`, `#>>`, `#<<`, `#succ`, `#next` and the four calendar readers all
route through those two seats. `Date#dup` / `DateTime#dup` did not — they named
the class outright — and now allocate through the receiver's class, as
`Object#dup`'s allocator does.

Blocker 2, `Marshal`, is new: `marshalDump` / `marshalLoad` port
`d_lite_marshal_dump` / `d_lite_marshal_load` (`date_core.c:7529-7625`), with
`DateTime` overriding the complex arm exactly where it overrides
`initialize_copy` — one C function whose two arms write different data, and TS
class fields are private to the class that declares them. The test spells
`Marshal.dump` / `Marshal.load` as the two-call helper the port needs (allocate
an instance of the dumped class, send it `marshal_load`), next to the existing
`RubyHash` / `RubyRange` helpers in that file.

All three arms of the C's `switch` are here: `case 2` (1.6.x) and `case 3`
(1.8.x, 1.9.2) go through `old_to_new` (`:3105-3137`), which brings `decode_day`
(`:1101-1109`), `div_day` / `div_df` (`:1070-1086`) and `half_days_in_day`
(`:9496`) with it. `old_to_new`'s sub-second range test has no body upstream —
it gates the offset clamp rather than raising — and is ported as written; its
`c_valid_start_p` clamp comes along. ruby/date's own suite only round-trips the
6-element dump, so the two legacy arms are covered in `date.trails.test.ts`
against what MRI 3.3 answers.

One deviation, storied rather than ratified:

- `assert_instance_of(DateSub, DateSub.today)` and its `DateTimeSub.now`
  sibling (`:53-54`) cannot answer a receiver class: RFC 0088's mapping table
  has both statics answer `Temporal`. The two lines assert what the port does
  answer, with the deviation named at the call site. Filed as
  `port-date-sub-today-now-receiver-class` (RFC 0088).

## `callback-chain-compile-type-arm`

`CallbackChain#compile` takes `type` and carries Rails' two branches
(`callbacks.rb:614-630`), with `_singleCallbacks` beside `_allCallbacks`; every
site that cleared `_allCallbacks` clears it too, matching Rails'
`@single_callbacks.clear` at each of them. `runCallbacks` accepts and forwards
`type` (`callbacks.rb:96-104`).

`type` lands after `block` and `opts` rather than after `name`: Ruby's second
positional is `run_callbacks(kind, type = nil)` with the block as a *block*,
which TS has to spell positionally, and `opts` is trails' async-strictness
argument. Reordering would touch 193 call sites. Noted at the call site.

Three trails-only tests drive it (Rails has no test for the type arm), and the
first fails on baseline — without the arm the whole chain runs.

## `sqlite3-mem-lane-has-no-fast-path-boot` — measured, closing as not worth fixing

Measured with a timer around each arm of `test-setup-dy.ts` (the sibling
story's method), over `packages/activerecord/src/relation/` — 57 boots per run:

| lane | arm taken | boots | mean per boot |
|---|---|---|---|
| `sqlite3_mem` | `fullLoad`, 57/57 | 57 | **193.9 ms** |
| sqlite file | `fastPath`, 57/57 | 57 | 64.3 ms |

So the story's premise holds — zero fast-path boots on `sqlite3_mem` — and the
arm costs ~194 ms per boot. The **ceiling** on any per-process `:memory:`
template is the gap to the other lane's fast path, ~130 ms/boot, and a template
clone is not free, so the real saving is less. Over the whole AR suite (783
test files) that is ~102 s of CPU, ~17 s of wall clock across 6 workers, on a
label-gated 20-minute lane that does not run per-PR.

Against that: a per-process template is new boot-path machinery in the one file
every lane boots through, and `in_memory_db?` being lane-specific does not make
the code it touches lane-specific. Not worth it — closing measured-and-fine,
with the other three lanes untouched (no boot-path change ships here).

## `bare-attribute-method-pattern-generates-reader` — released, not in this PR

Released back unstarted rather than shipped half-converged. Two reasons:

1. The converged shape needs `attribute()` to stop installing the accessor on
   `this.prototype` and `defineMethodAttribute` to install it into
   `generatedAttributeMethods` instead. That is a load-bearing change to every
   AM and AR model's reader installation, well past what is left of this
   bundle's LOC budget, and it wants its own AR-suite verification.
2. The story's AC names `defineMethodAttribute` in **both**
   `activemodel/attributes.ts` and `activerecord/attribute-methods/read.ts` as
   the reader hook, but Rails' ActiveModel has no reader hook — `attributes.rb:92`
   is `define_method_attribute=`, the *writer*; only
   `activerecord/attribute_methods/read.rb:11` is the reader. trails spells both
   `defineMethodAttribute`, and which one the bare pattern's
   `define_method_#{proxy_target}` fork should reach is a naming decision
   (Ruby `foo=` in TS) that wants a maintainer call before the refactor, not
   after.

Closes-story: port-test-date-sub-class-propagation
Closes-story: sqlite3-mem-lane-has-no-fast-path-boot
Closes-story: callback-chain-compile-type-arm
