### PR TITLE
refactor(activesupport,activemodel,activerecord): converge four one-Rails-thing/N-trails-things deviations

### DIFF
--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -66,21 +66,16 @@ describe("AttributeAssignmentTest", () => {
 
   it("assign non-existing attribute by overriding #attribute_writer_missing", () => {
     class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-      _customAttrs: Record<string, unknown> = {};
-      writeAttribute(name: string, value: unknown): void {
-        if (!(this.constructor as typeof Model)._attributeDefinitions.has(name)) {
-          this._customAttrs[name] = value;
-        } else {
-          super.writeAttribute(name, value);
-        }
+      assignedAttributes: Record<string, unknown> = {};
+      override attributeWriterMissing(name: string, value: unknown): void {
+        this.assignedAttributes[name] = value;
       }
     }
-    const p = new Person({});
-    p.assignAttributes({ unknown_field: "hello" });
-    expect(p._customAttrs["unknown_field"]).toBe("hello");
+    const model = new Person({});
+
+    model.assignAttributes({ unknown: "attribute" });
+
+    expect(model.assignedAttributes).toEqual({ unknown: "attribute" });
   });
 
   it("assign private attribute", () => {

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -1,6 +1,5 @@
 import { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
 import { UnknownAttributeError } from "./errors.js";
-import { MissingAttributeError } from "./attribute-methods.js";
 
 interface PermittedAttributes {
   permitted?: boolean | (() => boolean);
@@ -33,37 +32,68 @@ export function _assignAttributes(
   }
 }
 
-/** @internal Rails-private helper. */
+/**
+ * Mirrors: ActiveModel::AttributeAssignment#_assign_attribute
+ * (attribute_assignment.rb:67-75)
+ *
+ *   def _assign_attribute(k, v)
+ *     setter = :"#{k}="
+ *     public_send(setter, v)
+ *   rescue NoMethodError
+ *     if respond_to?(setter)
+ *       raise
+ *     else
+ *       attribute_writer_missing(k.to_s, v)
+ *     end
+ *   end
+ *
+ * There is no `write_attribute` on this path: the only write Rails makes is
+ * `public_send(setter, v)`, and a key with no setter goes straight to
+ * `attribute_writer_missing`. `findSetter` stands in for the `respond_to?`
+ * half of the send, so the rescue arm's re-raise for a setter that exists but
+ * itself raised `NoMethodError` is the one branch not modelled here — a
+ * `NoMethodError` from inside the setter propagates, which is what the
+ * re-raise arm does anyway.
+ *
+ * @internal Rails-private helper.
+ */
 export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
-  const setter = findSetter(model, k);
-  if (setter) {
-    setter.call(model, v);
+  const setter = `${k}=`;
+  // `public_send(setter, v)`. Rails' generated writer is a real method named
+  // `name=` (attributes.rb:92-102), so it is reachable by that key; a
+  // user-authored `def name=` ported as a TS `set` accessor is the same Ruby
+  // method under the spelling docs/ruby-ts-conventions.md gives it, and
+  // `findSetter` is that half of the send.
+  const own = findSetter(model, k);
+  if (own) {
+    own.call(model, v);
     return;
   }
-  try {
-    model.writeAttribute(k, v);
-  } catch (error) {
-    // Rails `_assign_attribute` only writes through a setter; a key with no
-    // setter goes straight to `attribute_writer_missing` → UnknownAttributeError.
-    // trails routes the write through `writeAttribute`, which now raises
-    // `MissingAttributeError` for an unknown name (the strict `write_from_user`
-    // path). Either way — an explicit UnknownAttributeError or a strict
-    // MissingAttributeError with no setter — surface it as Rails does.
-    if (error instanceof UnknownAttributeError || error instanceof MissingAttributeError) {
-      if (typeof model.attributeWriterMissing === "function") {
-        model.attributeWriterMissing(k, v);
-      } else {
-        attributeWriterMissing(model, k, v);
-      }
-    } else {
-      throw error;
-    }
+  const generated = (model as unknown as Record<string, unknown>)[setter];
+  if (typeof generated === "function") {
+    (generated as (this: AttributeAssignment, value: unknown) => void).call(model, v);
+    return;
   }
+  // The `rescue NoMethodError` arm. Ruby reaches it through
+  // AttributeMethods#method_missing (attribute_methods.rb:508-517), which
+  // routes a name matching an attribute-method pattern to `attribute_missing`
+  // before any NoMethodError escapes — that is how assignment still works
+  // after `undefine_attribute_methods`. TS has no `method_missing`, so the
+  // dispatch is explicit; a name with no pattern match is the
+  // `respond_to?(setter)` false arm and goes to `attribute_writer_missing`.
+  const match = model.matchedAttributeMethod?.(setter);
+  if (match && model.attributeMissing) {
+    model.attributeMissing(match, v);
+    return;
+  }
+  model.attributeWriterMissing(k, v);
 }
 
 export interface AttributeAssignment {
   writeAttribute(name: string, value: unknown): void;
-  attributeWriterMissing?(name: string, value: unknown): void;
+  attributeWriterMissing(name: string, value: unknown): void;
+  matchedAttributeMethod?(methodName: string): { proxyTarget: string; attrName: string } | null;
+  attributeMissing?(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
 }
 
 /**

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -48,22 +48,31 @@ export function _assignAttributes(
  *   end
  *
  * There is no `write_attribute` on this path: the only write Rails makes is
- * `public_send(setter, v)`, and a key with no setter goes straight to
- * `attribute_writer_missing`. `findSetter` stands in for the `respond_to?`
- * half of the send, so the rescue arm's re-raise for a setter that exists but
- * itself raised `NoMethodError` is the one branch not modelled here — a
- * `NoMethodError` from inside the setter propagates, which is what the
- * re-raise arm does anyway.
+ * `public_send(setter, v)`.
+ *
+ * That send takes two spellings here because one Ruby method name reaches TS
+ * two ways. Rails' generated writer is a real method named `name=`
+ * (attributes.rb:92-102) and is reachable by that key; a user-authored
+ * `def name=` ported as a TS `set` accessor is the same Ruby method under the
+ * spelling docs/ruby-ts-conventions.md gives it, which `findSetter` resolves.
+ * The accessor is tried first because Ruby finds a class's own `name=` before
+ * the generated methods module's.
+ *
+ * Ruby reaches the `rescue NoMethodError` arm through
+ * AttributeMethods#method_missing (attribute_methods.rb:508-517), which routes
+ * a name matching an attribute-method pattern to `attribute_missing` before any
+ * NoMethodError escapes — that is how assignment still works after
+ * `undefine_attribute_methods`. TS has no `method_missing`, so that dispatch is
+ * explicit; a name with no pattern match is the `respond_to?(setter)` false arm
+ * and goes to `attribute_writer_missing`. The remaining arm — the setter exists
+ * and itself raised NoMethodError, so Rails re-raises at :70-71 — is tracked by
+ * `ar-assign-attribute-bypasses-attribute-writer-missing`; such an error
+ * propagates out of the send above, which is what the re-raise does.
  *
  * @internal Rails-private helper.
  */
 export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
   const setter = `${k}=`;
-  // `public_send(setter, v)`. Rails' generated writer is a real method named
-  // `name=` (attributes.rb:92-102), so it is reachable by that key; a
-  // user-authored `def name=` ported as a TS `set` accessor is the same Ruby
-  // method under the spelling docs/ruby-ts-conventions.md gives it, and
-  // `findSetter` is that half of the send.
   const own = findSetter(model, k);
   if (own) {
     own.call(model, v);
@@ -74,15 +83,8 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
     (generated as (this: AttributeAssignment, value: unknown) => void).call(model, v);
     return;
   }
-  // The `rescue NoMethodError` arm. Ruby reaches it through
-  // AttributeMethods#method_missing (attribute_methods.rb:508-517), which
-  // routes a name matching an attribute-method pattern to `attribute_missing`
-  // before any NoMethodError escapes — that is how assignment still works
-  // after `undefine_attribute_methods`. TS has no `method_missing`, so the
-  // dispatch is explicit; a name with no pattern match is the
-  // `respond_to?(setter)` false arm and goes to `attribute_writer_missing`.
-  const match = model.matchedAttributeMethod?.(setter);
-  if (match && model.attributeMissing) {
+  const match = model.matchedAttributeMethod(setter);
+  if (match) {
     model.attributeMissing(match, v);
     return;
   }
@@ -92,8 +94,8 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
 export interface AttributeAssignment {
   writeAttribute(name: string, value: unknown): void;
   attributeWriterMissing(name: string, value: unknown): void;
-  matchedAttributeMethod?(methodName: string): { proxyTarget: string; attrName: string } | null;
-  attributeMissing?(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
+  matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
+  attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
 }
 
 /**

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -66,8 +66,11 @@ export function _assignAttributes(
  * explicit; a name with no pattern match is the `respond_to?(setter)` false arm
  * and goes to `attribute_writer_missing`. The remaining arm — the setter exists
  * and itself raised NoMethodError, so Rails re-raises at :70-71 — is tracked by
- * `ar-assign-attribute-bypasses-attribute-writer-missing`; such an error
- * propagates out of the send above, which is what the re-raise does.
+ * `assign-attribute-respond-to-setter-reraise-arm`. Resolving the setter before
+ * dispatching means there is no rescue to re-enter: a NoMethodError from inside
+ * a setter propagates out of the send above, which is what the re-raise does,
+ * but Ruby's `respond_to?` consults the receiver's full method table where the
+ * ladder above consults only what it can resolve.
  *
  * @internal Rails-private helper.
  */

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -91,6 +91,7 @@ import {
   attributeMethodPatterns,
   isAttributeMethodPatterns,
   isRespondToWithoutAttributes,
+  type InstanceHost,
 } from "./attribute-methods.js";
 import {
   _assignAttribute as attrAssignOne,
@@ -1809,7 +1810,7 @@ export class Model {
    * @internal Rails-private helper.
    */
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null {
-    return _matchedAttributeMethod.call(this as never, methodName);
+    return _matchedAttributeMethod.call(this as unknown as InstanceHost, methodName);
   }
 
   /** Mirrors: ActiveModel::Attributes `alias :attribute= :_write_attribute` (attributes.rb:159). */

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -111,7 +111,12 @@ import { FormatValidator } from "./validations/format.js";
 import { AcceptanceValidator } from "./validations/acceptance.js";
 import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
-import { type AttributeDefinition, attribute, setDefineMethodAttribute } from "./attributes.js";
+import {
+  type AttributeDefinition,
+  attribute,
+  matchedAttributeMethod as _matchedAttributeMethod,
+  setDefineMethodAttribute,
+} from "./attributes.js";
 import {
   _defaultAttributes,
   attributeTypes,
@@ -1794,6 +1799,22 @@ export class Model {
    */
   attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown {
     return attributeMissing.call(this as Record<string, unknown>, match, ...args);
+  }
+
+  /**
+   * Mirrors: ActiveModel::AttributeMethods#matched_attribute_method
+   * (attribute_methods.rb:530-533) — the pattern lookup `method_missing` uses
+   * to recognize an attribute method that has not been generated.
+   *
+   * @internal Rails-private helper.
+   */
+  matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null {
+    return _matchedAttributeMethod.call(this as never, methodName);
+  }
+
+  /** Mirrors: ActiveModel::Attributes `alias :attribute= :_write_attribute` (attributes.rb:159). */
+  "attribute="(name: string, value: unknown): void {
+    this._writeAttribute(name, value);
   }
 
   writeAttribute(name: string, value: unknown): void {

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -224,13 +224,6 @@ describe("DateTimeType#isChanged", () => {
     expect(t.isChanged(a, b)).toBe(false);
   });
 
-  it("instants differing only in sub-microsecond nanoseconds are unchanged (precision=null defaults 6)", () => {
-    const t = new Types.DateTimeType();
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1); // 1_000_000ns = 1000μs exactly
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 999n); // 1000μs + 999ns (same μs bucket)
-    expect(t.isChanged(a, b)).toBe(false);
-  });
-
   it("instants differing by one full microsecond are changed (precision=null)", () => {
     const t = new Types.DateTimeType();
     const a = Temporal.Instant.fromEpochNanoseconds(MS1);

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -231,26 +231,11 @@ describe("DateTimeType#isChanged", () => {
     expect(t.isChanged(a, b)).toBe(true);
   });
 
-  it("instants differing only in sub-millisecond are unchanged (precision=3)", () => {
-    const t = new Types.DateTimeType({ precision: 3 });
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1); // exactly 1ms
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 999_000n); // 1ms + 999μs (same ms bucket)
-    expect(t.isChanged(a, b)).toBe(false);
-  });
-
   it("instants differing by one full millisecond are changed (precision=3)", () => {
     const t = new Types.DateTimeType({ precision: 3 });
     const a = Temporal.Instant.fromEpochNanoseconds(MS1);
     const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n); // next ms bucket
     expect(t.isChanged(a, b)).toBe(true);
-  });
-
-  it("instants differing only in sub-second are unchanged (precision=0)", () => {
-    const t = new Types.DateTimeType({ precision: 0 });
-    // Use 1s boundary + 999ms — both in the same second bucket
-    const a = Temporal.Instant.fromEpochNanoseconds(1_000_000_000n);
-    const b = Temporal.Instant.fromEpochNanoseconds(1_000_000_000n + 999_999_999n);
-    expect(t.isChanged(a, b)).toBe(false);
   });
 
   it("instants differing by one full nanosecond are changed (precision=9)", () => {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -243,7 +243,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return this.serializeCastValue(this.cast(value));
   }
 
-  // Mirrors ActiveModel::Type::Helpers::TimeValue#serialize_cast_value (apply_seconds_precision).
+  /**
+   * Mirrors: ActiveModel::Type::Helpers::TimeValue#serialize_cast_value
+   * (time_value.rb:10-21) — its `apply_seconds_precision` half. The `is_utc?`
+   * `getutc`/`getlocal` arm (`:12-19`) is not ported; that gap is tracked by
+   * `serialize-cast-value-drops-is-utc-normalization`.
+   */
   serializeCastValue(value: DateTimeCastResult | null): DateTimeCastResult | null {
     return this.applySecondsPrecision(value);
   }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -220,13 +220,11 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * Mirrors: ActiveModel::Type::Value#changed? (value.rb:84-86) — `old_value !=
    * new_value`. Ruby's `!=` on a `::Time` is value equality; `!==` on a
    * `Temporal.Instant` is reference identity, so the receiver's own `equals`
-   * stands in for it. Ruby compares values the attribute pipeline has already
-   * cast, so `apply_seconds_precision` (time_value.rb:24-34) has run on both;
-   * running it here keeps that true for a caller handing over raw instants.
+   * stands in for it.
    */
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     if (oldValue instanceof Temporal.Instant && newValue instanceof Temporal.Instant) {
-      return !this.applySecondsPrecision(oldValue).equals(this.applySecondsPrecision(newValue));
+      return !oldValue.equals(newValue);
     }
     return oldValue !== newValue;
   }

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -13,13 +13,16 @@ import { toS } from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
-import { fastStringToTime, newTime } from "./helpers/time-value.js";
+import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
 
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
+
+  /** Mixed in from Helpers::TimeValue (time_value.rb:24-34). @internal Rails-private helper. */
+  protected applySecondsPrecision = applySecondsPrecision;
 
   /** Mixed in from Helpers::TimeValue (time_value.rb:79-89). @internal Rails-private helper. */
   protected fastStringToTime = fastStringToTime;
@@ -214,49 +217,18 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   }
 
   /**
-   * Mirrors: Helpers::TimeValue#apply_seconds_precision (time_value.rb:24-34).
-   * `return value unless precision && value.respond_to?(:nsec)` — `Instant` is
-   * the receiver carrying nanoseconds here; everything else passes through.
+   * Mirrors: ActiveModel::Type::Value#changed? (value.rb:84-86) — `old_value !=
+   * new_value`. Ruby's `!=` on a `::Time` is value equality; `!==` on a
+   * `Temporal.Instant` is reference identity, so the receiver's own `equals`
+   * stands in for it. Ruby compares values the attribute pipeline has already
+   * cast, so `apply_seconds_precision` (time_value.rb:24-34) has run on both;
+   * running it here keeps that true for a caller handing over raw instants.
    */
-  private applySecondsPrecision<T>(value: T): T {
-    if (
-      this.precision == null ||
-      !Number.isInteger(this.precision) ||
-      this.precision < 0 ||
-      this.precision > 9 ||
-      !(value instanceof Temporal.Instant)
-    )
-      return value;
-    const mod = 10n ** BigInt(9 - this.precision);
-    let subsec = value.epochNanoseconds % 1_000_000_000n;
-    if (subsec < 0n) subsec += 1_000_000_000n;
-    const roundedOff = subsec % mod;
-    if (roundedOff === 0n) return value;
-    return Temporal.Instant.fromEpochNanoseconds(value.epochNanoseconds - roundedOff) as T;
-  }
-
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     if (oldValue instanceof Temporal.Instant && newValue instanceof Temporal.Instant) {
-      return (
-        this._nsAtPrecision(oldValue.epochNanoseconds) !==
-        this._nsAtPrecision(newValue.epochNanoseconds)
-      );
+      return !this.applySecondsPrecision(oldValue).equals(this.applySecondsPrecision(newValue));
     }
     return oldValue !== newValue;
-  }
-
-  // Truncate epoch nanoseconds to column precision, matching applySecondsPrecision /
-  // Temporal.toString() floor-style sub-second truncation. Used by isChanged so that
-  // sub-precision nanosecond noise from Temporal.Now (when precision=null) doesn't
-  // produce spurious dirty marks after serialize → cast round-trips.
-  private _nsAtPrecision(ns: bigint): bigint {
-    const raw = this.precision ?? 6;
-    const p = Number.isInteger(raw) && raw >= 0 && raw <= 9 ? raw : 6;
-    const mod = 10n ** BigInt(9 - p);
-    let subsec = ns % 1_000_000_000n;
-    if (subsec < 0n) subsec += 1_000_000_000n;
-    const roundedOff = subsec % mod;
-    return ns - roundedOff;
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -7,6 +7,8 @@ import {
   newTime,
   userInputInTimeZone,
 } from "./time-value.js";
+import { DateTimeType } from "../date-time.js";
+import { TimeType } from "../time.js";
 
 // Mirrors ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
 // (time_value.rb:24-34). Truncation, not rounding — verify each
@@ -129,6 +131,20 @@ describe("fastStringToTime", () => {
   it("normalizes Postgres short offset (+00) to (+00:00)", () => {
     const i = fastStringToTime("2026-04-26 14:23:55.123456+00");
     expect(i?.toString().startsWith("2026-04-26T14:23:55.123456")).toBe(true);
+  });
+
+  // `value.change(nsec: value.nsec - rounded_off_nsec)` (time_value.rb:31)
+  // operates on `nsec`, which is always in `0...1_000_000_000`, so a pre-1970
+  // instant truncates DOWN the same way a post-1970 one does. `Type::Time` and
+  // `Type::DateTime` both `include Helpers::TimeValue` (time.rb, date_time.rb:47)
+  // and so must agree.
+  it("truncates a pre-1970 sub-second instant on nsec, not toward zero", () => {
+    const inst = Temporal.Instant.from("1969-12-31T23:59:59.123456789Z");
+    const time = new TimeType({ precision: 3 });
+    const dateTime = new DateTimeType({ precision: 3 });
+
+    expect(String(time.serializeCastValue(inst))).toBe("1969-12-31T23:59:59.123Z");
+    expect(String(dateTime.serializeCastValue(inst))).toBe("1969-12-31T23:59:59.123Z");
   });
 });
 

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -50,14 +50,16 @@ const NANOS_PER_SECOND = 1_000_000_000n;
  *       value
  *     end
  *   end
+ *
+ * Ruby needs no guard past `precision` itself: for precision > 9,
+ * `10 ** (9 - precision)` is a Rational, `nsec % (1/10)` is `(0/1)`, and the
+ * `> 0` arm is false, so the value comes back unchanged (verified against
+ * MRI). BigInt exponentiation throws on a negative exponent instead, so the
+ * same answer is reached by an explicit early return.
  */
 export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {
   const precision = this.precision;
   if (precision == null || !respondToNsec(value)) return value;
-  // Rails' guard only covers nil precision. This additional pass-through for
-  // an invalid numeric precision is trails-specific: `10 ** (9 - precision)`
-  // is a Rational in Ruby for precision > 9 and stays exact, where BigInt
-  // exponentiation throws on a negative exponent.
   if (!Number.isInteger(precision) || precision < 0 || precision > 9) return value;
   const numberOfInsignificantDigits = 9 - precision;
   const roundPower = 10n ** BigInt(numberOfInsignificantDigits);

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -20,13 +20,20 @@ export interface TimeValue {
   applySecondsPrecision<T>(this: TimeValue, value: T): T;
 }
 
-type Roundable<T> = {
-  round: (options: {
-    smallestUnit: "second" | "millisecond" | "microsecond" | "nanosecond";
-    roundingIncrement?: number;
-    roundingMode: "trunc";
-  }) => T;
-};
+/**
+ * Ruby's `apply_seconds_precision` reads `value.nsec` and `value.change(nsec:)`
+ * off the receiver, which is a `::Time`. The port's time receivers are the
+ * Temporal types that carry sub-second fields, so `nsec` and `changeNsec` are
+ * module-private dispatchers over exactly those — everything else is the
+ * `respond_to?(:nsec)` else arm and passes through.
+ */
+type NsecBearing =
+  | Temporal.Instant
+  | Temporal.PlainDateTime
+  | Temporal.ZonedDateTime
+  | Temporal.PlainTime;
+
+const NANOS_PER_SECOND = 1_000_000_000n;
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::TimeValue#apply_seconds_precision
@@ -43,53 +50,23 @@ type Roundable<T> = {
  *       value
  *     end
  *   end
- *
- * Truncates sub-second precision on Temporal types that expose a
- * `round({ smallestUnit, roundingIncrement, roundingMode })` method —
- * Instant, PlainDateTime, PlainTime, and ZonedDateTime. Values without
- * sub-second resolution (PlainDate, primitives) lack `.round` and pass
- * through unchanged.
  */
 export function applySecondsPrecision<T>(this: { precision?: number }, value: T): T {
   const precision = this.precision;
-  if (precision === undefined || precision === null) return value;
-  // Rails' guard only covers nil/falsey precision (and values that do
-  // not respond to `nsec`). This additional pass-through for invalid
-  // numeric precision is trails-specific and preserves the current
-  // behavior instead of coercing to a default — Temporal#round would
-  // otherwise reject a non-integer or out-of-range roundingIncrement.
+  if (precision == null || !respondToNsec(value)) return value;
+  // Rails' guard only covers nil precision. This additional pass-through for
+  // an invalid numeric precision is trails-specific: `10 ** (9 - precision)`
+  // is a Rational in Ruby for precision > 9 and stays exact, where BigInt
+  // exponentiation throws on a negative exponent.
   if (!Number.isInteger(precision) || precision < 0 || precision > 9) return value;
-  if (value === null || value === undefined) return value;
-  // Temporal types (Instant, PlainDateTime, PlainTime, ZonedDateTime)
-  // expose a `round` method that accepts `roundingIncrement` and
-  // `roundingMode: "trunc"`, which together match Rails' "drop the
-  // insignificant trailing nanos" semantics. Values without `.round`
-  // (PlainDate, primitives) lack sub-second resolution and pass
-  // through unchanged.
-  const roundable = value as unknown as Partial<Roundable<T>>;
-  if (typeof roundable.round !== "function") return value;
-  if (precision >= 9) return value;
-  const opts =
-    precision <= 0
-      ? { smallestUnit: "second" as const, roundingMode: "trunc" as const }
-      : precision <= 3
-        ? {
-            smallestUnit: "millisecond" as const,
-            roundingIncrement: 10 ** (3 - precision),
-            roundingMode: "trunc" as const,
-          }
-        : precision <= 6
-          ? {
-              smallestUnit: "microsecond" as const,
-              roundingIncrement: 10 ** (6 - precision),
-              roundingMode: "trunc" as const,
-            }
-          : {
-              smallestUnit: "nanosecond" as const,
-              roundingIncrement: 10 ** (9 - precision),
-              roundingMode: "trunc" as const,
-            };
-  return (roundable as Roundable<T>).round(opts);
+  const numberOfInsignificantDigits = 9 - precision;
+  const roundPower = 10n ** BigInt(numberOfInsignificantDigits);
+  const roundedOffNsec = nsec(value) % roundPower;
+  if (roundedOffNsec > 0n) {
+    return changeNsec(value, nsec(value) - roundedOffNsec) as T;
+  } else {
+    return value;
+  }
 }
 
 /**
@@ -265,6 +242,41 @@ export function fastStringToTime(this: TimezoneAware | void, s: string): Tempora
   } catch {
     return null;
   }
+}
+
+function respondToNsec(value: unknown): value is NsecBearing {
+  return (
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.ZonedDateTime ||
+    value instanceof Temporal.PlainTime
+  );
+}
+
+/** `Time#nsec` — the fraction of the second, always in `0...1_000_000_000`. */
+function nsec(value: NsecBearing): bigint {
+  if (value instanceof Temporal.Instant) {
+    return ((value.epochNanoseconds % NANOS_PER_SECOND) + NANOS_PER_SECOND) % NANOS_PER_SECOND;
+  }
+  return (
+    BigInt(value.millisecond) * 1_000_000n +
+    BigInt(value.microsecond) * 1_000n +
+    BigInt(value.nanosecond)
+  );
+}
+
+/** `Time#change(nsec:)` — replaces the sub-second fraction, leaving the second. */
+function changeNsec<T extends NsecBearing>(value: T, newNsec: bigint): T {
+  if (value instanceof Temporal.Instant) {
+    return Temporal.Instant.fromEpochNanoseconds(
+      value.epochNanoseconds - nsec(value) + newNsec,
+    ) as T;
+  }
+  return value.with({
+    millisecond: Number(newNsec / 1_000_000n),
+    microsecond: Number((newNsec / 1_000n) % 1_000n),
+    nanosecond: Number(newNsec % 1_000n),
+  }) as T;
 }
 
 export function serializeTimeValue(value: unknown): string | null {

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -34,7 +34,6 @@ import { Member } from "./test-helpers/models/member.js";
 import { Membership } from "./test-helpers/models/membership.js";
 import { Human } from "./test-helpers/models/human.js";
 import { Interest } from "./test-helpers/models/interest.js";
-import { scope as hasManyScope } from "./associations/has-many-association.js";
 import "./test-helpers/models/ship.js";
 import "./test-helpers/models/bird.js";
 import "./test-helpers/models/treasure.js";
@@ -2431,85 +2430,6 @@ describe("AssociationsTest", () => {
       expect(agreements).toHaveLength(2);
       expect(agreements.map((a) => (a as any).signature).sort()).toEqual(["abc", "def"]);
     });
-  });
-
-  // Exercises loadHasMany's inline (no-reflection) fallback for a POLYMORPHIC
-  // (`as`) association on a query_constraints owner. The owner key must resolve
-  // to the owner's query_constraints list (`[blog_id, id]`, mirroring
-  // `reflection.activeRecordPrimaryKey`) and the scalar `parent_id` FK must
-  // widen to the composite `[blog_id, parent_id]` (mirroring
-  // `deriveFkQueryConstraints`) so a same-`parent_id` row in a DIFFERENT shard
-  // is excluded — rather than keying on the scalar `id` alone, which would
-  // wrongly include it.
-  it("has many loads via inline fallback resolving polymorphic owner key from query constraints", async () => {
-    const post = await ShardedBlogPost.create({ blog_id: 1, title: "Parent" });
-    const pid = (post as any).id;
-    await ShardedBlogPost.create({
-      blog_id: 1,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "match",
-    });
-    await ShardedBlogPost.create({
-      blog_id: 2,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "wrongShard",
-    });
-    const children = await findHasManyTarget(post, "freshChildren", {
-      className: "ShardedBlogPost",
-      as: "parent",
-    });
-    expect(children.map((c) => (c as any).title)).toEqual(["match"]);
-  });
-
-  // The `scope()` seam (the relation behind CollectionProxy / `.toSql()` /
-  // counts, and the one `findTarget` runs) must apply the
-  // same query_constraints widening: a polymorphic `as` scope on a
-  // query_constraints owner keys on the composite `[blog_id, parent_id]` so a
-  // cross-shard same-`parent_id` row is excluded from the relation itself,
-  // not only from the AssociationScope load path.
-  it("has many builds polymorphic relation keyed on owner query constraints", async () => {
-    const post = await ShardedBlogPost.create({ blog_id: 1, title: "Parent" });
-    const pid = (post as any).id;
-    await ShardedBlogPost.create({
-      blog_id: 1,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "match",
-    });
-    await ShardedBlogPost.create({
-      blog_id: 2,
-      parent_id: pid,
-      parent_type: "ShardedBlogPost",
-      title: "wrongShard",
-    });
-    const rel = hasManyScope(post, "freshChildren", {
-      type: "hasMany",
-      name: "freshChildren",
-      options: { className: "ShardedBlogPost", as: "parent" },
-    });
-    const rows: Base[] = await rel!.toArray();
-    expect(rows.map((r) => (r as any).title)).toEqual(["match"]);
-  });
-
-  // The inline (no-reflection) polymorphic fallback mirrors
-  // `deriveFkQueryConstraints` faithfully — including its ArgumentError raise
-  // for an underivable query_constraints shape. A >2-attribute list
-  // (`[blog_id, revision, id]` on `ShardedBlogPostWithRevision`) cannot be
-  // derived, so the inline path must raise rather than silently scalar-keying.
-  it("has many inline polymorphic fallback raises for underivable query constraints", async () => {
-    const post = await ShardedBlogPostWithRevision.create({
-      blog_id: 1,
-      revision: 1,
-      title: "Parent",
-    });
-    await expect(
-      findHasManyTarget(post, "freshChildren", {
-        className: "ShardedBlogPostWithRevision",
-        as: "parent",
-      }),
-    ).rejects.toThrow(ArgumentError);
   });
 
   it("delete single composite has many through join row", async () => {

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -499,46 +499,6 @@ describe("AssociationScope", () => {
     expect(sql).toMatch(/LIMIT\s+1/);
   });
 
-  it("loadHasMany rejects composite primary key with :as polymorphic", async () => {
-    // A composite owner PK without an "id" component cannot collapse to a
-    // scalar <as>_id value — reject with CompositePrimaryKeyMismatchError.
-    // (When the CPK includes "id", it collapses to "id" matching Rails'
-    // join_id_for; only the no-id case is unrepresentable.)
-    const { CompositePrimaryKeyMismatchError } = await import("../index.js");
-    const { findCollectionTarget: findTarget } =
-      await import("../test-helpers/find-collection-target.js");
-    class CpkAsOwner extends Base {
-      declare a: number | null;
-      declare b: number | null;
-
-      static {
-        this.attribute("a", "integer");
-        this.attribute("b", "integer");
-        this.primaryKey = ["a", "b"];
-      }
-    }
-    class CpkAsTarget extends Base {
-      declare commentable_id: number | null;
-      declare commentable_type: string | null;
-
-      static {
-        this.attribute("commentable_id", "integer");
-        this.attribute("commentable_type", "string");
-      }
-    }
-    registerModel(CpkAsOwner);
-    registerModel(CpkAsTarget);
-    // No reader form: `CpkAsOwner` declares no `comments` association — the
-    // rejected `as:`/CPK combination is passed straight to the loader.
-    const owner = new CpkAsOwner({ a: 1, b: 2 });
-    await expect(
-      findTarget(owner, "comments", {
-        className: "CpkAsTarget",
-        as: "commentable",
-      }),
-    ).rejects.toThrow(CompositePrimaryKeyMismatchError);
-  });
-
   it("addConstraints routes a composite-PK mismatch through checkValidityBang", async () => {
     // The scope-building bypass path (AssociationScope.scope → addConstraints)
     // never constructs an Association, so it doesn't reach the canonical

--- a/packages/activerecord/src/associations/foreign-association.ts
+++ b/packages/activerecord/src/associations/foreign-association.ts
@@ -23,28 +23,15 @@ export function ownerForeignKeyColumns(
   if (typeof fk === "string") return [fk];
   if (Array.isArray(fk)) return fk;
 
-  const reflectionFk = ownerReflectionForeignKey(ctor, assocName);
-  if (typeof reflectionFk === "string") return [reflectionFk];
-  if (Array.isArray(reflectionFk)) return reflectionFk;
-
-  throw new NoMethodError(`undefined method 'foreign_key' for nil`);
-}
-
-/**
- * Mirrors `reflection.foreign_key`, answering `undefined` when the association
- * has no registered reflection — a state Rails cannot be in.
- *
- * @internal
- */
-export function ownerReflectionForeignKey(
-  ctor: typeof Base,
-  assocName: string,
-): string | string[] | undefined {
-  return (
+  const reflectionFk = (
     ctor as unknown as {
       _reflectOnAssociation?: (n: string) => { foreignKey?: string | string[] } | undefined;
     }
   )._reflectOnAssociation?.(assocName)?.foreignKey;
+  if (typeof reflectionFk === "string") return [reflectionFk];
+  if (Array.isArray(reflectionFk)) return reflectionFk;
+
+  throw new NoMethodError(`undefined method 'foreign_key' for nil`);
 }
 
 /**

--- a/packages/activerecord/src/associations/foreign-association.ts
+++ b/packages/activerecord/src/associations/foreign-association.ts
@@ -1,25 +1,23 @@
-import { underscore } from "@blazetrails/activesupport";
+import { NoMethodError } from "@blazetrails/activemodel";
 
 import type { AssociationReflection } from "../reflection.js";
 import type { Base } from "../base.js";
 
 /**
- * Mirrors `reflection.foreign_key` (reflection.rb `compute_foreign_key`),
- * keyed on `reflection.active_record` — the class that *declared* the
- * association. The rungs below the reflection serve trails' inline
- * (unregistered) association fallbacks, which have no Rails counterpart.
+ * Mirrors `options[:foreign_key] || reflection.foreign_key` — the two rungs
+ * Rails has, the second being `compute_foreign_key` (reflection.rb) keyed on
+ * `reflection.active_record`, the class that *declared* the association.
+ *
+ * In Rails an association always has a registered reflection, so
+ * `reflection.foreign_key` has nothing to fall through to; reaching the third
+ * rung here means the receiver is `nil`, which is Ruby's NoMethodError.
  *
  * @internal
  */
 export function ownerForeignKeyColumns(
   ctor: typeof Base,
   assocName: string,
-  options: {
-    foreignKey?: string | string[];
-    as?: string;
-    primaryKey?: string | string[];
-    queryConstraints?: string[];
-  },
+  options: { foreignKey?: string | string[] },
 ): string[] {
   const fk = options.foreignKey;
   if (typeof fk === "string") return [fk];
@@ -29,17 +27,12 @@ export function ownerForeignKeyColumns(
   if (typeof reflectionFk === "string") return [reflectionFk];
   if (Array.isArray(reflectionFk)) return reflectionFk;
 
-  if (options.as) return [`${underscore(options.as)}_id`];
-  if (options.queryConstraints) return options.queryConstraints;
-
-  const pk = options.primaryKey ?? ctor.primaryKey ?? "id";
-  if (Array.isArray(pk)) return pk.map((col) => `${underscore(ctor.name)}_${col}`);
-  return [`${underscore(ctor.name)}_id`];
+  throw new NoMethodError(`undefined method 'foreign_key' for nil`);
 }
 
 /**
- * Mirrors `reflection.foreign_key`, returning `undefined` for an unregistered
- * association so `ownerForeignKeyColumns` falls through to its inline rungs.
+ * Mirrors `reflection.foreign_key`, answering `undefined` when the association
+ * has no registered reflection — a state Rails cannot be in.
  *
  * @internal
  */

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -702,7 +702,7 @@ export function scope(
 
   const targetModel = resolveAssocClass(record, assocName, className);
 
-  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
+  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, options);
   const foreignKey: string | string[] =
     foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;
 

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -479,7 +479,7 @@ function _validateHasOnePolymorphicKeys(
   if (!options.as) return;
   const ctor = record.constructor as typeof Base;
   const primaryKey = options.primaryKey ?? ctor.primaryKey;
-  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, { ...options, primaryKey });
+  const foreignKeyColumns = ownerForeignKeyColumns(ctor, assocName, options);
   const foreignKey: string | string[] =
     foreignKeyColumns.length === 1 ? foreignKeyColumns[0] : foreignKeyColumns;
   if (!Array.isArray(foreignKey) && !(Array.isArray(primaryKey) && !primaryKey.includes("id"))) {

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -18,22 +18,8 @@ import { Duration } from "../../duration.js";
 import { IsolatedExecutionState } from "../../isolated-execution-state.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { ArgumentError, zone as timeZone } from "../../time-zone-config.js";
+import { DAYS_INTO_WEEK } from "../date-and-time/calculations.js";
 import { inTimeZone } from "../date-and-time/zones.js";
-
-/**
- * Mirrors: `DateAndTime::Calculations::DAYS_INTO_WEEK`
- * (`core_ext/date_and_time/calculations.rb:8-16`) — the week-start day names
- * `Date.beginning_of_week=` validates against.
- */
-const DAYS_INTO_WEEK: Record<string, number> = {
-  sunday: 0,
-  monday: 1,
-  tuesday: 2,
-  wednesday: 3,
-  thursday: 4,
-  friday: 5,
-  saturday: 6,
-};
 
 const BEGINNING_OF_WEEK = "beginning_of_week";
 


### PR DESCRIPTION
Four RFC 0112 stories, each a Rails construct that trails had spelled more than once.

## `DAYS_INTO_WEEK` (days-into-week-duplicated-in-date-calculations)

`Date` includes `DateAndTime::Calculations` (`date_and_time/calculations.rb:8-16`), so `Date.find_beginning_of_week!` (`date/calculations.rb:32-35`) resolves one constant through the ancestors. `core-ext/date/calculations.ts` now imports the mixin's constant and its private copy is gone.

The import does close an ESM cycle — the mixin namespace-imports the `Date` arm — but neither module reads the other during evaluation, so it is inert. Verified with a plain-node import of the built `dist/**.js` modules as entry modules, both orders (date-first OK, mixin-first OK). No slot module needed.

## `apply_seconds_precision` (converge-date-time-apply-seconds-precision-onto-time-value-mixin)

`date_time.rb:47` is `include Helpers::TimeValue`, so `DateTime#apply_seconds_precision` **is** `time_value.rb:24-34` — the same method `Type::Time` gets. `DateTimeType` now mixes in `helpers/time-value.ts`'s function the settled way (as `type/time.ts:26` already did) and its private duplicate is deleted.

The two were not equivalent, which is the reason a previous PR did not simply swap them: the helper truncated via Temporal's `roundingMode: "trunc"` (toward zero), while Ruby's `value.change(nsec: value.nsec - rounded_off_nsec)` operates on `nsec`, which is always in `0...1_000_000_000` — it floors. They disagreed for pre-1970 instants with sub-second precision, and **the helper was the wrong side**. It now does the `nsec` arithmetic the Ruby does, with `nsec` / `changeNsec` as module-private dispatchers over the Temporal types that carry sub-second fields (Ruby resolves both off the `::Time` receiver). A test pins `1969-12-31T23:59:59.123456789Z` at precision 3 through both `Type::Time` and `Type::DateTime`.

`_nsAtPrecision` — a third spelling of the same truncation, with a default of 6 when `precision` was nil and no Rails counterpart — is deleted. `isChanged` is now plainly `old_value != new_value` (`value.rb:84-86`): `!==` on a `Temporal.Instant` is reference identity, so the receiver's `equals` stands in for Ruby's value-comparing `!=` on a `::Time`. Nothing truncates there, because Ruby compares values the attribute pipeline has already cast. `pnpm parity:api:extra --package activemodel` loses the `_nsAtPrecision` row.

The three trails-authored tests that fed `isChanged` raw, uncast instants and pinned per-precision bucketing are removed with the code they pinned.

The guard for `precision > 9` is no longer described as a deviation: MRI takes the same path — `10 ** (9 - precision)` is a Rational, `nsec % (1/10)` is `(0/1)`, and the `> 0` arm is false, so the value comes back unchanged. Only BigInt's throw on a negative exponent forces the explicit early return.

## `_assign_attribute` (activemodel-assign-attribute-still-writes-through-write-attribute)

`attribute_assignment.rb:67-75` makes **no** `write_attribute` call; the only write is `public_send(setter, v)`. The ActiveModel copy was writing through `writeAttribute` in a `try` and then inspecting the thrown error class to decide whether the key had a setter. It now sends the setter and, failing that, calls `attribute_writer_missing`.

Ruby reaches the rescue arm through `AttributeMethods#method_missing` (`attribute_methods.rb:508-517`), which routes a name matching an attribute-method pattern to `attribute_missing` before any `NoMethodError` escapes — that is why assignment still works after `undefine_attribute_methods`, and it is what the removed `writeAttribute` fallback was accidentally standing in for. TS has no `method_missing`, so the dispatch is explicit, and `Model` gains the two members it needs to make it: `matched_attribute_method` (`attribute_methods.rb:530-533`) and `alias :attribute= :_write_attribute` (`attributes.rb:159`).

`attributeWriterMissing` is now required on `AttributeAssignment` (as PR #6216 did to `AttributeIO`), so the `typeof … === "function"` guard and its unreachable `else` are gone.

The Rails test `assign non-existing attribute by overriding #attribute_writer_missing` now overrides `attribute_writer_missing`, as the Ruby test does (`attribute_assignment_test.rb:89-100`); it had been overriding `writeAttribute`, which only worked because of the divergence being removed.

## `ownerForeignKeyColumns` (owner-fk-inline-fallback-rungs-have-no-rails-counterpart)

Everything below `options[:foreign_key] || reflection.foreign_key` was a trails invention: in Rails an association always has a registered reflection, so `reflection.foreign_key` has nothing to fall through to.

Per the story's first acceptance criterion, I instrumented the third rung with a raise and ran the whole `associations` suite plus `associations.test.ts`. Exactly four tests reached it, all trails-authored, all constructing an association name their model never declares (`ShardedBlogPost.freshChildren`; `CpkAsOwner.comments`, whose own comment says "declares no `comments` association"). No ported path reaches it. The rungs and those four tests are removed together, and the third rung is now the `NoMethodError` Ruby raises on a nil receiver. The 107 association test files pass (2166 tests).

## Not in this PR

`strict-loading-check-in-reader-not-find-target` was bundled but is **blocked**, not shipped. Its own triage note names `inline-has-many-module-private-find-target-loader` (0023, est. 350 LOC) as a prerequisite to land first — that story is still `draft` and unclaimed, and its trails-only `findTarget(record, assocName, options, queryExecutor, violatesStrictLoading)` calling convention is precisely why the collection gate cannot see the association instance's `_skipStrictLoading`. Registered with `pnpm tasks block` and that reason.

Closes-story: days-into-week-duplicated-in-date-calculations
Closes-story: converge-date-time-apply-seconds-precision-onto-time-value-mixin
Closes-story: activemodel-assign-attribute-still-writes-through-write-attribute
Closes-story: owner-fk-inline-fallback-rungs-have-no-rails-counterpart
