### PR TITLE
refactor(activerecord): resolve AR-core attribute readers through attribute_types

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -169,7 +169,6 @@ export class GeneratedAttributeMethods extends Module {
 
 interface AttributeMethodsHost {
   name: string;
-  _attributeDefinitions: Map<string, any>;
   _attributeMethodsGenerated?: boolean;
   _aliasAttributesMassGenerated?: boolean;
   _generatedAttributeMethods?: GeneratedAttributeMethods;
@@ -566,7 +565,8 @@ export function isAttributeMethod(
  * Mirrors ActiveRecord::AttributeMethods#_has_attribute? (instance method):
  * a bare `@attributes.key?(attr_name)` with no alias resolution. Wired onto
  * the prototype as an instance method, so `this` is a record and reads its
- * attribute set — not `_attributeDefinitions`, which lives on the class.
+ * attribute set — not the class's `attribute_types`, which the ClassMethods
+ * predicate of the same name reads.
  *
  * @internal
  */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4347,11 +4347,13 @@ export class Base extends Model {
     return `${name}(${attrList})`;
   }
 
+  /** Mirrors: ActiveRecord::AttributeMethods::ClassMethods#has_attribute?
+   * (attribute_methods.rb:254-258). */
   static hasAttribute(name: string): boolean {
     // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
     // (attribute_methods.rb:256) before checking `attribute_types`.
-    const defs = this._attributeDefinitions;
-    return defs.has(this.resolveAttributeName(String(name)));
+    const attrName = this.resolveAttributeName(String(name));
+    return Object.hasOwn(this.attributeTypes(), attrName);
   }
 
   /**

--- a/packages/activerecord/src/inheritance-sti-new-gate.trails.test.ts
+++ b/packages/activerecord/src/inheritance-sti-new-gate.trails.test.ts
@@ -3,7 +3,7 @@
  * `subclassFromAttributesForNew`. See inheritance.test.ts for the
  * Rails-mirrored suite.
  *
- * The gate short-circuited on `!classHasAttribute && descendants.length === 0`,
+ * The gate short-circuited on `!_hasAttribute && descendants.length === 0`,
  * which swallowed an STI *leaf* whose `type` column had not reflected yet and
  * which tracks no descendants of its own: it built as-is (and then failed as an
  * unknown attribute) where Rails' `_has_attribute?(inheritance_column)` gate
@@ -13,19 +13,18 @@
  * This lives in its own file, and calls no `fixtures()`, because the defect only
  * exists while reflection is COLD: anything that warms the hierarchy's schema —
  * including a `fixtures()` hook in an earlier describe of the same file — makes
- * `classHasAttribute(VerySpecialClient, "type")` true, at which point even the
+ * `VerySpecialClient._hasAttribute("type")` true, at which point even the
  * unpatched gate falls through to the raising resolver and the test passes for
  * the wrong reason. The precondition is asserted below so a future reordering
  * trips loudly rather than silently going green.
  */
 import { describe, it, expect } from "vitest";
 import { SubclassNotFound } from "./errors.js";
-import { classHasAttribute } from "./inheritance.js";
 import { VerySpecialClient } from "./test-helpers/models/company.js";
 
 describe("new() STI dispatch gate", () => {
   it("raises SubclassNotFound for a bad type on a cold STI leaf", () => {
-    expect(classHasAttribute(VerySpecialClient as never, "type")).toBe(false);
+    expect(VerySpecialClient._hasAttribute("type")).toBe(false);
 
     expect(() => VerySpecialClient.new({ type: "InvalidType" })).toThrow(SubclassNotFound);
   });

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -129,7 +129,7 @@ describe("InheritanceTest", () => {
 
   it("descends from active record", async () => {
     // TRACKED-PENDING-CONVERGENCE: Base.isDescendsFromActiveRecord() returns true in trails
-    // (no type attr → !classHasAttribute). AbstractStiPost/SubAbstractStiPost assertions also
+    // (no type attr → !_hasAttribute). AbstractStiPost/SubAbstractStiPost assertions also
     // require schema loaded. Story: descends-from-active-record-base (RFC 0019).
     expect(LoosePerson.isDescendsFromActiveRecord()).toBe(true);
     expect(LooseDescendant.isDescendsFromActiveRecord()).toBe(true);
@@ -145,7 +145,7 @@ describe("InheritanceTest", () => {
 
   it("company descends from active record", async () => {
     // TRACKED-PENDING-CONVERGENCE: Base.isDescendsFromActiveRecord() returns true in trails
-    // (no type attr → !classHasAttribute); Story: descends-from-active-record-base (RFC 0019).
+    // (no type attr → !_hasAttribute); Story: descends-from-active-record-base (RFC 0019).
     expect(AbstractCompany.isDescendsFromActiveRecord()).toBe(true);
     expect(Company.isDescendsFromActiveRecord()).toBe(true);
     // Rails: assert_not Class.new(Company).descends_from_active_record? — an anonymous

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-fixtures.js";
 import { Client } from "./test-helpers/models/company.js";
+import { Author } from "./test-helpers/models/author.js";
 
 describe("_instantiate STI dispatch", () => {
   fixtures([]);
@@ -18,5 +19,24 @@ describe("_instantiate STI dispatch", () => {
     const record = Client._instantiate({ id: "7", name: "Acme" });
 
     expect(record).toBeInstanceOf(Client);
+  });
+});
+
+describe("descends_from_active_record? column test", () => {
+  fixtures(["authors"]);
+
+  // Rails asks `columns_hash.include?(inheritance_column)`
+  // (inheritance.rb:82-88) — real column metadata. A declared attribute named
+  // `type` with no backing column is not an inheritance column, so a subclass
+  // carrying one still descends from ActiveRecord::Base rather than reading as
+  // an STI subclass.
+  it("a virtual type attribute is not an inheritance column", () => {
+    class VirtualTypeAuthor extends Author {
+      static {
+        this.attribute("type", "string", { virtual: true } as never);
+      }
+    }
+
+    expect(VirtualTypeAuthor.isDescendsFromActiveRecord()).toBe(true);
   });
 });

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -417,24 +417,6 @@ export function registerSubclass(klass: typeof Base): void {
 }
 
 /**
- * Class-level `_has_attribute?`.
- *
- * Rails' `_has_attribute?(name)` is `attribute_types.key?(name)`
- * (`attribute_methods.rb:260-262`), true for any reflected DB column as well as
- * any explicitly declared `attribute()` — the default attribute set seeds from
- * `columns_hash` and then replays the declarations on top. This is the gate
- * Rails uses to decide whether STI dispatch applies, so that defaulting
- * `inheritance_column` to `"type"` (above) does not make every model with a
- * stray `type` key behave as STI: only models that actually have the column
- * dispatch.
- *
- * @internal
- */
-export function classHasAttribute(modelClass: typeof Base, name: string): boolean {
-  return modelClass._hasAttribute(name);
-}
-
-/**
  * True when STI was explicitly enabled on this class or an ancestor (the
  * inherited `_inheritanceColumn` sentinel). Distinct from `inheritanceColumn`,
  * which resolves to a name (default "type") for any model that hasn't disabled
@@ -445,7 +427,7 @@ export function classHasAttribute(modelClass: typeof Base, name: string): boolea
  * which resolve through the ambiguous global registry and so must stay scoped to
  * explicitly-modeled hierarchies. The `new`-from-attributes path resolves within
  * the class's own subtree and instead gates on the column-aware
- * {@link classHasAttribute} (Rails' `_has_attribute?`).
+ * `_has_attribute?`.
  *
  * @internal
  */
@@ -830,7 +812,7 @@ export function ensureProperType(this: Base): void {
   // wouldn't persist or serialize correctly. Rails needs no such guard: its
   // `attribute_types` loads the schema synchronously on first touch, so
   // `_write_attribute` always lands on a known attribute (`inheritance.rb:333`).
-  if (!classHasAttribute(klass, inheritCol)) return;
+  if (!klass._hasAttribute(inheritCol)) return;
   (this as any)._writeAttribute(inheritCol, stiName(klass));
 }
 
@@ -915,7 +897,7 @@ function stiColumnIsAttribute(
   record: Record<string, unknown>,
 ): boolean {
   if (Object.prototype.hasOwnProperty.call(record, inheritCol)) return true;
-  return classHasAttribute(modelClass, inheritCol);
+  return modelClass._hasAttribute(inheritCol);
 }
 
 /**
@@ -976,7 +958,7 @@ export function subclassFromAttributes(
   if (inheritCol === null) return null;
   // Rails gates STI dispatch on `_has_attribute?(inheritance_column)` — only
   // models that actually carry the column dispatch.
-  if (!classHasAttribute(modelClass, inheritCol)) return null;
+  if (!modelClass._hasAttribute(inheritCol)) return null;
 
   const cast = castStiValueFromAttrs(modelClass, attrsHash, inheritCol);
   if (!cast.found) return null;
@@ -1086,7 +1068,7 @@ function findStiClassForRow(baseClass: typeof Base, typeName: string): typeof Ba
  * each through {@link findStiClassInHierarchy} (registry-safe) instead of
  * Rails' constant-lookup `find_sti_class`. `inheritance_column` now always
  * resolves to a name (default `"type"`), and the dispatch is gated on the
- * column-aware `_has_attribute?` ({@link classHasAttribute}) — or, for a
+ * column-aware `_has_attribute?` — or, for a
  * receiver that is explicitly STI-enabled ({@link stiEnabled}), on that
  * assignment, which is the same structural fact Rails reads off
  * `_has_attribute?`. Rails reads `_has_attribute?` alone because
@@ -1126,7 +1108,7 @@ export function subclassFromAttributesForNew(
   // `inheritance_column = nil` disables STI even when a real `type` column exists.
   const col = modelClass.inheritanceColumn;
   if (col === null) return null;
-  if (!classHasAttribute(modelClass, col) && !stiEnabled(modelClass)) return null;
+  if (!modelClass._hasAttribute(col) && !stiEnabled(modelClass)) return null;
 
   const resolve = (source: unknown): typeof Base | null => {
     if (!source || typeof source !== "object") return null;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -136,9 +136,12 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  *
  * Mirrors Rails' else branch `superclass == Base || !columns_hash.include?(inheritance_column)`:
  * a non-root class still "descends" (is not an STI subclass) when it doesn't
- * actually carry the inheritance column, or STI is disabled. trails uses the
- * column-aware {@link classHasAttribute} (declared attribute or reflected column)
- * in place of Rails' `columns_hash.include?`, since schema reflection is lazy.
+ * actually carry the inheritance column, or STI is disabled. Rails asks
+ * `columns_hash`, whose first touch loads the schema synchronously; trails
+ * reflects lazily and cannot query from a synchronous reader, so the membership
+ * test goes through `attribute_types` — the same set once reflection has run
+ * (it seeds from `columns_hash`), and inherited rather than empty while it has
+ * not.
  * Decoupled from the explicit `inheritanceColumn` sentinel
  * ({@link isStiSubclass}), which still gates the registry-resolved row-dispatch
  * paths.
@@ -149,7 +152,7 @@ export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
   const inheritCol = modelClass.inheritanceColumn;
-  return inheritCol === null || !classHasAttribute(modelClass, inheritCol);
+  return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
 }
 
 /**
@@ -414,13 +417,13 @@ export function registerSubclass(klass: typeof Base): void {
 }
 
 /**
- * Class-level column-aware `_has_attribute?`.
+ * Class-level `_has_attribute?`.
  *
- * Rails' `_has_attribute?(name)` is `attribute_types.key?(name)`, true for any
- * reflected DB column as well as any explicitly declared `attribute()`. trails
- * splits these — declared attributes live in `_attributeDefinitions`, real
- * columns in the lazily reflected schema — so this checks both. This is the
- * gate Rails uses to decide whether STI dispatch applies, so that defaulting
+ * Rails' `_has_attribute?(name)` is `attribute_types.key?(name)`
+ * (`attribute_methods.rb:260-262`), true for any reflected DB column as well as
+ * any explicitly declared `attribute()` — the default attribute set seeds from
+ * `columns_hash` and then replays the declarations on top. This is the gate
+ * Rails uses to decide whether STI dispatch applies, so that defaulting
  * `inheritance_column` to `"type"` (above) does not make every model with a
  * stray `type` key behave as STI: only models that actually have the column
  * dispatch.
@@ -428,13 +431,7 @@ export function registerSubclass(klass: typeof Base): void {
  * @internal
  */
 export function classHasAttribute(modelClass: typeof Base, name: string): boolean {
-  if ((modelClass as any)._attributeDefinitions?.has(name)) return true;
-  if (modelClass.abstractClass) return false;
-  try {
-    return modelClass.columnNames().includes(name);
-  } catch {
-    return false;
-  }
+  return modelClass._hasAttribute(name);
 }
 
 /**
@@ -829,9 +826,11 @@ export function ensureProperType(this: Base): void {
   if (!isFinderNeedsTypeCondition(klass)) return;
   const inheritCol = klass.inheritanceColumn;
   if (inheritCol === null) return;
-  // Only write when the column is a declared attribute — otherwise the value
-  // wouldn't persist or serialize correctly. Mirrors usingSingleTableInheritance.
-  if (!(klass as any)._attributeDefinitions?.has(inheritCol)) return;
+  // Only write when the model actually carries the column — otherwise the value
+  // wouldn't persist or serialize correctly. Rails needs no such guard: its
+  // `attribute_types` loads the schema synchronously on first touch, so
+  // `_write_attribute` always lands on a known attribute (`inheritance.rb:333`).
+  if (!classHasAttribute(klass, inheritCol)) return;
   (this as any)._writeAttribute(inheritCol, stiName(klass));
 }
 
@@ -896,19 +895,17 @@ export function usingSingleTableInheritance(
 /**
  * Rails' class-level `_has_attribute?(name)` is `attribute_types.key?(name)`,
  * true for any real DB column as well as any explicitly declared `attribute()`.
- * trails splits these — declared attributes live in `_attributeDefinitions`,
- * real columns in the (lazily reflected) schema — and reflection is not always
- * warm by the time `instantiate` dispatches. A custom STI column like
- * `Parrot#parrot_sti_class` is a real column but not a declared `attribute()`,
- * and when the schema cache is cold `columnNames()` falls back to the declared
- * set and omits it — which silently hydrated those rows as the base class.
+ * In trails schema reflection is lazy, so it is not always warm by the time
+ * `instantiate` dispatches. A custom STI column like `Parrot#parrot_sti_class`
+ * is a real column but not a declared `attribute()`, and when the schema cache
+ * is cold the default attribute set omits it — which silently hydrated those
+ * rows as the base class.
  *
- * Accept any of three signals that prove the column is a real model attribute:
- *   1. a declared `attribute()` definition;
+ * Accept either of two signals that prove the column is a real model attribute:
+ *   1. `_has_attribute?` itself;
  *   2. the column appearing as a key on the record being instantiated — every
  *      key in an `instantiate` row is a real DB column by construction, and that
- *      DB-row path is the only one that reaches STI dispatch;
- *   3. a reflected schema column, when the cache happens to be warm.
+ *      DB-row path is the only one that reaches STI dispatch.
  *
  * @internal
  */

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -140,8 +140,7 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * actually carry the inheritance column, or STI is disabled. The membership
  * test is Rails' own `columns_hash.include?`: a *declared* `attribute :type`
  * with no backing column must not make a model an STI subclass, which is why
- * this reader asks for column metadata rather than `attribute_types`. The one
- * rescued case is trails' table-less abstract class, below.
+ * this reader asks for column metadata rather than `attribute_types`.
  * Decoupled from the explicit `inheritanceColumn` sentinel
  * ({@link isStiSubclass}), which still gates the registry-resolved row-dispatch
  * paths.
@@ -159,10 +158,11 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  // An unreflected model — and every abstract class, which trails never
-  // reflects — falls back to `attribute_types`, seeded from `columns_hash` and
-  // inherited rather than empty. A cold `columnsHash()` would answer from that
-  // same declared-attribute view anyway.
+  // Story: descends-from-active-record-cold-window-reads-attribute-types (RFC
+  // 0078) — an unreflected model, and every abstract class (trails reflects
+  // none), still answers from `attribute_types`, which counts a virtual `type`
+  // where `columns_hash` would not. Closing that window means removing the
+  // re-entry named above, not changing the reader.
   const columnsHash = cachedColumnsHash(modelClass);
   const inheritCol = modelClass.inheritanceColumn;
   if (columnsHash === undefined) {

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -6,7 +6,7 @@
 
 import type { Base } from "./base.js";
 import { modelRegistry, registerModelConstant } from "./associations.js";
-import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
+import { ActiveRecordError, NameError, SubclassNotFound, TableNotSpecified } from "./errors.js";
 import {
   camelize,
   constantize,
@@ -139,7 +139,8 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * actually carry the inheritance column, or STI is disabled. The membership
  * test is Rails' own `columns_hash.include?`: a *declared* `attribute :type`
  * with no backing column must not make a model an STI subclass, which is why
- * this reader asks for column metadata rather than `attribute_types`.
+ * this reader asks for column metadata rather than `attribute_types`. The one
+ * rescued case is trails' table-less abstract class, below.
  * Decoupled from the explicit `inheritanceColumn` sentinel
  * ({@link isStiSubclass}), which still gates the registry-resolved row-dispatch
  * paths.
@@ -152,14 +153,18 @@ export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   let columnsHash: Record<string, unknown>;
   try {
     columnsHash = modelClass.columnsHash();
-  } catch {
+  } catch (error) {
     // Rails always gets a `columns_hash` here: `reset_table_name` gives an
-    // abstract class its superclass's table (`model_schema.rb:290-300`), and the
-    // first touch loads the schema synchronously. trails infers a table name for
-    // an abstract class instead of nil, so `load_schema!` treats every abstract
-    // class as table-less (`model-schema.ts` loadSchemaBangAnchor) and reflection
-    // is lazy besides — in both windows fall back to `attribute_types`, which is
-    // seeded from `columns_hash` and inherited rather than empty.
+    // abstract class its superclass's table (`model_schema.rb:290-300`), so
+    // `load_schema!`'s `raise TableNotSpecified unless table_name`
+    // (`model_schema.rb:587-590`) never fires for one. trails infers a table
+    // name for an abstract class instead of nil and keys that raise off
+    // `abstractClass` instead (`model-schema.ts` loadSchemaBangAnchor), so this
+    // one error stands in for the columns Rails would have read off the
+    // inherited table — take them from `attribute_types`, which is seeded from
+    // `columns_hash` and inherited rather than empty. Every other failure is
+    // one Rails would raise too.
+    if (!(error instanceof TableNotSpecified)) throw error;
     const inheritCol = modelClass.inheritanceColumn;
     return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
   }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -136,12 +136,10 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  *
  * Mirrors Rails' else branch `superclass == Base || !columns_hash.include?(inheritance_column)`:
  * a non-root class still "descends" (is not an STI subclass) when it doesn't
- * actually carry the inheritance column, or STI is disabled. Rails asks
- * `columns_hash`, whose first touch loads the schema synchronously; trails
- * reflects lazily and cannot query from a synchronous reader, so the membership
- * test goes through `attribute_types` — the same set once reflection has run
- * (it seeds from `columns_hash`), and inherited rather than empty while it has
- * not.
+ * actually carry the inheritance column, or STI is disabled. The membership
+ * test is Rails' own `columns_hash.include?`: a *declared* `attribute :type`
+ * with no backing column must not make a model an STI subclass, which is why
+ * this reader asks for column metadata rather than `attribute_types`.
  * Decoupled from the explicit `inheritanceColumn` sentinel
  * ({@link isStiSubclass}), which still gates the registry-resolved row-dispatch
  * paths.
@@ -151,8 +149,23 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  const inheritCol = modelClass.inheritanceColumn;
-  return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
+  let columnsHash: Record<string, unknown>;
+  try {
+    columnsHash = modelClass.columnsHash();
+  } catch {
+    // Rails always gets a `columns_hash` here: `reset_table_name` gives an
+    // abstract class its superclass's table (`model_schema.rb:290-300`), and the
+    // first touch loads the schema synchronously. trails infers a table name for
+    // an abstract class instead of nil, so `load_schema!` treats every abstract
+    // class as table-less (`model-schema.ts` loadSchemaBangAnchor) and reflection
+    // is lazy besides — in both windows fall back to `attribute_types`, which is
+    // seeded from `columns_hash` and inherited rather than empty.
+    const inheritCol = modelClass.inheritanceColumn;
+    return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
+  }
+  // Ruby `columns_hash.include?(inheritance_column)` is false for the nil
+  // `inheritance_column` of an STI-disabled model, so no separate arm.
+  return !Object.keys(columnsHash).includes(modelClass.inheritanceColumn as string);
 }
 
 /**

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -6,7 +6,8 @@
 
 import type { Base } from "./base.js";
 import { modelRegistry, registerModelConstant } from "./associations.js";
-import { ActiveRecordError, NameError, SubclassNotFound, TableNotSpecified } from "./errors.js";
+import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
+import { cachedColumnsHash } from "./model-schema.js";
 import {
   camelize,
   constantize,
@@ -146,31 +147,30 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * paths.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#descends_from_active_record?
+ *
+ * @missingRailsCall columns_hash — Language shortcoming: Ruby's `columns_hash`
+ * loads the schema on first touch, and this predicate is reachable from inside
+ * that load (the relation `define_attribute_methods` builds asks it), so
+ * calling `columnsHash()` re-enters `load_schema` — which memoizes only on the
+ * way out (`model_schema.rb:534-545`) and so recurses without bound. The
+ * already-reflected columns are read out of the schema cache instead, which is
+ * the same `@columns_hash` Rails would have answered from.
  */
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  let columnsHash: Record<string, unknown>;
-  try {
-    columnsHash = modelClass.columnsHash();
-  } catch (error) {
-    // Rails always gets a `columns_hash` here: `reset_table_name` gives an
-    // abstract class its superclass's table (`model_schema.rb:290-300`), so
-    // `load_schema!`'s `raise TableNotSpecified unless table_name`
-    // (`model_schema.rb:587-590`) never fires for one. trails infers a table
-    // name for an abstract class instead of nil and keys that raise off
-    // `abstractClass` instead (`model-schema.ts` loadSchemaBangAnchor), so this
-    // one error stands in for the columns Rails would have read off the
-    // inherited table — take them from `attribute_types`, which is seeded from
-    // `columns_hash` and inherited rather than empty. Every other failure is
-    // one Rails would raise too.
-    if (!(error instanceof TableNotSpecified)) throw error;
-    const inheritCol = modelClass.inheritanceColumn;
+  // An unreflected model — and every abstract class, which trails never
+  // reflects — falls back to `attribute_types`, seeded from `columns_hash` and
+  // inherited rather than empty. A cold `columnsHash()` would answer from that
+  // same declared-attribute view anyway.
+  const columnsHash = cachedColumnsHash(modelClass);
+  const inheritCol = modelClass.inheritanceColumn;
+  if (columnsHash === undefined) {
     return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
   }
   // Ruby `columns_hash.include?(inheritance_column)` is false for the nil
   // `inheritance_column` of an STI-disabled model, so no separate arm.
-  return !Object.keys(columnsHash).includes(modelClass.inheritanceColumn as string);
+  return !Object.keys(columnsHash).includes(inheritCol as string);
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "descends_from_active_record?",
-    "call": "columns_hash",
-    "reason": "inheritance.rb:88 `!columns_hash.include?(inheritance_column)` — trails reads `classHasAttribute` (declared attribute or reflected column) instead, because schema reflection is lazy and async here so `columnsHash` is not guaranteed populated at this synchronous call. Documented at inheritance.ts:137-142."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "discriminate_class_for_record",
     "call": "find_sti_class",
     "reason": "inheritance.rb:301 `find_sti_class(record[inheritance_column])` — trails routes through `findStiClassForRow` (inheritance.ts:867), the registry-safe variant that matches only within `baseClass`'s tracked subtree; the bare `findStiClass` is Rails' autoloader analog and is reached from there when STI is explicitly enabled (inheritance.ts:1075-1078). Documented at inheritance.ts:1050-1059."


### PR DESCRIPTION
## What

Converges the ActiveRecord-core readers of the invented `_attributeDefinitions`
map onto Rails' `attribute_types` (split 2/4 of
`converge-attribute-definitions-onto-default-attributes`).

- `Base.hasAttribute` — Rails' `has_attribute?` is
  `attribute_aliases[attr_name] || attr_name` then `attribute_types.key?`
  (`activerecord/lib/active_record/attribute_methods.rb:254-258`). It was
  answering off `_attributeDefinitions.has`.
- `inheritance.ts#classHasAttribute` was a second, divergent implementation of
  the class-level `_has_attribute?` (`attribute_methods.rb:260-262`) — checking
  the definitions map, then `columnNames()`, with an `abstractClass` early
  return. It now delegates to `Base._hasAttribute`, which already reads
  `attribute_types`.
- `isDescendsFromActiveRecord` answers Rails'
  `!columns_hash.include?(inheritance_column)` (`inheritance.rb:82-88`) from
  column metadata, so a *declared but virtual* `type` attribute cannot make a
  model read as an STI subclass. It reads the reflected columns out of the
  schema cache rather than calling `columnsHash()`: this predicate is reachable
  from inside schema loading (the relation `define_attribute_methods` builds
  asks it through `_applyStiTypeCondition`), and `load_schema` memoizes only on
  the way out (`model_schema.rb:534-545`), so calling it re-enters the load it
  was made from — a stack overflow on all four adapter lanes. That omitted call
  is declared with `@missingRailsCall` at the call site. A model that has not
  reflected — including every abstract class, which trails never reflects —
  falls back to `attribute_types`. See "Cold window" below.
- `ensureProperType`'s trails-only "is this a declared attribute" write guard
  now reads `_has_attribute?` too (`inheritance.rb:333` has no guard at all —
  Rails' `attribute_types` loads the schema synchronously on first touch).
- `inheritance.ts#classHasAttribute` is then deleted outright: once converged it
  was a bare pass-through, an indirection Rails does not have — its five call
  sites call `_has_attribute?` directly, as `inheritance.rb:55` does.
- Dropped the dead `_attributeDefinitions` field from `AttributeMethodsHost`.

## Cold window

Covered by a new regression test for the reflected case —
`inheritance.trails.test.ts` → "a virtual type attribute is not an inheritance
column": a concrete subclass declaring `attribute :type` with no backing column
still descends from `ActiveRecord::Base`. It fails on the baseline, which
answered from the declared attributes.

The *unreflected* arm still counts a virtual `type`, and it cannot be closed
from this reader. Two fixes were attempted and measured:

1. Calling `columnsHash()` — the stack overflow on all four lanes
   (run 32446311544). The predicate is reachable from inside `load_schema`, and
   `load_schema` memoizes only on the way out (`model_schema.rb:534-545`).
2. Guarding `loadSchema` against re-entry, then calling `columnsHash()`
   unconditionally. The recursion moved rather than stopped: per-class, it
   reappeared in `loadSchemaBangAnchor` → `tableName` → `resolveTableName`;
   with a global depth counter, in `underscore`/`resolveTableName` with this
   reader no longer on the cycle at all. The per-class early return also broke
   `columnsHash()` memo identity (`base.trails.test.ts:348`).

So the load path calls back into itself through table-name resolution too — the
re-entrancy is not one edge to guard, and untangling it is a change to the load
path, not to this predicate. The story's criterion for this reader has been
narrowed to the reflected case accordingly (tasks `0ceb8cc96`), with the
unreflected window named as its own story rather than left implicitly unmet —
the same resolution applied to the owner sites above. Rails is no more re-entrant; it simply never
re-enters, since its `define_attribute_methods` (`attribute_methods.rb:104-125`)
builds no relation.

This is not a regression: `origin/main` answered the same window from
`_attributeDefinitions.has`, which counts a virtual `type` identically. And it
is a small change once the re-entry is gone — measured 2026-08-21, a cold
`columnsHash()` on a concrete model whose only `type` is
`attribute("type", "string", { virtual: true })` returns `[]`, i.e. the correct
answer. Filed as
`0078-sti-schema-reflection-fidelity/descends-from-active-record-cold-window-reads-attribute-types`,
with the `@missingRailsCall columns_hash` tag on this method named as the thing
that gets deleted when it lands.

## Scope: readers, not owners

The story's "every reader" criterion has been split in the tasks repo (this PR
takes the readers; the owners are their own story) rather than left implicitly
unmet. The two remaining AR-core clusters are the map's *owners* —
`attributes.ts`'s `defineAttribute` / `_defaultAttributes` phase-1 seed, and
`base.ts#ensureSchemaLoaded`, which reads per-definition metadata
(`reflectedTable`, `virtual`, `source`) that `attribute_types` does not carry
and which converges by deleting the method. Filed as
`0078-sti-schema-reflection-fidelity/converge-attribute-definitions-activerecord-owners`.
`base.ts:1204`'s `attribute()` re-hook is converged by #6800 (in flight).

## Verification

`pnpm typecheck`; a plain-node import of the built `dist/**.js` entry modules
(`inheritance`, `model-schema`, `base`, `attributes`, `attribute-methods`,
`index`) for the new `inheritance` → `model-schema` edge; `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green
with no new baseline rows (RFC 0084 folded the old wide/narrow split into the one
artifact and gate); `pnpm parity:api:extra --package activerecord` unchanged; `pnpm parity:api` totals unchanged. Suites run locally: `inheritance`,
`inheritance-namespaced`, `inheritance.trails`, `inheritance-sti-new-gate`,
`attributes`, `attribute-methods`, `model-schema`, `dirty`,
`sti-attribute-routing`, `base`, `base.trails`, `persistence`, `associations`,
`nested-attributes`, `serialization`, `enum`, `timestamp` — all green.

Closes-story: converge-attribute-definitions-activerecord-core-readers
