### PR TITLE
fix(activerecord,activemodel): repair attribute-registration call sites left by the pending-helper collapse

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -282,16 +282,6 @@ export class Attributes {
   }
 }
 
-function typeOptions(options?: AttributeOptions): Record<string, unknown> | undefined {
-  const {
-    default: _default,
-    virtual: _virtual,
-    userProvidedDefault: _userProvidedDefault,
-    ...rest
-  } = options ?? {};
-  return Object.keys(rest).length > 0 ? (rest as Record<string, unknown>) : undefined;
-}
-
 // ---------------------------------------------------------------------------
 // Rails privates surfaced by attributes.rb
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -20,8 +20,9 @@ import {
 // queue from ActiveRecord, so it imports the pushers off the defining module
 // rather than the package's public barrel.
 import {
-  pushPendingDefault,
-  pushPendingType,
+  PendingDefault,
+  PendingType,
+  pendingAttributeModifications,
 } from "@blazetrails/activemodel/attribute-registration";
 import { registerSubclass } from "@blazetrails/activesupport";
 import { encryptionHooks } from "./encryption-hooks.js";
@@ -119,9 +120,11 @@ export function defineAttribute(
   // when it IS user-provided is that same fork: the replay applies
   // `with_user_default` (cast), a `from_user: false` def stays a column seed.
   if (userProvidedDefault) {
-    pushPendingType(this, name, castType);
+    pendingAttributeModifications.call(this).push(new PendingType(name, castType));
     if (defaultValue !== NO_DEFAULT) {
-      pushPendingDefault(this, name, resolvedDefault ?? null);
+      pendingAttributeModifications
+        .call(this)
+        .push(new PendingDefault(name, resolvedDefault ?? null));
     }
   }
 

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -17,8 +17,8 @@ import {
 } from "@blazetrails/activemodel";
 // The pending queue is private on ActiveModel (attribute_registration.rb:77);
 // only `attribute` (:17) pushes onto it. `define_attribute` reaches the same
-// queue from ActiveRecord, so it imports the pushers off the defining module
-// rather than the package's public barrel.
+// queue from ActiveRecord, so it imports the queue accessor and the pending
+// classes off the defining module rather than the package's public barrel.
 import {
   PendingDefault,
   PendingType,


### PR DESCRIPTION
Fixes the `tsc --build` break on main @824d7397 (Unit Tests, Guides Code Type Check, Leaf Tests / DX type tests).

#6781 collapsed `pushPendingType` / `pushPendingDefault` into direct `pendingAttributeModifications.call(this).push(new PendingType(...))` pushes (`activemodel/lib/active_model/attribute_registration.rb:17-20`) and dropped `userProvidedDefault` from `AttributeOptions`. Two call sites that merged in parallel still referenced the removed names:

- `packages/activerecord/src/attributes.ts` — `defineAttribute` now pushes the pending entries directly, mirroring `packages/activemodel/src/attributes.ts:172-179`. Same branch structure and order as before.
- `packages/activemodel/src/attributes.ts` — the `typeOptions` helper is deleted. It was already dead (`attribute` inlines the same destructure at :137) and its only remaining reference was the removed `userProvidedDefault` key.

## Verification

- `pnpm build` clean
- `pnpm test:types` — 9 files, 99 tests, no type errors
- `packages/{activemodel,activerecord}/src/attributes.test.ts` — 106 passed
- `pnpm parity:api:calls` / `pnpm parity:api:calls:args` — OK, no new rows

Closes-story: red-824d7397