### PR TITLE
refactor(activemodel,activerecord): collapse userProvided/source onto the Rails user_provided_default kwarg

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,7 +1,6 @@
 import type { CodeGenerator } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
-import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
@@ -34,21 +33,19 @@ export interface AttributeDefinition {
   virtual?: boolean;
   limit?: number | null;
   /**
-   * True when the attribute was declared via `this.attribute(...)` (user code).
-   * False when registered from schema reflection (`load_schema`).
-   *
-   * Mirrors: Rails' `user_provided_default:` keyword on `define_attribute`.
-   * The distinction controls how defaults are materialized (user default vs.
-   * database default) and whether schema reflection is allowed to overwrite
-   * the definition — user-provided defs always win.
+   * Mirrors: the `user_provided_default:` keyword on
+   * `ActiveRecord::Attributes::ClassMethods#define_attribute`
+   * (activerecord/lib/active_record/attributes.rb:235-238), which Rails passes
+   * through to `define_default_attribute`'s `from_user:` and never stores.
+   * trails records it on the definition because schema reflection re-registers
+   * definitions and must not overwrite a user-declared one (model-schema.ts
+   * `ensureSchemaLoaded`).
    *
    * Optional for backwards compatibility with downstream consumers that
    * construct `AttributeDefinition` directly. When absent, treated as
-   * `true` (user-authored) — matching pre-load_schema behavior.
+   * `true` (user-authored).
    */
-  userProvided?: boolean;
-  /** Provenance tag — matches `userProvided` but kept explicit for clarity. */
-  source?: "user" | "schema";
+  userProvidedDefault?: boolean;
 }
 
 /**
@@ -145,7 +142,7 @@ export function attribute(
     typeName = undefined;
   }
   const typeProvided = typeName !== undefined;
-  const userProvided = options?.userProvidedDefault !== false;
+  const userProvidedDefault = options?.userProvidedDefault !== false;
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
     this._attributeDefinitions = new Map(this._attributeDefinitions);
   }
@@ -169,8 +166,7 @@ export function attribute(
     type,
     defaultValue,
     virtual: options?.virtual ?? existing?.virtual,
-    userProvided,
-    source: userProvided ? "user" : "schema",
+    userProvidedDefault,
     ...(options?.limit != null ? { limit: options.limit } : {}),
   });
 
@@ -298,37 +294,6 @@ function typeOptions(options?: AttributeOptions): Record<string, unknown> | unde
     ...rest
   } = options ?? {};
   return Object.keys(rest).length > 0 ? (rest as Record<string, unknown>) : undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Instance methods — Mirrors: ActiveModel::Attributes instance methods
-// ---------------------------------------------------------------------------
-
-/**
- * Build default AttributeSet from class definitions.
- *
- * Mirrors: ActiveModel::AttributeRegistration._default_attributes
- */
-export function buildDefaultAttributes(defs: Map<string, AttributeDefinition>): AttributeSet {
-  const attrMap = new Map<string, Attribute>();
-  for (const [name, def] of defs) {
-    const userProvided = def.userProvided ?? true;
-    if (def.defaultValue != null) {
-      if (userProvided) {
-        // Rails: user_provided_default: true → wraps the default so it is
-        // cast through the user-type (and procs re-evaluate per instance).
-        const base = Attribute.withCastValue(name, null, def.type);
-        attrMap.set(name, base.withUserDefault(def.defaultValue));
-      } else {
-        // Rails: user_provided_default: false → column default comes from
-        // the database; use fromDatabase so deserialize is applied.
-        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
-      }
-    } else {
-      attrMap.set(name, Attribute.withCastValue(name, null, def.type));
-    }
-  }
-  return new AttributeSet(attrMap);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -26,8 +26,7 @@ interface AttributeDefinition {
   name: string;
   type: Type;
   defaultValue?: unknown;
-  userProvided?: boolean;
-  source?: "user" | "schema";
+  userProvidedDefault?: boolean;
   limit?: number | null;
   /** Declared via `attribute(name, type, { virtual: true })` — not DB-backed. */
   virtual?: boolean;
@@ -93,14 +92,13 @@ export function defineAttribute(
   const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
 
   this._attributeDefinitions.set(name, {
-    // Spread existing to preserve metadata fields (source, virtual, etc.)
+    // Spread existing to preserve metadata fields (reflectedTable, virtual, etc.)
     // that other code paths (resetColumnInformation, schema reflection) rely on.
     ...existing,
     name,
     type: castType,
     defaultValue: resolvedDefault ?? null,
-    userProvided: userProvidedDefault,
-    source: userProvidedDefault ? "user" : "schema",
+    userProvidedDefault,
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
 
@@ -191,9 +189,8 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attributesHash = new Map<string, Attribute>();
     for (const [name, def] of defs) {
-      const source = def.source ?? (def.userProvided === false ? "schema" : "user");
       const column = columns[name];
-      if (source === "schema") {
+      if ((def.userProvidedDefault ?? true) === false) {
         // Seed from the BARE reflected column type, not `def.type` — trails
         // eagerly bakes decorations into `def.type` (a back-compat convenience
         // Rails lacks), and phase 2 replays those same decorators, so seeding

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1459,9 +1459,9 @@ export class Base extends Model {
       // ancestor's schema defs. Those carry a `reflectedTable` that differs from
       // ours — trust none of them; reflect our own table instead.
       for (const [, def] of this._attributeDefinitions) {
-        const d = def as { source?: string; reflectedTable?: string };
+        const d = def as { userProvidedDefault?: boolean; reflectedTable?: string };
         if (
-          d.source === "schema" &&
+          d.userProvidedDefault === false &&
           typeof d.reflectedTable === "string" &&
           d.reflectedTable !== thisTable
         ) {
@@ -1484,8 +1484,8 @@ export class Base extends Model {
 
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
     for (const [name, def] of this._attributeDefinitions) {
-      const d = def as { virtual?: boolean; source?: string };
-      if (!d.virtual && (d.source === "schema" || !enumNames?.has(name))) {
+      const d = def as { virtual?: boolean; userProvidedDefault?: boolean };
+      if (!d.virtual && (d.userProvidedDefault === false || !enumNames?.has(name))) {
         // The model declares its own attributes, but some may be virtual (no
         // backing DB column). Rails' `column_names` is always DB-sourced, so
         // reconcile against the real columns and flag those as virtual — keeping

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -171,8 +171,7 @@ export class EncryptableRecord {
         name,
         type: encryptedType,
         defaultValue: existingDef?.defaultValue ?? null,
-        userProvided: existingDef?.userProvided ?? false,
-        source: existingDef?.source ?? "schema",
+        userProvidedDefault: existingDef?.userProvidedDefault ?? false,
         ...(existingDef?.limit != null ? { limit: existingDef.limit } : {}),
       });
     }

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -378,7 +378,7 @@ describe("Enum subtype resolved from the reflected column type", () => {
 // enum whose subtype comes purely from SCHEMA REFLECTION. `numeric_data`'s
 // `decimal_number` is a real `decimal` column, so an integer-valued enum on it
 // must delegate to the reflected `DecimalType`, even though (a) mapping-shape
-// inference would guess `integer` and (b) reflection skips the userProvided
+// inference would guess `integer` and (b) reflection skips the user-provided
 // enum def, leaving `_attributeDefinitions` carrying the pre-reflection integer
 // EnumType — so the reflected subtype only lives in the replayed AttributeSet.
 describe("Enum subtype resolved from a schema-reflected column type", () => {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -160,7 +160,9 @@ export function installEnumAttribute(
   const existingTypeName =
     typeof existingDef?.type?.type === "function" ? existingDef.type.type() : undefined;
   const explicitlyTyped =
-    (existingDef?.userProvidedDefault ?? true) === true && existingTypeName != null;
+    existingDef !== undefined &&
+    (existingDef.userProvidedDefault ?? true) &&
+    existingTypeName != null;
   const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -160,8 +160,7 @@ export function installEnumAttribute(
   const existingTypeName =
     typeof existingDef?.type?.type === "function" ? existingDef.type.type() : undefined;
   const explicitlyTyped =
-    (existingDef?.source === "user" || existingDef?.userProvided === true) &&
-    existingTypeName != null;
+    (existingDef?.userProvidedDefault ?? true) === true && existingTypeName != null;
   const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {
@@ -1020,7 +1019,7 @@ function undeclaredEnumTypeError(klass: typeof Base, name: string): Error {
  * of truth built lazily from the reflected column type via the
  * `decorateAttributes` decorator. Resolves through the replayed AttributeSet
  * (`_defaultAttributes`), NOT `_attributeDefinitions`: reflection skips a
- * userProvided enum def, so its `type` stays the pre-reflection (mapping-shape-
+ * user-provided enum def, so its `type` stays the pre-reflection (mapping-shape-
  * inferred) EnumType, whereas the replayed decorator rebuilds the EnumType from
  * the reflected column subtype. Returns null when the attribute isn't an enum
  * on this class.

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -55,8 +55,8 @@ describe("loadSchemaFromAdapter", () => {
     const guid = Model._attributeDefinitions.get("guid");
     const payload = Model._attributeDefinitions.get("payload");
     expect(guid?.type.name).toBe("uuid");
-    expect(guid?.userProvided).toBe(false);
-    expect(guid?.source).toBe("schema");
+    expect(guid?.userProvidedDefault).toBe(false);
+    expect(guid?.userProvidedDefault).toBe(false);
     expect(payload?.type.name).toBe("jsonb");
   });
 
@@ -69,8 +69,8 @@ describe("loadSchemaFromAdapter", () => {
 
     const def = Model._attributeDefinitions.get("guid");
     expect(def?.type.name).toBe("string");
-    expect(def?.userProvided).toBe(true);
-    expect(def?.source).toBe("user");
+    expect(def?.userProvidedDefault).toBe(true);
+    expect(def?.userProvidedDefault).toBe(true);
   });
 
   it("is a no-op for abstract classes", async () => {
@@ -126,7 +126,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(Model._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Model._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
@@ -143,7 +143,7 @@ describe("loadSchemaFromAdapter", () => {
 
     const def = Model._attributeDefinitions.get("mystery");
     expect(def?.type).toBeInstanceOf(typeRegistry.lookup("value").constructor);
-    expect(def?.source).toBe("schema");
+    expect(def?.userProvidedDefault).toBe(false);
   });
 
   it("invalidates the _attributesBuilder cache", async () => {
@@ -214,7 +214,7 @@ describe("loadSchemaFromAdapter integration details", () => {
 
     // User-declared def survives ignoredColumns.
     expect(Post._attributeDefinitions.has("age")).toBe(true);
-    expect(Post._attributeDefinitions.get("age")?.userProvided).toBe(true);
+    expect(Post._attributeDefinitions.get("age")?.userProvidedDefault).toBe(true);
     // Accessor stripped.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
   });
@@ -239,7 +239,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     class Post extends Base {
       static override tableName = "posts";
     }
-    // Simulate a downstream-style def that predates the userProvided field.
+    // Simulate a downstream-style def that predates the userProvidedDefault field.
     (Post as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
       new Map([
         [
@@ -269,7 +269,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
-    expect(Post._attributeDefinitions.get("id")?.source).toBe("schema");
+    expect(Post._attributeDefinitions.get("id")?.userProvidedDefault).toBe(false);
 
     const rec = new Post();
     rec.writeAttribute("id", "abc-123");
@@ -319,7 +319,7 @@ describe("set adapter auto-loads schema", () => {
 
     const def = Post._attributeDefinitions.get("guid");
     expect(def?.type.name).toBe("uuid");
-    expect(def?.source).toBe("schema");
+    expect(def?.userProvidedDefault).toBe(false);
   });
 });
 
@@ -328,8 +328,8 @@ describe("attribute() userProvidedDefault option", () => {
     class Foo extends Base {}
     Foo.attribute("name", "string");
     const def = Foo._attributeDefinitions.get("name");
-    expect(def?.userProvided).toBe(true);
-    expect(def?.source).toBe("user");
+    expect(def?.userProvidedDefault).toBe(true);
+    expect(def?.userProvidedDefault).toBe(true);
   });
 
   it("sets userProvided=false when userProvidedDefault:false is passed", () => {
@@ -338,7 +338,7 @@ describe("attribute() userProvidedDefault option", () => {
       userProvidedDefault?: boolean;
     });
     const def = Foo._attributeDefinitions.get("name");
-    expect(def?.userProvided).toBe(false);
-    expect(def?.source).toBe("schema");
+    expect(def?.userProvidedDefault).toBe(false);
+    expect(def?.userProvidedDefault).toBe(false);
   });
 });

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -33,7 +33,7 @@ describe("sync loadSchema / columnsHash", () => {
     const hash = Post.columnsHash();
 
     expect(hash.guid).toBe(cols.guid);
-    expect(Post._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Post._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
   });
 
   it("columnsHash filters ignoredColumns out of the cached hash", () => {
@@ -81,7 +81,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
     expect(Shape._attributeDefinitions.has("guid")).toBe(false);
   });
@@ -108,7 +108,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     // Reflection should have landed on the STI base via subclass adapter;
     // subclass shares the base's map reference.
-    expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Shape._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
     expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
@@ -159,7 +159,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
-    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
   });
 
   it("resetColumnInformation scrubs schema-sourced defs from a subclass-forked map", () => {
@@ -180,8 +180,7 @@ describe("sync loadSchema / columnsHash", () => {
             name: "guid",
             type: { name: "uuid" },
             defaultValue: null,
-            userProvided: false,
-            source: "schema",
+            userProvidedDefault: false,
           },
         ],
       ]);
@@ -210,8 +209,8 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.get("guid")?.source).toBe("schema");
-    expect(Circle._attributeDefinitions.get("radius")?.userProvided).toBe(true);
+    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(Circle._attributeDefinitions.get("radius")?.userProvidedDefault).toBe(true);
     expect(Shape._attributeDefinitions.has("radius")).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
   });
@@ -343,7 +342,7 @@ describe("sync loadSchema / columnsHash", () => {
     const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Shape.columnsHash();
-    expect(Shape._attributeDefinitions.get("guid")?.source).toBe("schema");
+    expect(Shape._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
 
     (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
 
@@ -362,13 +361,13 @@ describe("sync loadSchema / columnsHash", () => {
     (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Post.columnsHash(); // triggers reflection
 
-    expect(Post._attributeDefinitions.get("guid")?.source).toBe("schema");
-    expect(Post._attributeDefinitions.get("title")?.source).toBe("user");
+    expect(Post._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(Post._attributeDefinitions.get("title")?.userProvidedDefault).toBe(true);
 
     (resetColumnInformation as any).call(Post);
 
     expect(Post._attributeDefinitions.has("guid")).toBe(false);
-    expect(Post._attributeDefinitions.get("title")?.source).toBe("user");
+    expect(Post._attributeDefinitions.get("title")?.userProvidedDefault).toBe(true);
   });
 
   // An internalSchemaCache that starts warm and tracks whether resetColumnInformation

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -961,12 +961,12 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
 
 /**
  * Drop schema-sourced attribute defs (and their generated accessors) so the
- * next load re-reflects them; user-declared defs (source === "user") are
+ * next load re-reflects them; user-declared defs are
  * preserved, matching Rails where user-provided attributes survive reload.
  */
 function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
   for (const [name, def] of Array.from(host._attributeDefinitions)) {
-    if ((def.userProvided ?? true) === false || def.source === "schema") {
+    if ((def.userProvidedDefault ?? true) === false) {
       host._attributeDefinitions.delete(name);
       if (Object.prototype.hasOwnProperty.call(host.prototype, name)) {
         delete host.prototype[name];
@@ -1138,14 +1138,14 @@ function applyColumnsHash(
         delete host.prototype[name];
       }
       const existing = host._attributeDefinitions.get(name);
-      if (!existing || (existing.userProvided ?? true) === false) {
+      if (!existing || (existing.userProvidedDefault ?? true) === false) {
         host._attributeDefinitions.delete(name);
       }
       continue;
     }
     filteredHash[name] = column;
     const existing = host._attributeDefinitions.get(name);
-    if (existing && (existing.userProvided ?? true)) {
+    if (existing && (existing.userProvidedDefault ?? true)) {
       // A user-declared type override (e.g. an enum) preserves its type across
       // reflection. The schema column's default is NOT merged onto the def;
       // `_defaultAttributes` seeds it via from_database directly from the cached
@@ -1187,8 +1187,7 @@ function applyColumnsHash(
       // `encrypts` on one column yields Encrypted(Serialized(Encrypted(...))).
       reflectedColumnType,
       defaultValue,
-      userProvided: false,
-      source: "schema",
+      userProvidedDefault: false,
       ...(typeof host.tableName === "string" ? { reflectedTable: host.tableName } : {}),
       ...(colLimit != null ? { limit: colLimit } : {}),
       ...(colDefaultFunction != null ? { defaultFunction: colDefaultFunction } : {}),
@@ -1262,7 +1261,7 @@ function applyColumnsHash(
  * than the generic ActiveModel type registry.
  *
  * Populates the schema cache if needed (async). User-declared attributes
- * (`userProvided: true`) are NEVER overwritten — matching Rails where
+ * (`userProvidedDefault: true`) are NEVER overwritten — matching Rails where
  * `attribute :foo, :bar` always wins over schema-reflected types.
  *
  * @internal
@@ -1431,9 +1430,7 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {
-    const userDeclared =
-      (def.source ?? (def.userProvided === false ? "schema" : "user")) === "user";
-    if (!userDeclared) continue;
+    if ((def.userProvidedDefault ?? true) === false) continue;
     const isVirtual = !real.has(name);
     if (!!def.virtual !== isVirtual) def.virtual = isVirtual;
   }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -920,7 +920,7 @@ function rewarmDataSourceCache(host: SchemaHost): PromiseLike<void> | void {
 /**
  * Rails: clears column cache, schema cache, reloads schema.
  * Drops schema-sourced attribute defs so the next load re-reflects
- * them; user-declared defs (source === "user") are preserved, matching
+ * them; user-declared defs are preserved, matching
  * Rails' reload_schema_from_cache behavior where user-provided
  * attributes survive reload.
  *

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -919,10 +919,9 @@ function rewarmDataSourceCache(host: SchemaHost): PromiseLike<void> | void {
 
 /**
  * Rails: clears column cache, schema cache, reloads schema.
- * Drops schema-sourced attribute defs so the next load re-reflects
- * them; user-declared defs are preserved, matching
- * Rails' reload_schema_from_cache behavior where user-provided
- * attributes survive reload.
+ * Drops schema-sourced attribute defs so the next load re-reflects them;
+ * user-declared defs are preserved, matching Rails' reload_schema_from_cache
+ * behavior where user-provided attributes survive reload.
  *
  * Returns the re-warm thenable (see {@link rewarmDataSourceCache}). Declared
  * `PromiseLike<void> | void` rather than `async` on purpose: every write above the
@@ -961,8 +960,8 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
 
 /**
  * Drop schema-sourced attribute defs (and their generated accessors) so the
- * next load re-reflects them; user-declared defs are
- * preserved, matching Rails where user-provided attributes survive reload.
+ * next load re-reflects them; user-declared defs are preserved, matching
+ * Rails where user-provided attributes survive reload.
  */
 function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
   for (const [name, def] of Array.from(host._attributeDefinitions)) {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -32,7 +32,7 @@ describe("STI subclass attribute() registration", () => {
 
     // Shape IS the STI base (not a subclass), so its map is its own.
     expect(Object.prototype.hasOwnProperty.call(Shape, "_attributeDefinitions")).toBe(true);
-    expect(Shape._attributeDefinitions.get("name")?.userProvided).toBe(true);
+    expect(Shape._attributeDefinitions.get("name")?.userProvidedDefault).toBe(true);
   });
 
   it("non-STI classes are unaffected", () => {
@@ -43,7 +43,7 @@ describe("STI subclass attribute() registration", () => {
     }
 
     expect(Object.prototype.hasOwnProperty.call(Widget, "_attributeDefinitions")).toBe(true);
-    expect(Widget._attributeDefinitions.get("price")?.userProvided).toBe(true);
+    expect(Widget._attributeDefinitions.get("price")?.userProvidedDefault).toBe(true);
   });
 
   it("STI subclass attribute declared AFTER base inherits the base's attrs too", () => {


### PR DESCRIPTION
`AttributeDefinition` stored the same fact twice — `userProvided?: boolean`
(`activemodel/src/attributes.ts:48`) and `source?: "user" | "schema"`, whose own
JSDoc read _"Provenance tag — matches `userProvided` but kept explicit for
clarity"_. Rails stores neither: `user_provided_default:` is a **kwarg** on
`ActiveRecord::Attributes::ClassMethods#define_attribute`
(`activerecord/lib/active_record/attributes.rb:229-238`), forwarded straight to
`define_default_attribute`'s `from_user:` and never persisted on a definition
record.

This collapses both onto a single field named after that kwarg —
`userProvidedDefault` — which is also the option key that already fed them, and
sweeps the call sites in `model-schema.ts`, `activerecord/src/attributes.ts`,
`base.ts`, `enum.ts`, `encryption/encryptable-record.ts` and the three test
files that asserted on the fields directly.

The AR schema-reflection precedence rule (a user-declared attribute is never
overwritten by `load_schema`, `model-schema.ts`) is unchanged; every guard that
previously OR'd the two fields now reads the one.

Also deletes the callerless `buildDefaultAttributes` — `_defaultAttributes` in
`activerecord/src/attributes.ts` is the live implementation.

### Verification

- `pnpm parity:api:extra --package activemodel`: `attributes.ts` **3 novel → 1**
  (the remaining row is `userProvidedDefault` itself, the Rails kwarg name).
- `pnpm parity:api:calls` / `pnpm parity:api:calls:args`: OK, no new rows.
- `pnpm parity:api` / `pnpm parity:test` deltas non-negative.
- Touched suites green: `model-schema-load`, `model-schema-sync-load`,
  `model-schema`, `sti-attribute-routing.trails`, `activerecord/attributes`,
  `activemodel/attributes`, `enum`, `enum.trails`, `base`, all of
  `encryption/`.

Closes-story: collapse-user-provided-and-source-onto-the-rails-kwarg

---

### Re: the `prepare_column_options`/`size` baseline row (round 3 — why it cannot be stale)

The row is structural to this source pair, so it cannot have converged.

Rails `mysql/schema_dumper.rb:13-14`:

```ruby
if /\A(?<size>tiny|medium|long)(?:text|blob)/ =~ column.sql_type
  spec = { size: size.to_sym.inspect }.merge!(spec)
```

The `size` on line 14 is a **bare identifier** — a local variable that `=~`
creates implicitly from the named capture. A static extractor cannot tell a bare
identifier from a receiverless method call, so it records `size` on the Ruby
call-set. The trails body binds the same capture as an explicit local,
`const size = sizeMatch.groups["size"].toLowerCase()`
(`mysql/schema-dumper.ts:124-125`), which is a local and therefore contributes
no `size` call. Ruby-set minus TS-set is permanently `size → size`. That is
precisely what the baseline row records, and no change on this branch — which
does not touch that file — could alter it.

**Self-diagnostic for the "no `prepare_column_options` entry" reading.** The same
`mysql/schema-dumper.ts` carries two *other* baselined rows in the same
artifact. From my regenerated `call-mismatches.json` (compared 7087, mismatched 725):

```
prepare_column_options            missing: ["size → size"]
schema_collation                  missing: ["quote → quote", "internal_exec_query → internalExecQuery", "first → first"]
extract_expression_for_virtual_column  missing: ["quote_column_name → quoteColumnName", "quote → quote", "query_value → queryValue"]
```

If your artifact lists **none** of the three, the file dropped out of the
comparison population rather than converging — the documented unbuilt-`dist`
failure mode, where an unresolved cross-package type takes the whole method out
of the population, so every baseline row for it reads as stale at once. If it
lists the other two but not `prepare_column_options`, that would be new evidence
and I'll act on it.

**CI is the tiebreak, and it is green.** `Rails API/Test Comparison` passes and
`Unit Tests` passes — the latter runs
`scripts/api-compare/lint-call-mismatches.test.ts`, the ratchet's own gate (40
tests). CI builds from a clean checkout. Deleting the row would red that job.

This PR touches no baseline file (`git diff --stat origin/main...HEAD --
scripts/api-compare/` is empty), so removing or reseeding a correct row from an
only-shrink baseline is not something I'll do without evidence the gate is
actually red outside one local environment.
