### PR TITLE
refactor(activerecord): sweep top-level src includes/preload call sites onto the colon spelling

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1016,7 +1016,7 @@ describe("BasicsTest", () => {
     const bulbsOfCar = Bulb.where({ car_id: car.id });
     // Rails: assert_equal bulbs_of_car, car.bulbs.includes(:car)
     // AssociationRelation (includes chain off proxy) returns same rows as plain Relation
-    const assocRelation = association(car, "bulbs").includes("car");
+    const assocRelation = association(car, "bulbs").includes(":car");
     const relationResults = await bulbsOfCar;
     const assocResults = await assocRelation;
     expect(relationResults).toHaveLength(1);
@@ -1033,7 +1033,7 @@ describe("BasicsTest", () => {
     // Rails: assert_equal car.bulbs, car.bulbs.includes(:car)
     // CollectionProxy and includes-chain produce the same underlying rows
     const proxyResults = await association(car, "bulbs");
-    const assocRelResults = await association(car, "bulbs").includes("car");
+    const assocRelResults = await association(car, "bulbs").includes(":car");
     expect(proxyResults).toHaveLength(1);
     expect(proxyResults.map((r: any) => r.id).sort()).toEqual(
       assocRelResults.map((r: any) => r.id).sort(),

--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -136,12 +136,12 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("cache_key for relation with includes", async () => {
-    const comments = Comment.includes("post").where({ "posts.type": "Post" });
+    const comments = Comment.includes(":post").where({ "posts.type": "Post" });
     expect(await comments.cacheKey()).toMatch(/^comments\/query-[0-9a-f]+-\d+-\d+$/);
   });
 
   it("cache_key for loaded relation with includes", async () => {
-    const comments = await Comment.includes("post").where({ "posts.type": "Post" }).load();
+    const comments = await Comment.includes(":post").where({ "posts.type": "Post" }).load();
     expect(await comments.cacheKey()).toMatch(/^comments\/query-[0-9a-f]+-\d+-\d+$/);
   });
 
@@ -155,7 +155,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("update_all with includes will update cache_key", async () => {
-    const developers = Developer.includes("projects").where({ "projects.name": "Active Record" });
+    const developers = Developer.includes(":projects").where({ "projects.name": "Active Record" });
     const cacheKey = await developers.cacheKey();
 
     await developers.updateAll({ updated_at: Temporal.Now.instant() });
@@ -173,7 +173,7 @@ describe("CollectionCacheKeyTest", () => {
   });
 
   it("delete_all with includes will update cache_key", async () => {
-    const developers = Developer.includes("projects").where({ "projects.name": "Active Record" });
+    const developers = Developer.includes(":projects").where({ "projects.name": "Active Record" });
     const cacheKey = await developers.cacheKey();
 
     await developers.deleteAll();
@@ -248,7 +248,7 @@ describe("CollectionCacheKeyTest", () => {
 
   it("cache_key for loaded collection with zero size", async () => {
     await Comment.deleteAll();
-    const posts = Post.includes("comments");
+    const posts = Post.includes(":comments");
     const emptyLoadedCollection = (
       (await posts.first()) as unknown as { comments: Relation<Comment> }
     ).comments;

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -230,7 +230,7 @@ describe("ExplainTest", () => {
   });
 
   it("captures queries for eager-loaded associations, one block per query", async () => {
-    const plan = await Car.all().preload("bulbs").explain();
+    const plan = await Car.all().preload(":bulbs").explain();
     const blocks = plan.split(/^(?=EXPLAIN)/m).filter((b) => /EXPLAIN/.test(b));
     expect(blocks.length).toBeGreaterThanOrEqual(2);
     expect(plan.toLowerCase()).toContain("cars");

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -474,19 +474,19 @@ describe("InheritanceTest", () => {
   });
 
   it("eager load belongs to something inherited", async () => {
-    const account = await Account.includes("firm").find(1);
+    const account = await Account.includes(":firm").find(1);
     expect(account.association("firm").loaded).toBe(true);
   });
 
   it("alt eager loading", async () => {
-    const cabbage = await RedCabbage.includes("seller").find(4);
+    const cabbage = await RedCabbage.includes(":seller").find(4);
     expect(cabbage.association("seller").loaded).toBe(true);
   });
 
   it("eager load belongs to primary key quoting", async () => {
     let error: unknown;
     try {
-      await Account.includes("firm").find(1);
+      await Account.includes(":firm").find(1);
     } catch (e) {
       error = e;
     }
@@ -704,7 +704,7 @@ describe("InheritanceAttributeMappingTest", () => {
     )) as string[];
     expect(rawTypes[0]).toMatch(/^omg_/);
 
-    const reloaded = await IamtSponsor.includes("sponsorable").find(sponsor.id);
+    const reloaded = await IamtSponsor.includes(":sponsorable").find(sponsor.id);
     expect((reloaded as any).sponsorable?.id).toBe(startup.id);
   });
 });

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -836,7 +836,7 @@ describe("PessimisticLockingTest", () => {
   // PostgreSQL protests SELECT ... FOR UPDATE on an outer join.
   it.skipIf(adapterType === "postgres")("eager find with lock", async () => {
     await Person.transaction(async () => {
-      await Person.includes("readers").lock().find(people("michael").id);
+      await Person.includes(":readers").lock().find(people("michael").id);
     });
   });
 

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -13,15 +13,15 @@ fixtures({ topics: [Topic, {}] });
 
 describe("QueryingTest — static forwarders on Base", () => {
   it("includes() returns a Relation without throwing", () => {
-    expect(Topic.includes("author")).toBeInstanceOf(Relation);
+    expect(Topic.includes(":author")).toBeInstanceOf(Relation);
   });
 
   it("preload() returns a Relation", () => {
-    expect(Topic.preload("comments")).toBeInstanceOf(Relation);
+    expect(Topic.preload(":comments")).toBeInstanceOf(Relation);
   });
 
   it("eagerLoad() returns a Relation", () => {
-    expect(Topic.eagerLoad("author")).toBeInstanceOf(Relation);
+    expect(Topic.eagerLoad(":author")).toBeInstanceOf(Relation);
   });
 
   it("references() returns a Relation", () => {
@@ -119,7 +119,7 @@ describe("QueryingTest — static forwarders on Base", () => {
   });
 
   it("includes().where() chains and produces valid SQL", () => {
-    const rel = Topic.includes("author").where({ title: "published" });
+    const rel = Topic.includes(":author").where({ title: "published" });
     expect(rel).toBeInstanceOf(Relation);
     const sql = rel.toSql();
     expect(sql).toContain("topics");

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -847,7 +847,7 @@ describe("ReflectionTest", () => {
     const dept = await Department.create({ hotel_id: hotel.id });
     await Chef.create({ department_id: dept.id });
     // includes should accept string association names
-    const hotels = await CanonicalHotel.all().includes("departments");
+    const hotels = await CanonicalHotel.all().includes(":departments");
     expect(hotels).toHaveLength(1);
   });
   it("reflect on association accepts symbols", () => {
@@ -1396,7 +1396,7 @@ describe("ReflectionTest", () => {
     const chef = await Chef.create({ department_id: dept.id });
     // includes should accept a nested association hash (Rails `[departments: :chefs]`)
     // and actually preload the nested association onto the loaded records.
-    const hotels = await CanonicalHotel.all().includes({ departments: "chefs" });
+    const hotels = await CanonicalHotel.all().includes({ ":departments": ":chefs" });
     expect(hotels).toHaveLength(1);
     const departments = hotels[0].association("departments").target as Base[];
     expect(departments).toHaveLength(1);

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -117,7 +117,7 @@ describe("Relation#load_async", () => {
     };
     const spy = vi.spyOn(connection, "selectAll");
 
-    await Topic.eagerLoad("replies").loadAsync();
+    await Topic.eagerLoad(":replies").loadAsync();
 
     const joinCall = spy.mock.calls.find((call) => call[1] === "SQL");
     expect(joinCall).toBeDefined();

--- a/packages/activerecord/src/relation-skip-preloading.trails.test.ts
+++ b/packages/activerecord/src/relation-skip-preloading.trails.test.ts
@@ -17,7 +17,7 @@ describe("Relation#exec_queries skip_preloading_value guard", () => {
   fixtures(["authors", "posts"]);
 
   it("issues no preload query and leaves the association unloaded", async () => {
-    const relation = Author.includes("posts").order("id");
+    const relation = Author.includes(":posts").order("id");
     relation.skipPreloadingBang();
 
     let authors: Author[] = [];
@@ -30,7 +30,7 @@ describe("Relation#exec_queries skip_preloading_value guard", () => {
   });
 
   it("preloads when the flag is not set", async () => {
-    const authors = await Author.includes("posts").order("id");
+    const authors = await Author.includes(":posts").order("id");
 
     expect(authors[0].association("posts").isLoaded()).toBe(true);
   });

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -314,17 +314,17 @@ describe("RelationTest", () => {
   });
 
   it("eager load values", () => {
-    const rel = CanonPost.all().includes("comments");
+    const rel = CanonPost.all().includes(":comments");
     expect(rel.toSql()).toContain("SELECT");
   });
 
   it("references values", () => {
-    const sql = CanonPost.all().includes("comments").toSql();
+    const sql = CanonPost.all().includes(":comments").toSql();
     expect(sql).toContain("SELECT");
   });
 
   it("references values dont duplicate", () => {
-    const sql = CanonPost.all().includes("comments").includes("comments").toSql();
+    const sql = CanonPost.all().includes(":comments").includes(":comments").toSql();
     expect(sql).toContain("SELECT");
   });
 

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -217,7 +217,7 @@ describe("ReservedWordTest", () => {
 
   it("associations work with reserved words", async () => {
     await createTestFixtures("select", "group");
-    const selects = await Select.all().includes("groups");
+    const selects = await Select.all().includes(":groups");
     // Rails asserts the eager-loaded `groups` trigger zero queries here.
     await assertNoQueries(false, async () => {
       for (const s of selects) {

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -216,8 +216,8 @@ describe("UnsafeRawSqlTest", () => {
   });
 
   it("pluck: allows column names with includes", async () => {
-    const valuesExpected = await Post.includes("comments").pluck(arelSql("title"), arelSql("id"));
-    const values = await Post.includes("comments").pluck("title", "id");
+    const valuesExpected = await Post.includes(":comments").pluck(arelSql("title"), arelSql("id"));
+    const values = await Post.includes(":comments").pluck("title", "id");
     expect(values).toEqual(valuesExpected);
   });
 
@@ -257,7 +257,7 @@ describe("UnsafeRawSqlTest", () => {
 
   it("pluck: disallows invalid column names with includes", async () => {
     await expect(
-      Post.includes("comments").pluck("title", "REPLACE(title, 'misc', 'zzzz')"),
+      Post.includes(":comments").pluck("title", "REPLACE(title, 'misc', 'zzzz')"),
     ).rejects.toBeInstanceOf(UnknownAttributeReference);
   });
 
@@ -271,10 +271,10 @@ describe("UnsafeRawSqlTest", () => {
   });
 
   it("pluck: always allows Arel", async () => {
-    const expectedValues = (await Post.includes("comments").pluck("title")).map(
+    const expectedValues = (await Post.includes(":comments").pluck("title")).map(
       (title: unknown) => [title, (title as string).length],
     );
-    const values = await Post.includes("comments").pluck("title", arelSql("length(title)"));
+    const values = await Post.includes(":comments").pluck("title", arelSql("length(title)"));
     expect(values).toEqual(expectedValues);
   });
 


### PR DESCRIPTION
Sweeps the remaining `includes` / `preload` / `eagerLoad` association-name
literals at the **top level of `packages/activerecord/src`** onto the
colon-prefixed Symbol spelling, matching Rails
(`relation/query_methods.rb:88-101`, which takes Symbols) and CLAUDE.md's rule
that a Ruby Symbol is a colon-prefixed string. `joins` / `leftOuterJoins` were
swept this way by #6704; this closes the gap for the includes family in this
cluster.

12 files, 31 lines. Most top-level call sites were already converged — what was
left were bare names in `base.test.ts`, `collection-cache-key.test.ts`,
`explain.test.ts`, `inheritance.test.ts`, `locking.test.ts`,
`querying.test.ts`, `reflection.test.ts`,
`relation-load-async.trails.test.ts`,
`relation-skip-preloading.trails.test.ts`, `relation.test.ts`,
`reserved-word.test.ts` and `unsafe-raw-sql.test.ts`.

No normalization site added — the strip stays at `Preloader::Branch`
(#6713) / `JoinDependency` (`associations/join-dependency.ts:933`).
`.references(...)` call sites are untouched: every one in scope names a
**table** (`companies`, `chapters`, `molecules`, `posts`, `comments`,
`authors`), which Rails passes as a String (`query_methods.rb`, `references!`).
No test name touched; generated SQL unchanged.

Gates: `pnpm parity:api:calls` OK (903 baselined, 425 unreviewed);
`pnpm parity:api:calls:args` OK (169 baselined shape rows). No public TS name
added, so `parity:api:extra` is unmoved. Touched suites pass locally.

### Bundled stories not shipped here

Two of the three bundled stories are blocked rather than included, with the
blocker recorded on each story:

- **`port-activejob-test-helper-for-destroy-association-async`** — trails has no
  `activejob` package at all. Reaching `assert_enqueued_jobs` /
  `perform_enqueued_jobs` needs `ActiveJob::Base`, the `QueueAdapters` registry,
  `Execution`, `ConfiguredJob`, `Arguments` serialization, `TestAdapter`
  (`activejob/lib/active_job/queue_adapters/test_adapter.rb`, 86 lines) and
  `TestHelper` (`activejob/lib/active_job/test_helper.rb`, 770 lines) plus a new
  workspace package — before `ActiveRecord::DestroyAssociationAsyncJob` and the
  `_afterCommitJobs` drain. Far past the LOC ceiling; the story body itself says
  splitting it into its own RFC/epic "is fine and probably right".
- **`unhoist-through-preloader-records-by-owner-loaded-guard`** — its own
  acceptance criteria require it to land after
  `converge-through-preloader-records-by-owner-onto-public-reader`, which is
  still `ready` and unclaimed. Until that removes the unconditional pre-fetch
  above the loop in `preloader/through-association.ts` `recordsByOwner`,
  unhoisting the guard would issue queries for a fully-loaded `owners` list that
  Rails (`through_association.rb:12-15`) never issues. `deps` set accordingly.

Closes-story: converge-includes-preload-colon-sweep-src-top-level
