### PR TITLE
refactor(activemodel,activesupport): move decimal rounding onto BigDecimal and drop the numericality/length parsing residue

### DIFF
--- a/packages/activemodel/src/type/decimal.trails.test.ts
+++ b/packages/activemodel/src/type/decimal.trails.test.ts
@@ -33,11 +33,12 @@ describe("DecimalTypeTrails", () => {
     expect(type.cast("1e10000000")).toBe("1e10000000");
   });
 
-  it("apply_scale ignores non-integer/negative scale values", () => {
-    // Ruby BigDecimal#round(n) requires an Integer; rather than invent
-    // new semantics, leave the raw value alone for scale = 2.5 / -1.
-    expect(new Types.DecimalType({ scale: 2.5 }).cast("1.234")).toEqual(bd("1.234"));
-    expect(new Types.DecimalType({ scale: -1 }).cast("1.234")).toEqual(bd("1.234"));
+  it("apply_scale rounds to a multiple of ten for a negative scale", () => {
+    // Ruby `BigDecimal#round(-1)` rounds to a multiple of 10 ** 1, so
+    // apply_scale passes a negative `scale:` straight through to it.
+    expect(new Types.DecimalType({ scale: -1 }).cast("14")).toEqual(bd("10"));
+    expect(new Types.DecimalType({ scale: -1 }).cast("15")).toEqual(bd("20"));
+    expect(new Types.DecimalType({ scale: -1 }).cast("-15")).toEqual(bd("-20"));
   });
 
   it("apply_scale rounds half away from zero", () => {

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -23,35 +23,74 @@ export class DecimalType extends NumericValueType {
     return JSON.stringify(value) ?? String(value);
   }
 
-  // Rails' `cast_value`:
-  //   - Numeric  -> BigDecimal(value)
-  //   - String   -> value.to_d  (returns BigDecimal(0) on invalid)
-  //   - nil      -> nil
-  // The precision-preserving math runs on digit strings (JS has no native
-  // arbitrary-precision decimal), then the result is wrapped in a
-  // BigDecimal so the value carries its type — decimal binds quote in
-  // fixed ("F") form (`1.5`, `42.0`) rather than as a `'1.5'` string
-  // literal (Rails: `when BigDecimal then value.to_s("F")`).
-  /** @internal Rails-private helper. */
+  /**
+   * Mirrors: decimal.rb:57-74
+   *
+   *   def cast_value(value)
+   *     casted_value = \
+   *       case value
+   *       when ::Float   then convert_float_to_big_decimal(value)
+   *       when ::Numeric then BigDecimal(value, precision || BIGDECIMAL_PRECISION)
+   *       when ::String
+   *         begin
+   *           value.to_d
+   *         rescue ArgumentError
+   *           BigDecimal(0)
+   *         end
+   *       else
+   *         if value.respond_to?(:to_d)
+   *           value.to_d
+   *         else
+   *           cast_value(value.to_s)
+   *         end
+   *       end
+   *     apply_scale(casted_value)
+   *   end
+   *
+   * BigDecimal has no NaN/±Infinity form, so those three values round-trip as
+   * sentinel strings rather than BigDecimals — PG's `'NaN'`/`'Infinity'::numeric`
+   * serialization reads them back out. Ruby has no such gap: `Float::NAN.to_d`
+   * is BigDecimal::NAN.
+   *
+   * @internal Rails-private helper.
+   */
   protected castValue(value: unknown): BigDecimal | string | null {
-    const casted = this.applyScale(this._castWithoutScale(value));
-    if (casted === null) return null;
-    // BigDecimal has no NaN/±Infinity form; keep those sentinel strings as-is
-    // so PG's 'NaN'/'Infinity'::numeric round-trip (quoted) still works.
-    if (casted === "NaN" || casted === "Infinity" || casted === "-Infinity") return casted;
-    try {
-      return new BigDecimal(casted);
-    } catch {
-      // Adversarial exponents (e.g. "1e10000000") exceed BigDecimal's
-      // expansion cap; leave the raw cast string untouched.
-      return casted;
+    if (value === null || value === undefined) return null;
+
+    let castedValue: BigDecimal | string | null;
+    if (typeof value === "number") {
+      if (Number.isNaN(value)) return "NaN";
+      if (value === Infinity) return "Infinity";
+      if (value === -Infinity) return "-Infinity";
+      castedValue = this.convertFloatToBigDecimal(value);
+    } else if (
+      value instanceof BigDecimal ||
+      typeof value === "bigint" ||
+      value instanceof Rational
+    ) {
+      // A Rational is the case that makes the significant-digit count matter
+      // here rather than in the Float arm: it carries an exact fraction, so
+      // `Rational(1, 3)` is `0.333333333333333333E0` at the default 18.
+      castedValue = new BigDecimal(
+        value instanceof BigDecimal ? value.toString("F") : value,
+        this.precision ?? BIGDECIMAL_PRECISION,
+      );
+    } else if (typeof value === "string") {
+      castedValue = toD(value);
+    } else {
+      const toDMethod = (value as { toD?: unknown }).toD;
+      castedValue =
+        typeof toDMethod === "function"
+          ? (toDMethod as () => BigDecimal).call(value)
+          : this.castValue(String(value));
     }
+
+    return this.applyScale(castedValue);
   }
 
   /**
-   * Mirrors the float-conversion portion of
-   * ActiveModel::Type::Decimal#convert_float_to_big_decimal
-   * (decimal.rb:75-81).
+   * Mirrors: ActiveModel::Type::Decimal#convert_float_to_big_decimal
+   * (decimal.rb:76-82).
    *
    *   def convert_float_to_big_decimal(value)
    *     if precision
@@ -61,27 +100,22 @@ export class DecimalType extends NumericValueType {
    *     end
    *   end
    *
-   * This helper runs on the digit-string stage of the pipeline (before
-   * `castValue` wraps the result in a BigDecimal), so `BigDecimal(_,
-   * float_precision)` translates to "round to `floatPrecision()`
-   * significant digits". The inner `apply_scale` is load-bearing and runs
-   * first, exactly as Rails has it — that ordering is what
-   * `decimal_test.rb:81-86` pins. When no precision is configured, fall
-   * through to `String(value)` (the same form `_castWithoutScale` would
-   * otherwise emit).
+   * The inner `apply_scale` is load-bearing and runs first, exactly as Rails
+   * has it — that ordering is what `decimal_test.rb:81-86` pins.
    *
    * @internal Rails-private helper.
    */
-  protected convertFloatToBigDecimal(value: number): string {
-    if (this.precision === undefined) return String(value);
-    const precision = this.floatPrecision();
-    const scaled = this.applyScale(String(value)) as string;
-    if (precision <= 0) return scaled;
-    return roundDecimalStringToSignificantDigits(scaled, precision);
+  protected convertFloatToBigDecimal(value: number): BigDecimal {
+    if (this.precision !== undefined) {
+      return new BigDecimal(this.applyScale(value), this.floatPrecision());
+    }
+    // `Float#to_d` reads the float's SHORTEST round-trip decimal string —
+    // what `String(value)` yields — not its binary expansion.
+    return new BigDecimal(String(value));
   }
 
   /**
-   * Mirrors: ActiveModel::Type::Decimal#float_precision (decimal.rb:83-89).
+   * Mirrors: ActiveModel::Type::Decimal#float_precision (decimal.rb:84-90).
    *
    *   def float_precision
    *     if precision.to_i > ::Float::DIG + 1
@@ -91,12 +125,10 @@ export class DecimalType extends NumericValueType {
    *     end
    *   end
    *
-   * Ruby `::Float::DIG` is 15 on IEEE-754 doubles; cap at 16 so we
-   * never request more digits than the underlying representation can
-   * preserve. `precision.to_i` on `nil` gives `0`, truncates
-   * fractional values toward zero, and treats non-finite values as
-   * `0` — mirror that exactly so a fractional or NaN `precision:`
-   * doesn't trip `Number#toPrecision`'s integer requirement.
+   * Ruby `::Float::DIG` is 15 on IEEE-754 doubles; cap at 16 so we never
+   * request more digits than the underlying representation can preserve.
+   * `precision.to_i` on `nil` gives `0`, truncates fractional values toward
+   * zero, and treats non-finite values as `0`.
    *
    * @internal Rails-private helper.
    */
@@ -107,245 +139,60 @@ export class DecimalType extends NumericValueType {
   }
 
   /**
-   * Apply Rails' `scale:` option to a decimal string, rounding to the
-   * configured number of fractional digits using Ruby's default
-   * `BigDecimal#round` mode (`ROUND_HALF_UP` — half away from zero).
+   * Mirrors: ActiveModel::Type::Decimal#apply_scale (decimal.rb:92-98).
    *
-   * Mirrors: ActiveModel::Type::Decimal#apply_scale
-   * (activemodel/lib/active_model/type/decimal.rb).
+   *   def apply_scale(value)
+   *     if scale
+   *       value.round(scale)
+   *     else
+   *       value
+   *     end
+   *   end
+   *
+   * Ruby dispatches `round` on whatever the value is — a Float in the
+   * `convert_float_to_big_decimal` call site, a BigDecimal in the `cast_value`
+   * tail — and both round half away from zero, which is `BigDecimal#round`'s
+   * default mode. The NaN/Infinity sentinel strings pass through untouched.
+   *
+   * @internal Rails-private helper.
    */
-  protected applyScale(value: string | null): string | null {
-    if (value === null) return null;
+  protected applyScale(value: number): number;
+  protected applyScale(value: BigDecimal | string | null): BigDecimal | string | null;
+  protected applyScale(
+    value: BigDecimal | string | number | null,
+  ): BigDecimal | string | number | null {
     if (this.scale === undefined) return value;
-    // Ruby `BigDecimal#round(n)` only accepts an Integer argument; a
-    // non-integer or negative TS `scale:` option would just misfire our
-    // slice/charCodeAt math, so leave the value untouched rather than
-    // invent new semantics.
-    if (!Number.isInteger(this.scale) || this.scale < 0) return value;
-    return roundHalfUpToScale(value, this.scale);
-  }
-
-  private _castWithoutScale(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
-    // A BigDecimal re-cast (e.g. through serialize) round-trips via its
-    // fixed-form string — Rails treats BigDecimal as ::Numeric and re-wraps
-    // it through `BigDecimal(value, precision)`.
-    if (value instanceof BigDecimal) return value.toString("F");
-    if (typeof value === "bigint") return value.toString();
-    // Mirrors decimal.rb:64-66 — a `::Numeric` that is not a `::Float` goes
-    // through `BigDecimal(value, precision || BIGDECIMAL_PRECISION)`. Rational
-    // is the case that distinguishes this arm from the Float one: it carries an
-    // exact fraction, so the significant-digit count is what decides the
-    // result (`Rational(1, 3)` is `0.333333333333333333E0` at the default 18).
-    if (value instanceof Rational) {
-      return rationalToSignificantDigits(value, this.precision ?? BIGDECIMAL_PRECISION);
-    }
+    if (value instanceof BigDecimal) return value.round(this.scale);
     if (typeof value === "number") {
-      // BigDecimal("NaN") / BigDecimal("Infinity") have no decimal string
-      // form, so the non-finite values round-trip as sentinel strings (not
-      // BigDecimals) — `nan?`/`infinite?`-style checks and PG's
-      // 'NaN'/'Infinity'::numeric serialization rely on them. Rails routes
-      // Float through `value.to_d`, and `Float::INFINITY.to_d` yields
-      // BigDecimal::INFINITY ("Infinity") rather than nil.
-      if (Number.isNaN(value)) return "NaN";
-      if (value === Infinity) return "Infinity";
-      if (value === -Infinity) return "-Infinity";
-      // Rails dispatches Float through `convert_float_to_big_decimal`
-      // (decimal.rb:75-81). Route every JS number through the same hook
-      // so a configured `precision:` applies the same significant-digit
-      // rounding per Rails; integer-valued inputs may still change when
-      // the value has more digits than `floatPrecision()` preserves.
-      return this.convertFloatToBigDecimal(value);
+      return Number(new BigDecimal(String(value)).round(this.scale).toString("F"));
     }
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed === "") return null;
-      // Ruby `"NaN".to_d` yields BigDecimal NaN, and the PG adapter hands
-      // numeric NaN back as the string "NaN" on load — both round-trip to
-      // the JS NaN sentinel rather than `to_d`'s leading-prefix parse.
-      // Likewise PG returns "Infinity"/"-Infinity" for non-finite numerics,
-      // and `"Infinity".to_d` yields BigDecimal::INFINITY.
-      if (trimmed === "NaN") return "NaN";
-      if (trimmed === "Infinity") return "Infinity";
-      if (trimmed === "-Infinity") return "-Infinity";
-      // Rails' `String#to_d` parses a leading numeric prefix and
-      // silently drops everything after, returning `BigDecimal(0)` if
-      // no leading number is present. Tests assert, e.g.,
-      // `"1ignore" -> BigDecimal("1")`, `"bad" -> BigDecimal("0")`.
-      const match = trimmed.match(/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?/);
-      return match ? match[0] : "0";
-    }
-    // Mirrors decimal.rb:73-77 — `value.to_d` when the object answers it.
-    const toD = (value as { toD?: unknown }).toD;
-    if (typeof toD === "function") {
-      const d = toD.call(value) as unknown;
-      return d instanceof BigDecimal ? d.toString("F") : this._castWithoutScale(d);
-    }
-    return null;
+    return value;
   }
 }
 
 /**
- * Round a JS number to `precision` significant digits, returning the
- * decimal string. Used by `convertFloatToBigDecimal` to emulate
- * Ruby's `BigDecimal(value, precision)`. Returns `String(value)` when
- * `precision <= 0` (Rails treats `precision: nil` as no rounding).
+ * Ruby's `String#to_d` (`bigdecimal/util.rb`), which `cast_value`'s `::String`
+ * arm calls: it parses a leading numeric prefix, silently drops everything
+ * after it, and answers `BigDecimal(0)` when there is no leading number —
+ * so its `rescue ArgumentError` arm is unreachable from a String.
+ *
+ * PG hands numeric NaN and ±Infinity back as those literal strings, and
+ * `"NaN".to_d` / `"Infinity".to_d` yield BigDecimal NAN / INFINITY, which
+ * trails carries as the same sentinel strings `cast_value` emits for the
+ * Float case.
  */
-export function roundFloatToSignificantDigits(value: number, precision: number): string {
-  if (precision <= 0 || !Number.isFinite(value)) return String(value);
-  return roundDecimalStringToSignificantDigits(String(value), precision);
-}
-
-/**
- * Ruby's `BigDecimal(value, precision)` on an exact `Rational`: the fraction is
- * expanded by long division over `bigint`s — never through a float, which would
- * lose digits well before the default precision of 18 — and the expansion is
- * then rounded to `precision` significant digits, half-up.
- */
-function rationalToSignificantDigits(value: Rational, precision: number): string {
-  if (precision <= 0) return String(value.toF());
-  const sign = value.numerator < 0n !== value.denominator < 0n ? "-" : "";
-  const n = value.numerator < 0n ? -value.numerator : value.numerator;
-  const d = value.denominator < 0n ? -value.denominator : value.denominator;
-  if (d === 0n || n === 0n) return `${n === 0n ? "0" : sign}0`;
-
-  const intDigits = n / d === 0n ? 0 : (n / d).toString().length;
-  let fracNeeded: number;
-  if (intDigits > 0) {
-    fracNeeded = Math.max(precision - intDigits, 0) + 2;
-  } else {
-    // Leading fractional zeros do not count as significant digits, so expand
-    // past them before asking for `precision` more.
-    let leadingZeros = 0;
-    for (let x = n * 10n; x < d && leadingZeros < MAX_EXPONENT_EXPANSION; x *= 10n) leadingZeros++;
-    fracNeeded = leadingZeros + precision + 2;
+function toD(value: string): BigDecimal | string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  if (trimmed === "NaN") return "NaN";
+  if (trimmed === "Infinity") return "Infinity";
+  if (trimmed === "-Infinity") return "-Infinity";
+  const match = trimmed.match(/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?/);
+  try {
+    return new BigDecimal(match ? match[0] : "0");
+  } catch {
+    // Adversarial exponents (e.g. "1e10000000") exceed BigDecimal's expansion
+    // cap; leave the raw prefix untouched rather than answering a wrong value.
+    return match ? match[0] : "0";
   }
-  const scaled = ((n * 10n ** BigInt(fracNeeded)) / d).toString().padStart(fracNeeded + 1, "0");
-  const raw = `${sign}${scaled.slice(0, scaled.length - fracNeeded)}.${scaled.slice(scaled.length - fracNeeded)}`;
-  return roundDecimalStringToSignificantDigits(raw, precision);
-}
-
-/** Round a decimal string to `precision` significant digits, half-up. */
-function roundDecimalStringToSignificantDigits(raw: string, precision: number): string {
-  // Ruby's `BigDecimal(float, n)` (BigDecimal 3.1.4+, an Active Support
-  // dependency) rounds the float's SHORTEST round-trip decimal string — what
-  // `String(value)` yields — to `n` significant digits, half-up. JS
-  // `Number#toPrecision` instead rounds the binary representation, which
-  // diverges on exact half-way decimals (`123.455` → `123.45` via the binary
-  // form, but `123.46` per BigDecimal). Round the decimal string directly so
-  // we match Ruby; see ruby/bigdecimal#70.
-  const parts = splitDecimal(raw);
-  if (!parts) return raw;
-  const { sign, intPart, fracPart } = parts;
-  // Significant-digit rounding maps to a fractional-scale round: subtract the
-  // count of leading significant integer digits (for |x| >= 1), or add the
-  // run of leading fractional zeros (for |x| < 1), from/to `precision`.
-  if (intPart !== "0" && precision < intPart.length) {
-    // Fewer significant digits than integer digits: round WITHIN the integer
-    // part and zero-fill the dropped places (e.g. 1234.5 @ 3 → "1230").
-    const kept = intPart.slice(0, precision);
-    const roundDigit = intPart.charCodeAt(precision) - 48; // '0' → 0
-    const droppedZeros = "0".repeat(intPart.length - precision);
-    const outDigits = roundDigit < 5 ? kept : incrementDecimalDigits(kept);
-    return `${sign}${outDigits}${droppedZeros}`;
-  }
-  let scale: number;
-  if (intPart !== "0") {
-    scale = precision - intPart.length;
-  } else {
-    let leadingZeros = 0;
-    while (leadingZeros < fracPart.length && fracPart.charCodeAt(leadingZeros) === 48) {
-      leadingZeros += 1;
-    }
-    scale = precision + leadingZeros;
-  }
-  return roundHalfUpToScale(`${sign}${intPart}.${fracPart}`, scale);
-}
-
-const MAX_EXPONENT_EXPANSION = 4000;
-
-/**
- * Normalize a decimal-string representation (including scientific notation
- * as emitted by JS `String(1e-7)`) into `sign` + integer + fractional
- * parts. Exponent magnitude is capped at `MAX_EXPONENT_EXPANSION` so
- * adversarial input like `"1e10000000"` can't drive `padEnd`/`padStart`
- * into allocating multi-gigabyte strings; over the cap we return null and
- * callers leave the raw form alone.
- */
-
-function splitDecimal(raw: string): { sign: "" | "-"; intPart: string; fracPart: string } | null {
-  let s = raw;
-  let sign: "" | "-" = "";
-  if (s.startsWith("-")) {
-    sign = "-";
-    s = s.slice(1);
-  } else if (s.startsWith("+")) {
-    s = s.slice(1);
-  }
-  // Accept the same numeric forms `_castWithoutScale` emits: `1`, `1.`,
-  // `.5`, `1.5`, `1e3`, `1.e3`. Reject input with no digits at all.
-  const m = s.match(/^(\d*)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/);
-  if (!m) return null;
-  if (m[1] === "" && (m[2] ?? "") === "") return null;
-  let intPart = m[1] || "0";
-  let fracPart = m[2] ?? "";
-  const exp = m[3] ? Number(m[3]) : 0;
-  if (Math.abs(exp) > MAX_EXPONENT_EXPANSION) return null;
-  if (exp > 0) {
-    if (fracPart.length >= exp) {
-      intPart += fracPart.slice(0, exp);
-      fracPart = fracPart.slice(exp);
-    } else {
-      intPart += fracPart.padEnd(exp, "0");
-      fracPart = "";
-    }
-  } else if (exp < 0) {
-    const shift = -exp;
-    if (intPart.length > shift) {
-      fracPart = intPart.slice(intPart.length - shift) + fracPart;
-      intPart = intPart.slice(0, intPart.length - shift);
-    } else {
-      fracPart = intPart.padStart(shift, "0") + fracPart;
-      intPart = "0";
-    }
-  }
-  return { sign, intPart: intPart.replace(/^0+(?=\d)/, "") || "0", fracPart };
-}
-
-function roundHalfUpToScale(raw: string, scale: number): string {
-  const parts = splitDecimal(raw);
-  if (!parts) return raw;
-  const { sign, intPart, fracPart } = parts;
-  if (fracPart.length <= scale) {
-    const padded = scale > 0 ? `.${fracPart.padEnd(scale, "0")}` : "";
-    return `${sign}${intPart}${padded}`;
-  }
-  const keep = fracPart.slice(0, scale);
-  const roundDigit = fracPart.charCodeAt(scale) - 48; // '0' → 0
-  if (roundDigit < 5) {
-    return scale > 0 ? `${sign}${intPart}.${keep}` : `${sign}${intPart}`;
-  }
-  // Carry: half-away-from-zero bumps magnitude by 1 ulp at position `scale`.
-  const out = incrementDecimalDigits(intPart + keep);
-  const newIntLen = out.length - scale;
-  const newInt = out.slice(0, newIntLen);
-  const newFrac = out.slice(newIntLen);
-  return scale > 0 ? `${sign}${newInt}.${newFrac}` : `${sign}${newInt}`;
-}
-
-/**
- * Increment a run of ASCII digits by 1 with carry, returning a new
- * string. Uses no intermediate arrays so a multi-million-digit input
- * doesn't blow up memory.
- */
-function incrementDecimalDigits(digits: string): string {
-  let i = digits.length - 1;
-  while (i >= 0 && digits.charCodeAt(i) === 57 /* "9" */) {
-    i -= 1;
-  }
-  if (i < 0) {
-    return `1${"0".repeat(digits.length)}`;
-  }
-  const incremented = String.fromCharCode(digits.charCodeAt(i) + 1);
-  return `${digits.slice(0, i)}${incremented}${"0".repeat(digits.length - i - 1)}`;
 }

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -71,10 +71,7 @@ export class DecimalType extends NumericValueType {
       // A Rational is the case that makes the significant-digit count matter
       // here rather than in the Float arm: it carries an exact fraction, so
       // `Rational(1, 3)` is `0.333333333333333333E0` at the default 18.
-      castedValue = new BigDecimal(
-        value instanceof BigDecimal ? value.toString("F") : value,
-        this.precision ?? BIGDECIMAL_PRECISION,
-      );
+      castedValue = new BigDecimal(value, this.precision ?? BIGDECIMAL_PRECISION);
     } else if (typeof value === "string") {
       castedValue = toD(value);
     } else {

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Range } from "@blazetrails/activesupport";
 import { Model } from "./index.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
@@ -107,7 +108,7 @@ describe("ValidationsTest (trails)", () => {
       class WithRange extends Model {
         static {
           this.attribute("name", "string");
-          this.validates("name", { length: { in: [2, 5] } });
+          this.validates("name", { length: { in: new Range(2, 5) } });
         }
       }
       expect(await new WithRange({ name: "a" }).isValid()).toBe(false);
@@ -1049,7 +1050,7 @@ describe("ValidationsTest (trails)", () => {
         class WithRange extends Model {
           static {
             this.attribute("name", "string");
-            this.validates("name", { length: { in: [2, 5] } });
+            this.validates("name", { length: { in: new Range(2, 5) } });
           }
         }
         expect(await new WithRange({ name: "a" }).isValid()).toBe(false);

--- a/packages/activemodel/src/validations/length-validation.test.ts
+++ b/packages/activemodel/src/validations/length-validation.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { assertPredicate, assertNothingRaised } from "@blazetrails/activesupport";
+import { assertPredicate, assertNothingRaised, Range } from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
 import { Model } from "../index.js";
-import type { LengthRange } from "./length.js";
 
 // Mirrors: activemodel/test/models/topic.rb — the subset this file exercises.
 class Topic extends Model {
@@ -112,7 +111,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of using within", async () => {
-    Topic.validatesLengthOf("title", "content", { within: { begin: 3, end: 5 } });
+    Topic.validatesLengthOf("title", "content", { within: new Range(3, 5) });
 
     const t = new Topic({ title: "a!", content: "I'm ooooooooh so very long" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -131,7 +130,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of using within with exclusive range", async () => {
-    Topic.validatesLengthOf("title", { within: { begin: 4, end: 10, excludeEnd: true } });
+    Topic.validatesLengthOf("title", { within: new Range(4, 10, true) });
 
     const t = new Topic({ title: "9 chars!!" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -145,16 +144,16 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of using within with infinite ranges", async () => {
-    const cases: Array<[LengthRange, number | null]> = [
-      [{ begin: -Infinity, end: 10 }, 11],
-      [{ begin: -Infinity, end: 11, excludeEnd: true }, 11],
-      [{ begin: -Infinity }, null],
-      [{ begin: 10, end: Infinity }, 9],
-      [{ begin: 10, end: Infinity, excludeEnd: true }, 9],
-      [{ begin: 10 }, 9],
-      [{ end: 10 }, 11],
-      [{ end: 11, excludeEnd: true }, 11],
-      [{ begin: -Infinity, end: Infinity }, null],
+    const cases: Array<[Range<number>, number | null]> = [
+      [new Range(-Infinity, 10), 11],
+      [new Range(-Infinity, 11, true), 11],
+      [new Range(-Infinity, null), null],
+      [new Range(10, Infinity), 9],
+      [new Range(10, Infinity, true), 9],
+      [new Range(10, null), 9],
+      [new Range(null, 10), 11],
+      [new Range(null, 11, true), 11],
+      [new Range(-Infinity, Infinity), null],
     ];
     for (const [range, invalidLength] of cases) {
       Topic.clearValidatorsBang();
@@ -172,7 +171,7 @@ describe("LengthValidationTest", () => {
 
   it("optionally validates length of using within", async () => {
     Topic.validatesLengthOf("title", "content", {
-      within: { begin: 3, end: 5 },
+      within: new Range(3, 5),
       allowNil: true,
     });
 
@@ -214,7 +213,7 @@ describe("LengthValidationTest", () => {
   it("validates length of using bignum", async () => {
     const bigmin = 2 ** 30;
     const bigmax = 2 ** 32;
-    const bigrange: LengthRange = { begin: bigmin, end: bigmax, excludeEnd: true };
+    const bigrange = new Range(bigmin, bigmax, true);
     await assertNothingRaised(() => {
       Topic.validatesLengthOf("title", { is: bigmin + 5 });
       Topic.validatesLengthOf("title", { within: bigrange });
@@ -258,7 +257,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of custom errors for in", async () => {
-    Topic.validatesLengthOf("title", { in: { begin: 10, end: 20 }, message: "hoo %{count}" });
+    Topic.validatesLengthOf("title", { in: new Range(10, 20), message: "hoo %{count}" });
     let t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
     assertPredicate(t.errors.messagesFor("title"), (errors) => errors.length > 0);
@@ -338,7 +337,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of using within utf8", async () => {
-    Topic.validatesLengthOf("title", "content", { within: { begin: 3, end: 5 } });
+    Topic.validatesLengthOf("title", "content", { within: new Range(3, 5) });
 
     const t = new Topic({ title: "一二", content: "12三四五六七" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -350,7 +349,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("optionally validates length of using within utf8", async () => {
-    Topic.validatesLengthOf("title", { within: { begin: 3, end: 5 }, allowNil: true });
+    Topic.validatesLengthOf("title", { within: new Range(3, 5), allowNil: true });
 
     let t = new Topic({ title: "一二三四五" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -403,7 +402,7 @@ describe("LengthValidationTest", () => {
   });
 
   it("validates length of for infinite maxima", async () => {
-    Topic.validatesLengthOf("title", { within: { begin: 5, end: Infinity } });
+    Topic.validatesLengthOf("title", { within: new Range(5, Infinity) });
 
     const t = new Topic({ title: "1234" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);

--- a/packages/activemodel/src/validations/length-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/length-validation.trails.test.ts
@@ -1,7 +1,7 @@
 // trails-only coverage for LengthValidator that has no Rails counterpart:
-// the TS spellings of a Ruby Range (`{ begin, end, excludeEnd }` and the
-// `[min, max]` tuple) and the option-leak / definition-time-error paths.
+// the option-leak and definition-time-error paths.
 import { describe, it, expect, afterEach } from "vitest";
+import { Range } from "@blazetrails/activesupport";
 import { Model, NoMethodError } from "../index.js";
 
 class Person extends Model {
@@ -20,16 +20,8 @@ describe("LengthValidator (trails)", () => {
     Person.clearValidatorsBang();
   });
 
-  it("accepts :in as a [min, max] tuple", async () => {
-    Person.validatesLengthOf("title", { in: [3, 10] });
-    expect(await new Person({ title: "ab" }).isValid()).toBe(false);
-    expect(await new Person({ title: "abc" }).isValid()).toBe(true);
-    expect(await new Person({ title: "abcdefghij" }).isValid()).toBe(true);
-    expect(await new Person({ title: "abcdefghijk" }).isValid()).toBe(false);
-  });
-
   it("accepts :within as a range object { begin, end }", async () => {
-    Person.validatesLengthOf("title", { within: { begin: 3, end: 10 } });
+    Person.validatesLengthOf("title", { within: new Range(3, 10) });
     expect(await new Person({ title: "ab" }).isValid()).toBe(false);
     expect(await new Person({ title: "abc" }).isValid()).toBe(true);
     expect(await new Person({ title: "abcdefghij" }).isValid()).toBe(true);
@@ -37,7 +29,7 @@ describe("LengthValidator (trails)", () => {
   });
 
   it("accepts :in as a range object with excludeEnd", async () => {
-    Person.validatesLengthOf("title", { in: { begin: 3, end: 5, excludeEnd: true } });
+    Person.validatesLengthOf("title", { in: new Range(3, 5, true) });
     expect(await new Person({ title: "abc" }).isValid()).toBe(true);
     expect(await new Person({ title: "abcd" }).isValid()).toBe(true);
     expect(await new Person({ title: "abcde" }).isValid()).toBe(false);
@@ -65,7 +57,7 @@ describe("LengthValidator (trails)", () => {
   });
 
   it("does not leak reserved keys into errors.add options (minimum/maximum path)", async () => {
-    Person.validatesLengthOf("title", { in: [3, 5] });
+    Person.validatesLengthOf("title", { in: new Range(3, 5) });
     const p = new Person({ title: "ab" });
     await p.isValid();
     const err = p.errors.objects[0];
@@ -99,7 +91,7 @@ describe("LengthValidator (trails)", () => {
     expect(await new Person({ title: "a" }).isValid()).toBe(true);
   });
 
-  it("throws at definition time when :in is not a tuple or range object", () => {
+  it("throws at definition time when :in is not a Range", () => {
     expect(() => Person.validatesLengthOf("title", { in: "3..10" })).toThrow(
       /:in and :within must be a Range/,
     );

--- a/packages/activemodel/src/validations/length-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/length-validation.trails.test.ts
@@ -91,6 +91,17 @@ describe("LengthValidator (trails)", () => {
     expect(await new Person({ title: "a" }).isValid()).toBe(true);
   });
 
+  it("throws at definition time when the range is empty", () => {
+    // length.rb:18 is `options[:minimum] = range.min if range.begin`, and
+    // Ruby's `(1...1).min` is nil for an empty range — so :minimum is SET to
+    // nil, reaches check_validity!, and fails its non-negative Integer test.
+    // Verified against vendor/rails: `validates_length_of :title, in: 1...1`
+    // raises ":minimum must be a non-negative Integer, Infinity, Symbol, or Proc".
+    expect(() => Person.validatesLengthOf("title", { in: new Range(1, 1, true) })).toThrow(
+      /:minimum must be a non-negative Integer/,
+    );
+  });
+
   it("throws at definition time when :in is not a Range", () => {
     expect(() => Person.validatesLengthOf("title", { in: "3..10" })).toThrow(
       /:in and :within must be a Range/,

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -1,7 +1,7 @@
 import { ArgumentError } from "../attribute-assignment.js";
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
-import { camelize, except } from "@blazetrails/activesupport";
+import { camelize, except, Range } from "@blazetrails/activesupport";
 import { resolveValue } from "./resolve-value.js";
 
 /**
@@ -39,13 +39,6 @@ const CHECKS: Record<CheckKey, (valueLength: number, checkValue: number) => bool
   maximum: (valueLength, checkValue) => valueLength <= checkValue,
 };
 
-/** Rails-style range object accepted by the `:in` / `:within` option. */
-export interface LengthRange {
-  begin?: number;
-  end?: number;
-  excludeEnd?: boolean;
-}
-
 /**
  * Keys stripped from options before forwarding to `errors.add` so they
  * don't leak as i18n interpolation variables.
@@ -79,27 +72,21 @@ export class LengthValidator extends EachValidator {
 
     // Normalize :in / :within to :minimum / :maximum before super() calls
     // checkValidityBang(), mirroring length.rb:16-20.
-    const range = options["in"] ?? options["within"];
-    if (range !== undefined) {
-      delete options["in"];
-      delete options["within"];
-      if (Array.isArray(range) && range.length === 2) {
-        options["minimum"] = range[0];
-        options["maximum"] = range[1];
-      } else if (
-        range !== null &&
-        typeof range === "object" &&
-        ("begin" in range || "end" in range)
-      ) {
-        const r = range as LengthRange;
-        if (r.begin !== undefined) options["minimum"] = r.begin;
-        if (r.end !== undefined) {
-          options["maximum"] = r.excludeEnd ? r.end - 1 : r.end;
-        }
-      } else {
-        // Mirrors length.rb:17. A Ruby Range spells as a `[min, max]` tuple or
-        // a `{ begin, end, excludeEnd? }` object in TS.
+    // Rails: `options.delete(:in) || options.delete(:within)` — both keys are
+    // removed, and Ruby `||` falls through only on nil/false.
+    const inOption = options["in"];
+    const withinOption = options["within"];
+    delete options["in"];
+    delete options["within"];
+    const range = inOption != null && inOption !== false ? inOption : withinOption;
+    if (range != null && range !== false) {
+      if (!(range instanceof Range)) {
         throw new ArgumentError(":in and :within must be a Range");
+      }
+      const r = range as Range<number>;
+      if (r.begin !== null) options["minimum"] = r.min();
+      if (r.end !== null) {
+        options["maximum"] = r.excludeEnd ? r.end - 1 : r.end;
       }
     }
 
@@ -176,7 +163,9 @@ export class LengthValidator extends EachValidator {
       if (checkValue == null) continue;
 
       if (value != null || this.skipNilCheck(key)) {
-        checkValue = resolveLengthOpt.call(this, record, checkValue);
+        // Rails length.rb:55 — a Proc / method-name reference is honored
+        // per-record before the comparison.
+        checkValue = this.resolveValue(record, checkValue);
         if (validityCheck(valueLength, checkValue as number)) continue;
       }
 
@@ -214,21 +203,6 @@ export function skipNilCheck(
     this.options.allowNil === undefined &&
     this.options.allowBlank === undefined
   );
-}
-
-/**
- * @internal Resolves a length option through this.resolveValue (so a
- * Proc / method-name reference is honored per Rails length.rb:55) and
- * narrows the result to a number.
- */
-function resolveLengthOpt(
-  this: { resolveValue(record: unknown, value: unknown): unknown },
-  record: ValidatableRecord,
-  raw: unknown,
-): number | undefined {
-  if (raw === undefined || raw === null) return undefined;
-  const resolved = this.resolveValue(record, raw);
-  return typeof resolved === "number" ? resolved : undefined;
 }
 
 LengthValidator.prototype.resolveValue = resolveValue;

--- a/packages/activemodel/src/validations/numericality-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.trails.test.ts
@@ -39,10 +39,12 @@ describe("NumericalityValidator (trails-only)", () => {
     expect(await new User({ name: "+0o10" }).isValid()).toBe(false);
   });
 
-  it("rejects hexadecimal literal strings (with or without leading whitespace)", async () => {
+  it("rejects hexadecimal literal strings HEXADECIMAL_REGEX anchors on", async () => {
     // Rails parse_as_number's elsif chain skips Kernel.Float when
-    // is_hexadecimal_literal?, so "0x10" is not-a-number even though
-    // JS Number("0x10") === 16.
+    // is_hexadecimal_literal?, so "0x10" is not-a-number. The regex is
+    // \A-anchored, so a leading space defeats it and Kernel.Float — which
+    // strips whitespace and DOES read hex (Float("  0x10") is 16.0 on
+    // MRI 3.3) — answers 16 instead.
     class User extends Model {
       static {
         this.attribute("name", "string");
@@ -50,8 +52,8 @@ describe("NumericalityValidator (trails-only)", () => {
       }
     }
     expect(await new User({ name: "0x10" }).isValid()).toBe(false);
-    expect(await new User({ name: "  0x10" }).isValid()).toBe(false);
     expect(await new User({ name: "+0x10" }).isValid()).toBe(false);
+    expect(await new User({ name: "  0x10" }).isValid()).toBe(true);
   });
 
   it("rejects non-string/non-number values (boolean, Temporal.Instant, plain object)", async () => {

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -1,11 +1,10 @@
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
-import { underscore, RoundingHelper, BigDecimal, Range } from "@blazetrails/activesupport";
+import { underscore, BigDecimal, Range, kernelFloat } from "@blazetrails/activesupport";
 import { COMPARE_CHECKS, compareOperator, errorOptions } from "./comparability.js";
 import type { CompareKey } from "./comparability.js";
 import { resolveValue } from "./resolve-value.js";
 import { ArgumentError } from "../attribute-assignment.js";
-import { roundFloatToSignificantDigits } from "../type/decimal.js";
 
 type NumericValue = number | ((record: ValidatableRecord) => number) | string;
 
@@ -31,7 +30,7 @@ export class NumericalityValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare optionAsNumber: typeof optionAsNumber;
   /** @internal Rails-private helper. */
-  declare parseFloat: typeof parseFloatRails;
+  declare parseFloat: typeof parseFloat;
   /** @internal Rails-private helper. */
   declare round: typeof round;
   /** @internal Rails-private helper. */
@@ -154,12 +153,6 @@ const INTEGER_REGEX = /^[+-]?\d+(?![\s\S])/;
 // Rails: /\A[+-]?0[xX]/ — no leading whitespace permitted.
 const HEXADECIMAL_REGEX = /^[+-]?0[xX]/;
 
-// Trails-only guard: JS Number() also coerces 0b… (binary) and 0o…
-// (octal) literal strings, which Rails Kernel.Float rejects. Reuse the
-// hex check for the elsif-chain semantic Rails would apply, then layer
-// this on for the JS-specific surface.
-const NON_DECIMAL_LITERAL_REGEX = /^[+-]?0[xXbBoO]/;
-
 // Mirrors Rails numericality.rb:16:
 //   RESERVED_OPTIONS = COMPARE_CHECKS.keys + NUMBER_CHECKS.keys + RANGE_CHECKS.keys + [:only_integer, :only_numeric]
 // camelCased for trails option-key conventions.
@@ -235,44 +228,16 @@ export function parseAsNumber(
     if (Number.isNaN(rawValue)) return undefined;
     // `% 1 === 0` stands in for Ruby's Float-vs-Integer type test (see above);
     // an integral value takes the `Numeric` pass-through branch.
-    return rawValue % 1 === 0 ? rawValue : parseFloatRails(rawValue, precision, scale);
+    return rawValue % 1 === 0 ? rawValue : parseFloat(rawValue, precision, scale);
   }
   if (rawValue instanceof BigDecimal) return round(Number(rawValue.toString("F")), scale);
   if (isInteger(rawValue)) return Number.parseInt(String(rawValue), 10);
   if (!isHexadecimalLiteral(rawValue)) {
     const float = kernelFloat(rawValue);
     if (float === undefined) return undefined;
-    return parseFloatRails(float, precision, scale);
+    return parseFloat(float, precision, scale);
   }
   return undefined;
-}
-
-/**
- * Ruby's `Kernel.Float`, as `parse_as_number` (numericality.rb:82) calls it:
- * a strict decimal parse that honors `to_f` on a non-Numeric object and raises
- * `ArgumentError`/`TypeError` otherwise. `is_number?` rescues both, so the
- * unparseable cases return undefined here rather than throwing.
- *
- * `Number()` is laxer than `Kernel.Float` in two directions trails has to close
- * by hand: it reads `0b…`/`0o…`/`0x…` literals, and it coerces `""` and
- * whitespace to `0`.
- *
- * @noRailsEquivalent PERMANENT — Ruby core `Kernel.Float`, not a Rails method,
- * so `parity:api` has no Ruby name to credit it against.
- */
-function kernelFloat(rawValue: unknown): number | undefined {
-  if (rawValue !== null && typeof rawValue === "object") {
-    const toF = (rawValue as { toF?: unknown }).toF;
-    return typeof toF === "function" ? (toF as () => number).call(rawValue) : undefined;
-  }
-  if (typeof rawValue !== "string") return undefined;
-  if (rawValue.trim() === "") return undefined;
-  // `is_hexadecimal_literal?` is anchored at \A, but Kernel.Float strips
-  // leading whitespace before parsing, so "  0x1" is still rejected there.
-  const trimmed = rawValue.trimStart();
-  if (isHexadecimalLiteral(trimmed) || NON_DECIMAL_LITERAL_REGEX.test(trimmed)) return undefined;
-  const coerced = Number(rawValue);
-  return Number.isNaN(coerced) ? undefined : coerced;
 }
 
 /** Ruby's `value.is_a?(Numeric)` over the two numeric types trails carries. */
@@ -292,18 +257,16 @@ function isSymbol(value: unknown): boolean {
  *   end
  *
  * Ruby Float#round defaults to half-away-from-zero (NOT banker's
- * rounding): 2.5.round == 3, (-2.5).round == -3.
- *
- * DEVIATION: Rails calls `Float#round`/`BigDecimal#round` on the value
- * itself; this routes through `RoundingHelper`, which shares the half-up
- * default but is a different object. Tracked by story
- * 0023-surfaced-deviations/numericality-round-calls-rounding-helper.
+ * rounding): 2.5.round == 3, (-2.5).round == -3, and it rounds the float's
+ * shortest round-trip decimal string, which is `BigDecimal#round`'s default
+ * mode over `String(num)`.
  *
  * @internal Rails-private helper.
  */
 export function round(num: number, scale?: number): number {
   if (scale === undefined || scale === null) return num;
-  return Number((new RoundingHelper({ precision: scale }).round(num) as BigDecimal).toString("F"));
+  if (!Number.isFinite(num)) return num;
+  return Number(new BigDecimal(String(num)).round(scale).toString("F"));
 }
 
 /**
@@ -518,25 +481,23 @@ export function isRecordAttributeChangedInPlace(
  *   end
  *
  * Rounds to `scale` decimal places, then rounds to `precision`
- * significant digits — matches Ruby's `BigDecimal(float.round(scale), precision)`.
- *
- * `to_d(precision)` (BigDecimal 3.1.4+) rounds the float's shortest decimal
- * string, not its binary form, so we route through
- * {@link roundFloatToSignificantDigits} rather than `Number#toPrecision`
- * (which rounds the binary value and diverges on exact half-way decimals like
- * `123.455`). See ruby/bigdecimal#70.
+ * significant digits — `BigDecimal(float.round(scale), precision)`, which is
+ * what `Float#to_d(precision)` (BigDecimal 3.1.4+) does. It rounds the
+ * float's shortest decimal string, not its binary form, which is why this
+ * cannot be `Number#toPrecision` — that rounds the binary value and diverges
+ * on exact half-way decimals like `123.455`. See ruby/bigdecimal#70.
  *
  * @internal Rails-private helper.
  */
-export function parseFloatRails(num: number, precision: number, scale?: number): number {
+function parseFloat(num: number, precision: number, scale?: number): number {
   // Ruby `(1.0/0.0).to_d(15)` is BigDecimal Infinity, not an error, so an
   // infinite Float survives the pipeline and reaches the comparisons.
   if (!Number.isFinite(num)) return num;
-  return Number(roundFloatToSignificantDigits(round(num, scale), precision));
+  return Number(new BigDecimal(round(num, scale), precision).toString("F"));
 }
 
 NumericalityValidator.prototype.optionAsNumber = optionAsNumber;
-NumericalityValidator.prototype.parseFloat = parseFloatRails;
+NumericalityValidator.prototype.parseFloat = parseFloat;
 NumericalityValidator.prototype.round = round;
 NumericalityValidator.prototype.isNumber = isNumber;
 NumericalityValidator.prototype.isInteger = isInteger;

--- a/packages/activerecord/src/test-helpers/models/company-in-module.ts
+++ b/packages/activerecord/src/test-helpers/models/company-in-module.ts
@@ -1,4 +1,5 @@
 import type { AssociationProxy } from "../../associations/collection-proxy.js";
+import { Range } from "@blazetrails/activesupport";
 import type { Developer } from "./developer.js";
 import type { Firm } from "./company.js";
 import type { Project } from "./project.js";
@@ -84,7 +85,7 @@ export class MyAppBusinessDeveloper extends Base {
 
   static {
     this.hasAndBelongsToMany("projects");
-    this.validates("name", { length: { in: [3, 20] } });
+    this.validates("name", { length: { in: new Range(3, 20) } });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -1,4 +1,5 @@
 import type { AssociationProxy } from "../../associations/collection-proxy.js";
+import { Range } from "@blazetrails/activesupport";
 import type { Temporal } from "@blazetrails/date";
 import type { Comment } from "./comment.js";
 import type { Company } from "./company.js";
@@ -183,7 +184,7 @@ export class Developer extends Base {
     this.validates("salary", {
       inclusion: { in: { includes: (v: unknown) => Number(v) >= 50000 && Number(v) <= 200000 } },
     } as any);
-    this.validates("name", { length: { in: [3, 20] } });
+    this.validates("name", { length: { in: new Range(3, 20) } });
 
     // Rails: `before_create do |developer| developer.audit_logs.build ... end`
     // — the record arrives as the callback argument, not `this`.

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -4,6 +4,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import { Range } from "@blazetrails/activesupport";
 import "../index.js";
 import { registerModel, association } from "../associations.js";
 import { fixtures } from "../test-fixtures.js";
@@ -50,7 +51,7 @@ describe("LengthValidationTest", () => {
 
   it("validates size of association using within", async () => {
     const owner = ownerClass();
-    owner.validatesSizeOf("pets", { within: [1, 2] });
+    owner.validatesSizeOf("pets", { within: new Range(1, 2) });
     const o = new owner({ name: "nopets" });
     expect(await o.save()).toBe(false);
     expect(o.errors.messagesFor("pets").length).toBeGreaterThan(0);

--- a/packages/activesupport/src/core-ext/big-decimal/conversions.ts
+++ b/packages/activesupport/src/core-ext/big-decimal/conversions.ts
@@ -42,11 +42,13 @@ export class BigDecimal {
    * expansion is otherwise unbounded.
    */
   constructor(
-    value: string | number | bigint | { numerator: bigint; denominator: bigint },
+    value: string | number | bigint | BigDecimal | { numerator: bigint; denominator: bigint },
     ndigits = 0,
   ) {
-    const isRational = typeof value === "object" && value !== null;
-    const parsed = isRational ? parseRational(value, ndigits) : parse(value);
+    const isRational = typeof value === "object" && !(value instanceof BigDecimal);
+    const parsed = isRational
+      ? parseRational(value, ndigits)
+      : parse(value instanceof BigDecimal ? value.toString("F") : value);
     if (parsed === null) {
       throw new TypeError(`BigDecimal: cannot parse ${String(value)}`);
     }

--- a/packages/activesupport/src/core-ext/big-decimal/conversions.ts
+++ b/packages/activesupport/src/core-ext/big-decimal/conversions.ts
@@ -12,6 +12,13 @@
 
 const MAX_EXPONENT_EXPANSION = 4000;
 
+/**
+ * The shape of a Ruby `Rational`, which `Kernel#BigDecimal` accepts as its
+ * first argument. Structural and unexported rather than an import:
+ * `Rational` lives in `@blazetrails/date`, which depends on this package.
+ */
+type RationalLike = { numerator: bigint; denominator: bigint };
+
 export class BigDecimal {
   /** "-" for negative values, "" otherwise. Zero is non-negative. */
   readonly sign: "" | "-";
@@ -20,14 +27,41 @@ export class BigDecimal {
   /** Fractional-part digits, trailing zeros stripped (possibly ""). */
   readonly fracDigits: string;
 
-  constructor(value: string | number | bigint) {
-    const parsed = parse(value);
+  /**
+   * Ruby `Kernel#BigDecimal(value, ndigits)`. `ndigits` is a count of
+   * SIGNIFICANT decimal digits, not a fractional scale, and it only rounds
+   * for the two arguments that carry more digits than a decimal can hold: a
+   * Float and a Rational. For a String, an Integer or another BigDecimal it
+   * is a minimum-precision hint and every digit survives — `BigDecimal(1234.5,
+   * 3)` is `0.123e4` where `BigDecimal("1234.5", 3)` is `0.12345e4`
+   * (verified on MRI 3.3).
+   *
+   * A Rational is expanded by exact long division over `bigint`s — never
+   * through a float, which would lose digits well before the default
+   * precision of 18 — and Ruby raises without a precision for one, since the
+   * expansion is otherwise unbounded.
+   */
+  constructor(
+    value: string | number | bigint | { numerator: bigint; denominator: bigint },
+    ndigits = 0,
+  ) {
+    const isRational = typeof value === "object" && value !== null;
+    const parsed = isRational ? parseRational(value, ndigits) : parse(value);
     if (parsed === null) {
       throw new TypeError(`BigDecimal: cannot parse ${String(value)}`);
     }
     this.sign = parsed.sign;
     this.intDigits = parsed.intDigits;
     this.fracDigits = parsed.fracDigits;
+    if (ndigits > 0 && (isRational || typeof value === "number")) {
+      // Significant-digit rounding IS a fractional-scale round, offset by the
+      // value's decimal exponent: 1234.5 at 3 digits rounds at scale -1, and
+      // 0.00123456 at 3 digits rounds at scale 5.
+      const rounded = this.round(ndigits - this.exponent());
+      this.sign = rounded.sign;
+      this.intDigits = rounded.intDigits;
+      this.fracDigits = rounded.fracDigits;
+    }
   }
 
   /**
@@ -194,6 +228,18 @@ export class BigDecimal {
     return BigDecimal.fromUnscaled(this.sign === "-" ? -value : value, Math.max(n, 0));
   }
 
+  /**
+   * Ruby `BigDecimal#exponent` — the power of ten of the value's leading
+   * significant digit under the `0.<digits>e<exp>` normalization, and `0` for
+   * zero.
+   */
+  private exponent(): number {
+    const allDigits = this.intDigits + this.fracDigits;
+    const stripped = allDigits.replace(/^0+/, "");
+    if (stripped === "") return 0;
+    return this.intDigits.length - (allDigits.length - stripped.length);
+  }
+
   /** Digits as one integer, scaled by `10 ** fracDigits.length`. */
   private unscaled(signum = 1): bigint {
     const magnitude = BigInt(this.intDigits + this.fracDigits);
@@ -218,10 +264,8 @@ export class BigDecimal {
     const allDigits = this.intDigits + this.fracDigits;
     const mantissa = allDigits.replace(/^0+/, "").replace(/0+$/, "");
     if (mantissa === "") return "0.0";
-    const leadingZeros = allDigits.length - allDigits.replace(/^0+/, "").length;
-    const exp = this.intDigits.length - leadingZeros;
     const digits = group > 0 ? groupFromLeft(mantissa, group) : mantissa;
-    return `0.${digits}e${exp}`;
+    return `0.${digits}e${this.exponent()}`;
   }
 }
 
@@ -298,6 +342,46 @@ function groupFromLeft(s: string, n: number): string {
   return out;
 }
 
+/**
+ * Expand a `Rational` to a decimal string by exact long division, carrying
+ * two guard digits past the requested significant-digit count so the
+ * constructor's rounding step sees a correctly-rounded tail.
+ */
+function parseRational(
+  value: RationalLike,
+  ndigits: number,
+): { sign: "" | "-"; intDigits: string; fracDigits: string } | null {
+  if (ndigits <= 0) {
+    // Ruby raises `ArgumentError` here. This module has no runtime imports by
+    // construction, and ActiveSupport's `ArgumentError` would drag the
+    // `time-with-zone` graph in behind it, so it reuses the `TypeError` this
+    // file already throws for an unparseable value — the message is Ruby's.
+    throw new TypeError("can't omit precision for a Rational.");
+  }
+  const negative = value.numerator < 0n !== value.denominator < 0n;
+  const sign: "" | "-" = negative ? "-" : "";
+  const n = value.numerator < 0n ? -value.numerator : value.numerator;
+  const d = value.denominator < 0n ? -value.denominator : value.denominator;
+  if (d === 0n) return null;
+  if (n === 0n) return { sign: "", intDigits: "0", fracDigits: "" };
+
+  let fracNeeded: number;
+  const intPartDigits = n / d;
+  if (intPartDigits > 0n) {
+    fracNeeded = Math.max(ndigits - intPartDigits.toString().length, 0) + 2;
+  } else {
+    // Leading fractional zeros are not significant digits, so expand past
+    // them before asking for `ndigits` more.
+    let leadingZeros = 0;
+    for (let x = n * 10n; x < d && leadingZeros < MAX_EXPONENT_EXPANSION; x *= 10n) leadingZeros++;
+    fracNeeded = leadingZeros + ndigits + 2;
+  }
+  const scaled = ((n * 10n ** BigInt(fracNeeded)) / d).toString().padStart(fracNeeded + 1, "0");
+  return parse(
+    `${sign}${scaled.slice(0, scaled.length - fracNeeded)}.${scaled.slice(scaled.length - fracNeeded)}`,
+  );
+}
+
 function parse(
   value: string | number | bigint,
 ): { sign: "" | "-"; intDigits: string; fracDigits: string } | null {
@@ -356,3 +440,41 @@ function parse(
   if (intPart === "0" && fracPart === "") sign = "";
   return { sign, intDigits: intPart, fracDigits: fracPart };
 }
+
+/**
+ * Ruby's `Kernel.Float` — the strict decimal parse Rails reaches for directly
+ * (`activemodel/lib/active_model/validations/numericality.rb:82`). It honors
+ * `to_f` on a non-Numeric object and raises `ArgumentError`/`TypeError`
+ * otherwise; every Rails call site rescues both, so the unparseable cases
+ * answer `undefined` here rather than throwing.
+ *
+ * JS `Number()` and `Kernel.Float` disagree in three places trails has to
+ * close by hand: `Number()` reads `0b…` and `0o…` literals, which Ruby
+ * rejects; it coerces `""` and whitespace to `0`, which Ruby rejects; and it
+ * rejects the `1_000` digit separators Ruby accepts. `0x…` is read by both
+ * (`Float("0x10")` is 16.0 on MRI 3.3).
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core (Kernel.Float), which Rails calls
+ * without defining, so there is no Ruby file in any gem for the port to
+ * mirror.
+ */
+export function kernelFloat(rawValue: unknown): number | undefined {
+  if (rawValue !== null && typeof rawValue === "object") {
+    const toF = (rawValue as { toF?: unknown }).toF;
+    return typeof toF === "function" ? (toF as () => number).call(rawValue) : undefined;
+  }
+  if (typeof rawValue === "number") return rawValue;
+  if (typeof rawValue !== "string") return undefined;
+  if (rawValue.trim() === "") return undefined;
+  // Kernel.Float strips leading whitespace before parsing, so "  0b1" is
+  // rejected too.
+  if (NON_DECIMAL_LITERAL_REGEX.test(rawValue.trimStart())) return undefined;
+  const coerced = Number(rawValue.replace(DIGIT_SEPARATOR_REGEX, ""));
+  return Number.isNaN(coerced) ? undefined : coerced;
+}
+
+/** The literal prefixes `Number()` reads and `Kernel.Float` rejects. */
+const NON_DECIMAL_LITERAL_REGEX = /^[+-]?0[bBoO]/;
+
+/** Ruby's `1_000` digit separator, which `Number()` does not read. */
+const DIGIT_SEPARATOR_REGEX = /(?<=\d)_(?=\d)/g;

--- a/packages/activesupport/src/core-ext/bigdecimal.test.ts
+++ b/packages/activesupport/src/core-ext/bigdecimal.test.ts
@@ -16,6 +16,50 @@ describe("BigDecimalTest", () => {
     expect(JSON.stringify({ price: new BigDecimal("42") })).toBe('{"price":"42.0"}');
   });
 
+  it("BigDecimal(value, ndigits) keeps ndigits significant digits of a Float", () => {
+    // Ruby: BigDecimal(1234.5, 3) => 0.123e4, BigDecimal(0.00123456, 3) => 0.123e-2.
+    expect(new BigDecimal(1234.5, 3).toString("F")).toBe("1230.0");
+    expect(new BigDecimal(0.00123456, 3).toString("F")).toBe("0.00123");
+    expect(new BigDecimal(1.23456789, 5).toString("F")).toBe("1.2346");
+    expect(new BigDecimal(1234.5, 0).toString("F")).toBe("1234.5");
+    expect(new BigDecimal(0, 5).toString("F")).toBe("0.0");
+  });
+
+  it("BigDecimal(value, ndigits) leaves a String, Integer or BigDecimal whole", () => {
+    // ndigits is a MINIMUM precision for those, not a rounding instruction:
+    // BigDecimal("1234.5", 3) is 0.12345e4 where BigDecimal(1234.5, 3) is 0.123e4.
+    expect(new BigDecimal("1234.5", 3).toString("F")).toBe("1234.5");
+    expect(new BigDecimal("0.00123456", 3).toString("F")).toBe("0.00123456");
+    expect(new BigDecimal(123456789012345678901234567890n, 3).toString("F")).toBe(
+      "123456789012345678901234567890.0",
+    );
+  });
+
+  it("BigDecimal(value, ndigits) carries through a run of nines", () => {
+    // The half-up carry path: every kept digit is a 9, so the rounded value
+    // gains a digit and the exponent moves.
+    expect(new BigDecimal(9.999, 3).toString("F")).toBe("10.0");
+    expect(new BigDecimal(0.9999, 2).toString("F")).toBe("1.0");
+    expect(new BigDecimal(-9.999, 3).toString("F")).toBe("-10.0");
+    expect(new BigDecimal(99999, 3).toString("F")).toBe("100000.0");
+    expect(new BigDecimal("1.005").round(2).toString("F")).toBe("1.01");
+    expect(new BigDecimal("-1.005").round(2).toString("F")).toBe("-1.01");
+  });
+
+  it("BigDecimal(rational, ndigits) expands the fraction exactly", () => {
+    // Ruby: BigDecimal(Rational(1, 3), 18) => 0.333333333333333333e0.
+    expect(new BigDecimal({ numerator: 1n, denominator: 3n }, 18).toString("F")).toBe(
+      "0.333333333333333333",
+    );
+    expect(new BigDecimal({ numerator: 2n, denominator: 3n }, 5).toString("F")).toBe("0.66667");
+    expect(new BigDecimal({ numerator: -1n, denominator: 8n }, 18).toString("F")).toBe("-0.125");
+    // Ruby raises without a precision, since the expansion of a Rational is
+    // otherwise unbounded.
+    expect(() => new BigDecimal({ numerator: 1n, denominator: 3n })).toThrow(
+      /can't omit precision for a Rational/,
+    );
+  });
+
   it("to s with scientific notation", () => {
     expect(new BigDecimal("1234.5678").toString("E")).toBe("0.12345678e4");
     expect(new BigDecimal("1234.5678").toString("e")).toBe("0.12345678e4");

--- a/packages/activesupport/src/core-ext/bigdecimal.test.ts
+++ b/packages/activesupport/src/core-ext/bigdecimal.test.ts
@@ -33,6 +33,9 @@ describe("BigDecimalTest", () => {
     expect(new BigDecimal(123456789012345678901234567890n, 3).toString("F")).toBe(
       "123456789012345678901234567890.0",
     );
+    // Ruby: BigDecimal(BigDecimal("1234.5"), 3) => 0.12345e4. This is the arm
+    // decimal.rb:63-64 sends every non-Float ::Numeric through.
+    expect(new BigDecimal(new BigDecimal("1234.5"), 3).toString("F")).toBe("1234.5");
   });
 
   it("BigDecimal(value, ndigits) carries through a run of nines", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -327,7 +327,7 @@ export { nilUuid, uuidFromHash, uuidV3, uuidV4, uuidV5 } from "./core-ext/digest
 
 export { HashWithIndifferentAccess } from "./hash-with-indifferent-access.js";
 
-export { BigDecimal } from "./core-ext/big-decimal/conversions.js";
+export { BigDecimal, kernelFloat } from "./core-ext/big-decimal/conversions.js";
 
 export {
   delegate,

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -48,6 +48,22 @@ export class Range<T> {
   }
 
   /**
+   * Ruby answers nil for an empty range and raises for a beginless one, since
+   * there is no least element to report.
+   *
+   * @noRailsEquivalent PERMANENT — core Ruby `Range#min`, read by
+   * `length.rb:18`. No Rails file declares it, so `parity:api:extra` has no
+   * Ruby name to credit it against.
+   */
+  min(): T | null {
+    if (this.begin === null) {
+      throw new RangeError("cannot get the minimum of beginless range");
+    }
+    if (this.end !== null && cmp(this.begin, this.end) > 0) return null;
+    return this.begin;
+  }
+
+  /**
    * Ruby raises `TypeError` for a non-Integer excluded end rather than
    * silently reporting a fractional maximum.
    *

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -59,7 +59,9 @@ export class Range<T> {
     if (this.begin === null) {
       throw new RangeError("cannot get the minimum of beginless range");
     }
-    if (this.end !== null && cmp(this.begin, this.end) > 0) return null;
+    // Ruby answers nil for an empty range, and an exclusive end makes
+    // `begin == end` empty: `(1...1).min` is nil where `(1..1).min` is 1.
+    if (this.end !== null && cmp(this.begin, this.end) >= (this.excludeEnd ? 0 : 1)) return null;
     return this.begin;
   }
 


### PR DESCRIPTION
Bundles two RFC 0115 convergence stories that both land on the same
decimal-arithmetic seam.

## `type/decimal.ts` → `BigDecimal` (move-decimal-rounding-into-activesupport-bigdecimal)

`decimal.rb:57-98` does its arithmetic entirely through Ruby's `BigDecimal`.
`type/decimal.ts` instead carried significant-digit truncation and half-up
rounding with carry as decimal-string helpers inside the type caster —
`_castWithoutScale`, `splitDecimal`, `roundDecimalStringToSignificantDigits`,
`roundHalfUpToScale`, `rationalToSignificantDigits`, `incrementDecimalDigits`,
`roundFloatToSignificantDigits`. All of it is gone.

- **`BigDecimal` gains Ruby's `BigDecimal(value, ndigits)`** as a second
  constructor argument: `ndigits` significant digits, layered on the
  `round(n)` half-up rounding the class already had, via a new private
  `exponent()` that maps significant digits onto a fractional scale. It also
  accepts a `Rational` structurally (expanded by exact `bigint` long division,
  never through a float), the way `Kernel#BigDecimal` does, and raises without
  a precision as Ruby does. `ndigits` rounds only for a Float and a Rational —
  for a String, an Integer or another BigDecimal it is a minimum-precision
  hint and every digit survives, which is verified on MRI 3.3
  (`BigDecimal(1234.5, 3)` is `0.123e4`; `BigDecimal("1234.5", 3)` is
  `0.12345e4`) and pinned by a test.
- **`type/decimal.ts` now mirrors `decimal.rb` branch for branch**: the
  `::Float` / `::Numeric` / `::String` / `else` arms of `cast_value`, the
  `apply_scale` tail, `convert_float_to_big_decimal`, `float_precision`,
  `BIGDECIMAL_PRECISION`. The `::String` arm is a `to_d` function at the Ruby
  name. The NaN/±Infinity sentinel strings stay (BigDecimal has no such form
  and PG's `'NaN'::numeric` round-trip reads them back).

One trails-only test changed meaning rather than being deleted:
`apply_scale ignores non-integer/negative scale values` enshrined an invented
guard, but Ruby's `BigDecimal#round(-1)` is a real rounding to a multiple of
ten. It is now `apply_scale rounds to a multiple of ten for a negative scale`
and asserts the Ruby behaviour.

## numericality + length residue (converge-numericality-and-length-parsing-residue)

- **`Kernel.Float` had two spellings in `numericality.ts`.** It now lives once
  in activesupport as `kernelFloat`, next to `BigDecimal` in
  `core-ext/big-decimal/conversions.ts` — the `kernelArray` precedent, in the
  Rails-mapped file that already hosts the Ruby-core numeric primitives.
- **`round` / `parse_float` route through `BigDecimal`** (`#round` and
  `BigDecimal(x, precision)`), which retires the documented `RoundingHelper`
  deviation and the cross-file import of a decimal-type helper.
- **`parse_float` is kept**, contrary to the story text: it is Rails'
  `parse_float` (`numericality.rb:86-88`), not a second `Kernel.Float`. What
  is gone is its exported `parseFloatRails` alias; the prototype member is
  `parseFloat`, the Rails name.
- **`isSymbol` already tests the colon-prefixed-string convention** CLAUDE.md
  mandates, so it stands as-is (the story's alternative).
- **`resolveLengthOpt` is inlined** into the `CHECKS` loop per `length.rb:55`.
- **`:in` / `:within` take an activesupport `Range`**, replacing the invented
  `LengthRange` tuple/object spellings, so `length.rb:16-20` reads as Rails
  has it — `range.min` included (added to `Range`, as `max` already was).
  Call sites updated: `developer.rb` / `company_in_module.rb` models and the
  length-validation tests, which Rails writes as `in: 3..20`.

Three trails-only assertions changed because they enshrined an invention this
PR converges, each re-verified against MRI 3.3:

- `apply_scale ignores non-integer/negative scale values` asserted that a
  negative `scale:` is left alone. `BigDecimal("14").round(-1)` is `10` in
  Ruby, so it is now `apply_scale rounds to a multiple of ten for a negative
  scale`.
- `rejects hexadecimal literal strings (with or without leading whitespace)`
  asserted `"  0x10"` is not-a-number. `HEXADECIMAL_REGEX` is `\A`-anchored, so
  a leading space defeats it and `Kernel.Float("  0x10")` answers `16.0` —
  Rails accepts it. The name now says which strings the regex anchors on.
- `kernelFloat` no longer rejects `0x…` (Ruby's `Float("0x10")` is `16.0`) and
  now reads the `1_000` digit separator Ruby accepts. It still rejects `0b…` /
  `0o…` / blank, which Ruby also rejects and JS `Number()` does not.

## Results

`parity:api:extra --package activemodel`: `type/decimal.ts` 2 → 1 novel;
`validations/length.ts` 3 → 0; `validations/numericality.ts` 1 → 0.
Parity deltas unchanged for both packages; `parity:api:calls` and
`:args` clean, no baseline rows added.

**LOC:** 820 (391+429) against the 700 ceiling. The overage is deletion-heavy
— `type/decimal.ts` alone loses ~230 net lines of invented decimal-string
arithmetic — and the two stories were bundled into one PR by the task prompt,
so there is no split that keeps each half coherent.

## Verification

```
pnpm vitest run packages/activemodel packages/activesupport/src/core-ext \
  packages/activesupport/src/range-ext.test.ts packages/activerecord/src/validations \
  packages/activerecord/src/readonly.test.ts packages/activerecord/src/numeric-data.test.ts \
  packages/activerecord/src/type.trails.test.ts
# 156 files, 3270 passed
```

Closes-story: converge-numericality-and-length-parsing-residue
Closes-story: move-decimal-rounding-into-activesupport-bigdecimal
