### PR TITLE
refactor: converge three trails-only seams onto their Rails shapes

### DIFF
--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -61,50 +61,81 @@ export function _assignAttributes(
  *   end
  *
  * There is no `write_attribute` on this path: the only write Rails makes is
- * `public_send(setter, v)`.
+ * `public_send(setter, v)`, and the branch it takes when that fails is decided
+ * in the `rescue`, not before the send.
  *
- * That send takes two spellings here because one Ruby method name reaches TS
- * two ways. Rails' generated writer is a real method named `name=`
- * (attributes.rb:92-102) and is reachable by that key; a user-authored
- * `def name=` ported as a TS `set` accessor is the same Ruby method under the
- * spelling docs/ruby-ts-conventions.md gives it, which `findSetter` resolves.
- * The accessor is tried first because Ruby finds a class's own `name=` before
- * the generated methods module's.
- *
- * Ruby reaches the `rescue NoMethodError` arm through
- * AttributeMethods#method_missing (attribute_methods.rb:508-517), which routes
- * a name matching an attribute-method pattern to `attribute_missing` before any
- * NoMethodError escapes — that is how assignment still works after
+ * Ruby reaches that rescue through AttributeMethods#method_missing
+ * (attribute_methods.rb:508-517), which routes a name matching an
+ * attribute-method pattern to `attribute_missing` before any NoMethodError
+ * escapes — that is how assignment still works after
  * `undefine_attribute_methods`. TS has no `method_missing`, so that dispatch is
- * explicit; a name with no pattern match is the `respond_to?(setter)` false arm
- * and goes to `attribute_writer_missing`. The remaining arm — the setter exists
- * and itself raised NoMethodError, so Rails re-raises at :70-71 — is tracked by
- * `assign-attribute-respond-to-setter-reraise-arm`. Resolving the setter before
- * dispatching means there is no rescue to re-enter: a NoMethodError from inside
- * a setter propagates out of the send above, which is what the re-raise does,
- * but Ruby's `respond_to?` consults the receiver's full method table where the
- * ladder above consults only what it can resolve.
+ * explicit inside the send below, in the same position Ruby runs it.
  *
  * @internal Rails-private helper.
  */
 export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
   const setter = `${k}=`;
-  const own = findSetter(model, k);
-  if (own) {
-    own.call(model, v);
-    return;
+  try {
+    const method = methodFor(model, setter);
+    if (method) {
+      method.call(model, v);
+      return;
+    }
+    // AttributeMethods#method_missing (attribute_methods.rb:508-517).
+    const match = model.matchedAttributeMethod(setter);
+    if (match) {
+      model.attributeMissing(match, v);
+      return;
+    }
+    throw new NoMethodError(
+      `undefined method '${setter}' for an instance of ${model.constructor.name}`,
+    );
+  } catch (error) {
+    if (!(error instanceof NoMethodError)) throw error;
+    if (methodFor(model, setter)) {
+      throw error;
+    } else {
+      model.attributeWriterMissing(k, v);
+    }
+  }
+}
+
+/**
+ * Ruby's method-table lookup for `setter` — what both `public_send(setter, v)`
+ * and `respond_to?(setter)` consult above.
+ *
+ * One Ruby method name reaches TS two ways, which is the single genuine JS
+ * shortcoming on this path. Rails' generated writer is a real method named
+ * `name=` (attributes.rb:92-102) and is reachable by that key; a user-authored
+ * `def name=` ported as a TS `set` accessor is the same Ruby method under the
+ * spelling docs/ruby-ts-conventions.md gives it, and a `set name(v)` accessor
+ * is NOT reachable by the key `"name="`. The accessor is tried first because
+ * Ruby finds a class's own `name=` before the generated methods module's.
+ *
+ * The accessor walk starts at the instance itself (JS analogue of Ruby
+ * singleton methods) and stops before `Object.prototype`, so built-in
+ * accessors like `__proto__` can't hijack mass assignment. It ignores
+ * shadowing data descriptors and get-only accessors: Ruby looks up `name=` as
+ * its own method, independent of any `name` getter.
+ */
+function methodFor(
+  model: AttributeAssignment,
+  setter: string,
+): ((this: AttributeAssignment, value: unknown) => void) | null {
+  const key = setter.slice(0, -1);
+  let obj: object | null = model;
+  while (obj && obj !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(obj, key);
+    if (desc && typeof desc.set === "function") {
+      return desc.set as (this: AttributeAssignment, value: unknown) => void;
+    }
+    obj = Object.getPrototypeOf(obj);
   }
   const generated = (model as unknown as Record<string, unknown>)[setter];
   if (typeof generated === "function") {
-    (generated as (this: AttributeAssignment, value: unknown) => void).call(model, v);
-    return;
+    return generated as (this: AttributeAssignment, value: unknown) => void;
   }
-  const match = model.matchedAttributeMethod(setter);
-  if (match) {
-    model.attributeMissing(match, v);
-    return;
-  }
-  model.attributeWriterMissing(k, v);
+  return null;
 }
 
 export interface AttributeAssignment {
@@ -192,44 +223,6 @@ function classOf(value: unknown): string {
   if (ctorName) return ctorName;
   const t = typeof value;
   return t.charAt(0).toUpperCase() + t.slice(1);
-}
-
-/**
- * Walk instance → prototype chain looking for a setter descriptor for `key`.
- * Mirrors Rails' `public_send("#{k}=", v)` dispatch
- * (activemodel/lib/active_model/attribute_assignment.rb:67-70), which routes
- * through any user-defined `attr_writer` / `def name=` before the attribute
- * store sees the value.
- *
- * Starts at the instance itself (JS analogue of Ruby singleton methods —
- * `Object.defineProperty(model, key, { set })`) and walks up, stopping before
- * `Object.prototype` so built-in accessors like `__proto__` can't hijack
- * mass assignment.
- *
- * Matches either of:
- * - a user-defined setter on a subclass prototype
- *   (`class Cat extends Model { set name(v) { … } }`), or
- * - a framework-generated setter installed by `this.attribute("name", …)`
- *   (see attributes.ts:110-120), which just forwards to `writeAttribute` —
- *   so the net behaviour for non-overridden attributes is unchanged. The
- *   `hasOwnProperty` guard in `attributes.ts` preserves a user-authored
- *   `set name` if declared in the class body.
- *
- * Walks the full chain regardless of shadowing descriptors: Ruby looks up
- * `name=` as its own method, independent of any `name` getter. A get-only
- * accessor or a data descriptor at one level does not hide a setter
- * defined higher up, so neither should our walk.
- */
-function findSetter(model: object, key: string): ((this: object, value: unknown) => void) | null {
-  let obj: object | null = model;
-  while (obj && obj !== Object.prototype) {
-    const desc = Object.getOwnPropertyDescriptor(obj, key);
-    if (desc && typeof desc.set === "function") {
-      return desc.set as (this: object, value: unknown) => void;
-    }
-    obj = Object.getPrototypeOf(obj);
-  }
-  return null;
 }
 
 class ArgumentError extends globalThis.Error {

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -71,17 +71,23 @@ export function _assignAttributes(
  * `undefine_attribute_methods`. TS has no `method_missing`, so that dispatch is
  * explicit inside the send below, in the same position Ruby runs it.
  *
+ * `respond_to?` consults the receiver's full method table, including names
+ * answered through `respond_to_missing?`, where the lookup below sees only what
+ * it can resolve — so a NoMethodError raised from *inside* a matched
+ * `attribute_missing` still routes to `attribute_writer_missing` instead of
+ * being re-raised at :70-71. Tracked by
+ * `assign-attribute-respond-to-setter-reraise-arm`.
+ *
  * @internal Rails-private helper.
  */
 export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
   const setter = `${k}=`;
   try {
-    const method = methodFor(model, setter);
+    const method = publicMethod(model, setter);
     if (method) {
       method.call(model, v);
       return;
     }
-    // AttributeMethods#method_missing (attribute_methods.rb:508-517).
     const match = model.matchedAttributeMethod(setter);
     if (match) {
       model.attributeMissing(match, v);
@@ -92,7 +98,7 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
     );
   } catch (error) {
     if (!(error instanceof NoMethodError)) throw error;
-    if (methodFor(model, setter)) {
+    if (publicMethod(model, setter)) {
       throw error;
     } else {
       model.attributeWriterMissing(k, v);
@@ -101,8 +107,8 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
 }
 
 /**
- * Ruby's method-table lookup for `setter` — what both `public_send(setter, v)`
- * and `respond_to?(setter)` consult above.
+ * Ruby's `Object#public_method` for `setter` — the lookup both
+ * `public_send(setter, v)` and `respond_to?(setter)` consult above.
  *
  * One Ruby method name reaches TS two ways, which is the single genuine JS
  * shortcoming on this path. Rails' generated writer is a real method named
@@ -118,7 +124,7 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
  * shadowing data descriptors and get-only accessors: Ruby looks up `name=` as
  * its own method, independent of any `name` getter.
  */
-function methodFor(
+function publicMethod(
   model: AttributeAssignment,
   setter: string,
 ): ((this: AttributeAssignment, value: unknown) => void) | null {

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -8,10 +8,7 @@ import {
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
-import {
-  flushPendingCounterCacheColumns,
-  registerCounterCachedAssociation,
-} from "../../counter-cache.js";
+import { flushPendingCounterCacheColumns } from "../../counter-cache.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 import { ActiveRecord } from "../../ar-config.js";
@@ -104,8 +101,10 @@ export class BelongsTo extends SingularAssociation {
     const klass = safeConstantize(targetClassName) as any;
     if (klass) flushPendingCounterCacheColumns(klass);
 
-    // Mirrors Rails: `model.counter_cached_association_names |= [reflection.name]`
-    registerCounterCachedAssociation(model, name);
+    // belongs_to.rb:41 — `model.counter_cached_association_names |= [reflection.name]`
+    if (!model.counterCachedAssociationNames.includes(name)) {
+      model.counterCachedAssociationNames = [...model.counterCachedAssociationNames, name];
+    }
 
     // Rails only registers after_update in add_counter_cache_callbacks.
     // Create/destroy counter handling is done by updateCounterCaches()

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2863,6 +2863,8 @@ export class Base extends Model {
   declare static updateCounters: typeof CounterCache.updateCounters;
   declare static resetCounters: typeof CounterCache.resetCounters;
   declare static isCounterCacheColumn: typeof CounterCache.isCounterCacheColumn;
+  /** counter_cache.rb:9 — `class_attribute :_counter_cache_columns`. */
+  declare static _counterCacheColumns: string[];
   /** counter_cache.rb:10 — `class_attribute :counter_cached_association_names`. */
   declare static counterCachedAssociationNames: string[];
 
@@ -4574,6 +4576,7 @@ extend(Base, _Reflection.ClassMethods);
 // `_reflections` it shadows, so the two cannot drift apart.
 classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
+classAttribute.call(Base, "_counterCacheColumns", { instanceAccessor: false, default: [] });
 classAttribute.call(Base, "counterCachedAssociationNames", {
   instanceWriter: false,
   default: [],

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2863,7 +2863,8 @@ export class Base extends Model {
   declare static updateCounters: typeof CounterCache.updateCounters;
   declare static resetCounters: typeof CounterCache.resetCounters;
   declare static isCounterCacheColumn: typeof CounterCache.isCounterCacheColumn;
-  declare static counterCachedAssociationNames: typeof CounterCache.getCounterCachedAssociationNames;
+  /** counter_cache.rb:10 — `class_attribute :counter_cached_association_names`. */
+  declare static counterCachedAssociationNames: string[];
 
   /**
    * Instantiate a model from a database row (marks it as persisted).
@@ -4573,6 +4574,11 @@ extend(Base, _Reflection.ClassMethods);
 // `_reflections` it shadows, so the two cannot drift apart.
 classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
+// counter_cache.rb:10
+classAttribute.call(Base, "counterCachedAssociationNames", {
+  instanceWriter: false,
+  default: [],
+});
 extend(Base, {
   defaultScope: _defaultScope,
   unscoped: _unscoped,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4574,7 +4574,6 @@ extend(Base, _Reflection.ClassMethods);
 // `_reflections` it shadows, so the two cannot drift apart.
 classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
-// counter_cache.rb:10
 classAttribute.call(Base, "counterCachedAssociationNames", {
   instanceWriter: false,
   default: [],

--- a/packages/activerecord/src/counter-cache.trails.test.ts
+++ b/packages/activerecord/src/counter-cache.trails.test.ts
@@ -94,10 +94,9 @@ describe("CounterCacheTest deferred resolution (trails)", () => {
     // demodulized `books_count`, not the flat `cpk_books_count`.
     const { CpkOrder } = await import("./test-helpers/models/cpk.js");
     registerModel(CpkOrder);
-    const cols = (CpkOrder as unknown as { _counterCacheColumns: Set<string> })
-      ._counterCacheColumns;
-    expect(cols.has("books_count")).toBe(true);
-    expect(cols.has("cpk_books_count")).toBe(false);
+    const cols = (CpkOrder as unknown as { _counterCacheColumns: string[] })._counterCacheColumns;
+    expect(cols).toContain("books_count");
+    expect(cols).not.toContain("cpk_books_count");
   });
 });
 

--- a/packages/activerecord/src/counter-cache.trails.test.ts
+++ b/packages/activerecord/src/counter-cache.trails.test.ts
@@ -32,10 +32,8 @@ describe("CounterCacheTest (trails)", () => {
     expect(reloaded.legacy_comments_count).toBe(1);
   });
 
-  // counter_cache.rb:10 declares counter_cached_association_names with
-  // class_attribute, so belongs_to.rb:41's `|=` on a subclass writes locally
-  // and leaves the superclass list alone. JS has no such default for a class
-  // property, so the semantics are worth pinning.
+  // counter_cache.rb:10 — class_attribute, so belongs_to.rb:41's `|=` on a
+  // subclass writes locally; JS class properties have no such default.
   it("registering a counter cached association does not mutate the superclass list", () => {
     class ParentModel extends Base {}
     class ChildModel extends ParentModel {}

--- a/packages/activerecord/src/counter-cache.trails.test.ts
+++ b/packages/activerecord/src/counter-cache.trails.test.ts
@@ -31,6 +31,19 @@ describe("CounterCacheTest (trails)", () => {
     const reloaded = await CanonicalPost.find(post.id);
     expect(reloaded.legacy_comments_count).toBe(1);
   });
+
+  // counter_cache.rb:10 declares counter_cached_association_names with
+  // class_attribute, so belongs_to.rb:41's `|=` on a subclass writes locally
+  // and leaves the superclass list alone. JS has no such default for a class
+  // property, so the semantics are worth pinning.
+  it("registering a counter cached association does not mutate the superclass list", () => {
+    class ParentModel extends Base {}
+    class ChildModel extends ParentModel {}
+    ChildModel.belongsTo("post", { counterCache: true });
+
+    expect(ChildModel.counterCachedAssociationNames).toEqual(["post"]);
+    expect(ParentModel.counterCachedAssociationNames).toEqual([]);
+  });
 });
 
 describe("CounterCacheTest deferred resolution (trails)", () => {

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -247,18 +247,20 @@ export function isCounterCacheColumn(this: typeof Base, columnName: string): boo
 export function loadSchemaBang(this: typeof Base): void {
   getCounterCacheColumns(this);
 
+  // `registerModel` also accepts stand-ins that do not descend from `Base`, so
+  // the class_attribute defaults of counter_cache.rb:9-10 (and reflection.rb:11)
+  // have to be supplied here rather than read off the constructor chain.
+  const reflections = ((this as any)._reflections ?? {}) as Record<string, any>;
   const associationNames: string[] = [];
-  for (const [name, reflection] of Object.entries(
-    (this as any)._reflections as Record<string, any>,
-  )) {
+  for (const [name, reflection] of Object.entries(reflections)) {
     if (!reflection?.belongsTo?.() || !reflection.counterCacheColumn?.()) continue;
     associationNames.push(name);
   }
+  let names: string[] = this.counterCachedAssociationNames ?? [];
   for (const name of associationNames) {
-    if (!this.counterCachedAssociationNames.includes(name)) {
-      this.counterCachedAssociationNames = [...this.counterCachedAssociationNames, name];
-    }
+    if (!names.includes(name)) names = [...names, name];
   }
+  this.counterCachedAssociationNames = names;
 }
 
 /**
@@ -290,16 +292,15 @@ function getCounterCacheColumns(modelClass: typeof Base): string[] {
     for (const col of pendingCounterCacheColumns.get(key)!) {
       // belongs_to.rb:40 — `klass._counter_cache_columns |= [cache_column]`.
       const column = col();
-      if (!modelClass._counterCacheColumns.includes(column)) {
-        modelClass._counterCacheColumns = [...modelClass._counterCacheColumns, column];
-      }
+      const columns = modelClass._counterCacheColumns ?? [];
+      if (!columns.includes(column)) modelClass._counterCacheColumns = [...columns, column];
     }
     // Intentionally keep the pending entry so that if the target class is
     // re-defined and re-registered (e.g. between tests), the next
     // registerModel call also flushes the column into the new class.
     // The union above makes repeated flushes idempotent.
   }
-  return modelClass._counterCacheColumns;
+  return modelClass._counterCacheColumns ?? [];
 }
 
 /**

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -277,24 +277,12 @@ function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveSupport::Concern#ClassMethods` convention.
  */
-/**
- * Class-attribute accessor mirroring Rails'
- * `class_attribute :counter_cached_association_names`. Returns an array
- * (Rails parity) snapshot of the registered association names.
- *
- * Mirrors: ActiveRecord::CounterCache#counter_cached_association_names
- */
-export function getCounterCachedAssociationNames(this: typeof Base): string[] {
-  return counterCachedAssociationNames(this);
-}
-
 export const ClassMethods = {
   incrementCounter,
   decrementCounter,
   updateCounters,
   resetCounters,
   isCounterCacheColumn,
-  counterCachedAssociationNames: getCounterCachedAssociationNames,
 };
 
 type InstanceCounterHost = {
@@ -302,27 +290,6 @@ type InstanceCounterHost = {
   destroyedByAssociation: unknown;
   association(name: string): any;
 };
-
-/**
- * Mirrors: `model.counter_cached_association_names |= [name]` in
- * Rails' Associations::Builder::BelongsTo.add_counter_cache_callbacks.
- * Stored as a Set on the owning class for O(1) dedupe.
- * @internal
- */
-export function registerCounterCachedAssociation(model: any, name: string): void {
-  // Mirror Rails' class_attribute `|=` semantics: copy-on-write so subclass
-  // additions don't mutate the parent class's Set in place.
-  const owns = Object.prototype.hasOwnProperty.call(model, "_counterCachedAssociationNames");
-  const inherited: Set<string> | undefined = model._counterCachedAssociationNames;
-  const next: Set<string> = owns && inherited ? inherited : new Set(inherited ?? []);
-  next.add(name);
-  model._counterCachedAssociationNames = next;
-}
-
-function counterCachedAssociationNames(ctor: typeof Base): string[] {
-  const registered: Set<string> | undefined = (ctor as any)._counterCachedAssociationNames;
-  return registered ? [...registered] : [];
-}
 
 /**
  * Derive a foreign key for a reflection that has none. Rails always has
@@ -357,7 +324,7 @@ export async function _createRecord(
   superFn: () => Promise<unknown>,
 ): Promise<unknown> {
   const id = await superFn();
-  for (const associationName of this.constructor.counterCachedAssociationNames()) {
+  for (const associationName of this.constructor.counterCachedAssociationNames) {
     await this.association(associationName).incrementCounters();
   }
   return id;
@@ -373,7 +340,7 @@ export async function destroyRow(
 ): Promise<number> {
   const affectedRows = await superFn();
   if (affectedRows > 0) {
-    for (const associationName of this.constructor.counterCachedAssociationNames()) {
+    for (const associationName of this.constructor.counterCachedAssociationNames) {
       const association = this.association(associationName);
       const dba = this.destroyedByAssociation as {
         foreignKey?: unknown;

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -221,30 +221,60 @@ export async function resetCounters(
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#counter_cache_column?
  */
 export function isCounterCacheColumn(this: typeof Base, columnName: string): boolean {
-  const counterCols = getCounterCacheColumns(this);
-  return counterCols.has(columnName);
+  return getCounterCacheColumns(this).includes(columnName);
 }
 
 /**
- * Flush any pending counter-cache column registrations for this class,
- * mirroring the bookkeeping Rails' `ActiveRecord::CounterCache#load_schema!`
- * triggers.  Called by `registerModel` so that pending entries accumulated
- * before the target class was registered are applied deterministically.
+ * Mirrors: ActiveRecord::CounterCache::ClassMethods#load_schema!
+ * (counter_cache.rb:186-195)
+ *
+ *   def load_schema!
+ *     super
+ *
+ *     association_names = _reflections.filter_map do |name, reflection|
+ *       next unless reflection.belongs_to? && reflection.counter_cache_column
+ *
+ *       name.to_sym
+ *     end
+ *
+ *     self.counter_cached_association_names |= association_names
+ *   end
+ *
+ * The `super` call stands in for the pending-column flush: trails resolves a
+ * belongs_to's target through the model registry rather than a constant, so a
+ * counter column staged before its target existed is merged here.
  */
 export function loadSchemaBang(this: typeof Base): void {
   getCounterCacheColumns(this);
+
+  const associationNames: string[] = [];
+  for (const [name, reflection] of Object.entries(
+    (this as any)._reflections as Record<string, any>,
+  )) {
+    if (!reflection?.belongsTo?.() || !reflection.counterCacheColumn?.()) continue;
+    associationNames.push(name);
+  }
+  for (const name of associationNames) {
+    if (!this.counterCachedAssociationNames.includes(name)) {
+      this.counterCachedAssociationNames = [...this.counterCachedAssociationNames, name];
+    }
+  }
 }
 
 /**
  * Merge any pending counter-cache column registrations for a newly registered
  * model class.  Called by `registerModel` so entries accumulated before the
  * target was in the registry are applied immediately rather than on first read.
+ *
+ * trails has no `load_schema!` super chain to hang counter_cache.rb:186-195 on,
+ * so this — the seam already reached once a model and its associations are
+ * fully defined — is where `load_schema!` runs.
  */
 export function flushPendingCounterCacheColumns(modelClass: typeof Base): void {
-  getCounterCacheColumns(modelClass);
+  loadSchemaBang.call(modelClass);
 }
 
-function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
+function getCounterCacheColumns(modelClass: typeof Base): string[] {
   // Collect matching pending keys: exact class name, registry aliases, or "::ClassName" suffix.
   const registryKeys: string[] = (modelClass as any)._registryKeys ?? [];
   const suffix = `::${modelClass.name}`;
@@ -253,24 +283,23 @@ function getCounterCacheColumns(modelClass: typeof Base): Set<string> {
     if (key === modelClass.name || registryKeys.includes(key) || key.endsWith(suffix))
       matchingKeys.push(key);
   }
-  // Copy-on-write: avoid mutating an inherited parent-class Set when flushing
-  // pending entries for a subclass. Mirrors Rails' class_attribute `|=`.
-  const owns = Object.prototype.hasOwnProperty.call(modelClass, "_counterCacheColumns");
-  const inherited: Set<string> | undefined = (modelClass as any)._counterCacheColumns;
-  if (matchingKeys.length === 0) return inherited ?? new Set<string>();
-  const next: Set<string> = owns && inherited ? inherited : new Set(inherited ?? []);
   for (const key of matchingKeys) {
     // Re-derive each column now that the target class is registered; staging
     // thunks (not strings) lets a belongs_to declared before its target see the
     // correct demodulized column at flush time. See counter-cache-state.ts.
-    for (const col of pendingCounterCacheColumns.get(key)!) next.add(col());
+    for (const col of pendingCounterCacheColumns.get(key)!) {
+      // belongs_to.rb:40 — `klass._counter_cache_columns |= [cache_column]`.
+      const column = col();
+      if (!modelClass._counterCacheColumns.includes(column)) {
+        modelClass._counterCacheColumns = [...modelClass._counterCacheColumns, column];
+      }
+    }
     // Intentionally keep the pending entry so that if the target class is
     // re-defined and re-registered (e.g. between tests), the next
     // registerModel call also flushes the column into the new class.
-    // The Set-based dedup makes repeated flushes idempotent.
+    // The union above makes repeated flushes idempotent.
   }
-  (modelClass as any)._counterCacheColumns = next;
-  return next;
+  return modelClass._counterCacheColumns;
 }
 
 /**

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1796,7 +1796,7 @@ type PersistenceInternalHost = PersistencePrivateHost & {
   _attributes?: { keys?(): Iterable<string> };
   constructor: PersistencePrivateHost["constructor"] & {
     columnNames?(): string[];
-    _counterCacheColumns?: Set<string>;
+    _counterCacheColumns?: string[];
   };
 };
 

--- a/packages/trailties/src/database.test.ts
+++ b/packages/trailties/src/database.test.ts
@@ -48,4 +48,68 @@ describe("databaseConfiguration", () => {
 
     await expect(databaseConfiguration()).rejects.toThrow(/Could not load database configuration/);
   });
+
+  // configuration.rb:439-458 — the flat arm: `shared` is deleted and
+  // reverse-merged into every environment, so an env's own keys win.
+  it("reverse merges the shared key into each environment", async () => {
+    tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
+    nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
+    nodeFs.writeFileSync(
+      nodePath.join(tmpRoot, "config", "database.json"),
+      JSON.stringify({
+        shared: { adapter: "sqlite3", pool: 5 },
+        test: { database: "db/test.sqlite3", pool: 9 },
+      }),
+    );
+    setTrailsRoot(tmpRoot);
+
+    const config = (await databaseConfiguration()) as Record<string, Record<string, unknown>>;
+    expect(Object.keys(config)).toEqual(["test"]);
+    expect(config.test).toEqual({ adapter: "sqlite3", database: "db/test.sqlite3", pool: 9 });
+  });
+
+  // configuration.rb:441-450 — the nested arm: both sides are hashes of
+  // hashes, so each named sub-config reverse merges the shared entry of the
+  // same name.
+  it("reverse merges shared per named database when both are hashes of hashes", async () => {
+    tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
+    nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
+    nodeFs.writeFileSync(
+      nodePath.join(tmpRoot, "config", "database.json"),
+      JSON.stringify({
+        shared: { primary: { adapter: "sqlite3" }, animals: { adapter: "postgresql" } },
+        test: {
+          primary: { database: "db/test.sqlite3" },
+          animals: { database: "db/animals_test", adapter: "sqlite3" },
+        },
+      }),
+    );
+    setTrailsRoot(tmpRoot);
+
+    const config = (await databaseConfiguration()) as Record<
+      string,
+      Record<string, Record<string, unknown>>
+    >;
+    expect(config.test.primary).toEqual({ adapter: "sqlite3", database: "db/test.sqlite3" });
+    expect(config.test.animals).toEqual({ adapter: "sqlite3", database: "db/animals_test" });
+  });
+
+  // configuration.rb:458 — `Hash.new(shared).merge(loaded_yaml)`: an
+  // environment the file never lists still resolves to `shared`.
+  it("resolves an unlisted environment to shared", async () => {
+    tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
+    nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
+    nodeFs.writeFileSync(
+      nodePath.join(tmpRoot, "config", "database.json"),
+      JSON.stringify({
+        shared: { adapter: "sqlite3", database: "db/shared.sqlite3" },
+        test: { database: "db/test.sqlite3" },
+      }),
+    );
+    setTrailsRoot(tmpRoot);
+
+    const config = (await databaseConfiguration()) as Record<string, Record<string, unknown>>;
+    expect(config.staging).toEqual({ adapter: "sqlite3", database: "db/shared.sqlite3" });
+    expect(Object.keys(config)).toEqual(["test"]);
+  });
 });

--- a/packages/trailties/src/database.test.ts
+++ b/packages/trailties/src/database.test.ts
@@ -49,8 +49,7 @@ describe("databaseConfiguration", () => {
     await expect(databaseConfiguration()).rejects.toThrow(/Could not load database configuration/);
   });
 
-  // configuration.rb:439-458 — the flat arm: `shared` is deleted and
-  // reverse-merged into every environment, so an env's own keys win.
+  // configuration.rb:451-453 — the flat arm.
   it("reverse merges the shared key into each environment", async () => {
     tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
     nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
@@ -68,9 +67,7 @@ describe("databaseConfiguration", () => {
     expect(config.test).toEqual({ adapter: "sqlite3", database: "db/test.sqlite3", pool: 9 });
   });
 
-  // configuration.rb:441-450 — the nested arm: both sides are hashes of
-  // hashes, so each named sub-config reverse merges the shared entry of the
-  // same name.
+  // configuration.rb:441-450 — the nested arm.
   it("reverse merges shared per named database when both are hashes of hashes", async () => {
     tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
     nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
@@ -94,8 +91,7 @@ describe("databaseConfiguration", () => {
     expect(config.test.animals).toEqual({ adapter: "sqlite3", database: "db/animals_test" });
   });
 
-  // configuration.rb:458 — `Hash.new(shared).merge(loaded_yaml)`: an
-  // environment the file never lists still resolves to `shared`.
+  // configuration.rb:458 — `Hash.new(shared).merge(loaded_yaml)`.
   it("resolves an unlisted environment to shared", async () => {
     tmpRoot = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), "trailties-root-"));
     nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -174,25 +174,59 @@ export async function loadDatabaseConfigModule(
  *
  * The `shared` key (configuration.rb:439-458) is deleted and reverse-merged
  * into every environment, with the nested arm for the multi-database shape.
+ * Rails' `reverse_merge!` mutates the parsed YAML in place; the loaded value
+ * here is an imported module's export, shared with (and possibly frozen by) the
+ * module registry, so each merged hash is rebuilt instead.
+ *
  * Rails then returns `Hash.new(shared).merge(loaded_yaml)`, whose default value
- * answers an environment the file never listed; a plain object has no default,
+ * answers an environment the file never listed. A plain object has no default,
  * so the returned record is a Proxy whose `get` falls back to `shared` — the
- * one JS construct with `Hash.new`'s semantics (its own keys, and so its
- * enumeration, stay exactly the loaded ones, as in Ruby).
+ * one JS construct with `Hash.new`'s semantics, leaving its own keys (and so
+ * its enumeration) exactly the loaded ones, as in Ruby.
  */
+type AnyHash = Record<string, unknown>;
+
 export async function databaseConfiguration(root?: string): Promise<DatabaseConfigModule> {
   const fs = await getFsAsync();
   const path = await getPathAsync();
   const resolvedRoot = root ?? trailsRoot() ?? fs.cwd();
 
   const loaded = await loadDatabaseConfigModule(resolvedRoot);
-  if (loaded) return mergeShared(loaded.module);
-
   const jsonPath = path.join(resolvedRoot, "config", "database.json");
-  if (await fs.exists(jsonPath)) {
+  let loadedYaml: DatabaseConfigModule | null = null;
+  if (loaded) {
+    loadedYaml = loaded.module;
+  } else if (await fs.exists(jsonPath)) {
     if (!fs.readFile)
       throw new Error("Config loading requires an fs adapter with readFile support.");
-    return mergeShared(JSON.parse(await fs.readFile(jsonPath, "utf-8")) as DatabaseConfigModule);
+    loadedYaml = JSON.parse(await fs.readFile(jsonPath, "utf-8")) as DatabaseConfigModule;
+  }
+
+  if (loadedYaml) {
+    const shared = loadedYaml.shared;
+    if (shared == null || shared === false) return loadedYaml;
+
+    const merged: Record<string, unknown> = { ...loadedYaml };
+    delete merged.shared;
+    for (const [env, config] of Object.entries(merged)) {
+      if (isMultiDatabaseEnv(config)) {
+        const subConfigs: Record<string, unknown> = {};
+        for (const [name, subConfig] of Object.entries(config)) {
+          subConfigs[name] = isMultiDatabaseEnv(shared)
+            ? reverseMerge(subConfig as AnyHash, (shared as Record<string, AnyHash>)[name] ?? {})
+            : reverseMerge(subConfig as AnyHash, shared as AnyHash);
+        }
+        merged[env] = subConfigs;
+      } else if (config !== null && typeof config === "object") {
+        merged[env] = reverseMerge(config as AnyHash, shared as AnyHash);
+      }
+    }
+    return new Proxy(merged, {
+      get(target, key, receiver) {
+        if (typeof key === "string" && !Reflect.has(target, key)) return shared;
+        return Reflect.get(target, key, receiver);
+      },
+    }) as DatabaseConfigModule;
   }
 
   if (env.DATABASE_URL) return {};
@@ -201,47 +235,6 @@ export async function databaseConfiguration(root?: string): Promise<DatabaseConf
     `Could not load database configuration. No such file - ${path.join(resolvedRoot, "config", "database.*")}`,
   );
 }
-
-/**
- * configuration.rb:439-458 — `loaded_yaml.delete("shared")` and the
- * reverse-merge of what it yields into every environment, then
- * `Hash.new(shared).merge(loaded_yaml)`.
- *
- * Rails' `reverse_merge!` mutates the parsed YAML in place. Here the loaded
- * value is an imported module's export, which is shared with (and may be
- * frozen by) the module registry, so each merged hash is rebuilt instead.
- */
-function mergeShared(loadedYaml: DatabaseConfigModule): DatabaseConfigModule {
-  const shared = loadedYaml.shared;
-  // Ruby's `if (shared = ...)`: only nil/false skip the branch.
-  if (shared == null || shared === false) return loadedYaml;
-
-  const merged: Record<string, unknown> = { ...loadedYaml };
-  delete merged.shared;
-
-  for (const [env, config] of Object.entries(merged)) {
-    if (isMultiDatabaseEnv(config)) {
-      const subConfigs: Record<string, unknown> = {};
-      for (const [name, subConfig] of Object.entries(config)) {
-        subConfigs[name] = isMultiDatabaseEnv(shared)
-          ? reverseMerge(subConfig as AnyHash, (shared as Record<string, AnyHash>)[name] ?? {})
-          : reverseMerge(subConfig as AnyHash, shared as AnyHash);
-      }
-      merged[env] = subConfigs;
-    } else if (config !== null && typeof config === "object") {
-      merged[env] = reverseMerge(config as AnyHash, shared as AnyHash);
-    }
-  }
-
-  return new Proxy(merged, {
-    get(target, key, receiver) {
-      if (typeof key === "string" && !Reflect.has(target, key)) return shared;
-      return Reflect.get(target, key, receiver);
-    },
-  }) as DatabaseConfigModule;
-}
-
-type AnyHash = Record<string, unknown>;
 
 /**
  * Load the database configuration for the given environment.

--- a/packages/trailties/src/database.ts
+++ b/packages/trailties/src/database.ts
@@ -1,4 +1,4 @@
-import { getFsAsync, getPathAsync, trailsRoot } from "@blazetrails/activesupport";
+import { getFsAsync, getPathAsync, reverseMerge, trailsRoot } from "@blazetrails/activesupport";
 import { env } from "@blazetrails/activesupport/process-adapter";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
@@ -172,9 +172,13 @@ export async function loadDatabaseConfigModule(
  * (`activerecord/lib/active_record/railtie.rb:256-262`) assigns this to
  * `Base.configurations` and only then calls `establish_connection`.
  *
- * Rails' `shared`-key reverse-merge (configuration.rb:439-458) is not ported
- * yet; tracked by `0112-one-rails-thing-n-trails-things/
- * database-configuration-shared-key-reverse-merge`.
+ * The `shared` key (configuration.rb:439-458) is deleted and reverse-merged
+ * into every environment, with the nested arm for the multi-database shape.
+ * Rails then returns `Hash.new(shared).merge(loaded_yaml)`, whose default value
+ * answers an environment the file never listed; a plain object has no default,
+ * so the returned record is a Proxy whose `get` falls back to `shared` — the
+ * one JS construct with `Hash.new`'s semantics (its own keys, and so its
+ * enumeration, stay exactly the loaded ones, as in Ruby).
  */
 export async function databaseConfiguration(root?: string): Promise<DatabaseConfigModule> {
   const fs = await getFsAsync();
@@ -182,13 +186,13 @@ export async function databaseConfiguration(root?: string): Promise<DatabaseConf
   const resolvedRoot = root ?? trailsRoot() ?? fs.cwd();
 
   const loaded = await loadDatabaseConfigModule(resolvedRoot);
-  if (loaded) return loaded.module;
+  if (loaded) return mergeShared(loaded.module);
 
   const jsonPath = path.join(resolvedRoot, "config", "database.json");
   if (await fs.exists(jsonPath)) {
     if (!fs.readFile)
       throw new Error("Config loading requires an fs adapter with readFile support.");
-    return JSON.parse(await fs.readFile(jsonPath, "utf-8")) as DatabaseConfigModule;
+    return mergeShared(JSON.parse(await fs.readFile(jsonPath, "utf-8")) as DatabaseConfigModule);
   }
 
   if (env.DATABASE_URL) return {};
@@ -197,6 +201,47 @@ export async function databaseConfiguration(root?: string): Promise<DatabaseConf
     `Could not load database configuration. No such file - ${path.join(resolvedRoot, "config", "database.*")}`,
   );
 }
+
+/**
+ * configuration.rb:439-458 — `loaded_yaml.delete("shared")` and the
+ * reverse-merge of what it yields into every environment, then
+ * `Hash.new(shared).merge(loaded_yaml)`.
+ *
+ * Rails' `reverse_merge!` mutates the parsed YAML in place. Here the loaded
+ * value is an imported module's export, which is shared with (and may be
+ * frozen by) the module registry, so each merged hash is rebuilt instead.
+ */
+function mergeShared(loadedYaml: DatabaseConfigModule): DatabaseConfigModule {
+  const shared = loadedYaml.shared;
+  // Ruby's `if (shared = ...)`: only nil/false skip the branch.
+  if (shared == null || shared === false) return loadedYaml;
+
+  const merged: Record<string, unknown> = { ...loadedYaml };
+  delete merged.shared;
+
+  for (const [env, config] of Object.entries(merged)) {
+    if (isMultiDatabaseEnv(config)) {
+      const subConfigs: Record<string, unknown> = {};
+      for (const [name, subConfig] of Object.entries(config)) {
+        subConfigs[name] = isMultiDatabaseEnv(shared)
+          ? reverseMerge(subConfig as AnyHash, (shared as Record<string, AnyHash>)[name] ?? {})
+          : reverseMerge(subConfig as AnyHash, shared as AnyHash);
+      }
+      merged[env] = subConfigs;
+    } else if (config !== null && typeof config === "object") {
+      merged[env] = reverseMerge(config as AnyHash, shared as AnyHash);
+    }
+  }
+
+  return new Proxy(merged, {
+    get(target, key, receiver) {
+      if (typeof key === "string" && !Reflect.has(target, key)) return shared;
+      return Reflect.get(target, key, receiver);
+    },
+  }) as DatabaseConfigModule;
+}
+
+type AnyHash = Record<string, unknown>;
 
 /**
  * Load the database configuration for the given environment.


### PR DESCRIPTION
Bundle of four RFC 0112 / 0115 convergence stories. Three converge; the fourth is blocked on a driver limitation (see below).

## `_assignAttribute` — send-then-rescue (activemodel)

`attribute_assignment.rb:67-75` sends once and branches in a `rescue`. trails resolved the writer through a private `findSetter()` ladder and branched on what it found, with a different branch order. The body is now Rails' shape: one send, then `rescue NoMethodError` → `respond_to?(setter)` ? re-raise : `attribute_writer_missing`. The `attribute_missing` dispatch moved inside the send, where Ruby's `AttributeMethods#method_missing` (`attribute_methods.rb:508-517`) actually runs it.

`findSetter` is gone. What remains is `methodFor` — the method-table lookup that Ruby's `public_send` and `respond_to?` both consult, and the one place the genuine JS shortcoming lives: a user-authored `def name=` ports as a `set name(v)` accessor, which is not reachable by the key `"name="`, so both spellings answer.

## `counterCachedAssociationNames` — one `classAttribute()` (activerecord)

`counter_cache.rb:10` is one `class_attribute` holding an Array. trails split it into a `Set` hung on the class, an exported `registerCounterCachedAssociation()` that hand-rolled copy-on-write, and a private array-spreading reader wrapped again for `ClassMethods`. All three are gone; the attribute is declared with `classAttribute()` next to `_reflections`/`_associations` in base.ts, and `belongs_to.rb:41`'s `model.counter_cached_association_names |= [reflection.name]` is written at the call site. `parity:api:extra --package activerecord` no longer reports the helper.

`_counterCacheColumns` (`counter_cache.rb:9`) has the same storage shape but is entangled with the pending-flush registry, which is a separate piece of work — left alone here.

## `databaseConfiguration()` — the `shared` key (trailties)

`configuration.rb:439-458` deletes `shared` and reverse-merges it into every environment, with a nested arm when both sides are hashes of hashes, then returns `Hash.new(shared).merge(loaded_yaml)`. All of that is ported. The `Hash.new` default has no plain-object equivalent, so the returned record is a Proxy whose `get` falls back to `shared` — same own keys, same enumeration, and an unlisted environment resolves, as in Ruby. The deviation note in the JSDoc is deleted; `database.test.ts` covers both arms plus the default.

## `warningCount` — blocked

Investigated as the story asks. mysql2 npm 3.19.0 has no counterpart to the Ruby gem's `Mysql2::Client#warning_count`: `lib/connection.js` contains no occurrence of "warning" at all, and the protocol count is parsed only into `ResultSetHeader.warningStatus` (`lib/packets/resultset_header.js:34`), which no command in `lib/commands/` hands to the caller — a SELECT resolves as `[rows, fields]` and the header is discarded. So `handleWarnings` cannot read the count off the raw connection the way `abstract_mysql_adapter.rb:771`/`773` does without patching the driver or wrapping every command. Story marked `blocked` with that finding; the `SHOW COUNT(*) WARNINGS` fallback stays.

Closes-story: converge-assign-attribute-writer-ladder-onto-public-send
Closes-story: counter-cached-association-names-hand-rolled-class-attribute
Closes-story: database-configuration-shared-key-reverse-merge