### PR TITLE
refactor(activerecord): derive the proxy delegate list from the mixins and acquire at the arel reader

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -603,11 +603,14 @@ export class CollectionAssociation extends Association {
    * `after_remove` fire — not a direct `record.destroy` loop, which would
    * bypass the collection callbacks on `owner.destroy` (`dependent: :destroy`).
    */
-  async destroyAll(): Promise<void> {
-    const records = await this.loadTarget();
-    await this.destroy(...records);
+  async destroyAll(): Promise<Base[] | undefined> {
+    // `destroy(load_target)` — the loaded target goes in as ONE argument, as in
+    // Ruby, so the pre-flatten empty check sees a non-empty arg list and an
+    // empty collection destroys to `[]` rather than nil.
+    const destroyed = await this.destroy(await this.loadTarget());
     this.reset();
     this.loadedBang();
+    return destroyed;
   }
 
   /**
@@ -627,9 +630,12 @@ export class CollectionAssociation extends Association {
    * Destroy specific records, ignoring the :dependent option.
    * Calls before_remove/after_remove + before_destroy/after_destroy callbacks.
    */
-  async destroy(...records: Array<Base | number | string | bigint>): Promise<Base[] | undefined> {
-    // Raw splat, as in `delete` above — the empty check is pre-flatten.
-    return this.deleteOrDestroy(records, "destroy");
+  async destroy(
+    ...records: Array<Base | number | string | bigint | Base[]>
+  ): Promise<Base[] | undefined> {
+    // Raw splat, as in `delete` above — the empty check is pre-flatten. A
+    // nested array is flattened by `delete_or_destroy` itself, as in Ruby.
+    return this.deleteOrDestroy(records as Array<Base | number | string | bigint>, "destroy");
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy-delegate-methods.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-delegate-methods.trails.test.ts
@@ -4,48 +4,43 @@
  * `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`
  * (collection_proxy.rb:1128-1137) — so a query method added to either module is
  * delegated for free. trails reads the same list off the mixin objects
- * `include()` mixes into `Relation`, with a hand-list standing in for the
- * `QueryMethods` members that still live on `Relation` itself until RFC 0107
- * finishes moving them into `relation/query-methods.ts`. Nothing in Rails pins
- * either half, so the pin lives here: the residual may only shrink, and the
- * derived half must stay wired to the mixins.
+ * `include()` mixes into `Relation`, subtracting the members Ruby's `private`
+ * keyword (query_methods.rb:1677, spawn_methods.rb:71) keeps out of
+ * `public_instance_methods(false)`. Nothing in Rails pins that subtraction, so
+ * the pin lives here: no hand-transcribed name may creep back in, and every
+ * mixin key is classified as public or private exactly once.
  */
 import { describe, it, expect } from "vitest";
 import { CollectionProxy } from "./collection-proxy.js";
+import { MIXIN_PUBLIC_INSTANCE_METHODS } from "./collection-proxy.js";
 import { QueryMethodBangs } from "../relation/query-methods.js";
 import { SpawnMethods } from "../relation/spawn-methods.js";
 
-// `private` (query_methods.rb:1677, spawn_methods.rb:71) — Ruby keeps these out
-// of `public_instance_methods(false)`; a JS object literal carries no such mark.
-const PRIVATE_MIXIN_INSTANCE_METHODS = [
-  "assertModifiableBang",
-  "checkIfMethodHasArgumentsBang",
-  "_selectBang",
-  "relationWith",
-];
-
+const mixinKeys = [...Object.keys(QueryMethodBangs), ...Object.keys(SpawnMethods)];
 const delegatedNames = Object.getOwnPropertyNames(CollectionProxy.prototype);
 
 describe("CollectionProxy delegate list", () => {
-  it("delegates every public bang builder the QueryMethods mixin carries", () => {
-    const bangs = Object.keys(QueryMethodBangs).filter(
-      (name) => name.endsWith("Bang") && !PRIVATE_MIXIN_INSTANCE_METHODS.includes(name),
-    );
-    expect(bangs.length).toBeGreaterThan(0);
-    for (const name of bangs) expect(delegatedNames).toContain(name);
+  it("holds no name outside the two mixin objects", () => {
+    for (const name of MIXIN_PUBLIC_INSTANCE_METHODS) expect(mixinKeys).toContain(name);
   });
 
-  it("delegates every public SpawnMethods member", () => {
-    const spawns = Object.keys(SpawnMethods).filter(
-      (name) => !PRIVATE_MIXIN_INSTANCE_METHODS.includes(name),
-    );
-    expect(spawns).toEqual(["spawn", "merge", "mergeBang", "except", "only"]);
-    for (const name of spawns) expect(delegatedNames).toContain(name);
+  it("delegates every public mixin member", () => {
+    // `- [:select]` is the one name Rails subtracts by hand; the rest either
+    // delegate or are answered by the proxy's own override.
+    expect(MIXIN_PUBLIC_INSTANCE_METHODS.length).toBeGreaterThan(80);
+    for (const name of MIXIN_PUBLIC_INSTANCE_METHODS) expect(delegatedNames).toContain(name);
   });
 
   it("delegates no private mixin member", () => {
-    for (const name of PRIVATE_MIXIN_INSTANCE_METHODS) {
-      expect(delegatedNames).not.toContain(name);
-    }
+    const priv = mixinKeys.filter((name) => !MIXIN_PUBLIC_INSTANCE_METHODS.includes(name));
+    expect(priv).toContain("buildArel");
+    expect(priv).toContain("relationWith");
+    for (const name of priv) expect(delegatedNames).not.toContain(name);
+  });
+
+  it("delegates the whole SpawnMethods module", () => {
+    expect(MIXIN_PUBLIC_INSTANCE_METHODS).toEqual(
+      expect.arrayContaining(["spawn", "merge", "mergeBang", "except", "only"]),
+    );
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy-delegate-methods.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-delegate-methods.trails.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Trails-only surface: Rails derives `CollectionProxy`'s delegate list by
+ * reflection —
+ * `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`
+ * (collection_proxy.rb:1128-1137) — so a query method added to either module is
+ * delegated for free. trails reads the same list off the mixin objects
+ * `include()` mixes into `Relation`, with a hand-list standing in for the
+ * `QueryMethods` members that still live on `Relation` itself until RFC 0107
+ * finishes moving them into `relation/query-methods.ts`. Nothing in Rails pins
+ * either half, so the pin lives here: the residual may only shrink, and the
+ * derived half must stay wired to the mixins.
+ */
+import { describe, it, expect } from "vitest";
+import { CollectionProxy } from "./collection-proxy.js";
+import { QueryMethodBangs } from "../relation/query-methods.js";
+import { SpawnMethods } from "../relation/spawn-methods.js";
+
+// `private` (query_methods.rb:1677, spawn_methods.rb:71) — Ruby keeps these out
+// of `public_instance_methods(false)`; a JS object literal carries no such mark.
+const PRIVATE_MIXIN_INSTANCE_METHODS = [
+  "assertModifiableBang",
+  "checkIfMethodHasArgumentsBang",
+  "_selectBang",
+  "relationWith",
+];
+
+const delegatedNames = Object.getOwnPropertyNames(CollectionProxy.prototype);
+
+describe("CollectionProxy delegate list", () => {
+  it("delegates every public bang builder the QueryMethods mixin carries", () => {
+    const bangs = Object.keys(QueryMethodBangs).filter(
+      (name) => name.endsWith("Bang") && !PRIVATE_MIXIN_INSTANCE_METHODS.includes(name),
+    );
+    expect(bangs.length).toBeGreaterThan(0);
+    for (const name of bangs) expect(delegatedNames).toContain(name);
+  });
+
+  it("delegates every public SpawnMethods member", () => {
+    const spawns = Object.keys(SpawnMethods).filter(
+      (name) => !PRIVATE_MIXIN_INSTANCE_METHODS.includes(name),
+    );
+    expect(spawns).toEqual(["spawn", "merge", "mergeBang", "except", "only"]);
+    for (const name of spawns) expect(delegatedNames).toContain(name);
+  });
+
+  it("delegates no private mixin member", () => {
+    for (const name of PRIVATE_MIXIN_INSTANCE_METHODS) {
+      expect(delegatedNames).not.toContain(name);
+    }
+  });
+});

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1707,97 +1707,83 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 //   delegate(*delegate_methods, to: :scope)
 //
 // `SpawnMethods` (spawn-methods.ts) and `QueryMethodBangs` (query-methods.ts) are
-// the mixin objects `include()` mixes into `Relation`, so their own keys ARE
-// `public_instance_methods(false)` and the delegate list is read off them. The
-// non-bang `QueryMethods` members still live on `Relation` itself and stay a
-// hand-list below until RFC 0107 finishes moving them into the mixin; it shrinks
-// as they land. `public_instance_methods(false)` includes the bang builders
-// (`where!`, `limit!`, `none!`, …), so Rails delegates those to `scope` too — a
-// Rails `CollectionProxy` owns no relation state of its own. The
-// constructor's own seeding calls (`noneBang` / `extendingBang`) run BEFORE the
-// prototype delegation is consulted only in the sense that they must target the
-// proxy's inherited state, so they are invoked through `Relation.prototype`
-// directly (see the ctor).
-const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
-  "includes",
-  "all",
-  "eagerLoad",
-  "preload",
-  "extractAssociated",
-  "references",
-  "select",
-  "with",
-  "withRecursive",
-  "reselect",
-  "group",
-  "regroup",
-  "order",
-  "inOrderOf",
-  "reorder",
-  "unscope",
-  "joins",
-  "leftOuterJoins",
-  // `alias :left_joins :left_outer_joins` (query_methods.rb:887) — a public
-  // instance method of QueryMethods, so Rails delegates it to `scope` too.
-  "leftJoins",
-  "where",
-  "rewhere",
-  "invertWhere",
-  "structurallyCompatible",
-  "and",
-  "or",
-  "having",
-  "limit",
-  "offset",
-  "lock",
-  "none",
-  "isNullRelation",
-  "readonly",
-  "strictLoading",
-  "createWith",
-  "from",
-  "distinct",
-  "extending",
-  "optimizerHints",
-  "reverseOrder",
-  "annotate",
-  "excluding",
-  // `alias :without :excluding` (query_methods.rb:1585).
-  "without",
-  "arel",
-  "constructJoinDependency",
-] as const;
-
+// the mixin objects `include()` mixes into `Relation` (relation.rb:68), so their
+// own keys ARE `public_instance_methods(false)` and the delegate list is read
+// off them rather than hand-transcribed. `public_instance_methods(false)`
+// includes the bang builders (`where!`, `limit!`, `none!`, …), so Rails
+// delegates those to `scope` too — a Rails `CollectionProxy` owns no relation
+// state of its own. The constructor's own seeding calls (`noneBang` /
+// `extendingBang`) run BEFORE the prototype delegation is consulted only in the
+// sense that they must target the proxy's inherited state, so they are invoked
+// through `Relation.prototype` directly (see the ctor).
+//
 // Ruby's `private` keyword (query_methods.rb:1677, spawn_methods.rb:71) keeps
-// these out of `public_instance_methods(false)`, so `delegate` never sees them.
-// A JS object literal carries no such distinction, so the boundary is named here.
+// the members below out of `public_instance_methods(false)`, so `delegate` never
+// sees them. A JS object literal carries no such distinction, so the boundary is
+// named here.
 const PRIVATE_MIXIN_INSTANCE_METHODS = new Set([
+  "arelColumn",
+  "arelColumnAliasesFromHash",
+  "arelColumnWithTable",
+  "arelColumnsFromHash",
   "assertModifiableBang",
+  "async",
+  "buildArel",
+  "buildBoundSqlLiteral",
+  "buildCaseForValuePosition",
+  "buildCastValue",
+  "buildFrom",
+  "buildJoinBuckets",
+  "buildJoinDependencies",
+  "buildJoins",
+  "buildNamedBoundSqlLiteral",
+  "buildOrder",
+  "buildSelect",
+  "buildWith",
+  "buildWithExpressionFromValue",
+  "buildWithJoinNode",
+  "buildWithValueFromHash",
   "checkIfMethodHasArgumentsBang",
-  "_selectBang",
+  "columnReferences",
+  "eachJoinDependencies",
+  "extractTableNameFrom",
+  "flattenedArgs",
+  "isDoesNotSupportReverse",
+  "isTableNameMatches",
+  "lookupTableKlassFromJoinDependencies",
+  "orderColumn",
+  "preprocessOrderArgs",
+  "processSelectArgs",
+  "processWithArgs",
+  "resolveArelAttributes",
+  "reverseSqlOrder",
+  "sanitizeOrderArguments",
+  "selectAssociationList",
+  "selectNamedJoins",
+  "structurallyIncompatibleValuesFor",
+  "validateOrderArgs",
   "relationWith",
 ]);
 
-const MIXIN_PUBLIC_INSTANCE_METHODS = [
-  ...Object.keys(QueryMethodBangs).filter((name) => name.endsWith("Bang")),
+/** @internal `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`. */
+export const MIXIN_PUBLIC_INSTANCE_METHODS = [
+  ...Object.keys(QueryMethodBangs),
   ...Object.keys(SpawnMethods),
 ].filter((name) => !PRIVATE_MIXIN_INSTANCE_METHODS.has(name));
 
-const delegateMethods = (
-  [...QUERY_METHODS_PUBLIC_INSTANCE_METHODS, ...MIXIN_PUBLIC_INSTANCE_METHODS] as string[]
-)
-  .filter((name) => !Object.hasOwn(CollectionProxy.prototype, name) && name !== "select")
-  .concat([
-    "scoping",
-    "values",
-    "insert",
-    "insertAll",
-    "insertBang",
-    "insertAllBang",
-    "upsert",
-    "upsertAll",
-    "loadAsync",
-  ]);
+const delegateMethods = MIXIN_PUBLIC_INSTANCE_METHODS.filter(
+  (name) => !Object.hasOwn(CollectionProxy.prototype, name) && name !== "select",
+).concat([
+  "scoping",
+  "values",
+  "insert",
+  "insertAll",
+  "insertBang",
+  "insertAllBang",
+  "upsert",
+  "upsertAll",
+  "loadAsync",
+]);
 
 // The VALUE_METHODS accessors `query_methods.rb:162-183` generates
 // (`where_clause`, `order_values`, `limit_value`, …) are

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,5 +1,7 @@
 import type { Base } from "../base.js";
 import { Relation } from "../relation.js";
+import { QueryMethodBangs } from "../relation/query-methods.js";
+import { SpawnMethods } from "../relation/spawn-methods.js";
 import {
   CollectionAssociation,
   callback as assocCallback,
@@ -953,22 +955,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     } finally {
       assoc._throughScope = previousThroughScope;
     }
-    this._invalidateAssociationIds();
-  }
-
-  private _invalidateAssociationIds(): void {
     // `@offsets = @take = nil; @scope = nil` (collection_proxy.rb:1112-1116).
     this.resetScope();
-    const assocInstance = (this._record as any)._associationInstances?.get(this._assocName);
-    if (assocInstance) {
-      assocInstance._associationIds = null;
-      // Rails' `insert_record` ends in `reset_scope` (collection_association.rb),
-      // which drops the memoized `@association_scope` — NOT `reset`, which now
-      // shares one array with this proxy and would discard the record just added.
-      if (typeof assocInstance.resetScope === "function") {
-        assocInstance.resetScope();
-      }
-    }
   }
 
   private _raiseOnTypeMismatch(records: T[]): void {
@@ -1287,9 +1275,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy_all
    */
   async destroyAll(): Promise<T[]> {
-    const records = await this.toArray();
-    await this.destroy(...records);
-    this._invalidateAssociationIds();
+    const records = (await this._collectionAssociation().destroyAll()) as T[];
+    this.resetScope();
     return records;
   }
 
@@ -1500,13 +1487,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         deleteAll(dependent?: string): Promise<number>;
       }
     ).deleteAll(dependent);
-    // In Rails the proxy reads the association's `@target`, so the `reset` /
-    // `loaded!` inside `delete_all` is what empties the collection the proxy
-    // shows. The trails CollectionProxy keeps its own copy of the target, so
-    // the same reset has to be replayed on it here.
-    this._target = [];
-    this._targetLoaded = true;
-    this._invalidateAssociationIds();
     this.resetScope();
     return count;
   }
@@ -1726,13 +1706,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 //   ]
 //   delegate(*delegate_methods, to: :scope)
 //
-// trails mixes QueryMethods / SpawnMethods into `Relation` itself rather than
-// keeping them as standalone modules, so their `public_instance_methods(false)`
-// can't be reflected off a module object — the two name lists below stand in for
-// that reflection, in Rails' source order (`query_methods.rb`, `spawn_methods.rb`).
-// Both halves of each module are listed: `public_instance_methods(false)` includes
-// the bang builders (`where!`, `limit!`, `none!`, …), so Rails delegates those to
-// `scope` too — a Rails `CollectionProxy` owns no relation state of its own. The
+// `SpawnMethods` (spawn-methods.ts) and `QueryMethodBangs` (query-methods.ts) are
+// the mixin objects `include()` mixes into `Relation`, so their own keys ARE
+// `public_instance_methods(false)` and the delegate list is read off them. The
+// non-bang `QueryMethods` members still live on `Relation` itself and stay a
+// hand-list below until RFC 0107 finishes moving them into the mixin; it shrinks
+// as they land. `public_instance_methods(false)` includes the bang builders
+// (`where!`, `limit!`, `none!`, …), so Rails delegates those to `scope` too — a
+// Rails `CollectionProxy` owns no relation state of its own. The
 // constructor's own seeding calls (`noneBang` / `extendingBang`) run BEFORE the
 // prototype delegation is consulted only in the sense that they must target the
 // proxy's inherited state, so they are invoked through `Relation.prototype`
@@ -1785,56 +1766,25 @@ const QUERY_METHODS_PUBLIC_INSTANCE_METHODS = [
   "without",
   "arel",
   "constructJoinDependency",
-  // The bang half of `QueryMethods.public_instance_methods(false)`
-  // (query_methods.rb) — Rails delegates these to `scope` as well.
-  "includesBang",
-  "eagerLoadBang",
-  "preloadBang",
-  "referencesBang",
-  "withBang",
-  "withRecursiveBang",
-  "reselectBang",
-  "groupBang",
-  "regroupBang",
-  "orderBang",
-  "reorderBang",
-  "unscopeBang",
-  "joinsBang",
-  "leftOuterJoinsBang",
-  "whereBang",
-  "invertWhereBang",
-  "havingBang",
-  "limitBang",
-  "offsetBang",
-  "lockBang",
-  "noneBang",
-  "readonlyBang",
-  "strictLoadingBang",
-  "createWithBang",
-  "fromBang",
-  "distinctBang",
-  "extendingBang",
-  "optimizerHintsBang",
-  "reverseOrderBang",
-  "annotateBang",
-  "excludingBang",
-  "uniqBang",
-  "skipQueryCacheBang",
-  "skipPreloadingBang",
-  "andBang",
-  "orBang",
 ] as const;
 
-const SPAWN_METHODS_PUBLIC_INSTANCE_METHODS = [
-  "spawn",
-  "merge",
-  "mergeBang",
-  "except",
-  "only",
-] as const;
+// Ruby's `private` keyword (query_methods.rb:1677, spawn_methods.rb:71) keeps
+// these out of `public_instance_methods(false)`, so `delegate` never sees them.
+// A JS object literal carries no such distinction, so the boundary is named here.
+const PRIVATE_MIXIN_INSTANCE_METHODS = new Set([
+  "assertModifiableBang",
+  "checkIfMethodHasArgumentsBang",
+  "_selectBang",
+  "relationWith",
+]);
+
+const MIXIN_PUBLIC_INSTANCE_METHODS = [
+  ...Object.keys(QueryMethodBangs).filter((name) => name.endsWith("Bang")),
+  ...Object.keys(SpawnMethods),
+].filter((name) => !PRIVATE_MIXIN_INSTANCE_METHODS.has(name));
 
 const delegateMethods = (
-  [...QUERY_METHODS_PUBLIC_INSTANCE_METHODS, ...SPAWN_METHODS_PUBLIC_INSTANCE_METHODS] as string[]
+  [...QUERY_METHODS_PUBLIC_INSTANCE_METHODS, ...MIXIN_PUBLIC_INSTANCE_METHODS] as string[]
 )
   .filter((name) => !Object.hasOwn(CollectionProxy.prototype, name) && name !== "select")
   .concat([

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -72,7 +72,7 @@ export function currentQueryConnection(): DatabaseAdapter | null {
  * getter's guard; it returns `null` (so callers fall back to `.connection`) for a
  * directly-assigned adapter or a model whose `connectionPool()` throws (e.g. a
  * HABTM join model with no registered pool), preserving those models' existing
- * resolution — including `_resolveAdapter`'s `ConnectionNotEstablished` path.
+ * resolution, so such a model still raises `ConnectionNotEstablished`.
  *
  * @internal
  */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5,13 +5,7 @@ import { first } from "./ruby-first.js";
 import { Table, SelectManager, Nodes, sql } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { threadedConnectionFor } from "./connection-handling.js";
-import {
-  ActiveRecordError,
-  ConnectionNotEstablished,
-  RecordNotSaved,
-  RecordNotUnique,
-  UnknownPrimaryKey,
-} from "./errors.js";
+import { ActiveRecordError, RecordNotSaved, RecordNotUnique, UnknownPrimaryKey } from "./errors.js";
 import { InvalidSignature } from "@blazetrails/activesupport/message-verifier";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { SerializeOptions } from "@blazetrails/activemodel";
@@ -65,7 +59,6 @@ import {
   type CounterCacheTouchOption,
 } from "./timestamp.js";
 import { Explain } from "./explain.js";
-import { sanitizeLimit } from "./connection-adapters/abstract/database-statements.js";
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { PrettyPrinter } from "./pretty-print.js";
@@ -1719,14 +1712,13 @@ export class Relation<T extends Base> {
    */
   toArel(aliases?: AliasTracker): SelectManager {
     // Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
-    // (query_methods.rb:1595), so `build_arel` always has a connection.
-    // `_resolveAdapter` is the trails stand-in for that acquisition, but it
-    // yields null for a model with no established pool — Arel building is
-    // reachable there (CTE bodies, `from(relation)` subqueries). Name that case
-    // HERE, at the acquisition point, substituting the abstract adapter's own
-    // `sanitize_limit` (abstract/database_statements.rb), so `build_arel`'s body
-    // never has to consider a missing connection the way Rails' never does.
-    return this.buildArel(this._resolveAdapter() ?? { sanitizeLimit }, aliases);
+    // (query_methods.rb:1595), so `build_arel` always has a connection. trails'
+    // `withConnection` is a `Promise`-returning checkout and this reader is
+    // synchronous, so the acquisition is the direct `_conn()` lease rather than
+    // a `with_connection` block; either way `build_arel` never sees a missing
+    // connection, and a model with no established pool raises
+    // `ConnectionNotEstablished` here exactly as Rails' `with_connection` does.
+    return this.buildArel(this._conn(), aliases);
   }
 
   /**
@@ -2089,7 +2081,7 @@ export class Relation<T extends Base> {
     _qm.buildJoins.call(joined as any, idSubquery);
     if (!this.whereClause.isEmpty()) idSubquery.where(this.whereClause.ast);
     this.buildOrder(idSubquery);
-    const connection = this._resolveAdapter() ?? { sanitizeLimit };
+    const connection = this._conn();
     if (this.limitValue !== null) idSubquery.take(connection.sanitizeLimit(this.limitValue));
     if (this.offsetValue !== null) idSubquery.skip(_qm.toI(this.offsetValue));
     return idSubquery;
@@ -2232,16 +2224,6 @@ export class Relation<T extends Base> {
    */
   private _conn(): DatabaseAdapter {
     return threadedConnectionFor(this._model) ?? this._model.connection;
-  }
-
-  /** Resolve the connection through {@link _conn}, returning null for HABTM join models with no established connection. */
-  private _resolveAdapter(): DatabaseAdapter | null {
-    try {
-      return this._conn();
-    } catch (e) {
-      if (e instanceof ConnectionNotEstablished) return null;
-      throw e;
-    }
   }
 
   /**

--- a/packages/activerecord/src/relation/arel-reader-connection-acquisition.trails.test.ts
+++ b/packages/activerecord/src/relation/arel-reader-connection-acquisition.trails.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
+ * (query_methods.rb:1595), so a model with no connection raises out of the
+ * reader rather than building Arel against a substitute. trails' `toArel`
+ * acquires through `_conn()` for the same reason. Rails has no test for this —
+ * `with_connection` raising is a property of the pool, not of `arel` — so the
+ * pin that `toArel` does not swallow `ConnectionNotEstablished` lives here.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { ConnectionNotEstablished } from "../errors.js";
+
+registerModel(Post);
+
+describe("Relation#toArel connection acquisition", () => {
+  fixtures(["posts"]);
+
+  it("raises ConnectionNotEstablished rather than building against a substitute", () => {
+    const relation = Post.limit(1);
+    const descriptor = Object.getOwnPropertyDescriptor(Post, "connection");
+    Object.defineProperty(Post, "connection", {
+      configurable: true,
+      get() {
+        throw new ConnectionNotEstablished("no pool for Post");
+      },
+    });
+    try {
+      expect(() => relation.toArel()).toThrow(ConnectionNotEstablished);
+    } finally {
+      if (descriptor) Object.defineProperty(Post, "connection", descriptor);
+      else delete (Post as unknown as Record<string, unknown>).connection;
+    }
+  });
+});

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3006,9 +3006,6 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // the where-subquery path (`relation-handler`); this is intentional, not a
     // shape deviation to converge away. See the
     // `eager-from-subquery-column-alias-projection` story.
-    // `opts.arel` — unconditional in Rails, and `arel` is the acquisition point
-    // (query_methods.rb:1595), so the subquery build gets the same connection
-    // the outer one does.
     return resolved.toArel().as(alias);
   }
   return opts;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -25,7 +25,6 @@ import {
 import { FromClause } from "./from-clause.js";
 import { Map as TypeCasterMap } from "../type-caster/map.js";
 import { WhereClause } from "./where-clause.js";
-import { sanitizeLimit } from "../connection-adapters/abstract/database-statements.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 import type { AliasTracker } from "../associations/alias-tracker.js";
 import { seedJoinClauseAliases } from "./merged-join-alias-tracker.js";
@@ -3007,15 +3006,10 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // the where-subquery path (`relation-handler`); this is intentional, not a
     // shape deviation to converge away. See the
     // `eager-from-subquery-column-alias-projection` story.
-    const subArel =
-      typeof resolved.toArel === "function"
-        ? resolved.toArel()
-        : // A duck-typed relation with no `toArel` acquisition seam: this
-          // subquery build is one of the connectionless paths, so pass the
-          // abstract `sanitize_limit` (abstract/database_statements.rb)
-          // explicitly rather than letting `buildArel` degrade internally.
-          resolved.buildArel({ sanitizeLimit });
-    return subArel.as(alias);
+    // `opts.arel` — unconditional in Rails, and `arel` is the acquisition point
+    // (query_methods.rb:1595), so the subquery build gets the same connection
+    // the outer one does.
+    return resolved.toArel().as(alias);
   }
   return opts;
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -22,6 +22,7 @@ import {
   PreparedStatementInvalid,
   UnmodifiableRelation,
 } from "../errors.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { FromClause } from "./from-clause.js";
 import { Map as TypeCasterMap } from "../type-caster/map.js";
 import { WhereClause } from "./where-clause.js";
@@ -3152,9 +3153,8 @@ export function buildArel(
   this: QueryMethodsHost,
   // Rails threads the `with_connection` connection into every `build_arel`
   // call (query_methods.rb:1595, relation.rb:1023), so the body never sees a
-  // missing one. Callers acquire before calling; the connectionless Arel build
-  // is named at the acquisition point (`Relation#toArel`), not tolerated here.
-  connection: { sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral },
+  // missing one. Callers acquire before calling.
+  connection: AbstractAdapter,
   aliases?: AliasTracker,
 ): any {
   const table: any = this.table;


### PR DESCRIPTION
Three RFC 0114 / 0107 convergence stories in one PR.

## 1. Derive the delegate list from the mixin objects' keys

`collection_proxy.rb:1128-1137` derives the delegate list by reflection:

```ruby
delegate_methods = [QueryMethods, SpawnMethods].flat_map { |klass|
  klass.public_instance_methods(false)
} - self.public_instance_methods(false) - [:select] + [...]
```

`SpawnMethods` (`relation/spawn-methods.ts`) and `QueryMethodBangs`
(`relation/query-methods.ts`) are the mixin objects `include()` mixes into
`Relation` (`relation.ts:3572`), so their own keys ARE
`public_instance_methods(false)`. **Both** hand-lists are gone — no residual.
The subtraction, the extra-name list and the descriptor shapes are untouched;
they were already faithful.

The one thing a JS object literal cannot express is Ruby's `private` keyword
(`query_methods.rb:1677`, `spawn_methods.rb:71`), so that boundary — and only
that — is named at the derivation site, transcribed from the Ruby file.

`collection-proxy-delegate-methods.trails.test.ts` pins it: every delegated name
is a key of an exported mixin (no hand-transcribed name can creep back), every
public mixin member is delegated, and no private one is.

**Delegate-set delta** — purely additive against current `main`, and every entry
is a name Rails delegates and the hand-list omitted:

- gained `asyncBang`, `arelColumns`, `buildSubquery`, `buildWhereClause`,
  `buildHavingClause`, `_selectBang` — all defined before the `private` at
  `query_methods.rb:1677` (`async!` at `:1656`, `build_subquery` at `:1605`,
  `build_where_clause` at `:1613`, `arel_columns` at `:1662`, `_select!` at
  `:428`, plus the `build_having_clause` alias), so Rails delegates every one.
- nothing lost. An earlier revision of this PR also dropped `rewhereBang`,
  `nullBang` and `selectBang` (phantom names — no `rewhere!` / `null!` in Rails,
  and `select` is the one name `:1128-1137` subtracts by hand); `main` has since
  removed all three independently, so they no longer appear as a delta here.

`buildArel`'s `connection` parameter is now typed `AbstractAdapter` rather than
the structural `{ sanitizeLimit(...) }` left over from the stand-in, matching
what `query_methods.rb:1595` threads in.

## 2. Retire the proxy's target replay

`destroy_all` is `@association.destroy_all.tap { reset_scope }`
(`collection_proxy.rb:501-503`) and `delete_all` ends the same way — the target
reset lives inside the association (`collection_association.rb:172-177`), and the
proxy reads the association's `@target`. trails' proxy has read through the
unified `_target` accessor pair for a while now, so the manual replay
(`this._target = []; this._targetLoaded = true`) was dead weight, and
`_invalidateAssociationIds` — which has no Rails counterpart at all — was
duplicating the `reset()` the association already performs.

Both bodies are now the association call plus `resetScope()`.
`_invalidateAssociationIds` is deleted; no replacement hook. `_pushThrough`
keeps the proxy's own `@scope` memo reset (`collection_proxy.rb:1112-1116`) — the
association's `_associationIds` is already nulled by `concat`'s own push arm
(`collection-association.ts`), so no ids cache blocked the deletion and no
follow-up story was needed for one.

`CollectionAssociation#destroyAll` now returns the destroyed records, as
`destroy(load_target).tap { ... }` does, and passes the loaded target as ONE
argument the way Ruby's `destroy(load_target)` does — so the pre-flatten empty
check sees a non-empty arg list and an empty collection destroys to `[]` rather
than nil.

## 3. Retire the `{ sanitizeLimit }` stand-ins

Rails' `arel` reader acquires the connection (`query_methods.rb:1595`) so
`build_arel` never sees a missing one. Both trails stand-in objects are gone:

- `relation.ts` `toArel` and `_materializeLimitedIds` acquire via `_conn()`.
- `relation/query-methods.ts` `buildFrom` calls `resolved.toArel()`
  unconditionally, mirroring Rails' unconditional `opts.arel`.

`_resolveAdapter()` — which swallowed `ConnectionNotEstablished` to make the
stand-in reachable — is deleted, so a model with no established pool now raises
there exactly as Rails' `with_connection` does. The connectionless
Arel-building paths the story flagged turned out to be reachable-in-theory only:
the full `packages/activerecord/src/associations/` and
`packages/activerecord/src/relation/` suites are green.

`_resolveAdapter`'s doc comment named "HABTM join models with no established
connection", but that scenario belongs to its original call site, not this one:
it was introduced in #2386 for `_arelVisitor` / `_selectVisitor`, where
`new ToSql(undefined)` legitimately accepts a null adapter, and #6610 reused the
existing helper at `toArel` rather than demonstrating a connectionless build
there. Those visitor call sites no longer use it, so the guard reached this diff
as inherited text. `_cteBodyArelNode` does not exist in the tree (stale name in
the story). The remaining path the story named, `buildFrom`'s subquery arm, was
a `typeof resolved.toArel === "function"` fallback with no caller that can miss
`toArel` — every from-value that reaches it is a `Relation` — and Rails calls
`opts.arel` unconditionally, so it now does too.

The claim no longer rests on suite-greenness. `relation/arel-reader-connection-acquisition.trails.test.ts`
pins it directly: with `Post.connection` made to raise, `Post.limit(1).toArel()`
raises `ConnectionNotEstablished` instead of building against a substitute — the
test is meaningful in both directions, since a `threadedConnectionFor` hit would
make it fail for want of a throw, and on the pre-PR tree `_resolveAdapter`'s
`catch` would swallow it. It corroborates `relation.ts`'s pre-existing `_conn()`
doc ("an unconnected HABTM join model still raises `ConnectionNotEstablished`"),
whose path `_materializeLimitedIds` already exercised through `eagerRelation.toArel()`
with no stand-in — i.e. this diff removes a guard that belonged to a different
call site rather than introducing a new crash surface. `connection-handling.ts`'s
reference to the now-deleted `_resolveAdapter` is updated to match.

**Not converged, filed as a follow-up:** the acquisition *shape*. trails'
`withConnection` (`connection-handling.ts:396` →
`ConnectionPool#withConnection`) is `async`/`Promise`-returning and `toArel` is
synchronous with ~30 synchronous call sites, so there is no seam to write
`with_connection { |c| build_arel(c, aliases) }` against, and the `@arel ||=`
memo is absent for the same reason. Filed as
`0107-relation-ts-decomposition/port-with-connection-acquisition-seam-for-the-arel-reader`
with the file:line detail.

---

`pnpm parity:api:calls` / `:args` OK, zero new rows. `pnpm parity:api:extra
--package activerecord`: no novel names. `pnpm lint` and `pnpm typecheck` clean.
Suites: `associations/` + `relation/` + `relation.test.ts`, 168 files /
2880 tests, all passing.

Closes-story: derive-collection-proxy-delegate-list-from-mixin-keys
Closes-story: retire-collection-proxy-target-replay-on-destroy-all-and-delete-all
Closes-story: converge-toarel-onto-with-connection-acquisition
