### PR TITLE
refactor(activerecord): converge the peripheral _attributeDefinitions readers onto attribute_types

### DIFF
--- a/packages/activerecord/src/fixtures.ts
+++ b/packages/activerecord/src/fixtures.ts
@@ -23,7 +23,7 @@ import { isPresent, singularize, underscore } from "@blazetrails/activesupport";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { EncryptableRecord, encryptedAttributes } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
-import type { Type } from "@blazetrails/activemodel";
+import { defaultValue, type Type } from "@blazetrails/activemodel";
 
 /**
  * Mirrors Rails' `ActiveRecord::FixtureSet::TableRow::PrimaryKeyError`.
@@ -745,25 +745,23 @@ async function checkAllForeignKeysValidBang(conn: DatabaseAdapter): Promise<void
 function encryptFixtureRows(ModelClass: BaseClass, rows: FixtureAttrs[]): void {
   const encryptedAttrs = encryptedAttributes.call(ModelClass);
   // Build a name→EncryptedAttributeType map from _pendingEncryptions. This lets
-  // us serialize even before loadSchemaFromAdapter has run (schema-reflected types
-  // won't be in _attributeDefinitions yet, but the scheme is already recorded).
-  // When an existing _attributeDefinitions entry is present (e.g. attribute(:name, :date)
-  // was called before encrypts(:name)), its castType is preserved so the fixture value
-  // is serialized through the correct inner type before encryption — mirrors Rails'
-  // `model_class.type_for_attribute(attribute_name)` which returns the full decorated type.
+  // us serialize even before loadSchemaFromAdapter has run (the scheme is
+  // already recorded, while `type_for_attribute` still answers the fallback
+  // `Type.default_value` for an unreflected column). The resolved type is Rails'
+  // `model_class.type_for_attribute(attribute_name)` — the full decorated type —
+  // so a `attribute(:name, :date)` declared before `encrypts(:name)` keeps its
+  // cast type and the fixture value is serialized through it before encryption.
   const typeMap = new Map<string, EncryptedAttributeType>();
   const pending: Array<{ name: string; scheme: unknown }> =
     (ModelClass as any)._pendingEncryptions ?? [];
-  const defs: Map<string, { type: unknown }> | undefined = (ModelClass as any)
-    ._attributeDefinitions;
   for (const { name, scheme } of pending) {
-    const existingType = defs?.get(name)?.type;
+    const existingType = (ModelClass as any).typeForAttribute(name) as Type;
     const castType =
       existingType instanceof EncryptedAttributeType
         ? existingType.castType
-        : existingType !== undefined
-          ? (existingType as Type)
-          : undefined;
+        : existingType === defaultValue()
+          ? undefined
+          : existingType;
     typeMap.set(name, new EncryptedAttributeType({ scheme: scheme as any, castType }));
   }
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -323,7 +323,7 @@ async function processNestedAttributes(record: Base): Promise<void> {
       // Validate attributes against the target model's known columns, resolving
       // `alias_attribute` keys the same way the build path does. `childAttrs`
       // already has the PK/`id` addressing keys stripped; the foreign-key
-      // columns are real target columns (present in `_attributeDefinitions`), so
+      // columns are real target columns (present in `attribute_types`), so
       // `assertNestedAttributesAreKnown` accepts them without a bespoke set.
       assertNestedAttributesAreKnown(targetModel, childAttrs);
 
@@ -612,8 +612,8 @@ export function isPolymorphicBelongsTo(record: Base, associationName: string): b
  * explicitly — mirroring the same check the collection flush path already runs.
  * Control keys (`_destroy`, the addressing `id`) are stripped by
  * `except(*UNASSIGNABLE_KEYS)` before this sees them; the primary key is always
- * assignable. When the target schema isn't loaded (`_attributeDefinitions`
- * empty) there is nothing to validate against, so the check is skipped.
+ * assignable. When the target schema isn't loaded (`attribute_types` empty)
+ * there is nothing to validate against, so the check is skipped.
  */
 function assertNestedAttributesAreKnown(
   targetModel: typeof Base,
@@ -621,24 +621,19 @@ function assertNestedAttributesAreKnown(
 ): void {
   const keys = Object.keys(assignable);
   if (keys.length === 0) return;
-  let attrDefs: Map<string, unknown> | undefined = (targetModel as any)._attributeDefinitions;
-  // trails loads a model's schema lazily on first `new`, so `_attributeDefinitions`
-  // may still be empty before the first nested build. Warm it once (and reuse the
-  // instance as an alias-aware probe below); when the model is genuinely
-  // schemaless there is nothing to validate against, so skip.
+  // `attribute_types` reflects the schema on first read (`_default_attributes`),
+  // so no warming construction is needed; a genuinely schemaless model yields an
+  // empty set and there is nothing to validate against.
+  const attributeTypes = targetModel.attributeTypes();
+  if (Object.keys(attributeTypes).length === 0) return;
   let probe: Base | undefined;
-  if (!attrDefs || attrDefs.size === 0) {
-    probe = new (targetModel as any)() as Base;
-    attrDefs = (targetModel as any)._attributeDefinitions;
-  }
-  if (!attrDefs || attrDefs.size === 0) return;
   const pk = (targetModel as any).primaryKey;
   const pkColumns = new Set<string>((Array.isArray(pk) ? pk : [pk]).map(String));
   // `assignable` comes from `except(*UNASSIGNABLE_KEYS)`, which already strips
   // the `id` addressing key (UNASSIGNABLE_KEYS), so only a non-`id` primary key
   // needs an explicit exemption here.
   for (const key of keys) {
-    if (attrDefs.has(key) || pkColumns.has(key)) continue;
+    if (Object.hasOwn(attributeTypes, key) || pkColumns.has(key)) continue;
     // Resolve aliases before raising: `hasAttribute` maps an aliased name onto
     // its real column (matching the flush path's lazy dummy construction).
     probe ??= new (targetModel as any)() as Base;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -683,7 +683,6 @@ interface SaveRecord {
   isValid(context?: ValidationContextArg): Promise<boolean>;
   constructor: {
     name: string;
-    _attributeDefinitions: Map<string, unknown>;
   };
 }
 
@@ -975,16 +974,11 @@ interface UpdateColumnsRecord {
     name: string;
     primaryKey: string | string[];
     arelTable: InstanceType<typeof ArelTable>;
-    _attributeDefinitions: Map<
-      string,
-      {
-        type: {
-          cast(v: unknown): unknown;
-          serialize?(v: unknown): unknown;
-          type?(): string;
-        };
-      }
-    >;
+    attributeTypes(): Record<string, unknown>;
+    _defaultAttributes(): {
+      isKey(name: string): boolean;
+      getAttribute(name: string): { value: unknown };
+    };
     typeForAttribute(name: string): {
       cast(v: unknown): unknown;
       serialize?(v: unknown): unknown;
@@ -1061,7 +1055,7 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
   // values for the UPDATE's SET clause. Reject unknown keys up-front so a
   // malicious/invalid key can't sneak an un-schema'd identifier into the
   // SQL identifier position. Primary-key columns are implicit on Base and
-  // aren't always in _attributeDefinitions, so allow them through.
+  // aren't always in `attribute_types`, so allow them through.
   const pkCols = Array.isArray(ctor.primaryKey) ? ctor.primaryKey : [ctor.primaryKey];
   // Rails resolves attribute aliases before writing (update_columns flows
   // through the alias-aware attribute layer), so a model aliasing e.g.
@@ -1084,17 +1078,18 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
 
   const setPairs: Array<[unknown, unknown]> = [];
   const updatedKeys: string[] = [];
+  // Rails casts through `@attributes.write_cast_value` (persistence.rb:625),
+  // i.e. the `_default_attributes` type — the pending-decorator chain replayed
+  // — so `attribute_types` is also the set a key is known against, and a
+  // `serialize` / `encrypts` decoration applies here too.
+  const attributeTypes = ctor.attributeTypes();
   for (const [key, value] of resolvedEntries) {
     updatedKeys.push(key);
-    const def = ctor._attributeDefinitions.get(key);
-    if (!def && !pkCols.includes(key)) {
+    const known = Object.hasOwn(attributeTypes, key);
+    if (!known && !pkCols.includes(key)) {
       throw new UnknownAttributeError(this, key);
     }
-    // Rails casts through `@attributes.write_cast_value` (persistence.rb:625),
-    // i.e. the `_default_attributes` type — the pending-decorator chain replayed
-    // — not a per-class definition cache, so a `serialize` / `encrypts`
-    // decoration applies here too.
-    const attrType = def ? (ctor.typeForAttribute(key) ?? def.type) : undefined;
+    const attrType = known ? ctor.typeForAttribute(key) : undefined;
     const cast = attrType ? attrType.cast(value) : value;
     this._attributes.set(key, cast);
     // Bridge the in-memory cast value to its DB representation via the
@@ -1801,9 +1796,9 @@ export async function _createRecord(
   // seed is what actually carries the 0 into the row.
   if (ctor.lockingEnabled) {
     const lockCol = ctor.lockingColumn;
-    const lockDef = ctor._attributeDefinitions.get(lockCol);
-    if (lockDef && this._readAttribute(lockCol) == null) {
-      this._writeAttribute(lockCol, lockDef.type.cast(lockDef.defaultValue));
+    const defaults = ctor._defaultAttributes();
+    if (defaults.isKey(lockCol) && this._readAttribute(lockCol) == null) {
+      this._writeAttribute(lockCol, defaults.getAttribute(lockCol).value);
     }
   }
 
@@ -1813,7 +1808,7 @@ export async function _createRecord(
   // declared columns present in the value map; an explicit `attributeNames`
   // arg overrides it (Persistence#_create_record(attribute_names)).
   const selfNames =
-    attributeNames ?? Object.keys(attrs).filter((k) => ctor._attributeDefinitions.has(k));
+    attributeNames ?? Object.keys(attrs).filter((k) => Object.hasOwn(ctor.attributeTypes(), k));
   // Rails AttributeMethods::Dirty#_create_record default arg:
   // attribute_names_for_partial_inserts (dirty.rb). The dirty set is populated
   // before the INSERT by reinstateNewRecordChanges (above),


### PR DESCRIPTION
`_attributeDefinitions` is a trails invention with no Rails counterpart
(RFC 0078). Slice 3 of its burndown: the **peripheral readers**, each of which
has a direct Rails-shaped replacement in `attribute_types` /
`_default_attributes`.

- **`Persistence#update_columns`** keyed both its known-attribute check and its
  cast type off the map. Rails casts through `@attributes.write_cast_value`
  (`persistence.rb:625`), i.e. the replayed `_default_attributes` types — so
  `attribute_types` is both the known-key set and the type source.
  `_create_record`'s default attribute-name list reads `attribute_types`, and
  Optimistic locking's lock-column seed (`optimistic.rb:78-82`) reads
  `_default_attributes`, taking the seeded attribute's cast value rather than
  re-casting a stored `defaultValue`.
- **`NestedAttributes`**' known-key guard warmed the map by constructing a probe
  record first; `attribute_types` reflects the schema itself on first read
  (`_default_attributes`), so the warming construction is gone.
- **`Fixtures#encrypt_fixture_rows`** resolves the pending attribute's cast type
  through `type_for_attribute` — Rails' single lookup surface, and the full
  decorated type (`fixtures.rb`'s `model_class.type_for_attribute`) — instead of
  reading a per-class definition entry.

## Scope

**Rebased down after #6806.** That PR — the encryption tranche of slice 2's
`converge-attribute-definitions-core-readers` — landed the `columns_hash` memo
guard (`model_schema.rb:428`), the encryption decorator's
`columns_hash[name]&.default` read, `validate_column_size`'s Rails body and
`load_schema!`-only call site, `isEncryptedAttribute`'s reader, and the
encryption-scheme tests' move onto real `Base` subclasses — all of which this
branch also carried, including the same three baseline-row deletions. Those
commits are dropped here rather than duplicated; what remains is the three files
#6806 did not touch.

The other readers a repo-wide `rg` still finds — `base.ts`, `attributes.ts`,
`attribute-methods.ts`, `inheritance.ts` — are slice 2's remaining clusters, and
`model-schema.ts`'s machinery is slice 4. `rg -n "_attributeDefinitions"` over
this slice's own file list now returns nothing but comments.

## Verification

`persistence`, `nested-attributes`, `fixtures`, `locking`, `encryption/`,
`model-schema*`, `enum` — 1021 passed, 11 skipped. `pnpm parity:api:calls` and
`pnpm parity:api:calls:args` green (890 baselined, marks tight); no new public
surface; typecheck clean. 38 insertions, 50 deletions across three files.

Closes-story: converge-attribute-definitions-peripheral-readers
