### PR TITLE
refactor(activerecord): retire the invented join/where/reflection discriminators

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -422,20 +422,17 @@ export function defineAttributeMethodPattern(
   const publicMethodName = pattern.methodName(as);
 
   // If defining a regular attribute method, we don't override methods that are
-  // explicitly defined in parent classes. The predicate is dispatched through
-  // the class, as Ruby dispatches it: ActiveRecord overrides it to raise
-  // DangerousAttributeError for a name Active Record itself defines
-  // (activerecord/attribute_methods.rb:165-168) before this base behaviour
-  // runs. The prototype arm is spelled `in`, as that override spells it,
-  // because a generated bare-pattern accessor is a getter that raises when read
-  // off the prototype.
+  // explicitly defined in parent classes (attribute_methods.rb:326). The
+  // predicate is a template method: Ruby dispatches it through the class, and
+  // ActiveRecord overrides it to raise DangerousAttributeError for a name
+  // Active Record itself defines and to consult the class's own methods
+  // (activerecord/attribute_methods.rb:165-179).
   const alreadyImplemented = (this as unknown as Record<string, unknown>)
     .isInstanceMethodAlreadyImplemented;
   if (
-    (typeof alreadyImplemented === "function"
+    typeof alreadyImplemented === "function"
       ? (alreadyImplemented as (methodName: string) => boolean).call(this, publicMethodName)
-      : isInstanceMethodAlreadyImplemented.call(this, publicMethodName)) ||
-    publicMethodName in this.prototype
+      : isInstanceMethodAlreadyImplemented.call(this, publicMethodName)
   ) {
     // However, for `alias_attribute`, we always define the method.
     if (!override) return;

--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -165,9 +165,9 @@ describe("query chaining DX", () => {
   });
 
   it("Post.joins / distinct / none / unscoped all return Relation<Post>", () => {
-    expectTypeOf(Post.joins("comments")).toMatchTypeOf<Relation<Post>>();
-    expectTypeOf(Post.leftJoins("comments")).toMatchTypeOf<Relation<Post>>();
-    expectTypeOf(Post.leftOuterJoins("comments")).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.joins(":comments")).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.leftJoins(":comments")).toMatchTypeOf<Relation<Post>>();
+    expectTypeOf(Post.leftOuterJoins(":comments")).toMatchTypeOf<Relation<Post>>();
     expectTypeOf(Post.distinct()).toMatchTypeOf<Relation<Post>>();
     expectTypeOf(Post.none()).toMatchTypeOf<Relation<Post>>();
     expectTypeOf(Post.unscoped()).toMatchTypeOf<Relation<Post>>();

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -230,50 +230,25 @@ export interface ReflectionLike {
 }
 
 /**
- * Model registry that tracks a monotonic `generation`, bumped on any mutation
- * that can change what a name resolves to — a FRESH registration as much as a
- * rebind (`super.get(name) !== model` is true for `prev === undefined`).
- * Reflections memoize their resolved `klass` and through/source chain alongside
- * the generation they were resolved at, so a later registration invalidates
- * every stale memo at once instead of poisoning it permanently.
- *
- * What that heals is a memo formed under an INCOMPLETE registry, not a shadowed
- * name. Instrumenting the two-file repro
- * (`nested-through-associations.test.ts` + `associations.test.ts`, RFC 0078)
- * counts 184 fresh registrations and ZERO rebinds: nothing is ever bound to a
- * different class, and both files import the canonical models. The poisoned
- * memo is `ThroughReflection#sourceReflectionName`'s `null`, written by the
- * catch that swallows `NameError: Missing model class Tagging` raised from
- * `throughRef.klass` while `Tagging` is not yet registered; `sourceReflection`
- * then reads that `null` and `checkValidityBang` raises
- * `HasManyThroughSourceAssociationNotFoundError` forever. The healing bump is
- * whatever model registers next.
- *
- * The consequence worth knowing: a negative memo formed after the LAST
- * registration in a worker has no later bump to heal it. Story
- * `dont-memoize-negative-source-resolution-from-unresolvable-klass` (RFC 0078)
- * covers not memoizing a resolution that failed for a missing class.
+ * Ruby has no model registry at all — Zeitwerk resolves a constant when the
+ * method naming it runs, and a reload discards the model classes and their
+ * reflection objects together, so a reflection memo can never outlive the class
+ * it resolved against. trails keeps one long-lived registry per worker instead,
+ * which is what makes a memo formed under a still-INCOMPLETE registry
+ * reachable. The answer is Rails' own `||=` (reflection.rb:422, :989, :261,
+ * :1113): a resolution that failed writes no memo and is retried, so it heals
+ * itself once the missing model registers. Do not add an invalidation counter
+ * here — memoizing a negative resolution is what needs one.
  * @internal
  */
 class ModelRegistry extends Map<string, typeof Base> {
-  #generation = 0;
-
-  /** Bumps only on a mutation that can change what a name resolves to. */
-  get generation(): number {
-    return this.#generation;
-  }
-
   // Write-through runs here, not at each caller, so a direct
   // `modelRegistry.set` (the HABTM join model) or `.delete` (the PG schema
   // helper) cannot leave the registry and the constant table disagreeing.
   // `registerModelConstant` is the single path that binds a model class to a
   // name; this must not write the constant table itself.
   override set(name: string, model: typeof Base): this {
-    // Guard (inside registerModelConstant) before any mutation: a rejected
-    // registration must not bump the generation, which would invalidate every
-    // reflection memo for a write that never happened.
     registerModelConstant(name, model);
-    if (super.get(name) !== model) this.#generation++;
     return super.set(name, model);
   }
 
@@ -283,15 +258,11 @@ class ModelRegistry extends Map<string, typeof Base> {
     // knows nothing about — only drop the constant when it is still ours.
     const model = super.get(name);
     const deleted = super.delete(name);
-    if (deleted) {
-      this.#generation++;
-      unregisterConstant(name, model);
-    }
+    if (deleted) unregisterConstant(name, model);
     return deleted;
   }
 
   override clear(): void {
-    if (this.size > 0) this.#generation++;
     for (const [name, model] of this) unregisterConstant(name, model);
     super.clear();
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from "@blazetrails/activesupport";
 import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
 import type { Base } from "../base.js";
@@ -972,7 +973,6 @@ export class AssociationScope {
     const item = evaluated as {
       referencesValues?: Array<string | Nodes.SqlLiteral>;
       joinsValues?: unknown[];
-      _isNamedJoinValue?: (v: unknown) => boolean;
       _joinClauses?: unknown[];
       leftOuterJoinsValues?: unknown[];
       includesValues?: unknown[];
@@ -998,7 +998,7 @@ export class AssociationScope {
     const namedInner: unknown[] = [];
     const others: unknown[] = [];
     for (const v of item.joinsValues ?? []) {
-      if (!(v instanceof JoinDependency) && item._isNamedJoinValue?.(v) === true) {
+      if (isPlainObject(v) || Array.isArray(v) || (typeof v === "string" && v.startsWith(":"))) {
         namedInner.push(v);
       } else {
         others.push(v);

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2219,7 +2219,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("has many through with left joined same table with through table", async () => {
     const mary = await Author.find(authors("mary").id);
     const eagerOther = await Comment.find(comments("eager_other_comment1").id);
-    const result = await (mary as any).comments.leftJoins("post").toArray();
+    const result = await (mary as any).comments.leftJoins(":post").toArray();
     expect(result.map((c: any) => c.id)).toEqual([eagerOther.id]);
   });
 

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -236,7 +236,7 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     // The canonical alias is addressable in the emitted SQL. Match either
     // quote style (PG/SQLite double-quote, MySQL backtick) so the assertion
     // isn't tied to the test adapter's quoting.
-    const sql = (StjAuthor as any).all().leftJoins("similarPosts").toSql();
+    const sql = (StjAuthor as any).all().leftJoins(":similarPosts").toSql();
     expect(sql).toMatch(/["`]taggings["`]\s+["`]taggings_authors_join["`]/);
     expect(sql).toMatch(/["`]posts["`]\s+["`]posts_authors_join["`]/);
   });

--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -63,12 +63,12 @@ describe("LeftOuterJoinAssociationTest", () => {
 
   it("merging multiple left joins from different associations", async () => {
     const count = await Author.joins(":posts")
-      .merge(Post.leftJoins("comments").merge(Comment.leftJoins("ratings")))
+      .merge(Post.leftJoins(":comments").merge(Comment.leftJoins(":ratings")))
       .count();
     expect(count).toBe(17);
 
-    const outerCount = await Author.leftJoins("posts")
-      .merge(Post.leftJoins("comments").merge(Comment.leftJoins("ratings")))
+    const outerCount = await Author.leftJoins(":posts")
+      .merge(Post.leftJoins(":comments").merge(Comment.leftJoins(":ratings")))
       .count();
     expect(outerCount).toBe(17);
   });
@@ -94,14 +94,14 @@ describe("LeftOuterJoinAssociationTest", () => {
 
   it("merging left joins should be left joins", async () => {
     expect(
-      await Author.leftJoins("posts")
+      await Author.leftJoins(":posts")
         .merge((Post as any).noComments())
         .count(),
     ).toBe(5);
   });
 
   it("left joins aliases left outer joins", () => {
-    expect(Post.leftOuterJoins(":comments").toSql()).toBe(Post.leftJoins("comments").toSql());
+    expect(Post.leftOuterJoins(":comments").toSql()).toBe(Post.leftJoins(":comments").toSql());
   });
 
   it("left outer joins return has value for every comment", async () => {

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -66,7 +66,7 @@ type HasManyHost = {
 (Member as unknown as HasOneHost).hasOne(
   "davidCategorizedClub",
   (rel: NestedRel) =>
-    rel.leftJoins({ category: "categorizations" }).where({ categorizations: { author_id: 1 } }),
+    rel.leftJoins({ category: ":categorizations" }).where({ categorizations: { author_id: 1 } }),
   {
     through: "currentMembership",
     source: "club",
@@ -154,7 +154,7 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     const groucho = members("groucho");
     const sql = throughScopeSql([groucho], "davidCategorizedClub");
     // The deeper `categorizations` join is realized on the through query by
-    // nesting the scope's `.leftJoins({ category: "categorizations" })` under the
+    // nesting the scope's `.leftJoins({ category: ":categorizations" })` under the
     // source reflection, and the copied full where_clause qualifies it, so the
     // predicate rides the through query's WHERE too.
     // Quote identifiers via the active adapter (Rails' `quote_table_name`

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -351,4 +351,23 @@ describe("AttributeMethodsTest (trails)", () => {
 
     expect(() => Employee.aliasAttribute("save", "name")).toThrow(DangerousAttributeError);
   });
+
+  it("an ordinary class-body method is not overridden by a generated attribute method", () => {
+    // attribute_methods.rb:326 — `instance_method_already_implemented?` is the
+    // ONLY guard, and ActiveRecord's override answers it from the class's own
+    // methods (activerecord/attribute_methods.rb:170-178), so a method written
+    // in the class body survives attribute-method generation.
+    class Employee extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+      nameChanged(): boolean {
+        return true;
+      }
+    }
+    (Employee as unknown as { defineAttributeMethods(): boolean }).defineAttributeMethods();
+
+    const employee = new Employee({ name: "David" });
+    expect(employee.nameChanged()).toBe(true);
+  });
 });

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -444,7 +444,7 @@ describe("CalculationsTest", () => {
   it("distinct joins count with group by", async () => {
     // Rails: Post.left_joins(:comments).group(:post_id).distinct.count(:author_id)
     // Groups by comments.post_id; posts with no comments get null key.
-    const result = (await Post.leftJoins("comments")
+    const result = (await Post.leftJoins(":comments")
       .group("comments.post_id")
       .distinct()
       .count("author_id")) as Map<unknown, number>;
@@ -1054,7 +1054,7 @@ describe("CalculationsTest", () => {
   });
 
   it("pluck type cast with left joins without table name qualified column", async () => {
-    const rows = await Author.leftJoins("topics").limit(1).pluck("id");
+    const rows = await Author.leftJoins(":topics").limit(1).pluck("id");
     expect(Array.isArray(rows)).toBe(true);
   });
 

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -2508,8 +2508,8 @@ describe("FinderTest", () => {
   });
 
   it("exists with distinct and offset and joins", async () => {
-    expect(await Post.leftJoins("comments").distinct().offset(10).exists()).toBe(true);
-    expect(await Post.leftJoins("comments").distinct().offset(11).exists()).toBe(false);
+    expect(await Post.leftJoins(":comments").distinct().offset(10).exists()).toBe(true);
+    expect(await Post.leftJoins(":comments").distinct().offset(11).exists()).toBe(false);
   });
 
   it("exists with distinct and offset and select", async () => {
@@ -2553,7 +2553,7 @@ describe("FinderTest", () => {
 
   it("exists with left joins", async () => {
     expect(
-      await Topic.leftJoins("replies")
+      await Topic.leftJoins(":replies")
         .where({ replies_topics: { approved: true } })
         .order("replies_topics.created_at DESC")
         .exists(),

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -15,9 +15,8 @@ import {
 } from "./encryption/test-helpers.js";
 import { EncryptedBookWithSerializedFirstBinary } from "./test-helpers/models/book-encrypted.js";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
-import { Associations, modelRegistry } from "./associations.js";
+import { Associations } from "./associations.js";
 import {
-  AssociationReflection,
   ThroughReflection,
   belongsToCounterCacheColumn,
   counterCacheColumnOption,
@@ -114,39 +113,6 @@ describe("ReflectionTest", () => {
     expect(nsRef!.klass).toBe(NsAdminUser);
   });
 
-  it("reflection klass re-resolves when the registry rebinds the class name", () => {
-    // The klass memo is keyed by class NAME via the global modelRegistry, so a
-    // model re-registered under a name a reflection already resolved must not
-    // keep serving the old class (a bespoke registration in one test file would
-    // otherwise poison canonical reflections for the whole vitest worker).
-    class ShFirstTarget extends Base {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    class ShSecondTarget extends Base {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    class ShOwner extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("shTargets", { className: "ShTarget" });
-      }
-    }
-    registerModel("ShOwner", ShOwner);
-    registerModel("ShTarget", ShFirstTarget);
-
-    const ref = reflectOnAssociation(ShOwner, "shTargets")!;
-    expect(ref.klass).toBe(ShFirstTarget);
-    // Memoized while the registry is unchanged.
-    expect(ref.klass).toBe(ShFirstTarget);
-
-    registerModel("ShTarget", ShSecondTarget);
-    expect(ref.klass).toBe(ShSecondTarget);
-  });
-
   it("re-registering the same class under the same name keeps the klass memo", () => {
     // Registration is idempotent and happens constantly during model loading;
     // only a rebind to a *different* class may invalidate a memo.
@@ -166,129 +132,8 @@ describe("ReflectionTest", () => {
 
     const ref = reflectOnAssociation(ShStableOwner, "shStableTargets")!;
     expect(ref.klass).toBe(ShStableTarget);
-    const generationBefore = modelRegistry.generation;
-    expect(typeof generationBefore).toBe("number");
     registerModel("ShStableTarget", ShStableTarget);
-    expect(modelRegistry.generation).toBe(generationBefore);
     expect(ref.klass).toBe(ShStableTarget);
-  });
-
-  it("inverse_of re-resolves when the registry rebinds the class name", () => {
-    // inverseOf/inverseName memo values resolved off `this.klass` — an inverse
-    // reflection owned by the target class, and a name derived from scanning it.
-    // They have to heal with `klass`, or a healed klass still hands back the
-    // previous target's reflection.
-    class ShInvFirst extends Base {
-      static {
-        this.attribute("name", "string");
-        this.belongsTo("shInvOwner", { className: "ShInvOwner" });
-      }
-    }
-    class ShInvSecond extends Base {
-      static {
-        this.attribute("name", "string");
-        this.belongsTo("shInvOwner", { className: "ShInvOwner" });
-      }
-    }
-    class ShInvOwner extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("shInvTargets", { className: "ShInvTarget" });
-      }
-    }
-    registerModel("ShInvOwner", ShInvOwner);
-    registerModel("ShInvTarget", ShInvFirst);
-
-    const ref = reflectOnAssociation(ShInvOwner, "shInvTargets") as AssociationReflection;
-    expect(ref.inverseOf()!.activeRecord).toBe(ShInvFirst);
-
-    registerModel("ShInvTarget", ShInvSecond);
-    expect(ref.klass).toBe(ShInvSecond);
-    expect(ref.inverseOf()!.activeRecord).toBe(ShInvSecond);
-  });
-
-  it("through reflection inverse_of re-resolves when the registry rebinds the class name", () => {
-    // ThroughReflection keeps its own _inverseOfCache holding a reflection
-    // resolved off its klass, so it needs the same gate as the
-    // AssociationReflection memo — a healed klass must not still hand back an
-    // inverse owned by the previous target.
-    class TiTagFirst extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("tiPosts", { className: "TiPost" });
-      }
-    }
-    class TiTagSecond extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("tiPosts", { className: "TiPost" });
-      }
-    }
-    class TiTagging extends Base {
-      static {
-        this.attribute("name", "string");
-        this.belongsTo("tiTag", { className: "TiTag" });
-      }
-    }
-    class TiPost extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("tiTaggings", { className: "TiTagging" });
-        this.hasMany("tiTags", { through: "tiTaggings", source: "tiTag", inverseOf: "tiPosts" });
-      }
-    }
-    registerModel("TiPost", TiPost);
-    registerModel("TiTagging", TiTagging);
-    registerModel("TiTag", TiTagFirst);
-
-    const ref = reflectOnAssociation(TiPost, "tiTags") as ThroughReflection;
-    expect(ref.inverseOf()!.activeRecord).toBe(TiTagFirst);
-
-    registerModel("TiTag", TiTagSecond);
-    expect(ref.klass).toBe(TiTagSecond);
-    expect(ref.inverseOf()!.activeRecord).toBe(TiTagSecond);
-  });
-
-  it("through reflection source re-resolves when the through target is rebound", () => {
-    // The shape of the PreloaderTest failure this fix targets: a bespoke
-    // through model with no source association is registered first, poisoning
-    // Post.tags' source/through memos; re-registering the real model must heal
-    // them rather than keep raising SourceAssociationNotFound.
-    class ShTag extends Base {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    class ShSourcelessTagging extends Base {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    class ShRealTagging extends Base {
-      static {
-        this.attribute("name", "string");
-        this.belongsTo("shTag", { className: "ShTag" });
-      }
-    }
-    class ShTaggedPost extends Base {
-      static {
-        this.attribute("name", "string");
-        this.hasMany("shTaggings", { className: "ShTagging" });
-        this.hasMany("shTags", { through: "shTaggings", source: "shTag" });
-      }
-    }
-    registerModel("ShTag", ShTag);
-    registerModel("ShTaggedPost", ShTaggedPost);
-    registerModel("ShTagging", ShSourcelessTagging);
-
-    const ref = reflectOnAssociation(ShTaggedPost, "shTags")!;
-    // Sourceless target: no source reflection resolvable, and the memo sticks.
-    expect(ref.sourceReflection).toBeNull();
-
-    registerModel("ShTagging", ShRealTagging);
-    expect(ref.sourceReflection).not.toBeNull();
-    expect(ref.sourceReflection!.name).toBe("shTag");
-    expect(ref.klass).toBe(ShTag);
   });
 
   it("counter cache column option extracts the explicit column from raw forms", () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -370,9 +370,9 @@ export class AbstractReflection {
         // Use a live registry lookup (not self.klass): addCounterCacheCallbacks fires
         // while the module is first loaded, potentially before the target class is
         // properly registered, so resolving through the reflection here would seed its
-        // memo from a half-built registry. (`klass` now self-heals on re-registration
-        // via the registry generation, so this is no longer a permanent-poisoning
-        // hazard — it just avoids the needless early resolve.)
+        // memo from a half-built registry. (`klass` memoizes with Rails' `||=`, so a
+        // failed resolve is retried rather than standing — this just avoids the
+        // needless early resolve.)
         const klassName = self.className;
         const resolvedKlass = modelRegistry.get(klassName);
         if (!resolvedKlass) throw new Error(`${klassName} not in registry`);
@@ -558,7 +558,6 @@ export class MacroReflection extends AbstractReflection {
   readonly pluralName: string;
   private _scope: ((...args: any[]) => any) | null;
   private _klassCache: typeof Base | null = null;
-  private _klassCacheGeneration = -1;
 
   constructor(
     name: string | null,
@@ -617,22 +616,14 @@ export class MacroReflection extends AbstractReflection {
   }
 
   get klass(): typeof Base {
-    // Rails memoizes `@klass ||=`. We additionally gate the memo on the model
-    // registry's generation so a memo resolved against an incomplete registry
-    // re-resolves instead of standing forever. The generation bumps on any
-    // registration, a fresh one included (see ModelRegistry in associations.ts),
-    // which is what heals it — a name rebound to a DIFFERENT class is not the
-    // mechanism, and does not occur in the repro this gate exists for.
-    if (this._klassCache && this._klassCacheGeneration === modelRegistry.generation) {
-      return this._klassCache;
-    }
+    // Rails `@klass ||= compute_class(class_name)` (reflection.rb:422-423). The
+    // `||=` is load-bearing: a resolve that fails never writes a memo, so a
+    // lookup made against a still-incomplete model registry is retried rather
+    // than standing forever.
+    if (this._klassCache) return this._klassCache;
     const resolved = this.options.anonymousClass
       ? (this.options.anonymousClass as typeof Base)
       : this._klass(this.className);
-    // Read the generation *after* resolving: an autoload miss registers the class
-    // it just found, bumping the generation mid-resolve. Recording the pre-resolve
-    // value would leave this memo flagged stale the moment it's written.
-    this._klassCacheGeneration = modelRegistry.generation;
     this._klassCache = resolved;
     return resolved;
   }
@@ -918,50 +909,26 @@ export class AssociationReflection extends MacroReflection {
   }
 
   inverseOf(): AssociationReflection | ThroughReflection | null {
-    this.expireInverseCachesIfRegistryChanged();
+    // Rails `return unless inverse_name; @inverse_of ||= klass._reflect_on_association
+    // inverse_name` (reflection.rb:258-261) — an unresolved inverse is not memoized.
     const name = this.inverseName();
     if (!name) return null;
-    if (this._inverseOfCache !== undefined) return this._inverseOfCache;
-    const result = this.klass._reflectOnAssociation(name) ?? null;
-    this._inverseOfCache = result;
-    // Re-stamp post-resolve for the same reason `klass` does (see its comment).
-    this._inverseCacheGeneration = modelRegistry.generation;
-    return result;
+    if (this._inverseOfCache) return this._inverseOfCache;
+    this._inverseOfCache = this.klass._reflectOnAssociation(name) ?? null;
+    return this._inverseOfCache;
   }
 
   private _inverseNameCache: string | null | undefined = undefined;
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
-  private _inverseCacheGeneration = -1;
 
-  /**
-   * Both inverse memos hold values resolved off `this.klass` — an inverse
-   * reflection *owned by* the target class, and a name derived from scanning
-   * it. `klass` self-heals on a registry rebind, so these must too, or they
-   * keep serving the previous target's reflection after it has healed.
-   * (`_foreignKeyCache` / `_activeRecordPrimaryKeyCache` derive from
-   * `activeRecord` and options rather than the resolved target, so they are
-   * deliberately not gated.)
-   * @internal
-   */
-  private expireInverseCachesIfRegistryChanged(): void {
-    if (this._inverseCacheGeneration === modelRegistry.generation) return;
-    this._inverseCacheGeneration = modelRegistry.generation;
-    this._inverseOfCache = undefined;
-    this._inverseNameCache = undefined;
-  }
-
-  /** @internal */
+  /** @internal Mirrors `inverse_name` (reflection.rb:749-755). */
   override inverseName(): string | null {
-    this.expireInverseCachesIfRegistryChanged();
     if (this._inverseNameCache !== undefined) return this._inverseNameCache;
     const explicit = this.options.inverseOf;
     if (explicit !== undefined) {
       this._inverseNameCache = explicit === false ? null : (explicit as string);
     } else {
       this._inverseNameCache = this.automaticInverseOf();
-      // automaticInverseOf scans `this.klass`, which can autoload-and-register
-      // mid-scan; re-stamp so the memo isn't written already flagged stale.
-      this._inverseCacheGeneration = modelRegistry.generation;
     }
     return this._inverseNameCache;
   }
@@ -1485,65 +1452,13 @@ export class ThroughReflection extends AbstractReflection {
   get delegateReflection(): AssociationReflection {
     return this._delegate;
   }
-  private _sourceReflectionCache: AssociationReflection | ThroughReflection | null | undefined =
-    undefined;
-  private _throughReflectionCache: AssociationReflection | ThroughReflection | null | undefined =
-    undefined;
   private _sourceReflectionNameCache: string | null | undefined = undefined;
   private _klassCache: typeof Base | null = null;
-  private _cacheGeneration = -1;
 
   constructor(delegate: AssociationReflection) {
     super();
     this._delegate = delegate;
     this.ensureOptionNotGivenAsClassBang("sourceType");
-  }
-
-  /**
-   * Record the generation this reflection's memos are valid at.
-   *
-   * The rule here is unconditional and greppable: **every write to a memo on
-   * this class is immediately followed by a stamp.** Never stamp before the
-   * resolve — resolving can autoload-and-register a class and bump the
-   * generation mid-flight, and stamping the pre-resolve value would leave the
-   * memo flagged stale the moment it is written, forcing the next touch to wipe
-   * and recompute the whole through/source chain. Error paths stamp too: a
-   * resolve that threw can have bumped the generation just as easily as one that
-   * succeeded (a namespaced candidate walk may register a class and then reject
-   * it), and the negative memo they write is just as much a memo.
-   *
-   * Two exits deliberately do not stamp, and neither writes a memo:
-   * `sourceReflectionName`'s ambiguity rethrow (it escapes before the write), and
-   * `inverseOf`'s no-inverse-name return. `expireCachesIfRegistryChanged` is the
-   * one caller that stamps at *entry*; see its comment for why.
-   * @internal
-   */
-  private stampGeneration(): void {
-    this._cacheGeneration = modelRegistry.generation;
-  }
-
-  /**
-   * Every memo this class owns (klass, through/source, and the inverse
-   * reflection resolved off `klass`) derives from classes resolved out of the
-   * model registry, so they all go stale together when a name is rebound to a
-   * different class. Drop them as a unit rather than returning a target that
-   * the registry no longer maps this reflection to. `inverseName` is absent
-   * because it delegates to the AssociationReflection memo, which gates itself.
-   *
-   * Stamps at *entry*, uniquely, so a nested getter (sourceReflection →
-   * sourceReflectionName → throughReflection) doesn't re-clear what its caller is
-   * mid-way through computing. Each getter re-stamps after it resolves, so a
-   * mid-flight autoload bump doesn't leave a memo stale on write.
-   * @internal
-   */
-  private expireCachesIfRegistryChanged(): void {
-    if (this._cacheGeneration === modelRegistry.generation) return;
-    this.stampGeneration();
-    this._klassCache = null;
-    this._sourceReflectionCache = undefined;
-    this._throughReflectionCache = undefined;
-    this._sourceReflectionNameCache = undefined;
-    this._inverseOfCache = undefined;
   }
 
   get name(): string {
@@ -1645,22 +1560,12 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   get klass(): typeof Base {
-    // Rails: @klass ||= delegate_reflection._klass(class_name), where @klass is
-    // seeded with options[:anonymous_class] in the constructor.
-    this.expireCachesIfRegistryChanged();
+    // Rails `@klass ||= delegate_reflection._klass(class_name)`
+    // (reflection.rb:989-990), where @klass is seeded with
+    // options[:anonymous_class] in the constructor.
     if (this._klassCache) return this._klassCache;
     const anonymousClass = this._delegate.options.anonymousClass as typeof Base | undefined;
     this._klassCache = anonymousClass ?? this._delegate._klass(this.className);
-    // Resolving can autoload-and-register the target, bumping the generation
-    // mid-flight; re-sync so this memo isn't stale the moment it's written.
-    //
-    // This also certifies any sibling memo repopulated during the resolve (e.g.
-    // `className` above can derive through `sourceReflection`) at the post-bump
-    // generation. That is sound because the only bump reachable inside a
-    // synchronous resolve is an autoload registering a name that was, by
-    // definition, absent from the registry — a registry *miss* is what triggers
-    // the autoload — so it cannot change what any earlier lookup resolved to.
-    this.stampGeneration();
     return this._klassCache;
   }
 
@@ -1711,40 +1616,25 @@ export class ThroughReflection extends AbstractReflection {
     return this._delegate.isCollection() ? singularize(this.nameString) : this.name;
   }
 
+  /**
+   * Mirrors: `source_reflection` (reflection.rb:1010-1014) — computed on every
+   * read, never memoized.
+   */
   get sourceReflection(): AssociationReflection | ThroughReflection | null {
-    this.expireCachesIfRegistryChanged();
-    if (this._sourceReflectionCache !== undefined) return this._sourceReflectionCache;
     const srcName = this.sourceReflectionName();
-    if (!srcName) {
-      this._sourceReflectionCache = null;
-      this.stampGeneration();
-      return null;
-    }
+    if (!srcName) return null;
     const throughRef = this.throughReflection;
-    if (!throughRef) {
-      this._sourceReflectionCache = null;
-      this.stampGeneration();
-      return null;
-    }
+    if (!throughRef) return null;
     try {
-      const src = throughRef.klass._reflectOnAssociation(srcName) ?? null;
-      this._sourceReflectionCache = src;
-      this.stampGeneration();
-      return src;
+      return throughRef.klass._reflectOnAssociation(srcName) ?? null;
     } catch {
-      this._sourceReflectionCache = null;
-      this.stampGeneration();
       return null;
     }
   }
 
+  /** Mirrors: `through_reflection` (reflection.rb:1028-1030) — not memoized. */
   get throughReflection(): AssociationReflection | ThroughReflection | null {
-    this.expireCachesIfRegistryChanged();
-    if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
-    const through = this.activeRecord._reflectOnAssociation(this.through) ?? null;
-    this._throughReflectionCache = through;
-    this.stampGeneration();
-    return through;
+    return this.activeRecord._reflectOnAssociation(this.through) ?? null;
   }
 
   get joinTable(): string {
@@ -1853,12 +1743,11 @@ export class ThroughReflection extends AbstractReflection {
     // the underlying reflection would resolve the inverse against the delegate's
     // name-derived klass (`leadDeveloper` → nonexistent `LeadDeveloper`) instead
     // of the source class (`Developer`).
-    this.expireCachesIfRegistryChanged();
+    // reflection.rb:258-261 — `return unless inverse_name` then `@inverse_of ||=`.
     const name = this.inverseName();
     if (!name) return null;
-    if (this._inverseOfCache !== undefined) return this._inverseOfCache;
+    if (this._inverseOfCache) return this._inverseOfCache;
     this._inverseOfCache = this.klass._reflectOnAssociation(name) ?? null;
-    this.stampGeneration();
     return this._inverseOfCache;
   }
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
@@ -1875,22 +1764,22 @@ export class ThroughReflection extends AbstractReflection {
     return [...new Set(names)];
   }
 
+  /**
+   * Mirrors: `source_reflection_name` (reflection.rb:1112-1130). The Ruby memo
+   * is `@source_reflection_name ||=`, so a run that finds no name writes
+   * nothing and the next read tries again — which is what makes a name resolved
+   * against a still-incomplete model registry recoverable.
+   */
   sourceReflectionName(): string | null {
-    this.expireCachesIfRegistryChanged();
-    if (this._sourceReflectionNameCache !== undefined) return this._sourceReflectionNameCache;
+    if (this._sourceReflectionNameCache) return this._sourceReflectionNameCache;
 
     if (this.options.source) {
       this._sourceReflectionNameCache = this.options.source as string;
-      this.stampGeneration();
       return this._sourceReflectionNameCache;
     }
 
     const throughRef = this.throughReflection;
-    if (!throughRef) {
-      this._sourceReflectionNameCache = null;
-      this.stampGeneration();
-      return null;
-    }
+    if (!throughRef) return null;
 
     try {
       const singular = singularize(this.nameString);
@@ -1905,12 +1794,9 @@ export class ThroughReflection extends AbstractReflection {
         );
       }
       this._sourceReflectionNameCache = matching[0] ?? null;
-      this.stampGeneration();
     } catch (e: unknown) {
-      // Escapes before any memo write, so there is nothing to stamp.
       if (e instanceof AmbiguousSourceReflectionForThroughAssociation) throw e;
       this._sourceReflectionNameCache = null;
-      this.stampGeneration();
     }
     return this._sourceReflectionNameCache ?? null;
   }

--- a/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
+++ b/packages/activerecord/src/register-model-canonical-guard.trails.test.ts
@@ -50,10 +50,8 @@ describe("registerModel canonical-name shadow guard", () => {
 
   it("throws when a bespoke class reaches the registry through a bare set", () => {
     class RfBareSetXyz extends Base {}
-    const before = modelRegistry.generation;
     expect(() => modelRegistry.set("Author", RfBareSetXyz)).toThrow(/shadow the canonical model/);
     expect(modelRegistry.get("Author")).toBe(Author);
-    expect(modelRegistry.generation).toBe(before);
   });
 
   it("keeps a constant rebound by another writer when the registry entry is dropped", () => {

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -198,7 +198,7 @@ describe("RelationTest", () => {
   });
 
   it("constructJoinDependency handles array-form spec — joins(['posts','comments'])", () => {
-    // leftJoins(["posts", "comments"]) is equivalent to chaining leftJoins("posts").leftJoins("comments").
+    // leftJoins(["posts", "comments"]) is equivalent to chaining leftJoins("posts").leftJoins(":comments").
     class Author extends Base {
       static {
         this.tableName = "authors";
@@ -222,7 +222,7 @@ describe("RelationTest", () => {
     registerModel("CJDPost", Post);
     registerModel("CJDComment", Comment);
     // Array spec goes directly through constructJoinDependency via leftJoins
-    const sql = Author.all().leftJoins(["posts", "comments"]).toSql();
+    const sql = Author.all().leftJoins([":posts", ":comments"]).toSql();
     expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
     expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
   });
@@ -251,7 +251,7 @@ describe("RelationTest", () => {
     registerModel("HashAuthor", Author);
     registerModel("HashPost", Post);
     registerModel("HashComment", Comment);
-    const sql = Author.all().leftJoins({ posts: "comments" }).toSql();
+    const sql = Author.all().leftJoins({ posts: ":comments" }).toSql();
     expect(sql).toMatch(/LEFT OUTER JOIN.*posts/i);
     expect(sql).toMatch(/LEFT OUTER JOIN.*comments/i);
     // Verify comments is joined through posts: ON clause must reference the
@@ -291,9 +291,9 @@ describe("RelationTest", () => {
     registerModel("LeftJoinAuthor2", Author);
     registerModel("LeftJoinPost2", Post);
 
-    const rel = Author.leftJoins("posts");
+    const rel = Author.leftJoins(":posts");
     // Association name stored in leftOuterJoinsValues, not pre-resolved to _joinClauses
-    expect((rel as any).leftOuterJoinsValues).toContain("posts");
+    expect((rel as any).leftOuterJoinsValues).toContain(":posts");
     expect((rel as any)._joinClauses.some((j: any) => j.table === "posts")).toBe(false);
     // SQL still contains LEFT OUTER JOIN
     expect(rel.toSql()).toMatch(/LEFT OUTER JOIN/i);
@@ -343,7 +343,7 @@ describe("RelationTest", () => {
     registerModel("RefLeftAuthor", Author);
     registerModel("RefLeftPost", Post);
 
-    const rel = Author.all().includes("posts").references("posts").leftJoins("posts");
+    const rel = Author.all().includes("posts").references("posts").leftJoins(":posts");
     const sqlStr = rel.toSql();
     // "posts" table should appear only once in LEFT OUTER JOIN clauses
     const leftJoinMatches = sqlStr.match(/LEFT OUTER JOIN/gi) ?? [];
@@ -369,9 +369,9 @@ describe("RelationTest", () => {
     registerModel("EagerLeftAuthor", Author);
     registerModel("EagerLeftPost", Post);
     // Both eagerLoad and leftJoins present, no explicit joins_values/_joinClauses
-    const rel = Author.leftJoins("posts").eagerLoad("posts");
+    const rel = Author.leftJoins(":posts").eagerLoad("posts");
     expect((rel as any).eagerLoadValues).toContain("posts");
-    expect((rel as any).leftOuterJoinsValues).toContain("posts");
+    expect((rel as any).leftOuterJoinsValues).toContain(":posts");
     // buildJoinBuckets must not short-circuit; SQL must be non-empty (no throw)
     expect(() => rel.toSql()).not.toThrow();
   });
@@ -555,7 +555,7 @@ describe("RelationTest", () => {
 
       const withCollectionLeftJoin = JlArticle.all()
         .eagerLoad("jlAuthor")
-        .leftJoins("jlComments")
+        .leftJoins(":jlComments")
         .limit(5);
       expect((withCollectionLeftJoin as any)._isDeferredDistinctPkSubquery()).toBe(true);
 

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -198,7 +198,7 @@ describe("RelationTest", () => {
   });
 
   it("constructJoinDependency handles array-form spec — joins(['posts','comments'])", () => {
-    // leftJoins(["posts", "comments"]) is equivalent to chaining leftJoins("posts").leftJoins(":comments").
+    // leftJoins([":posts", ":comments"]) is equivalent to chaining leftJoins(":posts").leftJoins(":comments").
     class Author extends Base {
       static {
         this.tableName = "authors";

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -18,14 +18,7 @@ import type { SerializeOptions } from "@blazetrails/activemodel";
 
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { QueryAttribute } from "./relation/query-attribute.js";
-import {
-  isPlainObject as _isPlainObject,
-  wrap,
-  any,
-  compactBlank,
-  groupBy,
-  indexBy,
-} from "@blazetrails/activesupport";
+import { wrap, any, compactBlank, groupBy, indexBy } from "@blazetrails/activesupport";
 
 import { Range } from "./connection-adapters/postgresql/oid/range.js";
 export { Range };
@@ -523,21 +516,6 @@ export class Relation<T extends Base> {
     // _selfJoinAlias) — used to attribute repeat counts to the right candidate.
     aliasBase?: string;
   }> = [];
-  // A `joins_values` entry is a "named" inner association join (resolved through
-  // JoinDependency) when it is a nested-association hash, a Symbol — spelled as
-  // a leading-colon string, trails' signal for an association/CTE name, e.g.
-  // `joins(":name")` — or a string naming an association; everything else (Arel
-  // join nodes, raw SQL strings) is a raw join value. The two derived getters
-  // below partition `joinsValues` by this rule — the same rule `joins` uses at
-  // insert time. A raw Symbol routed to the raw-join bucket would reach the arel
-  // visitor and raise "Unknown node type: Symbol", so Symbols must be named.
-  private _isNamedJoinValue(v: unknown): boolean {
-    return (
-      _isPlainObject(v) ||
-      v instanceof JoinDependency ||
-      (typeof v === "string" && (v.startsWith(":") || this._isAssociationName(v)))
-    );
-  }
   /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
   skipPreloadingValue = false;
   private _loaded = false;
@@ -701,19 +679,6 @@ export class Relation<T extends Base> {
   }
 
   // merge and spawn are mixed in from spawn-methods.ts
-
-  /**
-   * True when `name` is a declared association on this relation's model. A
-   * named `joins(:assoc)` routes through JoinDependency (mirroring Rails'
-   * joins_values → build_join_dependencies); anything else is a raw SQL join
-   * fragment stored verbatim in joins_values.
-   *
-   * @internal
-   */
-  private _isAssociationName(name: string): boolean {
-    const modelClass = this._model as any;
-    return (modelClass._associations ?? []).some((a: any) => a.name === name);
-  }
 
   // -- Relation state --
 

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -123,7 +123,7 @@ describe("DeleteAllTest", () => {
   });
 
   it("delete all with left joins", async () => {
-    const pets = Pet.leftJoins("toys").where({ toys: { name: "Bone" } });
+    const pets = Pet.leftJoins(":toys").where({ toys: { name: "Bone" } });
 
     expect(await pets.exists()).toBe(true);
     const countBefore = await pets.count();

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -35,7 +35,7 @@ describe("join value union structural dedup", () => {
   fixtures({});
 
   it("emits a single LEFT OUTER JOIN for a structurally-equal Hash spec joined twice", () => {
-    const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "comments" });
+    const rel = Author.leftJoins({ posts: ":comments" }).leftJoins({ posts: ":comments" });
     // left_outer_joins_values |= dedups the structurally-equal Hash spec (eql?),
     // so the value survives once — mirroring Rails, not JS reference identity.
     expect(asHost(rel).leftOuterJoinsValues).toHaveLength(1);
@@ -55,7 +55,7 @@ describe("join value union structural dedup", () => {
   it("keeps distinct Hash specs as separate joins", () => {
     // Dedup is by value, not by shape: two hashes with the same key but
     // different nested target must both survive.
-    const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "author" });
+    const rel = Author.leftJoins({ posts: ":comments" }).leftJoins({ posts: ":author" });
     expect(asHost(rel).leftOuterJoinsValues).toHaveLength(2);
   });
 

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -1,5 +1,5 @@
 import { Nodes } from "@blazetrails/arel";
-import { assertValidKeys, isBlank } from "@blazetrails/activesupport";
+import { assertValidKeys, isBlank, isPlainObject } from "@blazetrails/activesupport";
 
 import { JoinDependency } from "../associations/join-dependency.js";
 import { Relation } from "../relation.js";
@@ -161,10 +161,12 @@ export class Merger {
       return;
     }
 
+    // merger.rb:122-126 — `partition { |join| case join when Hash, Symbol,
+    // Array; true end }`. A Ruby Symbol is a leading-colon string in trails.
     const associations: unknown[] = [];
     const others: unknown[] = [];
     for (const v of joinsValues) {
-      if (!(v instanceof JoinDependency) && other._isNamedJoinValue(v)) {
+      if (isPlainObject(v) || Array.isArray(v) || (typeof v === "string" && v.startsWith(":"))) {
         associations.push(v);
       } else {
         others.push(v);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -107,8 +107,12 @@ export class WhereChain<R = any> {
       const associationConditions = Object.fromEntries(
         wrap(reflection.associationPrimaryKey).map((pk) => [pk, null]),
       );
+      // query_methods.rb:96-99 — the `class_name:` branch keys the hash with the
+      // association Symbol, the `else` branch with the table-name String.
       if (reflection.options.className) {
-        this.not({ [association]: associationConditions });
+        this.not({
+          [isRubySymbol(association) ? association : `:${association}`]: associationConditions,
+        });
       } else {
         this.not({ [reflection.tableName]: associationConditions });
       }
@@ -128,8 +132,12 @@ export class WhereChain<R = any> {
       const associationConditions = Object.fromEntries(
         wrap(reflection.associationPrimaryKey).map((pk) => [pk, null]),
       );
+      // query_methods.rb:130-133 — Symbol key for the `class_name:` branch, the
+      // table-name String otherwise.
       if (reflection.options.className) {
-        whereBang.call(scope, { [association]: associationConditions });
+        whereBang.call(scope, {
+          [isRubySymbol(association) ? association : `:${association}`]: associationConditions,
+        });
       } else {
         whereBang.call(scope, { [reflection.tableName]: associationConditions });
       }
@@ -344,11 +352,6 @@ interface QueryMethodsHost {
   // Converged Rails `Relation#alias_tracker(joins, aliases)` (relation.rb:1307);
   // `buildJoins` reads it to build the shared `build_joins` tracker.
   aliasTracker(joins?: Nodes.Node[], aliases?: Map<string, number>): AliasTracker;
-  // A `joins_values` entry is a "named" inner association join (resolved through
-  // JoinDependency) when it is a nested-association hash, a Symbol — spelled as a
-  // leading-colon string — or a string naming an association; everything else
-  // (Arel join nodes, raw SQL strings) is a raw join value.
-  _isNamedJoinValue(v: unknown): boolean;
   /** Rails' `clone` behind `spawn` (spawn_methods.rb:9-11). */
   clone(): any;
   /** Mirrors: ActiveRecord::SpawnMethods#spawn (spawn_methods.rb:9-11). */
@@ -1163,19 +1166,27 @@ export function buildWhereClause(
     // Mirrors build_where_clause (query_methods.rb:1640): a hash condition
     // auto-adds references for its nested-hash / dotted-key tables, so an
     // includes(...) with a WHERE on the joined table promotes to eager JOIN.
-    referencesBang.call(this, ...referencesFromConditions(opts));
     const mc = this.model;
     const aliases: Record<string, string> = mc?._attributeAliases ?? {};
     // Rails never pre-casts hash values here — build_where_clause hands them
     // raw to PredicateBuilder, whose QueryAttribute bind casts/serializes at
     // compile time (predicate_builder.rb:57-69 → build_bind_attribute →
     // value_for_database).
+    // Rails `opts.transform_keys { |key| key = key.to_s; attribute_aliases[key]
+    // || key }` (query_methods.rb:1632-1638) — `to_s` on a Symbol key drops the
+    // leading colon trails spells it with, so an association-named key and a
+    // table-named key are one string from here on, and `references` /
+    // `build_from_hash` both see the bare name.
     const transformed: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(opts)) {
-      const resolved = aliases[key] ?? key;
+      const name = isRubySymbol(key) ? symbolToName(key) : key;
+      const resolved = aliases[name] ?? name;
       transformed[resolved] = value;
     }
     opts = transformed;
+    // query_methods.rb:1640-1641 — references are taken from the TRANSFORMED
+    // hash, after key stringification.
+    referencesBang.call(this, ...referencesFromConditions(opts));
     const parts = this.predicateBuilder.buildFromHash(
       opts as Record<string, unknown>,
       (tableName: string) => lookupTableKlassFromJoinDependencies.call(this, tableName),
@@ -3257,10 +3268,9 @@ export function selectNamedJoins(
  * Mirrors `select_association_list` (query_methods.rb:1810-1823).
  *
  * Its `when Hash, Symbol, Array` arm keeps association specs and drops a raw
- * SQL String through the `else`. TypeScript collapses Ruby's Symbol and String
- * onto one type, so that `when` cannot be spelled by type: a string is a Symbol
- * here only when it names an association (or carries the leading colon), the
- * same discriminator `joins()` applies at insert time.
+ * SQL String through the `else`. A Ruby Symbol is a leading-colon string in
+ * trails (CLAUDE.md), which is the discriminator the Ruby `when` gets from the
+ * type.
  *
  * @internal
  */
@@ -3272,11 +3282,7 @@ export function selectAssociationList(
 ): unknown[] {
   const result: unknown[] = [];
   for (const association of associations) {
-    if (
-      Array.isArray(association) ||
-      isPlainObject(association) ||
-      (typeof association === "string" && this._isNamedJoinValue(association))
-    ) {
+    if (Array.isArray(association) || isPlainObject(association) || isRubySymbol(association)) {
       result.push(association);
     } else if (association instanceof JoinDependency) {
       stashedJoins?.push(association);
@@ -3406,11 +3412,10 @@ export function buildJoinBuckets(
   // query_methods.rb:1856-1862: `stashed_eager_load || stashed_left_joins`.
   const hasStashed = Boolean(stashedEagerLoad) || stashedLeft.length > 0;
 
-  // query_methods.rb:1851-1853. Rails wraps every String; trails collapses
-  // Ruby's Symbol and String into one type, so an association-name string
-  // stays a named join value instead of becoming a raw SQL fragment.
+  // query_methods.rb:1851-1853. A Ruby Symbol is a leading-colon string in
+  // trails, so a String join value is one without the colon.
   for (const [i, v] of joins.entries()) {
-    if (typeof v === "string" && !this._isNamedJoinValue(v)) {
+    if (typeof v === "string" && !v.startsWith(":")) {
       joins[i] = new Nodes.StringJoin(Arel.sql(v.trim()) as any) as Nodes.Join;
     }
   }

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -132,7 +132,7 @@ describe("UpdateAllTest", () => {
   });
 
   it("update all with left joins", async () => {
-    const petsScope = Pet.leftJoins("toys").where({ toys: { name: "Bone" } });
+    const petsScope = Pet.leftJoins(":toys").where({ toys: { name: "Bone" } });
 
     expect(await petsScope.exists()).toBe(true);
     const countBefore = await petsScope.count();

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -211,7 +211,7 @@ describe("WhereChainTest", () => {
 
   // Self-join `children` — see the self-join note above.
   it("associated with add left joins before", async () => {
-    const relation = await Comment.leftJoins("children").where().associated("children");
+    const relation = await Comment.leftJoins(":children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
   });
@@ -464,7 +464,7 @@ describe("WhereChainTest", () => {
       .where()
       .missing("comments")
       .rewhere({ "comments.id": comments("does_it_hurt").id });
-    const expected = Post.leftJoins("comments").where({
+    const expected = Post.leftJoins(":comments").where({
       "comments.id": comments("does_it_hurt").id,
     });
     expect(ids(await relation)).toEqual(ids(await expected));

--- a/packages/activerecord/src/relation/where-symbol-key-stringification.trails.test.ts
+++ b/packages/activerecord/src/relation/where-symbol-key-stringification.trails.test.ts
@@ -34,7 +34,12 @@ describe("a leading-colon where key", () => {
     // `Post#firstComment` is `class_name: "Comment"` over the `comments` table,
     // so the condition is keyed by the association Symbol
     // (query_methods.rb:96-98), not by `reflection.table_name`.
+    const conn = Post.connection;
     const sql = Post.where().associated("firstComment").toSql();
-    expect(sql).toContain('"firstComment"."id" IS NOT NULL');
+    const qualified = `${conn.quoteTableName("firstComment")}.${conn.quoteColumnName("id")}`;
+    expect(sql).toContain(`${qualified} IS NOT NULL`);
+    expect(sql).not.toContain(
+      `${conn.quoteTableName("comments")}.${conn.quoteColumnName("id")} IS NOT NULL`,
+    );
   });
 });

--- a/packages/activerecord/src/relation/where-symbol-key-stringification.trails.test.ts
+++ b/packages/activerecord/src/relation/where-symbol-key-stringification.trails.test.ts
@@ -1,0 +1,40 @@
+/**
+ * `build_where_clause` stringifies every hash key before looking up an
+ * attribute alias, taking references, or expanding the hash
+ * (query_methods.rb:1632-1641). Ruby gets that for free from `Symbol#to_s`;
+ * trails spells a Ruby Symbol as a leading-colon string, so the colon has to be
+ * dropped at the same point — `where.associated` / `where.missing` key the
+ * `class_name:` branch with the association Symbol (query_methods.rb:96-99,
+ * :130-133), and a Symbol key must name the same association a String key does.
+ *
+ * trails-only (hence `.trails.test.ts`): on the Ruby side the two spellings are
+ * different types rather than two strings, so Rails cannot write this test.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { Post } from "../test-helpers/models/post.js";
+import { fixtures } from "../test-fixtures.js";
+
+describe("a leading-colon where key", () => {
+  fixtures(["posts", "comments"]);
+
+  it("resolves the association the bare string resolves", () => {
+    expect(
+      Post.joins(":comments")
+        .where({ ":comments": { id: null } })
+        .toSql(),
+    ).toBe(
+      Post.joins(":comments")
+        .where({ comments: { id: null } })
+        .toSql(),
+    );
+  });
+
+  it("keys where.associated off a class_name association whose name is not its table", () => {
+    // `Post#firstComment` is `class_name: "Comment"` over the `comments` table,
+    // so the condition is keyed by the association Symbol
+    // (query_methods.rb:96-98), not by `reflection.table_name`.
+    const sql = Post.where().associated("firstComment").toSql();
+    expect(sql).toContain('"firstComment"."id" IS NOT NULL');
+  });
+});

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -788,7 +788,7 @@ describe("DefaultScopingTest", () => {
   it("unscope left joins", async () => {
     const expected = names(await Developer.all());
     const received = names(
-      await (Developer.leftJoins("projects") as any)
+      await (Developer.leftJoins(":projects") as any)
         .select("id")
         .unscope("leftJoins", "select")
         .toArray(),

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -415,10 +415,10 @@ describe("RelationScopingTest", () => {
   });
 
   it("circular left joins with scoping does not crash", async () => {
-    const posts = (await Post.leftJoins({ comments: "post" }).scoping(async () =>
+    const posts = (await Post.leftJoins({ comments: ":post" }).scoping(async () =>
       Post.first(10),
     )) as Base[];
-    const expected = (await Post.leftJoins({ comments: "post" }).first(10)) as Base[];
+    const expected = (await Post.leftJoins({ comments: ":post" }).first(10)) as Base[];
     expect(posts.map((p: any) => p.id)).toEqual(expected.map((p: any) => p.id));
   });
 

--- a/packages/activerecord/src/test-helpers/models/author.ts
+++ b/packages/activerecord/src/test-helpers/models/author.ts
@@ -402,7 +402,7 @@ export class Author extends Base {
     );
     this.hasMany(
       "postsWithNoComments_2",
-      (q: any) => q.leftJoins("comments").where({ "comments.id": null }),
+      (q: any) => q.leftJoins(":comments").where({ "comments.id": null }),
       { className: "Post" },
     );
 

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -52,7 +52,7 @@ export class Club extends Base {
 
     this.scope("general", (q: any) =>
       q
-        .leftJoins("category")
+        .leftJoins(":category")
         .where({ categories: { name: "General" } })
         .unscope("limit"),
     );

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -202,7 +202,9 @@ export class Post extends Base {
       q.joins(":comments").group("posts.id").having("count(comments.id) >= ?", commentsCount),
     );
 
-    this.scope("noComments", (q: any) => q.leftJoins("comments").where({ comments: { id: null } }));
+    this.scope("noComments", (q: any) =>
+      q.leftJoins(":comments").where({ comments: { id: null } }),
+    );
     this.scope("withSpecialComments", (q: any) =>
       q.joins(":comments").where({ comments: { type: "SpecialComment" } }),
     );

--- a/packages/activerecord/src/test-helpers/models/rating.ts
+++ b/packages/activerecord/src/test-helpers/models/rating.ts
@@ -18,7 +18,7 @@ export class Rating extends Base {
     this.hasMany("taggings", { as: "taggable" });
     this.hasMany(
       "taggingsWithoutTag",
-      (q: any) => q.leftJoins("tag").where({ "tags.id": [null, 0] }),
+      (q: any) => q.leftJoins(":tag").where({ "tags.id": [null, 0] }),
       { as: "taggable", className: "Tagging" },
     );
     this.hasMany(


### PR DESCRIPTION
Bundle of four convergence stories.

## 1. Retire `Relation#_isNamedJoinValue` / `#_isAssociationName` (RFC 0107)

Rails' `select_association_list` (`query_methods.rb:1810-1823`) keeps `Hash,
Symbol, Array` and drops a String through the `else`; `build_join_buckets`
(`:1851-1853`) wraps every String in a `StringJoin`. Both tests are on the
*type*. trails collapses Ruby Symbol and String onto one JS string, and the
settled idiom (CLAUDE.md) is the leading colon — so the colon is the
discriminator, not a model-association lookup.

Both helpers are deleted and all four external readers rewritten against the
Rails-named surface: `selectAssociationList` and `buildJoinBuckets` in
`query-methods.ts`, plus the `merger.rb:122-126` partition in `merger.ts` and
its twin in `association-scope.ts`, which now spell Rails' inline
`case join when Hash, Symbol, Array` directly.

#6704 swept the `joins` call sites; `leftJoins` / `leftOuterJoins` and the
nested-hash *values* were still bare, so they are swept here too (these are
Symbols in the Rails tests).

## 2. `WhereChain#associated` / `#missing` key the Symbol branch as a Symbol (RFC 0107)

Rails keys the condition hash with a **Symbol** in the `class_name:` branch and
a **String** (`reflection.table_name`) otherwise — `query_methods.rb:96-99` and
`:130-133`. trails passed a bare string in both. Fixed.

The story asked whether the predicate builder honours a colon-prefixed key.
It turns out Rails does not carry the distinction that far: `build_where_clause`
runs `opts.transform_keys { |key| key = key.to_s; attribute_aliases[key] || key }`
at `query_methods.rb:1632-1638`, **before** `PredicateBuilder.references` and
`build_from_hash`. (`PredicateBuilder.references({author: {...}})` in fact raises
`TypeError` on a Symbol key under MRI — verified against vendored 8.0.2.) So the
convergence is that `to_s`, which trails was missing: the key is stringified —
colon dropped — the alias lookup happens on the stringified name, and references
are taken from the transformed hash. Both were previously done on the raw key.

Regression test `where-symbol-key-stringification.trails.test.ts` (fails on
baseline both ways).

## 3. Reflection memo invalidation → Rails' `||=` (RFC 0078)

`reflection-registry-poison-actual-mechanism` (#6702) established the mechanism:
zero rebinds, 184 fresh registrations, and the poisoned memo is
`ThroughReflection#sourceReflectionName`'s `null`, written by the catch that
swallows `NameError: Missing model class Tagging` while `Tagging` is not yet
registered.

Zeitwerk-style discard-on-register is therefore not the fix — nothing is ever
rebound. **Rails' own memoization is**, and trails had diverged from it:

| Rails | before | now |
| --- | --- | --- |
| `@klass ||= compute_class(...)` (`:422`) | memo + generation gate | `||=` |
| `@klass ||= delegate_reflection._klass(...)` (`:989`) | memo + gate | `||=` |
| `@inverse_of ||=` (`:261`) | memoized `null` + gate | `||=` |
| `@source_reflection_name ||=` (`:1113`) | memoized `null` + gate | `||=` |
| `source_reflection` (`:1010`) — not memoized | memoized + gate | not memoized |
| `through_reflection` (`:1028`) — not memoized | memoized + gate | not memoized |

The `||=` is the load-bearing part: a resolve that finds nothing writes no memo,
so the negative resolution formed under an incomplete registry is simply retried
and heals itself — including after the last registration in a worker, which the
generation gate could not cover. `ModelRegistry`'s `generation` counter, every
gate, `stampGeneration`, `expireCachesIfRegistryChanged` and
`expireInverseCachesIfRegistryChanged` are deleted.

The two-file repro stays green (211 passed):

```
pnpm vitest run --no-file-parallelism \
  packages/activerecord/src/associations/nested-through-associations.test.ts \
  packages/activerecord/src/associations.test.ts
```

The `reflection.trails.test.ts` guards that pinned *rebind* re-resolution are
removed: they encode the gate's semantics, and Rails memoizes a successful
`klass` permanently. The "re-registering the same class keeps the klass memo"
guard stays.

## 4. ActiveRecord's own `instance_method_already_implemented?` (RFC 0096)

`defineAttributeMethodPattern`'s guard is now the single predicate call Rails
makes (`activemodel/attribute_methods.rb:326`); the extra
`publicMethodName in this.prototype` arm is gone. The predicate stays a template
method — ActiveModel's is `generated_attribute_methods.method_defined?`
(`:404-406`), ActiveRecord's override
(`activerecord/attribute_methods.rb:165-179`) raises `DangerousAttributeError`
and consults the class's own methods, and it is already assigned onto the AR
model host. Added a cover for an ordinary class-body method surviving
generation; the dangerous-name raise was already covered.

## Verification

- `pnpm parity:api:calls` — OK (1095 baselined, down from 1109; marks tight)
- `pnpm parity:api:calls:args` — OK (164 baselined shape rows)
- `pnpm parity:api:extra --package activerecord` — no novel name
- `pnpm typecheck`, `pnpm lint` clean on touched files
- `pnpm vitest run` over `relation/`, `scoping/`, `associations/`,
  `relations.test.ts`, `reflection*.test.ts`, `attribute-methods*.test.ts`,
  `base.test.ts`, `inheritance.test.ts`, activemodel — 180 files / 4075 passed
- 179+447 LOC

Closes-story: retire-relation-is-named-join-value-discriminator
Closes-story: where-chain-associated-missing-where-key-drops-symbol-spelling
Closes-story: reflection-registry-discard-on-rebind-vs-generation-gate
Closes-story: instance-method-already-implemented-ar-override