### PR TITLE
refactor(activesupport,activemodel,activerecord): converge three Rails-fidelity seams

### DIFF
--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -43,12 +43,14 @@ export interface Dirty {
  *   end
  *
  * Trails consolidates Rails' two mutation trackers into a single
- * `DirtyTracker`, so a fresh tracker is the equivalent reset.
- * Called from the Model constructor.
+ * `DirtyTracker`, so a fresh tracker is the equivalent reset. Ruby's `super`
+ * is `super_`, the link `prepend()` hands the module (model.ts wires the
+ * chain in include order); the Model constructor enters it.
  *
  * @internal Rails-private helper.
  */
-export function initInternals(this: DirtyInternalsHost): void {
+export function initInternals(this: DirtyInternalsHost, super_: () => void): void {
+  super_.call(this);
   this._dirty = new DirtyTracker();
 }
 
@@ -639,11 +641,17 @@ export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string):
  * so writing to one no longer marks the other dirty. Rails nils the ivar and lets
  * it rebuild from the deep-dup'd `@attributes`, which reproduces the source's
  * `changes` on the copy; {@link DirtyTracker.deepDup} is that rebuild, since a
- * fresh empty tracker would instead wipe pending changes.
+ * fresh empty tracker would instead wipe pending changes. Ruby's `super` is
+ * `super_`, the link `prepend()` hands the module.
  *
  * @internal Rails-private helper.
  */
-export function initializeDup(this: DirtyDupHost, _other: unknown): void {
+export function initializeDup(
+  this: DirtyDupHost,
+  super_: (other: unknown) => void,
+  other: unknown,
+): void {
+  super_.call(this, other);
   this._dirty = this._dirty.deepDup(this._attributes);
 }
 

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -44,13 +44,13 @@ export interface Dirty {
  *
  * Trails consolidates Rails' two mutation trackers into a single
  * `DirtyTracker`, so a fresh tracker is the equivalent reset. Ruby's `super`
- * is `super_`, the link `prepend()` hands the module (model.ts wires the
- * chain in include order); the Model constructor enters it.
+ * is `super_()`, the receiver-bound link `prepend()` hands the module (model.ts
+ * wires the chain in include order); the Model constructor enters it.
  *
  * @internal Rails-private helper.
  */
 export function initInternals(this: DirtyInternalsHost, super_: () => void): void {
-  super_.call(this);
+  super_();
   this._dirty = new DirtyTracker();
 }
 
@@ -642,7 +642,7 @@ export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string):
  * it rebuild from the deep-dup'd `@attributes`, which reproduces the source's
  * `changes` on the copy; {@link DirtyTracker.deepDup} is that rebuild, since a
  * fresh empty tracker would instead wipe pending changes. Ruby's `super` is
- * `super_`, the link `prepend()` hands the module.
+ * `super_()`, the receiver-bound link `prepend()` hands the module.
  *
  * @internal Rails-private helper.
  */
@@ -651,7 +651,7 @@ export function initializeDup(
   super_: (other: unknown) => void,
   other: unknown,
 ): void {
-  super_.call(this, other);
+  super_(other);
   this._dirty = this._dirty.deepDup(this._attributes);
 }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -25,6 +25,7 @@ import {
   withOptions,
   extend,
   include,
+  prepend,
   runLoadHooks,
   wrap,
   ToJsonWithActiveSupportEncoder,
@@ -306,6 +307,19 @@ export interface Model {
    * 334-336) stays assignable.
    */
   attributeNames(): string[];
+
+  /**
+   * The `super`-chained hooks Ruby's included modules define —
+   * `Validations#init_internals` / `#initialize_dup` (validations.rb:467-471,
+   * 310-313) and `Dirty#init_internals` / `#initialize_dup` (dirty.rb:371-376,
+   * 248-251) — prepended in include order at the bottom of this file. As in
+   * `model.rb`, this class defines no body for either.
+   *
+   * @internal
+   */
+  initInternals(): void;
+  /** @internal */
+  initializeDup(other: unknown): void;
 }
 
 /**
@@ -1684,28 +1698,6 @@ export class Model {
   _initializingAttributes = false;
 
   /**
-   * Mirrors the Rails chain `ActiveModel::{Validations,Dirty}#init_internals`
-   * (validations.rb:467-471, dirty.rb:371-376). Each Ruby module defines the
-   * method and opens with `super`, so the chain is the include order itself;
-   * there is no root definition in ActiveModel (the bottom is
-   * `ActiveRecord::Core#init_internals`, core.rb:834).
-   *
-   * TypeScript has no `super` across mixins — `include()` copies onto one
-   * prototype, so the second module's copy would overwrite the first's with no
-   * way to reach it, and `prepend()`'s explicit `super_` needs a root method to
-   * wrap that Rails does not define here. So the chain is written out, in
-   * include order, calling each module's own exported hook. This is the
-   * language shortcoming, not a preference: neither module's body is inlined or
-   * reordered.
-   *
-   * @internal Rails-private helper.
-   */
-  initInternals(): void {
-    validationsInitInternals.call(this);
-    dirtyInitInternals.call(this);
-  }
-
-  /**
    * Build the `if`-predicate that gates a validator on a validation
    * context. Mirrors Rails `predicate_for_validation_context`
    * (validations.rb:296-306).
@@ -2158,22 +2150,6 @@ export class Model {
     duped._attributes = this._attributes.deepDup();
     duped.initializeDup(this);
     return duped;
-  }
-
-  /**
-   * Ruby chains one `initialize_dup` per included module through `super`
-   * (attributes.rb:112-115, validations.rb:310-313, dirty.rb:248-251).
-   * TypeScript has no `super` across mixins — see `initInternals` above for why
-   * neither `include()` nor `prepend()` can express it — so this is the chain,
-   * in include order: `Validations` replaces `@errors` and `Dirty` resets the
-   * mutation tracker (without the latter the copy shares the source's tracker,
-   * so writing to one marks the other dirty). Both run after `dup()` has
-   * deep-dup'd `_attributes`, matching the point in Rails' chain where
-   * `Attributes#initialize_dup` has already replaced `@attributes`.
-   */
-  initializeDup(other: unknown): void {
-    validationsInitializeDup.call(this, other);
-    dirtyInitializeDup.call(this, other);
   }
 
   // -- Dirty tracking --
@@ -2892,6 +2868,22 @@ include(Model, {
   raiseValidationError: validationsRaiseValidationError,
   readAttributeForValidation: validationsReadAttributeForValidation,
   sanitizeForbiddenAttributes: forbiddenSanitize,
+});
+
+// The `super`-opening halves of the Validations and Dirty modules: each
+// defines `init_internals` / `initialize_dup` and opens with `super`
+// (validations.rb:467-471 and :310-313, dirty.rb:371-376 and :248-251), so
+// the chain IS the include order.
+// `prepend()` is that chain — the later include wraps the earlier one and
+// receives it as `super_`, with a no-op root where Ruby's only definition is
+// `ActiveRecord::Core#init_internals` (core.rb:834).
+prepend(Model.prototype, {
+  initInternals: validationsInitInternals,
+  initializeDup: validationsInitializeDup,
+});
+prepend(Model.prototype, {
+  initInternals: dirtyInitInternals,
+  initializeDup: dirtyInitializeDup,
 });
 
 // model.rb:77 — `ActiveSupport.run_load_hooks(:active_model, Model)`.

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -391,7 +391,8 @@ export interface ReadAttributeForValidationHost {
  * eagerly, so this assigns the replacement, as {@link initInternals} does. Like
  * Rails it leaves `@context_for_validation` aliased to the source's — `valid?`
  * sets and restores the context per run, so the copy is never observed in
- * flight. Ruby's `super` is `super_`, the link `prepend()` hands the module.
+ * flight. Ruby's `super` is `super_`, the link `prepend()` hands the module —
+ * and as in Rails the replacement is assigned BEFORE it, not after.
  *
  * @internal Rails-private helper.
  */
@@ -400,8 +401,8 @@ export function initializeDup<TBase extends object>(
   super_: (other: unknown) => void,
   other: unknown,
 ): void {
-  super_.call(this, other);
   this.errors = new Errors(this as unknown as TBase);
+  super_.call(this, other);
 }
 
 /**

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -260,9 +260,9 @@ const _predicatesForValidationContexts = new Map<
  *
  * Trails eagerly initializes `errors` (rather than Rails' lazy
  * `errors_or_create`), so this assigns a fresh `Errors` and clears
- * the active validation context. Ruby's `super` is `super_`, the link
- * `prepend()` hands the module (model.ts wires the chain in include order);
- * the Model constructor enters it.
+ * the active validation context. Ruby's `super` is `super_()`, the
+ * receiver-bound link `prepend()` hands the module (model.ts wires the chain in
+ * include order); the Model constructor enters it.
  *
  * @internal Rails-private helper.
  */
@@ -270,7 +270,7 @@ export function initInternals<TBase extends object>(
   this: ValidationsInternalsHost<TBase>,
   super_: () => void,
 ): void {
-  super_.call(this);
+  super_();
   this.errors = new Errors(this as unknown as TBase);
   this._contextForValidation = undefined;
 }
@@ -391,8 +391,8 @@ export interface ReadAttributeForValidationHost {
  * eagerly, so this assigns the replacement, as {@link initInternals} does. Like
  * Rails it leaves `@context_for_validation` aliased to the source's — `valid?`
  * sets and restores the context per run, so the copy is never observed in
- * flight. Ruby's `super` is `super_`, the link `prepend()` hands the module —
- * and as in Rails the replacement is assigned BEFORE it, not after.
+ * flight. Ruby's `super` is `super_()`, the receiver-bound link `prepend()`
+ * hands the module — and as in Rails the replacement is assigned BEFORE it.
  *
  * @internal Rails-private helper.
  */
@@ -402,7 +402,7 @@ export function initializeDup<TBase extends object>(
   other: unknown,
 ): void {
   this.errors = new Errors(this as unknown as TBase);
-  super_.call(this, other);
+  super_(other);
 }
 
 /**

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -260,11 +260,17 @@ const _predicatesForValidationContexts = new Map<
  *
  * Trails eagerly initializes `errors` (rather than Rails' lazy
  * `errors_or_create`), so this assigns a fresh `Errors` and clears
- * the active validation context. Called from the Model constructor.
+ * the active validation context. Ruby's `super` is `super_`, the link
+ * `prepend()` hands the module (model.ts wires the chain in include order);
+ * the Model constructor enters it.
  *
  * @internal Rails-private helper.
  */
-export function initInternals<TBase extends object>(this: ValidationsInternalsHost<TBase>): void {
+export function initInternals<TBase extends object>(
+  this: ValidationsInternalsHost<TBase>,
+  super_: () => void,
+): void {
+  super_.call(this);
   this.errors = new Errors(this as unknown as TBase);
   this._contextForValidation = undefined;
 }
@@ -384,14 +390,17 @@ export interface ReadAttributeForValidationHost {
  * and lets `errors_or_create` rebuild it lazily; trails initializes `errors`
  * eagerly, so this assigns the replacement, as {@link initInternals} does. Like
  * Rails it leaves `@context_for_validation` aliased to the source's — `valid?`
- * sets and restores the context per run, so the copy is never observed in flight.
+ * sets and restores the context per run, so the copy is never observed in
+ * flight. Ruby's `super` is `super_`, the link `prepend()` hands the module.
  *
  * @internal Rails-private helper.
  */
 export function initializeDup<TBase extends object>(
   this: ValidationsInternalsHost<TBase>,
-  _other: unknown,
+  super_: (other: unknown) => void,
+  other: unknown,
 ): void {
+  super_.call(this, other);
   this.errors = new Errors(this as unknown as TBase);
 }
 

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -128,10 +128,12 @@ describe("loadSchemaFromAdapter", () => {
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
+    const mysteryHash = { mystery: { sqlType: "weird" } };
     const adapter = {
       internalSchemaCache: {
         dataSourceExists: async () => true,
-        columnsHash: async () => ({ mystery: { sqlType: "weird" } }),
+        columnsHash: async () => mysteryHash,
+        getCachedColumnsHash: () => mysteryHash,
       },
       lookupCastTypeFromColumn: () => null,
     };

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1386,10 +1386,10 @@ function applyColumnsHash(
  * overwritten, matching Rails where the pending replay runs after the column
  * seed so `attribute :foo, :bar` always wins over the reflected type.
  *
- * This IS `ModelSchema#load_schema!`'s body on the async path, so it ends by
- * running the concern overrides (counter_cache.rb:186-195,
- * encryptable_record.rb:126-130) over an already-completed anchor rather than
- * re-entering `loadSchemaBang`.
+ * This is the async half of `schema_cache.columns_hash` (schema_cache.rb):
+ * it warms the cache and then enters the single `load_schema!` body, so the
+ * concern overrides (counter_cache.rb:186-195, encryptable_record.rb:126-130)
+ * run over a real anchor.
  *
  * @internal
  */
@@ -1445,15 +1445,11 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (currentAdapter !== startingAdapter) return;
 
-  applyColumnsHash(this, startingAdapter, hash);
-  // Rails' `load_schema` sets `@schema_loaded = true` before returning
-  // (model_schema.rb:534-546), and the reflected columns just applied are the
-  // authoritative ones — so mark the load settled before the generation hook,
-  // whose `define_attribute_methods` calls `load_schema` first
-  // (attribute_methods.rb:114) and would otherwise re-enter this load.
-  this._schemaLoaded = true;
-  defineAttributeMethodsAfterLoad(this);
-  runLoadSchemaChain(this, () => {});
+  // The cache is warm now, so `load_schema!` — the one body, chain and all —
+  // reflects from it exactly as it does on the sync path
+  // (model_schema.rb:534-546 puts the cache-vs-adapter distinction inside
+  // `schema_cache.columns_hash`, not in a second `load_schema!`).
+  loadSchemaBang.call(this);
 }
 
 /**

--- a/packages/activesupport/src/duration.test.ts
+++ b/packages/activesupport/src/duration.test.ts
@@ -81,14 +81,6 @@ describe("Scalar", () => {
     expect(a.times(3).value).toBe(30);
     expect(a.div(2).value).toBe(5);
   });
-
-  it("== answers a numeric and is answered by Duration#==", () => {
-    expect(new Scalar(172800).equals(172800)).toBe(true);
-    expect(new Scalar(172800).equals(new Scalar(172800))).toBe(true);
-    expect(new Scalar(172800).equals("foo")).toBe(false);
-    expect(days(2).equals(new Scalar(172800))).toBe(true);
-    expect(days(2).equals(new Scalar(1))).toBe(false);
-  });
 });
 
 describe("DurationTest", () => {

--- a/packages/activesupport/src/duration.test.ts
+++ b/packages/activesupport/src/duration.test.ts
@@ -81,6 +81,14 @@ describe("Scalar", () => {
     expect(a.times(3).value).toBe(30);
     expect(a.div(2).value).toBe(5);
   });
+
+  it("== answers a numeric and is answered by Duration#==", () => {
+    expect(new Scalar(172800).equals(172800)).toBe(true);
+    expect(new Scalar(172800).equals(new Scalar(172800))).toBe(true);
+    expect(new Scalar(172800).equals("foo")).toBe(false);
+    expect(days(2).equals(new Scalar(172800))).toBe(true);
+    expect(days(2).equals(new Scalar(1))).toBe(false);
+  });
 });
 
 describe("DurationTest", () => {

--- a/packages/activesupport/src/duration.trails.test.ts
+++ b/packages/activesupport/src/duration.trails.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { Scalar, days } from "./duration.js";
+
+describe("Scalar", () => {
+  it("<=> orders against a Scalar, a Duration and a Numeric", () => {
+    expect(new Scalar(2).compareTo(new Scalar(3))).toBe(-1);
+    expect(new Scalar(2).compareTo(days(1))).toBe(-1);
+    expect(new Scalar(3).compareTo(3)).toBe(0);
+    expect(new Scalar(3).compareTo("foo")).toBeNaN();
+  });
+
+  it("== answers a Numeric, and Duration#== answers a Scalar", () => {
+    expect(new Scalar(172800).equals(172800)).toBe(true);
+    expect(new Scalar(172800).equals(new Scalar(172800))).toBe(true);
+    expect(new Scalar(172800).equals("foo")).toBe(false);
+    expect(days(2).equals(new Scalar(172800))).toBe(true);
+    expect(days(2).equals(new Scalar(1))).toBe(false);
+  });
+});

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -884,21 +884,6 @@ export class Scalar {
     );
   }
 
-  /**
-   * Mirrors: Comparable#== over ActiveSupport::Duration::Scalar#<=>
-   * (duration.rb:31-38) — `Scalar < Numeric` includes Comparable, so `==` is
-   * `(self <=> other) == 0` and `Scalar.new(172800) == 172800` is true.
-   */
-  equals(other: unknown): boolean {
-    if (other instanceof Scalar || other instanceof Duration) {
-      return this.value === other.value;
-    } else if (typeof other === "number") {
-      return this.value === other;
-    } else {
-      return false;
-    }
-  }
-
   /** Mirrors: ActiveSupport::Duration::Scalar#variable? (duration.rb:93-95). */
   isVariable(): boolean {
     return false;
@@ -938,6 +923,35 @@ export class Scalar {
   /** Unary minus (`Scalar#-@`): `Scalar.new(-value)`. */
   negate(): Scalar {
     return new Scalar(-this.value);
+  }
+
+  /**
+   * Mirrors: ActiveSupport::Duration::Scalar#<=> (duration.rb:31-38). Ruby
+   * returns nil for an incomparable receiver; `Duration#compareTo` spells that
+   * NaN, so this does too.
+   */
+  compareTo(other: unknown): number {
+    let b: number;
+    if (other instanceof Scalar || other instanceof Duration) {
+      b = other.value;
+    } else if (typeof other === "number") {
+      b = other;
+    } else {
+      return NaN;
+    }
+    if (this.value < b) return -1;
+    if (this.value > b) return 1;
+    return 0;
+  }
+
+  /**
+   * `Scalar < Numeric` includes Comparable, so `==` is Comparable's
+   * `(self <=> other) == 0` over `<=>` above — which is why
+   * `Scalar.new(172800) == 172800` is true, and why `Duration#==`'s
+   * `other == value` arm (duration.rb:341-347) answers a Scalar.
+   */
+  equals(other: unknown): boolean {
+    return this.compareTo(other) === 0;
   }
 
   times(other: number): Scalar {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -7,6 +7,7 @@
  */
 
 import { Temporal } from "@blazetrails/date";
+import { rbEqual } from "./rb-equal.js";
 import { instantFrom } from "./temporal.js";
 import { advance as dateAdvance, since as dateSince } from "./core-ext/date/calculations.js";
 import { inspect } from "./core-ext/object/inspect.js";
@@ -380,14 +381,15 @@ export class Duration {
   /**
    * Mirrors: ActiveSupport::Duration#== (duration.rb:341-347) — another
    * Duration with the same `value`, or `other == value` for anything else, so
-   * `2.days == 172800` is true. `value` is seconds, a JS number, and Ruby
-   * `==` on it is numeric equality.
+   * `2.days == 172800` is true. The else arm is a `==` SEND to `other`, so a
+   * receiver that answers `==` against a number (a `Scalar`) decides it —
+   * `rbEqual` is that dispatch. `value` is seconds, a JS number.
    */
   equals(other: unknown): boolean {
     if (other instanceof Duration) {
       return other.value === this.value;
     } else {
-      return other === this.value;
+      return rbEqual(other, this.value);
     }
   }
 
@@ -880,6 +882,21 @@ export class Scalar {
     throw new TypeError(
       `no implicit conversion of ${(other as object)?.constructor?.name ?? String(other)} into Scalar`,
     );
+  }
+
+  /**
+   * Mirrors: Comparable#== over ActiveSupport::Duration::Scalar#<=>
+   * (duration.rb:31-38) — `Scalar < Numeric` includes Comparable, so `==` is
+   * `(self <=> other) == 0` and `Scalar.new(172800) == 172800` is true.
+   */
+  equals(other: unknown): boolean {
+    if (other instanceof Scalar || other instanceof Duration) {
+      return this.value === other.value;
+    } else if (typeof other === "number") {
+      return this.value === other;
+    } else {
+      return false;
+    }
   }
 
   /** Mirrors: ActiveSupport::Duration::Scalar#variable? (duration.rb:93-95). */

--- a/packages/activesupport/src/prepend.test.ts
+++ b/packages/activesupport/src/prepend.test.ts
@@ -47,11 +47,23 @@ describe("prepend", () => {
     expect(new Toggle().value()).toBe(42);
   });
 
-  it("throws when wrapping a method that doesn't exist on the target", () => {
+  it("wraps a method that doesn't exist on the target over a no-op super_", () => {
     class Empty {}
-    expect(() =>
-      prepend(Empty.prototype, { ghost: (s: (...args: unknown[]) => unknown) => s }),
-    ).toThrow(/no method with that name/);
+    const calls: string[] = [];
+    prepend(Empty.prototype, {
+      ghost(super_: (...args: unknown[]) => unknown) {
+        super_.call(this);
+        calls.push("ghost");
+      },
+    });
+    prepend(Empty.prototype, {
+      ghost(super_: (...args: unknown[]) => unknown) {
+        super_.call(this);
+        calls.push("later");
+      },
+    });
+    (new Empty() as unknown as { ghost(): void }).ghost();
+    expect(calls).toEqual(["ghost", "later"]);
   });
 
   it("throws when the target isn't an object or function", () => {
@@ -162,23 +174,6 @@ describe("prepend", () => {
     ).toThrow(/non-configurable and non-writable/);
     // `loose` must NOT have been wrapped — atomicity guarantee.
     expect(target.loose).toBe(origLoose);
-  });
-
-  it("validates all target methods exist before wrapping anything (atomicity)", () => {
-    class Partial {
-      good(): string {
-        return "ok";
-      }
-    }
-    const originalGood = Partial.prototype.good;
-    expect(() =>
-      prepend(Partial.prototype, {
-        good: (s: (...args: unknown[]) => unknown) => `wrapped-${s.call(undefined)}`,
-        missing: (s: (...args: unknown[]) => unknown) => s,
-      }),
-    ).toThrow(/missing/);
-    // `good` must NOT have been wrapped — atomicity guarantee.
-    expect(Partial.prototype.good).toBe(originalGood);
   });
 
   it("second prepend on the same method chains on top of the first", () => {

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -13,6 +13,12 @@
  * becomes an explicit first argument because TypeScript has no
  * language-level `super` equivalent for runtime-wrapped methods.
  *
+ * As in Ruby, the target need not already define the method: prepending a
+ * module that is the only definition is legal, and `super_` is then a no-op
+ * root — which is how a `super`-opening chain (ActiveModel's
+ * `init_internals`, validations.rb:467-471 / dirty.rb:371-376) is built in
+ * include order without a root definition.
+ *
  * Idempotency is the caller's responsibility — calling `prepend()` on
  * the same target+module twice will wrap twice, producing a chain.
  * For install-once semantics, guard with a flag as Rails does via
@@ -37,15 +43,17 @@ export interface PrependModule {
   readonly [methodName: string]: PrependMethod;
 }
 
+const NO_METHOD_ROOT = function (): void {};
+
 export function prepend<T extends object>(target: T, mod: PrependModule): void {
   if (!target || (typeof target !== "object" && typeof target !== "function")) {
     throw new TypeError("prepend: target must be an object or function");
   }
 
-  // All-or-nothing pre-validation. A missing method, a non-function
-  // wrapper, a frozen/sealed target, or a non-configurable own property
-  // would otherwise throw mid-loop and leave the target in a partial-
-  // patch state. We check all four up front and throw before mutating.
+  // All-or-nothing pre-validation. A non-function wrapper, a frozen/sealed
+  // target, or a non-configurable own property would otherwise throw mid-loop
+  // and leave the target in a partial-patch state. We check all three up front
+  // and throw before mutating.
   if (!Object.isExtensible(target)) {
     throw new TypeError("prepend: target is not extensible (frozen/sealed)");
   }
@@ -55,10 +63,6 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
       throw new TypeError(
         `prepend: module entry ${name} must be a function, got ${typeof mod[name]}`,
       );
-    }
-    const original = (target as Record<string, unknown>)[name];
-    if (typeof original !== "function") {
-      throw new Error(`prepend: cannot wrap ${name} — target has no method with that name`);
     }
     // If an own property exists and is non-configurable, `defineProperty`
     // below can still throw — three sub-cases:
@@ -86,7 +90,18 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
 
   for (const name of names) {
     const descriptor = findPropertyDescriptor(target, name);
-    const original = (target as Record<string, unknown>)[name] as (...args: unknown[]) => unknown;
+    // Ruby's `prepend` does not require the target to define the method: the
+    // module can be the only definition, and a `super` inside it then finds
+    // nothing below (ActiveModel's `init_internals`/`initialize_dup` chains,
+    // whose only Ruby root is `ActiveRecord::Core#init_internals`,
+    // core.rb:834 — absent when the chain is prepended onto a plain model).
+    // That bottom link is a no-op root rather than an error so the chain can be
+    // built in include order without manufacturing a root Rails does not have.
+    const existing = (target as Record<string, unknown>)[name];
+    const original =
+      typeof existing === "function"
+        ? (existing as (...args: unknown[]) => unknown)
+        : NO_METHOD_ROOT;
     const wrapper = mod[name];
     const wrapped = function (this: unknown, ...args: unknown[]) {
       return wrapper.call(this, original, ...args);
@@ -95,8 +110,7 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
     // non-enumerable by default; direct assignment would make them
     // enumerable and leak into `Object.keys` / `for..in`). Fall back to
     // a non-enumerable writable data property when no descriptor is
-    // found (shouldn't happen — the pre-validation above ensures the
-    // method exists somewhere on the prototype chain).
+    // found — the case where the module is the method's only definition.
     Object.defineProperty(target, name, {
       value: wrapped,
       writable: descriptor?.writable ?? true,

--- a/packages/activesupport/src/prepend.ts
+++ b/packages/activesupport/src/prepend.ts
@@ -7,7 +7,8 @@
  * method. TypeScript has no prototype-chain prepend; `prepend()` wraps
  * each target method in place. A call like `target.foo(...args)`
  * invokes `module.foo.call(this, originalFoo, ...args)`, letting the
- * module short-circuit or delegate via `originalFoo.call(this, ...)`.
+ * module short-circuit or delegate via `originalFoo(...)` — the link arrives
+ * bound to the receiver, as Ruby's `super` is.
  *
  * Mirrors: Ruby's `Module#prepend` — with the caveat that `super`
  * becomes an explicit first argument because TypeScript has no
@@ -29,7 +30,7 @@
  *
  *   prepend(Relation.prototype, {
  *     where(super_: (...args: unknown[]) => unknown, ...args: unknown[]) {
- *       return super_.call(this, ...processed(args));
+ *       return super_(...processed(args));
  *     },
  *   });
  */
@@ -104,7 +105,11 @@ export function prepend<T extends object>(target: T, mod: PrependModule): void {
         : NO_METHOD_ROOT;
     const wrapper = mod[name];
     const wrapped = function (this: unknown, ...args: unknown[]) {
-      return wrapper.call(this, original, ...args);
+      // Ruby's `super` is bound to the receiver, so the link is handed over
+      // bound too and the module body spells it `super_(...)`. A caller that
+      // spells it `super_.call(this, ...)` is unaffected — a bound function
+      // ignores the `thisArg`.
+      return wrapper.call(this, original.bind(this), ...args);
     };
     // Preserve the original property descriptor (class methods are
     // non-enumerable by default; direct assignment would make them

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -9,6 +9,7 @@
  */
 
 import { succ } from "./core-ext/string/succ.js";
+import { rbEqual } from "./rb-equal.js";
 
 /** Ruby's `a <=> b` over the endpoint types trails' ranges carry. */
 function cmp(a: unknown, b: unknown): number {
@@ -195,18 +196,4 @@ export class Range<T> {
       current += n;
     }
   }
-}
-
-/**
- * Ruby's `rb_equal` — the C primitive `range_eq`'s `recursive_equal`
- * (range.c) applies to each endpoint, which is identity first and then a
- * `==` send. A `Date`/`Time` endpoint answers its own `equals`.
- */
-function rbEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (typeof (a as { equals?: unknown }).equals === "function") {
-    return (a as { equals(other: unknown): boolean }).equals(b);
-  }
-  return false;
 }

--- a/packages/activesupport/src/rb-equal.ts
+++ b/packages/activesupport/src/rb-equal.ts
@@ -1,0 +1,18 @@
+/**
+ * Ruby's `rb_equal` — the C primitive behind every `==` send: identity first,
+ * then the receiver's own `==`. Ported callers (`Range#==`'s endpoint
+ * comparison, `Duration#==`'s non-Duration arm) all need the same dispatch,
+ * and JS `===` only covers its first arm.
+ *
+ * @noRailsEquivalent PERMANENT — `rb_equal` is a C primitive (object.c), not a
+ *   Ruby method, so it has no counterpart file; JS has no `==` send at all, so
+ *   one copy serves every ported `==`.
+ */
+export function rbEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof (a as { equals?: unknown }).equals === "function") {
+    return (a as { equals(other: unknown): boolean }).equals(b);
+  }
+  return false;
+}


### PR DESCRIPTION
Three convergence stories, one PR.

### 1. `Duration#==`'s non-Duration arm sends `==` (duration.rb:341-347)

`other == value` is a SEND to `other`, not a JS identity test. `range-ext.ts`'s
private `rbEqual` (Ruby's `rb_equal` C primitive: identity, then the receiver's
own `==`) moves to `packages/activesupport/src/rb-equal.ts` and is used by both
files — no new copy. `Scalar#<=>` (duration.rb:31-38) is ported as `compareTo`
alongside it and `Scalar#==` is Comparable's `(self <=> other) == 0` over it,
so `2.days == Scalar.new(172800)` is true as in Ruby, while `2.days == 172800` stays true and `2.days == "foo"` stays
false (`DurationTest > equals`).

### 2. `Model#initInternals` / `#initializeDup` become a real mixin super chain

`prepend()` now mirrors Ruby in one more respect: the target need not already
define the method. The module can be the only definition, and `super_` is then
a no-op root — which is the case here, since ActiveModel has no root and Ruby's
only one is `ActiveRecord::Core#init_internals` (core.rb:834). Validations and
Dirty are prepended in include order and each hook opens with its `super`
(validations.rb:467-471 / :310-313, dirty.rb:371-376 / :248-251), so `model.ts`
carries no body for either — exactly as `model.rb` carries none.

`prepend()` now hands the module a link bound to the receiver, as Ruby's
`super` is, so each hook spells it `super_()` / `super_(other)` — the
`packages/activemodel/src` non-test `.call(this` count drops from 13 to 9 as
the story requires. Existing `prepend` callers that spell it
`super_.call(this, …)` are unaffected: a bound function ignores the `thisArg`.

Two obsolete `prepend` tests changed with the relaxed contract: the
"throws when wrapping a method that doesn't exist" test now asserts the chained
no-op-root behaviour, and the atomicity test that existed only to cover the
removed pre-validation is deleted (the other atomicity cases keep their tests).

### 3. One `load_schema!` body

`loadSchemaFromAdapter` no longer re-implements the anchor and then dispatches
the concern chain over `() => {}`. It is the async half of
`schema_cache.columns_hash`: warm the cache, then call `loadSchemaBang`. So
`runLoadSchemaChain` has exactly one call site, over a real anchor, and the
`pkStillMissing` fallback is shared by both paths (model_schema.rb:534-546,
:587-597).

Hook order follows each Ruby body exactly: `Validations#initialize_dup` assigns
the replacement `Errors` BEFORE `super` (validations.rb:310-313), while
`Dirty#initialize_dup` and both `init_internals` open with `super`
(dirty.rb:248-251, validations.rb:467-471, dirty.rb:371-376).

### Verification

- `pnpm parity:api:calls` and `:args` clean, no baseline rows added, no reseed.
- `pnpm parity:api:extra` clean for activesupport and activemodel (the one new
  tag is `@noRailsEquivalent PERMANENT` on `rbEqual`, a C primitive with no
  Ruby counterpart file).
- `pnpm parity:api` / `pnpm parity:test` deltas non-negative.
- `pnpm lint` clean repo-wide; `tsc --build --force` clean.
- activemodel and activesupport suites green in full; activerecord: schema,
  dup, dirty, aggregations, persistence, validations, counter-cache,
  attribute-methods, encryption green locally.

Closes-story: converge-duration-equals-non-duration-arm-to-a-ruby-send
Closes-story: converge-model-init-internals-and-initialize-dup-super-chain
Closes-story: converge-async-load-schema-onto-the-single-load-schema-body
