### PR TITLE
refactor(activerecord): retire the encryption decorator's idempotence guard

### DIFF
--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -4,6 +4,7 @@ import { Contexts } from "./contexts.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { encrypts } from "./encryptable-record.js";
+import { Model } from "@blazetrails/activemodel";
 import { AutoFilteredParameters } from "./auto-filtered-parameters.js";
 import type { SchemeOptions } from "./scheme.js";
 
@@ -72,7 +73,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     });
 
     try {
-      const modelClass = { _attributeDefinitions: new Map() };
+      const modelClass = class extends Model {};
       encrypts.call(modelClass, "isbn");
 
       expect(capturedKlass).toBe(modelClass);
@@ -93,8 +94,8 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
 
     try {
       // Named class: filter key is "underscore(ClassName).attribute"
-      class NamedPirate {}
-      const modelClass = Object.assign(NamedPirate, { _attributeDefinitions: new Map() });
+      class NamedPirate extends Model {}
+      const modelClass = NamedPirate;
       encrypts.call(modelClass, "catchphrase");
 
       expect(filterParameters).toContain("named_pirate.catchphrase");
@@ -113,8 +114,9 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     });
 
     try {
-      // Truly anonymous class (empty .name): filter key is just the attribute name
-      const modelClass = Object.assign(class {}, { _attributeDefinitions: new Map() });
+      // Truly anonymous class (empty .name): filter key is just the attribute
+      // name. Returned from a function so JS name inference doesn't kick in.
+      const modelClass = (() => class extends Model {})();
       encrypts.call(modelClass, "catchphrase");
 
       expect(filterParameters).toContain("catchphrase");
@@ -136,7 +138,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     });
 
     try {
-      const modelClass = Object.assign(class {}, { _attributeDefinitions: new Map() });
+      const modelClass = class extends Model {};
       encrypts.call(modelClass, "catchphrase");
 
       expect(filterParameters).toEqual([]);
@@ -173,8 +175,8 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     });
 
     try {
-      class PaymentModel {}
-      const modelClass = Object.assign(PaymentModel, { _attributeDefinitions: new Map() });
+      class PaymentModel extends Model {}
+      const modelClass = PaymentModel;
       encrypts.call(modelClass, "card_number");
       encrypts.call(modelClass, "secret_token");
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -25,6 +25,7 @@ import {
   Base,
 } from "./test-helpers.js";
 import { Configurable } from "./configurable.js";
+import { Model as ActiveModel } from "@blazetrails/activemodel";
 import { itIfSupports } from "../support/supports.js";
 import { fixtures } from "../test-fixtures.js";
 import { withTransactionalFixtures } from "../test-fixtures/with-transactional-fixtures.js";
@@ -981,9 +982,8 @@ describe("EncryptableRecord.encryptAttribute — scheme-based ignore_case wiring
   });
 
   function makeMockModel(columns: string[]) {
-    class MockModel {}
+    class MockModel extends ActiveModel {}
     return Object.assign(MockModel, {
-      _attributeDefinitions: new Map(),
       columnNames: () => columns,
     }) as any;
   }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -401,7 +401,7 @@ export function deterministicEncryptedAttributes(this: any): Set<string> {
   }
   const result = new Set<string>();
   for (const attributeName of encryptedAttributes.call(this)) {
-    const type = encryptedTypeOf(getAttributeType(this, attributeName));
+    const type = encryptedTypeOf(this.typeForAttribute(attributeName));
     if (type?.deterministic) {
       result.add(attributeName);
     }
@@ -532,7 +532,7 @@ export function buildEncryptAttributeAssignments(this: any): Record<string, unkn
 export function buildDecryptAttributeAssignments(this: any): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const attributeName of encryptedAttributes.call(this.constructor)) {
-    const type = getAttributeType(this.constructor, attributeName) as {
+    const type = this.constructor.typeForAttribute(attributeName) as {
       deserialize: (v: unknown) => unknown;
     };
     const encryptedValue = ciphertextFor.call(this, attributeName);
@@ -631,17 +631,6 @@ export function preserveOriginalEncrypted(this: any, name: string): void {
   // the original column rides the same replay-safe machinery as its source.
   encrypts.call(this, originalAttributeName);
   EncryptableRecord.overrideAccessorsToPreserveOriginal(this, name, originalAttributeName);
-}
-
-/**
- * Resolve an attribute's type through `typeForAttribute` (Rails' single lookup
- * surface); falls back to `_attributeDefinitions` for plain mock models.
- */
-export function getAttributeType(klass: any, name: string): unknown {
-  if (typeof klass?.typeForAttribute === "function") {
-    return klass.typeForAttribute(name);
-  }
-  return klass._attributeDefinitions?.get?.(name)?.type;
 }
 
 /**

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -113,7 +113,7 @@ export class EncryptableRecord {
    * post-reflection rebuild, as before) keeps the decorator's queue position —
    * and therefore the resolved nesting relative to `serialize` — in declaration
    * order, and bounds the queue: repeated `_defaultAttributes` rebuilds never
-   * re-push (`registerEncryptedType` no longer touches the queue).
+   * re-push.
    *
    * The column default is resolved inside the decorator at replay time
    * (mirrors Rails' `default: columns_hash[name.to_s]&.default`, evaluated in
@@ -123,11 +123,6 @@ export class EncryptableRecord {
    */
   static pushEncryptionDecorator(modelClass: any, name: string, pending: PendingEncryption): void {
     modelClass.decorateAttributes([name], (attrName: string, castType: Type) => {
-      // Idempotence guard: a fresh-seed replay applies each queued decorator
-      // once, but the seeded cast type can itself already be encrypted (the
-      // `registerEncryptedType` path writes one into `_attributeDefinitions`,
-      // which AR's column seeding reads back).
-      if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
       return new EncryptedAttributeType({
         scheme: pending.scheme,
         castType,
@@ -142,41 +137,6 @@ export class EncryptableRecord {
         ),
       });
     });
-  }
-
-  /**
-   * Register the EncryptedAttributeType for a plain mock model (the immediate
-   * path in `encryptAttribute` — callers without `decorateAttributes`). Real
-   * Base subclasses never come through here: their wrapping is the durable
-   * decorator pushed by `pushEncryptionDecorator`, resolved via
-   * `typeForAttribute`.
-   * @internal
-   */
-  static registerEncryptedType(modelClass: any, name: string, scheme: Scheme): void {
-    // Get existing cast type from attribute definitions if available.
-    // If already encrypted, unwrap to avoid double-encryption.
-    const existingDef = modelClass._attributeDefinitions?.get?.(name);
-    let castType = existingDef?.type;
-    if (castType instanceof EncryptedAttributeType) {
-      castType = castType.castType;
-    }
-
-    const encryptedType = new EncryptedAttributeType({
-      scheme,
-      castType,
-      default: this.columnDefaultFor(modelClass, name, existingDef),
-    });
-
-    // Register directly into _attributeDefinitions (not via attribute()
-    // which expects a string type name).
-    if (modelClass._attributeDefinitions?.set) {
-      modelClass._attributeDefinitions.set(name, {
-        name,
-        type: encryptedType,
-        defaultValue: existingDef?.defaultValue ?? null,
-        ...(existingDef?.limit != null ? { limit: existingDef.limit } : {}),
-      });
-    }
   }
 
   /**
@@ -609,25 +569,17 @@ export function encryptAttribute(this: any, name: string, options: SchemeOptions
     },
   };
 
-  if (typeof modelClass.decorateAttributes === "function") {
-    // Durable path (real model classes): push the durable PendingDecorator NOW,
-    // at declaration time, so its position in the pending queue tracks
-    // declaration order relative to `serialize` / `normalizes` — mirroring
-    // Rails, where `encrypts` calls `decorate_attributes` inline
-    // (encryptable_record.rb:87-92) and AttributeRegistration replays in
-    // declaration order. The decorator resolves the column default at replay
-    // time, so it needs no re-push after schema reflection. The
-    // `_pendingEncryptions` buffer remains only for validator re-runs +
-    // frozen-validator install on rebuild (applyPendingEncryptions).
-    EncryptableRecord.registerPendingEncryption(this, pending);
-    EncryptableRecord.pushEncryptionDecorator(this, name, pending);
-    encryptionHooks.applyPendingEncryptions(modelClass);
-  } else {
-    // Immediate path (plain-object callers without decoration machinery, e.g.
-    // direct `EncryptableRecord.encrypts` tests): register the encrypted type
-    // synchronously so it's readable right after the call.
-    EncryptableRecord.registerEncryptedType(this, name, pending.scheme);
-  }
+  // Push the durable PendingDecorator NOW, at declaration time, so its position
+  // in the pending queue tracks declaration order relative to `serialize` /
+  // `normalizes` — mirroring Rails, where `encrypts` calls `decorate_attributes`
+  // inline (encryptable_record.rb:87-92) and AttributeRegistration replays in
+  // declaration order. The decorator resolves the column default at replay time,
+  // so it needs no re-push after schema reflection. The `_pendingEncryptions`
+  // buffer remains only for validator re-runs + frozen-validator install on
+  // rebuild (applyPendingEncryptions).
+  EncryptableRecord.registerPendingEncryption(this, pending);
+  EncryptableRecord.pushEncryptionDecorator(this, name, pending);
+  encryptionHooks.applyPendingEncryptions(modelClass);
 
   if (Configurable.config.validateColumnSize) {
     validateColumnSize.call(this, name);

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -5,6 +5,7 @@ import { Configurable } from "./configurable.js";
 import { Decryption } from "./errors.js";
 import type { EncryptorLike } from "./encryptor.js";
 import { encrypts } from "./encryptable-record.js";
+import { Model } from "@blazetrails/activemodel";
 import type { SchemeOptions } from "./scheme.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
 import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
@@ -285,13 +286,13 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
       { encryptor: new TestEncryptor({ "STEPHEN KING": "cipher_nondet" }) } as SchemeOptions,
     ];
 
-    const modelClass = { _attributeDefinitions: new Map() };
+    const modelClass = class extends Model {};
     // Non-deterministic attribute — only the non-deterministic global scheme is compatible.
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_nondet")).toBe("STEPHEN KING");
     expect(() => type.deserialize("cipher_det")).toThrow(Decryption);
@@ -397,14 +398,14 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
       { encryptor: new TestEncryptor({ nondet: "cipher_nondet" }) } as SchemeOptions,
     ];
 
-    const modelClass = { _attributeDefinitions: new Map() };
+    const modelClass = class extends Model {};
     // Deterministic attribute — only the deterministic global scheme is compatible.
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
       deterministic: true,
     });
 
-    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
     // Only the deterministic global previous scheme is wired in.
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_det")).toBe("STEPHEN KING");
@@ -434,12 +435,12 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
       { encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }) } as SchemeOptions,
     ];
 
-    const modelClass = { _attributeDefinitions: new Map() };
+    const modelClass = class extends Model {};
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
     expect(type.previousTypes).toHaveLength(2);
 
     // value encrypted with first global previous scheme decrypts correctly
@@ -461,12 +462,12 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
       { encryptor: new TestEncryptor({ legacy_non: "cipher_non" }) } as SchemeOptions,
     ];
 
-    const modelClass = { _attributeDefinitions: new Map() };
+    const modelClass = class extends Model {};
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
     // non-deterministic attribute: only the non-deterministic global scheme is compatible
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_non")).toBe("legacy_non");

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -293,7 +293,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery
     });
     return {
       _encryptedAttributes: new Set(["email"]),
-      _attributeDefinitions: new Map([["email", { type }]]),
+      typeForAttribute: () => type,
     };
   }
 
@@ -302,7 +302,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery
     // Prevents a chained `.where()` on the same relation from re-expanding
     // an already-expanded condition into AV-of-AV.
     const model = modelWithDeterministicEmail();
-    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const type = model.typeForAttribute();
     const already = [new AdditionalValue("x", type)];
     const out = EncryptedQuery.processArguments(model, [{ email: already }], true) as [
       Record<string, unknown>,
@@ -312,7 +312,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery
 
   it("does not short-circuit when checkForAdditionalValues=false (findBy path always expands)", () => {
     const model = modelWithDeterministicEmail();
-    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const type = model.typeForAttribute();
     const already = [new AdditionalValue("x", type)];
     const [out] = EncryptedQuery.processArguments(model, [{ email: already }], false) as [
       Record<string, unknown[]>,
@@ -325,7 +325,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery
     // Rails: within flat_map, `each_value` that is already an AV passes
     // through untouched instead of running through additional_values_for.
     const model = modelWithDeterministicEmail();
-    const type = (model._attributeDefinitions.get("email") as any).type as EncryptedAttributeType;
+    const type = model.typeForAttribute();
     const av = new AdditionalValue("x", type);
     // Mix: a plaintext AND an AV that isn't last — so the whole-array
     // short-circuit doesn't apply, but the per-element check should.
@@ -359,7 +359,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
 
     const model = {
       _encryptedAttributes: new Set(["email"]),
-      _attributeDefinitions: new Map([["email", { type }]]),
+      typeForAttribute: () => type,
     };
     const relation = {
       model,
@@ -377,7 +377,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const type = makeType(true);
     const model = {
       _encryptedAttributes: new Set(["email"]),
-      _attributeDefinitions: new Map([["email", { type }]]),
+      typeForAttribute: () => type,
     };
     const relation = { model, whereValuesHash: () => ({}) };
 
@@ -392,7 +392,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const av = new AdditionalValue("enc", type);
     const model = {
       _encryptedAttributes: new Set(["body"]),
-      _attributeDefinitions: new Map([["body", { type }]]),
+      typeForAttribute: () => type,
     };
     const relation = { model, whereValuesHash: () => ({ body: [av] }) };
 
@@ -404,7 +404,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const type = makeType(true);
     const model = {
       _encryptedAttributes: new Set(["email"]),
-      _attributeDefinitions: new Map([["email", { type }]]),
+      typeForAttribute: () => type,
     };
     const relation = {
       model,
@@ -518,7 +518,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       });
       const model = {
         _encryptedAttributes: new Set(["email"]),
-        _attributeDefinitions: new Map([["email", { type }]]),
+        typeForAttribute: () => type,
       };
       const rel = new (targets.Relation as any)(model);
       rel.where({ email: "a@x" });
@@ -542,7 +542,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       const av = new AdditionalValue("plain@x", type);
       const model = {
         _encryptedAttributes: new Set(["email"]),
-        _attributeDefinitions: new Map([["email", { type }]]),
+        typeForAttribute: () => type,
       };
       const rel = new (targets.Relation as any)(model);
       rel._wheres = { email: [av] };
@@ -565,7 +565,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       });
       class Contact extends (targets.Base as any) {
         static _encryptedAttributes = new Set(["email"]);
-        static _attributeDefinitions = new Map([["email", { type }]]);
+        static typeForAttribute = () => type;
       }
       (Contact as any).findBy({ email: "x" });
       const captured = (Contact as any)._lastFindBy.email as unknown[];

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -11,7 +11,7 @@ import {
   EncryptedUniquenessValidator,
 } from "./extended-deterministic-uniqueness-validator.js";
 import { UniquenessValidator } from "../validations.js";
-import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
+import { encryptedTypeOf } from "./encryptable-record.js";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import { Base } from "../base.js";
@@ -142,10 +142,10 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     // The mechanism, pinned directly: Serialized#serialize(AV) raises inside
     // coder.dump before any payload exists — the dumped-AV JSON (which would
     // embed previous-scheme internals) is never produced.
-    const fullType = getAttributeType(PreviousSchemeSerializedBook, "name") as {
+    const fullType = PreviousSchemeSerializedBook.typeForAttribute("name") as {
       serialize(v: unknown): unknown;
     };
-    const prevType = encryptedTypeOf(getAttributeType(PreviousSchemeSerializedBook, "name"))!
+    const prevType = encryptedTypeOf(PreviousSchemeSerializedBook.typeForAttribute("name"))!
       .previousTypes[0];
     const av = new AdditionalValue("Dune", prevType);
     expect(() => fullType.serialize(av)).toThrow(NoMethodError);
@@ -164,10 +164,10 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
       DisallowedClass,
     );
 
-    const fullType = getAttributeType(PreviousSchemeYamlBook, "name") as {
+    const fullType = PreviousSchemeYamlBook.typeForAttribute("name") as {
       serialize(v: unknown): unknown;
     };
-    const prevType = encryptedTypeOf(getAttributeType(PreviousSchemeYamlBook, "name"))!
+    const prevType = encryptedTypeOf(PreviousSchemeYamlBook.typeForAttribute("name"))!
       .previousTypes[0];
     const av = new AdditionalValue("Dune", prevType);
     expect(() => fullType.serialize(av)).toThrow(DisallowedClass);
@@ -175,7 +175,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
   });
 
   it("uniqueness ciphertext generation serializes through the full resolved type", () => {
-    const fullType = getAttributeType(PreviousSchemeSerializedBook, "name") as {
+    const fullType = PreviousSchemeSerializedBook.typeForAttribute("name") as {
       serialize(v: unknown): unknown;
     };
     // The resolved type is the outer Serialized wrapper, not the bare

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,6 +1,6 @@
 import { prepend } from "@blazetrails/activesupport";
 import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
-import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
+import { encryptedTypeOf } from "./encryptable-record.js";
 
 /**
  * What AdditionalValue needs from its type — one of the attribute's
@@ -133,7 +133,7 @@ export class EncryptedQuery {
       // (extended_deterministic_queries.rb:58-62); `deterministic`/
       // `previous_types` reach the inner EncryptedAttributeType via
       // DelegateClass delegation there, via encryptedTypeOf here.
-      const fullType = getAttributeType(model, attrName) as SerializableType | undefined;
+      const fullType = model.typeForAttribute(attrName) as SerializableType | undefined;
       const type = encryptedTypeOf(fullType);
       if (!fullType || !type) continue;
       if (!type.deterministic) continue;
@@ -226,7 +226,7 @@ export class RelationQueries {
     const scopeAttrs = originalScopeForCreate.call(this) as Record<string, unknown>;
     const wheres = this.whereValuesHash();
     for (const attrName of encryptedAttrs) {
-      const type = encryptedTypeOf(getAttributeType(model, attrName));
+      const type = encryptedTypeOf(model.typeForAttribute(attrName));
       if (!type?.deterministic) continue;
       const values = wheres[attrName];
       // An expanded list is raw plaintext at [0] followed only by

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
@@ -34,7 +34,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
 
     const klass = {
       _encryptedAttributes: new Set(["email"]),
-      _attributeDefinitions: new Map([["email", { type }]]),
+      typeForAttribute: () => type,
     };
     const record = { constructor: klass };
 
@@ -79,7 +79,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     });
     const klass = {
       _encryptedAttributes: new Set(["body"]),
-      _attributeDefinitions: new Map([["body", { type }]]),
+      typeForAttribute: () => type,
     };
     const record = { constructor: klass };
 

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -1,8 +1,4 @@
-import {
-  deterministicEncryptedAttributes,
-  getAttributeType,
-  encryptedTypeOf,
-} from "./encryptable-record.js";
+import { deterministicEncryptedAttributes, encryptedTypeOf } from "./encryptable-record.js";
 import {
   AdditionalValue,
   ExtendedDeterministicQueries,
@@ -102,7 +98,7 @@ export class EncryptedUniquenessValidator {
     const deterministicAttrs = deterministicEncryptedAttributes.call(klass);
     if (!deterministicAttrs.has(attribute)) return;
 
-    const encryptedType = encryptedTypeOf(getAttributeType(klass, attribute));
+    const encryptedType = encryptedTypeOf(klass.typeForAttribute(attribute));
     if (!encryptedType) return;
 
     // When ExtendedDeterministicQueries is installed it already expands the
@@ -132,7 +128,7 @@ export class EncryptedUniquenessValidator {
     // only previous-scheme candidates are AdditionalValue-wrapped. Gating
     // reaches the inner type via encryptedTypeOf (Rails' DelegateClass
     // delegation).
-    const fullType = getAttributeType(klass, attribute) as SerializableType | undefined;
+    const fullType = klass.typeForAttribute(attribute) as SerializableType | undefined;
     const type = encryptedTypeOf(fullType);
     if (!fullType || !type?.deterministic) {
       return [value];

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -678,7 +678,7 @@ export function assertNotEncryptedAttribute(
  */
 export function ciphertextFor(model: any, attrName: string): unknown {
   const klass = model.constructor;
-  const type = klass._attributeDefinitions?.get(attrName)?.type;
+  const type = klass.typeForAttribute?.(attrName);
   if (type && typeof type.serialize === "function" && typeof type.isEncrypted === "function") {
     const value = model[attrName];
     return type.serialize(value);


### PR DESCRIPTION
Rails' `encrypt_attribute` (`activerecord/lib/active_record/encryption/encryptable_record.rb:84-95`) only pushes the `decorate_attributes` block — no idempotence guard, because `_default_attributes` seeds a fresh set and applies each queued modification once, so the `cast_type` handed to the block is never already an `EncryptedAttributeType`.

trails carried an extra `castType instanceof EncryptedAttributeType` early return. Its remaining justification was `registerEncryptedType`, a trails-only path that wrote a built `EncryptedAttributeType` straight into `_attributeDefinitions` for callers with no `decorateAttributes`; AR's `_defaultAttributes` seeds cast types from that map, so a replay could be handed an already-wrapped type. Rails has no `register_encrypted_type`.

Both are gone:

- The guard is removed from `pushEncryptionDecorator`.
- `registerEncryptedType` is deleted, along with `encryptAttribute`'s branch — the decorator is pushed unconditionally, as encryptable_record.rb:87-92 does.
- The plain-object mock models that relied on the immediate path now extend ActiveModel's `Model`, so they resolve the encrypted type through `typeForAttribute` (`activemodel/lib/active_model/attribute_registration.rb:43-51`), and `test-helpers.ts#ciphertextFor` reads through `typeForAttribute` too.

The whole `packages/activerecord/src/encryption` suite is green locally (356 passed).

Closes-story: retire-the-encryption-decorator-idempotence-guard