### PR TITLE
refactor(activerecord): force load_records from preloaded_records, converge ensureMutable's HABTM arm and the safeKlass wrappers

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -456,14 +456,15 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // for every method except `:destroy` (whose per-record callbacks handle it).
     // `klass` is the ASSOCIATION's klass (the target model), not the source
     // reflection's — a polymorphic source belongs_to has none, and taggings'
+    // `taggable` is exactly such a source.
     const sourceRefl = (ownRefl as { sourceReflection?: SourceCounterReflection } | undefined)
       ?.sourceReflection;
     if (method !== "destroy" && sourceRefl?.options?.counterCache) {
       const counter = sourceRefl.counterCacheColumn?.();
-      const klass = this.klass as unknown as {
+      const klass = this.klass as {
         decrementCounter?: (col: string, ids: unknown) => Promise<unknown>;
       };
-      if (typeof counter === "string" && klass?.decrementCounter) {
+      if (typeof counter === "string" && klass.decrementCounter) {
         await klass.decrementCounter(
           counter,
           records.map((record) => (record as any).id),

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -22,14 +22,6 @@ import { associationKeysEqual } from "./key-normalization.js";
 import { isThenable } from "./collection-association.js";
 import { runAllCallbacks } from "@blazetrails/activemodel";
 
-function safeKlass(refl: { klass?: unknown } | null | undefined): any {
-  try {
-    return refl?.klass ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation
  */
@@ -464,15 +456,13 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // for every method except `:destroy` (whose per-record callbacks handle it).
     // `klass` is the ASSOCIATION's klass (the target model), not the source
     // reflection's — a polymorphic source belongs_to has none, and taggings'
-    // `taggable` is exactly such a source. `safeKlass` stays defensive
-    // (a polymorphic source has no klass at all).
     const sourceRefl = (ownRefl as { sourceReflection?: SourceCounterReflection } | undefined)
       ?.sourceReflection;
     if (method !== "destroy" && sourceRefl?.options?.counterCache) {
       const counter = sourceRefl.counterCacheColumn?.();
-      const klass = safeKlass({ klass: this.klass }) as {
+      const klass = this.klass as unknown as {
         decrementCounter?: (col: string, ids: unknown) => Promise<unknown>;
-      } | null;
+      };
       if (typeof counter === "string" && klass?.decrementCounter) {
         await klass.decrementCounter(
           counter,
@@ -687,7 +677,7 @@ async function saveThroughRecord(this: HasManyThroughAssociation, record: Base):
   // model on a secondary connection (HABTM "alternate database") has not been
   // reflected by the time we get here — assigning its FK would raise
   // UnknownAttributeError. No Rails counterpart; purely the async-schema seam.
-  const throughKlass = safeKlass(this.throughReflection() as { klass?: unknown } | null);
+  const throughKlass = (this.throughReflection() as { klass?: any } | null)?.klass;
   if (typeof throughKlass?.ensureSchemaLoaded === "function") {
     await throughKlass.ensureSchemaLoaded();
   }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -13,14 +13,6 @@ import {
   throughTargetScope,
 } from "./through-association.js";
 
-function safeKlass(refl: { klass?: unknown } | null | undefined): any {
-  try {
-    return refl?.klass ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Mirrors: ActiveRecord::Associations::HasOneThroughAssociation
  */

--- a/packages/activerecord/src/associations/preloader.ts
+++ b/packages/activerecord/src/associations/preloader.ts
@@ -60,7 +60,7 @@ export class Preloader {
     // `materialize()`, driven from the `isEmpty()` check in `Batch`.
     this._materialized = !isRelation(this.records);
     if (this._materialized) {
-      this._tree.preloadedRecords = this.records as Base[];
+      this._tree.setPreloadedRecords(this.records as Base[]);
     }
   }
 
@@ -76,7 +76,7 @@ export class Preloader {
   async isEmpty(): Promise<boolean> {
     if (this.associations == null) return true;
     await this.materialize();
-    return this._tree.preloadedRecords.length === 0;
+    return (await this._tree.preloadedRecords()).length === 0;
   }
 
   /**
@@ -85,21 +85,25 @@ export class Preloader {
    */
   async materialize(): Promise<void> {
     if (this._materialized) return;
-    this._tree.preloadedRecords = await (this.records as Relation<Base>);
+    this._tree.setPreloadedRecords(await (this.records as Relation<Base>));
     this._materialized = true;
   }
 
   async call(): Promise<Association[]> {
     const batch = new Batch([this], this._availableRecords);
     await batch.call();
-    return this.loaders;
+    return this.loaders();
   }
 
   get branches(): Branch[] {
     return this._tree.children;
   }
 
-  get loaders(): Association[] {
-    return this.branches.flatMap((b) => b.loaders);
+  async loaders(): Promise<Association[]> {
+    const loaders: Association[] = [];
+    for (const branch of this.branches) {
+      loaders.push(...(await branch.loaders()));
+    }
+    return loaders;
   }
 }

--- a/packages/activerecord/src/associations/preloader/association-preloaded-records-forcing.trails.test.ts
+++ b/packages/activerecord/src/associations/preloader/association-preloaded-records-forcing.trails.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Preloader::Association#preloaded_records forces `load_records`.
+ *
+ * Rails' reader is `load_records unless defined?(@preloaded_records)`
+ * (preloader/association.rb:153-157), so a preloader used outside the `Batch`
+ * runner still answers the queried records rather than an empty array. The
+ * guard is on the ivar being *assigned*, not on the value being present, so a
+ * legitimately-empty preload does not re-run the query.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../../index.js";
+import { fixtures } from "../../test-fixtures.js";
+import { Preloader } from "../preloader.js";
+import { Author } from "../../test-helpers/models/author.js";
+import { Post } from "../../test-helpers/models/post.js";
+
+registerModel(Author);
+registerModel(Post);
+
+describe("Preloader::Association#preloaded_records forcing", () => {
+  const { authors } = fixtures(["authors", "posts"]);
+
+  it("loads the records when read before the batch runs the loader", async () => {
+    const david = authors("david");
+    const [loader] = await new Preloader({
+      records: [david],
+      associations: ["posts"],
+      associateByDefault: false,
+    }).loaders();
+
+    expect(loader.isRun()).toBe(false);
+
+    const records = await loader.preloadedRecords();
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every((record) => record instanceof Post)).toBe(true);
+  });
+
+  it("does not re-run the query for an empty preload", async () => {
+    const david = authors("david");
+    const [loader] = await new Preloader({
+      records: [david],
+      associations: ["posts"],
+      associateByDefault: false,
+    }).loaders();
+
+    await loader.loadRecords([]);
+    const queryCount = { n: 0 };
+    const original = loader.loadRecords.bind(loader);
+    loader.loadRecords = async (...args: Parameters<typeof original>) => {
+      queryCount.n += 1;
+      return original(...args);
+    };
+
+    expect(await loader.preloadedRecords()).toEqual([]);
+    expect(queryCount.n).toBe(0);
+  });
+});

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -57,12 +57,12 @@ export class Association {
     return this.klass.tableName;
   }
 
-  futureClasses(): (typeof Base)[] {
+  async futureClasses(): Promise<(typeof Base)[]> {
     if (this.isRun()) return [];
     return [this.klass];
   }
 
-  runnableLoaders(): Association[] {
+  async runnableLoaders(): Promise<Association[]> {
     return [this];
   }
 
@@ -92,8 +92,16 @@ export class Association {
     return this._recordsByOwner!;
   }
 
-  get preloadedRecords(): Base[] {
-    return this._preloadedRecords ?? [];
+  /** Mirrors: Preloader::Association#preloaded_records
+   *  (`preloader/association.rb:153-157`) — the reader forces the preload
+   *  query on first access. Ruby's `defined?(@preloaded_records)` is an
+   *  assignment check, so the guard is on the backing field being unassigned:
+   *  a legitimately-empty preload must not re-run the query. */
+  async preloadedRecords(): Promise<Base[]> {
+    if (this._preloadedRecords === undefined) {
+      await this.loadRecords();
+    }
+    return this._preloadedRecords!;
   }
 
   get associationKeyName(): string | string[] {

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -36,7 +36,10 @@ export class Batch {
     let branches: Branch[] = this._preloaders.flatMap((p) => p.branches);
 
     while (branches.length > 0) {
-      const loaders = branches.flatMap((b) => b.runnableLoaders());
+      const loaders: Association[] = [];
+      for (const branch of branches) {
+        loaders.push(...(await branch.runnableLoaders()));
+      }
 
       for (const loader of loaders) {
         const available = this._availableRecords.get(loader.klass.baseClass);
@@ -44,15 +47,14 @@ export class Batch {
       }
 
       if (loaders.length > 0) {
-        const futureTables = new Set(
-          branches.flatMap((branch) => {
-            const futureClasses = branch.futureClasses();
-            const runnableClasses = branch.runnableLoaders().map((l) => l.klass);
-            return futureClasses
-              .filter((k) => !runnableClasses.includes(k))
-              .map((k) => k.tableName);
-          }),
-        );
+        const futureTables = new Set<string>();
+        for (const branch of branches) {
+          const futureClasses = await branch.futureClasses();
+          const runnableClasses = (await branch.runnableLoaders()).map((l) => l.klass);
+          for (const k of futureClasses) {
+            if (!runnableClasses.includes(k)) futureTables.add(k.tableName);
+          }
+        }
 
         let targetLoaders = loaders.filter((l) => !futureTables.has(l.tableName));
         if (targetLoaders.length === 0) targetLoaders = loaders;
@@ -67,7 +69,7 @@ export class Batch {
       const inProgress: Branch[] = [];
       for (const branch of branches) {
         if (branch.isDone()) {
-          this._setDefaultsForUncoveredRecords(branch);
+          await this._setDefaultsForUncoveredRecords(branch);
           finished.push(branch);
         } else {
           inProgress.push(branch);
@@ -78,17 +80,17 @@ export class Batch {
     }
   }
 
-  private _setDefaultsForUncoveredRecords(branch: Branch): void {
+  private async _setDefaultsForUncoveredRecords(branch: Branch): Promise<void> {
     if (branch.isRoot() || !branch.association) return;
 
     const coveredRecords = new Set<Base>();
-    for (const loader of branch.loaders) {
+    for (const loader of await branch.loaders()) {
       for (const owner of loader.owners) {
         coveredRecords.add(owner);
       }
     }
 
-    for (const record of branch.sourceRecords) {
+    for (const record of await branch.sourceRecords()) {
       if (coveredRecords.has(record)) continue;
       // Record a preloaded-nil default on the real holder so readers gating on
       // `holder.isLoaded() && _loadedFromPreload` see it (RFC 0022).

--- a/packages/activerecord/src/associations/preloader/branch.ts
+++ b/packages/activerecord/src/associations/preloader/branch.ts
@@ -39,22 +39,34 @@ export class Branch {
     this._loaders = null;
   }
 
-  set preloadedRecords(records: Base[]) {
+  /** Mirrors: Preloader::Branch#preloaded_records= — `attr_writer`
+   *  (`preloader/branch.rb:9`). A JS property setter cannot pair with the
+   *  awaitable reader below, so the writer keeps the Rails name in `set` form. */
+  setPreloadedRecords(records: Base[]): void {
     this._preloadedRecords = records;
   }
 
-  get preloadedRecords(): Base[] {
+  /** Mirrors: Preloader::Branch#preloaded_records
+   *  (`preloader/branch.rb:68-70`). */
+  async preloadedRecords(): Promise<Base[]> {
     if (this._preloadedRecords !== undefined) return this._preloadedRecords;
     if (this.parent == null) {
       throw new Error("Root preloader branch requires preloadedRecords to be set before access");
     }
-    this._preloadedRecords = this.loaders.flatMap((l) => l.preloadedRecords);
+    const records: Base[] = [];
+    for (const loader of await this.loaders()) {
+      records.push(...(await loader.preloadedRecords()));
+    }
+    this._preloadedRecords = records;
     return this._preloadedRecords;
   }
 
-  futureClasses(): (typeof Base)[] {
-    const immediate = this.immediateFutureClasses();
-    const childClasses = this.children.flatMap((c) => c.futureClasses());
+  async futureClasses(): Promise<(typeof Base)[]> {
+    const immediate = await this.immediateFutureClasses();
+    const childClasses: (typeof Base)[] = [];
+    for (const child of this.children) {
+      childClasses.push(...(await child.futureClasses()));
+    }
     const seen = new Set<typeof Base>();
     return [...immediate, ...childClasses].filter((k) => {
       if (seen.has(k)) return false;
@@ -63,24 +75,26 @@ export class Branch {
     });
   }
 
-  immediateFutureClasses(): (typeof Base)[] {
+  async immediateFutureClasses(): Promise<(typeof Base)[]> {
     if (this.parent == null) {
       return [];
     }
 
     if (this.parent.isDone()) {
+      const classes: (typeof Base)[] = [];
+      for (const loader of await this.loaders()) {
+        classes.push(...(await loader.futureClasses()));
+      }
       const seen = new Set<typeof Base>();
-      return this.loaders
-        .flatMap((l) => l.futureClasses())
-        .filter((k) => {
-          if (seen.has(k)) return false;
-          seen.add(k);
-          return true;
-        });
+      return classes.filter((k) => {
+        if (seen.has(k)) return false;
+        seen.add(k);
+        return true;
+      });
     }
 
     const seen = new Set<typeof Base>();
-    return this.likelyReflections()
+    return (await this.likelyReflections())
       .filter((r) => !r.isPolymorphic())
       .flatMap((r) => r.chain.map((c: AbstractReflection) => c.klass))
       .filter((k) => {
@@ -90,10 +104,10 @@ export class Branch {
       });
   }
 
-  targetClasses(): (typeof Base)[] {
+  async targetClasses(): Promise<(typeof Base)[]> {
     if (this.isDone()) {
       const seen = new Set<typeof Base>();
-      return this.preloadedRecords
+      return (await this.preloadedRecords())
         .map((r) => r.constructor as typeof Base)
         .filter((k) => {
           if (seen.has(k)) return false;
@@ -104,7 +118,7 @@ export class Branch {
 
     if (this.parent!.isDone()) {
       const seen = new Set<typeof Base>();
-      return this.loaders
+      return (await this.loaders())
         .map((l) => l.klass)
         .filter((k) => {
           if (seen.has(k)) return false;
@@ -114,7 +128,7 @@ export class Branch {
     }
 
     const seen = new Set<typeof Base>();
-    return this.likelyReflections()
+    return (await this.likelyReflections())
       .filter((r) => !r.isPolymorphic())
       .map((r) => r.klass)
       .filter((k) => {
@@ -124,8 +138,8 @@ export class Branch {
       });
   }
 
-  likelyReflections(): AbstractReflection[] {
-    const parentClasses = this.parent!.targetClasses();
+  async likelyReflections(): Promise<AbstractReflection[]> {
+    const parentClasses = await this.parent!.targetClasses();
     const result: AbstractReflection[] = [];
     for (const parentKlass of parentClasses) {
       const refl = parentKlass._reflectOnAssociation(this.association!);
@@ -138,25 +152,29 @@ export class Branch {
     return this.parent === null;
   }
 
-  get sourceRecords(): Base[] {
+  async sourceRecords(): Promise<Base[]> {
     if (this.isRoot()) return [];
-    return this.parent!.preloadedRecords;
+    return this.parent!.preloadedRecords();
   }
 
   isDone(): boolean {
     return this.isRoot() || (this._loaders != null && this._loaders.every((l) => l.isRun()));
   }
 
-  runnableLoaders(): Association[] {
+  async runnableLoaders(): Promise<Association[]> {
     if (this.isRoot()) return [];
-    return this.loaders.flatMap((l) => l.runnableLoaders()).filter((l) => !l.isRun());
+    const runnable: Association[] = [];
+    for (const loader of await this.loaders()) {
+      runnable.push(...(await loader.runnableLoaders()));
+    }
+    return runnable.filter((l) => !l.isRun());
   }
 
-  groupedRecords(): Map<AbstractReflection, Base[]> {
+  async groupedRecords(): Promise<Map<AbstractReflection, Base[]>> {
     const h = new Map<AbstractReflection, Base[]>();
-    const polymorphicParent = !this.isRoot() && this.parent!.isPolymorphic();
+    const polymorphicParent = !this.isRoot() && (await this.parent!.isPolymorphic());
 
-    for (const record of this.sourceRecords) {
+    for (const record of await this.sourceRecords()) {
       const reflection = (record.constructor as typeof Base)._reflectOnAssociation(
         this.association!,
       );
@@ -241,11 +259,11 @@ export class Branch {
     });
   }
 
-  isPolymorphic(): boolean {
+  async isPolymorphic(): Promise<boolean> {
     if (this.isRoot()) return false;
     if (this._polymorphic !== undefined) return this._polymorphic;
 
-    this._polymorphic = this.sourceRecords.some((record) => {
+    this._polymorphic = (await this.sourceRecords()).some((record) => {
       const reflection = (record.constructor as typeof Base)._reflectOnAssociation(
         this.association!,
       );
@@ -254,9 +272,9 @@ export class Branch {
     return this._polymorphic;
   }
 
-  get loaders(): Association[] {
+  async loaders(): Promise<Association[]> {
     if (this._loaders !== null) return this._loaders;
-    this._loaders = [...this.groupedRecords()].flatMap(([reflection, reflectionRecords]) =>
+    this._loaders = [...(await this.groupedRecords())].flatMap(([reflection, reflectionRecords]) =>
       this.preloadersForReflection(reflection, reflectionRecords),
     );
     return this._loaders;

--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -77,20 +77,20 @@ type HasManyHost = {
 describe("Preloader::ThroughAssociation#through_scope has_many raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
 
-  function throughLoader(owners: Member[], name: string): ThroughAssociation {
-    const loaders = new Preloader({
+  async function throughLoader(owners: Member[], name: string): Promise<ThroughAssociation> {
+    const loaders = await new Preloader({
       records: owners,
       associations: [name],
       associateByDefault: false,
-    }).loaders;
+    }).loaders();
     const loader = loaders.find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
   }
 
-  it("nests the reflection scope's raw join under the source reflection, as Rails does", () => {
+  it("nests the reflection scope's raw join under the source reflection, as Rails does", async () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "rawClubs");
+    const loader = await throughLoader([groucho], "rawClubs");
     expect(() =>
       (loader as unknown as { throughScope: () => { toSql: () => string } }).throughScope().toSql(),
     ).toThrow(ConfigurationError);

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -138,21 +138,23 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     "authors",
   ]);
 
-  function throughScopeSql(owners: Member[], name: string): string {
-    const loader = new Preloader({
-      records: owners,
-      associations: [name],
-      associateByDefault: false,
-    }).loaders.find((l) => l instanceof ThroughAssociation);
+  async function throughScopeSql(owners: Member[], name: string): Promise<string> {
+    const loader = (
+      await new Preloader({
+        records: owners,
+        associations: [name],
+        associateByDefault: false,
+      }).loaders()
+    ).find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return (loader as unknown as { throughScope: () => { toSql: () => string } })
       .throughScope()
       .toSql();
   }
 
-  it("nests the two-level scope join under the source reflection on the through query", () => {
+  it("nests the two-level scope join under the source reflection on the through query", async () => {
     const groucho = members("groucho");
-    const sql = throughScopeSql([groucho], "davidCategorizedClub");
+    const sql = await throughScopeSql([groucho], "davidCategorizedClub");
     // The deeper `categorizations` join is realized on the through query by
     // nesting the scope's `.leftJoins({ ":category": ":categorizations" })` under the
     // source reflection, and the copied full where_clause qualifies it, so the
@@ -166,9 +168,9 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     );
   });
 
-  it("nests an explicit scope includes under the source reflection on the through query", () => {
+  it("nests an explicit scope includes under the source reflection on the through query", async () => {
     const groucho = members("groucho");
-    const sql = throughScopeSql([groucho], "davidIncludedCategorizedClub");
+    const sql = await throughScopeSql([groucho], "davidIncludedCategorizedClub");
     // Rails nests `values[:includes]` under the source reflection, joining the
     // deeper tables so the copied `categorizations.author_id` predicate resolves
     // on the through query (rather than being left on the source query where the
@@ -180,9 +182,9 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     );
   });
 
-  it("nests a belongs_to scope includes onto the through query for a has_many-through", () => {
+  it("nests a belongs_to scope includes onto the through query for a has_many-through", async () => {
     const groucho = members("groucho");
-    const sql = throughScopeSql([groucho], "generalClubs");
+    const sql = await throughScopeSql([groucho], "generalClubs");
     // `category` (belongs_to on Club) is a 1:1 join, so even for this collection
     // target it is nested onto the through query and the `categories.name`
     // predicate resolves there — not left on the source query where `categories`
@@ -191,9 +193,9 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     expect(sql).toMatch(new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categories.name"))}`));
   });
 
-  it("nests a has_many-through fan-out include+predicate onto the through query via eager-load", () => {
+  it("nests a has_many-through fan-out include+predicate onto the through query via eager-load", async () => {
     const groucho = members("groucho");
-    const sql = throughScopeSql([groucho], "categorizedClubs");
+    const sql = await throughScopeSql([groucho], "categorizedClubs");
     // Rails nests the scope's `values[:includes]` under the source reflection
     // and eager-loads it; the JoinDependency dedups the middle records by PK, so
     // the two-level `categorizations` join is realized on the through query and

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -133,12 +133,14 @@ type HasOneHost = {
 describe("Preloader::ThroughAssociation#through_scope nested raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
 
-  function throughLoader(owners: Member[], name: string): ThroughAssociation {
-    const loader = new Preloader({
-      records: owners,
-      associations: [name],
-      associateByDefault: false,
-    }).loaders.find((l) => l instanceof ThroughAssociation);
+  async function throughLoader(owners: Member[], name: string): Promise<ThroughAssociation> {
+    const loader = (
+      await new Preloader({
+        records: owners,
+        associations: [name],
+        associateByDefault: false,
+      }).loaders()
+    ).find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
   }
@@ -149,35 +151,33 @@ describe("Preloader::ThroughAssociation#through_scope nested raw-join handling",
       .toSql();
   }
 
-  it("raises when the outer reflection's own scope carries a raw join", () => {
+  it("raises when the outer reflection's own scope carries a raw join", async () => {
     const groucho = members("groucho");
-    expect(() => buildSql(throughLoader([groucho], "rawMembersOfClub"))).toThrow(
-      ConfigurationError,
-    );
+    const loader = await throughLoader([groucho], "rawMembersOfClub");
+    expect(() => buildSql(loader)).toThrow(ConfigurationError);
   });
 
-  it("raises when only the source sub-chain carries a raw join, matching Rails", () => {
+  it("raises when only the source sub-chain carries a raw join, matching Rails", async () => {
     const groucho = members("groucho");
     // The sub-chain's raw join is flattened into `reflection_scope`; the
     // flattened where_clause is non-empty, so Rails nests it under the source
     // reflection at the outer build and raises — it is NOT deferred.
-    expect(() => buildSql(throughLoader([groucho], "membersViaRawClub"))).toThrow(
-      ConfigurationError,
-    );
+    const loader = await throughLoader([groucho], "membersViaRawClub");
+    expect(() => buildSql(loader)).toThrow(ConfigurationError);
   });
 
-  it("raises for a has_one nested through whose scope carries a raw join", () => {
+  it("raises for a has_one nested through whose scope carries a raw join", async () => {
     const groucho = members("groucho");
-    expect(() => buildSql(throughLoader([groucho], "rawCategoryOfClub"))).toThrow(
-      ConfigurationError,
-    );
+    const loader = await throughLoader([groucho], "rawCategoryOfClub");
+    expect(() => buildSql(loader)).toThrow(ConfigurationError);
   });
 
-  it("does NOT raise when the chain carries a raw join but an empty where_clause", () => {
+  it("does NOT raise when the chain carries a raw join but an empty where_clause", async () => {
     const groucho = members("groucho");
     // Empty flattened where_clause → Rails skips the `elsif` branch entirely, so
     // the raw join is never nested and nothing raises.
-    expect(() => buildSql(throughLoader([groucho], "noWhereRawMembersOfClub"))).not.toThrow();
+    const loader = await throughLoader([groucho], "noWhereRawMembersOfClub");
+    expect(() => buildSql(loader)).not.toThrow();
   });
 
   it("raises ConfigurationError on preload, matching Rails", async () => {

--- a/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
@@ -77,20 +77,20 @@ type HasOneHost = {
 describe("Preloader::ThroughAssociation#through_scope raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
 
-  function throughLoader(owners: Member[], name: string): ThroughAssociation {
-    const loaders = new Preloader({
+  async function throughLoader(owners: Member[], name: string): Promise<ThroughAssociation> {
+    const loaders = await new Preloader({
       records: owners,
       associations: [name],
       associateByDefault: false,
-    }).loaders;
+    }).loaders();
     const loader = loaders.find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
   }
 
-  it("nests the reflection scope's raw join under the source reflection, as Rails does", () => {
+  it("nests the reflection scope's raw join under the source reflection, as Rails does", async () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "rawGeneralClub");
+    const loader = await throughLoader([groucho], "rawGeneralClub");
     // Rails: `joins!(source_reflection.name => values[:joins])`. Building the
     // through query then raises ConfigurationError because the raw string is
     // treated as an association name that Club has no reflection for.

--- a/packages/activerecord/src/associations/preloader/through-association-records-by-owner.trails.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-records-by-owner.trails.test.ts
@@ -4,9 +4,8 @@
  * Rails reaches `through_records_by_owner` / `source_records_by_owner` through
  * the public `records_by_owner` reader, which forces `load_records` before
  * answering (preloader/association.rb:148-151), so neither reader can observe
- * an unloaded child loader. trails' readers are synchronous — `middle_records`
- * is reached from `runnable_loaders` / `future_classes`, which cannot await —
- * so `recordsByOwner` awaits the children itself.
+ * an unloaded child loader. trails' `loadRecords` is async, so `recordsByOwner`
+ * awaits the children itself.
  *
  * The `Batch` runner always runs the through and source loaders before calling
  * `recordsByOwner`, so this pins the *direct* call, which nothing else covers:
@@ -29,19 +28,21 @@ registerModel(Organization);
 describe("Preloader::ThroughAssociation#records_by_owner child forcing", () => {
   const { members, memberDetails } = fixtures(["members", "organizations", "memberDetails"]);
 
-  function throughLoader(owners: Member[], name: string): ThroughAssociation {
-    const loader = new Preloader({
-      records: owners,
-      associations: [name],
-      associateByDefault: false,
-    }).loaders.find((l) => l instanceof ThroughAssociation);
+  async function throughLoader(owners: Member[], name: string): Promise<ThroughAssociation> {
+    const loader = (
+      await new Preloader({
+        records: owners,
+        associations: [name],
+        associateByDefault: false,
+      }).loaders()
+    ).find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
   }
 
   it("loads the through and source records when called before the batch runs them", async () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "organizationMemberDetails_2");
+    const loader = await throughLoader([groucho], "organizationMemberDetails_2");
 
     expect(loader.isRun()).toBe(false);
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -47,9 +47,15 @@ export class ThroughAssociation extends Association {
     super(klass, owners, reflection, preloadScope, reflectionScope, associateByDefault);
   }
 
-  get preloadedRecords(): Base[] {
+  /** Mirrors: Preloader::ThroughAssociation#preloaded_records
+   *  (`preloader/through_association.rb:7-9`). */
+  async preloadedRecords(): Promise<Base[]> {
     if (this._throughPreloadedRecords !== undefined) return this._throughPreloadedRecords;
-    this._throughPreloadedRecords = this.sourcePreloaders().flatMap((l) => l.preloadedRecords);
+    const records: Base[] = [];
+    for (const loader of await this.sourcePreloaders()) {
+      records.push(...(await loader.preloadedRecords()));
+    }
+    this._throughPreloadedRecords = records;
     return this._throughPreloadedRecords;
   }
 
@@ -83,11 +89,11 @@ export class ThroughAssociation extends Association {
     // which cannot await — so the forcing happens here, on the one path that
     // can. Through loaders first: `source_preloaders` is derived from the
     // middle records they produce.
-    await Promise.all(this.throughPreloaders().map((l) => l.recordsByOwner()));
-    await Promise.all(this.sourcePreloaders().map((l) => l.recordsByOwner()));
+    await Promise.all((await this.throughPreloaders()).map((l) => l.recordsByOwner()));
+    await Promise.all((await this.sourcePreloaders()).map((l) => l.recordsByOwner()));
 
-    const throughRecordsByOwner = this.throughRecordsByOwner();
-    const sourceRecordsByOwner = this.sourceRecordsByOwner();
+    const throughRecordsByOwner = await this.throughRecordsByOwner();
+    const sourceRecordsByOwner = await this.sourceRecordsByOwner();
 
     const throughRefl = this.throughReflection;
     const firstOwner = this.owners[0] as any;
@@ -126,7 +132,7 @@ export class ThroughAssociation extends Association {
 
       // Preserve scope ordering via preload index
       if (this.scope?.orderValues?.length > 0) {
-        const index = this.preloadIndex();
+        const index = await this.preloadIndex();
         records.sort((a, b) => (index.get(a) ?? 0) - (index.get(b) ?? 0));
       }
 
@@ -147,35 +153,48 @@ export class ThroughAssociation extends Association {
     return result;
   }
 
-  runnableLoaders(): Association[] {
-    if (this.dataAvailable()) {
+  async runnableLoaders(): Promise<Association[]> {
+    if (await this.dataAvailable()) {
       return [this];
     }
 
-    const throughPreloaders = this.throughPreloaders();
+    const throughPreloaders = await this.throughPreloaders();
     if (throughPreloaders.every((l) => l.isRun())) {
-      return this.sourcePreloaders().flatMap((l) => l.runnableLoaders());
+      const runnable: Association[] = [];
+      for (const loader of await this.sourcePreloaders()) {
+        runnable.push(...(await loader.runnableLoaders()));
+      }
+      return runnable;
     }
 
-    return throughPreloaders.flatMap((l) => l.runnableLoaders());
+    const runnable: Association[] = [];
+    for (const loader of throughPreloaders) {
+      runnable.push(...(await loader.runnableLoaders()));
+    }
+    return runnable;
   }
 
-  futureClasses(): (typeof Base)[] {
+  async futureClasses(): Promise<(typeof Base)[]> {
     if (this.isRun()) return [];
 
-    const throughPreloaders = this.throughPreloaders();
+    const throughPreloaders = await this.throughPreloaders();
     if (throughPreloaders.every((l) => l.isRun())) {
+      const sourceClasses: (typeof Base)[] = [];
+      for (const loader of await this.sourcePreloaders()) {
+        sourceClasses.push(...(await loader.futureClasses()));
+      }
       const seen = new Set<typeof Base>();
-      return this.sourcePreloaders()
-        .flatMap((l) => l.futureClasses())
-        .filter((k) => {
-          if (seen.has(k)) return false;
-          seen.add(k);
-          return true;
-        });
+      return sourceClasses.filter((k) => {
+        if (seen.has(k)) return false;
+        seen.add(k);
+        return true;
+      });
     }
 
-    const throughClasses = throughPreloaders.flatMap((l) => l.futureClasses());
+    const throughClasses: (typeof Base)[] = [];
+    for (const loader of throughPreloaders) {
+      throughClasses.push(...(await loader.futureClasses()));
+    }
     const sourceRefl = this.sourceReflection;
     const sourceClasses: (typeof Base)[] = [];
     if (sourceRefl) {
@@ -202,18 +221,18 @@ export class ThroughAssociation extends Association {
     });
   }
 
-  private dataAvailable(): boolean {
+  private async dataAvailable(): Promise<boolean> {
     return (
       this.owners.every((owner) => this.isLoaded(owner)) ||
-      (this.throughPreloaders().every((l) => l.isRun()) &&
-        this.sourcePreloaders().every((l) => l.isRun()))
+      ((await this.throughPreloaders()).every((l) => l.isRun()) &&
+        (await this.sourcePreloaders()).every((l) => l.isRun()))
     );
   }
 
-  private sourcePreloaders(): Association[] {
+  private async sourcePreloaders(): Promise<Association[]> {
     if (this._sourcePreloaders !== undefined) return this._sourcePreloaders;
 
-    const middleRecords = this.middleRecords();
+    const middleRecords = await this.middleRecords();
     const sourceRefl = this.sourceReflection;
     if (!sourceRefl || middleRecords.length === 0) {
       return [];
@@ -266,11 +285,11 @@ export class ThroughAssociation extends Association {
       scope: sourceScope,
       associateByDefault: false,
     });
-    this._sourcePreloaders = preloader.loaders;
+    this._sourcePreloaders = await preloader.loaders();
     return this._sourcePreloaders;
   }
 
-  private throughPreloaders(): Association[] {
+  private async throughPreloaders(): Promise<Association[]> {
     if (this._throughPreloaders !== undefined) return this._throughPreloaders;
 
     const throughRefl = this.throughReflection;
@@ -285,32 +304,32 @@ export class ThroughAssociation extends Association {
       scope: this.throughScope(),
       associateByDefault: false,
     });
-    this._throughPreloaders = preloader.loaders;
+    this._throughPreloaders = await preloader.loaders();
     return this._throughPreloaders;
   }
 
-  private middleRecords(): Base[] {
-    return [...this.throughRecordsByOwner().values()].flat();
+  private async middleRecords(): Promise<Base[]> {
+    return [...(await this.throughRecordsByOwner()).values()].flat();
   }
 
-  private sourceRecordsByOwner(): Map<Base, Base[]> {
-    this._sourceRecordsByOwner ??= this.sourcePreloaders()
+  private async sourceRecordsByOwner(): Promise<Map<Base, Base[]>> {
+    this._sourceRecordsByOwner ??= (await this.sourcePreloaders())
       .map((l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined)
       .reduce(merge, new Map<Base, Base[]>());
     return this._sourceRecordsByOwner ?? new Map();
   }
 
-  private throughRecordsByOwner(): Map<Base, Base[]> {
-    this._throughRecordsByOwner ??= this.throughPreloaders()
+  private async throughRecordsByOwner(): Promise<Map<Base, Base[]>> {
+    this._throughRecordsByOwner ??= (await this.throughPreloaders())
       .map((l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined)
       .reduce(merge, new Map<Base, Base[]>());
     return this._throughRecordsByOwner ?? new Map();
   }
 
-  private preloadIndex(): Map<Base, number> {
+  private async preloadIndex(): Promise<Map<Base, number>> {
     if (this._preloadIndex !== undefined) return this._preloadIndex;
     this._preloadIndex = new Map();
-    this.preloadedRecords.forEach((record, index) => {
+    (await this.preloadedRecords()).forEach((record, index) => {
       this._preloadIndex!.set(record, index);
     });
     return this._preloadIndex;

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -84,11 +84,8 @@ export class ThroughAssociation extends Association {
 
     // Rails reaches `through_records_by_owner` / `source_records_by_owner`
     // through the public `records_by_owner` reader, which forces `load_records`
-    // (preloader/association.rb:148-151). Both readers below are synchronous —
-    // `middle_records` calls them from `runnable_loaders` / `future_classes`,
-    // which cannot await — so the forcing happens here, on the one path that
-    // can. Through loaders first: `source_preloaders` is derived from the
-    // middle records they produce.
+    // (preloader/association.rb:148-151). Through loaders first:
+    // `source_preloaders` is derived from the middle records they produce.
     await Promise.all((await this.throughPreloaders()).map((l) => l.recordsByOwner()));
     await Promise.all((await this.sourcePreloaders()).map((l) => l.recordsByOwner()));
 

--- a/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
@@ -53,20 +53,20 @@ interface ThroughScopeProbe {
 describe("Preloader::ThroughAssociation#through_scope composite-PK through", () => {
   const { cpkOrders } = fixtures(["cpkOrders", "cpkTags", "cpkOrderTags"]);
 
-  function throughLoader(owners: CpkOrder[], name: string): ThroughAssociation {
-    const loaders = new Preloader({
+  async function throughLoader(owners: CpkOrder[], name: string): Promise<ThroughAssociation> {
+    const loaders = await new Preloader({
       records: owners,
       associations: [name],
       associateByDefault: false,
-    }).loaders;
+    }).loaders();
     const loader = loaders.find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
   }
 
-  it("JOINs the source and copies a mixed through+source predicate onto the composite-PK through query", () => {
+  it("JOINs the source and copies a mixed through+source predicate onto the composite-PK through query", async () => {
     const order = cpkOrders("cpk_groceries_order_1");
-    const loader = throughLoader([order], "tagsWithMixedCondition");
+    const loader = await throughLoader([order], "tagsWithMixedCondition");
     const sql = (loader as unknown as ThroughScopeProbe).throughScope().toSql();
     // The whole mixed predicate rides the through query (both column references
     // are the verbatim raw-SQL string, adapter-quoting-independent), and the

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -123,13 +123,17 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     "taggings",
   ]);
 
-  function throughLoader(owners: Author[], name: string, scope?: any): ThroughAssociation {
-    const loaders = new Preloader({
+  async function throughLoader(
+    owners: Author[],
+    name: string,
+    scope?: any,
+  ): Promise<ThroughAssociation> {
+    const loaders = await new Preloader({
       records: owners,
       associations: [name],
       scope,
       associateByDefault: false,
-    }).loaders;
+    }).loaders();
     const loader = loaders.find((l) => l instanceof ThroughAssociation);
     if (!loader) throw new Error("expected a ThroughAssociation loader");
     return loader;
@@ -137,7 +141,7 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
 
   it("carries annotate from the through reflection scope onto the through query", async () => {
     const david = authors("david");
-    const loader = throughLoader([david], "annotatedComments");
+    const loader = await throughLoader([david], "annotatedComments");
     const scope = (loader as any).throughScope();
     expect(scope.toSql()).toContain("preload-through");
 
@@ -146,9 +150,9 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     expect(comments.length).toBeGreaterThan(0);
   });
 
-  it("keeps a source-table condition on a collection source at the source stage, not the through query", () => {
+  it("keeps a source-table condition on a collection source at the source stage, not the through query", async () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithSourceCondition");
+    const loader = await throughLoader([david], "commentsWithSourceCondition");
     // Rails copies the full where_clause and eager-loads the source (JOIN
     // comments), whose JoinDependency dedups the middle records by PK — so the
     // source condition rides the through query with the source JOIN, resolving
@@ -159,27 +163,27 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     expect(sql).toMatch(/JOIN .*comments/);
   });
 
-  it("copies a through-table condition onto the through query for a collection source", () => {
+  it("copies a through-table condition onto the through query for a collection source", async () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithThroughCondition");
+    const loader = await throughLoader([david], "commentsWithThroughCondition");
     const scope = (loader as any).throughScope();
     const sql = scope.toSql();
     // The through-table predicate constrains the intermediate (posts) rows.
     expect(sql).toContain("Welcome to the weblog");
   });
 
-  it("copies a raw-SQL through-table condition onto the through query for a collection source", () => {
+  it("copies a raw-SQL through-table condition onto the through query for a collection source", async () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithRawThroughCondition");
+    const loader = await throughLoader([david], "commentsWithRawThroughCondition");
     const scope = (loader as any).throughScope();
     // Raw through-table predicate rides the through query (Rails' full
     // where_clause assignment), not the source query where `posts` is unjoined.
     expect(scope.toSql()).toContain("posts.title");
   });
 
-  it("does not copy a mixed through+source predicate onto the through query", () => {
+  it("does not copy a mixed through+source predicate onto the through query", async () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithMixedCondition");
+    const loader = await throughLoader([david], "commentsWithMixedCondition");
     const scope = (loader as any).throughScope();
     // The predicate references both `posts` (through) and `comments` (source) in
     // one node. Rails copies the full where_clause and JOINs the source, so both
@@ -223,7 +227,7 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
   it("cascades strict loading from the preload scope onto the through query", async () => {
     const david = authors("david");
 
-    const loader = throughLoader([david], "annotatedComments", Comment.all().strictLoading());
+    const loader = await throughLoader([david], "annotatedComments", Comment.all().strictLoading());
     const scope = (loader as any).throughScope();
     expect(scope.strictLoadingValue).toBe(true);
   });

--- a/packages/activerecord/src/associations/through-association.ts
+++ b/packages/activerecord/src/associations/through-association.ts
@@ -37,19 +37,6 @@ export interface ThroughAssociationHost {
   ensureMutable(): void;
 }
 
-// A third copy of the subclass files' `safeKlass`: `constructJoinAttributes`
-// needs `reflection.klass` before `checkValidityBang` has run, where the getter
-// throws. Not a Rails member, so hoisting it to a shared home would be new
-// non-Rails surface in a file `parity:api` scores — it stays file-local until
-// the guard itself is retired.
-function safeKlass(refl: { klass?: unknown } | null | undefined): any {
-  try {
-    return refl?.klass ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Wrap `block` in a transaction on the through-reflection's class.
  *
@@ -146,7 +133,7 @@ export function constructJoinAttributes(
   const refl = ctor._reflectOnAssociation?.(this.reflection.name);
   const sourceRefl = refl?.sourceReflection;
   if (!sourceRefl) return {};
-  const reflKlass = safeKlass(refl);
+  const reflKlass = refl.klass;
   const assocPk =
     (typeof sourceRefl.associationPrimaryKeyFor === "function"
       ? sourceRefl.associationPrimaryKeyFor(reflKlass)
@@ -160,9 +147,7 @@ export function constructJoinAttributes(
   // FK value. That form carries the (possibly unsaved) source record itself, so
   // owner autosave cascades to persist it — the FK-value form would stamp a nil
   // id for a new source record.
-  const compositeConstraints: string[] = reflKlass
-    ? compositeQueryConstraintsList.call(reflKlass)
-    : [];
+  const compositeConstraints: string[] = compositeQueryConstraintsList.call(reflKlass);
 
   let joinAttributes: Record<string, unknown>;
   if (
@@ -200,11 +185,6 @@ export function constructJoinAttributes(
  * @internal
  */
 export function ensureMutable(this: ThroughAssociationHost): void {
-  // HABTM associations are always mutable: the join model's right side is an
-  // implicit belongsTo, but our habtm reflection doesn't expose that chain.
-  // Rails reaches the same conclusion via source_reflection.belongs_to?.
-  if (this.reflection.macro === "hasAndBelongsToMany") return;
-
   const ctor = this.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
   const refl = ctor._reflectOnAssociation?.(this.reflection.name);
   // Rails' `reflection.has_one?`; the lightweight definition is the fallback

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "preloaded_records",
-    "call": "load_records",
-    "reason": "Verified per-site (RFC 0106): `load_records unless defined?(@preloaded_records)` (preloader/association.rb:155) — `loadRecords` is async in trails (it runs the preload query), so the synchronous getter cannot call it; it is awaited by `load()` (preloader/association.ts) before any reader touches `preloadedRecords`."
-  }
-]


### PR DESCRIPTION
Three related through/preloader convergences.

## 1. `Preloader::Association#preloaded_records` forces `load_records`

Rails (`preloader/association.rb:153-157`):

```ruby
def preloaded_records
  load_records unless defined?(@preloaded_records)
  @preloaded_records
end
```

trails ported the sibling `records_by_owner` as an awaitable reader that does
force, but `preloadedRecords` as a synchronous getter returning
`this._preloadedRecords ?? []` — so a preloader read outside the `Batch` runner
silently answered `[]` where Rails would have run the query, and the two
same-shaped Ruby readers were asymmetric for no Rails reason.

`preloadedRecords()` is now awaitable and guarded on the backing field being
**unassigned** — Ruby's `defined?(@preloaded_records)` is an assignment check,
not a truthiness one, so a legitimately-empty preload does not re-run the query.
The forcing cascades through the readers that reach it, each keeping its Rails
name and shape: `Branch#preloaded_records` / `#source_records` /
`#target_classes` / `#likely_reflections` / `#grouped_records` / `#polymorphic?`
/ `#loaders` / `#runnable_loaders` / `#future_classes`, `Preloader#loaders`, and
`ThroughAssociation#preloaded_records` / `#runnable_loaders` / `#future_classes`
/ `#source_preloaders` / `#through_preloaders` / `#data_available?`.

`Branch`'s `attr_writer :preloaded_records` (`preloader/branch.rb:9`) keeps the
Rails name in `setPreloadedRecords`, since a JS property setter cannot pair with
an awaitable reader.

The baselined row
`activerecord associations/preloader/association.ts preloaded_records load_records`
is deleted by hand (no `--write`, no reseed); `parity:api:calls` and
`:calls:args` are green and the mark tree is already tight.

New regression test: `association-preloaded-records-forcing.trails.test.ts`
pins both arms — a fresh loader read before the batch runs it returns the
queried records (fails on baseline, which returned `[]`), and an empty preload
does not re-issue the query.

## 2. HABTM passes `ensure_mutable` on its source reflection, not its macro

Rails' `ensure_mutable` (`through_association.rb:86-92`) is a single
unconditional `source_reflection.belongs_to?` test; HABTM passes it because the
synthesised join model carries a genuine `belongs_to` on the right-hand side.

trails opened the body with `if (this.reflection.macro === "hasAndBelongsToMany") return;`
— a branch Rails does not have, keyed on a macro Rails never inspects here, and
one that left the check permanently blind for HABTM.

The HABTM reflection already resolves a real `BelongsToReflection` source (the
join model's right side, built by `Builder::HasAndBelongsToMany`), verified
directly: `Developer._reflectOnAssociation("projects").sourceReflection` is a
`BelongsToReflection` whose `isBelongsTo()` is `true`. So the arm is deleted and
the body is Rails' single test for every macro.

## 3. The three `safeKlass` wrappers are retired

Rails reads `reflection.klass` directly in `construct_join_attributes`
(`through_association.rb:59`) with no guard, because raising `NameError` is the
intended outcome. Three files each carried a private `safeKlass` swallowing the
throw into `null`. That is not behaviour-neutral: in `constructJoinAttributes` a
null `reflKlass` emptied `compositeConstraints`, flipping the
`Array(association_primary_key) == composite_query_constraints_list` test to
false and silently routing the join into the FK-value arm instead of the
association-form arm — a wrong answer where Rails would have raised.

All three are gone (the `has-one-through-association.ts` copy was already dead
code) and `reflection.klass` is read directly at each site.

## Verification

- `pnpm vitest run packages/activerecord/src/associations/` — 112 files, 2039 passed
- `pnpm vitest run packages/activerecord/src/relation packages/activerecord/src/querying.test.ts packages/activerecord/src/scoping` — 74 files, 1503 passed
- `associations.test.ts`, `relations.test.ts`, `strict-loading*.test.ts` — 509 passed
- `pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args` green
- `pnpm parity:api:extra --package activerecord` does not grow — the only new
  name is `setPreloadedRecords`, which is what the convention table produces for
  Ruby's `preloaded_records=`

Closes-story: converge-preloader-preloaded-records-onto-load-records
Closes-story: habtm-source-reflection-drops-ensure-mutable-macro-arm
Closes-story: retire-safe-klass-wrappers-read-reflection-klass-directly
