### PR TITLE
refactor(activemodel,activerecord): collapse the two assign_attributes ports and retire the eager decorate bake

### DIFF
--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -42,7 +42,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Bob" });
+    void p.assignAttributes({ name: "Bob" });
     expect(p.readAttribute("name")).toBe("Bob");
   });
 
@@ -56,7 +56,7 @@ describe("AttributeAssignmentTest", () => {
     // Rails raises UnknownAttributeError for a key with no setter / column.
     let raised: unknown;
     try {
-      p.assignAttributes({ unknown_attr: "value" });
+      void p.assignAttributes({ unknown_attr: "value" });
     } catch (e) {
       raised = e;
     }
@@ -73,7 +73,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const model = new Person({});
 
-    model.assignAttributes({ unknown: "attribute" });
+    void model.assignAttributes({ unknown: "attribute" });
 
     expect(model.assignedAttributes).toEqual({ unknown: "attribute" });
   });
@@ -85,7 +85,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "private_val" });
+    void p.assignAttributes({ name: "private_val" });
     expect(p.readAttribute("name")).toBe("private_val");
   });
 
@@ -123,7 +123,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const c = new Child({});
-    c.assignAttributes({ name: "bob" });
+    void c.assignAttributes({ name: "bob" });
     expect(c.readAttribute("name")).toBe("BOB");
   });
 
@@ -142,7 +142,7 @@ describe("AttributeAssignmentTest", () => {
       },
       configurable: true,
     });
-    p.assignAttributes({ name: "bob" });
+    void p.assignAttributes({ name: "bob" });
     expect(seen).toEqual(["bob"]);
     expect(p.readAttribute("name")).toBe("BOB");
   });
@@ -157,7 +157,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "  bob  " });
+    void p.assignAttributes({ name: "  bob  " });
     expect(p.readAttribute("name")).toBe("BOB");
   });
 
@@ -219,7 +219,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "test" });
+    void p.assignAttributes({ name: "test" });
     expect(p.readAttribute("name")).toBe("test");
   });
 
@@ -231,7 +231,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Alice", age: 30 });
+    void p.assignAttributes({ name: "Alice", age: 30 });
     expect(p.readAttribute("name")).toBe("Alice");
     expect(p.readAttribute("age")).toBe(30);
   });
@@ -243,7 +243,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Bob" });
+    void p.assignAttributes({ name: "Bob" });
     expect(p.readAttribute("name")).toBe("Bob");
   });
 
@@ -259,7 +259,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Carol" });
+    void p.assignAttributes({ name: "Carol" });
     expect(called).toHaveLength(1);
     expect(called[0]).toEqual({ name: "Carol" });
     expect(p.readAttribute("name")).toBe("Carol");
@@ -277,7 +277,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Dave", role: "admin" });
+    void p.assignAttributes({ name: "Dave", role: "admin" });
     expect(p.readAttribute("name")).toBe("Dave");
     expect(p.readAttribute("role")).toBeNull();
   });
@@ -339,7 +339,7 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    p.assignAttributes({ name: "Eve", age: 5 });
+    void p.assignAttributes({ name: "Eve", age: 5 });
     expect(seen).toContainEqual(["name", "Eve"]);
     expect(seen).toContainEqual(["age", 5]);
     expect(p.readAttribute("name")).toBe("Eve");

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -14,9 +14,21 @@ import { UnknownAttributeError } from "./errors.js";
  *   end
  *
  * Both sends go through the model, as Ruby's implicit `self` receiver does, so
- * a subclass override of either is honoured.
+ * a subclass override of either is honoured — including ActiveRecord's
+ * `_assign_attributes` (activerecord/attribute_assignment.rb:6-23), whose
+ * writers can reach the database at assignment (`replace`,
+ * collection_association.rb:46-48; `ids_writer`, :61-83; has_one's displacing
+ * writer, has_one_association.rb:59-84).
+ *
+ * That is why the return type is `Promise<void> | void` and the body is
+ * deliberately not `async`: an `async` body would push even a plain column
+ * write past the caller's next line, where Ruby's `assign_attributes` has
+ * already done it. It answers a promise only when a send owed I/O.
  */
-export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
+export function assignAttributes(
+  model: AttributeAssignment,
+  newAttributes: unknown,
+): Promise<void> | void {
   if (!respondToEachPair(newAttributes)) {
     throw new ArgumentError(
       `When assigning attributes, you must pass a hash as an argument, ${classOf(newAttributes)} passed.`,
@@ -24,7 +36,7 @@ export function assignAttributes(model: AttributeAssignment, newAttributes: unkn
   }
   if (isMassAssignmentEmpty(newAttributes)) return;
 
-  model._assignAttributes(model.sanitizeForMassAssignment(newAttributes));
+  return model._assignAttributes(model.sanitizeForMassAssignment(newAttributes));
 }
 
 export function attributeWriterMissing(
@@ -112,7 +124,7 @@ export interface AttributeAssignment {
   /** @internal */
   sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
   /** @internal Rails-private helper. */
-  _assignAttributes(attributes: Record<string, unknown>): void;
+  _assignAttributes(attributes: Record<string, unknown>): Promise<void> | void;
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
   attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
 }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -90,12 +90,17 @@ export class PendingDefault implements PendingModification {
 
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#decorate_attributes
+ * (attribute_registration.rb:26-30):
  *
- * Pushes a PendingDecorator onto the modification queue so it replays in the
- * correct order during _defaultAttributes (after any PendingType entries that
- * precede it). Also updates _attributeDefinitions immediately so backward-compat
- * reads (typeForAttribute, columnForAttribute) and double-decoration guards
- * see the decorated type without waiting for _defaultAttributes to be rebuilt.
+ *   def decorate_attributes(names = nil, &decorator)
+ *     names = names&.map { |name| resolve_attribute_name(name) }
+ *     pending_attribute_modifications << PendingDecorator.new(names, decorator)
+ *     reset_default_attributes
+ *   end
+ *
+ * The decoration itself is applied when `_default_attributes` next
+ * materializes (attribute_registration.rb:32-36) — nothing is written to
+ * `_attributeDefinitions` here.
  */
 export function decorateAttributes(
   this: AttributeHostInternals,
@@ -104,26 +109,7 @@ export function decorateAttributes(
 ): void {
   names = names?.map((name) => this.resolveAttributeName(name)) ?? null;
 
-  // Push to pending queue so _defaultAttributes replays in declaration order.
   pendingAttributeModifications.call(this).push(new PendingDecorator(names, decorator));
-
-  // Also apply immediately to _attributeDefinitions for backward compat and
-  // so guards like `def.type instanceof EncryptedAttributeType` work without
-  // forcing a _defaultAttributes rebuild.
-  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-    this._attributeDefinitions = new Map(this._attributeDefinitions);
-  }
-  const defs = this._attributeDefinitions as Map<string, { name: string; type: Type }>;
-  const targetNames = names ?? Array.from(defs.keys());
-  for (const name of targetNames) {
-    const def = defs.get(name);
-    // Deviation: Rails has no eager pass, so it cannot bake a decoration over
-    // `Type.default_value` into the definitions AR's seed reads (enum.rb:240).
-    if (def && def.type !== defaultValue()) {
-      const newType = decorator(name, def.type);
-      if (newType) defs.set(name, { ...def, type: newType });
-    }
-  }
 
   resetDefaultAttributes(this);
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2642,8 +2642,8 @@ export class Model {
    *
    * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
    */
-  assignAttributes(newAttributes: unknown): void {
-    attrAssign(this, newAttributes);
+  assignAttributes(newAttributes: unknown): Promise<void> | void {
+    return attrAssign(this, newAttributes);
   }
 
   /**

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -52,6 +52,12 @@ function isNestedParameterHash(value: unknown): boolean {
  * has finished writing by the time the loop reaches the next key, so where a send
  * here answers a promise the rest of the loop is chained behind it to keep that
  * order. Every send that stays in memory keeps running inline.
+ *
+ * `_assign_attribute` is Ruby's implicit-self send, but trails' AR-side one is
+ * a module-private function in `persistence.ts` (where the association-writer
+ * resolution it needs lives) rather than a method on the class — publishing it
+ * as one would put an `_assign_attribute` override on ActiveRecord that Rails
+ * does not have. It is called directly here instead.
  */
 export function _assignAttributes(
   this: AttributeAssignmentHost,

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -3,66 +3,109 @@
  *
  * Mirrors: ActiveRecord::AttributeAssignment
  *
- * Runtime note: the public `assignAttributes` entry-point lives in
- * `persistence.ts` (wired onto Base), which delegates to the helpers in
- * `multiparameter-attribute-assignment.ts`. The functions exported here are
- * the Rails-private layer (`_assign_attributes`, `assign_multiparameter_attributes`,
- * etc.) that Rails' `assign_attributes` calls internally — they exist here for
- * Rails-layout parity (`parity:api`) and are @internal.
+ * Runtime note: as in Rails, `assign_attributes` itself is ActiveModel's
+ * (activemodel/attribute_assignment.rb:28-34) and is not redefined here; the
+ * functions exported here are the Rails-private layer
+ * (`_assign_attributes`, `assign_multiparameter_attributes`, etc.) that it
+ * calls internally. They are mixed onto `Base`, so ActiveModel's
+ * `assign_attributes` reaches this `_assign_attributes` exactly as Ruby's
+ * `self` send does. All are @internal.
  */
 import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
+import { _assignAttribute } from "./persistence.js";
 
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
-  // ActiveModel's `_assign_attribute` (attribute_assignment.rb:67-75): dispatch
-  // a key through its writer, or route a writer-less key to
-  // `attribute_writer_missing` (→ UnknownAttributeError). Inherited from `Model`.
-  _assignAttribute(key: string, value: unknown): void;
+  attributeWriterMissing(name: string, value: unknown): void;
+  readAttribute(name: string): unknown;
+  /** @internal */
+  assignNestedParameterAttributes(pairs: Record<string, unknown>): Promise<void> | void;
+  /** @internal */
+  assignMultiparameterAttributes(pairs: Record<string, unknown>): void;
+}
+
+/**
+ * Ruby `v.is_a?(Hash)` (attribute_assignment.rb:13). A Date/Temporal/model
+ * value is `typeof "object"` in JS but is not a Hash in Ruby, so only plain
+ * objects may be deferred.
+ */
+function isNestedParameterHash(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 /**
  * @internal
  * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
+ * (attribute_assignment.rb:6-23).
+ *
+ * Rails buckets multiparameter keys AND Hash values out of the main loop and
+ * assigns the nested hashes only after the scalar pass (:21), so a nested
+ * writer's `reject_if` / the built record's callbacks observe an owner whose
+ * own attributes are already set. Nested runs before multiparameter (:21-22).
+ *
+ * `pending` is the one accommodation Rails does not need: its `_assign_attribute`
+ * has finished writing by the time the loop reaches the next key, so where a send
+ * here answers a promise the rest of the loop is chained behind it to keep that
+ * order. Every send that stays in memory keeps running inline.
  */
 export function _assignAttributes(
   this: AttributeAssignmentHost,
   attributes: Record<string, unknown>,
-): void {
+): Promise<void> | void {
   let multiParameterAttributes: Record<string, unknown> | null = null;
   let nestedParameterAttributes: Record<string, unknown> | null = null;
+  let pending: Promise<void> | undefined;
 
   for (const [k, v] of Object.entries(attributes)) {
-    if (k.includes("(")) {
-      (multiParameterAttributes ??= Object.create(null))[k] = v;
-    } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-      (nestedParameterAttributes ??= Object.create(null))[k] = v;
+    const key = String(k);
+    if (key.includes("(")) {
+      (multiParameterAttributes ??= {})[key] = v;
+    } else if (isNestedParameterHash(v)) {
+      (nestedParameterAttributes ??= {})[key] = v;
+    } else if (pending) {
+      pending = pending.then(() => _assignAttribute(this, key, v));
     } else {
-      this._assignAttribute(k, v);
+      pending = _assignAttribute(this, key, v) as Promise<void> | undefined;
     }
   }
 
-  if (nestedParameterAttributes) {
-    assignNestedParameterAttributes.call(this, nestedParameterAttributes);
-  }
-  if (multiParameterAttributes) {
-    assignMultiparameterAttributes.call(this, multiParameterAttributes);
-  }
+  const assignDeferred = (): Promise<void> | void => {
+    const nested = (
+      nestedParameterAttributes
+        ? this.assignNestedParameterAttributes(nestedParameterAttributes)
+        : undefined
+    ) as Promise<void> | undefined;
+    const assignMulti = (): void => {
+      if (multiParameterAttributes) this.assignMultiparameterAttributes(multiParameterAttributes);
+    };
+    return nested ? nested.then(assignMulti) : assignMulti();
+  };
+
+  return pending ? pending.then(assignDeferred) : assignDeferred();
 }
 
 /**
  * @internal
  * Mirrors: ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes
+ * (attribute_assignment.rb:26-28) — assign any deferred nested attributes after
+ * the base attributes have been set.
  */
 export function assignNestedParameterAttributes(
   this: AttributeAssignmentHost,
   pairs: Record<string, unknown>,
-): void {
+): Promise<void> | void {
+  let pending: Promise<void> | undefined;
   for (const [k, v] of Object.entries(pairs)) {
-    this._assignAttribute(k, v);
+    pending = (
+      pending ? pending.then(() => _assignAttribute(this, k, v)) : _assignAttribute(this, k, v)
+    ) as Promise<void> | undefined;
   }
+  return pending;
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -22,7 +22,7 @@ describe("TimeZoneConversionTest", () => {
         this.attribute("published_at", "datetime");
       }
     }
-    const type = Post._attributeDefinitions.get("published_at")?.type;
+    const type = Post.typeForAttribute("published_at");
     expect(type).toBeInstanceOf(TimeZoneConverter);
   });
 
@@ -33,7 +33,7 @@ describe("TimeZoneConversionTest", () => {
         this.attribute("published_at", "datetime");
       }
     }
-    const type = Post._attributeDefinitions.get("published_at")?.type;
+    const type = Post.typeForAttribute("published_at");
     expect(type).not.toBeInstanceOf(TimeZoneConverter);
   });
 
@@ -44,7 +44,7 @@ describe("TimeZoneConversionTest", () => {
         this.attribute("title", "string");
       }
     }
-    const type = Post._attributeDefinitions.get("title")?.type;
+    const type = Post.typeForAttribute("title");
     expect(type).not.toBeInstanceOf(TimeZoneConverter);
   });
 
@@ -56,7 +56,7 @@ describe("TimeZoneConversionTest", () => {
         this.attribute("published_at", "datetime");
       }
     }
-    const type = Post._attributeDefinitions.get("published_at")?.type;
+    const type = Post.typeForAttribute("published_at");
     expect(type).not.toBeInstanceOf(TimeZoneConverter);
   });
 
@@ -67,7 +67,7 @@ describe("TimeZoneConversionTest", () => {
         this.attribute("starts_at", "time");
       }
     }
-    const type = Post._attributeDefinitions.get("starts_at")?.type;
+    const type = Post.typeForAttribute("starts_at");
     expect(type).toBeInstanceOf(TimeZoneConverter);
   });
 

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.test.ts
@@ -109,8 +109,8 @@ describe("TimeZoneConversionTest", () => {
     }
     (Post as unknown as { adapter: unknown }).adapter = adapter;
     await loadSchemaFromAdapter.call(Post);
-    expect(Post._attributeDefinitions.get("published_at")?.type).toBeInstanceOf(TimeZoneConverter);
-    expect(Post._attributeDefinitions.get("title")?.type).not.toBeInstanceOf(TimeZoneConverter);
+    expect(Post.typeForAttribute("published_at")).toBeInstanceOf(TimeZoneConverter);
+    expect(Post.typeForAttribute("title")).not.toBeInstanceOf(TimeZoneConverter);
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4633,7 +4633,6 @@ include(Base, {
   reload: _Persistence.reload,
   slice: _Persistence.slice,
   valuesAt: _Persistence.valuesAt,
-  assignAttributes: _Persistence.assignAttributes,
   setAttributes: _Persistence.setAttributes,
   updateAttribute: _Persistence.updateAttribute,
   updateAttributeBang: _Persistence.updateAttributeBang,

--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -137,7 +137,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     expect(typeof ciphertext).toBe("string");
     expect(ciphertext).not.toBe("Dune");
     // Verify the ciphertext decrypts to the correct value.
-    const type = Book._attributeDefinitions?.get("name")?.type;
+    const type = Book.typeForAttribute("name");
     expect(type.deserialize(ciphertext)).toBe("Dune");
   });
 
@@ -151,7 +151,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const reloaded = await Post.find(post.id);
     const ciphertext = reloaded.ciphertextFor("title");
     expect(ciphertext).toBe(reloaded.readAttributeBeforeTypeCast("title"));
-    const type = Post._attributeDefinitions?.get("title")?.type;
+    const type = Post.typeForAttribute("title");
     expect(type.deserialize(ciphertext)).toBe("Fear is the mind-killer");
   });
 
@@ -160,7 +160,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const book = await Book.create({ name: "Dune" });
     book.name = "Arrakis";
     const ciphertext = book.ciphertextFor("name");
-    const type = Book._attributeDefinitions?.get("name")?.type;
+    const type = Book.typeForAttribute("name");
     expect(type.deserialize(ciphertext)).toBe("Arrakis");
   });
 
@@ -169,7 +169,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const book = await Book.create({ name: "Dune" });
     await book.decrypt();
     const ciphertext = book.ciphertextFor("name");
-    const type = Book._attributeDefinitions?.get("name")?.type;
+    const type = Book.typeForAttribute("name");
     expect(type.deserialize(ciphertext)).toBe("Dune");
   });
 
@@ -178,7 +178,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const book = new Book();
     book.name = "Dune";
     const ciphertext = book.ciphertextFor("name");
-    const type = Book._attributeDefinitions?.get("name")?.type;
+    const type = Book.typeForAttribute("name");
     expect(type.deserialize(ciphertext)).toBe("Dune");
   });
 
@@ -194,7 +194,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
     const author = await Author.create({ name: "david" });
 
     // Encrypt "dhh" using the previous scheme to simulate an old row.
-    const type = Author._attributeDefinitions?.get("name")?.type;
+    const type = Author.typeForAttribute("name");
     expect(type.previousTypes.length).toBeGreaterThan(0);
     const prevType = type.previousTypes[0];
     const oldCiphertext = prevType.serialize("dhh") as string;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -122,9 +122,10 @@ export class EncryptableRecord {
    */
   static pushEncryptionDecorator(modelClass: any, name: string, pending: PendingEncryption): void {
     modelClass.decorateAttributes([name], (attrName: string, castType: Type, host?: unknown) => {
-      // Idempotence guard for the eager immediate-apply pass (a fresh-seed
-      // replay applies each queued decorator once, but `decorateAttributes`
-      // also applies eagerly to a possibly already-wrapped definitions view).
+      // Idempotence guard: a fresh-seed replay applies each queued decorator
+      // once, but the seeded cast type can itself already be encrypted (the
+      // `registerEncryptedType` path writes one into `_attributeDefinitions`,
+      // which AR's column seeding reads back).
       if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
       const target = host ?? modelClass;
       return new EncryptedAttributeType({

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -121,13 +121,13 @@ export class EncryptableRecord {
    * @internal
    */
   static pushEncryptionDecorator(modelClass: any, name: string, pending: PendingEncryption): void {
-    modelClass.decorateAttributes([name], (attrName: string, castType: Type, host?: unknown) => {
+    modelClass.decorateAttributes([name], (attrName: string, castType: Type, host: unknown) => {
       // Idempotence guard: a fresh-seed replay applies each queued decorator
       // once, but the seeded cast type can itself already be encrypted (the
       // `registerEncryptedType` path writes one into `_attributeDefinitions`,
       // which AR's column seeding reads back).
       if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
-      const target = host ?? modelClass;
+      const target = host;
       return new EncryptedAttributeType({
         scheme: pending.scheme,
         castType,

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -121,22 +121,23 @@ export class EncryptableRecord {
    * @internal
    */
   static pushEncryptionDecorator(modelClass: any, name: string, pending: PendingEncryption): void {
-    modelClass.decorateAttributes([name], (attrName: string, castType: Type, host: unknown) => {
+    modelClass.decorateAttributes([name], (attrName: string, castType: Type) => {
       // Idempotence guard: a fresh-seed replay applies each queued decorator
       // once, but the seeded cast type can itself already be encrypted (the
       // `registerEncryptedType` path writes one into `_attributeDefinitions`,
       // which AR's column seeding reads back).
       if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
-      const target = host;
       return new EncryptedAttributeType({
         scheme: pending.scheme,
         castType,
+        // Rails reads `columns_hash[name.to_s]&.default` off the class the
+        // block was declared in (encryptable_record.rb:91).
         default: this.columnDefaultFor(
-          target,
+          modelClass,
           attrName,
-          (target as { _attributeDefinitions?: Map<string, unknown> })._attributeDefinitions?.get?.(
-            attrName,
-          ),
+          (
+            modelClass as { _attributeDefinitions?: Map<string, unknown> }
+          )._attributeDefinitions?.get?.(attrName),
         ),
       });
     });

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -3,9 +3,10 @@
  * subclass's attribute types. Rails keeps this per-class (`normalized_attributes`
  * is a `class_attribute` and `_default_attributes` replays only the class's own
  * pending decorators), but trails' STI reflection installed the base's shared
- * `_attributeDefinitions` map as an OWN property of the subclass, which fooled
- * the copy-on-write guard in `decorateAttributes` — so the subclass decoration
- * landed on the base's definitions and leaked to sibling subclasses.
+ * `_attributeDefinitions` map as an OWN property of the subclass, so a
+ * subclass decoration could land on the base and leak to sibling subclasses.
+ * The decorated type is read where Rails reads it — `type_for_attribute` over
+ * the replayed attribute set (attribute_registration.rb:43-51).
  *
  * The leak only reproduces when the SUBCLASS drives the first reflection of the
  * STI table (that is the path that installs the base map as an own property), so
@@ -40,9 +41,9 @@ describe("STI subclass normalizes", () => {
       typeof name === "string" ? name.trim().toUpperCase() : name,
     );
 
-    expect(defTypeFor(NormalizedCompany, "name").cast("  acme  ")).toBe("ACME");
-    expect(defTypeFor(Company, "name").cast("  acme  ")).toBe("  acme  ");
-    expect(defTypeFor(OtherCompany, "name").cast("  acme  ")).toBe("  acme  ");
+    expect(NormalizedCompany.typeForAttribute("name").cast("  acme  ")).toBe("ACME");
+    expect(Company.typeForAttribute("name").cast("  acme  ")).toBe("  acme  ");
+    expect(OtherCompany.typeForAttribute("name").cast("  acme  ")).toBe("  acme  ");
 
     expect(NormalizedCompany.new({ name: "  acme  " }).name).toBe("ACME");
     expect(Company.new({ name: "  acme  " }).name).toBe("  acme  ");

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -13,10 +13,8 @@ import type { Base } from "./base.js";
 import type { CounterCacheCounters } from "./counter-cache.js";
 import {
   ArgumentError,
-  sanitizeForMassAssignment,
   SerializeCastValue,
   runAfterCallbacksOnProto,
-  isMassAssignmentEmpty,
 } from "@blazetrails/activemodel";
 import {
   InsertManager,
@@ -32,10 +30,6 @@ import {
   RecordNotSaved,
   UnknownAttributeError,
 } from "./errors.js";
-import {
-  extractMultiparameterCallstack,
-  executeMultiparameterAssignment,
-} from "./multiparameter-attribute-assignment.js";
 import { threadedConnectionFor, withConnection } from "./connection-handling.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
 import {
@@ -869,8 +863,8 @@ export async function destroyBang<T extends DestroyRecord & { destroy(): Promise
 }
 
 // ---------------------------------------------------------------------------
-// Instance read-helpers — slice / valuesAt / assignAttributes.
-// Mirror ActiveRecord::Base#slice / #values_at / #assign_attributes.
+// Instance read-helpers — slice / valuesAt.
+// Mirror ActiveRecord::Base#slice / #values_at.
 // ---------------------------------------------------------------------------
 
 /** Mirrors: ActiveRecord::Base#slice */
@@ -1000,7 +994,11 @@ function associationWriter(
  * (has_one_association.rb:69) a write; that promise is returned rather than
  * dropped.
  */
-function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promise<void> | void {
+export function _assignAttribute(
+  self: AttributeIO,
+  key: string,
+  value: unknown,
+): Promise<void> | void {
   const configs = (self as any).constructor?._nestedAttributeConfigs as
     | { associationName: string }[]
     | undefined;
@@ -1019,130 +1017,17 @@ function _assignAttribute(self: AttributeIO, key: string, value: unknown): Promi
 }
 
 /**
- * Mirrors: ActiveModel::AttributeAssignment#assign_attributes
- * (attribute_assignment.rb:28-34) — raise unless the argument is a Hash, return
- * on a blank one, then sanitize and hand off to `_assign_attributes`.
- *
- * Rails returns nil and so does this. Deliberately not `async`: three of the
- * writers its `each_pair` sends to reach the database at assignment (`replace`,
- * collection_association.rb:46-48; `ids_writer`, :61-83; has_one's displacing
- * writer, has_one_association.rb:59-84), and an `async` body would push even a
- * plain column write past the caller's next line — where Ruby's `assign_attributes`
- * has already done it, and where the synchronous callers `initialize` still has
- * (`_applyScopeAttributes`, `attributes=`) read it. So it answers a promise only
- * when a send owed I/O, the same shape as the `set#{Name}Attributes` writer
- * (nested-attributes.ts).
- */
-export function assignAttributes(
-  this: AttributeIO,
-  attrs: Record<string, unknown>,
-): Promise<void> | void {
-  // `unless new_attributes.respond_to?(:each_pair)` (attribute_assignment.rb:29-31).
-  // ActiveModel's own `assignAttributes` spells the same three lines; this port
-  // exists separately only because it has to be async, so the guard is repeated
-  // rather than shared through a helper Rails does not have.
-  if (!respondToEachPair(attrs)) {
-    throw new ArgumentError(
-      `When assigning attributes, you must pass a hash as an argument, ${classOf(attrs)} passed.`,
-    );
-  }
-  // `new_attributes.empty?` (attribute_assignment.rb:32) runs before the
-  // sanitizer, so a blank strong-params object is a no-op rather than raising;
-  // `isMassAssignmentEmpty` reads a wrapper's contents, not its own fields.
-  if (isMassAssignmentEmpty(attrs)) return;
-  return _assignAttributes(this, sanitizeForMassAssignment(attrs));
-}
-
-/**
  * Mirrors: `alias attributes= assign_attributes` (attribute_assignment.rb:36).
  * A TS `set` accessor cannot be awaited, so the alias keeps the Rails name in a
- * `setX()` method (CLAUDE.md § "Fidelity is the job").
+ * `setX()` method (CLAUDE.md § "Fidelity is the job"). `assign_attributes`
+ * itself is not redefined here — as in Rails, it is ActiveModel's
+ * (attribute_assignment.rb:28-34), inherited through `Model`.
  */
 export function setAttributes(
-  this: AttributeIO,
+  this: AttributeIO & { assignAttributes(attrs: Record<string, unknown>): Promise<void> | void },
   attrs: Record<string, unknown>,
 ): Promise<void> | void {
-  return assignAttributes.call(this, attrs);
-}
-
-/**
- * Ruby `v.is_a?(Hash)`. A Date/Temporal/model value is `typeof "object"` in JS
- * but is not a Hash in Ruby, so only plain objects may be deferred.
- */
-function isNestedParameterHash(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
-
-/**
- * Mirrors: ActiveRecord::AttributeAssignment#_assign_attributes
- * (attribute_assignment.rb:6-23).
- *
- * Rails buckets multiparameter keys AND Hash values out of the main loop and
- * assigns the nested hashes only after the scalar pass (:21), so a nested
- * writer's `reject_if` / the built record's callbacks observe an owner whose
- * own attributes are already set. Nested runs before multiparameter (:21-22).
- *
- * `pending` is the one accommodation Rails does not need: its `_assign_attribute`
- * has finished writing by the time the loop reaches the next key, so where a send
- * here answers a promise the rest of the loop is chained behind it to keep that
- * order. Every send that stays in memory keeps running inline.
- */
-function _assignAttributes(
-  self: AttributeIO,
-  attrs: Record<string, unknown>,
-): Promise<void> | void {
-  let multiParameterAttributes: Record<string, unknown> | null = null;
-  let nestedParameterAttributes: Record<string, unknown> | null = null;
-  let pending: Promise<void> | undefined;
-
-  for (const [key, value] of Object.entries(attrs)) {
-    if (key.includes("(")) {
-      (multiParameterAttributes ??= {})[key] = value;
-    } else if (isNestedParameterHash(value)) {
-      (nestedParameterAttributes ??= {})[key] = value;
-    } else if (pending) {
-      pending = pending.then(() => _assignAttribute(self, key, value));
-    } else {
-      pending = _assignAttribute(self, key, value) as Promise<void> | undefined;
-    }
-  }
-
-  const assignDeferred = (): Promise<void> | void => {
-    const nested = (
-      nestedParameterAttributes
-        ? assignNestedParameterAttributes(self, nestedParameterAttributes)
-        : undefined
-    ) as Promise<void> | undefined;
-    const assignMulti = (): void => {
-      if (multiParameterAttributes) {
-        const multi = extractMultiparameterCallstack(multiParameterAttributes).multiparams;
-        executeMultiparameterAssignment(self as any, multi);
-      }
-    };
-    return nested ? nested.then(assignMulti) : assignMulti();
-  };
-
-  return pending ? pending.then(assignDeferred) : assignDeferred();
-}
-
-/**
- * Mirrors: ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes
- * (attribute_assignment.rb:26-28) — assign any deferred nested attributes after
- * the base attributes have been set.
- */
-function assignNestedParameterAttributes(
-  self: AttributeIO,
-  pairs: Record<string, unknown>,
-): Promise<void> | void {
-  let pending: Promise<void> | undefined;
-  for (const [k, v] of Object.entries(pairs)) {
-    pending = (
-      pending ? pending.then(() => _assignAttribute(self, k, v)) : _assignAttribute(self, k, v)
-    ) as Promise<void> | undefined;
-  }
-  return pending;
+  return this.assignAttributes(attrs);
 }
 
 // ---------------------------------------------------------------------------
@@ -2248,24 +2133,3 @@ export function buildDefaultConstraint(this: {
 export const InstanceMethods = {
   _updateRecord: instanceUpdateRecord,
 };
-
-/** The JS spelling of `new_attributes.respond_to?(:each_pair)` (attribute_assignment.rb:29). */
-function respondToEachPair(attrs: unknown): attrs is Record<string, unknown> {
-  if (typeof attrs !== "object" || attrs === null || Array.isArray(attrs)) return false;
-  const proto = Object.getPrototypeOf(attrs);
-  if (proto === Object.prototype || proto === null) return true;
-  // A params-style wrapper (the `ActionController::Parameters` analogue) is the
-  // other Ruby receiver that answers `each_pair`.
-  const wrapper = attrs as { permitted?: unknown; toH?: unknown };
-  return "permitted" in wrapper || typeof wrapper.toH === "function";
-}
-
-/** The JS spelling of Ruby's `value.class` name, for the guard's message. */
-function classOf(value: unknown): string {
-  if (value === null) return "NilClass";
-  if (Array.isArray(value)) return "Array";
-  const ctorName = (value as { constructor?: { name?: string } } | undefined)?.constructor?.name;
-  if (ctorName) return ctorName;
-  const t = typeof value;
-  return t.charAt(0).toUpperCase() + t.slice(1);
-}

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -95,9 +95,6 @@ describe("STI subclass attribute() registration", () => {
     expect(isEncryptedAttribute(Dog, "name")).toBe(true);
     expect(isEncryptedAttribute(Animal, "name")).toBe(false);
     expect(isEncryptedAttribute(Cat, "name")).toBe(false);
-
-    // Copy-on-write: the subclass no longer shares the base's definitions map.
-    expect(Dog._attributeDefinitions).not.toBe(Animal._attributeDefinitions);
   });
 
   it("subclass attribute survives the subclass's own schema reflection (end-to-end)", async () => {


### PR DESCRIPTION
Two RFC 0115 convergences in one PR — both are deletions of trails-only
machinery that sat next to the ActiveModel attribute registration/assignment
ports.

## 1. One `assign_attributes`

Rails has exactly one (`activemodel/lib/active_model/attribute_assignment.rb:28-34`);
ActiveRecord does not redefine it. trails had two — the ActiveModel port and a
copy in `persistence.ts` — which forced the `respond_to?(:each_pair)` guard, its
`ArgumentError` message, `respondToEachPair` and `classOf` to be written twice.

- `assignAttributes` now exists only in `packages/activemodel/src/attribute-assignment.ts`,
  returning `Promise<void> | void` — the settled trails idiom for a body that
  can owe I/O (`replace`, collection_association.rb:46-48; `ids_writer`, :61-83;
  has_one's displacing writer, has_one_association.rb:59-84). The body is
  deliberately **not** `async`, so a plain column write still lands before the
  caller's next line.
- AR inherits it through `Model`; `persistence.ts` keeps only the
  `attributes=` alias (`setAttributes`), which now delegates to
  `this.assignAttributes`.
- The AR override Rails *does* have — `_assign_attributes`
  (`activerecord/lib/active_record/attribute_assignment.rb:6-23`) — now lives
  once, at its Rails home in `activerecord/src/attribute-assignment.ts`,
  replacing the sync duplicate that was there. It calls
  `assign_nested_parameter_attributes` / `assign_multiparameter_attributes`
  through `this`, as Rails does, instead of inlining the multiparameter
  callstack extraction.
- `respondToEachPair` / `classOf` remain file-private in ActiveModel:
  `attribute-assignment.ts` stays at 0 novel and `index.ts` gains no row.

## 2. No eager `_attributeDefinitions` bake in `decorateAttributes`

`decorate_attributes` (`activemodel/lib/active_model/attribute_registration.rb:26-30`)
only resolves the names, pushes a `PendingDecorator`, and calls
`reset_default_attributes`; the decoration is applied when `_default_attributes`
next materializes (:32-36). trails additionally walked `_attributeDefinitions`
at declaration time.

- That walk is gone; `decorateAttributes` is now the Rails three lines.
- The `isDecoratorReplay()` depth counter and its `inDecoratorReplay` wrapper
  are deleted and no longer exported from `activemodel`. The enum decorator's
  "Undeclared attribute type" check keeps only its `!target.abstractClass`
  gate and reads the materializing class from `PendingDecorator#apply_to`
  (attribute_registration.rb:66-73, replayed into subclasses at :81-87).
- No decorator signature change is left here: #6793 landed
  `converge-enum-undeclared-type-check-to-subtype` (the follow-up this branch
  filed) and already converged `AttributeDecorator` to Rails' two call
  arguments, `decorator.call(name, attribute.type)`
  (attribute_registration.rb:83), retiring the host channel. What remains is
  the encryption block's now-dead `host?` third parameter, dropped here: it
  reads `columns_hash` off the declaring class, which is the `self` Rails'
  block reads (encryptable_record.rb:91).
- Readers that were relying on the baked definition moved to
  `type_for_attribute`: the STI normalization leak guard
  (`normalized-attribute.trails.test.ts`) and the encryption API tests, and the
  `sti-attribute-routing` assertion that `encrypts()` forks the subclass's
  `_attributeDefinitions` map is gone — that fork *was* the eager bake; the
  per-class isolation Rails actually has is asserted on `_pendingEncryptions`
  right above it. No
  production reader was left on it — encryption and `serialize` had already
  moved (encryption.ts:107, serialize.ts:170).

## Verification

`pnpm typecheck` (forced), `parity:api:calls` and `parity:api:calls:args` both
OK with no new baseline rows, `parity:api:extra --package activemodel` keeps
`attribute-assignment.ts` at 0 novel. Green locally: persistence,
nested-attributes (+ trails/callbacks variants), attribute-assignment,
attribute-registration, base, model, enum, serialize, normalization, attributes,
model-schema, types, multiparameter, forbidden-attributes, has-one/has-many/
belongs-to associations, dirty, attribute-methods, and the whole
`activemodel` + `activerecord/encryption` suites.

Closes-story: collapse-the-two-assign-attributes-ports-onto-one
Closes-story: retire-eager-decorate-attributes-bake
