### PR TITLE
refactor(activemodel,activerecord): one _assign_attribute, the attributes= alias in ActiveModel, and Ruby's match? TypeError

### DIFF
--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -333,9 +333,9 @@ describe("AttributeAssignmentTest", () => {
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
-      override _assignAttribute(k: string, v: unknown): void {
+      override _assignAttribute(k: string, v: unknown): Promise<void> | void {
         seen.push([k, v]);
-        super._assignAttribute(k, v);
+        return super._assignAttribute(k, v);
       }
     }
     const p = new Person({});

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -39,6 +39,21 @@ export function assignAttributes(
   return model._assignAttributes(model.sanitizeForMassAssignment(newAttributes));
 }
 
+/**
+ * Mirrors: `alias attributes= assign_attributes` (attribute_assignment.rb:36) —
+ * the alias sits immediately under the method it aliases, as it does in Ruby.
+ * A TS `set` accessor cannot be awaited and the aliased write path can owe I/O
+ * (`replace`, collection_association.rb:46-48; `ids_writer`, :61-83; has_one's
+ * displacing writer, has_one_association.rb:59-84), so the alias keeps the
+ * Rails name in a `setX()` method (CLAUDE.md § "Fidelity is the job").
+ */
+export function setAttributes(
+  model: AttributeAssignment,
+  newAttributes: unknown,
+): Promise<void> | void {
+  return assignAttributes(model, newAttributes);
+}
+
 export function attributeWriterMissing(
   model: AttributeAssignment,
   name: string,
@@ -53,7 +68,10 @@ export function _assignAttributes(
   attributes: Record<string, unknown>,
 ): void {
   for (const [k, v] of Object.entries(attributes)) {
-    _assignAttribute(model, k, v);
+    // Ruby's loop is plain: only ActiveRecord's override
+    // (activerecord/attribute_assignment.rb:6-23) has writers that reach the
+    // database, and it chains them itself.
+    void model._assignAttribute(k, v);
   }
 }
 
@@ -92,13 +110,17 @@ export function _assignAttributes(
  *
  * @internal Rails-private helper.
  */
-export function _assignAttribute(model: AttributeAssignment, k: string, v: unknown): void {
+export function _assignAttribute(
+  model: AttributeAssignment,
+  k: string,
+  v: unknown,
+): Promise<void> | void {
   const setter = `${k}=`;
   try {
     const method = publicMethod(model, setter);
     if (method) {
-      method.call(model, v);
-      return;
+      const result: unknown = method.call(model, v);
+      return result instanceof Promise ? (result as Promise<void>) : undefined;
     }
     const match = model.matchedAttributeMethod(setter);
     if (match) {
@@ -139,19 +161,19 @@ export function _assignAttribute(model: AttributeAssignment, k: string, v: unkno
 function publicMethod(
   model: AttributeAssignment,
   setter: string,
-): ((this: AttributeAssignment, value: unknown) => void) | null {
+): ((this: AttributeAssignment, value: unknown) => unknown) | null {
   const key = setter.slice(0, -1);
   let obj: object | null = model;
   while (obj && obj !== Object.prototype) {
     const desc = Object.getOwnPropertyDescriptor(obj, key);
     if (desc && typeof desc.set === "function") {
-      return desc.set as (this: AttributeAssignment, value: unknown) => void;
+      return desc.set as (this: AttributeAssignment, value: unknown) => unknown;
     }
     obj = Object.getPrototypeOf(obj);
   }
   const generated = (model as unknown as Record<string, unknown>)[setter];
   if (typeof generated === "function") {
-    return generated as (this: AttributeAssignment, value: unknown) => void;
+    return generated as (this: AttributeAssignment, value: unknown) => unknown;
   }
   return null;
 }
@@ -162,6 +184,8 @@ export interface AttributeAssignment {
   sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
   /** @internal Rails-private helper. */
   _assignAttributes(attributes: Record<string, unknown>): Promise<void> | void;
+  /** @internal Rails-private helper. */
+  _assignAttribute(k: string, v: unknown): Promise<void> | void;
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
   attributeMissing(match: { proxyTarget: string; attrName: string }, ...args: unknown[]): unknown;
 }

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -68,9 +68,6 @@ export function _assignAttributes(
   attributes: Record<string, unknown>,
 ): void {
   for (const [k, v] of Object.entries(attributes)) {
-    // Ruby's loop is plain: only ActiveRecord's override
-    // (activerecord/attribute_assignment.rb:6-23) has writers that reach the
-    // database, and it chains them itself.
     void model._assignAttribute(k, v);
   }
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -88,6 +88,7 @@ import {
 import {
   _assignAttribute as attrAssignOne,
   assignAttributes as attrAssign,
+  setAttributes as attrSetAttributes,
   attributeWriterMissing as defaultAttributeWriterMissing,
   isMassAssignmentEmpty,
   ArgumentError,
@@ -2637,19 +2638,26 @@ export class Model {
   }
 
   /**
+   * Mirrors: `alias attributes= assign_attributes` (attribute_assignment.rb:36).
+   */
+  setAttributes(newAttributes: unknown): Promise<void> | void {
+    return attrSetAttributes(this, newAttributes);
+  }
+
+  /**
    * @internal Rails-private helper.
    */
   _assignAttributes(attributes: Record<string, unknown>): void {
     for (const [k, v] of Object.entries(attributes)) {
-      this._assignAttribute(k, v);
+      void this._assignAttribute(k, v);
     }
   }
 
   /**
    * @internal Rails-private helper.
    */
-  _assignAttribute(k: string, v: unknown): void {
-    attrAssignOne(this, k, v);
+  _assignAttribute(k: string, v: unknown): Promise<void> | void {
+    return attrAssignOne(this, k, v);
   }
 
   /**

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 import { ModelName, Naming } from "./naming.js";
-import { ArgumentError } from "./attribute-assignment.js";
+import { TypeError } from "./attribute-assignment.js";
 import { Inflections, assert, assertNot } from "@blazetrails/activesupport";
 
 describe("NamingTest", () => {
@@ -421,8 +421,13 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(mn.match("Post")).toBe(true);
     expect(mn.match("os")).toBe(true);
     expect(mn.match("\\d")).toBe(false);
-    expect(() => mn.match(null)).toThrow(ArgumentError);
-    expect(() => mn.match(undefined)).toThrow(ArgumentError);
+    expect(() => mn.match(null)).toThrow("wrong argument type nil (expected Regexp)");
+    expect(() => mn.match(undefined)).toThrow("wrong argument type nil (expected Regexp)");
+    expect(() => mn.match(42)).toThrow("wrong argument type Integer (expected Regexp)");
+    expect(() => mn.match(1.5)).toThrow("wrong argument type Float (expected Regexp)");
+    expect(() => mn.match(true)).toThrow("wrong argument type true (expected Regexp)");
+    expect(() => mn.match([1])).toThrow("wrong argument type Array (expected Regexp)");
+    expect(() => mn.match(null)).toThrow(TypeError);
   });
 
   it("caseEquals and eql delegate to the name", () => {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -196,10 +196,8 @@ export class ModelName {
   match(pattern: unknown): boolean {
     if (typeof pattern === "string") pattern = new RegExp(pattern);
     if (!(pattern instanceof RegExp)) {
-      // The `rails-error-parity` rule keys on the constructor name, so it flags
-      // this throw whether the class is the global `TypeError` or the ported
-      // mirror imported above; `calculations.ts` and `cache/store.ts` carry the
-      // same suppression for the same reason.
+      // Rule keys on the constructor name, so the ported mirror trips it too —
+      // same suppression `calculations.ts` and `cache/store.ts` carry.
       // eslint-disable-next-line blazetrails/rails-error-parity
       throw new TypeError(`wrong argument type ${builtinClassName(pattern)} (expected Regexp)`);
     }

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -10,7 +10,7 @@ import {
   ToJsonWithActiveSupportEncoder,
   type Included,
 } from "@blazetrails/activesupport";
-import { ArgumentError } from "./attribute-assignment.js";
+import { ArgumentError, TypeError } from "./attribute-assignment.js";
 
 /**
  * Naming mixin — provides model_name on classes and naming helpers.
@@ -189,11 +189,19 @@ export class ModelName {
    * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
    * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
    * on stateful flags, but Ruby `match?` is stateless.
+   *
+   * Anything else raises the `TypeError` Ruby's `get_pat` raises (string.c
+   * `rb_str_match_m_p` -> `get_pat`), not a trails-invented `ArgumentError`.
    */
   match(pattern: unknown): boolean {
     if (typeof pattern === "string") pattern = new RegExp(pattern);
     if (!(pattern instanceof RegExp)) {
-      throw new ArgumentError("ModelName#match requires a RegExp");
+      // The `rails-error-parity` rule keys on the constructor name, so it flags
+      // this throw whether the class is the global `TypeError` or the ported
+      // mirror imported above; `calculations.ts` and `cache/store.ts` carry the
+      // same suppression for the same reason.
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new TypeError(`wrong argument type ${builtinClassName(pattern)} (expected Regexp)`);
     }
     const savedLastIndex = pattern.lastIndex;
     try {
@@ -344,3 +352,21 @@ export class ModelName {
 }
 
 include(ModelName, ToJsonWithActiveSupportEncoder);
+
+/**
+ * The JS spelling of MRI's `rb_builtin_class_name`, which is what `get_pat`
+ * (string.c) interpolates into `wrong argument type %s (expected Regexp)`:
+ * `nil` / `true` / `false` for the special constants, the class name
+ * otherwise. JS has one numeric type where Ruby has two, so an integral
+ * `number` reports `Integer` and a fractional one `Float`, as MRI does.
+ *
+ * @noRailsEquivalent Module-private message helper for `ModelName#match`'s
+ *   ported `TypeError`; Ruby gets the class name from the object itself.
+ */
+function builtinClassName(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number") return Number.isInteger(value) ? "Integer" : "Float";
+  if (typeof value === "bigint") return "Integer";
+  return (value as { constructor?: { name?: string } })?.constructor?.name ?? typeof value;
+}

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -163,5 +163,27 @@ export class CollectionAssociation extends Association {
   // neither is expressible as one. The awaitable ports carry the Rails names
   // on the association itself — `association(name).writer` / `replace` /
   // `idsWriter` — and are the only collection-mutation surface (RFC 0087 §1).
-  static override defineWriters(_mixin: object, _name: string): void {}
+  //
+  // They are ALSO installed under Ruby's own method names, the string keys
+  // `"#{name}="` and `"#{name.singularize}_ids="` camelCased, which is what
+  // ActiveModel's `_assign_attribute` reaches with `public_send(setter, v)`
+  // (attribute_assignment.rb:68). A string-keyed method is not a property
+  // setter, so it can return the promise the writer owes.
+  static override defineWriters(mixin: object, name: string): void {
+    if (!mixin || typeof mixin !== "object") return;
+    Object.defineProperty(mixin, `${name}=`, {
+      value(this: AssociationInstanceHost, value: unknown): unknown {
+        return this.association(name).writer(value);
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(mixin, `${singularize(name)}Ids=`, {
+      value(this: AssociationInstanceHost, value: unknown): unknown {
+        return this.association(name).idsWriter(value);
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
 }

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -163,12 +163,9 @@ export class CollectionAssociation extends Association {
   // neither is expressible as one. The awaitable ports carry the Rails names
   // on the association itself — `association(name).writer` / `replace` /
   // `idsWriter` — and are the only collection-mutation surface (RFC 0087 §1).
-  //
-  // They are ALSO installed under Ruby's own method names, the string keys
-  // `"#{name}="` and `"#{name.singularize}_ids="` camelCased, which is what
-  // ActiveModel's `_assign_attribute` reaches with `public_send(setter, v)`
-  // (attribute_assignment.rb:68). A string-keyed method is not a property
-  // setter, so it can return the promise the writer owes.
+  // They are installed under Rails' own method names — string keys, not
+  // property setters, so `public_send(setter, v)` (attribute_assignment.rb:68)
+  // reaches them and the promise they owe survives the send.
   static override defineWriters(mixin: object, name: string): void {
     if (!mixin || typeof mixin !== "object") return;
     Object.defineProperty(mixin, `${name}=`, {

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -116,21 +116,22 @@ export class HasOne extends SingularAssociation {
       });
     }
 
-    // The same writer under Ruby's own method name — the string key `"#{name}="`
-    // that ActiveModel's `_assign_attribute` reaches with
-    // `public_send(setter, v)` (attribute_assignment.rb:68). A string-keyed
-    // method is not a property setter, so it can return the promise the
-    // displacing writer owes (has_one_association.rb:59-84).
-    Object.defineProperty(mixin, `${name}=`, {
-      value: function (
-        this: { association(n: string): { writer(v: unknown): unknown } },
-        value: unknown,
-      ) {
-        return this.association(name).writer(value);
-      },
-      writable: true,
-      configurable: true,
-    });
+    // Rails' `#{name}=` (has_one_association.rb:59-84) — a string key, not a
+    // property setter, so `public_send(setter, v)`
+    // (attribute_assignment.rb:68) reaches it and its promise survives.
+    const rubyWriter = Object.getOwnPropertyDescriptor(mixin, `${name}=`);
+    if (!rubyWriter || rubyWriter.configurable) {
+      Object.defineProperty(mixin, `${name}=`, {
+        value: function (
+          this: { association(n: string): { writer(v: unknown): unknown } },
+          value: unknown,
+        ) {
+          return this.association(name).writer(value);
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
   }
 
   static override validDependentOptions(): string[] {

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -115,6 +115,22 @@ export class HasOne extends SingularAssociation {
         configurable: true,
       });
     }
+
+    // The same writer under Ruby's own method name — the string key `"#{name}="`
+    // that ActiveModel's `_assign_attribute` reaches with
+    // `public_send(setter, v)` (attribute_assignment.rb:68). A string-keyed
+    // method is not a property setter, so it can return the promise the
+    // displacing writer owes (has_one_association.rb:59-84).
+    Object.defineProperty(mixin, `${name}=`, {
+      value: function (
+        this: { association(n: string): { writer(v: unknown): unknown } },
+        value: unknown,
+      ) {
+        return this.association(name).writer(value);
+      },
+      writable: true,
+      configurable: true,
+    });
   }
 
   static override validDependentOptions(): string[] {

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -15,11 +15,12 @@ import {
   extractMultiparameterCallstack,
   executeMultiparameterAssignment,
 } from "./multiparameter-attribute-assignment.js";
-import { _assignAttribute } from "./persistence.js";
 
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
   attributeWriterMissing(name: string, value: unknown): void;
+  /** @internal */
+  _assignAttribute(k: string, v: unknown): Promise<void> | void;
   readAttribute(name: string): unknown;
   /** @internal */
   assignNestedParameterAttributes(pairs: Record<string, unknown>): Promise<void> | void;
@@ -53,11 +54,11 @@ function isNestedParameterHash(value: unknown): boolean {
  * here answers a promise the rest of the loop is chained behind it to keep that
  * order. Every send that stays in memory keeps running inline.
  *
- * `_assign_attribute` is Ruby's implicit-self send, but trails' AR-side one is
- * a module-private function in `persistence.ts` (where the association-writer
- * resolution it needs lives) rather than a method on the class — publishing it
- * as one would put an `_assign_attribute` override on ActiveRecord that Rails
- * does not have. It is called directly here instead.
+ * `_assign_attribute` is sent to `this` (:17), as in Rails: there is exactly one
+ * of them, ActiveModel's (activemodel/attribute_assignment.rb:67-75), inherited
+ * through `Base`. The association and nested-attribute writers it reaches are
+ * the `#{name}=` methods themselves, installed under those Ruby names by the
+ * association builders and `generate_association_writer`.
  */
 export function _assignAttributes(
   this: AttributeAssignmentHost,
@@ -74,9 +75,9 @@ export function _assignAttributes(
     } else if (isNestedParameterHash(v)) {
       (nestedParameterAttributes ??= {})[key] = v;
     } else if (pending) {
-      pending = pending.then(() => _assignAttribute(this, key, v));
+      pending = pending.then(() => this._assignAttribute(key, v));
     } else {
-      pending = _assignAttribute(this, key, v) as Promise<void> | undefined;
+      pending = this._assignAttribute(key, v) as Promise<void> | undefined;
     }
   }
 
@@ -108,7 +109,7 @@ export function assignNestedParameterAttributes(
   let pending: Promise<void> | undefined;
   for (const [k, v] of Object.entries(pairs)) {
     pending = (
-      pending ? pending.then(() => _assignAttribute(this, k, v)) : _assignAttribute(this, k, v)
+      pending ? pending.then(() => this._assignAttribute(k, v)) : this._assignAttribute(k, v)
     ) as Promise<void> | undefined;
   }
   return pending;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4442,7 +4442,6 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   slice(...keys: string[]): Record<string, unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): Promise<void> | void;
-  setAttributes(attrs: Record<string, unknown>): Promise<void> | void;
   updateAttribute(name: string, value: unknown): Promise<boolean | undefined>;
   updateAttributeBang(name: string, value: unknown): Promise<true | undefined>;
   updateColumn(name: string, value: unknown): Promise<boolean>;
@@ -4645,7 +4644,6 @@ include(Base, {
   reload: _Persistence.reload,
   slice: _Persistence.slice,
   valuesAt: _Persistence.valuesAt,
-  setAttributes: _Persistence.setAttributes,
   updateAttribute: _Persistence.updateAttribute,
   updateAttributeBang: _Persistence.updateAttributeBang,
   updateColumn: _Persistence.updateColumn,
@@ -4947,7 +4945,7 @@ _setSuperValidates(Model.validates);
         // A TS `set` accessor cannot await, so a key whose writer reaches the
         // database is parked for `save` to drain; `setAttributes` is the
         // awaitable spelling of the same alias (attribute_assignment.rb:36).
-        const pending = this.assignAttributes(attrs);
+        const pending = this.setAttributes(attrs);
         if (pending) _NestedAttributes.parkNestedReaderLoad(this, pending);
       },
       configurable: true,

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -584,6 +584,19 @@ export function generateAssociationWriter(
     writable: true,
     configurable: true,
   });
+
+  // The same writer under Ruby's own method name — the string key
+  // `"#{name}_attributes="` camelCased, which is what ActiveModel's
+  // `_assign_attribute` reaches with `public_send(setter, v)`
+  // (attribute_assignment.rb:68). A string-keyed method is not a property
+  // setter, so it can return the promise the writer owes.
+  Object.defineProperty(modelClass.prototype, `${attrName}=`, {
+    value(this: Base, value: any): Promise<void> | void {
+      return assign(this, associationName, value);
+    },
+    writable: true,
+    configurable: true,
+  });
 }
 
 /** @internal */

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -585,11 +585,9 @@ export function generateAssociationWriter(
     configurable: true,
   });
 
-  // The same writer under Ruby's own method name — the string key
-  // `"#{name}_attributes="` camelCased, which is what ActiveModel's
-  // `_assign_attribute` reaches with `public_send(setter, v)`
-  // (attribute_assignment.rb:68). A string-keyed method is not a property
-  // setter, so it can return the promise the writer owes.
+  // Rails' `#{name}_attributes=` (nested_attributes.rb:401-404) — a string key,
+  // not a property setter, so `public_send(setter, v)`
+  // (attribute_assignment.rb:68) reaches it and its promise survives.
   Object.defineProperty(modelClass.prototype, `${attrName}=`, {
     value(this: Base, value: any): Promise<void> | void {
       return assign(this, associationName, value);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -6,8 +6,7 @@
  */
 
 import { Temporal } from "@blazetrails/date";
-import { camelize, singularize } from "@blazetrails/activesupport";
-import { reflectOnAllAssociations } from "./reflection.js";
+import { camelize } from "@blazetrails/activesupport";
 import { parkNestedReaderLoad } from "./nested-attributes.js";
 import type { Base } from "./base.js";
 import type { CounterCacheCounters } from "./counter-cache.js";
@@ -882,26 +881,6 @@ export function valuesAt(this: AttributeIO, ...keys: string[]): unknown[] {
 }
 
 /**
- * Walk the prototype chain of `instance` to find a setter descriptor for
- * `key`. Returns the setter function, or undefined if none exists.
- *
- * Sole caller: {@link _assignAttribute}'s store-accessor arm. `store_accessor`
- * generates its readers/writers with `define_method` in Rails
- * (store.rb:130-148), so `public_send("#{k}=", v)` reaches them by name; ours
- * are property setters, which `record[k] = v` cannot distinguish from writing a
- * plain attribute slot, hence the descriptor lookup.
- */
-function findPrototypeSetter(instance: object, key: string): ((v: unknown) => void) | undefined {
-  let proto = Object.getPrototypeOf(instance);
-  while (proto !== null && proto !== Object.prototype) {
-    const desc = Object.getOwnPropertyDescriptor(proto, key);
-    if (desc?.set) return desc.set;
-    proto = Object.getPrototypeOf(proto);
-  }
-  return undefined;
-}
-
-/**
  * Re-dispatch any `*Attributes` nested attribute keys that the Base
  * constructor wrote as plain attribute values (via `writeAttribute`) rather
  * than through the generated writer. Called by `create`/`createBang` after
@@ -939,95 +918,6 @@ export function _reapplyNestedAttrSetters(
     }
     cls = Object.getPrototypeOf(cls);
   }
-}
-
-/**
- * Resolves the association arm of Rails' `public_send("#{key}=", value)`
- * (attribute_assignment.rb:67-69) to the writer it would reach. RFC 0087 §1
- * removed the generated `#{name}=` property setter for the writers that do I/O
- * at assignment — `replace`'s diffed deletes+inserts
- * (collection_association.rb:46-48) and `ids_writer`'s resolving query (:61-83)
- * — because a JS property setter cannot await them, so the dispatch finds them
- * by their association-level Rails names here instead.
- *
- * Resolution only: `_assignAttribute` does the sending, so `respond_to?(setter)`
- * and `public_send(setter, v)` (attribute_assignment.rb:67-70) stay the two
- * steps Rails has.
- */
-function associationWriter(
-  self: AttributeIO,
-  key: string,
-): ((value: unknown) => unknown) | undefined {
-  const ctor = (self as any).constructor as typeof Base;
-  for (const ref of reflectOnAllAssociations(ctor)) {
-    const name = String(ref.name);
-    if (ref.isCollection()) {
-      if (key === name) return (value) => (self as any).association(name).writer(value);
-      if (key === `${singularize(name)}Ids`)
-        return (value) => (self as any).association(name).idsWriter(value);
-    } else if (key === name && ref.macro === "hasOne") {
-      // Rails' `#{name}=` removes the displaced record and saves the new one
-      // inline (has_one_association.rb:59-84).
-      return (value) => (self as any).association(name).writer(value);
-    }
-  }
-  return undefined;
-}
-
-/**
- * Mirrors Rails' `_assign_attribute` (ActiveModel
- * attribute_assignment.rb:67-75): dispatch through the public setter when one
- * exists (store accessors write to the store hash, not a standalone attribute
- * slot). A key with no setter is `respond_to?(setter)` false, so it reaches
- * `attribute_writer_missing` (:73) and raises `UnknownAttributeError`.
- *
- * Rails lets setter exceptions propagate raw — the only rescue is the
- * `NoMethodError` arm that reaches `attribute_writer_missing` (:71-74) — so a
- * `ReadonlyAttributeError` out of a writer reaches the caller as itself. The
- * `AttributeAssignmentError` wrap belongs to
- * `execute_callstack_for_multiparameter_attributes`
- * (activerecord/attribute_assignment.rb:47) alone.
- *
- * A `#{name}_attributes=` key dispatches to `set#{Name}Attributes`
- * (nested-attributes.ts), which answers a promise when the assignment displaces
- * a record and so owes Rails' inline `remove_target!`
- * (has_one_association.rb:69) a write; that promise is returned rather than
- * dropped.
- */
-export function _assignAttribute(
-  self: AttributeIO,
-  key: string,
-  value: unknown,
-): Promise<void> | void {
-  const configs = (self as any).constructor?._nestedAttributeConfigs as
-    | { associationName: string }[]
-    | undefined;
-  if (configs?.some((c) => `${c.associationName}Attributes` === key)) {
-    return (self as any)[`set${camelize(key, true)}`](value) as Promise<void> | void;
-  }
-  const writer = associationWriter(self, key);
-  if (writer) return writer(value) as Promise<void> | void;
-  const setter = findPrototypeSetter(self, key);
-  if (setter) {
-    const result: unknown = setter.call(self, value);
-    if (result instanceof Promise) return result as Promise<void>;
-  } else {
-    self.attributeWriterMissing(key, value);
-  }
-}
-
-/**
- * Mirrors: `alias attributes= assign_attributes` (attribute_assignment.rb:36).
- * A TS `set` accessor cannot be awaited, so the alias keeps the Rails name in a
- * `setX()` method (CLAUDE.md § "Fidelity is the job"). `assign_attributes`
- * itself is not redefined here — as in Rails, it is ActiveModel's
- * (attribute_assignment.rb:28-34), inherited through `Model`.
- */
-export function setAttributes(
-  this: AttributeIO & { assignAttributes(attrs: Record<string, unknown>): Promise<void> | void },
-  attrs: Record<string, unknown>,
-): Promise<void> | void {
-  return this.assignAttributes(attrs);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Three ActiveModel fidelity convergences (RFC 0115).

**`ModelName#match`'s raise.** Rails delegates `match?` to `@name`
(naming.rb:151-152), so the raise a caller sees is Ruby `String#match?`'s —
`TypeError: wrong argument type nil (expected Regexp)` (string.c
`rb_str_match_m_p` → `get_pat`), not trails' invented
`ArgumentError("ModelName#match requires a RegExp")`. The message is built the
way `rb_builtin_class_name` prints it (`nil`/`true`/`false` for the special
constants, `Integer`/`Float` for the two numeric classes JS collapses into one);
verified against MRI. The String and RegExp arms and the `lastIndex`
save/restore are unchanged.

**The `attributes=` alias.** `alias attributes= assign_attributes` is one line
in ActiveModel (attribute_assignment.rb:36), immediately under the method it
aliases; ActiveRecord does not restate it. `setAttributes` moves from
`activerecord/src/persistence.ts` (whose Rails counterpart has neither the alias
nor the method) to `activemodel/src/attribute-assignment.ts`, and `Base`
inherits it. The `attributes` property setter on `Base.prototype` still parks
the promise — the sync half of the same alias — but delegates to the inherited
method. It stays a `setX()` method because a TS `set` accessor cannot be
awaited and the aliased write path can owe I/O.

**The second `_assign_attribute`.** Rails has exactly one, ActiveModel's
(attribute_assignment.rb:67-75); ActiveRecord overrides only
`_assign_attributes` and sends `_assign_attribute` to self
(activerecord/attribute_assignment.rb:17). trails had a second one — a
module-private function in `persistence.ts` resolving nested-attribute setters
and association writers before falling back to a prototype setter, imported and
called directly, so a subclass override would not be honoured.

It collapses rather than moving: the association and nested-attribute writers
are now installed under Ruby's own method names — the string keys `name=`,
`{singular}Ids=` and `{name}Attributes=` — which is exactly what
`public_send(setter, v)` reaches (attribute_assignment.rb:68). A string-keyed
method is not a property setter, so it can return the promise RFC 0087's
awaitable writers owe, and ActiveModel's single `_assign_attribute` answers
`Promise<void> | void` accordingly. Store accessors were already property
setters and are found by the existing descriptor walk, so
`findPrototypeSetter`/`associationWriter` retire with it.

`parity:api:calls` / `:args` clean; `parity:api:extra` shows
`activemodel/attribute-assignment.ts` still at 0 novel and no new novel name in
activerecord.

Closes-story: converge-model-name-match-raise-onto-string-match
Closes-story: move-the-attributes-writer-alias-to-activemodel
Closes-story: retire-the-activerecord-assign-attribute-override