### PR TITLE
refactor(activerecord): converge the leaf _attributeDefinitions readers onto Rails' surfaces

### DIFF
--- a/packages/activerecord/src/i18n.trails.test.ts
+++ b/packages/activerecord/src/i18n.trails.test.ts
@@ -21,8 +21,6 @@ describe("ActiveRecordTranslationLookupAncestorsTest", () => {
     class Topic extends Base {}
     class Reply extends Topic {}
 
-    // Mirrors translation.rb:11-13 — the walk ends at `base_class?`, so
-    // ActiveRecord::Base itself is never in the chain for a model.
     expect(Reply.lookupAncestors()).toEqual([Reply, Topic]);
     expect(Topic.lookupAncestors()).toEqual([Topic]);
     expect(Base.lookupAncestors()).toEqual([Base]);

--- a/packages/activerecord/src/i18n.trails.test.ts
+++ b/packages/activerecord/src/i18n.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { I18n } from "@blazetrails/activemodel";
 import "./i18n.js";
+import { Base } from "./index.js";
 
 describe("ActiveRecordI18nLoadPathTest", () => {
   it("re-reads Active Model's and Active Record's locales after reload!", async () => {
@@ -12,5 +13,18 @@ describe("ActiveRecordI18nLoadPathTest", () => {
 
     expect(I18n.t("errors.messages.blank")).toBe("can't be blank");
     expect(I18n.t("errors.messages.taken")).toBe("has already been taken");
+  });
+});
+
+describe("ActiveRecordTranslationLookupAncestorsTest", () => {
+  it("stops at the STI base class", () => {
+    class Topic extends Base {}
+    class Reply extends Topic {}
+
+    // Mirrors translation.rb:11-13 — the walk ends at `base_class?`, so
+    // ActiveRecord::Base itself is never in the chain for a model.
+    expect(Reply.lookupAncestors()).toEqual([Reply, Topic]);
+    expect(Topic.lookupAncestors()).toEqual([Topic]);
+    expect(Base.lookupAncestors()).toEqual([Base]);
   });
 });

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -10,11 +10,10 @@ import type { Relation } from "./relation.js";
 import { Result } from "./result.js";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { withConnection } from "./connection-handling.js";
+import { allTimestampAttributesInModel, timestampAttributesForUpdateInModel } from "./timestamp.js";
 
 type ModelClass = typeof Base;
 
-const TIMESTAMP_COLUMNS = ["created_at", "created_on", "updated_at", "updated_on"] as const;
-const UPDATE_TIMESTAMP_COLUMNS = ["updated_at", "updated_on"] as const;
 // Mirrors timestamp.ts CREATED_ATTRS/UPDATED_ATTRS: both _at and _on are magic
 // timestamp columns, so verifyAttributes must allow either pair even when only
 // the other is in the model's declared attribute set.
@@ -263,7 +262,7 @@ export class InsertAll {
     if (this._keysIncludingTimestamps) return this._keysIncludingTimestamps;
     if (this.recordTimestamps()) {
       const result = new Set(this.keys);
-      for (const col of this._physicalTimestampCols(TIMESTAMP_COLUMNS)) {
+      for (const col of allTimestampAttributesInModel.call(this.model as never)) {
         result.add(col);
       }
       this._keysIncludingTimestamps = result;
@@ -533,35 +532,11 @@ export class InsertAll {
     );
   }
 
-  /**
-   * Returns physical column names for the given logical timestamp columns,
-   * resolving alias_attribute mappings (e.g. created_at → legacy_created_at).
-   * @internal
-   */
-  private _physicalTimestampCols(logicalCols: readonly string[]): string[] {
-    const aliases = (this.model as any)._attributeAliases as Record<string, string> | undefined;
-    const result: string[] = [];
-    for (const col of logicalCols) {
-      if (this.model._attributeDefinitions.has(col)) {
-        result.push(col);
-      } else {
-        const physical = aliases?.[col];
-        if (physical && this.model._attributeDefinitions.has(physical)) result.push(physical);
-      }
-    }
-    return result;
-  }
-
-  /** Physical column names for all update timestamp columns (resolves aliases). @internal */
-  updateTimestampColumnsInModel(): string[] {
-    return this._physicalTimestampCols(UPDATE_TIMESTAMP_COLUMNS);
-  }
-
-  /** @internal */
+  /** Mirrors: ActiveRecord::InsertAll#timestamps_for_create (insert_all.rb:221-223). @internal */
   private timestampsForCreate(): Record<string, unknown> {
     const now = Temporal.Now.instant();
     const result: Record<string, unknown> = {};
-    for (const col of this._physicalTimestampCols(TIMESTAMP_COLUMNS)) {
+    for (const col of allTimestampAttributesInModel.call(this.model as never)) {
       result[col] = now;
     }
     return result;
@@ -684,10 +659,11 @@ export class Builder implements InsertBuilder {
     const model = this._insertAll.model;
     const rows = this._insertAll.mapKeyWithValue<unknown>((key, value) => {
       if (value instanceof Nodes.SqlLiteral) return value;
-      // Cast then serialize via the column type if available, falling back
-      // to SerializeCastValue.serializeCastValue (identity) when no type exists
-      const def = model._attributeDefinitions.get(key) as any;
-      const type = def?.type ?? def;
+      // Rails resolves the cast type through `model.type_for_attribute(key)`
+      // (insert_all.rb:312, via `extract_types_from_columns_on`) — the decorated
+      // `attribute_types` set, so serialize/normalizes/encrypts decorators are
+      // honored — not a raw column-definition lookup.
+      const type = model.typeForAttribute(key) as any;
       const castValue = type && typeof type.cast === "function" ? type.cast(value) : value;
       // Faithful dispatch (ActiveModel::Type::SerializeCastValue.serialize):
       // only short-circuit through serializeCastValue when the type declares
@@ -748,8 +724,8 @@ export class Builder implements InsertBuilder {
     if (!this._insertAll.updateDuplicates() || !this._insertAll.recordTimestamps()) {
       return "";
     }
-    return this._insertAll
-      .updateTimestampColumnsInModel()
+    return timestampAttributesForUpdateInModel
+      .call(this.model as never)
       .filter((columnName) => this.touchTimestampAttribute(columnName))
       .map(
         (columnName) =>

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -659,25 +659,8 @@ export class Builder implements InsertBuilder {
     const model = this._insertAll.model;
     const rows = this._insertAll.mapKeyWithValue<unknown>((key, value) => {
       if (value instanceof Nodes.SqlLiteral) return value;
-      // Rails resolves the cast type through `model.type_for_attribute(key)`
-      // (insert_all.rb:312, via `extract_types_from_columns_on`) — the decorated
-      // `attribute_types` set, so serialize/normalizes/encrypts decorators are
-      // honored — not a raw column-definition lookup.
-      const type = model.typeForAttribute(key) as any;
-      const castValue = type && typeof type.cast === "function" ? type.cast(value) : value;
-      // Faithful dispatch (ActiveModel::Type::SerializeCastValue.serialize):
-      // only short-circuit through serializeCastValue when the type declares
-      // it compatible, otherwise call full serialize. A type overriding
-      // serialize but not serializeCastValue (binary, json, serialized, the
-      // PG OID types) inherits identity serializeCastValue and would
-      // otherwise persist the in-memory cast value.
-      if (type && typeof type.serialize === "function") {
-        value = SerializeCastValue.serialize(type, castValue);
-      } else if (type && typeof type.serializeCastValue === "function") {
-        value = type.serializeCastValue(castValue);
-      } else {
-        value = SerializeCastValue.serializeCastValue(castValue);
-      }
+      const type = model.typeForAttribute(key);
+      value = SerializeCastValue.serialize(type, type.cast(value));
       // Rails hands the serialized value to the ValuesList *as a value*
       // (insert_all.rb:246): `connection.visitor.compile` renders it, quoting
       // each entry through `connection.quote` (to_sql.rb:106-114). So no

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -1507,8 +1507,6 @@ function pluckCastTypeForKnownColumn(
   model: CalculationRelation["_model"],
   name: string,
 ): ColumnType | null {
-  // Rails' `model.attribute_types.fetch(name) { ... }` (calculations.rb:617):
-  // the fallback runs only when the model owns no such KEY.
   if (!Object.hasOwn(model.attributeTypes(), name)) return null;
   const coder = model._serializedAttributes?.get(name);
   if (coder) return { deserialize: (value) => coder.load(value) };

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -114,7 +114,6 @@ interface CalculationRelation {
     typeForAttribute?(name: string, block?: () => ColumnType): ColumnType;
     /** Mirrors `Model.attribute_types` (attribute_registration.rb) — Rails' hash-with-default. */
     attributeTypes(): Record<string, ColumnType>;
-    _attributeDefinitions?: { has(name: string): boolean };
     _serializedAttributes?: { get(name: string): { load(raw: unknown): unknown } | undefined };
     connection: CalculationConnection;
     /** Mirrors `Model.load_schema` — `type_cast_pluck_values` needs attribute_types. */
@@ -1508,7 +1507,9 @@ function pluckCastTypeForKnownColumn(
   model: CalculationRelation["_model"],
   name: string,
 ): ColumnType | null {
-  if (!model._attributeDefinitions?.has(name)) return null;
+  // Rails' `model.attribute_types.fetch(name) { ... }` (calculations.rb:617):
+  // the fallback runs only when the model owns no such KEY.
+  if (!Object.hasOwn(model.attributeTypes(), name)) return null;
   const coder = model._serializedAttributes?.get(name);
   if (coder) return { deserialize: (value) => coder.load(value) };
   return model.typeForAttribute?.(name) ?? null;

--- a/packages/activerecord/src/translation.ts
+++ b/packages/activerecord/src/translation.ts
@@ -1,4 +1,5 @@
 import type { Base } from "./base.js";
+import { isBaseClass } from "./inheritance.js";
 
 /**
  * Translation and i18n support for ActiveRecord models.
@@ -16,27 +17,22 @@ export function i18nScope(this: typeof Base): string {
 }
 
 /**
- * Return the ancestor chain for i18n lookup, stopping before the
- * ActiveRecord Base class (the first class whose parent constructor
- * does not have _attributeDefinitions).
+ * Set the lookup ancestors for ActiveModel.
  *
- * Mirrors: ActiveRecord::Translation#lookup_ancestors
+ * Mirrors: ActiveRecord::Translation#lookup_ancestors (translation.rb:6-15)
  */
 export function lookupAncestors(this: typeof Base): Array<typeof Base> {
-  const ancestors: Array<typeof Base> = [];
-  let klass: any = this;
-  while (klass) {
-    const parent = Object.getPrototypeOf(klass);
-    if (!parent || !("_attributeDefinitions" in parent)) {
-      // klass is Base (its parent is Model which doesn't have _attributeDefinitions).
-      // Only include Base if it was the original receiver.
-      if (klass === this) ancestors.push(klass);
-      break;
-    }
-    ancestors.push(klass);
-    klass = parent;
+  let klass: typeof Base = this;
+  const classes: Array<typeof Base> = [klass];
+  // Rails compares against the `ActiveRecord::Base` constant; trails detects it
+  // through the `_isActiveRecordBase` own-property sentinel `setBaseClass` uses.
+  if (Object.prototype.hasOwnProperty.call(klass, "_isActiveRecordBase")) return classes;
+
+  while (!isBaseClass(klass)) {
+    klass = Object.getPrototypeOf(klass) as typeof Base;
+    classes.push(klass);
   }
-  return ancestors;
+  return classes;
 }
 
 /**


### PR DESCRIPTION
`_attributeDefinitions` is a trails invention with no Rails counterpart
(RFC 0078). This starts its burndown at the leaves, where each reader has a
direct Rails-shaped replacement.

- **`Translation#lookup_ancestors`** walked the prototype chain probing for
  `"_attributeDefinitions" in parent`, which put `ActiveRecord::Base` in the
  chain for every model. Rails walks to `base_class?`
  (`activerecord/lib/active_record/translation.rb:6-15`); port that.
- **`InsertAll`** grew `_physicalTimestampCols`,
  `updateTimestampColumnsInModel` and its own
  `TIMESTAMP_COLUMNS`/`UPDATE_TIMESTAMP_COLUMNS` lists, all alias-resolving
  against `_attributeDefinitions`. Rails already has these as
  `all_timestamp_attributes_in_model` /
  `timestamp_attributes_for_update_in_model` (`insert_all.rb:94, 222, 282`),
  which trails ports in `timestamp.ts` and which intersect against
  `column_names` — the parallel machinery is deleted.
- **`Builder#values_list`** looked its cast type up in `_attributeDefinitions`;
  Rails resolves it through `model.type_for_attribute(key)`
  (`insert_all.rb:312`), i.e. the decorated `attribute_types` set, so
  serialize/normalizes/encrypts decorators are honored.
- **`pluckCastTypeForKnownColumn`** keyed off `_attributeDefinitions.has`;
  Rails' `model.attribute_types.fetch(name) { ... }` (`calculations.rb:617`)
  keys off `attribute_types`.

## Scope

The story's remaining acceptance criteria — the core readers (`model-schema`,
`base`, `attributes`, `attribute-methods`, `persistence`, `inheritance`,
`encryption`, ~140 references) and the `_schemaRevision` /
`scrubSchemaSourcedDefinitions` / `replayOwnPendingDecorators` deletions that
depend on them — do not fit under the LOC ceiling and are filed as
`0078-sti-schema-reflection-fidelity/converge-attribute-definitions-core-readers`,
which carries the full reader inventory and the two readers deliberately
deferred (`secure-password.ts`, `enum.ts`'s `source`/`userProvided`
provenance).

The bundled story `port-activejob-test-helper-for-destroy-association-async` was
released, not shipped: trails has no `activejob` package and the gem is entirely
off the parity radar, so the minimal enqueue/execute chain plus gem enrollment
is an epic rather than a PR.

## Verification

`insert-all`, `calculations`, `i18n`, `timestamp`, `inheritance`,
`validations`, `sti` suites pass. `parity:api:calls` and
`parity:api:calls:args` OK; no new public surface. The added
`ActiveRecordTranslationLookupAncestorsTest` case fails on baseline
(`[Reply, Topic, Base]`) and passes here.

Closes-story: converge-attribute-definitions-onto-default-attributes
