### PR TITLE
refactor(activerecord): thread async through execMainQuery, drop Relation#distinctOn

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -485,7 +485,6 @@ export class Relation<T extends Base> {
    * with the rest of the receiver's ivars rather than through `@values`.
    */
   _withIsRecursive = false;
-  private _distinctOnColumns: string[] = [];
   private _isNone = false;
   /**
    * @internal True when this relation's WHERE base is the stale new-owner
@@ -552,21 +551,6 @@ export class Relation<T extends Base> {
    */
   private _loadAsyncPromise?: Promise<T[]>;
   /**
-   * Set by `loadAsync()` so `execMainQuery` issues its SELECT with `async:` on, the way Rails' `load_async` calls
-   * `exec_main_query(async: ...)` (relation.rb:1142).
-   *
-   * **No Rails equivalent — NOT PERMANENT.** A shape deviation with a convergence
-   * target, not a language shortcoming. Rails threads this as a method
-   * ARGUMENT: `load_async` calls `exec_main_query(async: ...)` directly
-   * (relation.rb:1142) while `exec_queries` calls it with the default
-   * (`async: false`, relation.rb:1423). trails stores it as a field because
-   * `loadAsync()` reaches `execMainQuery` through `toArray()`/`execQueries()`,
-   * which take no such parameter. Converging means threading `async` down that
-   * whole path — or having `loadAsync` drive `execMainQuery` itself the way
-   * Rails does — and retiring this field.
-   */
-  private _asyncLoad = false;
-  /**
    * Monotonic token bumped on reset()/reload() so an in-flight toArray()
    * that started before the reset can detect it lost the race and skip
    * committing stale records/loaded state.
@@ -610,18 +594,6 @@ export class Relation<T extends Base> {
     if (predicateBuilder) {
       this._predicateBuilder = predicateBuilder;
     }
-  }
-
-  /**
-   * PostgreSQL DISTINCT ON — select distinct rows based on specific columns.
-   *
-   * Mirrors: ActiveRecord::Relation#distinct_on (PostgreSQL only)
-   */
-  distinctOn(...columns: string[]): Relation<T> {
-    const rel = this.spawn();
-    rel.distinctValue = true;
-    rel._distinctOnColumns = columns;
-    return rel;
   }
 
   /**
@@ -742,9 +714,6 @@ export class Relation<T extends Base> {
     // load can't re-populate records after a reset.
     this._loadToken += 1;
     this._loadAsyncPromise = undefined;
-    // Rails' reset also drops the scheduled query (`@future_result&.cancel;
-    // @future_result = nil`, relation.rb:1195-1196).
-    this._asyncLoad = false;
     return this;
   }
 
@@ -802,10 +771,8 @@ export class Relation<T extends Base> {
     // instead of racing to fire additional ones.
     if (!this._loadAsyncPromise && !this._loaded) {
       // Rails' `unless loaded?` guards the async query too (relation.rb:1141).
-      this._asyncLoad = true;
-      const loadPromise = this.toArray().finally(() => {
+      const loadPromise = this.toArray(true).finally(() => {
         this._loadAsyncPromise = undefined;
-        this._asyncLoad = false;
       });
       // Attach a no-op rejection handler so a failure here isn't treated
       // as an unhandled rejection if nothing else awaits the relation.
@@ -1064,8 +1031,14 @@ export class Relation<T extends Base> {
    * Execute the query and return all records.
    *
    * Mirrors: ActiveRecord::Relation#to_a / #load
+   *
+   * `async` is Rails' `exec_main_query(async:)` keyword (relation.rb:1423),
+   * threaded from `loadAsync()` — trails' `load_async` reaches the query
+   * through this method rather than calling `exec_main_query` itself, because
+   * instantiation, eager loading and preloading are all awaited inside
+   * `execQueries`.
    */
-  async toArray(): Promise<T[]> {
+  async toArray(async = false): Promise<T[]> {
     if (this.isNullRelation()) return [];
     if (this._loaded) return [...this._records];
     if (this._loadAsyncPromise) {
@@ -1092,7 +1065,7 @@ export class Relation<T extends Base> {
     // in `exec_queries`, which is what makes `.explain` (which calls
     // `exec_queries` directly, relation.rb:13) side-effect-free.
     const token = this._loadToken;
-    const records = await this.withConnection(() => this.execQueries());
+    const records = await this.withConnection(() => this.execQueries(async));
     // A reset() landed while the query was in flight: return the rows we got
     // without clobbering the fresh state.
     if (token !== this._loadToken) return records;
@@ -1103,7 +1076,7 @@ export class Relation<T extends Base> {
   /**
    * Mirrors: ActiveRecord::Relation#exec_queries (relation.rb:1403-1421).
    */
-  private async execQueries(): Promise<T[]> {
+  private async execQueries(async = false): Promise<T[]> {
     return this.skipQueryCacheIfNecessary(async () => {
       // Lazily reflect the schema before issuing the query so consumers
       // don't have to call loadSchema explicitly. Idempotent and cheap.
@@ -1123,7 +1096,7 @@ export class Relation<T extends Base> {
       // clobbering the fresh state.
       const token = this._loadToken;
 
-      const rows = await this.execMainQuery();
+      const rows = await this.execMainQuery(async);
       if (token !== this._loadToken) return [];
       const records = this.instantiateRecords(rows);
 
@@ -1165,7 +1138,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#exec_main_query (relation.rb:1423-1452).
    * Returns rows; `instantiateRecords` turns them into records.
    */
-  private async execMainQuery(): Promise<Result> {
+  private async execMainQuery(async = false): Promise<Result> {
     // Rails' load_async bails to a plain `load` unless `c.async_enabled?` and
     // passes `async: !c.current_transaction.joinable?` into `exec_main_query`
     // (relation.rb:1140-1142), which forwards it to BOTH of its query arms —
@@ -1177,8 +1150,12 @@ export class Relation<T extends Base> {
     if (this._isNone) return Result.empty();
 
     const c = this._conn();
-    const async =
-      this._asyncLoad && c.asyncEnabled?.() === true && !c.currentTransaction?.()?.joinable;
+    // Rails computes `async: !c.current_transaction.joinable?` in `load_async`,
+    // where the connection is already in hand, and bails to a plain `load`
+    // unless `c.async_enabled?` (relation.rb:1140-1142). trails' `loadAsync` is
+    // synchronous and has no connection yet, so it passes `async: true` and the
+    // connection-dependent half of Rails' condition is applied here.
+    async = async && c.asyncEnabled?.() === true && !c.currentTransaction?.()?.joinable;
 
     // Mirrors relation.rb:1431-1451: ONE `skip_query_cache_if_necessary` over
     // the contradiction / eager_loading? / plain arms, not one per arm.
@@ -3083,7 +3060,6 @@ export class Relation<T extends Base> {
     this._values = { ...source._values };
     this._rawOrderClauses = [...source._rawOrderClauses];
     this._withIsRecursive = source._withIsRecursive;
-    this._distinctOnColumns = [...source._distinctOnColumns];
     this._isNone = source._isNone;
     this._joinClauses = [...source._joinClauses];
     // Rebind extension-module methods onto this clone. Ruby's `extend`

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -330,7 +330,6 @@ interface QueryMethodsHost {
   createWithValue: Record<string, unknown>;
   skipQueryCacheValue: boolean | null;
   _rawOrderClauses: string[];
-  _distinctOnColumns: string[];
   _isNone: boolean;
   _joinClauses: Array<{
     type: "inner" | "left";

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -42,6 +42,15 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_queries",
+    "call": "exec_main_query",
+    "kind": "args",
+    "rubyArgs": [],
+    "reason": "relation.rb:1408 calls `exec_main_query` bare because `load_async` (relation.rb:1142) calls it directly with `async:`; trails' loadAsync is synchronous and reaches the query through toArray/execQueries, so the flag is threaded down that path as the same `async` argument instead."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exec_queries",
     "call": "preload_associations",
     "kind": "args",
     "rubyArgs": [


### PR DESCRIPTION
Retires two `relation.ts` deviations surfaced by the RFC 0107 private-member
audit.

`async` is now Rails' method argument (`exec_main_query(async: false)`,
relation.rb:1423) rather than the `_asyncLoad` field: it is threaded
`toArray` -> `execQueries` -> `execMainQuery`, `loadAsync()` passes
`toArray(true)` where relation.rb:1142 passes `exec_main_query(async: ...)`,
and the connection-dependent half of Rails' condition (`async_enabled?` /
`current_transaction.joinable?`, relation.rb:1140-1142) stays in
`execMainQuery`, where the connection is in hand. `reset()` no longer clears a
flag — Rails' reset drops `@future_result`, not a flag (relation.rb:1195-1196).
`exec_queries`' one-argument call site is baselined with its reason.

`Relation#distinctOn` and `_distinctOnColumns` are deleted: there is no
`distinct_on` under `activerecord/lib/active_record/`, so the
`Mirrors: ActiveRecord::Relation#distinct_on` tag was false. The real surface
is `Arel::SelectManager#distinct_on` (arel/lib/arel/select_manager.rb:163),
already ported and untouched, plus the adapter's `columns_for_distinct` seam.
This also retires the third `@values` sidecar store.

## Why `toArray` takes the parameter rather than `loadAsync` driving `execMainQuery`

Reviewer question on the public signature. Rails' `load_async` calls
`exec_main_query(async:)` directly (relation.rb:1142) and never routes through
`exec_queries` (relation.rb:1403), so the Rails-shaped alternative is for
`loadAsync` to drive `execMainQuery` itself. It cannot here, and the reason is
structural rather than a preference.

Rails can bypass `exec_queries` because `load_async` only has to park a
`FutureResult` in `@future_result` and set `@loaded`; every later step —
`future.result`, `instantiate_records`, `preload_associations`, the
`readonly!` / `strict_loading!` passes (relation.rb:1404-1420) — happens on the
foreground pass, dispatched by `scheduled?`. trails has no such split: the
whole tail is awaited inside `execQueries`, and `_loadAsyncPromise` stands in
for `@future_result` precisely because the handle a second caller must join
covers instantiation and preloading too, not just the rows.

So a `loadAsync` that called `execMainQuery` directly would have to re-do
`execQueries`' body plus `toArray`'s commit — the `isNullRelation()` and
`_loaded` guards, the `_loadToken` capture and post-await race check, and
`loadRecords` (relation.ts:1032-1073). That is duplicated logic Rails does not
have, which `parity:api:extra` measures and CLAUDE.md forbids; the story's own
tie-breaker ("prefer whichever keeps `exec_queries`' own signature closest to
Rails") is about `exec_queries`, whose ported signature already carries no
block parameter either.

The cost of the shape actually shipped is one optional argument no external
caller passes. It is not scored as extra surface (`relation.ts` stays at
2 novel / 2 moved) and the advisory arity gate records no `relation.ts`
mismatch — `to_a` -> `toArray` is absent from `output/arity-mismatches.json`
(84 rows, none in this file). The one measurable cost is the single `args`
baseline row for `exec_queries` -> `exec_main_query`, which carries a per-site
reason.

Closes-story: thread-async-through-exec-main-query-argument
Closes-story: drop-relation-distinct-on-invented-surface

