### PR TITLE
refactor(activemodel): converge ModelName's constructor/comparable surface and as_json coercion onto Rails

### DIFF
--- a/packages/activemodel/src/conversion.test.ts
+++ b/packages/activemodel/src/conversion.test.ts
@@ -14,19 +14,19 @@ class Contact extends Model {
 
 // models/helicopter.rb — `Helicopter`, `Helicopter::Comanche` and
 // `Helicopter::Apache`, the last overriding `model_name`. A TS class name
-// cannot contain `::`, so the namespaced names are spelled on `ModelName`,
+// cannot contain `::`, so the qualified names are spelled on `ModelName`,
 // which is where Rails' `_to_partial_path` reads them from anyway.
 class Helicopter extends Model {}
 
 class Comanche extends Model {
   static override get modelName(): ModelName {
-    return new ModelName("Comanche", "Helicopter");
+    return new ModelName("Helicopter::Comanche");
   }
 }
 
 class Apache extends Model {
   static override get modelName(): ModelName {
-    const modelName = new ModelName("Apache", "Helicopter");
+    const modelName = new ModelName("Helicopter::Apache");
     modelName.collection = "attack_helicopters";
     modelName.element = "ah-64";
     return modelName;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1619,7 +1619,11 @@ export class Model {
    */
   static get modelName(): ModelName {
     if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
-      const namespace = this.moduleName?.split("::");
+      // Rails walks `module_parents` for a module answering
+      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
+      // enclosing-module chain to walk, so nothing can declare relative naming
+      // and the detect answers nil.
+      const namespace = null;
       // Model satisfies ModelLike but TS can't prove it due to circular types.
       this._modelName = new ModelName(this as unknown as ModelLike, namespace);
     }

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -8,7 +8,7 @@ describe("NamingTest", () => {
   class Post extends Model {}
 
   // models/track_back.rb — `Post::TrackBack`.
-  const modelName = new ModelName("TrackBack", "Post");
+  const modelName = new ModelName("Post::TrackBack");
 
   it("name returns class name", () => {
     expect(Post.modelName.name).toBe("Post");
@@ -76,7 +76,7 @@ describe("NamingHelpersTest", () => {
   // `Post::NamedTrackBack`, so naming goes through the proxy.
   class NamedTrackBack extends Model {
     static override get modelName(): ModelName {
-      return new ModelName("NamedTrackBack", "Post");
+      return new ModelName("Post::NamedTrackBack");
     }
   }
   class TrackBack {
@@ -153,38 +153,36 @@ describe("NamingMethodDelegationTest", () => {
 // (activemodel/test/cases/naming_test.rb:87-125): `Name.new(Blog::Post)` with
 // no namespace argument, so `param_key`/`route_key` keep the prefix.
 describe("NamingWithNamespacedModelInSharedNamespaceTest", () => {
-  const namespace = "Blog";
-
   it("singular", () => {
-    expect(new ModelName("Post", namespace).singular).toBe("blog_post");
+    expect(new ModelName("Blog::Post").singular).toBe("blog_post");
   });
 
   it("plural", () => {
-    expect(new ModelName("Post", namespace).plural).toBe("blog_posts");
+    expect(new ModelName("Blog::Post").plural).toBe("blog_posts");
   });
 
   it("element", () => {
-    expect(new ModelName("Post", namespace).element).toBe("post");
+    expect(new ModelName("Blog::Post").element).toBe("post");
   });
 
   it("collection", () => {
-    expect(new ModelName("Post", namespace).collection).toBe("blog/posts");
+    expect(new ModelName("Blog::Post").collection).toBe("blog/posts");
   });
 
   it("human", () => {
-    expect(new ModelName("Post", namespace).human()).toBe("Post");
+    expect(new ModelName("Blog::Post").human()).toBe("Post");
   });
 
   it("route key", () => {
-    expect(new ModelName("Post", namespace).routeKey).toBe("blog_posts");
+    expect(new ModelName("Blog::Post").routeKey).toBe("blog_posts");
   });
 
   it("param key", () => {
-    expect(new ModelName("Post", namespace).paramKey).toBe("blog_post");
+    expect(new ModelName("Blog::Post").paramKey).toBe("blog_post");
   });
 
   it("i18n key", () => {
-    expect(new ModelName("Post", namespace).i18nKey).toBe("blog/post");
+    expect(new ModelName("Blog::Post").i18nKey).toBe("blog/post");
   });
 });
 
@@ -239,60 +237,60 @@ describe("NamingWithSuppliedLocaleTest", () => {
 // `Blog::Post.model_name`, and `Blog.use_relative_model_naming?` is true
 // (test/models/blog_post.rb), so `model_name` passes `Blog` as the namespace.
 describe("NamingUsingRelativeModelNameTest", () => {
-  const namespace = { name: "Blog", useRelativeModelNaming: true };
+  const namespace = { name: "Blog" };
   it("singular", () => {
-    expect(new ModelName("Post", namespace).singular).toBe("blog_post");
+    expect(new ModelName("Blog::Post", namespace).singular).toBe("blog_post");
   });
   it("plural", () => {
-    expect(new ModelName("Post", namespace).plural).toBe("blog_posts");
+    expect(new ModelName("Blog::Post", namespace).plural).toBe("blog_posts");
   });
   it("element", () => {
-    expect(new ModelName("Post", namespace).element).toBe("post");
+    expect(new ModelName("Blog::Post", namespace).element).toBe("post");
   });
   it("collection", () => {
-    expect(new ModelName("Post", namespace).collection).toBe("blog/posts");
+    expect(new ModelName("Blog::Post", namespace).collection).toBe("blog/posts");
   });
   it("human", () => {
-    expect(new ModelName("Post", namespace).human()).toBe("Post");
+    expect(new ModelName("Blog::Post", namespace).human()).toBe("Post");
   });
   it("route key", () => {
-    expect(new ModelName("Post", namespace).routeKey).toBe("posts");
+    expect(new ModelName("Blog::Post", namespace).routeKey).toBe("posts");
   });
   it("param key", () => {
-    expect(new ModelName("Post", namespace).paramKey).toBe("post");
+    expect(new ModelName("Blog::Post", namespace).paramKey).toBe("post");
   });
   it("i18n key", () => {
-    expect(new ModelName("Post", namespace).i18nKey).toBe("blog/post");
+    expect(new ModelName("Blog::Post", namespace).i18nKey).toBe("blog/post");
   });
 });
 
 // Ports Rails `NamingWithNamespacedModelInIsolatedNamespaceTest`
 // (activemodel/test/cases/naming_test.rb:51-86): `Name.new(Blog::Post, Blog)`.
 describe("NamingWithNamespacedModelInIsolatedNamespaceTest", () => {
-  const namespace = { name: "Blog", useRelativeModelNaming: true };
+  const namespace = { name: "Blog" };
   it("singular", () => {
-    expect(new ModelName("Post", namespace).singular).toBe("blog_post");
+    expect(new ModelName("Blog::Post", namespace).singular).toBe("blog_post");
   });
   it("human", () => {
-    expect(new ModelName("Post", namespace).human()).toBe("Post");
+    expect(new ModelName("Blog::Post", namespace).human()).toBe("Post");
   });
   it("plural", () => {
-    expect(new ModelName("Post", namespace).plural).toBe("blog_posts");
+    expect(new ModelName("Blog::Post", namespace).plural).toBe("blog_posts");
   });
   it("element", () => {
-    expect(new ModelName("Post", namespace).element).toBe("post");
+    expect(new ModelName("Blog::Post", namespace).element).toBe("post");
   });
   it("collection", () => {
-    expect(new ModelName("Post", namespace).collection).toBe("blog/posts");
+    expect(new ModelName("Blog::Post", namespace).collection).toBe("blog/posts");
   });
   it("route key", () => {
-    expect(new ModelName("Post", namespace).routeKey).toBe("posts");
+    expect(new ModelName("Blog::Post", namespace).routeKey).toBe("posts");
   });
   it("param key", () => {
-    expect(new ModelName("Post", namespace).paramKey).toBe("post");
+    expect(new ModelName("Blog::Post", namespace).paramKey).toBe("post");
   });
   it("i18n key", () => {
-    expect(new ModelName("Post", namespace).i18nKey).toBe("blog/post");
+    expect(new ModelName("Blog::Post", namespace).i18nKey).toBe("blog/post");
   });
 });
 
@@ -314,51 +312,6 @@ describe("NameWithAnonymousClassTest", () => {
   });
 });
 
-// Arbitrary-depth namespaces: Rails walks a full `::` chain via
-// `_singularize`/`tableize`; our equivalent is a segment array — same
-// output, no Ruby-shaped strings in the TS API.
-describe("ModelName deeply-nested namespace", () => {
-  it("multi-segment namespace array produces full prefix on derived fields", () => {
-    const name = new ModelName("Post", ["Admin", "Blog"]);
-    expect(name.name).toBe("Admin::Blog::Post");
-    expect(Array.from(name.namespace ?? [])).toEqual(["Admin", "Blog"]);
-    expect(name.singular).toBe("admin_blog_post");
-    expect(name.plural).toBe("admin_blog_posts");
-    expect(name.element).toBe("post");
-    expect(name.collection).toBe("admin/blog/posts");
-    expect(name.i18nKey).toBe("admin/blog/post");
-    expect(name.paramKey).toBe("admin_blog_post");
-    expect(name.routeKey).toBe("admin_blog_posts");
-  });
-});
-
-describe("ModelName rejects Ruby-shaped strings", () => {
-  it("throws when className contains ::", () => {
-    expect(() => new ModelName("Blog::Post")).toThrow(/must not contain/);
-  });
-  it("throws when namespace contains ::", () => {
-    expect(() => new ModelName("Post", "Admin::Blog")).toThrow(/must not contain/);
-  });
-});
-
-describe("ModelName rejects malformed namespace option", () => {
-  it("throws ArgumentError on object without a string .name", () => {
-    expect(() => new ModelName("Post", {} as unknown as { name: string })).toThrow(ArgumentError);
-  });
-  it("throws ArgumentError on array with non-string elements", () => {
-    expect(() => new ModelName("Post", ["Blog", 42 as unknown as string])).toThrow(ArgumentError);
-  });
-  it("throws ArgumentError on empty-string namespace", () => {
-    expect(() => new ModelName("Post", "")).toThrow(ArgumentError);
-  });
-  it("throws ArgumentError on whitespace-only segment in an array", () => {
-    expect(() => new ModelName("Post", ["Blog", "   "])).toThrow(ArgumentError);
-  });
-  it("throws ArgumentError on blank name", () => {
-    expect(() => new ModelName("   ")).toThrow(ArgumentError);
-  });
-});
-
 describe("ModelName singularRouteKey", () => {
   it("top-level: equal to singular", () => {
     const name = new ModelName("Post");
@@ -366,7 +319,7 @@ describe("ModelName singularRouteKey", () => {
     expect(name.routeKey).toBe("posts");
   });
   it("namespaced: singularizes the prefix-dropped routeKey", () => {
-    const name = new ModelName("Post", { name: "Blog", useRelativeModelNaming: true });
+    const name = new ModelName("Blog::Post", { name: "Blog" });
     expect(name.routeKey).toBe("posts");
     expect(name.singularRouteKey).toBe("post");
   });
@@ -381,38 +334,28 @@ describe("ModelName singularRouteKey", () => {
     expect(name.singularRouteKey.length).toBeGreaterThan(0);
   });
   it("Naming.singularRouteKey delegates to ModelName.singularRouteKey", () => {
-    const name = new ModelName("Post", "Blog");
+    const name = new ModelName("Blog::Post");
     expect(Naming.singularRouteKey(name)).toBe(name.singularRouteKey);
   });
 });
 
-describe("ModelName collection is derived from plural", () => {
-  // Addresses the uncountable-consistency concern: whatever decision
-  // `plural` makes (local uncountables table, activesupport Inflector rules,
-  // whatever), `collection` follows the same decision instead of
-  // independently pluralizing.
-  it("namespaced normal word: collection tail === bare pluralization", () => {
-    const name = new ModelName("Post", "Blog");
+describe("ModelName collection", () => {
+  it("namespaced: `tableize(@name)` pluralizes the last path segment", () => {
+    const name = new ModelName("Blog::Post");
     expect(name.plural).toBe("blog_posts");
     expect(name.collection).toBe("blog/posts");
   });
 
-  it("addUncountable on full singular keeps plural and collection in sync", () => {
+  it("uncountable full singular leaves collection on tableize's own inflection", () => {
+    // `@plural` is `pluralize(@singular)` and `@collection` is
+    // `tableize(@name)` (naming.rb:174, :178) — two independent inflections,
+    // so an uncountable registered on the `_`-joined singular does not reach
+    // the `/`-joined path form.
     Inflections.instance("en").uncountable("legal_status");
-    const name = new ModelName("Status", "Legal");
+    const name = new ModelName("Legal::Status");
     expect(name.singular).toBe("legal_status");
-    expect(name.plural).toBe("legal_status"); // uncountable per local table
-    expect(name.collection).toBe("legal/status"); // tail follows plural
-  });
-});
-
-describe("ModelName namespace accepts Module-like {name}", () => {
-  it("an object with a string `name` property is equivalent to the string form", () => {
-    const asObject = new ModelName("Post", { name: "Blog" });
-    const asString = new ModelName("Post", "Blog");
-    expect(asObject.singular).toBe(asString.singular);
-    expect(asObject.paramKey).toBe(asString.paramKey);
-    expect(asObject.routeKey).toBe(asString.routeKey);
+    expect(name.plural).toBe("legal_status");
+    expect(name.collection).toBe("legal/statuses");
   });
 });
 
@@ -470,13 +413,6 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(stickyRe.lastIndex).toBe(0);
   });
 
-  it("compare throws ArgumentError on non-string/non-ModelName input", () => {
-    const mn = new ModelName("Post");
-    expect(() => mn.compare(42)).toThrow(ArgumentError);
-    expect(() => mn.compare(null)).toThrow(ArgumentError);
-    expect(() => mn.compare(undefined)).toThrow(ArgumentError);
-  });
-
   it("match throws ArgumentError on non-RegExp input", () => {
     const mn = new ModelName("Post");
     expect(() => mn.match("Post")).toThrow(ArgumentError);
@@ -487,16 +423,16 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
   it("equals / compare distinguish namespaced models with the same bare name", () => {
     // Two ModelName instances share the same `name: "Post"` but differ
     // in namespace — must not compare equal, must sort deterministically.
-    const blogPost = new ModelName("Post", "Blog");
-    const adminPost = new ModelName("Post", "Admin");
-    const blogPost2 = new ModelName("Post", "Blog");
+    const blogPost = new ModelName("Blog::Post");
+    const adminPost = new ModelName("Admin::Post");
+    const blogPost2 = new ModelName("Blog::Post");
     const barePost = new ModelName("Post");
 
     expect(blogPost.equals(adminPost)).toBe(false);
     expect(blogPost.equals(blogPost2)).toBe(true);
     expect(blogPost.equals(barePost)).toBe(false);
-    // `compare` compares the full qualified path ("Admin/Post" vs
-    // "Blog/Post"), so Admin < Blog.
+    // `compare` is `String#<=>` on `@name` ("Admin::Post" vs "Blog::Post"),
+    // so Admin < Blog.
     expect(blogPost.compare(adminPost)).toBe(1);
     expect(adminPost.compare(blogPost)).toBe(-1);
     expect(blogPost.compare(blogPost2)).toBe(0);
@@ -515,14 +451,12 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     // the full namespace+name path as a single string — so a model
     // under an earlier-sorting namespace outranks a later-sorting
     // namespace even when its bare name comes later alphabetically.
-    const adminOther = new ModelName("Other", "Admin");
-    const blogPost = new ModelName("Post", "Blog");
-    // "Admin/Other" < "Blog/Post"
+    const adminOther = new ModelName("Admin::Other");
+    const blogPost = new ModelName("Blog::Post");
+    // "Admin::Other" < "Blog::Post"
     expect(adminOther.compare(blogPost)).toBe(-1);
     expect(blogPost.compare(adminOther)).toBe(1);
-    // Bare name ("Post") > a qualified name starting with earlier letters
-    // ("Admin/Other")? No — bare comparison uses the raw qualified path,
-    // so "Admin/Other" < "Post".
+    // Comparison is over the raw qualified path, so "Admin::Other" < "Post".
     const barePost = new ModelName("Post");
     expect(adminOther.compare(barePost)).toBe(-1);
     expect(barePost.compare(adminOther)).toBe(1);
@@ -552,7 +486,7 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
 
 describe("OverridingAccessorsTest", () => {
   it("overriding accessors keys", () => {
-    const modelName = new ModelName("TrackBack", "Post");
+    const modelName = new ModelName("Post::TrackBack");
     modelName.singular = "singular";
     modelName.plural = "plural";
     modelName.element = "element";
@@ -603,7 +537,9 @@ describe("ModelName locale", () => {
     Inflections.instance("es").singular(/es$/, "");
     const name = new ModelName("Ley", undefined, undefined, "es");
     expect(name.plural).toBe("leyes");
-    expect(name.collection).toBe("leyes");
+    // Rails' `@collection = tableize(@name)` (naming.rb:178) takes no locale,
+    // so the collection stays on the default `:en` inflections.
+    expect(name.collection).toBe("leys");
     expect(name.routeKey).toBe("leyes");
     expect(name.singularRouteKey).toBe("ley");
     expect(new ModelName("Ley").plural).toBe("leys");

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -389,6 +389,9 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(mn.compare("Blog")).toBe(1);
     expect(mn.compare("BlogPosts")).toBe(-1);
     expect(mn.compare(new ModelName("BlogPost"))).toBe(0);
+    // `String#<=>` answers nil for an operand that is not string-like.
+    expect(mn.compare(42)).toBe(undefined);
+    expect(mn.compare(null)).toBe(undefined);
   });
 
   it("match tests a regexp against the class name", () => {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -188,8 +188,8 @@ export class ModelName {
   /**
    * Implicit coercion hook so `String(mn)`, `` `${mn}` ``, `mn + ""` all work.
    *
-   * @noRailsEquivalent Ruby gets this from `Name`'s `to_str`; JS reads only
-   *   `Symbol.toPrimitive` when coercing an object to a string
+   * @noRailsEquivalent PERMANENT — Ruby gets this from `Name`'s `to_str`; JS
+   *   reads only `Symbol.toPrimitive` when coercing an object to a string
    */
   [Symbol.toPrimitive](_hint: string): string {
     return this.name;

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -3,21 +3,14 @@ import {
   pluralize,
   singularize,
   humanize,
-  Inflections,
-  Uncountables,
+  tableize,
+  demodulize,
+  isBlank,
   include,
   ToJsonWithActiveSupportEncoder,
   type Included,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "./attribute-assignment.js";
-
-function sameSegments(a: readonly string[] | null, b: readonly string[] | null): boolean {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
-}
 
 /**
  * Naming mixin — provides model_name on classes and naming helpers.
@@ -97,10 +90,8 @@ export interface ModelName {
 }
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ModelName {
-  /** Bare class name (no separators), e.g. `"Post"`. */
+  /** Rails' `@name` — the fully-qualified constant path, e.g. `"Blog::Post"`. */
   name: string;
-  /** Namespace segments from outermost to innermost; `null` if top-level. */
-  readonly namespace: readonly string[] | null;
 
   /** Snake-cased identifier with namespace joined by `_` — `"blog_post"`. */
   singular: string;
@@ -122,53 +113,34 @@ export class ModelName {
   /** I18n key in path form — `"blog/post"`. */
   i18nKey: string;
   /** Mirrors `ActiveModel::Name#uncountable?` (naming.rb:209-211). */
-  readonly isUncountable: boolean;
+  isUncountable: boolean;
 
   private _human: string;
   private _klass: ModelLike | null;
+  private _unnamespaced?: string;
 
   get cacheKey(): string {
     return this.collection;
   }
 
   /**
-   * Mirrors Rails `@name == other` (String#==). When comparing to
-   * another `ModelName`, both the bare name AND namespace segments
-   * must match — so `ModelName("Post")` and
-   * `ModelName("Post", { namespace: "Blog" })` are NOT equal. When
-   * comparing to a string, only `.name` is matched (a plain string
-   * can't express a namespace).
+   * Rails `delegate :==, to: :name` (naming.rb:151-152) — `String#==`. Ruby's
+   * `String#==` returns `other == self` when `other` responds to `to_str`,
+   * which is how two `Name`s compare equal (naming_test.rb:300).
    */
   equals(other: unknown): boolean {
-    if (other instanceof ModelName) {
-      if (this.name !== other.name) return false;
-      return sameSegments(this.namespace, other.namespace);
-    }
-    return typeof other === "string" && this.name === other;
+    if (other instanceof ModelName) return this.name === other.name;
+    return this.name === other;
   }
 
   /**
-   * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
-   * or `1`. Throws `ArgumentError` for non-string / non-ModelName
-   * arguments. For ModelName-to-ModelName, compares the full
-   * identity (name + namespace) so namespace-differing models sort
-   * distinctly; for ModelName-to-string, compares `.name` only.
+   * Rails `delegate :<=>, to: :name` (naming.rb:151-152) — `String#<=>`.
+   * `include Comparable` (naming.rb:10) builds the operators off it; TS has no
+   * operator overloading, so call sites spell them `compare(...) < 0` etc.
    */
-  compare(other: unknown): -1 | 0 | 1 {
-    if (other instanceof ModelName) {
-      // Single string compare over the full `::`-qualified constant path —
-      // matches Rails' `String#<=>` on `@name` (e.g. "Admin::Other" <
-      // "Blog::Post" by first segment, regardless of bare-name ordering).
-      const l = ModelName._qualified(this);
-      const r = ModelName._qualified(other);
-      if (l === r) return 0;
-      return l < r ? -1 : 1;
-    }
-    if (typeof other === "string") {
-      if (this.name === other) return 0;
-      return this.name < other ? -1 : 1;
-    }
-    throw new ArgumentError("comparison of ModelName with non-string failed");
+  compare(other: string | ModelName): number {
+    const name = String(other);
+    return this.name === name ? 0 : this.name < name ? -1 : 1;
   }
 
   /**
@@ -206,18 +178,17 @@ export class ModelName {
   // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
   // ---------------------------------------------------------------------------
 
-  /**
-   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
-   * (naming.rb:131-152). Rails' `@name` is the full constant path
-   * (`"Blog::Post"`). TS class names carry no `::`, so we reconstruct the
-   * qualified path from the namespace segments in the constructor; `toString`
-   * returns that full path (`"Blog::Post"`) to match Rails.
-   */
+  /** Rails `delegate :to_s, :to_str, to: :name` (naming.rb:151-152). */
   toString(): string {
     return this.name;
   }
 
-  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
+  /**
+   * Implicit coercion hook so `String(mn)`, `` `${mn}` ``, `mn + ""` all work.
+   *
+   * @noRailsEquivalent Ruby gets this from `Name`'s `to_str`; JS reads only
+   *   `Symbol.toPrimitive` when coercing an object to a string
+   */
   [Symbol.toPrimitive](_hint: string): string {
     return this.name;
   }
@@ -235,144 +206,53 @@ export class ModelName {
   }
 
   /**
-   * Mirrors Rails `ActiveModel::Name#initialize`
-   * (activemodel/lib/active_model/naming.rb:166-185), same four positional
-   * arguments: `(klass, namespace = nil, name = nil, locale = :en)`.
+   * Mirrors Rails `ActiveModel::Name#initialize` (naming.rb:166-185), same four
+   * positional arguments: `(klass, namespace = nil, name = nil, locale = :en)`.
    *
-   * Rails derives the bare name from `klass.name` — the fully-qualified Ruby
-   * constant path — with `demodulize`. A JS class name carries no module
-   * path, so the demodulized name comes from the `_demodulizedName` carrier
-   * when the class has one, and the namespace is passed in as segments: a
-   * single string (`"Blog"`), a segment array (`["Admin", "Blog"]`), or a
-   * module-like object with a string `name` (`{ name: "Blog" }`).
-   *
-   * `klass` also accepts a bare name string. Ruby always has a class or module
-   * to pass, and reaches the same place with the `name` argument
-   * (`ActiveModel::Name.new(Class.new, nil, "Anonymous")`, naming_test.rb:295);
-   * the string arm is that call spelled without the placeholder class, for a
-   * `ModelName` built with no host class to walk for I18n lookup.
-   *
-   * Field math follows naming.rb:173-184 but operates on the namespace
-   * segments directly rather than round-tripping through a Ruby-shaped
-   * `::`-joined string — equivalent output, no Ruby-ism in TS code.
+   * Rails' `klass.name` is the fully-qualified constant path. A JS class name
+   * carries no module path, so the qualified name is reassembled from the
+   * `moduleName` / `_demodulizedName` carriers the model declares; `klass` also
+   * accepts that qualified name as a bare string, for a `ModelName` built with
+   * no host class to walk for I18n lookup.
    */
   constructor(
     klass: ModelLike | string,
-    namespace?:
-      | string
-      | readonly string[]
-      | { name: string; useRelativeModelNaming?: boolean }
-      | null,
-    name?: string,
-    /** Rails' fourth positional argument (naming.rb:166), `:en` by default. */
+    namespace: { name: string } | null = null,
+    name: string | null = null,
     locale = "en",
   ) {
-    this._klass = typeof klass === "string" ? null : klass;
-    name ??= typeof klass === "string" ? klass : (klass._demodulizedName ?? klass.name);
-    const rawNs = namespace ?? null;
-    const invalidNamespace = (): ArgumentError =>
-      new ArgumentError(
-        "namespace must be a non-blank string, an array of non-blank strings, or an object with a non-blank string `name`",
-      );
-    let segments: string[];
-    let isolated = false;
-    if (rawNs == null) {
-      segments = [];
-    } else if (typeof rawNs === "string") {
-      segments = [rawNs];
-    } else if (Array.isArray(rawNs)) {
-      if (!rawNs.every((s) => typeof s === "string")) throw invalidNamespace();
-      segments = [...rawNs];
-    } else if (
-      typeof rawNs === "object" &&
-      typeof (rawNs as { name?: unknown }).name === "string"
-    ) {
-      segments = [(rawNs as { name: string }).name];
-      // naming.rb:271-276 — `model_name` passes a `namespace` only for a module
-      // that answers `use_relative_model_naming?` truthily, and naming.rb:171
-      // `@unnamespaced` (hence the prefix-dropped `param_key`/`route_key`) is
-      // derived only when that argument is present.
-      isolated = (rawNs as { useRelativeModelNaming?: boolean }).useRelativeModelNaming === true;
-    } else {
-      throw invalidNamespace();
-    }
-    // Trim + reject blank segments. `underscore("")` and `underscore(" ")`
-    // leak through as empty / whitespace tails, which would produce invalid
-    // identifiers in `singular`, `collection`, `i18nKey`.
-    segments = segments.map((s) => s.trim());
-    if (segments.some((s) => s.length === 0)) throw invalidNamespace();
+    this.name =
+      name ??
+      (typeof klass === "string"
+        ? klass
+        : (klass as { moduleName?: string }).moduleName
+          ? `${(klass as { moduleName?: string }).moduleName}::${klass._demodulizedName ?? klass.name}`
+          : (klass._demodulizedName ?? klass.name));
 
-    // Rails' `@name.blank?` guard — anonymous class without an explicit name.
-    if (!name || !name.trim()) {
+    if (isBlank(this.name))
       throw new ArgumentError(
         "Class name cannot be blank. You need to supply a name argument when anonymous class given",
       );
+
+    if (namespace) {
+      const prefix = `${namespace.name}::`;
+      this._unnamespaced = this.name.startsWith(prefix)
+        ? this.name.slice(prefix.length)
+        : this.name;
     }
-    // Reject Ruby-style separators. TS classes don't carry `::` in their
-    // `.name`, so presence here means a caller pasted a Ruby-shaped
-    // string — point them at the right option.
-    const hasRubySeparator = (s: string): boolean => s.includes("::");
-    if (hasRubySeparator(name) || segments.some(hasRubySeparator)) {
-      throw new ArgumentError(
-        'ModelName arguments must not contain "::" — pass namespace segments as the namespace argument (string, string[], or { name: string })',
-      );
-    }
-
-    // Rails `@name = name || klass.name` keeps the fully-qualified constant
-    // path (`"Admin::User"`). JS class names carry no `::`, so reconstruct the
-    // qualified name from the namespace segments plus the bare name.
-    this.name = segments.length > 0 ? [...segments, name].join("::") : name;
-    this.namespace = segments.length > 0 ? Object.freeze([...segments]) : null;
-
-    const bareUnderscored = underscore(name);
-    const segmentsUnderscored = segments.map(underscore);
-
-    // Rails `@singular = _singularize(@name)` flattens the path separator
-    // to `_`; with the namespace segments split out we equivalently join
-    // the underscored segments with `_`. Pre-segmented input lets us
-    // skip an explicit `_singularize(name)` here without changing the
-    // result. (`_singularize` is exposed below for parity with Rails.)
-    this.singular = [...segmentsUnderscored, bareUnderscored].join("_");
-    // Rails `@plural = pluralize(@singular)`.
-    this.plural = ModelName._uncountables(locale).isUncountable(this.singular)
-      ? this.singular
-      : pluralize(this.singular, locale);
-    const uncountable = this.plural === this.singular;
-    // Rails `@element = underscore(demodulize(@name))` — bare name only.
-    this.element = bareUnderscored;
+    this._klass = typeof klass === "string" ? null : klass;
+    this.singular = this._singularize(this.name);
+    this.plural = pluralize(this.singular, locale);
+    this.isUncountable = this.plural === this.singular;
+    this.element = underscore(demodulize(this.name));
     this._human = humanize(this.element);
-    // Rails `@collection = tableize(@name)` — path form, last segment
-    // pluralized. Derive the last segment from `this.plural` (rather than
-    // pluralizing the bare name independently) so any uncountable decision
-    // made above — via `ModelName._uncountables` or via activesupport's
-    // Inflector — applies identically here.
-    let collectionTail: string;
-    if (segmentsUnderscored.length === 0) {
-      collectionTail = this.plural;
-    } else {
-      const prefix = `${segmentsUnderscored.join("_")}_`;
-      collectionTail = this.plural.startsWith(prefix)
-        ? this.plural.slice(prefix.length)
-        : pluralize(bareUnderscored, locale);
-    }
-    this.collection = [...segmentsUnderscored, collectionTail].join("/");
-    // Rails `@param_key = namespace ? _singularize(@unnamespaced) : @singular`
-    // (naming.rb:180). `@unnamespaced` is the name with the isolated
-    // namespace's prefix removed (naming.rb:171), which is the bare element
-    // for a one-segment namespace.
-    this.paramKey = isolated ? this.element : this.singular;
-    // Rails `@i18n_key = @name.underscore.to_sym` — path form with bare name.
-    this.i18nKey = [...segmentsUnderscored, bareUnderscored].join("/");
-    // Rails `@route_key = namespace ? pluralize(@param_key) : @plural.dup`.
-    let routeKey = isolated ? pluralize(this.paramKey, locale) : this.plural;
-    // naming.rb:182-184 — `singular_route_key` singularizes the route key
-    // BEFORE the uncountable `_index` suffix is appended, so an uncountable
-    // model's singular route key stays `"sheep"`, not `"sheep_index"`.
-    this.singularRouteKey = singularize(routeKey, locale);
-    if (uncountable) routeKey = `${routeKey}_index`;
-    this.routeKey = routeKey;
-    // naming.rb:175 `@uncountable = @plural == @singular`.
-    this.isUncountable = uncountable;
+    this.collection = tableize(this.name);
+    this.paramKey = namespace ? this._singularize(this._unnamespaced!) : this.singular;
+    this.i18nKey = underscore(this.name);
+
+    this.routeKey = namespace ? pluralize(this.paramKey, locale) : this.plural;
+    this.singularRouteKey = singularize(this.routeKey, locale);
+    if (this.isUncountable) this.routeKey += "_index";
   }
 
   human(options: TranslateOptions = {}): string {
@@ -434,24 +314,7 @@ export class ModelName {
     return typeof klassScope === "string" ? [klassScope, "models"] : [];
   }
 
-  // Uncountable lookup delegates to `@blazetrails/activesupport`'s
-  // `Inflections.instance(locale)` — the same store Rails models go
-  // through via `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
-  // (activesupport/lib/active_support/inflections.rb). Previously we
-  // maintained a local 6-word set that ignored user-added inflections
-  // and diverged from activesupport's own pluralize() which uses the
-  // shared store.
-  private static _uncountables(locale: string): Uncountables {
-    return Inflections.instance(locale).uncountables;
-  }
-
   private _cachedI18nKeys?: string[];
-
-  private static _qualified(mn: ModelName): string {
-    // `name` is already the full `::`-qualified constant path, so it doubles as
-    // the single-string sort key Rails' `String#<=>` compares.
-    return mn.name;
-  }
 }
 
 include(ModelName, ToJsonWithActiveSupportEncoder);

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -142,12 +142,20 @@ export class ModelName {
   }
 
   /**
-   * Rails `delegate :<=>, to: :name` (naming.rb:151-152) — `String#<=>`.
+   * Rails `delegate :<=>, to: :name` (naming.rb:151-152) — `String#<=>`, which
+   * answers `nil` for an operand that is neither a String nor `to_str`-able
+   * (naming.rb:50-62 documents the String-operand contract). `nil` is spelled
+   * `undefined`, the repo's settled spelling for an incomparable spaceship
+   * (`activerecord/src/core.ts`'s `compare`).
+   *
    * `include Comparable` (naming.rb:10) builds the operators off it; TS has no
    * operator overloading, so call sites spell them `compare(...) < 0` etc.
    */
-  compare(other: string | ModelName): number {
-    const name = String(other);
+  compare(other: unknown): number | undefined {
+    // `Name` answers `to_str`, so a `Name` operand takes String#<=>'s
+    // string-like arm rather than falling through to nil.
+    const name = other instanceof ModelName ? other.name : other;
+    if (typeof name !== "string") return undefined;
     return this.name === name ? 0 : this.name < name ? -1 : 1;
   }
 

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -71,6 +71,14 @@ import type { TranslateOptions } from "@blazetrails/i18n";
 /** @internal Mirrors ActiveModel::Name::MISSING_TRANSLATION */
 const MISSING_TRANSLATION = -(2 ** 60);
 
+/**
+ * The enclosing module path a Ruby `klass.name` already carries and a JS class
+ * name does not; declared by the model, read only by `ModelName`'s constructor.
+ */
+interface ModulePath {
+  readonly moduleName?: string;
+}
+
 export interface ModelLike {
   readonly name: string;
   /**
@@ -164,20 +172,6 @@ export class ModelName {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
-  //   include Comparable
-  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
-  //            :to_str, :as_json, to: :name
-  //
-  // JS can't overload operators, so we expose methods + the one coercion
-  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
-  // coercion only — `String(modelName)`, template literals, `modelName +
-  // ""`, and loose `==` against a string. It does NOT trigger on strict
-  // `===` / `Object.is` / matchers that use strict identity without
-  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
-  // ---------------------------------------------------------------------------
-
   /** Rails `delegate :to_s, :to_str, to: :name` (naming.rb:151-152). */
   toString(): string {
     return this.name;
@@ -221,13 +215,14 @@ export class ModelName {
     name: string | null = null,
     locale = "en",
   ) {
+    const constant = typeof klass === "string" ? null : (klass as ModelLike & ModulePath);
     this.name =
       name ??
-      (typeof klass === "string"
-        ? klass
-        : (klass as { moduleName?: string }).moduleName
-          ? `${(klass as { moduleName?: string }).moduleName}::${klass._demodulizedName ?? klass.name}`
-          : (klass._demodulizedName ?? klass.name));
+      (constant === null
+        ? (klass as string)
+        : constant.moduleName
+          ? `${constant.moduleName}::${constant._demodulizedName ?? constant.name}`
+          : (constant._demodulizedName ?? constant.name));
 
     if (isBlank(this.name))
       throw new ArgumentError(
@@ -240,7 +235,7 @@ export class ModelName {
         ? this.name.slice(prefix.length)
         : this.name;
     }
-    this._klass = typeof klass === "string" ? null : klass;
+    this._klass = constant;
     this.singular = this._singularize(this.name);
     this.plural = pluralize(this.singular, locale);
     this.isUncountable = this.plural === this.singular;

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Model } from "./index.js";
 import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
 import { NoMethodError } from "./attribute-assignment.js";
@@ -496,21 +495,6 @@ describe("SerializationTest", () => {
     // the subset that actually occurs in JS: BigInt → string, Date →
     // ISO8601 (so the hash form already contains strings, not Date
     // objects), and recursive coercion within arrays/objects.
-    it("asJson coerces bigint attributes to string (JSON.stringify-safe)", () => {
-      class Row extends Model {
-        static {
-          this.attribute("id", "big_integer");
-          this.attribute("name", "string");
-        }
-      }
-      const r = new Row({ id: "99999999999999999999", name: "row-1" });
-      const json = r.asJson();
-      // bigint attributes are coerced to decimal strings by coerceForJson.
-      expect(json["id"]).toBe("99999999999999999999");
-      expect(json["name"]).toBe("row-1");
-      // JSON.stringify now round-trips without throwing.
-      expect(() => JSON.stringify(json)).not.toThrow();
-    });
 
     it("asJson coerces Temporal attributes to ISO 8601 strings", () => {
       class Event extends Model {
@@ -520,14 +504,9 @@ describe("SerializationTest", () => {
       }
       const e = new Event({ startsAt: "2026-04-24T10:00:00.123456Z" });
       const json = e.asJson();
-      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.123456Z");
-    });
-
-    it("asJson preserves microsecond precision for Temporal.Instant", async () => {
-      const { coerceForJson } = await import("./serialization.js");
-      const i = instant("2026-04-24T10:00:00.123456Z");
-      const out = coerceForJson({ at: i }) as { at: unknown };
-      expect(out.at).toBe("2026-04-24T10:00:00.123456Z");
+      // `Time#as_json` renders at `ActiveSupport::JSON::Encoding.time_precision`
+      // (json.rb:200-208), which defaults to 3 (encoding.rb:135).
+      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.123Z");
     });
 
     it("asJson recurses into include: arrays and nested objects", () => {
@@ -609,137 +588,6 @@ describe("SerializationTest", () => {
       expect(typeof parsed.id).toBe("string");
       expect(parsed.id).toBe("4611686018427387904");
       expect(parsed.name).toBe("row-2");
-    });
-
-    it("coerceForJson maps null to null", async () => {
-      const { coerceForJson } = await import("./serialization.js");
-      const out = coerceForJson({ at: null }) as { at: unknown };
-      expect(out.at).toBe(null);
-    });
-
-    it("coerceForJson maps invalid Date to null (Date path still active during dual-typed window)", async () => {
-      const { coerceForJson } = await import("./serialization.js");
-      const out = coerceForJson({ at: new Date("not a date") }) as { at: unknown };
-      expect(out.at).toBe(null);
-    });
-
-    it("coerceForJson preserves shared references (no silent data loss)", async () => {
-      // `{ a: obj, b: obj }` — same object twice. Must not be treated
-      // as a cycle. Previously the WeakSet-based cycle guard would
-      // return null on the second occurrence; the in-progress/seen
-      // split now returns the memoized coerced result and preserves
-      // identity in the output.
-      const { coerceForJson } = await import("./serialization.js");
-      const shared = { kind: "tag", count: 5 };
-      const root = { a: shared, b: shared };
-      const out = coerceForJson(root) as { a: unknown; b: unknown };
-      expect(out.a).toEqual({ kind: "tag", count: 5 });
-      expect(out.b).toEqual({ kind: "tag", count: 5 });
-      expect(out.a).toBe(out.b); // same coerced reference
-    });
-
-    it("coerceForJson breaks true cycles (self-referential object → null)", async () => {
-      const { coerceForJson } = await import("./serialization.js");
-      const a: Record<string, unknown> = { name: "a" };
-      a.self = a; // cycle
-      const out = coerceForJson(a) as { name: string; self: unknown };
-      expect(out.name).toBe("a");
-      // Inner self-reference collapses to null so the result stays
-      // JSON.stringify-safe.
-      expect(out.self).toBe(null);
-      expect(() => JSON.stringify(out)).not.toThrow();
-    });
-
-    it("asJson terminates on model-through-model cycles (no stack overflow)", () => {
-      // A cycle modelA.ref → modelB → modelA would blow the stack if
-      // coerceForJson delegated to each Model's own asJson (each call
-      // resetting cycle state). Nested models arrive pre-flattened by
-      // serializableHash, so coerceForJson walks plain objects with
-      // shared cycle state.
-      class Node extends Model {
-        static {
-          this.attribute("name", "string");
-        }
-      }
-      const a = new Node({ name: "a" });
-      const b = new Node({ name: "b" });
-      setAssociationAccessors(a, { next: b });
-      setAssociationAccessors(b, { next: a });
-      // serializableHash only traverses associations that are
-      // explicitly included. Here we include "next" on `a`, so that
-      // association is serialized once; it won't keep traversing
-      // `b.next` unless a nested include is provided. So asJson emits
-      // a single hop and doesn't loop.
-      expect(() => a.asJson({ include: ["next"] })).not.toThrow();
-      const json = a.asJson({ include: ["next"] }) as { next: { name: string } };
-      expect(json.next.name).toBe("b");
-    });
-
-    it("coerceForJson breaks true cycles in arrays (self-containing)", async () => {
-      const { coerceForJson } = await import("./serialization.js");
-      const arr: unknown[] = [1, 2];
-      arr.push(arr); // cycle
-      const out = coerceForJson(arr) as unknown[];
-      expect(out[0]).toBe(1);
-      expect(out[1]).toBe(2);
-      expect(out[2]).toBe(null);
-      expect(() => JSON.stringify(out)).not.toThrow();
-    });
-
-    it("coerceForJson is safe against __proto__ prototype pollution", async () => {
-      // JSON.parse('{"__proto__": {"polluted": true}}') produces an own
-      // `__proto__` key. Naïve `out[k] = val` assignment would invoke
-      // `Object.prototype.__proto__`'s setter and mutate the output's
-      // prototype. `Object.defineProperty` treats it as a data key.
-      const { coerceForJson } = await import("./serialization.js");
-      const hostile = JSON.parse('{"__proto__": {"polluted": true}, "legit": 1}');
-      const out = coerceForJson(hostile) as Record<string, unknown>;
-      // Output's prototype should NOT be polluted.
-      expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
-      // Plain Object should still return polluted=undefined (sanity).
-      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
-      expect(out.legit).toBe(1);
-    });
-
-    it("coerceForJson maps undefined to null (matches Ruby nil → JSON null)", async () => {
-      // `JSON.stringify({ a: undefined })` silently drops the key,
-      // which would make an unset attribute disappear from output.
-      // Ruby `nil` serializes to JSON `null`, so we match that.
-      const { coerceForJson } = await import("./serialization.js");
-      const out = coerceForJson({ name: "x", missing: undefined, nested: [undefined, 1] }) as {
-        name: unknown;
-        missing: unknown;
-        nested: unknown[];
-      };
-      expect(out.missing).toBe(null);
-      expect(out.nested).toEqual([null, 1]);
-      expect(JSON.parse(JSON.stringify(out))).toEqual({
-        name: "x",
-        missing: null,
-        nested: [null, 1],
-      });
-    });
-
-    it("coerceForJson does not shell open class instances (no internal-field leak)", async () => {
-      // A raw Model instance reaching coerceForJson (e.g. as a direct
-      // attribute value) must NOT be walked via Object.entries — that
-      // would expose _attributes/_dirty/errors/etc. Instead, it passes
-      // through as the instance itself, and JSON.stringify will later
-      // invoke its toJSON() (which calls asJson with its own
-      // coerceForJson context).
-      const { coerceForJson } = await import("./serialization.js");
-      class Wrapper {
-        public internal = "hidden";
-        toJSON() {
-          return { kind: "wrapper" };
-        }
-      }
-      const w = new Wrapper();
-      const out = coerceForJson({ nested: w }) as { nested: unknown };
-      // Pass-through — still the class instance, not `{ internal: "..." }`.
-      expect(out.nested).toBe(w);
-      // JSON.stringify at the end invokes toJSON on the instance.
-      expect(JSON.parse(JSON.stringify(out))).toEqual({ nested: { kind: "wrapper" } });
     });
 
     it("asJson is idempotent on JSON-safe values", () => {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -584,9 +584,9 @@ function isSerializableCollection(value: unknown): value is Iterable<unknown> {
  * key may originate from user input — attribute names, include keys,
  * association names from a JSON-decoded options bag.
  *
- * @noRailsEquivalent Ruby's `hash[key] = value` always writes an entry; the JS
- *   assignment it ports invokes `Object.prototype`'s `__proto__` setter instead
- *   of writing one
+ * @noRailsEquivalent PERMANENT — Ruby's `hash[key] = value` always writes an
+ *   entry; the JS assignment it ports invokes `Object.prototype`'s `__proto__`
+ *   setter instead of writing one
  */
 function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
   Object.defineProperty(target, key, {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -1,4 +1,5 @@
-import { Temporal } from "@blazetrails/date";
+import { asJson } from "@blazetrails/activesupport";
+
 import { NoMethodError, RuntimeError } from "./attribute-assignment.js";
 
 /** Minimum shape required of a record object passed to serialization helpers. */
@@ -481,7 +482,7 @@ export function asJsonThenable(
   options: SerializeOptions,
 ): Record<string, unknown> {
   const finalize = (raw: unknown): Record<string, unknown> => {
-    const hash = coerceForJson(raw) as Record<string, unknown>;
+    const hash = asJson(raw) as Record<string, unknown>;
     if (root === false || root == null) return hash;
     return { [root === true ? element() : root]: hash };
   };
@@ -582,6 +583,10 @@ function isSerializableCollection(value: unknown): value is Iterable<unknown> {
  * setter and mutate the target's prototype chain. Used everywhere the
  * key may originate from user input — attribute names, include keys,
  * association names from a JSON-decoded options bag.
+ *
+ * @noRailsEquivalent Ruby's `hash[key] = value` always writes an entry; the JS
+ *   assignment it ports invokes `Object.prototype`'s `__proto__` setter instead
+ *   of writing one
  */
 function safeSet(target: Record<string, unknown>, key: string, value: unknown): void {
   Object.defineProperty(target, key, {
@@ -590,153 +595,6 @@ function safeSet(target: Record<string, unknown>, key: string, value: unknown): 
     enumerable: true,
     configurable: true,
   });
-}
-
-/**
- * Coerce a value into a JSON-safe shape, mirroring Rails'
- * `ActiveSupport::JSON.encode` → `Object#as_json` dispatch.
- *
- * Native `JSON.stringify` handles most primitives + Date
- * (`Date.prototype.toJSON()` → ISO 8601), but throws on `BigInt` and
- * emits nothing useful for non-enumerable types. Rails' encoder:
- *
- * - BigDecimal → string (to preserve precision)
- * - Time / Date / DateTime → ISO 8601 string
- * - Symbol → string (Ruby symbols are interned strings)
- *
- * We cover the JS analog:
- * - `bigint` → decimal string. Rails serializes large integers as JSON
- *   numbers because Ruby's Integer is arbitrary-precision and the JSON
- *   encoder handles them natively. JS `JSON.stringify` throws on bigint,
- *   and JS numbers lose precision above 2^53-1, so we emit a decimal
- *   string instead. Consumers that need the numeric value must parse
- *   with `BigInt(str)`.
- * - Temporal types → ISO 8601 string via `toJSON()`. Precision is
- *   native (no trailing-zero truncation for JSON consumers).
- * - Plain arrays / objects → recurse
- * - Everything else → pass through (numbers, strings, booleans, null)
- *
- * Does NOT delegate to nested `asJson()` / `toJSON()` methods. Rails'
- * `Object#as_json` dispatch is recursive from a single encoder, so
- * cycle tracking threads through every call. In our JS port
- * `Model#asJson` starts a fresh coerceForJson with new cycle state,
- * so re-entering through a Model's `asJson` would reset the guards
- * and stack-overflow on model-model cycles. Instead, Model instances
- * reach coerceForJson already pre-flattened by `serializableHash`
- * (via its include path at serialization.ts:88-104 for associations
- * and via the usual attribute read for scalars), so no delegation is
- * needed.
- *
- * Note on JS Symbols: we intentionally do NOT coerce. Ruby symbols
- * are interned-string identifiers (Rails' `:active ≈ "active"`). JS
- * `Symbol()` is a unique identity sigil — different concept. Coercing
- * would misrepresent it. `JSON.stringify` already drops symbol-valued
- * properties per spec, which correctly signals "this doesn't
- * serialize".
- */
-export function coerceForJson(value: unknown): unknown {
-  return _coerceForJson(value, new WeakMap(), new WeakSet());
-}
-
-/**
- * Internal recursion for `coerceForJson`. Threaded with shared cycle
- * state (`seen` for memoization, `inProgress` for self-recursion
- * detection) so the top-level entry point can keep a narrow public
- * signature.
- */
-function _coerceForJson(
-  value: unknown,
-  seen: WeakMap<object, unknown>,
-  inProgress: WeakSet<object>,
-): unknown {
-  // `null` is valid JSON. `undefined` is not — `JSON.stringify` silently
-  // drops object properties whose value is `undefined`, so an attribute
-  // that happens to be unset would just disappear from the output
-  // instead of appearing as `null` (matches Ruby `nil` mapping to JSON
-  // `null`). Normalize both to `null` at the top of the recursion.
-  if (value === null || value === undefined) return null;
-  if (typeof value === "bigint") return value.toString();
-  // Note: no JS `Symbol` handling. Ruby symbols are interned-string
-  // identifiers (`:active` ≈ "active"), which is why Rails
-  // `Symbol#as_json` returns the name. JS `Symbol()` is a unique
-  // identity sigil (well-known symbols, private keys) — coercing to
-  // its description would misrepresent its role. Leave symbols alone;
-  // `JSON.stringify` already drops them per spec, which correctly
-  // signals "this doesn't serialize".
-  // boundary: defensive ISO 8601 emission for any Date attribute value supplied
-  // by a custom (non-Temporal-cast) type. Invalid Dates coerce to null like
-  // Date#toJSON does, keeping asJson safe for downstream JSON.stringify.
-  if (value instanceof Date) {
-    if (Number.isNaN(value.getTime())) return null;
-    return value.toISOString();
-  }
-  if (
-    value instanceof Temporal.Instant ||
-    value instanceof Temporal.PlainDateTime ||
-    value instanceof Temporal.PlainDate ||
-    value instanceof Temporal.PlainTime ||
-    value instanceof Temporal.ZonedDateTime
-  ) {
-    // Temporal.prototype.toJSON() emits ISO 8601 with native precision.
-    return value.toJSON();
-  }
-  if (Array.isArray(value)) {
-    // True cycle: short-circuit to null (Rails' JSON encoder raises, but
-    // `null` is less hostile for accidental self-refs and JSON.stringify
-    // would also fail).
-    if (inProgress.has(value)) return null;
-    // Previously coerced: return the same coerced result so shared
-    // references preserve object identity in the output (avoids silent
-    // data loss on `{ a: obj, b: obj }`-shaped hashes).
-    if (seen.has(value)) return seen.get(value);
-    const out: unknown[] = [];
-    seen.set(value, out);
-    inProgress.add(value);
-    try {
-      for (const entry of value) {
-        out.push(_coerceForJson(entry, seen, inProgress));
-      }
-    } finally {
-      inProgress.delete(value);
-    }
-    return out;
-  }
-  if (typeof value === "object") {
-    // Only recurse into plain objects (no prototype, or
-    // `Object.prototype` directly). Class instances keep an opaque
-    // pass-through so their internals don't leak — e.g. a `Model`
-    // reached here as a raw attribute value would expose
-    // `_attributes`/`_dirty`/`errors` via `Object.entries`. For these,
-    // JSON.stringify will invoke the instance's own `toJSON()` at
-    // encode time, which is the right Rails-parity boundary.
-    const proto = Object.getPrototypeOf(value);
-    if (proto !== null && proto !== Object.prototype) return value;
-
-    if (inProgress.has(value)) return null;
-    if (seen.has(value)) return seen.get(value);
-    const v = value as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    seen.set(value, out);
-    inProgress.add(value);
-    try {
-      for (const [k, val] of Object.entries(v)) {
-        // Use defineProperty so an own `__proto__` key (common on
-        // JSON.parse output) is written as a data property rather than
-        // invoking `Object.prototype.__proto__`'s setter and polluting
-        // the output's prototype.
-        Object.defineProperty(out, k, {
-          value: _coerceForJson(val, seen, inProgress),
-          writable: true,
-          enumerable: true,
-          configurable: true,
-        });
-      }
-    } finally {
-      inProgress.delete(value);
-    }
-    return out;
-  }
-  return value;
 }
 
 /**

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -131,7 +131,7 @@ describe("Serializers::JSON host", () => {
     }
     const b = new Big();
     b._id = 9007199254740993n;
-    // Without coerceForJson, JSON.stringify(b.asJson()) would throw.
+    // Without `Numeric#as_json`, JSON.stringify(b.asJson()) would throw.
     expect(() => globalThis.JSON.stringify(b.asJson())).not.toThrow();
   });
 

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -143,7 +143,11 @@ export class JSON {
    */
   static get modelName(): ModelName {
     if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
-      const namespace = this.moduleName?.split("::");
+      // Rails walks `module_parents` for a module answering
+      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
+      // enclosing-module chain to walk, so nothing can declare relative naming
+      // and the detect answers nil.
+      const namespace = null;
       this._modelName = new ModelName(this, namespace);
     }
     return this._modelName;

--- a/packages/activesupport/src/core-ext/object/json.trails.test.ts
+++ b/packages/activesupport/src/core-ext/object/json.trails.test.ts
@@ -25,6 +25,35 @@ describe("asJson (TypeScript-only arms)", () => {
     expect(JSON.stringify(asJson({ id: 12n }))).toBe('{"id":"12"}');
   });
 
+  it("Hash#as_json and Array#as_json answer null for a true cycle", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    const out = asJson(a) as { name: string; self: unknown };
+    expect(out.name).toBe("a");
+    expect(out.self).toBe(null);
+    expect(() => JSON.stringify(out)).not.toThrow();
+
+    const arr: unknown[] = [1, 2];
+    arr.push(arr);
+    expect(asJson(arr)).toEqual([1, 2, null]);
+  });
+
+  it("a repeated reference is not a cycle and answers the same result", () => {
+    const shared = { kind: "tag", count: 5 };
+    const out = asJson({ a: shared, b: shared }) as { a: unknown; b: unknown };
+    expect(out.a).toEqual({ kind: "tag", count: 5 });
+    expect(out.a).toBe(out.b);
+  });
+
+  it("cycle state does not leak between top-level calls", () => {
+    const shared = { kind: "tag" };
+    const first = asJson({ a: shared }) as { a: unknown };
+    const second = asJson({ a: shared }) as { a: unknown };
+    expect(first.a).toEqual({ kind: "tag" });
+    expect(second.a).toEqual({ kind: "tag" });
+    expect(second.a).not.toBe(first.a);
+  });
+
   it("Hash#as_json writes __proto__ as an entry, not as the result's prototype", () => {
     const hostile = JSON.parse('{"__proto__": {"polluted": true}, "legit": 1}') as object;
     const out = asJson(hostile) as Record<string, unknown>;

--- a/packages/activesupport/src/core-ext/object/json.trails.test.ts
+++ b/packages/activesupport/src/core-ext/object/json.trails.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { asJson } from "./json.js";
+
+// TS-only arms of `core_ext/object/json.rb`: the three places where Ruby's
+// answer is not directly encodable by `JSON.stringify`.
+describe("asJson (TypeScript-only arms)", () => {
+  it("NilClass#as_json answers null for undefined as well as null", () => {
+    // `JSON.stringify({ a: undefined })` drops the key entirely, which would
+    // make an unset attribute vanish instead of encoding as Ruby's `nil`.
+    expect(asJson(undefined)).toBe(null);
+    expect(asJson(null)).toBe(null);
+    expect(asJson({ name: "x", missing: undefined, nested: [undefined, 1] })).toEqual({
+      name: "x",
+      missing: null,
+      nested: [null, 1],
+    });
+  });
+
+  it("Numeric#as_json answers a bigint's decimal digits as a string", () => {
+    // `JSON.stringify` throws on a BigInt, and a JS number loses precision
+    // above 2^53-1, so the digits survive as a string.
+    expect(asJson(99999999999999999999n)).toBe("99999999999999999999");
+    expect(asJson({ id: 12n })).toEqual({ id: "12" });
+    expect(JSON.stringify(asJson({ id: 12n }))).toBe('{"id":"12"}');
+  });
+
+  it("Hash#as_json writes __proto__ as an entry, not as the result's prototype", () => {
+    const hostile = JSON.parse('{"__proto__": {"polluted": true}, "legit": 1}') as object;
+    const out = asJson(hostile) as Record<string, unknown>;
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(out.legit).toBe(1);
+  });
+});

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -181,7 +181,8 @@ export class Range {
  * it is filled, so a second reference to the same value answers the same
  * result) and `leave()` closes it.
  *
- * @noRailsEquivalent Ruby's recursion has no guard: a cyclic structure raises
+ * @noRailsEquivalent PERMANENT — Ruby's recursion has no guard: a cyclic
+ *   structure raises
  *   SystemStackError, which a caller can rescue and which leaves the process
  *   usable. A JS RangeError from the same recursion unwinds a native stack the
  *   engine gives no comparable recovery for, so a cycle answers `nil` — the

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -158,7 +158,7 @@ export class Regexp {
  * a `Set`, a generator — and `[...value]` is its `to_a`.
  */
 export class Enumerable {
-  static asJson(value: Iterable<unknown>, options?: EncodeOptions | null): unknown[] {
+  static asJson(value: Iterable<unknown>, options?: EncodeOptions | null): unknown[] | null {
     return Array.asJson([...value], options);
   }
 }
@@ -172,14 +172,65 @@ export class Range {
   }
 }
 
-/** `Array#as_json` (json.rb:163-172). */
+/**
+ * Cycle bookkeeping for the `Array#as_json` / `Hash#as_json` recursion above —
+ * Ruby's `v.as_json` at json.rb:167 and :192-194.
+ *
+ * `null` means the value is already being built one frame up, i.e. a true
+ * cycle; otherwise the frame hands back the container to fill (memoized before
+ * it is filled, so a second reference to the same value answers the same
+ * result) and `leave()` closes it.
+ *
+ * @noRailsEquivalent Ruby's recursion has no guard: a cyclic structure raises
+ *   SystemStackError, which a caller can rescue and which leaves the process
+ *   usable. A JS RangeError from the same recursion unwinds a native stack the
+ *   engine gives no comparable recovery for, so a cycle answers `nil` — the
+ *   value Ruby's own `NilClass#as_json` would have produced for the absent
+ *   branch — rather than felling the encode
+ */
+function enterCycle(value: object): CycleFrame | null {
+  if (inProgress.has(value)) return null;
+  if (memo.has(value)) return { claim: () => memo.get(value), leave: () => {} } as CycleFrame;
+  inProgress.add(value);
+  depth += 1;
+  return {
+    claim: (container) => {
+      memo.set(value, container);
+      return container;
+    },
+    leave: () => {
+      inProgress.delete(value);
+      depth -= 1;
+      if (depth === 0) memo = new WeakMap();
+    },
+  };
+}
+
+interface CycleFrame {
+  claim<T extends object>(container: T): T;
+  leave(): void;
+}
+
+let depth = 0;
+const inProgress = new WeakSet<object>();
+let memo = new WeakMap<object, unknown>();
+
+/**
+ * `Array#as_json` (json.rb:163-172). The `map` is guarded (see `enterCycle`) —
+ * a JS `RangeError` from a cyclic structure is not recoverable the way Ruby's
+ * `SystemStackError` is.
+ */
 export class Array {
-  static asJson(value: unknown[], options?: EncodeOptions | null): unknown[] {
-    if (options) {
-      return value.map((v) => asJson(v, options));
-    } else {
-      return value.map((v) => asJson(v));
+  static asJson(value: unknown[], options?: EncodeOptions | null): unknown[] | null {
+    const frame = enterCycle(value);
+    if (frame === null) return null;
+    const result = frame.claim<unknown[]>([]);
+    try {
+      for (const v of value) result.push(options ? asJson(v, options) : asJson(v));
+    } finally {
+      frame.leave();
     }
+    return result;
   }
 }
 
@@ -193,7 +244,7 @@ export class Array {
  * index signature on `EncodeOptions` lets one reach here.
  */
 export class Hash {
-  static asJson(value: unknown, options?: EncodeOptions | null): Record<string, unknown> {
+  static asJson(value: unknown, options?: EncodeOptions | null): Record<string, unknown> | null {
     const entries =
       value instanceof Map
         ? [...value.entries()]
@@ -215,18 +266,24 @@ export class Hash {
       }
     }
 
-    // Ruby's `hash[key] = value` always writes an entry. A JS assignment to
-    // `__proto__` — an own key any `JSON.parse` output can carry — invokes
-    // `Object.prototype`'s accessor and reparents the result instead, so the
-    // write goes through `defineProperty` to stay a plain data entry.
-    const result: globalThis.Record<string, unknown> = {};
-    for (const [k, v] of subset) {
-      globalThis.Object.defineProperty(result, globalThis.String(k), {
-        value: options ? asJson(v, options) : asJson(v),
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      });
+    const frame = enterCycle(value as object);
+    if (frame === null) return null;
+    const result = frame.claim<globalThis.Record<string, unknown>>({});
+    try {
+      // Ruby's `hash[key] = value` always writes an entry. A JS assignment to
+      // `__proto__` — an own key any `JSON.parse` output can carry — invokes
+      // `Object.prototype`'s accessor and reparents the result instead, so the
+      // write goes through `defineProperty` to stay a plain data entry.
+      for (const [k, v] of subset) {
+        globalThis.Object.defineProperty(result, globalThis.String(k), {
+          value: options ? asJson(v, options) : asJson(v),
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      }
+    } finally {
+      frame.leave();
     }
     return result;
   }

--- a/packages/activesupport/src/core-ext/object/json.ts
+++ b/packages/activesupport/src/core-ext/object/json.ts
@@ -88,10 +88,15 @@ export class TrueClass {
   }
 }
 
-/** `NilClass#as_json` (json.rb:92-96). */
+/**
+ * `NilClass#as_json` (json.rb:92-96) — Ruby answers `nil` for its one absent
+ * value. JS has two, and `JSON.stringify` silently *drops* a property whose
+ * value is `undefined` rather than emitting `null`, so both absences answer
+ * `null` here to reach Ruby's single JSON form.
+ */
 export class NilClass {
-  static asJson(value: null | undefined): null | undefined {
-    return value;
+  static asJson(_value: null | undefined): null {
+    return null;
   }
 }
 
@@ -102,10 +107,19 @@ export class String {
   }
 }
 
-/** `Numeric#as_json` (json.rb:110-114). */
+/**
+ * `Numeric#as_json` (json.rb:110-114) — Ruby answers `self`, and its encoder
+ * renders an arbitrary-precision Integer as a JSON number.
+ *
+ * A JS `bigint` is the analogue of that Integer, but `JSON.stringify` throws
+ * `TypeError: Do not know how to serialize a BigInt` on one and a JS `number`
+ * loses precision above 2^53-1, so there is no way to answer `self` and stay
+ * encodable. It answers the decimal digits as a string instead; consumers
+ * recover the value with `BigInt(str)`.
+ */
 export class Numeric {
-  static asJson(value: number | bigint): number | bigint {
-    return value;
+  static asJson(value: number | bigint): number | string {
+    return typeof value === "bigint" ? value.toString() : value;
   }
 }
 
@@ -201,11 +215,18 @@ export class Hash {
       }
     }
 
+    // Ruby's `hash[key] = value` always writes an entry. A JS assignment to
+    // `__proto__` — an own key any `JSON.parse` output can carry — invokes
+    // `Object.prototype`'s accessor and reparents the result instead, so the
+    // write goes through `defineProperty` to stay a plain data entry.
     const result: globalThis.Record<string, unknown> = {};
-    if (options) {
-      for (const [k, v] of subset) result[globalThis.String(k)] = asJson(v, options);
-    } else {
-      for (const [k, v] of subset) result[globalThis.String(k)] = asJson(v);
+    for (const [k, v] of subset) {
+      globalThis.Object.defineProperty(result, globalThis.String(k), {
+        value: options ? asJson(v, options) : asJson(v),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     return result;
   }


### PR DESCRIPTION
Two RFC 0115 convergences in `activemodel`, both of the "second spelling of a Rails construct" shape.

## `ModelName` (naming.rb:166-185)

The constructor was 77 code lines against Rails' 20, because it inverted the argument shape: a bare class name plus namespace *segments to prepend*, with every field re-derived off those segments. It now runs Rails' statements over `@name`, the qualified constant path — `_singularize(@name)`, `underscore(demodulize(@name))`, `tableize(@name)`, `@name.underscore`, and `namespace` as Ruby's Module argument whose prefix `@unnamespaced` deletes (`naming.rb:171`). `moduleName` / `_demodulizedName` feed only the first statement, standing in for the module path a Ruby `klass.name` already carries; `Model.model_name` passes the `namespace` Rails passes (always nil — JS has no `module_parents` to walk).

Gone with it: `sameSegments`, `_qualified`, `_uncountables`, the `namespace` field, and the "must not contain `::`" guard — Rails names *do* contain `::`. `equals` / `compare` are now the `delegate :==, :<=>, to: :name` of `naming.rb:151-152`; `compare` is the repo's settled `<=>` spelling (`abstract_adapter.rb`'s `compare`).

`parity:api:extra` for `naming.ts`: **3 novel → 1** (`[Symbol.toPrimitive]`, tagged `@noRailsEquivalent`).

## `as_json` coercion

`coerceForJson` / `_coerceForJson` (63 lines) were a second port of ActiveSupport's `Object#as_json` family, which `activesupport/src/core-ext/object/json.ts` already carries in full. `asJsonThenable` now calls `asJson()`. The three cases only the activemodel copy covered moved to the Rails class each belongs to, with tests in `json.trails.test.ts`:

- `NilClass#as_json` answers `null` for `undefined` too — Ruby answers `nil` for its one absent value, and `JSON.stringify` *drops* an `undefined` property rather than emitting `null`.
- `Numeric#as_json` answers a bigint's decimal digits as a string — `JSON.stringify` throws on a BigInt and a JS number loses precision above 2^53-1.
- `Hash#as_json` writes through `defineProperty`, so an own `__proto__` key becomes an entry instead of reparenting the result.

`coerceForJson`'s row is gone from `parity:api:extra`.

### Two behaviours converge onto Rails

- `@collection` is `tableize(@name)`'s own inflection (`naming.rb:178`), not one derived from `@plural`. An uncountable registered on the `_`-joined singular no longer reaches the `/`-joined path form — as in Rails.
- `Time#as_json` renders at `Encoding.time_precision` (default 3, `encoding.rb:135`), not at full Temporal precision.

### Cycles

`Array#as_json`'s and `Hash#as_json`'s recursion (json.rb:167, :192-194) runs inside a frame that answers `nil` for a value already being built one frame up, and memoizes each container *before* filling it, so a repeated reference stays a repeated reference rather than degrading into a cycle. State releases when the outermost frame closes. Ruby has no such guard — a cycle raises `SystemStackError` — but a JS `RangeError` unwinds a native stack the engine gives no comparable recovery for, so the guard is tagged `@noRailsEquivalent PERMANENT` at the call site. Cycle, shared-reference, and no-leak-between-calls tests live in `json.trails.test.ts`.

### `ModelName#compare`

`compare` returns `number | undefined`. Rails delegates `<=>` to `@name`, and `String#<=>` answers `nil` for an operand that is neither a String nor `to_str`-able (naming.rb:151-152, contract documented at :50-62); `undefined` is the repo's settled spelling for an incomparable spaceship, per `activerecord/src/core.ts`'s `compare`. A `Name` operand still takes the string-like arm, since `Name` answers `to_str`.

## Verification

- `pnpm vitest run packages/activesupport/src packages/activemodel/src` — 6586 passed, 0 failed
- `packages/activerecord/src/{inheritance,inheritance-namespaced,i18n,serialization,json-serialization}.test.ts` — green
- `parity:api:extra` — `naming.ts` 1 novel (was 3), `core-ext/object/json.ts` 0 novel, `coerceForJson`'s row gone; permanence claims 0 unclassified
- `parity:api:calls` OK · `parity:api:calls:args` OK (no new rows, no reseed) · `pnpm lint` clean · `parity:api` / `parity:test` deltas non-negative

Closes-story: converge-model-name-constructor-and-comparable-surface
Closes-story: converge-serialization-json-coercion-onto-activesupport-as-json
