### PR TITLE
feat(activemodel): port Helpers::TimeValue#type_cast_for_schema

### DIFF
--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -164,3 +164,15 @@ describe("DateTimeType serialize_cast_value_compatible?", () => {
     expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
   });
 });
+
+// `type_cast_for_schema` comes from Helpers::TimeValue (time_value.rb:36-38) —
+// `value.to_fs(:db).inspect` — where without the mixin the class would inherit
+// `Type::Value`'s `value.inspect` (value.rb:71-73). Verified against MRI:
+// `ActiveModel::Type::DateTime.new.type_cast_for_schema(cast)` answers
+// `"2000-01-01 00:00:00"` (quoted).
+describe("DateTimeType type_cast_for_schema", () => {
+  it("answers the to_fs(:db) form, quoted", () => {
+    const type = new Types.DateTimeType();
+    expect(type.typeCastForSchema(type.cast("2000-01-01 00:00:00"))).toBe('"2000-01-01 00:00:00"');
+  });
+});

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -245,8 +245,8 @@ const acceptsMultiparameterTime = new AcceptsMultiparameterTime({ defaults: { "4
 include(DateTimeType, acceptsMultiparameterTime);
 
 /**
- * Ruby `include Helpers::TimeValue` (date_time.rb:47) for the one member of that module
- * the class does not carry as a field: `type_cast_for_schema`
+ * Ruby `include Helpers::TimeValue` (date_time.rb:47) for the one member of
+ * that module the class does not carry as a field: `type_cast_for_schema`
  * (time_value.rb:36-38) is public and `PostgreSQL::OID::DateTime` overrides it
  * with a `super` call (postgresql/oid/date_time.rb:21-27), so it has to land
  * on the prototype rather than on each instance.

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -17,7 +17,12 @@ import {
   type InstanceMethods,
 } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
-import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
+import {
+  applySecondsPrecision,
+  fastStringToTime,
+  newTime,
+  typeCastForSchema,
+} from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
@@ -238,3 +243,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
  */
 const acceptsMultiparameterTime = new AcceptsMultiparameterTime({ defaults: { "4": 0, "5": 0 } });
 include(DateTimeType, acceptsMultiparameterTime);
+
+/**
+ * Ruby `include Helpers::TimeValue` (date_time.rb:47) for the one member of that module
+ * the class does not carry as a field: `type_cast_for_schema`
+ * (time_value.rb:36-38) is public and `PostgreSQL::OID::DateTime` overrides it
+ * with a `super` call (postgresql/oid/date_time.rb:21-27), so it has to land
+ * on the prototype rather than on each instance.
+ */
+include(DateTimeType, { typeCastForSchema });

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Rational, Temporal } from "@blazetrails/date";
-import { zone } from "@blazetrails/activesupport";
+import { toFs, zone } from "@blazetrails/activesupport";
 
 import { isUtc } from "./timezone.js";
 
@@ -69,6 +69,24 @@ export function applySecondsPrecision<T>(this: { precision?: number }, value: T)
   } else {
     return value;
   }
+}
+
+/**
+ * Mirrors: ActiveModel::Type::Helpers::TimeValue#type_cast_for_schema
+ * (time_value.rb:36-38)
+ *
+ *   def type_cast_for_schema(value)
+ *     value.to_fs(:db).inspect
+ *   end
+ *
+ * Ruby dispatches `to_fs` on the receiver. The cast value of a datetime/time
+ * attribute is a `Temporal.Instant` here — the seat `Time#to_fs`
+ * (`core_ext/time/conversions.rb:55-61`) reads — and `String#inspect` of the
+ * `:db` form is its quoted spelling, the same one `Type::Value` and
+ * `Type::Date` reach through `JSON.stringify` (value.rb:71-73, date.rb:34-36).
+ */
+export function typeCastForSchema(value: unknown): string {
+  return JSON.stringify(toFs(value as Temporal.Instant, "db"));
 }
 
 /**

--- a/packages/activemodel/src/type/time.trails.test.ts
+++ b/packages/activemodel/src/type/time.trails.test.ts
@@ -49,3 +49,16 @@ describe("TimeType serialize_cast_value_compatible?", () => {
     expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
   });
 });
+
+// `type_cast_for_schema` comes from Helpers::TimeValue (time_value.rb:36-38) —
+// `value.to_fs(:db).inspect` — where without the mixin the class would inherit
+// `Type::Value`'s `value.inspect` (value.rb:71-73). Verified against MRI:
+// `ActiveModel::Type::Time.new.type_cast_for_schema(cast)` answers
+// `"2000-01-01 10:20:30"` (quoted) — the 2000-01-01 dummy date is the one
+// `AcceptsMultiparameterTime`'s defaults give a bare time (time.rb:40-42).
+describe("TimeType type_cast_for_schema", () => {
+  it("answers the to_fs(:db) form, quoted", () => {
+    const type = new Types.TimeType();
+    expect(type.typeCastForSchema(type.cast("10:20:30"))).toBe('"2000-01-01 10:20:30"');
+  });
+});

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -254,10 +254,11 @@ const acceptsMultiparameterTime = new AcceptsMultiparameterTime({
 include(TimeType, acceptsMultiparameterTime);
 
 /**
- * Ruby `include Helpers::TimeValue` (time.rb:43) for the one member of that module
- * the class does not carry as a field: `type_cast_for_schema`
- * (time_value.rb:36-38) is public and `PostgreSQL::OID::DateTime` overrides it
- * with a `super` call (postgresql/oid/date_time.rb:21-27), so it has to land
- * on the prototype rather than on each instance.
+ * Ruby `include Helpers::TimeValue` (time.rb:43) for the one member of that
+ * module the class does not carry as a field: `type_cast_for_schema`
+ * (time_value.rb:36-38) is the module's only public member, so it lands on the
+ * prototype where a subclass's `super` reaches it — as
+ * `PostgreSQL::OID::DateTime` does on the sibling class
+ * (postgresql/oid/date_time.rb:21-27).
  */
 include(TimeType, { typeCastForSchema });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -11,7 +11,12 @@ import {
   type InstanceMethods,
 } from "./helpers/accepts-multiparameter-time.js";
 import { isUtc } from "./helpers/timezone.js";
-import { applySecondsPrecision, fastStringToTime, newTime } from "./helpers/time-value.js";
+import {
+  applySecondsPrecision,
+  fastStringToTime,
+  newTime,
+  typeCastForSchema,
+} from "./helpers/time-value.js";
 import { ValueType } from "./value.js";
 
 /**
@@ -247,3 +252,12 @@ const acceptsMultiparameterTime = new AcceptsMultiparameterTime({
   defaults: { "1": 2000, "2": 1, "3": 1, "4": 0, "5": 0 },
 });
 include(TimeType, acceptsMultiparameterTime);
+
+/**
+ * Ruby `include Helpers::TimeValue` (time.rb:43) for the one member of that module
+ * the class does not carry as a field: `type_cast_for_schema`
+ * (time_value.rb:36-38) is public and `PostgreSQL::OID::DateTime` overrides it
+ * with a `super` call (postgresql/oid/date_time.rb:21-27), so it has to land
+ * on the prototype rather than on each instance.
+ */
+include(TimeType, { typeCastForSchema });


### PR DESCRIPTION
Ports `type_cast_for_schema` (`activemodel/lib/active_model/type/helpers/time_value.rb:36-38`), the one member of `Helpers::TimeValue` trails did not carry:

```ruby
def type_cast_for_schema(value)
  value.to_fs(:db).inspect
end
```

Without it `Type::DateTime` / `Type::Time` inherited `Type::Value#type_cast_for_schema` (`value.rb:71-73`, `value.inspect`), so a schema dump of a datetime/time default rendered the Temporal value rather than the `to_fs(:db)` form. Verified against MRI: `ActiveModel::Type::DateTime.new.type_cast_for_schema(cast)` answers `"2000-01-01 00:00:00"` (quoted); `Type::Time` answers `"2000-01-01 10:20:30"`.

Mixed into `DateTimeType` / `TimeType` with `include()` (Ruby `include Helpers::TimeValue`, `date_time.rb:47` / `time.rb:43`) rather than a field assignment, because `PostgreSQL::OID::DateTime#type_cast_for_schema` (`postgresql/oid/date_time.rb:21-27`) overrides it with a `super` call and so needs it on the prototype.

`parity:api` delta non-negative; `parity:api:extra --package activemodel` unchanged; call and call-args ratchets OK.

Closes-story: port-time-value-type-cast-for-schema