### PR TITLE
refactor(activerecord): CollectionProxy#clear and #include? delegate to the association

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -817,7 +817,13 @@ export class CollectionAssociation extends Association {
     } else if (this.isLoaded()) {
       return this.target.includes(record);
     } else {
-      const recordId = this.primaryKeyValue(record);
+      // Rails: `klass.primary_key.zip(record.id).to_h` for a composite key —
+      // `exists?` needs the column=>value hash, not a bare tuple.
+      const recordId = klass.compositePrimaryKey
+        ? Object.fromEntries(
+            (klass.primaryKey as string[]).map((key, i) => [key, (record.id as unknown[])[i]]),
+          )
+        : record.id;
       return await this.scope().exists(recordId);
     }
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -813,13 +813,43 @@ export class CollectionAssociation extends Association {
     if (!(record instanceof klass)) return false;
 
     if (record.isNewRecord()) {
-      return await isIncludeInMemory(this, record);
+      return await this.isIncludeInMemory(record);
     } else if (this.isLoaded()) {
       return this.target.includes(record);
     } else {
       const recordId = this.primaryKeyValue(record);
       return await this.scope().exists(recordId);
     }
+  }
+
+  /**
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#include_in_memory?
+   * (collection_association.rb:507-519).
+   */
+  private async isIncludeInMemory(record: Base): Promise<boolean> {
+    const reflection = this.reflection as unknown as {
+      isThroughReflection?: () => boolean;
+      throughReflection?: { name: string } | null;
+      sourceReflection?: { name: string } | null;
+    };
+    if (reflection.isThroughReflection?.()) {
+      const assoc = (
+        this.owner as unknown as { association: (n: string) => Association }
+      ).association(reflection.throughReflection!.name);
+      const sourceName = reflection.sourceReflection!.name;
+      const reader = (await assoc.reader) as Base[];
+      const targetReflections = await Promise.all(
+        reader.map((source) => (source as unknown as Record<string, unknown>)[sourceName]),
+      );
+      return (
+        targetReflections.some((targetReflection) =>
+          Array.isArray(targetReflection)
+            ? targetReflection.includes(record)
+            : targetReflection === record,
+        ) || this.target.includes(record)
+      );
+    }
+    return this.target.includes(record);
   }
 
   /**
@@ -1693,42 +1723,6 @@ export function callbacksFor(this: CallbackHost, callbackName: string): unknown[
   if (Array.isArray(stored)) return stored;
   const fromOptions = (this.reflection.options as Record<string, unknown>)[callbackName];
   return Array.isArray(fromOptions) ? fromOptions : fromOptions != null ? [fromOptions] : [];
-}
-
-/**
- * Mirrors: ActiveRecord::Associations::CollectionAssociation#include_in_memory?
- * (collection_association.rb:507-519).
- * @internal
- */
-async function isIncludeInMemory(assoc: CollectionAssociation, record: Base): Promise<boolean> {
-  const reflection = assoc.reflection as unknown as {
-    isThroughReflection?: () => boolean;
-    throughReflection?: { name: string } | null;
-    sourceReflection?: { name: string } | null;
-  };
-  if (reflection.isThroughReflection?.()) {
-    const throughReflection = reflection.throughReflection;
-    const sourceReflection = reflection.sourceReflection;
-    if (!throughReflection || !sourceReflection) return assoc.target.includes(record);
-    const throughAssoc = (
-      assoc.owner as unknown as { association: (n: string) => Association }
-    ).association(throughReflection.name);
-    const sources = ((await throughAssoc.reader) ?? []) as Base[];
-    for (const source of sources) {
-      const targetReflection = await (source as unknown as Record<string, unknown>)[
-        sourceReflection.name
-      ];
-      // Rails' `respond_to?(:include?)` — a collection source answers
-      // `include?`, a singular one is compared by identity.
-      if (Array.isArray(targetReflection)) {
-        if (targetReflection.includes(record)) return true;
-      } else if (targetReflection === record) {
-        return true;
-      }
-    }
-    return assoc.target.includes(record);
-  }
-  return assoc.target.includes(record);
 }
 
 function arraysEqual(a: Base[], b: Base[]): boolean {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -813,7 +813,7 @@ export class CollectionAssociation extends Association {
     if (!(record instanceof klass)) return false;
 
     if (record.isNewRecord()) {
-      return isIncludeInMemory(this, record);
+      return await isIncludeInMemory(this, record);
     } else if (this.isLoaded()) {
       return this.target.includes(record);
     } else {
@@ -1695,28 +1695,38 @@ export function callbacksFor(this: CallbackHost, callbackName: string): unknown[
   return Array.isArray(fromOptions) ? fromOptions : fromOptions != null ? [fromOptions] : [];
 }
 
-/** @internal */
-function isIncludeInMemory(assoc: CollectionAssociation, record: Base): boolean {
-  // For through reflections, also check through the source chain.
-  const refl = assoc.reflection as any;
-  if (refl.isThroughReflection?.()) {
-    const name = refl.options?.through;
-    if (name) {
-      const throughAssoc = (assoc.owner as any).association?.(name);
-      const sourceRefl = refl.sourceReflection?.();
-      if (throughAssoc && sourceRefl) {
-        const sourceName = sourceRefl.name;
-        const reader = throughAssoc.target as Base[];
-        if (Array.isArray(reader)) {
-          const found = reader.some((source: any) => {
-            const targetRefl = source[sourceName];
-            if (Array.isArray(targetRefl)) return targetRefl.includes(record);
-            return targetRefl === record;
-          });
-          if (found) return true;
-        }
+/**
+ * Mirrors: ActiveRecord::Associations::CollectionAssociation#include_in_memory?
+ * (collection_association.rb:507-519).
+ * @internal
+ */
+async function isIncludeInMemory(assoc: CollectionAssociation, record: Base): Promise<boolean> {
+  const reflection = assoc.reflection as unknown as {
+    isThroughReflection?: () => boolean;
+    throughReflection?: { name: string } | null;
+    sourceReflection?: { name: string } | null;
+  };
+  if (reflection.isThroughReflection?.()) {
+    const throughReflection = reflection.throughReflection;
+    const sourceReflection = reflection.sourceReflection;
+    if (!throughReflection || !sourceReflection) return assoc.target.includes(record);
+    const throughAssoc = (
+      assoc.owner as unknown as { association: (n: string) => Association }
+    ).association(throughReflection.name);
+    const sources = ((await throughAssoc.reader) ?? []) as Base[];
+    for (const source of sources) {
+      const targetReflection = await (source as unknown as Record<string, unknown>)[
+        sourceReflection.name
+      ];
+      // Rails' `respond_to?(:include?)` — a collection source answers
+      // `include?`, a singular one is compared by identity.
+      if (Array.isArray(targetReflection)) {
+        if (targetReflection.includes(record)) return true;
+      } else if (targetReflection === record) {
+        return true;
       }
     }
+    return assoc.target.includes(record);
   }
   return assoc.target.includes(record);
 }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1443,40 +1443,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
   }
 
-  /**
-   * Walk the through-chain looking for `record` via the source reflection.
-   * Mirrors the through branch of
-   * `CollectionAssociation#include_in_memory?` —
-   * `assoc.reader.any? { |source| source.send(source_reflection.name)... }`.
-   */
-  private async _includeInMemoryThrough(record: T): Promise<boolean> {
-    const ctor = this._record.constructor as typeof Base;
-    const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
-    const throughName = this._assocDef.options.through!;
-    const throughAssoc = associations.find((a: any) => a.name === throughName);
-    if (!throughAssoc) return false;
-    // Rails reads `reflection.source_reflection.name` — the *actual* source
-    // association name, which for a collection source (e.g. `has_many :comments
-    // through: :posts`, source `Post#comments`) is plural. `singularize` would
-    // mis-guess `comment`, so prefer the resolved source reflection.
-    const sourceRefl = (this.reflection as { sourceReflection?: { name?: string } })
-      .sourceReflection;
-    const sourceName =
-      sourceRefl?.name ?? this._assocDef.options.source ?? singularize(this._assocName);
-    const sources = (await (this._record as any)[throughName]) as Base[] | undefined;
-    if (!sources) return false;
-    for (const joinRecord of sources) {
-      const source = await (joinRecord as any)[sourceName];
-      if (source == null) continue;
-      if (Array.isArray(source)) {
-        if (source.includes(record)) return true;
-      } else if (source === record) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private _raiseOnTypeMismatch(records: T[]): void {
     const opts = this._assocDef.options;
     // Polymorphic associations have no fixed klass — Rails no-ops type checking there.
@@ -1527,77 +1493,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return removed;
   }
 
-  private _removeFromTarget(records: Base[]): void {
-    const pkIdentities = new Set<string>();
-    const nullPkRecords = new Set<Base>();
-    for (const r of records) {
-      const id = this._identityFor(r);
-      if (id == null) {
-        nullPkRecords.add(r);
-      } else {
-        pkIdentities.add(id);
-      }
-    }
-
-    this._target = this._target.filter((r) => {
-      const id = this._identityFor(r);
-      if (id != null) return !pkIdentities.has(id);
-      return !nullPkRecords.has(r);
-    });
-    this._invalidateAssociationIds();
-  }
-
-  /**
-   * Decrement the owner's counter cache by `count`, mirroring Rails
-   * `CollectionAssociation#update_counter` for the bulk delete/nullify path.
-   */
-  private async _decrementCounterCache(count: number): Promise<void> {
-    let column: string | null = this._assocDef.options.counterCache
-      ? String(this._assocDef.options.counterCache)
-      : null;
-    // A has_many without an explicit `counter_cache:` may still update a counter
-    // through the child's belongs_to inverse (e.g. Car.engines ← Engine
-    // belongs_to :my_car, counter_cache: :engines_count). The bulk delete path
-    // bypasses the child callbacks, so resolve the reflection's cached-counter
-    // column and decrement it here, matching Rails' `update_counter(-count)`.
-    if (!column) {
-      const refl = this.reflection;
-      if (refl.hasCachedCounter?.()) column = refl.counterCacheColumn?.() ?? null;
-    }
-    if (!column) return;
-    const owner = this._record as any;
-    if (typeof owner.incrementBang === "function") {
-      await owner.incrementBang(column, -count);
-    } else if (typeof owner.updateCounters === "function") {
-      await owner.updateCounters({ [column]: -count });
-    } else if (typeof owner.increment === "function") {
-      owner.increment(column, -count);
-    }
-  }
-
-  private _buildNullifyUpdates(): Record<string, null> {
-    const ctor = this._record.constructor as typeof Base;
-    const asName = this._assocDef.options.as;
-    const primaryKey = this._assocDef.options.primaryKey ?? ctor.primaryKey;
-    const foreignKey =
-      this._assocDef.options.foreignKey ??
-      this._reflectionForeignKey() ??
-      this._assocDef.options.queryConstraints ??
-      (asName
-        ? `${underscore(asName)}_id`
-        : Array.isArray(primaryKey)
-          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-          : `${underscore(ctor.name)}_id`);
-    const updates: Record<string, null> = {};
-    if (Array.isArray(foreignKey)) {
-      for (const fk of foreignKey) updates[fk] = null;
-    } else {
-      updates[foreignKey] = null;
-    }
-    if (asName) updates[this._assocDef.options.foreignType ?? `${underscore(asName)}_type`] = null;
-    return updates;
-  }
-
   /**
    * Destroys the `records` supplied and removes them from the collection,
    * always removing the row from the database regardless of `:dependent`.
@@ -1620,153 +1515,31 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Remove all records from the collection by nullifying FKs.
+   * Equivalent to `deleteAll`. The difference is that it returns `this`,
+   * instead of an array of the deleted objects, so methods can be chained.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#clear
+   * (collection_proxy.rb:1066-1069) — `delete_all; self`. The `:dependent`
+   * collapse, the delete/nullify dispatch, the counter-cache update and the
+   * target reset all live once on `CollectionAssociation#delete_all` /
+   * `#delete_or_nullify_all_records` (collection_association.rb:150-176).
    */
-  async clear(): Promise<void> {
-    // Rails' `clear` → `delete_all` → through `delete_records` runs through
-    // `ensure_mutable` / the nested-through readonly check; mirror `deleteAll`
-    // and the prior per-record `delete` path by enforcing the same guard
-    // before touching join rows.
-    this._ensureThroughWritable();
-    return this._withoutStrictLoading(async () => {
-      // A new-record owner whose scope is a `null_scope?` has no persisted
-      // children to delete or nullify, so Rails' `scope.none!`
-      // (collection_association.rb:300-305) makes the delete/nullify a no-op.
-      // `null_scope?` is `owner.new_record? && !foreign_key_present?`, so a new
-      // owner WITH the owner PK present (e.g. a client-assigned UUID) still
-      // queries — only the genuinely keyless new owner short-circuits. Reset
-      // the in-memory target without touching the DB in that case.
-      if (this.isNullScope()) {
-        this._target = [];
-        this._targetLoaded = true;
-        this._invalidateAssociationIds();
-        return;
-      }
-      // Rails' `clear` routes through `delete_all`, which removes the rows in
-      // bulk and does NOT run `before_remove`/`after_remove` callbacks (those
-      // live in `remove_records`, not the delete path) — unlike per-record
-      // `delete`.
-      if (this._isThrough) {
-        // Mirror `delete_or_nullify_all_records` → `delete_records(load_target,
-        // method)` (has_many_through_association.rb:136-175): destroy the join
-        // rows for the loaded target so the join model's `belongsTo`
-        // counter-cache callbacks still fire, without the collection
-        // before/after-remove callbacks. Like Rails, this follows the
-        // association-layer `load_target` (the full association target), not
-        // the proxy's in-place relation state.
-        const assoc = this._record.association(this._assocName) as unknown as {
-          loadTarget: () => Promise<Base[]>;
-          deleteRecords: (records: Base[], method: string) => Promise<number>;
-        };
-        const target = await assoc.loadTarget();
-        if (target.length > 0) {
-          await assoc.deleteRecords(target, (this._assocDef.options.dependent as string) ?? "");
-        }
-        // The whole association target was cleared (load_target, not the
-        // diverged proxy scope), so reset the full in-memory target the way
-        // `deleteAll` does — pruning only the pre-clear `toArray()` subset
-        // would leave stale records for `size()`/`isEmpty()` to read.
-        this._target = [];
-        this._targetLoaded = true;
-        this._invalidateAssociationIds();
-        return;
-      }
-      // Capture the records to prune BEFORE removing — afterwards a delete /
-      // nullified FK makes a reload return nothing. Only the non-through path
-      // needs this; the through branch returns early after a full reset, so its
-      // `toArray()` load is avoided entirely.
-      const records = await this.toArray();
-      // Honor the association's `:dependent` like Rails `delete_all` (nil arg):
-      // `dependent == :destroy` collapses to `:delete_all`, so
-      // destroy/delete/delete_all bulk-DELETE the child rows while
-      // nullify/default nullify the owner FK — all without per-record remove
-      // callbacks (collection_association.rb:150-167 + has_many_association.rb:112-118).
-      const dep = this._assocDef.options.dependent as string | undefined;
-      const deleteRows =
-        dep === "destroy" || dep === "delete" || dep === "delete_all" || dep === "deleteAll";
-      let count: number;
-      if (deleteRows) {
-        count = await this.scope().deleteAll();
-      } else {
-        count = await this.scope().updateAll(this._buildNullifyUpdates());
-      }
-      // Rails `delete_records` else-branch: update_counter(-delete_count). The
-      // bulk DELETE/UPDATE bypasses the child's belongs_to callbacks, so decrement
-      // the owner's counter cache by the affected count here (matching the
-      // per-record `delete` path). `clear` collapses `:destroy` to a bulk delete,
-      // so this fires for delete_all/nullify alike, never the gated destroy branch.
-      if (count > 0) await this._decrementCounterCache(count);
-      this._removeFromTarget(records);
-      this._invalidateAssociationIds();
-    });
+  async clear(): Promise<Omit<this, "then">> {
+    await this.deleteAll();
+    return stripThenable(this._proxySelf ?? this);
   }
 
   /**
    * Check if a record is in the collection.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#include?
+   * (collection_proxy.rb:927-929) — `!!@association.include?(record)`. The
+   * `reflection.klass` guard, the `include_in_memory?` scan (through arm
+   * included) and the `scope.exists?` fallback all live on
+   * `CollectionAssociation#include?` (collection_association.rb:258-270).
    */
   async isInclude(record: T): Promise<boolean> {
-    // Rails `include?` short-circuits on type mismatch — a record whose
-    // class is unrelated to the reflection's `klass` can never be in the
-    // target. Without this guard, a bogus record would issue a needless
-    // `exists?` query and might silently match a row with the same PK on
-    // the wrong table.
-    // Mirrors `ActiveRecord::Associations::CollectionAssociation#include?`
-    // (`return false unless record.is_a?(reflection.klass)`).
-    if (!this._assocDef.options.polymorphic) {
-      const className = this._assocDef.options.className ?? camelize(singularize(this._assocName));
-      const klass = resolveAssocClass(this._record, this._assocName, className);
-      if (!(record instanceof klass)) return false;
-    }
-    if (record.isNewRecord()) {
-      // Mirrors `CollectionAssociation#include_in_memory?`: for through
-      // associations, walk the through target looking for `record` via the
-      // source reflection; OR fall back to the local target. For
-      // non-through associations, just check the local target.
-      if (this._assocDef.options.through) {
-        if (await this._includeInMemoryThrough(record)) return true;
-      }
-      return this._target.includes(record);
-    }
-
-    if (this._targetLoaded) {
-      const targetId = this._identityFor(record);
-      if (targetId != null) {
-        return this._target.some((r) => this._identityFor(r) === targetId);
-      }
-      return this._target.includes(record);
-    }
-
-    const primaryKey = (record.constructor as typeof Base).primaryKey;
-    const s = this.scope();
-    if (typeof s.exists === "function") {
-      if (Array.isArray(primaryKey)) {
-        const condition: Record<string, unknown> = {};
-        let allPresent = true;
-        for (const key of primaryKey) {
-          const value = record._readAttribute(key);
-          if (value == null) {
-            allPresent = false;
-            break;
-          }
-          condition[key] = value;
-        }
-        if (allPresent) return s.exists(condition);
-      } else {
-        const pkValue = record._readAttribute(primaryKey);
-        if (pkValue != null) return s.exists({ [primaryKey]: pkValue });
-      }
-    }
-
-    const loaded = await this.loadTarget();
-    const targetId = this._identityFor(record);
-    if (targetId != null) {
-      return loaded.some((r) => this._identityFor(r) === targetId);
-    }
-    return loaded.includes(record);
+    return !!(await this._collectionAssociation().isInclude(record));
   }
 
   /**
@@ -1998,8 +1771,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * plain `Array#-`, which drops EVERY occurrence of a deleted record, not the
    * `difference` hook's per-occurrence count. For a `:through` reflection that
    * is what makes `[david, david].replace([david])` delete both join rows and
-   * re-concat a fresh one, exactly as Rails does — and it matches what
-   * `_removeFromTarget` does to the real `_target`.
+   * re-concat a fresh one, exactly as Rails does.
    * @internal
    */
   private async _replaceRecords(newTarget: T[], originalTarget: T[]): Promise<T[]> {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1039,20 +1039,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Owner FK column(s) from the reflection, which derives them from the class
-   * that *declared* the association (`reflection.active_record`), not the owner
-   * instance's class. For an STI subclass owner (e.g. a `SpecialPost` whose
-   * `has_many :special_comments` is declared on `Post`) this yields `post_id`,
-   * not `special_post_id` — mirrors Rails `reflection.foreign_key`. Returns
-   * undefined for anonymous inline associations with no registered reflection,
-   * so callers fall back to the owner-class derivation.
-   * @internal
-   */
-  private _reflectionForeignKey(): string | string[] | undefined {
-    return this.reflection.foreignKey ?? undefined;
-  }
-
-  /**
    * Bulk insert/upsert through a collection association. Mirrors
    * ActiveRecord::AssociationRelation, which guards `insert`, `insert_all`,
    * `insert!`, `insert_all!`, `upsert`, and `upsert_all`: when the

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3574,8 +3574,14 @@ describe("HasManyAssociationsTest", () => {
     expect(await ReLocalePost.all().count()).toBe(1);
   });
   it("included in collection for composite keys", async () => {
+    // `cpk_books.id` is not auto-increment under its composite PK, so the id
+    // part is assigned explicitly — MariaDB rejects the insert otherwise.
     const greatAuthor = await CpkAuthor.create({ name: "Alice" });
-    await CpkBook.create({ author_id: greatAuthor.id, title: "The first book", revision: 1 });
+    await CpkBook.create({
+      id: [greatAuthor.id as number, 1],
+      title: "The first book",
+      revision: 1,
+    });
 
     // Rails reads `great_author.books.first`, which does NOT mark the
     // association loaded, so `include?` takes the `scope.exists?(record_id)`

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -94,6 +94,7 @@ import { Human } from "../test-helpers/models/human.js";
 import { Category } from "../test-helpers/models/category.js";
 import { Categorization } from "../test-helpers/models/categorization.js";
 import {
+  CpkAuthor,
   CpkBook,
   CpkOrder,
   CpkBrokenOrder,
@@ -3573,33 +3574,15 @@ describe("HasManyAssociationsTest", () => {
     expect(await ReLocalePost.all().count()).toBe(1);
   });
   it("included in collection for composite keys", async () => {
-    class InclAuthor extends Base {
-      declare name: string | null;
+    const greatAuthor = await CpkAuthor.create({ name: "Alice" });
+    await CpkBook.create({ author_id: greatAuthor.id, title: "The first book", revision: 1 });
 
-      static {
-        this._tableName = "authors";
-        this.attribute("name", "string");
-      }
-    }
-    class InclPost extends Base {
-      declare author_id: number | null;
-      declare title: string | null;
+    // Rails reads `great_author.books.first`, which does NOT mark the
+    // association loaded, so `include?` takes the `scope.exists?(record_id)`
+    // branch — the one that needs the composite key as a column=>value hash.
+    const book = await (await CpkAuthor.find(greatAuthor.id)).books.first();
 
-      static {
-        this._tableName = "posts";
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-      }
-    }
-    registerModel(InclAuthor);
-    registerModel(InclPost);
-    const author = await InclAuthor.create({ name: "Alice" });
-    const post = await InclPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await findHasManyTarget(author, "incl_posts", {
-      className: "InclPost",
-      foreignKey: "author_id",
-    });
-    expect(posts.some((p: any) => p.id === post.id)).toBe(true);
+    expect(await greatAuthor.books.isInclude(book!)).toBe(true);
   });
   it("adding array and collection", async () => {
     class ArrAuthor extends Base {


### PR DESCRIPTION
RFC 0114 — collection-proxy decomposition. Two proxy bodies that re-derived
work `CollectionAssociation` already owns.

## `clear` (collection_proxy.rb:1066-1069)

Rails' body is `delete_all; self`. The proxy carried 38 inline lines instead —
the `null_scope?` short-circuit, a separate `_isThrough` arm reaching into the
association for `loadTarget`/`deleteRecords`, the
`destroy|delete|delete_all|deleteAll` collapse, and the
`scope().deleteAll()` / `scope().updateAll(...)` split — plus 58 lines of
private helpers.

All of it already lives once on the association
(`collection_association.rb:150-176` → `deleteAll` /
`deleteOrNullifyAllRecords` / `nullifyAllRecords` / `deleteAllRecords`, with
`HasManyThroughAssociation#deleteOrNullifyAllRecords` owning the through arm and
`ensureNotNested` the writability guard). `deleteAll()` on the proxy was already
the correct `@association.delete_all(dependent).tap { reset_scope }` delegation,
so `clear()` is now just that call plus `self`.

Deleted: `_buildNullifyUpdates` (duplicate of
`computeNullifiedOwnerAttributes`), `_decrementCounterCache` (duplicate of
`updateCounter`), `_removeFromTarget`, and `_reflectionForeignKey` (dead once
`_buildNullifyUpdates` went). No new helper replaces them.

`clear()` now returns `self` like Rails rather than `void`; every call site in
the repo discards the result.

## `include?` (collection_proxy.rb:927-929)

Rails' body is `!!@association.include?(record)`. The proxy had 46 lines that
rebuilt the class name from
`options.className ?? camelize(singularize(assocName))` instead of reading
`reflection.klass`, then ran its own in-memory scan and `exists` fallback, with
`_includeInMemoryThrough` (23 lines) as the through arm.
`CollectionAssociation#isInclude` (`collection_association.rb:258-270`) already
owns the whole decision.

Converging exposed two bugs in `include_in_memory?`
(`collection_association.rb:507-519`), which the proxy body had been shadowing:
it called `sourceReflection` as a method when it is a getter (so the through arm
threw `TypeError`), and it scanned `throughAssoc.target` where Rails scans
`assoc.reader`. Both are fixed against the Rails body, which also lets it read
`throughReflection.name` rather than `options.through`. It also moves from a
module-private free function onto the class as a private method, matching Rails'
decomposition, and the through arm is the single
`assoc.reader.any? { ... } || target.include?(record)` expression Rails writes.

### The composite-key bug this surfaced

Rails' `include?` builds `klass.primary_key.zip(record.id).to_h` before
`scope.exists?` (`collection_association.rb:266`). trails passed
`primaryKeyValue`, which returns a bare **tuple** for a composite key —
`buildWhereClause` rejects that with an `ArgumentError`. The proxy's own body
used to build the hash itself, so it had been masking the gap; delegating to the
association would have shipped the throw.

`test_included_in_collection_for_composite_keys` did not catch it because the
port was a stub in all but name: bespoke single-PK models on `authors`/`posts`,
and it never called `include?` at all. Restored to Rails' body
(`has_many_associations_test.rb:2030-2035`) on the canonical `CpkAuthor` /
`CpkBook` models. Name unchanged; verified failing on the tuple and passing on
the hash.

### The one deviation, justified at the call site

`include_in_memory?`'s block awaits the source reader, and a JS predicate cannot
await — so `Promise.all` resolves the source readers up front and `.some(...)`
runs over the resolved array. The call set is unchanged (`any?` credits `some`
via `JS_ENUMERABLE_ALIASES`), so this costs no baseline row. An earlier revision
used a `for...of` loop here; `pnpm parity:api:calls` correctly flagged it as
dropping Rails' `any?`, and the fix was to restore the call rather than baseline
a 24th row beside the 23 existing `any?` ones.

## Verification

- 106 association test files, 2022 tests: all pass. No test renamed.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK — zero new rows,
  no shard created for `collection-proxy.json`.
- `pnpm parity:api` flat; `pnpm parity:test` flat at 15737.
- `pnpm parity:api:extra --package activerecord` unchanged (every deleted or
  added member is private).
- `pnpm lint` and `pnpm typecheck` clean.
- Net −248 LOC.

Closes-story: collection-proxy-clear-delegates-to-delete-or-nullify-all-records
Closes-story: collection-proxy-include-delegates-to-association