### PR TITLE
refactor(activerecord,activemodel): read class attribute_names off attribute_types and retire the stored provenance flag

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -32,10 +32,7 @@ export interface AttributeHostInternals {
   _cachedDefaultAttributes?: AttributeSet | null;
   _cachedAttributeTypes?: Record<string, Type> | null;
   _attributesBuilder?: unknown;
-  _attributeDefinitions?: Map<
-    string,
-    { name: string; type?: Type; virtual?: boolean; userProvidedDefault?: boolean }
-  >;
+  _attributeDefinitions?: Map<string, { name: string; type?: Type; virtual?: boolean }>;
   _pendingAttributeModifications?: PendingModification[];
   _attributeAliases?: Record<string, string>;
   /** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */
@@ -360,6 +357,47 @@ export function hookAttributeType(
   type: Type,
 ): Type {
   return type;
+}
+
+/**
+ * True when `name` was declared by user code — i.e. some class in the ancestry
+ * pushed a `PendingType` / `PendingDefault` for it through `attribute(...)`
+ * (attribute_registration.rb:53-72).
+ *
+ * @noRailsEquivalent CONVERGEABLE — retired by
+ * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
+ * Rails never has to ask: a user declaration lives only in
+ * the pending-modification queue and a reflected column lives only in
+ * `columns_hash`, so the two are already distinct records. trails' ActiveRecord
+ * re-registers reflected columns INTO `_attributeDefinitions` beside the user
+ * declarations, so the paths that must not clobber a declaration read the
+ * provenance back off the same queue Rails replays — rather than off a stored
+ * flag, which is the shape Rails has no counterpart for.
+ */
+export function pendingAttributeDeclarationQ(cls: AttributeHostInternals, name: string): boolean {
+  return collectPendingModifications(cls).some(
+    (modification) =>
+      (modification instanceof PendingType || modification instanceof PendingDefault) &&
+      modification.name === name,
+  );
+}
+
+/**
+ * True when user code declared a concrete *type* for `name` — Rails pushes a
+ * `PendingType` with a non-nil type only for `attribute(name, type)`, never for
+ * a default-only or bare re-declaration (attribute_registration.rb:12-18).
+ *
+ * @noRailsEquivalent CONVERGEABLE — same reason as
+ * {@link pendingAttributeDeclarationQ}; retired by
+ * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
+ */
+export function pendingAttributeTypeQ(cls: AttributeHostInternals, name: string): boolean {
+  return collectPendingModifications(cls).some(
+    (modification) =>
+      modification instanceof PendingType &&
+      modification.name === name &&
+      modification.type != null,
+  );
 }
 
 /** True while a PendingDecorator is replaying during materialization. @internal */

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -359,47 +359,6 @@ export function hookAttributeType(
   return type;
 }
 
-/**
- * True when `name` was declared by user code — i.e. some class in the ancestry
- * pushed a `PendingType` / `PendingDefault` for it through `attribute(...)`
- * (attribute_registration.rb:53-72).
- *
- * @noRailsEquivalent CONVERGEABLE — retired by
- * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
- * Rails never has to ask: a user declaration lives only in
- * the pending-modification queue and a reflected column lives only in
- * `columns_hash`, so the two are already distinct records. trails' ActiveRecord
- * re-registers reflected columns INTO `_attributeDefinitions` beside the user
- * declarations, so the paths that must not clobber a declaration read the
- * provenance back off the same queue Rails replays — rather than off a stored
- * flag, which is the shape Rails has no counterpart for.
- */
-export function pendingAttributeDeclarationQ(cls: AttributeHostInternals, name: string): boolean {
-  return collectPendingModifications(cls).some(
-    (modification) =>
-      (modification instanceof PendingType || modification instanceof PendingDefault) &&
-      modification.name === name,
-  );
-}
-
-/**
- * True when user code declared a concrete *type* for `name` — Rails pushes a
- * `PendingType` with a non-nil type only for `attribute(name, type)`, never for
- * a default-only or bare re-declaration (attribute_registration.rb:12-18).
- *
- * @noRailsEquivalent CONVERGEABLE — same reason as
- * {@link pendingAttributeDeclarationQ}; retired by
- * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
- */
-export function pendingAttributeTypeQ(cls: AttributeHostInternals, name: string): boolean {
-  return collectPendingModifications(cls).some(
-    (modification) =>
-      modification instanceof PendingType &&
-      modification.name === name &&
-      modification.type != null,
-  );
-}
-
 /** True while a PendingDecorator is replaying during materialization. @internal */
 export function isDecoratorReplay(): boolean {
   return _decoratorReplayDepth > 0;

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -32,20 +32,6 @@ export interface AttributeDefinition {
   defaultValue: unknown;
   virtual?: boolean;
   limit?: number | null;
-  /**
-   * Mirrors: the `user_provided_default:` keyword on
-   * `ActiveRecord::Attributes::ClassMethods#define_attribute`
-   * (activerecord/lib/active_record/attributes.rb:235-238), which Rails passes
-   * through to `define_default_attribute`'s `from_user:` and never stores.
-   * trails records it on the definition because schema reflection re-registers
-   * definitions and must not overwrite a user-declared one (model-schema.ts
-   * `ensureSchemaLoaded`).
-   *
-   * Optional for backwards compatibility with downstream consumers that
-   * construct `AttributeDefinition` directly. When absent, treated as
-   * `true` (user-authored).
-   */
-  userProvidedDefault?: boolean;
 }
 
 /**
@@ -90,13 +76,6 @@ export function _writeAttribute(
 export interface AttributeOptions {
   default?: unknown;
   virtual?: boolean;
-  /**
-   * Mirrors Rails' `user_provided_default:` keyword. Defaults to true —
-   * any call to `attribute(...)` is treated as user-authored. Internal
-   * schema-reflection paths pass `false` so user-declared attributes win
-   * on re-registration.
-   */
-  userProvidedDefault?: boolean;
   limit?: number | null;
   /**
    * PG type modifiers, forwarded to the registry as Rails' `**options` are:
@@ -142,7 +121,6 @@ export function attribute(
     typeName = undefined;
   }
   const typeProvided = typeName !== undefined;
-  const userProvidedDefault = options?.userProvidedDefault !== false;
   if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
     this._attributeDefinitions = new Map(this._attributeDefinitions);
   }
@@ -151,15 +129,10 @@ export function attribute(
   // PendingType `with_type` inheritance path); fall back to the value type only
   // when nothing is known about the attribute yet.
   // Rails' `attribute(name, ...)` forwards `**options` straight to the type
-  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the three
-  // keys consumed here — `default`, `virtual`, `user_provided_default` — are
-  // the ones Rails names explicitly, so only the rest reach the registry.
-  const {
-    default: _default,
-    virtual: _virtual,
-    userProvidedDefault: _upd,
-    ...typeOptions
-  } = options ?? {};
+  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the two keys
+  // consumed here — `default` and `virtual` — are the ones Rails names
+  // explicitly, so only the rest reach the registry.
+  const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
   const type = typeProvided
     ? typeName instanceof Type
       ? typeName
@@ -181,7 +154,6 @@ export function attribute(
     type,
     defaultValue,
     virtual: options?.virtual ?? existing?.virtual,
-    userProvidedDefault,
     ...(options?.limit != null ? { limit: options.limit } : {}),
   });
 

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -42,10 +42,7 @@ export {
   applyPendingAttributeModifications,
   isDecoratorReplay,
   pushPendingDecorator,
-  pushPendingDefault,
-  pushPendingType,
   resetDefaultAttributes,
-  resetDefaultAttributesBang,
 } from "./attribute-registration.js";
 export { Attributes } from "./attributes.js";
 export type { AttributeDefinition, AttributeOptions } from "./attributes.js";

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -41,8 +41,6 @@ export {
 export {
   applyPendingAttributeModifications,
   isDecoratorReplay,
-  PendingDefault,
-  PendingType,
   pushPendingDecorator,
   pushPendingDefault,
   pushPendingType,

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -41,8 +41,8 @@ export {
 export {
   applyPendingAttributeModifications,
   isDecoratorReplay,
-  pendingAttributeDeclarationQ,
-  pendingAttributeTypeQ,
+  PendingDefault,
+  PendingType,
   pushPendingDecorator,
   pushPendingDefault,
   pushPendingType,

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -41,8 +41,13 @@ export {
 export {
   applyPendingAttributeModifications,
   isDecoratorReplay,
+  pendingAttributeDeclarationQ,
+  pendingAttributeTypeQ,
   pushPendingDecorator,
+  pushPendingDefault,
+  pushPendingType,
   resetDefaultAttributes,
+  resetDefaultAttributesBang,
 } from "./attribute-registration.js";
 export { Attributes } from "./attributes.js";
 export type { AttributeDefinition, AttributeOptions } from "./attributes.js";

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -6,6 +6,9 @@
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],
+      "@blazetrails/activemodel/attribute-registration": [
+        "../../activemodel/src/attribute-registration.ts"
+      ],
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
       "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -648,24 +648,18 @@ export function pkAttribute(this: InstanceMethodHost, name: string): boolean {
 }
 
 interface AttributeNamesHost {
-  _attributeDefinitions: { keys(): Iterable<string>; has(name: string): boolean };
+  attributeTypes(): Record<string, unknown>;
   abstractClass?: boolean;
-  columnNames?(): string[];
   _schemaRevision?: number;
   _attributeNamesMemo?: { revision: number; names: readonly string[] };
 }
 
 /**
- * Returns the list of attribute names for the model class.
+ * Returns an array of column names as strings if it's not an abstract class and
+ * table exists. Otherwise it returns an empty array.
  *
  * Mirrors: ActiveRecord::AttributeMethods::ClassMethods#attribute_names
- *
- * Rails returns schema column order first, then any declared/virtual
- * attributes that aren't columns (attributes_test.rb "overloading properties
- * does not attribute method order"). A user `attribute :col` override keeps the
- * column's schema position rather than jumping to its declaration slot, so we
- * walk `column_names` first and append the non-column declarations in
- * declaration order.
+ * (attribute_methods.rb:236-242).
  */
 function classAttributeNames(this: AttributeNamesHost): string[] {
   // Rails' `@attribute_names ||= ...freeze` memo, own-property per class (a
@@ -693,20 +687,10 @@ function classAttributeNames(this: AttributeNamesHost): string[] {
     this._attributeNamesMemo = { revision: this._schemaRevision ?? 0, names: frozen };
     return frozen as string[];
   }
-  const declared = [...this._attributeDefinitions.keys()];
-  const columnNames = this.columnNames?.() ?? [];
-  let names: string[];
-  if (columnNames.length === 0) {
-    names = declared;
-  } else {
-    const columnSet = new Set(columnNames);
-    const orderedColumns = columnNames.filter((name) => this._attributeDefinitions.has(name));
-    const virtuals = declared.filter((name) => !columnSet.has(name));
-    names = [...orderedColumns, ...virtuals];
-  }
+  const names = Object.keys(this.attributeTypes());
   if (exists !== undefined) {
     const frozen = Object.freeze(names);
-    // Re-read the revision: `columnNames()` above can run the first sync
+    // Re-read the revision: `attributeTypes()` above can run the first sync
     // `loadSchema` → `applyColumnsHash`, which bumps it mid-call.
     this._attributeNamesMemo = { revision: this._schemaRevision ?? 0, names: frozen };
     return frozen as string[];

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -32,7 +32,10 @@ describe("ReadTest", () => {
       static defineMethodAttribute = Base.defineMethodAttribute;
       static setDefineMethodAttribute = Base.setDefineMethodAttribute;
       static attributeMethodsGenerated = isAttributeMethodsGenerated;
-      static attributeNames = ClassMethods.attributeNames;
+      // read_test.rb:22-24 overrides `attribute_names` with the literal array
+      // (its `attribute_types` is empty), so the fake does the same rather than
+      // routing through the real `attribute_names`, which reads attribute_types.
+      static attributeNames = () => ["one", "two", "three"];
       static _hasAttribute = ClassMethods._hasAttribute;
       static attributeTypes = () => ({});
       static aliasAttribute = Base.aliasAttribute;

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -32,9 +32,6 @@ describe("ReadTest", () => {
       static defineMethodAttribute = Base.defineMethodAttribute;
       static setDefineMethodAttribute = Base.setDefineMethodAttribute;
       static attributeMethodsGenerated = isAttributeMethodsGenerated;
-      // read_test.rb:22-24 overrides `attribute_names` with the literal array
-      // (its `attribute_types` is empty), so the fake does the same rather than
-      // routing through the real `attribute_names`, which reads attribute_types.
       static attributeNames = () => ["one", "two", "three"];
       static _hasAttribute = ClassMethods._hasAttribute;
       static attributeTypes = () => ({});

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,6 +13,9 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
+  pendingAttributeDeclarationQ,
+  pushPendingDefault,
+  pushPendingType,
   resetDefaultAttributes as amResetDefaultAttributes,
 } from "@blazetrails/activemodel";
 import { registerSubclass } from "@blazetrails/activesupport";
@@ -26,7 +29,6 @@ interface AttributeDefinition {
   name: string;
   type: Type;
   defaultValue?: unknown;
-  userProvidedDefault?: boolean;
   limit?: number | null;
   /** Declared via `attribute(name, type, { virtual: true })` — not DB-backed. */
   virtual?: boolean;
@@ -98,9 +100,25 @@ export function defineAttribute(
     name,
     type: castType,
     defaultValue: resolvedDefault ?? null,
-    userProvidedDefault,
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
+
+  // Rails forwards `user_provided_default:` to `define_default_attribute`'s
+  // `from_user:` and stores nothing (attributes.rb:229-238,277-291): a
+  // from_user default builds `Attribute::UserProvidedDefault`, otherwise
+  // `Attribute.from_database`. trails gets the same split by pushing the
+  // declaration onto the pending-modification queue only when it IS
+  // user-provided — `_defaultAttributes` then replays it with
+  // `with_user_default` (cast), while a `from_user: false` definition stays a
+  // bare column seed deserialized through its type.
+  if (userProvidedDefault) {
+    pushPendingType(this, name, castType);
+    // NO_DEFAULT is Rails' NO_DEFAULT_PROVIDED: `define_default_attribute`
+    // then only re-types the existing attribute, leaving its default alone.
+    if (defaultValue !== NO_DEFAULT) {
+      pushPendingDefault(this, name, resolvedDefault ?? null);
+    }
+  }
 
   amResetDefaultAttributes(this);
   // A newly declared attribute may be virtual (no DB column); force the next
@@ -190,29 +208,39 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     const columns = cachedColumnsHash(cacheHost);
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attributesHash = new Map<string, Attribute>();
-    for (const [name, def] of defs) {
+    // Rails seeds phase 1 from `columns_hash` alone (attributes.rb:241-245), so
+    // a real column keeps its schema position even when the class also declares
+    // an `attribute` override for it; the non-column declarations only enter the
+    // set through the phase-2 replay, i.e. after every column. Walk the defs in
+    // that same order — columns first, declarations-without-a-column after —
+    // which is the order `attribute_names` (attribute_methods.rb:236-242) reads
+    // back off `attribute_types`.
+    const orderedDefNames = [
+      ...Object.keys(columns).filter((name) => defs.has(name)),
+      ...[...defs.keys()].filter((name) => columns[name] === undefined),
+    ];
+    for (const name of orderedDefNames) {
+      const def = defs.get(name)!;
       const column = columns[name];
-      if ((def.userProvidedDefault ?? true) === false) {
+      if (column !== undefined || !pendingAttributeDeclarationQ(cacheHost, name)) {
+        // A real DB column — even one carrying a user type-override (an enum,
+        // `serialize`, `normalizes`, `encrypts`) — seeds from_database with the
+        // column's raw default through the REFLECTED column type, mirroring
+        // Rails' `columns_hash.transform_values { Attribute.from_database(...,
+        // type_for_column(connection, column)) }` (attributes.rb:241-245); the
+        // override is layered back on in phase 2, where decorators receive the
+        // reflected type as their `subtype` and an explicit
+        // `attribute(name, type)` PendingType still wins over the seed.
+        //
         // Seed from the BARE reflected column type, not `def.type` — trails
         // eagerly bakes decorations into `def.type` (a back-compat convenience
         // Rails lacks), and phase 2 replays those same decorators, so seeding
-        // from `def.type` applies each one twice.
+        // from `def.type` applies each one twice. `reflectedColumnType` is
+        // stashed by applyColumnsHash (model-schema.ts) where the adapter is in
+        // hand; fall back to the def's own type before the schema has reflected.
         const seedType = def.reflectedColumnType ?? def.type;
-        attributesHash.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, seedType));
-      } else if (column !== undefined) {
-        // User type-override on a real DB column (e.g. enum, serialize,
-        // normalizes, encryption): seed with the REFLECTED column type, not the
-        // override's own type, mirroring Rails' `type_for_column(connection,
-        // column)` seed (attributes.rb:241-245). The cached column carries the
-        // authoritative raw default; from_database deserializes it through the
-        // reflected type. The user override is layered back on in phase 2 —
-        // decorators receive the reflected type as their `subtype`, and an
-        // explicit `attribute(name, type)` PendingType still wins over the seed.
-        // `reflectedColumnType` is stashed by applyColumnsHash (model-schema.ts)
-        // where the adapter is in hand; fall back to the def's own type before
-        // the schema has reflected.
-        const seedType = def.reflectedColumnType ?? def.type;
-        attributesHash.set(name, Attribute.fromDatabase(name, column.default ?? null, seedType));
+        const defaultValue = column !== undefined ? column.default : def.defaultValue;
+        attributesHash.set(name, Attribute.fromDatabase(name, defaultValue ?? null, seedType));
       } else if (def.defaultValue != null) {
         const base = Attribute.withCastValue(name, null, def.type);
         attributesHash.set(name, base.withUserDefault(def.defaultValue));

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -103,18 +103,13 @@ export function defineAttribute(
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
 
-  // Rails forwards `user_provided_default:` to `define_default_attribute`'s
-  // `from_user:` and stores nothing (attributes.rb:229-238,277-291): a
-  // from_user default builds `Attribute::UserProvidedDefault`, otherwise
-  // `Attribute.from_database`. trails gets the same split by pushing the
-  // declaration onto the pending-modification queue only when it IS
-  // user-provided — `_defaultAttributes` then replays it with
-  // `with_user_default` (cast), while a `from_user: false` definition stays a
-  // bare column seed deserialized through its type.
+  // Rails stores nothing for `user_provided_default:`; it forwards it to
+  // `define_default_attribute`'s `from_user:`, which picks the Attribute
+  // subclass (attributes.rb:229-238,277-291). Queueing the declaration only
+  // when it IS user-provided is that same fork: the replay applies
+  // `with_user_default` (cast), a `from_user: false` def stays a column seed.
   if (userProvidedDefault) {
     pushPendingType(this, name, castType);
-    // NO_DEFAULT is Rails' NO_DEFAULT_PROVIDED: `define_default_attribute`
-    // then only re-types the existing attribute, leaving its default alone.
     if (defaultValue !== NO_DEFAULT) {
       pushPendingDefault(this, name, resolvedDefault ?? null);
     }
@@ -208,13 +203,9 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     const columns = cachedColumnsHash(cacheHost);
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attributesHash = new Map<string, Attribute>();
-    // Rails seeds phase 1 from `columns_hash` alone (attributes.rb:241-245), so
-    // a real column keeps its schema position even when the class also declares
-    // an `attribute` override for it; the non-column declarations only enter the
-    // set through the phase-2 replay, i.e. after every column. Walk the defs in
-    // that same order — columns first, declarations-without-a-column after —
-    // which is the order `attribute_names` (attribute_methods.rb:236-242) reads
-    // back off `attribute_types`.
+    // Rails seeds phase 1 from `columns_hash` alone (attributes.rb:241-245) and
+    // the non-column declarations arrive with the phase-2 replay, so a column
+    // holds its schema position even under an `attribute` override.
     const orderedDefNames = [
       ...Object.keys(columns).filter((name) => defs.has(name)),
       ...[...defs.keys()].filter((name) => columns[name] === undefined),
@@ -223,21 +214,15 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
       const def = defs.get(name)!;
       const column = columns[name];
       if (column !== undefined || !pendingAttributeDeclarationQ(cacheHost, name)) {
-        // A real DB column — even one carrying a user type-override (an enum,
-        // `serialize`, `normalizes`, `encrypts`) — seeds from_database with the
-        // column's raw default through the REFLECTED column type, mirroring
-        // Rails' `columns_hash.transform_values { Attribute.from_database(...,
-        // type_for_column(connection, column)) }` (attributes.rb:241-245); the
-        // override is layered back on in phase 2, where decorators receive the
-        // reflected type as their `subtype` and an explicit
-        // `attribute(name, type)` PendingType still wins over the seed.
+        // Rails' `columns_hash.transform_values { Attribute.from_database(name,
+        // column.default, type_for_column(connection, column)) }`
+        // (attributes.rb:241-245) — a user type-override on a real column (an
+        // enum, `serialize`, `encrypts`) is layered back on in phase 2.
         //
         // Seed from the BARE reflected column type, not `def.type` — trails
         // eagerly bakes decorations into `def.type` (a back-compat convenience
         // Rails lacks), and phase 2 replays those same decorators, so seeding
-        // from `def.type` applies each one twice. `reflectedColumnType` is
-        // stashed by applyColumnsHash (model-schema.ts) where the adapter is in
-        // hand; fall back to the def's own type before the schema has reflected.
+        // from `def.type` applies each one twice.
         const seedType = def.reflectedColumnType ?? def.type;
         const defaultValue = column !== undefined ? column.default : def.defaultValue;
         attributesHash.set(name, Attribute.fromDatabase(name, defaultValue ?? null, seedType));

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,7 +13,6 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
-  pendingAttributeDeclarationQ,
   pushPendingDefault,
   pushPendingType,
   resetDefaultAttributes as amResetDefaultAttributes,
@@ -21,7 +20,12 @@ import {
 import { registerSubclass } from "@blazetrails/activesupport";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup, adapterNameFrom, type AdapterNameSource } from "./type.js";
-import { cachedColumnsHash, isSchemaLoaded, schemaStaleAgainstAncestors } from "./model-schema.js";
+import {
+  cachedColumnsHash,
+  isSchemaLoaded,
+  pendingAttributeDeclarationQ,
+  schemaStaleAgainstAncestors,
+} from "./model-schema.js";
 
 type AnyClass = any;
 

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,10 +13,16 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
-  pushPendingDefault,
-  pushPendingType,
   resetDefaultAttributes as amResetDefaultAttributes,
 } from "@blazetrails/activemodel";
+// The pending queue is private on ActiveModel (attribute_registration.rb:77);
+// only `attribute` (:17) pushes onto it. `define_attribute` reaches the same
+// queue from ActiveRecord, so it imports the pushers off the defining module
+// rather than the package's public barrel.
+import {
+  pushPendingDefault,
+  pushPendingType,
+} from "@blazetrails/activemodel/attribute-registration";
 import { registerSubclass } from "@blazetrails/activesupport";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup, adapterNameFrom, type AdapterNameSource } from "./type.js";

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1461,8 +1461,6 @@ export class Base extends Model {
       // ancestor's schema defs. Those carry a `reflectedTable` that differs from
       // ours — trust none of them; reflect our own table instead.
       for (const [, def] of this._attributeDefinitions) {
-        // `reflectedTable` is stamped only by `applyColumnsHash`, so a def
-        // carrying one is schema-sourced by construction.
         const d = def as { reflectedTable?: string };
         if (typeof d.reflectedTable === "string" && d.reflectedTable !== thisTable) {
           foreignTable = true;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -134,7 +134,6 @@ import {
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
-  pendingAttributeDeclarationQ,
   resolveAliasNameIn,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
@@ -1485,7 +1484,7 @@ export class Base extends Model {
       const d = def as { virtual?: boolean };
       if (
         !d.virtual &&
-        (!pendingAttributeDeclarationQ(this as never, name) || !enumNames?.has(name))
+        (!ModelSchema.pendingAttributeDeclarationQ(this, name) || !enumNames?.has(name))
       ) {
         // The model declares its own attributes, but some may be virtual (no
         // backing DB column). Rails' `column_names` is always DB-sourced, so

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -134,6 +134,7 @@ import {
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
+  pendingAttributeDeclarationQ,
   resolveAliasNameIn,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
@@ -1460,12 +1461,10 @@ export class Base extends Model {
       // ancestor's schema defs. Those carry a `reflectedTable` that differs from
       // ours — trust none of them; reflect our own table instead.
       for (const [, def] of this._attributeDefinitions) {
-        const d = def as { userProvidedDefault?: boolean; reflectedTable?: string };
-        if (
-          d.userProvidedDefault === false &&
-          typeof d.reflectedTable === "string" &&
-          d.reflectedTable !== thisTable
-        ) {
+        // `reflectedTable` is stamped only by `applyColumnsHash`, so a def
+        // carrying one is schema-sourced by construction.
+        const d = def as { reflectedTable?: string };
+        if (typeof d.reflectedTable === "string" && d.reflectedTable !== thisTable) {
           foreignTable = true;
           break;
         }
@@ -1485,8 +1484,11 @@ export class Base extends Model {
 
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
     for (const [name, def] of this._attributeDefinitions) {
-      const d = def as { virtual?: boolean; userProvidedDefault?: boolean };
-      if (!d.virtual && (d.userProvidedDefault === false || !enumNames?.has(name))) {
+      const d = def as { virtual?: boolean };
+      if (
+        !d.virtual &&
+        (!pendingAttributeDeclarationQ(this as never, name) || !enumNames?.has(name))
+      ) {
         // The model declares its own attributes, but some may be virtual (no
         // backing DB column). Rails' `column_names` is always DB-sourced, so
         // reconcile against the real columns and flag those as virtual — keeping

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -171,7 +171,6 @@ export class EncryptableRecord {
         name,
         type: encryptedType,
         defaultValue: existingDef?.defaultValue ?? null,
-        userProvidedDefault: existingDef?.userProvidedDefault ?? false,
         ...(existingDef?.limit != null ? { limit: existingDef.limit } : {}),
       });
     }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -6,6 +6,7 @@ import {
   IntegerType,
   Type,
   isDecoratorReplay,
+  pendingAttributeTypeQ,
 } from "@blazetrails/activemodel";
 import { lookup as arTypeLookup } from "./type.js";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
@@ -152,17 +153,10 @@ export function installEnumAttribute(
   // present (attribute_registration.rb:12-18); a default-only / type-less
   // attribute keeps the fallback `value` type until the column reflects, so its
   // subtype must still come from the column (enum decorates the column type,
-  // enum.rb:238-248). Requiring a user-provided def AND a concrete type
-  // distinguishes the two: the `value` default's `type()` is nil (like Rails'
-  // `Value#type`), so a default-only attribute reads as `existingTypeName ==
-  // null` and is treated as column-reflected.
-  const existingDef = (klass as any)._attributeDefinitions?.get(resolved);
-  const existingTypeName =
-    typeof existingDef?.type?.type === "function" ? existingDef.type.type() : undefined;
-  const explicitlyTyped =
-    existingDef !== undefined &&
-    (existingDef.userProvidedDefault ?? true) &&
-    existingTypeName != null;
+  // enum.rb:238-248). Reading the pending queue for a `PendingType` carrying
+  // a concrete type distinguishes the two exactly as Rails does: a default-only
+  // attribute pushes no typed `PendingType`, so it reads as column-reflected.
+  const explicitlyTyped = pendingAttributeTypeQ(klass as never, resolved);
   const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -6,7 +6,6 @@ import {
   IntegerType,
   Type,
   isDecoratorReplay,
-  pendingAttributeTypeQ,
 } from "@blazetrails/activemodel";
 import { lookup as arTypeLookup } from "./type.js";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
@@ -14,7 +13,12 @@ import { getOrCreateModuleCarrier } from "./module-carrier.js";
 import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
 // The synchronous schema reflector (warm-cache path), NOT the async
 // `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
-import { loadSchema as reflectSchemaSync, ownProp, type SchemaHost } from "./model-schema.js";
+import {
+  loadSchema as reflectSchemaSync,
+  ownProp,
+  pendingAttributeTypeQ,
+  type SchemaHost,
+} from "./model-schema.js";
 
 /** Value a label can map to — matches Rails' hash-value support for enums. */
 type EnumValue = number | string | boolean | null;
@@ -154,7 +158,7 @@ export function installEnumAttribute(
   // attribute keeps the fallback `value` type until the column reflects, so its
   // subtype must still come from the column (enum decorates the column type,
   // enum.rb:238-248) — so the pending queue answers this as Rails asks it.
-  const explicitlyTyped = pendingAttributeTypeQ(klass as never, resolved);
+  const explicitlyTyped = pendingAttributeTypeQ(klass, resolved);
   const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -153,9 +153,7 @@ export function installEnumAttribute(
   // present (attribute_registration.rb:12-18); a default-only / type-less
   // attribute keeps the fallback `value` type until the column reflects, so its
   // subtype must still come from the column (enum decorates the column type,
-  // enum.rb:238-248). Reading the pending queue for a `PendingType` carrying
-  // a concrete type distinguishes the two exactly as Rails does: a default-only
-  // attribute pushes no typed `PendingType`, so it reads as column-reflected.
+  // enum.rb:238-248) — so the pending queue answers this as Rails asks it.
   const explicitlyTyped = pendingAttributeTypeQ(klass as never, resolved);
   const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { ValueType, pendingAttributeDeclarationQ, typeRegistry } from "@blazetrails/activemodel";
+import { ValueType, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
-import { loadSchemaFromAdapter } from "./model-schema.js";
+import { loadSchemaFromAdapter, pendingAttributeDeclarationQ } from "./model-schema.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { ValueType, typeRegistry } from "@blazetrails/activemodel";
+import { ValueType, pendingAttributeDeclarationQ, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
@@ -55,8 +55,7 @@ describe("loadSchemaFromAdapter", () => {
     const guid = Model._attributeDefinitions.get("guid");
     const payload = Model._attributeDefinitions.get("payload");
     expect(guid?.type.name).toBe("uuid");
-    expect(guid?.userProvidedDefault).toBe(false);
-    expect(guid?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(false);
     expect(payload?.type.name).toBe("jsonb");
   });
 
@@ -69,8 +68,7 @@ describe("loadSchemaFromAdapter", () => {
 
     const def = Model._attributeDefinitions.get("guid");
     expect(def?.type.name).toBe("string");
-    expect(def?.userProvidedDefault).toBe(true);
-    expect(def?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(true);
   });
 
   it("is a no-op for abstract classes", async () => {
@@ -126,7 +124,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(Model._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(false);
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
@@ -143,7 +141,7 @@ describe("loadSchemaFromAdapter", () => {
 
     const def = Model._attributeDefinitions.get("mystery");
     expect(def?.type).toBeInstanceOf(typeRegistry.lookup("value").constructor);
-    expect(def?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Model, "mystery")).toBe(false);
   });
 
   it("invalidates the _attributesBuilder cache", async () => {
@@ -219,7 +217,7 @@ describe("loadSchemaFromAdapter integration details", () => {
 
     // User-declared def survives ignoredColumns.
     expect(Post._attributeDefinitions.has("age")).toBe(true);
-    expect(Post._attributeDefinitions.get("age")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Post, "age")).toBe(true);
     // Accessor stripped.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
   });
@@ -240,31 +238,6 @@ describe("loadSchemaFromAdapter integration details", () => {
     expect((Post as unknown as { _columns: unknown })._columns).toBeUndefined();
   });
 
-  it("treats externally-constructed defs without userProvided as user-authored (no overwrite)", async () => {
-    class Post extends Base {
-      static override tableName = "posts";
-    }
-    // Simulate a downstream-style def that predates the userProvidedDefault field.
-    (Post as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
-      new Map([
-        [
-          "guid",
-          {
-            name: "guid",
-            type: typeRegistry.lookup("string"),
-            defaultValue: null,
-          },
-        ],
-      ]);
-
-    const adapter = makeAdapter({ guid: { sqlType: "uuid" } }, { uuid: new UuidType() });
-    (Post as unknown as { adapter: unknown }).adapter = adapter;
-    await Post.loadSchema();
-
-    const def = Post._attributeDefinitions.get("guid");
-    expect(def?.type.name).toBe("string");
-  });
-
   it("does not shadow Base.prototype.id when reflecting an id column", async () => {
     class Post extends Base {
       static override tableName = "posts";
@@ -274,7 +247,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
-    expect(Post._attributeDefinitions.get("id")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Post, "id")).toBe(false);
 
     const rec = new Post();
     rec.writeAttribute("id", "abc-123");
@@ -324,26 +297,6 @@ describe("set adapter auto-loads schema", () => {
 
     const def = Post._attributeDefinitions.get("guid");
     expect(def?.type.name).toBe("uuid");
-    expect(def?.userProvidedDefault).toBe(false);
-  });
-});
-
-describe("attribute() userProvidedDefault option", () => {
-  it("defaults to userProvided=true (source=user)", () => {
-    class Foo extends Base {}
-    Foo.attribute("name", "string");
-    const def = Foo._attributeDefinitions.get("name");
-    expect(def?.userProvidedDefault).toBe(true);
-    expect(def?.userProvidedDefault).toBe(true);
-  });
-
-  it("sets userProvided=false when userProvidedDefault:false is passed", () => {
-    class Foo extends Base {}
-    Foo.attribute("name", "string", { userProvidedDefault: false } as {
-      userProvidedDefault?: boolean;
-    });
-    const def = Foo._attributeDefinitions.get("name");
-    expect(def?.userProvidedDefault).toBe(false);
-    expect(def?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
   });
 });

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { ValueType, pendingAttributeDeclarationQ } from "@blazetrails/activemodel";
+import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
-import { resetColumnInformation } from "./model-schema.js";
+import { pendingAttributeDeclarationQ, resetColumnInformation } from "./model-schema.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ValueType } from "@blazetrails/activemodel";
+import { ValueType, pendingAttributeDeclarationQ } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
@@ -33,7 +33,7 @@ describe("sync loadSchema / columnsHash", () => {
     const hash = Post.columnsHash();
 
     expect(hash.guid).toBe(cols.guid);
-    expect(Post._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
   });
 
   it("columnsHash filters ignoredColumns out of the cached hash", () => {
@@ -81,7 +81,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
     // The subclass's own map is its own — but the base reflects too: generating
     // Circle's attribute methods runs `superclass.define_attribute_methods
@@ -113,7 +113,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     // Reflection should have landed on the STI base via subclass adapter;
     // subclass shares the base's map reference.
-    expect(Shape._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Shape, "guid")).toBe(false);
     expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
@@ -164,7 +164,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
-    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
   });
 
   it("resetColumnInformation scrubs schema-sourced defs from a subclass-forked map", () => {
@@ -185,7 +185,6 @@ describe("sync loadSchema / columnsHash", () => {
             name: "guid",
             type: { name: "uuid" },
             defaultValue: null,
-            userProvidedDefault: false,
           },
         ],
       ]);
@@ -214,8 +213,8 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
-    expect(Circle._attributeDefinitions.get("radius")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
+    expect(pendingAttributeDeclarationQ(Circle, "radius")).toBe(true);
     expect(Shape._attributeDefinitions.has("radius")).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
   });
@@ -347,7 +346,7 @@ describe("sync loadSchema / columnsHash", () => {
     const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Shape.columnsHash();
-    expect(Shape._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
+    expect(pendingAttributeDeclarationQ(Shape, "guid")).toBe(false);
 
     (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
 
@@ -366,13 +365,13 @@ describe("sync loadSchema / columnsHash", () => {
     (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Post.columnsHash(); // triggers reflection
 
-    expect(Post._attributeDefinitions.get("guid")?.userProvidedDefault).toBe(false);
-    expect(Post._attributeDefinitions.get("title")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
+    expect(pendingAttributeDeclarationQ(Post, "title")).toBe(true);
 
     (resetColumnInformation as any).call(Post);
 
     expect(Post._attributeDefinitions.has("guid")).toBe(false);
-    expect(Post._attributeDefinitions.get("title")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Post, "title")).toBe(true);
   });
 
   // An internalSchemaCache that starts warm and tracks whether resetColumnInformation

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -984,11 +984,10 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   this._schemaLoaded = false;
   this._virtualAttributesReconciled = false;
   this._schemaRevision = nextSchemaEpoch();
-  // Mirrors ActiveRecord::Attributes' `reload_schema_from_cache` override
-  // (activerecord/lib/active_record/attributes.rb:268-271), which calls
-  // `reset_default_attributes!` before `super` — nilling BOTH
-  // `@default_attributes` and `@attribute_types`
-  // (activemodel/lib/active_model/attribute_registration.rb:96-99).
+  // ActiveRecord::Attributes overrides `reload_schema_from_cache` to call
+  // `reset_default_attributes!` before `super` (attributes.rb:268-271), which
+  // nils `@attribute_types` as well as `@default_attributes`
+  // (attribute_registration.rb:96-99).
   resetDefaultAttributesBang.call(this as never);
   (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   clearAttributeNamesMemo(this);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -5,6 +5,8 @@ import {
   Attribute,
   AttributeSetBuilder,
   YAMLEncoder,
+  pendingAttributeDeclarationQ,
+  resetDefaultAttributesBang,
   typeRegistry,
   type Type,
 } from "@blazetrails/activemodel";
@@ -963,8 +965,8 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
  * Rails where user-provided attributes survive reload.
  */
 function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
-  for (const [name, def] of Array.from(host._attributeDefinitions)) {
-    if ((def.userProvidedDefault ?? true) === false) {
+  for (const [name] of Array.from(host._attributeDefinitions)) {
+    if (!pendingAttributeDeclarationQ(host as never, name)) {
       host._attributeDefinitions.delete(name);
       if (Object.prototype.hasOwnProperty.call(host.prototype, name)) {
         delete host.prototype[name];
@@ -982,7 +984,12 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   this._schemaLoaded = false;
   this._virtualAttributesReconciled = false;
   this._schemaRevision = nextSchemaEpoch();
-  (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  // Mirrors ActiveRecord::Attributes' `reload_schema_from_cache` override
+  // (activerecord/lib/active_record/attributes.rb:268-271), which calls
+  // `reset_default_attributes!` before `super` — nilling BOTH
+  // `@default_attributes` and `@attribute_types`
+  // (activemodel/lib/active_model/attribute_registration.rb:96-99).
+  resetDefaultAttributesBang.call(this as never);
   (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   clearAttributeNamesMemo(this);
   if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
@@ -1140,15 +1147,14 @@ function applyColumnsHash(
   const filteredHash: Record<string, unknown> = {};
   for (const [name, column] of Object.entries(hash)) {
     if (ignored.has(name)) {
-      const existing = host._attributeDefinitions.get(name);
-      if (!existing || (existing.userProvidedDefault ?? true) === false) {
+      if (!pendingAttributeDeclarationQ(host as never, name)) {
         host._attributeDefinitions.delete(name);
       }
       continue;
     }
     filteredHash[name] = column;
     const existing = host._attributeDefinitions.get(name);
-    if (existing && (existing.userProvidedDefault ?? true)) {
+    if (existing && pendingAttributeDeclarationQ(host as never, name)) {
       // A user-declared type override (e.g. an enum) preserves its type across
       // reflection. The schema column's default is NOT merged onto the def;
       // `_defaultAttributes` seeds it via from_database directly from the cached
@@ -1190,7 +1196,6 @@ function applyColumnsHash(
       // `encrypts` on one column yields Encrypted(Serialized(Encrypted(...))).
       reflectedColumnType,
       defaultValue,
-      userProvidedDefault: false,
       ...(typeof host.tableName === "string" ? { reflectedTable: host.tableName } : {}),
       ...(colLimit != null ? { limit: colLimit } : {}),
       ...(colDefaultFunction != null ? { defaultFunction: colDefaultFunction } : {}),
@@ -1217,6 +1222,7 @@ function applyColumnsHash(
     _attributesBuilder?: unknown;
     _yamlEncoder?: unknown;
     _cachedDefaultAttributes?: unknown;
+    _cachedAttributeTypes?: unknown;
     _columnsHash?: unknown;
     _columns?: unknown;
   };
@@ -1224,6 +1230,7 @@ function applyColumnsHash(
   bag._attributesBuilder = undefined;
   bag._yamlEncoder = undefined;
   bag._cachedDefaultAttributes = null;
+  bag._cachedAttributeTypes = null;
   bag._columns = undefined;
   host._columnsHash = filteredHash;
 
@@ -1256,9 +1263,10 @@ function applyColumnsHash(
  * column so the cast type comes from the adapter (e.g. PG OID map) rather
  * than the generic ActiveModel type registry.
  *
- * Populates the schema cache if needed (async). User-declared attributes
- * (`userProvidedDefault: true`) are NEVER overwritten — matching Rails where
- * `attribute :foo, :bar` always wins over schema-reflected types.
+ * Populates the schema cache if needed (async). User-declared attributes —
+ * the ones carrying a pending `attribute(...)` modification — are NEVER
+ * overwritten, matching Rails where the pending replay runs after the column
+ * seed so `attribute :foo, :bar` always wins over the reflected type.
  *
  * @internal
  */
@@ -1426,7 +1434,7 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {
-    if ((def.userProvidedDefault ?? true) === false) continue;
+    if (!pendingAttributeDeclarationQ(host as never, name)) continue;
     const isVirtual = !real.has(name);
     if (!!def.virtual !== isVirtual) def.virtual = isVirtual;
   }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -5,7 +5,6 @@ import {
   Attribute,
   AttributeSetBuilder,
   YAMLEncoder,
-  resetDefaultAttributesBang,
   typeRegistry,
   type Type,
 } from "@blazetrails/activemodel";
@@ -1062,8 +1061,9 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   // ActiveRecord::Attributes overrides `reload_schema_from_cache` to call
   // `reset_default_attributes!` before `super` (attributes.rb:268-271), which
   // nils `@attribute_types` as well as `@default_attributes`
-  // (attribute_registration.rb:96-99).
-  resetDefaultAttributesBang.call(this as never);
+  // (attribute_registration.rb:96-99). Sent to `this`, the way Ruby sends an
+  // inherited private method — ActiveModel's `Model` defines the static.
+  (this as SchemaHost & { resetDefaultAttributesBang(): void }).resetDefaultAttributesBang();
   (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   clearAttributeNamesMemo(this);
   if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -4,8 +4,9 @@ import { pluralize, underscore } from "@blazetrails/activesupport";
 import {
   Attribute,
   AttributeSetBuilder,
+  PendingDefault,
+  PendingType,
   YAMLEncoder,
-  pendingAttributeDeclarationQ,
   resetDefaultAttributesBang,
   typeRegistry,
   type Type,
@@ -960,13 +961,72 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
 }
 
 /**
+ * Walk the ancestry's pending-modification queues, oldest ancestor first —
+ * the loop written out of `apply_pending_attribute_modifications`' `superclass`
+ * recursion (attribute_registration.rb:81-90). Reads the own queues directly
+ * rather than through `pending_attribute_modifications`, whose `||= []` would
+ * stamp an empty queue onto every ancestor it passes.
+ */
+function pendingAttributeModificationsInAncestry(host: unknown): unknown[] {
+  const queues: unknown[][] = [];
+  for (let klass = host; klass != null; klass = Object.getPrototypeOf(klass)) {
+    if (Object.prototype.hasOwnProperty.call(klass, "_pendingAttributeModifications")) {
+      queues.unshift(
+        (klass as { _pendingAttributeModifications: unknown[] })._pendingAttributeModifications,
+      );
+    }
+  }
+  return queues.flat();
+}
+
+/**
+ * True when `name` was declared by user code — some class in the ancestry
+ * queued a `PendingType` / `PendingDefault` for it through `attribute(...)`
+ * (attribute_registration.rb:53-72).
+ *
+ * @internal
+ * @noRailsEquivalent CONVERGEABLE — retired by
+ * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
+ * Rails never asks: a user declaration lives only in the pending queue and a
+ * reflected column only in `columns_hash`, so the two are already distinct
+ * records. `applyColumnsHash` below re-registers reflected columns INTO
+ * `_attributeDefinitions` beside the declarations, so the paths that must not
+ * clobber a declaration read the provenance back off the queue Rails replays.
+ */
+export function pendingAttributeDeclarationQ(host: unknown, name: string): boolean {
+  return pendingAttributeModificationsInAncestry(host).some(
+    (modification) =>
+      (modification instanceof PendingType || modification instanceof PendingDefault) &&
+      modification.name === name,
+  );
+}
+
+/**
+ * True when user code declared a concrete *type* for `name`: Rails queues a
+ * `PendingType` carrying a type only for `attribute(name, type)`, never for a
+ * default-only or bare re-declaration (attribute_registration.rb:12-18).
+ *
+ * @internal
+ * @noRailsEquivalent CONVERGEABLE — same reason as
+ * {@link pendingAttributeDeclarationQ}.
+ */
+export function pendingAttributeTypeQ(host: unknown, name: string): boolean {
+  return pendingAttributeModificationsInAncestry(host).some(
+    (modification) =>
+      modification instanceof PendingType &&
+      modification.name === name &&
+      modification.type != null,
+  );
+}
+
+/**
  * Drop schema-sourced attribute defs (and their generated accessors) so the
  * next load re-reflects them; user-declared defs are preserved, matching
  * Rails where user-provided attributes survive reload.
  */
 function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
   for (const [name] of Array.from(host._attributeDefinitions)) {
-    if (!pendingAttributeDeclarationQ(host as never, name)) {
+    if (!pendingAttributeDeclarationQ(host, name)) {
       host._attributeDefinitions.delete(name);
       if (Object.prototype.hasOwnProperty.call(host.prototype, name)) {
         delete host.prototype[name];
@@ -1146,14 +1206,14 @@ function applyColumnsHash(
   const filteredHash: Record<string, unknown> = {};
   for (const [name, column] of Object.entries(hash)) {
     if (ignored.has(name)) {
-      if (!pendingAttributeDeclarationQ(host as never, name)) {
+      if (!pendingAttributeDeclarationQ(host, name)) {
         host._attributeDefinitions.delete(name);
       }
       continue;
     }
     filteredHash[name] = column;
     const existing = host._attributeDefinitions.get(name);
-    if (existing && pendingAttributeDeclarationQ(host as never, name)) {
+    if (existing && pendingAttributeDeclarationQ(host, name)) {
       // A user-declared type override (e.g. an enum) preserves its type across
       // reflection. The schema column's default is NOT merged onto the def;
       // `_defaultAttributes` seeds it via from_database directly from the cached
@@ -1433,7 +1493,7 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {
-    if (!pendingAttributeDeclarationQ(host as never, name)) continue;
+    if (!pendingAttributeDeclarationQ(host, name)) continue;
     const isVirtual = !real.has(name);
     if (!!def.virtual !== isVirtual) def.virtual = isVirtual;
   }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -4,8 +4,6 @@ import { pluralize, underscore } from "@blazetrails/activesupport";
 import {
   Attribute,
   AttributeSetBuilder,
-  PendingDefault,
-  PendingType,
   YAMLEncoder,
   resetDefaultAttributesBang,
   typeRegistry,
@@ -961,6 +959,24 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
 }
 
 /**
+ * The `PendingType` / `PendingDefault` member lists
+ * (attribute_registration.rb:53,60) — those two Structs are what a user
+ * `attribute(...)` queues. `name` is what separates them from
+ * `PendingDecorator`, whose member is `names` (:66); `type` in turn separates
+ * `PendingType` from `PendingDefault`, whose members are `name` and `default`.
+ * Reading the members is how Ruby tells the three apart, and it keeps these
+ * predicates off the structs themselves, which Rails declares `private` (:52)
+ * and ActiveModel therefore does not export.
+ */
+type PendingAttributeDeclaration = { name: string; type?: Type | null };
+
+function isPendingAttributeDeclaration(
+  modification: unknown,
+): modification is PendingAttributeDeclaration {
+  return typeof (modification as { name?: unknown })?.name === "string";
+}
+
+/**
  * Walk the ancestry's pending-modification queues, oldest ancestor first —
  * the loop written out of `apply_pending_attribute_modifications`' `superclass`
  * recursion (attribute_registration.rb:81-90). Reads the own queues directly
@@ -984,20 +1000,19 @@ function pendingAttributeModificationsInAncestry(host: unknown): unknown[] {
  * queued a `PendingType` / `PendingDefault` for it through `attribute(...)`
  * (attribute_registration.rb:53-72).
  *
- * @internal
- * @noRailsEquivalent CONVERGEABLE — retired by
- * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
- * Rails never asks: a user declaration lives only in the pending queue and a
- * reflected column only in `columns_hash`, so the two are already distinct
+ * Rails never asks this: a user declaration lives only in the pending queue and
+ * a reflected column only in `columns_hash`, so the two are already distinct
  * records. `applyColumnsHash` below re-registers reflected columns INTO
  * `_attributeDefinitions` beside the declarations, so the paths that must not
  * clobber a declaration read the provenance back off the queue Rails replays.
+ * Retired with that registry by
+ * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
+ *
+ * @internal
  */
 export function pendingAttributeDeclarationQ(host: unknown, name: string): boolean {
   return pendingAttributeModificationsInAncestry(host).some(
-    (modification) =>
-      (modification instanceof PendingType || modification instanceof PendingDefault) &&
-      modification.name === name,
+    (modification) => isPendingAttributeDeclaration(modification) && modification.name === name,
   );
 }
 
@@ -1006,14 +1021,14 @@ export function pendingAttributeDeclarationQ(host: unknown, name: string): boole
  * `PendingType` carrying a type only for `attribute(name, type)`, never for a
  * default-only or bare re-declaration (attribute_registration.rb:12-18).
  *
+ * Same registry-shaped reason as {@link pendingAttributeDeclarationQ}.
+ *
  * @internal
- * @noRailsEquivalent CONVERGEABLE — same reason as
- * {@link pendingAttributeDeclarationQ}.
  */
 export function pendingAttributeTypeQ(host: unknown, name: string): boolean {
   return pendingAttributeModificationsInAncestry(host).some(
     (modification) =>
-      modification instanceof PendingType &&
+      isPendingAttributeDeclaration(modification) &&
       modification.name === name &&
       modification.type != null,
   );
@@ -1261,22 +1276,6 @@ function applyColumnsHash(
     });
   }
 
-  // Regenerate attribute accessors through the single define_attribute_methods
-  // path now that schema reflection has settled the attribute definitions.
-  const methodHost = host as unknown as {
-    _attributeMethodsGenerated?: boolean;
-    defineAttributeMethods?: () => boolean;
-  };
-  methodHost._attributeMethodsGenerated = false;
-  if (!regeneratingAttributeMethods.has(host)) {
-    regeneratingAttributeMethods.add(host);
-    try {
-      methodHost.defineAttributeMethods?.();
-    } finally {
-      regeneratingAttributeMethods.delete(host);
-    }
-  }
-
   type CacheBag = {
     _attributesBuilder?: unknown;
     _yamlEncoder?: unknown;
@@ -1292,6 +1291,25 @@ function applyColumnsHash(
   bag._cachedAttributeTypes = null;
   bag._columns = undefined;
   host._columnsHash = filteredHash;
+
+  // Regenerate attribute accessors through the single define_attribute_methods
+  // path now that schema reflection has settled the attribute definitions AND
+  // the derived caches above have been dropped: generation reads
+  // `attribute_names` → `attribute_types` (attribute_methods.rb:236-242), which
+  // would otherwise answer from the pre-load memo and generate nothing.
+  const methodHost = host as unknown as {
+    _attributeMethodsGenerated?: boolean;
+    defineAttributeMethods?: () => boolean;
+  };
+  methodHost._attributeMethodsGenerated = false;
+  if (!regeneratingAttributeMethods.has(host)) {
+    regeneratingAttributeMethods.add(host);
+    try {
+      methodHost.defineAttributeMethods?.();
+    } finally {
+      regeneratingAttributeMethods.delete(host);
+    }
+  }
 
   // Encryption still needs a post-reflection pass — not for type wrapping (the
   // durable decorator was pushed at declaration; `typeForAttribute` resolves it)

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pendingAttributeDeclarationQ } from "@blazetrails/activemodel";
+import { pendingAttributeDeclarationQ } from "./model-schema.js";
 import { Base } from "./base.js";
 
 describe("STI subclass attribute() registration", () => {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { pendingAttributeDeclarationQ } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 
 describe("STI subclass attribute() registration", () => {
@@ -32,7 +33,7 @@ describe("STI subclass attribute() registration", () => {
 
     // Shape IS the STI base (not a subclass), so its map is its own.
     expect(Object.prototype.hasOwnProperty.call(Shape, "_attributeDefinitions")).toBe(true);
-    expect(Shape._attributeDefinitions.get("name")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Shape, "name")).toBe(true);
   });
 
   it("non-STI classes are unaffected", () => {
@@ -43,7 +44,7 @@ describe("STI subclass attribute() registration", () => {
     }
 
     expect(Object.prototype.hasOwnProperty.call(Widget, "_attributeDefinitions")).toBe(true);
-    expect(Widget._attributeDefinitions.get("price")?.userProvidedDefault).toBe(true);
+    expect(pendingAttributeDeclarationQ(Widget, "price")).toBe(true);
   });
 
   it("STI subclass attribute declared AFTER base inherits the base's attrs too", () => {

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -6,6 +6,9 @@
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],
+      "@blazetrails/activemodel/attribute-registration": [
+        "../../activemodel/src/attribute-registration.ts"
+      ],
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
       "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -171,6 +171,10 @@ const alias = {
   "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
   "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
   "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
+  "@blazetrails/activemodel/attribute-registration": path.resolve(
+    __dirname,
+    "packages/activemodel/src/attribute-registration.ts",
+  ),
   "@blazetrails/activemodel/yaml": path.resolve(
     __dirname,
     "packages/activemodel/src/attribute-set/codecs/yaml.ts",


### PR DESCRIPTION
Bundles two RFC stories that turned out to be the same knot: class-level
`attribute_names` and the stored provenance flag both existed because trails'
`_attributeDefinitions` mixes schema-reflected columns with user declarations.

## `attribute_names` reads `attribute_types`

`activerecord/lib/active_record/attribute_methods.rb:236-242`:

```ruby
@attribute_names ||= if !abstract_class? && table_exists?
  attribute_types.keys
else
  []
end.freeze
```

`classAttributeNames` now returns `Object.keys(this.attributeTypes())` under
that same guard. The `columnNames()` walk, the non-column
`_attributeDefinitions` append and the hand-rolled ordering comment are gone.
The `table_exists?` half stays trails' schema-cache-derived answer (Rails makes
a sync DB hit a sync TS API cannot) — that comment is unchanged.

The ordering that rule existed to satisfy —
`attributes_test.rb` "overloading properties does not attribute method order" —
now comes from where Rails gets it. `_defaultAttributes` seeds phase 1 in
`columns_hash` order (`attributes.rb:241-245`), so a real column keeps its
schema position even when the class also declares an `attribute` override for
it, and declarations without a column follow via the phase-2 replay.

One fidelity gap surfaced on the way: ActiveRecord overrides
`reload_schema_from_cache` to call `reset_default_attributes!` before `super`
(`attributes.rb:268-271`), which nils **both** `@default_attributes` and
`@attribute_types` (`attribute_registration.rb:96-99`). trails cleared only the
first, so after `resetColumnInformation` a subclass read a stale
`_cachedAttributeTypes` — invisible while `attribute_names` went through
`columnNames()`, a red `PersistenceTest > reset column information resets
children` once it didn't.

## Retiring `AttributeDefinition.userProvidedDefault`

Rails stores no such flag. `define_attribute`'s `user_provided_default:`
forwards to `define_default_attribute`'s `from_user:` (`attributes.rb:229-238`)
and the provenance ends up in *which `Attribute` subclass* is built; a user
declaration otherwise lives only in the pending-modification queue
(`attribute_registration.rb:53-72`).

The field is gone from both packages. Every reader — `applyColumnsHash`,
`scrubSchemaSourcedDefinitions`, `reconcileVirtualAttributes`,
`_defaultAttributes`, `ensureSchemaLoaded`, `installEnumAttribute`,
`encryptable-record` — now reads the provenance off that queue via
`pendingAttributeDeclarationQ` / `pendingAttributeTypeQ`. AR's
`defineAttribute` keeps the Rails kwarg and expresses it by pushing the pending
declaration only when it is user-provided, so the seed/replay produces the
`cast` vs `deserialize` split `from_user:` produces in Rails. The
`base.ts` foreign-table branch drops its flag check entirely: `reflectedTable`
is stamped only by `applyColumnsHash`, so it already implies schema provenance.
`installEnumAttribute`'s `explicitlyTyped` loses its type-name probe — a typed
`PendingType` *is* the "user declared a concrete type" question, as the comment
above it already said Rails asks it.

`pnpm parity:api:extra --package activemodel` shows `attributes.ts` at 0 novel,
and `attribute-registration.ts` unchanged from main.

The two queue-reading predicates live in `activerecord/src/model-schema.ts`,
colocated with the schema re-registration that is the only reason the question
exists — Rails keeps the pending queue private (`attribute_registration.rb:77,81`),
so they are not ActiveModel API. Their ancestry walk is written out of
`apply_pending_attribute_modifications`' `superclass` recursion
(`attribute_registration.rb:81-90`); it reads the own queues directly, since
routing through `pending_attribute_modifications` would stamp its `||= []` onto
every ancestor it passes. ActiveModel's barrel gains only the Rails-backed
`PendingType` / `PendingDefault` structs (`attribute_registration.rb:53,60`) the
predicates match on. Both are tagged CONVERGEABLE against the follow-up story
`retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).

## Test-name changes

Three trails-only names that spelled the retired field are retired with it, as
the story specifies:

- `"treats externally-constructed defs without userProvided as user-authored
  (no overwrite)"` — deleted; a def with no pending entry is now schema-sourced
  by definition, so the behaviour it asserted no longer exists.
- `describe("attribute() userProvidedDefault option")` and its two cases —
  deleted; the option is gone (Rails' `attribute` never had it).

`attribute_methods/read_test.rb`'s fake klass overrides `attribute_names` with
the literal `%w{ one two three }` (read_test.rb:22-24) against an empty
`attribute_types`; ours had wired the real `attributeNames` instead, which now
correctly returns `[]`. The fake now mirrors Rails.

## Checks

- `pnpm parity:api:calls` / `:args`: clean, zero rows added.
- `pnpm parity:api:extra --package activemodel`: `attributes.ts` 0 novel.
- `pnpm lint`, `pnpm typecheck`: clean.
- ~1400 local tests across attributes / attribute-methods / model-schema
  load+sync-load / enum / encryption / persistence / dirty / inheritance /
  STI routing / serialization, plus all of `packages/activemodel`.

Closes-story: class-attribute-names-must-read-attribute-types
Closes-story: retire-attribute-definition-provenance-flag
