### PR TITLE
refactor(activemodel,activerecord): dispatch the bare attribute pattern through define_method_attribute

### DIFF
--- a/packages/activemodel/src/attribute-methods.trails.test.ts
+++ b/packages/activemodel/src/attribute-methods.trails.test.ts
@@ -49,4 +49,28 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(new Person({ name: "Alexander" }).nicknameShort()).toBe("parent");
     expect(new Employee({ name: "Alexander" }).nicknameShort()).toBe("Ale");
   });
+
+  it("the bare pattern generates the reader through the define_method_attribute hook", () => {
+    const seen: string[] = [];
+    class Person extends Model {
+      static defineMethodAttribute = function (
+        this: unknown,
+        canonicalName: string,
+        options: Parameters<typeof Model.defineMethodAttribute>[1],
+      ) {
+        seen.push(canonicalName);
+        return Model.defineMethodAttribute.call(this, canonicalName, options);
+      };
+      static {
+        this.attribute("name", "string");
+      }
+    }
+
+    expect(seen).toEqual(["name"]);
+    expect(Object.getOwnPropertyDescriptor(Person.prototype, "name")).toBeUndefined();
+    const person = new Person({ name: "Alexander" });
+    expect(person.name).toBe("Alexander");
+    person.name = "Bob";
+    expect(person.readAttribute("name")).toBe("Bob");
+  });
 });

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -411,6 +411,12 @@ const NAME_COMPILABLE_REGEXP = /^[a-zA-Z_]\w*[!?=]?$/;
  *
  * Rails' only `override: true` caller is `alias_attribute_method_definition`
  * (activerecord/attribute_methods.rb:94), and so is trails'.
+ *
+ * `"define_method_#{pattern.proxy_target}"` (attribute_methods.rb:333) is
+ * spelled out rather than interpolated: a proxy target ending in `=` names a
+ * Ruby writer, whose bare camel spelling belongs to the reader hook of the same
+ * name, so it takes the `set*` fallback docs/ruby-ts-conventions.md gives a
+ * `name=` writer.
  */
 export function defineAttributeMethodPattern(
   this: AttributeMethodHost,
@@ -438,21 +444,9 @@ export function defineAttributeMethodPattern(
     if (!override) return;
   }
 
-  // Rails' default bare pattern (empty prefix/suffix) exists to route the plain
-  // `attribute` reader through method_missing. trails exposes readers as real
-  // accessor properties via `attribute()`, so generating a bare `attr` method
-  // for the attribute's own name would collide with that accessor — the seeded
-  // bare pattern is kept only so `attributeMethodPatterns()` matches Rails'
-  // default. An alias name has no such accessor, so for `alias_attribute` this
-  // pattern is what defines it, as it is in Rails; the writer rides along on
-  // the same accessor property instead of coming from an `attribute=` pattern.
-  if (pattern.prefix === "" && pattern.suffix === "") {
-    if (as === attrName) return;
-    defineAliasAccessor(owner, canonicalMethodName, publicMethodName, attrName);
-    return;
-  }
-
-  const generateMethod = camelize(`define_method_${pattern.proxyTarget}`, false);
+  const generateMethod = pattern.proxyTarget.endsWith("=")
+    ? camelize(`set_define_method_${pattern.proxyTarget.slice(0, -1)}`, false)
+    : camelize(`define_method_${pattern.proxyTarget}`, false);
 
   const generator = (this as unknown as Record<string, unknown>)[generateMethod];
   if (typeof generator === "function") {
@@ -593,16 +587,6 @@ export function defineProxyCall(
   });
 }
 
-// ---------------------------------------------------------------------------
-// Instance-level Rails privates (attribute_methods.rb)
-// ---------------------------------------------------------------------------
-
-export type InstanceHost = {
-  _attributes?: { has(name: string): boolean };
-  _attributeMethodPatterns?: AttributeMethodPattern[];
-  constructor: AttributeMethodHost;
-};
-
 /**
  * @internal Rails-private helper. Mirrors: ClassMethods#build_mangled_name
  * Returns a compilable temp name for attributes with non-identifier characters.
@@ -614,6 +598,16 @@ export function buildMangledName(name: string): string {
     .join("");
   return `__temp__${hex}`;
 }
+
+// ---------------------------------------------------------------------------
+// Instance-level Rails privates (attribute_methods.rb)
+// ---------------------------------------------------------------------------
+
+export type InstanceHost = {
+  _attributes?: { has(name: string): boolean };
+  _attributeMethodPatterns?: AttributeMethodPattern[];
+  constructor: AttributeMethodHost;
+};
 
 /**
  * @internal Rails-private helper. Mirrors: ClassMethods#define_call
@@ -665,46 +659,83 @@ function extractParameters(affixes: Array<string | { parameters?: string | null 
 }
 
 /**
- * @internal The alias reader/writer pair for the bare pattern. Rails generates
- * a plain reader here and takes the writer from the `attribute=` pattern; trails
- * spells readers as accessor properties (see `attribute()`), so the alias is one
- * get/set property. `@noRailsEquivalent` — the accessor half of
- * `define_attribute_method_pattern`'s bare arm, which has no separate name in
- * Rails.
+ * Whether a class body — as opposed to a generated attribute-methods module —
+ * answers `name` anywhere up the chain. `include()` splices a module's carrier
+ * directly below the including class's prototype, and a carrier has no own
+ * `constructor`, which is what tells the two apart; that is the JS spelling of
+ * Rails' `!superclass.instance_method(name).owner.is_a?(GeneratedAttributeMethods)`
+ * (activerecord/attribute_methods.rb:170-176).
+ *
+ * @noRailsEquivalent PERMANENT. Rails' ActiveModel happily generates a reader
+ * over an inherited method, because a Ruby reader is an ordinary method and
+ * nothing in the runtime depends on `to_json` staying callable. A trails reader
+ * is an accessor property, so generating one for `attribute("toJSON")` would
+ * leave `JSON.stringify` with a string where the runtime demands a function —
+ * pinned by "attribute named toJSON does not shadow Model#toJSON". ActiveRecord
+ * needs none of this: its `instance_method_already_implemented?` override
+ * (attribute_methods.rb:165-179) rejects such a name before the hook runs.
  */
-function defineAliasAccessor(
-  owner: CodeGenerator,
-  canonicalMethodName: string,
-  publicMethodName: string,
-  attrName: string,
+function isDefinedByAClassBody(klass: unknown, name: string): boolean {
+  const start = (klass as { prototype?: object }).prototype;
+  for (
+    let link: object | null = start ?? null;
+    link;
+    link = Object.getPrototypeOf(link) as object | null
+  ) {
+    if (!Object.prototype.hasOwnProperty.call(link, name)) continue;
+    return Object.prototype.hasOwnProperty.call(link, "constructor");
+  }
+  return false;
+}
+
+/**
+ * @noRailsEquivalent PERMANENT. ActiveModel has no `define_method_attribute`:
+ * for a plain `ActiveModel::Attributes` includer,
+ * `respond_to?("define_method_attribute", true)` is false, so the bare pattern
+ * takes the `else` branch of attribute_methods.rb:333-346 and
+ * `define_proxy_call` generates the ordinary method
+ * `def name; attribute("name"); end`, dispatching to the private instance
+ * method `attribute(attr_name)` (attributes.rb:161). Only ActiveRecord defines
+ * the hook (attribute_methods/read.rb:11). This is invented surface, taking
+ * that hook's name so `define_attribute_method_pattern` reaches it, because
+ * trails spells an attribute reader as an accessor property (`person.name`,
+ * not `person.name()`) and `define_proxy_call` emits an ordinary method. The
+ * descriptor also carries the `set` half, since a `MethodSet` applies one
+ * descriptor per generated name (code_generator.rb:32-36) and a property
+ * cannot take its halves from two — so `define_method_attribute=`'s generated
+ * `name=` (attributes.rb:92) is a method beside it rather than this property's
+ * setter.
+ */
+export function defineMethodAttribute(
+  this: unknown,
+  canonicalName: string,
+  { owner, as = canonicalName }: { owner: CodeGenerator; as?: string },
 ): void {
-  const mangledName = buildMangledName(canonicalMethodName);
-  owner.defineCachedMethod(
-    mangledName,
-    { namespace: "alias_attribute", as: publicMethodName },
-    (sources) => {
-      sources.push((mod) => {
-        Object.defineProperty(mod, mangledName, {
-          get(
-            this: ReadWriteHost & {
-              _attributes: { getAttribute(n: string): { isInitialized(): boolean } };
-            },
-          ) {
-            if (!this._attributes.getAttribute(attrName).isInitialized()) {
-              throw new MissingAttributeError(
-                `missing attribute '${attrName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
-              );
-            }
-            return this.readAttribute(attrName);
+  if (as === canonicalName && isDefinedByAClassBody(this, as)) return;
+  const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
+  const mangledName = buildMangledName(methodName);
+  owner.defineCachedMethod(mangledName, { namespace: "active_model", as }, (sources) => {
+    sources.push((mod) => {
+      Object.defineProperty(mod, mangledName, {
+        get(
+          this: ReadWriteHost & {
+            _attributes: { getAttribute(n: string): { isInitialized(): boolean } };
           },
-          set(this: ReadWriteHost, value: unknown) {
-            this.writeAttribute(attrName, value);
-          },
-          configurable: true,
-        });
+        ) {
+          if (!this._attributes.getAttribute(canonicalName).isInitialized()) {
+            throw new MissingAttributeError(
+              `missing attribute '${canonicalName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+            );
+          }
+          return this.readAttribute(canonicalName);
+        },
+        set(this: ReadWriteHost, value: unknown) {
+          this.writeAttribute(canonicalName, value);
+        },
+        configurable: true,
       });
-    },
-  );
+    });
+  });
 }
 
 function ensureOwnPatterns(host: AttributeMethodHost): void {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,3 +1,4 @@
+import type { CodeGenerator } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
@@ -13,6 +14,8 @@ import {
   attributeAliases as _attributeAliases,
   isAttributeAliases as _isAttributeAliases,
   attributeMethodPatterns as _attributeMethodPatterns,
+  buildMangledName,
+  defineAttributeMethod as _defineAttributeMethod,
   isAttributeMethodPatterns as _isAttributeMethodPatterns,
   isRespondToWithoutAttributes as _isRespondToWithoutAttributes,
   type AttributeMethodHost,
@@ -23,7 +26,7 @@ import {
   pushPendingDefault,
   resetDefaultAttributes,
 } from "./attribute-registration.js";
-import { MissingAttributeError, type InstanceHost } from "./attribute-methods.js";
+import { type InstanceHost } from "./attribute-methods.js";
 
 export interface AttributeDefinition {
   name: string;
@@ -108,7 +111,16 @@ export interface AttributeOptions {
   range?: boolean;
 }
 
-/** @internal */
+/**
+ * Mirrors: ActiveModel::Attributes::ClassMethods#attribute (attributes.rb:59-61)
+ * — registers the attribute, then `define_attribute_method(name)` generates its
+ * methods. A name the class already answers (`toJSON`, `freeze`, `attributes`)
+ * gets no accessor, because `define_attribute_method_pattern`'s
+ * `instance_method_already_implemented?` arm rejects it; such an attribute still
+ * round-trips through `readAttribute` / `writeAttribute`.
+ *
+ * @internal
+ */
 export function attribute(
   this: {
     _attributeDefinitions: Map<string, AttributeDefinition>;
@@ -184,63 +196,48 @@ export function attribute(
   // and all known subclasses so they recompute on next _defaultAttributes() call.
   resetDefaultAttributes(this);
 
-  // Don't install an accessor if `name` resolves anywhere on the prototype
-  // chain (Model.prototype or any ancestor). Otherwise an attribute named
-  // e.g. `toJSON` / `asJson` / `freeze` / `attributes` would shadow the
-  // framework method on this subclass — JSON.stringify would hit the
-  // attribute getter instead of `Model#toJSON`, serialization callers
-  // would get the raw value instead of the mixin, etc. The attribute
-  // still round-trips via `readAttribute(name)` / `writeAttribute(name,
-  // value)`, which operate on `_attributes` directly — callers MUST use
-  // those methods for reserved names, NOT direct property access
-  // (`instance[name]`) or assignment (`instance[name] = value`). Direct
-  // assignment would create an own property on the instance and shadow
-  // the framework method per-instance.
-  if (!(name in this.prototype)) {
-    Object.defineProperty(this.prototype, name, {
-      get(this: {
-        readAttribute(n: string): unknown;
-        _attributes: { getAttribute(n: string): { isInitialized(): boolean } };
-      }) {
-        if (!this._attributes.getAttribute(name).isInitialized()) {
-          throw new MissingAttributeError(
-            `missing attribute '${name}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
-          );
-        }
-        return this.readAttribute(name);
-      },
-      set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
-        this.writeAttribute(name, value);
-      },
-      configurable: true,
-    });
-  }
+  _defineAttributeMethod.call(this as unknown as AttributeMethodHost, name);
 
   defineDirtyAttributeMethods(this.prototype, name);
 }
 
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods#define_method_attribute=
+ * (attributes.rb:92-102) — the writer hook `define_attribute_method_pattern`
+ * dispatches the `"="` suffix pattern (attributes.rb:35) through
+ * (attribute_methods.rb:333-335), generating
+ * `def name=(value); _write_attribute("name", value); end`.
  *
- * In Rails this generates a `canonical_name=` writer via code evaluation.
- * Trails installs writers via Object.defineProperty in `attribute()`, so no
- * code generation is required here. The method exists for API-compare parity
- * and to expose the AttrNames accessor-method computation that Rails uses
- * to derive the writer method name.
+ * Ruby's `name=` writer takes the `set*` spelling here
+ * (docs/ruby-ts-conventions.md) because the bare camel name belongs to the
+ * bare pattern's generated reader, as it does in Ruby. The generated method
+ * keeps Rails' own name, `"#{as}="`; a JS assignment (`person.name = x`)
+ * reaches the `set` half of that reader's accessor property instead, because a
+ * `MethodSet` applies one descriptor per generated name
+ * (code_generator.rb:32-36) and a property cannot take its halves from two.
  *
  * @internal Rails-private helper.
  */
-export function defineMethodAttribute(
+export function setDefineMethodAttribute(
+  this: unknown,
   canonicalName: string,
-  { owner }: { owner?: unknown; as?: string } = {},
+  { owner, as = canonicalName }: { owner: CodeGenerator; as?: string },
 ): void {
-  // Writers are already installed by attribute() via Object.defineProperty.
-  // Compute and expose the method name the same way Rails would, for callers
-  // that inspect the name (e.g. alias generation paths).
   const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName, {
     writer: true,
   });
-  void methodName;
+  const tempMethodName = buildMangledName(methodName);
+  owner.defineCachedMethod(tempMethodName, { namespace: "active_model", as: `${as}=` }, (batch) => {
+    batch.push((mod) => {
+      Object.defineProperty(mod, tempMethodName, {
+        value: function (this: { _writeAttribute(n: string, v: unknown): void }, value: unknown) {
+          this._writeAttribute(canonicalName, value);
+        },
+        writable: true,
+        configurable: true,
+      });
+    });
+  });
 }
 
 /**

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -14,6 +14,7 @@ export {
   resolveAliasName,
   resolveAliasNameIn,
   AttrNames,
+  buildMangledName,
   defineDirtyAttributeMethods,
   isInstanceMethodAlreadyImplemented,
 } from "./attribute-methods.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -83,6 +83,7 @@ import {
   type AttributeMethodHost,
   resolveAliasName,
   resolveAliasNameIn,
+  defineMethodAttribute,
   undefineAttributeMethods,
   attributeMissing,
   attributeAliases,
@@ -110,7 +111,7 @@ import { FormatValidator } from "./validations/format.js";
 import { AcceptanceValidator } from "./validations/acceptance.js";
 import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
-import { type AttributeDefinition, attribute } from "./attributes.js";
+import { type AttributeDefinition, attribute, setDefineMethodAttribute } from "./attributes.js";
 import {
   _defaultAttributes,
   attributeTypes,
@@ -280,13 +281,12 @@ export class Model {
   static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
   // Rails: `class_attribute :attribute_method_patterns, … default:
   // [ ClassMethods::AttributeMethodPattern.new ]`
-  // (activemodel/lib/active_model/attribute_methods.rb:72). The bare pattern
-  // (empty prefix/suffix) routes the plain `attribute` reader through Ruby's
-  // method_missing. trails has no method_missing — attribute readers are real
-  // accessor properties defined by `attribute()` — so `defineAttributeMethodPattern`
-  // skips the bare pattern to avoid generating a colliding `attr` method, while
-  // the seed keeps `attributeMethodPatterns()` faithful to Rails' default.
-  static _attributeMethodPatterns: AttributeMethodPattern[] = [new AttributeMethodPattern()];
+  // (activemodel/lib/active_model/attribute_methods.rb:72), plus the `"="`
+  // suffix pattern `Attributes` adds on include (attributes.rb:35).
+  static _attributeMethodPatterns: AttributeMethodPattern[] = [
+    new AttributeMethodPattern(),
+    new AttributeMethodPattern({ suffix: "=", parameters: "value" }),
+  ];
   static _attributeAliases: Record<string, string> = {};
   static _aliasesByAttributeName: Map<string, string[]> = new Map();
   // Rails: `class_attribute :_validators, … default: Hash.new { |h, k| h[k] = [] }`
@@ -310,6 +310,8 @@ export class Model {
   // -- Attributes (Phase 1000) --
 
   static attribute = attribute;
+  static defineMethodAttribute = defineMethodAttribute;
+  static setDefineMethodAttribute = setDefineMethodAttribute;
   static _defaultAttributes = _defaultAttributes;
   static decorateAttributes = decorateAttributes;
   static attributeTypes = attributeTypes;

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -4,7 +4,10 @@
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey
  */
 import { underscore } from "@blazetrails/activesupport";
-import { dangerousAttributeMethods } from "../attribute-methods.js";
+import {
+  dangerousAttributeMethods,
+  isInstanceMethodAlreadyImplemented as attributeMethodsIsInstanceMethodAlreadyImplemented,
+} from "../attribute-methods.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 interface PrimaryKeyRecord {
@@ -284,15 +287,47 @@ export function id(this: PrimaryKeyInstance, value?: unknown): unknown {
   return readId.call(this);
 }
 
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods::ID_ATTRIBUTE_METHODS
+ * (primary_key.rb:66). The Ruby names are translated by
+ * docs/ruby-ts-conventions.md, except `id=` and `id?`, which are the names
+ * `define_attribute_method_pattern` builds from the `"="` and `"?"` suffix
+ * patterns and so are what the guard is asked about.
+ */
+const ID_ATTRIBUTE_METHODS = new Set([
+  "id",
+  "id=",
+  "id?",
+  "idBeforeTypeCast",
+  "idWas",
+  "idInDatabase",
+  "idForDatabase",
+]);
+
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#instance_method_already_implemented?
+ * (primary_key.rb:69-71) — `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`.
+ * `PrimaryKey` is included after `AttributeMethods`, so this override runs
+ * first and `super` is the one in attribute-methods.ts.
+ */
 export function isInstanceMethodAlreadyImplemented(
   this: PrimaryKeyHost & { prototype: any },
   methodName: string,
 ): boolean {
-  return methodName in this.prototype;
+  return (
+    attributeMethodsIsInstanceMethodAlreadyImplemented.call(this as any, methodName) ||
+    (primaryKey.call(this) != null && ID_ATTRIBUTE_METHODS.has(methodName))
+  );
 }
 
-export function isDangerousAttributeMethod(_this: PrimaryKeyHost, name: string): boolean {
-  return dangerousAttributeMethods().has(name);
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#dangerous_attribute_method?
+ * (primary_key.rb:74-76) — `super && !ID_ATTRIBUTE_METHODS.include?(method_name)`,
+ * which is what keeps the `super` above from raising for the id methods Active
+ * Record itself defines.
+ */
+export function isDangerousAttributeMethod(this: PrimaryKeyHost, name: string): boolean {
+  return dangerousAttributeMethods().has(name) && !ID_ATTRIBUTE_METHODS.has(name);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -9,7 +9,8 @@
  */
 
 import type { AttributeSet } from "@blazetrails/activemodel";
-import { AttrNames } from "@blazetrails/activemodel";
+import { AttrNames, buildMangledName } from "@blazetrails/activemodel";
+import type { CodeGenerator } from "@blazetrails/activesupport";
 
 /**
  * The Read module interface.
@@ -44,17 +45,50 @@ export function _readAttribute(
   return this._attributes.fetchValue(name, block) ?? null;
 }
 
-// Mirrors: ActiveRecord::AttributeMethods::Read::ClassMethods private#define_method_attribute
-// Rails derives reader method metadata via defineAttributeAccessorMethod and
-// uses it while generating dynamic attribute readers. TypeScript attribute
-// access is handled statically, so we compute the same metadata for parity
-// but intentionally do not register or define anything.
-/** @internal */
-function defineMethodAttribute(
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::Read::ClassMethods private
+ * #define_method_attribute (read.rb:11-22) — the reader hook
+ * `define_attribute_method_pattern` dispatches the bare pattern through
+ * (activemodel/attribute_methods.rb:333-335).
+ *
+ * Rails generates `def name; _read_attribute("name") { |n| missing_attribute(n,
+ * caller) }; end`. A TS reader is an accessor property, so the generated
+ * descriptor also carries the `set` half `define_method_attribute=`
+ * (write.rb:15) would otherwise install: a `MethodSet` applies one descriptor
+ * per generated name (code_generator.rb:32-36), and a set-only descriptor
+ * applied second would drop the getter.
+ *
+ * Rails marks the attribute read on the Attribute itself, inside `fetch_value`
+ * (activemodel/attribute.rb:44-47), which is what `accessed_fields`
+ * (attribute_set.rb:38) reports; trails keeps that marker on the record, so the
+ * generated reader is where it is set.
+ *
+ * @internal Rails-private helper.
+ */
+export function defineMethodAttribute(
+  this: unknown,
   canonicalName: string,
-  { owner }: { owner?: unknown; as?: string } = {},
+  { owner, as = canonicalName }: { owner: CodeGenerator; as?: string },
 ): void {
-  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
-  void methodName;
-  void attrNameRef;
+  const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
+  const tempMethodName = buildMangledName(methodName);
+  owner.defineCachedMethod(tempMethodName, { namespace: "active_record", as }, (batch) => {
+    batch.push((mod) => {
+      Object.defineProperty(mod, tempMethodName, {
+        get(this: {
+          _attributes: AttributeSet;
+          _accessedFields: Set<string>;
+          _readAttribute(n: string, block: (n: string) => unknown): unknown;
+          missingAttribute(n: string, stack?: string): never;
+        }) {
+          if (this._attributes.has(canonicalName)) this._accessedFields.add(canonicalName);
+          return this._readAttribute(canonicalName, (n) => this.missingAttribute(n));
+        },
+        set(this: { writeAttribute(n: string, v: unknown): void }, value: unknown) {
+          this.writeAttribute(canonicalName, value);
+        },
+        configurable: true,
+      });
+    });
+  });
 }

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -9,7 +9,8 @@
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */
 
-import { Model, AttrNames } from "@blazetrails/activemodel";
+import { Model, AttrNames, buildMangledName } from "@blazetrails/activemodel";
+import type { CodeGenerator } from "@blazetrails/activesupport";
 
 /**
  * The Write module interface.
@@ -37,23 +38,46 @@ export function _writeAttribute(this: Model, name: string, value: unknown): void
   Model.prototype._writeAttribute.call(this, name, value);
 }
 
-// Mirrors: ActiveRecord::AttributeMethods::Write::ClassMethods private#define_method_attribute=
-// Rails derives writer method metadata via defineAttributeAccessorMethod and
-// uses it while generating dynamic attribute writers. TypeScript attribute
-// access is handled statically, so we compute the same metadata for parity
-// but intentionally do not register or define anything.
-/** @internal */
-function defineMethodAttribute(
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::Write::ClassMethods private
+ * #define_method_attribute= (write.rb:15-26) — the writer hook
+ * `define_attribute_method_pattern` dispatches the `"="` suffix pattern
+ * (write.rb:10) through (activemodel/attribute_methods.rb:333-335), generating
+ * `def name=(value); _write_attribute("name", value); end`.
+ *
+ * Ruby's `name=` writer takes the `set*` spelling here
+ * (docs/ruby-ts-conventions.md) because the bare camel name belongs to `Read`'s
+ * `define_method_attribute` (read.rb:11), as it does in Ruby. The generated
+ * method keeps Rails' own name, `"#{as}="`; a JS assignment reaches the `set`
+ * half of that hook's accessor property instead, because a
+ * `MethodSet` applies one descriptor per generated name
+ * (activesupport/code_generator.rb:32-36) and a property cannot take its halves
+ * from two.
+ *
+ * @internal Rails-private helper.
+ */
+export function setDefineMethodAttribute(
+  this: unknown,
   canonicalName: string,
-  { owner }: { owner?: unknown; as?: string } = {},
+  { owner, as = canonicalName }: { owner: CodeGenerator; as?: string },
 ): void {
-  const { methodName, attrNameRef } = AttrNames.defineAttributeAccessorMethod(
-    owner,
-    canonicalName,
-    {
-      writer: true,
+  const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName, {
+    writer: true,
+  });
+  const tempMethodName = buildMangledName(methodName);
+  owner.defineCachedMethod(
+    tempMethodName,
+    { namespace: "active_record", as: `${as}=` },
+    (batch) => {
+      batch.push((mod) => {
+        Object.defineProperty(mod, tempMethodName, {
+          value: function (this: Model, value: unknown) {
+            this._writeAttribute(canonicalName, value);
+          },
+          writable: true,
+          configurable: true,
+        });
+      });
     },
   );
-  void methodName;
-  void attrNameRef;
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -191,8 +191,6 @@ import {
   attributesForUpdate as _attributesForUpdate,
   ClassMethods as AttributeMethodsClassMethods,
   isAttributeMethod as _isAttributeMethod,
-  isDangerousAttributeMethod as _isDangerousAttributeMethod,
-  isInstanceMethodAlreadyImplemented as _isInstanceMethodAlreadyImplemented,
   defineAttributeMethods as _defineAttributeMethods,
   initializeGeneratedModules as _initializeGeneratedModules,
   GeneratedAttributeMethods,
@@ -228,9 +226,15 @@ import {
   getPrimaryKeyAttr as _getPrimaryKeyAttr,
   getPrimaryKey as _getPrimaryKey,
   setPrimaryKeyAttr as _setPrimaryKeyAttr,
+  isInstanceMethodAlreadyImplemented as _pkIsInstanceMethodAlreadyImplemented,
+  isDangerousAttributeMethod as _pkIsDangerousAttributeMethod,
   isCompositePrimaryKey as _isCompositePrimaryKey,
 } from "./attribute-methods/primary-key.js";
-import { _readAttribute as _readAttributeFn } from "./attribute-methods/read.js";
+import {
+  _readAttribute as _readAttributeFn,
+  defineMethodAttribute as _defineMethodAttribute,
+} from "./attribute-methods/read.js";
+import { setDefineMethodAttribute as _setDefineMethodAttribute } from "./attribute-methods/write.js";
 import { isAttributeCameFromUser as _isAttributeCameFromUser } from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
@@ -4569,11 +4573,15 @@ extend(Base, {
 // AttributeMethods class method — gates association/attribute names that would
 // clash with an Active Record instance method (Rails: dangerous_attribute_method?).
 // Consumed by Associations::Builder::Association#build to reject e.g. `has_one :save`.
-extend(Base, { isDangerousAttributeMethod: _isDangerousAttributeMethod });
+extend(Base, { isDangerousAttributeMethod: _pkIsDangerousAttributeMethod });
 // ActiveRecord's override of ActiveModel's predicate (attribute_methods.rb:165):
 // define_attribute_method_pattern dispatches it through the class, so the
 // dangerous-method raise runs before any accessor is generated.
-extend(Base, { isInstanceMethodAlreadyImplemented: _isInstanceMethodAlreadyImplemented });
+extend(Base, { isInstanceMethodAlreadyImplemented: _pkIsInstanceMethodAlreadyImplemented });
+extend(Base, {
+  defineMethodAttribute: _defineMethodAttribute,
+  setDefineMethodAttribute: _setDefineMethodAttribute,
+});
 extend(Base, {
   // ConnectionHandling.ClassMethods does not include resolveConfigForConnection
   // (it's a standalone export, not in the ClassMethods object), so wire it here.

--- a/packages/date/src/test-date.test.ts
+++ b/packages/date/src/test-date.test.ts
@@ -118,12 +118,12 @@ describe("TestDate", () => {
    * ruby/date `test/date/test_date.rb:46-107`.
    *
    * `assert_instance_of(DateSub, DateSub.today)` and its `DateTimeSub.now`
-   * sibling (`:53-54`) assert the class the port cannot answer there: RFC
-   * 0088's mapping table has the two statics answer a `Temporal.PlainDate` /
+   * sibling (`:53-54`) assert the class the port cannot answer there: the
+   * mapping table RFC 0088 commits to (`README.md:110-122`, "Temporal is the
+   * default return type") has the two statics answer a `Temporal.PlainDate` /
    * `Temporal.ZonedDateTime` rather than a gem-shaped instance, so there is no
    * receiver class for them to carry and the two lines assert what the port
-   * does answer instead. Story `port-date-sub-today-now-receiver-class`
-   * (RFC 0088) converges them; every other assertion is here verbatim.
+   * does answer instead. Every other assertion is here verbatim.
    */
   it("sub", () => {
     const d = new DateSub();

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
@@ -44,20 +44,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "instance_method_already_implemented?",
-    "call": "include?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails primary_key.rb:69-71 is `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`; trails primary-key.ts:274-279 answers via `methodName in this.prototype` — the prototype chain already contains the id methods the Rails guard enumerates."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "instance_method_already_implemented?",
-    "call": "primary_key",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails primary_key.rb:69-71 is `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`; trails primary-key.ts:274-279 answers via `methodName in this.prototype` — the prototype chain already contains the id methods the Rails guard enumerates."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "reset_primary_key",
     "call": "base_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

`defineAttributeMethodPattern` opened with a bare-pattern early return Rails has no counterpart for (`activemodel/lib/active_model/attribute_methods.rb:320-347`), so the default pattern never reached the `define_method_#{proxy_target}` fork and all three `defineMethodAttribute` ports were dead code that computed a method name and discarded it.

- The bare pattern now goes through the fork like every other pattern. The reader hook generates the accessor into `generated_attribute_methods` under the generator's namespace — where `attribute()` used to install it straight onto the prototype. `attribute()` now calls `define_attribute_method` as Rails does (`activemodel/lib/active_model/attributes.rb:59-61`), and the alias arm collapses into the same path, so the bespoke `defineAliasAccessor` is gone.
- Reader and writer hooks no longer share one TS name. Ruby `define_method_attribute=` (`attributes.rb:92`, `attribute_methods/write.rb:15`) takes the `set*` writer spelling `docs/ruby-ts-conventions.md:25,44-55` gives it, because the reader hook (`attribute_methods/read.rb:11`) has claimed the bare camel name exactly as it has in Ruby. Both are wired to their class (`Model`, `Base`), and the `"="` suffix pattern `attributes.rb:35` seeds is seeded here too, so the fork reaches both.
- A TS accessor property is a single descriptor and a `MethodSet` applies one descriptor per generated name (`activesupport/lib/active_support/code_generator.rb:32-36`), so the writer half rides along with the reader; that is stated at both hooks rather than left implicit.
- `Date.today` / `DateTime.now` answer a `Temporal` type by RFC 0088's mapping table (`0088-date-gem-port/README.md:110-122`), so `test_sub`'s two receiver-class assertions stay as they are; the note in `it("sub")` now cites the RFC instead of the (now closed) story.

## On the three stories

The bundle was assigned as one unit, and the two RFC 0096 stories are mutually blocking by construction: `define-method-attribute-writer-reader-name-collision` says in its own body that `bare-attribute-method-pattern-generates-reader` "cannot land until it is decided which TS name the fork should reach". The 0088 story resolves by citation and costs a comment-only edit. Splitting would have produced two PRs touching the same three files.

## The CI-only failure: cause and fix

`serialization.test.ts` "attribute named toJSON does not shadow Model#toJSON" failed on CI and nowhere else, across four commits. The cause was a sibling merge, not a flake, and CI was right.

`main` gained #6720, which removed the `|| publicMethodName in this.prototype` arm from `define_attribute_method_pattern`'s guard — correct, since ownership belongs in ActiveRecord's `instance_method_already_implemented?` override (activerecord/attribute_methods.rb:165-179). This PR removes the bare-pattern early return so the default pattern generates a reader. Either change alone is fine; merged, a plain ActiveModel class declaring `attribute("toJSON")` had nothing left to stop the generated accessor from shadowing `Model#toJSON`, and `JSON.stringify` then found a string where the runtime needs a function. CI tests the branch merged with `main`, which is why only CI saw it — every local run was on a branch that still carried the old arm. After rebasing onto `main` the failure reproduces locally, and the fix clears it.

The protection now lives in `isDefinedByAClassBody`, next to the invented ActiveModel hook that needs it: it walks the prototype chain and tells a class body from a generated carrier by own-`constructor` — the JS spelling of Rails' `!owner.is_a?(GeneratedAttributeMethods)`, and the same reasoning #6720 used. It applies only when `as === canonicalName`, leaving `alias_attribute`'s override path (which Rails always defines) untouched. ActiveRecord needs none of it: its override rejects such a name before the hook runs.

All diagnostics are gone, and the branch is squashed to one commit rebased onto `main`.

## Two names the generated reader must not take

Making the bare pattern generate turned the hooks into a second accessor-generation path, and two names the old path deliberately left alone had to be carried over.

- `toJSON` (ActiveModel). `main`'s #6720 removed the `|| publicMethodName in this.prototype` arm from `define_attribute_method_pattern`'s guard — right, since ownership belongs in ActiveRecord's `instance_method_already_implemented?` override (activerecord/attribute_methods.rb:165-179). Merged with this PR, a plain ActiveModel class declaring `attribute("toJSON")` had nothing left to stop the generated accessor from shadowing `Model#toJSON`, and `JSON.stringify` then found a string where the runtime needs a function. `isDefinedByAClassBody` restores the protection next to the invented ActiveModel hook that needs it, telling a class body from a generated carrier by own-`constructor` — the JS spelling of Rails' `!owner.is_a?(GeneratedAttributeMethods)`, the same reasoning #6720 used. It applies only when `as === canonicalName`, so `alias_attribute`'s override path is untouched. This is why CI and local disagreed for several rounds: CI tests the branch merged with `main`, and every local run predated the rebase.
- `id` and `id=` (ActiveRecord). A composite-PK model declaring `attribute("id")` got a generated `id` accessor above `Base.prototype`'s primary-key-aware pair (`AttributeMethods::PrimaryKey#id`/`#id=`, primary_key.rb:18-30, which read and write `@primary_key` and answer an array for a composite key), turning `record.id = [shopId, id]` into a write of an array to a column named `id`. The fix is Rails' own guard, now ported: `PrimaryKey::ClassMethods#instance_method_already_implemented?` (primary_key.rb:69-71) is `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`, with `dangerous_attribute_method?` (primary_key.rb:74-76) excluding the same set so `super` does not raise for them. Both are wired onto `Base`, so the guard short-circuits before any of the seven id generators run — reader and writer alike. Two `primary-key.ts` baseline rows converged and were deleted (1014 -> 1012).

Both are pinned by existing Rails-named tests that fail without the fix on this branch: "attribute named toJSON does not shadow Model#toJSON", and the composite-PK cases in `belongs-to-inverse-seed-composite-pk.test.ts` / `autosave-association.test.ts`.

## Follow-ups filed

- `method-set-cache-is-order-dependent` (0023-surfaced-deviations) — `MethodSet.METHOD_CACHES` is a process-global singleton (code_generator.rb:8), so generation order across a process affects what a class ends up with; that is why the composite-PK regression reproduced only in the full-suite run.
- `generate-concrete-attribute-methods-is-a-second-generation-path` (0096-naming-identifier-burndown) — `generateConcreteAttributeMethods` is a bespoke path Rails does not have (`attribute_methods.rb:104-125` routes everything through the patterns), and is why the `id` skip lived in one path and not the other.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls` (OK), `pnpm parity:api:calls:args` (OK), `pnpm parity:api:extra --package activemodel` (no novel surface), full `packages/activemodel` suite plus the AR attribute-methods / attributes / dirty / inheritance / serialization / model-schema files and `packages/date/src/test-date.test.ts`.

Closes-story: port-date-sub-today-now-receiver-class
Closes-story: bare-attribute-method-pattern-generates-reader
Closes-story: define-method-attribute-writer-reader-name-collision





