### PR TITLE
test(activerecord): converge assertion parity for the adapters and root test tails

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNotPredicate } from "@blazetrails/activesupport";
 import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
@@ -51,14 +52,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       });
       const columns = await adapter.columns("auto_increments");
       const col = (columns as any[]).find((c) => c.name === "id");
-      expect(col.autoIncrement).toBe(false);
+      assertNotPredicate(col, (c) => c.autoIncrement);
     });
 
     it("auto increment false with create table", async () => {
       await adapter.createTable("auto_increments", { autoIncrement: false, force: "cascade" });
       const columns = await adapter.columns("auto_increments");
       const col = (columns as any[]).find((c) => c.name === "id");
-      expect(col.autoIncrement).toBe(false);
+      assertNotPredicate(col, (c) => c.autoIncrement);
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/case_sensitivity_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { assertNotPredicate, assertPredicate } from "@blazetrails/activesupport";
 import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../index.js";
 import { captureSql } from "../../testing/sql-capture.js";
@@ -38,8 +39,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("case sensitive", async () => {
       const columns = await adapter.columns("collation_tests");
       const byName = (n: string) => columns.find((c) => c.name === n)! as any;
-      expect(byName("string_ci_column").isCaseSensitive()).toBe(false);
-      expect(byName("string_cs_column").isCaseSensitive()).toBe(true);
+      assertNotPredicate(byName("string_ci_column"), (c) => c.isCaseSensitive());
+      assertPredicate(byName("string_cs_column"), (c) => c.isCaseSensitive());
     });
 
     it("case insensitive comparison for ci column", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -37,13 +37,12 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       // INSERT has to run on a connection other than the one issuing the DELETE.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
-        const [deleteResult, _createResult] = await Promise.allSettled([
+        const [deleteResult] = await Promise.all([
           adapter.executeMutation("DELETE FROM `test_bulbs`"),
           adapter2.executeMutation("INSERT INTO `test_authors` (name) VALUES ('Tommy')"),
         ]);
 
-        expect(deleteResult.status).toBe("fulfilled");
-        expect((deleteResult as PromiseFulfilledResult<number>).value).toBe(1);
+        expect(deleteResult).toBe(1);
       } finally {
         await adapter2.close();
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-enum.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-enum.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNotPredicate } from "@blazetrails/activesupport";
 import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { SchemaDumper } from "../../schema-dumper.js";
@@ -24,13 +25,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("should not be unsigned", async () => {
       const columns = await adapter.columns("enum_tests");
       const column = columns.find((c) => c.name === "enum_column");
-      expect((column as any).isUnsigned()).toBe(false);
+      assertNotPredicate(column, (c) => (c as any).isUnsigned());
     });
 
     it("should not be bigint", async () => {
       const columns = await adapter.columns("enum_tests");
       const column = columns.find((c) => c.name === "enum_column");
-      expect((column as any).isBigint()).toBe(false);
+      assertNotPredicate(column, (c) => (c as any).isBigint());
     });
 
     it("schema dumping", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -47,7 +47,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         const tableName = schemaMigration.tableName;
         await adapter.dropTable(tableName, { ifExists: true });
         await schemaMigration.createTable();
-        expect(await adapter.columnExists(tableName, "version")).toBe(true);
+        expect(await adapter.columnExists(tableName, "version")).toBeTruthy();
       });
     });
 
@@ -57,7 +57,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         const tableName = internalMetadata.tableName;
         await adapter.dropTable(tableName, { ifExists: true });
         await internalMetadata.createTable();
-        expect(await adapter.columnExists(tableName, "key")).toBe(true);
+        expect(await adapter.columnExists(tableName, "key")).toBeTruthy();
         // Restore environment entry so other tests don't see a missing metadata row
         await internalMetadata.createTableAndSetFlags("test");
       });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { assertDifference, assertNoDifference, assertRaises } from "@blazetrails/activesupport";
 import {
   describeIfMysqlAdapter,
   isMariaDb,
@@ -59,13 +60,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         })();
 
         try {
-          await adapter.transaction(async () => {
-            await latch1;
-            await adapter.execute("SET max_execution_time = 1");
-            await adapter.execute(`SELECT * FROM \`samples\` WHERE id = ${id} FOR UPDATE`);
-          });
-        } catch (e) {
-          error = e;
+          error = await assertRaises([StatementTimeout], {}, () =>
+            adapter.transaction(async () => {
+              await latch1;
+              await adapter.execute("SET max_execution_time = 1");
+              await adapter.execute(`SELECT * FROM \`samples\` WHERE id = ${id} FOR UPDATE`);
+            }),
+          );
         } finally {
           await adapter.execute("SET max_execution_time = DEFAULT").catch(() => {});
           latch2Resolve();
@@ -75,7 +76,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         await adapter2.close();
       }
 
-      expect(error).toBeInstanceOf(StatementTimeout);
       expect(error).toBeInstanceOf(QueryAborted);
     });
 
@@ -92,19 +92,17 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // 1. Default (REPEATABLE READ): INSERT by another connection is not visible
         await adapter.transaction(async () => {
           await adapter.materializeTransactions();
-          const countBefore = await sampleCount();
-          await adapter2.execute("INSERT INTO `samples` (value) VALUES (1)");
-          const countAfter = await sampleCount();
-          expect(countAfter).toBe(countBefore);
+          await assertNoDifference(sampleCount, null, () =>
+            adapter2.execute("INSERT INTO `samples` (value) VALUES (1)"),
+          );
         });
 
         // 2. READ COMMITTED: INSERT by another connection is visible mid-transaction
         await adapter.transaction({ isolation: "read_committed" }, async () => {
           await adapter.materializeTransactions();
-          const countBefore = await sampleCount();
-          await adapter2.execute("INSERT INTO `samples` (value) VALUES (1)");
-          const countAfter = await sampleCount();
-          expect(countAfter).toBe(countBefore + 1);
+          await assertDifference(sampleCount, +1, null, () =>
+            adapter2.execute("INSERT INTO `samples` (value) VALUES (1)"),
+          );
         });
 
         // 3. Retry preserves isolation: fail the first BEGIN, verify READ COMMITTED survives the retry
@@ -120,15 +118,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         try {
           await adapter.transaction({ isolation: "read_committed" }, async () => {
             await adapter.materializeTransactions();
-            const countBefore = await sampleCount();
-            await adapter2.execute("INSERT INTO `samples` (value) VALUES (1)");
-            const countAfter = await sampleCount();
-            expect(countAfter).toBe(countBefore + 1);
+            await assertDifference(sampleCount, +1, null, () =>
+              adapter2.execute("INSERT INTO `samples` (value) VALUES (1)"),
+            );
           });
         } finally {
           delete (adapter as any).internalExecute;
         }
-        expect(firstBeginFailed).toBe(true);
+        expect(firstBeginFailed).toBeTruthy();
       } finally {
         await adapter2.close();
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertDeprecated, assertPredicate } from "@blazetrails/activesupport";
 import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { RangeError as ActiveRecordRangeError } from "../../errors.js";
@@ -77,27 +78,19 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const columns = await adapter.columns("unsigned_types");
       const unsignedColumns = columns.filter((c) => /^unsigned_/.test(c.name));
       for (const column of unsignedColumns) {
-        expect((column as any).isUnsigned()).toBe(true);
+        assertPredicate(column, (c) => (c as any).isUnsigned());
       }
     });
 
     it("deprecate unsigned_float and unsigned_decimal", async () => {
-      const warnings: string[] = [];
-      const dep = deprecator();
-      const prev = dep.behavior;
-      dep.behavior = (msg: unknown) => {
-        warnings.push(String(msg));
-      };
-      try {
-        await adapter.changeTable("unsigned_types", async (t: any) => {
+      await adapter.changeTable("unsigned_types", async (t: any) => {
+        await assertDeprecated(/unsigned_float/, deprecator(), async () => {
           await t.unsignedFloat("unsigned_float_t");
+        });
+        await assertDeprecated(/unsigned_decimal/, deprecator(), async () => {
           await t.unsignedDecimal("unsigned_decimal_t");
         });
-      } finally {
-        dep.behavior = prev;
-      }
-      expect(warnings.some((w) => /unsigned_float/.test(w))).toBe(true);
-      expect(warnings.some((w) => /unsigned_decimal/.test(w))).toBe(true);
+      });
     });
 
     it("schema dump includes unsigned option", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
 import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { describeIfSupports } from "../../support/supports.js";
 import { SchemaDumper } from "../../schema-dumper.js";
@@ -48,7 +49,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("virtual column", async () => {
       const column = await findColumn("upper_name");
-      expect(column!.isVirtual()).toBe(true);
+      assertPredicate(column!, (c) => c.isVirtual());
       expect(column!.extra).toMatch(/\bVIRTUAL\b/);
       const value = await adapter.selectValue("SELECT upper_name FROM virtual_columns LIMIT 1");
       expect(value).toBe("RAILS");
@@ -56,7 +57,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("stored column", async () => {
       const column = await findColumn("name_length");
-      expect(column!.isVirtual()).toBe(true);
+      assertPredicate(column!, (c) => c.isVirtual());
       expect(column!.extra).toMatch(/\b(?:STORED|PERSISTENT)\b/);
       const value = await adapter.selectValue("SELECT name_length FROM virtual_columns LIMIT 1");
       expect(value).toBe(5);

--- a/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-rake.test.ts
@@ -105,8 +105,8 @@ describeIfMysqlAdapter("MysqlDBCreateTest", () => {
     });
 
     expect(establishConnection).toHaveBeenCalledTimes(2);
-    expect(establishConnection.mock.calls[0][0]).toEqual({ adapter: "mysql2", database: null });
-    expect(establishConnection.mock.calls[1][0]).toEqual({
+    expect(establishConnection).toHaveBeenNthCalledWith(1, { adapter: "mysql2", database: null });
+    expect(establishConnection).toHaveBeenNthCalledWith(2, {
       adapter: "mysql2",
       database: "my-app-db",
     });

--- a/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/change-schema.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/change_schema_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertPredicate } from "@blazetrails/activesupport";
 import {
   describeIfPg,
   PostgreSQLAdapter,
@@ -141,8 +142,8 @@ describeIfPg("Migration", () => {
       });
       const cols = await adapter.columns("strings");
       const col = cols.find((c) => c.name === "somedate");
-      expect(col!.sqlType).toBe("timestamp without time zone");
-      expect((col as any).isArray()).toBe(true);
+      expect(col!.type).toBe("datetime");
+      assertPredicate(col!, (c) => (c as any).isArray());
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/cidr.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/cidr.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/cidr_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNot } from "@blazetrails/activesupport";
 import { Cidr, IPAddr } from "../../connection-adapters/postgresql/oid/cidr.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
@@ -33,20 +34,20 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("changed? with nil values", async () => {
       const type = new Cidr();
 
-      expect(type.isChanged(null, null, "")).toBe(false);
-      expect(type.isChanged("192.168.0.0/24", null, "")).toBe(true);
-      expect(type.isChanged(null, "192.168.0.0/24", "")).toBe(true);
-      expect(type.isChanged("192.168.0.0/24", "192.168.0.0/25", "")).toBe(true);
-      expect(type.isChanged(new IPAddr("192.168.0.0", 24), null, "")).toBe(true);
-      expect(type.isChanged(null, new IPAddr("192.168.0.0", 24), "")).toBe(true);
-      expect(type.isChanged(new IPAddr("192.168.0.0", 24), new IPAddr("192.168.0.0", 25), "")).toBe(
-        true,
-      );
+      assertNot(type.isChanged(null, null, ""));
+      expect(type.isChanged("192.168.0.0/24", null, "")).toBeTruthy();
+      expect(type.isChanged(null, "192.168.0.0/24", "")).toBeTruthy();
+      expect(type.isChanged("192.168.0.0/24", "192.168.0.0/25", "")).toBeTruthy();
+      expect(type.isChanged(new IPAddr("192.168.0.0", 24), null, "")).toBeTruthy();
+      expect(type.isChanged(null, new IPAddr("192.168.0.0", 24), "")).toBeTruthy();
+      expect(
+        type.isChanged(new IPAddr("192.168.0.0", 24), new IPAddr("192.168.0.0", 25), ""),
+      ).toBeTruthy();
 
-      expect(type.isChanged(new IPAddr("0.0.0.0", 32), null, "")).toBe(true);
-      expect(type.isChanged(null, new IPAddr("0.0.0.0", 32), "")).toBe(true);
-      expect(type.isChanged(new IPAddr("::", 128), null, "")).toBe(true);
-      expect(type.isChanged(null, new IPAddr("::", 128), "")).toBe(true);
+      expect(type.isChanged(new IPAddr("0.0.0.0", 32), null, "")).toBeTruthy();
+      expect(type.isChanged(null, new IPAddr("0.0.0.0", 32), "")).toBeTruthy();
+      expect(type.isChanged(new IPAddr("::", 128), null, "")).toBeTruthy();
+      expect(type.isChanged(null, new IPAddr("::", 128), "")).toBeTruthy();
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/domain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/domain.test.ts
@@ -2,8 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/domain_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { assertNotPredicate } from "@blazetrails/activesupport";
-import { BigDecimal } from "@blazetrails/activesupport";
+import { assertNotPredicate, BigDecimal } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base } from "../../index.js";

--- a/packages/activerecord/src/adapters/postgresql/domain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/domain.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/domain_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNotPredicate } from "@blazetrails/activesupport";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { fixtures } from "../../test-fixtures.js";
@@ -58,11 +59,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: assert_equal "custom_money", column.sql_type
       expect(column.sqlType).toBe("custom_money");
       // Rails: assert_not_predicate column, :array?
-      expect(column.isArray()).toBe(false);
+      assertNotPredicate(column, (c) => c.isArray());
       // Rails: type = PostgresqlDomain.type_for_attribute("price")
       const type = PostgresqlDomain.typeForAttribute("price");
       // Rails: assert_not_predicate type, :binary?
-      expect(type.isBinary()).toBe(false);
+      assertNotPredicate(type, (t) => t.isBinary());
     });
 
     it("domain acts like basetype", async () => {

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -97,8 +97,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       i.maximum_term = "P1YT2M";
       i.minimum_term = "PT10H";
       i.legacy_term = "P1DT1H";
-      expect(i.maximum_term).toBeInstanceOf(Duration);
-      expect(typeof i.legacy_term).toBe("string");
+      expect(i.maximum_term instanceof Duration).toBeTruthy();
+      expect(typeof i.legacy_term === "string").toBeTruthy();
       expect((i.maximum_term as Duration).iso8601()).toBe("P1YT2M");
       expect((i.minimum_term as Duration).iso8601()).toBe("PT10H");
       expect(i.legacy_term).toBe("P1DT1H");

--- a/packages/activerecord/src/adapters/postgresql/partitions.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/partitions.test.ts
@@ -32,7 +32,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           t.column("issued_at", "timestamp");
         },
       );
-      expect(await adapter.tableExists("partitioned_events")).toBe(true);
+      expect(await adapter.tableExists("partitioned_events")).toBeTruthy();
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNot } from "@blazetrails/activesupport";
 import "../../index.js";
 import { describeIfPg } from "./test-helper.js";
 import { Base } from "../../base.js";
@@ -42,7 +43,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("select query works even when prepared statements are disabled", async () => {
-      expect(ps(Developer.connection).preparedStatements).toBe(false);
+      assertNot(ps(Developer.connection).preparedStatements);
 
       const david = developers("david");
 

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-pool-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNot } from "@blazetrails/activesupport";
 import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { ambientPoolConfiguration } from "../test-adapter.js";
@@ -60,8 +61,8 @@ describe.skipIf(inMemoryDb())("ConnectionHandlersMultiPoolConfigTest", () => {
     // connect to default
     await (await handler.connectionPoolList("writing")[0].checkout()).connectBang();
 
-    expect(handler.isConnected("primary")).toBe(true);
-    expect(handler.isConnected("primary", { shard: "default" })).toBe(true);
-    expect(handler.isConnected("primary", { shard: "pool_config_two" })).toBe(false);
+    expect(handler.isConnected("primary")).toBeTruthy();
+    expect(handler.isConnected("primary", { shard: "default" })).toBeTruthy();
+    assertNot(handler.isConnected("primary", { shard: "pool_config_two" }));
   });
 });

--- a/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
@@ -231,7 +231,7 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
   it("url removed from hash", () => {
     const config = { default_env: { url: "postgres://localhost/foo" } };
     const actual = resolveDbConfig(DEFAULT_ENV, config);
-    expect(actual.configurationHash).not.toHaveProperty("url");
+    expect(Object.keys(actual.configurationHash)).not.toContain("url");
   });
 
   it("url with equals in query value", () => {

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -33,14 +33,8 @@ function assertLookupType(expected: string, lookup: string) {
 
 describeIfMysqlAdapter("MysqlTypeLookupTest", () => {
   it("boolean types", () => {
-    // emulate_booleans = true: tinyint(1) → boolean
     assertLookupType("boolean", "tinyint(1)");
     assertLookupType("boolean", "TINYINT(1)");
-
-    // emulate_booleans = false: tinyint(1) → integer
-    adapter.emulateBooleans = false;
-    assertLookupType("integer", "tinyint(1)");
-    assertLookupType("integer", "TINYINT(1)");
   });
 
   it("string types", () => {
@@ -65,8 +59,6 @@ describeIfMysqlAdapter("MysqlTypeLookupTest", () => {
   it("binary types", () => {
     assertLookupType("binary", "bit");
     assertLookupType("binary", "BIT");
-    assertLookupType("binary", "binary(100)");
-    assertLookupType("binary", "varbinary(255)");
   });
 
   it("integer types", () => {

--- a/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
+++ b/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
@@ -7,6 +7,7 @@
  * `loadAdapter()` because ESM adapter resolution is async.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNot } from "@blazetrails/activesupport";
 import { Base } from "../index.js";
 import type { AbstractAdapter } from "./abstract-adapter.js";
 
@@ -37,11 +38,11 @@ describe("StandaloneConnectionTest", () => {
 
   it("can throw away", async () => {
     connection.throwAwayBang();
-    expect(await connection.active()).toBe(false);
+    assertNot(await connection.active());
   });
 
   it("can close", async () => {
     await connection.close();
-    expect(await connection.active()).toBe(false);
+    assertNot(await connection.active());
   });
 });

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
+import { ArgumentError, assertSame } from "@blazetrails/activesupport";
 import { StatementPool } from "./statement-pool.js";
 import { isSqliteRun } from "../support/sqlite-template.js";
 import { checkoutRawTestAdapter } from "../test-adapter.js";
 
 describe("StatementPoolTest", () => {
   it("#delete doesn't call dealloc if the statement didn't exist", async () => {
-    const dealloced: string[] = [];
-    class TestPool extends StatementPool<string> {
-      protected dealloc(stmt: string): void {
-        dealloced.push(stmt);
+    class TestPool extends StatementPool<object> {
+      protected dealloc(stmt: object): void {
+        if (!stmt) throw new ArgumentError();
       }
     }
     const pool = new TestPool();
-    await pool.delete("nonexistent");
-    expect(dealloced).toHaveLength(0);
+    const stmt = {};
+    const sql = "SELECT 1";
+    await pool.set(sql, stmt);
+    assertSame(stmt, pool.get(sql));
+    assertSame(stmt, await pool.delete(sql));
+    expect(await pool.delete(sql)).toBeUndefined();
   });
 
   it("#delete calls dealloc when statement exists", async () => {

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { assertNot, assertNothingRaised } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import {
@@ -64,14 +65,10 @@ describe("ModulesTest", () => {
   it("assign ids", async () => {
     const firm = await MyAppBusinessFirm.first();
     const client = await MyAppBusinessClient.first();
-    let error: unknown;
-    try {
+    await assertNothingRaised(async () => {
       type WithClients = { clients: { setIds(ids: number[]): Promise<void> } };
       await (firm as unknown as WithClients).clients.setIds([client!.id as number]);
-    } catch (e) {
-      error = e;
-    }
-    expect(error).toBeUndefined();
+    });
   });
 
   it.skip("eager loading in modules", () => {
@@ -163,14 +160,8 @@ describe("ModulesTest", () => {
     Base.storeFullStiClass = true;
     try {
       const collection = await ShopCollection.first();
-      expect(await collection!.products).not.toEqual([]);
-      let error: unknown;
-      try {
-        await collection!.destroy();
-      } catch (e) {
-        error = e;
-      }
-      expect(error).toBeUndefined();
+      assertNot((await collection!.products).length === 0, "Collection should have products");
+      await assertNothingRaised(() => collection!.destroy());
     } finally {
       Base.storeFullStiClass = prev;
     }
@@ -181,14 +172,8 @@ describe("ModulesTest", () => {
     Base.storeFullStiClass = true;
     try {
       const product = await ShopProduct.first();
-      expect(await product!.variants).not.toEqual([]);
-      let error: unknown;
-      try {
-        await product!.destroy();
-      } catch (e) {
-        error = e;
-      }
-      expect(error).toBeUndefined();
+      assertNot((await product!.variants).length === 0, "Product should have variants");
+      await assertNothingRaised(() => product!.destroy());
     } finally {
       Base.storeFullStiClass = prev;
     }

--- a/packages/activerecord/src/result.test.ts
+++ b/packages/activerecord/src/result.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
+import { assert, assertNot } from "@blazetrails/activesupport";
 import { Result, type ColumnTypes } from "./result.js";
+
+// Rails asserts `assert_kind_of Integer, index`. JS numbers are primitives and
+// there is no Integer class to test with `instanceof`, so the kind check is
+// `Number.isInteger`; the Rails argument order is kept.
+function assertKindOf(klass: NumberConstructor, actual: unknown): void {
+  assert(
+    klass === Number && Number.isInteger(actual),
+    `Expected ${String(actual)} to be an Integer`,
+  );
+}
 
 function buildResult(): Result {
   return new Result(
@@ -27,8 +38,8 @@ const floatType = {
 describe("ResultTest", () => {
   it("includes_column?", () => {
     const result = buildResult();
-    expect(result.includesColumn("col_1")).toBe(true);
-    expect(result.includesColumn("foo")).toBe(false);
+    expect(result.includesColumn("col_1")).toBeTruthy();
+    assertNot(result.includesColumn("foo"));
   });
 
   it("length", () => {
@@ -84,10 +95,9 @@ describe("ResultTest", () => {
     let index = 0;
     for (const row of iter) {
       expect(Object.keys(row)).toEqual(["col_1", "col_2"]);
-      expect(Number.isInteger(index)).toBe(true);
+      assertKindOf(Number, index);
       index++;
     }
-    expect(index).toBe(3);
   });
 
   it("each without block returns a sized enumerator", () => {

--- a/packages/activerecord/src/result.test.ts
+++ b/packages/activerecord/src/result.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import { assert, assertNot } from "@blazetrails/activesupport";
 import { Result, type ColumnTypes } from "./result.js";
 
-// Rails asserts `assert_kind_of Integer, index`. JS numbers are primitives and
-// there is no Integer class to test with `instanceof`, so the kind check is
-// `Number.isInteger`; the Rails argument order is kept.
+/**
+ * Minitest's `assert_kind_of Integer, index` (result_test.rb:73). JS numbers are
+ * primitives and there is no Integer class to test with `instanceof`, so the
+ * kind check is `Number.isInteger`; Rails' argument order is kept.
+ */
 function assertKindOf(klass: NumberConstructor, actual: unknown): void {
   assert(
     klass === Number && Number.isInteger(actual),

--- a/packages/activerecord/src/statement-invalid.test.ts
+++ b/packages/activerecord/src/statement-invalid.test.ts
@@ -1,5 +1,6 @@
 import pg from "pg";
 import { describe, it, expect, beforeAll } from "vitest";
+import { assertNot, assertRaises } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { StatementInvalid } from "./errors.js";
 import { fixtures } from "./test-fixtures.js";
@@ -36,28 +37,27 @@ describe("StatementInvalidTest", () => {
   it("message contains no sql", async () => {
     const conn = Base.connection as any;
     const sql = Book.where({ author_id: 96, cover: "hard" }).toSql();
-    const error: StatementInvalid = await conn
-      .log(sql, "Book", [], [], false, () =>
+    const error = (await assertRaises([StatementInvalid], {}, () =>
+      conn.log(sql, "Book", [], [], false, () =>
         conn.withRawConnection(() => {
           throw mockDatabaseError();
         }),
-      )
-      .catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(StatementInvalid);
-    expect(error.message.includes("SELECT")).toBe(false);
+      ),
+    )) as StatementInvalid;
+    assertNot(error.message.includes("SELECT"));
   });
 
   it("statement and binds are set on select", async () => {
     const conn = Base.connection as any;
     const sql = Book.where({ author_id: 96, cover: "hard" }).toSql();
     const binds = [{}, {}];
-    const error: StatementInvalid = await conn
-      .log(sql, "Book", binds, [], false, () =>
+    const error = (await assertRaises([StatementInvalid], {}, () =>
+      conn.log(sql, "Book", binds, [], false, () =>
         conn.withRawConnection(() => {
           throw mockDatabaseError();
         }),
-      )
-      .catch((e: unknown) => e);
+      ),
+    )) as StatementInvalid;
     expect(error.sql).toEqual(sql);
     expect(error.binds).toEqual(binds);
   });

--- a/packages/activerecord/src/type.test.ts
+++ b/packages/activerecord/src/type.test.ts
@@ -38,15 +38,15 @@ describe("TypeTest", () => {
 
   it("registering a new type", () => {
     register("foo", ArgType);
-    expect(lookup("foo")).toBeInstanceOf(ArgType);
+    expect(lookup("foo")).toStrictEqual(new ArgType());
   });
 
   it("looking up a type for a specific adapter", () => {
     register("foo", ArgType, { override: false });
     register("foo", PgArgType, { adapter: "postgres" });
 
-    expect(lookup("foo", { adapter: "sqlite" })).toBeInstanceOf(ArgType);
-    expect(lookup("foo", { adapter: "postgres" })).toBeInstanceOf(PgArgType);
+    expect(lookup("foo", { adapter: "sqlite" })).toStrictEqual(new ArgType());
+    expect(lookup("foo", { adapter: "postgres" })).toStrictEqual(new PgArgType());
   });
 
   it("lookup defaults to the current adapter", () => {
@@ -54,6 +54,6 @@ describe("TypeTest", () => {
     register("foo", ArgType, { override: false });
     register("foo", PgArgType, { adapter: currentAdapter });
 
-    expect(lookup("foo")).toBeInstanceOf(PgArgType);
+    expect(lookup("foo")).toStrictEqual(new PgArgType());
   });
 });

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -26,13 +26,13 @@
       "value": 59
     },
     "activerecord": {
-      "assertionCount": 1965,
-      "kind": 4008,
+      "assertionCount": 1958,
+      "kind": 3971,
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 888,
-      "kind": 1229,
+      "assertionCount": 884,
+      "kind": 1227,
       "value": 104
     },
     "arel": {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -31,8 +31,8 @@
       "value": 39
     },
     "activesupport": {
-      "assertionCount": 884,
-      "kind": 1227,
+      "assertionCount": 888,
+      "kind": 1229,
       "value": 104
     },
     "arel": {


### PR DESCRIPTION
RFC 0105 batches `assertions-tail-adapters-3c` (20 adapter/connection-adapter files) and `assertions-tail-root-5c` (4 root files): our tests now assert what the Rails test asserts, with the same assertion kinds in the same order.

| cluster | before | after |
| ------- | -----: | ----: |
| adapters batch 3c | 30 | **0** |
| root batch 5c | 12 | **0** |

Shape of the changes, all Rails-ward:

- `assert_predicate` / `assert_not_predicate` → `assertPredicate` / `assertNotPredicate` (unsigned-type, auto-increment, mysql-enum, virtual-column, case-sensitivity, change-schema, domain).
- `assert` / `assert_not` → `toBeTruthy()` / `assertNot` (schema-migrations, partitions, cidr, standalone-connection, multi-pool-config, prepared-statements-disabled, modules, result).
- `assert_raises` → `assertRaises` (statement-invalid, mysql transaction).
- `assert_nothing_raised` → `assertNothingRaised` (modules).
- `assert_difference` / `assert_no_difference` / `assert_deprecated` → the ActiveSupport helpers, so the block-assertion stays unmapped on both sides (mysql transaction, unsigned-type).
- `assert_same` / `assert_nil` → `assertSame` / `toBeUndefined` — `statement-pool.test.ts`'s `#delete doesn't call dealloc if the statement didn't exist` was asserting something else entirely and is now a line-by-line port of `statement_pool_test.rb:19-26`.
- Trails-only extra assertions removed where Rails has none (`mysql-type-lookup` boolean/binary types, `count-deleted-rows-with-lock`, `result`'s enumerator test).
- `change-schema`'s `change type with array` now asserts `column.type == :datetime` as Rails does, rather than the raw `sql_type` (this was the one remaining assertion-VALUE mismatch once the kinds lined up).

`scripts/test-compare/assertion-mismatch-mark.json` lowered on a passing run (`parity:test:assertions:reseed`); activerecord `assertionCount` 1965→1958, `kind` 4008→3971. `pnpm parity:test` for activerecord is unchanged at 8236/8351 (98.6%), no test names changed, no new `scripts/parity/unported-files/` rows.

Local: typecheck, lint, and the sqlite-lane files pass. The PostgreSQL and MySQL lanes have no local server here; CI covers them.

Closes-story: assertions-tail-adapters-3c
Closes-story: assertions-tail-root-5c