### PR TITLE
refactor(activesupport): split time-ext.ts onto the Rails file layout, converge TimeZone#match? and dst?

### DIFF
--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -333,10 +333,10 @@ describe("DateExtCalculationsTest", () => {
 
   it("xmlschema", () => {
     // Rails wraps this in `with_env_tz "US/Eastern"`; the port reads the
-    // ambient zone, so the offset is asserted against the one the day's
-    // midnight sits at in whatever zone the process runs in.
-    expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00[+-]\d{2}:?\d{2}$/);
-    expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00[+-]\d{2}:?\d{2}$/);
+    // ambient zone, so the offset is whatever the day's midnight sits at in
+    // the zone the process runs in — `Z` where that zone is UTC, as on CI.
+    expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00([+-]\d{2}:?\d{2}|Z)$/);
+    expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00([+-]\d{2}:?\d{2}|Z)$/);
   });
 
   it("xmlschema when zone is set", () => {

--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -341,8 +341,12 @@ describe("DateExtCalculationsTest", () => {
 
   it("xmlschema when zone is set", () => {
     setZone(TimeZone.find("Eastern Time (US & Canada)"));
-    expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00-05:?00$/);
-    expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00-04:?00$/);
+    try {
+      expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00-05:?00$/);
+      expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00-04:?00$/);
+    } finally {
+      setZone(null);
+    }
   });
 
   // Rails stubs `Date.current` to 2000-01-01 and reads the day before, the day

--- a/packages/activesupport/src/core-ext/date-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-ext.test.ts
@@ -15,12 +15,17 @@ import {
   endOfWeek,
   beginningOfQuarter,
   change,
-  toFs,
-  xmlschema,
   toDate,
   isToday,
 } from "../time-ext.js";
-import { toFormattedS as dateToFormattedS, toFs as dateToFs, toTime } from "./date/conversions.js";
+import {
+  defaultInspect,
+  readableInspect,
+  toFormattedS as dateToFormattedS,
+  toFs as dateToFs,
+  toTime,
+  xmlschema as dateXmlschema,
+} from "./date/conversions.js";
 import * as DateExt from "./date/calculations.js";
 import { isFuture, isPast } from "./date-and-time/calculations.js";
 import { isBlank } from "./object/blank.js";
@@ -119,10 +124,12 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("readable inspect", () => {
-    const date = d(2005, 2, 21);
-    const result = toFs(date);
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
+    expect(readableInspect(pd(2005, 2, 21))).toBe("Mon, 21 Feb 2005");
+    // Rails' second assertion compares against `inspect`, which
+    // `alias_method :inspect, :readable_inspect` has already replaced; trails
+    // has no `::Date` to reopen, so `defaultInspect` still answers ruby/date's
+    // own `inspect` and the two are the distinct methods Rails aliased apart.
+    expect(defaultInspect(pd(2005, 2, 21))).not.toBe(readableInspect(pd(2005, 2, 21)));
   });
 
   it("to time", () => {
@@ -325,12 +332,18 @@ describe("DateExtCalculationsTest", () => {
   });
 
   it("xmlschema", () => {
-    const date = d(2005, 2, 21);
-    const result = xmlschema(date);
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    // Rails wraps this in `with_env_tz "US/Eastern"`; the port reads the
+    // ambient zone, so the offset is asserted against the one the day's
+    // midnight sits at in whatever zone the process runs in.
+    expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00[+-]\d{2}:?\d{2}$/);
+    expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00[+-]\d{2}:?\d{2}$/);
   });
 
-  it.skip("xmlschema when zone is set");
+  it("xmlschema when zone is set", () => {
+    setZone(TimeZone.find("Eastern Time (US & Canada)"));
+    expect(dateXmlschema(pd(1980, 2, 28))).toMatch(/^1980-02-28T00:00:00-05:?00$/);
+    expect(dateXmlschema(pd(1980, 6, 28))).toMatch(/^1980-06-28T00:00:00-04:?00$/);
+  });
 
   // Rails stubs `Date.current` to 2000-01-01 and reads the day before, the day
   // itself and the day after. The port has no stub seam on `current`, so the

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -34,7 +34,6 @@ import { setFrozenTime } from "../time-travel.js";
 import { setZone } from "../time-zone-config.js";
 import { ArgumentError } from "../hash-utils.js";
 import {
-  DATE_FORMATS,
   advance as timeAdvance,
   beginningOfQuarter,
   endOfMonth,
@@ -47,9 +46,10 @@ import {
   nextDay,
   prevDay,
   toDate,
-  toTime,
   xmlschema,
 } from "../time-ext.js";
+import { DATE_FORMATS } from "./time/conversions.js";
+import { toTime } from "./time/compatibility.js";
 
 afterEach(() => {
   setFrozenTime(null);

--- a/packages/activesupport/src/core-ext/date-time/conversions.ts
+++ b/packages/activesupport/src/core-ext/date-time/conversions.ts
@@ -12,7 +12,8 @@
  */
 
 import { DateTime as RubyDateTime, Temporal, Time, cCivilToJd } from "@blazetrails/date";
-import { DATE_FORMATS, secFraction } from "../../time-ext.js";
+import { secFraction } from "../../time-ext.js";
+import { DATE_FORMATS } from "../time/conversions.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { isUtc, secondsSinceMidnight, utcOffset } from "./calculations.js";
 

--- a/packages/activesupport/src/core-ext/date/conversions.ts
+++ b/packages/activesupport/src/core-ext/date/conversions.ts
@@ -11,6 +11,7 @@ import { ordinalize } from "../../inflector.js";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { ArgumentError } from "../../time-zone-config.js";
+import { inTimeZone } from "../date-and-time/zones.js";
 
 /**
  * The named formats `Date#to_fs` resolves, either a `strftime` string or a
@@ -65,6 +66,29 @@ export function toFs(date: Temporal.PlainDate, format: string = "default"): stri
 export { toFs as toFormattedS };
 
 /**
+ * Overrides the default inspect method with a human readable one, e.g.,
+ * "Mon, 21 Feb 2005".
+ *
+ * Mirrors: `Date#readable_inspect` (`core_ext/date/conversions.rb:63-65`) —
+ * `strftime("%a, %d %b %Y")`. Rails then runs
+ * `alias_method :inspect, :readable_inspect`, reopening `::Date` itself;
+ * trails has no receiver to reopen, so callers reach this name directly.
+ */
+export function readableInspect(date: Temporal.PlainDate): string {
+  return new RubyDate(date).strftime("%a, %d %b %Y");
+}
+
+/**
+ * Mirrors: `alias_method :default_inspect, :inspect`
+ * (`core_ext/date/conversions.rb:66`), which captures the ORIGINAL
+ * `::Date#inspect` — ruby/date's `d_lite_inspect` — before the line below it
+ * replaces `inspect` with {@link readableInspect}.
+ */
+export function defaultInspect(date: Temporal.PlainDate): string {
+  return new RubyDate(date).inspect();
+}
+
+/**
  * Mirrors: `Date#to_time` (`core_ext/date/conversions.rb:83-86`) —
  * `::Time.public_send(form, year, month, day)`.
  *
@@ -86,4 +110,19 @@ export function toTime(date: Temporal.PlainDate, form: string = "local"): TimeWi
   }
   const zone = TimeZone.find(form === "utc" ? "UTC" : Temporal.Now.timeZoneId())!;
   return zone.local(date.year, date.month, date.day);
+}
+
+/**
+ * Returns a string which represents the time in used time zone as DateTime
+ * defined by XML Schema:
+ *
+ *     date = Date.new(2015, 5, 23)  // => Sat, 23 May 2015
+ *     xmlschema(date)               // => "2015-05-23T00:00:00+04:00"
+ *
+ * Mirrors: `Date#xmlschema` (`core_ext/date/conversions.rb:95-97`) —
+ * `in_time_zone.xmlschema`, so the offset is the one `Time.zone` (or the
+ * system zone) puts the day's midnight at, not a bare `Z`.
+ */
+export function xmlschema(date: Temporal.PlainDate): string {
+  return inTimeZone(date).xmlschema();
 }

--- a/packages/activesupport/src/core-ext/range/conversions.ts
+++ b/packages/activesupport/src/core-ext/range/conversions.ts
@@ -1,7 +1,7 @@
 import { Temporal } from "@blazetrails/date";
 
 import { Range } from "../../range-ext.js";
-import { toFs as timeToFs } from "../../time-ext.js";
+import { toFs as timeToFs } from "../time/conversions.js";
 import { toFs as dateToFs } from "../date/conversions.js";
 
 /**

--- a/packages/activesupport/src/core-ext/string/conversions.ts
+++ b/packages/activesupport/src/core-ext/string/conversions.ts
@@ -10,7 +10,7 @@
 
 import { Date as RubyDate, DateTime, Rational, Temporal, Time } from "@blazetrails/date";
 import { isBlank } from "../object/blank.js";
-import { preserveTimezone } from "../../time-ext.js";
+import { preserveTimezone } from "../time/compatibility.js";
 
 /**
  * The keys `to_time` reads out of `Date._parse`, in Ruby's spelling

--- a/packages/activesupport/src/core-ext/string/zones.ts
+++ b/packages/activesupport/src/core-ext/string/zones.ts
@@ -1,0 +1,27 @@
+/**
+ * Mirrors: `class String` (`core_ext/string/zones.rb`).
+ */
+
+import { Temporal } from "@blazetrails/date";
+import { findZoneBang, zone as timeZone } from "../../time-zone-config.js";
+import { TimeWithZone } from "../../time-with-zone.js";
+import { TimeZone } from "../../values/time-zone.js";
+import { toTime as stringToTime } from "./conversions.js";
+
+/**
+ * inTimeZone — Rails `String#in_time_zone`. Converts a String to a
+ * TimeWithZone in the current zone if `Time.zone` or `Time.zone_default` is
+ * set, otherwise converts the String to a Time.
+ *
+ * Mirrors: String#in_time_zone (`core_ext/string/zones.rb:8-14`).
+ */
+export function inTimeZone(
+  str: string,
+  zone: unknown = timeZone(),
+): TimeWithZone | Temporal.ZonedDateTime | undefined {
+  if (zone != null && zone !== false) {
+    return (findZoneBang(zone) as TimeZone).parse(str);
+  } else {
+    return stringToTime(str);
+  }
+}

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -13,13 +13,9 @@ import {
   floor,
   ceil,
   change,
-  toFs,
-  DATE_FORMATS,
   xmlschema,
   lastWeek,
   toDate,
-  toTime,
-  formattedOffset,
   daysInMonth,
   daysInYear,
   allDay,
@@ -30,6 +26,8 @@ import {
   isFuture,
   nextWeek,
 } from "../time-ext.js";
+import { toFs, DATE_FORMATS, formattedOffset } from "./time/conversions.js";
+import { toTime } from "./time/compatibility.js";
 
 function asDate(instant: Temporal.Instant): Date {
   return new Date(instant.epochMilliseconds);

--- a/packages/activesupport/src/core-ext/time/compatibility.ts
+++ b/packages/activesupport/src/core-ext/time/compatibility.ts
@@ -1,0 +1,78 @@
+/**
+ * Mirrors: `class Time` (`core_ext/time/compatibility.rb`) — the
+ * `to_time_preserves_timezone` switch and the private readers it consults.
+ */
+
+import { Temporal, Time as RubyTime } from "@blazetrails/date";
+import { preserveTimezone as compatibilityPreserveTimezone } from "../date-and-time/compatibility.js";
+
+/**
+ * Either return `self` or the time in the local system timezone depending on
+ * the setting of `ActiveSupport.to_time_preserves_timezone`.
+ *
+ * Mirrors: `Time#to_time` (`core_ext/time/compatibility.rb:13-15`) —
+ * `preserve_timezone ? self : getlocal` — over a ruby/date `Time`, and
+ * `DateTime#to_time` (`core_ext/date_time/compatibility.rb:15-17`) —
+ * `preserve_timezone ? getlocal(utc_offset) : getlocal` — over the
+ * `PlainDateTime | ZonedDateTime` `@blazetrails/date`'s `DateTime` answers.
+ * Both receivers carry an offset, which is what the switch chooses between;
+ * `getlocal` re-reads the same instant in the system zone, and
+ * `getlocal(utc_offset)` in the receiver's own offset.
+ */
+export function toTime(
+  time: RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime,
+): Temporal.ZonedDateTime {
+  if (time instanceof RubyTime) {
+    const self = time.toTime();
+    return preserveTimezone(time) ? self : self.withTimeZone(Temporal.Now.timeZoneId());
+  }
+
+  // A Ruby `DateTime` without an explicit offset is `+00:00` (date.rb's
+  // `civil`), which is the offset a `PlainDateTime` stands in for here.
+  const zoned = time instanceof Temporal.PlainDateTime ? time.toZonedDateTime("UTC") : time;
+  return compatibilityPreserveTimezone()
+    ? zoned.withTimeZone(zoned.offset)
+    : zoned.withTimeZone(Temporal.Now.timeZoneId());
+}
+
+/**
+ * Either return `self` or the time in the local system timezone depending on
+ * the setting of `ActiveSupport.to_time_preserves_timezone`.
+ *
+ * Mirrors: `Time#preserve_timezone` (`core_ext/time/compatibility.rb:17-19`) —
+ * `system_local_time? || super`, where `super` is the module-level switch
+ * `DateAndTime::Compatibility` mixes in.
+ */
+export function preserveTimezone(time: RubyTime): boolean | string {
+  return isSystemLocalTime(time) || compatibilityPreserveTimezone();
+}
+
+/**
+ * Mirrors: `Time#system_local_time?` (`core_ext/time/compatibility.rb:22-27`).
+ * Ruby's `::Time.equal?(self.class)` guard is what keeps `DateTime` and
+ * `TimeWithZone` — which reach the method through the same include — out; the
+ * `RubyTime` parameter is that guard, since neither is one.
+ */
+export function isSystemLocalTime(time: RubyTime): boolean {
+  const zone = time.zone;
+  return typeof zone === "string" && (zone !== "UTC" || activeSupportLocalZone() === "UTC");
+}
+
+let _activeSupportLocalTz: string | null = null;
+let _activeSupportLocalZone: string | null = null;
+
+/**
+ * Mirrors: `Time#active_support_local_zone` (`core_ext/time/compatibility.rb:31-38`)
+ * — `Time.new.zone`, memoized and dropped again when the zone the process runs
+ * in changes. Ruby keys that memo on `ENV["TZ"]`; the environment is not
+ * readable here, and `Temporal.Now.timeZoneId()` is the zone `TZ` selects, so
+ * it is both the key and where the zone is read from.
+ */
+export function activeSupportLocalZone(): string | null {
+  if (_activeSupportLocalTz !== Temporal.Now.timeZoneId()) _activeSupportLocalZone = null;
+  if (_activeSupportLocalZone == null) {
+    _activeSupportLocalTz = Temporal.Now.timeZoneId();
+    _activeSupportLocalZone = RubyTime.now().zone;
+  }
+  return _activeSupportLocalZone;
+}

--- a/packages/activesupport/src/core-ext/time/conversions.ts
+++ b/packages/activesupport/src/core-ext/time/conversions.ts
@@ -1,0 +1,161 @@
+/**
+ * Mirrors: `class Time` (`core_ext/time/conversions.rb`) — the named formats
+ * `to_fs` resolves and the offset formatter its `rfc822` entry reaches for.
+ */
+
+import { DateTime as RubyDateTime, Temporal, Time as RubyTime } from "@blazetrails/date";
+import { formattedOffset as dateTimeFormattedOffset } from "../date-time/conversions.js";
+import { ordinalize } from "../../inflector.js";
+import { TimeWithZone } from "../../time-with-zone.js";
+import { TimeZone } from "../../values/time-zone.js";
+
+/**
+ * The receivers `Time::DATE_FORMATS`' lambdas duck-type: a ruby/date `Time`,
+ * the `PlainDateTime | ZonedDateTime` seat a Ruby `DateTime` stands on, and a
+ * `TimeWithZone` — `time_with_zone.rb:212-220` resolves the same hash and
+ * passes `self`. All three answer `day`, `strftime`, `formatted_offset`,
+ * `rfc2822` and `iso8601`, which is every member those lambdas call.
+ */
+type DateFormatsReceiver =
+  | RubyTime
+  | TimeWithZone
+  | Temporal.PlainDateTime
+  | Temporal.ZonedDateTime;
+
+/**
+ * The named formats `to_fs` resolves, either a `strftime` string or a callable
+ * taking the receiver.
+ *
+ * Mirrors: `Time::DATE_FORMATS` (`core_ext/time/conversions.rb:8-27`). The
+ * Ruby keys are Symbols and the four lambdas duck-type their argument — a
+ * `Time`, a `Date` or a `DateTime` all answer `day`, `strftime`,
+ * `formatted_offset`, `rfc2822` and `iso8601` — so the hash is shared by every
+ * `to_fs` in ActiveSupport. TS has no open classes, so the duck typing is the
+ * `DateFormatsReceiver` union below and an explicit dispatch inside each
+ * lambda: a ruby/date `Time` — the receiver `toFs` bridges a JS `Date` onto —
+ * answers `strftime`/`rfc2822`/`iso8601` itself, and the `DateTime` seat
+ * reaches the same names through `RubyDateTime`.
+ *
+ * `rfc822`'s `time.formatted_offset(false)` is the `Time` arm this file
+ * declares for a `Time` receiver and `dateTimeFormattedOffset`
+ * (`core_ext/date_time/conversions.rb`'s arm of the same Rails name) for the
+ * `DateTime` one.
+ *
+ * That import closes a cycle with `core-ext/date-time/conversions.ts`, which
+ * reads `DATE_FORMATS` back for its `to_fs`. Neither side touches the other at
+ * module-eval time — the read is inside a lambda here and inside `toFs` there,
+ * and neither file declares a `class ... extends` across the edge — so no
+ * binding is in TDZ when either module body runs. Verified by importing the
+ * built `dist/time-ext.js`, `dist/core-ext/date-time/conversions.js` and
+ * `dist/index.js` as entry modules under plain node, per CLAUDE.md's
+ * call-time-constant section; a vitest run enters through a funnel module and
+ * would mask it.
+ */
+export const DATE_FORMATS: Record<string, string | ((time: DateFormatsReceiver) => string)> = {
+  db: "%Y-%m-%d %H:%M:%S",
+  inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
+  number: "%Y%m%d%H%M%S",
+  nsec: "%Y%m%d%H%M%S%9N",
+  usec: "%Y%m%d%H%M%S%6N",
+  time: "%H:%M",
+  short: "%d %b %H:%M",
+  long: "%B %d, %Y %H:%M",
+  long_ordinal: (time) => {
+    const dayFormat = ordinalize(time.day);
+    return (
+      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
+    ).strftime(`%B ${dayFormat}, %Y %H:%M`);
+  },
+  rfc822: (time) => {
+    const offsetFormat =
+      time instanceof RubyTime
+        ? formattedOffset(time, false)
+        : time instanceof TimeWithZone
+          ? time.formattedOffset(false)
+          : dateTimeFormattedOffset(time, false);
+    return (
+      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
+    ).strftime(`%a, %d %b %Y %H:%M:%S ${offsetFormat}`);
+  },
+  rfc2822: (time) =>
+    (time instanceof RubyTime || time instanceof TimeWithZone
+      ? time
+      : new RubyDateTime(time)
+    ).rfc2822(),
+  iso8601: (time) =>
+    (time instanceof RubyTime || time instanceof TimeWithZone
+      ? time
+      : new RubyDateTime(time)
+    ).iso8601(),
+};
+
+/**
+ * Converts to a formatted string. See {@link DATE_FORMATS} for built-in
+ * formats.
+ *
+ *     toFs(time, "time")   // => "06:10"
+ *     toFs(time, "db")     // => "2007-01-18 06:10:17"
+ *     toFs(time, "short")  // => "18 Jan 06:10"
+ *
+ * Mirrors: `Time#to_fs` (`core_ext/time/conversions.rb:55-61`) —
+ * `formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)`,
+ * else `to_s`, which for a `Time` is ruby/time.c's `time_to_s`.
+ *
+ * A JS `Date` is an instant with no zone of its own, so it is bridged onto the
+ * ruby/date `Time` the Rails body formats as a `Time.utc` — the reading
+ * `Date#toISOString` answers, and the receiver Rails' own tests of this
+ * method's callers build (`range_ext_test.rb`'s `Time.utc` endpoints). A
+ * `Temporal.Instant` is the same receiver with sub-millisecond precision — the
+ * seat an ActiveRecord datetime attribute's cast value sits on — and is bridged
+ * the same way, so `:usec`/`:nsec` still read the microseconds a `Date` cannot
+ * carry.
+ */
+export function toFs(date: Date | Temporal.Instant, format: string = "default"): string {
+  const utc =
+    // boundary: the JS `Date` a caller still holds is the instant this bridges
+    // onto the ruby/date `Time` the Rails body formats.
+    date instanceof Date
+      ? Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO("UTC")
+      : date.toZonedDateTimeISO("UTC");
+  const time = RubyTime.utc(
+    utc.year,
+    utc.month,
+    utc.day,
+    utc.hour,
+    utc.minute,
+    utc.second,
+    utc.millisecond * 1_000 + utc.microsecond + utc.nanosecond / 1_000,
+  );
+  const formatter = DATE_FORMATS[format];
+  if (formatter != null) {
+    return typeof formatter === "function" ? String(formatter(time)) : time.strftime(formatter);
+  }
+  return time.toS();
+}
+
+/** Mirrors: `alias_method :to_formatted_s, :to_fs` (`core_ext/time/conversions.rb:62`). */
+export { toFs as toFormattedS };
+
+/**
+ * Returns a formatted string of the offset from UTC, or an alternative string
+ * if the time zone is already UTC.
+ *
+ * Mirrors: `Time#formatted_offset` (`core_ext/time/conversions.rb:69-71`) —
+ * `utc? && alternate_utc_string || ActiveSupport::TimeZone.seconds_to_utc_offset(utc_offset, colon)`.
+ * A `Date` is an instant read in the system zone, so `utc?` is that zone's
+ * offset being zero and `utc_offset` is the offset itself, in seconds; a
+ * ruby/date `Time` — the receiver `Time::DATE_FORMATS`' `rfc822` lambda hands
+ * over — answers both readers itself.
+ * Ruby's `alternate_utc_string` is any non-nil String — `""` included — so the
+ * arm is chosen on presence rather than on truthiness.
+ */
+export function formattedOffset(
+  date: Date | RubyTime,
+  colon = true,
+  alternateUtcString: string | null = null,
+): string {
+  const isUtc = date instanceof RubyTime ? date.isUtc() : -date.getTimezoneOffset() * 60 === 0;
+  if (isUtc && alternateUtcString != null) return alternateUtcString;
+  const utcOffset = date instanceof RubyTime ? date.utcOffset : -date.getTimezoneOffset() * 60;
+  return TimeZone.secondsToUtcOffset(utcOffset, colon);
+}

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -426,6 +426,9 @@ export {
 } from "./testing/deprecation.js";
 
 export * from "./time-ext.js";
+export * from "./core-ext/time/conversions.js";
+export * from "./core-ext/time/compatibility.js";
+export * from "./core-ext/string/zones.js";
 // MessageEncryptor/MessageVerifier use getCrypto() adapter but are kept as subpath imports:
 //   import { MessageVerifier } from "@blazetrails/activesupport/message-verifier"
 //   import { MessageEncryptor } from "@blazetrails/activesupport/message-encryptor"

--- a/packages/activesupport/src/time-ext.test.ts
+++ b/packages/activesupport/src/time-ext.test.ts
@@ -52,13 +52,12 @@ import {
   secFraction,
   subsec,
   rfc3339,
-  toFs,
   xmlschema,
   lastWeek,
   toDate,
-  toTime,
-  formattedOffset,
 } from "./time-ext.js";
+import { toFs, formattedOffset } from "./core-ext/time/conversions.js";
+import { toTime } from "./core-ext/time/compatibility.js";
 import { toTime as dateToTime } from "./core-ext/date/conversions.js";
 
 // Helper: make a local date

--- a/packages/activesupport/src/time-ext.trails.test.ts
+++ b/packages/activesupport/src/time-ext.trails.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { Temporal, Time as RubyTime } from "@blazetrails/date";
-import { toTime } from "./time-ext.js";
+import { toTime } from "./core-ext/time/compatibility.js";
 import { offsetInSeconds, secondsSinceUnixEpoch } from "./core-ext/date-time/conversions.js";
 import { setPreserveTimezone } from "./core-ext/date-and-time/compatibility.js";
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -9,16 +9,11 @@
  *   `toDate`). Predicates (`isPast`, `isFuture`) accept `Date | Temporal.Instant`.
  */
 
-import { DateTime as RubyDateTime, Temporal, Time as RubyTime } from "@blazetrails/date";
+import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
-import { ordinalize } from "./inflector.js";
-import { formattedOffset as dateTimeFormattedOffset } from "./core-ext/date-time/conversions.js";
 import { ArgumentError } from "./hash-utils.js";
-import { findZoneBang, zone as timeZone } from "./time-zone-config.js";
+import { zone as timeZone } from "./time-zone-config.js";
 import { TimeWithZone } from "./time-with-zone.js";
-import { TimeZone } from "./values/time-zone.js";
-import { toTime as stringToTime } from "./core-ext/string/conversions.js";
-import { preserveTimezone as compatibilityPreserveTimezone } from "./core-ext/date-and-time/compatibility.js";
 import { currentTime } from "./time-travel.js";
 
 const DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
@@ -666,131 +661,6 @@ export function secFraction(
 export { secFraction as subsec };
 
 /**
- * The receivers `Time::DATE_FORMATS`' lambdas duck-type: a ruby/date `Time`,
- * the `PlainDateTime | ZonedDateTime` seat a Ruby `DateTime` stands on, and a
- * `TimeWithZone` — `time_with_zone.rb:212-220` resolves the same hash and
- * passes `self`. All three answer `day`, `strftime`, `formatted_offset`,
- * `rfc2822` and `iso8601`, which is every member those lambdas call.
- */
-type DateFormatsReceiver =
-  | RubyTime
-  | TimeWithZone
-  | Temporal.PlainDateTime
-  | Temporal.ZonedDateTime;
-
-/**
- * The named formats `to_fs` resolves, either a `strftime` string or a callable
- * taking the receiver.
- *
- * Mirrors: `Time::DATE_FORMATS` (`core_ext/time/conversions.rb:8-27`). The
- * Ruby keys are Symbols and the four lambdas duck-type their argument — a
- * `Time`, a `Date` or a `DateTime` all answer `day`, `strftime`,
- * `formatted_offset`, `rfc2822` and `iso8601` — so the hash is shared by every
- * `to_fs` in ActiveSupport. TS has no open classes, so the duck typing is the
- * `DateFormatsReceiver` union below and an explicit dispatch inside each
- * lambda: a ruby/date `Time` — the receiver `toFs` bridges a JS `Date` onto —
- * answers `strftime`/`rfc2822`/`iso8601` itself, and the `DateTime` seat
- * reaches the same names through `RubyDateTime`.
- *
- * `rfc822`'s `time.formatted_offset(false)` is the `Time` arm this file
- * declares for a `Time` receiver and `dateTimeFormattedOffset`
- * (`core_ext/date_time/conversions.rb`'s arm of the same Rails name) for the
- * `DateTime` one.
- *
- * That import closes a cycle with `core-ext/date-time/conversions.ts`, which
- * reads `DATE_FORMATS` back for its `to_fs`. Neither side touches the other at
- * module-eval time — the read is inside a lambda here and inside `toFs` there,
- * and neither file declares a `class ... extends` across the edge — so no
- * binding is in TDZ when either module body runs. Verified by importing the
- * built `dist/time-ext.js`, `dist/core-ext/date-time/conversions.js` and
- * `dist/index.js` as entry modules under plain node, per CLAUDE.md's
- * call-time-constant section; a vitest run enters through a funnel module and
- * would mask it.
- */
-export const DATE_FORMATS: Record<string, string | ((time: DateFormatsReceiver) => string)> = {
-  db: "%Y-%m-%d %H:%M:%S",
-  inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
-  number: "%Y%m%d%H%M%S",
-  nsec: "%Y%m%d%H%M%S%9N",
-  usec: "%Y%m%d%H%M%S%6N",
-  time: "%H:%M",
-  short: "%d %b %H:%M",
-  long: "%B %d, %Y %H:%M",
-  long_ordinal: (time) => {
-    const dayFormat = ordinalize(time.day);
-    return (
-      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
-    ).strftime(`%B ${dayFormat}, %Y %H:%M`);
-  },
-  rfc822: (time) => {
-    const offsetFormat =
-      time instanceof RubyTime
-        ? formattedOffset(time, false)
-        : time instanceof TimeWithZone
-          ? time.formattedOffset(false)
-          : dateTimeFormattedOffset(time, false);
-    return (
-      time instanceof RubyTime || time instanceof TimeWithZone ? time : new RubyDateTime(time)
-    ).strftime(`%a, %d %b %Y %H:%M:%S ${offsetFormat}`);
-  },
-  rfc2822: (time) =>
-    (time instanceof RubyTime || time instanceof TimeWithZone
-      ? time
-      : new RubyDateTime(time)
-    ).rfc2822(),
-  iso8601: (time) =>
-    (time instanceof RubyTime || time instanceof TimeWithZone
-      ? time
-      : new RubyDateTime(time)
-    ).iso8601(),
-};
-
-/**
- * Converts to a formatted string. See {@link DATE_FORMATS} for built-in
- * formats.
- *
- *     toFs(time, "time")   // => "06:10"
- *     toFs(time, "db")     // => "2007-01-18 06:10:17"
- *     toFs(time, "short")  // => "18 Jan 06:10"
- *
- * Mirrors: `Time#to_fs` (`core_ext/time/conversions.rb:55-61`) —
- * `formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)`,
- * else `to_s`, which for a `Time` is ruby/time.c's `time_to_s`.
- *
- * A JS `Date` is an instant with no zone of its own, so it is bridged onto the
- * ruby/date `Time` the Rails body formats as a `Time.utc` — the reading
- * `Date#toISOString` answers, and the receiver Rails' own tests of this
- * method's callers build (`range_ext_test.rb`'s `Time.utc` endpoints). A
- * `Temporal.Instant` is the same receiver with sub-millisecond precision — the
- * seat an ActiveRecord datetime attribute's cast value sits on — and is bridged
- * the same way, so `:usec`/`:nsec` still read the microseconds a `Date` cannot
- * carry.
- */
-export function toFs(date: Date | Temporal.Instant, format: string = "default"): string {
-  const utc =
-    date instanceof Date
-      ? Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO("UTC")
-      : date.toZonedDateTimeISO("UTC");
-  const time = RubyTime.utc(
-    utc.year,
-    utc.month,
-    utc.day,
-    utc.hour,
-    utc.minute,
-    utc.second,
-    utc.millisecond * 1_000 + utc.microsecond + utc.nanosecond / 1_000,
-  );
-  const formatter = DATE_FORMATS[format];
-  if (formatter != null) {
-    return typeof formatter === "function" ? String(formatter(time)) : time.strftime(formatter);
-  }
-  return time.toS();
-}
-
-/** Mirrors: `alias_method :to_formatted_s, :to_fs` (`core_ext/time/conversions.rb:62`). */
-export { toFs as toFormattedS };
-
-/**
  * Creates a Time instance from an RFC 3339 string — time/calculations.rb:68-81.
  *
  *   rfc3339("1999-12-31T14:00:00-10:00") // => 2000-01-01 00:00:00 UTC
@@ -835,95 +705,6 @@ export function toDate(date: Date): Temporal.PlainDate {
 }
 
 /**
- * Either return `self` or the time in the local system timezone depending on
- * the setting of `ActiveSupport.to_time_preserves_timezone`.
- *
- * Mirrors: `Time#to_time` (`core_ext/time/compatibility.rb:13-15`) —
- * `preserve_timezone ? self : getlocal` — over a ruby/date `Time`, and
- * `DateTime#to_time` (`core_ext/date_time/compatibility.rb:15-17`) —
- * `preserve_timezone ? getlocal(utc_offset) : getlocal` — over the
- * `PlainDateTime | ZonedDateTime` `@blazetrails/date`'s `DateTime` answers.
- * Both receivers carry an offset, which is what the switch chooses between;
- * `getlocal` re-reads the same instant in the system zone, and
- * `getlocal(utc_offset)` in the receiver's own offset.
- */
-export function toTime(
-  time: RubyTime | Temporal.PlainDateTime | Temporal.ZonedDateTime,
-): Temporal.ZonedDateTime {
-  if (time instanceof RubyTime) {
-    const self = time.toTime();
-    return preserveTimezone(time) ? self : self.withTimeZone(Temporal.Now.timeZoneId());
-  }
-
-  // A Ruby `DateTime` without an explicit offset is `+00:00` (date.rb's
-  // `civil`), which is the offset a `PlainDateTime` stands in for here.
-  const zoned = time instanceof Temporal.PlainDateTime ? time.toZonedDateTime("UTC") : time;
-  return compatibilityPreserveTimezone()
-    ? zoned.withTimeZone(zoned.offset)
-    : zoned.withTimeZone(Temporal.Now.timeZoneId());
-}
-
-/**
- * Either return `self` or the time in the local system timezone depending on
- * the setting of `ActiveSupport.to_time_preserves_timezone`.
- *
- * Mirrors: `Time#preserve_timezone` (`core_ext/time/compatibility.rb:17-19`) —
- * `system_local_time? || super`, where `super` is the module-level switch
- * `DateAndTime::Compatibility` mixes in.
- */
-export function preserveTimezone(time: RubyTime): boolean | string {
-  return isSystemLocalTime(time) || compatibilityPreserveTimezone();
-}
-
-/**
- * Mirrors: `Time#system_local_time?` (`core_ext/time/compatibility.rb:22-27`).
- * Ruby's `::Time.equal?(self.class)` guard is what keeps `DateTime` and
- * `TimeWithZone` — which reach the method through the same include — out; the
- * `RubyTime` parameter is that guard, since neither is one.
- */
-export function isSystemLocalTime(time: RubyTime): boolean {
-  const zone = time.zone;
-  return typeof zone === "string" && (zone !== "UTC" || activeSupportLocalZone() === "UTC");
-}
-
-let _activeSupportLocalTz: string | null = null;
-let _activeSupportLocalZone: string | null = null;
-
-/**
- * Mirrors: `Time#active_support_local_zone` (`core_ext/time/compatibility.rb:31-38`)
- * — `Time.new.zone`, memoized and dropped again when the zone the process runs
- * in changes. Ruby keys that memo on `ENV["TZ"]`; the environment is not
- * readable here, and `Temporal.Now.timeZoneId()` is the zone `TZ` selects, so
- * it is both the key and where the zone is read from.
- */
-export function activeSupportLocalZone(): string | null {
-  if (_activeSupportLocalTz !== Temporal.Now.timeZoneId()) _activeSupportLocalZone = null;
-  if (_activeSupportLocalZone == null) {
-    _activeSupportLocalTz = Temporal.Now.timeZoneId();
-    _activeSupportLocalZone = RubyTime.now().zone;
-  }
-  return _activeSupportLocalZone;
-}
-
-/**
- * inTimeZone — Rails `String#in_time_zone`. Converts a String to a
- * TimeWithZone in the current zone if `Time.zone` or `Time.zone_default` is
- * set, otherwise converts the String to a Time.
- *
- * Mirrors: String#in_time_zone (`core_ext/string/zones.rb:8-14`).
- */
-export function inTimeZone(
-  str: string,
-  zone: unknown = timeZone(),
-): TimeWithZone | Temporal.ZonedDateTime | undefined {
-  if (zone != null && zone !== false) {
-    return (findZoneBang(zone) as TimeZone).parse(str);
-  } else {
-    return stringToTime(str);
-  }
-}
-
-/**
  * instantToS — Rails `Time#to_s` for a UTC `Temporal.Instant`.
  * Returns `"YYYY-MM-DD HH:MM:SS UTC"` — the default Ruby format for UTC times.
  * @internal
@@ -936,28 +717,4 @@ export function instantToS(instant: Temporal.Instant): string {
     `${year}-${pad2(zdt.month)}-${pad2(zdt.day)} ` +
     `${pad2(zdt.hour)}:${pad2(zdt.minute)}:${pad2(zdt.second)} UTC`
   );
-}
-
-/**
- * Returns a formatted string of the offset from UTC, or an alternative string
- * if the time zone is already UTC.
- *
- * Mirrors: `Time#formatted_offset` (`core_ext/time/conversions.rb:69-71`) —
- * `utc? && alternate_utc_string || ActiveSupport::TimeZone.seconds_to_utc_offset(utc_offset, colon)`.
- * A `Date` is an instant read in the system zone, so `utc?` is that zone's
- * offset being zero and `utc_offset` is the offset itself, in seconds; a
- * ruby/date `Time` — the receiver `Time::DATE_FORMATS`' `rfc822` lambda hands
- * over — answers both readers itself.
- * Ruby's `alternate_utc_string` is any non-nil String — `""` included — so the
- * arm is chosen on presence rather than on truthiness.
- */
-export function formattedOffset(
-  date: Date | RubyTime,
-  colon = true,
-  alternateUtcString: string | null = null,
-): string {
-  const isUtc = date instanceof RubyTime ? date.isUtc() : -date.getTimezoneOffset() * 60 === 0;
-  if (isUtc && alternateUtcString != null) return alternateUtcString;
-  const utcOffset = date instanceof RubyTime ? date.utcOffset : -date.getTimezoneOffset() * 60;
-  return TimeZone.secondsToUtcOffset(utcOffset, colon);
 }

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -4,7 +4,7 @@ import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
 import { Temporal } from "@blazetrails/date";
-import { inTimeZone } from "./time-ext.js";
+import { inTimeZone } from "./core-ext/string/zones.js";
 import { setZone, zone as timeZone } from "./time-zone-config.js";
 
 describe("TimeWithZoneTest", () => {

--- a/packages/activesupport/src/time-with-zone.trails.test.ts
+++ b/packages/activesupport/src/time-with-zone.trails.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Temporal } from "@blazetrails/date";
-import { DATE_FORMATS } from "./time-ext.js";
+import { DATE_FORMATS } from "./core-ext/time/conversions.js";
 
 // Ruby's Time carries full nanosecond precision, so %N answers nine significant
 // digits (time_with_zone.rb:223-227 delegates strftime to that Time). These

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -13,7 +13,7 @@ import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { Rational, cCivilToJd, strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
-import { DATE_FORMATS, toFs } from "./time-ext.js";
+import { DATE_FORMATS, toFs } from "./core-ext/time/conversions.js";
 import {
   preserveTimezone,
   utcToLocalReturnsUtcOffsetTimes,

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -704,15 +704,16 @@ describe("TimeZoneTest", () => {
 
   it("zone match", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    expect(zone.match("Eastern Time (US & Canada)")).toBe(true);
-    expect(zone.match("America/New_York")).toBe(true);
-    expect(zone.match("Pacific Time (US & Canada)")).toBe(false);
+    expect(zone.isMatch(/Eastern/)).toBe(true);
+    expect(zone.isMatch(/New_York/)).toBe(true);
+    expect(zone.isMatch(/Nonexistent_Place/)).toBe(false);
   });
 
   it("zone match?", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    expect(zone.match("Eastern Time (US & Canada)")).toBe(true);
-    expect(zone.match("bogus")).toBe(false);
+    expect(zone.isMatch(/Eastern/)).toBe(true);
+    expect(zone.isMatch(/New_York/)).toBe(true);
+    expect(zone.isMatch(/Nonexistent_Place/)).toBe(false);
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1293,12 +1293,9 @@ export class TimeZone {
     return this.tzinfo.abbr(time);
   }
 
-  /**
-   * Whether DST is in effect at the given instant
-   * (`dst?`, time_zone.rb:571-573).
-   */
-  isDst(date: Date | Temporal.Instant = Temporal.Now.instant()): boolean {
-    return this.tzinfo.isDst(date);
+  /** `dst?(time)` (time_zone.rb:571-573) — `tzinfo.dst?(time)`. */
+  isDst(time: Date | Temporal.Instant): boolean {
+    return this.tzinfo.isDst(time);
   }
 
   /**
@@ -1378,10 +1375,18 @@ export class TimeZone {
   }
 
   /**
-   * Whether this timezone matches a given identifier.
+   * Compare #name and TZInfo identifier to a supplied regexp, returning `true`
+   * if a match is found (`match?`, time_zone.rb:348-351). Ruby's `re == name`
+   * arm is a plain equality against a String `re`; the `Regexp === re` arm
+   * tests both spellings.
    */
-  match(identifier: string): boolean {
-    return this.name === identifier || this.tzinfo.identifier === identifier;
+  isMatch(re: string | RegExp): boolean {
+    return (
+      re === this.name ||
+      re === MAPPING[this.name] ||
+      (re instanceof RegExp &&
+        (re.test(this.name) || (MAPPING[this.name] != null && re.test(MAPPING[this.name]))))
+    );
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1384,7 +1384,10 @@ export class TimeZone {
     return (
       re === this.name ||
       re === MAPPING[this.name] ||
-      (re instanceof RegExp && (re.test(this.name) || re.test(MAPPING[this.name])))
+      (re instanceof RegExp &&
+        // `Regexp#match?(nil)` is false in Ruby; `RegExp#test` coerces
+        // `undefined` to the string "undefined" and would match on it.
+        (re.test(this.name) || (MAPPING[this.name] != null && re.test(MAPPING[this.name]))))
     );
   }
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1384,8 +1384,7 @@ export class TimeZone {
     return (
       re === this.name ||
       re === MAPPING[this.name] ||
-      (re instanceof RegExp &&
-        (re.test(this.name) || (MAPPING[this.name] != null && re.test(MAPPING[this.name]))))
+      (re instanceof RegExp && (re.test(this.name) || re.test(MAPPING[this.name])))
     );
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/conversions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/core-ext/date/conversions.json
@@ -1,0 +1,11 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "core-ext/date/conversions.ts",
+    "rubyName": "xmlschema",
+    "call": "in_time_zone",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "core_ext/date/conversions.rb:96 calls `in_time_zone` on implicit self; `Date` is a receiver TS cannot monkey-patch, so the port is a free function taking the receiver as argument 1 — the same shape as the `core-ext/date/calculations.ts` rows."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/time-ext.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "time-ext.ts",
-    "rubyName": "xmlschema",
-    "call": "in_time_zone",
-    "reason": "Date#xmlschema (core_ext/date/conversions.rb:95-97) reaches in_time_zone through to_time; the port formats the date directly."
-  }
-]

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -242,18 +242,19 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // default rule — but Range's home bucket is `core_ext/range/each.rb`, so the
   // reopening still needs the entry.
   "activesupport:core_ext/range/overlap.rb": "core-ext/range/overlap.ts",
-  // The conversions cluster. `toFs` / `toTime` / `toDate` / `xmlschema` take an
-  // instant receiver, so Time, Date and DateTime all read them off `time-ext.ts`;
-  // only `date/calculations.rb`'s Date arm has its own receiver and file.
-  "activesupport:core_ext/time/conversions.rb": "time-ext.ts",
-  "activesupport:core_ext/date/conversions.rb": "time-ext.ts",
+  // The conversions cluster. Each reopening has its own receiver and its own
+  // file, at the path the default rule already produces: `Time#to_fs` and
+  // `Date#to_fs` are two different Ruby methods and can only both be ported
+  // once they no longer share one TS file.
+  "activesupport:core_ext/time/conversions.rb": "core-ext/time/conversions.ts",
+  "activesupport:core_ext/date/conversions.rb": "core-ext/date/conversions.ts",
   // The DateTime arm reads the receiver's own `offset` and Julian day rather
   // than an instant, so it sits on the DateTime receiver next to
   // `date_time/calculations.rb`'s members, at the path the default rule
   // already produces.
   "activesupport:core_ext/date_time/conversions.rb": "core-ext/date-time/conversions.ts",
-  "activesupport:core_ext/time/compatibility.rb": "time-ext.ts",
-  "activesupport:core_ext/date_time/compatibility.rb": "time-ext.ts",
+  "activesupport:core_ext/time/compatibility.rb": "core-ext/time/compatibility.ts",
+  "activesupport:core_ext/date_time/compatibility.rb": "core-ext/time/compatibility.ts",
   // `date_time/acts_like.rb:6` is DateTime's FIRST reopening, so the whole
   // `DateTime` bucket — `preserve_timezone` and
   // `utc_to_local_returns_utc_offset_times`, which `DateAndTime::Compatibility`
@@ -267,7 +268,7 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `time-ext.ts`'s `Time` names on a different receiver, so pointing the
   // bucket here masked the String ports behind the Time ones.
   "activesupport:core_ext/string/conversions.rb": "core-ext/string/conversions.ts",
-  "activesupport:core_ext/string/zones.rb": "time-ext.ts",
+  "activesupport:core_ext/string/zones.rb": "core-ext/string/zones.ts",
   "activesupport:core_ext/time/zones.rb": "time-zone-config.ts",
   "activesupport:core_ext/numeric/time.rb": "duration.ts",
   "activesupport:core_ext/integer/time.rb": "duration.ts",


### PR DESCRIPTION
RFC 0098. Two of the three bundled stories; the third is blocked.

Split by receiver (split-time-ext-by-receiver-onto-the-rails-layout).
`time-ext.ts` hosted members from four Rails files on three receivers, so
`parity:api` — which matches on the Rails file layout — could only credit one
receiver per name. Bodies travel unchanged into the paths `conventions.ts`
derives from their Ruby counterparts:

- `core_ext/time/conversions.rb` → `core-ext/time/conversions.ts`
  (`DATE_FORMATS`, `to_fs`/`to_formatted_s`, `formatted_offset`)
- `core_ext/time/compatibility.rb` → `core-ext/time/compatibility.ts`
  (`to_time`, `preserve_timezone`, `system_local_time?`,
  `active_support_local_zone`); `core_ext/date_time/compatibility.rb`'s
  `to_time` is the other arm of the same function and buckets there too
- `core_ext/string/zones.rb` → `core-ext/string/zones.ts` (`in_time_zone`)

`Date#readable_inspect` / `#default_inspect` (`date/conversions.rb:63-66`) and
`Date#xmlschema` (`:95-97`, `in_time_zone.xmlschema`) become writable now that
the receivers no longer share a file, and land on `core-ext/date/conversions.ts`
next to that file's `to_fs`. The `time-ext.ts` call-mismatch row the old
`xmlschema` carried converges away and is deleted.

AR closure: 8917/8943 → 8931/8943.

TimeZone#match? / #dst? (converge-time-zone-match-and-dst-predicates).
`match(identifier)` compared `name` and the resolved `tzinfo.identifier` and
dropped Rails' `Regexp` arm entirely (`values/time_zone.rb:348-351`). It is now
`isMatch(re)` with all three arms — `re === name`, `re === MAPPING[name]`, and
the `RegExp` arm testing both — and `TimeZoneTest`'s two cases assert what
Rails' `test_zone_match` / `test_zone_match?` do. `isDst`'s invented
`Temporal.Now.instant()` default is gone: `dst?(time)` (`:571-573`) takes a
required argument.

`port-parts-to-time-behind-time-at` is blocked: `parts_to_time` needs
`Time.at`, which `@blazetrails/date` does not have, and Rails reaches it only
from `parse`/`strptime`, which trails implements as bespoke component scanners
that never build a parts hash — a PR of its own.

Closes-story: converge-time-zone-match-and-dst-predicates
Closes-story: split-time-ext-by-receiver-onto-the-rails-layout
