### PR TITLE
refactor(activerecord): converge has_transactional_callbacks? onto CallbackChain#isEmpty

### DIFF
--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -678,11 +678,13 @@ export async function addToTransaction(this: Base, ensureFinalize = true): Promi
 export function hasTransactionalCallbacks(this: Base): boolean {
   const proto = (this.constructor as any).prototype;
   const rollback = asPeekCallbackChain(proto, "rollback");
-  if (rollback && rollback.entries.length > 0) return true;
   const commit = asPeekCallbackChain(proto, "commit");
-  if (commit && commit.entries.length > 0) return true;
   const beforeCommitChain = asPeekCallbackChain(proto, "before_commit");
-  return !!(beforeCommitChain && beforeCommitChain.entries.length > 0);
+  return (
+    !(rollback == null || rollback.isEmpty) ||
+    !(commit == null || commit.isEmpty) ||
+    !(beforeCommitChain == null || beforeCommitChain.isEmpty)
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/transactions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/transactions.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "transactions.ts",
-    "rubyName": "has_transactional_callbacks?",
-    "call": "empty?",
-    "reason": "Reviewed (RFC 0106 wave 4c): trails has no `CallbackChain#empty?` — `peekCallbackChain` returns the raw chain, so emptiness is spelled `entries.length > 0`. Converges when the chain object grows the Rails predicate."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
     "rubyName": "restore_transaction_record_state",
     "call": "map",
     "reason": "Reviewed (RFC 0106 wave 4c): Rails `map`s the composite primary key back onto the restored attributes; trails restores the snapshot object wholesale, so there is no per-key projection to spell."


### PR DESCRIPTION
## Summary
- `hasTransactionalCallbacks` now spells emptiness via `chain.isEmpty` (the getter already ported on `CallbackChain`, `packages/activesupport/src/callbacks.ts:1219`) instead of `entries.length > 0`, matching `vendor/rails/activerecord/lib/active_record/transactions.rb:518-520`'s `!_rollback_callbacks.empty? || !_commit_callbacks.empty? || !_before_commit_callbacks.empty?`.
- Retires the `has_transactional_callbacks? -> empty?` row from `scripts/api-compare/call-mismatches-exclude/activerecord/transactions.json` by hand (no `--write`/reseed); `pnpm parity:api:calls` / `:args` stay green.
- No other `peekCallbackChain` caller was doing the `entries.length` dance.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/transactions.test.ts` — 95 passed, 7 skipped
- [x] `pnpm parity:api:calls` — OK
- [x] `pnpm parity:api:calls:args` — OK

Closes-story: callback-chain-empty-predicate-bakeoff-sonnet