### PR TITLE
refactor(activerecord): drop the nine inherited CollectionProxy finder overrides; inline JoinAssociation scope join sources

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -34,7 +34,7 @@ import {
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
 import { singularize, camelize, constantize } from "@blazetrails/activesupport";
-import { ConfigurationError, AssociationTypeMismatch, RecordNotFound } from "../errors.js";
+import { ConfigurationError, AssociationTypeMismatch } from "../errors.js";
 import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
 import { AssociationNotFoundError } from "./errors.js";

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1071,17 +1071,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Mirrors: ActiveRecord::Relation::FinderMethods#first!
-   */
-  override async firstBang(): Promise<T> {
-    const record = await this.first();
-    if (!record) {
-      throw new RecordNotFound(`${this.model.name} not found`, this.model.name);
-    }
-    return record;
-  }
-
-  /**
    * Return the last associated record.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#last
@@ -1099,17 +1088,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Mirrors: ActiveRecord::Relation::FinderMethods#last!
-   */
-  override async lastBang(): Promise<T> {
-    const record = await this.last();
-    if (!record) {
-      throw new RecordNotFound(`${this.model.name} not found`, this.model.name);
-    }
-    return record;
-  }
-
-  /**
    * Return the first n records (or first record if n omitted).
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#take
@@ -1123,17 +1101,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // the base `FinderMethods` bodies'.
     if (this.isFindFromTarget()) await this.loadTarget();
     return super.take(n as number);
-  }
-
-  /**
-   * Mirrors: ActiveRecord::Relation::FinderMethods#take!
-   */
-  override async takeBang(): Promise<T> {
-    const record = await this.take();
-    if (!record) {
-      throw new RecordNotFound(`${this.model.name} not found`, this.model.name);
-    }
-    return record;
   }
 
   /**
@@ -1162,101 +1129,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   protected override async findNthFromLast(index: number): Promise<T | null> {
     if (this.isFindFromTarget()) await this.loadTarget();
     return baseFindNthFromLast.call(this as any, index);
-  }
-
-  /**
-   * True if the collection has more than one record.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#many?
-   */
-  async many(predicate?: (record: T) => boolean): Promise<boolean> {
-    if (predicate !== undefined) {
-      const records = await this.loadTarget();
-      let matched = 0;
-      for (const r of records) {
-        if (predicate(r) && ++matched > 1) return true;
-      }
-      return false;
-    }
-    // Rails Relation#many? uses records.many? when loaded (no query),
-    // otherwise limited_count > 1.
-    if (this._targetLoaded) return this._target.length > 1;
-    return ((await this.count()) as number) > 1;
-  }
-
-  /**
-   * True if the collection has exactly one record.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#one?
-   */
-  async one(): Promise<boolean> {
-    return (await this.count()) === 1;
-  }
-
-  /**
-   * True if any records exist in the collection (optionally matching conditions).
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#exists?
-   */
-  async exists(conditions?: Record<string, unknown> | unknown): Promise<boolean> {
-    if (this._assocDef.options.through != null) {
-      const records = (await this.loadTarget()).filter((r) => !r.isNewRecord());
-      if (conditions === undefined) return records.length > 0;
-      if (typeof conditions === "object" && conditions !== null && !Array.isArray(conditions)) {
-        const entries = Object.entries(conditions as Record<string, unknown>);
-        return records.some((r) => entries.every(([k, v]) => r.readAttribute(k) === v));
-      }
-      const targetModel = this.model;
-      const pk = targetModel.primaryKey;
-      if (Array.isArray(pk)) {
-        throw new Error(
-          `CollectionProxy#exists does not support composite primary keys for through associations on "${this._assocName}".`,
-        );
-      }
-      if (Array.isArray(conditions)) {
-        const idSet = new Set(conditions);
-        return records.some((r) => idSet.has(r.readAttribute(pk)));
-      }
-      return records.some((r) => r.readAttribute(pk) === conditions);
-    }
-    this._checkStrictLoading();
-    return this.scope().exists(conditions);
-  }
-
-  /**
-   * Find first record matching conditions, or build (but don't save) a new one.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#first_or_initialize
-   */
-  async firstOrInitialize(conditions: Record<string, unknown> = {}): Promise<T> {
-    this._checkStrictLoading();
-    const matches = await this.scope().where(conditions).toArray();
-    if (matches.length > 0) return matches[0];
-    return this.build(conditions);
-  }
-
-  /**
-   * Find first record matching conditions, or create one.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#first_or_create
-   */
-  async firstOrCreate(conditions: Record<string, unknown> = {}): Promise<T> {
-    this._checkStrictLoading();
-    const matches = await this.scope().where(conditions).toArray();
-    if (matches.length > 0) return matches[0];
-    return this.create(conditions);
-  }
-
-  /**
-   * Find first record matching conditions, or create one (raises on failure).
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#first_or_create!
-   */
-  async firstOrCreateBang(conditions: Record<string, unknown> = {}): Promise<T> {
-    this._checkStrictLoading();
-    const matches = await this.scope().where(conditions).toArray();
-    if (matches.length > 0) return matches[0];
-    return this.createBang(conditions);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1344,17 +1344,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("calling many should return false if none or one", async () => {
     let firm = companies("another_firm") as any;
-    expect(await firm.clientsLikeMs.many()).toBe(false);
+    expect(await firm.clientsLikeMs.isMany()).toBe(false);
     expect(await firm.clientsLikeMs.size()).toBe(0);
 
     firm = companies("first_firm") as any;
-    expect(await firm.limitedClients.many()).toBe(false);
+    expect(await firm.limitedClients.isMany()).toBe(false);
     expect(await firm.limitedClients.size()).toBe(1);
   });
 
   it("calling many should return true if more than one", async () => {
     const firm = companies("first_firm") as any;
-    expect(await firm.clients.many()).toBe(true);
+    expect(await firm.clients.isMany()).toBe(true);
     expect(await firm.clients.size()).toBe(3);
   });
 
@@ -4390,7 +4390,7 @@ describe("HasManyAssociationsTest", () => {
     await ManyCountPost.create({ author_id: author.id, title: "B", body: "body" });
     const proxy = association(author, "manyCountPosts");
     expect(proxy.loaded).toBe(false);
-    expect(await proxy.many()).toBe(true);
+    expect(await proxy.isMany()).toBe(true);
     // many() uses COUNT — must NOT have loaded the target
     expect(proxy.loaded).toBe(false);
   });
@@ -4432,7 +4432,7 @@ describe("HasManyAssociationsTest", () => {
       if (e?.payload?.sql) sqlQueries.push(e.payload.sql);
     });
     try {
-      expect(await proxy.many()).toBe(true);
+      expect(await proxy.isMany()).toBe(true);
     } finally {
       Notifications.unsubscribe(sub);
     }
@@ -4469,11 +4469,11 @@ describe("HasManyAssociationsTest", () => {
     await ManySubPost.create({ author_id: author.id, title: "A", body: "body" });
     const proxy = association(author, "manySubPosts");
     // 1 post → not many
-    expect(await proxy.many()).toBe(false);
+    expect(await proxy.isMany()).toBe(false);
     expect(proxy.loaded).toBe(false);
     // second call still issues a COUNT (not cached)
     await ManySubPost.create({ author_id: author.id, title: "B", body: "body" });
-    expect(await proxy.many()).toBe(true);
+    expect(await proxy.isMany()).toBe(true);
   });
   it("calling many should defer to collection if using a block", async () => {
     class ManyBlkAuthor extends Base {
@@ -4506,9 +4506,9 @@ describe("HasManyAssociationsTest", () => {
     await ManyBlkPost.create({ author_id: author.id, title: "B", body: "body" });
     const proxy = association(author, "manyBlkPosts");
     // predicate form: loads target, filters, checks count > 1
-    expect(await proxy.many((p) => (p as any).title === "A")).toBe(false);
+    expect(await proxy.isMany((p: any) => p.title === "A")).toBe(false);
     // predicate matched all → many
-    expect(await proxy.many((_p) => true)).toBe(true);
+    expect(await proxy.isMany((_p: any) => true)).toBe(true);
     // loading side-effect: target should now be loaded
     expect(proxy.loaded).toBe(true);
   });
@@ -6594,7 +6594,7 @@ describe("HasManyAssociationsTest", () => {
 
   it("calling one should return true if one", async () => {
     const firm = companies("first_firm") as any;
-    expect(await firm.limitedClients.one()).toBe(true);
+    expect(await firm.limitedClients.isOne()).toBe(true);
     expect(await firm.limitedClients.size()).toBe(1);
   });
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -509,6 +509,12 @@ export class JoinDependency {
       const chainLen = child.reflection.chain.length;
       const resolvedByIdx: Array<{ aliased: TableRef; effectiveName: string } | undefined> =
         new Array(chainLen);
+      // How far `joinConstraints` walked the chain before terminating on an
+      // already-resolved tail — i.e. how many constraint joins it emits. The
+      // returned array also carries each step's scope join sources inline
+      // (Rails' `joins.concat arel.join_sources`,
+      // join_association.rb:64-69), so it is no longer 1:1 with chain links.
+      let walkedLen = chainLen;
       const built = child.joinConstraints(
         foreignTable,
         foreignKlass,
@@ -528,6 +534,7 @@ export class JoinDependency {
           if (memo && (!root || !memo.terminated)) {
             if (root) memo.terminated = true;
             resolvedByIdx[idx] = memo;
+            walkedLen = idx;
             return [memo.aliased, true];
           }
 
@@ -572,8 +579,7 @@ export class JoinDependency {
         if (!node) continue;
         const resolved = resolvedByIdx[idx];
         node.arelJoin = null;
-        node.scopeJoinSources = [];
-        if (resolved && (idx < built.length || idx === 0)) {
+        if (resolved && (idx < walkedLen || idx === 0)) {
           node.arelTable = resolved.aliased;
           node.effectiveSqlName = resolved.effectiveName;
         } else {
@@ -582,19 +588,27 @@ export class JoinDependency {
           node.tableIndex = -1;
         }
       }
-      // `joinConstraints` walks the chain in reverse, so built[i] is chain link
-      // `built.length - 1 - i`; each join is followed by that step's scope join
-      // sources (Rails' `joins.concat arel.join_sources`).
-      for (let i = 0; i < built.length; i++) {
-        const node = nodes[built.length - 1 - i];
-        const join = built[i] as Nodes.Join;
-        const sources = child.joinSourcesByJoin[i] ?? [];
-        if (node) {
-          node.arelJoin = join;
-          node.scopeJoinSources = sources;
+      // `joinConstraints` walks the chain in reverse and emits each step's
+      // constraint join followed by that step's scope join sources, so the
+      // returned array is `[J(n-1), sources…, J(n-2), sources…, …]`. Only the
+      // constraint joins map back onto a chain link's tree node: an entry is
+      // one when it joins the table the walk resolved for the next link.
+      let linkIdx = walkedLen - 1;
+      for (const entry of built) {
+        const join = entry as Nodes.Join;
+        const resolved = linkIdx >= 0 ? resolvedByIdx[linkIdx] : undefined;
+        const left = (join as { left?: unknown }).left;
+        if (
+          resolved &&
+          left != null &&
+          typeof left === "object" &&
+          tableSqlName(left as TableRef) === resolved.effectiveName
+        ) {
+          const node = nodes[linkIdx];
+          if (node) node.arelJoin = join;
+          linkIdx--;
         }
         joins.push(join);
-        for (const src of sources) joins.push(src as Nodes.Join);
       }
       this._aliasesCache = undefined;
     } else if (!child.throughGroup) {

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -590,18 +590,16 @@ export class JoinDependency {
       // (`joins.concat arel.join_sources`, join_association.rb:64-69), so the
       // returned array is `[J(n-1), sources…, J(n-2), sources…, …]`. Only the
       // constraint joins map back onto a chain link's tree node: an entry is
-      // one when it joins the table the walk resolved for the next link.
+      // one when its `left` IS the table object this block handed the walk for
+      // the next link. Identity, not table name — a scope join source is built
+      // from `scope.arel(...).join_sources` and so can never be the same
+      // instance even when it joins a same-named table, and `appendConstraints`
+      // carries `left` through by reference when it rebuilds a join.
       let linkIdx = walkedLen - 1;
       for (const entry of built) {
         const join = entry as Nodes.Join;
         const resolved = linkIdx >= 0 ? resolvedByIdx[linkIdx] : undefined;
-        const left = (join as { left?: unknown }).left;
-        if (
-          resolved &&
-          left != null &&
-          typeof left === "object" &&
-          tableSqlName(left as TableRef) === resolved.effectiveName
-        ) {
+        if (resolved && (join as { left?: unknown }).left === resolved.aliased) {
           const node = nodes[linkIdx];
           if (node) node.arelJoin = join;
           linkIdx--;

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -509,11 +509,8 @@ export class JoinDependency {
       const chainLen = child.reflection.chain.length;
       const resolvedByIdx: Array<{ aliased: TableRef; effectiveName: string } | undefined> =
         new Array(chainLen);
-      // How far `joinConstraints` walked the chain before terminating on an
-      // already-resolved tail — i.e. how many constraint joins it emits. The
-      // returned array also carries each step's scope join sources inline
-      // (Rails' `joins.concat arel.join_sources`,
-      // join_association.rb:64-69), so it is no longer 1:1 with chain links.
+      // How far `joinConstraints` walked before terminating on an
+      // already-resolved tail — i.e. how many constraint joins it emits.
       let walkedLen = chainLen;
       const built = child.joinConstraints(
         foreignTable,
@@ -589,7 +586,8 @@ export class JoinDependency {
         }
       }
       // `joinConstraints` walks the chain in reverse and emits each step's
-      // constraint join followed by that step's scope join sources, so the
+      // constraint join followed by that step's scope join sources
+      // (`joins.concat arel.join_sources`, join_association.rb:64-69), so the
       // returned array is `[J(n-1), sources…, J(n-2), sources…, …]`. Only the
       // constraint joins map back onto a chain link's tree node: an entry is
       // one when it joins the table the walk resolved for the next link.

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -31,23 +31,6 @@ export class JoinAssociation extends JoinPart {
   readonly reflection: AbstractReflection;
   private _table: TableRef | null = null;
   readonly tables: TableRef[] = [];
-  /**
-   * Extra join sources contributed by the association scope's own `joins(...)`
-   * (Rails `joins.concat arel.join_sources`). Kept separate from the per-chain
-   * constraint joins so callers that map joins 1:1 to chain entries aren't
-   * disturbed; `makeConstraints` emits these after the node's own join.
-   * @internal
-   */
-  readonly joinSources: Nodes.Node[] = [];
-  /**
-   * Scope join sources bucketed by their emitted constraint-join index (aligned
-   * 1:1 with the array `joinConstraints` returns). The single-step path reads the
-   * flat `joinSources`; the through path reads this so each chain step's string
-   * joins attach to that step's tree node — Rails' per-step
-   * `joins.concat arel.join_sources` inside `chain.reverse_each`.
-   * @internal
-   */
-  readonly joinSourcesByJoin: Nodes.Node[][] = [];
   private _readonly?: boolean;
   private _strictLoading?: boolean;
 
@@ -102,12 +85,6 @@ export class JoinAssociation extends JoinPart {
   ): Nodes.Node[] {
     const joins: Nodes.Node[] = [];
     const chain: [AbstractReflection, TableRef][] = [];
-
-    // Ruby rebuilds the scope's join sources on every call; the accumulators
-    // below are trails-side state, so clear them so a re-emit doesn't inherit
-    // the previous emit's sources (or shift their per-join buckets).
-    this.joinSources.length = 0;
-    this.joinSourcesByJoin.length = 0;
 
     const reflectionChain = this.reflection.chain;
 
@@ -202,7 +179,6 @@ export class JoinAssociation extends JoinPart {
       }
 
       joins.push(new joinType(table, new Nodes.On(nodes)));
-      this.joinSourcesByJoin.push([]);
 
       // Rails, gated on `unless others.empty?`:
       //   joins.concat arel.join_sources
@@ -226,21 +202,10 @@ export class JoinAssociation extends JoinPart {
         const sources: Nodes.Node[] = scope?.arel
           ? ([...scope.arel(aliasTracker).joinSources()] as Nodes.Node[])
           : [];
-        // `this.joinSources` accumulates flat across the chain (consumed by the
-        // single-step `has_one`/`has_many` path, whose chain is length 1). The
-        // through path instead reads `joinSourcesByJoin`, which buckets each
-        // step's sources against that step's emitted join index — Rails' per-step
-        // `joins.concat arel.join_sources` inside `chain.reverse_each`.
-        if (sources.length > 0) {
-          const lastIdx = sources.length - 1;
-          sources[lastIdx] = appendConstraints(sources[lastIdx], others) ?? sources[lastIdx];
-          this.joinSources.push(...sources);
-          this.joinSourcesByJoin[joins.length - 1] = sources;
-        } else {
-          const lastIdx = joins.length - 1;
-          joins[lastIdx] = (appendConstraints(joins[lastIdx], others) ??
-            joins[lastIdx]) as Nodes.Join;
-        }
+        joins.push(...sources);
+        const lastIdx = joins.length - 1;
+        joins[lastIdx] = (appendConstraints(joins[lastIdx], others) ??
+          joins[lastIdx]) as Nodes.Join;
       }
 
       foreignTable = table;

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -28,13 +28,6 @@ export abstract class JoinPart {
   assocName = "";
   assocType: "hasMany" | "hasOne" | "belongsTo" = "hasMany";
   arelJoin: Nodes.Join | null = null;
-  /**
-   * Extra join sources from the association scope's own `joins(...)` (raw-string
-   * joins). Emitted by `makeConstraints` right after this node's `arelJoin` so
-   * aliases the scope introduces (and its WHERE references) are in scope.
-   * @internal
-   */
-  scopeJoinSources: Nodes.Node[] = [];
   /** @internal */
   nodeReflection: any | null = null;
   isThroughNode = false;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -873,7 +873,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#empty?
    */
   async isEmpty(): Promise<boolean> {
-    if (this._loaded) return this._records.length === 0;
+    if (this.isLoaded) return (await this.records()).length === 0;
     return !(await this.exists());
   }
 
@@ -913,7 +913,7 @@ export class Relation<T extends Base> {
       }
       return count > 1;
     }
-    if (this._loaded) return this._records.length > 1;
+    if (this.isLoaded) return (await this.records()).length > 1;
     return (await this.limitedCount()) > 1;
   }
 
@@ -937,7 +937,7 @@ export class Relation<T extends Base> {
       }
       return count === 1;
     }
-    if (this._loaded) return this._records.length === 1;
+    if (this.isLoaded) return (await this.records()).length === 1;
     return (await this.limitedCount()) === 1;
   }
 


### PR DESCRIPTION
Two of the three bundled stories; the third is blocked with evidence (below).

## `retire-collection-proxy-bang-finder-and-first-or-overrides`

A Rails `CollectionProxy` answers `first!`, `last!`, `take!`, `many?`, `one?`,
`exists?`, `first_or_create`, `first_or_initialize` and `first_or_create!` with
**no override at all** — they are inherited from `Relation` / `FinderMethods`
and work on the target because the proxy redefines only the two seams those
bodies read: `records` is `load_target` (`collection_proxy.rb:1024-1026`) and
`loaded?` is `@association.loaded?` (`:53-55`). All nine trails overrides are
deleted.

Rails' own five finder overrides stay, each already the
`load_target if find_from_target?` + `super` pair Rails writes: `find` (`:138`),
`last` (`:259`), `take` (`:289`), `find_nth_with_limit` (`:1140`),
`find_nth_from_last` (`:1145`).

Two follow-on notes:

- The proxy's `many` / `one` were also misnamed — `many?` / `one?` are `isMany`
  / `isOne` under the conventions, and `Relation` already carries both
  (`relation.rb:404-419`). The nine call sites in `has-many-associations.test.ts`
  move to the inherited spelling; no test name changes.
- `Relation#isEmpty` / `#isMany` / `#isOne` read `this._loaded` / `this._records`
  directly, which a proxy does not populate. Rails reads `loaded?` and `records`
  (`relation.rb:362-419`, `records` at `:342`), i.e. exactly the overridable
  seams — converged, which is what lets the inherited bodies take their loaded
  arm on a proxy without a query.

## `converge-join-constraints-scope-join-sources-inline`

`JoinAssociation#join_constraints` (`join_association.rb:64-69`) emits the
scope's own join sources into the array it returns, in place:

```ruby
joins << join_type.new(table, Arel::Nodes::On.new(nodes))

if others && !others.empty?
  joins.concat arel.join_sources
  append_constraints(joins.last, others)
end
```

trails pushed them onto two trails-only accumulators (`joinSources`,
`joinSourcesByJoin`) and left them out of the returned array, so
`JoinDependency#makeConstraints` re-flattened them by index. Both accumulators
also needed a per-call reset so a re-emit did not inherit the previous emit's
sources — a hazard that existed only because the sources left the method by a
side channel.

Now `joinConstraints` is the Ruby two lines, and `joinSources`,
`joinSourcesByJoin`, their reset, and `JoinPart#scopeJoinSources` (written but
never read) are gone. `makeConstraints` no longer interleaves by index: it maps
a returned entry back to a chain link when the entry joins the table the walk
resolved for that link, and tracks how far the walk got (`walkedLen`) rather
than inferring it from the returned array's length.

## `collapse-collection-proxy-toarray-onto-load` — blocked, not included

Implementing Rails' `load_target` shape literally (`toArray()` is
`return this.load()`; `load()` guards the query with `find_target?`,
`collection_association.rb:272-279`) was tried on this branch. It **fixes** the
arm the story predicted would break —
`autosave-association.test.ts > … > parent should save children record with
foreign key validation set in before save callback` — and reds exactly one test:
`has-many-through-associations.test.ts > HasManyThroughAssociationsTest >
nested has many through association with unpersisted parent instance` (`:2337`).

That test has no Rails counterpart, and asserts behaviour Rails does not have:
for `post.subscriptions` (`through: :books`, itself `through: :author`) on an
unpersisted `post`, `ThroughAssociation#foreign_key_present?`
(`through_association.rb:90-94`) is false because `through_reflection.belongs_to?`
is false, and `owner.new_record?` is true — so `find_target?`
(`association.rb:320-322`) is false, `load_target` skips the query, and Rails
returns `[]`. The only thing keeping that test green today is the
cache-bypassing `toArray` arm this story deletes.

So the collapse stays gated on the RFC 0075 residue the story already names —
`retire-collection-proxy-query-executor-flag` (draft) and
`hoist-mid-load-guard-to-doasyncfindtarget-callers` (ready) — plus a decision on
that trails-only test. Story marked `blocked` with this evidence.

## Verification

- `pnpm typecheck` clean.
- `pnpm vitest run packages/activerecord/src/associations packages/activerecord/src/relation packages/activerecord/src/relation.test.ts` — 173 files, 3382 passed.
- `join-dependency-through-aliasing`, `inner-join-association`,
  `left-outer-join-association`, `has-many-through-associations`, `eager` — 440 green.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK — zero new rows.
- `pnpm parity:api:extra --package activerecord`: none of the nine names remain
  under `associations/collection-proxy.ts`.
- 45 insertions, 201 deletions.

Closes-story: retire-collection-proxy-bang-finder-and-first-or-overrides
Closes-story: converge-join-constraints-scope-join-sources-inline
