### PR TITLE
refactor(activerecord): park a future-result handle in loadAsync and delegate the bulk-insert family to scope

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -40,7 +40,6 @@ import {
   AssociationTypeMismatch,
   RecordNotFound,
 } from "../errors.js";
-import { ArgumentError } from "@blazetrails/activemodel";
 import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
 import {
@@ -934,66 +933,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Bulk insert/upsert through a collection association. Mirrors
-   * ActiveRecord::AssociationRelation, which guards `insert`, `insert_all`,
-   * `insert!`, `insert_all!`, `upsert`, and `upsert_all`: when the
-   * association is `has_many :through`, it raises ArgumentError because the
-   * join records can't be built from the bulk path. Non-through associations
-   * fall through to the inherited Relation implementation.
-   */
-  private _assertBulkInsertable(): void {
-    if (this.isThrough) {
-      throw new ArgumentError(
-        "Bulk insert or upsert is currently not supported for has_many through association",
-      );
-    }
-  }
-
-  async insert(
-    attrs: Record<string, unknown>,
-    options?: { uniqueBy?: string | string[] },
-  ): ReturnType<Relation<T>["insert"]> {
-    this._assertBulkInsertable();
-    return super.insert(attrs, options);
-  }
-
-  async insertBang(
-    ...args: Parameters<Relation<T>["insertBang"]>
-  ): ReturnType<Relation<T>["insertBang"]> {
-    this._assertBulkInsertable();
-    return super.insertBang(...args);
-  }
-
-  async insertAll(
-    ...args: Parameters<Relation<T>["insertAll"]>
-  ): ReturnType<Relation<T>["insertAll"]> {
-    this._assertBulkInsertable();
-    return super.insertAll(...args);
-  }
-
-  async insertAllBang(
-    ...args: Parameters<Relation<T>["insertAllBang"]>
-  ): ReturnType<Relation<T>["insertAllBang"]> {
-    this._assertBulkInsertable();
-    return super.insertAllBang(...args);
-  }
-
-  async upsert(
-    attrs: Record<string, unknown>,
-    options?: { uniqueBy?: string | string[] },
-  ): ReturnType<Relation<T>["upsert"]> {
-    this._assertBulkInsertable();
-    return super.upsert(attrs, options);
-  }
-
-  async upsertAll(
-    ...args: Parameters<Relation<T>["upsertAll"]>
-  ): ReturnType<Relation<T>["upsertAll"]> {
-    this._assertBulkInsertable();
-    return super.upsertAll(...args);
-  }
-
-  /**
    * Mirrors `CollectionProxy#create` (collection_proxy.rb:334-336): a plain
    * delegation to `@association.create(attributes, &block)`. The persisted-owner
    * guard, the Array arm, `build_record`, and the
@@ -1768,12 +1707,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Set the collection to exactly the records identified by ids, e.g.
    * `order.book_ids = [...]`.
    *
-   * Delegates to `CollectionAssociation#idsWriter` — the same method the
-   * generated `<name>_ids=` writer calls — so there is one Rails-faithful
-   * `ids_writer` and tests exercise the real writer path. Mirrors Rails'
-   * `CollectionProxy`, which forwards `ids_writer` to its `@association`.
+   * Delegates to `CollectionAssociation#idsWriter`
+   * (collection_association.rb:62-85) — the same method the generated
+   * `<name>_ids=` writer calls (builder/collection_association.rb:73) — so
+   * there is one Rails-faithful `ids_writer` and tests exercise the real
+   * writer path. Rails reaches it as `record.association(:name).ids_writer`;
+   * a JS property assignment cannot be awaited, so the Rails name lives here
+   * as the awaitable entry point.
+   *
+   * @noRailsEquivalent collection_proxy.rb writes no `ids_writer`; the Ruby
+   *   spelling of this call site is the generated `<name>_ids=` setter, which
+   *   TypeScript cannot make awaitable.
    */
-  async setIds(ids: (number | string | (number | string)[])[]): Promise<void> {
+  async idsWriter(ids: (number | string | (number | string)[])[]): Promise<void> {
     await (
       this._record.association(this._assocName) as unknown as {
         idsWriter(ids: unknown[]): Promise<void>;
@@ -1814,7 +1760,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   override reset(): this {
     // Call Relation.reset() so inherited query state (_records,
-    // _loaded, _loadToken, _loadAsyncPromise) is cleared alongside the
+    // _loaded, _loadToken, _futureResult) is cleared alongside the
     // association-specific target cache. Without super, callers using
     // Relation#load() / Relation#loadAsync() patterns on the proxy
     // would see stale results after reset.

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1704,30 +1704,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Set the collection to exactly the records identified by ids, e.g.
-   * `order.book_ids = [...]`.
-   *
-   * Delegates to `CollectionAssociation#idsWriter`
-   * (collection_association.rb:62-85) — the same method the generated
-   * `<name>_ids=` writer calls (builder/collection_association.rb:73) — so
-   * there is one Rails-faithful `ids_writer` and tests exercise the real
-   * writer path. Rails reaches it as `record.association(:name).ids_writer`;
-   * a JS property assignment cannot be awaited, so the Rails name lives here
-   * as the awaitable entry point.
-   *
-   * @noRailsEquivalent collection_proxy.rb writes no `ids_writer`; the Ruby
-   *   spelling of this call site is the generated `<name>_ids=` setter, which
-   *   TypeScript cannot make awaitable.
-   */
-  async idsWriter(ids: (number | string | (number | string)[])[]): Promise<void> {
-    await (
-      this._record.association(this._assocName) as unknown as {
-        idsWriter(ids: unknown[]): Promise<void>;
-      }
-    ).idsWriter(ids);
-  }
-
-  /**
    * Mirrors: ActiveRecord::Associations::CollectionProxy#pluck
    * (collection_proxy.rb:728-730) — `null_scope? ? scope.pluck(*column_names) : super`.
    */

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -365,8 +365,8 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
       devs.push(await Developer.create({ name: `JME ${i}`, salary: 50000 }));
     }
 
-    await newProject.developers.setIds([devs[0].id, devs[1].id] as any);
-    await newProject.developersWithCallbacks.setIds([devs[2].id, devs[3].id] as any);
+    await newProject.developers.idsWriter([devs[0].id, devs[1].id] as any);
+    await newProject.developersWithCallbacks.idsWriter([devs[2].id, devs[3].id] as any);
     expect(await newProject.save()).toBe(true);
 
     await newProject.reload();
@@ -937,7 +937,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const activeRecord = projects("active_record");
     const actionController = projects("action_controller");
     const developer = new Developer({ name: "Joe" });
-    await developer.projects.setIds([activeRecord.id, actionController.id] as any);
+    await developer.projects.idsWriter([activeRecord.id, actionController.id] as any);
     await (developer as any).save();
     await developer.reload();
     expect((await developer.projects).length).toBe(2);
@@ -951,7 +951,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const activeRecord = projects("active_record");
     const actionController = projects("action_controller");
     const developer = new Developer({ name: "Joe" });
-    await developer.projects.setIds([activeRecord.id, null, actionController.id, ""] as any);
+    await developer.projects.idsWriter([activeRecord.id, null, actionController.id, ""] as any);
     await (developer as any).save();
     await developer.reload();
     expect((await developer.projects).length).toBe(2);

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -365,8 +365,10 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
       devs.push(await Developer.create({ name: `JME ${i}`, salary: 50000 }));
     }
 
-    await newProject.developers.idsWriter([devs[0].id, devs[1].id] as any);
-    await newProject.developersWithCallbacks.idsWriter([devs[2].id, devs[3].id] as any);
+    await (newProject as any).association("developers").idsWriter([devs[0].id, devs[1].id]);
+    await (newProject as any)
+      .association("developersWithCallbacks")
+      .idsWriter([devs[2].id, devs[3].id]);
     expect(await newProject.save()).toBe(true);
 
     await newProject.reload();
@@ -937,7 +939,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const activeRecord = projects("active_record");
     const actionController = projects("action_controller");
     const developer = new Developer({ name: "Joe" });
-    await developer.projects.idsWriter([activeRecord.id, actionController.id] as any);
+    await (developer as any)
+      .association("projects")
+      .idsWriter([activeRecord.id, actionController.id]);
     await (developer as any).save();
     await developer.reload();
     expect((await developer.projects).length).toBe(2);
@@ -951,7 +955,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const activeRecord = projects("active_record");
     const actionController = projects("action_controller");
     const developer = new Developer({ name: "Joe" });
-    await developer.projects.idsWriter([activeRecord.id, null, actionController.id, ""] as any);
+    await (developer as any)
+      .association("projects")
+      .idsWriter([activeRecord.id, null, actionController.id, ""]);
     await (developer as any).save();
     await developer.reload();
     expect((await developer.projects).length).toBe(2);

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1609,7 +1609,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter", async () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;
-    await association(company, "developers").idsWriter([dev.id as number]);
+    await (company as any).association("developers").idsWriter([dev.id as number]);
     const devs = await (company as any).developers.toArray();
     expect(devs.map((d: any) => d.id)).toEqual([dev.id]);
   });
@@ -1617,7 +1617,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter with required type cast", async () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;
-    await association(company, "developers").idsWriter([`${dev.id}`]);
+    await (company as any).association("developers").idsWriter([`${dev.id}`]);
     const devs = await (company as any).developers.toArray();
     expect(devs.map((d: any) => d.id)).toEqual([dev.id]);
   });
@@ -1625,12 +1625,12 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter with string primary keys", async () => {
     const book = await Book.find(books("awdr").id);
     const second = await Subscriber.find(subscribers("second").nick);
-    await association(book, "subscribers").idsWriter([second.nick]);
+    await (book as any).association("subscribers").idsWriter([second.nick]);
     expect((await (book as any).subscribers.reload()).map((s: any) => s.nick)).toEqual([
       second.nick,
     ]);
 
-    await association(book, "subscribers").idsWriter([]);
+    await (book as any).association("subscribers").idsWriter([]);
     await (book as any).subscribers.reload();
     expect(await (book as any).subscribers.toArray()).toEqual([]);
   });
@@ -1641,7 +1641,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const ids = [dev.id as number, -9999];
     // Rails asserts the full message, including the trailing `not_found_ids`
     // sentence (`klass.all.raise_record_not_found_exception!(…, not_found_ids)`).
-    await expect(association(company, "developers").idsWriter(ids)).rejects.toThrow(
+    await expect((company as any).association("developers").idsWriter(ids)).rejects.toThrow(
       `Couldn't find all Developers with 'id': (${dev.id}, -9999) (found 1 results, but was looking for 2). Couldn't find Developer with id -9999.`,
     );
   });
@@ -1649,7 +1649,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids through setter raises exception when invalid ids set", async () => {
     const david = await Author.find(authors("david").id);
     const ids = [(categories("general") as any).name, "Unknown"];
-    await expect(association(david, "essayCategories").idsWriter(ids)).rejects.toThrow(
+    await expect((david as any).association("essayCategories").idsWriter(ids)).rejects.toThrow(
       "Couldn't find all Categories with 'name': (General, Unknown) (found 1 results, but was looking for 2). Couldn't find Category with name Unknown.",
     );
   });

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1609,7 +1609,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter", async () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;
-    await association(company, "developers").setIds([dev.id as number]);
+    await association(company, "developers").idsWriter([dev.id as number]);
     const devs = await (company as any).developers.toArray();
     expect(devs.map((d: any) => d.id)).toEqual([dev.id]);
   });
@@ -1617,7 +1617,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter with required type cast", async () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;
-    await association(company, "developers").setIds([`${dev.id}`]);
+    await association(company, "developers").idsWriter([`${dev.id}`]);
     const devs = await (company as any).developers.toArray();
     expect(devs.map((d: any) => d.id)).toEqual([dev.id]);
   });
@@ -1625,12 +1625,12 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids setter with string primary keys", async () => {
     const book = await Book.find(books("awdr").id);
     const second = await Subscriber.find(subscribers("second").nick);
-    await association(book, "subscribers").setIds([second.nick]);
+    await association(book, "subscribers").idsWriter([second.nick]);
     expect((await (book as any).subscribers.reload()).map((s: any) => s.nick)).toEqual([
       second.nick,
     ]);
 
-    await association(book, "subscribers").setIds([]);
+    await association(book, "subscribers").idsWriter([]);
     await (book as any).subscribers.reload();
     expect(await (book as any).subscribers.toArray()).toEqual([]);
   });
@@ -1641,7 +1641,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const ids = [dev.id as number, -9999];
     // Rails asserts the full message, including the trailing `not_found_ids`
     // sentence (`klass.all.raise_record_not_found_exception!(…, not_found_ids)`).
-    await expect(association(company, "developers").setIds(ids)).rejects.toThrow(
+    await expect(association(company, "developers").idsWriter(ids)).rejects.toThrow(
       `Couldn't find all Developers with 'id': (${dev.id}, -9999) (found 1 results, but was looking for 2). Couldn't find Developer with id -9999.`,
     );
   });
@@ -1649,7 +1649,7 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids through setter raises exception when invalid ids set", async () => {
     const david = await Author.find(authors("david").id);
     const ids = [(categories("general") as any).name, "Unknown"];
-    await expect(association(david, "essayCategories").setIds(ids)).rejects.toThrow(
+    await expect(association(david, "essayCategories").idsWriter(ids)).rejects.toThrow(
       "Couldn't find all Categories with 'name': (General, Unknown) (found 1 results, but was looking for 2). Couldn't find Category with name Unknown.",
     );
   });

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -700,10 +700,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
   it("assign ids", async () => {
     const firm = new Firm({ name: "Apple" });
-    await firm.clients.idsWriter([
-      companies("first_client").id as number,
-      companies("second_client").id as number,
-    ]);
+    await (firm as any)
+      .association("clients")
+      .idsWriter([companies("first_client").id as number, companies("second_client").id as number]);
     await firm.save();
     await firm.reload();
     const clients = await firm.clients;
@@ -759,7 +758,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const proxy = association(order, "orderAgreements");
     expect(await proxy).toHaveLength(0);
 
-    await proxy.idsWriter(orderAgreements as number[]);
+    await (order as any).association("orderAgreements").idsWriter(orderAgreements as number[]);
     await order.save();
     await order.reload();
 
@@ -833,7 +832,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const proxy = association(order, "books");
     expect(await proxy).toHaveLength(0);
 
-    await proxy.idsWriter(bookIds as number[][]);
+    await (order as any).association("books").idsWriter(bookIds as number[][]);
     await order.save();
     await order.reload();
 
@@ -892,10 +891,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
   it("assign ids for through a belongs to", async () => {
     const firm = new Firm({ name: "Apple" });
-    await firm.developers.idsWriter([
-      developers("david").id as number,
-      developers("jamis").id as number,
-    ]);
+    await (firm as any)
+      .association("developers")
+      .idsWriter([developers("david").id as number, developers("jamis").id as number]);
     await firm.save();
     await firm.reload();
     const devs = await firm.developers;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -700,7 +700,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
   it("assign ids", async () => {
     const firm = new Firm({ name: "Apple" });
-    await firm.clients.setIds([
+    await firm.clients.idsWriter([
       companies("first_client").id as number,
       companies("second_client").id as number,
     ]);
@@ -759,7 +759,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const proxy = association(order, "orderAgreements");
     expect(await proxy).toHaveLength(0);
 
-    await proxy.setIds(orderAgreements as number[]);
+    await proxy.idsWriter(orderAgreements as number[]);
     await order.save();
     await order.reload();
 
@@ -833,7 +833,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const proxy = association(order, "books");
     expect(await proxy).toHaveLength(0);
 
-    await proxy.setIds(bookIds as number[][]);
+    await proxy.idsWriter(bookIds as number[][]);
     await order.save();
     await order.reload();
 
@@ -892,7 +892,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
   it("assign ids for through a belongs to", async () => {
     const firm = new Firm({ name: "Apple" });
-    await firm.developers.setIds([
+    await firm.developers.idsWriter([
       developers("david").id as number,
       developers("jamis").id as number,
     ]);

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -66,8 +66,12 @@ describe("ModulesTest", () => {
     const firm = await MyAppBusinessFirm.first();
     const client = await MyAppBusinessClient.first();
     await assertNothingRaised(async () => {
-      type WithClients = { clients: { idsWriter(ids: number[]): Promise<void> } };
-      await (firm as unknown as WithClients).clients.idsWriter([client!.id as number]);
+      type WithAssociation = {
+        association(name: string): { idsWriter(ids: number[]): Promise<void> };
+      };
+      await (firm as unknown as WithAssociation)
+        .association("clients")
+        .idsWriter([client!.id as number]);
     });
   });
 

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -66,8 +66,8 @@ describe("ModulesTest", () => {
     const firm = await MyAppBusinessFirm.first();
     const client = await MyAppBusinessClient.first();
     await assertNothingRaised(async () => {
-      type WithClients = { clients: { setIds(ids: number[]): Promise<void> } };
-      await (firm as unknown as WithClients).clients.setIds([client!.id as number]);
+      type WithClients = { clients: { idsWriter(ids: number[]): Promise<void> } };
+      await (firm as unknown as WithClients).clients.idsWriter([client!.id as number]);
     });
   });
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -537,19 +537,20 @@ export class Relation<T extends Base> {
    */
   _instantiateBlock?: (record: T) => void;
   /**
-   * The in-flight handle `loadAsync()` leaves behind so a later awaiter joins
-   * the running query instead of issuing a second one.
+   * Mirrors Rails' `@future_result` (relation.rb:91, :1148) — the handle
+   * `loadAsync` parks so the foreground `execQueries` pass drains the ROWS
+   * (relation.rb:1405-1409) instead of issuing the query itself.
    *
-   * **No Rails equivalent — PERMANENT.** Rails' counterpart state is `@future_result`
-   * (relation.rb:91, :1148), a `Concurrent::FutureResult` posted to a
-   * `Concurrent::ThreadPoolExecutor` (connection_pool.rb:717). Concurrent-ruby
-   * is a gem, not a Rails class, so there is no Ruby file to mirror, and JS has
-   * one thread: the only handle to background work is a Promise. Same decision,
-   * same reason, as the `@noRailsEquivalent PERMANENT` tag on `ar-config.ts:55`
-   * — spelled as prose here because `parity:api:extra` never scores a
-   * `_`-prefixed private member, so a real tag on one reads back as stale.
+   * Rails holds a `Concurrent`-backed `FutureResult`; trails holds the promise
+   * `execMainQuery` returns. `FutureResult` is a thenable, so an `async` method
+   * that returns one already resolves it — that promise IS trails' handle to
+   * the same scheduled query, and it is what `isScheduled` reads. Same
+   * decision, same reason, as the `@noRailsEquivalent PERMANENT` tag on
+   * `ar-config.ts:55` — spelled as prose here because `parity:api:extra` never
+   * scores a `_`-prefixed private member, so a real tag on one reads back as
+   * stale.
    */
-  private _loadAsyncPromise?: Promise<T[]>;
+  private _futureResult?: Promise<Result>;
   /**
    * Monotonic token bumped on reset()/reload() so an in-flight toArray()
    * that started before the reset can detect it lost the race and skip
@@ -708,12 +709,13 @@ export class Relation<T extends Base> {
     this._shouldEagerLoad = undefined;
     this._cacheKeys = undefined;
     this._cacheVersions = undefined;
-    // Bump the load token and drop any in-flight loadAsync() promise —
-    // an already-running toArray() checks the token after its await and
-    // will skip committing if it lost the race, so a stale background
-    // load can't re-populate records after a reset.
+    // Mirrors relation.rb:1195-1196 (`@future_result&.cancel; @future_result =
+    // nil`). A JS promise has no `cancel`, so the load token stands in: an
+    // already-running toArray() checks it after its await and skips committing
+    // if it lost the race, so a stale background load can't re-populate
+    // records after a reset.
     this._loadToken += 1;
-    this._loadAsyncPromise = undefined;
+    this._futureResult = undefined;
     return this;
   }
 
@@ -751,35 +753,21 @@ export class Relation<T extends Base> {
     // (relation.rb:1138-1154). Both of those reads need the connection that
     // will run the query, so trails makes them where it is in hand — in
     // `execMainQuery` — and marks the load async here.
-    //
-    // The `_loadAsyncPromise` memoization is retained in place of Rails'
-    // `@future_result` + `scheduled?`: Rails' foreground `exec_queries` reads
-    // `future.result` for the ROWS and still instantiates records itself, so
-    // the future is all it has to hold. trails' loading path is a promise the
-    // whole way down — instantiation, eager loading and preloading are awaited
-    // inside `execQueries` — so the in-flight handle a second caller must
-    // join is that promise, not the FutureResult, which covers only the first
-    // of those steps.
-    // Kick off the load in the background and stash the in-flight promise.
-    // toArray() already caches _loaded/_records when it resolves, so no
-    // .then bookkeeping is needed. A later `await rel.toArray()` drains
-    // the stashed promise instead of issuing a second query — and carries
-    // any rejection to the awaiter, matching Rails' load_async behavior.
-    //
-    // Keep the promise cached for the full lifetime of the load (clear
-    // in finally) so concurrent callers share the one in-flight query
-    // instead of racing to fire additional ones.
-    if (!this._loadAsyncPromise && !this._loaded) {
-      // Rails' `unless loaded?` guards the async query too (relation.rb:1141).
-      const loadPromise = this.toArray(true).finally(() => {
-        this._loadAsyncPromise = undefined;
-      });
-      // Attach a no-op rejection handler so a failure here isn't treated
-      // as an unhandled rejection if nothing else awaits the relation.
-      // The stored promise still carries the rejection to explicit
-      // awaiters (.toArray(), etc.) via a separate chain.
-      void loadPromise.catch(() => {});
-      this._loadAsyncPromise = loadPromise;
+    if (!this._loaded && !this._futureResult) {
+      // Rails' `unless loaded?` (relation.rb:1141). trails also guards on the
+      // parked handle so a second `loadAsync()` joins the scheduled query
+      // rather than issuing another one; Rails cannot reach that state because
+      // its `load_async` sets `@loaded` in the same breath (relation.rb:1149),
+      // which trails leaves to `toArray` — its `_loaded` fast paths, and
+      // `size`/`isEmpty`'s, read `_records` directly rather than routing
+      // through `load` the way Rails' do.
+      const futureResult = this.execMainQuery(true);
+      // Attach a no-op rejection handler so a failure here isn't treated as an
+      // unhandled rejection if nothing else awaits the relation. The stored
+      // promise still carries the rejection to `execQueries` through a separate
+      // chain.
+      void futureResult.catch(() => {});
+      this._futureResult = futureResult;
     }
     return this;
   }
@@ -1031,28 +1019,10 @@ export class Relation<T extends Base> {
    * Execute the query and return all records.
    *
    * Mirrors: ActiveRecord::Relation#to_a / #load
-   *
-   * `async` is Rails' `exec_main_query(async:)` keyword (relation.rb:1423),
-   * threaded from `loadAsync()` — trails' `load_async` reaches the query
-   * through this method rather than calling `exec_main_query` itself, because
-   * instantiation, eager loading and preloading are all awaited inside
-   * `execQueries`.
    */
-  async toArray(async = false): Promise<T[]> {
+  async toArray(): Promise<T[]> {
     if (this.isNullRelation()) return [];
     if (this._loaded) return [...this._records];
-    if (this._loadAsyncPromise) {
-      // A prior loadAsync() kicked off the query — share the in-flight
-      // promise so callers drain the same query (and carry its errors)
-      // instead of racing to issue additional ones. The promise clears
-      // itself in loadAsync's .finally once the load settles.
-      //
-      // This check must stay synchronous (before any await): loadAsync
-      // calls toArray() and only assigns _loadAsyncPromise once it
-      // returns. Awaiting earlier would let this call resume after the
-      // assignment and return the promise derived from itself, deadlocking.
-      return this._loadAsyncPromise;
-    }
     // Run the query inside `with_connection` so the pool releases the connection
     // afterwards instead of holding it permanently. The build / execute path
     // reads the threaded connection via `_conn()` (see {@link withConnection})
@@ -1065,7 +1035,7 @@ export class Relation<T extends Base> {
     // in `exec_queries`, which is what makes `.explain` (which calls
     // `exec_queries` directly, relation.rb:13) side-effect-free.
     const token = this._loadToken;
-    const records = await this.withConnection(() => this.execQueries(async));
+    const records = await this.withConnection(() => this.execQueries());
     // A reset() landed while the query was in flight: return the rows we got
     // without clobbering the fresh state.
     if (token !== this._loadToken) return records;
@@ -1076,7 +1046,7 @@ export class Relation<T extends Base> {
   /**
    * Mirrors: ActiveRecord::Relation#exec_queries (relation.rb:1403-1421).
    */
-  private async execQueries(async = false): Promise<T[]> {
+  private async execQueries(): Promise<T[]> {
     return this.skipQueryCacheIfNecessary(async () => {
       // Lazily reflect the schema before issuing the query so consumers
       // don't have to call loadSchema explicitly. Idempotent and cheap.
@@ -1096,7 +1066,17 @@ export class Relation<T extends Base> {
       // clobbering the fresh state.
       const token = this._loadToken;
 
-      const rows = await this.execMainQuery(async);
+      // Mirrors relation.rb:1405-1409: when `load_async` already scheduled the
+      // query, the foreground pass drains that handle instead of issuing its
+      // own.
+      let rows: Result;
+      if (this.isScheduled) {
+        const future = this._futureResult!;
+        this._futureResult = undefined;
+        rows = await future;
+      } else {
+        rows = await this.execMainQuery();
+      }
       if (token !== this._loadToken) return [];
       const records = this.instantiateRecords(rows);
 
@@ -1185,8 +1165,9 @@ export class Relation<T extends Base> {
         });
       }
 
-      // Awaiting the FutureResult here is trails' `future.result` in
-      // `exec_queries` (relation.rb:1408).
+      // Mirrors relation.rb:1449 (`_query_by_sql` → querying.rb:67-68). A
+      // scheduled FutureResult is a thenable, so the promise this returns
+      // settles to the same rows `future.result` yields in `execQueries`.
       return c.selectAll(this.toArel(), `${this.model.name} Load`, [], { async });
     });
   }
@@ -2704,8 +2685,13 @@ export class Relation<T extends Base> {
     return pb;
   }
 
+  /**
+   * Returns true if the relation was scheduled on the background thread pool.
+   *
+   * Mirrors: ActiveRecord::Relation#scheduled? (relation.rb:1170-1172)
+   */
   get isScheduled(): boolean {
-    return false;
+    return !!this._futureResult;
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -42,15 +42,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_queries",
-    "call": "exec_main_query",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "relation.rb:1408 calls `exec_main_query` bare because `load_async` (relation.rb:1142) calls it directly with `async:`; trails' loadAsync is synchronous and reaches the query through toArray/execQueries, so the flag is threaded down that path as the same `async` argument instead."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exec_queries",
     "call": "preload_associations",
     "kind": "args",
     "rubyArgs": [


### PR DESCRIPTION
Bundles two RFC stories.

## 1. Split `@future_result` / `scheduled?` out of `execQueries` (RFC 0107)

Rails' `load_async` calls `exec_main_query(async:)` **directly**
(`relation.rb:1142`) and parks the returned FutureResult in `@future_result`; the
foreground pass drains it through the `scheduled?` arm of `exec_queries`
(`relation.rb:1405-1409`), which is why `exec_queries` calls `exec_main_query`
bare (`relation.rb:1408`). trails instead threaded `async` down
`toArray` → `execQueries` → `execMainQuery` (PR #6744), which gave the public
`toArray` a parameter no Rails caller of `to_a` passes and cost one `args`
baseline row.

This PR gives trails the same dispatch:

- `_futureResult` holds the ROWS handle `loadAsync` parks — the promise
  `execMainQuery` returns, which is what `FutureResult` (a thenable) settles to.
  It replaces `_loadAsyncPromise`, whose whole-load memo the split subsumes.
- `isScheduled` is implemented against it (`relation.rb:1170-1172`); it was a
  stub returning `false`.
- `execQueries` gets the `if scheduled?` arm (`relation.rb:1405-1409`) and calls
  `execMainQuery()` with no arguments.
- `reset()` drops the handle (`relation.rb:1195-1196`); a JS promise has no
  `cancel`, so the existing `_loadToken` still covers the reset-mid-flight race.
- `toArray` and `execQueries` no longer take an `async` parameter.
- The `exec_queries` → `exec_main_query` `args` baseline row is **deleted** (by
  hand, no reseed). No new rows; `parity:api:calls` / `:args` both OK.

## 2. CollectionProxy bulk-insert family delegates to `scope` (RFC 0114)

Rails routes `insert, insert_all, insert!, insert_all!, upsert, upsert_all` to
`scope` through `delegate_methods` (`collection_proxy.rb:1128-1137`) and writes
no override. trails wrote six, each calling an invented `_assertBulkInsertable`
guard and then `super.X` — which runs the inherited `Relation` method against
the proxy's own seeded relation state rather than the association's.

All six overrides and the guard are deleted; the names reach `scope` through the
delegate table already listing them. The `has_many :through` ArgumentError is not
lost: it lives where Rails puts it, on `AssociationRelation`
(`association_relation.rb:18-27`), and `scope()` returns one — verified against a
throwaway test that `book.subscribers.insertAll(...)` still raises
`Bulk insert or upsert is currently not supported for has_many through association`.

`setIds` takes the Rails name `idsWriter` (`collection_association.rb:62-85`,
the same method the generated `<name>_ids=` writer calls); all in-repo callers
updated.

`parity:api:extra` for `associations/collection-proxy.ts`: 6 novel / 33 moved →
5 novel / 27 moved.

## Verification

- `pnpm parity:api` — `relation.rb` → `relation.ts` stays 401/401.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK (no stale marks).
- `pnpm parity:test` deltas non-negative; `pnpm lint`, `pnpm typecheck` clean.
- Green locally: `relation-load-async.trails.test.ts`, `relation/load-async.test.ts`,
  `asynchronous-queries.test.ts`, `null-relation.test.ts`, `relations.test.ts`,
  `has-many-associations.test.ts`, `has-many-through-associations.test.ts`,
  `has-and-belongs-to-many-associations.test.ts`, `autosave-association.test.ts`,
  `modules.test.ts`, `insert-all.test.ts`, `constructor-form-and-hmt-insert.test.ts`.
  No test renamed.

Closes-story: split-future-result-scheduled-dispatch-out-of-exec-queries
Closes-story: collection-proxy-bulk-insert-family-delegates-to-scope

## Review round 1

**`loadAsync().size()` does not drain the future — confirmed, filed.**
Correct, and correctly diagnosed: Rails' `size` takes `records.length`
(`relation.rb:354`) because `load_async` sets `@loaded` (`relation.rb:1149`),
and `records` -> `load`'s `!loaded? || scheduled?` guard (`relation.rb:1180`)
drains the future there. trails sets no `_loaded` and its readers hit
`_records` directly (`relation.ts:866-869`, `:876-879`, `:917`).

Not fixed here because the one-line version is a correctness regression, not a
fix. Four readers of `_loaded` are **synchronous** and reach `_records`
directly — `inspect()` (`relation.ts:618`), the `isLoaded`/`loaded` getters
(`:695`, `:2644`), and `computeCacheVersion()` (`:2941`) — and a sync TS method
cannot await the drain that Rails' `records` does synchronously at
`relation.rb:1180`. With `_loaded` true and `_records` empty, each of those
would answer as though the relation loaded to zero rows. Deciding how a
scheduled-but-undrained relation answers a *synchronous* question is the actual
work, and it spans methods not in this diff.

Filed as `0107-relation-ts-decomposition/load-async-sets-loaded-so-loaded-readers-drain-the-future`
with the Rails cites above and the four sync-reader sites enumerated.

**`load_async` delegation on `CollectionProxy` — already converged; no gap.**
This one is a misread of the current code. trails' `CollectionProxy` has no
`loadAsync` *override*, which is exactly right — it has the *delegate*, and
`"loadAsync"` is already in the delegate list at `collection-proxy.ts:2421`,
alongside the six bulk-insert names this PR just stopped shadowing. The loop at
`collection-proxy.ts:2450-2459` installs each as an own property on
`CollectionProxy.prototype` whose body is `this.scope()[name](...args)` — so
`proxy.loadAsync()` runs against `scope()`, matching
`collection_proxy.rb:1131`, and never reaches the proxy's own relation state.

Verified with a throwaway test:
`Object.hasOwn(CollectionProxy.prototype, "loadAsync")` is `true`, and
patching `scope().loadAsync` observes the call arriving through the scope when
`proxy.loadAsync()` is invoked. No change needed.

## CI fix (22bf8a4)

`Rails API/Test Comparison` failed in its `extra-surface.ts` step on an
unclassified permanence claim — the `@noRailsEquivalent` tag I put on
`CollectionProxy#idsWriter` opened with neither PERMANENT nor CONVERGEABLE:

```
permanence claims: 181 PERMANENT, 11 CONVERGEABLE, 1 unclassified.
    activerecord  associations/collection-proxy.ts  idsWriter
```

Rather than pick a classifier, I checked whether the tag was defensible — and it
was not, so the surface is gone instead. Ruby's `<name>_ids=` writer genuinely
cannot be awaited in TS, but that shortcoming is already answered by two
sanctioned surfaces, and the repo's own error message names exactly those two
(`associations/errors.ts:543-544`, RFC 0068):
`owner.update({ itemIds: [...] })` and
`owner.association(name).idsWriter([...])`. Since `collection_proxy.rb` writes
no `ids_writer` of its own, a third spelling on the proxy was redundant extra
surface, not a language necessity — CONVERGEABLE, and cheap enough to converge
now.

Call sites move to `record.association(name).idsWriter(...)`. Worth noting for
review: the exported `association(record, name)` helper returns the **proxy**,
not the association, so the has_many-through sites that looked like they already
used the association were routing through the deleted method too.

Re-verified after a rebuild (`extra-surface.ts` refuses to measure a stale
manifest): `parity:api:extra` **0 unclassified**, `associations/collection-proxy.ts`
moved 27 -> 26; `parity:api` `relation.rb` -> `relation.ts` still 401/401;
`parity:api:calls` and `:args` OK; `lint` and `typecheck` clean; the five touched
suites green (493 passed). No test renamed.

### CI on the current HEAD (22bf8a4a4)

`Rails API/Test Comparison` — the job that failed on the previous HEAD — is
**green** on this one, which closes the only item review round 2 left open.
The full run for this sha, **32316412013, is green end to end** (including
`Active Record SQLite Tests`, `Lint`, `Unit Tests`, `Build & Type Check`,
`Trailties Tests`, `Leaf Tests`, `Virtualized DX Type Tests`).

If you see a red `CI` entry in the checks rollup: run **32316051074** is on this
same sha and was **cancelled** by the concurrency group when superseded, and a
cancelled run reports `FAILURE` on the aggregate `CI` check. No job in it
failed on its merits — the SQLite job was cancelled mid-flight and re-ran green
in 32316412013.

