### PR TITLE
fix(activerecord,scripts): unbreak the nightly stats sync

### DIFF
--- a/packages/activerecord/src/model-schema-stale-against-ancestor-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-stale-against-ancestor-recursion.trails.test.ts
@@ -8,7 +8,7 @@ function col(name: string): Cols[string] {
   return { sqlType: "varchar", name, default: null };
 }
 
-const columns: Cols = { number: col("number"), title: col("title") };
+const columns: Cols = { id: col("id"), title: col("title") };
 
 function makeAdapter(): unknown {
   return {
@@ -24,26 +24,18 @@ function makeAdapter(): unknown {
 
 describe("loadSchema — subclass left stale by an ancestor invalidation", () => {
   it("settles the load instead of re-entering it until the stack overflows", () => {
-    // A subclass that never called `registerSubclass` is unreachable from
-    // `reload_schema_from_cache`'s descendant walk, so an ancestor
-    // invalidation bumps the ancestor's revision past the subclass's own and
-    // leaves the subclass permanently stale. This is the shape the nightly
-    // stats sync hits: its models are plain `extends Base` classes whose
-    // columns come from `attribute()` declarations, so the load settles on the
-    // synthesize arm rather than on a reflected schema-cache entry.
-    class PullRequest extends Base {
+    class Topic extends Base {
       static {
-        this.tableName = "pull_requests";
-        this.primaryKey = "number";
-        this.attribute("number", "integer");
+        this.tableName = "topics";
+        this.attribute("id", "integer");
         this.attribute("title", "string");
       }
     }
-    (PullRequest as unknown as { adapter: unknown }).adapter = makeAdapter();
+    (Topic as unknown as { adapter: unknown }).adapter = makeAdapter();
 
     reloadSchemaFromCache.call(Base as never);
 
-    expect(() => loadSchema.call(PullRequest as never)).not.toThrow();
-    expect(Object.keys(PullRequest.columnsHash())).toEqual(["number", "title"]);
+    expect(() => loadSchema.call(Topic as never)).not.toThrow();
+    expect(Object.keys(Topic.columnsHash())).toEqual(["id", "title"]);
   });
 });

--- a/packages/activerecord/src/model-schema-stale-against-ancestor-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-stale-against-ancestor-recursion.trails.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "./base.js";
+import { loadSchema, reloadSchemaFromCache } from "./model-schema.js";
+
+type Cols = Record<string, { sqlType: string; name: string; default: null }>;
+
+function col(name: string): Cols[string] {
+  return { sqlType: "varchar", name, default: null };
+}
+
+const columns: Cols = { number: col("number"), title: col("title") };
+
+function makeAdapter(): unknown {
+  return {
+    internalSchemaCache: {
+      isCached: () => true,
+      getCachedColumnsHash: () => undefined,
+      dataSourceExists: async () => true,
+      columnsHash: async () => columns,
+    },
+    lookupCastTypeFromColumn: () => null,
+  };
+}
+
+describe("loadSchema — subclass left stale by an ancestor invalidation", () => {
+  it("settles the load instead of re-entering it until the stack overflows", () => {
+    // A subclass that never called `registerSubclass` is unreachable from
+    // `reload_schema_from_cache`'s descendant walk, so an ancestor
+    // invalidation bumps the ancestor's revision past the subclass's own and
+    // leaves the subclass permanently stale. This is the shape the nightly
+    // stats sync hits: its models are plain `extends Base` classes whose
+    // columns come from `attribute()` declarations, so the load settles on the
+    // synthesize arm rather than on a reflected schema-cache entry.
+    class PullRequest extends Base {
+      static {
+        this.tableName = "pull_requests";
+        this.primaryKey = "number";
+        this.attribute("number", "integer");
+        this.attribute("title", "string");
+      }
+    }
+    (PullRequest as unknown as { adapter: unknown }).adapter = makeAdapter();
+
+    reloadSchemaFromCache.call(Base as never);
+
+    expect(() => loadSchema.call(PullRequest as never)).not.toThrow();
+    expect(Object.keys(PullRequest.columnsHash())).toEqual(["number", "title"]);
+  });
+});

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -98,6 +98,28 @@ export function schemaStaleAgainstAncestors(host: SchemaHost): boolean {
 }
 
 /**
+ * A load that just ran read the *current* schema state, so the class is no
+ * longer behind any ancestor's invalidation: stamp its own revision at the
+ * current epoch, which is what {@link schemaStaleAgainstAncestors} compares
+ * against, and drop the verdict it memoized before the load.
+ *
+ * Without this, a class whose ancestor was invalidated after the subclass was
+ * defined — an ancestor reload cannot reach a subclass that never called
+ * `registerSubclass` — stays permanently stale, so {@link ownSchemaMemo} keeps
+ * answering `undefined` for a `_schemaLoaded` that is `true`. `load_schema`
+ * then re-enters the load it just finished, through the generation hook at the
+ * end of it, until the stack overflows. The reflected arms stamp a revision
+ * through `applyColumnsHash`; the synthesize arm below is the one that
+ * otherwise settles a load without ever recording that it ran.
+ *
+ * @internal
+ */
+function markSchemaFresh(host: SchemaHost): void {
+  host._schemaRevision = schemaEpoch;
+  host._staleCheck = undefined;
+}
+
+/**
  * Ruby class ivars are not inherited, but JS `static` members ARE — a bare
  * `this._columnsHash` read on a subclass would see the base's memo and skip the
  * subclass's own `load_schema!` (model_schema.rb:587-597).
@@ -1188,6 +1210,7 @@ function loadSchemaBangAnchor(this: SchemaHost): void {
     this._columnsHash = hash;
   }
   if (!pkStillMissing) {
+    markSchemaFresh(this);
     this._schemaLoaded = true;
     defineAttributeMethodsAfterLoad(this);
   }

--- a/scripts/sync-stats/expired-job-log.test.ts
+++ b/scripts/sync-stats/expired-job-log.test.ts
@@ -11,6 +11,15 @@ describe("isExpiredJobLogError", () => {
     ).toBe(true);
   });
 
+  it("recognizes the 410 gh returns for the oldest logs", () => {
+    expect(
+      isExpiredJobLogError(
+        "Command failed: gh api --allow-escape-sequences " +
+          "repos/blazetrailsdev/trails/actions/jobs/77412035438/logs\ngh: Server Error (HTTP 410)\n",
+      ),
+    ).toBe(true);
+  });
+
   it("does not claim a transient transport failure is expired", () => {
     expect(isExpiredJobLogError("stream error: stream ID 1; CANCEL; received from peer")).toBe(
       false,

--- a/scripts/sync-stats/expired-job-log.test.ts
+++ b/scripts/sync-stats/expired-job-log.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isExpiredJobLogError } from "./expired-job-log.js";
+
+describe("isExpiredJobLogError", () => {
+  it("recognizes the 404 gh returns for a log past its retention window", () => {
+    expect(
+      isExpiredJobLogError(
+        "Command failed: gh api --allow-escape-sequences " +
+          "repos/blazetrailsdev/trails/actions/jobs/79099858897/logs\ngh: HTTP 404\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not claim a transient transport failure is expired", () => {
+    expect(isExpiredJobLogError("stream error: stream ID 1; CANCEL; received from peer")).toBe(
+      false,
+    );
+    expect(isExpiredJobLogError("gh: HTTP 502 Bad Gateway")).toBe(false);
+  });
+});

--- a/scripts/sync-stats/expired-job-log.ts
+++ b/scripts/sync-stats/expired-job-log.ts
@@ -1,0 +1,11 @@
+// GitHub deletes workflow job logs after its retention window, so `gh api
+// .../jobs/<id>/logs` answers 404 forever for an old job. The nightly sync
+// selects unfetched jobs newest-first, so once every remaining job is past
+// retention the whole batch 404s, nothing is fetched, and the run dies on
+// JobLogFetchFailedError — which is how the 2026-08-21 catch-up run died after
+// the schema-recursion fix let it get that far.
+const EXPIRED_JOB_LOG_ERROR_RE = /HTTP 404/;
+
+export function isExpiredJobLogError(message: string): boolean {
+  return EXPIRED_JOB_LOG_ERROR_RE.test(message);
+}

--- a/scripts/sync-stats/expired-job-log.ts
+++ b/scripts/sync-stats/expired-job-log.ts
@@ -1,11 +1,12 @@
-// GitHub deletes workflow job logs after its retention window, so `gh api
-// .../jobs/<id>/logs` answers 404 forever for an old job. The nightly sync
-// selects unfetched jobs newest-first, so once every remaining job is past
-// retention the whole batch 404s, nothing is fetched, and the run dies on
-// JobLogFetchFailedError — which is how the 2026-08-21 catch-up run died after
-// the schema-recursion fix let it get that far.
-const EXPIRED_JOB_LOG_ERROR_RE = /HTTP 404/;
+const EXPIRED_JOB_LOG_ERROR_RE = /HTTP (404|410)/;
 
+/**
+ * True when `gh api .../actions/jobs/<id>/logs` failed because GitHub has aged
+ * the log out of its retention window — a permanent 404 or 410, not a transport
+ * blip worth retrying. Both codes appear in the same backlog: the newer jobs
+ * answer `HTTP 404` and the oldest answer `Server Error (HTTP 410)`. See
+ * {@link isTransientGhError} for the retryable set.
+ */
 export function isExpiredJobLogError(message: string): boolean {
   return EXPIRED_JOB_LOG_ERROR_RE.test(message);
 }

--- a/scripts/sync-stats/job-log-fetch.test.ts
+++ b/scripts/sync-stats/job-log-fetch.test.ts
@@ -19,8 +19,15 @@ describe("sync-stats job log fetch", () => {
   });
 
   it("fails the run when jobs were selected but no logs were fetched", () => {
-    expect(source).toMatch(/if \(fetched === 0\) \{\s*throw new JobLogFetchFailedError\(/);
+    expect(source).toMatch(
+      /if \(fetched === 0 && expired === 0\) \{\s*throw new JobLogFetchFailedError\(/,
+    );
     expect(source).toMatch(/class JobLogFetchFailedError extends Error/);
+  });
+
+  it("records a log past GitHub's retention window instead of retrying it forever", () => {
+    expect(source).toMatch(/if \(isExpiredJobLogError\(message\)\) \{/);
+    expect(source).toMatch(/NOT EXISTS \(\s*\n\s*SELECT 1 FROM expired_job_logs ejl/);
   });
 
   it("does not swallow the fetch failure as a rate-limit stop", () => {

--- a/scripts/sync-stats/job-log-fetch.test.ts
+++ b/scripts/sync-stats/job-log-fetch.test.ts
@@ -20,7 +20,7 @@ describe("sync-stats job log fetch", () => {
 
   it("fails the run when jobs were selected but no logs were fetched", () => {
     expect(source).toMatch(
-      /if \(fetched === 0 && expired === 0\) \{\s*throw new JobLogFetchFailedError\(/,
+      /if \(fetched === 0 && \(failed > 0 \|\| expired === 0\)\) \{\s*throw new JobLogFetchFailedError\(/,
     );
     expect(source).toMatch(/class JobLogFetchFailedError extends Error/);
   });
@@ -28,6 +28,11 @@ describe("sync-stats job log fetch", () => {
   it("records a log past GitHub's retention window instead of retrying it forever", () => {
     expect(source).toMatch(/if \(isExpiredJobLogError\(message\)\) \{/);
     expect(source).toMatch(/NOT EXISTS \(\s*\n\s*SELECT 1 FROM expired_job_logs ejl/);
+  });
+
+  it("does not let an expired log excuse a batch that also failed for other reasons", () => {
+    expect(source).toMatch(/failed\+\+;\s*\n\s*console\.warn\(/);
+    expect(source).not.toMatch(/if \(fetched === 0 && expired === 0\)/);
   });
 
   it("does not swallow the fetch failure as a rate-limit stop", () => {

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -43,9 +43,10 @@ class RateLimitExhaustedError extends Error {
 }
 
 class JobLogFetchFailedError extends Error {
-  constructor(selected: number) {
+  constructor(selected: number, expired: number, failed: number) {
     super(
-      `Job log fetch failed: selected ${selected} jobs and fetched 0. ` +
+      `Job log fetch failed: selected ${selected} jobs and fetched 0 ` +
+        `(${failed} failed, ${expired} past GitHub's retention window). ` +
         `The compare-stats feed is stalled; see the per-job warnings above.`,
     );
   }
@@ -2000,6 +2001,7 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   console.log(`Fetching logs for ${jobsToFetch.length} jobs...`);
   let fetched = 0;
   let expired = 0;
+  let failed = 0;
 
   for (const job of jobsToFetch) {
     const jobId = job.job_id as number;
@@ -2045,6 +2047,7 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
         expired++;
         continue;
       }
+      failed++;
       console.warn(
         `  Failed to fetch logs for job ${jobId} "${jobName}" (PR #${prNumber}): ${message}`,
       );
@@ -2055,8 +2058,8 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   if (expired > 0) {
     console.log(`  ${expired} job log(s) past GitHub's retention window — will not be retried`);
   }
-  if (fetched === 0 && expired === 0) {
-    throw new JobLogFetchFailedError(jobsToFetch.length);
+  if (fetched === 0 && (failed > 0 || expired === 0)) {
+    throw new JobLogFetchFailedError(jobsToFetch.length, expired, failed);
   }
   return fetched;
 }

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -9,6 +9,7 @@ import { parseTestCompareFromLogs } from "./parse-test-compare.js";
 import { parseCallSummariesFromLogs } from "./parse-call-summaries.js";
 import { classifyCompareStep } from "./classify-compare-step.js";
 import { isTransientGhError } from "./gh-transient-error.js";
+import { isExpiredJobLogError } from "./expired-job-log.js";
 
 const REPO = "blazetrailsdev/trails";
 const [REPO_OWNER, REPO_NAME] = REPO.split("/");
@@ -446,6 +447,17 @@ class RawJobLog extends Base {
   }
 }
 
+class ExpiredJobLog extends Base {
+  static {
+    this.tableName = "expired_job_logs";
+    this.primaryKey = "job_id";
+    this.attribute("job_id", "big_integer");
+    this.attribute("job_name", "string");
+    this.attribute("pr_number", "integer");
+    this.attribute("checked_at", "string");
+  }
+}
+
 class SyncLog extends Base {
   static {
     this.tableName = "sync_log";
@@ -700,6 +712,15 @@ async function migrateDb(adapter: SQLite3Adapter) {
       });
     }
 
+    if (!(await tableExists(adapter, "expired_job_logs"))) {
+      await adapter.createTable("expired_job_logs", { id: false }, (t) => {
+        t.integer("job_id", { primaryKey: true });
+        t.string("job_name");
+        t.integer("pr_number");
+        t.string("checked_at");
+      });
+    }
+
     return;
   }
 
@@ -946,6 +967,13 @@ async function migrateDb(adapter: SQLite3Adapter) {
       t.text("log_output");
       t.index(["merge_commit_sha"]);
       t.index(["run_id"]);
+    });
+
+    await adapter.createTable("expired_job_logs", { id: false }, (t) => {
+      t.integer("job_id", { primaryKey: true });
+      t.string("job_name");
+      t.integer("pr_number");
+      t.string("checked_at");
     });
 
     await adapter.createTable("sync_log", {}, (t) => {
@@ -1957,6 +1985,13 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
     AND NOT EXISTS (
       SELECT 1 FROM raw_job_logs rjl WHERE rjl.job_id = wj.id
     )
+    -- A log GitHub has already aged out 404s forever. Without this arm the
+    -- newest-first batch fills up with the same dead jobs every night, the run
+    -- fetches nothing, and JobLogFetchFailedError takes down a sync that has
+    -- no live work left to do.
+    AND NOT EXISTS (
+      SELECT 1 FROM expired_job_logs ejl WHERE ejl.job_id = wj.id
+    )
     ORDER BY wr.pr_number DESC, wj.run_id, wj.id
     ${limitClause}
   `);
@@ -1968,6 +2003,7 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
 
   console.log(`Fetching logs for ${jobsToFetch.length} jobs...`);
   let fetched = 0;
+  let expired = 0;
 
   for (const job of jobsToFetch) {
     const jobId = job.job_id as number;
@@ -1997,14 +2033,36 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
       }
     } catch (err) {
       if (err instanceof RateLimitExhaustedError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      if (isExpiredJobLogError(message)) {
+        await ExpiredJobLog.upsertAll(
+          [
+            {
+              job_id: jobId,
+              job_name: jobName,
+              pr_number: prNumber,
+              checked_at: new Date().toISOString(),
+            },
+          ],
+          { uniqueBy: "job_id" },
+        );
+        expired++;
+        continue;
+      }
       console.warn(
-        `  Failed to fetch logs for job ${jobId} "${jobName}" (PR #${prNumber}): ${err instanceof Error ? err.message : err}`,
+        `  Failed to fetch logs for job ${jobId} "${jobName}" (PR #${prNumber}): ${message}`,
       );
     }
   }
 
   console.log(`  Fetched ${fetched} job logs`);
-  if (fetched === 0) {
+  if (expired > 0) {
+    console.log(`  ${expired} job log(s) past GitHub's retention window — will not be retried`);
+  }
+  // Only a batch that neither fetched nor aged out is a stalled feed: an
+  // all-expired batch is the queue draining, and each of its jobs is now
+  // recorded so it never comes back.
+  if (fetched === 0 && expired === 0) {
     throw new JobLogFetchFailedError(jobsToFetch.length);
   }
   return fetched;

--- a/scripts/sync-stats/sync.ts
+++ b/scripts/sync-stats/sync.ts
@@ -1985,10 +1985,6 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
     AND NOT EXISTS (
       SELECT 1 FROM raw_job_logs rjl WHERE rjl.job_id = wj.id
     )
-    -- A log GitHub has already aged out 404s forever. Without this arm the
-    -- newest-first batch fills up with the same dead jobs every night, the run
-    -- fetches nothing, and JobLogFetchFailedError takes down a sync that has
-    -- no live work left to do.
     AND NOT EXISTS (
       SELECT 1 FROM expired_job_logs ejl WHERE ejl.job_id = wj.id
     )
@@ -2059,9 +2055,6 @@ async function syncJobLogs(mode: "latest" | "refresh" | "backfill"): Promise<num
   if (expired > 0) {
     console.log(`  ${expired} job log(s) past GitHub's retention window — will not be retried`);
   }
-  // Only a batch that neither fetched nor aged out is a stalled feed: an
-  // all-expired batch is the queue draining, and each of its jobs is now
-  // recorded so it never comes back.
   if (fetched === 0 && expired === 0) {
     throw new JobLogFetchFailedError(jobsToFetch.length);
   }


### PR DESCRIPTION
The nightly stats sync (`scripts/sync-stats/cron-wrapper.sh`, 06:00 America/New_York) died on its 2026-08-21 run with a bare `[ELIFECYCLE] Command failed with exit code 1.` Two distinct failures were in the way; both are fixed here, and the backlog is drained.

## 1. `RangeError: Maximum call stack size exceeded` in `load_schema`

The wrapper's log shows the real error under the ELIFECYCLE line:

```
RangeError: Maximum call stack size exceeded
    at PullRequest.loadSchemaBangAnchor (packages/activerecord/src/model-schema.ts:1129:30)
    ...
    at PullRequest.defineAttributeMethods (packages/activerecord/src/attribute-methods.ts:381:16)
```

`ownSchemaMemo` (`model-schema.ts:107`) refuses to serve a memo the class owns when `schemaStaleAgainstAncestors` says an ancestor was invalidated more recently — that pair is trails' stand-in for Ruby class ivars not being inherited where JS statics are (Rails' `schema_loaded?` is a plain `@schema_loaded` read, `model_schema.rb:583-585`).

Staleness compares `_schemaRevision` stamps, and only *invalidation* stamped one. `load_schema!`'s reflected arms get a stamp for free from `applyColumnsHash` (`model-schema.ts:1396`), but the attribute-defs **synthesize** arm settled the load without recording that it had run. So a class whose ancestor is invalidated after it was defined — an ancestor reload cannot reach a subclass that never called `registerSubclass` — stays permanently stale: `_schemaLoaded` is `true`, `ownSchemaMemo` keeps answering `undefined`, and `load_schema` re-enters the load it just finished through the generation hook at the end of it, forever.

The sync's models are exactly that shape: plain `extends Base` classes whose columns come from `attribute()` declarations, with no cached columns hash to reflect from.

Fix: `markSchemaFresh` stamps the class's own revision at the current epoch and drops the verdict memoized before the load, at the one arm that lacked it.

`packages/activerecord/src/model-schema-stale-against-ancestor-recursion.trails.test.ts` reproduces the production stack overflow and fails on baseline (verified: `RangeError: Maximum call stack size exceeded`).

## 2. `JobLogFetchFailedError` on a queue of aged-out logs

With the recursion fixed, the next run got as far as the job-log fetch and died there. `syncJobLogs` selects unfetched compare jobs newest-first; every job left in the queue was past GitHub's log-retention window, so all 50 answered `gh: HTTP 404`, `fetched === 0`, and the stalled-feed guard killed the run — and would have picked the same 50 dead jobs again every night.

Fix: a permanent expiry response is recorded in a new `expired_job_logs` table and excluded from the selection, so a job that can never be fetched stops being selected. The stalled-feed guard stays armed otherwise: a zero-fetch batch is tolerated only when *every* miss was an expiry. One aged-out job does not excuse a batch that also failed for real reasons — that would defer the outage to the next run instead of reporting it — and the error now names both counts.

GitHub uses two codes for this and the backlog contained both: the newer jobs answer `gh: HTTP 404`, the oldest answer `gh: Server Error (HTTP 410)`. `isExpiredJobLogError` matches both — matching only 404 left the run dying one batch later on the 410s.

## Backfill

`pnpm stats:sync --latest` now completes (exit 0), and the queue was run down until it reported **`All job logs already synced`** — the catch-up is finished, not left to the next scheduled run.

- **PRs:** 6788 rows (6579 merged, 199 closed, 10 open), latest **#6808** — this PR, with `Found 0 new PRs to sync` behind it.
- **Workflow runs:** 5664 (95996 jobs, 603349 steps, 28301 check annotations).
- **Compare rows:** 3911 commits with `parity:test` and `parity:api` stats, 3219 with `--privates`, 3905 with compare logs. The latest `parity:api` row reads `activerecord: 6166/6168 (100%)`, `activemodel: 725/725 (100%)`, `arel: 952/952 (100%)`.
- **79 job logs** GitHub has aged out are recorded in `expired_job_logs` instead of being retried every night forever.

## Verification

- `pnpm stats:sync --latest` — exit 0, and clean on a re-run (`All job logs already synced`).
- `pnpm vitest run` on the model-schema suite (7 files, 47 passed) and the attribute-methods suite (7 files, 215 passed).
- `pnpm vitest run scripts/sync-stats/` — 36 passed.
- `pnpm parity:api:calls` — OK (894 baselined, unchanged). `pnpm parity:api:calls:args` — OK (169 shape rows, unchanged). No baseline row added.
- `pnpm typecheck`, `pnpm lint` — clean.

No change to the cron schedule or the wrapper's alerting behaviour.

Closes-story: stats-sync-20260821
