### PR TITLE
refactor(arel,date): pass a String relation through SelectManager#join, walk the strftime range with Date#upto

### DIFF
--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -33,8 +33,6 @@ describe("SelectManagerTest (trails)", () => {
     const mgr = new SelectManager(users);
     mgr.join("comments ON comments.user_id = users.id");
     expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.StringJoin);
-    // Rails stores the raw String on the node (string_join.rb:5-9); the visitor
-    // visits it (to_sql.rb:528-530), so there is no SqlLiteral wrap.
     expect((mgr.joinSources()[0] as Nodes.StringJoin).left).toBe(
       "comments ON comments.user_id = users.id",
     );

--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -33,6 +33,11 @@ describe("SelectManagerTest (trails)", () => {
     const mgr = new SelectManager(users);
     mgr.join("comments ON comments.user_id = users.id");
     expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.StringJoin);
+    // Rails stores the raw String on the node (string_join.rb:5-9); the visitor
+    // visits it (to_sql.rb:528-530), so there is no SqlLiteral wrap.
+    expect((mgr.joinSources()[0] as Nodes.StringJoin).left).toBe(
+      "comments ON comments.user_id = users.id",
+    );
   });
 
   // Trails-only coverage for Arel::SelectManager#lock's `case` arms

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -219,8 +219,6 @@ export class SelectManager extends TreeManager {
       klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
 
-    if (typeof relation === "string") relation = new SqlLiteral(relation);
-
     this.core.source.right.push(this.createJoin(relation, null, klass));
     return this;
   }

--- a/packages/date/src/test-date-strftime.test.ts
+++ b/packages/date/src/test-date-strftime.test.ts
@@ -192,7 +192,7 @@ describe("TestDateStrftime", () => {
   });
 
   it("strftime 3 1", { timeout: 30_000 }, () => {
-    for (const d of dateRange(new RubyDate(1970, 1, 1), new RubyDate(2037, 12, 31))) {
+    for (const d of new RubyDate(1970, 1, 1).upto(new RubyDate(2037, 12, 31))) {
       const t = RubyTime.utc(Number(d.year), d.mon, d.day);
       expect(d.strftime("%U")).toEqual(t.strftime("%U"));
       expect(d.strftime("%W")).toEqual(t.strftime("%W"));
@@ -203,7 +203,7 @@ describe("TestDateStrftime", () => {
     const s = RubyTime.now().strftime("%G");
     // eslint-disable-next-line vitest/no-conditional-in-test -- Ruby's `omit if`
     if (s.length === 0 || s === "%G") return ctx.skip();
-    for (const d of dateRange(new RubyDate(1970, 1, 1), new RubyDate(2037, 12, 31))) {
+    for (const d of new RubyDate(1970, 1, 1).upto(new RubyDate(2037, 12, 31))) {
       const t = RubyTime.utc(Number(d.year), d.mon, d.day);
       expect(d.strftime("%G")).toEqual(t.strftime("%G"));
       expect(d.strftime("%g")).toEqual(t.strftime("%g"));
@@ -543,17 +543,4 @@ describe("TestDateStrftime", () => {
 /** Ruby's `Object#inspect` over the message argument, whose Rationals hold BigInts. */
 function inspect(value: unknown): string {
   return JSON.stringify(value, (_k, v) => (typeof v === "bigint" ? String(v) : v));
-}
-
-/**
- * Ruby's `(Date.new(1970,1,1)..Date.new(2037,12,31)).each`, whose `Range#each`
- * walks by `Date#succ` — `d_lite_next_day` over `d_lite_plus(self, 1)`. `#succ`
- * itself is not ported yet (0088-date-gem-port/port-test-date-arith-operators
- * owns it), so the walk calls the `plus` it is defined as, and `cmp` for the
- * `<= end` the Range walks to.
- */
-function* dateRange(from: RubyDate, to: RubyDate): Generator<RubyDate> {
-  for (let d = from; d.cmp(to)! <= 0; d = d.plus(1)) {
-    yield d;
-  }
 }


### PR DESCRIPTION
Two small convergences from a three-story bundle; the third is blocked (below).

## `SelectManager#join` passes a String through

`select-manager.ts` wrapped a String `relation` in a `SqlLiteral` before
`createJoin`. Rails passes it straight through (`arel/select_manager.rb:102-113`):
`Nodes::StringJoin` stores `left` as given (`arel/nodes/string_join.rb:5-9`) and
`visit_Arel_Nodes_StringJoin` visits it (`arel/visitors/to_sql.rb:528-530`).
trails' `visit()` dispatches on runtime type including `string`
(`visitors/visitor.ts:50`) with `visitString` aliased to `unsupported` exactly as
`visit_String` is (`to_sql.rb:842`), so rendering is unchanged. Same a3 as
#6708, which deliberately left this sibling standing.

The trails-only pin now also asserts `left` is the raw String.

## `dateRange` retired for `Date#upto`

`test-date-strftime.test.ts` carried a module-private generator standing in for
`(Date.new(1970,1,1)..Date.new(2037,12,31)).each`
(`vendor/date/test/date/test_date_strftime.rb:118-136`). `Date#upto` has since
landed, so `strftime 3 1` / `strftime 3 2` walk the full 24,837-day range through
it. Both still pass (3.1s / 4.6s) and keep their explicit 30s timeout.

## Blocked story

`converge-includes-preload-colon-sweep-src-top-level` is **not** in this PR. Its
dependency `converge-preloader-branch-colon-symbol-entry-point` is unmerged in
draft #6713 — main's `Preloader::Branch#_normalizeAssociationName`
(`associations/preloader/branch.ts:305-322`) still returns the name without
stripping a leading colon, so colon-spelled `includes`/`preload` values would not
resolve. Stacking is not allowed, so the story is blocked for re-claim once
#6713 lands.

Gates: `parity:api:calls` OK (1095 baselined), `parity:api:calls:args` OK (164
shape rows) — no new rows, and no `select-manager.ts` `create_join` row existed
to retire. `packages/arel/src` (1465 tests), the AR string-join files
(`relations`, `finder`, `relation`) and the two date tests pass.

Closes-story: retire-date-range-test-helper-for-succ
Closes-story: arel-select-manager-join-string-callsite-conversion
