### PR TITLE
refactor(activemodel,activerecord): mix AcceptsMultiparameterTime in via include(), read the public recordsByOwner, colon-sweep scoping/adapters

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -180,6 +180,10 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * `Temporal.Instant` this port spells a `::Time` as, so the instant is read
    * back off it.
    *
+   * `super` is reached as Ruby's own `instance_method(...).bind_call(self, ...)`
+   * does: TS types `super` against a declared base class only, never against a
+   * mixed-in module.
+   *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
@@ -191,10 +195,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${toS(values)} doesn't contain necessary keys: ${toS(missing)}`,
       );
     }
-    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
-    // Ruby reaches by ancestry and TS types only for a declared base class, so
-    // it is taken off the module as Ruby's own
-    // `instance_method(...).bind_call(self, ...)` does.
     const time = (
       acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
         this: unknown,

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -3,21 +3,32 @@ import {
   Date as RubyDate,
   Rational,
   Temporal,
+  Time as RubyTime,
   type DateParts,
 } from "@blazetrails/date";
 import {
   type DateInfinity as DateInfinityType,
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
-import { isPlainObject, toS } from "@blazetrails/activesupport";
+import { include, toS } from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
-import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
+import {
+  AcceptsMultiparameterTime,
+  type InstanceMethods,
+} from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type -- Ruby `include` (date_time.rb:44-46); the class/interface merge is how `include()` surfaces on the type side.
+export interface DateTimeType extends Omit<
+  InstanceMethods<DateTimeCastResult>,
+  "valueFromMultiparameterAssignment"
+> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DateTimeType extends ValueType<DateTimeCastResult> {
   readonly name: string = "datetime";
 
@@ -162,9 +173,9 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * trails spells one with (CLAUDE.md), so `{ ":a": 1 }` renders the `{:a=>1}`
    * MRI 3.3 emits.
    *
-   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly,
-   * which trails reaches through the wrapper in
-   * `helpers/accepts-multiparameter-time.ts` rather than an ancestor. Rails'
+   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly, which
+   * this class mixes in below itself (see the `include` at the bottom of this
+   * file). Rails'
    * cast result for a Hash IS that `::Time`; `DateTimeCastResult` is the
    * `Temporal.Instant` this port spells a `::Time` as, so the instant is read
    * back off it.
@@ -180,46 +191,21 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
         `Provided hash ${toS(values)} doesn't contain necessary keys: ${toS(missing)}`,
       );
     }
-    const time = new AcceptsMultiparameterTime(this, {
-      "4": 0,
-      "5": 0,
-    }).valueFromMultiparameterAssignment(values as Record<string, unknown>);
+    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
+    // Ruby reaches by ancestry and TS types only for a declared base class, so
+    // it is taken off the module as Ruby's own
+    // `instance_method(...).bind_call(self, ...)` does.
+    const time = (
+      acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
+        this: unknown,
+        valuesHash: Record<string, unknown>,
+      ) => RubyTime | null
+    ).call(this, values as Record<string, unknown>);
     return time && time.toTime().toInstant();
   }
 
   get isUtc(): boolean {
     return isUtc();
-  }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
-   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
-   * `Value#cast` (value.rb:53-55), which is `super`.
-   */
-  override cast(value: unknown): DateTimeCastResult | null {
-    if (isPlainObject(value)) {
-      return this.valueFromMultiparameterAssignment(value);
-    } else {
-      return super.cast(value);
-    }
-  }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value.
-   * Runs eagerly at write_from_user time — this is how Rails surfaces
-   * MultiparameterAssignmentErrors at assignment (missing keys 1..3 raise).
-   */
-  override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) {
-      this.valueFromMultiparameterAssignment(value);
-    } else {
-      super.assertValidValue(value);
-    }
-  }
-
-  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
-  override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isPlainObject(value);
   }
 
   /**
@@ -259,3 +245,10 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return this.applySecondsPrecision(value);
   }
 }
+
+/**
+ * Mirrors: `include Helpers::AcceptsMultiparameterTime.new(defaults: { 4 => 0, 5 => 0 })`
+ * (date_time.rb:44-46).
+ */
+const acceptsMultiparameterTime = new AcceptsMultiparameterTime({ defaults: { "4": 0, "5": 0 } });
+include(DateTimeType, acceptsMultiparameterTime);

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -23,7 +23,6 @@ export type { DateInfinityType, DateNegativeInfinityType };
 
 export type DateCastResult = Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType;
 
-/** Mirrors: `include Helpers::AcceptsMultiparameterTime.new` (date.rb:28). */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type -- Ruby `include` (date.rb:28); the class/interface merge is how `include()` surfaces on the type side.
 export interface DateType extends Omit<
   InstanceMethods<DateCastResult>,
@@ -187,15 +186,15 @@ export class DateType extends ValueType<DateCastResult> {
    * this class mixes in below itself (see the `include` at the bottom of this
    * file).
    *
+   * `super` is reached as Ruby's own `instance_method(...).bind_call(self, ...)`
+   * does: TS types `super` against a declared base class only, never against a
+   * mixed-in module.
+   *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
-    // Ruby reaches by ancestry and TS types only for a declared base class, so
-    // it is taken off the module as Ruby's own
-    // `instance_method(...).bind_call(self, ...)` does.
     const time = (
       acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
         this: unknown,

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -2,10 +2,14 @@ import {
   ArgumentError as RubyArgumentError,
   Date as RubyDate,
   Temporal,
+  Time as RubyTime,
   type DateParts,
 } from "@blazetrails/date";
-import { isPlainObject } from "@blazetrails/activesupport";
-import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
+import { include } from "@blazetrails/activesupport";
+import {
+  AcceptsMultiparameterTime,
+  type InstanceMethods,
+} from "./helpers/accepts-multiparameter-time.js";
 import {
   DateInfinity,
   DateNegativeInfinity,
@@ -19,6 +23,14 @@ export type { DateInfinityType, DateNegativeInfinityType };
 
 export type DateCastResult = Temporal.PlainDate | DateInfinityType | DateNegativeInfinityType;
 
+/** Mirrors: `include Helpers::AcceptsMultiparameterTime.new` (date.rb:28). */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type -- Ruby `include` (date.rb:28); the class/interface merge is how `include()` surfaces on the type side.
+export interface DateType extends Omit<
+  InstanceMethods<DateCastResult>,
+  "valueFromMultiparameterAssignment"
+> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DateType extends ValueType<DateCastResult> {
   readonly name: string = "date";
 
@@ -171,49 +183,26 @@ export class DateType extends ValueType<DateCastResult> {
    *     time && new_date(time.year, time.mon, time.mday)
    *   end
    *
-   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly,
-   * which trails reaches through the wrapper in
-   * `helpers/accepts-multiparameter-time.ts` rather than an ancestor.
+   * `super` is `Helpers::AcceptsMultiparameterTime`'s `::Time` assembly, which
+   * this class mixes in below itself (see the `include` at the bottom of this
+   * file).
    *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    const time = new AcceptsMultiparameterTime(this).valueFromMultiparameterAssignment(
-      values as Record<string, unknown>,
-    );
+    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
+    // Ruby reaches by ancestry and TS types only for a declared base class, so
+    // it is taken off the module as Ruby's own
+    // `instance_method(...).bind_call(self, ...)` does.
+    const time = (
+      acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
+        this: unknown,
+        valuesHash: Record<string, unknown>,
+      ) => RubyTime | null
+    ).call(this, values as Record<string, unknown>);
     return time && this.newDate(time.year, time.mon, time.mday);
-  }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
-   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
-   * `Value#cast` (value.rb:53-55), which is `super`.
-   */
-  override cast(value: unknown): DateCastResult | null {
-    if (isPlainObject(value)) {
-      return this.valueFromMultiparameterAssignment(value);
-    } else {
-      return super.cast(value);
-    }
-  }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
-   * a Hash value is validated by assembling it (raising on invalid input).
-   */
-  override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) {
-      this.valueFromMultiparameterAssignment(value);
-    } else {
-      super.assertValidValue(value);
-    }
-  }
-
-  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
-  override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isPlainObject(value);
   }
 
   /**
@@ -234,3 +223,7 @@ export class DateType extends ValueType<DateCastResult> {
 
 /** Mirrors: ActiveModel::Type::Date::ISO_DATE (date.rb:54). */
 const ISO_DATE = /^(\d{4})-(\d\d)-(\d\d)$/;
+
+/** Mirrors: `include Helpers::AcceptsMultiparameterTime.new` (date.rb:28). */
+const acceptsMultiparameterTime = new AcceptsMultiparameterTime();
+include(DateType, acceptsMultiparameterTime);

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -1,41 +1,48 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { include } from "@blazetrails/activesupport";
 import { Types } from "../../index.js";
 import { AcceptsMultiparameterTime } from "./accepts-multiparameter-time.js";
 
+/**
+ * `include Helpers::AcceptsMultiparameterTime.new(defaults: ...)` into a fresh
+ * class, the way each type does in its own class body — the mixin's methods
+ * then answer on the instance, so `cast` reaches its `::Time` assembly.
+ */
+function typeIncluding(defaults?: Record<string, number>): { cast(value: unknown): unknown } {
+  class IncludingType extends Types.DateTimeType {}
+  include(IncludingType, new AcceptsMultiparameterTime(defaults ? { defaults } : {}));
+  return new IncludingType() as unknown as { cast(value: unknown): unknown };
+}
+
 describe("AcceptsMultiparameterTime defaults", () => {
   it("defaults fill missing slots", () => {
-    const type = new Types.DateTimeType();
-    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0, "5": 0 });
+    const wrapper = typeIncluding({ "4": 0, "5": 0 });
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4 });
     expect(result).not.toBeNull();
   });
 
   it("user values override defaults", () => {
-    const type = new Types.DateTimeType();
-    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
+    const wrapper = typeIncluding({ "4": 0 });
     const result = wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": 15 });
     expect((result as { hour: number }).hour).toBe(15);
   });
 
   it("a blank slot is a present value and reaches ::Time", () => {
-    const type = new Types.DateTimeType();
-    const wrapper = new AcceptsMultiparameterTime(type, { "4": 0 });
+    const wrapper = typeIncluding({ "4": 0 });
     expect(() => wrapper.cast({ "1": 2025, "2": 7, "3": 4, "4": "" })).toThrow(
       'invalid value for Integer(): ""',
     );
   });
 
   it("no defaults, missing year/month/day keys → null (key-based guard)", () => {
-    const type = new Types.DateType();
-    const wrapper = new AcceptsMultiparameterTime(type);
+    const wrapper = typeIncluding();
     const result = wrapper.cast({ "6": 0 });
     expect(result).toBeNull();
   });
 
   it("slots are ordered by index, not by their string spelling", () => {
-    const type = new Types.DateTimeType();
-    const wrapper = new AcceptsMultiparameterTime(type, { "10": 0 });
+    const wrapper = typeIncluding({ "10": 0 });
     const time = wrapper.cast({ "1": 2004, "2": 6, "3": 24, "4": 16, "5": 24, "6": 12 }) as {
       hour: number;
       min: number;
@@ -45,7 +52,7 @@ describe("AcceptsMultiparameterTime defaults", () => {
   });
 
   it("sub-second precision truncates at a pre-1970 instant", () => {
-    const wrapper = new AcceptsMultiparameterTime(new Types.DateTimeType());
+    const wrapper = typeIncluding();
     const parts = { "1": 1969, "2": 7, "3": 20, "4": 20, "5": 17, "6": 40.9999999999 };
     const time = wrapper.cast(parts) as { nsec: number; sec: number };
     expect(time.nsec).toBe(999_999_999);

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time-defaults.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import { include } from "@blazetrails/activesupport";
-import { Types } from "../../index.js";
+import { Types, ValueType } from "../../index.js";
 import { AcceptsMultiparameterTime } from "./accepts-multiparameter-time.js";
 
 /**
  * `include Helpers::AcceptsMultiparameterTime.new(defaults: ...)` into a fresh
- * class, the way each type does in its own class body — the mixin's methods
- * then answer on the instance, so `cast` reaches its `::Time` assembly.
+ * type, the way each type does in its own class body — the mixin's methods then
+ * answer on the instance, so `cast` reaches its `::Time` assembly. The base is a
+ * plain `ValueType`, since Ruby holds a module once per ancestry and each of
+ * date.rb / date_time.rb / time.rb includes its own instance exactly once.
  */
 function typeIncluding(defaults?: Record<string, number>): { cast(value: unknown): unknown } {
-  class IncludingType extends Types.DateTimeType {}
+  class IncludingType extends ValueType {}
   include(IncludingType, new AcceptsMultiparameterTime(defaults ? { defaults } : {}));
   return new IncludingType() as unknown as { cast(value: unknown): unknown };
 }

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -18,17 +18,6 @@ export interface InstanceMethods<T = unknown> {
 }
 
 /**
- * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
- * (accepts_multiparameter_time.rb).
- *
- * A `Module` subclass whose `initialize` includes `InstanceMethods` and
- * `define_method`s `value_from_multiparameter_assignment` closed over the
- * `defaults:` kwarg; `include AcceptsMultiparameterTime.new(...)` in a type's
- * class body then puts all of it in that type's ancestry, so `cast` and
- * `assert_valid_value` reach the type's real `super`. trails' `Module` /
- * `include()` (`activesupport/src/include.ts`) splice the same way.
- */
-/**
  * `super` from a module method: Ruby resolves it from the method's OWNER in the
  * receiver's ancestry, not from the receiver's class, so the owner is located
  * by identity and its own ancestor answers. (TS `super` is only available to a
@@ -46,13 +35,13 @@ function superOf(
   return (Object.getPrototypeOf(owner!) as Record<string, (...args: unknown[]) => unknown>)[name];
 }
 
+/** The type mixing `InstanceMethods` in — Ruby's `self` inside a module method. */
+type Receiver = InstanceMethods & { valueFromMultiparameterAssignment(value: unknown): unknown };
+
 /**
  * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods
  * (accepts_multiparameter_time.rb:7-35).
  */
-/** The type mixing `InstanceMethods` in — Ruby's `self` inside a module method. */
-type Receiver = InstanceMethods & { valueFromMultiparameterAssignment(value: unknown): unknown };
-
 const InstanceMethods = {
   /** Mirrors: InstanceMethods#serialize (accepts_multiparameter_time.rb:9-11). */
   serialize(this: Receiver, value: unknown): unknown {
@@ -91,6 +80,17 @@ const InstanceMethods = {
   },
 };
 
+/**
+ * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
+ * (accepts_multiparameter_time.rb).
+ *
+ * A `Module` subclass whose `initialize` includes `InstanceMethods` and
+ * `define_method`s `value_from_multiparameter_assignment` closed over the
+ * `defaults:` kwarg; `include AcceptsMultiparameterTime.new(...)` in a type's
+ * class body then puts all of it in that type's ancestry, so `cast` and
+ * `assert_valid_value` reach the type's real `super`. trails' `Module` /
+ * `include()` (`activesupport/src/include.ts`) splice the same way.
+ */
 /**
  * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
  * (accepts_multiparameter_time.rb).

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -22,15 +22,24 @@ export interface InstanceMethods<T = unknown> {
  * receiver's ancestry, not from the receiver's class, so the owner is located
  * by identity and its own ancestor answers. (TS `super` is only available to a
  * class body, and these are module methods.)
+ *
+ * Ruby never holds one module twice in an ancestry — `include` skips a module
+ * already there — so the owner is the LAST link carrying the method: a JS
+ * prototype chain can hold the same carried function more than once, and
+ * answering the first would make `super` re-enter it.
  */
 function superOf(
   receiver: object,
   name: string,
   self: unknown,
 ): (this: unknown, ...args: unknown[]) => unknown {
-  let owner: object | null = Object.getPrototypeOf(receiver);
-  while (owner && Object.getOwnPropertyDescriptor(owner, name)?.value !== self) {
-    owner = Object.getPrototypeOf(owner);
+  let owner: object | null = null;
+  for (
+    let link: object | null = Object.getPrototypeOf(receiver);
+    link;
+    link = Object.getPrototypeOf(link)
+  ) {
+    if (Object.getOwnPropertyDescriptor(link, name)?.value === self) owner = link;
   }
   return (Object.getPrototypeOf(owner!) as Record<string, (...args: unknown[]) => unknown>)[name];
 }
@@ -80,17 +89,6 @@ const InstanceMethods = {
   },
 };
 
-/**
- * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
- * (accepts_multiparameter_time.rb).
- *
- * A `Module` subclass whose `initialize` includes `InstanceMethods` and
- * `define_method`s `value_from_multiparameter_assignment` closed over the
- * `defaults:` kwarg; `include AcceptsMultiparameterTime.new(...)` in a type's
- * class body then puts all of it in that type's ancestry, so `cast` and
- * `assert_valid_value` reach the type's real `super`. trails' `Module` /
- * `include()` (`activesupport/src/include.ts`) splice the same way.
- */
 /**
  * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
  * (accepts_multiparameter_time.rb).

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -1,115 +1,157 @@
 import { Time } from "@blazetrails/date";
-import { isPlainObject } from "@blazetrails/activesupport";
-import { Type } from "../value.js";
+import { Module, isPlainObject } from "@blazetrails/activesupport";
 import { isUtc } from "./timezone.js";
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods
+ * (accepts_multiparameter_time.rb:7-35), as the instance-side type a class
+ * mixing the module in merges via `Included<>`.
+ */
+export interface InstanceMethods<T = unknown> {
+  serialize(value: unknown): unknown;
+  serializeCastValue(value: T | null): unknown;
+  cast(value: unknown): T | null;
+  assertValidValue(value: unknown): void;
+  isValueConstructedByMassAssignment(value: unknown): boolean;
+  /** @internal Rails-private (`private :value_from_multiparameter_assignment`). */
+  valueFromMultiparameterAssignment(valuesHash: Record<string, unknown>): T | null;
+}
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
  * (accepts_multiparameter_time.rb).
  *
- * Ruby builds the module with `defaults:` and closes `define_method` over it;
- * TS has no anonymous-module `include`, so the same state is a constructor
- * argument and the wrapped type is the receiver `super` would have reached.
+ * A `Module` subclass whose `initialize` includes `InstanceMethods` and
+ * `define_method`s `value_from_multiparameter_assignment` closed over the
+ * `defaults:` kwarg; `include AcceptsMultiparameterTime.new(...)` in a type's
+ * class body then puts all of it in that type's ancestry, so `cast` and
+ * `assert_valid_value` reach the type's real `super`. trails' `Module` /
+ * `include()` (`activesupport/src/include.ts`) splice the same way.
  */
-export class AcceptsMultiparameterTime {
-  readonly type: Type;
-  /** @internal `AcceptsMultiparameterTime#initialize`'s `defaults:` kwarg. */
-  readonly defaults: Record<string, number>;
-
-  constructor(type: Type, defaults: Record<string, number> = {}) {
-    this.type = type;
-    this.defaults = defaults;
+/**
+ * `super` from a module method: Ruby resolves it from the method's OWNER in the
+ * receiver's ancestry, not from the receiver's class, so the owner is located
+ * by identity and its own ancestor answers. (TS `super` is only available to a
+ * class body, and these are module methods.)
+ */
+function superOf(
+  receiver: object,
+  name: string,
+  self: unknown,
+): (this: unknown, ...args: unknown[]) => unknown {
+  let owner: object | null = Object.getPrototypeOf(receiver);
+  while (owner && Object.getOwnPropertyDescriptor(owner, name)?.value !== self) {
+    owner = Object.getPrototypeOf(owner);
   }
+  return (Object.getPrototypeOf(owner!) as Record<string, (...args: unknown[]) => unknown>)[name];
+}
 
+/**
+ * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods
+ * (accepts_multiparameter_time.rb:7-35).
+ */
+/** The type mixing `InstanceMethods` in — Ruby's `self` inside a module method. */
+type Receiver = InstanceMethods & { valueFromMultiparameterAssignment(value: unknown): unknown };
+
+const InstanceMethods = {
   /** Mirrors: InstanceMethods#serialize (accepts_multiparameter_time.rb:9-11). */
-  serialize(value: unknown): unknown {
+  serialize(this: Receiver, value: unknown): unknown {
     return this.serializeCastValue(this.cast(value));
-  }
+  },
 
   /** Mirrors: InstanceMethods#serialize_cast_value (accepts_multiparameter_time.rb:13-15). */
-  serializeCastValue(value: unknown): unknown {
+  serializeCastValue(this: Receiver, value: unknown): unknown {
     return value;
-  }
+  },
 
   /** Mirrors: InstanceMethods#cast (accepts_multiparameter_time.rb:17-23). */
-  cast(value: unknown): unknown {
+  cast(this: Receiver, value: unknown): unknown {
     if (isPlainObject(value)) {
       return this.valueFromMultiparameterAssignment(value);
     } else {
-      return this.type.cast(value);
+      return superOf(this, "cast", InstanceMethods.cast).call(this, value);
     }
-  }
+  },
 
   /** Mirrors: InstanceMethods#assert_valid_value (accepts_multiparameter_time.rb:25-31). */
-  assertValidValue(value: unknown): unknown {
+  assertValidValue(this: Receiver, value: unknown): unknown {
     if (isPlainObject(value)) {
       return this.valueFromMultiparameterAssignment(value);
     } else {
-      return this.type.assertValidValue(value);
+      return superOf(this, "assertValidValue", InstanceMethods.assertValidValue).call(this, value);
     }
-  }
+  },
 
   /**
    * Mirrors: InstanceMethods#value_constructed_by_mass_assignment?
    * (accepts_multiparameter_time.rb:33-35).
    */
-  isValueConstructedByMassAssignment(value: unknown): boolean {
+  isValueConstructedByMassAssignment(this: Receiver, value: unknown): boolean {
     return isPlainObject(value);
-  }
+  },
+};
 
-  /**
-   * Mirrors: the `define_method(:value_from_multiparameter_assignment)`
-   * `AcceptsMultiparameterTime#initialize` installs
-   * (accepts_multiparameter_time.rb:38-46).
-   *
-   *   defaults.each do |k, v|
-   *     values_hash[k] ||= v
-   *   end
-   *   return unless values_hash[1] && values_hash[2] && values_hash[3]
-   *   values = values_hash.sort.map!(&:last)
-   *   ::Time.public_send(default_timezone, *values)
-   *
-   * `||=` and the `1`/`2`/`3` guard are Ruby truthiness, so only `nil`/`false`
-   * count as absent — an empty string is a present value and reaches `::Time`,
-   * which raises for it. ActiveRecord never arrives with one:
-   * `extract_callstack_for_multiparameter_attributes` maps `value.empty?` to
-   * `nil` first (activerecord/attribute_assignment.rb:157).
-   *
-   * `sort` orders the Integer keys Ruby holds; a JS object spells them as
-   * strings, whose own order puts `"10"` ahead of `"2"`, so the comparison is
-   * numeric. `default_timezone` is `Helpers::Timezone#is_utc?`'s choice of
-   * receiver, `Time.utc` or `Time.local` (timezone.rb:9-11).
-   *
-   * @internal Rails-private helper.
-   */
-  valueFromMultiparameterAssignment(valuesHash: Record<string, unknown>): Time | null {
-    for (const [k, v] of Object.entries(this.defaults)) {
-      if (valuesHash[k] == null || valuesHash[k] === false) valuesHash[k] = v;
-    }
-    if (!truthy(valuesHash["1"]) || !truthy(valuesHash["2"]) || !truthy(valuesHash["3"])) {
-      return null;
-    }
-    const values = Object.entries(valuesHash)
-      .sort(([a], [b]) => Number(a) - Number(b))
-      .map(([, v]) => v as number | string);
-    return isUtc()
-      ? Time.utc(...(values as [number, number, number]))
-      : Time.local(...(values as [number, number, number]));
+/**
+ * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime
+ * (accepts_multiparameter_time.rb).
+ *
+ * A `Module` subclass whose `initialize` includes `InstanceMethods` and
+ * `define_method`s `value_from_multiparameter_assignment` closed over the
+ * `defaults:` kwarg; `include AcceptsMultiparameterTime.new(...)` in a type's
+ * class body then puts all of it in that type's ancestry, so `cast` and
+ * `assert_valid_value` reach the type's real `super`. trails' `Module` /
+ * `include()` (`activesupport/src/include.ts`) splice the same way.
+ */
+export class AcceptsMultiparameterTime extends Module {
+  constructor({ defaults = {} }: { defaults?: Record<string, number> } = {}) {
+    super();
+
+    this.include(InstanceMethods);
+
+    /**
+     * Mirrors: the `define_method(:value_from_multiparameter_assignment)`
+     * `AcceptsMultiparameterTime#initialize` installs
+     * (accepts_multiparameter_time.rb:38-46).
+     *
+     *   defaults.each do |k, v|
+     *     values_hash[k] ||= v
+     *   end
+     *   return unless values_hash[1] && values_hash[2] && values_hash[3]
+     *   values = values_hash.sort.map!(&:last)
+     *   ::Time.public_send(default_timezone, *values)
+     *
+     * `||=` and the `1`/`2`/`3` guard are Ruby truthiness, so only `nil`/`false`
+     * count as absent — an empty string is a present value and reaches `::Time`,
+     * which raises for it. ActiveRecord never arrives with one:
+     * `extract_callstack_for_multiparameter_attributes` maps `value.empty?` to
+     * `nil` first (activerecord/attribute_assignment.rb:157).
+     *
+     * `sort` orders the Integer keys Ruby holds; a JS object spells them as
+     * strings, whose own order puts `"10"` ahead of `"2"`, so the comparison is
+     * numeric. `default_timezone` is `Helpers::Timezone#is_utc?`'s choice of
+     * receiver, `Time.utc` or `Time.local` (timezone.rb:9-11).
+     */
+    this.defineMethod(
+      "valueFromMultiparameterAssignment",
+      function (valuesHash: Record<string, unknown>): Time | null {
+        for (const [k, v] of Object.entries(defaults)) {
+          if (valuesHash[k] == null || valuesHash[k] === false) valuesHash[k] = v;
+        }
+        if (!truthy(valuesHash["1"]) || !truthy(valuesHash["2"]) || !truthy(valuesHash["3"])) {
+          return null;
+        }
+        const values = Object.entries(valuesHash)
+          .sort(([a], [b]) => Number(a) - Number(b))
+          .map(([, v]) => v as number | string);
+        return isUtc()
+          ? Time.utc(...(values as [number, number, number]))
+          : Time.local(...(values as [number, number, number]));
+      },
+    );
   }
 }
 
 /** Ruby truthiness: only `nil` and `false` are falsy (CLAUDE.md). */
 function truthy(value: unknown): boolean {
   return value != null && value !== false;
-}
-
-/**
- * Mirrors: ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods
- */
-export interface InstanceMethods {
-  serialize(value: unknown): unknown;
-  serializeCastValue(value: unknown): unknown;
-  cast(value: unknown): unknown;
-  assertValidValue(value: unknown): unknown;
-  isValueConstructedByMassAssignment(value: unknown): boolean;
 }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -220,15 +220,15 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * of its own; this one only re-spells that `::Time` as the
    * `Temporal.Instant` this port casts to.
    *
+   * `super` is reached as Ruby's own `instance_method(...).bind_call(self, ...)`
+   * does: TS types `super` against a declared base class only, never against a
+   * mixed-in module.
+   *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
     values: Record<string, unknown>,
   ): Temporal.Instant | null {
-    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
-    // Ruby reaches by ancestry and TS types only for a declared base class, so
-    // it is taken off the module as Ruby's own
-    // `instance_method(...).bind_call(self, ...)` does.
     const time = (
       acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
         this: unknown,

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -2,10 +2,14 @@ import {
   ArgumentError as RubyArgumentError,
   Date as RubyDate,
   Temporal,
+  Time as RubyTime,
   type DateParts,
 } from "@blazetrails/date";
-import { zone, isBlank, isPlainObject } from "@blazetrails/activesupport";
-import { AcceptsMultiparameterTime } from "./helpers/accepts-multiparameter-time.js";
+import { zone, isBlank, include } from "@blazetrails/activesupport";
+import {
+  AcceptsMultiparameterTime,
+  type InstanceMethods,
+} from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
 import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
@@ -19,6 +23,13 @@ import { ValueType } from "./value.js";
  * instant. `Temporal.Instant` is the port's `::Time` (see `newTime`), so the
  * cast result carries that instant rather than a bare time of day.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type -- Ruby `include` (time.rb:40-42); the class/interface merge is how `include()` surfaces on the type side.
+export interface TimeType extends Omit<
+  InstanceMethods<Temporal.Instant>,
+  "valueFromMultiparameterAssignment"
+> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class TimeType extends ValueType<Temporal.Instant> {
   readonly name = "time";
 
@@ -203,51 +214,36 @@ export class TimeType extends ValueType<Temporal.Instant> {
   }
 
   /**
-   * Mirrors: ActiveModel::Type::Time includes AcceptsMultiparameterTime.new(defaults: { 1 => 2000, 2 => 1, 3 => 1, 4 => 0, 5 => 0 }).
-   * Rails' base date 2000-01-01 lets hour-only form inputs (e.g. { "4": 15 }) produce a valid Time.
+   * `super` is the mixin's `::Time` assembly (see the `include` at the bottom
+   * of this file), whose Rails base date 2000-01-01 lets hour-only form inputs
+   * (e.g. { "4": 15 }) produce a valid Time. Rails' Type::Time has no override
+   * of its own; this one only re-spells that `::Time` as the
+   * `Temporal.Instant` this port casts to.
    *
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
     values: Record<string, unknown>,
   ): Temporal.Instant | null {
-    const time = new AcceptsMultiparameterTime(this, {
-      "1": 2000,
-      "2": 1,
-      "3": 1,
-      "4": 0,
-      "5": 0,
-    }).valueFromMultiparameterAssignment(values);
+    // `super` — the mixin's own `value_from_multiparameter_assignment`, which
+    // Ruby reaches by ancestry and TS types only for a declared base class, so
+    // it is taken off the module as Ruby's own
+    // `instance_method(...).bind_call(self, ...)` does.
+    const time = (
+      acceptsMultiparameterTime.instanceMethod("valueFromMultiparameterAssignment")!.value as (
+        this: unknown,
+        valuesHash: Record<string, unknown>,
+      ) => RubyTime | null
+    ).call(this, values);
     return time && time.toTime().toInstant();
   }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#cast
-   * (accepts_multiparameter_time.rb:16-22). The nil guard stays in
-   * `Value#cast` (value.rb:53-55), which is `super`.
-   */
-  override cast(value: unknown): Temporal.Instant | null {
-    if (isPlainObject(value)) {
-      return this.valueFromMultiparameterAssignment(value);
-    } else {
-      return super.cast(value);
-    }
-  }
-
-  /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
-   * a Hash value is validated by assembling it (raising on invalid input).
-   */
-  override assertValidValue(value: unknown): void {
-    if (isPlainObject(value)) {
-      this.valueFromMultiparameterAssignment(value);
-    } else {
-      super.assertValidValue(value);
-    }
-  }
-
-  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
-  override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isPlainObject(value);
-  }
 }
+
+/**
+ * Mirrors: `include Helpers::AcceptsMultiparameterTime.new(defaults: { 1 => 2000, 2 => 1, 3 => 1, 4 => 0, 5 => 0 })`
+ * (time.rb:40-42).
+ */
+const acceptsMultiparameterTime = new AcceptsMultiparameterTime({
+  defaults: { "1": 2000, "2": 1, "3": 1, "4": 0, "5": 0 },
+});
+include(TimeType, acceptsMultiparameterTime);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -73,7 +73,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("explain options with eager loading", async () => {
       // Rails: Author.where(id: 1).includes(:posts).explain(explain_option)
       const result = await Author.where({ id: authors("david").id })
-        .includes("posts")
+        .includes(":posts")
         .explain(explainOpt);
       expect(result).toContain(`${expectedClause} for:`);
       const blocks = result.split("\n\n").filter((b) => /EXPLAIN|ANALYZE/.test(b));
@@ -120,7 +120,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("Relation#explain on MySQL captures preload queries", async () => {
       const plan = await Author.where({ id: authors("david").id })
-        .preload("posts")
+        .preload(":posts")
         .explain();
       const blocks = plan.split("\n\n").filter((b) => /EXPLAIN/.test(b));
       // The fallback path emits exactly one block (toSql() of the outer

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -86,7 +86,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const a = (await ExAuthor.create({ name: "A" })) as any;
       await ExBook.create({ title: "B", ex_author_id: a.id });
 
-      const plan = await ExAuthor.all().preload("exBooks").explain();
+      const plan = await ExAuthor.all().preload(":exBooks").explain();
       const blocks = plan.split("\n\n").filter((b) => /EXPLAIN/.test(b));
       expect(blocks.length).toBeGreaterThanOrEqual(2);
       expect(plan).toContain("ex_authors");
@@ -161,7 +161,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const author = (await OpAuthor.create({ name: "A" })) as any;
       await OpPost.create({ title: "B", op_author_id: author.id });
 
-      const plan = await OpAuthor.where({ id: author.id }).includes("opPosts").explain("analyze");
+      const plan = await OpAuthor.where({ id: author.id }).includes(":opPosts").explain("analyze");
       // Rails: assert_match %(QUERY PLAN), explain
       expect(plan).toContain("QUERY PLAN");
       // Rails: assert_match %r(EXPLAIN \(ANALYZE\) SELECT "authors".*), explain

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -29,7 +29,7 @@ describeIfSqlite("SQLite3ExplainTest", () => {
 
   it("explain with eager loading", async () => {
     const explain = await Author.where({ id: authors("david").id })
-      .includes("posts")
+      .includes(":posts")
       .explain();
     expect(explain).toMatch(
       /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|1)/,

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -8,16 +8,8 @@ import { pluralize, singularize } from "@blazetrails/activesupport";
 
 type AssociationLikeReflection = AssociationReflection | ThroughReflection;
 
-/**
- * `reduce(:merge)`. Rails' `records_by_owner` forces `load_records`
- * (preloader/association.rb:148-151); ours is async, so the forcing is hoisted to
- * `recordsByOwner` and this answers `undefined` while a loader has yet to load.
- */
-function merge(
-  acc: Map<Base, Base[]> | undefined,
-  recordsByOwner: Map<Base, Base[]> | undefined,
-): Map<Base, Base[]> | undefined {
-  if (acc === undefined || recordsByOwner === undefined) return undefined;
+/** `Hash#merge`, the block `reduce(:merge)` names (through_association.rb:89, :93). */
+function merge(acc: Map<Base, Base[]>, recordsByOwner: Map<Base, Base[]>): Map<Base, Base[]> {
   return new Map([...acc, ...recordsByOwner]);
 }
 
@@ -81,13 +73,6 @@ export class ThroughAssociation extends Association {
       this._recordsByOwner = result;
       return result;
     }
-
-    // Rails reaches `through_records_by_owner` / `source_records_by_owner`
-    // through the public `records_by_owner` reader, which forces `load_records`
-    // (preloader/association.rb:148-151). Through loaders first:
-    // `source_preloaders` is derived from the middle records they produce.
-    await Promise.all((await this.throughPreloaders()).map((l) => l.recordsByOwner()));
-    await Promise.all((await this.sourcePreloaders()).map((l) => l.recordsByOwner()));
 
     const throughRecordsByOwner = await this.throughRecordsByOwner();
     const sourceRecordsByOwner = await this.sourceRecordsByOwner();
@@ -309,18 +294,20 @@ export class ThroughAssociation extends Association {
     return [...(await this.throughRecordsByOwner()).values()].flat();
   }
 
+  /** Mirrors: `preloader/through_association.rb:88-90`. */
   private async sourceRecordsByOwner(): Promise<Map<Base, Base[]>> {
-    this._sourceRecordsByOwner ??= (await this.sourcePreloaders())
-      .map((l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined)
-      .reduce(merge, new Map<Base, Base[]>());
-    return this._sourceRecordsByOwner ?? new Map();
+    this._sourceRecordsByOwner ??= (
+      await Promise.all((await this.sourcePreloaders()).map((l) => l.recordsByOwner()))
+    ).reduce(merge, new Map<Base, Base[]>());
+    return this._sourceRecordsByOwner;
   }
 
+  /** Mirrors: `preloader/through_association.rb:92-94`. */
   private async throughRecordsByOwner(): Promise<Map<Base, Base[]>> {
-    this._throughRecordsByOwner ??= (await this.throughPreloaders())
-      .map((l) => (l as any)._recordsByOwner as Map<Base, Base[]> | undefined)
-      .reduce(merge, new Map<Base, Base[]>());
-    return this._throughRecordsByOwner ?? new Map();
+    this._throughRecordsByOwner ??= (
+      await Promise.all((await this.throughPreloaders()).map((l) => l.recordsByOwner()))
+    ).reduce(merge, new Map<Base, Base[]>());
+    return this._throughRecordsByOwner;
   }
 
   private async preloadIndex(): Promise<Map<Base, number>> {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -586,7 +586,7 @@ describe("DefaultScopingTest", () => {
   it("unscope includes", async () => {
     const expected = names(await Developer.all());
     const received = names(
-      await Developer.includes("projects").select("id").unscope("includes", "select"),
+      await Developer.includes(":projects").select("id").unscope("includes", "select"),
     );
     expect(received).toEqual(expected);
   });
@@ -601,7 +601,7 @@ describe("DefaultScopingTest", () => {
 
   it("unscope eager load", async () => {
     const expected = names(await Developer.all());
-    const received = Developer.eagerLoad("projects").select("id").unscope("eagerLoad", "select");
+    const received = Developer.eagerLoad(":projects").select("id").unscope("eagerLoad", "select");
     const rows = await received;
     expect(names(rows)).toEqual(expected);
     expect((rows[0] as any).projects.loaded).toBe(false);
@@ -609,7 +609,7 @@ describe("DefaultScopingTest", () => {
 
   it("unscope preloads", async () => {
     const expected = names(await Developer.all());
-    const received = Developer.preload("projects").select("id").unscope("preload", "select");
+    const received = Developer.preload(":projects").select("id").unscope("preload", "select");
     const rows = await received;
     expect(names(rows)).toEqual(expected);
     expect((rows[0] as any).projects.loaded).toBe(false);
@@ -853,9 +853,9 @@ describe("DefaultScopingTest", () => {
     await (SpecialComment as any).unscoped(async () => {
       expect((await Post.joins(":specialComments").find(post.id)).id).toBe(post.id);
       expect(await specialCommentIds(Post.joins(":specialComments"))).toEqual(expected);
-      expect(await specialCommentIds(Post.eagerLoad("specialComments"))).toEqual(expected);
-      expect(await specialCommentIds(Post.includes("specialComments"))).toEqual(expected);
-      expect(await specialCommentIds(Post.preload("specialComments"))).toEqual(expected);
+      expect(await specialCommentIds(Post.eagerLoad(":specialComments"))).toEqual(expected);
+      expect(await specialCommentIds(Post.includes(":specialComments"))).toEqual(expected);
+      expect(await specialCommentIds(Post.preload(":specialComments"))).toEqual(expected);
     });
   });
 

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -245,7 +245,7 @@ describe("RelationScopingTest", () => {
   });
 
   it("scoped find include", async () => {
-    const scopedDevelopers = (await Developer.includes("projects").scoping(async () =>
+    const scopedDevelopers = (await Developer.includes(":projects").scoping(async () =>
       Developer.where({ "projects.id": 2 }).toArray(),
     )) as Base[];
     expect(scopedDevelopers.map((d: any) => d.id)).toContain(developers("david").id);
@@ -623,7 +623,7 @@ describe("HasManyScopingTest", () => {
   it("should maintain default scope on eager loaded associations", async () => {
     const michael = people("michael");
     const loaded = (await Person.where({ id: michael.id })
-      .includes("badReferences")
+      .includes(":badReferences")
       .first()) as Base;
     const magician = (await BadReference.find(1)) as Base;
     const refs = await (loaded as any).badReferences.toArray();

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -49,6 +49,22 @@ export class Module {
     return block(carrierOf(this));
   }
 
+  /**
+   * Mirrors: Ruby's Module#include — mixes another module's instance methods
+   * into this module, so a class that includes this one gets them too.
+   */
+  include(mod: ModuleObject): void {
+    const carrier = carrierOf(this);
+    for (const key of Object.keys(mod)) {
+      if (typeof mod[key] !== "function" || /^[A-Z]/.test(key)) continue;
+      Object.defineProperty(carrier, key, {
+        value: mod[key],
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+
   /** Mirrors: Ruby's Module#define_method. */
   defineMethod(name: string, body: (...args: any[]) => unknown): void {
     Object.defineProperty(carrierOf(this), name, {


### PR DESCRIPTION
Bundle of three convergence stories.

**1. `includes`/`preload` colon sweep — `scoping/` + `adapters/`** (RFC 0107)
The final cluster of the association-name sweep: every `includes` /
`preload` / `eagerLoad` call site under `packages/activerecord/src/scoping`
and `.../adapters` now passes the association name colon-prefixed, matching
Rails' Symbols (`query_methods.rb:88-101`) and the `joins` values that
already carry that spelling. Test literals only; no new normalization site —
the strip stays at `JoinDependency#walkTree` and
`Preloader::Branch#_normalizeAssociationName`.

**2. `AcceptsMultiparameterTime` is a real mixin** (RFC 0115)
It is a `Module` subclass again, as in Ruby: `initialize` includes
`InstanceMethods` and `define_method`s `value_from_multiparameter_assignment`
closed over the `defaults:` kwarg, and `DateType` / `DateTimeType` /
`TimeType` `include` it at class definition with Rails' defaults
(`date.rb:28`, `date_time.rb:44-46`, `time.rb:40-42`). The three
hand-spelled `cast` / `assertValidValue` /
`isValueConstructedByMassAssignment` copies are gone; `super` inside
`InstanceMethods` is the type's real ancestor, resolved from the method's
owner the way Ruby does. The two overrides Rails actually has —
`date.rb:75-78`'s `new_date` narrowing and `date_time.rb:77-83`'s
missing-key check — stay and reach the mixin's definition.

`Module#include` (Ruby's own) is added to `activesupport/src/include.ts` so
`initialize` can include `InstanceMethods` into the anonymous module, as the
Ruby does.

TS cannot type `super` for a mixed-in method (`super` resolves against the
declared base class only), so the two class-body overrides reach it through
Ruby's `instance_method(...).bind_call(self, ...)` — justified at each call
site.

**3. Through-preloader reads the public `recordsByOwner`** (RFC 0112)
`sourceRecordsByOwner` / `throughRecordsByOwner` now await each child
loader's public `recordsByOwner()` and reduce with a plain `merge`, exactly
as `through_association.rb:88-94` does. The `(l as any)._recordsByOwner`
casts, the `undefined`-propagating merge, the `?? new Map()` arms and the
pre-forcing `Promise.all` pass in `recordsByOwner` are all gone — forcing is
the reader's own contract again.

Gates: `pnpm typecheck`, `parity:api:calls`, `parity:api:calls:args` green
with no baseline rows added (two `reduce(:merge)` arg rows stay valid);
`parity:api:extra --package activemodel` holds
`accepts-multiparameter-time.ts` at 0 novel. Suites run: activemodel,
activerecord scoping / preloader / has-many-through / explain /
multiparameter-attributes.

Closes-story: converge-includes-preload-colon-sweep-scoping-and-adapters
Closes-story: converge-accepts-multiparameter-time-to-a-real-mixin
Closes-story: converge-through-preloader-records-by-owner-onto-public-reader