### PR TITLE
refactor(activerecord): converge the CollectionProxy delegate list, through guard and load/merge block

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1360,8 +1360,9 @@ export class CollectionAssociation extends Association {
    *
    * Mirrors: ActiveRecord::Associations::CollectionAssociation#merge_target_lists
    * (collection_association.rb:335-352).
+   * @internal
    */
-  private mergeTargetLists(persisted: Base[], memory: Base[]): Base[] {
+  mergeTargetLists(persisted: Base[], memory: Base[]): Base[] {
     if (memory.length === 0) return persisted;
 
     // `memory.delete(record)` is Array#delete over AR `==` — id equality for a

--- a/packages/activerecord/src/associations/collection-proxy-delegation.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-delegation.trails.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Trails-only surface: Rails derives `CollectionProxy`'s delegate-to-scope list
+ * by reflection —
+ * `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`
+ * (collection_proxy.rb:1128-1137). trails stands that reflection in with a
+ * hand-written name list, which drifted from it in both directions: it omitted
+ * the public aliases `left_joins` (query_methods.rb:887) and `without`
+ * (query_methods.rb:1585), and it carried `null!`, `rewhere!` and `select!`,
+ * none of which Rails or trails defines (the real alias is `_select!`,
+ * query_methods.rb:428). Ruby cannot drift this way — the list is computed — so
+ * there is no Rails test to mirror and the coverage lives here.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import { CollectionProxy } from "./collection-proxy.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
+
+registerModel(Author);
+registerModel(Post);
+registerModel(Comment);
+
+describe("CollectionProxy scope delegation matches QueryMethods", () => {
+  const { authors, posts } = fixtures(["authors", "posts", "comments"]);
+
+  it("delegates the public QueryMethods aliases to scope", () => {
+    for (const name of ["leftJoins", "without"]) {
+      expect(Object.hasOwn(CollectionProxy.prototype, name)).toBe(true);
+    }
+  });
+
+  it("delegates no name QueryMethods does not define", () => {
+    for (const name of ["nullBang", "rewhereBang", "selectBang"]) {
+      expect(Object.hasOwn(CollectionProxy.prototype, name)).toBe(false);
+    }
+  });
+
+  // A hydrated PK is a BigInt on some adapters (int8 under MariaDB/PG) and a
+  // number on others, while a fixture accessor hands back the raw value, so
+  // every id comparison below goes through the same string fold.
+  const id = (record: { id: unknown }) => String(record.id);
+
+  it("leftJoins runs against the association scope", async () => {
+    const author = await Author.find(authors("david").id);
+    const scoped = new Set((await author.posts).map(id));
+    const relation = author.posts.leftJoins(":comments");
+    const records = await relation;
+
+    expect(scoped.size).toBeGreaterThan(0);
+    expect(records.length).toBeGreaterThan(0);
+    // Scoped to the owner: every row is one of the author's own posts, which is
+    // what the delegation to `scope()` buys. Asserted on ids rather than on the
+    // SQL text so the identifier quoting stays adapter-neutral.
+    expect(records.every((post: Post) => scoped.has(id(post)))).toBe(true);
+    expect(relation.toSql().toLowerCase()).toContain("left outer join");
+  });
+
+  it("without runs against the association scope", async () => {
+    const author = await Author.find(authors("david").id);
+    const excluded = posts("welcome");
+    const scoped = new Set((await author.posts).map(id));
+    const records = await author.posts.without(excluded);
+
+    expect(scoped.has(id(excluded))).toBe(true);
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.map(id)).not.toContain(id(excluded));
+    expect(records.every((post: Post) => scoped.has(id(post)))).toBe(true);
+  });
+});

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -37,13 +37,7 @@ import { singularize, camelize, constantize } from "@blazetrails/activesupport";
 import { ConfigurationError, AssociationTypeMismatch, RecordNotFound } from "../errors.js";
 import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
-import {
-  HasManyThroughCantAssociateThroughHasOneOrManyReflection,
-  HasManyThroughNestedAssociationsAreReadonly,
-  HasOneThroughNestedAssociationsAreReadonly,
-  HasManyThroughOrderError,
-  AssociationNotFoundError,
-} from "./errors.js";
+import { AssociationNotFoundError } from "./errors.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   autoloadModel,
@@ -316,11 +310,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /** @internal Association name — used by AssociationRelation. */
   get associationName(): string {
     return this._assocName;
-  }
-
-  /** @internal Whether this is a through association — used by AssociationRelation. */
-  get isThrough(): boolean {
-    return !!this._assocDef.options.through;
   }
 
   /**
@@ -621,34 +610,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Load and return all associated records.
+   * Load and return all associated records — Rails' `to_a` is `records` is
+   * `load_target` (collection_proxy.rb:1024-1026, :44-46), so this is `load()`
+   * plus one trails-only arm.
+   *
+   * `null_scope?` on an unloaded target is exactly `!find_target?`, the arm
+   * where `load_target` (collection_association.rb:272-279) leaves `@target`
+   * unassigned. trails re-traverses the in-memory chain on each read there
+   * instead, so the arm must merge WITHOUT caching, and it cannot move into
+   * `load()`: `CollectionAssociation#concat` calls `loadTarget()` on a
+   * new-record owner before appending (collection_association.rb:439-446) and
+   * needs that call to cache. Retiring it belongs with the `_queryExecutor`
+   * residue that RFC 0075 owns.
    */
   async toArray(): Promise<T[]> {
-    // Rails `to_a` → `CollectionProxy#records` → `load_target`
-    // (collection_proxy.rb, collection_association.rb) hydrates and caches the
-    // association target (`@target = merge_target_lists(...)`) and marks it
-    // loaded. Delegate to `load` for that full hydrate-and-cache path.
-    //
-    // Keep the cache-bypassing re-query path when either (a) an in-place bang
-    // mutation (`whereBang`/`orderBang`/...) has diverged the proxy scope — this
-    // is effectively a scoped AssociationRelation whose `to_a` runs
-    // `exec_queries` without touching the owner's cached target — or (b) the
-    // target is not yet loaded and `find_target?` is false: a new-record owner
-    // with no foreign key present. Rails' `load_target` only assigns/caches
-    // `@target` from a query when `find_target?` (or the target is stale); for
-    // the new-record-without-FK case it leaves the in-memory target untouched,
-    // which for a through association means re-traversing the in-memory chain
-    // (`post.author.books` …) on each read rather than caching a scoped subset.
-    //
-    // The `!_targetLoaded` guard is essential: on an unloaded target
-    // `null_scope?` is exactly `!find_target?` (`owner.new_record? &&
-    // !foreign_key_present?`), so OR-ing on a bare `null_scope?` would send
-    // *every* post-load `toArray()` back down the re-query path and defeat
-    // caching entirely. `load()` is the hydrate/cache chokepoint for the
-    // already-loaded case (including staleness).
     if (!this._targetLoaded && this.isNullScope()) {
       const results = await this._execLoad();
-      return this._mergeTargetLists(results);
+      return this._collectionAssociation().mergeTargetLists(results, this._target) as T[];
     }
     return this.load();
   }
@@ -687,94 +665,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       wrapper?.resetScope?.();
     }
     const results = await this._execLoad();
-    this._target = this._mergeTargetLists(results);
+    // `@target = merge_target_lists(find_target, target)`
+    // (collection_association.rb:274).
+    this._target = this._collectionAssociation().mergeTargetLists(results, this._target) as T[];
     this._targetLoaded = true;
     // Snapshot the owner's `@stale_state` NOW (while owner FKs still reflect
     // the load time). Letting it happen later — after a FK change — would
     // capture the wrong state and mask the staleness.
     this._staleWrapper()?.loadedBang?.();
     return this._target;
-  }
-
-  /**
-   * Merge freshly-loaded DB rows with the in-memory `_target`, mirroring Rails'
-   * `CollectionAssociation#merge_target_lists` (collection_association.rb): for
-   * each DB row, prefer the matching in-memory instance by primary key (so
-   * unsaved attribute changes and scheduled destroys are preserved), copying DB
-   * values only onto attributes not changed in memory; then append the in-memory
-   * new records that have no DB counterpart. Used by both `toArray` (Rails
-   * `to_a`) and `load` so both surface in-memory state the same way.
-   * @internal
-   */
-  private _mergeTargetLists(results: T[]): T[] {
-    const existingByPk = new Map<string, T>();
-    for (const r of this._target) {
-      const id = this._identityFor(r);
-      if (id != null) existingByPk.set(id, r);
-    }
-    const merged: T[] = results.map((dbRecord) => {
-      const id = this._identityFor(dbRecord);
-      if (id == null || !existingByPk.has(id)) return dbRecord;
-      const memRecord = existingByPk.get(id)!;
-      this._refreshUnchangedAttributes(memRecord, dbRecord);
-      return memRecord;
-    });
-    const unsaved = this._target.filter((r) => r.isNewRecord());
-    return unsaved.length > 0 ? [...merged, ...unsaved] : merged;
-  }
-
-  /**
-   * Reconcile a fresh DB record with the matching in-memory record, mirroring
-   * the attribute merge inside Rails' `CollectionAssociation#merge_target_lists`
-   * (collection_association.rb): for every attribute the two share, copy the
-   * database value onto the in-memory record *unless* that attribute carries an
-   * unsaved change or is readonly. Unsaved updates and scheduled destroys win;
-   * every other attribute reflects the database. This keeps the in-memory
-   * instance (so order, identity, and dirty/destroy state are preserved) while
-   * refreshing its untouched columns from the just-loaded row.
-   * @internal
-   */
-  private _refreshUnchangedAttributes(memRecord: T, dbRecord: T): void {
-    const memClass = memRecord.constructor as typeof Base;
-    // Rails intersects the *instance* `attribute_names` of both records
-    // (collection_association.rb:340) — the actually-loaded keys, not the class
-    // set — so a collection loaded under a `select` projection only refreshes
-    // the columns both rows actually carry. The instance
-    // `attributeNames()` reads `_attributes.keys()`; using the class-level
-    // static would write columns absent from a partially-loaded dbRecord.
-    const dbNames = new Set(dbRecord.attributeNames());
-    const changed = new Set(
-      (memRecord as unknown as { changedAttributeNamesToSave: string[] })
-        .changedAttributeNamesToSave,
-    );
-    const readonly = new Set(memClass.readonlyAttributes);
-    // We iterate the intersection of loaded attribute names (not aliases/virtual
-    // reads), so the low-level `_readAttribute` is equivalent to Rails'
-    // `record[name]` (`read_attribute`, collection_association.rb:342) for every
-    // name here — the value is already type-cast from the fresh row. Both sides
-    // use the raw read/write pair, mirroring `_write_attribute` on the Rails side.
-    for (const name of memRecord.attributeNames()) {
-      if (!dbNames.has(name) || changed.has(name) || readonly.has(name)) continue;
-      memRecord._writeAttribute(name, dbRecord._readAttribute(name));
-    }
-  }
-
-  private _identityFor(r: Base): string | null {
-    const pk = (r.constructor as typeof Base).primaryKey;
-    if (Array.isArray(pk)) {
-      const vals = pk.map((col) => r._readAttribute(col));
-      if (vals.some((v) => v == null)) return null;
-      // Stringify each column value (matching the scalar branch below) so a
-      // BigInt PK value — how PG/MariaDB surface a bigint `id` — is serializable;
-      // JSON.stringify throws on a raw BigInt.
-      return JSON.stringify(vals.map((v) => String(v)));
-    }
-    const val = r._readAttribute(pk);
-    return val == null ? null : String(val);
-  }
-
-  private get _isThrough(): boolean {
-    return !!this._assocDef.options.through;
   }
 
   /**
@@ -819,39 +718,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     };
     if (typeof assoc.setStrictLoading !== "function") return;
     for (const r of records) assoc.setStrictLoading(r);
-  }
-
-  private _ensureThroughWritable(): void {
-    if (!this._isThrough) return;
-    const ctor = this._record.constructor as typeof Base;
-    const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
-    const throughAssoc = associations.find((a: any) => a.name === this._assocDef.options.through);
-    if (!throughAssoc) {
-      throw new HasManyThroughOrderError(
-        ctor.name,
-        this._assocName,
-        this._assocDef.options.through as string,
-      );
-    }
-
-    if (throughAssoc.type === "hasOne" && !throughAssoc.options.through) {
-      throw new HasManyThroughCantAssociateThroughHasOneOrManyReflection(
-        ctor.name,
-        this._assocName,
-      );
-    }
-
-    // Nested through: the through association is itself a through association
-    const isNestedThrough =
-      throughAssoc.options.through ||
-      (throughAssoc.type as string) === "hasManyThrough" ||
-      (throughAssoc.type as string) === "hasOneThrough";
-    if (isNestedThrough) {
-      if (this._assocDef.type === "hasOne" || (this._assocDef.type as string) === "hasOneThrough") {
-        throw new HasOneThroughNestedAssociationsAreReadonly(this._record, this._assocDef);
-      }
-      throw new HasManyThroughNestedAssociationsAreReadonly(this._record, this._assocDef);
-    }
   }
 
   private async _withoutStrictLoading<T>(fn: () => Promise<T>): Promise<T> {
@@ -1040,7 +906,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * callbacks all land on this proxy too.
    */
   async push(...records: T[]): Promise<Omit<this, "then"> | false> {
-    this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
     // Through association (including HABTM): create join records
     if (this._assocDef.options.through) {
@@ -1079,13 +944,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * reads back; a scoped create (`AssociationRelation#create`) captured it
    * before this call, so it is lent to the association for this write only.
    */
-  /** @internal The OO association object backing this through-collection. */
-  private _throughAssociation(): ThroughAssociationHandle {
-    return this._record.association(this._assocName) as unknown as ThroughAssociationHandle;
-  }
-
   private async _pushThrough(records: T[], throughScope?: unknown): Promise<void> {
-    const assoc = this._throughAssociation();
+    const assoc = this._record.association(this._assocName) as unknown as ThroughAssociationHandle;
     const previousThroughScope = assoc._throughScope;
     if (throughScope != null) assoc._throughScope = throughScope;
     try {
@@ -1339,7 +1199,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#exists?
    */
   async exists(conditions?: Record<string, unknown> | unknown): Promise<boolean> {
-    if (this._isThrough) {
+    if (this._assocDef.options.through != null) {
       const records = (await this.loadTarget()).filter((r) => !r.isNewRecord());
       if (conditions === undefined) return records.length > 0;
       if (typeof conditions === "object" && conditions !== null && !Array.isArray(conditions)) {
@@ -1519,8 +1379,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#load_target
    */
   async loadTarget(): Promise<T[]> {
-    await this.load();
-    return this._target;
+    return this.load();
   }
 
   /**
@@ -1744,7 +1603,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#<< (bang semantics)
    */
   async appendBang(...records: T[]): Promise<void> {
-    this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
     if (this._assocDef.options.through) {
       await this._pushThrough(records);
@@ -1898,6 +1756,9 @@ const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
   "unscope",
   "joins",
   "leftOuterJoins",
+  // `alias :left_joins :left_outer_joins` (query_methods.rb:887) — a public
+  // instance method of QueryMethods, so Rails delegates it to `scope` too.
+  "leftJoins",
   "where",
   "rewhere",
   "invertWhere",
@@ -1920,6 +1781,8 @@ const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
   "reverseOrder",
   "annotate",
   "excluding",
+  // `alias :without :excluding` (query_methods.rb:1585).
+  "without",
   "arel",
   "constructJoinDependency",
   // The bang half of `QueryMethods.public_instance_methods(false)`
@@ -1928,7 +1791,6 @@ const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
   "eagerLoadBang",
   "preloadBang",
   "referencesBang",
-  "selectBang",
   "withBang",
   "withRecursiveBang",
   "reselectBang",
@@ -1940,14 +1802,12 @@ const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
   "joinsBang",
   "leftOuterJoinsBang",
   "whereBang",
-  "rewhereBang",
   "invertWhereBang",
   "havingBang",
   "limitBang",
   "offsetBang",
   "lockBang",
   "noneBang",
-  "nullBang",
   "readonlyBang",
   "strictLoadingBang",
   "createWithBang",

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -675,9 +675,15 @@ describe("NestedThroughAssociationsTest", () => {
   it("nested has many through writers should raise error", async () => {
     const david = authors("david");
     const subscriber = subscribers("first");
-    await expect((david.subscribers as any).push(subscriber)).rejects.toThrow(
-      /goes through more than one other association/,
-    );
+    const readonly = /goes through more than one other association/;
+    const association = david.association("subscribers") as any;
+    await expect(association.writer([subscriber])).rejects.toThrow(readonly);
+    await expect(association.idsWriter([subscriber.id])).rejects.toThrow(readonly);
+    await expect((david.subscribers as any).push(subscriber)).rejects.toThrow(readonly);
+    await expect((david.subscribers as any).delete(subscriber)).rejects.toThrow(readonly);
+    await expect((david.subscribers as any).clear()).rejects.toThrow(readonly);
+    expect(() => (david.subscribers as any).build()).toThrow(readonly);
+    await expect((david.subscribers as any).create()).rejects.toThrow(readonly);
   });
 
   it("nested has one through writers should raise error", async () => {


### PR DESCRIPTION
Three cuts at `CollectionProxy`'s trails-only surface, all toward the Rails
bodies that already exist elsewhere in the package.

1. Delegate list. Rails computes it by reflection —
   `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`
   (collection_proxy.rb:1128-1137) — so it picks up the public aliases
   `left_joins` (query_methods.rb:887) and `without` (query_methods.rb:1585).
   trails' hand-written stand-in omitted both and carried three names neither
   Rails nor trails defines (`null!`, `rewhere!`, `select!` — the real alias is
   `_select!`, query_methods.rb:428), each of which resolved to `undefined` on
   `scope`. Add the two, drop the three.

2. Through mutation guard. `_ensureThroughWritable` was a proxy-side copy of
   `ThroughAssociation#ensure_mutable` / `#ensure_not_nested`, which Rails runs
   from `insert_record` / `delete_records`, never from the proxy — and which
   `HasManyThroughAssociation` already ports and already calls. Delete the copy
   along with `_throughAssociation` and the `isThrough` / `_isThrough`
   predicate pair; the surviving call site reads the reflection directly. The
   two errors the copy raised have their own Rails homes already
   (`reflection.ts:1859`, `through-association.ts:125`).

3. Load/merge block. `_mergeTargetLists`, `_identityFor` and
   `_refreshUnchangedAttributes` were a second copy of
   `CollectionAssociation#merge_target_lists` / `record_identity`
   (collection_association.rb:335-352), ported at
   `collection-association.ts:1364`. The proxy now calls the association's
   single copy, which loses its `private` for an `@internal` tag so the call
   needs no cast.

`nested_through_associations_test.rb:493`'s writer test grows the five arms it
was missing — `subscribers=`, `subscriber_ids=`, `delete`, `clear`, `build`,
`create` — all of which now raise from the association-side guard.

Residue, left in place deliberately and owned by open stories:
`_execLoad` / `_findTargetViaAssociation` and the `_queryExecutor` flag they
thread, and `_staleWrapper` (RFC 0075). `toArray()` keeps one arm `load()` does
not: the null-scope path merges without caching, and neither hoisting it into
`load()` nor deleting it works while `_execLoad` queries a scope Rails would
skip — filed as 0114/collapse-collection-proxy-toarray-onto-load with the two
tests that pin each direction.

Closes-story: collection-proxy-delegate-leftjoins-without-fix
Closes-story: retire-collection-proxy-ensure-through-writable
Closes-story: retire-collection-proxy-load-and-merge-block
