### PR TITLE
refactor(activemodel,activerecord): converge enum's undeclared-type raise, validate's filters, and Errors#base onto Rails

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -374,26 +374,4 @@ describe("AttributeRegistrationTest", () => {
 
     expect((Leaf as any)._defaultAttributes().getAttribute("new_attr").value).toBe(7);
   });
-
-  it("replaying pending decorators establishes decorator-replay context", () => {
-    // Mirrors ActiveModel::AttributeRegistration::PendingDecorator#apply_to,
-    // which passes the materializing class. Decorators gated on replay context
-    // (enum's undeclared-type check) change behavior without it.
-    const seen: boolean[] = [];
-    class MyModel extends Model {
-      static {
-        this.attribute("title", "string");
-        this.decorateAttributes(["title"], (_name, type, host) => {
-          seen.push(host !== undefined);
-          return type;
-        });
-      }
-    }
-
-    seen.length = 0;
-    (MyModel as unknown as { _cachedDefaultAttributes: unknown })._cachedDefaultAttributes = null;
-    (MyModel as unknown as { _defaultAttributes(): unknown })._defaultAttributes();
-
-    expect(seen).toEqual([true]);
-  });
 });

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,5 +1,6 @@
 import { DescendantsTracker, registerSubclass } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
+import { defaultValue } from "./type.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
@@ -45,25 +46,15 @@ export interface AttributeHostInternals {
 // ---------------------------------------------------------------------------
 
 /**
- * A decorator receives the attribute name and its current type, and — only on
- * the `_default_attributes` replay — the *materializing* class (`host`): the
- * class whose AttributeSet is being built. Rails' `decorate_attributes` block
- * resolves against that class's attributes, so a superclass's decorator replayed
- * into a subclass sees the subclass's columns; trails threads `host` through for
- * that.
- *
- * `host` is absent on the eager pass `decorateAttributes` runs at declaration
- * time, which Rails has no counterpart for. A decorator that must fire only
- * where Rails' block fires — enum's "Undeclared attribute type" raise, which
- * Rails evaluates when the attribute set is built (enum.rb:240-245) — keys off
- * its presence.
+ * A decorator receives the attribute name and its current type — Ruby's
+ * `decorator.call(name, attribute.type)` (attribute_registration.rb:83).
  */
-export type AttributeDecorator = (name: string, type: Type, host?: unknown) => Type;
+export type AttributeDecorator = (name: string, type: Type) => Type;
 
 /** @internal Rails-private helper. */
 export interface PendingModification {
   /** @internal */
-  applyTo(attributeSet: AttributeSet, host?: unknown): void;
+  applyTo(attributeSet: AttributeSet): void;
 }
 
 /** @internal Rails-private helper. */
@@ -126,7 +117,9 @@ export function decorateAttributes(
   const targetNames = names ?? Array.from(defs.keys());
   for (const name of targetNames) {
     const def = defs.get(name);
-    if (def) {
+    // Deviation: Rails has no eager pass, so it cannot bake a decoration over
+    // `Type.default_value` into the definitions AR's seed reads (enum.rb:240).
+    if (def && def.type !== defaultValue()) {
       const newType = decorator(name, def.type);
       if (newType) defs.set(name, { ...def, type: newType });
     }
@@ -165,11 +158,11 @@ export class PendingDecorator implements PendingModification {
   ) {}
 
   /** @internal */
-  applyTo(attributeSet: AttributeSet, host?: unknown): void {
+  applyTo(attributeSet: AttributeSet): void {
     const targets = this.names ?? attributeSet.keys();
     for (const name of targets) {
       const existing = attributeSet.getAttribute(name);
-      const newType = this.decorator(name, existing.type, host);
+      const newType = this.decorator(name, existing.type);
       if (newType) {
         attributeSet.set(name, existing.withType(newType));
       }
@@ -205,7 +198,7 @@ export function attributeTypes(this: AttributeHostInternals): Record<string, Typ
   const proxy = new Proxy(cast, {
     get(target, prop, receiver) {
       if (typeof prop === "string" && !Object.hasOwn(target, prop)) {
-        return typeRegistry.lookup("value");
+        return defaultValue();
       }
       return Reflect.get(target, prop, receiver);
     },
@@ -267,27 +260,21 @@ export function pendingAttributeModifications(this: AttributeHostInternals): Pen
  * module function is not a member of the class, so the participation test is
  * the public entry point every AttributeRegistration includer answers.
  *
- * `host` is the class whose AttributeSet is being materialized, threaded down
- * the recursion so a superclass's PendingDecorator resolves against the
- * subclass it is replaying into — the same `host` thread AttributeDecorator
- * documents, which Ruby gets from `self` inside the `decorate_attributes` block.
- *
  * @internal
  */
 export function applyPendingAttributeModifications(
   cls: AttributeHostInternals,
   attributeSet: AttributeSet,
-  host: AttributeHostInternals = cls,
 ): void {
   const superclass = Object.getPrototypeOf(cls) as
     | (AttributeHostInternals & { _defaultAttributes?: unknown })
     | null;
   if (superclass && typeof superclass._defaultAttributes === "function") {
-    applyPendingAttributeModifications(superclass, attributeSet, host);
+    applyPendingAttributeModifications(superclass, attributeSet);
   }
 
   for (const modification of pendingAttributeModifications.call(cls)) {
-    modification.applyTo(attributeSet, host);
+    modification.applyTo(attributeSet);
   }
 }
 

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -1,5 +1,5 @@
 import { Type } from "./type/value.js";
-import { typeRegistry } from "./type/registry.js";
+import { defaultValue } from "./type.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 import { RuntimeError } from "./attribute-assignment.js";
 
@@ -326,7 +326,7 @@ export class WithCastValue extends Attribute {
 
 export class Null extends Attribute {
   constructor(name: string) {
-    super(name, null, typeRegistry.lookup("value"));
+    super(name, null, defaultValue());
   }
 
   typeCast(): unknown {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,6 +1,6 @@
 import type { CodeGenerator } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
-import { typeRegistry } from "./type/registry.js";
+import { defaultValue as typeDefaultValue } from "./type.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
@@ -144,7 +144,7 @@ export function attribute(
             ? (typeOptions as Record<string, unknown>)
             : undefined,
         )
-    : (existing?.type ?? typeRegistry.lookup("value"));
+    : (existing?.type ?? typeDefaultValue());
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and
   // leaves the current default/value untouched.

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -8,6 +8,8 @@
 import { ArgumentError } from "./attribute-assignment.js";
 import {
   Callback,
+  Value,
+  kernelArray,
   CallbackChain as ASCallbackChain,
   type BeforeCallback,
   type AfterCallback,
@@ -135,7 +137,8 @@ export interface RunCallbacksOptions {
  * to `CallbackConditions<object>` under `strictFunctionTypes`.
  */
 export type CallbackConditionFilter<TRecord = CallbackRecord> =
-  { _(record: TRecord, value?: unknown): boolean }["_"] | string;
+  | { _(record: TRecord, value?: unknown): boolean }["_"]
+  | string;
 
 export interface CallbackConditions<TRecord = CallbackRecord> {
   if?: CallbackConditionFilter<TRecord> | Array<CallbackConditionFilter<TRecord>>;
@@ -279,20 +282,12 @@ function _buildAfterModelIfConditions(
   timing: CallbackTiming,
   event: string,
   userIf: CallbackConditions["if"] | undefined,
-):
-  | ((target: object, value?: unknown) => boolean)
-  | Array<(target: object, value?: unknown) => boolean>
-  | undefined {
-  const userIfs = (
-    userIf === undefined ? [] : Array.isArray(userIf) ? [...userIf] : [userIf]
-  ) as Array<(target: object, value?: unknown) => boolean>;
+): CallbackConditions["if"] | Value | Array<CallbackConditionFilter | Value> {
+  const userIfs = kernelArray(userIf) as Array<CallbackConditionFilter | Value>;
   if (timing !== "after" || PLAIN_DEFINE_CALLBACKS_EVENTS.has(event)) {
-    return userIf as
-      | ((target: object, value?: unknown) => boolean)
-      | Array<(target: object, value?: unknown) => boolean>
-      | undefined;
+    return userIf;
   }
-  return [...userIfs, (_target: object, value?: unknown) => value !== false];
+  return [...userIfs, new Value((v) => v !== false)];
 }
 
 export function _registerCallbackOnProto(

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -124,9 +124,22 @@ export type CallbackObject = object;
 export interface RunCallbacksOptions {
   strict?: "sync";
 }
+/**
+ * `if:` / `unless:` accept one filter or an array of them, and a filter is a
+ * callable or a Symbol naming a method on the record — the shape Rails hands
+ * straight to `set_callback` (validations.rb:160-185).
+ *
+ * The method-in-object indirection keeps `TRecord` bivariant, which the
+ * `if?(record): boolean` method shorthand this replaced gave for free; a plain
+ * function-property type makes every `CallbackConditions<Subclass>` unassignable
+ * to `CallbackConditions<object>` under `strictFunctionTypes`.
+ */
+export type CallbackConditionFilter<TRecord = CallbackRecord> =
+  { _(record: TRecord, value?: unknown): boolean }["_"] | string;
+
 export interface CallbackConditions<TRecord = CallbackRecord> {
-  if?(record: TRecord): boolean;
-  unless?(record: TRecord): boolean;
+  if?: CallbackConditionFilter<TRecord> | Array<CallbackConditionFilter<TRecord>>;
+  unless?: CallbackConditionFilter<TRecord> | Array<CallbackConditionFilter<TRecord>>;
   prepend?: boolean;
 }
 

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -1158,11 +1158,6 @@ describe("Errors<TBase> type parameter", () => {
     age: number;
   }
 
-  it("base getter returns TBase | null", () => {
-    const e = new Errors<User>({ name: "Alice", age: 30 });
-    expectTypeOf(e.base).toEqualTypeOf<User | null>();
-  });
-
   it("add() type callback receives TBase | null", () => {
     const e = new Errors<User>({ name: "Alice", age: 30 });
     e.add("name", (record, _opts) => {
@@ -1194,9 +1189,13 @@ describe("Errors<TBase> type parameter", () => {
 
   it("unparameterized Errors annotation compiles (default = object)", () => {
     // Proves the `= object` default is in effect: the type annotation `Errors`
-    // (no type arg) is accepted and `base` resolves to `object | null`.
+    // (no type arg) is accepted and the record handed to an `add()` callback
+    // resolves to `object | null`.
     const e: Errors = new Errors({} as object);
-    expectTypeOf(e.base).toEqualTypeOf<object | null>();
+    e.add("name", (record, _opts) => {
+      expectTypeOf(record).toEqualTypeOf<object | null>();
+      return "invalid";
+    });
   });
 
   it("where() type callback receives TBase | null", () => {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -104,7 +104,7 @@ export class Errors<TBase extends object = object> {
    *   end
    */
   import(error: ActiveModelError, overrideOptions?: { attribute?: string; type?: string }): void {
-    this._errors.push(new NestedError(this.base, error, overrideOptions));
+    this._errors.push(new NestedError(this._base, error, overrideOptions));
   }
 
   /**
@@ -265,7 +265,7 @@ export class Errors<TBase extends object = object> {
     } & Record<string, unknown>,
   ): ActiveModelError {
     const [normAttr, normType, normOpts] = this.normalizeArguments(attribute, type, options);
-    const error = new ActiveModelError(this.base, normAttr, normType, normOpts);
+    const error = new ActiveModelError(this._base, normAttr, normType, normOpts);
     const strict = normOpts.strict;
     if (strict) {
       const ExceptionClass: new (message?: string) => globalThis.Error =
@@ -341,7 +341,7 @@ export class Errors<TBase extends object = object> {
   }
 
   fullMessage(attribute: string, message: string): string {
-    return ActiveModelError.fullMessage(attribute, message, this.base);
+    return ActiveModelError.fullMessage(attribute, message, this._base);
   }
 
   generateMessage(
@@ -349,7 +349,7 @@ export class Errors<TBase extends object = object> {
     type: string = ":invalid",
     options?: Record<string, unknown>,
   ): string {
-    return ActiveModelError.generateMessage(attribute, type, this.base, options);
+    return ActiveModelError.generateMessage(attribute, type, this._base, options);
   }
 
   /**
@@ -385,10 +385,6 @@ export class Errors<TBase extends object = object> {
    */
   [Symbol.iterator](): IterableIterator<ActiveModelError> {
     return this._errors[Symbol.iterator]();
-  }
-
-  get base(): TBase | null {
-    return this._base;
   }
 
   get count(): number {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -127,6 +127,7 @@ import { Type as TypeBase, ValueType } from "./type/value.js";
 import { BinaryType } from "./type/binary.js";
 import { TimeType } from "./type/time.js";
 import { typeRegistry } from "./type/registry.js";
+export { defaultValue } from "./type.js";
 
 export const Types = {
   Type: TypeBase,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -29,6 +29,7 @@ import {
   ToJsonWithActiveSupportEncoder,
   type Included,
   classAttribute,
+  kernelArray,
 } from "@blazetrails/activesupport";
 import {
   humanAttributeName as translationHumanAttributeName,
@@ -74,7 +75,6 @@ import {
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
 import type { ConditionalOptions, ConditionFn } from "./validations.js";
-import { evaluateCondition } from "./validations.js";
 import {
   AttributeMethodPattern,
   attributeMethodPrefix,
@@ -151,10 +151,10 @@ export type ValidationCallbackConditions<TRecord> = CallbackConditions<TRecord> 
 };
 
 /**
- * Mirrors Rails `ActiveModel::Validations.before_validation` / `after_validation`:
- * the `on:` option is translated into an `:if` predicate over the record's
- * current `validation_context` (Rails prepends `predicate_for_validation_context`
- * to any existing `:if`). We AND it with an existing `if` so both must pass.
+ * Mirrors Rails `ActiveModel::Validations.before_validation` / `after_validation`
+ * (validations/callbacks.rb): the `on:` option becomes an `:if` predicate over the
+ * record's current `validation_context`, PREPENDED to any existing `:if` —
+ * `options[:if] = [predicate, *options[:if]]`.
  */
 function _validationOnToIf<TRecord extends object>(
   conditions?: ValidationCallbackConditions<TRecord>,
@@ -164,7 +164,7 @@ function _validationOnToIf<TRecord extends object>(
   const onPredicate = validationsPredicateForValidationContext(on) as (r: TRecord) => boolean;
   return {
     ...rest,
-    if: (record: TRecord) => onPredicate(record) && (existingIf ? existingIf(record) : true),
+    if: [onPredicate, ...kernelArray(existingIf)],
   };
 }
 
@@ -1518,44 +1518,33 @@ export class Model {
   private static _buildValidateConditions(
     options: ConditionalOptions,
   ): CallbackConditions | undefined {
-    const parts: Array<(record: object) => boolean> = [];
+    let ifConds = kernelArray(options.if as CallbackConditions["if"]);
+    let unlessConds = kernelArray(options.unless as CallbackConditions["unless"]);
 
     if (options.on !== undefined) {
-      // Mirrors Rails (validations.rb:170-172): the `on:` clause is
-      // installed via `predicate_for_validation_context(options[:on])`,
-      // so route through the same module-level cache here. Single
-      // source of truth for the intersection-vs-equality semantics.
       const pred = validationsPredicateForValidationContext(options.on);
-      parts.push((record: object) => pred(record as ValidationsContextHost));
-    }
-
-    if (options.if !== undefined) {
-      const conds = Array.isArray(options.if) ? options.if : [options.if];
-      parts.push((record: object) =>
-        conds.every((c) => evaluateCondition(record as ValidatableRecord, c)),
-      );
+      ifConds = [(record: object) => pred(record as ValidationsContextHost), ...ifConds];
     }
 
     if (options.exceptOn !== undefined) {
-      const exceptOn = Array.isArray(options.exceptOn) ? options.exceptOn : [options.exceptOn];
-      parts.push((record: object) => {
-        const mc = (record as unknown as ValidationsContextHost).validationContext;
-        const current = mc == null ? [] : Array.isArray(mc) ? mc : [mc];
-        return !exceptOn.some((c) => current.includes(c));
-      });
+      const exceptOn = kernelArray(options.exceptOn);
+      unlessConds = [
+        (record: object) => {
+          const mc = (record as unknown as ValidationsContextHost).validationContext;
+          const current = kernelArray(mc);
+          return exceptOn.some((c) => current.includes(c));
+        },
+        ...unlessConds,
+      ];
     }
 
-    if (options.unless !== undefined) {
-      const conds = Array.isArray(options.unless) ? options.unless : [options.unless];
-      parts.push(
-        (record: object) => !conds.some((c) => evaluateCondition(record as ValidatableRecord, c)),
-      );
+    if (ifConds.length === 0 && unlessConds.length === 0) {
+      return options.prepend ? { prepend: true } : undefined;
     }
-
-    if (parts.length === 0) return options.prepend ? { prepend: true } : undefined;
 
     return {
-      if: (record: object) => parts.every((fn) => fn(record)),
+      ...(ifConds.length > 0 ? { if: ifConds } : {}),
+      ...(unlessConds.length > 0 ? { unless: unlessConds } : {}),
       ...(options.prepend ? { prepend: true } : {}),
     };
   }

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -405,15 +405,20 @@ export function raiseOnMissingTranslations(value?: boolean): boolean {
 }
 
 /**
- * A single `if:` / `unless:` condition — a callable, or the name of a method
- * on the record. Mirrors the Symbol-or-Proc filter Rails hands to
- * `ActiveSupport::Callbacks` (validations.rb:160-185).
+ * A single `if:` / `unless:` condition — the Symbol-or-Proc filter Rails hands
+ * straight to `set_callback` (validations.rb:160-185), resolved by
+ * `ActiveSupport::Callbacks::CallTemplate` (callbacks.rb:326-331, :394-443).
+ * A Ruby Symbol is spelled colon-prefixed: `if: ":conditionIsTrue"`.
  */
 export type ConditionFn = ((record: ValidatableRecord) => boolean) | string;
 
 /**
  * The option keys `validate` accepts (validations.rb:160-185) and that
  * `validates` forwards to each validator (validates.rb:162-164).
+ *
+ * @noRailsEquivalent PERMANENT (`vendor/rails/activemodel/lib/active_model/validations.rb:160-185`
+ *   — `VALID_OPTIONS_FOR_VALIDATE`). Ruby's options hash needs no declaration;
+ *   its keys are the members below.
  */
 export interface ConditionalOptions {
   if?: ConditionFn | ConditionFn[];
@@ -433,23 +438,6 @@ export interface ConditionalOptions {
   exceptOn?: string | string[];
   /** Register ahead of the already-registered validate callbacks. */
   prepend?: boolean;
-}
-
-/**
- * Resolve one `if:`/`unless:` filter against the record. Ruby reaches this
- * through `ActiveSupport::Callbacks::CallTemplate.build(filter, self)` +
- * `make_lambda` (activesupport/lib/active_support/callbacks.rb:394-443),
- * reached because `validate` hands the filters to `set_callback`
- * (validations.rb:160-185).
- *
- * @internal Rails-private helper.
- */
-export function evaluateCondition(record: ValidatableRecord, cond: ConditionFn): boolean {
-  if (typeof cond === "function") return cond(record);
-  const rec = record as unknown as Record<string, unknown>;
-  const method = rec[cond];
-  if (typeof method === "function") return (method as () => boolean).call(record);
-  return !!rec[cond];
 }
 
 /**

--- a/packages/activemodel/src/validations/conditional-validation.test.ts
+++ b/packages/activemodel/src/validations/conditional-validation.test.ts
@@ -28,7 +28,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: "conditionIsTrue",
+      if: ":conditionIsTrue",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -40,7 +40,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: ["conditionIsTrue", "conditionIsTrue"],
+      if: [":conditionIsTrue", ":conditionIsTrue"],
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -52,7 +52,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      unless: ["conditionIsFalse", "conditionIsFalse"],
+      unless: [":conditionIsFalse", ":conditionIsFalse"],
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -65,7 +65,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      unless: "conditionIsTrue",
+      unless: ":conditionIsTrue",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -76,7 +76,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: ["conditionIsTrue", "conditionIsFalse"],
+      if: [":conditionIsTrue", ":conditionIsFalse"],
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -87,7 +87,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      unless: ["conditionIsTrue", "conditionIsFalse"],
+      unless: [":conditionIsTrue", ":conditionIsFalse"],
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -99,7 +99,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: "conditionIsFalse",
+      if: ":conditionIsFalse",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -111,7 +111,7 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      unless: "conditionIsFalse",
+      unless: ":conditionIsFalse",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);
@@ -173,8 +173,8 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: "conditionIsTrue",
-      unless: "conditionIsTrue",
+      if: ":conditionIsTrue",
+      unless: ":conditionIsTrue",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isValid(), (valid) => valid);
@@ -185,8 +185,8 @@ describe("ConditionalValidationTest", () => {
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
-      if: "conditionIsTrue",
-      unless: "conditionIsFalse",
+      if: ":conditionIsTrue",
+      unless: ":conditionIsFalse",
     });
     const t = new Topic({ title: "uhohuhoh", content: "whatever" });
     assertPredicate(await t.isInvalid(), (invalid) => invalid);

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -300,7 +300,7 @@ describe("ValidatesWithTest", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
-        this.validatesWith(MinLenValidator, { minimum: 5, if: "conditionIsTrue", foo: "bar" });
+        this.validatesWith(MinLenValidator, { minimum: 5, if: ":conditionIsTrue", foo: "bar" });
       }
       conditionIsTrue(): boolean {
         return true;
@@ -308,7 +308,7 @@ describe("ValidatesWithTest", () => {
     }
     expect(capturedOpts).toEqual({
       minimum: 5,
-      if: "conditionIsTrue",
+      if: ":conditionIsTrue",
       foo: "bar",
       class: Person,
     });

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -214,7 +214,11 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     // that are NOT DB columns seed from `_attributeDefinitions`: with a default
     // via withUserDefault (cast), without one via fromDatabase(null) — the latter
     // matters for LockingType, where deserialize(null) → 0.
-    const columns = cachedColumnsHash(cacheHost);
+    // `undefined` = the schema cache has no entry for this table (not reflected
+    // yet); `{}` = reflected and genuinely columnless. The seed below must tell
+    // them apart, so keep the miss rather than folding it into an empty hash.
+    const cachedColumns = cachedColumnsHash(cacheHost);
+    const columns = cachedColumns ?? {};
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attributesHash = new Map<string, Attribute>();
     // Rails seeds phase 1 from `columns_hash` alone (attributes.rb:241-245) and
@@ -245,15 +249,16 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
         attributesHash.set(name, base.withUserDefault(def.defaultValue));
       } else if (def.type !== typeDefaultValue()) {
         attributesHash.set(name, Attribute.fromDatabase(name, null, def.type));
-      } else if (Object.keys(columns).length === 0) {
+      } else if (cachedColumns === undefined) {
         // Deviation: Rails resolves `columns_hash` synchronously before
-        // `_default_attributes` (attributes.rb:239-248), so a decorator branching
+        // `_default_attributes` (attributes.rb:241-250), so a decorator branching
         // on `subtype == Type.default_value` (enum.rb:240) never has to tell "no
-        // such column" from trails' "not reflected yet". An EMPTY hash is that
-        // state — `_schemaLoaded` is not the test, since the warm-cache probe
-        // above stamps it even when the reflection yielded nothing (PG). A
-        // non-singleton `value` stands in until columns arrive; once ANY column
-        // has reflected, an absent name is genuinely absent and stays out, as
+        // such column" from trails' "not reflected yet". A schema-cache MISS is
+        // that state — not an empty hash (a reflected columnless table must still
+        // raise) and not `!_schemaLoaded` (the warm-cache probe above stamps the
+        // flag even when the reflection yielded nothing, which is how PG got
+        // here). A non-singleton `value` stands in until the table reflects; once
+        // it has, an absent name is genuinely absent and stays out of the set, as
         // Rails' columns-only seed leaves it.
         attributesHash.set(name, Attribute.fromDatabase(name, null, typeLookup("value")));
       }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,6 +13,7 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
+  defaultValue as typeDefaultValue,
   resetDefaultAttributes as amResetDefaultAttributes,
 } from "@blazetrails/activemodel";
 // The pending queue is private on ActiveModel (attribute_registration.rb:77);
@@ -242,8 +243,16 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
       } else if (def.defaultValue != null) {
         const base = Attribute.withCastValue(name, null, def.type);
         attributesHash.set(name, base.withUserDefault(def.defaultValue));
-      } else {
+      } else if (def.type !== typeDefaultValue()) {
         attributesHash.set(name, Attribute.fromDatabase(name, null, def.type));
+      } else if (!isSchemaLoaded.call(cacheHost as never)) {
+        // Deviation: Rails resolves `columns_hash` synchronously before
+        // `_default_attributes` (attributes.rb:239-248), so a decorator branching
+        // on `subtype == Type.default_value` (enum.rb:240) never has to tell "no
+        // such column" from trails' "not reflected yet". A non-singleton `value`
+        // stands in until reflection; afterwards the name stays absent, as Rails'
+        // columns-only seed leaves it.
+        attributesHash.set(name, Attribute.fromDatabase(name, null, typeLookup("value")));
       }
     }
 

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -245,13 +245,16 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
         attributesHash.set(name, base.withUserDefault(def.defaultValue));
       } else if (def.type !== typeDefaultValue()) {
         attributesHash.set(name, Attribute.fromDatabase(name, null, def.type));
-      } else if (!isSchemaLoaded.call(cacheHost as never)) {
+      } else if (Object.keys(columns).length === 0) {
         // Deviation: Rails resolves `columns_hash` synchronously before
         // `_default_attributes` (attributes.rb:239-248), so a decorator branching
         // on `subtype == Type.default_value` (enum.rb:240) never has to tell "no
-        // such column" from trails' "not reflected yet". A non-singleton `value`
-        // stands in until reflection; afterwards the name stays absent, as Rails'
-        // columns-only seed leaves it.
+        // such column" from trails' "not reflected yet". An EMPTY hash is that
+        // state — `_schemaLoaded` is not the test, since the warm-cache probe
+        // above stamps it even when the reflection yielded nothing (PG). A
+        // non-singleton `value` stands in until columns arrive; once ANY column
+        // has reflected, an absent name is genuinely absent and stays out, as
+        // Rails' columns-only seed leaves it.
         attributesHash.set(name, Attribute.fromDatabase(name, null, typeLookup("value")));
       }
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1242,19 +1242,9 @@ export class Base extends Model {
    */
   static override typeForAttribute(name: string, block?: () => Type): Type {
     (ModelSchema.loadSchema as any).call(this);
-    // Check the *un-resolved* name first: an `enum` declared before its
-    // `alias_attribute` keys a phantom attribute under the un-aliased name, and
-    // resolving the alias first would look past that phantom to the real backing
-    // column. `assertEnumTypeDeclared` raises only when the name has no column of
-    // its own (Rails' `subtype == default_value` condition, enum.rb:240-245), so
-    // a column-backed enum whose name is later aliased is unaffected.
-    _EnumModule.assertEnumTypeDeclared(this as unknown as typeof Base, name);
     // Rails resolves attribute aliases first
     // (`attr_name = attribute_aliases[attr_name] || attr_name`).
     const resolved = (this as any).attributeAliases?.[name] ?? name;
-    // Rails raises inside enum's `decorate_attributes` block for an enum backed
-    // by neither a DB column nor an explicit `attribute` type.
-    _EnumModule.assertEnumTypeDeclared(this as unknown as typeof Base, resolved);
     // Resolve through the decorated default attribute set — Rails'
     // `attribute_types[name]` is `_default_attributes.cast_types[name]` with a
     // `Type.default_value` hash default (attribute_registration.rb:43-50). The set

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -781,7 +781,9 @@ describe("EnumTest", () => {
   // into the subclass attribute set). A concrete subclass that DOES back the enum
   // (Lion has lions.gender via Cat) stays green; one that does NOT raises against
   // its own columns — not silently install, and not throw TableNotSpecified on the
-  // abstract parent's tableless schema.
+  // abstract parent's tableless schema. The message names the DECLARING class:
+  // Rails interpolates `self.name` (enum.rb:241) and the block is a closure over
+  // the class body `enum` was called in, not the materializing subclass.
   it("enum on abstract parent resolves against concrete subclass columns", () => {
     class AbstractParent extends Base {
       static {
@@ -795,7 +797,7 @@ describe("EnumTest", () => {
     registerModel(Concrete);
 
     expect(() => (Concrete as any).typeForAttribute("typeless_genre")).toThrow(
-      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+      /Undeclared attribute type for enum 'typeless_genre' in AbstractParent/,
     );
   });
 
@@ -822,10 +824,10 @@ describe("EnumTest", () => {
     registerModel(Concrete);
 
     expect(() => (Concrete as any)._defaultAttributes()).toThrow(
-      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+      /Undeclared attribute type for enum 'typeless_genre' in AbstractParent/,
     );
     expect(() => new (Concrete as any)({})).toThrow(
-      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+      /Undeclared attribute type for enum 'typeless_genre' in AbstractParent/,
     );
   });
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,18 +1,19 @@
 import type { Base } from "./base.js";
 import { camelize, isBlank, pluralize } from "@blazetrails/activesupport";
-import { ArgumentError, ValueType, IntegerType, Type } from "@blazetrails/activemodel";
+import {
+  ArgumentError,
+  ValueType,
+  IntegerType,
+  Type,
+  defaultValue,
+} from "@blazetrails/activemodel";
 import { lookup as arTypeLookup } from "./type.js";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
 import { getOrCreateModuleCarrier } from "./module-carrier.js";
 import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
 // The synchronous schema reflector (warm-cache path), NOT the async
 // `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
-import {
-  loadSchema as reflectSchemaSync,
-  ownProp,
-  pendingAttributeTypeQ,
-  type SchemaHost,
-} from "./model-schema.js";
+import { loadSchema as reflectSchemaSync } from "./model-schema.js";
 
 /** Value a label can map to — matches Rails' hash-value support for enums. */
 type EnumValue = number | string | boolean | null;
@@ -137,34 +138,6 @@ export function installEnumAttribute(
   // column-seeded FromDatabase attribute.
   // The deferred-type-check marker below keys off the same name `attribute` /
   // `decorate_attributes` register under (attribute_registration.rb:13,24).
-  const resolved = klass.resolveAttributeName(name);
-  // Rails raises for an enum on an attribute with no declared type AND no
-  // backing DB column, but only once the schema is reflected (inside the
-  // `decorate_attributes` block, at `type_for_attribute`). We can't tell a real
-  // column apart from a typeless attribute at `enum` time, so any enum NOT
-  // explicitly typed via `attribute(name, type)` is queued for a deferred check
-  // (`_enumsPendingTypeCheck`) that `typeForAttribute` runs post-loadSchema and
-  // clears once a backing column is confirmed. See `assertEnumTypeDeclared`.
-  // "Explicitly typed" means the user declared a concrete attribute *type*
-  // (`attribute(name, "integer")`), NOT merely a default (`attribute(name,
-  // { default })`) or nothing. Rails pushes a `PendingType` only when a type is
-  // present (attribute_registration.rb:12-18); a default-only / type-less
-  // attribute keeps the fallback `value` type until the column reflects, so its
-  // subtype must still come from the column (enum decorates the column type,
-  // enum.rb:238-248) — so the pending queue answers this as Rails asks it.
-  const explicitlyTyped = pendingAttributeTypeQ(klass, resolved);
-  const pendingHost = klass as unknown as { _enumsPendingTypeCheck?: Set<string> };
-  if (!explicitlyTyped) {
-    if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {
-      pendingHost._enumsPendingTypeCheck = new Set(pendingHost._enumsPendingTypeCheck);
-    }
-    pendingHost._enumsPendingTypeCheck!.add(resolved);
-  } else if (pendingHost._enumsPendingTypeCheck?.has(resolved)) {
-    // An explicit type now backs the enum — drop any inherited pending marker.
-    pendingHost._enumsPendingTypeCheck = new Set(pendingHost._enumsPendingTypeCheck);
-    pendingHost._enumsPendingTypeCheck.delete(resolved);
-  }
-
   if (attributeOptions && "default" in attributeOptions) {
     klass.attribute(name, { default: attributeOptions.default });
   } else {
@@ -174,33 +147,15 @@ export function installEnumAttribute(
   // reflected column type (enum.rb:239-246); the decorator re-runs on every
   // _defaultAttributes replay, so once the schema is loaded `reflected` is the
   // column's real Type::Value and the EnumType delegates to it.
-  klass.decorateAttributes([name], (_name: string, reflected: Type, host?: unknown) => {
-    // Rails raises inside the `decorate_attributes` block when the decorated
-    // subtype is `ActiveModel::Type.default_value` — an enum name with no backing
-    // column and no explicit type (enum.rb:240-245). trails can't mirror that via
-    // the `reflected` subtype: its alias-aware column-seeding hands the aliased
-    // phantom the *target* column's type at replay (so `reflected.type()` is e.g.
-    // "integer", not "value"). Instead check the real column via
-    // `assertEnumTypeDeclared` (an alias-unaware `columnForAttribute` lookup).
-    //
-    // Resolve the check against the *materializing* class (`host`), not the
-    // declaring `klass`: Rails replays a superclass's pending decorator into the
-    // subclass's attribute set (attribute_registration.rb:81-87), so a concrete
-    // subclass of an abstract parent (e.g. `Lion` < abstract `Cat`) checks its own
-    // columns — while an abstract parent that declares an enum defers until a
-    // concrete subclass materializes rather than throwing `TableNotSpecified` on
-    // its own tableless schema.
-    //
-    // Two trails-specific gates: a `host` is passed only on the
-    // `_default_attributes` replay, so its absence marks the eager
-    // class-definition-time application (a back-compat convenience Rails lacks,
-    // when the subtype is still the bare default), and `!target.abstractClass`
-    // skips the rare direct materialization of an abstract class itself.
-    const target = (host as typeof Base | undefined) ?? klass;
-    if (host !== undefined && !target.abstractClass) {
-      assertEnumTypeDeclared(target, resolved);
+  klass.decorateAttributes([name], (_name: string, subtype: Type) => {
+    if (subtype === defaultValue()) {
+      throw new Error(
+        `Undeclared attribute type for enum '${name}' in ${klass.name}. Enums must be` +
+          " backed by a database column or declared with an explicit type" +
+          " via `attribute`.",
+      );
     }
-    return enumTypeFrom(name, mapping, reflected, raiseOnInvalidValues);
+    return enumTypeFrom(name, mapping, subtype, raiseOnInvalidValues);
   });
 
   // Define the getter after attribute() so the EnumType is already in
@@ -952,62 +907,6 @@ export function raiseConflictError(
 }
 
 /**
- * Raise if an enum was declared on an attribute that ends up with no declared
- * type — no backing DB column and no explicit `attribute(name, type)`. Called
- * lazily from `typeForAttribute` (after `loadSchema`) so the check sees real
- * columns, mirroring Rails raising inside the `decorate_attributes` block when
- * `subtype == ActiveModel::Type.default_value`.
- *
- * Reads ALREADY-RESOLVED schema state (`_columnsHash`) rather than calling
- * `columnForAttribute`, which would call `loadSchema`. Rails' check runs inside
- * the decorate block during `_default_attributes` materialization
- * (enum.rb:239-246), by which point the schema is resolved — the decorator never
- * drives a schema load. Calling `columnForAttribute` here made it drive one, and
- * since a load replays the pending decorators, the cycle
- * replay → columnForAttribute → loadSchema → replay recursed until the stack
- * blew. Every caller (`Base.typeForAttribute`, `enumTypeOf`) already resolves
- * the schema before asking.
- *
- * @internal
- */
-export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
-  const host = klass as unknown as {
-    _enumsPendingTypeCheck?: Set<string>;
-  };
-  const pending = host._enumsPendingTypeCheck;
-  if (!pending || !pending.has(name)) return;
-  // A backing DB column resolves the subtype; an unknown name is simply absent
-  // from the resolved columns hash. `ownProp`, NOT `ownSchemaMemo`: this runs
-  // inside the class's own decorator replay, before `applyColumnsHash` stamps
-  // `_schemaRevision`, so the `schemaStaleAgainstAncestors` pull fallback would
-  // blank the hash just written.
-  const columnsHash = ownProp(klass as unknown as SchemaHost, "_columnsHash") as
-    | Record<string, { type?: unknown } | undefined>
-    | undefined;
-  const column = columnsHash?.[name];
-  if (column && column.type != null) {
-    // Backed by a real column — clear the marker so we don't re-check on every
-    // subsequent `typeForAttribute` call. Copy-on-write to avoid mutating an
-    // inherited set shared with the parent class.
-    if (!Object.prototype.hasOwnProperty.call(klass, "_enumsPendingTypeCheck")) {
-      host._enumsPendingTypeCheck = new Set(pending);
-    }
-    host._enumsPendingTypeCheck!.delete(name);
-    return;
-  }
-  throw undeclaredEnumTypeError(klass, name);
-}
-
-/** The Rails "Undeclared attribute type for enum" RuntimeError message. */
-function undeclaredEnumTypeError(klass: typeof Base, name: string): Error {
-  return new Error(
-    `Undeclared attribute type for enum '${name}' in ${klass.name}. Enums must be` +
-      " backed by a database column or declared with an explicit type" +
-      " via `attribute`.",
-  );
-}
-
-/**
  * Fetch the single registered EnumType for an enum attribute — the one source
  * of truth built lazily from the reflected column type via the
  * `decorateAttributes` decorator. Resolves through the replayed AttributeSet
@@ -1025,15 +924,6 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
     attributeAliases?: Record<string, string>;
     _defaultAttributes(): { getAttribute(n: string): { type: Type } };
   };
-  // Check the *un-resolved* name before resolving the alias: an `enum` declared
-  // before its `alias_attribute` keys a phantom `_enums` entry under the
-  // un-aliased name, so resolving first would look past it to the backing column
-  // and silently return null. `assertEnumTypeDeclared` raises only when the name
-  // has no column of its own (Rails' `subtype == default_value` condition), so a
-  // column-backed enum whose name is later aliased is unaffected. Mirrors Rails
-  // routing type casting through `type_for_attribute(name)`, whose
-  // `decorate_attributes` block raises (type_caster/map.rb:10-16, enum.rb:240-245).
-  //
   // Reflect synchronously from the warm schema cache FIRST — the SAME path
   // `Base.typeForAttribute` uses (base.ts). The public `Base.loadSchema()` is
   // async and would fire-and-forget, letting a caller read the pre-reflection
@@ -1041,16 +931,10 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
   // type and rebuilds `_defaultAttributes` before either the guard or the read
   // below, so the reflected subtype is already in place.
   reflectSchemaSync.call(klass);
-  assertEnumTypeDeclared(klass, attribute);
   // `defined_enums` is keyed by the *declared* enum name, alias or not
   // (enum.rb:232); only the attribute-set lookup resolves the alias.
   if (!host._enums?.has(attribute)) return null;
   const resolved = host.attributeAliases?.[attribute] ?? attribute;
-  // Mirror `Base.typeForAttribute`'s guard: a typeless enum (no backing column,
-  // no explicit `attribute` type) must raise rather than silently serialize
-  // through the pre-reflection fallback (Rails raises from the enum
-  // `decorate_attributes` block, enum.rb:240-245).
-  assertEnumTypeDeclared(klass, resolved);
   const type = host._defaultAttributes().getAttribute(resolved).type;
   return type instanceof EnumType ? type : null;
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -378,16 +378,20 @@ type DatabaseAdapterLike = { internalSchemaCache?: unknown };
  * ever touching `.connection` — which under the default `permanentConnectionCheckout`
  * would permanently lease a connection on every record construction. Reads the warm
  * schema cache off an already-available connection only: the threaded (in-query)
- * connection, else a connection the pool has already leased. Returns `{}` when
- * neither is available (a bare `new Model()` with no active connection); the caller
- * then seeds that column from its attribute definition instead. Any real DB column
- * whose default matters here has already pinned a connection via the
- * `!_schemaLoaded` reflection in `_defaultAttributes`, so `{}` is only reached for
- * columns that carry no client-side default anyway.
+ * connection, else a connection the pool has already leased. Returns `undefined`
+ * when the cache has no entry for the table — no connection was available (a bare
+ * `new Model()`), or the table has not been reflected yet — as distinct from a `{}`
+ * entry for a table that reflected and genuinely has no columns. Callers that only
+ * need to look a column up can `?? {}`; the one that must tell "not reflected yet"
+ * from "no such column" — `_defaultAttributes`' seed, feeding decorators that
+ * branch on `subtype == Type.default_value` — depends on the difference. Any real
+ * DB column whose default matters here has already pinned a connection via the
+ * `!_schemaLoaded` reflection in `_defaultAttributes`, so a miss is only reached
+ * for columns that carry no client-side default anyway.
  *
  * @internal
  */
-export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
+export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> | undefined {
   const cachedFrom = (conn: { internalSchemaCache?: unknown } | null | undefined) => {
     const cache = conn?.internalSchemaCache as
       | { getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined }
@@ -408,7 +412,7 @@ export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike
   } catch {
     /* fall through */
   }
-  return {};
+  return undefined;
 }
 
 /**

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -44,7 +44,7 @@ export class Map {
 
     // Rails' `TypeCaster::Map#type_for_attribute` is a one-line delegation to
     // `klass.type_for_attribute(name)` (type_caster/map.rb:15-16). Delegating gets
-    // alias resolution, the enum `assertEnumTypeDeclared` guard, and the decorated
+    // alias resolution and the decorated
     // default attribute set (`attribute_types`) for free — so pending decorators
     // (serialize/normalizes/encrypts) are honored on the query side without a
     // per-feature post-reflection replay onto `_attributeDefinitions`. `ValueType`

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  Value,
   defineCallbacks,
   setCallback,
   skipCallback,
@@ -430,13 +431,17 @@ describe("Callbacks", () => {
     });
 
     it("forwards the block's return value (env.value) to after-callback conditions", () => {
-      // Mirrors ActiveModel's after-model-callback guard (`value != false`):
-      // the condition reads the run_callbacks block's return, so an after
-      // callback is skipped when the block returned false and runs otherwise.
+      // Mirrors ActiveModel's after-model-callback guard (`value != false`,
+      // activemodel/lib/active_model/callbacks.rb:147-149): the condition reads
+      // the run_callbacks block's return, so an after callback is skipped when
+      // the block returned false and runs otherwise. `Conditionals::Value` is
+      // the only filter arm handed that value — `CallTemplate.build` routes a
+      // Proc by arity, and the 2-arity arm is InstanceExec2, which demands a
+      // block (callbacks.rb:494-508).
       const target = { log: [] as string[] };
       defineCallbacks(target, "save");
       setCallback(target, "save", "after", (t: any) => t.log.push("after"), {
-        unless: (_t, value) => value === false,
+        unless: new Value((value) => value === false),
       });
 
       runCallbacks(target, "save", () => false);

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -36,13 +36,17 @@ export function isAbortSignal(e: unknown): boolean {
 // conditions only look at `target`; ActiveModel's after-model-callback
 // conditional (`v != false`, define_model_callbacks) reads `value`.
 /**
- * One `if:` / `unless:` filter — a callable, or a Ruby Symbol naming a method on
- * the target, spelled colon-prefixed (`":someMethod"`).
- * {@link Callback.conditionsLambdas} resolves it through `CallTemplate.build`
- * (callbacks.rb:326-331).
+ * One `if:` / `unless:` filter — the same set `CallTemplate.build` dispatches on
+ * (callbacks.rb:494-508): a Ruby Symbol naming a method on the target, spelled
+ * colon-prefixed (`":someMethod"`); a `Conditionals::Value`, the only arm that
+ * reads the chain's `value`; or a Proc, whose arity picks
+ * `InstanceExec0`/`InstanceExec1` and which therefore runs with `this` bound to
+ * the target. {@link Callback.conditionsLambdas} resolves every one of them
+ * through `CallTemplate` (callbacks.rb:326-331).
  */
 export type CallbackCondition<T extends object = object> =
   | ((target: T, value?: unknown) => boolean)
+  | Value
   | string;
 
 export interface CallbackOptions<T extends object = object> {
@@ -720,24 +724,15 @@ export class Callback {
    * `@if.map { |c| CallTemplate.build(c, self).make_lambda } +
    *  @unless.map { |c| CallTemplate.build(c, self).inverted_lambda }`.
    *
-   * A callable filter is called directly with `(target, value)` rather than
-   * through `CallTemplate`: `value` is `env.value` (the run_callbacks block's
-   * return), which ActiveModel's after-model-callback guard (`value != false`)
-   * reads, and Rails' Proc arms take that second argument too.
-   *
    * @internal Rails-private helper.
    */
   conditionsLambdas(): Array<(target: object, value: unknown) => boolean> {
     const conditions = [
-      ...kernelArray(this.options.if as CallbackCondition | CallbackCondition[]).map((c) =>
-        typeof c === "string"
-          ? (CallTemplate.build(c, this).makeLambda() as (t: object, v: unknown) => boolean)
-          : (t: object, v: unknown) => c(t, v),
+      ...kernelArray(this.options.if as CallbackCondition | CallbackCondition[]).map(
+        (c) => CallTemplate.build(c, this).makeLambda() as (t: object, v: unknown) => boolean,
       ),
       ...kernelArray(this.options.unless as CallbackCondition | CallbackCondition[]).map((c) =>
-        typeof c === "string"
-          ? CallTemplate.build(c, this).invertedLambda()
-          : (t: object, v: unknown) => !c(t, v),
+        CallTemplate.build(c, this).invertedLambda(),
       ),
     ];
     return conditions;

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -35,7 +35,15 @@ export function isAbortSignal(e: unknown): boolean {
 // callback chain's `env.value` (the run_callbacks block's return). Most
 // conditions only look at `target`; ActiveModel's after-model-callback
 // conditional (`v != false`, define_model_callbacks) reads `value`.
-export type CallbackCondition<T extends object = object> = (target: T, value?: unknown) => boolean;
+/**
+ * One `if:` / `unless:` filter — a callable, or a Ruby Symbol naming a method on
+ * the target, spelled colon-prefixed (`":someMethod"`).
+ * {@link Callback.conditionsLambdas} resolves it through `CallTemplate.build`
+ * (callbacks.rb:326-331).
+ */
+export type CallbackCondition<T extends object = object> =
+  | ((target: T, value?: unknown) => boolean)
+  | string;
 
 export interface CallbackOptions<T extends object = object> {
   if?: CallbackCondition<T> | CallbackCondition<T>[];
@@ -133,16 +141,8 @@ export class Value {
     return this.block(value);
   }
 
-  static check(options: CallbackOptions, target: object, value?: unknown): boolean {
-    if (options.if) {
-      const conditions = Array.isArray(options.if) ? options.if : [options.if];
-      if (!conditions.every((cond) => cond(target, value))) return false;
-    }
-    if (options.unless) {
-      const conditions = Array.isArray(options.unless) ? options.unless : [options.unless];
-      if (conditions.some((cond) => cond(target, value))) return false;
-    }
-    return true;
+  static check(callback: Callback, target: object, value?: unknown): boolean {
+    return callback.conditionsLambdas().every((cond) => cond(target, value));
   }
 }
 
@@ -524,7 +524,7 @@ export class Before {
   static build(callback: Callback, options: DefineCallbacksOptions): (target: object) => boolean {
     const terminatorFn = options.terminator;
     return (target: object) => {
-      if (!Value.check(callback.options, target)) return true;
+      if (!Value.check(callback, target)) return true;
       const cb = callback.filter as BeforeCallback;
       if (terminatorFn === false) {
         cb.call(target, target);
@@ -584,7 +584,7 @@ export class After {
 
   static build(callback: Callback): (target: object) => void {
     return (target: object) => {
-      if (!Value.check(callback.options, target)) return;
+      if (!Value.check(callback, target)) return;
       (callback.filter as AfterCallback).call(target, target);
     };
   }
@@ -609,7 +609,7 @@ export class Around {
 
   static build(callback: Callback): (target: object, block: () => void) => void {
     return (target: object, block: () => void) => {
-      if (!Value.check(callback.options, target)) {
+      if (!Value.check(callback, target)) {
         block();
         return;
       }
@@ -714,26 +714,39 @@ export class Callback {
     return false;
   }
 
+  /**
+   * Mirrors: ActiveSupport::Callbacks::Callback#conditions_lambdas
+   * (callbacks.rb:326-331) —
+   * `@if.map { |c| CallTemplate.build(c, self).make_lambda } +
+   *  @unless.map { |c| CallTemplate.build(c, self).inverted_lambda }`.
+   *
+   * A callable filter is called directly with `(target, value)` rather than
+   * through `CallTemplate`: `value` is `env.value` (the run_callbacks block's
+   * return), which ActiveModel's after-model-callback guard (`value != false`)
+   * reads, and Rails' Proc arms take that second argument too.
+   *
+   * @internal Rails-private helper.
+   */
+  conditionsLambdas(): Array<(target: object, value: unknown) => boolean> {
+    const conditions = [
+      ...kernelArray(this.options.if as CallbackCondition | CallbackCondition[]).map((c) =>
+        typeof c === "string"
+          ? (CallTemplate.build(c, this).makeLambda() as (t: object, v: unknown) => boolean)
+          : (t: object, v: unknown) => c(t, v),
+      ),
+      ...kernelArray(this.options.unless as CallbackCondition | CallbackCondition[]).map((c) =>
+        typeof c === "string"
+          ? CallTemplate.build(c, this).invertedLambda()
+          : (t: object, v: unknown) => !c(t, v),
+      ),
+    ];
+    return conditions;
+  }
+
   get compiled(): Before | After | Around {
     if (this._compiled) return this._compiled;
 
-    const userConditions: Array<(target: object, value: unknown) => boolean> = [];
-    const ifConds = Array.isArray(this.options.if)
-      ? this.options.if
-      : this.options.if
-        ? [this.options.if]
-        : [];
-    const unlessConds = Array.isArray(this.options.unless)
-      ? this.options.unless
-      : this.options.unless
-        ? [this.options.unless]
-        : [];
-    // Forward `value` (env.value — the run_callbacks block's return) to each
-    // condition. ActiveModel's after-model-callback guard (`value != false`)
-    // reads it to skip after callbacks when the block returned false or the
-    // chain halted. Mirrors Rails conditions_lambdas + Conditionals::Value.
-    for (const c of ifConds) userConditions.push((t, v) => c(t, v));
-    for (const c of unlessConds) userConditions.push((t, v) => !c(t, v));
+    const userConditions = this.conditionsLambdas();
 
     const userCallback = CallTemplate.build(this.filter, this);
 


### PR DESCRIPTION
Three RFC 0115 convergences, bundled because they overlap in `activemodel`.

## 1. enum's undeclared-type check moves onto the subtype

Rails raises from the subtype the `decorate_attributes` block is handed
(`subtype == ActiveModel::Type.default_value`, `enum.rb:240-245`). trails
deferred a per-name `_enumsPendingTypeCheck` marker and checked `_columnsHash`
from inside the block, which is why the block needed to know the materializing
class. Both are gone: `assertEnumTypeDeclared` and its callers in `base.ts` /
`enum.ts` are deleted, and `PendingDecorator#applyTo` no longer binds a
receiver — the decorator is called as Rails calls it,
`decorator.call(name, attribute.type)` (`attribute_registration.rb:83`).

Making the identity check meaningful required `Type.default_value` to be the
singleton everywhere Rails uses it:

- `Attribute::Null`'s type (`attribute.rb:224`)
- `attribute_types`' hash default (`attribute_registration.rb:37`)
- a type-less `attribute(name)` (`attribute_registration.rb:12-18` pushes a
  `PendingType` with a nil type; nothing declares a type)

and AR's phase-1 seed now leaves a name with no column, no default and no
declared type out of the attribute set, as Rails' `columns_hash`-only seed
does (`attributes.rb:239-248`). The one exception is before the class has
reflected: trails' schema load is async and has no Rails counterpart there, so
a bare `value` type stands in and no decorator can read "no such column" out of
"not reflected yet".

**Message names the declaring class.** Rails interpolates `self.name`
(`enum.rb:241`) and the block closes over the class body `enum` was called in,
not the materializing subclass. The two abstract-parent expectations move from
`Concrete` to `AbstractParent`. No test name changed.

## 2. `validate`'s `if:` / `unless:` resolve through `CallTemplate`

Rails' `validate` resolves nothing — it folds `on:` / `except_on:` into the
`:if` / `:unless` arrays and hands the user's filters to `set_callback`
(`validations.rb:170-182`); `Callback#conditions_lambdas`
(`callbacks.rb:326-331`) builds one lambda per filter via
`CallTemplate.build(c, self).make_lambda` / `.inverted_lambda`.

`_buildValidateConditions` now does exactly that, and the new
`Callback#conditionsLambdas` does the resolution — so a Symbol filter, spelled
colon-prefixed per CLAUDE.md (`if: ":conditionIsTrue"`), goes through
`MethodCall`. `evaluateCondition` and its bare-property-read arm (which had no
`CallTemplate` counterpart) are deleted, and `_validationOnToIf` prepends into
the `:if` array rather than AND-ing, mirroring `validations/callbacks.rb`.

`Value.check` now takes the `Callback` and gates on the same lambdas, mirroring
`CallbackSequence#skip?` (`callbacks.rb:544-546`).

**Every** filter goes through `CallTemplate` — callables included, so a Proc
condition runs as `InstanceExec0`/`InstanceExec1` with `this` bound to the
target (`callbacks.rb:494-508`). The one condition that reads the chain's
`value` is ActiveModel's after-model-callback guard, and Rails writes that as a
`Conditionals::Value` (`activemodel/lib/active_model/callbacks.rb:147-149`),
not a Proc — `build` routes it to `ProcCall`, the only arm handed `value`. A
2-arity Proc is `InstanceExec2`, which demands a block and is an
around-callback shape. `_buildAfterModelIfConditions` now appends a real
`Value`, which is what removes the last reason to special-case callables.

`ConditionalOptions` carries a `@noRailsEquivalent PERMANENT` tag: Ruby's
options hash needs no declaration and its keys are the interface's members.
`parity:api:extra --package activemodel` puts validations.ts at **1 novel**
(from 4 novel / 5 moved).

## 3. `Errors#base` retired

`errors.rb:117-120` sets `@base` in `initialize` and declares no reader; the
class's only `attr_reader` is `:errors`. Every in-class read is now
`this._base`, as Ruby reads `@base`. `parity:api:extra` puts errors.ts at
**0 novel / 0 moved**.

## Telling "not reflected yet" from "no such column"

Rails resolves `columns_hash` synchronously before `_default_attributes`
(`attributes.rb:241-250`), so a decorator branching on
`subtype == Type.default_value` never has to. trails' schema load is async, so
the seed needs an explicit answer, and two earlier attempts got it wrong:

- `!isSchemaLoaded` — the warm-cache probe at `attributes.ts:186` swallows its
  own failure and stamps the flag even when the reflection yielded nothing, so
  PG reached the seed flagged-loaded with an empty hash and the column-backed
  `postgresql_enums.current_mood` raised.
- an empty `columns` hash — conflates a cache miss with a table that reflected
  and genuinely has no columns; the latter must still raise.

`SchemaCache#getCachedColumnsHash` already returns `undefined` on a miss and
`cachedColumnsHash` was flattening it to `{}`. It now propagates the
`undefined`, and the seed branches on the miss alone. A reflected-but-columnless
table therefore still leaves the name absent and still raises.

`attribute-registration.test.ts`'s "replaying pending decorators establishes
decorator-replay context" is deleted rather than renamed: it is a trails-only
test whose whole subject is the `host` thread this PR retires. The behaviour that
depended on it — enum raising only where Rails' block raises — is pinned by
`enum.test.ts` instead.

## Gates

- `pnpm parity:api:calls` — OK (898 baselined, 418 unreviewed; no new rows)
- `pnpm parity:api:calls:args` — OK (170 baselined shape rows; no new rows)
- `pnpm parity:api` / `parity:api:extra` — deltas non-negative
- `pnpm lint` clean, `pnpm typecheck` clean
- activemodel + activesupport suites: 6587 passed / 438 skipped
- PostgreSQL adapter suite (`ARCONN=postgresql`, 60 files): green — the enum
  regression above was caught and fixed here, verified against a live PG 17
- activerecord associations (115 files), transactions, callbacks, validations,
  autosave, nested-attributes and actionpack abstract-controller: green
- activerecord enum + validations + callbacks + attribute-methods suites green

Closes-story: converge-enum-undeclared-type-check-to-subtype
Closes-story: converge-validate-conditions-onto-calltemplate
Closes-story: retire-errors-base-reader
