### PR TITLE
refactor(activemodel): resolve attribute readers through _default_attributes

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -109,7 +109,6 @@ interface ReadWriteHost {
 }
 
 export interface AttributeMethodHost {
-  // Rails' `attribute_names` (attributes.rb:74-75) — `attribute_types.keys`.
   attributeNames(): string[];
   attributeMethodPatterns: AttributeMethodPattern[];
   attributeAliases: Record<string, string>;

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -109,7 +109,8 @@ interface ReadWriteHost {
 }
 
 export interface AttributeMethodHost {
-  _attributeDefinitions: Map<string, { name: string }>;
+  // Rails' `attribute_names` (attributes.rb:74-75) — `attribute_types.keys`.
+  attributeNames(): string[];
   attributeMethodPatterns: AttributeMethodPattern[];
   attributeAliases: Record<string, string>;
   _aliasesByAttributeName: Map<string, string[]>;
@@ -263,7 +264,7 @@ export function attributeMethodPrefix(
     ...(prefixes as string[]).map((prefix) => new AttributeMethodPattern({ prefix, parameters })),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...Array.from(this._attributeDefinitions.keys()));
+  this.defineAttributeMethods(...this.attributeNames());
 }
 
 /** Mirrors: ClassMethods#attribute_method_suffix (attribute_methods.rb:140-143). */
@@ -277,7 +278,7 @@ export function attributeMethodSuffix(
     ...(suffixes as string[]).map((suffix) => new AttributeMethodPattern({ suffix, parameters })),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...Array.from(this._attributeDefinitions.keys()));
+  this.defineAttributeMethods(...this.attributeNames());
 }
 
 /** Mirrors: ClassMethods#attribute_method_affix (attribute_methods.rb:175-178). */
@@ -290,7 +291,7 @@ export function attributeMethodAffix(
     ...affixes.map((affix) => new AttributeMethodPattern(affix)),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...Array.from(this._attributeDefinitions.keys()));
+  this.defineAttributeMethods(...this.attributeNames());
 }
 
 export function aliasAttribute(this: ClassMethods, newName: string, oldName: string): void {

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -33,7 +33,6 @@ export interface AttributeHostInternals {
   _cachedDefaultAttributes?: AttributeSet | null;
   _cachedAttributeTypes?: Record<string, Type> | null;
   _attributesBuilder?: unknown;
-  _attributeDefinitions?: Map<string, { name: string; type?: Type; virtual?: boolean }>;
   _pendingAttributeModifications?: PendingModification[];
   attributeAliases?: Record<string, string>;
   /** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */

--- a/packages/activemodel/src/attributes.trails.test.ts
+++ b/packages/activemodel/src/attributes.trails.test.ts
@@ -13,7 +13,7 @@ describe("Attributes#attribute_names", () => {
     expect(new User().attributeNames()).toEqual(["name", "token"]);
   });
 
-  it("the class-level reader still filters virtual attributes", () => {
-    expect(User.attributeNames()).toEqual(["name"]);
+  it("the class-level reader is attribute_types.keys, virtual attributes included", () => {
+    expect(User.attributeNames()).toEqual(["name", "token"]);
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -394,10 +394,9 @@ export class Model {
     );
   }
 
+  /** Mirrors: ActiveModel::Attributes::ClassMethods#attribute_names (attributes.rb:74-75). */
   static attributeNames(): string[] {
-    return Array.from(this._attributeDefinitions.entries())
-      .filter(([, def]) => !def.virtual)
-      .map(([name]) => name);
+    return Object.keys(this.attributeTypes());
   }
 
   // -- Normalizations --
@@ -727,7 +726,7 @@ export class Model {
   }
 
   static isAttributeMethod(attribute: string): boolean {
-    return this._attributeDefinitions.has(attribute);
+    return Object.hasOwn(this.attributeTypes(), attribute);
   }
 
   /**
@@ -1903,9 +1902,9 @@ export class Model {
    * Mirrors: ActiveRecord::Base.column_for_attribute
    */
   columnForAttribute(name: string): { name: string; type: Type } | null {
-    const def = (this.constructor as typeof Model)._attributeDefinitions.get(name);
-    if (!def) return null;
-    return { name: def.name, type: def.type };
+    const klass = this.constructor as typeof Model;
+    if (!Object.hasOwn(klass.attributeTypes(), name)) return null;
+    return { name, type: klass.typeForAttribute(name) };
   }
 
   /**
@@ -1915,8 +1914,7 @@ export class Model {
    */
   hasAttribute(name: string): boolean {
     const ctor = this.constructor as typeof Model;
-    const defs = ctor._attributeDefinitions;
-    return defs.has(ctor.resolveAttributeName(name));
+    return this._attributes.has(ctor.resolveAttributeName(name));
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -725,8 +725,13 @@ export class Model {
     asResetCallbacks(this.prototype, "validate");
   }
 
+  /**
+   * Mirrors: ActiveModel::Validations::ClassMethods#attribute_method?
+   * (validations.rb:282-284) — `method_defined?(attribute)`. Ruby's
+   * `method_defined?` walks the ancestor chain, which `in` does for a prototype.
+   */
   static isAttributeMethod(attribute: string): boolean {
-    return Object.hasOwn(this.attributeTypes(), attribute);
+    return attribute in this.prototype;
   }
 
   /**
@@ -1910,11 +1915,13 @@ export class Model {
   /**
    * Check if this model has the given attribute defined.
    *
-   * Mirrors: ActiveModel::AttributeMethods#has_attribute?
+   * Mirrors: ActiveRecord::AttributeMethods#has_attribute? — `attr_name =
+   * self.class.attribute_aliases[attr_name] || attr_name` then
+   * `@attributes.key?(attr_name)` (activerecord/attribute_methods.rb:316-320).
    */
   hasAttribute(name: string): boolean {
     const ctor = this.constructor as typeof Model;
-    return this._attributes.has(ctor.resolveAttributeName(name));
+    return this._attributes.isKey(ctor.resolveAttributeName(name));
   }
 
   /**

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -40,14 +40,14 @@ export function hasSecurePassword(
   const challengeAttr = `${attribute}Challenge`;
   const validations = options.validations !== false;
 
-  if (!modelClass._attributeDefinitions.has(digestAttr)) {
+  if (!modelClass._defaultAttributes().isKey(digestAttr)) {
     modelClass.attribute(digestAttr, "string");
   }
 
   // The confirmation is virtual (no DB column) but is genuinely stored in the
   // attribute set (read back via `readAttribute`), so declare it as a known
   // name — `AttributeSet#writeFromUser` raises for any name not in the set.
-  if (!modelClass._attributeDefinitions.has(confirmationAttr)) {
+  if (!modelClass._defaultAttributes().isKey(confirmationAttr)) {
     modelClass.attribute(confirmationAttr, "string");
   }
 

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -8,7 +8,7 @@ export interface SerializationRecord {
   _attributes?: unknown;
   attributes?: Record<string, unknown>;
   readAttribute?: (key: string) => unknown;
-  constructor: { name: string; _attributeDefinitions?: unknown };
+  constructor: { name: string };
 }
 
 /**
@@ -244,12 +244,6 @@ export function attributeNamesForSerialization(record: SerializationRecord): str
     keys = [];
   }
 
-  const defs = record.constructor._attributeDefinitions as
-    | Map<string, { virtual?: boolean }>
-    | undefined;
-  if (defs) {
-    keys = keys.filter((k) => !defs.get(k)?.virtual);
-  }
   return keys;
 }
 

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -243,7 +243,6 @@ export function attributeNamesForSerialization(record: SerializationRecord): str
   } else {
     keys = [];
   }
-
   return keys;
 }
 


### PR DESCRIPTION
Split 1/4 of `converge-attribute-definitions-onto-default-attributes` — the
ActiveModel half.

Rails has no `_attributeDefinitions`. It carries `_default_attributes` (a
memoized `AttributeSet`) and derives `attribute_types` from it
(`activemodel/lib/active_model/attribute_registration.rb:31-49`). Every reader
of the trails-only map under `packages/activemodel/src` now resolves through
that pair — except `isAttributeMethod`, whose Rails counterpart turns out not to
be an attribute lookup at all: `ActiveModel::Validations::ClassMethods#attribute_method?`
is `method_defined?(attribute)` (`validations.rb:282-284`), so it ports as an
ancestor-chain lookup rather than swapping one map for another.

| site | now | Rails |
| --- | --- | --- |
| `Model.attributeNames` | `Object.keys(attributeTypes())` | `attributes.rb:74-75` |
| `Model.isAttributeMethod` | `attribute in this.prototype` | `validations.rb:282-284` |
| `Model#hasAttribute` | `this._attributes.isKey(...)` | `activerecord/attribute_methods.rb:316-320` |
| `Model#columnForAttribute` | `typeForAttribute` | `attribute_registration.rb:44-50` |
| `attributeMethodPrefix/Suffix/Affix` | `this.attributeNames()` | `attributes.rb:74-75` |
| `hasSecurePassword` guards | `_defaultAttributes().isKey(...)` | — |
| `attributeNamesForSerialization` | `attributes.keys` | `serialization.rb:170-172` |

Two trails-only `virtual` filters go with them — the class-level
`attributeNames` one and the serialization one. Rails has no `virtual` concept
in either body; AR overrides `attributeNames` itself, so nothing downstream
depends on the AM filter. `attributes.trails.test.ts`'s class-level case is
updated to assert the Rails behaviour (it enshrined the deviation).

The declaration-path *write* in `packages/activemodel/src/attributes.ts` stays:
`ActiveRecord::Base.attribute` supersends into it, and the AR readers of the map
are slices 2-4. Acceptance criterion 4 anticipates this.

The eager copy-on-write apply in `decorateAttributes` is already gone on `main`
(#6799); `PendingDecorator#applyTo` is the single apply path.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm parity:api:calls` OK (894 baselined, no new rows); `parity:api:calls:args`
  OK (169 shape rows, no new rows); `parity:api:extra --package activemodel`
  reports 0 novel.
- activemodel suite: 1953 tests green.
- AR spot checks green: `attributes`, `model-schema`, `dirty`,
  `serialized-attribute`, `serialization`, `json-serialization`,
  `secure-password`.

## Review response — `attributes.ts:129` (the declaration path)

Attempted and reverted, with measurements. Converging that read to
`_defaultAttributes()` / `typeForAttribute()` **cannot** be done while the map
survives, because the two differ in *when* they resolve, not in where they read:

Rails' `attribute` only **queues** (`attribute_registration.rb:11-20`):

```ruby
pending_attribute_modifications << PendingType.new(name, type) if type || no_default
pending_attribute_modifications << PendingDefault.new(name, default) unless no_default
reset_default_attributes
```

Nothing is resolved at declaration time. The prior type is picked up later, at
replay, by `PendingType#apply_to` (`attribute_registration.rb:53-58`):

```ruby
attribute = attribute_set[name]
attribute_set[name] = attribute.with_type(type || attribute.type)
```

The trails map, by contrast, stores a *resolved* `type` in the entry it writes,
so sourcing that value from `typeForAttribute` forces `_default_attributes` to
materialize **inside** `attribute()` — a full pending-chain replay one line
before `resetDefaultAttributes` throws it away, and, on ActiveRecord, a
schema reflection (`activerecord/src/attributes.ts:186-192` calls
`columnsHash()`) during the class body.

Measured on this branch:

- Sourcing both `type` and `defaultValue` from the attribute set:
  **170 AR failures** across `attributes`, `model-schema`, `dirty`, `enum`,
  `inheritance`, `defaults`.
- Sourcing only the `type` fallback (Rails' `PendingType(name, nil)` arm):
  still **168 failures**. The premature replay runs decorators that are only
  legal after the schema lands — e.g. `enum`'s decorator
  (`activerecord/src/enum.ts:155-163`) raises *"Undeclared attribute type for
  enum"* because it now sees `Type.default_value` where the replayed column type
  would have been.

That is the campaign's actual thesis: this reader is eager **because the map is**,
and it converges by the map's deletion, not by re-pointing the read. It is one of
the AR-side readers slices 2-4 remove — `activerecord/src/base.ts:1204` reads the
same entry back immediately after supersending here, so the write and this read
have to go together, in the slice that owns the AR side.

Closes-story: converge-attribute-definitions-activemodel-readers
