### PR TITLE
refactor(activerecord,activemodel): retire the JoinLeaf node kind; restore assert_valid_value's super arm

### DIFF
--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { Types } from "../index.js";
+import { Types, ValueType } from "../index.js";
 
 // Fallback-parser coverage for shapes `Date._parse` accepts that no Rails test
 // exercises directly. Rails reaches them through `Date._parse` in
@@ -122,5 +122,34 @@ describe("DateTimeType#serializeCastValue", () => {
     expect((type.serializeCastValue(value) as Temporal.Instant).toString()).toBe(
       "1999-12-31T22:34:56.7Z",
     );
+  });
+});
+
+// AcceptsMultiparameterTime::InstanceMethods#assert_valid_value
+// (activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb:24-30)
+// sends a non-Hash value on to `super`. `ActiveModel::Type::Value#assert_valid_value`
+// is a no-op, so the arm is only observable once an ancestor supplies a real one —
+// which ActiveRecord's Type::Serialized and the enum/PG OID types do.
+describe("DateTimeType assert_valid_value", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends a non-hash value to super", () => {
+    const spy = vi.spyOn(ValueType.prototype, "assertValidValue").mockImplementation(() => {
+      throw new Error("from super");
+    });
+    const type = new Types.DateTimeType();
+    expect(() => type.assertValidValue("2020-07-04T12:30:00Z")).toThrow("from super");
+    expect(spy).toHaveBeenCalledWith("2020-07-04T12:30:00Z");
+  });
+
+  it("does not send a multiparameter hash to super", () => {
+    const spy = vi.spyOn(ValueType.prototype, "assertValidValue").mockImplementation(() => {
+      throw new Error("from super");
+    });
+    const type = new Types.DateTimeType();
+    expect(() => type.assertValidValue({ 1: 2025, 2: 7, 3: 4 })).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -210,7 +210,11 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * MultiparameterAssignmentErrors at assignment (missing keys 1..3 raise).
    */
   override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) {
+      this.valueFromMultiparameterAssignment(value);
+    } else {
+      super.assertValidValue(value);
+    }
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */

--- a/packages/activemodel/src/type/date.trails.test.ts
+++ b/packages/activemodel/src/type/date.trails.test.ts
@@ -1,21 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Types, ValueType } from "../index.js";
 
-describe("TimeTypeTrails", () => {
-  it("serialize_cast_value applies the declared precision", () => {
-    const type = new Types.TimeType({ precision: 1 });
-    const value = type.cast("1999-12-31T12:34:56.789-10:00");
-
-    expect(String(type.serializeCastValue(value))).toBe("2000-01-01T22:34:56.7Z");
-  });
-});
-
 // AcceptsMultiparameterTime::InstanceMethods#assert_valid_value
 // (activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb:24-30)
 // sends a non-Hash value on to `super`. `ActiveModel::Type::Value#assert_valid_value`
 // is a no-op, so the arm is only observable once an ancestor supplies a real one —
 // which ActiveRecord's Type::Serialized and the enum/PG OID types do.
-describe("TimeType assert_valid_value", () => {
+describe("DateType assert_valid_value", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -24,17 +15,17 @@ describe("TimeType assert_valid_value", () => {
     const spy = vi.spyOn(ValueType.prototype, "assertValidValue").mockImplementation(() => {
       throw new Error("from super");
     });
-    const type = new Types.TimeType();
-    expect(() => type.assertValidValue("2020-07-04T12:30:00Z")).toThrow("from super");
-    expect(spy).toHaveBeenCalledWith("2020-07-04T12:30:00Z");
+    const type = new Types.DateType();
+    expect(() => type.assertValidValue("2020-07-04")).toThrow("from super");
+    expect(spy).toHaveBeenCalledWith("2020-07-04");
   });
 
   it("does not send a multiparameter hash to super", () => {
     const spy = vi.spyOn(ValueType.prototype, "assertValidValue").mockImplementation(() => {
       throw new Error("from super");
     });
-    const type = new Types.TimeType();
-    expect(() => type.assertValidValue({ 4: 12, 5: 30 })).not.toThrow();
+    const type = new Types.DateType();
+    expect(() => type.assertValidValue({ 1: 2025, 2: 7, 3: 4 })).not.toThrow();
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -204,7 +204,11 @@ export class DateType extends ValueType<DateCastResult> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) {
+      this.valueFromMultiparameterAssignment(value);
+    } else {
+      super.assertValidValue(value);
+    }
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -239,7 +239,11 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) this.valueFromMultiparameterAssignment(value);
+    if (isPlainObject(value)) {
+      this.valueFromMultiparameterAssignment(value);
+    } else {
+      super.assertValidValue(value);
+    }
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -88,8 +88,6 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(targetTable.name).toBe("jdt_comments");
     expect(targetTable.tableAlias).toBeNull();
 
-    // The through link, joined from inside the same JoinAssociation, also uses
-    // its real name.
     expect(joinedTableNames(joins)).toContain("jdt_posts");
     const throughJoin = joins.find((j) => tableSqlName(j.left as TableRef) === "jdt_posts")!;
     expect(throughJoin).toBeInstanceOf(Nodes.OuterJoin);
@@ -143,7 +141,6 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(targetChild.immediateAssocName).toBe("jdtComments");
     expect(targetChild.tableName).toBe("jdt_comments");
 
-    // Both chain links are still joined — from inside that one node.
     expect(joinedTableNames(joins)).toEqual(["jdt_posts", "jdt_comments"]);
   });
 

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -21,6 +21,16 @@ function nodeAt(jd: JoinDependency, path: string): JoinPart {
   return jd.nodes.find((n) => n.assocName === path)!;
 }
 
+/**
+ * The SQL name of every table the emitted joins join, in emission order.
+ * A `has_many :through` chain's intermediate links live inside the one
+ * JoinAssociation (join_association.rb:32-73) and have no tree node of their
+ * own, so the emitted joins are the only place their aliasing is observable.
+ */
+function joinedTableNames(joins: Nodes.Join[]): string[] {
+  return joins.map((join) => tableSqlName(join.left as TableRef));
+}
+
 describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
   // Ride the boot-laid canonical `Base.connection` (single-pool test model)
   // rather than a sidecar `_pool` lease; these wiring tests only need an
@@ -67,7 +77,7 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
 
   it("uses real table names for through+target when no collision", () => {
     const jd = new JoinDependency(JdtAuthor, null, "jdtComments", Nodes.OuterJoin);
-    jd.joinConstraints([]);
+    const joins = jd.joinConstraints([]);
     const node = nodeAt(jd, "jdtComments");
     expect(node).not.toBeNull();
     expect(node.arelJoin).toBeInstanceOf(Nodes.OuterJoin);
@@ -78,13 +88,12 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(targetTable.name).toBe("jdt_comments");
     expect(targetTable.tableAlias).toBeNull();
 
-    // Through node also uses real name
-    const throughNode = jd.nodes.find((n) => n.tableName === "jdt_posts");
-    expect(throughNode).toBeDefined();
-    expect(throughNode!.arelJoin).toBeInstanceOf(Nodes.OuterJoin);
-    const throughTable = (throughNode!.arelJoin as Nodes.OuterJoin).left as Table;
-    expect(throughTable.name).toBe("jdt_posts");
-    expect(throughTable.tableAlias).toBeNull();
+    // The through link, joined from inside the same JoinAssociation, also uses
+    // its real name.
+    expect(joinedTableNames(joins)).toContain("jdt_posts");
+    const throughJoin = joins.find((j) => tableSqlName(j.left as TableRef) === "jdt_posts")!;
+    expect(throughJoin).toBeInstanceOf(Nodes.OuterJoin);
+    expect((throughJoin.left as Table).tableAlias).toBeNull();
   });
 
   it("uses the Rails alias_candidate when the target real name collides", () => {
@@ -102,7 +111,7 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(node).not.toBeNull();
 
     // Aliasing is deferred to emit: resolve against the shared AliasTracker.
-    jd.joinConstraints([]);
+    const joins = jd.joinConstraints([]);
     // Rails names the collision `{plural_name}_{owner_table}` (root link, no _join).
     expect(node.effectiveSqlName).toBe("jdt_comments_jdt_authors");
 
@@ -112,31 +121,30 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(tableSqlName(targetTable)).toBe("jdt_comments_jdt_authors");
 
     // Through still uses real name
-    const throughNode = jd.nodes.find(
-      (n) => n.tableName === "jdt_posts" && n.assocName.includes("_through_"),
-    );
-    expect(throughNode).toBeDefined();
-    const throughTable = (throughNode!.arelJoin as Nodes.OuterJoin).left as Table;
-    expect(throughTable.name).toBe("jdt_posts");
-    expect(throughTable.tableAlias).toBeNull();
+    const throughJoin = joins.find((j) => tableSqlName(j.left as TableRef) === "jdt_posts")!;
+    expect(throughJoin).toBeDefined();
+    expect((throughJoin.left as Table).tableAlias).toBeNull();
   });
 
-  it("builds tree with through node as child of root and target as sibling", () => {
+  it("builds one JoinAssociation for a has_many :through, not a node per chain link", () => {
+    // Rails' join tree holds only JoinBase and JoinAssociation
+    // (join_dependency.rb:228-240): a `has_many :through` is ONE tree edge whose
+    // `join_constraints` walks `reflection.chain` internally, so the through
+    // link never becomes a child of the root.
     const jd = new JoinDependency(JdtAuthor, null, "jdtComments", Nodes.OuterJoin);
-    jd.joinConstraints([]);
+    const joins = jd.joinConstraints([]);
     const node = nodeAt(jd, "jdtComments");
     expect(node).not.toBeNull();
 
     const root = jd.joinRoot;
     expect(root.baseKlass).toBe(JdtAuthor);
-    // Through + target are both children of root (flat under root for has_many :through)
-    expect(root.children.length).toBe(2);
-    const throughChild = root.children[0];
-    expect(throughChild.immediateAssocName).toBe("_through_jdtPosts");
-    expect(throughChild.tableName).toBe("jdt_posts");
-    const targetChild = root.children[1];
+    expect(root.children.length).toBe(1);
+    const targetChild = root.children[0];
     expect(targetChild.immediateAssocName).toBe("jdtComments");
     expect(targetChild.tableName).toBe("jdt_comments");
+
+    // Both chain links are still joined — from inside that one node.
+    expect(joinedTableNames(joins)).toEqual(["jdt_posts", "jdt_comments"]);
   });
 
   it("emits canonical self-join aliases when a nested-through chain references a table multiple times", () => {
@@ -224,8 +232,7 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
 
     // Aliasing is deferred to emit: the one `joinConstraints` call resolves the
     // whole chain against the shared AliasTracker.
-    jd.joinConstraints([]);
-    const effectiveNames = jd.nodes.map((n) => n.effectiveSqlName);
+    const effectiveNames = joinedTableNames(jd.joinConstraints([]));
     // A twice-visited table keeps its real name on first encounter and is
     // self-join aliased only on the colliding second encounter (the emit-time
     // chain resolution claims each link in forward order), so exactly one
@@ -263,9 +270,8 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(tableRealName(target.arelTable as TableRef)).toBe("jdt_comments");
     expect(tableSqlName(target.arelTable as TableRef)).toBe("jdtComments");
 
-    // The intermediate `_through_` link is internal and never reference-aliased.
-    const throughNode = jd.nodes.find((n) => n.assocName.includes("_through_"))!;
-    expect(throughNode.effectiveSqlName).toBe("jdt_posts");
+    // The intermediate chain link is internal and never reference-aliased.
+    expect(joinedTableNames(jd.joinConstraints([]))).toContain("jdt_posts");
   });
 
   it("reuses one chain-tail alias for two distinct through associations sharing it", () => {
@@ -314,9 +320,7 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     }
 
     const jd = new JoinDependency(MemAuthor, null, ["memComments", "memRatings"], Nodes.OuterJoin);
-    jd.joinConstraints([]);
-
-    const effectiveNames = jd.nodes.map((n) => n.effectiveSqlName);
+    const effectiveNames = joinedTableNames(jd.joinConstraints([]));
     // Exactly one `mem_posts` join survives; the shared tail emits no spurious
     // `_join` alias for the second through path.
     expect(effectiveNames.filter((n) => n === "mem_posts").length).toBe(1);
@@ -336,13 +340,10 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     // ONE `jdt_posts` join instead of minting a second
     // `jdt_posts_jdt_authors_join` alias.
     const jd = new JoinDependency(JdtAuthor, null, ["jdtPosts", "jdtComments"], Nodes.OuterJoin);
-    jd.joinConstraints([]);
+    const joins = jd.joinConstraints([]);
     const directNode = nodeAt(jd, "jdtPosts");
     const node = nodeAt(jd, "jdtComments");
     expect(node).not.toBeNull();
-
-    // Aliasing is deferred to emit: resolve against the shared AliasTracker.
-    jd.joinConstraints([]);
 
     // The direct include keeps the real `jdt_posts` name (first use) and owns
     // the one emitted join.
@@ -352,14 +353,11 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(directTable.tableAlias).toBeNull();
 
     // The through link reuses the memoized `jdt_posts` alias — it is suppressed
-    // (no duplicate join, dropped from the projected `nodes`) so exactly one
-    // `jdt_posts` join survives and no spurious `_join` alias is minted.
-    const effectiveNames = jd.nodes.map((n) => n.effectiveSqlName);
+    // (no duplicate join emitted) so exactly one `jdt_posts` join survives and
+    // no spurious `_join` alias is minted.
+    const effectiveNames = joinedTableNames(joins);
     expect(effectiveNames.filter((n) => n === "jdt_posts").length).toBe(1);
     expect(effectiveNames.some((n) => n.includes("_join"))).toBe(false);
-    expect(
-      jd.nodes.some((n) => n.tableName === "jdt_posts" && n.assocName.includes("_through_")),
-    ).toBe(false);
 
     // Target uses real name (first use), keyed off the one shared `jdt_posts`.
     const targetTable = (node.arelJoin as Nodes.OuterJoin).left as Table;

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -1,12 +1,10 @@
 /**
- * Covers the real-table-name reuse in JoinDependency#_addThroughAssociation.
+ * Covers the real-table-name reuse a `has_many :through` chain gets from
+ * `JoinDependency#makeConstraints` (`join_dependency.rb:189-211`).
  *
  * Mirrors AliasTracker behavior (`activerecord/lib/active_record/table_metadata.rb`
  * / `alias_tracker.rb`): a joined table uses its real name when not already
- * in use, falling back to a tN alias only on collision. Previously
- * `_addThroughAssociation` hard-coded `tN` aliases for both the through
- * and target tables regardless of collisions, diverging from the
- * single-step join path.
+ * in use, falling back to a tN alias only on collision.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
@@ -31,7 +29,7 @@ function joinedTableNames(joins: Nodes.Join[]): string[] {
   return joins.map((join) => tableSqlName(join.left as TableRef));
 }
 
-describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
+describe("JoinDependency has_many :through real-table-name reuse", () => {
   // Ride the boot-laid canonical `Base.connection` (single-pool test model)
   // rather than a sidecar `_pool` lease; these wiring tests only need an
   // adapter for JoinDependency's quoting, not a bespoke schema.

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -496,8 +496,6 @@ export class JoinDependency {
     const joins: Nodes.Join[] = [];
 
     if (child instanceof JoinAssociation) {
-      // The chain's ROOT link is the one the tree node stands for; the rest of
-      // the chain lives inside this single `joinConstraints` walk, as in Rails.
       let resolvedRoot: { aliased: TableRef; effectiveName: string } | undefined;
       const built = child.joinConstraints(
         foreignTable,

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -279,17 +279,15 @@ export class JoinDependency {
   }
 
   /**
-   * Materialize the JOIN node(s) for one already-checked reflection off
+   * Materialize the JOIN node for one already-checked reflection off
    * `modelClass` — the body of Rails' `JoinAssociation.new(reflection, ...)`,
-   * which in trails also allocates the node's t-index and its provisional join.
-   * A `through` reflection materializes one node per chain link (the target plus
-   * its `_through_` leaves), so the return is an array; the target is last.
+   * which in trails also allocates the node's t-index. A `through` reflection
+   * is ONE node here, as in Rails: `JoinAssociation#join_constraints` walks
+   * `reflection.chain` internally (join_association.rb:32-73), and the tree
+   * holds only JoinBase and JoinAssociation.
    * @internal
    */
-  private addAssociation(reflection: any, modelClass: typeof Base): JoinPart[] {
-    if (reflection.isThroughReflection()) {
-      return this._addThroughViaJoinAssociation(reflection, modelClass);
-    }
+  private addAssociation(reflection: any): JoinPart {
     const assocName: string = reflection.name;
 
     const assocType: "hasMany" | "hasOne" | "belongsTo" =
@@ -316,8 +314,7 @@ export class JoinDependency {
     treePart.immediateAssocName = assocName;
     treePart.assocType = assocType;
     treePart.nodeReflection = reflection;
-    treePart.isThroughNode = false;
-    return [treePart];
+    return treePart;
   }
 
   /**
@@ -348,10 +345,9 @@ export class JoinDependency {
       if (reflection.isPolymorphic?.()) {
         throw new EagerLoadPolymorphicError(name);
       }
-      const nodes = this.addAssociation(reflection, baseKlass);
-      const node = nodes[nodes.length - 1];
+      const node = this.addAssociation(reflection);
       if (right != null) node.children.push(...this.build(right, reflection.klass));
-      return nodes;
+      return [node];
     });
   }
 
@@ -367,11 +363,6 @@ export class JoinDependency {
    * Mirrors: `join_root.drop(1).map!(&:reflection)` (join_dependency.rb:81-83) —
    * the Enumerable walk of the join tree, root dropped, reading the reflection
    * each node already carries.
-   *
-   * `_through_` hops are trails-only tree nodes (`JoinLeaf`, declared below in
-   * this file): Rails keeps a
-   * through association's whole chain inside the one JoinAssociation, so the
-   * hops carry no reflection of their own and Rails never lists one here.
    */
   get reflections(): any[] {
     return this.joinRoot
@@ -469,7 +460,7 @@ export class JoinDependency {
 
     const joins = intersection.flatMap(([l, r]) => {
       // Rails: `r.table = l.table`.
-      if (r instanceof JoinAssociation || r instanceof JoinLeaf) {
+      if (r instanceof JoinAssociation) {
         const lt = l.table;
         r.table = l.effectiveSqlName || (typeof lt === "string" ? lt : tableSqlName(lt));
       }
@@ -490,9 +481,8 @@ export class JoinDependency {
    * `AliasTracker` in order, so a `merge` onto an already-joined table — or a
    * self-join / dup-include collision WITHIN this dependency — collides and
    * aliases here. A `has_many :through` walks its whole `reflection.chain`
-   * through this same block; the joins it returns are redistributed onto the
-   * chain's `_through_` tree nodes, which trails carries so each link can
-   * project its own columns.
+   * through this same block, inside the one JoinAssociation; only the chain's
+   * root link is a tree node, and only its columns are projected.
    * @internal
    */
   private makeConstraints(
@@ -506,19 +496,15 @@ export class JoinDependency {
     const joins: Nodes.Join[] = [];
 
     if (child instanceof JoinAssociation) {
-      const chainLen = child.reflection.chain.length;
-      const resolvedByIdx: Array<{ aliased: TableRef; effectiveName: string } | undefined> =
-        new Array(chainLen);
-      // How far `joinConstraints` walked before terminating on an
-      // already-resolved tail — i.e. how many constraint joins it emits.
-      let walkedLen = chainLen;
+      // The chain's ROOT link is the one the tree node stands for; the rest of
+      // the chain lives inside this single `joinConstraints` walk, as in Rails.
+      let resolvedRoot: { aliased: TableRef; effectiveName: string } | undefined;
       const built = child.joinConstraints(
         foreignTable,
         foreignKlass,
         joinType,
         this.aliasTracker,
         (reflection, remainingReflectionChain) => {
-          const idx = chainLen - remainingReflectionChain.length;
           const chainKey = reflectionChainKey(remainingReflectionChain);
           const memo = this._joinedTables.get(chainKey);
           const root = reflection === child.reflection;
@@ -529,9 +515,10 @@ export class JoinDependency {
           // keys off the one shared alias rather than minting a spurious
           // `{candidate}_join`.
           if (memo && (!root || !memo.terminated)) {
-            if (root) memo.terminated = true;
-            resolvedByIdx[idx] = memo;
-            walkedLen = idx;
+            if (root) {
+              memo.terminated = true;
+              resolvedRoot = memo;
+            }
             return [memo.aliased, true];
           }
 
@@ -553,7 +540,7 @@ export class JoinDependency {
             (reflection as any).tableName,
             effectiveName,
           );
-          resolvedByIdx[idx] = { aliased, effectiveName };
+          if (root) resolvedRoot = { aliased, effectiveName };
 
           // `@joined_tables[remaining_reflection_chain] ||= [table, root] if
           // join_type == Arel::Nodes::OuterJoin` (join_dependency.rb:208). Keyed
@@ -566,46 +553,24 @@ export class JoinDependency {
         },
       );
 
-      // Rails keeps the whole chain inside the one JoinAssociation; trails also
-      // carries a tree node per link (the target plus its `_through_` leaves) so
-      // each can project its columns, so the resolved tables and joins are
-      // redistributed onto them here.
-      const nodes = child.throughGroup ? child.throughGroup.nodes : [child];
-      for (let idx = 0; idx < chainLen; idx++) {
-        const node = nodes[idx];
-        if (!node) continue;
-        const resolved = resolvedByIdx[idx];
-        node.arelJoin = null;
-        if (resolved && (idx < walkedLen || idx === 0)) {
-          node.arelTable = resolved.aliased;
-          node.effectiveSqlName = resolved.effectiveName;
-        } else {
-          // A link past the walked prefix was reused from an already-resolved
-          // chain tail: it must neither emit a join nor project duplicate columns.
-          node.tableIndex = -1;
-        }
+      // Rails keeps the whole chain inside the one JoinAssociation
+      // (join_association.rb:32-73); only the chain's ROOT link is a tree node,
+      // so only its resolved table lands back on the node.
+      child.arelJoin = null;
+      if (resolvedRoot) {
+        child.arelTable = resolvedRoot.aliased;
+        child.effectiveSqlName = resolvedRoot.effectiveName;
+        // `joinConstraints` walks the chain in reverse, so the root link's own
+        // constraint join is the one built against the table this block handed
+        // back for it. Identity, not table name — a scope join source is built
+        // from `scope.arel(...).join_sources` (join_association.rb:64-69) and so
+        // is never the same instance even when it joins a same-named table.
+        child.arelJoin =
+          (built as Nodes.Join[]).find(
+            (join) => (join as { left?: unknown }).left === resolvedRoot!.aliased,
+          ) ?? null;
       }
-      // `joinConstraints` walks the chain in reverse and emits each step's
-      // constraint join followed by that step's scope join sources
-      // (`joins.concat arel.join_sources`, join_association.rb:64-69), so the
-      // returned array is `[J(n-1), sources…, J(n-2), sources…, …]`. Only the
-      // constraint joins map back onto a chain link's tree node: an entry is
-      // one when its `left` IS the table object this block handed the walk for
-      // the next link. Identity, not table name — a scope join source is built
-      // from `scope.arel(...).join_sources` and so can never be the same
-      // instance even when it joins a same-named table, and `appendConstraints`
-      // carries `left` through by reference when it rebuilds a join.
-      let linkIdx = walkedLen - 1;
-      for (const entry of built) {
-        const join = entry as Nodes.Join;
-        const resolved = linkIdx >= 0 ? resolvedByIdx[linkIdx] : undefined;
-        if (resolved && (join as { left?: unknown }).left === resolved.aliased) {
-          const node = nodes[linkIdx];
-          if (node) node.arelJoin = join;
-          linkIdx--;
-        }
-        joins.push(join);
-      }
+      joins.push(...(built as Nodes.Join[]));
       this._aliasesCache = undefined;
     }
 
@@ -833,13 +798,6 @@ export class JoinDependency {
     for (const node of parent.children) {
       if (node.tableIndex < 0) continue;
 
-      // trails through-chain intermediates carry no AR record — pass the
-      // current parent straight through to the real target node.
-      if (node.isThroughNode) {
-        this.construct(arParent, node, row, seen, modelCache, strictLoadingValue);
-        continue;
-      }
-
       const isCollection = node.assocType === "hasMany";
       if (isCollection) {
         this._markCollectionLoaded(arParent, node);
@@ -929,7 +887,7 @@ export class JoinDependency {
     for (const [key, parent] of parents) {
       const assocs = new Map<string, any[]>();
       for (const child of this._joinRoot.children) {
-        if (child.tableIndex < 0 || child.isThroughNode) continue;
+        if (child.tableIndex < 0) continue;
         const proxy = parent.association?.(child.immediateAssocName);
         const target = proxy?.target;
         assocs.set(
@@ -983,13 +941,10 @@ export class JoinDependency {
     // Rails' join_root tree holds only the reflected association nodes — the
     // through/HABTM join-table links are joined by JoinAssociation#join_constraints
     // but never become JoinParts, so their columns are not projected into the
-    // eager SELECT (and thus never need a GROUP BY entry). trails models those
-    // links as `isThroughNode` leaves for constraint building; skip their
-    // columns here to match Rails' projection. The table index is the node's
-    // own `tableIndex` rather than Ruby's `each_with_index` position, since the
-    // skipped through-links would shift every later index.
+    // eager SELECT (and thus never need a GROUP BY entry). The table index is
+    // the node's own `tableIndex` rather than Ruby's `each_with_index` position.
     return (this._aliasesCache ??= new Aliases(
-      [this._joinRoot, ...this.nodes.filter((node) => !node.isThroughNode)].map((joinPart) => {
+      [this._joinRoot, ...this.nodes].map((joinPart) => {
         const isJoinRoot = joinPart === this._joinRoot;
         let columnNames: string[];
         if (isJoinRoot && !this._joinRootAlias) {
@@ -1141,91 +1096,5 @@ export class JoinDependency {
     } catch (e) {
       if (!(e instanceof AssociationNotFoundError)) throw e;
     }
-  }
-
-  private _addThroughViaJoinAssociation(reflection: any, modelClass: typeof Base): JoinPart[] {
-    // A through reflection's `chain` is `[self, *through_reflection.chain]`, so
-    // it always carries the target plus at least one through link.
-    // `JoinAssociation#joinConstraints` walks the whole chain in one call at
-    // emit; trails still carries a tree node per link so each can project its
-    // own columns and hydrate. The nodes are siblings in the joins' emission
-    // order (deepest link first, target last) and share a `ThroughJoinGroup` so
-    // `makeConstraints` can redistribute the joins it gets back.
-    const chain = reflection.chain;
-    const group: ThroughJoinGroup = { nodes: new Array(chain.length) };
-    const nodes: JoinPart[] = [];
-
-    // The indices for the whole chain are allocated up front, before any
-    // nested association under the target claims one.
-    const startIndex = this._tableIndexCounter;
-    this._tableIndexCounter += chain.length;
-
-    for (let chainIdx = chain.length - 1; chainIdx >= 0; chainIdx--) {
-      const refl = chain[chainIdx];
-      const model = refl.klass as typeof Base;
-      const tableName = (model as any).tableName;
-      const tableIndex = startIndex + chainIdx;
-      const isTarget = chainIdx === 0;
-
-      const treePart = isTarget ? new JoinAssociation(reflection) : new JoinLeaf(model);
-      treePart.tableIndex = tableIndex;
-      treePart.arelTable = aliasedArelTableFor(model as never, tableName);
-      treePart.tableAlias = `t${tableIndex}`;
-      treePart.effectiveSqlName = tableName;
-      treePart.columns = getModelColumns(model);
-      treePart.throughGroup = group;
-      if (isTarget) {
-        treePart.immediateAssocName = reflection.name;
-        treePart.assocType =
-          reflection.macro === "hasAndBelongsToMany" ? "hasMany" : reflection.macro;
-        treePart.nodeReflection = reflection;
-        treePart.isThroughNode = false;
-      } else {
-        treePart.immediateAssocName = `_through_${refl.name ?? tableName}`;
-        treePart.assocType = (refl._reflection ?? refl).macro === "hasOne" ? "hasOne" : "hasMany";
-        treePart.isThroughNode = true;
-      }
-      group.nodes[chainIdx] = treePart;
-      nodes.push(treePart);
-    }
-
-    return nodes;
-  }
-}
-
-/**
- * Shared per-through-association state, attached to every tree node a
- * `has_many :through` chain produces (target + `_through_` leaves). Rails keeps
- * the whole chain inside the one JoinAssociation, whose `joinConstraints`
- * resolves and joins every link in one call; the group is how `makeConstraints`
- * finds the tree nodes those joins belong to.
- * @internal
- */
-export interface ThroughJoinGroup {
-  /** Tree nodes by chain index (0 = target, 1.. = `_through_` leaves). */
-  nodes: JoinPart[];
-}
-
-class JoinLeaf extends JoinPart {
-  private _tableOverride: string | null = null;
-
-  constructor(baseKlass: typeof Base) {
-    super(baseKlass);
-  }
-
-  get table(): string {
-    return this._tableOverride ?? this.effectiveSqlName;
-  }
-
-  set table(value: string) {
-    this._tableOverride = value;
-  }
-
-  override isMatch(other: JoinPart): boolean {
-    if (this === other) return true;
-    if (!(other instanceof JoinLeaf)) return false;
-    return (
-      this.immediateAssocName === other.immediateAssocName && this.baseKlass === other.baseKlass
-    );
   }
 }

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -9,7 +9,6 @@
 
 import type { Base } from "../../base.js";
 import type { TableRef, Nodes } from "@blazetrails/arel";
-import type { ThroughJoinGroup } from "../join-dependency.js";
 
 export abstract class JoinPart {
   readonly baseKlass: typeof Base;
@@ -30,16 +29,6 @@ export abstract class JoinPart {
   arelJoin: Nodes.Join | null = null;
   /** @internal */
   nodeReflection: any | null = null;
-  isThroughNode = false;
-  /**
-   * Set on the tree nodes of a `has_many :through` chain (target + `_through_`
-   * leaves). Rails keeps the whole chain inside the one JoinAssociation, whose
-   * `joinConstraints` resolves and joins every link in one call; the group is
-   * how `JoinDependency#makeConstraints` finds the tree nodes those joins and
-   * tables belong to. Null for non-through nodes.
-   * @internal
-   */
-  throughGroup: ThroughJoinGroup | null = null;
   immediateAssocName = "";
   parentPath: string | null = null;
   effectiveSqlName = "";


### PR DESCRIPTION
## What

Two convergences from the bundle; the third story was released (see below).

### Retire the `JoinLeaf` node kind (`retire-join-leaf-node-kind`)

Rails' join tree holds only `JoinBase` and `JoinAssociation`
(`join_dependency.rb:228-240`): a `has_many :through` is ONE tree edge whose
`JoinAssociation#join_constraints` walks `reflection.chain` internally
(`join_association.rb:32-73`). trails carried an extra `JoinLeaf` per chain link
and redistributed the tables/joins from the one chain walk back onto them.
Nothing consumed that any more — `aliases()` and `construct` already skipped
`isThroughNode` leaves to match Rails' projection.

- `addAssociation` builds one `JoinAssociation` per edge and returns it, so
  `build` mirrors `JoinAssociation.new(reflection, build(right, klass))`.
- `makeConstraints` keeps only the chain's root link — the link the tree node
  stands for. The per-link `resolvedByIdx` / `walkedLen` bookkeeping and both
  redistribution loops are gone; one `joinConstraints` call per edge.
- `JoinLeaf`, `ThroughJoinGroup`, `JoinPart#throughGroup` and
  `JoinPart#isThroughNode` are deleted, with the `_through_` guards in
  `aliases()`, `construct` and `_collectAssociations`.

The through-aliasing tests observed intermediate links through their `_through_`
nodes; they now read the emitted join sources, which is the only place an
intermediate link's aliasing is observable in Rails' shape.

`parity:api:extra` for `join-dependency/join-part.ts` drops two names;
`parity:api:calls` and `:args` add zero rows. Green locally on SQLite:
`join-dependency-through-aliasing`, `eager`, `inner-join-association`,
`left-outer-join-association`, `has-many-through-associations`,
`nested-through-associations`, and the whole `join-dependency-*` set.

### Restore `assert_valid_value`'s `else super(value)` arm (`converge-accepts-multiparameter-time-assert-valid-value-super-arm`)

`accepts_multiparameter_time.rb:24-30` sends a non-Hash value to `super`.
`date.ts`, `date-time.ts` and `time.ts` all dropped that arm, so a non-hash
value was never validated at all. Harmless while `Type::Value#assert_valid_value`
is a no-op, but ActiveRecord's `Type::Serialized`, the enum types and several PG
OID types override it to raise, and a type inheriting from these three would
silently skip it on the ordinary path. A test per type pins that a scalar
reaches `super` and a multiparameter hash does not.

## Released, not shipped

`port-activejob-test-helper-for-destroy-association-async` is released back to
the queue rather than squeezed in here. Its scope is an entire new `activejob`
package — `QueueAdapters::TestAdapter`, `TestHelper`'s four assertions with
their `only:`/`args:` filters, `ActiveRecord::DestroyAssociationAsyncJob`, and
the `after_commit` drain — which is several hundred LOC of new package plus its
registrations on its own, well past this PR's ceiling. The story itself notes
"splitting this into its own RFC/epic is fine and probably right".

## Follow-up filed

`JoinPart#arelJoin` survives this PR: nothing in `src/` reads it, but three test
files use it as a handle on the emitted join, so retiring it is its own diff.
Rails' `JoinAssociation` has no counterpart — filed as
`0106-wide-call-set-direct-burndown/retire-join-part-arel-join`.

Closes-story: retire-join-leaf-node-kind
Closes-story: converge-accepts-multiparameter-time-assert-valid-value-super-arm
