### PR TITLE
refactor(activemodel,activerecord): hook the attribute type in `attribute`, port `Attributes#freeze`, converge the counter-cache staging layer

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -233,6 +233,11 @@ export class AttributeSet {
     return Attribute.null(name);
   }
 
+  /** Mirrors: attribute_set.rb:82-85 — `@attributes = @attributes.clone`. */
+  initializeClone(_other: AttributeSet): void {
+    this._attributes = new Map(this._attributes);
+  }
+
   /**
    * Force a database value to be cast through the supplied `type`, replacing any
    * existing (schema-declared) attribute. Unlike {@link writeFromDatabase}, whose

--- a/packages/activemodel/src/attributes.test.ts
+++ b/packages/activemodel/src/attributes.test.ts
@@ -166,11 +166,12 @@ describe("AttributesTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    // Freeze the entire model instance
-    const frozen = Object.freeze({ ...m.attributes });
+    m.freeze();
+    expect(Object.isFrozen(m)).toBe(true);
     expect(() => {
-      (frozen as any).name = "changed";
-    }).toThrow();
+      (m as any).name = "changed";
+    }).toThrow(/frozen/i);
+    expect(() => m._attributes.writeFromUser("name", "changed")).toThrow(/frozen/i);
   });
 
   it("attributes can be frozen again", () => {
@@ -180,8 +181,8 @@ describe("AttributesTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    Object.freeze(m._attributes);
-    expect(() => Object.freeze(m._attributes)).not.toThrow();
+    m.freeze();
+    expect(() => m.freeze()).not.toThrow();
   });
 
   it(".type_for_attribute supports attribute aliases", () => {

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -173,11 +173,7 @@ export function attribute(
             : undefined,
         )
     : (existing?.type ?? typeDefaultValue());
-  // Mirrors: `type = hook_attribute_type(name, type) if type`
-  // (attribute_registration.rb:15) — the hooked type IS the declared type, so
-  // the queued PendingType and `_attributeDefinitions` both carry the wrap
-  // (TimeZoneConverter, LockingType). Rails' `if type` guard is the
-  // type-was-provided arm: on a no-type call Rails' `type` is nil.
+  // attribute_registration.rb:15 — `type = hook_attribute_type(name, type) if type`.
   if (typeProvided) type = this.hookAttributeType(name, type);
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -33,31 +33,13 @@ export function attributes(attrs: AttributeSet): Record<string, unknown> {
   return attrs.toHash();
 }
 
-/**
- * Mirrors: ActiveModel::Attributes#freeze (attributes.rb:150-153)
- *
- *   def freeze # :nodoc:
- *     @attributes = @attributes.clone.freeze unless frozen?
- *     super
- *   end
- *
- * One link of Rails' `freeze` chain; `Model#freeze` runs it where Rails' `super`
- * from `Validations#freeze` (validations.rb:372-377) reaches it, since TS has no
- * `super` across mixins. Ruby's `Object#clone` copies the ivars and dispatches
- * `initialize_clone`, which `AttributeSet` overrides to dup its inner hash
- * (attribute_set.rb:82-85) — spelled here as the same allocate-and-copy `dup()`
- * uses.
- *
- * @internal Rails-private helper.
- */
-export function freeze(this: AttributeInstanceHost): void {
-  if (!Object.isFrozen(this)) {
-    const attributes = this._attributes;
-    const cloned = Object.create(Object.getPrototypeOf(attributes) as object) as AttributeSet;
-    Object.assign(cloned, attributes);
-    cloned.initializeClone(attributes);
-    this._attributes = cloned.freeze();
-  }
+/** @internal */
+export function _writeAttribute(
+  this: AttributeInstanceHost,
+  attrName: string,
+  value: unknown,
+): void {
+  this._attributes.writeFromUser(attrName, value);
 }
 
 /**
@@ -69,42 +51,6 @@ export function freeze(this: AttributeInstanceHost): void {
  * @internal Rails-private helper.
  */
 type AttributeInstanceHost = { _attributes: AttributeSet };
-
-/** @internal */
-export function _writeAttribute(
-  this: AttributeInstanceHost,
-  attrName: string,
-  value: unknown,
-): void {
-  this._attributes.writeFromUser(attrName, value);
-}
-
-// ---------------------------------------------------------------------------
-// Class methods — Mirrors: ActiveModel::Attributes::ClassMethods
-// ---------------------------------------------------------------------------
-
-/**
- * Declare a typed attribute with an optional default.
- *
- * Mirrors: ActiveModel::Attributes::ClassMethods#attribute
- *
- * Model.attribute() delegates here. This is the canonical implementation
- * of the class-level `attribute` declaration.
- *
- * @internal
- */
-export interface AttributeOptions {
-  default?: unknown;
-  virtual?: boolean;
-  limit?: number | null;
-  /**
-   * PG type modifiers, forwarded to the registry as Rails' `**options` are:
-   * `attribute :tags, :string, array: true` / `:my_range, :string, range: true`
-   * (postgresql_adapter.rb:1166-1167 register them via `add_modifier`).
-   */
-  array?: boolean;
-  range?: boolean;
-}
 
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods#attribute (attributes.rb:59-61)
@@ -213,6 +159,33 @@ export function attribute(
   this.defineAttributeMethod(name);
 }
 
+// ---------------------------------------------------------------------------
+// Class methods — Mirrors: ActiveModel::Attributes::ClassMethods
+// ---------------------------------------------------------------------------
+
+/**
+ * Declare a typed attribute with an optional default.
+ *
+ * Mirrors: ActiveModel::Attributes::ClassMethods#attribute
+ *
+ * Model.attribute() delegates here. This is the canonical implementation
+ * of the class-level `attribute` declaration.
+ *
+ * @internal
+ */
+export interface AttributeOptions {
+  default?: unknown;
+  virtual?: boolean;
+  limit?: number | null;
+  /**
+   * PG type modifiers, forwarded to the registry as Rails' `**options` are:
+   * `attribute :tags, :string, array: true` / `:my_range, :string, range: true`
+   * (postgresql_adapter.rb:1166-1167 register them via `add_modifier`).
+   */
+  array?: boolean;
+  range?: boolean;
+}
+
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods#define_method_attribute=
  * (attributes.rb:92-102) — the writer hook `define_attribute_method_pattern`
@@ -255,6 +228,33 @@ export function setDefineMethodAttribute(
       });
     });
   });
+}
+
+/**
+ * Mirrors: ActiveModel::Attributes#freeze (attributes.rb:150-153)
+ *
+ *   def freeze # :nodoc:
+ *     @attributes = @attributes.clone.freeze unless frozen?
+ *     super
+ *   end
+ *
+ * One link of Rails' `freeze` chain; `Model#freeze` runs it where Rails' `super`
+ * from `Validations#freeze` (validations.rb:372-377) reaches it, since TS has no
+ * `super` across mixins. Ruby's `Object#clone` copies the ivars and dispatches
+ * `initialize_clone`, which `AttributeSet` overrides to dup its inner hash
+ * (attribute_set.rb:82-85) — spelled here as the same allocate-and-copy `dup()`
+ * uses.
+ *
+ * @internal Rails-private helper.
+ */
+export function freeze(this: AttributeInstanceHost): void {
+  if (!Object.isFrozen(this)) {
+    const attributes = this._attributes;
+    const cloned = Object.create(Object.getPrototypeOf(attributes) as object) as AttributeSet;
+    Object.assign(cloned, attributes);
+    cloned.initializeClone(attributes);
+    this._attributes = cloned.freeze();
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include ActiveModel::AttributeMethods` (attributes.rb:8); the class/interface merge is how `include()` surfaces on the type side.

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -34,6 +34,33 @@ export function attributes(attrs: AttributeSet): Record<string, unknown> {
 }
 
 /**
+ * Mirrors: ActiveModel::Attributes#freeze (attributes.rb:150-153)
+ *
+ *   def freeze # :nodoc:
+ *     @attributes = @attributes.clone.freeze unless frozen?
+ *     super
+ *   end
+ *
+ * One link of Rails' `freeze` chain; `Model#freeze` runs it where Rails' `super`
+ * from `Validations#freeze` (validations.rb:372-377) reaches it, since TS has no
+ * `super` across mixins. Ruby's `Object#clone` copies the ivars and dispatches
+ * `initialize_clone`, which `AttributeSet` overrides to dup its inner hash
+ * (attribute_set.rb:82-85) — spelled here as the same allocate-and-copy `dup()`
+ * uses.
+ *
+ * @internal Rails-private helper.
+ */
+export function freeze(this: AttributeInstanceHost): void {
+  if (!Object.isFrozen(this)) {
+    const attributes = this._attributes;
+    const cloned = Object.create(Object.getPrototypeOf(attributes) as object) as AttributeSet;
+    Object.assign(cloned, attributes);
+    cloned.initializeClone(attributes);
+    this._attributes = cloned.freeze();
+  }
+}
+
+/**
  * Mirrors: ActiveModel::Attributes#_write_attribute
  *
  * Writes a value into the attribute store via the user-write path (casts
@@ -105,6 +132,7 @@ export function attribute(
     pendingAttributeModifications(): PendingModification[];
     attributeTypes(): Record<string, Type>;
     defineAttributeMethod(attrName: string): void;
+    hookAttributeType(name: string, type: Type): Type;
   },
   name: string,
   // Mirrors Rails' `attribute(name, type = nil, **options)`: the type is
@@ -135,7 +163,7 @@ export function attribute(
   // consumed here — `default` and `virtual` — are the ones Rails names
   // explicitly, so only the rest reach the registry.
   const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
-  const type = typeProvided
+  let type = typeProvided
     ? typeName instanceof Type
       ? typeName
       : this.resolveTypeName(
@@ -145,6 +173,12 @@ export function attribute(
             : undefined,
         )
     : (existing?.type ?? typeDefaultValue());
+  // Mirrors: `type = hook_attribute_type(name, type) if type`
+  // (attribute_registration.rb:15) — the hooked type IS the declared type, so
+  // the queued PendingType and `_attributeDefinitions` both carry the wrap
+  // (TimeZoneConverter, LockingType). Rails' `if type` guard is the
+  // type-was-provided arm: on a no-type call Rails' `type` is nil.
+  if (typeProvided) type = this.hookAttributeType(name, type);
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and
   // leaves the current default/value untouched.
@@ -289,6 +323,14 @@ export class Attributes {
   /** Mirrors: attributes.rb:146-148 — `def attribute_names; @attributes.keys; end` */
   attributeNames(): string[] {
     return this._attributes.keys();
+  }
+
+  /** Mirrors: attributes.rb:150-153 — `@attributes = @attributes.clone.freeze unless frozen?` */
+  freeze(): this {
+    freeze.call(this);
+    // attributes.rb:152 — `super`, which ends at `Object#freeze`.
+    Object.freeze(this);
+    return this;
   }
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -109,6 +109,7 @@ import {
   Attributes,
   attribute,
   setDefineMethodAttribute,
+  freeze as attributesFreeze,
 } from "./attributes.js";
 import {
   _defaultAttributes,
@@ -2139,6 +2140,9 @@ export class Model {
     // `context_for_validation` inside `freeze`. Touching
     // `validationContext` alone would not populate the cache.
     void this.contextForValidation();
+    // Rails' `super` from `Validations#freeze` reaches `Attributes#freeze`
+    // (attributes.rb:150-153), which clones-and-freezes the attribute set.
+    attributesFreeze.call(this);
     Object.freeze(this);
     return this;
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2140,8 +2140,7 @@ export class Model {
     // `context_for_validation` inside `freeze`. Touching
     // `validationContext` alone would not populate the cache.
     void this.contextForValidation();
-    // Rails' `super` from `Validations#freeze` reaches `Attributes#freeze`
-    // (attributes.rb:150-153), which clones-and-freezes the attribute set.
+    // validations.rb:376 — `super` reaches `Attributes#freeze` (attributes.rb:150-153).
     attributesFreeze.call(this);
     Object.freeze(this);
     return this;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -292,6 +292,23 @@ function frameworkBase(model: typeof Base): typeof Base | null {
 }
 
 /**
+ * Reject a class that does not descend from `Base`. Rails has no analogue —
+ * everything that reaches `ActiveRecord::Base.descendants` bookkeeping IS a
+ * `Base` subclass, and so always carries the `class_attribute` defaults its
+ * concerns declared (`counter_cache.rb:9-10`, `reflection.rb:11`). Ported
+ * readers rely on that, so the registry enforces it rather than making every
+ * reader re-supply the default.
+ * @internal
+ */
+function assertActiveRecordBase(model: typeof Base): void {
+  if (!frameworkBase(model)) {
+    throw new Error(
+      `registerModel expects an ActiveRecord::Base subclass, got ${String(model?.name ?? model)}`,
+    );
+  }
+}
+
+/**
  * Throw when a bespoke class is registered under a name a canonical model
  * already owns. The registry is global and never torn down between tests, so
  * such a shadow silently poisons every later test that resolves the name as an
@@ -381,13 +398,16 @@ export function registerModel(
   }
   if (typeof nameOrModel === "string") {
     if (!model) throw new Error("registerModel(name, model) requires a model class");
+    assertActiveRecordBase(model);
     modelRegistry.set(nameOrModel, model);
-    // Attach registry key so counter-cache pending-map lookup can match it.
+    // Attach registry key so callers that resolve a class back to the names it
+    // was registered under (reflection's `computeClass`) can match it.
     const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
     model._registryKeys = keys;
-    flushPendingCounterCacheColumns(model);
+    flushPendingCounterCacheColumns(model, nameOrModel);
   } else {
+    assertActiveRecordBase(nameOrModel);
     modelRegistry.set(nameOrModel.name, nameOrModel);
     // A namespaced model carries its Ruby module path via `static moduleName`;
     // derive the `::`-qualified registry key from it (e.g.
@@ -399,7 +419,7 @@ export function registerModel(
     if (qualified !== nameOrModel.name) {
       registerModel(qualified, nameOrModel);
     }
-    flushPendingCounterCacheColumns(nameOrModel);
+    flushPendingCounterCacheColumns(nameOrModel, nameOrModel.name);
   }
 }
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -72,17 +72,20 @@ export class BelongsTo extends SingularAssociation {
         ? reflection.counterCacheColumn()
         : null) ?? `${pluralize(underscore(model.name))}_count`;
     const klass = safeConstantize(reflection.className) as any;
-    if (klass && "_counterCacheColumns" in klass) {
-      const column = cacheColumn();
-      if (!klass._counterCacheColumns.includes(column)) {
-        klass._counterCacheColumns = [...klass._counterCacheColumns, column];
-      }
-    } else {
-      // The arm Ruby's autoload reaches and ESM cannot: see counter-cache-state.ts.
+    if (!klass) {
+      // The only arm Ruby's autoload reaches and ESM cannot — an unresolved
+      // constant: see counter-cache-state.ts. A resolved class that does not
+      // answer `_counterCacheColumns` falls through recording nothing, as
+      // Rails' `respond_to?` guard does.
       const pending =
         pendingCounterCacheColumns.get(reflection.className) ?? new Set<() => string>();
       pending.add(cacheColumn);
       pendingCounterCacheColumns.set(reflection.className, pending);
+    } else if ("_counterCacheColumns" in klass) {
+      const column = cacheColumn();
+      if (!klass._counterCacheColumns.includes(column)) {
+        klass._counterCacheColumns = [...klass._counterCacheColumns, column];
+      }
     }
 
     // belongs_to.rb:41 — `model.counter_cached_association_names |= [reflection.name]`

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -8,7 +8,6 @@ import {
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
-import { flushPendingCounterCacheColumns } from "../../counter-cache.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 import { ActiveRecord } from "../../ar-config.js";
@@ -72,34 +71,32 @@ export class BelongsTo extends SingularAssociation {
   static addCounterCacheCallbacks(model: any, reflection: any): void {
     const name = reflection.name;
 
-    // Register the counter column on the target class so isCounterCacheColumn
-    // works on the has-many side — mirrors Rails' builder/belongs_to.rb line:
-    //   klass._counter_cache_columns |= [cache_column]
-    // Re-derived at flush time, not now: see counter-cache-state.ts. Resolving
-    // eagerly here can fall back to the non-demodulized column (cpk_books_count)
-    // when the target class isn't registered yet.
+    // belongs_to.rb:39-40:
+    //   klass = reflection.class_name.safe_constantize
+    //   klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(:_counter_cache_columns)
+    // The column is derived through a thunk rather than eagerly: an unresolved
+    // target has to be re-derived after it registers, or `counterCacheColumn()`
+    // falls back to the non-demodulized `cpk_books_count` instead of
+    // `books_count`. See counter-cache-state.ts.
     const cacheColumn = (): string =>
       (typeof reflection.counterCacheColumn === "function"
         ? reflection.counterCacheColumn()
         : null) ?? `${pluralize(underscore(model.name))}_count`;
-    const targetClassName = reflection.options?.className ?? camelize(name);
-    // Rails: `klass = reflection.class_name.safe_constantize` — silently nil
-    // when the target class isn't loaded yet, then guarded by
-    // `if klass && klass.respond_to?(:_counter_cache_columns)`. We mirror by
-    // always staging into the pending map first, then flushing immediately
-    // when the target is already registered. The unconditional pending stage
-    // ensures the registration survives a target class being later re-defined
-    // (test re-runs, hot reload), at which point registerModel re-flushes —
-    // mirroring Rails' behavior where re-loading the target class re-runs
-    // the include chain.
-    const pending = pendingCounterCacheColumns.get(targetClassName) ?? new Set<() => string>();
-    pending.add(cacheColumn);
-    pendingCounterCacheColumns.set(targetClassName, pending);
-    // Resolved through the constant table rather than the reflection so a
-    // target class re-defined between tests does not get its `klass` memo
-    // prematurely seeded.
-    const klass = safeConstantize(targetClassName) as any;
-    if (klass) flushPendingCounterCacheColumns(klass);
+    const className = reflection.options?.className ?? camelize(name);
+    const klass = safeConstantize(className) as any;
+    if (klass && "_counterCacheColumns" in klass) {
+      const column = cacheColumn();
+      if (!klass._counterCacheColumns.includes(column)) {
+        klass._counterCacheColumns = [...klass._counterCacheColumns, column];
+      }
+    } else {
+      // The one thing Ruby's autoload gives Rails for free: a target declared
+      // later in the module graph. Staged under the class name the registry
+      // will use, and applied by `registerModel`.
+      const pending = pendingCounterCacheColumns.get(className) ?? new Set<() => string>();
+      pending.add(cacheColumn);
+      pendingCounterCacheColumns.set(className, pending);
+    }
 
     // belongs_to.rb:41 — `model.counter_cached_association_names |= [reflection.name]`
     if (!model.counterCachedAssociationNames.includes(name)) {

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,10 +1,4 @@
-import {
-  underscore,
-  pluralize,
-  camelize,
-  isBlank,
-  safeConstantize,
-} from "@blazetrails/activesupport";
+import { underscore, pluralize, isBlank, safeConstantize } from "@blazetrails/activesupport";
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
 import { beforeValidation, afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
@@ -71,31 +65,24 @@ export class BelongsTo extends SingularAssociation {
   static addCounterCacheCallbacks(model: any, reflection: any): void {
     const name = reflection.name;
 
-    // belongs_to.rb:39-40:
-    //   klass = reflection.class_name.safe_constantize
-    //   klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(:_counter_cache_columns)
-    // The column is derived through a thunk rather than eagerly: an unresolved
-    // target has to be re-derived after it registers, or `counterCacheColumn()`
-    // falls back to the non-demodulized `cpk_books_count` instead of
-    // `books_count`. See counter-cache-state.ts.
+    // belongs_to.rb:39-40 — `klass = reflection.class_name.safe_constantize` then
+    // `klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(...)`.
     const cacheColumn = (): string =>
       (typeof reflection.counterCacheColumn === "function"
         ? reflection.counterCacheColumn()
         : null) ?? `${pluralize(underscore(model.name))}_count`;
-    const className = reflection.options?.className ?? camelize(name);
-    const klass = safeConstantize(className) as any;
+    const klass = safeConstantize(reflection.className) as any;
     if (klass && "_counterCacheColumns" in klass) {
       const column = cacheColumn();
       if (!klass._counterCacheColumns.includes(column)) {
         klass._counterCacheColumns = [...klass._counterCacheColumns, column];
       }
     } else {
-      // The one thing Ruby's autoload gives Rails for free: a target declared
-      // later in the module graph. Staged under the class name the registry
-      // will use, and applied by `registerModel`.
-      const pending = pendingCounterCacheColumns.get(className) ?? new Set<() => string>();
+      // The arm Ruby's autoload reaches and ESM cannot: see counter-cache-state.ts.
+      const pending =
+        pendingCounterCacheColumns.get(reflection.className) ?? new Set<() => string>();
       pending.add(cacheColumn);
-      pendingCounterCacheColumns.set(className, pending);
+      pendingCounterCacheColumns.set(reflection.className, pending);
     }
 
     // belongs_to.rb:41 — `model.counter_cached_association_names |= [reflection.name]`

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1192,22 +1192,6 @@ export class Base extends Model {
     // ensureSchemaLoaded to re-run virtual reconciliation (model-schema.ts
     // reconcileVirtualAttributes) instead of skipping it via the one-shot guard.
     this._virtualAttributesReconciled = false;
-    // Apply hookAttributeType decorators (TZ conversion, locking) via
-    // `decorate_attributes` (attribute_registration.rb:22-28), which queues the
-    // decorator for the `_default_attributes` replay.
-    // Gated on an explicit type, mirroring Rails' `type = hook_attribute_type(name, type) if type`
-    // (attribute_registration.rb:15). On a no-type call (`attribute("col", { default })`)
-    // the existing type is already hooked from schema reflection — re-hooking would
-    // double-wrap unconditional wrappers like LockingType (`LockingType(LockingType(...))`).
-    const typeWasProvided =
-      typeName !== undefined && (typeof typeName === "string" || typeName instanceof Type);
-    const def = typeWasProvided ? this._attributeDefinitions.get(name) : undefined;
-    if (def) {
-      const hooked = this.hookAttributeType(name, def.type);
-      if (hooked !== def.type) {
-        this.decorateAttributes([name], (_n: string, _t: Type) => hooked);
-      }
-    }
     // If we just defined an "id" accessor on a subclass prototype, remove it
     // so Base.prototype.id (which handles CPK) is used instead.
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1935,6 +1935,8 @@ export class Base extends Model {
   }
 
   // --- Reflection::ClassMethods (wired via extend() after class body) ---
+  /** reflection.rb:11 — `class_attribute :_reflections, instance_writer: false, default: {}`. */
+  declare static _reflections: Record<string, _Reflection.AssociationReflection>;
   declare static _reflectOnAssociation: typeof _Reflection.ClassMethods._reflectOnAssociation;
   declare static reflections: typeof _Reflection.ClassMethods.reflections;
   declare static normalizedReflections: typeof _Reflection.ClassMethods.normalizedReflections;

--- a/packages/activerecord/src/counter-cache-state.ts
+++ b/packages/activerecord/src/counter-cache-state.ts
@@ -2,11 +2,20 @@
 // Shared between counter-cache.ts and associations/builder/belongs-to.ts
 // so that the pending map stays off the public subpath exports.
 //
+// The single deferral trails needs over Rails' belongs_to.rb:39-41, which
+// resolves the target with `reflection.class_name.safe_constantize` and unions
+// the column onto it right there. Ruby autoloads the constant at that moment;
+// ESM cannot, so a `belongs_to ..., counter_cache:` declared before its target
+// module has evaluated stages here, keyed by the class name the registry will
+// use, and `registerModel` applies it under that exact key.
+//
 // Values are *thunks*, not resolved column strings: the column name is
 // re-derived at flush time. A belongs_to staged before its target class is
 // registered (e.g. CpkBook defined before CpkOrder in cpk.ts) would otherwise
 // resolve `counterCacheColumn()` against an empty registry and fall back to the
-// non-demodulized `cpk_books_count` instead of `books_count`. Deferring the
-// computation lets the flush at registerModel time see the now-registered
-// target and its inverse hasMany, yielding the correct column.
+// non-demodulized `cpk_books_count` instead of `books_count`.
+//
+// Entries are kept after a flush so a target class re-defined and re-registered
+// between tests picks the column up again; the union at the flush site makes
+// repeated applications idempotent.
 export const pendingCounterCacheColumns = new Map<string, Set<() => string>>();

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -213,16 +213,11 @@ export async function resetCounters(
 }
 
 /**
- * Check whether a column is a counter-cache column on this model — i.e. some
- * other model's belongs_to targets this model with counter_cache: enabled,
- * and the resolved counter column name matches.  Registration happens in the
- * belongs_to builder (mirroring Rails' builder/belongs_to.rb), eagerly when
- * the target class is already registered or via a pending map otherwise.
- *
  * Mirrors: ActiveRecord::CounterCache::ClassMethods#counter_cache_column?
+ * (counter_cache.rb:182-184)
  */
 export function isCounterCacheColumn(this: typeof Base, columnName: string): boolean {
-  return getCounterCacheColumns(this).includes(columnName);
+  return this._counterCacheColumns.includes(columnName);
 }
 
 /**
@@ -243,26 +238,17 @@ export function isCounterCacheColumn(this: typeof Base, columnName: string): boo
  *
  * `superFn` is Ruby `super` — the next link of the chain assembled in
  * `model-schema.ts`, which this joins at `include CounterCache` (base.rb:309).
- * The `getCounterCacheColumns` call ahead of the reflection scan is the
- * pending-column flush: trails resolves a belongs_to's target through the model
- * registry rather than a constant, so a counter column staged before its target
- * existed is merged at this same schema-load seam.
  */
 export function loadSchemaBang(this: typeof Base, superFn: () => void): void {
   superFn();
 
-  getCounterCacheColumns(this);
-
-  // `registerModel` also accepts stand-ins that do not descend from `Base`, so
-  // the class_attribute defaults of counter_cache.rb:9-10 (and reflection.rb:11)
-  // have to be supplied here rather than read off the constructor chain.
-  const reflections = ((this as any)._reflections ?? {}) as Record<string, any>;
   const associationNames: string[] = [];
-  for (const [name, reflection] of Object.entries(reflections)) {
-    if (!reflection?.belongsTo?.() || !reflection.counterCacheColumn?.()) continue;
+  const _reflections = (this as unknown as { _reflections: Record<string, unknown> })._reflections;
+  for (const [name, reflection] of Object.entries(_reflections)) {
+    if (!(reflection as any).belongsTo?.() || !(reflection as any).counterCacheColumn?.()) continue;
     associationNames.push(name);
   }
-  let names: string[] = this.counterCachedAssociationNames ?? [];
+  let names = this.counterCachedAssociationNames;
   for (const name of associationNames) {
     if (!names.includes(name)) names = [...names, name];
   }
@@ -270,39 +256,24 @@ export function loadSchemaBang(this: typeof Base, superFn: () => void): void {
 }
 
 /**
- * Merge any pending counter-cache column registrations for a newly registered
- * model class.  Called by `registerModel` so entries accumulated before the
- * target was in the registry are applied immediately rather than on first read.
+ * Applies the counter-cache columns staged for `key` by a `belongs_to` whose
+ * target class was not yet resolvable. Called by `registerModel` with the exact
+ * key the class is being registered under — see {@link pendingCounterCacheColumns}
+ * for why the deferral exists at all.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby autoloads the target constant at builder
+ * time (belongs_to.rb:39). ESM evaluates every import eagerly and has no hook
+ * that faults a module in when a name is first referenced, so a `belongs_to`
+ * whose target module has not evaluated yet cannot resolve it there.
  */
-export function flushPendingCounterCacheColumns(modelClass: typeof Base): void {
-  getCounterCacheColumns(modelClass);
-}
-
-function getCounterCacheColumns(modelClass: typeof Base): string[] {
-  // Collect matching pending keys: exact class name, registry aliases, or "::ClassName" suffix.
-  const registryKeys: string[] = (modelClass as any)._registryKeys ?? [];
-  const suffix = `::${modelClass.name}`;
-  const matchingKeys: string[] = [];
-  for (const key of pendingCounterCacheColumns.keys()) {
-    if (key === modelClass.name || registryKeys.includes(key) || key.endsWith(suffix))
-      matchingKeys.push(key);
-  }
-  for (const key of matchingKeys) {
-    // Re-derive each column now that the target class is registered; staging
-    // thunks (not strings) lets a belongs_to declared before its target see the
-    // correct demodulized column at flush time. See counter-cache-state.ts.
-    for (const col of pendingCounterCacheColumns.get(key)!) {
-      // belongs_to.rb:40 — `klass._counter_cache_columns |= [cache_column]`.
-      const column = col();
-      const columns = modelClass._counterCacheColumns ?? [];
-      if (!columns.includes(column)) modelClass._counterCacheColumns = [...columns, column];
+export function flushPendingCounterCacheColumns(modelClass: typeof Base, key: string): void {
+  for (const cacheColumn of pendingCounterCacheColumns.get(key) ?? []) {
+    // belongs_to.rb:40 — `klass._counter_cache_columns |= [cache_column]`.
+    const column = cacheColumn();
+    if (!modelClass._counterCacheColumns.includes(column)) {
+      modelClass._counterCacheColumns = [...modelClass._counterCacheColumns, column];
     }
-    // Intentionally keep the pending entry so that if the target class is
-    // re-defined and re-registered (e.g. between tests), the next
-    // registerModel call also flushes the column into the new class.
-    // The union above makes repeated flushes idempotent.
   }
-  return modelClass._counterCacheColumns ?? [];
 }
 
 /**

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -243,9 +243,8 @@ export function loadSchemaBang(this: typeof Base, superFn: () => void): void {
   superFn();
 
   const associationNames: string[] = [];
-  const _reflections = (this as unknown as { _reflections: Record<string, unknown> })._reflections;
-  for (const [name, reflection] of Object.entries(_reflections)) {
-    if (!(reflection as any).belongsTo?.() || !(reflection as any).counterCacheColumn?.()) continue;
+  for (const [name, reflection] of Object.entries(this._reflections)) {
+    if (!reflection.belongsTo?.() || !reflection.counterCacheColumn?.()) continue;
     associationNames.push(name);
   }
   let names = this.counterCachedAssociationNames;

--- a/packages/activerecord/src/test-fixtures.test.ts
+++ b/packages/activerecord/src/test-fixtures.test.ts
@@ -883,19 +883,14 @@ describe("useFixtures encryption add-on is opt-in", () => {
     const originalAddOn = entry.addOn;
     const originalModel = entry.model;
     const order: string[] = [];
-    // A minimal class (not a bare object): `resolveFixtureNames` now folds in
-    // `registerModel`, so the stub must look like an AR model class.
-    // `tableName` keeps the resolver happy.
-    class StubModel {
-      static tableName = "encrypted_books";
-    }
-    const stubModel = StubModel as unknown as typeof Base;
     entry.addOn = vi.fn(async () => {
       order.push("addOn");
     });
     entry.model = vi.fn(async () => {
       order.push("model");
-      return stubModel;
+      // `resolveFixtureNames` folds in `registerModel`, which takes a `Base`
+      // subclass only, so the spy forwards to the real thunk.
+      return originalModel.call(entry);
     });
     try {
       await resolveFixtureNames(["encryptedBooks"]);


### PR DESCRIPTION
Four convergence stories, all in the attribute-declaration / model-registration seam.

### 1. `hook_attribute_type` runs inside `attribute` (RFC 0115)

Rails hooks the resolved type before queueing the `PendingType`
(`attribute_registration.rb:15`), so the hooked type IS the declared type
everywhere it is read. ActiveModel's `attribute` now does that. ActiveRecord's
`Base.attribute` no longer re-reads the definition, re-hooks it, and pushes a
`decorateAttributes` decorator Rails has no counterpart for; the
`typeWasProvided` gate and its "re-hooking would double-wrap LockingType"
comment go with it, since the hook now runs in the right place.
Time-zone and locking wraps still resolve through `type_for_attribute`, and
`_attributeDefinitions` carries the hooked type again.

### 2. `ActiveModel::Attributes#freeze` (RFC 0115)

`attributes.rb:150-153` is ported onto `Attributes.prototype` and run from
`Model#freeze` at the point Rails' `super` from `Validations#freeze`
(`validations.rb:372-377`) reaches it — the same flattened-chain shape
`Model#initializeDup` uses. `AttributeSet#initializeClone`
(`attribute_set.rb:82-85`) backs the clone. A frozen model's attribute set is
now frozen: `record._attributes.writeFromUser(...)` raises where it previously
mutated. The two Rails-named freeze tests in `attributes.test.ts` were
converged onto that behavior (bodies only — names untouched) and fail on the
pre-change baseline.

### 3. counter-cache staging reduced to the Rails guard (RFC 0112)

`addCounterCacheCallbacks` now ports `belongs_to.rb:39-41` directly: resolve
the target with `safeConstantize`, union the column onto it under the
`respond_to?(:_counter_cache_columns)` guard. Staging happens only in the arm
Rails cannot reach — the target module has not evaluated yet, which is a real
ESM ordering constraint Ruby's autoload does not have. That residue is one
documented deferral in `counter-cache-state.ts`; the `_registryKeys` and
`"::ClassName"` suffix matching are gone, `registerModel` flushes under the
exact key it registers, and `counter_cache_column?` / `load_schema!` are now
literal ports.

### 4. `registerModel` requires a `Base` subclass (RFC 0112)

A registered class now always carries the `class_attribute` defaults its
concerns declared, so the `?? {}` / `?? []` stand-ins for `reflection.rb:11`
and `counter_cache.rb:9-10` are deleted and the readers name the attributes
directly. The only non-`Base` stand-in was `test-fixtures.test.ts`'s
`StubModel`; that spy now forwards to the real fixture thunk.

### Verification

- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK.
- `pnpm parity:api:extra --package activerecord`: novel 542 → 541.
- `pnpm typecheck`, `pnpm lint` clean.
- Green locally: all of `packages/activemodel`, plus AR `counter-cache`,
  `counter-cache.trails`, `test-fixtures`, `associations`,
  `belongs-to-associations`, `has-many-associations`, `persistence`,
  `time-zone-conversion`, `locking`, `reflection`, `base`, `core`,
  `model-schema`, `attribute-methods/*`.

Closes-story: apply-hook-attribute-type-inside-activemodel-attribute
Closes-story: port-attributes-freeze-link-into-model-freeze-chain
Closes-story: pending-counter-cache-columns-registry-has-no-rails-counterpart
Closes-story: register-model-accepts-non-base-forcing-class-attribute-fallbacks
