### PR TITLE
refactor(parity,activesupport,activerecord): claim suppressed calls in the order check, converge TimeZone.create and method_defined_within?

### DIFF
--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base, DangerousAttributeError, ReadonlyAttributeError, registerModel } from "./index.js";
-import { GeneratedAttributeMethods } from "./attribute-methods.js";
+import { GeneratedAttributeMethods, isMethodDefinedWithin } from "./attribute-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
 import { registerSubclass } from "./inheritance.js";
 
@@ -404,5 +404,42 @@ describe("AttributeMethodsTest (trails)", () => {
       isInstanceMethodAlreadyImplemented(n: string): boolean;
     };
     expect(host.isInstanceMethodAlreadyImplemented("nickname")).toBe(true);
+  });
+});
+
+describe("methodDefinedWithin (trails)", () => {
+  class Super {
+    greet(): string {
+      return "super";
+    }
+  }
+  class Redefines extends Super {
+    override greet(): string {
+      return "sub";
+    }
+  }
+  class Inherits extends Super {}
+  const within = (name: string, klass: unknown, superklass?: unknown) =>
+    isMethodDefinedWithin.call({} as never, name, klass, superklass);
+
+  it("is true when both classes define the name and the subclass redefines it", () => {
+    expect(within("greet", Redefines, Super)).toBe(true);
+  });
+
+  it("is false when both classes define the name and the subclass inherits it", () => {
+    expect(within("greet", Inherits, Super)).toBe(false);
+  });
+
+  it("is true when only the class defines the name", () => {
+    expect(within("greet", Redefines, class {})).toBe(true);
+  });
+
+  it("is false when the class does not define the name", () => {
+    expect(within("missing", Redefines, Super)).toBe(false);
+  });
+
+  it("defaults superklass to the class's superclass", () => {
+    expect(within("greet", Redefines)).toBe(true);
+    expect(within("greet", Inherits)).toBe(false);
   });
 });

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -538,13 +538,13 @@ export function undefineAttributeMethods(this: AttributeMethodsHost): void {
  * ancestry the way method lookup does — `include()` splices a module's carrier
  * into the prototype chain directly below the including class's prototype, so
  * per ancestor the class body outranks its generated module — and report which
- * kind of link defines the name first.
+ * kind of link defines the name first: `is_a?(GeneratedAttributeMethods)` reads
+ * as "the owner IS the `_generatedAttributeMethods` field", since ActiveModel's
+ * lazy `generated_attribute_methods` seats a plain `Module` there where
+ * ActiveRecord seats the subclass — the field, not the constructor, is the
+ * discriminator.
  */
 function isOwnedByGeneratedAttributeMethods(klass: any, name: string): boolean {
-  // `is_a?(GeneratedAttributeMethods)`: the `_generatedAttributeMethods` field
-  // IS that module. ActiveModel's lazy `generated_attribute_methods` seats a
-  // plain `Module` there where ActiveRecord seats the subclass, so the field,
-  // not the constructor, is the discriminator.
   return instanceMethodOwner(klass, name) instanceof Module;
 }
 

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -541,18 +541,28 @@ export function undefineAttributeMethods(this: AttributeMethodsHost): void {
  * kind of link defines the name first.
  */
 function isOwnedByGeneratedAttributeMethods(klass: any, name: string): boolean {
+  // `is_a?(GeneratedAttributeMethods)`: the `_generatedAttributeMethods` field
+  // IS that module. ActiveModel's lazy `generated_attribute_methods` seats a
+  // plain `Module` there where ActiveRecord seats the subclass, so the field,
+  // not the constructor, is the discriminator.
+  return instanceMethodOwner(klass, name) instanceof Module;
+}
+
+/**
+ * Ruby's `klass.instance_method(name).owner` — the ancestor that defines
+ * `name`, or `undefined` when none does. A class prototype outranks the class's
+ * own generated-attribute-methods module, matching how `include()` splices a
+ * module's carrier directly below the including class's prototype.
+ */
+function instanceMethodOwner(klass: any, name: string): unknown {
   for (let c = klass; typeof c === "function"; c = Object.getPrototypeOf(c)) {
-    if (c.prototype && Object.prototype.hasOwnProperty.call(c.prototype, name)) return false;
+    if (c.prototype && Object.prototype.hasOwnProperty.call(c.prototype, name)) return c.prototype;
     const mod = Object.prototype.hasOwnProperty.call(c, "_generatedAttributeMethods")
       ? c._generatedAttributeMethods
       : undefined;
-    // `is_a?(GeneratedAttributeMethods)`: the `_generatedAttributeMethods`
-    // field IS that module. ActiveModel's lazy `generated_attribute_methods`
-    // seats a plain `Module` there where ActiveRecord seats the subclass, so
-    // the field, not the constructor, is the discriminator.
-    if (mod instanceof Module && mod.isMethodDefined(name)) return true;
+    if (mod instanceof Module && mod.isMethodDefined(name)) return mod;
   }
-  return false;
+  return undefined;
 }
 
 /**
@@ -607,15 +617,28 @@ export function isDangerousAttributeMethod(this: AttributeMethodsHost, name: str
   return dangerousAttributeMethods().has(name);
 }
 
+/**
+ * Mirrors: ClassMethods#method_defined_within?
+ * (attribute_methods.rb:187-198). Ruby's `method_defined?` /
+ * `private_method_defined?` pair is one `name in klass.prototype` here — JS has
+ * no private-method reflection over the prototype chain, so the `in` test
+ * already covers both Ruby visibilities.
+ */
 export function isMethodDefinedWithin(
   this: AttributeMethodsHost,
   name: string,
   klass: any,
-  superklass?: any,
+  superklass: any = Object.getPrototypeOf(klass),
 ): boolean {
-  if (!(name in klass.prototype)) return false;
-  if (!superklass) return true;
-  return !(name in superklass.prototype);
+  if (name in klass.prototype) {
+    if (superklass?.prototype != null && name in superklass.prototype) {
+      return instanceMethodOwner(klass, name) !== instanceMethodOwner(superklass, name);
+    } else {
+      return true;
+    }
+  } else {
+    return false;
+  }
 }
 
 export function isDangerousClassMethod(this: AttributeMethodsHost, methodName: string): boolean {

--- a/packages/activerecord/src/test-helpers/models/vegetables.ts
+++ b/packages/activerecord/src/test-helpers/models/vegetables.ts
@@ -10,8 +10,11 @@ export class Vegetable extends Base {
   declare seller_id: number;
 
   static {
-    this.inheritanceColumn = "custom_type";
     this.validates("name", { presence: true });
+  }
+
+  static override get inheritanceColumn(): string {
+    return "custom_type";
   }
 }
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -560,10 +560,40 @@ export class TimezonePeriod {
 export class TimeZone {
   readonly name: string;
   readonly tzinfo: string; // IANA name
+  /** `@utc_offset` (time_zone.rb:311), which {@link utcOffset} reads first. */
+  readonly #utcOffset: number | null;
 
-  constructor(name: string, ianaName?: string) {
+  /**
+   * `initialize(name, utc_offset = nil, tzinfo = nil)` (time_zone.rb:309-313):
+   * a caller holding the resolved zone hands it over rather than making
+   * `find_tzinfo` re-resolve it (`load_country_zones`, time_zone.rb:278).
+   */
+  constructor(name: string, utcOffset: number | null = null, tzinfo: string | null = null) {
     this.name = name;
-    this.tzinfo = ianaName ?? name;
+    this.#utcOffset = utcOffset;
+    this.tzinfo = tzinfo ?? TimeZone.findTzinfo(name);
+  }
+
+  /**
+   * `find_tzinfo(name)` — `TZInfo::Timezone.get(MAPPING[name] || name)`
+   * (time_zone.rb:207-209). trails has no `TZInfo::Timezone` object, so the
+   * zone IS its IANA identifier and `Timezone.get`'s resolve-or-raise is an
+   * `Intl.DateTimeFormat` probe.
+   */
+  static findTzinfo(name: string): string {
+    const ianaName = MAPPING[name] ?? name;
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
+    } catch (error) {
+      // ECMA-402 mandates a RangeError for a `timeZone` the runtime does not
+      // know, and only for that — so it is the one failure standing in for
+      // `Timezone.get`'s InvalidTimezoneIdentifier. Anything else out of the
+      // probe is a different fault and propagates, as a non-TZInfo error would
+      // through `find_tzinfo` (time_zone.rb:208).
+      if (!(error instanceof RangeError)) throw error;
+      throw new InvalidTimezoneIdentifier(`Invalid identifier: ${ianaName}`);
+    }
+    return ianaName;
   }
 
   /**
@@ -632,20 +662,12 @@ export class TimeZone {
    * (`@lazy_zones_map[arg] ||= create(arg)`, time_zone.rb:237-238), so every
    * call here builds a fresh instance as Ruby's `new` does.
    */
-  static create(name: string): TimeZone {
-    const ianaName = MAPPING[name] ?? name;
-    try {
-      new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
-    } catch (error) {
-      // ECMA-402 mandates a RangeError for a `timeZone` the runtime does not
-      // know, and only for that — so it is the one failure standing in for
-      // `Timezone.get`'s InvalidTimezoneIdentifier. Anything else out of the
-      // probe is a different fault and propagates, as a non-TZInfo error would
-      // through `find_tzinfo` (time_zone.rb:208).
-      if (!(error instanceof RangeError)) throw error;
-      throw new InvalidTimezoneIdentifier(`Invalid identifier: ${ianaName}`);
-    }
-    return new TimeZone(name, ianaName);
+  static create(
+    name: string,
+    utcOffset: number | null = null,
+    tzinfo: string | null = null,
+  ): TimeZone {
+    return new TimeZone(name, utcOffset, tzinfo);
   }
 
   /**
@@ -1010,6 +1032,7 @@ export class TimeZone {
    * derivation `isDst` already uses).
    */
   get utcOffset(): number {
+    if (this.#utcOffset !== null) return this.#utcOffset;
     const now = new Date();
     const jan = getZoneInfo(this.tzinfo, new Date(now.getFullYear(), 0, 1)).utcOffsetSeconds;
     const jul = getZoneInfo(this.tzinfo, new Date(now.getFullYear(), 6, 1)).utcOffsetSeconds;
@@ -1258,7 +1281,7 @@ export class TimeZone {
           }
           return memo;
         }
-        return [TimeZone.create(tzId)];
+        return [TimeZone.create(tzId, null, tzId)];
       })
       .sort((a, b) => a.compareTo(b) ?? 0);
   }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -578,18 +578,17 @@ export class TimeZone {
    * `find_tzinfo(name)` — `TZInfo::Timezone.get(MAPPING[name] || name)`
    * (time_zone.rb:207-209). trails has no `TZInfo::Timezone` object, so the
    * zone IS its IANA identifier and `Timezone.get`'s resolve-or-raise is an
-   * `Intl.DateTimeFormat` probe.
+   * `Intl.DateTimeFormat` probe. ECMA-402 mandates a RangeError for a `timeZone`
+   * the runtime does not know, and only for that, so it is the one failure
+   * standing in for `Timezone.get`'s InvalidTimezoneIdentifier; anything else
+   * out of the probe is a different fault and propagates, as a non-TZInfo error
+   * would through `find_tzinfo`.
    */
   static findTzinfo(name: string): string {
     const ianaName = MAPPING[name] ?? name;
     try {
       new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
     } catch (error) {
-      // ECMA-402 mandates a RangeError for a `timeZone` the runtime does not
-      // know, and only for that — so it is the one failure standing in for
-      // `Timezone.get`'s InvalidTimezoneIdentifier. Anything else out of the
-      // probe is a different fault and propagates, as a non-TZInfo error would
-      // through `find_tzinfo` (time_zone.rb:208).
       if (!(error instanceof RangeError)) throw error;
       throw new InvalidTimezoneIdentifier(`Invalid identifier: ${ianaName}`);
     }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -575,27 +575,6 @@ export class TimeZone {
   }
 
   /**
-   * `find_tzinfo(name)` — `TZInfo::Timezone.get(MAPPING[name] || name)`
-   * (time_zone.rb:207-209). trails has no `TZInfo::Timezone` object, so the
-   * zone IS its IANA identifier and `Timezone.get`'s resolve-or-raise is an
-   * `Intl.DateTimeFormat` probe. ECMA-402 mandates a RangeError for a `timeZone`
-   * the runtime does not know, and only for that, so it is the one failure
-   * standing in for `Timezone.get`'s InvalidTimezoneIdentifier; anything else
-   * out of the probe is a different fault and propagates, as a non-TZInfo error
-   * would through `find_tzinfo`.
-   */
-  static findTzinfo(name: string): string {
-    const ianaName = MAPPING[name] ?? name;
-    try {
-      new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
-    } catch (error) {
-      if (!(error instanceof RangeError)) throw error;
-      throw new InvalidTimezoneIdentifier(`Invalid identifier: ${ianaName}`);
-    }
-    return ianaName;
-  }
-
-  /**
    * The port of `ActiveSupport::TimeZone.[]` (time_zone.rb:232-250): a Rails
    * name or IANA identifier, a `TimeZone`, or a `Numeric`/`Duration` UTC
    * offset. `null` for a name that resolves to no zone (Ruby's
@@ -652,6 +631,26 @@ export class TimeZone {
     throw new ArgumentError(`invalid argument to TimeZone[]: ${inspect(arg)}`);
   }
 
+  /**
+   * `find_tzinfo(name)` — `TZInfo::Timezone.get(MAPPING[name] || name)`
+   * (time_zone.rb:207-209). trails has no `TZInfo::Timezone` object, so the
+   * zone IS its IANA identifier and `Timezone.get`'s resolve-or-raise is an
+   * `Intl.DateTimeFormat` probe. ECMA-402 mandates a RangeError for a `timeZone`
+   * the runtime does not know, and only for that, so it is the one failure
+   * standing in for `Timezone.get`'s InvalidTimezoneIdentifier; anything else
+   * out of the probe is a different fault and propagates, as a non-TZInfo error
+   * would through `find_tzinfo`.
+   */
+  static findTzinfo(name: string): string {
+    const ianaName = MAPPING[name] ?? name;
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: ianaName });
+    } catch (error) {
+      if (!(error instanceof RangeError)) throw error;
+      throw new InvalidTimezoneIdentifier(`Invalid identifier: ${ianaName}`);
+    }
+    return ianaName;
+  }
   /**
    * `alias_method :create, :new` (time_zone.rb:211) — the allocator, whose
    * `initialize` resolves the zone through `find_tzinfo` (time_zone.rb:208) and

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
@@ -9,22 +9,16 @@
   {
     "package": "activesupport",
     "tsFile": "values/time-zone.ts",
-    "rubyName": "iso8601",
-    "call": "ordinal",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "find_tzinfo",
+    "call": "get",
+    "reason": "`TZInfo::Timezone.get(MAPPING[name] || name)` (time_zone.rb:208): trails has no TZInfo, so a zone IS its IANA identifier and `get`'s resolve-or-raise is an `Intl.DateTimeFormat` probe raising the same InvalidTimezoneIdentifier. Converges when trails grows a tzinfo object (the `time-with-zone-residue-structural-blockers` seam)."
   },
   {
     "package": "activesupport",
     "tsFile": "values/time-zone.ts",
-    "rubyName": "load_country_zones",
-    "call": "create",
-    "kind": "args",
-    "rubyArgs": [
-      "ref:tzId",
-      "nil",
-      "ref:get"
-    ],
-    "reason": "Rails passes `create(tz_id, nil, TZInfo::Timezone.get(tz_id))` (time_zone.rb:278) because `create` is `alias_method :create, :new` over `initialize(name, utc_offset = nil, tzinfo = nil)`. trails resolves zones through `Intl`, which has no TZInfo::Timezone object to hand over, so `create` takes the name alone and looks the zone data up itself; the third argument has no value to carry. Converges when trails grows a tzinfo object (the `time-with-zone-residue-structural-blockers` seam)."
+    "rubyName": "iso8601",
+    "call": "ordinal",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -2583,6 +2583,42 @@ describe("reorderedCalls (RFC 0084 order-only call parity)", () => {
     ).toEqual([`${ORDER_PREFIX}validate,defineNonCyclicMethod → defineNonCyclicMethod,validate`]);
   });
 
+  it("drops a TS name a suppressed Ruby call claims as its own spelling", () => {
+    // `method_defined?` maps to nothing ported-with-args, so this check never
+    // reaches it — but trails spells it `has`, so `include?` must not be
+    // credited with that position (RFC 0106 Open Question 1).
+    const claimMap = (c: string) =>
+      c === "method_defined?"
+        ? ["methodDefined"]
+        : c === "include?"
+          ? ["includes", "has"]
+          : c === "define_method"
+            ? ["defineMethod"]
+            : null;
+    const notMethodDefined = (ts: string) => ts !== "methodDefined";
+    expect(
+      reorderedCalls(
+        "generate_method",
+        ["define_method", "include?"],
+        ["has", "defineMethod"],
+        notMethodDefined,
+        claimMap,
+        wide,
+        ["method_defined?", "define_method", "include?"],
+      ),
+    ).toEqual([]);
+    expect(
+      reorderedCalls(
+        "generate_method",
+        ["define_method", "include?"],
+        ["has", "defineMethod"],
+        notMethodDefined,
+        claimMap,
+        wide,
+      ),
+    ).toEqual([`${ORDER_PREFIX}has,defineMethod → defineMethod,has`]);
+  });
+
   it("respects the ported-with-args gate the missing-call check uses", () => {
     // A zero-arg reader Ruby records as a call but TS reads as `this.x` must not
     // manufacture a position — same gate 2 as significantMissingCalls.

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -604,9 +604,18 @@ export const ORDER_PREFIX = "order:";
  * reads "TS calls b before a; Rails calls a before b" — so the row is a stable
  * baseline key rather than a whole-sequence string that churns on every edit.
  *
- * A TS name two of the body's Ruby calls could both be ported as carries no
- * position for either ({@link ambiguousTsNames}), so it is skipped here; the
- * membership check still sees it.
+ * A TS name that carries no position for the call under test is skipped here;
+ * the membership check still sees it. Two causes, settled in ONE filter — the
+ * union computed below — rather than two overlapping ones:
+ *   - two of the body's Ruby calls could both be ported as it, so no position
+ *     can be attributed to either ({@link ambiguousTsNames});
+ *   - one of the body's Ruby calls is SUPPRESSED by the ported-with-args gate
+ *     and the name is the spelling it ports ({@link suppressedCallClaims}), so
+ *     the position belongs to a call this check never reaches. That is the
+ *     same indivisible-position fact as an ambiguous name, arriving by a
+ *     different route: the second owner is invisible to the gate rather than
+ *     visible-and-tied (RFC 0106 Open Question 1). `significantMissingCalls`
+ *     honours the same claims by withholding them from `tsCalls`.
  *
  * `bodyRubyCalls` is the body's call list BEFORE `dropWeakCalls` — the
  * disambiguation above is about what the Ruby body NAMES, and a call the weak
@@ -621,8 +630,19 @@ export function reorderedCalls(
   mapCall: (rubyCall: string) => string[] | null = rubyMethodToTs,
   significant: { has(value: string): boolean } = SIGNIFICANT_CALLS,
   bodyRubyCalls: readonly string[] = rubyCalls,
+  aliasCall: (rubyCall: string) => string[] = jsEnumerableAliases,
 ): string[] {
-  const ambiguous = ambiguousTsNames(bodyRubyCalls, mapCall);
+  const unpositioned = new Set([
+    ...ambiguousTsNames(bodyRubyCalls, mapCall),
+    ...suppressedCallClaims(
+      bodyRubyCalls.filter((rc) => rc !== rubyName),
+      new Set(tsCalls),
+      isPortedWithArgs,
+      mapCall,
+      significant,
+      aliasCall,
+    ),
+  ]);
   const rubySeq: string[] = [];
   for (const rc of rubyCalls) {
     if (rc === rubyName) continue;
@@ -632,7 +652,7 @@ export function reorderedCalls(
     if (!raw || raw.length === 0) continue;
     const mapped = narrowPredicateCandidates(rc, raw, bodyRubyCalls, mapCall);
     if (!mapped.some(isPortedWithArgs)) continue;
-    const hit = mapped.find((c) => tsCalls.includes(c) && !ambiguous.has(c));
+    const hit = mapped.find((c) => tsCalls.includes(c) && !unpositioned.has(c));
     if (hit === undefined) continue;
     if (rubySeq.includes(hit)) continue;
     rubySeq.push(hit);


### PR DESCRIPTION
Four bundled convergences.

### 1. Order check honours suppressed-call claims (RFC 0106 OQ1)

`reorderedCalls` applied the same gate sequence as `significantMissingCalls` but
without the `suppressedCallClaims` filter PR #6729 added, so a Ruby call the
ported-with-args gate suppresses still left its TS spelling available to a
sibling — which was then credited with a POSITION belonging to the suppressed
call. Settled in ONE filter: the order call site now compares against the union
of `ambiguousTsNames` and `suppressedCallClaims`, and the JSDoc says so (the
second owner being invisible to the gate rather than visible-and-tied is the
same indivisible-position fact).

Whole-artifact before/after (`API_COMPARE_FORCE=1 pnpm parity:api --calls`,
isolating the compare.ts change): **29 `order:` rows before, 29 after — zero
delta**, as expected while `SUPPRESSED_CALL_TS_SPELLINGS` carries one entry. No
new baseline rows from this half.

### 2. `TimeZone.create` onto Rails' three-arg allocator

`initialize(name, utc_offset = nil, tzinfo = nil)` (time_zone.rb:309-313) with
`alias_method :create, :new` (:211). The constructor and `create` now take
Rails' parameter list in Rails' order with Rails' defaults; `find_tzinfo`
(:207-209) is extracted at the Rails name and carries the `MAPPING[name] || name`
lookup plus the `Intl` probe standing in for `TZInfo::Timezone.get`; `utcOffset`
reads the stored `@utc_offset` before deriving one (:317-319); and
`loadCountryZones` passes the resolved zone it already holds —
`create(tzId, null, tzId)` (:278). trails' `tzinfo` is the IANA identifier
string, so the third parameter does have something to carry after all.

Baseline: the `load_country_zones` → `create` `kind: "args"` row is **deleted**.
One new row (`find_tzinfo` → `get`) with a reviewed reason — `TZInfo::Timezone.get`
has no trails counterpart; the probe is the port. Net −1 arg row, +1 call row.

### 3. `vegetables.ts` overrides the reader Rails overrides

`vegetables.rb:3-9` defines `def self.inheritance_column`; trails assigned the
writer. Now a `static override get inheritanceColumn()`.

This is observably different in trails: the assignment set `_inheritanceColumn`,
which is what `stiEnabled` (`inheritance.ts:456`) reads, so `stiEnabled(Vegetable)`
is now `false` while `Vegetable.inheritanceColumn` still answers `"custom_type"`.
STI dispatch is **unchanged** — `inheritance.test.ts` stays green, including
`Vegetable.find(1) instanceof Cucumber` (:208-211) and the `becomes` cases. That
is direct evidence the `stiEnabled` sentinel is not load-bearing on these paths,
and it is recorded on both coupled stories
(`converge-new-sti-gate-drop-stienabled-disjunct`,
`company-model-invents-inheritance-column-assignment`).

### 4. `method_defined_within?` owner comparison

`attribute_methods.rb:187-198` has three arms; trails had two, answering a flat
`false` where both classes define the name and Rails compares OWNERS. Restored
via an `instanceMethodOwner` walk (Ruby's `instance_method(name).owner`), which
`isOwnedByGeneratedAttributeMethods` now reads through rather than duplicating.
Ruby's `superklass = klass.superclass` default is honoured. Tests cover both
directions and fail on the baseline.

Gates: `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
`parity:api` totals unchanged.

Closes-story: order-check-ignores-suppressed-call-claims
Closes-story: converge-time-zone-create-onto-the-three-arg-allocator
Closes-story: vegetables-model-assigns-inheritance-column-rails-overrides-method
Closes-story: method-defined-within-drops-owner-comparison
