### PR TITLE
refactor(activerecord): sweep intersecting includes/preload call sites onto the colon Symbol spelling

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -623,7 +623,7 @@ describe("PreloaderTest", () => {
     const author = authors("david");
     const book = books("awdr");
     const post = posts("welcome");
-    const bookLoaded = (await Book.where({ id: book.id }).includes("author"))[0];
+    const bookLoaded = (await Book.where({ id: book.id }).includes(":author"))[0];
     const postFresh = (await Post.where({ id: post.id }))[0];
     const sqls = await captureSql(async () => {
       await new Preloader({ records: [bookLoaded, postFresh], associations: ["author"] }).call();
@@ -1250,7 +1250,7 @@ describe("PreloaderTest", () => {
 
     let orders: any[];
     const sqls = await captureSql(async () => {
-      orders = await CpkOrderPL.where("id = ?", orderId).includes("orderAgreements");
+      orders = await CpkOrderPL.where("id = ?", orderId).includes(":orderAgreements");
     });
     expect(sqls).toHaveLength(2);
     const preloadSql = sqls[1];
@@ -1267,7 +1267,7 @@ describe("PreloaderTest", () => {
 
     let agreements: any[];
     const sqls = await captureSql(async () => {
-      agreements = await CpkOrderAgreementPL.where("id = ?", ag.id).includes("order");
+      agreements = await CpkOrderAgreementPL.where("id = ?", ag.id).includes(":order");
     });
     expect(sqls).toHaveLength(2);
     const preloadSql = sqls[1];
@@ -1324,7 +1324,7 @@ describe("PreloaderTest", () => {
 
   it("preload marks belongs_to association loaded on owner", async () => {
     const welcome = posts("welcome");
-    const loaded = await Post.where({ id: welcome.id }).includes("author");
+    const loaded = await Post.where({ id: welcome.id }).includes(":author");
     expect(loaded).toHaveLength(1);
     const assoc = (loaded[0] as any).association("author");
     expect(assoc.isLoaded()).toBe(true);
@@ -1333,7 +1333,7 @@ describe("PreloaderTest", () => {
 
   it("preload sets has_many association target on owner", async () => {
     const david = authors("david");
-    const owners = await Author.where({ id: david.id }).includes("posts");
+    const owners = await Author.where({ id: david.id }).includes(":posts");
     const assoc = (owners[0] as any).association("posts");
     expect(assoc.isLoaded()).toBe(true);
     const ids = (assoc.target as Base[]).map((r) => r.id);
@@ -1588,12 +1588,12 @@ describe("WithAnnotationsTest", () => {
 
   it("has many through with annotation includes a query comment when eager loading", async () => {
     const plain = await captureSql(async () => {
-      await SpacePirateAnnotated.includes("treasureEstimates").first();
+      await SpacePirateAnnotated.includes(":treasureEstimates").first();
     });
     expect(plain.length).toBeGreaterThan(0);
     expect(plain.every((s) => !s.includes("/*"))).toBe(true);
     const sqls = await captureSql(async () => {
-      await SpacePirateAnnotated.includes("treasureEstimatesWithAnnotation").first();
+      await SpacePirateAnnotated.includes(":treasureEstimatesWithAnnotation").first();
     });
     expect(sqls.some((s) => s.includes("yarrr"))).toBe(true);
   });
@@ -1744,7 +1744,7 @@ describe("AssociationsTest", () => {
     await molecule.electrons.create({ name: "electron_1" });
     await molecule.electrons.create({ name: "electron_2" });
 
-    const liquids = await Liquid.includes({ molecules: "electrons" })
+    const liquids = await Liquid.includes({ ":molecules": ":electrons" })
       .references("molecules")
       .where("molecules.id is not null");
     expect((await (liquids[0] as any).molecules.toArray()).length).toBe(1);
@@ -1803,8 +1803,8 @@ describe("AssociationsTest", () => {
     // symbol/column-reference form.
     let raised: unknown;
     try {
-      await Account.all().order("id").includes("firm").first();
-      await Account.all().order({ id: "asc" }).includes("firm").first();
+      await Account.all().order("id").includes(":firm").first();
+      await Account.all().order({ id: "asc" }).includes(":firm").first();
     } catch (e) {
       raised = e;
     }
@@ -2007,7 +2007,7 @@ describe("AssociationsTest", () => {
   it("preloads model with query constraints by explicitly configured fk and pk", async () => {
     const comment = shardedComments("great_comment_blog_post_one");
     const comments = await ShardedComment.where({ id: (comment as any).id }).preload(
-      "blogPostById",
+      ":blogPostById",
     );
     const loaded = comments[0];
     // Rails reads `comment.blog_post_by_id` from the preloaded cache and compares

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -82,7 +82,7 @@ describe("CascadedEagerLoadingTest", () => {
     posts.reduce((sum, p) => sum + targetArr(p, "comments").length, 0);
 
   it("eager association loading with cascaded two levels", async () => {
-    const loaded = await Author.all().includes({ posts: "comments" }).order("id");
+    const loaded = await Author.all().includes({ ":posts": ":comments" }).order("id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
     expect(targetArr(loaded[1], "posts")).toHaveLength(3);
@@ -91,7 +91,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with cascaded two levels and one level", async () => {
     const loaded = await Author.all()
-      .includes({ posts: "comments" }, "categorizations")
+      .includes({ ":posts": ":comments" }, ":categorizations")
       .order("id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
@@ -103,7 +103,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with hmt does not table name collide when joining associations", async () => {
     const authors = await Author.joins(":posts")
-      .eagerLoad("comments")
+      .eagerLoad(":comments")
       .where({ posts: { tags_count: 1 } })
       .order(":id");
     await assertQueriesCount(0, false, () => {
@@ -121,7 +121,7 @@ describe("CascadedEagerLoadingTest", () => {
     // joined onto it. No second `posts`/`posts_authors` join, no ambiguous column.
     const loaded = await Author.all()
       .joins(":posts")
-      .eagerLoad({ posts: "comments" })
+      .eagerLoad({ ":posts": ":comments" })
       .order("authors.id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
@@ -132,7 +132,7 @@ describe("CascadedEagerLoadingTest", () => {
   it("eager association loading dedups a single-step manual join and eager root", async () => {
     // Author.joins(:posts).eager_load(:posts): single-step root coincides with
     // the manual join — one un-aliased INNER `posts`, no duplicate.
-    const loaded = await Author.all().joins(":posts").eagerLoad("posts").order("authors.id");
+    const loaded = await Author.all().joins(":posts").eagerLoad(":posts").order("authors.id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
     expect(targetArr(loaded[1], "posts")).toHaveLength(3);
@@ -158,7 +158,7 @@ describe("CascadedEagerLoadingTest", () => {
     // column. Mirrors the root-only string dedup but down the whole nested path.
     const loaded = await Author.all()
       .joins({ ":posts": ":comments" })
-      .eagerLoad({ posts: "comments" })
+      .eagerLoad({ ":posts": ":comments" })
       .order("authors.id");
     // INNER JOIN semantics (manual join wins): only authors with a post that has
     // a comment, only posts that have comments. The eager hydration reads the
@@ -177,7 +177,7 @@ describe("CascadedEagerLoadingTest", () => {
     // dedups the FULL reflection chain (join_dependency.rb:214-219), so the
     // intermediate `posts` collapses against the manual join too — not just the
     // `comments` target. No extra aliased `posts` (e.g. `posts_authors`).
-    const rel = Author.all().joins(":comments").eagerLoad("comments").order("authors.id");
+    const rel = Author.all().joins(":comments").eagerLoad(":comments").order("authors.id");
     // The intermediate `posts` join is deduped: no aliased duplicate such as
     // `posts_authors`/`posts_authors_join` re-emitted for the eager spec.
     const sql = rel.toSql();
@@ -193,7 +193,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading grafts stashed associations to correct parent", async () => {
     const person = await Person.all()
-      .eagerLoad({ primaryContact: "primaryContact" })
+      .eagerLoad({ ":primaryContact": ":primaryContact" })
       .where("primary_contacts_people_2.first_name = ?", "Susan")
       .order("people.id")
       .first();
@@ -205,7 +205,7 @@ describe("CascadedEagerLoadingTest", () => {
   it("cascaded eager association loading with join for count", async () => {
     const categories = Category.all()
       .joins(":categorizations")
-      .includes({ posts: "comments" }, "authors");
+      .includes({ ":posts": ":comments" }, ":authors");
     expect(await categories.count()).toBe(4);
     expect((await categories).length).toBe(4);
     expect(await categories.distinct().count()).toBe(3);
@@ -215,8 +215,8 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("cascaded eager association loading with duplicated includes", async () => {
     const categories = Category.all()
-      .includes("categorizations")
-      .includes({ categorizations: "author" })
+      .includes(":categorizations")
+      .includes({ ":categorizations": ":author" })
       .where("categorizations.id is not null")
       .references("categorizations");
     expect(await categories.count()).toBe(3);
@@ -225,8 +225,8 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("cascaded eager association loading with twice includes edge cases", async () => {
     const categories = Category.all()
-      .includes({ categorizations: "author" })
-      .includes({ categorizations: "post" })
+      .includes({ ":categorizations": ":author" })
+      .includes({ ":categorizations": ":post" })
       .where("posts.id is not null")
       .references("posts");
     expect(await categories.count()).toBe(3);
@@ -234,7 +234,7 @@ describe("CascadedEagerLoadingTest", () => {
   });
 
   it("eager association loading with join for count", async () => {
-    const authorsRel = Author.all().joins(":specialPosts").includes("posts", "categorizations");
+    const authorsRel = Author.all().joins(":specialPosts").includes(":posts", ":categorizations");
     await authorsRel.count();
     await assertQueriesCount(3, false, async () => {
       await authorsRel;
@@ -245,16 +245,16 @@ describe("CascadedEagerLoadingTest", () => {
     let authors = await Author.includes(null);
     expect(authors).toHaveLength(3);
 
-    authors = await Author.includes(["posts", null]);
+    authors = await Author.includes([":posts", null]);
     expect(authors).toHaveLength(3);
 
-    authors = await Author.includes({ posts: null });
+    authors = await Author.includes({ ":posts": null });
     expect(authors).toHaveLength(3);
   });
 
   it("eager association loading with cascaded two levels with two has many associations", async () => {
     const loaded = await Author.all()
-      .includes({ posts: ["comments", "categorizations"] })
+      .includes({ ":posts": [":comments", ":categorizations"] })
       .order("authors.id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
@@ -264,7 +264,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with cascaded two levels and self table reference", async () => {
     const loaded = await Author.all()
-      .includes({ posts: ["comments", "author"] })
+      .includes({ ":posts": [":comments", ":author"] })
       .order("authors.id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "posts")).toHaveLength(5);
@@ -277,7 +277,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with cascaded two levels with condition", async () => {
     const loaded = await Author.all()
-      .includes({ posts: "comments" })
+      .includes({ ":posts": ":comments" })
       .where("authors.id=1")
       .order("authors.id");
     expect(loaded).toHaveLength(1);
@@ -286,7 +286,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with cascaded three levels by ping pong", async () => {
     const firms = await Firm.all()
-      .includes({ account: { firm: "account" } })
+      .includes({ ":account": { ":firm": ":account" } })
       .order("companies.id");
     expect(firms).toHaveLength(3);
     const firstAccount = target(firms[0], "account") as Base;
@@ -311,7 +311,7 @@ describe("CascadedEagerLoadingTest", () => {
   });
 
   it("eager association loading with has many sti", async () => {
-    const loaded = await Topic.all().includes("replies").order("topics.id");
+    const loaded = await Topic.all().includes(":replies").order("topics.id");
     // topics(:first).replies.size / topics(:second).replies.size — Topic#replies
     // is has_many Reply by parent_id, so query it directly to avoid loading the
     // fixture record's proxy (whose STI subtree drags in an unrelated inverse_of).
@@ -327,7 +327,7 @@ describe("CascadedEagerLoadingTest", () => {
     const reply = new Reply({ title: "gaga", content: "boo-boo", parent_id: 1 });
     expect(await reply.save()).toBe(true);
 
-    const loaded = await Topic.all().includes("replies").order(["topics.id", "replies_topics.id"]);
+    const loaded = await Topic.all().includes(":replies").order(["topics.id", "replies_topics.id"]);
     await assertQueriesCount(0, false, () => {
       expect(targetArr(loaded[0], "replies")).toHaveLength(2);
       expect(targetArr(loaded[1], "replies")).toHaveLength(0);
@@ -335,7 +335,7 @@ describe("CascadedEagerLoadingTest", () => {
   });
 
   it("eager association loading with belongs to sti", async () => {
-    const replies = await Reply.all().includes("topic").order("topics.id");
+    const replies = await Reply.all().includes(":topic").order("topics.id");
     expect(replies.map((r) => r.id)).toContain((topics("second") as any).id);
     expect(replies.map((r) => r.id)).not.toContain((topics("first") as any).id);
     await assertQueriesCount(0, false, () => {
@@ -345,7 +345,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with multiple stis and order", async () => {
     const author = await Author.all()
-      .includes({ posts: ["specialComments", "verySpecialComment"] })
+      .includes({ ":posts": [":specialComments", ":verySpecialComment"] })
       .order(["authors.name", "comments.body", "very_special_comments_posts.body"])
       .where("posts.id = 4")
       .first();
@@ -359,7 +359,9 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading of stis with multiple references", async () => {
     const loaded = await Author.all()
-      .includes({ posts: { specialComments: { post: ["specialComments", "verySpecialComment"] } } })
+      .includes({
+        ":posts": { ":specialComments": { ":post": [":specialComments", ":verySpecialComment"] } },
+      })
       .order("comments.body, very_special_comments_posts.body")
       .where("posts.id = 4");
     expect(loaded.map((a) => a.id)).toEqual([(authors("david") as any).id]);
@@ -375,7 +377,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading where first level returns nil", async () => {
     const loaded = await Author.all()
-      .includes({ postAboutThinking: "comments" })
+      .includes({ ":postAboutThinking": ":comments" })
       .order("authors.id DESC");
     expect(loaded.map((a) => a.id)).toEqual([
       (authors("bob") as any).id,
@@ -396,7 +398,7 @@ describe("CascadedEagerLoadingTest", () => {
     const post = await Post.all()
       .where()
       .not({ author_id: Author.all().select("id") })
-      .preload({ author: { comments: "post" } })
+      .preload({ ":author": { ":comments": ":post" } })
       .firstBang();
     await assertQueriesCount(0, false, () => {
       expect(target(post, "author")).toBeNull();
@@ -406,14 +408,14 @@ describe("CascadedEagerLoadingTest", () => {
   it("eager association loading with missing first record", async () => {
     const posts = await Post.all()
       .where({ id: 3 })
-      .preload({ author: { comments: "post" } });
+      .preload({ ":author": { ":comments": ":post" } });
     expect(posts).toHaveLength(1);
   });
 
   it("eager association loading with recursive cascading four levels has many through", async () => {
     const source = (
       await Vertex.all()
-        .includes({ sinks: { sinks: { sinks: "sinks" } } })
+        .includes({ ":sinks": { ":sinks": { ":sinks": ":sinks" } } })
         .order("vertices.id")
     )[0];
     await assertQueriesCount(0, false, () => {
@@ -426,7 +428,7 @@ describe("CascadedEagerLoadingTest", () => {
   it("eager association loading with recursive cascading four levels has and belongs to many", async () => {
     const sink = (
       await Vertex.all()
-        .includes({ sources: { sources: { sources: "sources" } } })
+        .includes({ ":sources": { ":sources": { ":sources": ":sources" } } })
         .order("vertices.id DESC")
     )[0];
     await assertQueriesCount(0, false, () => {
@@ -441,7 +443,7 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("eager association loading with cascaded interdependent one level and two levels", async () => {
     const loaded = await Author.all()
-      .includes("comments", { posts: "categorizations" })
+      .includes(":comments", { ":posts": ":categorizations" })
       .order("authors.id");
     expect(loaded).toHaveLength(3);
     expect(targetArr(loaded[0], "comments")).toHaveLength(11);
@@ -457,11 +459,13 @@ describe("CascadedEagerLoadingTest", () => {
 
   it("preloaded records are not duplicated", async () => {
     const author = (await Author.first())!;
-    const expectedPosts = await Post.where({ author }).includes({ author: "firstPosts" });
+    const expectedPosts = await Post.where({ author }).includes({ ":author": ":firstPosts" });
     const expected = expectedPosts.map(
       (post) => targetArr(target(post, "author")!, "firstPosts").length,
     );
-    const actualPosts = await (author as any).posts.includes({ author: "firstPosts" }).toArray();
+    const actualPosts = await (author as any).posts
+      .includes({ ":author": ":firstPosts" })
+      .toArray();
     const actual = actualPosts.map(
       (post: Base) => targetArr(target(post, "author")!, "firstPosts").length,
     );
@@ -493,7 +497,7 @@ describe("CascadedEagerLoadingTest", () => {
       Comment.afterInitialize((record: Comment) => {
         retrievedComments.push(record);
       });
-      await authorsRel.preload({ recentPost: "comments" }).load();
+      await authorsRel.preload({ ":recentPost": ":comments" }).load();
     });
 
     // Rails: assert_equal [last_comment], retrieved_comments — AR#== is same
@@ -528,7 +532,7 @@ describe("CascadedEagerLoadingTest", () => {
       Author.afterInitialize((record: Author) => {
         retrievedAuthors.push(record);
       });
-      await authorsRel.preload({ recentResponse: "author" }).load();
+      await authorsRel.preload({ ":recentResponse": ":author" }).load();
     });
 
     // Rails: assert_equal [author, authors(:bob)], retrieved_authors — AR#== is

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -6304,13 +6304,13 @@ describe("HasManyAssociationsTest", () => {
     const allBulbs = await (car as any).allBulbs.sortBy((b: any) => b.id);
     expect(allBulbs.map((b: any) => b.id)).toEqual([bulb1.id, bulb2.id]);
 
-    const includesCar = (await HmCar.includes("allBulbs").find(car.id)) as any;
+    const includesCar = (await HmCar.includes(":allBulbs").find(car.id)) as any;
     expect((await includesCar.allBulbs.sortBy((b: any) => b.id)).map((b: any) => b.id)).toEqual([
       bulb1.id,
       bulb2.id,
     ]);
 
-    const eagerCar = (await HmCar.eagerLoad("allBulbs").find(car.id)) as any;
+    const eagerCar = (await HmCar.eagerLoad(":allBulbs").find(car.id)) as any;
     expect((await eagerCar.allBulbs.sortBy((b: any) => b.id)).map((b: any) => b.id)).toEqual([
       bulb1.id,
       bulb2.id,
@@ -6753,7 +6753,7 @@ describe("HasManyAssociationsTest", () => {
   });
 
   it("has many preloading with duplicate records", async () => {
-    const allPosts = await HmPost.joins(":comments").preload("comments").order("id");
+    const allPosts = await HmPost.joins(":comments").preload(":comments").order("id");
     const first = allPosts[0] as any;
     const commentIds = (await first.comments)
       .map((c: any) => Number(c.id))

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -279,7 +279,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const davidId = authors("david").id;
     const maryId = authors("mary").id;
     const postList = await Post.where({ id: [davidId, maryId] })
-      .preload("author", "authorFavoritesWithScope")
+      .preload(":author", ":authorFavoritesWithScope")
       .order("id");
     // With preloading, author_favorites_with_scope should be cached
     for (const p of postList) {
@@ -290,7 +290,7 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   it("preload sti rhs class", async () => {
-    const devs = await Developer.includes("firms").all();
+    const devs = await Developer.includes(":firms").all();
     expect(devs.length).toBeGreaterThan(0);
     for (const dev of devs) {
       expect((dev as any).firms).toBeDefined();
@@ -304,7 +304,7 @@ describe("HasManyThroughAssociationsTest", () => {
     await SuperMembership.create({ club_id: club.id, member_id: member1.id });
     await CurrentMembership.create({ club_id: club.id, member_id: member2.id });
 
-    const club1 = await Club.includes("members").findBy({ id: club.id });
+    const club1 = await Club.includes(":members").findBy({ id: club.id });
     const clubMembers = ((club1 as any).members as any[]).sort(
       (a: any, b: any) => Number(a.id) - Number(b.id),
     );
@@ -323,7 +323,7 @@ describe("HasManyThroughAssociationsTest", () => {
       member_id: (await Member.create({ name: "Bob" })).id,
     });
 
-    const preloadedClubs = await Club.joins(":memberships").preload("membership");
+    const preloadedClubs = await Club.joins(":memberships").preload(":membership");
     expect(preloadedClubs.length).toBeGreaterThan(0);
     for (const c of preloadedClubs) {
       expect((c as any).membership).toBeDefined();
@@ -348,7 +348,7 @@ describe("HasManyThroughAssociationsTest", () => {
     registerModel("PersonPrime", PersonPrime);
 
     const posts = await (PersonPrime as any)
-      .includes("posts")
+      .includes(":posts")
       .first()
       .then((p: any) => p.posts);
     expect(posts.length).toBeGreaterThan(1);
@@ -532,8 +532,8 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   it("pk is not required for join", async () => {
-    const post = await Post.includes("scategories").first();
-    const post2 = await Post.includes("categories").first();
+    const post = await Post.includes(":scategories").first();
+    const post2 = await Post.includes(":categories").first();
     const sCategories = await (post as any).scategories.toArray();
     const categories2 = await (post2 as any).categories.toArray();
     expect(sCategories.length).toBeGreaterThan(0);
@@ -1368,7 +1368,7 @@ describe("HasManyThroughAssociationsTest", () => {
 
   it("count with include should alias join table", async () => {
     const michael = await Person.find(people("michael").id);
-    expect(await (michael as any).posts.includes("readers").count()).toBe(2);
+    expect(await (michael as any).posts.includes(":readers").count()).toBe(2);
   });
 
   it("inner join with quoted table name", async () => {
@@ -1743,27 +1743,27 @@ describe("HasManyThroughAssociationsTest", () => {
     const first = await Author.first();
 
     const preloadedGeneralCats = (await Author.preload(
-      "generalPosts",
-      "generalCategorizations",
+      ":generalPosts",
+      ":generalCategorizations",
     ).first())!.generalCategorizations;
     expect(preloadedGeneralCats.map((c: any) => c.id)).toEqual([davidWelcomeGeneral.id]);
 
     const eagerGeneralCats = (await Author.eagerLoad(
-      "generalPosts",
-      "generalCategorizations",
+      ":generalPosts",
+      ":generalCategorizations",
     ).first())!.generalCategorizations;
     expect(eagerGeneralCats.map((c: any) => c.id)).toEqual([davidWelcomeGeneral.id]);
 
     const welcomePost = await Post.find(posts("welcome").id);
     const preloadedGeneralPosts = (await Author.preload(
-      "generalCategorizations",
-      "generalPosts",
+      ":generalCategorizations",
+      ":generalPosts",
     ).first())!.generalPosts;
     expect(preloadedGeneralPosts.map((p: any) => p.id)).toEqual([welcomePost.id]);
 
     const eagerGeneralPosts = (await Author.eagerLoad(
-      "generalCategorizations",
-      "generalPosts",
+      ":generalCategorizations",
+      ":generalPosts",
     ).first())!.generalPosts;
     expect(eagerGeneralPosts.map((p: any) => p.id)).toEqual([welcomePost.id]);
   });
@@ -1771,9 +1771,9 @@ describe("HasManyThroughAssociationsTest", () => {
   it("has many through polymorphic with rewhere", async () => {
     const post = await TaggedPost.create({ title: "Tagged", body: "Post" });
     const tag = await (post as any).tags.create({ name: "Tag" });
-    const preloaded = (await TaggedPost.preload("tags").last())!.tags;
+    const preloaded = (await TaggedPost.preload(":tags").last())!.tags;
     expect(preloaded.map((t: any) => t.id)).toEqual([tag.id]);
-    const eagerLoaded = (await TaggedPost.eagerLoad("tags").last())!.tags;
+    const eagerLoaded = (await TaggedPost.eagerLoad(":tags").last())!.tags;
     expect(eagerLoaded.map((t: any) => t.id)).toEqual([tag.id]);
   });
 
@@ -1994,7 +1994,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const loaded = await Person.where({ id: person.id })
       .where(`readers.id = ${readerId} or 1=1`)
       .references("readers")
-      .includes("posts");
+      .includes(":posts");
     const p = loaded[0];
     expect((p as any).posts.loaded).toBe(true);
     expect(await (p as any).posts.toArray()).toEqual([]);
@@ -2018,7 +2018,7 @@ describe("HasManyThroughAssociationsTest", () => {
     });
 
     const result = await Owner.where({ name: "Rainbow Unicat" })
-      .includes({ pets: "persons" })
+      .includes({ ":pets": ":persons" })
       .first();
     const persons = await (result as any).persons.toArray();
     expect(persons.map((p: any) => p.id)).toEqual([person.id]);
@@ -2236,7 +2236,7 @@ describe("HasManyThroughAssociationsTest", () => {
       ":commentsForFirstAuthor": ":post",
     })
       .joins("inner join posts posts_alias on authors.id = posts_alias.author_id")
-      .eagerLoad("categories")
+      .eagerLoad(":categories")
       .take();
     expect(result?.id).toBe(david.id);
   });

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -476,7 +476,7 @@ describe("HasOneThroughAssociationsTest", () => {
   it("has one through eager loading", async () => {
     let loaded: any[] = [];
     await assertQueriesCount(3, false, async () => {
-      loaded = await Member.all().includes("club").where("name = ?", "Groucho Marx");
+      loaded = await Member.all().includes(":club").where("name = ?", "Groucho Marx");
     });
     expect(loaded.length).toBe(1);
     await assertQueriesCount(0, false, async () => {
@@ -487,7 +487,7 @@ describe("HasOneThroughAssociationsTest", () => {
   it("has one through eager loading through polymorphic", async () => {
     let loaded: any[] = [];
     await assertQueriesCount(3, false, async () => {
-      loaded = await Member.all().includes("sponsorClub").where("name = ?", "Groucho Marx");
+      loaded = await Member.all().includes(":sponsorClub").where("name = ?", "Groucho Marx");
     });
     expect(loaded.length).toBe(1);
     await assertQueriesCount(0, false, async () => {
@@ -499,22 +499,22 @@ describe("HasOneThroughAssociationsTest", () => {
     const member = members("groucho");
     // conditions on the through table
     expect(
-      ((await Member.all().includes("favoriteClub").find(member.id)) as any).association(
+      ((await Member.all().includes(":favoriteClub").find(member.id)) as any).association(
         "favoriteClub",
       ).target?.id,
     ).toBe(clubs("moustache_club").id);
     await memberships("membership_of_favorite_club").updateColumns({ favorite: false });
-    const refetched = (await Member.all().includes("favoriteClub").find(member.id)) as any;
+    const refetched = (await Member.all().includes(":favoriteClub").find(member.id)) as any;
     await refetched.reload();
     expect(refetched.association("favoriteClub").target).toBeNull();
 
     // conditions on the source table
     expect(
-      ((await Member.all().includes("hairyClub").find(member.id)) as any).association("hairyClub")
+      ((await Member.all().includes(":hairyClub").find(member.id)) as any).association("hairyClub")
         .target?.id,
     ).toBe(clubs("moustache_club").id);
     await clubs("moustache_club").updateColumns({ name: "Association of Clean-Shaven Persons" });
-    const refetched2 = (await Member.all().includes("hairyClub").find(member.id)) as any;
+    const refetched2 = (await Member.all().includes(":hairyClub").find(member.id)) as any;
     await refetched2.reload();
     expect(refetched2.association("hairyClub").target).toBeNull();
   });
@@ -527,7 +527,7 @@ describe("HasOneThroughAssociationsTest", () => {
 
   it("eager has one through polymorphic with source type", async () => {
     const loaded = await Club.all()
-      .includes("sponsoredMember")
+      .includes(":sponsoredMember")
       .where("name = ?", "Moustache and Eyebrow Fancier Club");
     // Only the eyebrow fanciers club has a sponsored_member
     await assertQueriesCount(0, false, () => {
@@ -539,7 +539,7 @@ describe("HasOneThroughAssociationsTest", () => {
     let loaded: any[] = [];
     await assertQueriesCount(1, false, async () => {
       loaded = await Member.all()
-        .includes("club")
+        .includes(":club")
         .where("members.name = ?", "Groucho Marx")
         .order("clubs.name")
         .references("clubs"); // force fallback
@@ -554,7 +554,7 @@ describe("HasOneThroughAssociationsTest", () => {
     let loaded: any[] = [];
     await assertQueriesCount(1, false, async () => {
       loaded = await Member.all()
-        .includes("sponsorClub")
+        .includes(":sponsorClub")
         .where("members.name = ?", "Groucho Marx")
         .order("clubs.name")
         .references("clubs"); // force fallback
@@ -571,7 +571,7 @@ describe("HasOneThroughAssociationsTest", () => {
     let loaded: any[] = [];
     await assertQueriesCount(1, false, async () => {
       loaded = await Member.all()
-        .includes("sponsorClub")
+        .includes(":sponsorClub")
         .where("members.name = ?", "Groucho Marx")
         .order("clubs.name DESC")
         .references("clubs"); // force fallback
@@ -676,7 +676,7 @@ describe("HasOneThroughAssociationsTest", () => {
     await member.reload();
     let loaded: any[] = [];
     await assertQueriesCount(3, false, async () => {
-      loaded = await MemberDetail.all().includes("memberType");
+      loaded = await MemberDetail.all().includes(":memberType");
     });
     const newDetail = loaded[0];
     expect(newDetail.association("memberType").isLoaded()).toBe(true);
@@ -691,12 +691,12 @@ describe("HasOneThroughAssociationsTest", () => {
     expect(await readHasOne(club, "sponsoredMember")).not.toBeNull();
 
     await (await Club.find(club.id)).save();
-    await (await Club.all().includes("sponsoredMember").find(club.id)).save();
+    await (await Club.all().includes(":sponsoredMember").find(club.id)).save();
 
     await (await readHasOne(club, "sponsor")).destroy();
 
     await (await Club.find(club.id)).save();
-    await (await Club.all().includes("sponsoredMember").find(club.id)).save();
+    await (await Club.all().includes(":sponsoredMember").find(club.id)).save();
   });
 
   it("through belongs to after destroy", async () => {

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -169,7 +169,7 @@ describe("InnerJoinAssociationTest", () => {
     const stringJoin =
       "LEFT JOIN people agents_people ON agents_people.primary_contact_id = agents_people_2.id AND agents_people.id > agents_people_2.id";
 
-    expect(await Person.eagerLoad("agents").joins(stringJoin).count()).toBe(3);
+    expect(await Person.eagerLoad(":agents").joins(stringJoin).count()).toBe(3);
   });
 
   it("eager load with arel joins", async () => {
@@ -181,7 +181,7 @@ describe("InnerJoinAssociationTest", () => {
       .and(agents.get("id").gt(agents2.get("id")));
     const arelJoin = new Nodes.OuterJoin(agents, new Nodes.On(constraint));
 
-    expect(await Person.eagerLoad("agents").joins(arelJoin).count()).toBe(3);
+    expect(await Person.eagerLoad(":agents").joins(arelJoin).count()).toBe(3);
   });
 
   it("construct finder sql ignores empty joins hash", () => {
@@ -206,7 +206,7 @@ describe("InnerJoinAssociationTest", () => {
   });
 
   it("join conditions allow nil associations", async () => {
-    const authorsRel = Author.includes("essays").where({ essays: { id: null } });
+    const authorsRel = Author.includes(":essays").where({ essays: { id: null } });
     expect(await authorsRel.count()).toBe(1);
   });
 
@@ -311,7 +311,7 @@ describe("InnerJoinAssociationTest", () => {
     await (author as any).specialCategories.create({ name: "Special" });
 
     const categoriesRel = await (author as any).categories
-      .includes("specialCategorizations")
+      .includes(":specialCategorizations")
       .references("specialCategorizations");
     expect(categoriesRel.length).toBe(2);
   });
@@ -321,7 +321,9 @@ describe("InnerJoinAssociationTest", () => {
     await (author as any).categories.create({ name: "Not Special" });
     await (author as any).specialCategories.create({ name: "Special" });
 
-    const cats = await (author as any).categories.eagerLoad("specialCategorizations").order("name");
+    const cats = await (author as any).categories
+      .eagerLoad(":specialCategorizations")
+      .order("name");
     expect((await cats[0].specialCategorizations).length).toBe(0);
     expect((await cats[1].specialCategorizations).length).toBe(1);
   });

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -416,7 +416,7 @@ describe("InverseHasOneTests", () => {
   });
 
   it("parent instance should be shared with eager loaded child on find", async () => {
-    let human = (await Human.where({ name: "Gordon" }).includes("face"))[0];
+    let human = (await Human.where({ name: "Gordon" }).includes(":face"))[0];
     let face = (human as any).face;
     expect(face.human.name).toBe((human as any).name);
     (human as any).name = "Bongo";
@@ -424,7 +424,7 @@ describe("InverseHasOneTests", () => {
     face.human.name = "Mungo";
     expect(face.human.name).toBe((human as any).name);
 
-    human = (await Human.where({ name: "Gordon" }).includes("face").order("faces.id"))[0];
+    human = (await Human.where({ name: "Gordon" }).includes(":face").order("faces.id"))[0];
     face = (human as any).face;
     expect(face.human.name).toBe((human as any).name);
     (human as any).name = "Bongo";
@@ -562,7 +562,7 @@ describe("InverseHasManyTests", () => {
   });
 
   it("parent instance should be shared with eager loaded children", async () => {
-    let human = (await Human.where({ name: "Gordon" }).includes("interests"))[0];
+    let human = (await Human.where({ name: "Gordon" }).includes(":interests"))[0];
     let interests = (human as any).interests;
     for (const interest of await interests.toArray()) {
       expect(interest.human.name).toBe((human as any).name);
@@ -572,7 +572,7 @@ describe("InverseHasManyTests", () => {
       expect(interest.human.name).toBe((human as any).name);
     }
 
-    human = (await Human.where({ name: "Gordon" }).includes("interests").order("interests.id"))[0];
+    human = (await Human.where({ name: "Gordon" }).includes(":interests").order("interests.id"))[0];
     interests = (human as any).interests;
     for (const interest of await interests.toArray()) {
       expect(interest.human.name).toBe((human as any).name);
@@ -787,10 +787,10 @@ describe("InverseHasManyTests", () => {
       const interests = await findHasManyTarget(human, "interests", { inverseOf: "human" });
       expect(interests.length).toBeGreaterThan(0);
 
-      const preloaded = (await (Human as any).includes("interests").first())!;
+      const preloaded = (await (Human as any).includes(":interests").first())!;
       expect(preloaded.association("interests").target.length).toBeGreaterThan(0);
 
-      const joined = (await (Human as any).joins(":interests").includes("interests").first())!;
+      const joined = (await (Human as any).joins(":interests").includes(":interests").first())!;
       expect(joined.association("interests").target.length).toBeGreaterThan(0);
     } finally {
       (Interest as any).resetCallbacks("find");
@@ -888,7 +888,7 @@ describe("InverseBelongsToTests", () => {
   });
 
   it("eager loaded child instance should be shared with parent on find", async () => {
-    let face = (await Face.where({ description: "trusting" }).includes("human"))[0] as any;
+    let face = (await Face.where({ description: "trusting" }).includes(":human"))[0] as any;
     let human = face.human;
     expect(human.face.description).toBe(face.description);
     face.description = "gormless";
@@ -897,7 +897,7 @@ describe("InverseBelongsToTests", () => {
     expect(human.face.description).toBe(face.description);
 
     face = (
-      await Face.where({ description: "trusting" }).includes("human").order("humans.id")
+      await Face.where({ description: "trusting" }).includes(":human").order("humans.id")
     )[0] as any;
     human = face.human;
     expect(human.face.description).toBe(face.description);
@@ -1085,7 +1085,7 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 
   it("eager loaded child instance should be shared with parent on find", async () => {
-    let face = (await Face.where({ description: "confused" }).includes("human"))[0] as any;
+    let face = (await Face.where({ description: "confused" }).includes(":human"))[0] as any;
     let human = (await loadSingularTarget(face, "polymorphicHuman")) as any;
     expect(human.polymorphicFace.description).toBe(face.description);
     face.description = "gormless";
@@ -1094,7 +1094,7 @@ describe("InversePolymorphicBelongsToTests", () => {
     expect(human.polymorphicFace.description).toBe(face.description);
 
     face = (
-      await Face.where({ description: "confused" }).includes("human").order("humans.id")
+      await Face.where({ description: "confused" }).includes(":human").order("humans.id")
     )[0] as any;
     human = (await loadSingularTarget(face, "polymorphicHuman")) as any;
     expect(human.polymorphicFace.description).toBe(face.description);

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -449,7 +449,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("include has many through", async () => {
     const allPosts = (await Post.all().order("posts.id")) as Base[];
-    const postsWithAuthors = (await Post.all().includes("authors").order("posts.id")) as Base[];
+    const postsWithAuthors = (await Post.all().includes(":authors").order("posts.id")) as Base[];
     expect(postsWithAuthors.length).toBe(allPosts.length);
     for (let i = 0; i < allPosts.length; i++) {
       const expected = ((await (allPosts[i] as any).authors.toArray()) as Base[]).length;
@@ -460,7 +460,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("include polymorphic has one", async () => {
-    const post = await Post.includes("tagging").find(posts("welcome").id);
+    const post = await Post.includes(":tagging").find(posts("welcome").id);
     const tagging = taggings("welcome_general");
     await assertNoQueries(false, async () => {
       const target = (post as any).association("tagging").target as Base;
@@ -469,7 +469,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("include polymorphic has one defined in abstract parent", async () => {
-    const item = await Item.includes("tagging").find(items("dvd").id);
+    const item = await Item.includes(":tagging").find(items("dvd").id);
     const tagging = taggings("godfather");
     await assertNoQueries(false, async () => {
       const target = (item as any).association("tagging").target as Base;
@@ -479,7 +479,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("include polymorphic has many through", async () => {
     const allPosts = (await Post.all().order("posts.id")) as Base[];
-    const postsWithTags = (await Post.all().includes("tags").order("posts.id")) as Base[];
+    const postsWithTags = (await Post.all().includes(":tags").order("posts.id")) as Base[];
     expect(postsWithTags.length).toBe(allPosts.length);
     for (let i = 0; i < allPosts.length; i++) {
       const expected = ((await (allPosts[i] as any).tags.toArray()) as Base[]).length;
@@ -491,7 +491,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("include polymorphic has many", async () => {
     const allPosts = (await Post.all().order("posts.id")) as Base[];
-    const postsWithTaggings = (await Post.all().includes("taggings").order("posts.id")) as Base[];
+    const postsWithTaggings = (await Post.all().includes(":taggings").order("posts.id")) as Base[];
     expect(postsWithTaggings.length).toBe(allPosts.length);
     for (let i = 0; i < allPosts.length; i++) {
       const expected = ((await (allPosts[i] as any).taggings.toArray()) as Base[]).length;
@@ -577,7 +577,7 @@ describe("AssociationsJoinModelTest", () => {
 
     await expect(
       (general as any).taggings
-        .includes("taggable")
+        .includes(":taggable")
         .where("bogus_table.column = 1")
         .references("bogus_table")
         .toArray(),
@@ -616,7 +616,7 @@ describe("AssociationsJoinModelTest", () => {
     // `taggable` source's own `-> { where(...) }` scope just like the direct
     // query, restricting the eager-loaded through target to the welcome post.
     const general = await ScopedSourceTag.all()
-      .includes("welcomeTaggedPosts")
+      .includes(":welcomeTaggedPosts")
       .find(tags("general").id);
     await assertNoQueries(false, async () => {
       const target = (general as any).association("welcomeTaggedPosts").target as Base[];
@@ -625,7 +625,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("eager has many polymorphic with source type", async () => {
-    const tagWithInclude = await Tag.all().includes("taggedPosts").find(tags("general").id);
+    const tagWithInclude = await Tag.all().includes(":taggedPosts").find(tags("general").id);
     const desired = [posts("welcome").id, posts("thinking").id].sort(
       (a: any, b: any) => Number(a) - Number(b),
     );
@@ -724,7 +724,7 @@ describe("AssociationsJoinModelTest", () => {
     // source reflection `nonexistentComments` on Post carries `where("comments.id < 0")`;
     // the preloader must fold that source scope just like the direct query, leaving
     // the eager-loaded through target empty.
-    const author = (await Author.all().includes("nonexistentComments").first()) as any;
+    const author = (await Author.all().includes(":nonexistentComments").first()) as any;
     // Assert the association was actually preloaded — a fresh collection proxy's
     // `target` is `[]`, so an empty target alone can't distinguish a preloaded
     // empty result from one that never loaded. With it loaded, read through the
@@ -931,7 +931,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("polymorphic has many", async () => {
     const expected = taggings("welcome_general");
-    const p = await Post.includes("taggings").find(posts("welcome").id);
+    const p = await Post.includes(":taggings").find(posts("welcome").id);
     await assertNoQueries(false, async () => {
       const target = (p as any).association("taggings").target as Base[];
       expect(target.map((t) => t.id)).toContain(expected.id);
@@ -944,7 +944,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("polymorphic has one", async () => {
     const expected = await Post.find(posts("welcome").id);
-    const tagging = await Tagging.includes("taggable").find(taggings("welcome_general").id);
+    const tagging = await Tagging.includes(":taggable").find(taggings("welcome_general").id);
     await assertNoQueries(false, async () => {
       const taggable = (tagging as any).association("taggable").target as Base;
       expect(taggable.id).toBe(expected.id);
@@ -952,7 +952,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("polymorphic belongs to", async () => {
-    const p = await Post.includes({ taggings: "taggable" }).find(posts("welcome").id);
+    const p = await Post.includes({ ":taggings": ":taggable" }).find(posts("welcome").id);
     await assertNoQueries(false, async () => {
       const firstTagging = ((p as any).association("taggings").target as Base[])[0];
       const taggable = (firstTagging as any).association("taggable").target as Base;
@@ -965,7 +965,7 @@ describe("AssociationsJoinModelTest", () => {
     // the two Post taggables; pin `taggings.id` so first/second resolve to
     // non-nil taggables on PG/MySQL too (heap order isn't guaranteed there).
     const taggingList = (await Tagging.where("taggable_type != ?", "FakeModel")
-      .includes("taggable")
+      .includes(":taggable")
       .order("taggings.id")) as Base[];
     await assertNoQueries(false, async () => {
       void ((taggingList[0] as any).association("taggable").target as Base).id;
@@ -983,7 +983,7 @@ describe("AssociationsJoinModelTest", () => {
   it("preload nil polymorphic belongs to", async () => {
     let error: unknown;
     try {
-      await Tagging.where("taggable_type IS NULL").includes("taggable");
+      await Tagging.where("taggable_type IS NULL").includes(":taggable");
     } catch (e) {
       error = e;
     }
@@ -992,7 +992,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("preload polymorphic has many", async () => {
     const allPosts = (await Post.all().order("posts.id")) as Base[];
-    const postsWithTaggings = (await Post.all().includes("taggings").order("posts.id")) as Base[];
+    const postsWithTaggings = (await Post.all().includes(":taggings").order("posts.id")) as Base[];
     expect(postsWithTaggings.length).toBe(allPosts.length);
     for (let i = 0; i < allPosts.length; i++) {
       const expected = ((await (allPosts[i] as any).taggings.toArray()) as Base[]).length;
@@ -1004,7 +1004,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("belongs to shared parent", async () => {
     const commentList = (await Comment.where(`post_id = ${posts("welcome").id}`).includes(
-      "post",
+      ":post",
     )) as Base[];
     await assertNoQueries(false, async () => {
       const p0 = (commentList[0] as any).association("post").target as Base;
@@ -1109,7 +1109,7 @@ describe("AssociationsJoinModelTest", () => {
     // Rails uses lazy load (posts(:welcome).tags.first); trails' lazy-load path does not
     // cache the join record on the tag, so includes() is used to exercise the same
     // no-query guarantee via the eager-load path.
-    const post = await Post.includes("tags").find(posts("welcome").id);
+    const post = await Post.includes(":tags").find(posts("welcome").id);
     const tag = ((post as any).tags.target as Base[])[0];
     expect(tag.id).toBe(tags("general").id);
     await assertNoQueries(false, async () => {
@@ -1120,7 +1120,7 @@ describe("AssociationsJoinModelTest", () => {
   it("polymorphic has many going through join model with find", async () => {
     // Rails (line 70) is identical to line 58 — same lazy-load + no-query assertion.
     // Same includes() substitution applies; see comment above.
-    const post = await Post.includes("tags").find(posts("welcome").id);
+    const post = await Post.includes(":tags").find(posts("welcome").id);
     const tag = ((post as any).tags.target as Base[])[0];
     expect(tag.id).toBe(tags("general").id);
     await assertNoQueries(false, async () => {
@@ -1129,7 +1129,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("polymorphic has many going through join model with include on source reflection", async () => {
-    const post = await Post.includes("funkyTags").find(posts("welcome").id);
+    const post = await Post.includes(":funkyTags").find(posts("welcome").id);
     const tag = ((post as any).funkyTags.target as Base[])[0];
     expect(tag.id).toBe(tags("general").id);
     await assertNoQueries(false, async () => {
@@ -1138,7 +1138,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("polymorphic has many going through join model with include on source reflection with find", async () => {
-    const post = await Post.includes("funkyTags").find(posts("welcome").id);
+    const post = await Post.includes(":funkyTags").find(posts("welcome").id);
     const tag = ((post as any).funkyTags.target as Base[])[0];
     expect(tag.id).toBe(tags("general").id);
     await assertNoQueries(false, async () => {
@@ -1164,7 +1164,7 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("include has many through polymorphic has many", async () => {
-    const author = await Author.includes("taggings").find(authors("david").id);
+    const author = await Author.includes(":taggings").find(authors("david").id);
     const expectedIds = [taggings("welcome_general").id, taggings("thinking_general").id]
       .map(Number)
       .sort((a, b) => a - b);
@@ -1180,7 +1180,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("eager load has many through has many", async () => {
     const author = (await Author.where({ name: "David" })
-      .includes("comments")
+      .includes(":comments")
       .order("comments.id")
       .first()) as Author;
     SpecialComment.new();
@@ -1192,15 +1192,15 @@ describe("AssociationsJoinModelTest", () => {
   });
 
   it("eager load has many through has many with conditions", async () => {
-    const post = (await Post.includes("invalidTags").first()) as Post;
+    const post = (await Post.includes(":invalidTags").first()) as Post;
     await assertNoQueries(false, async () => {
       await (post as any).invalidTags.toArray();
     });
   });
 
   it("eager belongs to and has one not singularized", async () => {
-    await expect(Author.includes("authorAddress").first()).resolves.not.toThrow();
-    await expect(AuthorAddress.includes("author").first()).resolves.not.toThrow();
+    await expect(Author.includes(":authorAddress").first()).resolves.not.toThrow();
+    await expect(AuthorAddress.includes(":author").first()).resolves.not.toThrow();
   });
 
   it("associating unsaved records with has many through", async () => {
@@ -1278,7 +1278,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("preload polymorphic has many through", async () => {
     const allPosts = (await Post.order("posts.id")) as Base[];
-    const postsWithTags = (await Post.includes("tags").order("posts.id")) as Base[];
+    const postsWithTags = (await Post.includes(":tags").order("posts.id")) as Base[];
     expect(allPosts.length).toBe(postsWithTags.length);
     for (let i = 0; i < allPosts.length; i++) {
       const expectedLen = ((await (allPosts[i] as any).tags.toArray()) as Base[]).length;
@@ -1293,22 +1293,22 @@ describe("AssociationsJoinModelTest", () => {
       "Can't join 'Post' to association named 'nonexistentRelation'; perhaps you misspelled it?";
 
     const includesFind = async () =>
-      Post.includes("nonexistentRelation")
+      Post.includes(":nonexistentRelation")
         .where({ nonexistentRelation: { name: "Rochester" } })
         .find(1);
     await expect(includesFind()).rejects.toThrow(ConfigurationError);
     await expect(includesFind()).rejects.toThrow(message);
 
     const eagerLoadFind = async () =>
-      Post.eagerLoad("nonexistentRelation")
+      Post.eagerLoad(":nonexistentRelation")
         .where({ nonexistentRelation: { name: "Rochester" } })
         .find(1);
     await expect(eagerLoadFind()).rejects.toThrow(ConfigurationError);
     await expect(eagerLoadFind()).rejects.toThrow(message);
 
     const combinedFind = async () =>
-      Post.eagerLoad("nonexistentRelation")
-        .includes("nonexistentRelation")
+      Post.eagerLoad(":nonexistentRelation")
+        .includes(":nonexistentRelation")
         .where({ nonexistentRelation: { name: "Rochester" } })
         .find(1);
     await expect(combinedFind()).rejects.toThrow(ConfigurationError);

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -126,7 +126,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has many through has many with has many through source reflection preload", async () => {
     const general = tags("general");
-    const [author] = await Author.includes("tags").order("authors.id").limit(1);
+    const [author] = await Author.includes(":tags").order("authors.id").limit(1);
     const preloaded = author.association("tags").target ?? [];
     expect((preloaded as any[]).map((t) => t.id)).toEqual([general.id, general.id]);
   });
@@ -157,7 +157,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has many through with has many source reflection preload", async () => {
     const luke = subscribers("first");
     const davidSub = subscribers("second");
-    const [author] = await Author.includes("subscribers").order("authors.id").limit(1);
+    const [author] = await Author.includes(":subscribers").order("authors.id").limit(1);
     const preloaded = ((author.association("subscribers").target ?? []) as any[])
       .slice()
       .sort((a: any, b: any) => a.nick.localeCompare(b.nick));
@@ -185,7 +185,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has many through has one with has one through source reflection preload", async () => {
     const founding = memberTypes("founding");
-    const [member] = await Member.includes("nestedMemberTypes").order("members.id").limit(1);
+    const [member] = await Member.includes(":nestedMemberTypes").order("members.id").limit(1);
     const preloaded = (member.association("nestedMemberTypes").target ?? []) as any[];
     expect(preloaded.map((t) => t.id)).toEqual([founding.id]);
   });
@@ -211,7 +211,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has many through has one through with has one source reflection preload", async () => {
     const mustache = sponsors("moustache_club_sponsor_for_groucho");
-    const [member] = await Member.includes("nestedSponsors").order("members.id").limit(1);
+    const [member] = await Member.includes(":nestedSponsors").order("members.id").limit(1);
     const preloaded = (member.association("nestedSponsors").target ?? []) as any[];
     expect(preloaded.map((s) => s.id)).toEqual([mustache.id]);
   });
@@ -240,7 +240,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has one with has many through source reflection preload", async () => {
     const grouchoDetails = memberDetails("groucho");
     const otherDetails = memberDetails("some_other_guy");
-    const [member] = await Member.includes("organizationMemberDetails")
+    const [member] = await Member.includes(":organizationMemberDetails")
       .order("members.id")
       .limit(1);
     const preloaded = ((member.association("organizationMemberDetails").target ?? []) as any[])
@@ -284,7 +284,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has one through with has many source reflection preload", async () => {
     const grouchoDetails = memberDetails("groucho");
     const otherDetails = memberDetails("some_other_guy");
-    const [member] = await Member.includes("organizationMemberDetails_2")
+    const [member] = await Member.includes(":organizationMemberDetails_2")
       .order("members.id")
       .limit(1);
     const preloaded = ((member.association("organizationMemberDetails_2").target ?? []) as any[])
@@ -328,7 +328,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has many with has and belongs to many source reflection preload", async () => {
     const general = categories("general");
     const cooking = categories("cooking");
-    const [, , author] = await Author.includes("postCategories").order("authors.id");
+    const [, , author] = await Author.includes(":postCategories").order("authors.id");
     const preloaded = ((author.association("postCategories").target ?? []) as any[])
       .slice()
       .sort((a: any, b: any) => Number(a.id) - Number(b.id));
@@ -357,7 +357,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has and belongs to many with has many source reflection preload", async () => {
     const greetings = comments("greetings");
     const moreGreetings = comments("more_greetings");
-    const [, category] = await Category.includes("postComments").order("categories.id");
+    const [, category] = await Category.includes(":postComments").order("categories.id");
     const preloaded = ((category.association("postComments").target ?? []) as any[])
       .slice()
       .sort((a: any, b: any) => Number(a.id) - Number(b.id));
@@ -391,7 +391,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has many with has many through habtm source reflection preload", async () => {
     const greetings = comments("greetings");
     const moreGreetings = comments("more_greetings");
-    const [, , author] = await Author.includes("categoryPostComments").order("authors.id");
+    const [, , author] = await Author.includes(":categoryPostComments").order("authors.id");
     const preloaded = ((author.association("categoryPostComments").target ?? []) as any[])
       .slice()
       .sort((a: any, b: any) => Number(a.id) - Number(b.id));
@@ -423,7 +423,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has many through has many through with belongs to source reflection preload", async () => {
     const general = tags("general");
-    const [author] = await Author.includes("taggingTags").order("authors.id").limit(1);
+    const [author] = await Author.includes(":taggingTags").order("authors.id").limit(1);
     const preloaded = (author.association("taggingTags").target ?? []) as any[];
     expect(preloaded.map((t) => t.id)).toEqual([general.id, general.id]);
   });
@@ -452,7 +452,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through belongs to with has many through source reflection preload", async () => {
     const welcomeGeneral = taggings("welcome_general");
     const thinkingGeneral = taggings("thinking_general");
-    const [categorization] = await Categorization.includes("postTaggings")
+    const [categorization] = await Categorization.includes(":postTaggings")
       .order("categorizations.id")
       .limit(1);
     const preloaded = ((categorization.association("postTaggings").target ?? []) as any[])
@@ -484,7 +484,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has one through has one with has one through source reflection preload", async () => {
     const founding = memberTypes("founding");
-    const [member] = await Member.includes("nestedMemberType").order("members.id").limit(1);
+    const [member] = await Member.includes(":nestedMemberType").order("members.id").limit(1);
     const preloaded = member.association("nestedMemberType").target as any;
     expect(preloaded?.id).toBe(founding.id);
   });
@@ -526,7 +526,7 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("has one through has one through with belongs to source reflection preload", async () => {
     const general = categories("general");
-    const [member] = await Member.includes("clubCategory").order("members.id").limit(1);
+    const [member] = await Member.includes(":clubCategory").order("members.id").limit(1);
     const preloaded = member.association("clubCategory").target as any;
     expect(preloaded?.id).toBe(general.id);
   });
@@ -701,7 +701,7 @@ describe("NestedThroughAssociationsTest", () => {
     const empty = await Author.where({ "tags.id": 100 }).joins(":miscPostFirstBlueTags");
     expect(empty).toHaveLength(0);
 
-    const [, , author] = await Author.includes("miscPostFirstBlueTags").order("authors.id");
+    const [, , author] = await Author.includes(":miscPostFirstBlueTags").order("authors.id");
     const preloaded = (author.association("miscPostFirstBlueTags").target ?? []) as any[];
     expect(preloaded.map((t) => t.id)).toEqual([blue.id]);
   });
@@ -730,7 +730,7 @@ describe("NestedThroughAssociationsTest", () => {
     // query — authors + posts(⋈ taggings ⋈ tags) = 2.
     let author!: Author;
     await assertQueriesCount(2, false, async () => {
-      [, , author] = await Author.includes("miscPostFirstBlueTags_2").order("authors.id");
+      [, , author] = await Author.includes(":miscPostFirstBlueTags_2").order("authors.id");
     });
     await assertNoQueries(false, async () => {
       const preloaded = await author.miscPostFirstBlueTags_2;
@@ -741,8 +741,8 @@ describe("NestedThroughAssociationsTest", () => {
   it("through association preload doesnt reset source association if already preloaded", async () => {
     const blue = tags("blue");
     const [, , author] = await Author.preload({
-      posts: "firstBlueTags_2",
-      miscPostFirstBlueTags_2: {},
+      ":posts": ":firstBlueTags_2",
+      ":miscPostFirstBlueTags_2": {},
     }).order("authors.id");
     await assertNoQueries(false, async () => {
       const firstPost = (await author.posts)[0];
@@ -796,7 +796,7 @@ describe("NestedThroughAssociationsTest", () => {
       chefs: [(cakeDesigner as any).chef, (drinkDesigner as any).chef],
     });
     await Hotel.create({ departments: [dept] });
-    const [hotel] = await Hotel.includes("cakeDesigners", "drinkDesigners").limit(1);
+    const [hotel] = await Hotel.includes(":cakeDesigners", ":drinkDesigners").limit(1);
 
     const cakes = (hotel.association("cakeDesigners").target ?? []) as any[];
     const drinks = (hotel.association("drinkDesigners").target ?? []) as any[];
@@ -811,7 +811,7 @@ describe("NestedThroughAssociationsTest", () => {
       chefs: [(cakeDesigner as any).chef, (drinkDesigner as any).chef],
     });
     await Hotel.create({ departments: [dept] });
-    const [hotel] = await Hotel.includes("chefs", "cakeDesigners", "drinkDesigners").limit(1);
+    const [hotel] = await Hotel.includes(":chefs", ":cakeDesigners", ":drinkDesigners").limit(1);
     const cakes = (hotel.association("cakeDesigners").target ?? []) as any[];
     const drinks = (hotel.association("drinkDesigners").target ?? []) as any[];
     expect(cakes.map((r) => r.id)).toEqual([cakeDesigner.id]);
@@ -849,7 +849,7 @@ describe("NestedThroughAssociationsTest", () => {
   });
 
   it("has many through reset source reflection after loading is complete", async () => {
-    const [, preloaded] = (await Category.preload("orderedPostComments").find(1, 2)) as any[];
+    const [, preloaded] = (await Category.preload(":orderedPostComments").find(1, 2)) as any[];
     const original = await Category.find(2);
     const preloadedIds = ((preloaded.association("orderedPostComments").target ?? []) as any[]).map(
       (c: any) => c.id,

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -397,7 +397,7 @@ export class ThroughAssociation extends Association {
           ...scope.whereClause.predicates,
           ...whereClause.predicates,
         ]);
-        const sourceName = sourceRefl.name;
+        const sourceName = `:${sourceRefl.name}`;
         const nestedIncludes: any[] = reflScope?.includesValues ?? [];
         if (nestedIncludes.length > 0) {
           scope = scope.includes({ [sourceName]: nestedIncludes });

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -141,7 +141,7 @@ describe("CalculationsTest", () => {
     expect(
       await Account.where("companies.name != 'Summit'")
         .references("companies")
-        .includes("firm")
+        .includes(":firm")
         .maximum("credit_limit"),
     ).toBe(55);
   });
@@ -150,7 +150,7 @@ describe("CalculationsTest", () => {
     expect(
       await Account.where("companies.name != 'Summit'")
         .references("companies")
-        .includes("firm")
+        .includes(":firm")
         .maximum(Account.arelTable.get("credit_limit")),
     ).toBe(55);
   });
@@ -387,19 +387,19 @@ describe("CalculationsTest", () => {
 
   it("count with eager loading and custom order", async () => {
     // Rails: Post.includes(:comments).order("comments.id").count() == 11
-    const count = await Post.includes("comments").order("comments.id").count();
+    const count = await Post.includes(":comments").order("comments.id").count();
     expect(typeof count).toBe("number");
     expect(count).toBeGreaterThan(0);
   });
 
   it("count with eager loading and custom select and order", async () => {
-    const count = await Post.includes("comments").order("comments.id").select("type").count();
+    const count = await Post.includes(":comments").order("comments.id").select("type").count();
     expect(typeof count).toBe("number");
     expect(count).toBeGreaterThan(0);
   });
 
   it("count with eager loading and custom order and distinct", async () => {
-    const count = await Post.includes("comments").order("comments.id").distinct().count();
+    const count = await Post.includes(":comments").order("comments.id").distinct().count();
     expect(typeof count).toBe("number");
     expect(count).toBeGreaterThan(0);
   });
@@ -478,7 +478,7 @@ describe("CalculationsTest", () => {
 
   it("count for a composite primary key model with includes and references", async () => {
     expect(await CpkBook.count()).toBe(
-      await CpkBook.includes("chapters").references("chapters").count(),
+      await CpkBook.includes(":chapters").references("chapters").count(),
     );
   });
 
@@ -698,20 +698,20 @@ describe("CalculationsTest", () => {
   });
 
   it("should count selected field with include", async () => {
-    expect(await Account.includes("firm").distinct().count()).toBe(6);
+    expect(await Account.includes(":firm").distinct().count()).toBe(6);
     // Rails: Account.includes(:firm).distinct.select(:credit_limit).count == 4
     // (4 distinct credit_limit values: 50, 53, 55, 60)
     expect(
-      await Account.includes("firm").distinct().select("credit_limit").count(),
+      await Account.includes(":firm").distinct().select("credit_limit").count(),
     ).toBeGreaterThanOrEqual(4);
   });
 
   it("should not perform joined include by default", async () => {
-    expect(await Account.count()).toBe(await Account.includes("firm").count());
+    expect(await Account.count()).toBe(await Account.includes(":firm").count());
   });
 
   it("should perform joined include when referencing included tables", async () => {
-    const joinedCount = await Account.includes("firm")
+    const joinedCount = await Account.includes(":firm")
       .where({ companies: { name: "37signals" } })
       .count();
     expect(joinedCount).toBe(1);
@@ -731,7 +731,7 @@ describe("CalculationsTest", () => {
   });
 
   it("should count manual select with include", async () => {
-    expect(await Account.select("DISTINCT accounts.id").includes("firm").count()).toBe(6);
+    expect(await Account.select("DISTINCT accounts.id").includes(":firm").count()).toBe(6);
   });
 
   it("should count manual select with count all", async () => {
@@ -1059,7 +1059,7 @@ describe("CalculationsTest", () => {
   });
 
   it("pluck type cast with eager load without table name qualified column", async () => {
-    const rows = await Author.eagerLoad("topics").limit(1).pluck("id");
+    const rows = await Author.eagerLoad(":topics").limit(1).pluck("id");
     expect(Array.isArray(rows)).toBe(true);
   });
 
@@ -1117,7 +1117,7 @@ describe("CalculationsTest", () => {
     const c = await Company.create({ name: "test" });
     const contract = await Contract.create({ company_id: c.id, developer_id: 7 });
     const ids = (
-      await Company.includes("contracts").where({ "contracts.id": contract.id }).pluck("id")
+      await Company.includes(":contracts").where({ "contracts.id": contract.id }).pluck("id")
     ).map(Number);
     expect(ids).toEqual([Number(c.id)]);
   });
@@ -1278,7 +1278,7 @@ describe("CalculationsTest", () => {
 
   it("ids with eager load", async () => {
     const all = (await Company.all()).map((c) => Number(c.id)).sort((a, b) => a - b);
-    const ids = (await Company.all().eagerLoad("contracts").ids())
+    const ids = (await Company.all().eagerLoad(":contracts").ids())
       .map(Number)
       .sort((a, b) => a - b);
     expect(ids).toEqual(all);
@@ -1286,19 +1286,21 @@ describe("CalculationsTest", () => {
 
   it("ids with preload", async () => {
     const all = (await Company.all()).map((c) => Number(c.id)).sort((a, b) => a - b);
-    const ids = (await Company.all().preload("contracts").ids()).map(Number).sort((a, b) => a - b);
+    const ids = (await Company.all().preload(":contracts").ids()).map(Number).sort((a, b) => a - b);
     expect(ids).toEqual(all);
   });
 
   it("ids with includes", async () => {
     const all = (await Company.all()).map((c) => Number(c.id)).sort((a, b) => a - b);
-    const ids = (await Company.all().includes("contracts").ids()).map(Number).sort((a, b) => a - b);
+    const ids = (await Company.all().includes(":contracts").ids())
+      .map(Number)
+      .sort((a, b) => a - b);
     expect(ids).toEqual(all);
   });
 
   it("ids with includes and non primary key order", async () => {
     const all = (await Company.all().order("id")).map((c) => Number(c.id));
-    const ids = (await Company.all().includes("contracts").order(":id").ids()).map(Number);
+    const ids = (await Company.all().includes(":contracts").order(":id").ids()).map(Number);
     expect(ids).toEqual(all);
   });
 
@@ -1307,7 +1309,7 @@ describe("CalculationsTest", () => {
     const expected = (await Company.where({ id: scopedIds }))
       .map((c) => Number(c.id))
       .sort((a, b) => a - b);
-    const ids = (await Company.includes("contracts").where({ id: scopedIds }).ids())
+    const ids = (await Company.includes(":contracts").where({ id: scopedIds }).ids())
       .map(Number)
       .sort((a, b) => a - b)
       .filter((v, i, arr) => arr.indexOf(v) === i);
@@ -1318,7 +1320,7 @@ describe("CalculationsTest", () => {
     const company = await Company.first();
     const contract = await Contract.create({ company_id: company!.id });
     const ids = (
-      await Company.includes("contracts").where({ "contracts.id": contract.id }).ids()
+      await Company.includes(":contracts").where({ "contracts.id": contract.id }).ids()
     ).map(Number);
     expect(ids).toEqual([Number(company!.id)]);
   });
@@ -1326,31 +1328,33 @@ describe("CalculationsTest", () => {
   it("ids on loaded relation with includes and table scope", async () => {
     const company = await Company.first();
     const contract = await Contract.create({ company_id: company!.id });
-    const loaded = await Company.includes("contracts").where({ "contracts.id": contract.id });
+    const loaded = await Company.includes(":contracts").where({ "contracts.id": contract.id });
     const ids = loaded.map((c) => Number(c.id));
     expect(ids).toEqual([Number(company!.id)]);
   });
 
   it("ids with includes limit and empty result", async () => {
-    expect(await Topic.includes("replies").limit(0).ids()).toEqual([]);
-    expect(await Topic.includes("replies").limit(1).where("0 = 1").ids()).toEqual([]);
+    expect(await Topic.includes(":replies").limit(0).ids()).toEqual([]);
+    expect(await Topic.includes(":replies").limit(1).where("0 = 1").ids()).toEqual([]);
   });
 
   it("ids with includes offset", async () => {
-    expect((await Topic.includes("replies").order(":id").offset(4).ids()).map(Number)).toEqual([5]);
-    expect(await Topic.includes("replies").order(":id").offset(5).ids()).toEqual([]);
+    expect((await Topic.includes(":replies").order(":id").offset(4).ids()).map(Number)).toEqual([
+      5,
+    ]);
+    expect(await Topic.includes(":replies").order(":id").offset(5).ids()).toEqual([]);
   });
 
   it("pluck with includes limit and empty result", async () => {
-    expect(await Topic.includes("replies").limit(0).pluck("id")).toEqual([]);
-    expect(await Topic.includes("replies").limit(1).where("0 = 1").pluck("id")).toEqual([]);
+    expect(await Topic.includes(":replies").limit(0).pluck("id")).toEqual([]);
+    expect(await Topic.includes(":replies").limit(1).where("0 = 1").pluck("id")).toEqual([]);
   });
 
   it("pluck with includes offset", async () => {
     expect(
-      (await Topic.includes("replies").order(":id").offset(4).pluck("id")).map(Number),
+      (await Topic.includes(":replies").order(":id").offset(4).pluck("id")).map(Number),
     ).toEqual([5]);
-    expect(await Topic.includes("replies").order(":id").offset(5).pluck("id")).toEqual([]);
+    expect(await Topic.includes(":replies").order(":id").offset(5).pluck("id")).toEqual([]);
   });
 
   it("pluck with join", async () => {
@@ -1359,7 +1363,7 @@ describe("CalculationsTest", () => {
     const ids = (await Reply.order("id").pluck("id")).map(Number);
     expect(ids).toEqual([2, 4]);
     // Verify includes(:topic) works (preloads parent topic via parent_id)
-    const replies = await Reply.includes("topic").order("id");
+    const replies = await Reply.includes(":topic").order("id");
     expect(replies.map((r) => Number(r.id))).toEqual([2, 4]);
   });
 
@@ -1393,7 +1397,7 @@ describe("CalculationsTest", () => {
   );
 
   it("group by with limit", async () => {
-    const actual = await Post.includes("comments")
+    const actual = await Post.includes(":comments")
       .group("type")
       .order({ type: "desc" })
       .limit(2)
@@ -1403,7 +1407,7 @@ describe("CalculationsTest", () => {
   });
 
   it("group by with offset", async () => {
-    const actual = await Post.includes("comments")
+    const actual = await Post.includes(":comments")
       .group("type")
       .order({ type: "desc" })
       .offset(1)
@@ -1413,7 +1417,7 @@ describe("CalculationsTest", () => {
   });
 
   it("group by with limit and offset", async () => {
-    const actual = await Post.includes("comments")
+    const actual = await Post.includes(":comments")
       .group("type")
       .order({ type: "desc" })
       .offset(1)
@@ -1719,7 +1723,7 @@ describe("CalculationsTest", () => {
     await Contract.create({ company_id: developer.id, developer_id: 1 });
     await expect(
       Company.where({ id: developer.id })
-        .includes("contracts")
+        .includes(":contracts")
         .where({ "contracts.id": 1 })
         .count(),
     ).resolves.toBeDefined();

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1491,7 +1491,7 @@ describe("FinderTest", () => {
     await EagerRating.create({ value: 1, comment_id: c1.id });
     await EagerRating.create({ value: 2, comment_id: c2.id });
 
-    const eager = await EagerPost.eagerLoad({ comments: "ratings" })
+    const eager = await EagerPost.eagerLoad({ ":comments": ":ratings" })
       .order("posts.id, ratings.id, comments.id")
       .first();
     const expected = await EagerPost.first();
@@ -2347,7 +2347,7 @@ describe("FinderTest", () => {
   // Post#tags_with_destroy (dependent: :destroy) walks the Tag class on the
   // destroy cascade in `exists with loaded relation having unsaved records`.
   registerModel("Tag", CanonicalTag);
-  // uniqueCategorizedPosts.includes("specialComments") resolves the SpecialComment
+  // uniqueCategorizedPosts.includes(":specialComments") resolves the SpecialComment
   // STI subtype through the registry.
   registerModel("SpecialComment", SpecialComment);
 
@@ -2385,7 +2385,7 @@ describe("FinderTest", () => {
 
   it("exists uses existing scope", async () => {
     const post = (await authors("david").posts.first())!;
-    const authorsRel = Author.includes("posts").where({ name: "David", posts: { id: post.id } });
+    const authorsRel = Author.includes(":posts").where({ name: "David", posts: { id: post.id } });
     expect(await authorsRel.exists(authors("david").id)).toBe(true);
   });
 
@@ -2519,14 +2519,14 @@ describe("FinderTest", () => {
 
   it("exists with distinct and offset and eagerload and order", async () => {
     expect(
-      await Post.eagerLoad("comments")
+      await Post.eagerLoad(":comments")
         .distinct()
         .offset(10)
         .merge(Comment.order({ post_id: "asc" }))
         .exists(),
     ).toBe(true);
     expect(
-      await Post.eagerLoad("comments")
+      await Post.eagerLoad(":comments")
         .distinct()
         .offset(11)
         .merge(Comment.order({ post_id: "asc" }))
@@ -2562,7 +2562,7 @@ describe("FinderTest", () => {
 
   it("exists with eager load", async () => {
     expect(
-      await Topic.eagerLoad("replies")
+      await Topic.eagerLoad(":replies")
         .where({ replies_topics: { approved: true } })
         .order("replies_topics.created_at DESC")
         .exists(),
@@ -2571,17 +2571,17 @@ describe("FinderTest", () => {
 
   it("exists with includes limit and empty result", async () => {
     await assertNoQueries(false, async () => {
-      expect(await Topic.includes("replies").limit(0).exists()).toBe(false);
+      expect(await Topic.includes(":replies").limit(0).exists()).toBe(false);
     });
     await assertQueriesCount(1, false, async () => {
-      expect(await Topic.includes("replies").limit(1).where("0 = 1").exists()).toBe(false);
+      expect(await Topic.includes(":replies").limit(1).where("0 = 1").exists()).toBe(false);
     });
   });
 
   it("exists with distinct association includes and limit", async () => {
     const author = (await Author.first())!;
     const uniqueCategorizedPosts = (author as any).uniqueCategorizedPosts.includes(
-      "specialComments",
+      ":specialComments",
     );
     await assertNoQueries(false, async () => {
       expect(await uniqueCategorizedPosts.limit(0).exists()).toBe(false);
@@ -2594,7 +2594,7 @@ describe("FinderTest", () => {
   it("exists with distinct association includes limit and order", async () => {
     const author = (await Author.first())!;
     const uniqueCategorizedPosts = (author as any).uniqueCategorizedPosts
-      .includes("specialComments")
+      .includes(":specialComments")
       .order("comments.tags_count DESC");
     await assertNoQueries(false, async () => {
       expect(await uniqueCategorizedPosts.limit(0).exists()).toBe(false);
@@ -2606,7 +2606,7 @@ describe("FinderTest", () => {
 
   it("exists should reference correct aliases while joining tables of has many through association", async () => {
     const ratings = (developers("david") as any).ratings
-      .includes({ comment: "post" })
+      .includes({ ":comment": ":post" })
       .where({ posts: { id: 1 } });
     await assertQueriesCount(1, false, async () => {
       expect(await ratings.limit(1).exists()).toBe(false);

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -139,14 +139,14 @@ describe("RelationTest", () => {
   // a merge must dedup structurally, not accumulate duplicate specs the preloader
   // then double-loads.
   it("merge unions preload/includes/eager_load specs without duplicating", () => {
-    const preloadMerged = CanonPost.preload("comments").merge(CanonPost.preload("comments"));
-    expect((preloadMerged as any).preloadValues).toEqual(["comments"]);
+    const preloadMerged = CanonPost.preload(":comments").merge(CanonPost.preload(":comments"));
+    expect((preloadMerged as any).preloadValues).toEqual([":comments"]);
 
-    const includesMerged = CanonPost.includes("comments").merge(CanonPost.includes("comments"));
-    expect((includesMerged as any).includesValues).toEqual(["comments"]);
+    const includesMerged = CanonPost.includes(":comments").merge(CanonPost.includes(":comments"));
+    expect((includesMerged as any).includesValues).toEqual([":comments"]);
 
-    const eagerMerged = CanonPost.eagerLoad("comments").merge(CanonPost.eagerLoad("comments"));
-    expect((eagerMerged as any).eagerLoadValues).toEqual(["comments"]);
+    const eagerMerged = CanonPost.eagerLoad(":comments").merge(CanonPost.eagerLoad(":comments"));
+    expect((eagerMerged as any).eagerLoadValues).toEqual([":comments"]);
   });
 
   // No like-named Rails test: guards the documented proc-merge path
@@ -343,7 +343,7 @@ describe("RelationTest", () => {
     registerModel("RefLeftAuthor", Author);
     registerModel("RefLeftPost", Post);
 
-    const rel = Author.all().includes("posts").references("posts").leftJoins(":posts");
+    const rel = Author.all().includes(":posts").references("posts").leftJoins(":posts");
     const sqlStr = rel.toSql();
     // "posts" table should appear only once in LEFT OUTER JOIN clauses
     const leftJoinMatches = sqlStr.match(/LEFT OUTER JOIN/gi) ?? [];
@@ -369,8 +369,8 @@ describe("RelationTest", () => {
     registerModel("EagerLeftAuthor", Author);
     registerModel("EagerLeftPost", Post);
     // Both eagerLoad and leftJoins present, no explicit joins_values/_joinClauses
-    const rel = Author.leftJoins(":posts").eagerLoad("posts");
-    expect((rel as any).eagerLoadValues).toContain("posts");
+    const rel = Author.leftJoins(":posts").eagerLoad(":posts");
+    expect((rel as any).eagerLoadValues).toContain(":posts");
     expect((rel as any).leftOuterJoinsValues).toContain(":posts");
     // buildJoinBuckets must not short-circuit; SQL must be non-empty (no throw)
     expect(() => rel.toSql()).not.toThrow();
@@ -454,7 +454,7 @@ describe("RelationTest", () => {
           registerModel(this);
         }
       }
-      const sql = Book.all().eagerLoad("author").limit(10).toSql();
+      const sql = Book.all().eagerLoad(":author").limit(10).toSql();
       expect(sql).toContain("LIMIT 10");
       expect(sql).not.toContain(" IN (SELECT");
     } finally {
@@ -485,7 +485,7 @@ describe("RelationTest", () => {
         }
       }
       // hasMany is a collection association → not limitable → IN-subquery for fan-out avoidance
-      const sql = EagerArticle.all().eagerLoad("eagerComments").limit(5).toSql();
+      const sql = EagerArticle.all().eagerLoad(":eagerComments").limit(5).toSql();
       expect(sql).toContain(" IN (SELECT");
       // LIMIT 5 lives inside the subquery, not on the outer query
       expect(sql).toMatch(/IN \(SELECT .* LIMIT 5\)/s);
@@ -544,17 +544,17 @@ describe("RelationTest", () => {
       // joins ∪ left_outer_joins clause (finder_methods.rb:464-470) has a
       // collection (hasMany), so the two-clause using_limitable_reflections? test
       // is false and the relation defers to distinct-PK materialization.
-      const limitableEager = JlArticle.all().eagerLoad("jlAuthor").limit(5);
+      const limitableEager = JlArticle.all().eagerLoad(":jlAuthor").limit(5);
       expect((limitableEager as any)._isDeferredDistinctPkSubquery()).toBe(false);
 
       const withCollectionJoin = JlArticle.all()
-        .eagerLoad("jlAuthor")
+        .eagerLoad(":jlAuthor")
         .joins(":jlComments")
         .limit(5);
       expect((withCollectionJoin as any)._isDeferredDistinctPkSubquery()).toBe(true);
 
       const withCollectionLeftJoin = JlArticle.all()
-        .eagerLoad("jlAuthor")
+        .eagerLoad(":jlAuthor")
         .leftJoins(":jlComments")
         .limit(5);
       expect((withCollectionLeftJoin as any)._isDeferredDistinctPkSubquery()).toBe(true);
@@ -563,11 +563,11 @@ describe("RelationTest", () => {
       // both belongsTo) — resolve to non-collection reflections, so the second
       // using_limitable_reflections? clause stays true and the relation does NOT
       // defer (Rails resolves the hash via construct_join_dependency.reflections).
-      const singularJoin = JlArticle.all().eagerLoad("jlAuthor").joins(":jlAuthor").limit(5);
+      const singularJoin = JlArticle.all().eagerLoad(":jlAuthor").joins(":jlAuthor").limit(5);
       expect((singularJoin as any)._isDeferredDistinctPkSubquery()).toBe(false);
 
       const singularNestedJoin = JlArticle.all()
-        .eagerLoad("jlAuthor")
+        .eagerLoad(":jlAuthor")
         .joins({ ":jlAuthor": ":jlProfile" })
         .limit(5);
       expect((singularNestedJoin as any)._isDeferredDistinctPkSubquery()).toBe(false);
@@ -659,7 +659,7 @@ describe("Relation#arel build_arel convergence", () => {
   // subquery with an explicit single-column select projects that one column,
   // not JoinDependency aliases (regression guard for build_arel convergence).
   it("arel of an eager relation projects normal columns, not join-dependency aliases", () => {
-    const rel = Gadget.eagerLoad("widget").select(Gadget.arelTable.get("id"));
+    const rel = Gadget.eagerLoad(":widget").select(Gadget.arelTable.get("id"));
     const sql = Gadget.connection.toSql(rel.arel().ast);
     expect(sql).not.toMatch(/t\d+_r\d+/);
     expect(sql).toMatch(/SELECT\s+["`]gadgets["`]\.["`]id["`]/);
@@ -669,7 +669,7 @@ describe("Relation#arel build_arel convergence", () => {
   // subquery: an eager-loading relation used as a `where(id: …)` value has its
   // eager_load converted to a LEFT OUTER JOIN (not dropped), projecting only PK.
   it("where with eager-loading relation subquery converts eager-load to a join", () => {
-    const sql = Widget.where({ id: Gadget.eagerLoad("widget") }).toSql();
+    const sql = Widget.where({ id: Gadget.eagerLoad(":widget") }).toSql();
     expect(sql).toContain("LEFT OUTER JOIN");
     expect(sql).toMatch(/IN \(SELECT ["`]gadgets["`]\.["`]id["`]/);
     expect(sql).not.toMatch(/t\d+_r\d+/);
@@ -697,7 +697,7 @@ describe("Relation#arel build_arel convergence", () => {
   // fallback (valid on SQLite/PostgreSQL). The load path substitutes a literal
   // id list instead — see the canonical RelationTest materialization tests.
   it("where with eager-loading limited collection relation subquery renders the inline distinct subquery for sync toSql", () => {
-    const sql = Gadget.where({ widget_id: Widget.eagerLoad("gadgets").limit(5) }).toSql();
+    const sql = Gadget.where({ widget_id: Widget.eagerLoad(":gadgets").limit(5) }).toSql();
     expect(sql).toMatch(/widget_id\W+IN \(SELECT DISTINCT ["`]widgets["`]\.["`]id["`]/);
     expect(sql).toContain("LEFT OUTER JOIN");
     expect(sql).toMatch(/LIMIT 5/);
@@ -732,7 +732,7 @@ describe("RelationTest", () => {
   // load time: the main query carries the literal `author_id IN (<ids>)`, never
   // a LIMIT-bearing subquery, on every adapter.
   it("where with eager-loading limited collection relation subquery materializes distinct primary keys at load time", async () => {
-    const subquery = CanonAuthor.eagerLoad("posts").order({ id: "asc" }).limit(2);
+    const subquery = CanonAuthor.eagerLoad(":posts").order({ id: "asc" }).limit(2);
 
     let records: any[] = [];
     const queries = await captureSql(async () => {
@@ -765,7 +765,10 @@ describe("RelationTest", () => {
   // short-circuits as a contradiction (Rails `none!`): an empty result with no
   // main query issued and no error.
   it("where with eager-loading limited collection relation subquery yielding no ids is empty", async () => {
-    const subquery = CanonAuthor.where({ id: -1 }).eagerLoad("posts").order({ id: "asc" }).limit(2);
+    const subquery = CanonAuthor.where({ id: -1 })
+      .eagerLoad(":posts")
+      .order({ id: "asc" })
+      .limit(2);
 
     let records: any[] = [];
     const queries = await captureSql(async () => {
@@ -782,7 +785,7 @@ describe("RelationTest", () => {
   // inline LIMIT-in-IN subquery MySQL rejects. Rails materializes at
   // `.where()`-build time, so all terminals see `pk IN (ids)`.
   it("count, pluck, and exists over an eager-loading limited collection subquery materialize distinct primary keys", async () => {
-    const subquery = () => CanonAuthor.eagerLoad("posts").order({ id: "asc" }).limit(2);
+    const subquery = () => CanonAuthor.eagerLoad(":posts").order({ id: "asc" }).limit(2);
     const limitedAuthorIds = await CanonAuthor.order("id").limit(2).pluck("id");
     const expectedPostIds = await CanonPost.where({ author_id: limitedAuthorIds })
       .order("id")
@@ -807,7 +810,7 @@ describe("RelationTest", () => {
   // skipping distinct_relation_for_primary_key — so a grouped eager+limit
   // subquery is NOT deferred and builds the plain `IN (SELECT … GROUP BY …)`.
   it("where with a grouped eager-loading limited subquery does not defer materialization", () => {
-    const subquery = CanonAuthor.eagerLoad("posts").group("authors.id").limit(2);
+    const subquery = CanonAuthor.eagerLoad(":posts").group("authors.id").limit(2);
     const sql = CanonPost.where({ author_id: subquery }).toSql();
     expect(sql).toMatch(/IN \(SELECT/i);
     expect(sql).toMatch(/GROUP BY/i);
@@ -820,7 +823,7 @@ describe("RelationTest", () => {
   // (Author hasOne post → Post belongsTo author) stays limitable, so a
   // limit/offset relation is NOT deferred to distinct_relation_for_primary_key.
   it("where with a singular nested-hash eager-loading limited subquery does not defer materialization", () => {
-    const subquery = CanonAuthor.eagerLoad({ post: "author" }).order({ id: "asc" }).limit(2);
+    const subquery = CanonAuthor.eagerLoad({ ":post": ":author" }).order({ id: "asc" }).limit(2);
     expect((subquery as any)._isDeferredDistinctPkSubquery()).toBe(false);
   });
 
@@ -828,7 +831,7 @@ describe("RelationTest", () => {
   // hasMany comments) makes the reflection set non-limitable, so the relation
   // defers to distinct-PK materialization just as a top-level collection does.
   it("where with a collection nested-hash eager-loading limited subquery defers materialization", () => {
-    const subquery = CanonAuthor.eagerLoad({ post: "comments" }).order({ id: "asc" }).limit(2);
+    const subquery = CanonAuthor.eagerLoad({ ":post": ":comments" }).order({ id: "asc" }).limit(2);
     expect((subquery as any)._isDeferredDistinctPkSubquery()).toBe(true);
   });
 });
@@ -938,13 +941,13 @@ describe("apply_join_dependency limitable reflections (trails)", () => {
     // select_association_list(joins_values) + left_outer_joins_values. `author`
     // is singular, but the joined `comments` collection is not, so a limit here
     // takes the rewrite rather than a direct LIMIT on the fanned-out join.
-    const sql = CanonPost.eagerLoad("author").joins(":comments").limit(1).toSql();
+    const sql = CanonPost.eagerLoad(":author").joins(":comments").limit(1).toSql();
     expect(sql).toMatch(/WHERE .*IN \(SELECT DISTINCT /);
     expect(sql).not.toMatch(/\bLIMIT 1\s*$/);
   });
 
   it("applies the limit directly when every eager and joined reflection is singular", () => {
-    const sql = CanonPost.eagerLoad("author").limit(1).toSql();
+    const sql = CanonPost.eagerLoad(":author").limit(1).toSql();
     expect(sql).not.toContain("SELECT DISTINCT");
     expect(sql).toMatch(/\bLIMIT 1\s*$/);
   });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2742,13 +2742,8 @@ export class Relation<T extends Base> {
    * intersection.
    */
   get joinedIncludesValues(): AssociationSpec[] {
-    // DEBT: Rails intersects two Symbol arrays. joins_values now carries the
-    // Symbol spelling while includes_values does not, so both sides drop a
-    // leading colon here. Retires with the includes/preload sweep.
-    const symbolName = (v: unknown): unknown =>
-      typeof v === "string" && v.startsWith(":") ? v.slice(1) : v;
-    const joinsValues = new Set<unknown>(this.joinsValues.map(symbolName));
-    return [...new Set(this.includesValues)].filter((spec) => joinsValues.has(symbolName(spec)));
+    const joinsValues = new Set<unknown>(this.joinsValues);
+    return [...new Set(this.includesValues)].filter((spec) => joinsValues.has(spec));
   }
 
   /** Mirrors: ActiveRecord::Relation#values (relation.rb:1281-1283) — `@values.dup`. */

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -145,7 +145,7 @@ describe("build_joins from(subquery) dedup", () => {
   // live-path exclusion filter deciding which value to drop before emission.
   it("dedups an association named in both joins and eager_load", () => {
     const liveSql = (
-      Post.joins(":author").eagerLoad("author") as unknown as { toSql(): string }
+      Post.joins(":author").eagerLoad(":author") as unknown as { toSql(): string }
     ).toSql();
     expect((liveSql.match(/INNER JOIN/g) ?? []).length).toBe(1);
     expect(liveSql).not.toContain("LEFT OUTER JOIN");
@@ -159,7 +159,7 @@ describe("build_joins from(subquery) dedup", () => {
   // `eager_load(:x).left_outer_joins(:x)` legitimately emits two joins.
   it("emits the eager and left_outer joins separately when there is no named join to walk against", () => {
     const liveSql = (
-      Post.eagerLoad("author").leftOuterJoins(":author") as unknown as { toSql(): string }
+      Post.eagerLoad(":author").leftOuterJoins(":author") as unknown as { toSql(): string }
     ).toSql();
     const q = (name: string) => escapeRegExp(quoteTableName(name));
     expect((liveSql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2);
@@ -171,7 +171,7 @@ describe("build_joins from(subquery) dedup", () => {
   // with one AliasTracker on both halves.
   it("emits the same joins for eager_load + left_outer_joins + a raw join on both paths", () => {
     const build = () =>
-      Post.joins("CROSS JOIN categories").eagerLoad("author").leftOuterJoins(":comments");
+      Post.joins("CROSS JOIN categories").eagerLoad(":author").leftOuterJoins(":comments");
     const liveSql = (build() as unknown as { toSql(): string }).toSql();
     const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
     // The eager live path projects `t0_r*` aliases, so compare from the FROM on:

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -135,10 +135,10 @@ export class Merger {
     if (!reflection) return;
 
     if (this.other.preloadValues.length > 0) {
-      rel.preloadBang({ [reflection.name]: this.other.preloadValues });
+      rel.preloadBang({ [`:${reflection.name}`]: this.other.preloadValues });
     }
     if (this.other.includesValues.length > 0) {
-      rel.includesBang({ [reflection.name]: this.other.includesValues });
+      rel.includesBang({ [`:${reflection.name}`]: this.other.includesValues });
     }
   }
 

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -181,7 +181,7 @@ describe("OrTest", () => {
   });
 
   it("or with references inequality", async () => {
-    const joined = Post.includes("author");
+    const joined = Post.includes(":author");
     const actual = joined
       .where({ authors: { id: 1 } })
       .or(joined.where({ title: "I don't have any comments" }));
@@ -230,9 +230,9 @@ describe("OrTest", () => {
     // hits because it doesn't run the query.
     let threw = false;
     try {
-      Post.includes("author").includes("author").or(Post.includes("author"));
-      Post.eagerLoad("author").eagerLoad("author").or(Post.eagerLoad("author"));
-      Post.preload("author").preload("author").or(Post.preload("author"));
+      Post.includes(":author").includes(":author").or(Post.includes(":author"));
+      Post.eagerLoad(":author").eagerLoad(":author").or(Post.eagerLoad(":author"));
+      Post.preload(":author").preload(":author").or(Post.preload(":author"));
       Post.group("author_id").group("author_id").or(Post.group("author_id"));
       Post.joins(":author").joins(":author").or(Post.joins(":author"));
       Post.leftOuterJoins(":author").leftOuterJoins(":author").or(Post.leftOuterJoins(":author"));

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -198,8 +198,8 @@ describe("SelectTest", () => {
     };
 
     assertNonSelectColumnsWontBeLoaded((await posts.first()) as never);
-    assertNonSelectColumnsWontBeLoaded((await posts.preload("comments").first()) as never);
-    assertNonSelectColumnsWontBeLoaded((await posts.eagerLoad("comments").first()) as never);
+    assertNonSelectColumnsWontBeLoaded((await posts.preload(":comments").first()) as never);
+    assertNonSelectColumnsWontBeLoaded((await posts.eagerLoad(":comments").first()) as never);
   });
 
   it("merging select from different model", async () => {
@@ -225,7 +225,7 @@ describe("SelectTest", () => {
     // Rails reads the aliased extra select via `posts.first.foo`; trails exposes
     // query-only aliases through `readAttribute` (no dynamic accessor is
     // generated for non-schema columns), matching the sibling hash-select tests.
-    const posts = Post.select("posts.id * 1.1 AS foo").eagerLoad("comments");
+    const posts = Post.select("posts.id * 1.1 AS foo").eagerLoad(":comments");
     const post = (await posts.first()) as never as { readAttribute(n: string): unknown };
     // The explicit extra select is preserved through the JoinDependency and
     // hydrated onto the base record, type-cast via the result set's column_types
@@ -248,19 +248,19 @@ describe("SelectTest", () => {
   });
 
   it("aliased select using as with joins and includes", async () => {
-    const posts = Post.select("posts.id AS field_alias").joins(":comments").includes("comments");
+    const posts = Post.select("posts.id AS field_alias").joins(":comments").includes(":comments");
     const post = (await posts.first()) as never as { attributes: Record<string, unknown> };
     expect(Object.keys(post.attributes)).toEqual(["id", "field_alias"]);
   });
 
   it("aliased select not using as with joins and includes", async () => {
-    const posts = Post.select("posts.id field_alias").joins(":comments").includes("comments");
+    const posts = Post.select("posts.id field_alias").joins(":comments").includes(":comments");
     const post = (await posts.first()) as never as { attributes: Record<string, unknown> };
     expect(Object.keys(post.attributes)).toEqual(["id", "field_alias"]);
   });
 
   it("star select with joins and includes", async () => {
-    const posts = Post.select("posts.*").joins(":comments").includes("comments");
+    const posts = Post.select("posts.*").joins(":comments").includes(":comments");
     const post = (await posts.first()) as never as { attributes: Record<string, unknown> };
     expect(Object.keys(post.attributes)).toEqual([
       "id",

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -406,7 +406,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with subquery with eager loading in from", async () => {
-    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order(":id");
+    const relation = Comment.includes(":post").where({ "posts.type": "Post" }).order(":id");
     const expected = (await relation).map((c) => c.id);
     expect((await Comment.select("*").from(relation)).map((c) => c.id)).toEqual(expected);
     expect((await Comment.select("subquery.*").from(relation)).map((c) => c.id)).toEqual(expected);
@@ -423,7 +423,7 @@ describe("RelationTest", () => {
   // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
   // path (`relation-handler`); converging to `t0_r*` here would diverge.
   it("eager from() subquery projects the table star, not column aliases", async () => {
-    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order(":id");
+    const relation = Comment.includes(":post").where({ "posts.type": "Post" }).order(":id");
     const sql = await (Comment.select("*").from(relation) as any).toSql();
     // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,
     // backticks on mysql) so the shape assertion holds on every CI adapter.
@@ -433,7 +433,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with subquery with eager loading in where", async () => {
-    const relation = Comment.includes("post").where({ "posts.type": "Post" });
+    const relation = Comment.includes(":post").where({ "posts.type": "Post" });
     const expected = (await relation).map((c) => Number(c.id)).sort((a, b) => a - b);
     expect(
       (await Comment.where({ id: relation })).map((c) => Number(c.id)).sort((a, b) => a - b),
@@ -834,7 +834,7 @@ describe("RelationTest", () => {
 
   it("eager association loading of stis with multiple references", async () => {
     const loaded = await Author.eagerLoad({
-      posts: { specialComments: { post: ["specialComments", "verySpecialComment"] } },
+      ":posts": { ":specialComments": { ":post": [":specialComments", ":verySpecialComment"] } },
     })
       .order("comments.body, very_special_comments_posts.body")
       .where("posts.id = 4");
@@ -849,12 +849,12 @@ describe("RelationTest", () => {
   });
 
   it("find with preloaded associations", async () => {
-    const posts1 = await Post.preload("comments").order("posts.id");
+    const posts1 = await Post.preload(":comments").order("posts.id");
     const firstPost = posts1.find((p) => Number(p.id) === 1)!;
     const firstComments = await firstPost.comments;
     expect(firstComments.length).toBeGreaterThan(0);
 
-    const posts2 = await Post.preload("author").order("posts.id");
+    const posts2 = await Post.preload(":author").order("posts.id");
     const withAuthor = posts2[0];
     const author = await withAuthor.author;
     expect(author).toBeTruthy();
@@ -870,11 +870,11 @@ describe("RelationTest", () => {
   });
 
   it("find with included associations", async () => {
-    const posts1 = await Post.includes("comments").order("posts.id");
+    const posts1 = await Post.includes(":comments").order("posts.id");
     const firstComments = await posts1[0].comments;
     expect(firstComments.length).toBeGreaterThan(0);
 
-    const posts2 = await Post.includes("author").order("posts.id");
+    const posts2 = await Post.includes(":author").order("posts.id");
     const author = await posts2[0].author;
     expect(author).toBeTruthy();
   });
@@ -888,7 +888,7 @@ describe("RelationTest", () => {
   it("includes with select", async () => {
     const query = Post.select("legacy_comments_count AS ranking")
       .order("ranking")
-      .includes("comments")
+      .includes(":comments")
       .where({ comments: { id: 1 } });
     expect((query as any).selectValues).toEqual(["legacy_comments_count AS ranking"]);
     expect(await query.size()).toBe(1);
@@ -899,7 +899,7 @@ describe("RelationTest", () => {
     const reader = await Reader.createBang({ post_id: post.id, person_id: 1 });
     const comment = await Comment.createBang({ post_id: post.id, body: "body" });
 
-    const postRel = Post.preload("readers").joins(":readers").where({ title: "Uhuu" });
+    const postRel = Post.preload(":readers").joins(":readers").where({ title: "Uhuu" });
     let resultComment = (await Comment.joins(":post").merge(postRel))[0];
     expect(Number(resultComment.id)).toBe(Number(comment.id));
 
@@ -910,7 +910,7 @@ describe("RelationTest", () => {
     expect(readersAssoc.isLoaded()).toBe(true);
     expect(readersAssoc.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
 
-    const postRel2 = Post.includes("readers").where({ title: "Uhuu" });
+    const postRel2 = Post.includes(":readers").where({ title: "Uhuu" });
     resultComment = (await Comment.joins(":post").merge(postRel2).first())!;
     expect(Number(resultComment.id)).toBe(Number(comment.id));
 
@@ -924,16 +924,16 @@ describe("RelationTest", () => {
     // Rails merges :eager_load as a NORMAL_VALUE (merger.rb) — a straight union
     // via eager_load!, never gated on model equality nor nested under a
     // reflection, so it crosses the model boundary untouched.
-    const merged = Comment.joins(":post").merge(Post.eagerLoad("readers")) as any;
-    expect(merged.eagerLoadValues).toContain("readers");
+    const merged = Comment.joins(":post").merge(Post.eagerLoad(":readers")) as any;
+    expect(merged.eagerLoadValues).toContain(":readers");
 
     // merge! (in-place) shares Merger#merge in Rails; trails routes both through
     // the same foldMerge* helpers, so the cross-model reflection-nesting applies
     // identically — the bang path must nest `{ post: [:readers] }`, not ask
     // Comment to preload `:readers` directly.
     const bang = Comment.joins(":post") as any;
-    bang.mergeBang(Post.preload("readers").where({ title: "Uhuu" }));
-    expect(bang.preloadValues).toEqual([{ post: ["readers"] }]);
+    bang.mergeBang(Post.preload(":readers").where({ title: "Uhuu" }));
+    expect(bang.preloadValues).toEqual([{ ":post": [":readers"] }]);
     const bangComment = (await bang.toArray())[0];
     const bangPost = bangComment.association("post");
     expect(bangPost.isLoaded()).toBe(true);
@@ -944,7 +944,7 @@ describe("RelationTest", () => {
     const post = await Post.createBang({ title: "Uhuu", body: "body" });
     await Reader.createBang({ post_id: post.id, person_id: 1 });
 
-    const postRel = PostWithPreloadDefaultScope.preload("readers")
+    const postRel = PostWithPreloadDefaultScope.preload(":readers")
       .joins("INNER JOIN readers ON readers.post_id = posts.id")
       .where({ title: "Uhuu" });
     const resultPosts = await PostWithPreloadDefaultScope.all().merge(postRel);
@@ -954,7 +954,7 @@ describe("RelationTest", () => {
     expect(Number(preloadedReaders[0].post_id)).toBe(Number(post.id));
 
     // includes branch: PostWithIncludesDefaultScope
-    const postRel2 = PostWithIncludesDefaultScope.includes("readers").where({ title: "Uhuu" });
+    const postRel2 = PostWithIncludesDefaultScope.includes(":readers").where({ title: "Uhuu" });
     const resultPosts2 = await PostWithIncludesDefaultScope.all().merge(postRel2);
     expect(resultPosts2).toHaveLength(1);
     const includedReaders = await resultPosts2[0].readers;
@@ -963,18 +963,18 @@ describe("RelationTest", () => {
   });
 
   it("loading with one association", async () => {
-    const allPosts = await Post.preload("comments");
+    const allPosts = await Post.preload(":comments");
     const post = allPosts.find((p) => Number(p.id) === 1)!;
     const postComments = await post.comments;
     expect(postComments).toHaveLength(2);
     expect(postComments.map((c: any) => c.id)).toContain(comments("greetings").id);
 
-    const post2 = await Post.where({ title: "Welcome to the weblog" }).preload("comments").first();
+    const post2 = await Post.where({ title: "Welcome to the weblog" }).preload(":comments").first();
     const post2Comments = await post2!.comments;
     expect(post2Comments).toHaveLength(2);
     expect(post2Comments.map((c: any) => c.id)).toContain(comments("greetings").id);
 
-    const postsWithLastComment = await Post.preload("lastComment");
+    const postsWithLastComment = await Post.preload(":lastComment");
     const postWithLastComment = postsWithLastComment.find((p) => Number(p.id) === 1)!;
     const freshPost = await Post.find(1);
     const directLastComment = await freshPost.loadHasOne("lastComment");
@@ -984,10 +984,10 @@ describe("RelationTest", () => {
   it("to sql on eager join", async () => {
     const expected = (
       await captureSql(async () => {
-        await Post.eagerLoad("lastComment").order("comments.id DESC");
+        await Post.eagerLoad(":lastComment").order("comments.id DESC");
       })
     )[0];
-    const actual = Post.eagerLoad("lastComment").order("comments.id DESC").toSql();
+    const actual = Post.eagerLoad(":lastComment").order("comments.id DESC").toSql();
     expect(expected).toEqual(actual);
   });
 
@@ -999,7 +999,7 @@ describe("RelationTest", () => {
 
   it("loading with one association with non preload", async () => {
     void posts("welcome");
-    const postsEager = await Post.eagerLoad("lastComment").order("comments.id DESC");
+    const postsEager = await Post.eagerLoad(":lastComment").order("comments.id DESC");
     const post = postsEager.find((p) => Number(p.id) === 1)!;
     const freshPost = await Post.find(1);
     const directLastComment = await freshPost.loadHasOne("lastComment");
@@ -1261,25 +1261,25 @@ describe("RelationTest", () => {
   });
 
   it("size with eager loading and custom order", async () => {
-    const postsRel = Post.includes("comments").order("comments.id");
+    const postsRel = Post.includes(":comments").order("comments.id");
     expect(await postsRel.size()).toBe(11);
     expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and custom select and order", async () => {
-    const postsRel = Post.includes("comments").order("comments.id").select("type");
+    const postsRel = Post.includes(":comments").order("comments.id").select("type");
     expect(await postsRel.size()).toBe(11);
     expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and custom order and distinct", async () => {
-    const postsRel = Post.includes("comments").order("comments.id").distinct();
+    const postsRel = Post.includes(":comments").order("comments.id").distinct();
     expect(await postsRel.size()).toBe(11);
     expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and manual distinct select and custom order", () => {
-    const sql = Post.includes("comments").select("DISTINCT posts.id").order("comments.id").toSql();
+    const sql = Post.includes(":comments").select("DISTINCT posts.id").order("comments.id").toSql();
     expect(sql).toContain("DISTINCT");
   });
 
@@ -2027,7 +2027,7 @@ describe("RelationTest", () => {
   });
 
   it("references triggers eager loading", () => {
-    const scope = Post.includes("comments");
+    const scope = Post.includes(":comments");
     expect(scope.isEagerLoading).toBe(false);
     expect(scope.references("comments").isEagerLoading).toBe(true);
   });
@@ -2038,32 +2038,32 @@ describe("RelationTest", () => {
   });
 
   it("order triggers eager loading", () => {
-    const scope = Post.includes("comments").order("comments.label ASC");
+    const scope = Post.includes(":comments").order("comments.label ASC");
     expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using the owner table", () => {
-    const scope = Post.includes("comments").order("posts.title ASC");
+    const scope = Post.includes(":comments").order("posts.title ASC");
     expect(scope.isEagerLoading).toBe(false);
   });
 
   it("order triggers eager loading when ordering using symbols", () => {
-    const scope = Post.includes("comments").order("comments.label");
+    const scope = Post.includes(":comments").order("comments.label");
     expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using owner table and symbols", () => {
-    const scope = Post.includes("comments").order("posts.title");
+    const scope = Post.includes(":comments").order("posts.title");
     expect(scope.isEagerLoading).toBe(false);
   });
 
   it("order triggers eager loading when ordering using hash syntax", () => {
-    const scope = Post.includes("comments").order({ "comments.label": "ASC" });
+    const scope = Post.includes(":comments").order({ "comments.label": "ASC" });
     expect(scope.isEagerLoading).toBe(true);
   });
 
   it("order doesnt trigger eager loading when ordering using the owner table and hash syntax", () => {
-    const scope = Post.includes("comments").order({ "posts.title": "ASC" });
+    const scope = Post.includes(":comments").order({ "posts.title": "ASC" });
     expect(scope.isEagerLoading).toBe(false);
   });
 
@@ -2570,13 +2570,13 @@ describe("RelationTest", () => {
   it("#skip_query_cache! with an eager load", async () => {
     await Post.cache(async () => {
       await assertQueriesCount(1, false, async () => {
-        await Post.eagerLoad("comments").load();
-        await Post.eagerLoad("comments").load();
+        await Post.eagerLoad(":comments").load();
+        await Post.eagerLoad(":comments").load();
       });
 
       await assertQueriesCount(2, false, async () => {
-        await Post.eagerLoad("comments").skipQueryCacheBang().load();
-        await Post.eagerLoad("comments").skipQueryCacheBang().load();
+        await Post.eagerLoad(":comments").skipQueryCacheBang().load();
+        await Post.eagerLoad(":comments").skipQueryCacheBang().load();
       });
     });
   });
@@ -2584,13 +2584,13 @@ describe("RelationTest", () => {
   it("#skip_query_cache! with a preload", async () => {
     await Post.cache(async () => {
       await assertQueriesCount(2, false, async () => {
-        await Post.preload("comments").load();
-        await Post.preload("comments").load();
+        await Post.preload(":comments").load();
+        await Post.preload(":comments").load();
       });
 
       await assertQueriesCount(4, false, async () => {
-        await Post.preload("comments").skipQueryCacheBang().load();
-        await Post.preload("comments").skipQueryCacheBang().load();
+        await Post.preload(":comments").skipQueryCacheBang().load();
+        await Post.preload(":comments").skipQueryCacheBang().load();
       });
     });
   });

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -358,7 +358,7 @@ describe("StrictLoadingTest", () => {
         developer_id: developer!.id,
       });
 
-      const preloaded = (await Developer.all().includes("ship").first())!;
+      const preloaded = (await Developer.all().includes(":ship").first())!;
       expect(preloaded.isStrictLoading()).toBe(true);
       const loaded = await loadSingularTarget(preloaded, "ship");
       expect(loaded?.id).toBe(ship.id);
@@ -376,7 +376,7 @@ describe("StrictLoadingTest", () => {
       const dev = await Developer.first();
       await AuditLog.create({ developer_id: dev!.id, message: "M" });
 
-      const devs = await Developer.all().includes("auditLogs");
+      const devs = await Developer.all().includes(":auditLogs");
 
       for (const d of devs) {
         await association(d, "auditLogs");
@@ -399,7 +399,7 @@ describe("StrictLoadingTest", () => {
       const dev0 = await Developer.first();
       await AuditLog.create({ developer_id: dev0!.id, message: "M" });
 
-      const dev = (await Developer.all().includes("auditLogs").first())!;
+      const dev = (await Developer.all().includes(":auditLogs").first())!;
       await association(dev, "auditLogs");
 
       await dev.reload();
@@ -415,7 +415,7 @@ describe("StrictLoadingTest", () => {
     const contract = await Contract.create({ developer_id: dev!.id, company_id: firm.id });
     await association(dev!, "contracts").concat(contract);
 
-    const loaded = await Developer.all().strictLoading().includes("firms").first();
+    const loaded = await Developer.all().strictLoading().includes(":firms").first();
     expect(loaded!.isStrictLoading()).toBe(true);
 
     const firms = (loaded as any).association("firms").target ?? [];
@@ -453,7 +453,7 @@ describe("StrictLoadingTest", () => {
       await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
     }
 
-    const dev = (await Developer.all().includes("auditLogs").strictLoading().first())!;
+    const dev = (await Developer.all().includes(":auditLogs").strictLoading().first())!;
     expect(dev.isStrictLoading()).toBe(true);
 
     const logs = (dev as any).association("auditLogs").target ?? [];
@@ -469,7 +469,7 @@ describe("StrictLoadingTest", () => {
         await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
       }
 
-      const dev = (await Developer.all().includes("auditLogs").first())!;
+      const dev = (await Developer.all().includes(":auditLogs").first())!;
       expect(dev.isStrictLoading()).toBe(false);
 
       const logs = (dev as any).association("auditLogs").target ?? [];
@@ -485,12 +485,12 @@ describe("StrictLoadingTest", () => {
       await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
     }
 
-    const dev = (await Developer.all().eagerLoad("strictLoadingAuditLogs").first())!;
+    const dev = (await Developer.all().eagerLoad(":strictLoadingAuditLogs").first())!;
     const logs = (dev as any).association("strictLoadingAuditLogs").target ?? [];
     expect(logs).toHaveLength(3);
     expect(logs.every((l: any) => l._strictLoading)).toBe(true);
 
-    const dev2 = (await Developer.all().eagerLoad("auditLogs").strictLoading(false).first())!;
+    const dev2 = (await Developer.all().eagerLoad(":auditLogs").strictLoading(false).first())!;
     const logs2 = (dev2 as any).association("auditLogs").target ?? [];
     expect(logs2.every((l: any) => !l._strictLoading)).toBe(true);
   });
@@ -502,13 +502,13 @@ describe("StrictLoadingTest", () => {
       await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
     }
 
-    const dev = (await Developer.all().eagerLoad("auditLogs").strictLoading().first())!;
+    const dev = (await Developer.all().eagerLoad(":auditLogs").strictLoading().first())!;
     expect(dev.isStrictLoading()).toBe(true);
     const logs = (dev as any).association("auditLogs").target ?? [];
     expect(logs).toHaveLength(3);
     expect(logs.every((l: any) => l._strictLoading)).toBe(true);
 
-    const dev2 = (await Developer.all().eagerLoad("auditLogs").strictLoading(false).first())!;
+    const dev2 = (await Developer.all().eagerLoad(":auditLogs").strictLoading(false).first())!;
     expect(dev2.isStrictLoading()).toBe(false);
     const logs2 = (dev2 as any).association("auditLogs").target ?? [];
     expect(logs2.every((l: any) => !l._strictLoading)).toBe(true);
@@ -522,7 +522,7 @@ describe("StrictLoadingTest", () => {
         await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
       }
 
-      const dev = (await Developer.all().eagerLoad("auditLogs").first())!;
+      const dev = (await Developer.all().eagerLoad(":auditLogs").first())!;
       expect(dev.isStrictLoading()).toBe(false);
       expect((await AuditLog.last())?.isStrictLoading()).toBe(true);
 
@@ -596,7 +596,7 @@ describe("StrictLoadingTest", () => {
     const first = await Developer.first();
     await first!.updateColumn("mentor_id", mentor.id);
 
-    const developer = (await Developer.all().includes("strictLoadingMentor").first())!;
+    const developer = (await Developer.all().includes(":strictLoadingMentor").first())!;
 
     const loaded = await loadSingularTarget(developer, "strictLoadingMentor");
     expect(loaded?.id).toBe(mentor.id);
@@ -609,7 +609,7 @@ describe("StrictLoadingTest", () => {
       const first = await Developer.first();
       await first!.updateColumn("mentor_id", mentor.id);
 
-      const developer = (await Developer.all().includes("mentor").first())!;
+      const developer = (await Developer.all().includes(":mentor").first())!;
       const loaded = await loadSingularTarget(developer, "mentor");
       expect(loaded?.id).toBe(mentor.id);
     });
@@ -644,7 +644,7 @@ describe("StrictLoadingTest", () => {
     const ship = await Ship.first();
     await ship!.updateColumn("developer_id", developers("david").id);
 
-    const developer = (await Developer.all().includes("strictLoadingShip").first())!;
+    const developer = (await Developer.all().includes(":strictLoadingShip").first())!;
     const loaded = await loadSingularTarget(developer, "strictLoadingShip");
     expect(loaded).not.toBeNull();
   });
@@ -655,7 +655,7 @@ describe("StrictLoadingTest", () => {
       const ship = await Ship.first();
       await ship!.updateColumn("developer_id", developers("david").id);
 
-      const developer = (await Developer.all().includes("ship").first())!;
+      const developer = (await Developer.all().includes(":ship").first())!;
       const loaded = await loadSingularTarget(developer, "ship");
       expect(loaded).not.toBeNull();
     });
@@ -694,7 +694,7 @@ describe("StrictLoadingTest", () => {
       await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
     }
 
-    const dev = (await Developer.all().includes("strictLoadingOptAuditLogs").first())!;
+    const dev = (await Developer.all().includes(":strictLoadingOptAuditLogs").first())!;
     const first = await association(dev, "strictLoadingOptAuditLogs").first();
     expect(first).not.toBeNull();
   });
@@ -707,7 +707,7 @@ describe("StrictLoadingTest", () => {
         await AuditLog.create({ developer_id: developer!.id, message: "I am message" });
       }
 
-      const dev = (await Developer.all().includes("auditLogs").first())!;
+      const dev = (await Developer.all().includes(":auditLogs").first())!;
       const first = await association(dev, "auditLogs").first();
       expect(first).not.toBeNull();
     });
@@ -746,7 +746,7 @@ describe("StrictLoadingTest", () => {
     const developer = await Developer.first();
     await association(developer!, "projects").concat((await Project.first())!);
 
-    const dev = (await Developer.all().includes("strictLoadingProjects").first())!;
+    const dev = (await Developer.all().includes(":strictLoadingProjects").first())!;
     const first = await association(dev, "strictLoadingProjects").first();
     expect(first).not.toBeNull();
   });
@@ -757,7 +757,7 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await association(developer!, "projects").concat((await Project.first())!);
 
-      const dev = (await Developer.all().includes("projects").first())!;
+      const dev = (await Developer.all().includes(":projects").first())!;
       const first = await association(dev, "projects").first();
       expect(first).not.toBeNull();
     });

--- a/packages/activerecord/src/test-helpers/models/author.ts
+++ b/packages/activerecord/src/test-helpers/models/author.ts
@@ -209,12 +209,12 @@ export class Author extends Base {
     this.hasMany("serializedPosts");
     this.hasOne("post");
     this.hasMany("verySpecialComments", { through: "posts" });
-    this.hasMany("postsWithComments", (q: any) => q.includes("comments"), { className: "Post" });
+    this.hasMany("postsWithComments", (q: any) => q.includes(":comments"), { className: "Post" });
     this.hasMany(
       "popularGroupedPosts",
       (q: any) =>
         q
-          .includes("comments")
+          .includes(":comments")
           .group("type")
           .having("SUM(legacy_comments_count) > 1")
           .select("type"),
@@ -222,19 +222,19 @@ export class Author extends Base {
     );
     this.hasMany(
       "postsWithCommentsSortedByCommentId",
-      (q: any) => q.includes("comments").order("comments.id"),
+      (q: any) => q.includes(":comments").order("comments.id"),
       { className: "Post" },
     );
     this.hasMany("postsSortedById", (q: any) => q.order("id"), { className: "Post" });
     this.hasMany("postsSortedByIdLimited", (q: any) => q.order("posts.id").limit(1), {
       className: "Post",
     });
-    this.hasMany("postsWithCategories", (q: any) => q.includes("categories"), {
+    this.hasMany("postsWithCategories", (q: any) => q.includes(":categories"), {
       className: "Post",
     });
     this.hasMany(
       "postsWithCommentsAndCategories",
-      (q: any) => q.includes("comments", "categories").order("posts.id"),
+      (q: any) => q.includes(":comments", ":categories").order("posts.id"),
       { className: "Post" },
     );
     this.hasMany("postsWithSpecialCategorizations", { className: "PostWithSpecialCategorization" });
@@ -243,7 +243,7 @@ export class Author extends Base {
     });
     this.hasOne(
       "postAboutThinkingWithLastComment",
-      (q: any) => q.where("posts.title like '%thinking%'").includes("lastComment"),
+      (q: any) => q.where("posts.title like '%thinking%'").includes(":lastComment"),
       { className: "Post" },
     );
 
@@ -317,7 +317,7 @@ export class Author extends Base {
     );
     this.hasMany(
       "commentsWithInclude",
-      (q: any) => q.includes("post").where({ posts: { type: "Post" } }),
+      (q: any) => q.includes(":post").where({ posts: { type: "Post" } }),
       { through: "posts", source: "comments" },
     );
     this.hasMany("commentsForFirstAuthor", (q: any) => q.forFirstAuthor(), {
@@ -397,7 +397,7 @@ export class Author extends Base {
     this.hasMany("helloPostComments", { through: "helloPosts", source: "comments" });
     this.hasMany(
       "postsWithNoComments",
-      (q: any) => q.where({ "comments.id": null }).includes("comments"),
+      (q: any) => q.where({ "comments.id": null }).includes(":comments"),
       { className: "Post" },
     );
     this.hasMany(

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -218,7 +218,7 @@ export class CommentWithDefaultScopeReferencesAssociation extends Comment {
 
   static {
     this.defaultScope((q: any) =>
-      q.includes("developer").order("developers.name").references("developer"),
+      q.includes(":developer").order("developers.name").references("developer"),
     );
     this.belongsTo("developer");
   }

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -65,7 +65,7 @@ export class Company extends AbstractCompany {
     this.hasMany("contracts");
     this.hasMany("developers", { through: "contracts" });
     this.hasMany("specialContracts", (q: any) =>
-      q.includes("specialDeveloper").where().not({ "developers.id": null }),
+      q.includes(":specialDeveloper").where().not({ "developers.id": null }),
     );
     this.hasMany("specialDevelopers", { through: "specialContracts" });
     this.hasMany("comments", { foreignKey: "company" });

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -322,7 +322,7 @@ export class DeveloperWithIncludes extends Base {
   static {
     this.tableName = "developers";
     this.hasMany("auditLogs", { foreignKey: "developer_id" });
-    this.defaultScope((q: any) => q.includes("auditLogs"));
+    this.defaultScope((q: any) => q.includes(":auditLogs"));
   }
 }
 
@@ -476,7 +476,7 @@ export class EagerDeveloperWithDefaultScope extends Base {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
-    this.defaultScope((q: any) => q.includes("projects"));
+    this.defaultScope((q: any) => q.includes(":projects"));
   }
 }
 
@@ -494,7 +494,7 @@ export class EagerDeveloperWithClassMethodDefaultScope extends Base {
   // Method-form `default_scope` override (Rails: `def self.default_scope`),
   // not the `default_scope { }` macro registry.
   static defaultScope(this: any): any {
-    return this.includes("projects");
+    return this.includes(":projects");
   }
 }
 
@@ -507,7 +507,7 @@ export class EagerDeveloperWithLambdaDefaultScope extends Base {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
-    this.defaultScope((q: any) => q.includes("projects"));
+    this.defaultScope((q: any) => q.includes(":projects"));
   }
 }
 
@@ -520,7 +520,7 @@ export class EagerDeveloperWithBlockDefaultScope extends Base {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
-    this.defaultScope((q: any) => q.includes("projects"));
+    this.defaultScope((q: any) => q.includes(":projects"));
   }
 }
 
@@ -533,7 +533,7 @@ export class EagerDeveloperWithCallableDefaultScope extends Base {
       foreignKey: "developer_id",
       joinTable: "developers_projects",
     });
-    this.defaultScope((q: any) => q.includes("projects"));
+    this.defaultScope((q: any) => q.includes(":projects"));
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/person.ts
+++ b/packages/activerecord/src/test-helpers/models/person.ts
@@ -81,7 +81,7 @@ export class Person extends Base {
     this.hasMany("securePosts", { through: "secureReaders" });
     this.hasMany(
       "postsWithNoComments",
-      (q: any) => q.includes("comments").where("comments.id is null").references("comments"),
+      (q: any) => q.includes(":comments").where("comments.id is null").references("comments"),
       { through: "readers", source: "post" },
     );
 
@@ -100,7 +100,7 @@ export class Person extends Base {
     this.hasOne("favoriteReferenceJob", { through: "favoriteReference", source: "job" });
     this.hasMany(
       "postsWithCommentsSortedByCommentId",
-      (q: any) => q.includes("comments").order("comments.id"),
+      (q: any) => q.includes(":comments").order("comments.id"),
       { through: "readers", source: "post" },
     );
     this.hasMany("firstPosts", (q: any) => q.where({ id: [1, 2] }), { through: "readers" });

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -214,8 +214,8 @@ export class Post extends Base {
     this.scope("withPost", (q: any, postId: number) =>
       q.joins(":comments").where({ comments: { post_id: postId } }),
     );
-    this.scope("withComments", (q: any) => q.preload("comments"));
-    this.scope("withTags", (q: any) => q.preload("taggings"));
+    this.scope("withComments", (q: any) => q.preload(":comments"));
+    this.scope("withTags", (q: any) => q.preload(":taggings"));
     this.scope("withTagsCte", (q: any) =>
       q.with({ posts_with_tags: q.model.where("tags_count > 0") }).from("posts_with_tags AS posts"),
     );
@@ -245,11 +245,11 @@ export class Post extends Base {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithPosts", (q: any) => q.includes("posts"), {
+    this.belongsTo("authorWithPosts", (q: any) => q.includes(":posts"), {
       className: "Author",
       foreignKey: "author_id",
     });
-    this.belongsTo("authorWithAddress", (q: any) => q.includes("authorAddress"), {
+    this.belongsTo("authorWithAddress", (q: any) => q.includes(":authorAddress"), {
       className: "Author",
       foreignKey: "author_id",
     });
@@ -327,7 +327,7 @@ export class Post extends Base {
     });
 
     this.hasOne("verySpecialComment");
-    this.hasOne("verySpecialCommentWithPost", (q: any) => q.includes("post"), {
+    this.hasOne("verySpecialCommentWithPost", (q: any) => q.includes(":post"), {
       className: "VerySpecialComment",
     });
     this.hasOne(
@@ -511,7 +511,7 @@ export class Post extends Base {
 
     this.hasMany("readers");
     this.hasMany("secureReaders");
-    this.hasMany("readersWithPerson", (q: any) => q.includes("person"), { className: "Reader" });
+    this.hasMany("readersWithPerson", (q: any) => q.includes(":person"), { className: "Reader" });
     this.hasMany("people", { through: "readers" });
     this.hasMany("singlePeople", { through: "readers" });
     this.hasMany("peopleWithCallbacks", {
@@ -758,7 +758,7 @@ export class PostWithDefaultInclude extends Base {
   static {
     this.inheritanceColumn = "disabled";
     this._tableName = "posts";
-    this.defaultScope((q: any) => q.includes("comments"));
+    this.defaultScope((q: any) => q.includes(":comments"));
     this.hasMany("comments", { foreignKey: "post_id" });
   }
 }
@@ -805,7 +805,7 @@ export class PostWithPreloadDefaultScope extends Base {
   static {
     this._tableName = "posts";
     this.hasMany("readers", { foreignKey: "post_id" });
-    this.defaultScope((q: any) => q.preload("readers"));
+    this.defaultScope((q: any) => q.preload(":readers"));
   }
 }
 
@@ -815,7 +815,7 @@ export class PostWithIncludesDefaultScope extends Base {
   static {
     this._tableName = "posts";
     this.hasMany("readers", { foreignKey: "post_id" });
-    this.defaultScope((q: any) => q.includes("readers"));
+    this.defaultScope((q: any) => q.includes(":readers"));
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/tagging.ts
+++ b/packages/activerecord/src/test-helpers/models/tagging.ts
@@ -30,7 +30,7 @@ export class Tagging extends Base {
   declare taggable: Base | null;
 
   static {
-    this.belongsTo("tag", (q: any) => q.includes("tagging"));
+    this.belongsTo("tag", (q: any) => q.includes(":tagging"));
     this.belongsTo("superTag", { className: "Tag", foreignKey: "super_tag_id" });
     this.belongsTo("invalidTag", { className: "Tag", foreignKey: "tag_id" });
     this.belongsTo("orderedTag", { className: "OrderedTag", foreignKey: "tag_id" });


### PR DESCRIPTION
Rails' `Relation#joined_includes_values` (`relation.rb:1247-1249`) is a plain
`includes_values & joins_values` Array intersection because both arrays hold
Symbols. Since `sweep-joins-call-sites-onto-the-colon-symbol-spelling` (#6704),
`joins_values` carried the colon spelling and `includes_values` did not, so the
intersection was papered over with a colon-stripping normalization on both
sides, annotated in place as debt to retire here.

## What this does

- Sweeps the `includes` / `preload` / `eagerLoad` call sites that **intersect**
  `joins_values` (plus the surrounding files) onto the colon Symbol spelling —
  `includes(":comments")`, `includes({ ":posts": ":comments" })` — matching the
  convention CLAUDE.md prescribes and the joins sweep established.
- Collapses `joinedIncludesValues` (`relation.ts`) back to Rails' plain
  intersection; the DEBT comment is gone.
- Drops the leading colon exactly where Ruby's `to_sym` drops it:
  `JoinDependency.walkTree` already did (`join-dependency.ts:933,952`), and
  `Preloader::Branch#_normalizeAssociationName` does too (`branch.rb:11-18`).
  This PR originally added the latter; a sibling landed the identical strip on
  main first, so after the rebase both entry points are pre-existing and this
  diff adds **no** normalization sites at all.
- `Merger` nests the other relation's preload/includes under a reflection name,
  a Symbol in Rails (`merger.rb`), so it now spells the key
  `` `:${reflection.name}` `` — same shape as `WhereChain#associated`. Same for
  `Preloader::ThroughAssociation`'s `includes(source_reflection.name)`
  (`through_association.rb:127`).

No generated SQL changes; no test name touched.

## Scope left behind

The full sweep is ~660 association-name call sites — well past the LOC ceiling
— so this PR takes the correctness-critical slice (everything the intersection
can see) and the core wiring. The remainder is filed, with the file inventory:

- `sweep-remaining-includes-preload-call-sites-onto-the-colon-symbol-spelling`
  (~354 sites, 224 of them in `associations/eager.test.ts`) — pure spelling now
  that the consumers all strip the colon.
- `sweep-references-call-sites-onto-the-colon-symbol-spelling` — `references`
  was left alone deliberately: converging it also requires
  `referencesEagerLoadedTables` to implement Rails' `references_values.map(&:to_s)`
  (`relation.rb:1486`, ported as `String(ref)` at `relation.ts:1257`), and the
  table-name-vs-association-name arms have to be separated per call site.

`converge-attribute-definitions-onto-default-attributes` is released back to the
queue — it is a ~50-file, load-bearing convergence that does not fit alongside
this one.

## Verification

- `pnpm typecheck`, `pnpm build` clean.
- Targeted suites green: `relation.trails`, `relations`, `relation`,
  `relation/select`, `relation/or`, `relation/merging`,
  `relation/build-joins-from-subquery-dedup`, `associations`, `associations/eager`,
  `cascaded-eager-loading`, `inverse-associations`, `has-many-associations`,
  `has-many-through-associations`, `has-one-through-associations`,
  `inner-join-association`, `join-model`, `nested-through-associations`,
  `nested-through-preloader`, `associations/preloader/**`, `scoping/**`,
  `calculations`, `finder`, `querying`, `strict-loading`, `fixtures`,
  `inheritance`, `collection-cache-key`, `unsafe-raw-sql`, `polymorphic-sti-through`,
  `habtm-associations`, `belongs-to-associations`, the two CPK eager files.
- `pnpm parity:api:calls` OK (1095 baselined, no new rows);
  `pnpm parity:api:calls:args` OK (164 baselined shape rows, no new rows);
  `pnpm parity:api:extra --package activerecord` shows no new surface.
- Diff size: 331 insertions / 334 deletions.

Closes-story: sweep-includes-preload-call-sites-onto-the-colon-symbol-spelling
