### PR TITLE
refactor(activemodel,activerecord): retire registerWithSuperclass and replayOwnPendingDecorators

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model, Types, ValueType, isDecoratorReplay, replayOwnPendingDecorators } from "./index.js";
+import { Model, Types, ValueType, isDecoratorReplay } from "./index.js";
 
 describe("AttributeRegistrationTest", () => {
   it("attributes can be registered", () => {
@@ -390,11 +390,9 @@ describe("AttributeRegistrationTest", () => {
       }
     }
 
-    const defs = new Map(
-      (MyModel as unknown as { _attributeDefinitions: Map<string, never> })._attributeDefinitions,
-    );
     seen.length = 0;
-    replayOwnPendingDecorators(MyModel as never, defs as never);
+    (MyModel as unknown as { _cachedDefaultAttributes: unknown })._cachedDefaultAttributes = null;
+    (MyModel as unknown as { _defaultAttributes(): unknown })._defaultAttributes();
 
     expect(seen).toEqual([true]);
   });

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,4 +1,4 @@
-import { DescendantsTracker } from "@blazetrails/activesupport";
+import { DescendantsTracker, registerSubclass } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
@@ -154,11 +154,12 @@ export function decorateAttributes(
  */
 export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
   if (!this._cachedDefaultAttributes) {
-    // Register with our superclass so resetDefaultAttributes() cascades to us
-    // when the superclass gains new attribute declarations. Mirrors the
-    // ActiveSupport::DescendantsTracker registration that Rails does via
-    // the `inherited` hook; we do it lazily here instead.
-    registerWithSuperclass(this);
+    // Ruby's `inherited` hook registers every subclass with the
+    // DescendantsTracker, which is what `reset_default_attributes`' recursion
+    // over `subclasses` walks (attribute_registration.rb:88-91). JS has no
+    // class-definition hook (CLAUDE.md, "Module mixins"), so trails registers
+    // lazily here, through the one repo-wide stand-in spelling.
+    registerSubclass(Object.getPrototypeOf(this) as HostAsClass, this as unknown as HostAsClass);
     const attributeSet = new AttributeSet(new Map<string, Attribute>());
     applyPendingAttributeModifications(this, attributeSet);
     this._cachedDefaultAttributes = attributeSet;
@@ -191,19 +192,6 @@ export class PendingDecorator implements PendingModification {
 // Mirrors: ActiveSupport::DescendantsTracker used by reset_default_attributes
 // ---------------------------------------------------------------------------
 
-/**
- * Register cls as a direct subclass of its prototype-chain superclass so
- * resetDefaultAttributes() can cascade to it.
- *
- * Delegates to DescendantsTracker (WeakRef-backed, dedup'd) — the same
- * infrastructure Rails uses via ActiveSupport::DescendantsTracker. Rails
- * registers via the `inherited` hook; we register lazily on the first
- * _defaultAttributes() call instead (same effect: only classes that have
- * a cache worth invalidating are tracked).
- *
- * Mirrors: ActiveSupport::DescendantsTracker registration triggered by
- * Class.inherited in Rails.
- */
 type HostAsClass = new (...args: unknown[]) => unknown;
 
 /**
@@ -399,17 +387,6 @@ function inDecoratorReplay<T>(fn: () => T): T {
   }
 }
 
-export function registerWithSuperclass(cls: AttributeHostInternals): void {
-  const superclass = Object.getPrototypeOf(cls) as AttributeHostInternals;
-  if (!superclass || (superclass as unknown) === Function.prototype) return;
-  // Only register if the superclass participates in the attribute system.
-  if (!("_attributeDefinitions" in superclass)) return;
-  DescendantsTracker.registerSubclass(
-    superclass as unknown as HostAsClass,
-    cls as unknown as HostAsClass,
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -427,40 +404,6 @@ function collectPendingModifications(cls: AttributeHostInternals): PendingModifi
 // ---------------------------------------------------------------------------
 // Exported functions
 // ---------------------------------------------------------------------------
-
-/**
- * Replay a class's OWN pending decorators onto a definitions map.
- *
- * Rails rebuilds `_default_attributes` from `columns_hash` and then replays the
- * pending-modification chain every time
- * (ActiveModel::AttributeRegistration#_default_attributes), so a decoration
- * declared on a class survives schema reflection/reload. AR's STI reflection
- * rebuilds a subclass's `_attributeDefinitions` from the base map, which drops
- * decorations unless they are replayed — this is that replay, restricted to the
- * class's OWN decorators because inherited ones are already baked into the base
- * map by `decorateAttributes`' immediate apply.
- *
- * @internal
- */
-export function replayOwnPendingDecorators(
-  cls: AttributeHostInternals,
-  defs: Map<string, { name: string; type: Type }>,
-): void {
-  if (!Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")) return;
-  for (const mod of cls._pendingAttributeModifications as PendingModification[]) {
-    if (!(mod instanceof PendingDecorator)) continue;
-    const targets = mod.names ?? Array.from(defs.keys());
-    for (const name of targets) {
-      const def = defs.get(name);
-      if (!def) continue;
-      // Same replay context Rails' PendingDecorator#apply_to establishes — this
-      // IS a replay of the pending chain, so decorators gated on
-      // `isDecoratorReplay()` must run here too.
-      const newType = inDecoratorReplay(() => mod.decorator(name, def.type, cls));
-      if (newType) defs.set(name, { ...def, type: newType });
-    }
-  }
-}
 
 /**
  * Push a type declaration onto the pending-modification queue.

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -154,11 +154,10 @@ export function decorateAttributes(
  */
 export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
   if (!this._cachedDefaultAttributes) {
-    // Ruby's `inherited` hook registers every subclass with the
-    // DescendantsTracker, which is what `reset_default_attributes`' recursion
-    // over `subclasses` walks (attribute_registration.rb:88-91). JS has no
-    // class-definition hook (CLAUDE.md, "Module mixins"), so trails registers
-    // lazily here, through the one repo-wide stand-in spelling.
+    // Stands in for Ruby's `inherited` hook, which populates the
+    // DescendantsTracker that `reset_default_attributes` recurses over
+    // (attribute_registration.rb:88-91); JS has no class-definition hook
+    // (CLAUDE.md, "Module mixins").
     registerSubclass(Object.getPrototypeOf(this) as HostAsClass, this as unknown as HostAsClass);
     const attributeSet = new AttributeSet(new Map<string, Attribute>());
     applyPendingAttributeModifications(this, attributeSet);

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -37,7 +37,6 @@ export {
   NullMutationTracker,
 } from "./attribute-mutation-tracker.js";
 export {
-  PendingDecorator,
   applyPendingAttributeModifications,
   isDecoratorReplay,
   pushPendingDecorator,

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -37,12 +37,11 @@ export {
   NullMutationTracker,
 } from "./attribute-mutation-tracker.js";
 export {
+  PendingDecorator,
   applyPendingAttributeModifications,
   isDecoratorReplay,
   pushPendingDecorator,
-  replayOwnPendingDecorators,
   resetDefaultAttributes,
-  registerWithSuperclass,
 } from "./attribute-registration.js";
 export { Attributes } from "./attributes.js";
 export type { AttributeDefinition, AttributeOptions } from "./attributes.js";

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -14,8 +14,8 @@ import {
   type Type,
   applyPendingAttributeModifications,
   resetDefaultAttributes as amResetDefaultAttributes,
-  registerWithSuperclass,
 } from "@blazetrails/activemodel";
+import { registerSubclass } from "@blazetrails/activesupport";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup, adapterNameFrom, type AdapterNameSource } from "./type.js";
 import { cachedColumnsHash, isSchemaLoaded, schemaStaleAgainstAncestors } from "./model-schema.js";
@@ -173,9 +173,12 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     !cacheHost._cachedDefaultAttributes ||
     schemaStaleAgainstAncestors(cacheHost)
   ) {
-    // Register cacheHost with its superclass so resetDefaultAttributes()
-    // cascades here when the superclass gains new attribute declarations.
-    registerWithSuperclass(cacheHost);
+    // Ruby's `inherited` hook registers every subclass with the
+    // DescendantsTracker that `reset_default_attributes` recurses over
+    // (activemodel/lib/active_model/attribute_registration.rb:88-91). JS has no
+    // class-definition hook (CLAUDE.md, "Module mixins"), so trails registers
+    // lazily here, through the one repo-wide stand-in spelling.
+    registerSubclass(Object.getPrototypeOf(cacheHost), cacheHost);
 
     // Phase 1: seed schema columns via `Attribute.fromDatabase`, mirroring Rails'
     // `columns_hash.transform_values { Attribute.from_database(col.name, col.default, type) }`.

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -173,11 +173,10 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     !cacheHost._cachedDefaultAttributes ||
     schemaStaleAgainstAncestors(cacheHost)
   ) {
-    // Ruby's `inherited` hook registers every subclass with the
-    // DescendantsTracker that `reset_default_attributes` recurses over
-    // (activemodel/lib/active_model/attribute_registration.rb:88-91). JS has no
-    // class-definition hook (CLAUDE.md, "Module mixins"), so trails registers
-    // lazily here, through the one repo-wide stand-in spelling.
+    // Stands in for Ruby's `inherited` hook, which populates the
+    // DescendantsTracker `reset_default_attributes` recurses over
+    // (activemodel/lib/active_model/attribute_registration.rb:88-91); JS has no
+    // class-definition hook (CLAUDE.md, "Module mixins").
     registerSubclass(Object.getPrototypeOf(cacheHost), cacheHost);
 
     // Phase 1: seed schema columns via `Attribute.fromDatabase`, mirroring Rails'

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1236,31 +1236,23 @@ function applyColumnsHash(
   encryptionHooks.requireOriginalColumnsAfterReflection?.(host, reflectedColumnNames);
 
   // Mirrors ActiveModel::AttributeRegistration#_default_attributes rebuilding
-  // from `columns_hash` and replaying the pending chain, so a `normalizes` /
-  // `serialize` decoration survives the overwrite above. Restricted to reflected
-  // columns: `_attributeDefinitions` is trails' eager type cache, not Rails'
-  // `_default_attributes`, so replaying a NON-column attribute here would fire
-  // guards Rails only raises when the default set is built (enum.rb:240-245).
+  // from `columns_hash` (seeded from the bare `type_for_column`, attributes.rb:
+  // 241-245) and replaying the pending chain through PendingDecorator#apply_to
+  // (attribute_registration.rb:66-74), so a `normalizes` / `serialize`
+  // decoration survives the overwrite above. Own decorators only — an inherited
+  // one is already baked into the base map by `decorateAttributes`. Restricted
+  // to reflected columns: `_attributeDefinitions` is trails' eager type cache,
+  // not Rails' `_default_attributes`, so replaying a NON-column attribute here
+  // would fire guards Rails only raises when the default set is built
+  // (enum.rb:240-245).
   const reflectedNames = Object.keys(filteredHash).filter((n) => host._attributeDefinitions.has(n));
   const attributeSet = new AttributeSet(new Map());
   for (const name of reflectedNames) {
     const def = host._attributeDefinitions.get(name);
-    // Seed from the BARE `type_for_column` result, exactly as Rails seeds
-    // `_default_attributes` (attributes.rb:241-245), so the decorator does the
-    // wrapping instead of re-wrapping a type it already wrapped.
     attributeSet.set(name, Attribute.fromDatabase(name, null, def.reflectedColumnType ?? def.type));
   }
   const reflected = new Set(reflectedNames);
   const decorated = new Set<string>();
-  // The class's OWN decorators only: an inherited one is already baked into the
-  // base map by `decorateAttributes`' immediate apply. Each is replayed through
-  // Rails' own `PendingDecorator#apply_to` (attribute_registration.rb:66-74) so
-  // the replay context it establishes is the same one materialization uses.
-  // NOT `apply_pending_attribute_modifications`: this runs mid-`load_schema!`,
-  // not at materialization, so a decorator naming an attribute with no reflected
-  // column (a typeless enum) would fire its "Undeclared attribute type" raise
-  // here — Rails only reaches that raise from `_default_attributes`
-  // (enum.rb:239-246), which is why the targets are clipped to real columns.
   const ownPending = Object.prototype.hasOwnProperty.call(host, "_pendingAttributeModifications")
     ? ((host as { _pendingAttributeModifications?: unknown[] })._pendingAttributeModifications ??
       [])
@@ -1272,9 +1264,6 @@ function applyColumnsHash(
     new PendingDecorator(names, mod.decorator).applyTo(attributeSet, host);
     for (const name of names) decorated.add(name);
   }
-  // Only the decorated names are written back: an undecorated def keeps whatever
-  // type it already carries, including a user-declared override that reflection
-  // must not revert to the raw column type.
   for (const name of decorated) {
     const def = host._attributeDefinitions.get(name);
     host._attributeDefinitions.set(name, { ...def, type: attributeSet.getAttribute(name).type });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -3,10 +3,11 @@ import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
 import {
   Attribute,
+  AttributeSet,
   AttributeSetBuilder,
+  PendingDecorator,
   YAMLEncoder,
   typeRegistry,
-  replayOwnPendingDecorators,
   type Type,
 } from "@blazetrails/activemodel";
 import {
@@ -1240,13 +1241,44 @@ function applyColumnsHash(
   // columns: `_attributeDefinitions` is trails' eager type cache, not Rails'
   // `_default_attributes`, so replaying a NON-column attribute here would fire
   // guards Rails only raises when the default set is built (enum.rb:240-245).
-  const reflectedDefs = new Map(
-    Object.keys(filteredHash)
-      .filter((n) => host._attributeDefinitions.has(n))
-      .map((n) => [n, host._attributeDefinitions.get(n)] as const),
-  );
-  replayOwnPendingDecorators(host as never, reflectedDefs as never);
-  for (const [name, def] of reflectedDefs) host._attributeDefinitions.set(name, def);
+  const reflectedNames = Object.keys(filteredHash).filter((n) => host._attributeDefinitions.has(n));
+  const attributeSet = new AttributeSet(new Map());
+  for (const name of reflectedNames) {
+    const def = host._attributeDefinitions.get(name);
+    // Seed from the BARE `type_for_column` result, exactly as Rails seeds
+    // `_default_attributes` (attributes.rb:241-245), so the decorator does the
+    // wrapping instead of re-wrapping a type it already wrapped.
+    attributeSet.set(name, Attribute.fromDatabase(name, null, def.reflectedColumnType ?? def.type));
+  }
+  const reflected = new Set(reflectedNames);
+  const decorated = new Set<string>();
+  // The class's OWN decorators only: an inherited one is already baked into the
+  // base map by `decorateAttributes`' immediate apply. Each is replayed through
+  // Rails' own `PendingDecorator#apply_to` (attribute_registration.rb:66-74) so
+  // the replay context it establishes is the same one materialization uses.
+  // NOT `apply_pending_attribute_modifications`: this runs mid-`load_schema!`,
+  // not at materialization, so a decorator naming an attribute with no reflected
+  // column (a typeless enum) would fire its "Undeclared attribute type" raise
+  // here — Rails only reaches that raise from `_default_attributes`
+  // (enum.rb:239-246), which is why the targets are clipped to real columns.
+  const ownPending = Object.prototype.hasOwnProperty.call(host, "_pendingAttributeModifications")
+    ? ((host as { _pendingAttributeModifications?: unknown[] })._pendingAttributeModifications ??
+      [])
+    : [];
+  for (const mod of ownPending) {
+    if (!(mod instanceof PendingDecorator)) continue;
+    const names = (mod.names ?? reflectedNames).filter((n) => reflected.has(n));
+    if (names.length === 0) continue;
+    new PendingDecorator(names, mod.decorator).applyTo(attributeSet, host);
+    for (const name of names) decorated.add(name);
+  }
+  // Only the decorated names are written back: an undecorated def keeps whatever
+  // type it already carries, including a user-declared override that reflection
+  // must not revert to the raw column type.
+  for (const name of decorated) {
+    const def = host._attributeDefinitions.get(name);
+    host._attributeDefinitions.set(name, { ...def, type: attributeSet.getAttribute(name).type });
+  }
 
   // Reflection may change a column's type/default without changing the key set,
   // so the revision stamps cannot infer staleness from key coverage.

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -3,9 +3,7 @@ import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
 import {
   Attribute,
-  AttributeSet,
   AttributeSetBuilder,
-  PendingDecorator,
   YAMLEncoder,
   typeRegistry,
   type Type,
@@ -1234,40 +1232,6 @@ function applyColumnsHash(
   // `columnNames()` partial-load path — are the source of truth here.
   const reflectedColumnNames = Object.keys(hash).filter((n) => !ignored.has(n));
   encryptionHooks.requireOriginalColumnsAfterReflection?.(host, reflectedColumnNames);
-
-  // Mirrors ActiveModel::AttributeRegistration#_default_attributes rebuilding
-  // from `columns_hash` (seeded from the bare `type_for_column`, attributes.rb:
-  // 241-245) and replaying the pending chain through PendingDecorator#apply_to
-  // (attribute_registration.rb:66-74), so a `normalizes` / `serialize`
-  // decoration survives the overwrite above. Own decorators only — an inherited
-  // one is already baked into the base map by `decorateAttributes`. Restricted
-  // to reflected columns: `_attributeDefinitions` is trails' eager type cache,
-  // not Rails' `_default_attributes`, so replaying a NON-column attribute here
-  // would fire guards Rails only raises when the default set is built
-  // (enum.rb:240-245).
-  const reflectedNames = Object.keys(filteredHash).filter((n) => host._attributeDefinitions.has(n));
-  const attributeSet = new AttributeSet(new Map());
-  for (const name of reflectedNames) {
-    const def = host._attributeDefinitions.get(name);
-    attributeSet.set(name, Attribute.fromDatabase(name, null, def.reflectedColumnType ?? def.type));
-  }
-  const reflected = new Set(reflectedNames);
-  const decorated = new Set<string>();
-  const ownPending = Object.prototype.hasOwnProperty.call(host, "_pendingAttributeModifications")
-    ? ((host as { _pendingAttributeModifications?: unknown[] })._pendingAttributeModifications ??
-      [])
-    : [];
-  for (const mod of ownPending) {
-    if (!(mod instanceof PendingDecorator)) continue;
-    const names = (mod.names ?? reflectedNames).filter((n) => reflected.has(n));
-    if (names.length === 0) continue;
-    new PendingDecorator(names, mod.decorator).applyTo(attributeSet, host);
-    for (const name of names) decorated.add(name);
-  }
-  for (const name of decorated) {
-    const def = host._attributeDefinitions.get(name);
-    host._attributeDefinitions.set(name, { ...def, type: attributeSet.getAttribute(name).type });
-  }
 
   // Reflection may change a column's type/default without changing the key set,
   // so the revision stamps cannot infer staleness from key coverage.

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -55,7 +55,7 @@ describe("STI subclass normalizes", () => {
     ReloadedCompany.normalizes("name", (name: unknown) =>
       typeof name === "string" ? name.trim().toUpperCase() : name,
     );
-    expect(defTypeFor(ReloadedCompany, "name").cast("  acme  ")).toBe("ACME");
+    expect(ReloadedCompany.typeForAttribute("name").cast("  acme  ")).toBe("ACME");
 
     // Rails re-seeds `_default_attributes` from `columns_hash` and replays the
     // pending-decorator chain on every rebuild, so reflection must not revert
@@ -64,8 +64,8 @@ describe("STI subclass normalizes", () => {
     await Company.loadSchema();
     await ReloadedCompany.loadSchema();
 
-    expect(defTypeFor(ReloadedCompany, "name").cast("  acme  ")).toBe("ACME");
-    expect(defTypeFor(Company, "name").cast("  acme  ")).toBe("  acme  ");
+    expect(ReloadedCompany.typeForAttribute("name").cast("  acme  ")).toBe("ACME");
+    expect(Company.typeForAttribute("name").cast("  acme  ")).toBe("  acme  ");
   });
 
   it("re-reflects a subclass whose key set is unchanged after a base reset", async () => {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1205,6 +1205,11 @@ interface UpdateColumnsRecord {
         };
       }
     >;
+    typeForAttribute(name: string): {
+      cast(v: unknown): unknown;
+      serialize?(v: unknown): unknown;
+      type?(): string;
+    };
     _buildPkWhereNode(id: unknown): Parameters<UpdateManager["where"]>[0];
     connection: {
       execUpdate(sql: string, name?: string, binds?: unknown[]): Promise<number>;
@@ -1305,7 +1310,12 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     if (!def && !pkCols.includes(key)) {
       throw new UnknownAttributeError(this, key);
     }
-    const cast = def ? def.type.cast(value) : value;
+    // Rails casts through `@attributes.write_cast_value` (persistence.rb:625),
+    // i.e. the `_default_attributes` type — the pending-decorator chain replayed
+    // — not a per-class definition cache, so a `serialize` / `encrypts`
+    // decoration applies here too.
+    const attrType = def ? (ctor.typeForAttribute(key) ?? def.type) : undefined;
+    const cast = attrType ? attrType.cast(value) : value;
     this._attributes.set(key, cast);
     // Bridge the in-memory cast value to its DB representation via the
     // faithful SerializeCastValue.serialize dispatcher — the same path
@@ -1318,7 +1328,7 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     // serialize-overriding type (binary, json, serialized, PG OID types). This
     // replaces the former Temporal+Enum type-name allowlist, which silently
     // wrote the in-memory value for any other diverging type.
-    const type = def?.type as
+    const type = attrType as
       | {
           serializeCastValue(v: unknown): unknown;
           serialize(v: unknown): unknown;


### PR DESCRIPTION
Converges the last two novel helpers in `packages/activemodel/src/attribute-registration.ts`.

### `registerWithSuperclass` → `registerSubclass`

It stood in for Ruby's `inherited` hook, which populates the DescendantsTracker that `reset_default_attributes` recurses over (`activemodel/lib/active_model/attribute_registration.rb:88-91`). trails already has exactly one ratified stand-in for that hook — `registerSubclass` from `@blazetrails/activesupport` — so both call sites (`activemodel/src/attribute-registration.ts` `_defaultAttributes`, `activerecord/src/attributes.ts`) use it now, cited at the call site.

### `replayOwnPendingDecorators` → deleted, with no replacement

Rails' `load_schema!` does not replay the pending chain at all: it resets `@default_attributes` (`activerecord/lib/active_record/model_schema.rb:487-489`) and lets `_default_attributes` re-seed from `columns_hash` and replay through `apply_pending_attribute_modifications` on the next read (`activerecord/lib/active_record/attributes.rb:241-249`, `activemodel/lib/active_model/attribute_registration.rb:81-87`). trails' AR `_defaultAttributes` already does exactly that, so the post-reflection replay inside `applyColumnsHash` was pure duplication — it is gone, along with the `PendingDecorator` export an earlier revision of this PR needed. Nothing in ActiveModel is exported for AR's benefit any more.

Two readers had been leaning on that eager re-bake of `_attributeDefinitions`, and both now read the type Rails reads:

- `update_columns` casts through `@attributes.write_cast_value` (`activerecord/lib/active_record/persistence.rb:625`) — the `_default_attributes` type, i.e. the replayed chain — so it resolves via `type_for_attribute` instead of the definition cache. This is what keeps `serialize`/`encrypts` decorations applied on that path.
- The STI-normalizes regression asserts through `type_for_attribute` for the same reason. Test name unchanged.

### Checks

- `pnpm parity:api:extra --package activemodel`: `index.ts` down two novel rows; `attribute-registration.ts` at 3 novel, all of them the `pushPendingType` / `pushPendingDefault` / `pushPendingDecorator` trio that the sibling `converge-attribute-registration-pending-modification-helpers` story collapses (not yet in `main`) — neither of this story's two names remains.
- `pnpm parity:api:calls` and `pnpm parity:api:calls:args`: OK, no new rows. `pnpm parity:api` deltas non-negative. `pnpm lint`, `pnpm build` clean.
- Locally green: all of `packages/activemodel/src` plus AR `attributes`, `enum{,.trails}`, `normalized-attribute*`, `serializ*`, `model-schema*`, `persistence*`, `dirty`, `timestamp`, `base`, `inheritance`, `encryption` — 3160 tests.

Closes-story: converge-attribute-registration-inherited-hook-and-decorator-replay