### PR TITLE
refactor(activerecord): home handle_warnings/drop_table on AbstractMysqlAdapter and de-duplicate DatabaseStatements

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -108,8 +108,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       await withDbWarningsAction("raise", async () => {
         // Force warning_count to 1 even though SHOW WARNINGS will return [].
         vi.spyOn(
-          adapter as unknown as { _warningCount: () => Promise<number> },
-          "_warningCount",
+          adapter as unknown as { warningCount: () => Promise<number> },
+          "warningCount",
         ).mockResolvedValue(1);
         const raised = adapter.execute(`SELECT 'x'`);
         await expect(raised).rejects.toBeInstanceOf(SQLWarning);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -114,7 +114,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         const raised = adapter.execute(`SELECT 'x'`);
         await expect(raised).rejects.toBeInstanceOf(SQLWarning);
         await expect(raised).rejects.toThrow(
-          `Query had warning_count=1 but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
+          `Query had warning_count=1 but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration.`,
         );
       });
     });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1676,7 +1676,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Rails reads `@raw_connection` directly; `_connection` is trails' spelling
    * of that same ivar, so the SHOW WARNINGS round-trip is sourced the same way
-   * rather than passed in.
+   * rather than passed in. Rails' `handle_warnings` has no null guard on it
+   * because `perform_query` only runs with a checked-out connection
+   * (mysql2/database_statements.rb:103); trails types `_connection` as
+   * nullable for the disconnected adapter, so the guard joins the `.nil?`
+   * early return rather than becoming a second branch Rails does not have.
    *
    * `ActiveRecord.db_warnings_action` is `nil` by default in Rails; trails
    * spells that default `"ignore"` on `AbstractAdapter` (abstract-adapter.ts),
@@ -1707,7 +1711,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         {
           Level: "Warning",
           Code: undefined,
-          Message: `Query had warning_count=${warningCount} but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
+          Message: `Query had warning_count=${warningCount} but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration.`,
         },
       ];
     }
@@ -1716,7 +1720,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       const code = row.Code == null ? null : String(row.Code);
       const message = row.Message ?? "";
       const warning = new SQLWarning(message, code, level, sql, this.pool);
-      if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
+      if (this.isWarningIgnored(warning as unknown as { level?: string; message?: string }))
         continue;
 
       if (action === "raise") throw warning;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1649,8 +1649,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
           { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
         ]
   ): Promise<void> {
-    // TS has no kwargs, so Rails' `*table_names, **options` arrives as a
-    // trailing options object on the rest parameter.
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
@@ -1678,9 +1676,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *
    * Rails reads `@raw_connection` directly; `_connection` is trails' spelling
    * of that same ivar, so the SHOW WARNINGS round-trip is sourced the same way
-   * rather than passed in. `warning_count` is the one driver-specific read —
-   * the mysql2 npm client does not always populate it, so it is a hook the
-   * concrete adapter fills.
+   * rather than passed in.
+   *
+   * `ActiveRecord.db_warnings_action` is `nil` by default in Rails; trails
+   * spells that default `"ignore"` on `AbstractAdapter` (abstract-adapter.ts),
+   * so both spellings of "unset" take Rails' `.nil?` early return. The symbol
+   * arms below are the behaviors Rails' `db_warnings_action=` bakes into the
+   * Proc it stores (active_record.rb:236-252), which its `handle_warnings`
+   * then reaches through a single `.call`.
    *
    * Public rather than Ruby-private for the same reason PostgreSQL's is:
    * `perform_query` reaches it through a structurally-typed mixin host.
@@ -1689,13 +1692,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    */
   async handleWarnings(sql: string): Promise<void> {
     const rawConnection = this._connection as unknown as {
+      warningCount?: unknown;
       query(sql: string): Promise<[unknown, unknown]>;
     } | null;
     const action = (this.constructor as typeof AbstractMysqlAdapter).dbWarningsAction;
     if (action == null || action === "ignore" || rawConnection == null) return;
-    if ((await this.warningCount(rawConnection)) === 0) return;
-
     const warningCount = await this.warningCount(rawConnection);
+    if (warningCount === 0) return;
+
     const [rawRows] = await rawConnection.query("SHOW WARNINGS");
     let result = rawRows as Array<{ Level?: string; Code?: number | string; Message?: string }>;
     if (result.length === 0) {
@@ -1715,9 +1719,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
         continue;
 
-      // Rails' `ActiveRecord.db_warnings_action.call(warning)`. The setter
-      // (active_record.rb:236-252) bakes each symbol into that Proc; trails
-      // stores the symbol itself, so the arms live at the one `.call` site.
       if (action === "raise") throw warning;
       if (action === "log") {
         const codeSuffix = code ? ` (${code})` : "";
@@ -1733,14 +1734,24 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * The `@raw_connection.warning_count` read of `handle_warnings`
-   * (abstract_mysql_adapter.rb:771). Ruby's mysql2 client exposes it as an
-   * attribute; the npm driver does not always, so the concrete adapter
-   * supplies it.
+   * (abstract_mysql_adapter.rb:771). Ruby's mysql2 gem exposes it as an
+   * attribute on the connection, so Rails needs no seam; the npm driver only
+   * populates it when the last protocol packet carried it, and falls back to
+   * `SHOW COUNT(*) WARNINGS` — a SHOW, so it does not itself reset the warning
+   * list the following `SHOW WARNINGS` reads.
    *
    * @internal
    */
-  protected warningCount(_rawConnection: unknown): Promise<number> {
-    return Promise.resolve(0);
+  protected async warningCount(rawConnection: {
+    warningCount?: unknown;
+    query(sql: string): Promise<[unknown, unknown]>;
+  }): Promise<number> {
+    if (typeof rawConnection.warningCount === "number") return rawConnection.warningCount;
+    const [rows] = await rawConnection.query("SHOW COUNT(*) WARNINGS");
+    const row = (rows as Record<string, unknown>[])[0];
+    if (!row) return 0;
+    const value = Object.values(row)[0];
+    return typeof value === "number" ? value : Number(value) || 0;
   }
 
   /** @internal Mirrors: AbstractMysqlAdapter#warning_ignored? */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -39,6 +39,7 @@ import {
   NotImplementedError,
   RecordNotUnique,
   StatementInvalid,
+  SQLWarning,
   StatementTimeout,
   ValueTooLong,
   sqlTypeToMigrationKeyword,
@@ -89,6 +90,7 @@ import {
   MysqlSchemaStatements,
 } from "./mysql/schema-statements.js";
 import {
+  ActiveSupport,
   compactBlank,
   include,
   isPresent,
@@ -1630,14 +1632,115 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return null;
   }
 
-  /** @internal */
-  protected async handleWarnings(sql: string): Promise<void> {
-    await this._handleWarnings(sql);
+  /**
+   * Mirrors: AbstractMysqlAdapter#drop_table
+   * (abstract_mysql_adapter.rb:354-357) — one `DROP` statement for every table
+   * name, with MySQL's `TEMPORARY` and `CASCADE` keywords the base adapter has
+   * no arm for.
+   *
+   * @internal
+   */
+  override async dropTable(
+    ...args:
+      | [string, ...string[]]
+      | [
+          string,
+          ...string[],
+          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
+        ]
+  ): Promise<void> {
+    // TS has no kwargs, so Rails' `*table_names, **options` arrives as a
+    // trailing options object on the rest parameter.
+    const last = args[args.length - 1];
+    const hasOptions = last !== null && last !== undefined && typeof last === "object";
+    const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const options = (hasOptions ? last : {}) as {
+      ifExists?: boolean;
+      force?: boolean | "cascade";
+      temporary?: boolean;
+    };
+    if (tableNames.length === 0) {
+      throw new ArgumentError("dropTable requires at least one table name");
+    }
+    for (const tableName of tableNames) {
+      await this.schemaCache.clearDataSourceCacheBang(tableName);
+    }
+    const temporary = options.temporary ? " TEMPORARY" : "";
+    const ifExists = options.ifExists ? " IF EXISTS" : "";
+    const cascade = options.force === "cascade" ? " CASCADE" : "";
+    const names = tableNames.map((tableName) => this.quoteTableName(tableName)).join(", ");
+    await this.execute(`DROP${temporary} TABLE${ifExists} ${names}${cascade}`);
   }
 
-  /** @internal */
-  protected _handleWarnings(_sql: string): Promise<void> {
-    return Promise.resolve();
+  /**
+   * Mirrors: AbstractMysqlAdapter#handle_warnings
+   * (abstract_mysql_adapter.rb:770-784).
+   *
+   * Rails reads `@raw_connection` directly; `_connection` is trails' spelling
+   * of that same ivar, so the SHOW WARNINGS round-trip is sourced the same way
+   * rather than passed in. `warning_count` is the one driver-specific read —
+   * the mysql2 npm client does not always populate it, so it is a hook the
+   * concrete adapter fills.
+   *
+   * Public rather than Ruby-private for the same reason PostgreSQL's is:
+   * `perform_query` reaches it through a structurally-typed mixin host.
+   *
+   * @internal
+   */
+  async handleWarnings(sql: string): Promise<void> {
+    const rawConnection = this._connection as unknown as {
+      query(sql: string): Promise<[unknown, unknown]>;
+    } | null;
+    const action = (this.constructor as typeof AbstractMysqlAdapter).dbWarningsAction;
+    if (action == null || action === "ignore" || rawConnection == null) return;
+    if ((await this.warningCount(rawConnection)) === 0) return;
+
+    const warningCount = await this.warningCount(rawConnection);
+    const [rawRows] = await rawConnection.query("SHOW WARNINGS");
+    let result = rawRows as Array<{ Level?: string; Code?: number | string; Message?: string }>;
+    if (result.length === 0) {
+      result = [
+        {
+          Level: "Warning",
+          Code: undefined,
+          Message: `Query had warning_count=${warningCount} but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
+        },
+      ];
+    }
+    for (const row of result) {
+      const level = row.Level ?? null;
+      const code = row.Code == null ? null : String(row.Code);
+      const message = row.Message ?? "";
+      const warning = new SQLWarning(message, code, level, sql, this.pool);
+      if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
+        continue;
+
+      // Rails' `ActiveRecord.db_warnings_action.call(warning)`. The setter
+      // (active_record.rb:236-252) bakes each symbol into that Proc; trails
+      // stores the symbol itself, so the arms live at the one `.call` site.
+      if (action === "raise") throw warning;
+      if (action === "log") {
+        const codeSuffix = code ? ` (${code})` : "";
+        const line = `[ActiveRecord::SQLWarning] ${message}${codeSuffix}`;
+        const logger = this.logger as { warn?: (msg: string) => void } | null;
+        if (logger?.warn) logger.warn(line);
+        else console.warn(line);
+      }
+      if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
+      if (typeof action === "function") action.call(this, warning);
+    }
+  }
+
+  /**
+   * The `@raw_connection.warning_count` read of `handle_warnings`
+   * (abstract_mysql_adapter.rb:771). Ruby's mysql2 client exposes it as an
+   * attribute; the npm driver does not always, so the concrete adapter
+   * supplies it.
+   *
+   * @internal
+   */
+  protected warningCount(_rawConnection: unknown): Promise<number> {
+    return Promise.resolve(0);
   }
 
   /** @internal Mirrors: AbstractMysqlAdapter#warning_ignored? */
@@ -1971,16 +2074,6 @@ export interface AbstractMysqlAdapter {
     columnName: string,
     type?: string,
     options?: { ifExists?: boolean },
-  ): Promise<void>;
-
-  dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [
-          string,
-          ...string[],
-          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
-        ]
   ): Promise<void>;
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -11,7 +11,6 @@ import {
   toSql,
   toSqlAndBinds,
   cacheableQuery,
-  isWriteQuery,
   explain,
   transaction,
   transactionIsolationLevels,
@@ -161,12 +160,6 @@ describe("DatabaseStatements", () => {
         throw new Rollback();
       });
       expect(result).toBeUndefined();
-    });
-  });
-
-  describe("isWriteQuery", () => {
-    it("raises not implemented", () => {
-      expect(() => isWriteQuery("INSERT INTO x")).toThrow();
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -32,13 +32,12 @@ import {
   performQuery,
   preprocessQuery,
   select,
-  execInsert,
-  execQuery,
   sqlForInsert,
   arelFromRelation,
   extractTableRefFromInsertSql,
   defaultInsertValue,
   returningColumnValues,
+  DatabaseStatements,
   type DatabaseStatementsHost,
 } from "./database-statements.js";
 import { Result } from "../../result.js";
@@ -773,40 +772,47 @@ describe("select", () => {
 
 describe("execInsert", () => {
   function makeInsertHost(supportsReturning: boolean) {
-    let capturedSql = "";
     const host: DatabaseStatementsHost = {
       log,
       pool,
       typeCastedBinds,
       supportsInsertReturning: () => supportsReturning,
       quoteColumnName: (c) => `"${c}"`,
-      internalExecute: async (sql: string) => {
-        capturedSql = sql;
-        return new Result([], []);
-      },
     };
-    return { host, getCapturedSql: () => capturedSql };
+    return host;
   }
 
-  it("appends RETURNING via sqlForInsert when adapter supports it", async () => {
-    const { host, getCapturedSql } = makeInsertHost(true);
-    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
-    expect(getCapturedSql()).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "id"`);
-  });
-
-  it("passes sql unchanged when adapter does not support RETURNING", async () => {
-    const { host, getCapturedSql } = makeInsertHost(false);
-    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
-    expect(getCapturedSql()).toBe("INSERT INTO t (x) VALUES (1)");
-  });
-
-  it("uses explicit returning list when provided", async () => {
-    const { host, getCapturedSql } = makeInsertHost(true);
-    await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], null, null, [
+  it("appends RETURNING via sqlForInsert when adapter supports it", () => {
+    const [sql] = sqlForInsert.call(
+      makeInsertHost(true),
+      "INSERT INTO t (x) VALUES (1)",
       "id",
-      "created_at",
-    ]);
-    expect(getCapturedSql()).toContain('RETURNING "id", "created_at"');
+      [],
+      null,
+    );
+    expect(sql).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "id"`);
+  });
+
+  it("passes sql unchanged when adapter does not support RETURNING", () => {
+    const [sql] = sqlForInsert.call(
+      makeInsertHost(false),
+      "INSERT INTO t (x) VALUES (1)",
+      "id",
+      [],
+      null,
+    );
+    expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
+  });
+
+  it("uses explicit returning list when provided", () => {
+    const [sql] = sqlForInsert.call(
+      makeInsertHost(true),
+      "INSERT INTO t (x) VALUES (1)",
+      null,
+      [],
+      ["id", "created_at"],
+    );
+    expect(sql).toContain('RETURNING "id", "created_at"');
   });
 });
 
@@ -836,16 +842,9 @@ describe("internal_exec_query is a virtual call", () => {
 
   it("execQuery reaches the adapter override", async () => {
     const { host, seen } = makeOverrideHost();
-    const result = await execQuery.call(host, "SELECT 1");
+    const result = await DatabaseStatements.execQuery.call(host as never, "SELECT 1");
     expect(result.columns).toEqual(["overridden"]);
     expect(seen).toEqual(["SELECT 1"]);
-  });
-
-  it("execInsert reaches the adapter override", async () => {
-    const { host, seen } = makeOverrideHost();
-    const result = await execInsert.call(host, "INSERT INTO t (x) VALUES (1)", null, [], "id");
-    expect(result.columns).toEqual(["overridden"]);
-    expect(seen).toEqual(["INSERT INTO t (x) VALUES (1)"]);
   });
 
   it("select reaches the adapter override", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -434,83 +434,6 @@ export function cacheableQuery(
 // --- Query execution ---
 
 /**
- * Returns rows as record hashes.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_all
- */
-export function selectAll(
-  sql: string,
-  _name?: string | null,
-  _binds?: unknown[],
-  _opts?: { allowRetry?: boolean; preparable?: boolean | null; async?: boolean },
-): Promise<Result> {
-  throw new Error("selectAll must be implemented by adapter subclass");
-}
-
-/**
- * Returns a single record hash.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_one
- */
-export function selectOne(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds?: unknown[],
-  { async = false }: { async?: boolean } = {},
-): Promise<Record<string, unknown> | undefined> {
-  const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  return doSelect(sql, name, binds, { async }).then((result) => result.first());
-}
-
-/**
- * Returns a single value from the first row/column.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_value
- */
-export function selectValue(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds?: unknown[],
-  { async = false }: { async?: boolean } = {},
-): Promise<unknown> {
-  return selectRows
-    .call(this, sql, name, binds, { async })
-    .then((rows) => singleValueFromRows(rows));
-}
-
-/**
- * Returns an array of the first column values.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_values
- */
-export function selectValues(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds?: unknown[],
-): Promise<unknown[]> {
-  return selectRows.call(this, sql, name, binds).then((rows) => rows.map((row) => row[0]));
-}
-
-/**
- * Returns an array of arrays (rows of column values).
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#select_rows
- */
-export function selectRows(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds?: unknown[],
-  { async = false }: { async?: boolean } = {},
-): Promise<unknown[][]> {
-  const doSelect = (this as DatabaseStatementsHost)?.selectAll ?? selectAll;
-  return doSelect(sql, name, binds, { async }).then((result) => result.rows);
-}
-
-/**
  * Returns a single value via internal_exec_query.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#query_value
@@ -557,13 +480,78 @@ export async function query(
 }
 
 /**
- * Determines whether the SQL statement is a write query.
- * Must be overridden by adapter subclasses.
+ * Executes a query with binds and returns an ActiveRecord::Result.
  *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#write_query?
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_query
+ * (abstract/database_statements.rb:147-149)
  */
-export function isWriteQuery(_sql: string): boolean {
-  throw new Error("isWriteQuery must be implemented by adapter subclass");
+export function execQuery(
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string | null = "SQL",
+  binds: unknown[] = [],
+  { prepare = false }: { prepare?: boolean } = {},
+): Promise<Result> {
+  // Dispatch through the instance so an adapter's internalExecQuery override
+  // wins, as Ruby's virtual call does.
+  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
+  return run(sql, name, binds, { prepare });
+}
+
+/**
+ * Executes an INSERT statement.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert
+ * (abstract/database_statements.rb:157-160)
+ */
+export function execInsert(
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string | null = null,
+  binds: unknown[] = [],
+  pk?: string | false | null,
+  _sequenceName?: string | null,
+  returning?: string[] | null,
+): Promise<Result> {
+  [sql, binds] = sqlForInsert.call(this, sql, pk, binds, returning ?? null);
+  // Dispatch through the instance so an adapter's internalExecQuery override
+  // wins, as Ruby's virtual call does.
+  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
+  return run(sql, name, binds);
+}
+
+/**
+ * Executes a DELETE statement and returns the number of affected rows.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_delete
+ * (abstract/database_statements.rb:165-167)
+ */
+export async function execDelete(
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string | null = null,
+  binds: unknown[] = [],
+): Promise<number> {
+  const doInternalExecute = this.internalExecute?.bind(this) ?? internalExecute.bind(this);
+  const doAffectedRows = this.affectedRows?.bind(this) ?? affectedRows;
+  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
+}
+
+/**
+ * Executes an UPDATE statement and returns the number of affected rows.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_update
+ * (abstract/database_statements.rb:172-174)
+ */
+export async function execUpdate(
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string | null = null,
+  binds: unknown[] = [],
+): Promise<number> {
+  const doInternalExecute = this.internalExecute?.bind(this) ?? internalExecute.bind(this);
+  const doAffectedRows = this.affectedRows?.bind(this) ?? affectedRows;
+  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
 }
 
 /**
@@ -573,55 +561,6 @@ export function isWriteQuery(_sql: string): boolean {
  */
 export function execute(_sql: string, _binds?: unknown[], _name?: string | null): Promise<unknown> {
   throw new Error("execute must be implemented by adapter subclass");
-}
-
-/**
- * Executes a query with binds and returns an ActiveRecord::Result.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_query
- */
-export function execQuery(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = "SQL",
-  binds: unknown[] = [],
-  { prepare = false }: { prepare?: boolean } = {},
-): Promise<Result> {
-  // Dispatch through the instance so an adapter's internalExecQuery override
-  // wins, as Ruby's virtual call does.
-  const run = ((this as DatabaseStatementsHost).internalExecQuery ?? internalExecQuery).bind(
-    this as DatabaseStatementsHost,
-  );
-  return run(sql, name, binds, { prepare });
-}
-
-/**
- * Executes an INSERT statement.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert
- */
-export function execInsert(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-  pk?: string | false | null,
-  _sequenceName?: string | null,
-  returning?: string[] | null,
-): Promise<Result> {
-  [sql, binds] = sqlForInsert.call(
-    this as DatabaseStatementsHost,
-    sql,
-    pk,
-    binds,
-    returning ?? null,
-  );
-  // Dispatch through the instance so an adapter's internalExecQuery override
-  // wins, as Ruby's virtual call does.
-  const run = ((this as DatabaseStatementsHost).internalExecQuery ?? internalExecQuery).bind(
-    this as DatabaseStatementsHost,
-  );
-  return run(sql, name, binds);
 }
 
 /**
@@ -671,40 +610,6 @@ export async function execInsertReturningReadback(
 }
 
 /**
- * Executes a DELETE statement and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_delete
- */
-export async function execDelete(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  const host = this as DatabaseStatementsHost;
-  const doInternalExecute = host?.internalExecute?.bind(host) ?? internalExecute.bind(host);
-  const doAffectedRows = host?.affectedRows?.bind(host) ?? affectedRows;
-  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
-}
-
-/**
- * Executes an UPDATE statement and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_update
- */
-export async function execUpdate(
-  this: DatabaseStatementsHost | void,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  const host = this as DatabaseStatementsHost;
-  const doInternalExecute = host?.internalExecute?.bind(host) ?? internalExecute.bind(host);
-  const doAffectedRows = host?.affectedRows?.bind(host) ?? affectedRows;
-  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
-}
-
-/**
  * Executes a bulk INSERT statement.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert_all
@@ -729,64 +634,6 @@ export function explain(_arel: unknown, _binds?: unknown[], _options?: unknown[]
 }
 
 // --- Data modification ---
-
-/**
- * Executes an INSERT and returns the new record's ID.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#insert
- */
-export async function insert(
-  this: DatabaseStatementsHost | void,
-  arel: unknown,
-  name: string | null = null,
-  pk?: string | null,
-  idValue?: unknown,
-  sequenceName?: string | null,
-  binds: unknown[] = [],
-): Promise<unknown> {
-  const host = this as DatabaseStatementsHost;
-  let sql: string;
-  [sql, binds] = toSqlAndBinds(arel, binds);
-  const result = await execInsert.call(this, sql, name, binds, pk, sequenceName);
-  if (idValue !== undefined && idValue !== null) return idValue;
-  return host.lastInsertedId!(result);
-}
-
-/**
- * Executes an UPDATE and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#update
- */
-export async function update(
-  this: DatabaseStatementsHost | void,
-  arel: unknown,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  let sql: string;
-  [sql, binds] = toSqlAndBinds(arel, binds);
-  return execUpdate.call(this, sql, name, binds);
-}
-
-/**
- * Executes a DELETE and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#delete
- */
-export async function deleteStatement(
-  this: DatabaseStatementsHost | void,
-  arel: unknown,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  let sql: string;
-  [sql, binds] = toSqlAndBinds(arel, binds);
-  return execDelete.call(this, sql, name, binds);
-}
-// Rails name: delete — aliased to avoid JS reserved word conflict.
-// Consumers can import as: import { delete as delete_ } from "..."
-
-export { deleteStatement as delete };
 
 /**
  * Executes a TRUNCATE statement.
@@ -1543,16 +1390,6 @@ function singleValueFromRows(rows: unknown[][]): unknown {
   return row ? row[0] : undefined;
 }
 
-/**
- * Alias: create = insert (matches Rails)
- */
-export { insert as create };
-
-/**
- * Alias: remove = delete (backwards compat with prior TS API)
- */
-export { deleteStatement as remove };
-
 // ---------------------------------------------------------------------------
 // Module object
 //
@@ -1776,67 +1613,19 @@ export const DatabaseStatements = {
     return this.selectAll(arel, name, binds, { async }).then((result) => result.rows);
   },
 
-  async execQuery(
-    this: DatabaseStatementsDefaultsHost,
-    sql: string,
-    name: string | null = "SQL",
-    binds: unknown[] = [],
-    { prepare = false }: { prepare?: boolean } = {},
-  ): Promise<Result> {
-    // Mirrors: abstract/database_statements.rb:147-149 — exec_query forwards to
-    // internal_exec_query, which each adapter overrides.
-    return this.internalExecQuery(sql, name, binds, { prepare });
-  },
+  execQuery,
+  execInsert,
 
-  async execInsert(
-    this: DatabaseStatementsDefaultsHost,
-    sql: string,
-    name: string | null = null,
-    binds?: unknown[],
-    _pk?: string | false | null,
-    _sequenceName?: string | null,
-    _returning?: string[] | null,
-  ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
-  },
-
-  async execDelete(
-    this: DatabaseStatementsDefaultsHost,
-    sql: string,
-    name: string | null = null,
-    binds?: unknown[],
-  ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
-  },
-
-  async execUpdate(
-    this: DatabaseStatementsDefaultsHost,
-    sql: string,
-    name: string | null = null,
-    binds?: unknown[],
-  ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
-  },
+  execDelete,
+  execUpdate,
 
   isWriteQuery(sql: string): boolean {
     return isWriteQuerySql(sql);
   },
 
-  emptyInsertStatementValue(_pk?: string | null): string {
-    return "DEFAULT VALUES";
-  },
+  emptyInsertStatementValue,
 
-  cacheableQuery(
-    this: unknown,
-    klass: {
-      query?(sql: string): unknown;
-      partialQuery?(parts: unknown): unknown;
-      partialQueryCollector?(): unknown;
-    },
-    arel: unknown,
-  ): [unknown, unknown[]] {
-    return cacheableQuery.call(this as never, klass, arel);
-  },
+  cacheableQuery,
 
   insert: insertStatement,
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -480,81 +480,6 @@ export async function query(
 }
 
 /**
- * Executes a query with binds and returns an ActiveRecord::Result.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_query
- * (abstract/database_statements.rb:147-149)
- */
-export function execQuery(
-  this: DatabaseStatementsHost,
-  sql: string,
-  name: string | null = "SQL",
-  binds: unknown[] = [],
-  { prepare = false }: { prepare?: boolean } = {},
-): Promise<Result> {
-  // Dispatch through the instance so an adapter's internalExecQuery override
-  // wins, as Ruby's virtual call does.
-  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
-  return run(sql, name, binds, { prepare });
-}
-
-/**
- * Executes an INSERT statement.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert
- * (abstract/database_statements.rb:157-160)
- */
-export function execInsert(
-  this: DatabaseStatementsHost,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-  pk?: string | false | null,
-  _sequenceName?: string | null,
-  returning?: string[] | null,
-): Promise<Result> {
-  [sql, binds] = sqlForInsert.call(this, sql, pk, binds, returning ?? null);
-  // Dispatch through the instance so an adapter's internalExecQuery override
-  // wins, as Ruby's virtual call does.
-  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
-  return run(sql, name, binds);
-}
-
-/**
- * Executes a DELETE statement and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_delete
- * (abstract/database_statements.rb:165-167)
- */
-export async function execDelete(
-  this: DatabaseStatementsHost,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  const doInternalExecute = this.internalExecute?.bind(this) ?? internalExecute.bind(this);
-  const doAffectedRows = this.affectedRows?.bind(this) ?? affectedRows;
-  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
-}
-
-/**
- * Executes an UPDATE statement and returns the number of affected rows.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_update
- * (abstract/database_statements.rb:172-174)
- */
-export async function execUpdate(
-  this: DatabaseStatementsHost,
-  sql: string,
-  name: string | null = null,
-  binds: unknown[] = [],
-): Promise<number> {
-  const doInternalExecute = this.internalExecute?.bind(this) ?? internalExecute.bind(this);
-  const doAffectedRows = this.affectedRows?.bind(this) ?? affectedRows;
-  return doAffectedRows(await doInternalExecute(sql, name, { binds }));
-}
-
-/**
  * Executes a SQL statement and returns the raw result.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#execute
@@ -1613,11 +1538,45 @@ export const DatabaseStatements = {
     return this.selectAll(arel, name, binds, { async }).then((result) => result.rows);
   },
 
-  execQuery,
-  execInsert,
+  async execQuery(
+    this: DatabaseStatementsDefaultsHost,
+    sql: string,
+    name: string | null = "SQL",
+    binds: unknown[] = [],
+    { prepare = false }: { prepare?: boolean } = {},
+  ): Promise<Result> {
+    return this.internalExecQuery(sql, name, binds, { prepare });
+  },
 
-  execDelete,
-  execUpdate,
+  async execInsert(
+    this: DatabaseStatementsDefaultsHost,
+    sql: string,
+    name: string | null = null,
+    binds?: unknown[],
+    _pk?: string | false | null,
+    _sequenceName?: string | null,
+    _returning?: string[] | null,
+  ): Promise<number> {
+    return this.executeMutation(sql, binds, name);
+  },
+
+  async execDelete(
+    this: DatabaseStatementsDefaultsHost,
+    sql: string,
+    name: string | null = null,
+    binds?: unknown[],
+  ): Promise<number> {
+    return this.executeMutation(sql, binds, name);
+  },
+
+  async execUpdate(
+    this: DatabaseStatementsDefaultsHost,
+    sql: string,
+    name: string | null = null,
+    binds?: unknown[],
+  ): Promise<number> {
+    return this.executeMutation(sql, binds, name);
+  },
 
   isWriteQuery(sql: string): boolean {
     return isWriteQuerySql(sql);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -23,9 +23,7 @@ type CreateTableArgs = Parameters<BaseSchemaStatements["createTable"]>;
 type CreateTableOptions = Extract<CreateTableArgs[1], { options?: string }>;
 
 /**
- * MySQL-specific SchemaStatements subclass. Extends the base `dropTable` to support
- * the `temporary: true` option, which emits `DROP TEMPORARY TABLE` — a MySQL/MariaDB
- * extension required to drop temporary tables without affecting base tables.
+ * MySQL-specific SchemaStatements subclass.
  *
  * Mixed into AbstractMysqlAdapter at the bottom of `abstract-mysql-adapter.ts`,
  * mirroring `include MySQL::SchemaStatements`.
@@ -225,40 +223,6 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
       await this.removeForeignKey(tableName, { column: columnName });
     }
     return super.removeColumn(tableName, columnName, type, options);
-  }
-
-  /** Mirrors: AbstractMysqlAdapter#drop_table */
-  override async dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [
-          string,
-          ...string[],
-          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
-        ]
-  ): Promise<void> {
-    // TS has no kwargs, so Rails' `*table_names, **options`
-    // (abstract/schema_statements.rb:540) arrives as a trailing options object
-    // on the rest parameter.
-    const last = args[args.length - 1];
-    const hasOptions = last !== null && last !== undefined && typeof last === "object";
-    const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];
-    const options = (hasOptions ? last : {}) as {
-      ifExists?: boolean;
-      force?: boolean | "cascade";
-      temporary?: boolean;
-    };
-    if (tableNames.length === 0) {
-      throw new ArgumentError("dropTable requires at least one table name");
-    }
-    const temporary = options.temporary ? " TEMPORARY" : "";
-    const ifExists = options.ifExists ? " IF EXISTS" : "";
-    const cascade = options.force === "cascade" ? " CASCADE" : "";
-    for (const name of tableNames) {
-      await this.schemaCache.clearDataSourceCacheBang(name);
-    }
-    const quoted = tableNames.map((n) => this.quoteTableName(n)).join(", ");
-    await this.execute(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -28,7 +28,6 @@ import {
   DatabaseConnectionError,
   MismatchedForeignKey,
   NoDatabaseError,
-  SQLWarning,
 } from "../errors.js";
 import { Result } from "../result.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
@@ -1775,83 +1774,32 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /**
    * Query `SHOW COUNT(*) WARNINGS` to learn how many warnings the most
-   * recent statement on `conn` produced. SHOW statements do not reset the
-   * warning list (unlike a normal SELECT), so the subsequent SHOW WARNINGS
+   * recent statement on `rawConnection` produced. SHOW statements do not reset
+   * the warning list (unlike a normal SELECT), so the subsequent SHOW WARNINGS
    * still returns the rows.
    *
-   * Exposed as a protected method so tests can stub it via `vi.spyOn` to
-   * exercise the "warning_count does not match returned warnings" branch.
+   * Fills AbstractMysqlAdapter's `warningCount` seam for Rails'
+   * `@raw_connection.warning_count` (abstract_mysql_adapter.rb:771). Protected
+   * so tests can stub it via `vi.spyOn` to exercise the "warning_count does
+   * not match returned warnings" branch.
+   *
    * @internal
    */
-  protected async _warningCount(conn: mysql.Connection): Promise<number> {
+  protected override async warningCount(rawConnection: unknown): Promise<number> {
+    const conn = rawConnection as mysql.Connection;
     // Optimization: when the mysql2 npm driver exposes the protocol's
     // last `serverStatus` packet, the bottom 16 bits of the per-connection
     // `warningCount` are populated for the most recent statement (mirrors
     // Rails reading `@raw_connection.warning_count` directly instead of
     // round-tripping `SHOW COUNT(*) WARNINGS`). Fall back to the SHOW
     // query when the field is absent or non-numeric.
-    const raw = (conn as unknown as { warningCount?: unknown; _warningCount?: unknown })
-      .warningCount;
+    const raw = (conn as unknown as { warningCount?: unknown }).warningCount;
     if (typeof raw === "number") return raw;
     const [rows] = await conn.query("SHOW COUNT(*) WARNINGS");
     const row = (rows as Record<string, unknown>[])[0];
     if (!row) return 0;
     const v = Object.values(row)[0];
     return typeof v === "number" ? v : Number(v) || 0;
-  }
-
-  /**
-   * Read pending warnings for the adapter's raw connection, filter via
-   * {@link isWarningIgnored}, and dispatch per the configured
-   * `dbWarningsAction`. Called from `performQuery` where Rails calls it
-   * (mysql2/database_statements.rb:103), while the connection is still held —
-   * warnings are connection-scoped.
-   *
-   * Rails reads `@raw_connection` for the SHOW WARNINGS round-trip
-   * (abstract_mysql_adapter.rb:770-784); `_client` is trails' spelling of that
-   * same ivar, so the connection is sourced the same way rather than passed in.
-   *
-   * Mirrors: AbstractMysqlAdapter#handle_warnings.
-   * @internal
-   */
-  override async handleWarnings(sql: string): Promise<void> {
-    const conn = this._client;
-    if (!conn) return;
-    const ctor = this.constructor as typeof Mysql2Adapter;
-    const action = ctor.dbWarningsAction;
-    if (!action || action === "ignore") return;
-    const count = await this._warningCount(conn);
-    if (count === 0) return;
-    const [rawRows] = await conn.query("SHOW WARNINGS");
-    let rows = rawRows as Array<{ Level?: string; Code?: number | string; Message?: string }>;
-    if (rows.length === 0) {
-      rows = [
-        {
-          Level: "Warning",
-          Code: undefined,
-          Message: `Query had warning_count=${count} but 'SHOW WARNINGS' did not return the warnings. Check MySQL logs or database configuration.`,
-        },
-      ];
-    }
-    for (const row of rows) {
-      const level = row.Level ?? null;
-      const code = row.Code == null ? null : String(row.Code);
-      const message = row.Message ?? "";
-      const warning = new SQLWarning(message, code, level, sql, this.pool);
-      if (this.isWarningIgnored({ level: level ?? undefined, code: code ?? undefined, message }))
-        continue;
-      if (action === "raise") throw warning;
-      if (action === "log") {
-        const logger = this.logger as { warn?: (msg: string) => void } | null;
-        const codeSuffix = code ? ` (${code})` : "";
-        const line = `[ActiveRecord::SQLWarning] ${message}${codeSuffix}`;
-        if (logger?.warn) logger.warn(line);
-        else console.warn(line);
-      }
-      // TODO(report): wire Rails.error.report(warning, handled: true) when ErrorReporter
-      // is exposed as a global singleton (PostgreSQL's handleWarnings already does).
-      if (typeof action === "function") action(warning);
-    }
   }
 
   // Mirrors AbstractMysqlAdapter#configure_connection.

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1772,36 +1772,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return conn;
   }
 
-  /**
-   * Query `SHOW COUNT(*) WARNINGS` to learn how many warnings the most
-   * recent statement on `rawConnection` produced. SHOW statements do not reset
-   * the warning list (unlike a normal SELECT), so the subsequent SHOW WARNINGS
-   * still returns the rows.
-   *
-   * Fills AbstractMysqlAdapter's `warningCount` seam for Rails'
-   * `@raw_connection.warning_count` (abstract_mysql_adapter.rb:771). Protected
-   * so tests can stub it via `vi.spyOn` to exercise the "warning_count does
-   * not match returned warnings" branch.
-   *
-   * @internal
-   */
-  protected override async warningCount(rawConnection: unknown): Promise<number> {
-    const conn = rawConnection as mysql.Connection;
-    // Optimization: when the mysql2 npm driver exposes the protocol's
-    // last `serverStatus` packet, the bottom 16 bits of the per-connection
-    // `warningCount` are populated for the most recent statement (mirrors
-    // Rails reading `@raw_connection.warning_count` directly instead of
-    // round-tripping `SHOW COUNT(*) WARNINGS`). Fall back to the SHOW
-    // query when the field is absent or non-numeric.
-    const raw = (conn as unknown as { warningCount?: unknown }).warningCount;
-    if (typeof raw === "number") return raw;
-    const [rows] = await conn.query("SHOW COUNT(*) WARNINGS");
-    const row = (rows as Record<string, unknown>[])[0];
-    if (!row) return 0;
-    const v = Object.values(row)[0];
-    return typeof v === "number" ? v : Number(v) || 0;
-  }
-
   // Mirrors AbstractMysqlAdapter#configure_connection.
   // Builds and returns the full SET statement (including the SET keyword and time_zone)
   // for wait_timeout, sql_mode (per strict flag), and arbitrary session variables.

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -23,34 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "handle_warnings",
-    "call": "call",
-    "reason": "Include stand-in (RFC 0106): `ActiveRecord.db_warnings_action.call(warning)` (abstract_mysql_adapter.rb:782) is dispatched from `mysql2-adapter.ts#handleWarnings` alongside the rest of the body; the abstract method only delegates."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "handle_warnings",
-    "call": "new",
-    "reason": "Include stand-in (RFC 0106): `SQLWarning.new(message, code, level, sql, @pool)` (abstract_mysql_adapter.rb:779) is constructed in `mysql2-adapter.ts#handleWarnings`, which owns the raw connection this body reads; the abstract method only delegates."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "handle_warnings",
-    "call": "query",
-    "reason": "Include stand-in (RFC 0106): the full `handle_warnings` body — `@raw_connection.warning_count`, the `SHOW WARNINGS` query, `SQLWarning.new`, `warning_ignored?` and the `db_warnings_action.call` dispatch — is ported on the concrete adapter (`mysql2-adapter.ts#handleWarnings`), where the raw mysql2 connection lives; this method is the abstract dispatch point and only delegates."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "handle_warnings",
-    "call": "warning_ignored?",
-    "reason": "Include stand-in (RFC 0106): the `warning_ignored?` guard (abstract_mysql_adapter.rb:780) runs in `mysql2-adapter.ts#handleWarnings`; `isWarningIgnored` itself IS overridden in this file, per abstract_mysql_adapter.rb:786-788."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mismatched_foreign_key_details",
     "call": "column_for",
     "reason": "Verified per-site (RFC 0106): `options[:primary_key_column] = column_for(...)` (abstract_mysql_adapter.rb:995) is an async schema read in trails, while this method is reached synchronously from `_translateException`. The lookup is performed instead in `_enrichMismatchedForeignKey`, which rebuilds the error with the referenced column's sql_type once it can await."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -2,6 +2,48 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_delete",
+    "call": "affected_rows",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_delete",
+    "call": "internal_execute",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_insert",
+    "call": "internal_exec_query",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_insert",
+    "call": "sql_for_insert",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_update",
+    "call": "affected_rows",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
+    "rubyName": "exec_update",
+    "call": "internal_execute",
+    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "initialize",
     "call": "reset_transaction",
     "reason": "Per-site verified (RFC 0106 wave 4b): abstract/database_statements.rb:12 is `reset_transaction` inside `initialize`; trails' DatabaseStatements is a mixin with no constructor of its own — the adapter's own constructor calls `resetTransaction()` (abstract-adapter.ts), so the call happens, just not from a body matched to this Ruby method."


### PR DESCRIPTION
Rails defines `handle_warnings` and `drop_table` on `AbstractMysqlAdapter`
(`abstract_mysql_adapter.rb:770-784`, `:354-357`). trails had the warnings body on
`Mysql2Adapter` behind a `_handleWarnings` hook with no Rails counterpart — while its
`warning_ignored?` guard already sat on the abstract class — and the MySQL `drop_table`
body in the `MySQL::SchemaStatements` companion, where `Mysql2Adapter`'s class-body copy
permanently shadowed it (a latent self-dispatch trap noted in #5490).

Both bodies now sit at the Rails location, line for line: the same early return, the same
`SHOW WARNINGS` fallback row, and the same `next if warning_ignored?` guard before a single
`db_warnings_action` dispatch — which also picks up the `:report` arm PostgreSQL already
had (`active_record.rb:248-249`), one of the two TODOs the old body carried.
`_handleWarnings` is gone. The one genuinely driver-specific read,
`@raw_connection.warning_count` (`rb:771`), is `warningCount` on the abstract class: the
attribute read Rails makes, plus the `SHOW COUNT(*) WARNINGS` fallback the npm driver needs
when the protocol packet did not carry it. `Mysql2Adapter` needs no override.

`abstract/database-statements.ts` defined every method twice — a file-level free function
and a body of the same name in the `DatabaseStatements` mixin object — of which only the
mixin copy was ever installed on a prototype. One definition per Rails method now; the free
copies are deleted and their coverage retargeted at live surface (`sqlForInsert`,
`DatabaseStatements.execQuery`).

Four converged `handle_warnings` rows deleted from the call-mismatch baseline.

### The six rows this adds, and why they are not new debt

Deleting the dead copies changes what `parity:api:calls` measures. The extractor had been
matching the dead free functions, which did make Rails' calls; the live mixin bodies for
`exec_insert` / `exec_delete` / `exec_update` route through trails' `executeMutation`
invention instead of `sql_for_insert` + `internal_exec_query` and
`affected_rows(internal_execute(...))` (`database_statements.rb:157-174`). That divergence
is pre-existing — the duplication is what hid it.

Promoting the free bodies instead was tried first and reds every adapter lane: the live
`internalExecute` on the adapters takes `(sql, binds, name)`, not the abstract file's
`(sql, name, {binds})`, and an unconditional `sql_for_insert` appends `RETURNING` where
PostgreSQL rejects it. Converging means converging `executeMutation` and `internalExecute`
together, which is its own PR — filed as
`0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape`,
named in each row's reason.

Closes-story: handle-warnings-body-belongs-on-abstract-mysql-adapter
Closes-story: database-statements-duplicate-bodies-free-function-and-mixin
