### PR TITLE
refactor(activemodel): drop the Date/DateTime/Time serialize copies the AcceptsMultiparameterTime mixin provides

### DIFF
--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -153,3 +153,14 @@ describe("DateTimeType assert_valid_value", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+// `serialize_cast_value` comes from Helpers::TimeValue, included AFTER
+// AcceptsMultiparameterTime (date_time.rb:44-47), so it sits nearer the class
+// than the mixin's `serialize` and the predicate
+// (serialize_cast_value.rb:9-12) is true.
+describe("DateTimeType serialize_cast_value_compatible?", () => {
+  it("is compatible", () => {
+    const type = new Types.DateTimeType();
+    expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
+  });
+});

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -222,20 +222,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   }
 
   /**
-   * Mirrors: ActiveModel::Type::Value#serialize (near-identity). `value_for_database`
-   * returns the cast Temporal value — NOT a SQL string. The connection adapter's
-   * quoting/bind layer converts it to a SQL literal at quote/type_cast time, matching
-   * Rails where `value_for_database` for a datetime yields the cast Time and the
-   * adapter does the quoting. Sub-second precision is already applied in `castValue`.
-   */
-  // Return type is `unknown` (matching ActiveModel::Type::Value#serialize) so
-  // adapter subclasses can widen it — e.g. PostgreSQL's OID::DateTime emits the
-  // "infinity" wire string for the infinity sentinels.
-  serialize(value: unknown): unknown {
-    return this.serializeCastValue(this.cast(value));
-  }
-
-  /**
    * Mirrors: ActiveModel::Type::Helpers::TimeValue#serialize_cast_value
    * (time_value.rb:10-21) — its `apply_seconds_precision` half. The `is_utc?`
    * `getutc`/`getlocal` arm (`:12-19`) is not ported; that gap is tracked by

--- a/packages/activemodel/src/type/date.trails.test.ts
+++ b/packages/activemodel/src/type/date.trails.test.ts
@@ -29,3 +29,13 @@ describe("DateType assert_valid_value", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+// `serialize` comes from the AcceptsMultiparameterTime mixin and Type::Date
+// defines no `serialize_cast_value` of its own, so both are answered by the
+// same ancestor and the predicate (serialize_cast_value.rb:9-12) is true.
+describe("DateType serialize_cast_value_compatible?", () => {
+  it("is compatible", () => {
+    const type = new Types.DateType();
+    expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
+  });
+});

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -203,21 +203,6 @@ export class DateType extends ValueType<DateCastResult> {
     ).call(this, values as Record<string, unknown>);
     return time && this.newDate(time.year, time.mon, time.mday);
   }
-
-  /**
-   * Mirrors: ActiveModel::Type::Value#serialize (near-identity). `value_for_database`
-   * returns the cast Temporal.PlainDate — NOT a SQL string; the adapter quotes it later.
-   */
-  // Return type is `unknown` (matching ActiveModel::Type::Value#serialize) so
-  // adapter subclasses can widen it — e.g. PostgreSQL's OID::Date emits the
-  // "infinity" wire string for the infinity sentinels.
-  serialize(value: unknown): unknown {
-    return this.cast(value);
-  }
-
-  serializeCastValue(value: DateCastResult | null): DateCastResult | null {
-    return value;
-  }
 }
 
 /** Mirrors: ActiveModel::Type::Date::ISO_DATE (date.rb:54). */

--- a/packages/activemodel/src/type/time.trails.test.ts
+++ b/packages/activemodel/src/type/time.trails.test.ts
@@ -38,3 +38,14 @@ describe("TimeType assert_valid_value", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+// `serialize_cast_value` comes from Helpers::TimeValue, included AFTER
+// AcceptsMultiparameterTime (time.rb:40-43), so it sits nearer the class than
+// the mixin's `serialize` and the predicate (serialize_cast_value.rb:9-12) is
+// true.
+describe("TimeType serialize_cast_value_compatible?", () => {
+  it("is compatible", () => {
+    const type = new Types.TimeType();
+    expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
+  });
+});

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -201,16 +201,15 @@ export class TimeType extends ValueType<Temporal.Instant> {
   }
 
   /**
-   * Mirrors: ActiveModel::Type::Value#serialize (near-identity). `value_for_database`
-   * returns the cast Temporal.Instant — NOT a SQL string; the adapter quotes it later.
+   * Mirrors: ActiveModel::Type::Helpers::TimeValue#serialize_cast_value
+   * (time_value.rb:10-21) — its `apply_seconds_precision` half. The `is_utc?`
+   * `getutc`/`getlocal` arm (`:12-19`) is not ported; that gap is tracked by
+   * `serialize-cast-value-drops-is-utc-normalization`.
    */
-  serialize(value: unknown): unknown {
-    return this.serializeCastValue(this.cast(value));
-  }
-
-  // Mirrors ActiveModel::Type::Helpers::TimeValue#serialize_cast_value (apply_seconds_precision).
+  // Return type is `unknown` so adapter subclasses can widen it — ActiveRecord's
+  // Type::Time serializes to a SQL time string.
   serializeCastValue(value: Temporal.Instant | null): unknown {
-    return value === null ? null : this.applySecondsPrecision(value);
+    return this.applySecondsPrecision(value);
   }
 
   /**

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -205,9 +205,10 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * (time_value.rb:10-21) — its `apply_seconds_precision` half. The `is_utc?`
    * `getutc`/`getlocal` arm (`:12-19`) is not ported; that gap is tracked by
    * `serialize-cast-value-drops-is-utc-normalization`.
+   *
+   * The return type is `unknown` so a subclass can widen it, as ActiveRecord's
+   * `Type::Time` does (activerecord/lib/active_record/type/time.rb:20-22).
    */
-  // Return type is `unknown` so adapter subclasses can widen it — ActiveRecord's
-  // Type::Time serializes to a SQL time string.
   serializeCastValue(value: Temporal.Instant | null): unknown {
     return this.applySecondsPrecision(value);
   }


### PR DESCRIPTION
`Helpers::AcceptsMultiparameterTime::InstanceMethods` defines `serialize` /
`serialize_cast_value` (`activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb:9-15`),
and `Type::Date` / `Type::DateTime` / `Type::Time` do not redefine `serialize`
in their own class bodies — the mixin's version answers. trails carried
hand-spelled class-body copies, which outrank the mixin.

- `date.ts` — dropped both halves. Rails' `Type::Date` (date.rb:26-28) defines
  neither, and its old `serialize` was `cast(value)` rather than the mixin's
  `serialize_cast_value(cast(value))`.
- `date-time.ts`, `time.ts` — dropped `serialize`; kept `serializeCastValue`,
  which is `Helpers::TimeValue#serialize_cast_value` (time_value.rb:10-21),
  included after the mixin (date_time.rb:44-47, time.rb:40-43). `TimeType`'s
  redundant `value === null` guard is gone: `apply_seconds_precision` already
  passes a non-`nsec` receiver through (time_value.rb:24-25).

`serializeCastValueCompatible` (`serialize_cast_value.rb:9-12`) still answers
true for all three — the mixin carrier splices above the class prototype, so
`serialize` moves no nearer than `serializeCastValue` — and each type's trails
test now asserts it.

Closes-story: converge-date-time-type-serialize-onto-the-mixin
