### PR TITLE
refactor(activerecord): retire CollectionProxy keys/entries and express the QueryMethods protected boundary

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1916,7 +1916,7 @@ function wrapCollectionProxy<T extends Base = Base>(
       if (typeof prop === "symbol") return false;
       const modelClass = target.model as typeof Base & { _scopes?: Map<string, unknown> };
       if (modelClass._scopes?.has(prop)) return true;
-      if (delegateEnumerableMethod(prop, () => target.load()) !== undefined) return true;
+      if (delegateEnumerableMethod(prop, () => target.loadTarget()) !== undefined) return true;
       return typeof (modelClass as any)[prop] === "function";
     },
   });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1872,16 +1872,15 @@ function wrapCollectionProxy<T extends Base = Base>(
       }
 
       // Enumerable-method delegation — async + self-loading, checked before
-      // scope lookup so it routes to the collection cache rather than the scope
-      // relation's `_records`. Covers `partition` and all
-      // DELEGATED_ARRAY_METHODS on *unloaded* proxies (the sync path above
-      // handles loaded proxies). Rails resolves every `to: :records` delegate
-      // through `CollectionProxy#records` (collection_proxy.rb:1024-1026),
-      // which is `load_target` — and `load_target` MERGES rather than replaces
-      // (`@target = merge_target_lists(find_target, target)`,
-      // collection_association.rb:270-278), so a proxy holding built-but-unsaved
-      // records answers with them included. Reading through `loadTarget()`
-      // rather than `load()` names that seam at the call site.
+      // scope lookup so it routes to the collection cache via
+      // `target.loadTarget()` rather than the scope relation's `_records`.
+      // Covers `partition` and all DELEGATED_ARRAY_METHODS on *unloaded*
+      // proxies (the sync path above handles loaded proxies). Rails resolves
+      // every `to: :records` delegate through `CollectionProxy#records`
+      // (collection_proxy.rb:1024-1026), which is `load_target` — it merges
+      // `find_target` into the in-memory target rather than replacing it
+      // (collection_association.rb:270-278), so a proxy holding
+      // built-but-unsaved records answers with them included.
       const enumerableDelegate = delegateEnumerableMethod(prop, () => target.loadTarget());
       if (enumerableDelegate) return enumerableDelegate;
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1872,13 +1872,17 @@ function wrapCollectionProxy<T extends Base = Base>(
       }
 
       // Enumerable-method delegation — async + self-loading, checked before
-      // scope lookup so it routes to the collection cache via `target.load()`
-      // rather than the scope relation's `_records`. Covers `partition` and all
+      // scope lookup so it routes to the collection cache rather than the scope
+      // relation's `_records`. Covers `partition` and all
       // DELEGATED_ARRAY_METHODS on *unloaded* proxies (the sync path above
-      // handles loaded proxies). Rails' `CollectionProxy#records` calls
-      // `load_target`, hydrating `@target` and marking the association loaded;
-      // `target.load()` does the same.
-      const enumerableDelegate = delegateEnumerableMethod(prop, () => target.load());
+      // handles loaded proxies). Rails resolves every `to: :records` delegate
+      // through `CollectionProxy#records` (collection_proxy.rb:1024-1026),
+      // which is `load_target` — and `load_target` MERGES rather than replaces
+      // (`@target = merge_target_lists(find_target, target)`,
+      // collection_association.rb:270-278), so a proxy holding built-but-unsaved
+      // records answers with them included. Reading through `loadTarget()`
+      // rather than `load()` names that seam at the call site.
+      const enumerableDelegate = delegateEnumerableMethod(prop, () => target.loadTarget());
       if (enumerableDelegate) return enumerableDelegate;
 
       const scope = target.scope();

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -230,15 +230,6 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect([...proxy].map((p: Post) => p.title).sort()).toEqual(["x", "y"]);
   });
 
-  it("keys / entries work (values intentionally not added)", async () => {
-    const author = await authorWithPosts();
-    const proxy = association<Post>(author, "posts");
-    expect([...proxy.keys()]).toEqual([0, 1, 2]);
-    expect([...proxy.entries()].map(([i, p]) => `${i}:${p.title}`)).toEqual(
-      proxy.target.map((p, i) => `${i}:${p.title}`),
-    );
-  });
-
   it("array methods accept a thisArg (matches Array.prototype signatures)", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -333,19 +333,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return this.target[Symbol.iterator]();
   }
 
-  // `keys` / `entries` are the index-yielding half of the same JS iteration
-  // protocol as `[Symbol.iterator]` above — like it, they read the delegated
-  // records (`records` → `load_target`, collection_proxy.rb:1024). `values()`
-  // is NOT added: it would shadow `Relation#values()`.
-
-  keys(): IterableIterator<number> {
-    return this.target.keys();
-  }
-
-  entries(): IterableIterator<[number, T]> {
-    return this.target.entries();
-  }
-
   /**
    * @internal Resolve the target model an association's proxy scopes to —
    * preferring the rich reflection's namespace-aware klass, else `className`.
@@ -1424,8 +1411,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 //   ]
 //   delegate(*delegate_methods, to: :scope)
 //
-// The mixin files name Ruby's `private` boundary structurally
-// (query_methods.rb:1677, spawn_methods.rb:71), so
+// The mixin files name Ruby's `protected` and `private` boundaries
+// structurally (query_methods.rb:1604 and query_methods.rb:1663 for the two
+// protected sections, query_methods.rb:1677 and spawn_methods.rb:71 for
+// private) — Ruby excludes both from `public_instance_methods(false)` — so
 // `QueryMethodsPublicInstanceMethods` / `SpawnMethodsPublicInstanceMethods` ARE
 // `public_instance_methods(false)` and the delegate list is read off them
 // rather than hand-transcribed. `public_instance_methods(false)`

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2625,8 +2625,8 @@ export function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]):
 // ---------------------------------------------------------------------------
 /**
  * `QueryMethods.public_instance_methods(false)` — the members Ruby defines
- * above `private` (query_methods.rb:1677). `CollectionProxy` delegates exactly
- * this set to `scope` (collection_proxy.rb:1128-1137), so the boundary is a
+ * above the first `protected` (query_methods.rb:1604). `CollectionProxy`
+ * delegates exactly this set to `scope` (collection_proxy.rb:1128-1137), so the boundary is a
  * fact about this module and is expressed here rather than transcribed there.
  *
  * @internal
@@ -2644,7 +2644,6 @@ export const QueryMethodsPublicInstanceMethods = {
   leftOuterJoins,
   leftJoins,
   arel,
-  arelColumns,
   includesBang,
   eagerLoadBang,
   preloadBang,
@@ -2714,12 +2713,29 @@ export const QueryMethodsPublicInstanceMethods = {
   without,
   excludingBang,
   constructJoinDependency,
+} as const;
+
+/**
+ * The members between query_methods.rb's two `protected` keywords
+ * (query_methods.rb:1604 and query_methods.rb:1663) and the following
+ * `private` (query_methods.rb:1677). Ruby excludes `protected` members from
+ * `public_instance_methods(false)` exactly as it excludes private ones, so
+ * `CollectionProxy` delegates none of them to `scope`
+ * (collection_proxy.rb:1128-1137); they ride the same mixin here so
+ * `relation.ts` does not redeclare a second copy.
+ *
+ * @internal
+ */
+export const QueryMethodsProtectedInstanceMethods = {
+  // query_methods.rb:1604 (`protected`).
   buildSubquery,
   buildWhereClause,
   // Mirrors `alias :build_having_clause :build_where_clause`
   // (query_methods.rb:1654) — HAVING conditions parse identically to WHERE.
   buildHavingClause: buildWhereClause,
   asyncBang,
+  // query_methods.rb:1663 (a second `protected` section).
+  arelColumns,
 } as const;
 
 /**
@@ -2775,6 +2791,7 @@ export const QueryMethodsPrivateInstanceMethods = {
 
 export const QueryMethodBangs = {
   ...QueryMethodsPublicInstanceMethods,
+  ...QueryMethodsProtectedInstanceMethods,
   ...QueryMethodsPrivateInstanceMethods,
 } as const;
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2626,8 +2626,9 @@ export function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]):
 /**
  * `QueryMethods.public_instance_methods(false)` — the members Ruby defines
  * above the first `protected` (query_methods.rb:1604). `CollectionProxy`
- * delegates exactly this set to `scope` (collection_proxy.rb:1128-1137), so the boundary is a
- * fact about this module and is expressed here rather than transcribed there.
+ * delegates exactly this set to `scope` (collection_proxy.rb:1128-1137), so
+ * the boundary is a fact about this module and is expressed here rather than
+ * transcribed there.
  *
  * @internal
  */
@@ -2716,9 +2717,9 @@ export const QueryMethodsPublicInstanceMethods = {
 } as const;
 
 /**
- * The members between query_methods.rb's two `protected` keywords
- * (query_methods.rb:1604 and query_methods.rb:1663) and the following
- * `private` (query_methods.rb:1677). Ruby excludes `protected` members from
+ * The members in query_methods.rb's two `protected` sections
+ * (query_methods.rb:1604 and query_methods.rb:1663, the second running to
+ * `private` at query_methods.rb:1677). Ruby excludes `protected` members from
  * `public_instance_methods(false)` exactly as it excludes private ones, so
  * `CollectionProxy` delegates none of them to `scope`
  * (collection_proxy.rb:1128-1137); they ride the same mixin here so


### PR DESCRIPTION
Two `CollectionProxy` convergences, plus one call-site seam rename. The third
story in the bundle turned out not to reproduce and is **blocked**, not closed —
details at the bottom.

## 1. `keys` / `entries` retired (`retire-collection-proxy-keys-and-entries`)

`CollectionProxy#keys` and `#entries` are deleted. Rails has neither:
`delegate ... to: :records` (`relation/delegation.rb:100-103`) does not list
them, and `Enumerable` gives `each_with_index` / `each_entry`, not a JS index
iterator. `[...proxy].keys()` / `[...proxy].entries()` already work through
`[Symbol.iterator]`, which IS the ported iteration seam, so the surface was
redundant rather than load-bearing — option 1 of the story's preference order.

Its one caller, the trails-only `collection-proxy.test.ts` case
`"keys / entries work (values intentionally not added)"`, is retired with them.
No new `@noRailsEquivalent` tag and no allowlist row;
`pnpm parity:api:extra --package activerecord` for
`associations/collection-proxy.ts` stays at **1 novel** (`new`).

## 2. Protected boundary made structural (`express-mixin-protected-boundary-structurally`)

`QueryMethods` has two `protected` sections — `query_methods.rb:1604`
(`build_subquery`, `build_where_clause` plus its `build_having_clause` alias at
`:1654`, `async!`) and `query_methods.rb:1663` (`arel_columns`). Ruby excludes
protected members from `public_instance_methods(false)` exactly as it excludes
private ones, so `CollectionProxy`'s delegate list
(`collection_proxy.rb:1128-1137`) contains none of those five names.

A new `QueryMethodsProtectedInstanceMethods` object sits between the public and
private ones in `relation/query-methods.ts`, holding them in Rails source order
at those two boundaries, and composes into `QueryMethodBangs` alongside the
other two. `MIXIN_PUBLIC_INSTANCE_METHODS` still reads only the public objects'
keys, so `buildSubquery`, `buildWhereClause`, `buildHavingClause`, `asyncBang`
and `arelColumns` are no longer own properties of `CollectionProxy.prototype`
(verified). `CollectionProxy extends Relation`, so the implementations stay
reachable through the prototype chain — only the delegate-to-`scope` forwarding
goes away, which is what Rails does.

`collection-proxy-delegate-methods.trails.test.ts` still passes unchanged.

## 3. `load_target` seam named at the delegate call site

`wrapCollectionProxy`'s async record-delegate path reads through
`target.loadTarget()` rather than `target.load()`, naming the method Rails
resolves every `to: :records` delegate through (`CollectionProxy#records` →
`load_target`, `collection_proxy.rb:1024-1026`). Behavior is unchanged —
`loadTarget()` *is* `load()` — the call site now says which Rails method it is.

## Story 3 of the bundle is blocked, not closed

`proxy-record-delegates-read-through-merging-load-target` asserted that a
`to: :records` delegate on a proxy holding built-but-unsaved records requeries
without seeing them. **It does not reproduce on `main`.** The unloaded path
routes through `CollectionProxy#load()`, which already performs
`@target = merge_target_lists(find_target, target)`
(`collection_association.rb:270-278`). I probed the whole delegate surface —
`map`, `each`, `filter`, `slice`, `at`, `asJson`, `sort`, `partition`, `toFs`,
`reverse`, `shuffle`, `rotate`, the set operators — on both a persisted owner
and the null-scope new-record owner arm: every one reports the built record. So
acceptance criterion 1 (a regression test that FAILS on baseline) is
unsatisfiable as written.

The residue was criterion 2: removing the two `await`s #6759 added to
`has-many-through-associations.test.ts`. Ruby's `load_target` is synchronous
because Ruby has blocking IO; trails' delegate must issue the `find_target`
query on an unloaded proxy, so the call cannot be synchronous. Answering from
the in-memory target instead would *drop* the query Rails performs and be
strictly less faithful. That is the ratified no-blocking-IO language
shortcoming, so the `await`s stay and the story is blocked with that finding
rather than closed by a better justification.

## Gates

- `pnpm parity:api:calls` — OK, zero rows added (912 baselined, unchanged).
- `pnpm parity:api:calls:args` — OK, zero rows added (169 baselined shape rows).
- `pnpm parity:api:extra --package activerecord` — no new novel surface.
- `pnpm typecheck`, `pnpm lint` — clean.
- `associations/` suite green on SQLite locally; PG and MySQL/MariaDB via CI.

Closes-story: retire-collection-proxy-keys-and-entries
Closes-story: express-mixin-protected-boundary-structurally
