### PR TITLE
refactor(activerecord): converge the encryption attribute-type readers onto columnsHash/typeForAttribute

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -31,7 +31,6 @@ import {
   encrypt,
   encryptAttribute,
   encryptedAttribute,
-  encryptedTypeOf,
 } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
@@ -139,12 +138,6 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
   while (current) {
     const pending: PendingEncryption[] | undefined = current._pendingEncryptions;
     if (pending?.some((p) => p.name === attr)) return true;
-    const defs = current._attributeDefinitions;
-    if (defs) {
-      // Mock-model arm: real Base subclasses no longer hold wrapped defs (the
-      // eager view is retired) — their declarations hit the pending arm above.
-      if (encryptedTypeOf(defs.get(attr)?.type)) return true;
-    }
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -1,7 +1,7 @@
 import { Scheme, type SchemeOptions } from "./scheme.js";
 import { Contexts } from "./contexts.js";
 import { Configuration as ConfigurationError } from "./errors.js";
-import { LengthValidator, type Type } from "@blazetrails/activemodel";
+import { type Type } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Configurable } from "./configurable.js";
 import { encryptionHooks } from "../encryption-hooks.js";
@@ -57,11 +57,6 @@ interface PendingEncryption {
 }
 
 const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
-
-// Sentinel distinguishing "column not reflected in the warm cache" from a
-// genuinely-cached `undefined`/`null` column default. Lets columnDefaultFor
-// fall back to the def default only when the schema cache has no answer.
-const NOT_CACHED = Symbol("encryption.columnDefault.notCached");
 
 /**
  * Provides the `encrypts` declaration for model classes, enabling
@@ -128,71 +123,9 @@ export class EncryptableRecord {
         castType,
         // Rails reads `columns_hash[name.to_s]&.default` off the class the
         // block was declared in (encryptable_record.rb:91).
-        default: this.columnDefaultFor(
-          modelClass,
-          attrName,
-          (
-            modelClass as { _attributeDefinitions?: Map<string, unknown> }
-          )._attributeDefinitions?.get?.(attrName),
-        ),
+        default: modelClass.columnsHash()[attrName]?.default ?? undefined,
       });
     });
-  }
-
-  /**
-   * Resolve the column's schema default, mirroring Rails'
-   * `default: columns_hash[name.to_s]&.default` (encryptable_record.rb:91).
-   *
-   * Rails threads the TRUE DB column default — not the possibly-overridden
-   * `attribute(name, { default: X })` value. When a model declares an
-   * `attribute()` default that differs from the column default, the reflected
-   * def's `defaultValue` holds the override, so reading it would thread the
-   * wrong value into `EncryptedAttributeType`.
-   *
-   * So we first peek the already-warm schema cache (query-free, no
-   * `loadSchema`/`columnsHash` — those warm the shared cache and perturb
-   * sibling encryption tests). If the column is reflected there, its `.default`
-   * is the authoritative DB default. Otherwise (plain mock models, or a def
-   * seen before reflection) we fall back to the def's `defaultValue` — which,
-   * absent an `attribute()` override, already carries the column default.
-   * Returns undefined (Rails' nil default) when neither yields a value.
-   * @internal
-   */
-  static columnDefaultFor(modelClass: any, name: string, def: any): unknown {
-    const cached = this.cachedColumnDefaultFor(modelClass, name);
-    if (cached !== NOT_CACHED) return cached ?? undefined;
-    return def?.defaultValue ?? undefined;
-  }
-
-  /**
-   * Query-free peek of a reflected column's DB default from the raw schema
-   * cache, WITHOUT leasing a connection or calling `loadSchema` (either would
-   * warm the shared cache — see the story's sibling-perturbation note). Resolves
-   * the raw sync `SchemaCache` the same connection-less way
-   * `reset_column_information` does: a directly-assigned `_adapter`, else the
-   * pool config's cache slot. Returns `NOT_CACHED` when the table isn't warm
-   * yet or the column isn't present, so callers fall back to the def default.
-   * @internal
-   */
-  static cachedColumnDefaultFor(modelClass: any, name: string): unknown {
-    try {
-      const table: string | undefined = modelClass?.tableName;
-      if (!table) return NOT_CACHED;
-      const direct = modelClass._adapter as
-        | { internalSchemaCache?: { getCachedColumnsHash?: (t: string) => any } }
-        | undefined;
-      const cache =
-        direct?.internalSchemaCache ??
-        modelClass.connectionPool?.()?.poolConfig?.schemaCache ??
-        undefined;
-      if (typeof cache?.getCachedColumnsHash !== "function") return NOT_CACHED;
-      const columns = cache.getCachedColumnsHash(table);
-      const column = columns?.[name];
-      if (!column) return NOT_CACHED;
-      return column.default ?? undefined;
-    } catch {
-      return NOT_CACHED;
-    }
   }
 
   /**
@@ -341,17 +274,8 @@ export class EncryptableRecord {
  * @internal
  */
 export function validateColumnSize(this: any, attributeName: string): void {
-  if (typeof this.validatesLengthOf !== "function") return;
-  const limit = this._attributeDefinitions?.get(attributeName)?.limit;
-  if (limit == null) return;
-  // Guard against double registration (called at encrypts() time and again
-  // after schema reflection). Check whether a LengthValidator with this
-  // exact maximum already exists for the attribute.
-  const existing: unknown[] = this._validators?.get(attributeName) ?? [];
-  const alreadyRegistered = existing.some(
-    (v: unknown) => v instanceof LengthValidator && (v as any).options?.maximum === limit,
-  );
-  if (!alreadyRegistered) {
+  const limit = this.columnsHash()[attributeName]?.limit;
+  if (limit != null) {
     this.validatesLengthOf(attributeName, { maximum: limit });
   }
 }
@@ -580,10 +504,6 @@ export function encryptAttribute(this: any, name: string, options: SchemeOptions
   EncryptableRecord.registerPendingEncryption(this, pending);
   EncryptableRecord.pushEncryptionDecorator(this, name, pending);
   encryptionHooks.applyPendingEncryptions(modelClass);
-
-  if (Configurable.config.validateColumnSize) {
-    validateColumnSize.call(this, name);
-  }
 
   // Mirrors Rails encryptable_record.rb:94 —
   // `preserve_original_encrypted(name) if ignore_case`. Wires the

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -5,7 +5,6 @@ import { Configurable } from "./configurable.js";
 import { Decryption } from "./errors.js";
 import type { EncryptorLike } from "./encryptor.js";
 import { encrypts } from "./encryptable-record.js";
-import { Model } from "@blazetrails/activemodel";
 import type { SchemeOptions } from "./scheme.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
 import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
@@ -278,7 +277,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     expect(type.deserialize(cipher)).toBe("alice");
   });
 
-  it("don't use global previous schemes with a different deterministic nature", () => {
+  it("don't use global previous schemes with a different deterministic nature", async () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previousSchemes = [];
     Configurable.config.previous = [
@@ -286,13 +285,19 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
       { encryptor: new TestEncryptor({ "STEPHEN KING": "cipher_nondet" }) } as SchemeOptions,
     ];
 
-    const modelClass = class extends Model {};
+    const modelClass = class extends Base {
+      static {
+        this._tableName = "authors";
+        this.attribute("name", "string");
+      }
+    } as any;
+    modelClass.adapter = await freshAdapter();
     // Non-deterministic attribute — only the non-deterministic global scheme is compatible.
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as unknown as EncryptedAttributeType;
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_nondet")).toBe("STEPHEN KING");
     expect(() => type.deserialize("cipher_det")).toThrow(Decryption);
@@ -387,7 +392,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     }
   });
 
-  it("don't use global previous schemes with a different deterministic nature when performing queries", () => {
+  it("don't use global previous schemes with a different deterministic nature when performing queries", async () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previousSchemes = [];
     Configurable.config.previous = [
@@ -398,14 +403,20 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
       { encryptor: new TestEncryptor({ nondet: "cipher_nondet" }) } as SchemeOptions,
     ];
 
-    const modelClass = class extends Model {};
+    const modelClass = class extends Base {
+      static {
+        this._tableName = "authors";
+        this.attribute("name", "string");
+      }
+    } as any;
+    modelClass.adapter = await freshAdapter();
     // Deterministic attribute — only the deterministic global scheme is compatible.
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
       deterministic: true,
     });
 
-    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as unknown as EncryptedAttributeType;
     // Only the deterministic global previous scheme is wired in.
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_det")).toBe("STEPHEN KING");
@@ -428,19 +439,25 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
     Configurable.config.previousSchemes = savedPreviousSchemes;
   });
 
-  it("config.previous schemes are merged into the attribute type's previousTypes", () => {
+  it("config.previous schemes are merged into the attribute type's previousTypes", async () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previous = [
       { encryptor: new TestEncryptor({ legacy1: "legacy_cipher_1" }) } as SchemeOptions,
       { encryptor: new TestEncryptor({ legacy2: "legacy_cipher_2" }) } as SchemeOptions,
     ];
 
-    const modelClass = class extends Model {};
+    const modelClass = class extends Base {
+      static {
+        this._tableName = "authors";
+        this.attribute("name", "string");
+      }
+    } as any;
+    modelClass.adapter = await freshAdapter();
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as unknown as EncryptedAttributeType;
     expect(type.previousTypes).toHaveLength(2);
 
     // value encrypted with first global previous scheme decrypts correctly
@@ -452,7 +469,7 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
     expect(type.deserialize(ciphertext2)).toBe("legacy2");
   });
 
-  it("only compatible global previous schemes are applied (matching deterministic nature)", () => {
+  it("only compatible global previous schemes are applied (matching deterministic nature)", async () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previous = [
       {
@@ -462,12 +479,18 @@ describe("global previous schemes wiring — config.previous → EncryptableReco
       { encryptor: new TestEncryptor({ legacy_non: "cipher_non" }) } as SchemeOptions,
     ];
 
-    const modelClass = class extends Model {};
+    const modelClass = class extends Base {
+      static {
+        this._tableName = "authors";
+        this.attribute("name", "string");
+      }
+    } as any;
+    modelClass.adapter = await freshAdapter();
     encrypts.call(modelClass, "name", {
       encryptor: new TestEncryptor({ current: "current_cipher" }),
     });
 
-    const type = modelClass.typeForAttribute("name") as EncryptedAttributeType;
+    const type = modelClass.typeForAttribute("name") as unknown as EncryptedAttributeType;
     // non-deterministic attribute: only the non-deterministic global scheme is compatible
     expect(type.previousTypes).toHaveLength(1);
     expect(type.deserialize("cipher_non")).toBe("legacy_non");

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -314,8 +314,14 @@ export interface ColumnLike {
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
  */
 export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
-  // load_schema! raises TableNotSpecified for abstract (table-less) classes.
-  loadSchema.call(this as SchemaHost);
+  // `load_schema unless @columns_hash` (model_schema.rb:428): the memo guard is
+  // what keeps a `columns_hash` read from inside `load_schema!` — the encryption
+  // decorator's `columns_hash[name]&.default`, the length validations — from
+  // re-entering the load it is already inside of.
+  if (ownSchemaMemo(this as unknown as SchemaHost, "_columnsHash") == null) {
+    // load_schema! raises TableNotSpecified for abstract (table-less) classes.
+    loadSchema.call(this as SchemaHost);
+  }
 
   const memoized = ownSchemaMemo(this as unknown as SchemaHost, "_columnsHash");
   if (memoized != null) return memoized as Record<string, ColumnLike>;

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "encrypt_attribute",
-    "call": "columns_hash",
-    "reason": "Rails reads the column default eagerly with `columns_hash[name.to_s]&.default` (encryptable_record.rb:91); trails' durable decorator resolves that default at attribute-replay time instead, because `encrypts` runs at class-definition time where `columnsHash` would force schema reflection before a connection exists."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypt_attribute",
     "call": "order:constructor,schemeFor",
     "reason": "Rails calls `scheme_for` then `EncryptedAttributeType.new` inside the `decorate_attributes` block (encryptable_record.rb:88-91); trails builds the pending decorator first and hangs `schemeFor` off a lazy `scheme` getter on it, so the constructor is recorded ahead of `schemeFor`."
   },
@@ -26,19 +19,5 @@
     "rubyName": "override_accessors_to_preserve_original",
     "call": "include",
     "reason": "Rails mixes the overriding reader/writer in with `include(Module.new { ... })` (encryptable_record.rb:110-123) so the generated methods can `super()` into the attribute methods; TS has no ancestor chain, so trails defines the accessor pair on the prototype with `Object.defineProperty` and there is no module to include."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "validate_column_size",
-    "call": "columns_hash",
-    "reason": "Rails reads `columns_hash[attribute_name.to_s]&.limit` (encryptable_record.rb:139); trails reads `_attributeDefinitions` because this runs from `encrypts` at class-definition time, where `columnsHash` would force schema reflection before a connection exists."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "validate_column_size",
-    "call": "order:validatesLengthOf,limit",
-    "reason": "Ordering artifact of the `columns_hash` substitution on the same line (encryptable_record.rb:139-140): the limit is read off `_attributeDefinitions`, so the only `limit` call left is the one inside the already-registered LengthValidator check that precedes `validatesLengthOf`."
   }
 ]


### PR DESCRIPTION
The **encryption** reader tranche of
`converge-attribute-definitions-core-readers`. The story specifies its own split
("split it by reader cluster (schema/columns, attribute methods, encryption,
enum/provenance)"), so this ships the encryption cluster and the `columnsHash`
re-entrancy fix that cluster needed. **Deliberately no `Closes-story:` trailer** —
the story stays open for the remaining clusters, and its body records what landed
here and what is left.

Rebased onto #6803 / #6804 / #6805, which landed while this was in review and
independently converged some of what the first push carried (`registerEncryptedType`
and `encrypt_attribute`'s "immediate path" branch, the decorator's idempotence
guard, `getAttributeType`, and most of the test mocks). What remains below is
what none of them reached.

## Rails bodies converged

- **`encrypt_attribute`**'s decorator resolves its default with
  `columns_hash[name.to_s]&.default` (`encryptable_record.rb:91`).
  `columnDefaultFor`, `cachedColumnDefaultFor` and the `NOT_CACHED` sentinel — a
  query-free schema-cache peek falling back to
  `_attributeDefinitions[name].defaultValue` — are deleted.
- **`validate_column_size`** is now Rails' three lines verbatim
  (`encryptable_record.rb:138-142`): `columns_hash[attribute_name.to_s]&.limit`,
  then `validates_length_of`. The invented already-registered-LengthValidator
  scan is gone, and `encrypts` no longer calls it eagerly — that is
  `load_schema!`'s (`encryptable_record.rb:126-130`).
- **`columns_hash`** is `load_schema unless @columns_hash`
  (`model_schema.rb:428`); trails called `loadSchema` unconditionally. That memo
  guard is precisely what lets a `columns_hash` read from inside `load_schema!`
  — the encryption decorator's default, the length validations — resolve against
  the hash the anchor just set instead of re-entering the load. Without it the
  two convergences above stack-overflow, which is why the deviation existed.
- **`isEncryptedAttribute`** drops its `_attributeDefinitions` arm and relies on
  the pending-declaration walk alone.

## Tests

The four remaining plain-object model mocks in `encryption-schemes.test.ts`
become real `Base` subclasses on the canonical `authors` table, mirroring
`Class.new(Author) { self.table_name = "authors" }`
(`encryption_schemes_test.rb:125-129,171-175`). #6804 had converged them to
ActiveModel classes, which have no `columnsHash`; Rails' fixture is an AR class.

No test name changed. No bespoke tables.

## Gates

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green. **Three**
  baseline rows converged and were deleted from
  `call-mismatches-exclude/activerecord/encryption/encryptable-record.json`
  (`encrypt_attribute columns_hash`, `validate_column_size columns_hash`,
  `validate_column_size order:validatesLengthOf,limit`) — 6 rows down to 3. No
  rows added, no reseed, marks already tight.
- `pnpm parity:api:extra --package activerecord` — no new extra surface;
  `encryptable-record.ts` drops to 1 novel name.
- Suites: full `encryption/`, plus `model-schema*`, `attributes`, `base`,
  `persistence`, `defaults`, `reflection`, `primary-keys`, `schema-cache`,
  `migration/columns`, `migration/change-schema`, `time-precision`,
  `date-time-precision`, `inheritance`, `enum`, `dirty`, `sti/`,
  `encrypted-attribute-sti`, `sti-attribute-routing` — all green (1301 tests).

Net −68 LOC.
