### PR TITLE
refactor(activemodel,activesupport,activerecord): converge five Rails-fidelity seams

### DIFF
--- a/packages/activemodel/src/attributes.trails.test.ts
+++ b/packages/activemodel/src/attributes.trails.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "./model.js";
+
+describe("Attributes#attribute_names", () => {
+  class User extends Model {
+    static {
+      this.attribute("name", "string");
+      this.attribute("token", "string", { virtual: true });
+    }
+  }
+
+  it("is the instance's @attributes keys, virtual attributes included", () => {
+    expect(new User().attributeNames()).toEqual(["name", "token"]);
+  });
+
+  it("the class-level reader still filters virtual attributes", () => {
+    expect(User.attributeNames()).toEqual(["name"]);
+  });
+});

--- a/packages/activemodel/src/error.trails.test.ts
+++ b/packages/activemodel/src/error.trails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { Range } from "@blazetrails/activesupport";
+import { Duration, Range } from "@blazetrails/activesupport";
 import { Error as ModelError } from "./error.js";
 
 describe("Error option value equality", () => {
@@ -15,6 +15,17 @@ describe("Error option value equality", () => {
     expect(error.strictMatch("name", ":too_long", { count: new Range(5, 20) })).toBe(true);
     expect(
       error.equals(new ModelError(base, "name", ":too_long", { count: new Range(5, 20) })),
+    ).toBe(true);
+  });
+
+  it("compares two separately-constructed equal Durations as equal", () => {
+    const error = new ModelError(base, "startsAt", ":greater_than", { count: Duration.days(2) });
+
+    expect(error.match("startsAt", ":greater_than", { count: Duration.days(2) })).toBe(true);
+    expect(error.match("startsAt", ":greater_than", { count: Duration.days(3) })).toBe(false);
+    expect(error.strictMatch("startsAt", ":greater_than", { count: Duration.days(2) })).toBe(true);
+    expect(
+      error.equals(new ModelError(base, "startsAt", ":greater_than", { count: Duration.days(2) })),
     ).toBe(true);
   });
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -296,6 +296,16 @@ export interface Model {
   readAttributeForValidation(attribute: string): unknown;
   /** @internal */
   sanitizeForbiddenAttributes(attributes: Record<string, unknown>): Record<string, unknown>;
+
+  /**
+   * `ActiveModel::Attributes#attribute_names` (attributes.rb:146-148),
+   * installed on the prototype by the `include(Model, Attributes)` at the
+   * bottom of this file. Declared here only for its type, which Model's index
+   * signature otherwise widens to `unknown`; the merge spells it as a method
+   * so ActiveRecord's own `attribute_names` override (attribute_methods.rb:
+   * 334-336) stays assignable.
+   */
+  attributeNames(): string[];
 }
 
 /**
@@ -1907,17 +1917,6 @@ export class Model {
     const ctor = this.constructor as typeof Model;
     const defs = ctor._attributeDefinitions;
     return defs.has(ctor.resolveAttributeName(name));
-  }
-
-  /**
-   * Return the list of attribute names for this instance's class.
-   *
-   * Mirrors: ActiveModel::AttributeMethods#attribute_names (instance)
-   */
-  attributeNames(): string[] {
-    // Copy: the class-level result is frozen (memoized); Rails' instance
-    // method returns a fresh mutable `@attributes.keys` array.
-    return [...(this.constructor as typeof Model).attributeNames()];
   }
 
   /**

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -75,10 +75,6 @@ describe("DateTest", () => {
     expect(type.typeCastForSchema(d)).toBe('"2024-01-15"');
   });
 
-  it("typeCastForSchema returns null for null", () => {
-    expect(type.typeCastForSchema(null)).toBe("null");
-  });
-
   it("newDate rejects out-of-range components (rescue nil parity)", () => {
     class Probe extends Types.DateType {
       newDateFor(y: number, m: number, d: number) {

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -6,6 +6,7 @@ import {
   type DateParts,
 } from "@blazetrails/date";
 import { include } from "@blazetrails/activesupport";
+import { toFs } from "@blazetrails/activesupport/core-ext/date/conversions";
 import {
   AcceptsMultiparameterTime,
   type InstanceMethods,
@@ -37,10 +38,15 @@ export class DateType extends ValueType<DateCastResult> {
     return this.name;
   }
 
+  /**
+   * Mirrors: ActiveModel::Type::Date#type_cast_for_schema (date.rb:34-36) —
+   * `value.to_fs(:db).inspect`. The schema dumper hands in an already-cast
+   * default, so there is no re-cast here; the PG infinity spellings belong to
+   * `PostgreSQL::OID::Date#type_cast_for_schema`
+   * (`postgresql/oid/date.rb:20-26`), which overrides this.
+   */
   typeCastForSchema(value: unknown): string {
-    const cast = this.cast(value);
-    if (cast === null || cast === DateInfinity || cast === DateNegativeInfinity) return "null";
-    return JSON.stringify(cast.toString());
+    return JSON.stringify(toFs(value as Temporal.PlainDate, "db"));
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -335,17 +335,3 @@ function changeNsec<T extends NsecBearing>(value: T, newNsec: bigint): T {
     nanosecond: Number(newNsec % 1_000n),
   }) as T;
 }
-
-export function serializeTimeValue(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (
-    value instanceof Temporal.Instant ||
-    value instanceof Temporal.PlainDateTime ||
-    value instanceof Temporal.PlainDate ||
-    value instanceof Temporal.PlainTime ||
-    value instanceof Temporal.ZonedDateTime
-  ) {
-    return value.toJSON();
-  }
-  return String(value);
-}

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -18,6 +18,9 @@
       ],
       "@blazetrails/activesupport/key-generator": ["../../activesupport/src/key-generator.ts"],
       "@blazetrails/activesupport/temporal": ["../../activesupport/src/temporal.ts"],
+      "@blazetrails/activesupport/core-ext/date/conversions": [
+        "../../activesupport/src/core-ext/date/conversions.ts"
+      ],
       "@blazetrails/activesupport/core-ext/date/calculations": [
         "../../activesupport/src/core-ext/date/calculations.ts"
       ],

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -3,6 +3,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { underscore } from "@blazetrails/activesupport";
 import { pendingCounterCacheColumns } from "./counter-cache-state.js";
+import { registerLoadSchemaOverride } from "./load-schema-overrides-slot.js";
 import {
   touchAttributesWithTime,
   parseCounterCacheTouch,
@@ -244,7 +245,12 @@ export function isCounterCacheColumn(this: typeof Base, columnName: string): boo
  * belongs_to's target through the model registry rather than a constant, so a
  * counter column staged before its target existed is merged here.
  */
-export function loadSchemaBang(this: typeof Base): void {
+export function loadSchemaBang(this: typeof Base, superFn: () => void): void {
+  superFn();
+
+  // trails resolves a belongs_to's target through the model registry rather
+  // than a constant, so a counter column staged before its target existed is
+  // merged here, at the same schema-load seam.
   getCounterCacheColumns(this);
 
   // `registerModel` also accepts stand-ins that do not descend from `Base`, so
@@ -267,13 +273,9 @@ export function loadSchemaBang(this: typeof Base): void {
  * Merge any pending counter-cache column registrations for a newly registered
  * model class.  Called by `registerModel` so entries accumulated before the
  * target was in the registry are applied immediately rather than on first read.
- *
- * trails has no `load_schema!` super chain to hang counter_cache.rb:186-195 on,
- * so this — the seam already reached once a model and its associations are
- * fully defined — is where `load_schema!` runs.
  */
 export function flushPendingCounterCacheColumns(modelClass: typeof Base): void {
-  loadSchemaBang.call(modelClass);
+  getCounterCacheColumns(modelClass);
 }
 
 function getCounterCacheColumns(modelClass: typeof Base): string[] {
@@ -403,3 +405,7 @@ export function _foreignKeysEqual(fkey1: unknown, fkey2: unknown): boolean {
   );
   return arr1.length === arr2.length && arr1.every((k, i) => k === arr2[i]);
 }
+
+// `include CounterCache` (base.rb:309) — its `load_schema!` override
+// (counter_cache.rb:186-195) joins the chain at that ancestor position.
+registerLoadSchemaOverride(309, loadSchemaBang as never);

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -241,16 +241,16 @@ export function isCounterCacheColumn(this: typeof Base, columnName: string): boo
  *     self.counter_cached_association_names |= association_names
  *   end
  *
- * The `super` call stands in for the pending-column flush: trails resolves a
- * belongs_to's target through the model registry rather than a constant, so a
- * counter column staged before its target existed is merged here.
+ * `superFn` is Ruby `super` — the next link of the chain assembled in
+ * `model-schema.ts`, which this joins at `include CounterCache` (base.rb:309).
+ * The `getCounterCacheColumns` call ahead of the reflection scan is the
+ * pending-column flush: trails resolves a belongs_to's target through the model
+ * registry rather than a constant, so a counter column staged before its target
+ * existed is merged at this same schema-load seam.
  */
 export function loadSchemaBang(this: typeof Base, superFn: () => void): void {
   superFn();
 
-  // trails resolves a belongs_to's target through the model registry rather
-  // than a constant, so a counter column staged before its target existed is
-  // merged here, at the same schema-load seam.
   getCounterCacheColumns(this);
 
   // `registerModel` also accepts stand-ins that do not descend from `Base`, so
@@ -406,6 +406,4 @@ export function _foreignKeysEqual(fkey1: unknown, fkey2: unknown): boolean {
   return arr1.length === arr2.length && arr1.every((k, i) => k === arr2[i]);
 }
 
-// `include CounterCache` (base.rb:309) — its `load_schema!` override
-// (counter_cache.rb:186-195) joins the chain at that ancestor position.
 registerLoadSchemaOverride(309, loadSchemaBang as never);

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -32,7 +32,6 @@ import {
   encryptAttribute,
   encryptedAttribute,
   encryptedTypeOf,
-  validateColumnSize,
 } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
@@ -105,22 +104,13 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
  * durable PendingDecorator once at declaration time, and every type inspection
  * resolves through `typeForAttribute` (Rails' single lookup surface) — there is
  * no eager `_attributeDefinitions` re-wrap to maintain. What remains is the
- * bookkeeping Rails runs from `load_schema!` / `validate`: column-size
- * validation re-runs and the frozen-encryption validator install.
+ * bookkeeping Rails runs from `validate`: the frozen-encryption validator
+ * install. The column-size validation is `load_schema!`'s
+ * (encryptable_record.rb:126-130) and runs from that chain instead.
  */
 export function applyPendingEncryptions(klass: any): void {
   const pending: PendingEncryption[] | undefined = klass._pendingEncryptions;
   if (!pending || pending.length === 0) return;
-
-  // Re-run column-size validation after schema reflection so limits learned
-  // from the DB (not declared via attribute()) are also picked up. Safe even
-  // if validateColumnSize already ran at encrypts() time — it guards against
-  // registering the same LengthValidator twice.
-  if (Configurable.config.validateColumnSize) {
-    for (const { name } of pending) {
-      validateColumnSize.call(klass, name);
-    }
-  }
 
   // Register the frozen-encryption validator once per class. Own-property check
   // so subclasses that have already snapped their callback chain don't miss it —

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -47,10 +47,12 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
     restoreEncryptionConfig(configSnapshot);
   });
 
-  // `load_schema!` is a super chain in Rails (model_schema.rb:587-597 with
-  // encryptable_record.rb:126-130 layered over it), so the column limit
-  // reflected by the schema load is what turns into the length validation.
-  // Declaring `encrypts` runs before any reflection, where no limit is known.
+  /**
+   * `load_schema!` is a super chain in Rails (model_schema.rb:587-597 with
+   * encryptable_record.rb:126-130 layered over it), so the column limit the
+   * schema load reflects is what turns into the length validation. Declaring
+   * `encrypts` runs before any reflection, where no limit is known yet.
+   */
   it("adds the encrypted column's length validation at schema load", async () => {
     await freshAdapter();
     Configurable.config.validateColumnSize = true;

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -18,6 +18,8 @@ import { EncryptableRecord, deterministicEncryptedAttributes } from "./encryptab
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { applyPendingEncryptions } from "../encryption.js";
 import { Serialized } from "../type/serialized.js";
+import { Base } from "../base.js";
+import { LengthValidator } from "@blazetrails/activemodel";
 import { BinaryType } from "@blazetrails/activemodel";
 
 /**
@@ -43,6 +45,39 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
 
   afterEach(() => {
     restoreEncryptionConfig(configSnapshot);
+  });
+
+  // `load_schema!` is a super chain in Rails (model_schema.rb:587-597 with
+  // encryptable_record.rb:126-130 layered over it), so the column limit
+  // reflected by the schema load is what turns into the length validation.
+  // Declaring `encrypts` runs before any reflection, where no limit is known.
+  it("adds the encrypted column's length validation at schema load", async () => {
+    await freshAdapter();
+    Configurable.config.validateColumnSize = true;
+
+    class EncryptedBookValidatingColumnSize extends Base {
+      static _tableName = "encrypted_books";
+      static {
+        this.encrypts("name", { deterministic: true });
+      }
+    }
+
+    const validatorsFor = (name: string): unknown[] =>
+      (
+        EncryptedBookValidatingColumnSize as unknown as { _validators?: Map<string, unknown[]> }
+      )._validators?.get(name) ?? [];
+
+    expect(validatorsFor("name").some((v) => v instanceof LengthValidator)).toBe(false);
+
+    await EncryptedBookValidatingColumnSize.loadSchema();
+
+    expect(
+      validatorsFor("name").some(
+        (v) =>
+          v instanceof LengthValidator &&
+          (v as { options?: { maximum?: number } }).options?.maximum === 1024,
+      ),
+    ).toBe(true);
   });
 
   // Rails replays pending decorators in declaration order

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -324,9 +324,11 @@ export class EncryptableRecord {
   /**
    * Mirrors: ActiveRecord::Encryption::EncryptableRecord::ClassMethods#load_schema!
    * (encryptable_record.rb:126-130) — `super`, then the length validations when
-   * `validate_column_size` is on.
+   * `validate_column_size` is on. `superFn` is Ruby `super`: the next link of
+   * the chain assembled in `model-schema.ts`, which this joins at
+   * `include Encryption::EncryptableRecord` (base.rb:313).
    */
-  static loadSchemaBang(this: any, superFn: () => void): void {
+  static loadSchemaBang(this: typeof EncryptableRecord, superFn: () => void): void {
     superFn();
 
     if (Configurable.config.validateColumnSize) {
@@ -704,6 +706,4 @@ export function encryptedTypeOf(type: unknown): EncryptedAttributeType | undefin
   return undefined;
 }
 
-// `include Encryption::EncryptableRecord` (base.rb:313) — later than
-// CounterCache (:309), so this override sits closer to the class and runs first.
 registerLoadSchemaOverride(313, EncryptableRecord.loadSchemaBang as never);

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -5,6 +5,7 @@ import { LengthValidator, type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 import { encryptionHooks } from "../encryption-hooks.js";
+import { registerLoadSchemaOverride } from "../load-schema-overrides-slot.js";
 
 /**
  * Mirrors Rails' EncryptableRecord#global_previous_schemes_for.
@@ -320,10 +321,16 @@ export class EncryptableRecord {
     });
   }
 
-  /** @internal */
-  static loadSchemaBang(modelClass: any): void {
+  /**
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord::ClassMethods#load_schema!
+   * (encryptable_record.rb:126-130) — `super`, then the length validations when
+   * `validate_column_size` is on.
+   */
+  static loadSchemaBang(this: any, superFn: () => void): void {
+    superFn();
+
     if (Configurable.config.validateColumnSize) {
-      this.addLengthValidationForEncryptedColumns(modelClass);
+      EncryptableRecord.addLengthValidationForEncryptedColumns(this);
     }
   }
 
@@ -696,3 +703,7 @@ export function encryptedTypeOf(type: unknown): EncryptedAttributeType | undefin
   }
   return undefined;
 }
+
+// `include Encryption::EncryptableRecord` (base.rb:313) — later than
+// CounterCache (:309), so this override sits closer to the class and runs first.
+registerLoadSchemaOverride(313, EncryptableRecord.loadSchemaBang as never);

--- a/packages/activerecord/src/load-schema-overrides-slot.trails.test.ts
+++ b/packages/activerecord/src/load-schema-overrides-slot.trails.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  loadSchemaOverrides,
+  registerLoadSchemaOverride,
+  type LoadSchemaOverride,
+} from "./load-schema-overrides-slot.js";
+import { loadSchemaBang } from "./model-schema.js";
+import "./counter-cache.js";
+import "./encryption/encryptable-record.js";
+
+/**
+ * TS-only: Rails gets the ordering from `include` (base.rb:309 CounterCache,
+ * :313 Encryption::EncryptableRecord), so a Ruby test would have nothing to
+ * assert. trails rebuilds the chain by hand, so the order and the `super`
+ * wiring are worth pinning.
+ */
+describe("load_schema! super chain", () => {
+  it("registers CounterCache and EncryptableRecord at their include positions", () => {
+    expect(loadSchemaOverrides.map((entry) => entry.includeOrder)).toEqual([309, 313]);
+  });
+
+  it("runs the later-included override first, each reaching the next through super", () => {
+    const calls: string[] = [];
+    const late: LoadSchemaOverride = function (superFn) {
+      calls.push("late");
+      superFn();
+    };
+    const early: LoadSchemaOverride = function (superFn) {
+      calls.push("early");
+      superFn();
+    };
+    registerLoadSchemaOverride(9999, late);
+    registerLoadSchemaOverride(1, early);
+
+    try {
+      const host = { _schemaLoaded: true } as never;
+      // `_schemaLoaded` short-circuits the concerns' own bodies; the anchor
+      // still throws for a table-less host, which is all we need past the
+      // ordering assertion.
+      expect(() => loadSchemaBang.call(host)).toThrow();
+      expect(calls).toEqual(["late", "early"]);
+    } finally {
+      loadSchemaOverrides.splice(
+        0,
+        loadSchemaOverrides.length,
+        ...loadSchemaOverrides.filter((e) => e.override !== late && e.override !== early),
+      );
+    }
+  });
+});

--- a/packages/activerecord/src/load-schema-overrides-slot.trails.test.ts
+++ b/packages/activerecord/src/load-schema-overrides-slot.trails.test.ts
@@ -12,7 +12,8 @@ import "./encryption/encryptable-record.js";
  * TS-only: Rails gets the ordering from `include` (base.rb:309 CounterCache,
  * :313 Encryption::EncryptableRecord), so a Ruby test would have nothing to
  * assert. trails rebuilds the chain by hand, so the order and the `super`
- * wiring are worth pinning.
+ * wiring are worth pinning. The table-less host makes the anchor throw, which
+ * is all the ordering assertion needs.
  */
 describe("load_schema! super chain", () => {
   it("registers CounterCache and EncryptableRecord at their include positions", () => {
@@ -34,9 +35,6 @@ describe("load_schema! super chain", () => {
 
     try {
       const host = { _schemaLoaded: true } as never;
-      // `_schemaLoaded` short-circuits the concerns' own bodies; the anchor
-      // still throws for a table-less host, which is all we need past the
-      // ordering assertion.
       expect(() => loadSchemaBang.call(host)).toThrow();
       expect(calls).toEqual(["late", "early"]);
     } finally {

--- a/packages/activerecord/src/load-schema-overrides-slot.ts
+++ b/packages/activerecord/src/load-schema-overrides-slot.ts
@@ -12,8 +12,9 @@
  * concerns that register, so holding the registry in `model-schema.ts` itself
  * evaluates `registerLoadSchemaOverride` while its `const` is still in TDZ.
  *
- * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
- * "Module mixins".
+ * @noRailsEquivalent PERMANENT — a TS class cannot splice a module into its
+ * ancestor chain, so Ruby `super` over an included module has no direct
+ * spelling; see CLAUDE.md "Module mixins".
  */
 
 /**
@@ -25,8 +26,9 @@ export type LoadSchemaOverride = (this: unknown, superFn: () => void) => void;
 /**
  * Sorted ascending by `includeOrder`, i.e. by Rails' ancestor position.
  *
- * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
- * "Module mixins".
+ * @noRailsEquivalent PERMANENT — a TS class cannot splice a module into its
+ * ancestor chain, so Ruby `super` over an included module has no direct
+ * spelling; see CLAUDE.md "Module mixins".
  */
 export const loadSchemaOverrides: Array<{
   includeOrder: number;
@@ -38,8 +40,9 @@ export const loadSchemaOverrides: Array<{
  * `include` line in `activerecord/lib/active_record/base.rb`, which is what
  * fixes its position in Ruby's ancestor chain.
  *
- * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
- * "Module mixins".
+ * @noRailsEquivalent PERMANENT — a TS class cannot splice a module into its
+ * ancestor chain, so Ruby `super` over an included module has no direct
+ * spelling; see CLAUDE.md "Module mixins".
  */
 export function registerLoadSchemaOverride(
   includeOrder: number,

--- a/packages/activerecord/src/load-schema-overrides-slot.ts
+++ b/packages/activerecord/src/load-schema-overrides-slot.ts
@@ -1,0 +1,51 @@
+/**
+ * Rails builds `load_schema!` as a super chain: `ModelSchema#load_schema!`
+ * (`activerecord/lib/active_record/model_schema.rb:587-597`) is the anchor and
+ * each concern that needs schema-time bookkeeping overrides it and calls
+ * `super` — `CounterCache` (`counter_cache.rb:186-195`),
+ * `Encryption::EncryptableRecord` (`encryptable_record.rb:126-130`). A TS class
+ * cannot splice a module into its ancestor chain, so the overrides register
+ * here and `model-schema.ts` wraps them innermost-first.
+ *
+ * This is a zero-import slot module (CLAUDE.md, "Call-time constant
+ * resolution"): `model-schema.ts` is already in an import cycle with the
+ * concerns that register, so holding the registry in `model-schema.ts` itself
+ * evaluates `registerLoadSchemaOverride` while its `const` is still in TDZ.
+ *
+ * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
+ * "Module mixins".
+ */
+
+/**
+ * One concern's `load_schema!` override. `superFn` is Ruby `super` — the next
+ * link down the chain, ending at ModelSchema's own body.
+ */
+export type LoadSchemaOverride = (this: unknown, superFn: () => void) => void;
+
+/**
+ * Sorted ascending by `includeOrder`, i.e. by Rails' ancestor position.
+ *
+ * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
+ * "Module mixins".
+ */
+export const loadSchemaOverrides: Array<{
+  includeOrder: number;
+  override: LoadSchemaOverride;
+}> = [];
+
+/**
+ * Register a concern's `load_schema!` override. `includeOrder` is the concern's
+ * `include` line in `activerecord/lib/active_record/base.rb`, which is what
+ * fixes its position in Ruby's ancestor chain.
+ *
+ * @noRailsEquivalent Ruby `super` over an included module; see CLAUDE.md
+ * "Module mixins".
+ */
+export function registerLoadSchemaOverride(
+  includeOrder: number,
+  override: LoadSchemaOverride,
+): void {
+  if (loadSchemaOverrides.some((entry) => entry.override === override)) return;
+  loadSchemaOverrides.push({ includeOrder, override });
+  loadSchemaOverrides.sort((a, b) => a.includeOrder - b.includeOrder);
+}

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -17,6 +17,7 @@ import {
 import { singularize } from "@blazetrails/activesupport";
 import { modelRegistry } from "./associations.js";
 import { TableNotSpecified } from "./errors.js";
+import { loadSchemaOverrides } from "./load-schema-overrides-slot.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
 import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
@@ -1091,8 +1092,44 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
  * isn't populated), call `Base.loadSchema()` (base.ts).
  */
 export function loadSchema(this: SchemaHost): void {
+  // Mirrors: `return if schema_loaded?` (model_schema.rb:535). Rails' Monitor
+  // has no JS counterpart — a single-threaded runtime cannot interleave here.
   if (ownSchemaMemo(this, "_schemaLoaded")) return;
+  loadSchemaBang.call(this);
+}
 
+/**
+ * Rails builds `load_schema!` as a super chain: `ModelSchema#load_schema!`
+ * (model_schema.rb:587-597) is the anchor, and each concern that needs
+ * schema-time bookkeeping overrides it and calls `super` — `CounterCache`
+ * (counter_cache.rb:186-195), `Encryption::EncryptableRecord`
+ * (encryptable_record.rb:126-130). A TS class cannot splice a module into its
+ * ancestor chain, so the overrides register through
+ * `registerLoadSchemaOverride` (load-schema-overrides-slot.ts) and are wrapped
+ * here innermost-first, each
+ * handed the next link as `superFn` — the same idiom
+ * `CounterCache._createRecord` already uses for a `super`-calling override.
+ */
+export function loadSchemaBang(this: SchemaHost): void {
+  runLoadSchemaChain(this, () => loadSchemaBangAnchor.call(this));
+}
+
+function runLoadSchemaChain(host: SchemaHost, anchor: () => void): void {
+  let next = anchor;
+  // Ascending `includeOrder` = Rails' include order, so the last-included
+  // module ends up outermost, exactly where `include` puts it in the ancestors.
+  for (const { override } of loadSchemaOverrides) {
+    const superFn = next;
+    next = () => override.call(host, superFn);
+  }
+  next();
+}
+
+/**
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#load_schema!
+ * (model_schema.rb:587-597) — the base of the chain.
+ */
+function loadSchemaBangAnchor(this: SchemaHost): void {
   // Rails ModelSchema#load_schema!: `raise TableNotSpecified unless table_name`.
   // Rails' `table_name` is nil for an abstract class; ours computes an inferred
   // name even for abstract classes, so mirror the Rails effect by treating an
@@ -1414,6 +1451,10 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // (attribute_methods.rb:114) and would otherwise re-enter this load.
   this._schemaLoaded = true;
   defineAttributeMethodsAfterLoad(this);
+  // The reflection above IS `ModelSchema#load_schema!`'s body, so run the
+  // concern overrides (counter_cache.rb:186-195, encryptable_record.rb:126-130)
+  // over an already-completed anchor rather than re-entering it.
+  runLoadSchemaChain(this, () => {});
 }
 
 /**
@@ -1704,11 +1745,6 @@ function initializeLoadSchemaMonitor(this: SchemaHost): void {
 /** @internal */
 export function isSchemaLoaded(this: SchemaHost): boolean {
   return ownSchemaMemo(this, "_schemaLoaded") ?? false;
-}
-
-/** @internal */
-function loadSchemaBang(this: SchemaHost): void {
-  loadSchema.call(this);
 }
 
 /** @internal */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1092,8 +1092,6 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
  * isn't populated), call `Base.loadSchema()` (base.ts).
  */
 export function loadSchema(this: SchemaHost): void {
-  // Mirrors: `return if schema_loaded?` (model_schema.rb:535). Rails' Monitor
-  // has no JS counterpart — a single-threaded runtime cannot interleave here.
   if (ownSchemaMemo(this, "_schemaLoaded")) return;
   loadSchemaBang.call(this);
 }
@@ -1106,9 +1104,10 @@ export function loadSchema(this: SchemaHost): void {
  * (encryptable_record.rb:126-130). A TS class cannot splice a module into its
  * ancestor chain, so the overrides register through
  * `registerLoadSchemaOverride` (load-schema-overrides-slot.ts) and are wrapped
- * here innermost-first, each
- * handed the next link as `superFn` — the same idiom
- * `CounterCache._createRecord` already uses for a `super`-calling override.
+ * here by ascending `includeOrder` — the last-included module ends up
+ * outermost, exactly where `include` puts it in the ancestors — each handed the
+ * next link as `superFn`, the idiom `CounterCache._createRecord` already uses
+ * for a `super`-calling override.
  */
 export function loadSchemaBang(this: SchemaHost): void {
   runLoadSchemaChain(this, () => loadSchemaBangAnchor.call(this));
@@ -1116,8 +1115,6 @@ export function loadSchemaBang(this: SchemaHost): void {
 
 function runLoadSchemaChain(host: SchemaHost, anchor: () => void): void {
   let next = anchor;
-  // Ascending `includeOrder` = Rails' include order, so the last-included
-  // module ends up outermost, exactly where `include` puts it in the ancestors.
   for (const { override } of loadSchemaOverrides) {
     const superFn = next;
     next = () => override.call(host, superFn);
@@ -1389,6 +1386,11 @@ function applyColumnsHash(
  * overwritten, matching Rails where the pending replay runs after the column
  * seed so `attribute :foo, :bar` always wins over the reflected type.
  *
+ * This IS `ModelSchema#load_schema!`'s body on the async path, so it ends by
+ * running the concern overrides (counter_cache.rb:186-195,
+ * encryptable_record.rb:126-130) over an already-completed anchor rather than
+ * re-entering `loadSchemaBang`.
+ *
  * @internal
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
@@ -1451,9 +1453,6 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // (attribute_methods.rb:114) and would otherwise re-enter this load.
   this._schemaLoaded = true;
   defineAttributeMethodsAfterLoad(this);
-  // The reflection above IS `ModelSchema#load_schema!`'s body, so run the
-  // concern overrides (counter_cache.rb:186-195, encryptable_record.rb:126-130)
-  // over an already-completed anchor rather than re-entering it.
   runLoadSchemaChain(this, () => {});
 }
 

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -18,6 +18,9 @@
         "../../activesupport/src/message-verifier.ts"
       ],
       "@blazetrails/activesupport/process-adapter": ["../../activesupport/src/process-adapter.ts"],
+      "@blazetrails/activesupport/core-ext/date/conversions": [
+        "../../activesupport/src/core-ext/date/conversions.ts"
+      ],
       "@blazetrails/activesupport/core-ext/date/calculations": [
         "../../activesupport/src/core-ext/date/calculations.ts"
       ],

--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/core-ext/date/calculations.d.ts",
       "default": "./dist/core-ext/date/calculations.js"
     },
+    "./core-ext/date/conversions": {
+      "types": "./dist/core-ext/date/conversions.d.ts",
+      "default": "./dist/core-ext/date/conversions.js"
+    },
     "./core-ext/date-time/calculations": {
       "types": "./dist/core-ext/date-time/calculations.d.ts",
       "default": "./dist/core-ext/date-time/calculations.js"

--- a/packages/activesupport/src/duration.test.ts
+++ b/packages/activesupport/src/duration.test.ts
@@ -82,3 +82,11 @@ describe("Scalar", () => {
     expect(a.div(2).value).toBe(5);
   });
 });
+
+describe("DurationTest", () => {
+  it("equals", () => {
+    expect(days(1).equals(days(1))).toBe(true);
+    expect(days(1).equals(days(1).toI())).toBe(true);
+    expect(days(1).equals("foo")).toBe(false);
+  });
+});

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -377,6 +377,20 @@ export class Duration {
     return `${rest}, and ${last}`;
   }
 
+  /**
+   * Mirrors: ActiveSupport::Duration#== (duration.rb:341-347) — another
+   * Duration with the same `value`, or `other == value` for anything else, so
+   * `2.days == 172800` is true. `value` is seconds, a JS number, and Ruby
+   * `==` on it is numeric equality.
+   */
+  equals(other: unknown): boolean {
+    if (other instanceof Duration) {
+      return other.value === this.value;
+    } else {
+      return other === this.value;
+    }
+  }
+
   toString(): string {
     return String(Math.round(this.inSeconds()));
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/core-ext/date/calculations.ts",
   ),
+  "@blazetrails/activesupport/core-ext/date/conversions": path.resolve(
+    __dirname,
+    "packages/activesupport/src/core-ext/date/conversions.ts",
+  ),
   "@blazetrails/activesupport/core-ext/hash/slice": path.resolve(
     __dirname,
     "packages/activesupport/src/core-ext/hash/slice.ts",


### PR DESCRIPTION
Bundles five convergence stories (RFC 0115, RFC 0112).

### `Type::Date#type_cast_for_schema` (date.rb:34-36)
Now the Rails one-liner `value.to_fs(:db).inspect`: the schema dumper hands in an already-cast default, so the port no longer re-casts, and the invented `"null"` arm is gone. The PG infinity spellings already live where Rails puts them, on `PostgreSQL::OID::Date#type_cast_for_schema` (postgresql/oid/date.rb:20-26). Reaching `Date#to_fs` needed a new `@blazetrails/activesupport/core-ext/date/conversions` subpath (package.json export, vitest alias, both dx-test tsconfigs).

### Instance `attributeNames()` (attributes.rb:146-148)
`Model`'s class-body instance `attributeNames()` shadowed `Attributes.prototype.attributeNames` and delegated to the class-level, virtual-filtered reader. Deleted, so `include(Model, Attributes)` installs `@attributes.keys` — virtual attributes included, as in Rails. The class-level reader is unchanged; the type comes through the merged `interface Model` (spelled as a method so ActiveRecord's own `attribute_names` override, attribute_methods.rb:334-336, stays assignable).

### `serializeTimeValue`
Deleted — no Rails member in time_value.rb:9-95, no caller.

### `Duration#==` (duration.rb:341-347)
Ported, both arms, so `2.days == 2.days` and `2.days == 172800` are both true. `Error#optionsEqual`'s existing `equals()` dispatch picks it up with no change in `error.ts`, so a `greater_than: 2.days` option value now compares by value through `#match`, `#strictMatch` and `#equals`.

### `load_schema!` super chain (model_schema.rb:587-597)
trails had no chain, so `CounterCache#load_schema!` hung off `registerModel` (the wrong seam) and `EncryptableRecord.loadSchemaBang` had zero callers. `model-schema.ts`'s `loadSchemaBang` is now the anchor and wraps the registered overrides innermost-first, each handed the next as `superFn`. `CounterCache` (base.rb:309) and `Encryption::EncryptableRecord` (base.rb:313) register at their `include` positions, so the later-included one runs first exactly as Ruby's ancestors order them. `loadSchema` becomes the `return if schema_loaded?` guard it is in Rails.

The registry lives in a zero-import slot module (CLAUDE.md, "Call-time constant resolution"): `model-schema.ts` is already in an import cycle with both concerns, so holding it there evaluates `registerLoadSchemaOverride` while its `const` is still in TDZ.

Fallout: `flushPendingCounterCacheColumns` is back to being only the pending-column flush, and `applyPendingEncryptions` no longer re-runs `validateColumnSize` — that pass is `load_schema!`'s (encryptable_record.rb:126-130) and now runs from the chain. The new test fails on the pre-change baseline.

### Verification
`pnpm typecheck`, `pnpm lint`, `parity:api:calls` and `parity:api:calls:args` clean; `parity:api:extra` grows only by the slot module's two `@noRailsEquivalent` names and loses `serializeTimeValue`. Ran the activemodel suite, activesupport duration, and the activerecord encryption / counter-cache / model-schema / attribute-methods / schema-dumper / serialization slices.

Closes-story: converge-date-type-cast-for-schema-to-rails
Closes-story: converge-instance-attribute-names-onto-attributes-module
Closes-story: delete-dead-serialize-time-value-export
Closes-story: port-duration-value-equality-for-error-options
Closes-story: no-load-schema-super-chain-concern-hooks-unreachable