### PR TITLE
refactor(activerecord): CollectionProxy#initialize seeds no Relation state

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1932,18 +1932,6 @@ function wrapCollectionProxy<T extends Base = Base>(
       const enumerableDelegate = delegateEnumerableMethod(prop, () => target.load());
       if (enumerableDelegate) return enumerableDelegate;
 
-      // Named scopes are memoized per association load (trails-specific, RFC
-      // 0030 — Rails rebuilds the named-scope relation on every call and has no
-      // such cache). Route them through `_cachedNamedScopeRelation` so repeated
-      // `things.someScope()` within one association load returns the same
-      // relation object until a reset/insert/remove invalidates the cache.
-      const scopeModel = target.model as typeof Base & {
-        _scopes?: Map<string, unknown>;
-      };
-      if (typeof prop === "string" && scopeModel._scopes?.has(prop)) {
-        return (...args: any[]) => target._cachedNamedScopeRelation(prop, args);
-      }
-
       const scope = target.scope();
       const scopeVal = Reflect.get(scope, prop, scope);
       if (typeof scopeVal === "function") {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -60,18 +60,6 @@ export class CollectionAssociation extends Association {
   // CollectionProxy through-branch reads this to avoid pruning its loaded
   // target when the removal was actually aborted. Read externally by the proxy.
   _lastRemoveAborted = false;
-  // trails-specific (RFC 0030): memoized named-scope relations built off the
-  // proxy (`things.someScope()`). Rails has NO such cache — `scope :name`
-  // rebuilds a fresh relation on every call (named.rb:174-178), so two
-  // consecutive `things.someScope()` are distinct objects there. We memoize per
-  // scope name so they're identical within one association load, which is what
-  // gives `named_scoping_test`'s post-reset `assert_not_same` real teeth. Held
-  // on the association (not the proxy) so a reset driven through
-  // `owner.association(:things)` clears it; invalidated by `reset` (reset /
-  // destroy_all / delete_all / reload / insert / remove). Read/written by
-  // `CollectionProxy`.
-  _namedScopeRelations?: Map<string, unknown>;
-
   /**
    * Mirrors: `CollectionAssociation#callback` / `#callbacks_for`
    * (collection_association.rb:492-505) — instance methods on the association,
@@ -355,11 +343,6 @@ export class CollectionAssociation extends Association {
     // members by identity.
     this._replacedOrAddedTargets = new Set<Base>();
     this._associationIds = null;
-    // Drop the trails-specific named-scope memo (see `_namedScopeRelations`) so
-    // the next `things.someScope()` rebuilds against the reset collection. (This
-    // sits alongside Rails' `reset`, which clears @target/@association_ids; the
-    // named-scope cache itself has no Rails counterpart.)
-    this._namedScopeRelations = undefined;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -227,15 +227,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // object they hold, since `this` is the raw target, not the wrapper.
   private _proxySelf?: this;
 
-  // An `ArgumentError` raised while deriving the has_many foreign key
-  // (e.g. an owner whose `query_constraints` list has >2 attributes, so the FK
-  // is underivable). Rails surfaces this only when the association is *loaded*
-  // (`blog_post.comments.to_a`), not when the proxy is constructed — the
-  // reflection's `foreign_key` is computed lazily inside the scope build that
-  // `load_target` runs. We mirror that: catch the error during construction,
-  // stash it here, and re-throw from the single load chokepoint (`_execLoad`).
-  private _deferredFkError?: Error;
-
   /**
    * Mirrors: ActiveRecord::Associations::CollectionProxy#loaded?
    * (`@association.loaded?`, collection_proxy.rb:53) — the proxy's loadedness is
@@ -574,126 +565,40 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       ? instance
       : new CollectionAssociation(record, assocDef);
 
-    // Seed the proxy's inherited Relation state so direct Relation calls
-    // (`cp.toSql()`, `cp.where(...)`, `cp.toArray()`) scope to the owner
-    // — matches Rails, where CollectionProxy IS the scoped Relation.
-    //
-    // Non-through path delegates to the `scope()` seam (the same relation
-    // `findTarget` runs, and what `countHasMany()` counts) so CP
-    // gets identical semantics: the relation starts from
-    // `targetModel.all()` (default scope applied), is scope-proxied
-    // (so the definition's scope callbacks can call named scopes / generated
-    // methods on it), and composite-PK mismatches throw
-    // `CompositePrimaryKeyMismatchError`. State is then copied onto
-    // `this` so the inherited Relation methods observe the same scope.
-    //
-    // Through path copies state from `_buildThroughScope()`. Config
-    // errors (missing through assoc, unregistered target model) are
-    // validated upfront; only adapter/schema failures fall to the
-    // fail-closed `_isNone` path.
-    const ctor = record.constructor as typeof Base;
-    // The seeding bangs must land on the proxy's OWN inherited Relation state,
-    // not on the memoized `scope()` the prototype delegation would forward them
-    // to (collection_proxy.rb:1128-1137) — and `scope()` is not even buildable
-    // yet mid-construction. Invoke them through `Relation.prototype` directly.
-    const proxySelf = this as unknown as {
-      initializeCopy: (other: Relation<T>) => void;
-    };
-    const relationProto = Relation.prototype as unknown as {
-      extendingBang: (this: unknown, ...mods: unknown[]) => unknown;
-    };
-    // `none!` reads `where_clause` (query_methods.rb) — a reader delegated to
-    // `scope` — so it is applied to a plain relation and copied onto the
-    // proxy's own inherited state rather than called on the proxy.
-    const seedNone = (): void => {
-      proxySelf.initializeCopy((targetModel as any).all().noneBang() as Relation<T>);
-      // Rails never sets `@none` on a CollectionProxy: `none!` is one of the
-      // methods delegated to `scope` (collection_proxy.rb:1128-1137), so it
-      // flips the SCOPE's flag and the proxy sees the `1=0` only through the
-      // delegated `where_clause` reader. Copying the seed's predicates onto our
-      // own inherited state must not also copy that flag, or the inherited
-      // `update_all`'s `return 0 if @none` (relation.rb:1013) — and every other
-      // `@none` short-circuit — fires on the proxy itself.
-      (this as unknown as { _isNone: boolean })._isNone = false;
-    };
-    if (assocDef.options.through) {
-      // Config validation FIRST, outside the try — missing through
-      // association or unregistered target model are deterministic
-      // bugs that must surface immediately, not silently fall to
-      // `_isNone`. The try only wraps the schema/adapter-dependent
-      // parts (join resolution, subquery build).
-      const ownerAssociations: AssociationDefinition[] =
-        (ctor as unknown as { _associations?: AssociationDefinition[] })._associations ?? [];
-      const throughAssoc = ownerAssociations.find((a) => a.name === assocDef.options.through);
-      if (!throughAssoc) {
-        throw new ConfigurationError(
-          `Through association "${assocDef.options.through}" not found on ${ctor.name}`,
-        );
-      }
-      // No try/catch: if `_buildThroughScope()` throws, the caller
-      // sees the real error (composite-PK mismatch, join resolution
-      // failure, etc.) instead of a silently `none`-coerced proxy.
-      // Previous fail-closed catch swallowed deterministic config
-      // errors — worse than letting construction fail.
-      const throughRel = this._buildThroughScope() as Relation<T>;
-      proxySelf.initializeCopy(throughRel);
-    } else {
-      // Build via the `scope()` seam so CP's inherited Relation
-      // state matches `scope()` / direct Relation callers: default
-      // scope from `targetModel.all()` is applied, the relation is
-      // scope-proxied (so the definition's scope can call named scopes /
-      // generated methods on it), and composite-PK validation runs.
-      // Then `initializeCopy` onto `this`. Missing owner PK →
-      // `_isNone = true` (Rails' NullRelation fallback).
-      // `scope()` derives the foreign key, which can raise a
-      // `ArgumentError` when the owner's `query_constraints` make the FK
-      // underivable. Rails defers that error to load time (the FK is computed
-      // lazily inside `load_target`'s scope build), so catch it here, seed a
-      // none relation to keep construction valid, and re-throw on load via
-      // `_execLoad`. Other errors (composite-PK mismatch guards, etc.) still
-      // surface eagerly — they are not part of Rails' lazy-FK contract.
-      let seedRel: Relation<T> | null;
-      try {
-        seedRel = hasManyScope(record, assocName, assocDef) as Relation<T> | null;
-      } catch (err) {
-        if (err instanceof ArgumentError) {
-          this._deferredFkError = err;
-          seedNone();
-          seedRel = null;
+    // `extensions = association.extensions; extend(*extensions) if extensions.any?`
+    // (collection_proxy.rb:35-37). Ruby's `extend` mixes the modules into this
+    // object only — it does NOT touch relation state; the scope gets the same
+    // modules independently through `scope.extending! reflection.extensions`
+    // (association_scope.rb:28), which is what carries them onto chained
+    // relations. So the TS spelling of `extend` is a method copy onto the
+    // instance.
+    const extensions = this._targetAssociation.extensions;
+    if (extensions.length > 0) {
+      // `self` inside an extension body is the extended proxy, which answers a
+      // named scope through `method_missing` (`has_many :comments do; def
+      // newest; created.last; end; end`). The trails equivalent of that lookup
+      // is the scope proxy, so extension methods bind to the wrapped proxy.
+      const wrapped = wrapWithScopeProxy(this as unknown as Relation<T>);
+      for (const mod of extensions) {
+        if (typeof mod === "function") {
+          (mod as (rel: unknown) => void)(wrapped);
         } else {
-          throw err;
+          for (const [name, fn] of Object.entries(
+            mod as Record<string, (...args: unknown[]) => unknown>,
+          )) {
+            (this as unknown as Record<string, unknown>)[name] = fn.bind(wrapped);
+          }
         }
       }
-      if (seedRel === null) {
-        if (this._deferredFkError === undefined) {
-          seedNone();
-        }
-      } else {
-        proxySelf.initializeCopy(seedRel);
-      }
-    }
-
-    // Apply the `extend:` option — mirrors Rails
-    // `CollectionProxy#initialize`, which does `extend(*extensions)` with
-    // `association.extensions` (`reflection.extensions` =
-    // `Array(options[:extend])`). Routing through `extendingBang` (rather
-    // than binding methods directly onto the instance) records the
-    // modules in `extendingValues`, so extension methods survive every spawned
-    // scope (`owner.things.where(...).fooExtension()`) via the rebinding
-    // in `initializeCopy`.
-    const ext = assocDef.options.extend;
-    if (ext) {
-      const extensions = Array.isArray(ext) ? ext : [ext];
-      relationProto.extendingBang.call(this, ...extensions);
     }
   }
 
   /**
    * Shared execution core for `toArray()` and `load()`. Routes both the
    * unmutated and mutated (whereBang / orderBang / ...) proxy through a
-   * single `findTarget` call. When the proxy state has diverged from the
-   * seed, a `queryExecutor` callback is passed so `findTarget` skips cache
-   * and scope rebuild and runs the mutated Relation directly — mirrors Rails'
+   * single `findTarget` call. A mutating bang lands on the memoized `scope`
+   * (collection_proxy.rb:1128-1137), so `findTarget` picks the mutation up
+   * from the scope rebuild — mirrors Rails'
    * `CollectionProxy → AssociationRelation#exec_queries → loadTarget` path
    * which always routes through the OO association regardless of scope state.
    *
@@ -702,10 +607,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * applies `strict_loading_value` after `set_strict_loading` per record).
    */
   private async _execLoad(): Promise<T[]> {
-    // Re-throw a foreign-key derivation error deferred from construction, so
-    // the underivable-FK `ArgumentError` surfaces at load time (Rails'
-    // `load_target`), not when the proxy was built.
-    if (this._deferredFkError !== undefined) throw this._deferredFkError;
     const results = (await this._findTargetViaAssociation()) as T[];
     this._cascadeStrictLoading(results);
     // Relation's strict_loading wins over cascade — applied last to match
@@ -1425,7 +1326,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (typeof assocInstance.resetScope === "function") {
         assocInstance.resetScope();
       }
-      assocInstance._namedScopeRelations = undefined;
     }
   }
 
@@ -1928,47 +1828,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._targetLoaded = false;
     this._target = [];
     this._replacedOrAddedTargets.clear();
-    // Drop the OO association's memoized named-scope relations (Rails'
-    // `reset_scope`) so the next `things.someScope()` rebuilds. Only an
-    // already-built instance can hold a cache, so don't construct one here.
-    const assoc = (this._record as any)._associationInstances?.get(this._assocName) as
-      | { _namedScopeRelations?: Map<string, unknown> }
-      | undefined;
-    if (assoc) assoc._namedScopeRelations = undefined;
     this.resetScope();
     return this;
-  }
-
-  /**
-   * Build (or return the memoized) named-scope relation for `name`. This memo
-   * is trails-specific (RFC 0030): Rails' `scope :name` rebuilds a fresh
-   * relation on every call (named.rb:174-178) — it does NOT cache the named-
-   * scope return value (only `@association_scope` inside `Association#scope` is
-   * memoized). We cache per scope name so two consecutive zero-arg calls within
-   * one association load return the same object. The cache lives on the OO
-   * `CollectionAssociation` so a reset driven through
-   * `owner.association(:things)` invalidates it even though the proxy and the
-   * association are distinct objects here. Only zero-arg scope calls are
-   * memoized — arg'd calls vary per invocation and rebuild fresh, sidestepping
-   * any need to key on (potentially unserializable) arguments. The memo is safe
-   * because the underlying `scope()` is stable within one load: every owner-
-   * state change that would alter it (reload / insert / remove / destroy_all /
-   * delete_all / reset) routes through `CollectionAssociation#reset`, which
-   * clears this cache.
-   * @internal
-   */
-  _cachedNamedScopeRelation(name: string, args: unknown[]): unknown {
-    if (args.length > 0) {
-      return (this.scope() as Record<string, (...a: unknown[]) => unknown>)[name](...args);
-    }
-    const assoc = this._record.association(this._assocName) as unknown as {
-      _namedScopeRelations?: Map<string, unknown>;
-    };
-    const cache = (assoc._namedScopeRelations ??= new Map());
-    if (cache.has(name)) return cache.get(name);
-    const built = (this.scope() as Record<string, () => unknown>)[name]();
-    cache.set(name, built);
-    return built;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -565,19 +565,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       ? instance
       : new CollectionAssociation(record, assocDef);
 
-    // `extensions = association.extensions; extend(*extensions) if extensions.any?`
-    // (collection_proxy.rb:35-37). Ruby's `extend` mixes the modules into this
-    // object only — it does NOT touch relation state; the scope gets the same
-    // modules independently through `scope.extending! reflection.extensions`
-    // (association_scope.rb:28), which is what carries them onto chained
-    // relations. So the TS spelling of `extend` is a method copy onto the
-    // instance.
+    // `extend(*extensions)` (collection_proxy.rb:35-37) mixes into this object
+    // only; chained relations get the same modules independently through
+    // `scope.extending! reflection.extensions` (association_scope.rb:28).
     const extensions = this._targetAssociation.extensions;
     if (extensions.length > 0) {
-      // `self` inside an extension body is the extended proxy, which answers a
-      // named scope through `method_missing` (`has_many :comments do; def
-      // newest; created.last; end; end`). The trails equivalent of that lookup
-      // is the scope proxy, so extension methods bind to the wrapped proxy.
+      // `self` in an extension body answers a named scope through
+      // `method_missing` on the extended proxy; the scope proxy is that lookup.
       const wrapped = wrapWithScopeProxy(this as unknown as Relation<T>);
       for (const mod of extensions) {
         if (typeof mod === "function") {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1491,6 +1491,16 @@ export class ThroughReflection extends AbstractReflection {
     return this.delegateReflection.options;
   }
 
+  // `extensions` is in `AssociationReflection.public_instance_methods`, so
+  // ThroughReflection's blanket `delegate(*delegate_methods, to:
+  // :delegate_reflection)` (reflection.rb:1221-1225) routes it to the delegate.
+  // This is how a HABTM's `extend:` — forwarded onto the generated
+  // `has_many :through` (associations.rb:1900) — reaches
+  // `Association#extensions` (association.rb:170).
+  extensions(): any[] {
+    return this.delegateReflection.extensions();
+  }
+
   // Rails ThroughReflection delegates `autosave=` to the delegate reflection
   // (delegate_methods), where the setter writes `options[:autosave]`. Mirror it
   // so `accepts_nested_attributes_for` on a HABTM/through association flips

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -676,17 +676,11 @@ describe("NamedScopingTest", () => {
 
     for (const method of ["destroyAll", "reset", "deleteAll"] as const) {
       const before = post.comments.containingTheLetterE();
-      // trails-specific (RFC 0030): trails memoizes named-scope relations per
-      // association load, so a second call before the reset hands back the SAME
-      // object. (Rails rebuilds each call, so this `toBe` would NOT hold there —
-      // it asserts trails' added cache.) This is what gives the post-reset
-      // `not.toBe` below its teeth; without the cache it would pass trivially.
-      expect(post.comments.containingTheLetterE()).toBe(before);
       // Mirror Rails' `post.association(:comments).public_send(method)`: drive
       // the reset through the association object, not the proxy reader.
       await post.association("comments")[method]();
-      // Rails' `assert_not_same`; here the reset invalidates trails' named-scope
-      // memo so the next call rebuilds a fresh relation.
+      // Rails' `assert_not_same` — `scope :name` rebuilds a fresh relation on
+      // every call (named.rb:174-178), so the reset object is never the same.
       expect(post.comments.containingTheLetterE()).not.toBe(before);
     }
 


### PR DESCRIPTION
## Summary

Rails' `CollectionProxy#initialize` (`collection_proxy.rb:32-38`) is four
statements — hold the association, `super klass`, `extend(*extensions)`. The
proxy carries **no relation state**; every query method it answers reaches
`@scope ||= @association.scope` through `delegate(*QueryMethods, to: :scope)`
(`:1128-1137`), which trails' delegate table (methods *and* value accessors)
already carries at the bottom of `collection-proxy.ts`.

trails' constructor did the opposite: 61 code lines eagerly building a relation
(`hasManyScope(...)` or `_buildThroughScope()`) and `initializeCopy`-ing it onto
the proxy's own inherited `Relation` state. This removes the seeding.

## Deleted

- **`seedNone()`** — existed only to hand-unset `_isNone` after the copy so the
  copied flag wouldn't fire `update_all`'s `return 0 if @none`
  (`relation.rb:1013`) on the proxy itself.
- **`_deferredFkError`** — a field holding an `ArgumentError` raised during
  construction and re-thrown at load. Rails never raises it early because it
  never builds the scope early; the error now surfaces from the scope build
  inside the load, with no field to stash it in. Still covered by
  `query constraints over three without defining explicit foreign key query
  constraints raises`, whose body asserts exactly this: reading the accessor
  does not throw, `toArray()` rejects.
- **The `Relation.prototype` reach-around** — needed only because the seeding
  bangs would otherwise be forwarded to a `scope()` that is not buildable
  mid-construction.
- **`_cachedNamedScopeRelation`** and its `_namedScopeRelations` store, plus the
  three invalidation sites. Rails' `scope :name` rebuilds a fresh relation on
  every call (`named.rb:174-178`) and has no such cache; named-scope calls fall
  through to `scope()` in the proxy's method_missing.

## Extensions

The `extend(*extensions)` arm now matches Rails on both halves:

- It reads **`association.extensions`** (`association.rb:169-176` — the union of
  `klass.default_extensions`, `reflection.extensions`, and the scope's) rather
  than `assocDef.options.extend`. That is how a `default_scope { extending
  OopsExtension }` reaches the proxy (`association with default scope`).
- `ThroughReflection` gains the `extensions` delegation its blanket
  `delegate(*delegate_methods, to: :delegate_reflection)`
  (`reflection.rb:1221-1225`) provides — the route a HABTM's forwarded
  `extend:` (`associations.rb:1900`) takes to `Association#extensions`.
- Ruby's `extend` mixes into the object only; it does not touch relation state.
  The scope gets the same modules independently via `scope.extending!
  reflection.extensions` (`association_scope.rb:28`), which is what carries them
  onto chained relations — so the TS spelling is a method copy onto the
  instance, no longer `extendingBang`. Methods bind to the scope-proxy-wrapped
  proxy so a bare named-scope call in an extension body (`has_many :comments do;
  def newest; created.last; end; end`) resolves the way Ruby's `method_missing`
  does on the extended proxy.

## Test change

`scopes are reset on association reload` loses one trails-only assertion —
`expect(post.comments.containingTheLetterE()).toBe(before)`, whose own comment
said "Rails rebuilds each call, so this `toBe` would NOT hold there — it asserts
trails' added cache." The Rails body (`named_scoping_test.rb:570-578`) is the
`assert_not_same` alone. No test renamed.

## Verification

- `pnpm vitest run packages/activerecord/src/scoping/ src/associations/
  src/associations.test.ts src/relation.test.ts` — **113 files, 2477 passed**,
  15 skipped, 1 todo. Covers `has-many-associations`,
  `has-many-through-associations`, `habtm`, `collection-proxy`,
  `null-scope.trails`, `extension`, `named-scoping`.
- `pnpm parity:api:calls` — OK (943 baselined, unchanged). `pnpm
  parity:api:calls:args` — OK (170 baselined shape rows, unchanged). Zero rows
  added.
- `pnpm parity:api:extra --package activerecord` — no new names (one removed).
- `pnpm typecheck`, `pnpm lint` clean.

Net: **-190 / +27**.

Closes-story: collection-proxy-initialize-is-five-lines
