### PR TITLE
refactor(activemodel,date): converge value_from_multiparameter_assignment; inline the :include normalisation

### DIFF
--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -392,38 +392,18 @@ function isIncludeHash(value: unknown): value is Record<string, SerializeOptions
 }
 
 /**
- * `serialization.rb:187-189`'s normalisation, for `preloadIncludes` alone.
- *
- * `serializableAddIncludes` spells this out inline because Rails does; this
- * exists because `preloadIncludes` has no Rails counterpart to inline into and
- * cannot borrow the Rails method's copy — it must reach each association
- * through `resolveIncludeAsync`, where `serializableAddIncludes` reaches it
- * through the synchronous `send` that preloading exists to get ahead of.
- *
- * @noRailsEquivalent Serves trails' awaitable `serializable_hash` (RFC 0022 b2).
- * @internal
- */
-function normalizeIncludes(
-  includeOpt:
-    | string
-    | Array<string | Record<string, SerializeOptions>>
-    | Record<string, SerializeOptions>,
-): Record<string, SerializeOptions> {
-  if (isIncludeHash(includeOpt)) return includeOpt;
-  const includes: Record<string, SerializeOptions> = {};
-  for (const n of Array.isArray(includeOpt) ? includeOpt : [includeOpt]) {
-    if (isIncludeHash(n)) {
-      for (const [k, v] of Object.entries(n)) safeSet(includes as Record<string, unknown>, k, v);
-    } else {
-      safeSet(includes as Record<string, unknown>, n, {});
-    }
-  }
-  return includes;
-}
-
-/**
  * Recursively lazy-load every `include`d association (and nested includes) via
  * `resolveIncludeAsync`, so the subsequent sync pass finds them all loaded.
+ *
+ * The entry walk is `serialization.rb:188`'s own
+ * `Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }`, taken
+ * without the `Hash[...]` that wraps it there. That wrapper only dedupes, and
+ * dropping it can visit a name twice — which for a preload is a superset of the
+ * work, never a miss, so the sync pass still finds everything loaded.
+ * `serializableAddIncludes` keeps the wrapper, since Rails' own iteration is
+ * over the deduped hash.
+ *
+ * @noRailsEquivalent Serves trails' awaitable `serializable_hash` (RFC 0022 b2).
  */
 async function preloadIncludes(
   record: SerializationRecord,
@@ -431,7 +411,12 @@ async function preloadIncludes(
 ): Promise<void> {
   const includeOpt = options.include;
   if (includeOpt == null || (includeOpt as unknown) === false) return;
-  for (const [name, opts] of Object.entries(normalizeIncludes(includeOpt))) {
+  const entries: Array<[string, SerializeOptions]> = isIncludeHash(includeOpt)
+    ? Object.entries(includeOpt)
+    : (Array.isArray(includeOpt) ? includeOpt : [includeOpt]).flatMap((n) =>
+        isIncludeHash(n) ? Object.entries(n) : [[n, {}] as [string, SerializeOptions]],
+      );
+  for (const [name, opts] of entries) {
     const records = await resolveIncludeAsync(record, name);
     const children = isSerializableCollection(records)
       ? Array.isArray(records)

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -40,19 +40,7 @@ export function serializableHash(
   options: SerializeOptions = {},
   sync = false,
 ): Record<string, unknown> {
-  if (
-    (() => {
-      // Rails has no such probe: `serializable_hash` is synchronous. This is the
-      // async-serialization re-entry gate (RFC 0022 b2) and it asks only whether
-      // `:include` names anything at all, in any of the option's three spellings.
-      const include = options.include as unknown;
-      if (include == null || include === false) return false;
-      if (typeof include === "string") return true;
-      if (Array.isArray(include)) return include.length > 0;
-      return Object.keys(include as object).length > 0;
-    })() &&
-    !sync
-  ) {
+  if (hasIncludes(options) && !sync) {
     return thenableHash(
       () => serializableHash(record, options, true),
       async () => {
@@ -368,9 +356,6 @@ export function serializableAddIncludes(
     | undefined;
   if (includeOpt == null || includeOpt === false) return;
 
-  // Rails: `unless includes.is_a?(Hash)
-  //           includes = Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]
-  //         end` (serialization.rb:187-189).
   let includes: Record<string, SerializeOptions>;
   if (isIncludeHash(includeOpt)) {
     includes = includeOpt;
@@ -398,6 +383,23 @@ export function serializableAddIncludes(
 }
 
 /**
+ * Whether `:include` names anything at all, in any of the three spellings the
+ * option takes. Rails has no such probe — `serializable_hash` is synchronous;
+ * this is the async-serialization re-entry gate (RFC 0022 b2).
+ *
+ * @noRailsEquivalent The gate for trails' awaitable `serializable_hash`, which
+ * lazy-loads an unloaded association where Rails' `to_ary` would block.
+ * @internal
+ */
+function hasIncludes(options: SerializeOptions): boolean {
+  const include = options.include as unknown;
+  if (include == null || include === false) return false;
+  if (typeof include === "string") return true;
+  if (Array.isArray(include)) return include.length > 0;
+  return Object.keys(include as object).length > 0;
+}
+
+/**
  * Ruby `n.is_a?(Hash)` for an `:include` entry — a plain object mapping
  * association names to their own options, as against the String/Symbol (a JS
  * string) and Array spellings the same option takes.
@@ -409,6 +411,8 @@ function isIncludeHash(value: unknown): value is Record<string, SerializeOptions
 /**
  * Recursively lazy-load every `include`d association (and nested includes) via
  * `resolveIncludeAsync`, so the subsequent sync pass finds them all loaded.
+ * Runs `serialization.rb:187-189`'s normalisation ahead of the load, the same
+ * one `serializableAddIncludes` runs before its `send`.
  */
 async function preloadIncludes(
   record: SerializationRecord,
@@ -416,8 +420,6 @@ async function preloadIncludes(
 ): Promise<void> {
   const includeOpt = options.include;
   if (includeOpt == null || (includeOpt as unknown) === false) return;
-  // The same `serialization.rb:187-189` normalisation `serializableAddIncludes`
-  // runs, ahead of the async load this walk exists for.
   let includes: Record<string, SerializeOptions>;
   if (isIncludeHash(includeOpt)) {
     includes = includeOpt;
@@ -500,19 +502,7 @@ export function asJsonThenable(
     if (root === false || root == null) return hash;
     return { [root === true ? element() : root]: hash };
   };
-  if (
-    !(() => {
-      // Rails has no such probe: `serializable_hash` is synchronous. This is the
-      // async-serialization re-entry gate (RFC 0022 b2) and it asks only whether
-      // `:include` names anything at all, in any of the option's three spellings.
-      const include = options.include as unknown;
-      if (include == null || include === false) return false;
-      if (typeof include === "string") return true;
-      if (Array.isArray(include)) return include.length > 0;
-      return Object.keys(include as object).length > 0;
-    })()
-  )
-    return finalize(serialize());
+  if (!hasIncludes(options)) return finalize(serialize());
   return thenableHash(
     () => finalize(serialize()),
     async () => finalize(await serialize()),

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -40,7 +40,19 @@ export function serializableHash(
   options: SerializeOptions = {},
   sync = false,
 ): Record<string, unknown> {
-  if (hasIncludes(options) && !sync) {
+  if (
+    (() => {
+      // Rails has no such probe: `serializable_hash` is synchronous. This is the
+      // async-serialization re-entry gate (RFC 0022 b2) and it asks only whether
+      // `:include` names anything at all, in any of the option's three spellings.
+      const include = options.include as unknown;
+      if (include == null || include === false) return false;
+      if (typeof include === "string") return true;
+      if (Array.isArray(include)) return include.length > 0;
+      return Object.keys(include as object).length > 0;
+    })() &&
+    !sync
+  ) {
     return thenableHash(
       () => serializableHash(record, options, true),
       async () => {
@@ -205,7 +217,13 @@ export function readAttributeForSerialization(record: SerializationRecord, key: 
   // no installed accessor (a bare `_attributes` Map / AttributeSet) and a
   // reserved-name declared attribute (e.g. toJSON) whose function member would
   // recurse if invoked.
-  if (hasStore && storeHasKey(attrStore, key)) {
+  const storeHasKey =
+    attrStore instanceof Map
+      ? attrStore.has(key)
+      : attrStore && typeof (attrStore as { keys?: unknown }).keys === "function"
+        ? (attrStore as { keys(): string[] }).keys().includes(key)
+        : false;
+  if (hasStore && storeHasKey) {
     return attrStore instanceof Map
       ? attrStore.get(key)
       : (attrStore as { fetchValue(k: string): unknown }).fetchValue(key);
@@ -349,7 +367,24 @@ export function serializableAddIncludes(
     | null
     | undefined;
   if (includeOpt == null || includeOpt === false) return;
-  const includes = normalizeIncludes(includeOpt);
+
+  // Rails: `unless includes.is_a?(Hash)
+  //           includes = Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]
+  //         end` (serialization.rb:187-189).
+  let includes: Record<string, SerializeOptions>;
+  if (isIncludeHash(includeOpt)) {
+    includes = includeOpt;
+  } else {
+    includes = {};
+    for (const n of Array.isArray(includeOpt) ? includeOpt : [includeOpt]) {
+      if (isIncludeHash(n)) {
+        for (const [k, v] of Object.entries(n)) safeSet(includes as Record<string, unknown>, k, v);
+      } else {
+        safeSet(includes as Record<string, unknown>, n, {});
+      }
+    }
+  }
+
   for (const [assocName, assocOpts] of Object.entries(includes)) {
     const records = sendAssociation(record, assocName);
     // Rails: `if records = send(association)` skips on nil — a defined-but-nil
@@ -362,20 +397,13 @@ export function serializableAddIncludes(
   }
 }
 
-/** Whether `key` is a stored attribute on an `_attributes` store (Map or AttributeSet). */
-function storeHasKey(attrStore: AttributeStore, key: string): boolean {
-  if (attrStore instanceof Map) return attrStore.has(key);
-  if (attrStore && typeof (attrStore as { keys?: unknown }).keys === "function") {
-    return (attrStore as { keys(): string[] }).keys().includes(key);
-  }
-  return false;
-}
-
-/** Whether `options` carries at least one `:include` entry to (maybe) load. */
-function hasIncludes(options: SerializeOptions): boolean {
-  const include = options.include;
-  if (include == null || (include as unknown) === false) return false;
-  return Object.keys(normalizeIncludes(include)).length > 0;
+/**
+ * Ruby `n.is_a?(Hash)` for an `:include` entry — a plain object mapping
+ * association names to their own options, as against the String/Symbol (a JS
+ * string) and Array spellings the same option takes.
+ */
+function isIncludeHash(value: unknown): value is Record<string, SerializeOptions> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -388,7 +416,22 @@ async function preloadIncludes(
 ): Promise<void> {
   const includeOpt = options.include;
   if (includeOpt == null || (includeOpt as unknown) === false) return;
-  for (const [name, opts] of Object.entries(normalizeIncludes(includeOpt))) {
+  // The same `serialization.rb:187-189` normalisation `serializableAddIncludes`
+  // runs, ahead of the async load this walk exists for.
+  let includes: Record<string, SerializeOptions>;
+  if (isIncludeHash(includeOpt)) {
+    includes = includeOpt;
+  } else {
+    includes = {};
+    for (const n of Array.isArray(includeOpt) ? includeOpt : [includeOpt]) {
+      if (isIncludeHash(n)) {
+        for (const [k, v] of Object.entries(n)) safeSet(includes as Record<string, unknown>, k, v);
+      } else {
+        safeSet(includes as Record<string, unknown>, n, {});
+      }
+    }
+  }
+  for (const [name, opts] of Object.entries(includes)) {
     const records = await resolveIncludeAsync(record, name);
     const children = isSerializableCollection(records)
       ? Array.isArray(records)
@@ -457,7 +500,19 @@ export function asJsonThenable(
     if (root === false || root == null) return hash;
     return { [root === true ? element() : root]: hash };
   };
-  if (!hasIncludes(options)) return finalize(serialize());
+  if (
+    !(() => {
+      // Rails has no such probe: `serializable_hash` is synchronous. This is the
+      // async-serialization re-entry gate (RFC 0022 b2) and it asks only whether
+      // `:include` names anything at all, in any of the option's three spellings.
+      const include = options.include as unknown;
+      if (include == null || include === false) return false;
+      if (typeof include === "string") return true;
+      if (Array.isArray(include)) return include.length > 0;
+      return Object.keys(include as object).length > 0;
+    })()
+  )
+    return finalize(serialize());
   return thenableHash(
     () => finalize(serialize()),
     async () => finalize(await serialize()),
@@ -720,40 +775,4 @@ function rubyArray(value: string | string[] | null | undefined): string[] {
   if (value == null) return [];
   const list = Array.isArray(value) ? value : [value];
   return list.map((entry) => String(entry));
-}
-
-/**
- * Normalize `:include` to a `{ name → opts }` hash. Mirrors Rails'
- * `Hash[Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }]`
- * — strings/arrays of strings get empty opts, embedded hashes flatten
- * into the result so `[:posts, { comments: {} }]` becomes
- * `{ posts: {}, comments: {} }`.
- */
-function normalizeIncludes(
-  include:
-    | Record<string, SerializeOptions>
-    | Array<string | Record<string, SerializeOptions>>
-    | string,
-): Record<string, SerializeOptions> {
-  const result: Record<string, SerializeOptions> = {};
-  if (typeof include === "string") {
-    safeSet(result as Record<string, unknown>, include, {});
-    return result;
-  }
-  if (Array.isArray(include)) {
-    for (const entry of include) {
-      if (typeof entry === "string") {
-        safeSet(result as Record<string, unknown>, entry, {});
-      } else {
-        for (const [k, v] of Object.entries(entry)) {
-          safeSet(result as Record<string, unknown>, k, v);
-        }
-      }
-    }
-    return result;
-  }
-  for (const [k, v] of Object.entries(include)) {
-    safeSet(result as Record<string, unknown>, k, v);
-  }
-  return result;
 }

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -40,7 +40,7 @@ export function serializableHash(
   options: SerializeOptions = {},
   sync = false,
 ): Record<string, unknown> {
-  if (hasIncludes(options) && !sync) {
+  if (options.include != null && (options.include as unknown) !== false && !sync) {
     return thenableHash(
       () => serializableHash(record, options, true),
       async () => {
@@ -383,23 +383,6 @@ export function serializableAddIncludes(
 }
 
 /**
- * Whether `:include` names anything at all, in any of the three spellings the
- * option takes. Rails has no such probe — `serializable_hash` is synchronous;
- * this is the async-serialization re-entry gate (RFC 0022 b2).
- *
- * @noRailsEquivalent The gate for trails' awaitable `serializable_hash`, which
- * lazy-loads an unloaded association where Rails' `to_ary` would block.
- * @internal
- */
-function hasIncludes(options: SerializeOptions): boolean {
-  const include = options.include as unknown;
-  if (include == null || include === false) return false;
-  if (typeof include === "string") return true;
-  if (Array.isArray(include)) return include.length > 0;
-  return Object.keys(include as object).length > 0;
-}
-
-/**
  * Ruby `n.is_a?(Hash)` for an `:include` entry — a plain object mapping
  * association names to their own options, as against the String/Symbol (a JS
  * string) and Array spellings the same option takes.
@@ -409,10 +392,38 @@ function isIncludeHash(value: unknown): value is Record<string, SerializeOptions
 }
 
 /**
+ * `serialization.rb:187-189`'s normalisation, for `preloadIncludes` alone.
+ *
+ * `serializableAddIncludes` spells this out inline because Rails does; this
+ * exists because `preloadIncludes` has no Rails counterpart to inline into and
+ * cannot borrow the Rails method's copy — it must reach each association
+ * through `resolveIncludeAsync`, where `serializableAddIncludes` reaches it
+ * through the synchronous `send` that preloading exists to get ahead of.
+ *
+ * @noRailsEquivalent Serves trails' awaitable `serializable_hash` (RFC 0022 b2).
+ * @internal
+ */
+function normalizeIncludes(
+  includeOpt:
+    | string
+    | Array<string | Record<string, SerializeOptions>>
+    | Record<string, SerializeOptions>,
+): Record<string, SerializeOptions> {
+  if (isIncludeHash(includeOpt)) return includeOpt;
+  const includes: Record<string, SerializeOptions> = {};
+  for (const n of Array.isArray(includeOpt) ? includeOpt : [includeOpt]) {
+    if (isIncludeHash(n)) {
+      for (const [k, v] of Object.entries(n)) safeSet(includes as Record<string, unknown>, k, v);
+    } else {
+      safeSet(includes as Record<string, unknown>, n, {});
+    }
+  }
+  return includes;
+}
+
+/**
  * Recursively lazy-load every `include`d association (and nested includes) via
  * `resolveIncludeAsync`, so the subsequent sync pass finds them all loaded.
- * Runs `serialization.rb:187-189`'s normalisation ahead of the load, the same
- * one `serializableAddIncludes` runs before its `send`.
  */
 async function preloadIncludes(
   record: SerializationRecord,
@@ -420,20 +431,7 @@ async function preloadIncludes(
 ): Promise<void> {
   const includeOpt = options.include;
   if (includeOpt == null || (includeOpt as unknown) === false) return;
-  let includes: Record<string, SerializeOptions>;
-  if (isIncludeHash(includeOpt)) {
-    includes = includeOpt;
-  } else {
-    includes = {};
-    for (const n of Array.isArray(includeOpt) ? includeOpt : [includeOpt]) {
-      if (isIncludeHash(n)) {
-        for (const [k, v] of Object.entries(n)) safeSet(includes as Record<string, unknown>, k, v);
-      } else {
-        safeSet(includes as Record<string, unknown>, n, {});
-      }
-    }
-  }
-  for (const [name, opts] of Object.entries(includes)) {
+  for (const [name, opts] of Object.entries(normalizeIncludes(includeOpt))) {
     const records = await resolveIncludeAsync(record, name);
     const children = isSerializableCollection(records)
       ? Array.isArray(records)
@@ -502,7 +500,8 @@ export function asJsonThenable(
     if (root === false || root == null) return hash;
     return { [root === true ? element() : root]: hash };
   };
-  if (!hasIncludes(options)) return finalize(serialize());
+  if (options.include == null || (options.include as unknown) === false)
+    return finalize(serialize());
   return thenableHash(
     () => finalize(serialize()),
     async () => finalize(await serialize()),

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -9,9 +9,9 @@ import {
   type DateInfinity as DateInfinityType,
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
-import { toS } from "@blazetrails/activesupport";
+import { isPlainObject, toS } from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
-import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
+import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
@@ -162,12 +162,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * trails spells one with (CLAUDE.md), so `{ ":a": 1 }` renders the `{:a=>1}`
    * MRI 3.3 emits.
    *
-   * Validates that year/mon/mday (multiparameter keys 1, 2, 3) are
-   * present, then defers to the multiparameter wrapper. Trails routes
-   * the actual reconstruction through `AcceptsMultiparameterTime`
-   * (`helpers/accepts-multiparameter-time.ts`); this helper exists for
-   * Rails parity and as the entry point for callers that want the
-   * key-presence check.
+   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly,
+   * which trails reaches through the wrapper in
+   * `helpers/accepts-multiparameter-time.ts` rather than an ancestor. Rails'
+   * cast result for a Hash IS that `::Time`; `DateTimeCastResult` is the
+   * `Temporal.Instant` this port spells a `::Time` as, so the instant is read
+   * back off it.
    *
    * @internal Rails-private helper.
    */
@@ -180,9 +180,11 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${toS(values)} doesn't contain necessary keys: ${toS(missing)}`,
       );
     }
-    return new AcceptsMultiparameterTime(this, { "4": 0, "5": 0 }).cast(
-      values,
-    ) as DateTimeCastResult | null;
+    const time = new AcceptsMultiparameterTime(this, {
+      "4": 0,
+      "5": 0,
+    }).valueFromMultiparameterAssignment(values as Record<string, unknown>);
+    return time && time.toTime().toInstant();
   }
 
   get isUtc(): boolean {
@@ -195,7 +197,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * `Value#cast` (value.rb:53-55), which is `super`.
    */
   override cast(value: unknown): DateTimeCastResult | null {
-    if (isHash(value)) {
+    if (isPlainObject(value)) {
       return this.valueFromMultiparameterAssignment(value);
     } else {
       return super.cast(value);
@@ -208,12 +210,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * MultiparameterAssignmentErrors at assignment (missing keys 1..3 raise).
    */
   override assertValidValue(value: unknown): void {
-    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isHash(value);
+    return isPlainObject(value);
   }
 
   /**

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -4,7 +4,8 @@ import {
   Temporal,
   type DateParts,
 } from "@blazetrails/date";
-import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
+import { isPlainObject } from "@blazetrails/activesupport";
+import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import {
   DateInfinity,
   DateNegativeInfinity,
@@ -170,24 +171,19 @@ export class DateType extends ValueType<DateCastResult> {
    *     time && new_date(time.year, time.mon, time.mday)
    *   end
    *
-   * The Rails version delegates to `Helpers::AcceptsMultiparameterTime`
-   * for the `Time` reconstruction, then narrows the result to a `::Date`.
-   * Trails routes multiparameter casts through
-   * `AcceptsMultiparameterTime`'s wrapper
-   * (`helpers/accepts-multiparameter-time.ts`); this helper mirrors the
-   * narrowing step so subclasses / consumers can call the Rails-named
-   * hook directly with the `{ 1: year, 2: mon, 3: mday, ... }` form
-   * pulled out of the multiparameter hash.
+   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly,
+   * which trails reaches through the wrapper in
+   * `helpers/accepts-multiparameter-time.ts` rather than an ancestor.
    *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    // Rails' `super` — AcceptsMultiparameterTime's Time assembly, which rolls
-    // within-range overflow like Time.local (Nov 31 → Dec 1).
-    const time = new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
-    return time && this.newDate(time.year, time.month, time.day);
+    const time = new AcceptsMultiparameterTime(this).valueFromMultiparameterAssignment(
+      values as Record<string, unknown>,
+    );
+    return time && this.newDate(time.year, time.mon, time.mday);
   }
 
   /**
@@ -196,7 +192,7 @@ export class DateType extends ValueType<DateCastResult> {
    * `Value#cast` (value.rb:53-55), which is `super`.
    */
   override cast(value: unknown): DateCastResult | null {
-    if (isHash(value)) {
+    if (isPlainObject(value)) {
       return this.valueFromMultiparameterAssignment(value);
     } else {
       return super.cast(value);
@@ -208,12 +204,12 @@ export class DateType extends ValueType<DateCastResult> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isHash(value);
+    return isPlainObject(value);
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -7,7 +7,6 @@ describe("AcceptsMultiparameterTime defaults", () => {
   it("defaults fill missing slots", () => {
     const type = new Types.DateTimeType();
     const wrapper = new AcceptsMultiparameterTime(type, { "4": 0, "5": 0 });
-    // Only year/month/day provided — hour and minute should default to 0
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4 });
     expect(result).not.toBeNull();
   });
@@ -15,20 +14,13 @@ describe("AcceptsMultiparameterTime defaults", () => {
   it("user values override defaults", () => {
     const type = new Types.DateTimeType();
     const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
-    // hour explicitly provided as 15 — default of 0 must not overwrite it
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": 15 });
-    expect(result).not.toBeNull();
-    // Rails' cast for a Hash answers the assembled ::Time itself.
     expect((result as { hour: number }).hour).toBe(15);
   });
 
   it("a blank slot is a present value and reaches ::Time", () => {
     const type = new Types.DateTimeType();
     const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
-    // Ruby `values_hash[k] ||= v` leaves "" alone (it is truthy), so the empty
-    // string reaches ::Time and its strict Integer() raises. ActiveRecord never
-    // gets here with one: `extract_callstack_for_multiparameter_attributes`
-    // maps `value.empty?` to nil first (attribute_assignment.rb:157).
     expect(() => wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" })).toThrow(
       'invalid value for Integer(): ""',
     );
@@ -37,39 +29,29 @@ describe("AcceptsMultiparameterTime defaults", () => {
   it("no defaults, missing year/month/day keys → null (key-based guard)", () => {
     const type = new Types.DateType();
     const wrapper = new AcceptsMultiparameterTime(type);
-    // Only key "6" (second) present, no defaults → keys "1"/"2"/"3" absent → guard fires.
     const result = wrapper.cast({ "6": 0 });
     expect(result).toBeNull();
   });
 
+  it("slots are ordered by index, not by their string spelling", () => {
+    const type = new Types.DateTimeType();
+    const wrapper = new AcceptsMultiparameterTime(type, { "10": 0 });
+    const time = wrapper.cast({ "1": 2004, "2": 6, "3": 24, "4": 16, "5": 24, "6": 12 }) as {
+      hour: number;
+      min: number;
+      sec: number;
+    };
+    expect([time.hour, time.min, time.sec]).toEqual([16, 24, 12]);
+  });
+
   it("sub-second precision truncates at a pre-1970 instant", () => {
-    // MRI: Time.utc(1969, 7, 20, 20, 17, 40.9999999999).nsec == 999_999_999 —
-    // the exact binary value of the Float is truncated at nine digits, never
-    // rounded up into the next second, and the negative epoch does not flip the
-    // truncation direction.
     const wrapper = new AcceptsMultiparameterTime(new Types.DateTimeType());
-    const time = wrapper.cast({
-      "1": 1969,
-      "2": 7,
-      "3": 20,
-      "4": 20,
-      "5": 17,
-      "6": 40.9999999999,
-    }) as { nsec: number; sec: number };
+    const parts = { "1": 1969, "2": 7, "3": 20, "4": 20, "5": 17, "6": 40.9999999999 };
+    const time = wrapper.cast(parts) as { nsec: number; sec: number };
     expect(time.nsec).toBe(999_999_999);
     expect(time.sec).toBe(40);
 
-    const instant = new Types.DateTimeType().cast({
-      "1": 1969,
-      "2": 7,
-      "3": 20,
-      "4": 20,
-      "5": 17,
-      "6": 40.9999999999,
-    }) as Temporal.Instant;
-    // MRI: the same Time#to_i is -14182940, so the instant is that whole
-    // second plus the 999_999_999 nanoseconds — one nanosecond shy of the
-    // epoch second above it, not rounded past it.
+    const instant = new Types.DateTimeType().cast(parts) as Temporal.Instant;
     expect(instant.epochNanoseconds).toBe(-14_182_940n * 1_000_000_000n + 999_999_999n);
   });
 });

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/date";
 import { Types } from "../../index.js";
 import { AcceptsMultiparameterTime } from "./accepts-multiparameter-time.js";
 
@@ -17,19 +18,20 @@ describe("AcceptsMultiparameterTime defaults", () => {
     // hour explicitly provided as 15 — default of 0 must not overwrite it
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": 15 });
     expect(result).not.toBeNull();
-    // The Instant's UTC hour should be 15 (timezone is UTC in test env)
-    const instant = result as import("@blazetrails/date").Temporal.Instant;
-    expect(instant.toZonedDateTimeISO("UTC").hour).toBe(15);
+    // Rails' cast for a Hash answers the assembled ::Time itself.
+    expect((result as { hour: number }).hour).toBe(15);
   });
 
-  it("empty-string slots get defaults", () => {
+  it("a blank slot is a present value and reaches ::Time", () => {
     const type = new Types.DateTimeType();
     const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
-    // hour is empty string — should be treated as missing and filled with 0
-    const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" });
-    expect(result).not.toBeNull();
-    const instant = result as import("@blazetrails/date").Temporal.Instant;
-    expect(instant.toZonedDateTimeISO("UTC").hour).toBe(0);
+    // Ruby `values_hash[k] ||= v` leaves "" alone (it is truthy), so the empty
+    // string reaches ::Time and its strict Integer() raises. ActiveRecord never
+    // gets here with one: `extract_callstack_for_multiparameter_attributes`
+    // maps `value.empty?` to nil first (attribute_assignment.rb:157).
+    expect(() => wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" })).toThrow(
+      'invalid value for Integer(): ""',
+    );
   });
 
   it("no defaults, missing year/month/day keys → null (key-based guard)", () => {
@@ -38,5 +40,36 @@ describe("AcceptsMultiparameterTime defaults", () => {
     // Only key "6" (second) present, no defaults → keys "1"/"2"/"3" absent → guard fires.
     const result = wrapper.cast({ "6": 0 });
     expect(result).toBeNull();
+  });
+
+  it("sub-second precision truncates at a pre-1970 instant", () => {
+    // MRI: Time.utc(1969, 7, 20, 20, 17, 40.9999999999).nsec == 999_999_999 —
+    // the exact binary value of the Float is truncated at nine digits, never
+    // rounded up into the next second, and the negative epoch does not flip the
+    // truncation direction.
+    const wrapper = new AcceptsMultiparameterTime(new Types.DateTimeType());
+    const time = wrapper.cast({
+      "1": 1969,
+      "2": 7,
+      "3": 20,
+      "4": 20,
+      "5": 17,
+      "6": 40.9999999999,
+    }) as { nsec: number; sec: number };
+    expect(time.nsec).toBe(999_999_999);
+    expect(time.sec).toBe(40);
+
+    const instant = new Types.DateTimeType().cast({
+      "1": 1969,
+      "2": 7,
+      "3": 20,
+      "4": 20,
+      "5": 17,
+      "6": 40.9999999999,
+    }) as Temporal.Instant;
+    // MRI: the same Time#to_i is -14182940, so the instant is that whole
+    // second plus the 999_999_999 nanoseconds — one nanosecond shy of the
+    // epoch second above it, not rounded past it.
+    expect(instant.epochNanoseconds).toBe(-14_182_940n * 1_000_000_000n + 999_999_999n);
   });
 });

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -71,10 +71,14 @@ export class AcceptsMultiparameterTime {
    *
    * `||=` and the `1`/`2`/`3` guard are Ruby truthiness, so only `nil`/`false`
    * count as absent — an empty string is a present value and reaches `::Time`,
-   * which raises for it. The keys are the multiparameter indices, a JS object's
-   * string spelling of the Integer ones Ruby sorts, so `sort` is over `"1"`..`"6"`
-   * and orders the same. `default_timezone` is `Helpers::Timezone#is_utc?`'s
-   * choice of receiver, `Time.utc` or `Time.local` (timezone.rb:9-11).
+   * which raises for it. ActiveRecord never arrives with one:
+   * `extract_callstack_for_multiparameter_attributes` maps `value.empty?` to
+   * `nil` first (activerecord/attribute_assignment.rb:157).
+   *
+   * `sort` orders the Integer keys Ruby holds; a JS object spells them as
+   * strings, whose own order puts `"10"` ahead of `"2"`, so the comparison is
+   * numeric. `default_timezone` is `Helpers::Timezone#is_utc?`'s choice of
+   * receiver, `Time.utc` or `Time.local` (timezone.rb:9-11).
    *
    * @internal Rails-private helper.
    */
@@ -86,7 +90,7 @@ export class AcceptsMultiparameterTime {
       return null;
     }
     const values = Object.entries(valuesHash)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .sort(([a], [b]) => Number(a) - Number(b))
       .map(([, v]) => v as number | string);
     return isUtc()
       ? Time.utc(...(values as [number, number, number]))

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -1,70 +1,19 @@
-import { Temporal } from "@blazetrails/date";
-import { ArgumentError } from "../../attribute-assignment.js";
+import { Time } from "@blazetrails/date";
+import { isPlainObject } from "@blazetrails/activesupport";
 import { Type } from "../value.js";
+import { isUtc } from "./timezone.js";
 
 /**
- * AcceptsMultiparameterTime — wraps a time-based type to handle
- * multiparameter assignment from HTML forms.
- *
  * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
+ * (accepts_multiparameter_time.rb).
  *
- * In Rails, date/time form fields are submitted as multiple parameters
- * (year, month, day, hour, minute, second). This class reassembles them
- * into a single Temporal.PlainDateTime and delegates to the wrapped type,
- * which extracts what it needs (PlainDate, PlainTime, or PlainDateTime).
+ * Ruby builds the module with `defaults:` and closes `define_method` over it;
+ * TS has no anonymous-module `include`, so the same state is a constructor
+ * argument and the wrapped type is the receiver `super` would have reached.
  */
-/**
- * Ruby `value.is_a?(Hash)` analogue — a plain object (including null-prototype
- * objects, which the multiparameter extractor produces).
- * @internal
- */
-export function isHash(value: unknown): value is Record<string, unknown> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
-
-// Ruby Time's month-name coercion table (time.c months[]).
-const MONTH_ABBREVIATIONS = [
-  "jan",
-  "feb",
-  "mar",
-  "apr",
-  "may",
-  "jun",
-  "jul",
-  "aug",
-  "sep",
-  "oct",
-  "nov",
-  "dec",
-];
-
-/**
- * Split non-negative seconds into whole seconds + truncated nanoseconds using
- * the double's exact binary value (mantissa * 2^exponent), mirroring Ruby
- * Time's Float → Rational conversion. Negative or non-finite input falls back
- * to a plain trunc — the caller's domain check raises for it anyway.
- */
-function exactSecondsToNanoseconds(second: number): { whole: number; ns: number } {
-  if (!(second >= 0) || !Number.isFinite(second)) {
-    return { whole: Math.trunc(second), ns: 0 };
-  }
-  const dv = new DataView(new ArrayBuffer(8));
-  dv.setFloat64(0, second);
-  const bits = dv.getBigUint64(0);
-  const expBits = Number((bits >> 52n) & 0x7ffn);
-  let mantissa = bits & 0xf_ffff_ffff_ffffn;
-  if (expBits !== 0) mantissa |= 1n << 52n;
-  const exponent = expBits === 0 ? -1074 : expBits - 1075;
-  let totalNs = mantissa * 1_000_000_000n;
-  totalNs = exponent >= 0 ? totalNs << BigInt(exponent) : totalNs >> BigInt(-exponent);
-  return { whole: Number(totalNs / 1_000_000_000n), ns: Number(totalNs % 1_000_000_000n) };
-}
-
 export class AcceptsMultiparameterTime {
   readonly type: Type;
-  /** @internal */
+  /** @internal `AcceptsMultiparameterTime#initialize`'s `defaults:` kwarg. */
   readonly defaults: Record<string, number>;
 
   constructor(type: Type, defaults: Record<string, number> = {}) {
@@ -72,139 +21,82 @@ export class AcceptsMultiparameterTime {
     this.defaults = defaults;
   }
 
+  /** Mirrors: InstanceMethods#serialize (accepts_multiparameter_time.rb:9-11). */
   serialize(value: unknown): unknown {
-    return this.type.serialize(value);
+    return this.serializeCastValue(this.cast(value));
   }
 
+  /** Mirrors: InstanceMethods#serialize_cast_value (accepts_multiparameter_time.rb:13-15). */
   serializeCastValue(value: unknown): unknown {
-    if (
-      typeof (this.type as unknown as { serializeCastValue?(v: unknown): unknown })
-        .serializeCastValue === "function"
-    ) {
-      return (
-        this.type as unknown as { serializeCastValue(v: unknown): unknown }
-      ).serializeCastValue(value);
-    }
-    return this.type.serialize(value);
+    return value;
   }
 
+  /** Mirrors: InstanceMethods#cast (accepts_multiparameter_time.rb:17-23). */
   cast(value: unknown): unknown {
-    if (this.isMultiparameterHash(value)) {
-      return this.castFromMultiparameter(value as Record<string, unknown>);
+    if (isPlainObject(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else {
+      return this.type.cast(value);
     }
-    return this.type.cast(value);
   }
 
-  assertValidValue(value: unknown): void {
-    this.type.cast(value);
+  /** Mirrors: InstanceMethods#assert_valid_value (accepts_multiparameter_time.rb:25-31). */
+  assertValidValue(value: unknown): unknown {
+    if (isPlainObject(value)) {
+      return this.valueFromMultiparameterAssignment(value);
+    } else {
+      return this.type.assertValidValue(value);
+    }
   }
 
+  /**
+   * Mirrors: InstanceMethods#value_constructed_by_mass_assignment?
+   * (accepts_multiparameter_time.rb:33-35).
+   */
   isValueConstructedByMassAssignment(value: unknown): boolean {
-    return this.isMultiparameterHash(value);
+    return isPlainObject(value);
   }
 
-  private isMultiparameterHash(value: unknown): boolean {
-    return isHash(value);
-  }
-
-  private castFromMultiparameter(hash: Record<string, unknown>): unknown {
-    // Apply per-type defaults before the year/month/day guard — mirrors
-    // AcceptsMultiparameterTime#initialize's defaults.each { |k,v| values_hash[k] ||= v }.
-    const filled: Record<string, unknown> = { ...hash };
+  /**
+   * Mirrors: the `define_method(:value_from_multiparameter_assignment)`
+   * `AcceptsMultiparameterTime#initialize` installs
+   * (accepts_multiparameter_time.rb:38-46).
+   *
+   *   defaults.each do |k, v|
+   *     values_hash[k] ||= v
+   *   end
+   *   return unless values_hash[1] && values_hash[2] && values_hash[3]
+   *   values = values_hash.sort.map!(&:last)
+   *   ::Time.public_send(default_timezone, *values)
+   *
+   * `||=` and the `1`/`2`/`3` guard are Ruby truthiness, so only `nil`/`false`
+   * count as absent — an empty string is a present value and reaches `::Time`,
+   * which raises for it. The keys are the multiparameter indices, a JS object's
+   * string spelling of the Integer ones Ruby sorts, so `sort` is over `"1"`..`"6"`
+   * and orders the same. `default_timezone` is `Helpers::Timezone#is_utc?`'s
+   * choice of receiver, `Time.utc` or `Time.local` (timezone.rb:9-11).
+   *
+   * @internal Rails-private helper.
+   */
+  valueFromMultiparameterAssignment(valuesHash: Record<string, unknown>): Time | null {
     for (const [k, v] of Object.entries(this.defaults)) {
-      if (filled[k] === undefined || filled[k] === null || filled[k] === "") {
-        filled[k] = v;
-      }
+      if (valuesHash[k] == null || valuesHash[k] === false) valuesHash[k] = v;
     }
-
-    // Rails guard: return unless values_hash[1] && values_hash[2] && values_hash[3]
-    // Ruby 0 is truthy, so only nil/"" absence counts — use explicit nil/empty check.
-    const absent = (k: string) => filled[k] === undefined || filled[k] === null || filled[k] === "";
-    if (absent("1") || absent("2") || absent("3")) return null;
-
-    // Extract each slot by key with ::Time.utc/local's argument coercion
-    // (verified on Ruby 3.3): nil → the slot default; Numeric truncates except
-    // the seconds slot (Time.utc(...,5.5) keeps the fraction); String goes
-    // through strict Integer() — "2004abc", "5.5", and "" all raise
-    // ArgumentError — except the month slot, which also accepts 3-letter
-    // month-name abbreviations case-insensitively ("JAN" works, "june" raises).
-    const num = (key: string, fallback: number): number => {
-      const v = filled[key];
-      if (v === undefined || v === null) return fallback;
-      if (typeof v === "number") return key === "6" ? v : Math.trunc(v);
-      const s = String(v).trim();
-      if (key === "2") {
-        const monthIndex = MONTH_ABBREVIATIONS.indexOf(s.toLowerCase());
-        if (monthIndex !== -1) return monthIndex + 1;
-      }
-      if (!/^[+-]?\d+$/.test(s)) {
-        throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(v)}`);
-      }
-      return parseInt(s, 10);
-    };
-
-    const year = num("1", 0);
-    const month = num("2", 1);
-    const day = num("3", 1);
-    const hour = num("4", 0);
-    const minute = num("5", 0);
-    const second = num("6", 0);
-
-    // Ruby converts the seconds Float to an exact Rational and truncates:
-    // Time.utc(...,0.9999999999).nsec == 999_999_999 (never carried into the
-    // next second), and Time.utc(...,0.7).nsec == 699_999_999 because 0.7's
-    // exact binary value is 0.69999999999999995…. Decompose the double's bits
-    // so the truncation operates on that exact value, not an FP product.
-    const { whole: wholeSecond, ns: totalNanoseconds } = exactSecondsToNanoseconds(second);
-    const millisecond = Math.trunc(totalNanoseconds / 1_000_000);
-    const microsecond = Math.trunc((totalNanoseconds % 1_000_000) / 1_000);
-    const nanosecond = totalNanoseconds % 1_000;
-    const timeParts = { hour, minute, second: wholeSecond, millisecond, microsecond, nanosecond };
-    try {
-      const pdt = Temporal.PlainDateTime.from(
-        { year, month, day, ...timeParts },
-        { overflow: "reject" },
-      );
-      return this.type.cast(pdt);
-    } catch {
-      // Rails assembles via ::Time.public_send(default_timezone, *values).
-      // Time.utc/local rolls *within-range* overflow (Nov 31 → Dec 1, Feb 29
-      // in a common year → Mar 1, hour 24 with 0 min/sec → next midnight,
-      // sec 60 → next minute) but raises ArgumentError outside its accepted
-      // domain (month 13, mday 32, hour 25 — verified on Ruby 3.3), which AR
-      // surfaces as MultiparameterAssignmentErrors. Roll over only inside that
-      // accepted domain; otherwise raise to match Time's strictness.
-      // Ruby requires min and whole sec to be 0 at hour 24 but accepts a
-      // fractional second: Time.utc(2004,1,1,24,0,0.1) → 2004-01-02 00:00:00.1.
-      const midnight24 = hour === 24 && minute === 0 && wholeSecond === 0;
-      if (
-        month >= 1 &&
-        month <= 12 &&
-        day >= 1 &&
-        day <= 31 &&
-        ((hour >= 0 && hour <= 23) || midnight24) &&
-        minute >= 0 &&
-        minute <= 59 &&
-        wholeSecond >= 0 &&
-        wholeSecond <= 60
-      ) {
-        // Duration add carries all out-of-range components (day-in-month,
-        // hour 24, leap-second 60) the way Time normalizes them.
-        const rolled = Temporal.PlainDate.from({ year, month: 1, day: 1 })
-          .toPlainDateTime()
-          .add({
-            months: month - 1,
-            days: day - 1,
-            hours: hour,
-            minutes: minute,
-            seconds: wholeSecond,
-            nanoseconds: totalNanoseconds,
-          });
-        return this.type.cast(rolled);
-      }
-      throw new ArgumentError("argument out of range");
+    if (!truthy(valuesHash["1"]) || !truthy(valuesHash["2"]) || !truthy(valuesHash["3"])) {
+      return null;
     }
+    const values = Object.entries(valuesHash)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([, v]) => v as number | string);
+    return isUtc()
+      ? Time.utc(...(values as [number, number, number]))
+      : Time.local(...(values as [number, number, number]));
   }
+}
+
+/** Ruby truthiness: only `nil` and `false` are falsy (CLAUDE.md). */
+function truthy(value: unknown): boolean {
+  return value != null && value !== false;
 }
 
 /**
@@ -214,6 +106,6 @@ export interface InstanceMethods {
   serialize(value: unknown): unknown;
   serializeCastValue(value: unknown): unknown;
   cast(value: unknown): unknown;
-  assertValidValue(value: unknown): void;
+  assertValidValue(value: unknown): unknown;
   isValueConstructedByMassAssignment(value: unknown): boolean;
 }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -4,8 +4,8 @@ import {
   Temporal,
   type DateParts,
 } from "@blazetrails/date";
-import { zone, isBlank } from "@blazetrails/activesupport";
-import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
+import { zone, isBlank, isPlainObject } from "@blazetrails/activesupport";
+import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
@@ -211,15 +211,14 @@ export class TimeType extends ValueType<Temporal.Instant> {
   protected valueFromMultiparameterAssignment(
     values: Record<string, unknown>,
   ): Temporal.Instant | null {
-    return (
-      (new AcceptsMultiparameterTime(this, {
-        "1": 2000,
-        "2": 1,
-        "3": 1,
-        "4": 0,
-        "5": 0,
-      }).cast(values) as Temporal.Instant | null) ?? null
-    );
+    const time = new AcceptsMultiparameterTime(this, {
+      "1": 2000,
+      "2": 1,
+      "3": 1,
+      "4": 0,
+      "5": 0,
+    }).valueFromMultiparameterAssignment(values);
+    return time && time.toTime().toInstant();
   }
 
   /**
@@ -228,7 +227,7 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * `Value#cast` (value.rb:53-55), which is `super`.
    */
   override cast(value: unknown): Temporal.Instant | null {
-    if (isHash(value)) {
+    if (isPlainObject(value)) {
       return this.valueFromMultiparameterAssignment(value);
     } else {
       return super.cast(value);
@@ -240,11 +239,11 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isHash(value);
+    return isPlainObject(value);
   }
 }

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -202,6 +202,40 @@ function subsecNanoseconds(sec: number | Rational): number {
 }
 
 /**
+ * MRI's `months[]` table (`time.c`), the three-letter month names
+ * `month_arg` matches a String positional against.
+ */
+const months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+
+/**
+ * MRI's `obj2vint` (`time.c`), the conversion every `::Time` constructor
+ * positional goes through before `obj2ubits` sees it. A String is taken
+ * through `rb_str_to_inum(str, 10, TRUE)` — strict `Integer()`, so
+ * `Time.utc("2004")` is the year 2004 while `"5.5"`, `"2004abc"` and `""` all
+ * raise. A Numeric is truncated toward zero.
+ */
+function obj2vint(obj: number | string): number {
+  if (typeof obj !== "string") return Math.trunc(obj);
+  if (!/^[+-]?\d+$/.test(obj.trim())) {
+    throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(obj)}`);
+  }
+  return parseInt(obj.trim(), 10);
+}
+
+/**
+ * MRI's `month_arg` (`time.c`): the month positional alone also takes one of
+ * `months[]`, matched case-insensitively over exactly three characters, so
+ * `Time.utc(2004, "JAN")` is January and `Time.utc(2004, "june")` raises.
+ */
+function monthArg(obj: number | string): number {
+  if (typeof obj === "string") {
+    const index = months.indexOf(obj.trim().toLowerCase());
+    if (index !== -1) return index + 1;
+  }
+  return obj2vint(obj);
+}
+
+/**
  * MRI's `obj2ubits` (`time.c`), which every `::Time` constructor positional
  * goes through before `validate_vtm` sees it: the value has to fit in `bits`
  * unsigned bits or the argument is rejected outright, with a message that names
@@ -258,12 +292,12 @@ export class Time {
    * `Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec` is `5000`.
    */
   static utc(
-    year: number,
-    month: number,
-    day: number,
-    hour = 0,
-    min = 0,
-    sec: number | Rational = 0,
+    year: number | string,
+    month: number | string | null = 1,
+    day: number | string | null = 1,
+    hour: number | string | null = 0,
+    min: number | string | null = 0,
+    sec: number | string | Rational | null = 0,
     usec?: number,
   ): Time {
     return new Time(
@@ -274,7 +308,7 @@ export class Time {
       min,
       usec === undefined
         ? sec
-        : new Rational(sec instanceof Rational ? sec.toI() : Math.trunc(sec), 1).add(
+        : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
             new Rational(Math.round(usec * 1_000), 1_000_000_000),
           ),
       "UTC",
@@ -288,12 +322,12 @@ export class Time {
    * truncates `sec` to a whole second.
    */
   static mktime(
-    year: number,
-    month: number,
-    day: number,
-    hour = 0,
-    min = 0,
-    sec: number | Rational = 0,
+    year: number | string,
+    month: number | string | null = 1,
+    day: number | string | null = 1,
+    hour: number | string | null = 0,
+    min: number | string | null = 0,
+    sec: number | string | Rational | null = 0,
     usec?: number,
   ): Time {
     return new Time(
@@ -304,7 +338,7 @@ export class Time {
       min,
       usec === undefined
         ? sec
-        : new Rational(sec instanceof Rational ? sec.toI() : Math.trunc(sec), 1).add(
+        : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
             new Rational(Math.round(usec * 1_000), 1_000_000_000),
           ),
     );
@@ -316,12 +350,12 @@ export class Time {
    * positionals and builds in the LOCAL zone too.
    */
   static local(
-    year: number,
-    month: number,
-    day: number,
-    hour = 0,
-    min = 0,
-    sec: number | Rational = 0,
+    year: number | string,
+    month: number | string | null = 1,
+    day: number | string | null = 1,
+    hour: number | string | null = 0,
+    min: number | string | null = 0,
+    sec: number | string | Rational | null = 0,
     usec?: number,
   ): Time {
     return Time.mktime(year, month, day, hour, min, sec, usec);
@@ -360,14 +394,25 @@ export class Time {
    * shape trails has.
    */
   constructor(
-    year: number,
-    month: number,
-    day: number,
-    hour = 0,
-    min = 0,
-    sec: number | Rational = 0,
+    year: number | string,
+    month: number | string | null = 1,
+    day: number | string | null = 1,
+    hour: number | string | null = 0,
+    min: number | string | null = 0,
+    sec: number | string | Rational | null = 0,
     zone: string | number | null = null,
   ) {
+    // MRI defaults a `nil` positional to the field's own default rather than
+    // rejecting it (`time.c` `time_utc_or_local`), which is what makes
+    // `Time.utc(2004, 6, 24, 16, 24, nil)` a whole minute — the shape
+    // `AcceptsMultiparameterTime` hands it for a form field left blank.
+    year = obj2vint(year);
+    month = month == null ? 1 : monthArg(month);
+    day = day == null ? 1 : obj2vint(day);
+    hour = hour == null ? 0 : obj2vint(hour);
+    min = min == null ? 0 : obj2vint(min);
+    if (sec == null) sec = 0;
+    else if (typeof sec === "string") sec = obj2vint(sec);
     const nsec = subsecNanoseconds(sec);
     const wholeSec = sec instanceof Rational ? sec.div(1) : Math.floor(sec);
     obj2ubits(month, 4);
@@ -414,6 +459,11 @@ export class Time {
   }
 
   get day(): number {
+    return this.#plain.day;
+  }
+
+  /** Ruby `Time#mday`, the `day` alias (`time.c` binds both to `time_mday`). */
+  get mday(): number {
     return this.#plain.day;
   }
 

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -388,6 +388,12 @@ export class Time {
    * `Time.utc(2015, 2, 31)` is the 3rd of March. `Temporal.PlainDateTime`
    * rejects both outright, so the day is carried in as `1` and added back.
    *
+   * Every positional but the year also takes `nil`, which MRI defaults to the
+   * field's own default rather than rejecting (`time.c` `time_utc_or_local`) —
+   * so `Time.utc(2004, 6, 24, 16, 24, nil)` is a whole minute, the shape
+   * `AcceptsMultiparameterTime` hands it for a form field left blank — and a
+   * String, which `obj2vint` / `month_arg` convert.
+   *
    * That MRI reading is why `Time#toDatetime`'s `s == 60` fold
    * (`date_core.c:8913-8915`) is unreachable through the constructor on both
    * runtimes; the C carries it for a `right/`-zoneinfo build, which is not a
@@ -402,10 +408,6 @@ export class Time {
     sec: number | string | Rational | null = 0,
     zone: string | number | null = null,
   ) {
-    // MRI defaults a `nil` positional to the field's own default rather than
-    // rejecting it (`time.c` `time_utc_or_local`), which is what makes
-    // `Time.utc(2004, 6, 24, 16, 24, nil)` a whole minute — the shape
-    // `AcceptsMultiparameterTime` hands it for a form field left blank.
     year = obj2vint(year);
     month = month == null ? 1 : monthArg(month);
     day = day == null ? 1 : obj2vint(day);


### PR DESCRIPTION
## What

Two RFC 0115 convergences in ActiveModel, plus the `time.c` coercions the first one needs in `@blazetrails/date`.

### 1. `value_from_multiparameter_assignment` (`accepts_multiparameter_time.rb:38-46`)

Rails' body is twelve lines:

```ruby
defaults.each { |k, v| values_hash[k] ||= v }
return unless values_hash[1] && values_hash[2] && values_hash[3]
values = values_hash.sort.map!(&:last)
::Time.public_send(default_timezone, *values)
```

trails had that as a 69-line `castFromMultiparameter` with hand-rolled fractional-second bit decomposition, an `Integer()` coercion ladder, a month-name table and a `try`/`catch` roll-over arm — 109 code lines with no Rails counterpart, across `castFromMultiparameter`, `isHash`, `isMultiparameterHash` and `exactSecondsToNanoseconds`.

The assembly now goes through `@blazetrails/date`'s `Time`, the port of `time.c`, which already carries every one of those behaviours: `subsecNanoseconds` is the exact-Rational truncation `exactSecondsToNanoseconds` duplicated, and `obj2ubits` / `validate_vtm_range` are the domain checks the catch arm re-derived. What it was missing is the argument coercion MRI does *ahead* of them, so `obj2vint` (strict `Integer()` for a String positional), `month_arg` (the `months[]` table) and MRI's nil-positional defaulting are ported into `time.ts` where `time.c` has them, along with `Time#mday`.

`valueFromMultiparameterAssignment` now answers the `::Time` Rails answers, so `Type::Date` narrows it through `new_date(time.year, time.mon, time.mday)` exactly as `date.rb:75-78` does, and the `Type::DateTime` / `Type::Time` arms read the instant off it. `isHash` was byte-identical to activesupport's exported `isPlainObject` and is replaced by it at all three call sites.

`type/helpers/accepts-multiparameter-time.ts` is **0 novel** on `parity:api:extra --package activemodel`.

**Bug found while converging.** Ruby's `values_hash.sort` orders Integer keys; a JS object spells them as strings, whose own order puts `"10"` ahead of `"2"`. `extract_callstack_for_multiparameter_attributes` accepts an index up to 100, so a two-digit slot fed `::Time` a month of `0`. The sort is numeric now, with a regression test that raises `mon out of range` on the baseline.

**Behaviour note.** Ruby's `||=` and the `values_hash[1] && [2] && [3]` guard are Ruby truthiness, so an empty string is a *present* value that reaches `::Time` and raises there — where trails previously treated it as absent. ActiveRecord never arrives with one: `extract_callstack_for_multiparameter_attributes` maps `value.empty?` to `nil` first (`activerecord/attribute_assignment.rb:157`), and trails' extractor does the same, so the form path is unchanged and `multiparameter-attributes.test.ts` stays green. Two trails-only tests in `accepts-multiparameter-time-defaults.test.ts` pinned the *old* wrapper contract and are re-specced onto the Rails one — including one whose name asserted the deviation itself. There is no Rails test file mapping to that path, so no `parity:test` credit moves. Sub-second truncation is pinned at a pre-1970 instant with nanosecond precision (`Time.utc(1969, 7, 20, 20, 17, 40.9999999999).nsec == 999_999_999`, verified against MRI), the case PR #6738 found the direction wrong on.

### 2. `serializable_add_includes` (`serialization.rb:184-196`)

The `unless includes.is_a?(Hash)` normalisation is three lines inline in Rails; trails extracted it into `normalizeIncludes` plus `hasIncludes` and `storeHasKey`. All three are gone.

`serializableAddIncludes` spells the normalisation inline, per "if Rails inlines something, inline it". `hasIncludes`' two call sites take Rails' own guard instead — `return unless includes = options[:include]` (`serialization.rb:185`), which is nil/false and nothing more; the emptiness refinement it added had no Rails basis, and `serializableAddIncludes` already no-ops on an empty list, so the only effect is that `serializable_hash(include: [])` answers a thenable rather than a plain hash, a distinction no caller draws. `storeHasKey` is inlined at its one call site.

`preloadIncludes` — the async walk that has no Rails counterpart — does not need the normalised map, only the `[name, opts]` pairs, so it walks `serialization.rb:188`'s own `Array(includes).flat_map { |n| n.is_a?(Hash) ? n.to_a : [[n, {}]] }` directly, without the `Hash[...]` that wraps it there. That wrapper only dedupes; dropping it can visit a name twice, which for a preload is a superset of the work and never a miss, so the sync pass still finds everything loaded. So there is neither a second copy of the block to drift nor a named helper outliving the criterion.

The two `serializableAddIncludes` sites the story flagged turned out to be one definition and one call site — nothing to converge there.

## Not in this PR

`converge-attribute-assignment-hash-guards` is released back to the queue, unclaimed. Converging `assertHashAttributes` / `isHashLike` / `typeNameForError` / `isMassAssignmentEmpty` means inlining Rails' three-line guard at six call sites across activemodel and activerecord; that does not fit under this PR's 700-LOC ceiling alongside the two above, and splitting it out is the honest answer rather than shipping a slice that closes nothing.

## Verification

```
pnpm typecheck                                          clean
pnpm lint --fix                                         clean, no changes
pnpm parity:api:calls                                   OK (915 baselined, 433 unreviewed, tight)
pnpm parity:api:calls:args                              OK (170 baselined shape rows)
pnpm parity:api:extra --package activemodel             accepts-multiparameter-time.ts 0 novel
pnpm parity:api / pnpm parity:test                      deltas non-negative
git diff --shortstat origin/main...HEAD                 578 (under the 700 ceiling)

pnpm vitest run packages/activemodel/src/type packages/date/src
                                                        732 passed
pnpm vitest run packages/activemodel/src/serialization.test.ts
                                                        76 passed
pnpm vitest run packages/activerecord/src/multiparameter-attributes.test.ts \
                packages/activerecord/src/date.test.ts \
                packages/activerecord/src/attribute-methods/time-zone-converter.test.ts \
                packages/activerecord/src/cache-key.test.ts
                                                        67 passed
```

Closes-story: converge-accepts-multiparameter-time-cast-from-multiparameter
Closes-story: inline-serialization-normalize-includes-into-serializable-add-includes
