### PR TITLE
fix(activerecord): build the nested references_values join dependency in joinConstraints

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -332,10 +332,10 @@ describe("BelongsToAssociationsTest", () => {
   });
 
   it("eager loading wont mutate owner record", async () => {
-    const client = await Client.eagerLoad("firmWithBasicId").first();
+    const client = await Client.eagerLoad(":firmWithBasicId").first();
     expect((client as any).firmIdCameFromUser?.()).toBeFalsy();
 
-    const client2 = await Client.preload("firmWithBasicId").first();
+    const client2 = await Client.preload(":firmWithBasicId").first();
     expect((client2 as any).firmIdCameFromUser?.()).toBeFalsy();
   });
 
@@ -602,7 +602,7 @@ describe("BelongsToAssociationsTest", () => {
   it("eager loading with primary key", async () => {
     await Firm.create({ name: "Apple" });
     await Client.create({ name: "Citibank", firm_name: "Apple" });
-    const result = await Client.where({ name: "Citibank" }).includes("firmWithPrimaryKey").first();
+    const result = await Client.where({ name: "Citibank" }).includes(":firmWithPrimaryKey").first();
     expect(result!.association("firmWithPrimaryKey").loaded).toBe(true);
   });
 
@@ -610,7 +610,7 @@ describe("BelongsToAssociationsTest", () => {
     await Firm.create({ name: "Apple" });
     await Client.create({ name: "Citibank", firm_name: "Apple" });
     const result = await Client.where({ name: "Citibank" })
-      .includes("firmWithPrimaryKeySymbols")
+      .includes(":firmWithPrimaryKeySymbols")
       .first();
     expect(result!.association("firmWithPrimaryKeySymbols").loaded).toBe(true);
   });
@@ -854,8 +854,8 @@ describe("BelongsToAssociationsTest", () => {
     expect(await (sponsor as any).loadBelongsTo("sponsorableWithConditions")).toBeNull();
 
     const [sponsorPreloaded] = await Sponsor.includes(
-      "sponsorable",
-      "sponsorableWithConditions",
+      ":sponsorable",
+      ":sponsorableWithConditions",
     ).where({ id: sponsor.id });
     expect((sponsorPreloaded as any).sponsorable!.id).toBe(member.id);
     expect((sponsorPreloaded as any).sponsorableWithConditions).toBeNull();
@@ -1374,11 +1374,11 @@ describe("BelongsToAssociationsTest", () => {
 
     expect(Number(david.id)).toBe(1);
     expect(Number((comment as any).author_id)).toBe(1);
-    expect((await Comment.includes("author").first())!.author!.id).toBe(david.id);
+    expect((await Comment.includes(":author").first())!.author!.id).toBe(david.id);
 
     expect(Number(groucho.id)).toBe(1);
     expect((comment as any).resource_id).toBe("1");
-    expect((await Comment.includes("resource").first())!.resource!.id).toBe(groucho.id);
+    expect((await Comment.includes(":resource").first())!.resource!.id).toBe(groucho.id);
   });
 
   it("polymorphic assignment foreign type field updating", async () => {
@@ -1474,7 +1474,7 @@ describe("BelongsToAssociationsTest", () => {
 
     await expect(foundAccount.save()).resolves.toBeDefined();
     await expect(
-      Account.includes("firm")
+      Account.includes(":firm")
         .find(acct.id!)
         .then((a) => a.save()),
     ).resolves.toBeDefined();

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -218,7 +218,7 @@ describe("CascadedEagerLoadingTest", () => {
       .includes(":categorizations")
       .includes({ ":categorizations": ":author" })
       .where("categorizations.id is not null")
-      .references("categorizations");
+      .references(":categorizations");
     expect(await categories.count()).toBe(3);
     expect((await categories).length).toBe(3);
   });
@@ -228,7 +228,7 @@ describe("CascadedEagerLoadingTest", () => {
       .includes({ ":categorizations": ":author" })
       .includes({ ":categorizations": ":post" })
       .where("posts.id is not null")
-      .references("posts");
+      .references(":posts");
     expect(await categories.count()).toBe(3);
     expect((await categories).length).toBe(3);
   });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -149,7 +149,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     // includes — that would shadow Relation#includes(...associations).
     // proxy.includes(...) falls through to Relation and builds an
     // eager-loading Relation. Membership is via Array.from(proxy).
-    const rel = proxy.includes("comments");
+    const rel = proxy.includes(":comments");
     expect(typeof rel?.where).toBe("function"); // it's a Relation, not a boolean
     expect(Array.from(proxy as Iterable<Post>).includes(first)).toBe(true);
     expect(proxy.target.includes(first)).toBe(true);

--- a/packages/activerecord/src/associations/eager-load-includes-full-sti-class.test.ts
+++ b/packages/activerecord/src/associations/eager-load-includes-full-sti-class.test.ts
@@ -48,11 +48,11 @@ function findByTitle(): Promise<NamespacedPost | null> {
 }
 
 function includesFindByTitle(): Promise<NamespacedPost | null> {
-  return NamespacedPost.includes("tagging").findBy({ title: "Great stuff" });
+  return NamespacedPost.includes(":tagging").findBy({ title: "Great stuff" });
 }
 
 function eagerLoadFindByTitle(): Promise<NamespacedPost | null> {
-  return NamespacedPost.eagerLoad("tagging").findBy({ title: "Great stuff" });
+  return NamespacedPost.eagerLoad(":tagging").findBy({ title: "Great stuff" });
 }
 
 describe("FullStiClassNamesTest", () => {

--- a/packages/activerecord/src/associations/eager-load-nested-include.test.ts
+++ b/packages/activerecord/src/associations/eager-load-nested-include.test.ts
@@ -144,7 +144,7 @@ describe("EagerLoadPolyAssocsTest", () => {
       });
     }
 
-    const res = await ShapeExpression.all().includes("shape", { paint: "nonPoly" });
+    const res = await ShapeExpression.all().includes(":shape", { ":paint": ":nonPoly" });
     expect(res).toHaveLength(NUM_SHAPE_EXPRESSIONS);
     await assertNoQueries(false, async () => {
       for (const se of res) {
@@ -185,9 +185,9 @@ describe("EagerLoadNestedIncludeWithMissingDataTest", () => {
     // when constructing objects across the missing branch.
     await Author.all()
       .includes(
-        { posts: "comments" },
-        { categorizations: "category" },
-        { authorFavorites: "favoriteAuthor" },
+        { ":posts": ":comments" },
+        { ":categorizations": ":category" },
+        { ":authorFavorites": ":favoriteAuthor" },
       )
       .where({ authors: { name: (daveyMcdave as unknown as { name: string }).name } })
       .order("categories.name");

--- a/packages/activerecord/src/associations/eager-load-unjoinable-raises.trails.test.ts
+++ b/packages/activerecord/src/associations/eager-load-unjoinable-raises.trails.test.ts
@@ -28,27 +28,27 @@ describe("eager_load with an unresolvable association", () => {
   const expected = /Can't join 'Post' to association named 'monkeys'; perhaps you misspelled it\?/;
 
   it("raises on the record-loading path", async () => {
-    await expect(Post.all().eagerLoad("monkeys").toArray()).rejects.toThrow(expected);
+    await expect(Post.all().eagerLoad(":monkeys").toArray()).rejects.toThrow(expected);
   });
 
   it("raises on a nested spec's inner segment", async () => {
-    await expect(Post.all().eagerLoad({ comments: "monkeys" }).toArray()).rejects.toThrow(
+    await expect(Post.all().eagerLoad({ ":comments": ":monkeys" }).toArray()).rejects.toThrow(
       /Can't join 'Comment' to association named 'monkeys'/,
     );
   });
 
   it("raises on the calculation path", async () => {
-    await expect(Post.all().eagerLoad("monkeys").count()).rejects.toThrow(expected);
-    await expect(Post.all().eagerLoad("monkeys").sum("legacyCommentsCount")).rejects.toThrow(
+    await expect(Post.all().eagerLoad(":monkeys").count()).rejects.toThrow(expected);
+    await expect(Post.all().eagerLoad(":monkeys").sum("legacyCommentsCount")).rejects.toThrow(
       expected,
     );
   });
 
   it("raises on the exists? path", async () => {
-    await expect(Post.all().eagerLoad("monkeys").exists()).rejects.toThrow(expected);
+    await expect(Post.all().eagerLoad(":monkeys").exists()).rejects.toThrow(expected);
   });
 
   it("raises on the pluck path", async () => {
-    await expect(Post.all().eagerLoad("monkeys").pluck("title")).rejects.toThrow(expected);
+    await expect(Post.all().eagerLoad(":monkeys").pluck("title")).rejects.toThrow(expected);
   });
 });

--- a/packages/activerecord/src/associations/eager-singularization.test.ts
+++ b/packages/activerecord/src/associations/eager-singularization.test.ts
@@ -197,31 +197,31 @@ describe("EagerSingularizationTest", () => {
   registerModel("Compress", Compress);
 
   it("eager no extra singularization belongs to", async () => {
-    await expect(Virus.all().includes("octopus").toArray()).resolves.toBeDefined();
+    await expect(Virus.all().includes(":octopus").toArray()).resolves.toBeDefined();
   });
 
   it("eager no extra singularization has one", async () => {
-    await expect(Octopus.all().includes("virus").toArray()).resolves.toBeDefined();
+    await expect(Octopus.all().includes(":virus").toArray()).resolves.toBeDefined();
   });
 
   it("eager no extra singularization has many", async () => {
-    await expect(Bus.all().includes("passes").toArray()).resolves.toBeDefined();
+    await expect(Bus.all().includes(":passes").toArray()).resolves.toBeDefined();
   });
 
   it("eager no extra singularization has and belongs to many", async () => {
     await expect(
       (async () => {
-        await Crisis.all().includes("messes");
-        return Mess.all().includes("crises").toArray();
+        await Crisis.all().includes(":messes");
+        return Mess.all().includes(":crises").toArray();
       })(),
     ).resolves.toBeDefined();
   });
 
   it("eager no extra singularization has many through belongs to", async () => {
-    await expect(Crisis.all().includes("successes").toArray()).resolves.toBeDefined();
+    await expect(Crisis.all().includes(":successes").toArray()).resolves.toBeDefined();
   });
 
   it("eager no extra singularization has many through has many", async () => {
-    await expect(Crisis.all().includes("compresses").toArray()).resolves.toBeDefined();
+    await expect(Crisis.all().includes(":compresses").toArray()).resolves.toBeDefined();
   });
 });

--- a/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
+++ b/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
@@ -5,7 +5,7 @@
  *
  * `Company` declares `attribute("metadata", "json")` (company.ts) but the
  * canonical `companies` table has no `metadata` column. Eager-loading
- * `Firm.includes("clients")` (both STI on `companies`) over a *partial* schema
+ * `Firm.includes(":clients")` (both STI on `companies`) over a *partial* schema
  * — only `companies` defined — previously projected `companies.metadata`,
  * failing the query with `no such column: companies.metadata`. Rails' eager
  * SELECT projects only real table columns.
@@ -29,7 +29,9 @@ describe("getModelColumns virtual-attribute eager projection", () => {
     });
     let firm: Firm;
     try {
-      firm = (await Firm.includes("clients").where({ "clients.newName": "Summit" }).last()) as Firm;
+      firm = (await Firm.includes(":clients")
+        .where({ "clients.newName": "Summit" })
+        .last()) as Firm;
     } finally {
       Notifications.unsubscribe(sub);
     }

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -839,7 +839,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("join middle table alias", async () => {
     const records = await (Project as any)
-      .includes("developers_projects")
+      .includes(":developers_projects")
       .where()
       .not({ "developers_projects.joined_on": null })
       .toArray();
@@ -848,7 +848,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("join table alias", async () => {
     const records = await (Developer as any)
-      .includes({ projects: "developers" })
+      .includes({ ":projects": ":developers" })
       .where()
       .not({ "developers_projects_projects_join.joined_on": null })
       .toArray();
@@ -864,7 +864,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     for (const c of Project.columnNames()) group.push(`projects.${c}`);
 
     const records = await (Developer as any)
-      .includes({ projects: "developers" })
+      .includes({ ":projects": ":developers" })
       .where()
       .not({ "developers_projects_projects_join.joined_on": null })
       .group(group.join(","))
@@ -1207,7 +1207,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     await (developer as any).saveBang();
     await (project as any).developers.push(developer);
 
-    const projs = ProjectUnscopingDavidDefaultScope.includes("developers").where({
+    const projs = ProjectUnscopingDavidDefaultScope.includes(":developers").where({
       id: project.id,
     });
     expect(await ((await projs.first())! as any).developers.size()).toBe(1);
@@ -1215,13 +1215,13 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("preloaded associations size", async () => {
     const firstProjectDirect = await Project.first();
-    const preloadedProject = await Project.preload("salariedDevelopers").first();
+    const preloadedProject = await Project.preload(":salariedDevelopers").first();
     expect(await preloadedProject!.salariedDevelopers.size()).toBe(
       await firstProjectDirect!.salariedDevelopers.size(),
     );
 
-    const includesProject = await Project.includes("salariedDevelopers")
-      .references("salariedDevelopers")
+    const includesProject = await Project.includes(":salariedDevelopers")
+      .references(":salariedDevelopers")
       .first();
     expect(await includesProject!.salariedDevelopers.size()).toBe(
       await preloadedProject!.salariedDevelopers.size(),
@@ -1231,7 +1231,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const developer = await Developer.first();
     const firstProject = await developer!.projects.first();
     const preloadedDeveloper = await Developer.preload({
-      projects: "salariedDevelopers",
+      ":projects": ":salariedDevelopers",
     }).first();
     const preloadedProjects = await preloadedDeveloper!.projects;
     const preloadedFirstProject = preloadedProjects.find(

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1993,7 +1993,7 @@ describe("HasManyThroughAssociationsTest", () => {
     const person = await Person.createBang({ first_name: "Gaga" });
     const loaded = await Person.where({ id: person.id })
       .where(`readers.id = ${readerId} or 1=1`)
-      .references("readers")
+      .references(":readers")
       .includes(":posts");
     const p = loaded[0];
     expect((p as any).posts.loaded).toBe(true);

--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -185,13 +185,13 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
   it("preloading has many through disable joins", async () => {
     const expectedIds = [rating1.id, rating2.id].sort(sortIds);
 
-    const authorsList = await Author.all().preload("goodRatings");
+    const authorsList = await Author.all().preload(":goodRatings");
     const preloadedAuthor = authorsList.find((a: any) => a.id === author.id) as any;
     expect(preloadedAuthor).toBeDefined();
     const goodRatings = preloadedAuthor.association("goodRatings").target as any[];
     expect(goodRatings.map((r: any) => r.id).sort(sortIds)).toEqual(expectedIds);
 
-    const authorsList2 = await Author.all().preload("noJoinsGoodRatings");
+    const authorsList2 = await Author.all().preload(":noJoinsGoodRatings");
     const preloadedAuthor2 = authorsList2.find((a: any) => a.id === author.id) as any;
     expect(preloadedAuthor2).toBeDefined();
     const noJoinsGoodRatings = preloadedAuthor2.association("noJoinsGoodRatings").target as any[];

--- a/packages/activerecord/src/associations/has-one-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-disable-joins-associations.test.ts
@@ -151,7 +151,7 @@ describe("HasOneThroughDisableJoinsAssociationsTest", () => {
   });
 
   it("preload on disable joins through", async () => {
-    const loaded = await Member.preload("organization", "organizationWithoutJoins");
+    const loaded = await Member.preload(":organization", ":organizationWithoutJoins");
     const first = loaded[0];
     // preload must have populated both holders — assert they read as loaded so the
     // zero-query checks below actually exercise the preload path (a sync `.target`

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -312,7 +312,7 @@ describe("InnerJoinAssociationTest", () => {
 
     const categoriesRel = await (author as any).categories
       .includes(":specialCategorizations")
-      .references("specialCategorizations");
+      .references(":specialCategorizations");
     expect(categoriesRel.length).toBe(2);
   });
 

--- a/packages/activerecord/src/associations/join-association-references-eager-load.trails.test.ts
+++ b/packages/activerecord/src/associations/join-association-references-eager-load.trails.test.ts
@@ -1,0 +1,33 @@
+/**
+ * `JoinAssociation#join_constraints` builds a nested join dependency for an
+ * association scope that both `references` and eager-loads
+ * (`join_association.rb:45-55`):
+ *
+ *   unless scope.references_values.empty?
+ *     associations = scope.eager_load_values | scope.includes_values
+ *     unless associations.empty?
+ *       scope.joins! scope.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+ *     end
+ *   end
+ *
+ * Person's canonical `posts_with_no_comments` (`test/models/person.rb:10`) is
+ * exactly that shape — `includes(:comments).where("comments.id is null")
+ * .references(:comments)` — so joining it has to emit the nested
+ * `LEFT OUTER JOIN comments` its WHERE names. Without the block the emitted
+ * SQL constrains `comments.id` with no `comments` in the FROM list.
+ */
+import { describe, it, expect } from "vitest";
+import { Person } from "../test-helpers/models/person.js";
+
+import { fixtures } from "../test-fixtures.js";
+
+describe("JoinAssociation#join_constraints references_values", () => {
+  fixtures(["people", "readers", "posts", "comments"]);
+
+  it("joins an association scope that references and includes another association", async () => {
+    const sql = await Person.joins(":postsWithNoComments").toSql();
+
+    expect(sql).toMatch(/LEFT OUTER JOIN\s+"?comments"?/i);
+    expect(sql).toMatch(/comments\.id is null/i);
+  });
+});

--- a/packages/activerecord/src/associations/join-association-references-eager-load.trails.test.ts
+++ b/packages/activerecord/src/associations/join-association-references-eager-load.trails.test.ts
@@ -18,8 +18,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { Person } from "../test-helpers/models/person.js";
-
 import { fixtures } from "../test-fixtures.js";
+import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 
 describe("JoinAssociation#join_constraints references_values", () => {
   fixtures(["people", "readers", "posts", "comments"]);
@@ -27,7 +27,9 @@ describe("JoinAssociation#join_constraints references_values", () => {
   it("joins an association scope that references and includes another association", async () => {
     const sql = await Person.joins(":postsWithNoComments").toSql();
 
-    expect(sql).toMatch(/LEFT OUTER JOIN\s+"?comments"?/i);
+    expect(sql).toMatch(
+      new RegExp(`LEFT OUTER JOIN\\s+${escapeRegExp(quoteTableName("comments"))}`, "i"),
+    );
     expect(sql).toMatch(/comments\.id is null/i);
   });
 });

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -144,8 +144,16 @@ export class JoinAssociation extends JoinPart {
 
       const scope = refl.joinScope(table, foreignTable, foreignKlass);
 
-      if (scope && scope.referencesValues && scope.referencesValues.length > 0) {
-        const associations = unionAppend(scope.eagerLoadValues ?? [], scope.includesValues ?? []);
+      if (scope && scope.referencesValues.length > 0) {
+        // `scope.eager_load_values | scope.includes_values` — Ruby's array
+        // union, which compares a Hash/String spec by `eql?`; `structuralUnionEq`
+        // is the same comparison `joins!` unions with.
+        const associations = [...scope.eagerLoadValues];
+        for (const spec of scope.includesValues) {
+          if (!associations.some((seen: unknown) => structuralUnionEq(seen, spec))) {
+            associations.push(spec);
+          }
+        }
 
         if (associations.length > 0) {
           scope.joinsBang(scope.constructJoinDependency(associations, Nodes.OuterJoin));
@@ -329,18 +337,4 @@ function appendConstraints(join: unknown, constraints: unknown[]): Nodes.Node | 
     );
   }
   return join as Nodes.Node | null;
-}
-
-/**
- * Ruby `a | b` over association specs — array union by `eql?`, which for a
- * Hash/String spec is structural. `structuralUnionEq` is the same comparison
- * `joins!` uses.
- * @internal
- */
-function unionAppend<T>(target: readonly T[], incoming: readonly T[]): T[] {
-  const union = [...target];
-  for (const spec of incoming) {
-    if (!union.some((seen) => structuralUnionEq(seen, spec))) union.push(spec);
-  }
-  return union;
 }

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -19,6 +19,7 @@ import {
 import type { AbstractReflection } from "../../reflection.js";
 import { JoinPart } from "./join-part.js";
 import { aliasedArelTableForReflection, type AliasTracker } from "../alias-tracker.js";
+import { structuralUnionEq } from "../../relation/query-methods.js";
 
 type JoinType = typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
 type TableResolver = (
@@ -143,9 +144,13 @@ export class JoinAssociation extends JoinPart {
 
       const scope = refl.joinScope(table, foreignTable, foreignKlass);
 
-      // TODO: Rails checks scope.references_values and builds join dependencies
-      // for eager-loaded associations here. We skip this until Relation#arel() and
-      // construct_join_dependency are implemented.
+      if (scope && scope.referencesValues && scope.referencesValues.length > 0) {
+        const associations = unionAppend(scope.eagerLoadValues ?? [], scope.includesValues ?? []);
+
+        if (associations.length > 0) {
+          scope.joinsBang(scope.constructJoinDependency(associations, Nodes.OuterJoin));
+        }
+      }
 
       let nodes: Nodes.Node;
       if (scope && scope.whereClause && !scope.whereClause.isEmpty()) {
@@ -324,4 +329,18 @@ function appendConstraints(join: unknown, constraints: unknown[]): Nodes.Node | 
     );
   }
   return join as Nodes.Node | null;
+}
+
+/**
+ * Ruby `a | b` over association specs — array union by `eql?`, which for a
+ * Hash/String spec is structural. `structuralUnionEq` is the same comparison
+ * `joins!` uses.
+ * @internal
+ */
+function unionAppend<T>(target: readonly T[], incoming: readonly T[]): T[] {
+  const union = [...target];
+  for (const spec of incoming) {
+    if (!union.some((seen) => structuralUnionEq(seen, spec))) union.push(spec);
+  }
+  return union;
 }

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -147,7 +147,11 @@ export class JoinAssociation extends JoinPart {
       if (scope && scope.referencesValues.length > 0) {
         // `scope.eager_load_values | scope.includes_values` — Ruby's array
         // union, which compares a Hash/String spec by `eql?`; `structuralUnionEq`
-        // is the same comparison `joins!` unions with.
+        // is the same comparison `joins!` unions with. Inlined rather than
+        // reusing query-methods' private `unionAppend`: exporting that helper
+        // adds a novel public name to a Rails-matched file (measured — it takes
+        // `relation/query-methods.ts` from 9 novel to 10 on `parity:api:extra`),
+        // and Rails spells this as one `|` operator with no helper at all.
         const associations = [...scope.eagerLoadValues];
         for (const spec of scope.includesValues) {
           if (!associations.some((seen: unknown) => structuralUnionEq(seen, spec))) {

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -579,7 +579,7 @@ describe("AssociationsJoinModelTest", () => {
       (general as any).taggings
         .includes(":taggable")
         .where("bogus_table.column = 1")
-        .references("bogus_table")
+        .references(":bogus_table")
         .toArray(),
     ).rejects.toThrow(EagerLoadPolymorphicError);
   });

--- a/packages/activerecord/src/associations/nested-through-advanced.test.ts
+++ b/packages/activerecord/src/associations/nested-through-advanced.test.ts
@@ -52,8 +52,8 @@ describe("HMT Slot E — nested-through advanced", () => {
     const david = authors("david");
     const bob = authors("bob");
     // Load each author's tags in separate preload queries.
-    const [davidRow] = await Author.where({ id: david.id }).preload("tags");
-    const [bobRow] = await Author.where({ id: bob.id }).preload("tags");
+    const [davidRow] = await Author.where({ id: david.id }).preload(":tags");
+    const [bobRow] = await Author.where({ id: bob.id }).preload(":tags");
     const davidTags = (davidRow.association("tags").target ?? []) as any[];
     const bobTags = (bobRow.association("tags").target ?? []) as any[];
     // david: welcome+thinking both tagged "general"
@@ -66,8 +66,8 @@ describe("HMT Slot E — nested-through advanced", () => {
     // Author → posts → taggings: two separate preloads of the same chain
     // must produce stable results (no alias collision between invocations).
     const david = authors("david");
-    const [r1] = await Author.where({ id: david.id }).preload("taggings");
-    const [r2] = await Author.where({ id: david.id }).preload("taggings");
+    const [r1] = await Author.where({ id: david.id }).preload(":taggings");
+    const [r2] = await Author.where({ id: david.id }).preload(":taggings");
     const t1 = ((r1.association("taggings").target ?? []) as any[]).map((r: any) => r.id).sort();
     const t2 = ((r2.association("taggings").target ?? []) as any[]).map((r: any) => r.id).sort();
     expect(t1).toEqual(t2);
@@ -103,7 +103,7 @@ describe("HMT Slot E — nested-through advanced", () => {
     // Preload all authors' tags in one query — each owner must get only their own tags.
     const david = authors("david");
     const bob = authors("bob");
-    const preloaded = await Author.where({ id: [david.id, bob.id] }).preload("tags");
+    const preloaded = await Author.where({ id: [david.id, bob.id] }).preload(":tags");
     const byId = new Map(preloaded.map((row) => [row.id, row]));
     const davidTags = ((byId.get(david.id)!.association("tags").target ?? []) as any[]).map(
       (t) => t.name,

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -709,7 +709,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("nested has many through with conditions on through associations preload via joins", async () => {
     const bob = authors("bob");
     const result = await Author.where("tags.id = tags.id")
-      .references("tags")
+      .references(":tags")
       .joins(":miscPostFirstBlueTags");
     expect(result.map((a) => a.id)).toContain(bob.id);
   });
@@ -754,7 +754,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("nested has many through with conditions on source associations preload via joins", async () => {
     const bob = authors("bob");
     const result = await Author.where("tags.id = tags.id")
-      .references("tags")
+      .references(":tags")
       .joins(":miscPostFirstBlueTags_2");
     expect(result.map((a) => a.id)).toContain(bob.id);
   });

--- a/packages/activerecord/src/associations/nested-through-preloader.test.ts
+++ b/packages/activerecord/src/associations/nested-through-preloader.test.ts
@@ -67,7 +67,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     const r1 = ratings("normal_comment_rating");
     const r2 = ratings("special_comment_rating");
     const r3 = ratings("sub_special_comment_rating");
-    const [author] = await Author.where({ id: david.id }).includes("ratings");
+    const [author] = await Author.where({ id: david.id }).includes(":ratings");
     const preloaded = (author.association("ratings").target ?? []) as any[];
     expect(preloaded.map((r: any) => r.id).sort((a: any, b: any) => Number(a) - Number(b))).toEqual(
       [r1.id, r2.id, r3.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -78,7 +78,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     // `comments` on Author = through: "posts" (a direct 2-level through).
     // Loading it independently must not bleed into a separate `ratings` preload.
     const david = authors("david");
-    const [author] = await Author.where({ id: david.id }).includes("comments");
+    const [author] = await Author.where({ id: david.id }).includes(":comments");
     const preloadedComments = (author.association("comments").target ?? []) as any[];
     expect(preloadedComments.length).toBeGreaterThan(0);
     // The ratings association must NOT be loaded as a side-effect.
@@ -90,7 +90,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     const r1 = ratings("normal_comment_rating");
     const r2 = ratings("special_comment_rating");
     const r3 = ratings("sub_special_comment_rating");
-    const [author] = await Author.where({ id: david.id }).includes("ratings");
+    const [author] = await Author.where({ id: david.id }).includes(":ratings");
     const preloaded = (author.association("ratings").target ?? []) as any[];
     // Filtering the outer relation must not silently drop preloaded
     // targets, introduce duplicates, or leak stray rows.
@@ -118,7 +118,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     // When loaded through the Author→posts→comments chain, STI discriminator
     // must materialize the correct subclass — not the base Comment.
     const david = authors("david");
-    const preloaded = await Author.where({ id: david.id }).includes("comments");
+    const preloaded = await Author.where({ id: david.id }).includes(":comments");
     const comments = (preloaded[0].association("comments").target ?? []) as any[];
     const byId = new Map(comments.map((c: any) => [c.id, c]));
 

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -83,7 +83,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
 
   it("includes() preloads polymorphic-through with source_type into the association target", async () => {
     const { hotel, cake1, cake2 } = await seed();
-    const [h] = await Hotel.where({ id: (hotel as any).id }).includes("cakeDesigners");
+    const [h] = await Hotel.where({ id: (hotel as any).id }).includes(":cakeDesigners");
     const preloaded = (h.association("cakeDesigners").target ?? []) as any[];
     expect(preloaded.map((d: any) => d.id).sort((a: any, b: any) => Number(a) - Number(b))).toEqual(
       [(cake1 as any).id, (cake2 as any).id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -106,8 +106,8 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
   it("includes() preloads disjoint source-typed associations from the same intermediate", async () => {
     const { hotel, cake1, cake2, drink } = await seed();
     const [h] = await Hotel.where({ id: (hotel as any).id })
-      .includes("cakeDesigners")
-      .includes("drinkDesigners");
+      .includes(":cakeDesigners")
+      .includes(":drinkDesigners");
     const cakes = (h.association("cakeDesigners").target ?? []) as any[];
     const drinks = (h.association("drinkDesigners").target ?? []) as any[];
     expect(cakes.map((d: any) => d.id).sort((a: any, b: any) => Number(a) - Number(b))).toEqual(
@@ -127,7 +127,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
 
   it("includes() + outer where preserves every preloaded polymorphic-through target", async () => {
     const { hotel, cake1, cake2 } = await seed();
-    const [h] = await Hotel.where({ id: (hotel as any).id }).includes("cakeDesigners");
+    const [h] = await Hotel.where({ id: (hotel as any).id }).includes(":cakeDesigners");
     const preloaded = (h.association("cakeDesigners").target ?? []) as any[];
     // Filtering the outer relation must not silently drop preloaded targets.
     expect(preloaded.map((d: any) => d.id).sort((a: any, b: any) => Number(a) - Number(b))).toEqual(
@@ -139,7 +139,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
     const { hotel: h1, cake1, cake2 } = await seed();
     const { hotel: h2, cake1: h2cake1, cake2: h2cake2 } = await seed();
 
-    const [first] = await Hotel.where({ id: (h1 as any).id }).includes("cakeDesigners");
+    const [first] = await Hotel.where({ id: (h1 as any).id }).includes(":cakeDesigners");
     const firstIds = ((first.association("cakeDesigners").target ?? []) as any[])
       .map((d) => d.id)
       .sort((a: any, b: any) => Number(a) - Number(b));
@@ -147,7 +147,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
       [(cake1 as any).id, (cake2 as any).id].sort((a: any, b: any) => Number(a) - Number(b)),
     );
 
-    const [second] = await Hotel.where({ id: (h2 as any).id }).includes("cakeDesigners");
+    const [second] = await Hotel.where({ id: (h2 as any).id }).includes(":cakeDesigners");
     const secondIds = ((second.association("cakeDesigners").target ?? []) as any[])
       .map((d) => d.id)
       .sort((a: any, b: any) => Number(a) - Number(b));

--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -98,7 +98,7 @@ describe("Preloader::ThroughAssociation#through_scope has_many raw-join handling
 
   it("raises ConfigurationError on preload, matching Rails", async () => {
     const groucho = members("groucho");
-    await expect(Member.where({ id: groucho.id }).preload("rawClubs")).rejects.toThrow(
+    await expect(Member.where({ id: groucho.id }).preload(":rawClubs")).rejects.toThrow(
       ConfigurationError,
     );
   });

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -82,7 +82,7 @@ type HasManyHost = {
   "davidIncludedCategorizedClub",
   (rel: NestedRel) =>
     (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
-      .includes({ category: "categorizations" })
+      .includes({ ":category": ":categorizations" })
       .where({ categorizations: { author_id: 1 } }),
   {
     through: "currentMembership",
@@ -99,7 +99,7 @@ type HasManyHost = {
   "generalClubs",
   (rel: NestedRel) =>
     (rel as unknown as { includes: (s: string) => NestedRel })
-      .includes("category")
+      .includes(":category")
       .where({ categories: { name: "General" } }),
   {
     through: "favoriteMemberships",
@@ -119,7 +119,7 @@ type HasManyHost = {
   "categorizedClubs",
   (rel: NestedRel) =>
     (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
-      .includes({ category: "categorizations" })
+      .includes({ ":category": ":categorizations" })
       .where({ categorizations: { author_id: 1 } }),
   {
     through: "favoriteMemberships",
@@ -219,11 +219,11 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     expect(member?.id).toBe(members("groucho").id);
     expect((await assoc(member).loadTarget())?.id).toBe(clubs("boring_club").id);
 
-    member = (await Member.preload("davidCategorizedClub").first()) as unknown as AssocHost;
+    member = (await Member.preload(":davidCategorizedClub").first()) as unknown as AssocHost;
     expect(member?.id).toBe(members("groucho").id);
     expect(assoc(member).target?.id).toBe(clubs("boring_club").id);
 
-    member = (await Member.eagerLoad("davidCategorizedClub").first()) as unknown as AssocHost;
+    member = (await Member.eagerLoad(":davidCategorizedClub").first()) as unknown as AssocHost;
     expect(member?.id).toBe(members("groucho").id);
     expect(assoc(member).target?.id).toBe(clubs("boring_club").id);
   });

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -182,7 +182,7 @@ describe("Preloader::ThroughAssociation#through_scope nested raw-join handling",
 
   it("raises ConfigurationError on preload, matching Rails", async () => {
     const groucho = members("groucho");
-    await expect(Member.where({ id: groucho.id }).preload("membersViaRawClub")).rejects.toThrow(
+    await expect(Member.where({ id: groucho.id }).preload(":membersViaRawClub")).rejects.toThrow(
       ConfigurationError,
     );
   });

--- a/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
@@ -101,7 +101,7 @@ describe("Preloader::ThroughAssociation#through_scope raw-join handling", () => 
 
   it("raises ConfigurationError on preload, matching Rails", async () => {
     const groucho = members("groucho");
-    await expect(Member.where({ id: groucho.id }).preload("rawGeneralClub")).rejects.toThrow(
+    await expect(Member.where({ id: groucho.id }).preload(":rawGeneralClub")).rejects.toThrow(
       ConfigurationError,
     );
   });

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -148,7 +148,7 @@ export class SingularAssociation extends Association {
    * lazy DB load throws `StrictLoadingViolationError` — pointing
    * users at the explicit async load path
    * (`post.loadBelongsTo("author")` / `post.loadHasOne("profile")`)
-   * or an eager-load query (`Post.includes("author").find(id)`).
+   * or an eager-load query (`Post.includes(":author").find(id)`).
    *
    * The check only fires when a DB load would actually be needed — it
    * honors:

--- a/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
@@ -81,7 +81,7 @@ describe("Preloader::ThroughAssociation#through_scope composite-PK through", () 
     const [row] = await CpkOrder.where({
       shop_id: order.shop_id,
       id: order.readAttribute("id"),
-    }).preload("tagsWithMixedCondition");
+    }).preload(":tagsWithMixedCondition");
     const tags = (row.association("tagsWithMixedCondition").target ?? []) as CpkTag[];
     // Both predicate halves resolved in one JOINed query: the through-table half
     // did not raise, and the source-table half narrowed order_1's two tags to one.

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -141,7 +141,7 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     const scope = (loader as any).throughScope();
     expect(scope.toSql()).toContain("preload-through");
 
-    const [row] = await Author.where({ id: david.id }).preload("annotatedComments");
+    const [row] = await Author.where({ id: david.id }).preload(":annotatedComments");
     const comments = (row.association("annotatedComments").target ?? []) as any[];
     expect(comments.length).toBeGreaterThan(0);
   });
@@ -199,7 +199,7 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     // query end-to-end — the preload returns the welcome post's comments (matched
     // via `posts.title`), never raising `no such column`.
     const david = authors("david");
-    const [row] = await Author.where({ id: david.id }).preload("commentsWithMixedCondition");
+    const [row] = await Author.where({ id: david.id }).preload(":commentsWithMixedCondition");
     const bodies = ((row.association("commentsWithMixedCondition").target ?? []) as any[])
       .map((c) => c._readAttribute("body"))
       .sort();
@@ -213,7 +213,7 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     // `posts.title` predicate. Tag "general" tags two posts; the scoped
     // association must return only the matching one.
     const general = tags("general");
-    const [row] = await Tag.where({ id: general.id }).preload("welcomeTaggedPosts");
+    const [row] = await Tag.where({ id: general.id }).preload(":welcomeTaggedPosts");
     const titles = ((row.association("welcomeTaggedPosts").target ?? []) as any[])
       .map((p) => p._readAttribute("title"))
       .sort();


### PR DESCRIPTION
## Story 1 — `join-constraints-nested-eager-load-references-values`

`JoinAssociation#join_constraints`
(`activerecord/lib/active_record/associations/join_dependency/join_association.rb:45-55`)
builds a nested join dependency when the association scope references a table
and eager-loads:

```ruby
unless scope.references_values.empty?
  associations = scope.eager_load_values | scope.includes_values
  unless associations.empty?
    scope.joins! scope.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
  end
end
```

trails skipped the whole block behind a standing `TODO`, so an association
scope that both `references` and `includes`/`eagerLoad`s emitted a WHERE naming
a table that was never joined. The block is now ported branch for branch, and
the TODO is gone rather than reworded.

Regression test: `join-association-references-eager-load.trails.test.ts` joins
`Person#postsWithNoComments` (the canonical
`includes(:comments).where("comments.id is null").references(:comments)` scope,
`test/models/person.rb:10`) and asserts the nested `LEFT OUTER JOIN comments`.
Verified failing on the pre-fix baseline.

## Story 2 — `converge-includes-preload-colon-sweep-associations-remainder`

Sweeps `includes` / `preload` / `eagerLoad` / `references` association-name call
sites in `packages/activerecord/src/associations` (excluding `eager.test.ts`)
onto the colon spelling Rails' Symbols map to (`query_methods.rb:88-101`),
including nested-hash keys and values. Left bare:

- JS `String`/`Array#includes` receivers (`primaryKey.includes("id")`, the
  `assocName.includes("_through_")` node assertions).
- Raw table names — `references("clubs")` in the `has_one_through_associations`
  fallback test names the `clubs` TABLE, not the `club` association; Rails
  passes table names there as Strings.

No new normalization site: the strip stays at `JoinDependency.walkTree` /
`Preloader::Branch#_normalizeAssociationName`.

## Verification

- 25 touched association suites + the new test: green on SQLite.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
  `pnpm parity:api:extra --package activerecord` unchanged, `pnpm typecheck` clean.

Closes-story: join-constraints-nested-eager-load-references-values
Closes-story: converge-includes-preload-colon-sweep-associations-remainder

## Review response

**[minor/simplify] Reimplemented union instead of reusing `unionAppend`** — kept
inline, justified at the call site (`join-association.ts`).

Measured the suggested export: making `unionAppend` public takes
`relation/query-methods.ts` from **9 novel to 10 novel** on
`pnpm parity:api:extra --package activerecord`. That is a new invented public
name in a Rails-matched file, which the extra-surface rule forbids — Rails
spells this as a single `|` operator (`join_association.rb:47`) and has no
helper for it in either place. The duplication is three lines of a Ruby-idiom
conversion; the alternative is a permanent surface row. The call site now
records that trade-off with the measurement.
