### PR TITLE
refactor(activerecord): retire the proxy's Enumerable block, its strict-loading helpers, and the JoinLeaf table claim

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1830,8 +1830,6 @@ function wrapCollectionProxy<T extends Base = Base>(
         return target.target[Number(prop)];
       }
 
-      (target as unknown as { _checkStrictLoading(): void })._checkStrictLoading();
-
       // Class-method delegations resolve through the `Reflect.get(scope, prop,
       // scope)` fallback below: `target.scope()` returns an `AssociationRelation`
       // wrapped by `wrapWithScopeProxy`, whose miss path runs the

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -931,9 +931,8 @@ export class Association {
    * The `@skip_strict_loading` guard reads two flags rather than one: the
    * association-level ivar Rails has, plus the owner-level bypass counter the
    * explicit loaders (`loadBelongsTo` / `loadHasOne`) raise. Those loaders are
-   * the trails spelling of a
-   * deliberate load, and they run where Ruby would have had an association
-   * handle to call `skip_strict_loading` on.
+   * the trails spelling of a deliberate load, and they run where Ruby would
+   * have had an association handle to call `skip_strict_loading` on.
    * @internal
    */
   protected isViolatesStrictLoading(): boolean {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -925,7 +925,8 @@ export class Association {
   /**
    * Mirrors `Association#violates_strict_loading?` (association.rb:284-292),
    * called from `findTarget` (association.rb:248-250) and from
-   * `CollectionProxy._checkStrictLoading`.
+   * `HasManyAssociation`'s functional `findTarget`
+   * (has-many-association.ts, `Association#find_target`'s first statement).
    *
    * The `@skip_strict_loading` guard reads two flags rather than one: the
    * association-level ivar Rails has, plus the owner-level bypass counter the

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -103,23 +103,23 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("map / filter / forEach delegate to the target", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    expect(proxy.map((p) => p.title).sort()).toEqual(["a", "b", "c"]);
+    expect(proxy.map((p: Post) => p.title).sort()).toEqual(["a", "b", "c"]);
     expect(
       proxy
-        .filter((p) => p.title !== "b")
-        .map((p) => p.title)
+        .filter((p: Post) => p.title !== "b")
+        .map((p: Post) => p.title)
         .sort(),
     ).toEqual(["a", "c"]);
     const seen: string[] = [];
-    proxy.forEach((p) => seen.push(p.title));
+    proxy.forEach((p: Post) => seen.push(p.title));
     expect(seen.sort()).toEqual(["a", "b", "c"]);
   });
 
   it("some / every work", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    expect(proxy.some((p) => p.title === "b")).toBe(true);
-    expect(proxy.every((p) => p.title.length === 1)).toBe(true);
+    expect(proxy.some((p: Post) => p.title === "b")).toBe(true);
+    expect(proxy.every((p: Post) => p.title.length === 1)).toBe(true);
   });
 
   it("delegates arbitrary Array methods to the loaded target (method_missing)", async () => {
@@ -179,7 +179,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("reduce composes over the target", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    const concatenated = proxy.reduce((acc, p) => acc + p.title, "");
+    const concatenated = proxy.reduce((acc: string, p: Post) => acc + p.title, "");
     expect([...concatenated].sort().join("")).toBe("abc");
   });
 
@@ -188,7 +188,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const proxy = association<Post>(author, "posts");
     const second = proxy.at(1)!;
     expect(proxy.indexOf(second)).toBe(1);
-    expect(proxy.flatMap((p) => [p.title, p.title.toUpperCase()])).toEqual(
+    expect(proxy.flatMap((p: Post) => [p.title, p.title.toUpperCase()])).toEqual(
       proxy.target.flatMap((p) => [p.title, p.title.toUpperCase()]),
     );
   });
@@ -243,7 +243,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     const ctx = { suffix: "!" };
-    const titles = proxy.map(function (this: { suffix: string }, p) {
+    const titles = proxy.map(function (this: { suffix: string }, p: Post) {
       return p.title + this.suffix;
     }, ctx);
     expect(titles.sort()).toEqual(["a!", "b!", "c!"]);
@@ -253,7 +253,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
     // Without an initial value, accumulator type is the element type (T).
-    const concat = proxy.reduce((acc, p) => {
+    const concat = proxy.reduce((acc: Post, p: Post) => {
       return { ...acc, title: acc.title + p.title } as Post;
     });
     expect([...concat.title].sort().join("")).toBe("abc");

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -335,9 +335,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   // `keys` / `entries` are the index-yielding half of the same JS iteration
   // protocol as `[Symbol.iterator]` above — like it, they read the delegated
-  // records (`records` -> `load_target`, collection_proxy.rb:1024). `values()`
-  // is intentionally NOT added: it would shadow `Relation#values()`
-  // (query-state introspection used by the Relation merger).
+  // records (`records` → `load_target`, collection_proxy.rb:1024). `values()`
+  // is NOT added: it would shadow `Relation#values()`.
 
   keys(): IterableIterator<number> {
     return this.target.keys();
@@ -464,10 +463,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private async _execLoad(): Promise<T[]> {
     const results = (await this._findTargetViaAssociation()) as T[];
-    // `Association#set_strict_loading` per record — Rails applies it in
-    // `find_target` / `exec_queries` (association.rb:248-273). The functional
-    // `findTarget` path bypasses the OO `CollectionAssociation.loadTarget`
-    // where the cascade lives, so route through the OO association here.
+    // `Association#set_strict_loading` per record (association.rb:270-271).
+    // The functional `findTarget` path bypasses the OO
+    // `CollectionAssociation.loadTarget` where Rails runs it, so it runs here.
     const association = this._record.association(this._assocName) as unknown as {
       setStrictLoading?: (record: Base) => Base;
     };

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -37,9 +37,7 @@ import {
 import type { Nodes } from "@blazetrails/arel";
 import { singularize, camelize, constantize } from "@blazetrails/activesupport";
 import { ConfigurationError, AssociationTypeMismatch } from "../errors.js";
-import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
-import { AssociationNotFoundError } from "./errors.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   autoloadModel,
@@ -325,36 +323,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this;
   }
 
-  // ──────────────────────────────────────────────────────────────────
-  // Array-likeness — sync ops over the loaded target.
-  //
-  // Rails' CollectionProxy IS a Relation that's iterable / countable
-  // / array-shaped against the loaded records. JS has no blocking IO,
-  // so these methods do NOT trigger a fresh DB load — they read
-  // whatever's in `_target` (populated by `await proxy`,
-  // `await proxy.load()`, `Post.includes(...)`, or push / build /
-  // create through the proxy). For a fresh load, await the proxy
-  // first.
-  // ──────────────────────────────────────────────────────────────────
-
-  /**
-   * Return the number of records in the collection.
-   *
-   * Mirrors ActiveRecord::Associations::CollectionProxy#length
-   * (collection_proxy.rb): `records.length`. `records` resolves through
-   * `load_target`, which returns the cached `@target` when the association is
-   * already loaded — so a loaded proxy counts in memory with NO query and only
-   * an unloaded one re-queries. `Relation`'s `to: :records` delegate
-   * (delegation.rb:101) always re-queries via `toArray`/`_execLoad`, which is
-   * why this overrides it: the proxy keeps loaded state in
-   * `_target`/`_targetLoaded`, not Relation's `_records`/`_loaded`, so
-   * `loadTarget()` (which short-circuits on `_targetLoaded`) is the faithful
-   * path.
-   */
-  async length(): Promise<number> {
-    return (await this.loadTarget()).length;
-  }
-
   /**
    * @noRailsEquivalent PERMANENT
    *   (`vendor/rails/activerecord/lib/active_record/relation/delegation.rb:101` — `each` is
@@ -362,107 +330,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * JS iteration protocol — Ruby uses Enumerable#each
    */
   [Symbol.iterator](): IterableIterator<T> {
-    return this._target[Symbol.iterator]();
+    return this.target[Symbol.iterator]();
   }
 
-  at(index: number): T | undefined {
-    return this._target.at(index);
-  }
-
-  map<U>(fn: (record: T, index: number, all: T[]) => U, thisArg?: unknown): U[] {
-    return this._target.map(fn, thisArg);
-  }
-
-  // filter has the standard type-predicate overload from Array<T>.
-  filter<S extends T>(
-    predicate: (record: T, index: number, all: T[]) => record is S,
-    thisArg?: unknown,
-  ): S[];
-  filter(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[];
-  filter(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): T[] {
-    return this._target.filter(predicate, thisArg);
-  }
-
-  forEach(fn: (record: T, index: number, all: T[]) => void, thisArg?: unknown): void {
-    this._target.forEach(fn, thisArg);
-  }
-
-  some(fn: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
-    return this._target.some(fn, thisArg);
-  }
-
-  // Enumerable#detect / #sort_by are inherited, not overridden: `toArray()`
-  // below is this proxy's `records` → `load_target` (collection_proxy.rb:1024).
-
-  // every has the standard type-predicate overload from Array<T>.
-  every<S extends T>(
-    predicate: (record: T, index: number, all: T[]) => record is S,
-    thisArg?: unknown,
-  ): boolean;
-  every(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean;
-  every(predicate: (record: T, index: number, all: T[]) => unknown, thisArg?: unknown): boolean {
-    return this._target.every(predicate, thisArg);
-  }
-
-  // Mirrors Rails' Relation#any? / CollectionProxy#any? semantics:
-  // - No predicate: returns !empty? which uses exists? when not loaded
-  //   (SELECT 1 LIMIT 1) rather than materializing all rows.
-  // - With predicate: loads all records (via Enumerable#any? / to_a.any?).
-
-  async any(
-    fn?: (record: T, index: number, all: T[]) => unknown,
-    thisArg?: unknown,
-  ): Promise<boolean> {
-    if (!fn) return !(await this.isEmpty());
-    const records = await this.toArray();
-    return records.some(fn as (v: T, i: number, a: T[]) => unknown, thisArg);
-  }
-
-  // The Array-style `includes(record)` and `find(predicate)` overloads
-  // are intentionally NOT added:
-  //   - Array-style `includes(record)` would shadow
-  //     `Relation#includes(...associations)` (eager loading).
-  //   - Array-style `find(predicate)` would shadow this class's own
-  //     `async find(id)` and `Relation#find(id)` — the Rails-style
-  //     PK-lookup forms.
-  // Reach for Array semantics via `Array.from(proxy).includes(...)` /
-  // `Array.from(proxy).find(...)` (or `proxy.target.includes(...)` /
-  // `proxy.target.find(...)`). Matches Rails' priority — CollectionProxy
-  // preserves the Relation + PK-find surface and lets Array semantics
-  // route through `to_a`.
-
-  slice(start?: number, end?: number): T[] {
-    return this._target.slice(start, end);
-  }
-
-  reduce(fn: (acc: T, record: T, index: number, all: T[]) => T): T;
-  reduce<U>(fn: (acc: U, record: T, index: number, all: T[]) => U, initial: U): U;
-  reduce(...args: [unknown, ...unknown[]]): unknown {
-    // Forward verbatim with the array as receiver — reduce needs `this`
-    // to be the array. (with-vs-without initial value picks different
-    // semantics, hence the variadic forwarding.)
-    return (this._target.reduce as (...a: unknown[]) => unknown).apply(this._target, args);
-  }
-
-  indexOf(record: T, fromIndex?: number): number {
-    return this._target.indexOf(record, fromIndex);
-  }
-
-  flatMap<U>(fn: (record: T, index: number, all: T[]) => U | readonly U[], thisArg?: unknown): U[] {
-    return this._target.flatMap(fn, thisArg);
-  }
+  // `keys` / `entries` are the index-yielding half of the same JS iteration
+  // protocol as `[Symbol.iterator]` above — like it, they read the delegated
+  // records (`records` -> `load_target`, collection_proxy.rb:1024). `values()`
+  // is intentionally NOT added: it would shadow `Relation#values()`
+  // (query-state introspection used by the Relation merger).
 
   keys(): IterableIterator<number> {
-    return this._target.keys();
+    return this.target.keys();
   }
 
-  // `values()` is intentionally NOT added — it would shadow
-  // `Relation#values(): Record<string, unknown>` (query-state
-  // introspection used by the Relation merger). Use the proxy's
-  // built-in iteration (`for...of`, `[...proxy]`, `Array.from(proxy)`).
-
   entries(): IterableIterator<[number, T]> {
-    return this._target.entries();
+    return this.target.entries();
   }
 
   /** @internal Initialize from preloaded association data. */
@@ -576,13 +458,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `CollectionProxy → AssociationRelation#exec_queries → loadTarget` path
    * which always routes through the OO association regardless of scope state.
    *
-   * `_cascadeStrictLoading` is called exactly once here; the Relation's own
-   * `strictLoadingValue` is applied afterward so it wins over cascade (Rails
+   * `Association#set_strict_loading` cascades exactly once here; the Relation's
+   * own `strictLoadingValue` is applied afterward so it wins over cascade (Rails
    * applies `strict_loading_value` after `set_strict_loading` per record).
    */
   private async _execLoad(): Promise<T[]> {
     const results = (await this._findTargetViaAssociation()) as T[];
-    this._cascadeStrictLoading(results);
+    // `Association#set_strict_loading` per record — Rails applies it in
+    // `find_target` / `exec_queries` (association.rb:248-273). The functional
+    // `findTarget` path bypasses the OO `CollectionAssociation.loadTarget`
+    // where the cascade lives, so route through the OO association here.
+    const association = this._record.association(this._assocName) as unknown as {
+      setStrictLoading?: (record: Base) => Base;
+    };
+    if (typeof association.setStrictLoading === "function") {
+      for (const r of results) association.setStrictLoading(r);
+    }
     // Relation's strict_loading wins over cascade — applied last to match
     // Rails: AssociationRelation#exec_queries runs set_strict_loading per
     // record, then Relation#exec_queries applies strict_loading_value
@@ -689,37 +580,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       association?: (n: string) => StaleWrapper;
     };
     return typeof rec.association === "function" ? rec.association(this._assocName) : undefined;
-  }
-
-  private _checkStrictLoading(): void {
-    // Rails reaches `violates_strict_loading?` through the association the
-    // proxy delegates to (`find_target`, association.rb:248-250); trails' proxy
-    // loads on its own path, so it consults the same association instance.
-    const association = this._staleWrapper() as unknown as
-      | { isViolatesStrictLoading(): boolean }
-      | undefined;
-    if (association?.isViolatesStrictLoading()) {
-      const ctor = this._record.constructor as typeof Base;
-      const reflection = ctor._reflectOnAssociation?.(this._assocName);
-      if (!reflection) throw new AssociationNotFoundError(this._record, this._assocName);
-      strictLoadingViolationBang({ owner: ctor, reflection });
-    }
-  }
-
-  /**
-   * Propagate the owner's strict-loading mode onto each loaded child —
-   * mirrors `Association#set_strict_loading`, which Rails applies in
-   * `find_target` / `exec_queries`. The functional `findTarget` path
-   * (the common `await blog.posts` reader) bypasses the OO
-   * `CollectionAssociation.loadTarget` where this cascade lives, so we
-   * route through the OO association here to reuse the exact same logic.
-   */
-  private _cascadeStrictLoading(records: T[]): void {
-    const assoc = this._record.association(this._assocName) as unknown as {
-      setStrictLoading?: (record: Base) => Base;
-    };
-    if (typeof assoc.setStrictLoading !== "function") return;
-    for (const r of records) assoc.setStrictLoading(r);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -617,7 +617,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const result = await (post as any).people.concat(person);
     expect(await (post as any).people.size()).toBe(1);
     expect(await (await Post.find(posts("thinking").id)).people.size()).toBe(1);
-    expect((result as any[]).map((r: any) => r.id)).toContain(person.id);
+    expect(await (result as any[]).map((r: any) => r.id)).toContain(person.id);
   });
 
   it("associating a persisted record with unsaved changes saves those changes", async () => {
@@ -701,7 +701,7 @@ describe("HasManyThroughAssociationsTest", () => {
     await (post as any).people.build({ first_name: "Bob" });
     await (post as any).people.build({ first_name: "Ted" });
 
-    const firstNames = (post as any).people.map((p: any) => p.first_name);
+    const firstNames = await (post as any).people.map((p: any) => p.first_name);
     expect(firstNames).toContain("Bob");
     expect(firstNames).toContain("Ted");
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -607,19 +607,6 @@ export class JoinDependency {
         joins.push(join);
       }
       this._aliasesCache = undefined;
-    } else if (!child.throughGroup) {
-      // A non-reflection leaf has no chain to build, so it only claims its
-      // table — the `aliases[table_name] == 0` arm of `aliased_table_for`
-      // (alias_tracker.rb:60-63) — keeping a later merged join onto the same
-      // table detectable as a collision.
-      const t = child.tableName;
-      if (t) {
-        if ((this.aliasTracker.aliases.get(t) ?? 0) === 0) this.aliasTracker.aliases.set(t, 1);
-        const eff = child.effectiveSqlName;
-        if (eff && eff !== t) {
-          this.aliasTracker.aliases.set(eff, (this.aliasTracker.aliases.get(eff) ?? 0) + 1);
-        }
-      }
     }
 
     return joins.concat(child.children.flatMap((c) => this.makeConstraints(child, c, joinType)));

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -241,7 +241,7 @@ describe("AssociationsJoinModelTest", () => {
     // target via `load()` (Rails' `any?`-with-block loads it implicitly)
     // before the synchronous `sort`.
     const categories = (david as any).categories;
-    expect(await categories.any((category: Base) => (category as any).name === "General")).toBe(
+    expect(await categories.isAny((category: Base) => (category as any).name === "General")).toBe(
       true,
     );
     await categories.load();

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -779,7 +779,7 @@ describe("CounterCacheTest", () => {
       expect(await (car as any).bulbs.size()).toBe(2);
       expect(await (car as any).bulbs.count()).toBe(2);
       expect(await (car as any).bulbs.isEmpty()).toBe(false);
-      expect(await (car as any).bulbs.any()).toBe(true);
+      expect(await (car as any).bulbs.isAny()).toBe(true);
       expect(await (car as any).bulbs.isNone()).toBe(false);
     });
   });
@@ -795,7 +795,7 @@ describe("CounterCacheTest", () => {
     await assertQueriesCount(0, false, async () => {
       expect(await (car as any).tyres.size()).toBe(2);
       expect(await (car as any).tyres.isEmpty()).toBe(false);
-      expect(await (car as any).tyres.any()).toBe(true);
+      expect(await (car as any).tyres.isAny()).toBe(true);
       expect(await (car as any).tyres.isNone()).toBe(false);
     });
 

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -155,9 +155,9 @@ describe("ReadOnlyTest", () => {
   it("has many find readonly", async () => {
     const post = await Post.find(posts("welcome").id);
     // assert_not_empty post.comments
-    expect(await (post as any).comments.any()).toBe(true);
+    expect(await (post as any).comments.isAny()).toBe(true);
     // assert_not post.comments.any?(&:readonly?)
-    expect(await (post as any).comments.any((c: any) => c.isReadonly())).toBe(false);
+    expect(await (post as any).comments.isAny((c: any) => c.isReadonly())).toBe(false);
     // assert_not post.comments.to_a.any?(&:readonly?)
     const arr = await (post as any).comments.toArray();
     expect(arr.some((c: any) => c.isReadonly())).toBe(false);

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -957,6 +957,7 @@ const RECORD_DELEGATES: Record<string, RecordDelegate> = {
     return records.slice(shift).concat(records.slice(0, shift));
   },
   shuffle: (records) => shuffleInPlace([...records]),
+  slice: (records, start?: number, end?: number) => records.slice(start, end),
   split: (records, valueOrFn: Base | ((record: Base) => boolean)) => split(records, valueOrFn),
   inGroups: (records, number: number, fillWith: Base | null | false = null) =>
     inGroups(records, number, fillWith),

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "connection_pool_list",
-    "call": "flat_map",
-    "reason": "Per-site verified (RFC 0106 wave 4b): connection_handler.rb:75-79 is `connection_pool_list(role).flat_map { ... }` over Ruby Hashes; trails' connectionPoolList walks the pool-manager Maps with nested `for..of` and pushes, so no ported `flatMap` is called. Same pools, same order."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "connection_pool_list",
     "call": "map",
     "reason": "Per-site verified (RFC 0106 wave 4b): the inner `map` of connection_handler.rb:75-79 is the same Ruby-Enumerable idiom, spelled as the body of trails' explicit `for..of` accumulation."
   },

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/pool-manager.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/pool-manager.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/pool-manager.ts",
-    "rubyName": "pool_configs",
-    "call": "flat_map",
-    "reason": "Per-site verified (RFC 0106 wave 4b): pool_manager.rb:22 is `@role_to_shard_mapping.flat_map { |_, shard_map| shard_map.values }`; trails walks the nested JS Maps with two `for..of` loops (pool-manager.ts:34-39). Same pool configs, same order."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/delegation.json
@@ -40,12 +40,5 @@
     "rubyName": "initialize_relation_delegate_cache",
     "call": "include_relation_methods",
     "reason": "Verified per-site (RFC 0106): delegation.rb:38 — same lazy-subclass divergence as the `include` row above; `includeRelationMethods` runs from `buildDelegateClass` (delegation.ts:416) when the subclass is first needed."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/delegation.ts",
-    "rubyName": "uncacheable_methods",
-    "call": "flat_map",
-    "reason": "Verified per-site (RFC 0106): `delegated_classes.flat_map(&:public_instance_methods)` (delegation.rb:19) — Ruby Enumerable#flat_map over the class list; TS accumulates the same union with a `for` loop over `ownMethodNamesAbove` into a Set (delegation.ts:232-235), since JS has no `public_instance_methods` to flat-map."
   }
 ]


### PR DESCRIPTION
Three convergences on `CollectionProxy` / `JoinDependency`.

## 1. Enumerable block → `RECORD_DELEGATES` (`retire-collection-proxy-enumerable-block`)

`collection-proxy.ts` hand-wrote `length`, `at`, `map`, `filter`, `forEach`,
`some`, `every`, `any`, `slice`, `reduce`, `indexOf`, `flatMap` over
`this._target`. Rails writes none of them — `include Enumerable`
(`relation.rb:67`) plus `delegate ... to: :records`
(`relation/delegation.rb:99-102`), resolved through `records`, which on a proxy
is `load_target` (`collection_proxy.rb:1024-1026`).

They now resolve through `relation/delegation.ts`: `delegateRecordMethodSync`
on a loaded proxy, `delegateArrayMethod` / `delegateEnumerableMethod`
otherwise. `slice` is added to `RECORD_DELEGATES` because `delegation.rb:98`
lists it in the `to: :records` set, so a loaded proxy slices synchronously as
Rails does. `any` is dropped for `Relation#isAny` (`relation.rb:391-396`), the
port of `any?` — its five call sites move to `isAny`.

`[Symbol.iterator]` keeps its `@noRailsEquivalent PERMANENT` receipt and now
iterates the delegated records rather than the private field. `keys` /
`entries` stay beside it as the index-yielding half of the same JS iteration
protocol; neither is novel surface.

`pnpm parity:api:extra --package activerecord` for
`associations/collection-proxy.ts`: **5 novel → 1** (`every`, `flatMap`,
`reduce`, `some` retired; the remaining one is `new`). No allowlist row and no
new `@noRailsEquivalent` tag.

Two `has-many-through-associations.test.ts` bodies gain an `await` (no test
renamed): they called `.map` on an *unloaded* proxy holding built-but-unsaved
records, which the deleted block answered synchronously. Ruby's `load_target`
is synchronous; trails' delegate self-loads, so the trails spelling is `await`.

## 2. Strict-loading helpers (`retire-collection-proxy-strict-loading-helpers`)

`_checkStrictLoading`, `_cascadeStrictLoading` and `_withoutStrictLoading` are
deleted. Rails puts no strict-loading surface on a proxy:

- the violation raise is `Association#find_target`'s first statement
  (`association.rb:248-250`), already ported in `has-many-association.ts`;
- the cascade is `Association#set_strict_loading`, now inlined at its single
  `_execLoad` call site rather than wrapped in a proxy-only helper;
- `_withoutStrictLoading` had **no callers at all**.

The four proxy call sites (`exists`, `firstOrInitialize`, `firstOrCreate`,
`firstOrCreateBang`) and the `wrapCollectionProxy` property-miss call site drop
the duplicated check. `strict-loading.test.ts` (54 cases) and
`has-many-associations.test.ts` (321 cases) stay green — the raise still comes
from `find_target`.

## 3. `makeConstraints` leaf table claim (`retire-join-leaf-table-claim-in-make-constraints`)

The `else if (!child.throughGroup)` arm hand-rolled the
`aliases[table_name] == 0` arm of `aliased_table_for`
(`alias_tracker.rb:60-63`) for `JoinLeaf` nodes — a node kind Rails' tree has
no counterpart for. Since #6754 the whole chain is claimed by the one
`JoinAssociation#joinConstraints` walk, so the arm is deleted outright and no
alias bookkeeping happens outside `AliasTracker`.

`join-dependency-through-aliasing`, `eager`, `inner-join-association` and
`left-outer-join-association` are green (263 cases).

## Gates

- `pnpm parity:api` / `pnpm parity:test`: unchanged totals.
- `pnpm parity:api:calls`: OK. Three `flat_map` rows went **STALE** (they now
  match) and were deleted by hand; `pool-manager.json` emptied and was removed.
  No rows added.
- `pnpm parity:api:calls:args`: OK, no rows added.
- `pnpm typecheck`, `pnpm lint`: clean.
- `packages/activerecord/src/associations/` (106 files, 2022 cases) green, plus
  `strict-loading`, `readonly`, `counter-cache`, `relations`, `nested-attributes`,
  `autosave-association`, `serialization`, `base`, `callbacks`, `persistence`,
  `dirty`, `transactions`, `validations`.

Closes-story: retire-collection-proxy-enumerable-block
Closes-story: retire-collection-proxy-strict-loading-helpers
Closes-story: retire-join-leaf-table-claim-in-make-constraints