### PR TITLE
refactor(activemodel): converge the mass-assignment hash guards, attributes residue and Error dup/equality

### DIFF
--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -25,8 +25,8 @@ import {
 import {
   _assignAttributes as attrAssign,
   _assignAttribute as attrAssignOne,
-  sanitizeForMassAssignment as attrSanitize,
 } from "./attribute-assignment.js";
+import { sanitizeForMassAssignment as attrSanitize } from "./forbidden-attributes-protection.js";
 
 /**
  * Rails: ActiveModel::API includes Validations (api.rb), so the

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -1,17 +1,30 @@
-import { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
 import { UnknownAttributeError } from "./errors.js";
 
-interface PermittedAttributes {
-  permitted?: boolean | (() => boolean);
-  toH?(): Record<string, unknown>;
-}
-
+/**
+ * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
+ * (attribute_assignment.rb:28-34):
+ *
+ *   def assign_attributes(new_attributes)
+ *     unless new_attributes.respond_to?(:each_pair)
+ *       raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
+ *     end
+ *     return if new_attributes.empty?
+ *
+ *     _assign_attributes(sanitize_for_mass_assignment(new_attributes))
+ *   end
+ *
+ * Both sends go through the model, as Ruby's implicit `self` receiver does, so
+ * a subclass override of either is honoured.
+ */
 export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
-  assertHashAttributes(newAttributes);
-
+  if (!respondToEachPair(newAttributes)) {
+    throw new ArgumentError(
+      `When assigning attributes, you must pass a hash as an argument, ${classOf(newAttributes)} passed.`,
+    );
+  }
   if (isMassAssignmentEmpty(newAttributes)) return;
 
-  _assignAttributes(model, sanitizeForMassAssignment(newAttributes));
+  model._assignAttributes(model.sanitizeForMassAssignment(newAttributes));
 }
 
 export function attributeWriterMissing(
@@ -95,21 +108,13 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
 }
 
 export interface AttributeAssignment {
-  writeAttribute(name: string, value: unknown): void;
   attributeWriterMissing(name: string, value: unknown): void;
+  /** @internal */
+  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
+  /** @internal Rails-private helper. */
+  _assignAttributes(attributes: Record<string, unknown>): void;
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
   attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
-}
-
-/**
- * Reads a params-like wrapper's `permitted?`. The real
- * `ActionController::Parameters` exposes it as a boolean GETTER
- * (strong-parameters.ts:113), while duck-typed wrappers may expose a method —
- * Ruby draws no such distinction, so both must answer here.
- */
-function readPermitted(attrs: PermittedAttributes): boolean {
-  const permitted = attrs.permitted;
-  return typeof permitted === "function" ? permitted.call(attrs) : Boolean(permitted);
 }
 
 /**
@@ -139,100 +144,50 @@ export function isMassAssignmentEmpty(attrs: object): boolean {
 }
 
 /**
+ * The JS spelling of `new_attributes.respond_to?(:each_pair)`
+ * (attribute_assignment.rb:29). JS has no `each_pair`, so a plain object
+ * (prototype `Object.prototype` or null) or a params-style wrapper duck-typing
+ * `permitted?`/`to_h` stands in for a Ruby Hash; a Date, Map, Set, Array, or
+ * arbitrary class instance has none of Hash's semantics and fails the guard
+ * exactly as it does in Ruby.
+ *
+ * KNOWN GAP: `HashWithIndifferentAccess` is a Hash subclass Rails' guard admits
+ * (it inherits `Hash#each_pair`), but trails HWIA stores entries in a private
+ * `Map` — so it fails here AND the downstream `_assignAttributes`
+ * `Object.entries` loop cannot read it either (a pre-existing silent no-op).
+ * Tracked by `assign-attributes-hwia-each-pair`.
+ */
+function respondToEachPair(attrs: unknown): attrs is Record<string, unknown> {
+  if (typeof attrs !== "object" || attrs === null || Array.isArray(attrs)) return false;
+  const proto = Object.getPrototypeOf(attrs);
+  if (proto === Object.prototype || proto === null) return true;
+  return isParamsLikeWrapper(attrs);
+}
+
+/**
  * A non-plain object duck-typing the `ActionController::Parameters` surface —
  * the trails analogue of Rails' params wrapper, distinct from a plain hash whose
- * own keys ARE its contents. Single source of truth for wrapper recognition on
- * the mass-assignment path: `isHashLike` admits it as hash-like, and
+ * own keys ARE its contents. `respondToEachPair` admits it as hash-like, and
  * `isMassAssignmentEmpty` consults its `empty` (so a plain hash that happens to
  * carry an `empty: <boolean>` attribute is unaffected).
- *
- * For the real ActionController::Parameters, `permitted` is a boolean getter
- * (strong-parameters.ts:113), not a method, so the probe tests key presence
- * rather than callability — the non-plain-prototype gate above is what keeps a
- * plain hash with a literal `permitted` key from being mistaken for a wrapper.
  */
 function isParamsLikeWrapper(attrs: object): boolean {
-  // `where`/`exists` funnel raw primitives through sanitizeForMassAssignment, and
+  // `where`/`exists` funnel raw primitives through this path, and
   // `Object.getPrototypeOf` box-coerces them (so a number clears the plain-object
   // gate below) while `in` throws on them outright. A primitive is never a params
   // wrapper — reject before either check.
   if (typeof attrs !== "object" || attrs === null) return false;
   const proto = Object.getPrototypeOf(attrs);
   if (proto === Object.prototype || proto === null) return false;
-  const wrapper = attrs as PermittedAttributes;
+  const wrapper = attrs as { permitted?: unknown; toH?: unknown };
   return "permitted" in wrapper || typeof wrapper.toH === "function";
 }
 
-/** @internal Rails-private helper. */
-export function sanitizeForMassAssignment(
-  attributes: Record<string, unknown>,
-): Record<string, unknown> {
-  const attrs = attributes as Record<string, unknown> & PermittedAttributes;
-  // Mirrors ActiveModel::ForbiddenAttributesProtection#sanitize_for_mass_assignment:
-  // params-style objects expose `permitted?` — raise unless permitted, then
-  // unwrap via `to_h` so the caller iterates a plain hash, not the wrapper.
-  // Rails calls `attributes.to_h` unconditionally; a permitted params object is
-  // expected to respond to it (a malformed one would NoMethodError there too).
-  // The wrapper-hood conjunct is what stands in for `respond_to?`: it keeps a
-  // plain hash carrying a literal `permitted` key out of the guard, since
-  // Ruby's Hash does not `respond_to?(:permitted?)` either.
-  if (isParamsLikeWrapper(attrs) && "permitted" in attrs) {
-    if (!readPermitted(attrs)) {
-      throw new ForbiddenAttributesError();
-    }
-    return attrs.toH!();
-  }
-  return attributes;
-}
-
-/**
- * Enforces ActiveModel::AttributeAssignment#assign_attributes' guard
- * (attribute_assignment.rb:29-30): a non-hash argument raises ArgumentError,
- * not a raw TypeError. Shared by every entry point that mass-assigns —
- * `Model#assignAttributes`, this module's `assignAttributes`, and ActiveRecord
- * `#update`/`#update!` (which iterate a raw writeAttribute loop) — so all
- * agree on the class and message text for the same input.
- *
- * Rails checks `respond_to?(:each_pair)`, so a Ruby Date/Time/Struct raises
- * here; JS has no `each_pair`, so we accept a plain object (prototype is
- * `Object.prototype` or null) or a params-style wrapper that duck-types
- * `permitted?`/`to_h` (ActionController::Parameters' analogue). A Date, Map,
- * Set, or arbitrary class instance has no hash semantics and raises.
- *
- * KNOWN GAP: `HashWithIndifferentAccess` is a Hash subclass that Rails' guard
- * admits (it inherits `Hash#each_pair`), but trails HWIA stores entries in a
- * private `Map` — so it fails this proto/duck-type check AND the downstream
- * `_assignAttributes` `Object.entries` loop can't read it either (a pre-existing
- * silent no-op). Real HWIA mass-assignment is tracked separately in
- * `assign-attributes-hwia-each-pair`; this guard does not regress it (it was
- * never assigned before).
- */
-export function assertHashAttributes(attrs: unknown): asserts attrs is Record<string, unknown> {
-  if (typeof attrs !== "object" || attrs === null || Array.isArray(attrs) || !isHashLike(attrs)) {
-    throw new ArgumentError(
-      `When assigning attributes, you must pass a hash as an argument, ${typeNameForError(attrs)} passed.`,
-    );
-  }
-}
-
-/**
- * A plain object (literal / `Object.create(null)`) has hash semantics, as does
- * a params-style wrapper duck-typing `permitted`/`toH` — the trails analogue of
- * `ActionController::Parameters`, which Rails admits via `respond_to?(:each_pair)`.
- * Everything else (Date, Map, Set, arbitrary class instances) is rejected.
- */
-function isHashLike(attrs: object): boolean {
-  const proto = Object.getPrototypeOf(attrs);
-  if (proto === Object.prototype || proto === null) return true;
-  return isParamsLikeWrapper(attrs);
-}
-
-function typeNameForError(value: unknown): string {
+/** The JS spelling of Ruby's `value.class` name, for the guard's message. */
+function classOf(value: unknown): string {
   // Ruby: nil.class #=> NilClass (not "Null").
   if (value === null) return "NilClass";
   if (Array.isArray(value)) return "Array";
-  // Mirror Ruby's `value.class` name: a class instance (Date, Time, …) reports
-  // its constructor name, not the generic "Object" that `typeof` collapses to.
   const ctorName = (value as { constructor?: { name?: string } } | undefined)?.constructor?.name;
   if (ctorName) return ctorName;
   const t = typeof value;

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -150,10 +150,25 @@ export function attribute(
   // When the type is omitted, preserve the existing attribute's type (Rails'
   // PendingType `with_type` inheritance path); fall back to the value type only
   // when nothing is known about the attribute yet.
+  // Rails' `attribute(name, ...)` forwards `**options` straight to the type
+  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the three
+  // keys consumed here — `default`, `virtual`, `user_provided_default` — are
+  // the ones Rails names explicitly, so only the rest reach the registry.
+  const {
+    default: _default,
+    virtual: _virtual,
+    userProvidedDefault: _upd,
+    ...typeOptions
+  } = options ?? {};
   const type = typeProvided
     ? typeName instanceof Type
       ? typeName
-      : this.resolveTypeName(typeName as string, typeOptions(options))
+      : this.resolveTypeName(
+          typeName as string,
+          Object.keys(typeOptions).length > 0
+            ? (typeOptions as Record<string, unknown>)
+            : undefined,
+        )
     : (existing?.type ?? typeRegistry.lookup("value"));
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and
@@ -208,6 +223,11 @@ export function attribute(
  * reaches the `set` half of that reader's accessor property instead, because a
  * `MethodSet` applies one descriptor per generated name
  * (code_generator.rb:32-36) and a property cannot take its halves from two.
+ *
+ * ActiveModel has no `define_method_attribute` upstream — only ActiveRecord
+ * does (attribute_methods/read.rb:11). That it exists here is the repo-wide
+ * rule ratified in CLAUDE.md § "Generated attribute readers are properties",
+ * not a local decision; see that section rather than re-deriving it.
  *
  * @internal Rails-private helper.
  */
@@ -284,16 +304,6 @@ export class Attributes {
   attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown {
     return attributeMissing.call(this as unknown as Record<string, unknown>, match, ...args);
   }
-}
-
-function typeOptions(options?: AttributeOptions): Record<string, unknown> | undefined {
-  const {
-    default: _default,
-    virtual: _virtual,
-    userProvidedDefault: _userProvidedDefault,
-    ...rest
-  } = options ?? {};
-  return Object.keys(rest).length > 0 ? (rest as Record<string, unknown>) : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -80,11 +80,16 @@ function optionsEqual(a: unknown, b: unknown): boolean {
 export class Error {
   static i18nCustomizeFullMessage: boolean = false;
 
-  readonly base: ModelBase;
-  readonly attribute: string;
-  readonly type: string;
-  readonly rawType: string;
-  readonly options: Record<string, unknown>;
+  // Rails exposes these as `attr_reader` over plain ivars (error.rb:101), which
+  // `initialize_dup` (:111-115) and `Errors#copy!`'s
+  // `instance_variable_set(:@base, ...)` (errors.rb:141) both write through.
+  // TS has no `instance_variable_set` escape hatch from a `readonly` field, so
+  // the ivars are declared writable exactly as Ruby has them.
+  base: ModelBase;
+  attribute: string;
+  type: string;
+  rawType: string;
+  options: Record<string, unknown>;
 
   static fullMessage(attribute: string, message: string, base: ModelBase): string {
     if (attribute === "base") return message;
@@ -281,26 +286,21 @@ export class Error {
 
   /**
    * Strict match — Rails `Error#strict_match?`
-   * (activemodel/lib/active_model/error.rb:184-188): attribute/type must
-   * match and `options` must equal the error's `@options` with
-   * `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` stripped.
+   * (activemodel/lib/active_model/error.rb:184-190):
+   *
+   *   return false unless match?(attribute, type)
+   *   options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
+   *
+   * `optionsEqual` stands in for Ruby's `Hash#==`, which JS `===` does not
+   * provide.
    */
   strictMatch(attribute: string, type: string, options?: Record<string, unknown>): boolean {
     if (!this.match(attribute, type)) return false;
-    const expected = options ?? {};
-    const own: Record<string, unknown> = except(
-      this.options,
-      ...CALLBACKS_OPTIONS,
-      ...MESSAGE_OPTIONS,
+
+    return optionsEqual(
+      options ?? {},
+      except(this.options, ...CALLBACKS_OPTIONS, ...MESSAGE_OPTIONS),
     );
-    const expectedKeys = Object.keys(expected);
-    const ownKeys = Object.keys(own);
-    if (expectedKeys.length !== ownKeys.length) return false;
-    for (const k of expectedKeys) {
-      if (!Object.prototype.hasOwnProperty.call(own, k) || !optionsEqual(own[k], expected[k]))
-        return false;
-    }
-    return true;
   }
 
   equals(other: Error): boolean {
@@ -323,16 +323,36 @@ export class Error {
   }
 
   /**
-   * Return a deep-duped copy of this error, optionally rebinding `base` to a
-   * new model instance. Mirrors Rails' usage in
-   * `ActiveModel::Errors#copy!` where each error is `deep_dup`ed and then
-   * its `@base` is reset to the receiver
-   * (activemodel/lib/active_model/errors.rb:138-143). Preserves a split
-   * between `type` and `rawType` when a NestedError-style override was in
-   * play.
+   * Mirrors: ActiveModel::Error#initialize_dup
+   * (activemodel/lib/active_model/error.rb:111-116):
+   *
+   *   def initialize_dup(other)
+   *     @attribute = @attribute.dup
+   *     @raw_type  = @raw_type.dup
+   *     @type      = @type.dup
+   *     @options   = @options.deep_dup
+   *   end
+   *
+   * `@attribute` / `@raw_type` / `@type` are Ruby Strings, whose `dup` exists
+   * to unshare mutable storage; a JS string is a primitive and already
+   * unshared, so only the options hash needs the copy. `@base` is deliberately
+   * left shared, as in Rails.
    */
-  dupWithBase(newBase: ModelBase): Error {
-    return new Error(newBase, this.attribute, this.type, deepDup(this.options), this.rawType);
+  initializeDup(_other: Error): void {
+    this.options = deepDup(this.options);
+  }
+
+  /**
+   * Mirrors: `Object#deep_dup`
+   * (activesupport/lib/active_support/core_ext/object/deep_dup.rb:29-31) —
+   * `duplicable? ? dup : self`. JS has no `Object#dup`, so the shallow
+   * class-preserving copy Ruby gets for free is spelled out, followed by the
+   * `initialize_dup` hook Ruby runs for it.
+   */
+  deepDup(): this {
+    const copy = Object.assign(Object.create(Object.getPrototypeOf(this) as object) as this, this);
+    copy.initializeDup(this);
+    return copy;
   }
 
   inspect(): string {

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -1,4 +1,4 @@
-import { humanize, deepDup, except } from "@blazetrails/activesupport";
+import { humanize, deepDup, except, isPlainObject } from "@blazetrails/activesupport";
 import { MissingTranslation, catchException, type TranslateKey } from "@blazetrails/i18n";
 import { I18n } from "./i18n.js";
 
@@ -37,11 +37,19 @@ const CALLBACKS_OPTIONS: string[] = [
 const MESSAGE_OPTIONS: string[] = ["message"];
 
 /**
- * Value equality that matches Ruby `==` for the common option shapes:
- * primitives (identity), arrays (elementwise), and plain objects (key-set +
- * recursive value equality). Rails relies on `Array#==` / `Hash#==` here
- * since option values like `in: [1,2,3]` / `count: 2..5` are frequently
- * collections, and reference equality in JS would silently fail to match.
+ * Ruby `==`, which JS `===` is not. Rails leans on it throughout `error.rb` —
+ * `match?` compares option values with `!=` (:171), `strict_match?` compares
+ * whole hashes with `==` (:187), and `==` compares the `attributes_for_hash`
+ * arrays elementwise (:181) — and every one of those is `Array#==` / `Hash#==`
+ * value equality that JS gives no operator for.
+ *
+ * Dispatch mirrors Ruby's: `Array#==` and `Hash#==` recurse (a Ruby Hash is a
+ * plain object here), `Regexp#==` compares source + flags, and everything else
+ * is sent `==` — which for an object that defines one means its own equality,
+ * and otherwise falls back to `BasicObject#==` identity. That last arm is why
+ * `attributes_for_hash`'s `@base` slot compares correctly through this: two
+ * distinct model instances are not `==` in Ruby either unless the model says
+ * so.
  */
 function optionsEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
@@ -58,7 +66,7 @@ function optionsEqual(a: unknown, b: unknown): boolean {
     return a.source === b.source && a.flags === b.flags;
   }
   if (a instanceof RegExp || b instanceof RegExp) return false;
-  if (typeof a === "object" && typeof b === "object") {
+  if (isPlainObject(a) && isPlainObject(b)) {
     const ak = Object.keys(a);
     const bk = Object.keys(b);
     if (ak.length !== bk.length) return false;
@@ -68,6 +76,9 @@ function optionsEqual(a: unknown, b: unknown): boolean {
         return false;
     }
     return true;
+  }
+  if (typeof (a as { equals?: unknown }).equals === "function") {
+    return (a as { equals(other: unknown): boolean }).equals(b);
   }
   return false;
 }
@@ -303,12 +314,18 @@ export class Error {
     );
   }
 
+  /**
+   * Mirrors: ActiveModel::Error#== / #eql? (error.rb:190-193):
+   *
+   *   def ==(other)
+   *     other.is_a?(self.class) && attributes_for_hash == other.attributes_for_hash
+   *   end
+   */
   equals(other: Error): boolean {
-    if (!(other instanceof Error)) return false;
-    const a = this.attributesForHash();
-    const b = other.attributesForHash();
-    if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) return false;
-    return optionsEqual(a[3], b[3]);
+    return (
+      other instanceof this.constructor &&
+      optionsEqual(this.attributesForHash(), other.attributesForHash())
+    );
   }
 
   /**

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -765,7 +765,7 @@ describe("ErrorsTest", () => {
       expect(imported.type).toBe("wrong");
       expect(imported.rawType).toBe(":invalid");
 
-      // copy!/dupWithBase must preserve the {attribute, type, rawType} split.
+      // copy! must preserve the {attribute, type, rawType} split.
       const copy = new Errors({});
       copy.copyBang(target);
       const round = copy.objects[0];
@@ -775,9 +775,12 @@ describe("ErrorsTest", () => {
     });
   });
 
-  it("copy! deep-dups the inner error on NestedError (no shared mutable state)", () => {
-    // Rails `deep_dup` on a NestedError recurses into `@inner_error`, so the
-    // duplicated wrapper's inner error is independent of the source's.
+  it("copy! dups each error without recursing into a NestedError's inner error", () => {
+    // `@errors = other.errors.deep_dup` (errors.rb:139). ActiveSupport's
+    // `Object#deep_dup` is `duplicable? ? dup : self`, and only Array/Hash
+    // override it to recurse — so an Error element gets a plain `dup` plus
+    // `initialize_dup` (error.rb:111-116), which deep-dups `@options` and
+    // leaves every other ivar, `@inner_error` included, shared.
     const source = new Errors({});
     source.add("age", ":out_of_range", { range: { min: 1 } });
     const wrapper = new Errors({});
@@ -790,10 +793,9 @@ describe("ErrorsTest", () => {
     const tgtInner = (
       target.objects[0] as unknown as { innerError: { options: Record<string, unknown> } }
     ).innerError;
-    expect(tgtInner).not.toBe(srcInner);
-    expect((tgtInner.options.range as { min: number }).min).toBe(1);
-    (srcInner.options.range as { min: number }).min = 999;
-    expect((tgtInner.options.range as { min: number }).min).toBe(1);
+    expect(tgtInner).toBe(srcInner);
+    // The wrapper's own `@options` is independent, though.
+    expect(target.objects[0].options).not.toBe(wrapper.objects[0].options);
   });
 
   it("copy! rebinds each error's base to the receiver", () => {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -1,3 +1,4 @@
+import { deepDup } from "@blazetrails/activesupport";
 import { Error as ActiveModelError } from "./error.js";
 import { NestedError } from "./nested-error.js";
 
@@ -73,17 +74,15 @@ export class Errors<TBase extends object = object> {
    *     @errors.each { |error| error.instance_variable_set(:@base, @base) }
    *   end
    *
-   * @missingRailsCall deep_dup — Language shortcoming: Rails dups the array and
-   * then rebases each copy with `instance_variable_set(:@base, ...)`, writing
-   * through `Error#base`'s reader. `base` is `readonly` in TS with no
-   * `instance_variable_set` escape hatch, so the rebase has to happen at
-   * construction — which is what `Error#dupWithBase` does, deep-dupping the
-   * options as it goes. The per-element dup Rails gets from `Array#deep_dup` is
-   * therefore fused into the same call rather than omitted; splitting them back
-   * out would dup every error twice to no effect.
+   * `Array#deep_dup` dups each element with `Object#deep_dup`, which for an
+   * Error is `dup` plus `initialize_dup` (error.rb:111-116) — see
+   * `Error#deepDup`, which the shared `deepDup` dispatches to.
    */
   copyBang<U extends object>(other: Errors<U>): void {
-    this._errors = other._errors.map((e) => e.dupWithBase(this._base));
+    this._errors = deepDup(other._errors);
+    this._errors.forEach((error) => {
+      error.base = this._base;
+    });
   }
 
   /**

--- a/packages/activemodel/src/forbidden-attributes-protection.ts
+++ b/packages/activemodel/src/forbidden-attributes-protection.ts
@@ -10,10 +10,36 @@ export class ForbiddenAttributesError extends globalThis.Error {
   }
 }
 
-/** Host shape for the {@link sanitizeForbiddenAttributes} mixin method. */
-export interface ForbiddenAttributesProtectionHost {
-  /** @internal Rails-private helper. */
-  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
+interface PermittedAttributes {
+  permitted?: boolean | (() => boolean);
+  toH?(): Record<string, unknown>;
+}
+
+/**
+ * Mirrors: ActiveModel::ForbiddenAttributesProtection#sanitize_for_mass_assignment
+ * (forbidden_attributes_protection.rb:23-29).
+ *
+ * @internal Rails-private helper.
+ */
+export function sanitizeForMassAssignment(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
+  const attrs = attributes as Record<string, unknown> & PermittedAttributes;
+  // Rails: `if attributes.respond_to?(:permitted?)`
+  // (forbidden_attributes_protection.rb:24). params-style objects expose `permitted?` — raise unless permitted, then
+  // unwrap via `to_h` so the caller iterates a plain hash, not the wrapper.
+  // Rails calls `attributes.to_h` unconditionally; a permitted params object is
+  // expected to respond to it (a malformed one would NoMethodError there too).
+  // The wrapper-hood conjunct is what stands in for `respond_to?`: it keeps a
+  // plain hash carrying a literal `permitted` key out of the guard, since
+  // Ruby's Hash does not `respond_to?(:permitted?)` either.
+  if (respondToPermitted(attrs)) {
+    if (!readPermitted(attrs)) {
+      throw new ForbiddenAttributesError();
+    }
+    return attrs.toH!();
+  }
+  return attributes;
 }
 
 /**
@@ -32,4 +58,37 @@ export function sanitizeForbiddenAttributes(
   attributes: Record<string, unknown>,
 ): Record<string, unknown> {
   return this.sanitizeForMassAssignment(attributes);
+}
+
+/**
+ * Reads a params-like wrapper's `permitted?`. The real
+ * `ActionController::Parameters` exposes it as a boolean GETTER
+ * (strong-parameters.ts:113), while duck-typed wrappers may expose a method —
+ * Ruby draws no such distinction, so both must answer here.
+ */
+function readPermitted(attrs: PermittedAttributes): boolean {
+  const permitted = attrs.permitted;
+  return typeof permitted === "function" ? permitted.call(attrs) : Boolean(permitted);
+}
+
+/** Host shape for the {@link sanitizeForbiddenAttributes} mixin method. */
+export interface ForbiddenAttributesProtectionHost {
+  /** @internal Rails-private helper. */
+  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
+}
+
+/**
+ * The JS spelling of `attributes.respond_to?(:permitted?)`
+ * (forbidden_attributes_protection.rb:24). A plain hash does not respond to it
+ * in Ruby either, so the non-plain-prototype gate is what keeps a hash carrying
+ * a literal `permitted` key out of the guard. For the real
+ * `ActionController::Parameters` analogue, `permitted` is a boolean GETTER
+ * (strong-parameters.ts:113), not a method — hence key presence, not
+ * callability.
+ */
+function respondToPermitted(attrs: object): boolean {
+  if (typeof attrs !== "object" || attrs === null) return false;
+  const proto = Object.getPrototypeOf(attrs);
+  if (proto === Object.prototype || proto === null) return false;
+  return "permitted" in attrs;
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -20,12 +20,13 @@ export {
   isInstanceMethodAlreadyImplemented,
 } from "./attribute-methods.js";
 export type { InstanceHost } from "./attribute-methods.js";
-export { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
+export {
+  ForbiddenAttributesError,
+  sanitizeForMassAssignment,
+} from "./forbidden-attributes-protection.js";
 export {
   assignAttributes,
-  assertHashAttributes,
   attributeWriterMissing,
-  sanitizeForMassAssignment,
   isMassAssignmentEmpty,
   ArgumentError,
   NoMethodError,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -96,13 +96,13 @@ import {
 } from "./attribute-methods.js";
 import {
   _assignAttribute as attrAssignOne,
-  sanitizeForMassAssignment as attrSanitize,
+  assignAttributes as attrAssign,
   attributeWriterMissing as defaultAttributeWriterMissing,
-  assertHashAttributes,
   isMassAssignmentEmpty,
   ArgumentError,
   NoMethodError,
 } from "./attribute-assignment.js";
+import { sanitizeForMassAssignment as attrSanitize } from "./forbidden-attributes-protection.js";
 import { PresenceValidator } from "./validations/presence.js";
 import { AbsenceValidator } from "./validations/absence.js";
 import { LengthValidator } from "./validations/length.js";
@@ -2639,9 +2639,7 @@ export class Model {
    * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
    */
   assignAttributes(newAttributes: unknown): void {
-    assertHashAttributes(newAttributes);
-    if (isMassAssignmentEmpty(newAttributes)) return;
-    this._assignAttributes(this.sanitizeForMassAssignment(newAttributes));
+    attrAssign(this, newAttributes);
   }
 
   /**

--- a/packages/activemodel/src/nested-error.ts
+++ b/packages/activemodel/src/nested-error.ts
@@ -1,4 +1,3 @@
-import { deepDup } from "@blazetrails/activesupport";
 import { Error as ActiveModelError } from "./error.js";
 
 interface ErrorLike {
@@ -38,34 +37,5 @@ export class NestedError extends ActiveModelError {
 
   override get message(): string {
     return this.innerError.message;
-  }
-
-  /**
-   * Preserve the NestedError wrapper + deep-dup the wrapped inner error.
-   *
-   * Rails' `deep_dup` keeps the dynamic class and recurses through ivars,
-   * so a duplicated NestedError gets an independent inner error too —
-   * without this, a copy would still share mutable `innerError` state
-   * (options, attribute, type) with the source and contradict the
-   * deep-dup semantics documented for `Errors#copy!`.
-   *
-   * Inner error's own `base` is preserved (the inner error belongs to the
-   * inner model, not the outer one) — only the NestedError's base changes.
-   */
-  override dupWithBase(newBase: object | null): NestedError {
-    const inner = this.innerError;
-    const innerDup: ErrorLike =
-      inner instanceof ActiveModelError
-        ? inner.dupWithBase(inner.base)
-        : {
-            attribute: inner.attribute,
-            type: inner.type,
-            rawType: inner.rawType,
-            message: inner.message,
-            options: deepDup(inner.options ?? {}),
-          };
-    // Preserve both `attribute` (may have been overridden) and `type`
-    // (may differ from inner.type after `override_options[:type]`).
-    return new NestedError(newBase, innerDup, { attribute: this.attribute, type: this.type });
   }
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -16,7 +16,6 @@ import {
   sanitizeForMassAssignment,
   SerializeCastValue,
   runAfterCallbacksOnProto,
-  assertHashAttributes,
   isMassAssignmentEmpty,
 } from "@blazetrails/activemodel";
 import {
@@ -596,7 +595,6 @@ export async function update<T extends UpdateRecord>(
   this: T,
   attributes: Record<string, unknown>,
 ): Promise<boolean | undefined> {
-  assertHashAttributes(attributes);
   const self = this as any;
   return withTransactionReturningStatus.call(self, async () => {
     // `assign_attributes(attributes); save` (persistence.rb:563-570).
@@ -613,7 +611,6 @@ export async function updateBang<T extends UpdateRecord>(
   this: T,
   attributes: Record<string, unknown>,
 ): Promise<true | undefined> {
-  assertHashAttributes(attributes);
   const self = this as any;
   return withTransactionReturningStatus.call(self, async () => {
     // `assign_attributes(attributes); save!` (persistence.rb:576-579).
@@ -1040,7 +1037,15 @@ export function assignAttributes(
   this: AttributeIO,
   attrs: Record<string, unknown>,
 ): Promise<void> | void {
-  assertHashAttributes(attrs);
+  // `unless new_attributes.respond_to?(:each_pair)` (attribute_assignment.rb:29-31).
+  // ActiveModel's own `assignAttributes` spells the same three lines; this port
+  // exists separately only because it has to be async, so the guard is repeated
+  // rather than shared through a helper Rails does not have.
+  if (!respondToEachPair(attrs)) {
+    throw new ArgumentError(
+      `When assigning attributes, you must pass a hash as an argument, ${classOf(attrs)} passed.`,
+    );
+  }
   // `new_attributes.empty?` (attribute_assignment.rb:32) runs before the
   // sanitizer, so a blank strong-params object is a no-op rather than raising;
   // `isMassAssignmentEmpty` reads a wrapper's contents, not its own fields.
@@ -2243,3 +2248,24 @@ export function buildDefaultConstraint(this: {
 export const InstanceMethods = {
   _updateRecord: instanceUpdateRecord,
 };
+
+/** The JS spelling of `new_attributes.respond_to?(:each_pair)` (attribute_assignment.rb:29). */
+function respondToEachPair(attrs: unknown): attrs is Record<string, unknown> {
+  if (typeof attrs !== "object" || attrs === null || Array.isArray(attrs)) return false;
+  const proto = Object.getPrototypeOf(attrs);
+  if (proto === Object.prototype || proto === null) return true;
+  // A params-style wrapper (the `ActionController::Parameters` analogue) is the
+  // other Ruby receiver that answers `each_pair`.
+  const wrapper = attrs as { permitted?: unknown; toH?: unknown };
+  return "permitted" in wrapper || typeof wrapper.toH === "function";
+}
+
+/** The JS spelling of Ruby's `value.class` name, for the guard's message. */
+function classOf(value: unknown): string {
+  if (value === null) return "NilClass";
+  if (Array.isArray(value)) return "Array";
+  const ctorName = (value as { constructor?: { name?: string } } | undefined)?.constructor?.name;
+  if (ctorName) return ctorName;
+  const t = typeof value;
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -76,6 +76,12 @@ export function deepMergeBang<T extends AnyObject>(target: T, source: AnyObject)
 export function deepDup<T>(obj: T): T {
   if (obj === null || obj === undefined) return obj;
   if (Array.isArray(obj)) return obj.map((item) => deepDup(item)) as T;
+  // Ruby dispatches `deep_dup` on the receiver (core_ext/object/deep_dup.rb),
+  // so a class that defines its own answers instead of falling through to the
+  // Hash/Array recursion below.
+  if (typeof (obj as { deepDup?: unknown }).deepDup === "function") {
+    return (obj as unknown as { deepDup(): T }).deepDup();
+  }
   if (typeof obj === "object" && isPlainObject(obj)) {
     const result: AnyObject = {};
     for (const key of Object.keys(obj as AnyObject)) {


### PR DESCRIPTION
RFC 0115 — three bundled convergence stories over activemodel's non-Rails residue.

## `attribute_assignment.rb` (converge-attribute-assignment-hash-guards)

- `assignAttributes` is Rails' own three lines (`attribute_assignment.rb:29-32`): the
  `respond_to?(:each_pair)` guard with the `ArgumentError` message string verbatim,
  then `return if new_attributes.empty?`. `assertHashAttributes`, `isHashLike` and
  `typeNameForError` are gone; what remains is a file-private `respondToEachPair` /
  `classOf` pair, which is what `respond_to?(:each_pair)` and `#{...class}` have to
  become in a language with neither.
- Both sends now go through the model (`model._assignAttributes(model.sanitizeForMassAssignment(...))`)
  as Ruby's implicit `self` receiver does, so `Model#assignAttributes` delegates to
  the module method instead of re-implementing it.
- `sanitizeForMassAssignment` and `readPermitted` move to their Rails home,
  `forbidden-attributes-protection.ts` (`forbidden_attributes_protection.rb:23-29`),
  and the wrapper probe there becomes the `attributes.respond_to?(:permitted?)` it
  ports (`:24`).
- `writeAttribute` leaves the `AttributeAssignment` interface — nothing on this path
  calls it; the only write Rails makes is `public_send(setter, v)`.
- ActiveRecord's `update` / `update!` drop their redundant pre-guards:
  `persistence.rb:563-579` does not guard, `assign_attributes` does. AR's own async
  `assignAttributes` port keeps a file-private copy of the same guard, since the
  async split is what forced the duplicate port in the first place.

Carved out and filed: `converge-assign-attribute-writer-ladder-onto-public-send`
(the `findSetter` ladder, rewritten by #6738 with its own tracked story
`assign-attribute-respond-to-setter-reraise-arm`, scores no `parity:api:extra` row
and is pure risk inside a bundle at its LOC ceiling).

## `attributes.rb` (converge-attributes-define-method-attribute-and-defaults)

- `buildDefaultAttributes` deleted — it had **zero** callers; the ported path is
  `_defaultAttributes` / `resetDefaultAttributes` in `attribute-registration.ts`.
- `typeOptions` inlined at its caller: Rails' `attribute(name, ...)` forwards
  `**options` straight through (`attributes.rb:59-62` → `attribute_registration.rb:18`).
- `defineMethodAttribute=`'s JSDoc now cites CLAUDE.md's ratified
  "Generated attribute readers are properties" section, per that section's own
  instruction, rather than re-arguing the hook locally. It was already installed
  where the class is defined (`model.ts`) and was never on `index.ts`.

Carved out and filed: `issue-attribute-method-suffix-from-the-included-hook` —
issuing `attributes.rb:35-37` from the `[included]` hook first requires converting
`Model` onto `include()` / `Extended<>` for `Attributes` (it hand-assigns the
statics today), which is its own refactor across `attribute-methods.ts`,
`attribute-registration.ts` and every AR host.

## `error.rb` (converge-error-options-equality-and-dup-with-base)

- `strictMatch` is the single `options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)`
  of `error.rb:187` instead of a hand-rolled key-set walk; `optionsEqual` survives
  only as the stand-in for Ruby's `Hash#==`, which JS `===` does not provide.
- `dupWithBase` is replaced by the pair Rails actually uses at the corresponding
  site, `Errors#copy!` (`errors.rb:139-142`): `Object#deep_dup` plus
  `initialize_dup` (`error.rb:111-116`), with the rebase written through `@base`
  the way `instance_variable_set(:@base, @base)` does. `base` / `options` are
  therefore plain writable ivars, as `attr_reader` over an ivar is in Ruby.
- `Error#initializeDup` and `Error#deepDup` are the two ported Rails members that
  replace it, and the shared `deepDup` now dispatches to a receiver's own
  `deepDup`, as Ruby's `Object#deep_dup` does.
- `NestedError` loses its `dupWithBase` override and its inner-error recursion.
  That recursion asserted something Rails does not do — `[obj].deep_dup` shallow-dups
  each element, leaving `@inner_error` shared — verified against MRI:

  ```
  $ ruby -e 'require "active_support/all"; class Foo; attr_accessor :inner; def initialize(i); @inner=i; end; end
    a = Foo.new({x: 1}); b = [a].deep_dup; p b[0].equal?(a), b[0].inner.equal?(a.inner)'
  false
  true
  ```

  The one trails-invented test asserting the false premise is replaced by one
  asserting the Rails behaviour.

## Verification

- `pnpm parity:api:extra --package activemodel`: `attribute-assignment.ts` 1 → **0**
  novel, `error.ts` 1 → **0**, `nested-error.ts` 1 → **0**, `attributes.ts` 3 → **2**,
  `index.ts` 26 → **25**; `errors.ts` stays 0 with the `dupWithBase` leak gone.
- `pnpm parity:api` deltas unchanged (Data layer 7837/7839, AR closure 8930/8942,
  Overall 13391/15340).
- `pnpm parity:api:calls` OK; `pnpm parity:api:calls:args` OK. No baseline row added.
- `pnpm vitest run packages/activemodel/src` — 1965 passed, 1 skipped (87 files).
- AR spot checks green: `persistence`, `attribute-assignment`, `base`, `validations/`,
  `nested-attributes`, `dirty`, `errors`, `attribute-methods`.

---

## Review round 1 — responses

### 1. `[included]` hook for `attribute_method_suffix "="` — scoped out, needs a maintainer call

Confirmed unmet, and I agree it is not closed by the follow-up story. Stating the
blocker precisely so the call can be made on evidence rather than on my estimate:

`attributes.rb:35-37`'s `included do ... end` can only be issued from the
`[included]` hook if something calls `include(Model, Attributes)`. Nothing does.
`Model` composes `Attributes` by hand-assigning statics (`model.ts:317-330`) and
defines its own `attributes` getter, `attributeNames` and `attributeMissing` —
all three of which `include()` would copy off `Attributes.prototype` onto
`Model.prototype`, so the conversion is not additive and cannot be smoke-tested
in isolation. That is the whole of RFC 0115's F0 finding (activemodel has zero
callers of `include()`/`Included<>`, `extend()`/`Extended<>` or
`classAttribute()`), and it lands across `attribute-methods.ts`,
`attribute-registration.ts` and every ActiveRecord host.

Filed with that context as `issue-attribute-method-suffix-from-the-included-hook`.
**If the maintainer prefers this criterion met inside this PR, say so and I will
close this PR and reopen the story as the `include()` conversion** — it is not
work I can bolt onto a 482-LOC bundle without the reviewer seeing the same diff
twice.

### 2. `attributes.ts` at 2 novel, not ≤ 1 — blocked on a separate register

The bar is missed by exactly the two rows the deleted `buildDefaultAttributes`
did not cover: `userProvided` and `userProvidedDefault` (with `source`, whose own
JSDoc admits it "matches `userProvided` but kept explicit for clarity"). Rails
stores none of the three — `user_provided_default:` is a kwarg, and the
distinction it draws is carried by which `Attribute` subclass gets built, not by
a flag on a definition record.

They have 25+ call sites outside activemodel — `model-schema.ts:969,1141,1148,1190,1435`,
`enum.ts:163`, `encryption/encryptable-record.ts:174`, `attributes.ts:29,194` — plus
direct assertions in `model-schema-load.test.ts`, `model-schema-sync-load.test.ts`
and `sti-attribute-routing.trails.test.ts`. Collapsing them is a cross-package
change with its own AR precedence invariant to preserve (`model-schema.ts:1265`),
so it is filed as `collapse-user-provided-and-source-onto-the-rails-kwarg` rather
than smuggled in here.

On `index.ts` still exporting `defineDirtyAttributeMethods`: that one is not
blocked on the same carve-out and should not be removed. It is imported by
`activerecord/src/attribute-methods.ts:11,492`, so dropping the export breaks the
AR build; and it already carries its own `@noRailsEquivalent CONVERGEABLE` tag and
tracked story (`0096-naming-identifier-burndown/declare-dirty-cascade-as-attribute-method-suffix-patterns`)
for the real convergence, which is to declare the dirty cascade as
`attribute_method_suffix` patterns. The story criterion was written against a
stale reading of `index.ts` — `setDefineMethodAttribute`, the other name it
listed, was never exported there at all.

### 3. `classOf` / `respondToEachPair` duplicated in `persistence.ts` rather than imported

Deliberate, and the reuse would cost more than it saves. Exporting them from
`attribute-assignment.ts` puts two names with no Ruby counterpart back on that
file's public surface — `parity:api:extra --package activemodel` would go from
**0 novel to 2** on the file this PR just cleared, and they would have to travel
through `index.ts` to reach activerecord, adding two more rows there. Rails has
neither helper: they exist only because `respond_to?(:each_pair)` and
`#{x.class}` have no JS spelling, and the repo already resolves that the same way
in five other places (`nested-attributes.ts:756`, `query-methods.ts:1472`,
`validations/comparison.ts:18`, `param-builder.ts:178`, `session.ts:113`), each
keeping its own file-private copy rather than growing a shared utility Rails
does not have. Duplicating ~12 private lines is the cheaper side of that trade.


---

## Review round 2 — response

### 4. `optionsEqual` / `equals()` — fixed, and the bullet was half right

You are right that I addressed (1)-(3) and said nothing about this one. It was
dropped, not judged. Judging it now:

**The story's "`optionsEqual` is gone" bullet is unsatisfiable, but the reason I
had for keeping the destructured `equals()` was not.** Both halves matter.

`optionsEqual` cannot go: `error.rb` leans on Ruby `==` at three separate sites —
`match?` compares option values with `!=` (`:171`), `strict_match?` compares whole
hashes with `==` (`:187`), and `==` compares the `attributes_for_hash` **arrays**
elementwise (`:181`). Every one is `Array#==` / `Hash#==` value equality, and JS
has no operator for it. Deleting the shim would not converge those three sites, it
would break them.

What *was* wrong is the shape at `equals()`, and the cause was in `optionsEqual`
itself. Its object arm recursed into anything `typeof === "object"`, which
includes the `attributes_for_hash` tuple's `@base` slot — so folding the tuple
into one call would have compared two distinct model instances with matching
fields as equal. That is why the old body destructured the tuple and identity-
checked slots 0-2 by hand: a local workaround for a shim that was not Ruby-accurate.

Fixed at the root instead (`f3292d6`). The recursion is now restricted to Hash and
Array — a Ruby Hash is a plain object here — and anything else is sent `==`, which
is that object's own equality if it defines one and `BasicObject#==` identity
otherwise. That is Ruby's own dispatch, not a special case bolted on for `@base`,
and it also fixes a latent bug the old arm had: two `Date`s both have zero
enumerable keys, so the key-set walk returned `true` for *any* two Dates
regardless of value.

With the shim correct, `equals()` is now the one-liner:

```ts
equals(other: Error): boolean {
  return (
    other instanceof this.constructor &&
    optionsEqual(this.attributesForHash(), other.attributesForHash())
  );
}
```

against `error.rb:190-192`:

```ruby
def ==(other)
  other.is_a?(self.class) && attributes_for_hash == other.attributes_for_hash
end
```

`optionsEqual`'s JSDoc now carries the three Rails cites and states the dispatch
rule, so the deviation is justified at the call site rather than in this
description. Full activemodel suite (1965 tests) and the AR validations /
errors / nested-attributes files stay green; `parity:api:calls`,
`parity:api:calls:args` clean; `error.ts` still 0 novel.

### 1 and 2 — still open, still yours to call

No change and no new evidence, so per "do not revert prior decisions without new
evidence" they stand as filed:
`issue-attribute-method-suffix-from-the-included-hook` and
`collapse-user-provided-and-source-onto-the-rails-kwarg`. Agreed these should be
decided rather than left to linger — the offer in round 1 stands: say the word and
I close this PR in favour of the `include()` conversion, otherwise they ship as
scoped-out follow-ups.


---

## Rebased onto main — finding 2 is now closed by the diff, not by a follow-up

Conflict was in `attributes.ts`: main had deleted `buildDefaultAttributes` (same
dead code this PR removed), while this branch also inlines `typeOptions`. Took
this branch's side — both gone, the inlined destructure at `attribute()`'s call
site survives unchanged.

The interesting part is what else came with main. **#6783 landed
`collapse-user-provided-and-source-onto-the-rails-kwarg`** — the follow-up story
this PR filed in round 1 for exactly the `userProvided` / `source` duplication
that was holding `attributes.ts` above its bar. With that on main:

```
attributes.ts — 1 novel, 8 moved
  userProvidedDefault
```

So `converge-attributes-define-method-attribute-and-defaults`'s numeric criterion
**"`attributes.ts` at ≤ 1 novel"** is now **met** by this branch, and finding 2 is
closed on the evidence rather than deferred. The remaining row,
`userProvidedDefault`, is Rails' own `user_provided_default:` kwarg name
(`attribute_registration.rb`), which is what #6783 converged the pair onto.
`index.ts` also drops from 25 to **24** novel.

Finding 1 (the `[included]` hook) is unaffected and remains the accepted
carve-out, tracked by `issue-attribute-method-suffix-from-the-included-hook`.

Re-verified post-rebase: `pnpm typecheck` clean; `parity:api:calls` OK
(902 baselined, 424 tight — moved with main, no row added by this branch);
`parity:api:calls:args` OK; activemodel 1968 tests pass; AR `persistence`,
`model-schema-load`, `validations/`, `nested-attributes`, `enum.trails` pass
(523 tests).


---

## Review round 4 — finding 2 is measuring a pre-rebase tree

No code change this round; the correction is to the measurement, not the diff.

Round 4 opens with *"No new commits since my last review (`60c4ec3f1` is still
HEAD, unchanged)"*. `60c4ec3f1` is the **rebased** tip. Round 3 reviewed
`f3292d697`, and the force-push replaced it — same branch, different history,
40+ commits of `main` merged underneath. Comparing tip SHAs alone reads that as
"unchanged", which is how finding 2 carried forward a number that no longer holds.

Measured on the branch HEAD as it stands:

```
$ git merge-base --is-ancestor origin/main HEAD && echo ok
ok
$ git log --oneline HEAD | grep 6783
d4f2d7396 refactor(activemodel,activerecord): collapse userProvided/source onto the Rails user_provided_default kwarg (#6783)
$ pnpm build && pnpm parity:api && pnpm parity:api:extra --package activemodel
  attributes.ts — 1 novel, 8 moved
    userProvidedDefault
```

**`attributes.ts` is at 1 novel, not 2.** The `≤ 1` bar in
`converge-attributes-define-method-attribute-and-defaults` is met, so finding 2
is closed by the diff — not by a filed follow-up. What closed it is that
`collapse-user-provided-and-source-onto-the-rails-kwarg`, the story this PR filed
in round 1, was claimed and shipped by a sibling as #6783 (`d4f2d7396`) and is an
ancestor of this branch. Its tasks status is `done`. The single remaining row,
`userProvidedDefault`, is Rails' own `user_provided_default:` kwarg name from
`attribute_registration.rb` — the spelling #6783 converged the pair onto, so
there is nothing further to converge there.

Note `parity:api:extra` reports against **build state**, not commit state, so a
run over a `dist/` built before the rebase will still print the old 2. `pnpm build`
first — that is the likeliest source of the stale number.

`index.ts` moved 25 → **24** novel over the same rebase.

**Finding 1 is the only genuinely open item**, and it is unchanged and correctly
described: the `[included]` hook needs `Model` converted onto `include()` /
`Extended<>` first, tracked by
`issue-attribute-method-suffix-from-the-included-hook`. It was accepted as a
scoped-out carve-out when the PR was marked ready.
