### PR TITLE
refactor(activemodel): issue the "=" attribute-method suffix from Attributes' included hook

### DIFF
--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,9 +1,10 @@
-import type { CodeGenerator } from "@blazetrails/activesupport";
+import { type CodeGenerator, included } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
+  attributeMethodSuffix,
   attributeMissing,
   isAttributeMethod as _isAttributeMethod,
   matchedAttributeMethod as _matchedAttributeMethod,
@@ -241,6 +242,16 @@ export function setDefineMethodAttribute(
  * Mirrors: ActiveModel::Attributes (instance side, attributes.rb:31-160)
  */
 export class Attributes {
+  /**
+   * Mirrors: attributes.rb:35-37
+   *   included do
+   *     attribute_method_suffix "=", parameters: "value"
+   *   end
+   */
+  static [included](base: AttributeMethodHost): void {
+    attributeMethodSuffix.call(base, "=", { parameters: "value" });
+  }
+
   _attributes: AttributeSet;
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -24,10 +24,12 @@ import {
   resetCallbacks as asResetCallbacks,
   withOptions,
   include,
+  extend,
   runLoadHooks,
   wrap,
   ToJsonWithActiveSupportEncoder,
   type Included,
+  type Extended,
   classAttribute,
 } from "@blazetrails/activesupport";
 import {
@@ -111,9 +113,10 @@ import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
 import {
   type AttributeDefinition,
+  Attributes,
   attribute,
-  matchedAttributeMethod as _matchedAttributeMethod,
   setDefineMethodAttribute,
+  matchedAttributeMethod as _matchedAttributeMethod,
 } from "./attributes.js";
 import {
   _defaultAttributes,
@@ -127,6 +130,17 @@ import {
   type AttributeHostInternals,
 } from "./attribute-registration.js";
 import { _toPartialPath } from "./conversion.js";
+
+/**
+ * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-101) — the
+ * class half `include ActiveModel::Attributes` contributes, mixed onto `Model`
+ * by the `extend()` at the bottom of this file.
+ *
+ * `attribute_names` (attributes.rb:73-75) is not carried: `Model` defines its
+ * own in the class body, and where Ruby's ancestry lets a class-body method
+ * outrank the module's, `extend()` would overwrite it.
+ */
+const AttributesClassMethods = { attribute, setDefineMethodAttribute };
 
 /** Args accepted by `Model.normalizes` — attributes, transform fn, and optional options. */
 export type NormalizesArgs =
@@ -309,9 +323,11 @@ export class Model {
 
   // -- Attributes (Phase 1000) --
 
-  static attribute = attribute;
+  declare static attribute: Extended<typeof AttributesClassMethods>["attribute"];
+  declare static setDefineMethodAttribute: Extended<
+    typeof AttributesClassMethods
+  >["setDefineMethodAttribute"];
   static defineMethodAttribute = defineMethodAttribute;
-  static setDefineMethodAttribute = setDefineMethodAttribute;
   static _defaultAttributes = _defaultAttributes;
   static decorateAttributes = decorateAttributes;
   static attributeTypes = attributeTypes;
@@ -2819,17 +2835,18 @@ export class Model {
   }
 }
 
-// Rails' `included do` block (attribute_methods.rb:70-73). The `"="` suffix
-// pattern is the one `ActiveModel::Attributes` adds on include
-// (attributes.rb:35), folded into the default because trails has one host class.
+// Rails' `included do` block (attribute_methods.rb:70-73).
 classAttribute.call(Model, "attributeAliases", { instanceWriter: false, default: {} });
 classAttribute.call(Model, "attributeMethodPatterns", {
   instanceWriter: false,
-  default: [
-    new AttributeMethodPattern(),
-    new AttributeMethodPattern({ suffix: "=", parameters: "value" }),
-  ],
+  default: [new AttributeMethodPattern()],
 });
+
+// `include ActiveModel::Attributes` (attributes.rb:29) — its `included` hook
+// issues `attribute_method_suffix "=", parameters: "value"` (attributes.rb:35),
+// so it has to run after the `attributeMethodPatterns` class attribute exists.
+extend(Model, AttributesClassMethods);
+include(Model, Attributes);
 
 const VALID_ON_CONDITIONS = new Set(["create", "update", "destroy"]);
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1934,9 +1934,13 @@ export class Model {
     return [...(this.constructor as typeof Model).attributeNames()];
   }
 
-  get attributes(): Record<string, unknown> {
-    return this._attributes.toHash();
-  }
+  /**
+   * `ActiveModel::Attributes#attributes` (attributes.rb:131-133), installed on
+   * the prototype by the `include(Model, Attributes)` at the bottom of this
+   * file. Declared here only for its type: `Included<>` derives callable
+   * methods and cannot carry an accessor's type across the mixin.
+   */
+  declare attributes: Record<string, unknown>;
 
   attributePresent(name: string): boolean {
     const value = this.readAttribute(name);


### PR DESCRIPTION
Mixes `ActiveModel::Attributes` into `Model` the way Rails does instead of composing it by hand.

`model.ts` hard-coded `attributes.rb:35-37`'s

```ruby
included do
  attribute_method_suffix "=", parameters: "value"
end
```

as a second literal entry in the `attributeMethodPatterns` class-attribute default, because `Model` never `include`d `Attributes` at all — it assigned the statics one by one.

Now:

- `attributes.ts` gets a symbol-keyed `[included]` hook on `Attributes` (`attributes.rb:35-37`) that calls `attributeMethodSuffix.call(base, "=", { parameters: "value" })`.
- `model.ts` mixes the module in at the bottom of the file: `extend(Model, AttributesClassMethods)` for the `ClassMethods` half (`attributes.rb:38-101`) and `include(Model, Attributes)` for the instance half, after the `classAttribute()` call the hook writes through.
- The `attributeMethodPatterns` default drops back to the bare pattern (`attribute_methods.rb:70-73`).

`AttributesClassMethods` is built in `model.ts` rather than exported from `attributes.ts`: an `attribute` key living next to the `attribute` function in that file detaches the function from the call-set extractor, which silently retired a `parity:api:calls` baseline row (`attributes.ts attribute fetch_value`) by dropping the method from the compared population rather than by converging it.

`attribute_names` (`attributes.rb:73-75`) is deliberately not carried in the ClassMethods object: `Model` defines its own in the class body, and where Ruby ancestry lets a class-body method outrank the module's, `extend()` would overwrite it.

Verification: `pnpm parity:api` activemodel 725/725, `attributes.rb` 17/17; `parity:api:calls` and `:args` clean with no baseline movement; activemodel suite plus the ActiveRecord attribute-methods/attributes/base suites green.

Closes-story: issue-attribute-method-suffix-from-the-included-hook

`parity:api:extra --package activemodel` reports one novel name, `[included]` in `attributes.ts`. It is the symbol-keyed hook CLAUDE.md § "Module mixins" ratifies as the port of an `included do ... end` block, not invented surface — the extractor already lists other symbol-keyed members (`[Symbol.iterator]`, `[ATTRIBUTE_BRAND]`) the same way. No other file moves.


### The instance half

Review round 1 asked why `include(Model, Attributes)` looked like it only fired the hook. It now genuinely moves `Model#attributes` (`attributes.rb:131-133`): the class-body getter is deleted and the one on `Attributes.prototype` is what instances resolve. It survives in `model.ts` only as a `declare`, because `Included<>` derives callable methods and cannot carry an accessor's type across the mixin.

The other members named in the review stay in the class body, and Ruby resolves them the same way:

- `_write_attribute` (`attributes.rb:156-158`), `freeze` (`attributes.rb:150-153`), `initialize_dup` (`attributes.rb:111-114`) — each is overridden *above* `Attributes` in Rails' ancestry by a module that ends in `super`: `Validations#freeze` (`validations.rb:372-377`), `Validations#initialize_dup` (`validations.rb:310-313`), `Dirty#initialize_dup` (`dirty.rb:248-251`), and Dirty/Normalization for `_write_attribute`. TS has no `super` across mixins, so those chains are flattened into `Model`'s class body — and `include()` preserving a class-body method over the module's is precisely Ruby's ancestry rule, not an accident of the helper.
- Instance `attribute_names` (`attributes.rb:146-148`) is `@attributes.keys`; `Model`'s filters virtual attributes through the class-level reader. That divergence predates this PR and changing it is a behaviour change to every `attributeNames()` caller, so it is not folded in here.
