### PR TITLE
fix(parity): a suppressed call consumes the TS spelling it ports (RFC 0106 OQ1)

### DIFF
--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -108,23 +108,17 @@ export class GeneratedRelationMethods {
    * Install `fn` as this module's `name` method — Rails'
    * `GeneratedRelationMethods#generate_method` (delegation.rb:74-90).
    *
-   * Rails' `RESERVED_METHOD_NAMES.include?` guard (delegation.rb:78, over
-   * `ActiveSupport::Delegation::RESERVED_METHOD_NAMES`, delegation.rb:18) has no
-   * arm here, and deliberately so: it selects between Ruby's two INSTALLATION
-   * spellings — `module_eval` string codegen for a name that is a safe Ruby
-   * identifier, `define_method` for everything else — and both define the same
-   * delegator. The guard's purpose is protecting the codegen path from
-   * interpolating a Ruby keyword into source; TS has no codegen-from-string
-   * path, only the `define_method` equivalent below, so there is nothing for the
-   * name test to select. Porting the Ruby keyword list (`begin`, `elsif`, …)
-   * would guard against names that are harmless in JS while missing the ones
-   * that are not.
-   *
-   * This omission cannot be carried as a `call-mismatches-exclude` row or a
-   * `@missingRailsCall` tag: `method_defined?` is a suppressed call name
-   * (lint-calls.ts) while `include?` maps to `has` (enumerable-idioms.ts), so
-   * the extractor credits `RESERVED_METHOD_NAMES.include?` to the
-   * `method_defined?` memo below and both registers go stale.
+   * @missingRailsCall include? — Verified per-site (RFC 0106): Rails'
+   * `RESERVED_METHOD_NAMES.include?(method.to_s)` guard (delegation.rb:78, over
+   * `ActiveSupport::Delegation::RESERVED_METHOD_NAMES`, delegation.rb:18)
+   * selects between Ruby's two INSTALLATION spellings — `module_eval` string
+   * codegen for a name that is a safe Ruby identifier, `define_method` for
+   * everything else — and both define the same delegator. The guard's purpose is
+   * protecting the codegen path from interpolating a Ruby keyword into source;
+   * TS has no codegen-from-string path, only the `define_method` equivalent
+   * below, so there is nothing for the name test to select. Porting the Ruby
+   * keyword list (`begin`, `elsif`, …) would guard against names that are
+   * harmless in JS while missing the ones that are not.
    */
   generateMethod(name: string, fn: AnyCallable): void {
     // Rails: `return if method_defined?(method)` (delegation.rb:76).

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -20,6 +20,7 @@ import {
   buildEntitiesByName,
   resolveEntityByDeclaringFile,
   significantMissingCalls,
+  suppressedCallClaims,
   narrowPredicateCandidates,
   ambiguousTsNames,
   reorderedCalls,
@@ -185,6 +186,21 @@ describe("significantMissingCalls", () => {
       sig,
     );
     expect(missing).toEqual([]);
+  });
+
+  it("does not let a sibling call claim a suppressed call's TS spelling", () => {
+    // delegation.rb:74-90 — `method_defined?(method)` is suppressed (no ported
+    // TS method with args), and trails spells it `this._methods.has(name)`.
+    // `include?` aliases to `has` too, so without the claim it went unflagged.
+    const missing = significantMissingCalls(
+      "generate_method",
+      ["method_defined?", "include?"],
+      new Set(["has"]),
+      (ts) => ts === "include",
+      (rc) => (rc === "method_defined?" ? ["methodDefined"] : ["include"]),
+      new Set(["method_defined?", "include?"]),
+    );
+    expect(missing).toEqual(["include? → include"]);
   });
 
   it("skips zero-arg readers (callee not a ported method with args)", () => {
@@ -2560,5 +2576,38 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
     expect(
       reorderedCalls("create", ["build", "save"], ["save", "build"], () => false, map, wide),
     ).toEqual([]);
+  });
+});
+
+describe("suppressedCallClaims", () => {
+  it("claims the TS spelling of a call the ported-with-args gate suppresses", () => {
+    const claimed = suppressedCallClaims(
+      ["method_defined?", "include?"],
+      new Set(["has"]),
+      (ts) => ts === "include",
+      (rc) => (rc === "method_defined?" ? ["methodDefined"] : ["include"]),
+      new Set(["method_defined?", "include?"]),
+    );
+    expect([...claimed]).toEqual(["has"]);
+  });
+
+  it("claims nothing for a NO_JS_CALL_FORM name, whose port emits no callee", () => {
+    const claimed = suppressedCallClaims(
+      ["key?"],
+      new Set(["has"]),
+      () => false,
+      () => ["key"],
+    );
+    expect([...claimed]).toEqual([]);
+  });
+
+  it("claims nothing when the suppressed call's spelling is absent from the TS body", () => {
+    const claimed = suppressedCallClaims(
+      ["method_defined?"],
+      new Set(["set"]),
+      () => false,
+      () => ["methodDefined"],
+    );
+    expect([...claimed]).toEqual([]);
   });
 });

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -189,9 +189,6 @@ describe("significantMissingCalls", () => {
   });
 
   it("does not let a sibling call claim a suppressed call's TS spelling", () => {
-    // delegation.rb:74-90 — `method_defined?(method)` is suppressed (no ported
-    // TS method with args), and trails spells it `this._methods.has(name)`.
-    // `include?` aliases to `has` too, so without the claim it went unflagged.
     const missing = significantMissingCalls(
       "generate_method",
       ["method_defined?", "include?"],

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -381,6 +381,68 @@ export function narrowPredicateCandidates(
 }
 
 /**
+ * The TS call a Ruby name is spelled as when {@link significantMissingCalls}'s
+ * ported-with-args gate SUPPRESSES it — i.e. the name maps to no ported TS
+ * method that takes arguments, so the gate never asks whether the TS body makes
+ * it, and it never consumes the TS name it actually ports.
+ *
+ * That is fine while the spelling is unique to it, and wrong the moment a
+ * SIBLING Ruby call in the same body maps to the same TS name: the sibling is
+ * then credited with the suppressed call's port and stops flagging, so the real
+ * omission can be recorded in no register at all (RFC 0106 Open Question 1).
+ * `GeneratedRelationMethods#generate_method` is the worked case — Rails calls
+ * `method_defined?(method)` (delegation.rb:76) and
+ * `RESERVED_METHOD_NAMES.include?(method.to_s)` (delegation.rb:78), trails
+ * spells the memo guard `this._methods.has(name)` (relation/delegation.ts), and
+ * `include?`'s `has` alias claimed it.
+ *
+ * Entries are here rather than in {@link JS_ENUMERABLE_ALIASES} because that
+ * table's contract is that an alias can only ever SILENCE a flag; these
+ * spellings exist to take a name away from a sibling, which can raise one.
+ */
+export const SUPPRESSED_CALL_TS_SPELLINGS = new Map<string, string[]>([
+  // `Module#method_defined?(name)` asks whether a name is installed on a
+  // method table. trails' generated-method tables are `Map`s, so the port is
+  // `table.has(name)` — the same JS callee `include?`/`key?` alias to.
+  ["method_defined?", ["has"]],
+]);
+
+/**
+ * The TS call names in `tsCalls` already spoken for by a Ruby call the
+ * ported-with-args gate suppresses, so no OTHER Ruby call in the same body may
+ * be credited with them (see {@link SUPPRESSED_CALL_TS_SPELLINGS}).
+ *
+ * Deliberately keyed on that gate ALONE. The other suppression —
+ * {@link NO_JS_CALL_FORM} — is the set of names whose faithful port emits no
+ * callee at all, so those calls have no TS spelling to consume and claiming one
+ * for them would manufacture rows against ports that are correct.
+ */
+export function suppressedCallClaims(
+  rubyCalls: readonly string[],
+  tsCalls: Set<string>,
+  isPortedWithArgs: (tsName: string) => boolean,
+  mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
+  significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
+  aliasCall: (rubyCall: string) => string[] = jsEnumerableAliases,
+): Set<string> {
+  const claimed = new Set<string>();
+  for (const rc of rubyCalls) {
+    if (!significant.has(rc)) continue;
+    const mapped = mapCall(rc);
+    if (!mapped || mapped.length === 0) continue;
+    if (mapped.some(isPortedWithArgs)) continue;
+    for (const c of [
+      ...mapped,
+      ...aliasCall(rc),
+      ...(SUPPRESSED_CALL_TS_SPELLINGS.get(rc) ?? []),
+    ]) {
+      if (tsCalls.has(c)) claimed.add(c);
+    }
+  }
+  return claimed;
+}
+
+/**
  * Core of the advisory calls-parity check (pure, exported for tests). For a
  * name-matched pair, returns the fidelity-critical Ruby body calls that are
  * absent from the TS body's call-set, formatted as `ruby_call → tsCand|tsCand`.
@@ -413,6 +475,19 @@ export function significantMissingCalls(
   bodyRubyCalls: readonly string[] = rubyCalls,
 ): string[] {
   const missing: string[] = [];
+  // A TS name a SUPPRESSED Ruby call ports is not available to its siblings.
+  const claimed = suppressedCallClaims(
+    rubyCalls.filter((rc) => rc !== rubyName),
+    tsCalls,
+    isPortedWithArgs,
+    mapCall,
+    significant,
+    aliasCall,
+  );
+  const unclaimed = (calls: Set<string>) =>
+    claimed.size === 0 ? calls : new Set([...calls].filter((c) => !claimed.has(c)));
+  const availableTsCalls = unclaimed(tsCalls);
+  const availableNegatedTsCalls = unclaimed(negatedTsCalls);
   for (const rc of rubyCalls) {
     if (rc === rubyName) continue; // self/recursive call
     if (!significant.has(rc)) continue;
@@ -434,14 +509,14 @@ export function significantMissingCalls(
     if (!raw || raw.length === 0) continue;
     const mapped = narrowPredicateCandidates(rc, raw, bodyRubyCalls, mapCall);
     if (!mapped.some(isPortedWithArgs)) continue;
-    if (mapped.some((c) => tsCalls.has(c))) continue;
+    if (mapped.some((c) => availableTsCalls.has(c))) continue;
     // A NEGATED alias (`exclude? → includes`) is matched against the negated
     // call-set: a bare `xs.includes(y)` where Rails wrote `exclude?` is the
     // inverted condition, and must not silence the ratchet. Direct aliases —
     // including `none? → every`, whose de-Morgan port negates inside the
     // callback — keep matching the plain call-set (see NEGATED_ALIASES).
     const aliasMatched = aliasCall(rc).some((c) =>
-      requiresNegatedAlias(rc, c) ? negatedTsCalls.has(c) : tsCalls.has(c),
+      requiresNegatedAlias(rc, c) ? availableNegatedTsCalls.has(c) : availableTsCalls.has(c),
     );
     if (aliasMatched) continue;
     missing.push(`${rc} → ${mapped.join("|")}`);

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -399,11 +399,12 @@ export function narrowPredicateCandidates(
  * Entries are here rather than in {@link JS_ENUMERABLE_ALIASES} because that
  * table's contract is that an alias can only ever SILENCE a flag; these
  * spellings exist to take a name away from a sibling, which can raise one.
+ *
+ * `method_defined?` — `Module#method_defined?(name)` asks whether a name is
+ * installed on a method table; trails' generated-method tables are `Map`s, so
+ * the port is `table.has(name)`, the same JS callee `include?`/`key?` alias to.
  */
 export const SUPPRESSED_CALL_TS_SPELLINGS = new Map<string, string[]>([
-  // `Module#method_defined?(name)` asks whether a name is installed on a
-  // method table. trails' generated-method tables are `Map`s, so the port is
-  // `table.has(name)` — the same JS callee `include?`/`key?` alias to.
   ["method_defined?", ["has"]],
 ]);
 
@@ -475,9 +476,8 @@ export function significantMissingCalls(
   bodyRubyCalls: readonly string[] = rubyCalls,
 ): string[] {
   const missing: string[] = [];
-  // A TS name a SUPPRESSED Ruby call ports is not available to its siblings.
   const claimed = suppressedCallClaims(
-    rubyCalls.filter((rc) => rc !== rubyName),
+    bodyRubyCalls.filter((rc) => rc !== rubyName),
     tsCalls,
     isPortedWithArgs,
     mapCall,


### PR DESCRIPTION
Fixes RFC 0106 Open Question 1: the call-set extractor could credit one Ruby call's TS spelling to an unrelated sibling.

## The bug

`significantMissingCalls`'s second gate skips a Ruby call whose mapped TS candidates are none of them ported methods that take arguments. That is correct on its own — but the skipped call still had a TS spelling in the body, and nothing reserved it, so a **sibling** Ruby call mapping to the same TS name was credited with it and stopped flagging.

`ActiveRecord::Delegation::GeneratedRelationMethods#generate_method` is the worked case:

- `return if method_defined?(method)` — `delegation.rb:76`, suppressed by the gate;
- `!RESERVED_METHOD_NAMES.include?(method.to_s)` — `delegation.rb:78`, aliases to `has`.

trails spells the memo guard `this._methods.has(name)`. `include?` claimed that `has`, so the reserved-name omission could be recorded in **no machine-checked register at all** — neither a `call-mismatches-exclude` row nor a `@missingRailsCall` tag survived, both going stale against a call the gate believed was made. The justification had to live as prose JSDoc.

## The fix

`suppressedCallClaims` computes the TS names a suppressed call ports (mapped candidates, Enumerable aliases, and `SUPPRESSED_CALL_TS_SPELLINGS`) and withholds them from the body's other Ruby calls. Keyed on the ported-with-args gate **alone**: `NO_JS_CALL_FORM` names emit no callee at all by construction, so claiming a spelling for them would manufacture rows against correct ports.

`method_defined? → has` is the one `SUPPRESSED_CALL_TS_SPELLINGS` entry. It is deliberately not in `JS_ENUMERABLE_ALIASES`, whose documented contract is that an alias can only ever *silence* a flag; these spellings exist to take a name away from a sibling, which can raise one.

## Measurement

Full-artifact diff before/after, `API_COMPARE_FORCE=1 pnpm parity:api --calls`: **exactly one** new row, the intended `relation/delegation.ts generate_method → include?`, and no removals. It is now carried as a `@missingRailsCall include?` tag at the call site (replacing the prose paragraph that explained why no register could hold it), so the baselines are net-neutral — `parity:api:calls` and `parity:api:calls:args` both green, `parity:api:reasons` green.

## The other two bundled stories

Neither ships here; both were assessed against `origin/main` and handed back rather than forced into this PR.

- **`company-model-invents-inheritance-column-assignment`** — `pnpm tasks block`ed. Measured: deleting `Company.inheritanceColumn = "type"` reds `inheritance.test.ts:197` (`Company.find` on a `bad_class_name` row stops raising `SubclassNotFound` and returns the base-class record) plus a case in `inheritance-sti-new-gate.trails.test.ts`, exactly as the story predicted — `stiEnabled` is `_inheritanceColumn != null`, so `findStiClassForRow` degrades instead of raising. It needs the same synchronous schema signal that already blocks `converge-new-sti-gate-drop-stienabled-disjunct`, the story it says to sequence after. The story's second half — the audit of every other `inheritanceColumn` assignment under `test-helpers/models/` — is **done** and recorded in the blocker: `post.ts` ×8 and `parrot.ts:28` are real (`post.rb:247,268,280,302,310,320,331,349`; `parrot.rb:4`), `vegetables.ts:13` is real but spelled as an assignment where `vegetables.rb:6` overrides the method, and `membership.ts:62` is invented (`membership.rb` has only `enum :type, %i(...)`) — and blocks on the same signal as `company.ts`.
- **`converge-attribute-definitions-onto-default-attributes`** — released. `_attributeDefinitions` still has ~100 references across 17 non-test source files (`attribute-methods`, `inheritance`, `model-schema`, `join-dependency`, `encryption`, …); it does not fit under the 700 LOC ceiling alongside this change, and the story's own notes say it needs splitting once the reader inventory is known.

Closes-story: suppressed-call-lets-sibling-claim-ts-candidate