### PR TITLE
refactor(activerecord): express the QueryMethods/SpawnMethods private boundary in the mixin files

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,7 +1,7 @@
 import type { Base } from "../base.js";
 import { Relation } from "../relation.js";
-import { QueryMethodBangs } from "../relation/query-methods.js";
-import { SpawnMethods } from "../relation/spawn-methods.js";
+import { QueryMethodsPublicInstanceMethods } from "../relation/query-methods.js";
+import { SpawnMethodsPublicInstanceMethods } from "../relation/spawn-methods.js";
 import {
   CollectionAssociation,
   callback as assocCallback,
@@ -1569,70 +1569,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 //   ]
 //   delegate(*delegate_methods, to: :scope)
 //
-// `SpawnMethods` (spawn-methods.ts) and `QueryMethodBangs` (query-methods.ts) are
-// the mixin objects `include()` mixes into `Relation` (relation.rb:68), so their
-// own keys ARE `public_instance_methods(false)` and the delegate list is read
-// off them rather than hand-transcribed. `public_instance_methods(false)`
+// The mixin files name Ruby's `private` boundary structurally
+// (query_methods.rb:1677, spawn_methods.rb:71), so
+// `QueryMethodsPublicInstanceMethods` / `SpawnMethodsPublicInstanceMethods` ARE
+// `public_instance_methods(false)` and the delegate list is read off them
+// rather than hand-transcribed. `public_instance_methods(false)`
 // includes the bang builders (`where!`, `limit!`, `none!`, …), so Rails
 // delegates those to `scope` too — a Rails `CollectionProxy` owns no relation
 // state of its own. The constructor's own seeding calls (`noneBang` /
 // `extendingBang`) run BEFORE the prototype delegation is consulted only in the
 // sense that they must target the proxy's inherited state, so they are invoked
 // through `Relation.prototype` directly (see the ctor).
-//
-// Ruby's `private` keyword (query_methods.rb:1677, spawn_methods.rb:71) keeps
-// the members below out of `public_instance_methods(false)`, so `delegate` never
-// sees them. A JS object literal carries no such distinction, so the boundary is
-// named here.
-const PRIVATE_MIXIN_INSTANCE_METHODS = new Set([
-  "arelColumn",
-  "arelColumnAliasesFromHash",
-  "arelColumnWithTable",
-  "arelColumnsFromHash",
-  "assertModifiableBang",
-  "async",
-  "buildArel",
-  "buildBoundSqlLiteral",
-  "buildCaseForValuePosition",
-  "buildCastValue",
-  "buildFrom",
-  "buildJoinBuckets",
-  "buildJoinDependencies",
-  "buildJoins",
-  "buildNamedBoundSqlLiteral",
-  "buildOrder",
-  "buildSelect",
-  "buildWith",
-  "buildWithExpressionFromValue",
-  "buildWithJoinNode",
-  "buildWithValueFromHash",
-  "checkIfMethodHasArgumentsBang",
-  "columnReferences",
-  "eachJoinDependencies",
-  "extractTableNameFrom",
-  "flattenedArgs",
-  "isDoesNotSupportReverse",
-  "isTableNameMatches",
-  "lookupTableKlassFromJoinDependencies",
-  "orderColumn",
-  "preprocessOrderArgs",
-  "processSelectArgs",
-  "processWithArgs",
-  "resolveArelAttributes",
-  "reverseSqlOrder",
-  "sanitizeOrderArguments",
-  "selectAssociationList",
-  "selectNamedJoins",
-  "structurallyIncompatibleValuesFor",
-  "validateOrderArgs",
-  "relationWith",
-]);
-
 /** @internal `[QueryMethods, SpawnMethods].flat_map { |k| k.public_instance_methods(false) }`. */
 export const MIXIN_PUBLIC_INSTANCE_METHODS = [
-  ...Object.keys(QueryMethodBangs),
-  ...Object.keys(SpawnMethods),
-].filter((name) => !PRIVATE_MIXIN_INSTANCE_METHODS.has(name));
+  ...Object.keys(QueryMethodsPublicInstanceMethods),
+  ...Object.keys(SpawnMethodsPublicInstanceMethods),
+];
 
 const delegateMethods = MIXIN_PUBLIC_INSTANCE_METHODS.filter(
   (name) => !Object.hasOwn(CollectionProxy.prototype, name) && name !== "select",

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2623,7 +2623,15 @@ export function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]):
 // ---------------------------------------------------------------------------
 // Module export — all bang variants as a single object for `include()`.
 // ---------------------------------------------------------------------------
-export const QueryMethodBangs = {
+/**
+ * `QueryMethods.public_instance_methods(false)` — the members Ruby defines
+ * above `private` (query_methods.rb:1677). `CollectionProxy` delegates exactly
+ * this set to `scope` (collection_proxy.rb:1128-1137), so the boundary is a
+ * fact about this module and is expressed here rather than transcribed there.
+ *
+ * @internal
+ */
+export const QueryMethodsPublicInstanceMethods = {
   includes,
   all,
   eagerLoad,
@@ -2636,10 +2644,7 @@ export const QueryMethodBangs = {
   leftOuterJoins,
   leftJoins,
   arel,
-  assertModifiableBang,
-  checkIfMethodHasArgumentsBang,
   arelColumns,
-  arelColumnsFromHash,
   includesBang,
   eagerLoadBang,
   preloadBang,
@@ -2709,52 +2714,68 @@ export const QueryMethodBangs = {
   without,
   excludingBang,
   constructJoinDependency,
-  asyncBang,
-  // query_methods.rb's private column helpers. Rails defines these once, in
-  // QueryMethods, and Relation gets them by `include`; they ride the same
-  // mixin here so `relation.ts` does not redeclare a second copy.
-  isTableNameMatches,
-  arelColumn,
-  arelColumnWithTable,
-  async,
+  buildSubquery,
   buildWhereClause,
   // Mirrors `alias :build_having_clause :build_where_clause`
   // (query_methods.rb:1654) — HAVING conditions parse identically to WHERE.
   buildHavingClause: buildWhereClause,
+  asyncBang,
+} as const;
+
+/**
+ * The members below query_methods.rb's `private` (query_methods.rb:1677).
+ * Ruby keeps them out of `public_instance_methods(false)`, so they are not
+ * delegated; they ride the same mixin here so `relation.ts` does not redeclare
+ * a second copy.
+ *
+ * @internal
+ */
+export const QueryMethodsPrivateInstanceMethods = {
+  async,
   buildNamedBoundSqlLiteral,
   buildBoundSqlLiteral,
-  buildSubquery,
-  buildCastValue,
-  flattenedArgs,
-  validateOrderArgs,
-  processWithArgs,
-  isDoesNotSupportReverse,
-  reverseSqlOrder,
-  extractTableNameFrom,
-  columnReferences,
-  sanitizeOrderArguments,
-  preprocessOrderArgs,
-  buildOrder,
-  buildCaseForValuePosition,
-  resolveArelAttributes,
-  orderColumn,
-  processSelectArgs,
-  arelColumnAliasesFromHash,
-  buildFrom,
-  buildSelect,
-  buildWithExpressionFromValue,
-  buildWithValueFromHash,
   lookupTableKlassFromJoinDependencies,
   eachJoinDependencies,
   buildJoinDependencies,
+  assertModifiableBang,
   buildArel,
+  buildCastValue,
+  buildFrom,
   selectNamedJoins,
   selectAssociationList,
   buildJoinBuckets,
   buildJoins,
+  buildSelect,
   buildWith,
+  buildWithValueFromHash,
+  buildWithExpressionFromValue,
   buildWithJoinNode,
+  arelColumnsFromHash,
+  arelColumnWithTable,
+  arelColumn,
+  isTableNameMatches,
+  reverseSqlOrder,
+  isDoesNotSupportReverse,
+  buildOrder,
+  validateOrderArgs,
+  flattenedArgs,
+  preprocessOrderArgs,
+  sanitizeOrderArguments,
+  columnReferences,
+  extractTableNameFrom,
+  orderColumn,
+  buildCaseForValuePosition,
+  resolveArelAttributes,
+  checkIfMethodHasArgumentsBang,
+  processSelectArgs,
+  arelColumnAliasesFromHash,
+  processWithArgs,
   structurallyIncompatibleValuesFor,
+} as const;
+
+export const QueryMethodBangs = {
+  ...QueryMethodsPublicInstanceMethods,
+  ...QueryMethodsPrivateInstanceMethods,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -135,13 +135,34 @@ export function only<T extends SpawnRelation<T>>(this: T, ...onlies: Array<Excep
   return this.relationWith(slice(this.values(), ...onlies));
 }
 
-export const SpawnMethods = {
+/**
+ * `SpawnMethods.public_instance_methods(false)` — the members Ruby defines
+ * above `private` (spawn_methods.rb:71). `CollectionProxy` delegates exactly
+ * this set to `scope` (collection_proxy.rb:1128-1137).
+ *
+ * @internal
+ */
+export const SpawnMethodsPublicInstanceMethods = {
   spawn: performSpawn,
   merge: performMerge,
   mergeBang,
   except,
   only,
+} as const;
+
+/**
+ * The members below spawn_methods.rb's `private` (spawn_methods.rb:71) —
+ * `relation_with` (spawn_methods.rb:72), which is not delegated.
+ *
+ * @internal
+ */
+export const SpawnMethodsPrivateInstanceMethods = {
   relationWith,
+} as const;
+
+export const SpawnMethods = {
+  ...SpawnMethodsPublicInstanceMethods,
+  ...SpawnMethodsPrivateInstanceMethods,
 } as const;
 
 /**


### PR DESCRIPTION
Ruby's `private` keyword splits a module into `public_instance_methods(false)` and the rest — `query_methods.rb:1677`, `spawn_methods.rb:71` — and `CollectionProxy`'s delegate list is exactly the public half (`collection_proxy.rb:1128-1137`). A JS object literal carries no such distinction, so #6756 named the boundary in a 41-name hand-transcribed `PRIVATE_MIXIN_INSTANCE_METHODS` set in `collection-proxy.ts`.

This makes the boundary structural, in the file it is a fact about: each mixin file now declares `…PublicInstanceMethods` and `…PrivateInstanceMethods` in Rails source order, split at the Rails `private` line, and composes the mixed-in object from both. `collection-proxy.ts` reads the public objects' keys and the transcribed set is deleted.

The delegated set is byte-identical (verified against the previous derivation); the pin test passes unmodified. `parity:api:calls` / `:args` add zero rows; `parity:api:extra` adds no names.

Closes-story: express-mixin-private-boundary-structurally