### PR TITLE
fix(activerecord): route enum's columns-hash read through ownProp, move Relation#length onto the records delegation

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -373,13 +373,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (collection_proxy.rb): `records.length`. `records` resolves through
    * `load_target`, which returns the cached `@target` when the association is
    * already loaded — so a loaded proxy counts in memory with NO query and only
-   * an unloaded one re-queries. The inherited `Relation#length` always
-   * re-queries via `toArray`/`_execLoad`, which is why we override here: the
-   * proxy keeps loaded state in `_target`/`_targetLoaded`, not Relation's
-   * `_records`/`_loaded`, so `loadTarget()` (which short-circuits on
-   * `_targetLoaded`) is the faithful path.
+   * an unloaded one re-queries. `Relation`'s `to: :records` delegate
+   * (delegation.rb:101) always re-queries via `toArray`/`_execLoad`, which is
+   * why this overrides it: the proxy keeps loaded state in
+   * `_target`/`_targetLoaded`, not Relation's `_records`/`_loaded`, so
+   * `loadTarget()` (which short-circuits on `_targetLoaded`) is the faithful
+   * path.
    */
-  override async length(): Promise<number> {
+  async length(): Promise<number> {
     return (await this.loadTarget()).length;
   }
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -13,7 +13,7 @@ import { getOrCreateModuleCarrier } from "./module-carrier.js";
 import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
 // The synchronous schema reflector (warm-cache path), NOT the async
 // `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
-import { loadSchema as reflectSchemaSync } from "./model-schema.js";
+import { loadSchema as reflectSchemaSync, ownProp, type SchemaHost } from "./model-schema.js";
 
 /** Value a label can map to — matches Rails' hash-value support for enums. */
 type EnumValue = number | string | boolean | null;
@@ -981,13 +981,18 @@ export function raiseConflictError(
 export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
   const host = klass as unknown as {
     _enumsPendingTypeCheck?: Set<string>;
-    _columnsHash?: Record<string, { type?: unknown } | undefined>;
   };
   const pending = host._enumsPendingTypeCheck;
   if (!pending || !pending.has(name)) return;
   // A backing DB column resolves the subtype; an unknown name is simply absent
-  // from the resolved columns hash.
-  const column = host._columnsHash?.[name];
+  // from the resolved columns hash. `ownProp`, NOT `ownSchemaMemo`: this runs
+  // inside the class's own decorator replay, before `applyColumnsHash` stamps
+  // `_schemaRevision`, so the `schemaStaleAgainstAncestors` pull fallback would
+  // blank the hash just written.
+  const columnsHash = ownProp(klass as unknown as SchemaHost, "_columnsHash") as
+    | Record<string, { type?: unknown } | undefined>
+    | undefined;
+  const column = columnsHash?.[name];
   if (column && column.type != null) {
     // Backed by a real column — clear the marker so we don't re-check on every
     // subsequent `typeForAttribute` call. Copy-on-write to avoid mutating an

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -56,7 +56,16 @@ function nextSchemaEpoch(): number {
   return ++schemaEpoch;
 }
 
-function ownProp<K extends keyof SchemaHost>(host: SchemaHost, key: K): SchemaHost[K] | undefined {
+/**
+ * Ruby class ivars are not inherited; JS statics are. Reads the memo only when
+ * the class owns it, so a subclass never serves an ancestor's value.
+ *
+ * @internal
+ */
+export function ownProp<K extends keyof SchemaHost>(
+  host: SchemaHost,
+  key: K,
+): SchemaHost[K] | undefined {
   return Object.prototype.hasOwnProperty.call(host, key) ? host[key] : undefined;
 }
 
@@ -576,7 +585,7 @@ export async function createTable(this: typeof Base): Promise<void> {
 // Missing ClassMethods from parity:api
 // ---------------------------------------------------------------------------
 
-interface SchemaHost {
+export interface SchemaHost {
   name: string;
   tableName: string;
   primaryKey: string | string[];

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1019,17 +1019,6 @@ export class Relation<T extends Base> {
     return (await this.isPresent()) ? stripThenable(this as Relation<T>) : null;
   }
 
-  /**
-   * Return the number of loaded records — `delegate :length, to: :records`
-   * (delegation.rb:101), not an Enumerable member.
-   *
-   * Mirrors: ActiveRecord::Relation#length
-   */
-  async length(): Promise<number> {
-    const records = await this.toArray();
-    return records.length;
-  }
-
   // ---- include Enumerable (relation.rb:67) — see ENUMERABLE_DELEGATES ----
 
   /** `Enumerable#detect` / `#find` — `find` on a Relation is the AR PK finder. */
@@ -3615,6 +3604,7 @@ export interface Relation<T extends Base>
 // is a class-body method (its signature must stay override-compatible with
 // `CollectionProxy#slice`).
 export interface Relation<T extends Base> {
+  length(): Promise<number>;
   each(fn: (record: T, index: number) => void): Promise<T[]>;
   join(separator?: string): Promise<string>;
   isIntersect(other: T[]): Promise<boolean>;

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -897,6 +897,7 @@ interface XmlSerializable {
  * (async, self-loading) and `delegateRecordMethodSync` (sync, loaded proxy).
  */
 const RECORD_DELEGATES: Record<string, RecordDelegate> = {
+  length: (records) => records.length,
   each: (records, fn: (record: Base, index: number) => void) => {
     records.forEach(fn);
     return records;
@@ -1001,6 +1002,11 @@ export class DelegationMethods {
   // Each loads via `toArray()` (trails has no blocking IO) then applies the
   // shared `RECORD_DELEGATES` helper — the same pure function the synchronous
   // loaded-CollectionProxy path (`delegateRecordMethodSync`) uses.
+
+  /** `Array#length` — the number of loaded records. */
+  async length(this: DelegationHost): Promise<number> {
+    return RECORD_DELEGATES.length(await this.toArray()) as number;
+  }
 
   /** `Array#each` — yields each loaded record, returning the records. */
   async each(this: DelegationHost, fn: (record: Base, index: number) => void): Promise<Base[]> {


### PR DESCRIPTION
## Lint failing on main @5b0c3890

The Lint job failed with exactly one error:

```
packages/activerecord/src/enum.ts
  990:18  error  Raw read of `_columnsHash` … blazetrails/schema-memo-read-through-guard
```

`assertEnumTypeDeclared` read `host._columnsHash` directly, so on a subclass it
could serve the ancestor's memo (JS statics are inherited, Ruby class ivars are
not). It now reads through `ownProp`, exported from `model-schema.ts` along with
`SchemaHost`.

Deliberately **not** `ownSchemaMemo`, which the guard message suggests: this runs
from inside the class's own decorator replay (`applyColumnsHash` →
`replayOwnPendingDecorators` → the enum decorator), *before* `applyColumnsHash`
stamps `_schemaRevision`, so `schemaStaleAgainstAncestors` reports the class stale
against its own ancestors and blanks the hash that was just written. Measured:
routing through `ownSchemaMemo` reds 6 `WithAnnotationsTest` cases in
`associations.test.ts` with `Undeclared attribute type for enum 'breed' in
LiveParrot`. The own-property check is the half the guard is actually about, and
`ownProp` is that half.

## `Relation#length` onto the `to: :records` delegation

`vendor/rails/activerecord/lib/active_record/relation/delegation.rb:101`:

```ruby
delegate :to_xml, :encode_with, :length, :each, :join, :intersect?, … to: :records
```

Every other member of that list is already ported in `relation/delegation.ts` as
a `RECORD_DELEGATES` entry plus a matching `DelegationMethods` one-liner.
`length` alone was a hand-written body in `relation.ts`, so the mechanism had one
member missing and a reader could not tell `length` was a delegate.

- `RECORD_DELEGATES.length = (records) => records.length`, positioned per the
  Ruby argument order (`length` precedes `each`)
- `DelegationMethods.length()` as the one-liner over it
- `Relation#length`'s class body deleted; `length(): Promise<number>` added to the
  delegate declaration-merge block in `relation.ts` (alongside `each` / `join` /
  `isIntersect`)
- `CollectionProxy#length` drops its now-invalid `override` modifier and keeps
  its `load_target` body, which Rails also has at `collection_proxy.rb`

PR #6639 had to revert this move because it turned four unrelated `relation.ts`
call-set rows red. That comparator defect was fixed by #6659; verified here —
`pnpm parity:api:calls` is `OK (1095 baselined, 804 unreviewed, 270 marks
totalling 804 tight)` and `parity:api:calls:args` is `OK (164 baselined shape
rows)`, with no new rows.

## Third bundled story: split, not shipped

`converge-attribute-definitions-onto-default-attributes` is not in this PR. The
reader inventory it asks for shows `_attributeDefinitions` has **129 non-test
occurrences across 24 files** on `origin/main` — several times the 700 LOC ceiling
and not safely landable alongside the above. Per the story's own "likely needs
splitting once the reader inventory is known" note, it is released and replaced by
four scheduled slices under RFC 0078, each carrying the concrete `file:line`
inventory:

- `converge-attribute-definitions-activemodel-readers` (activemodel, ~25 refs)
- `converge-attribute-definitions-activerecord-core-readers` (`base.ts`,
  `attributes.ts`, `attribute-methods.ts`, `inheritance.ts`, ~34 refs)
- `converge-attribute-definitions-peripheral-readers` (persistence, encryption,
  fixtures, insert-all, …, ~40 refs)
- `delete-schema-revision-and-decorator-replay-machinery` (`_schemaRevision`,
  `scrubSchemaSourcedDefinitions`, `replayOwnPendingDecorators`, and the
  `schema-memo-read-through-guard` rule itself — which also retires the `ownProp`
  call site this PR adds)

## Verification

- `pnpm typecheck` clean; `pnpm eslint packages/activerecord/src` clean
- `pnpm parity:api:calls` / `parity:api:calls:args` — both `OK`, no new rows
- `pnpm parity:api:extra --package activerecord` — no new novel names (`ownProp`
  is `@internal`)
- `relation/**`, `relation.test.ts`, `relations.test.ts`, `collection-proxy`,
  `associations.test.ts`, `enum`, `model-schema`, `inheritance`, `attributes`,
  `normalized-attribute.trails` — 1396 passed / 44 skipped, plus 297 passed in the
  enum + associations group

Closes-story: red-5b0c3890
Closes-story: converge-relation-length-onto-records-delegation
