### PR TITLE
refactor(activerecord,trailties): converge HashConfig#primary?, MySQL build_explain_clause and Relation#scoping

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -56,8 +56,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("explain with options as symbol", async () => {
       // Rails: Author.where(id: 1).explain(explain_option)
       const result = await Author.where({ id: authors("david").id }).explain(explainOpt);
-      // Our header appends " for:" where Rails prints a bare clause.
-      expect(result).toContain(`${expectedClause} for:`);
+      expect(result).toContain(expectedClause);
       expect(result).toContain("SELECT `authors`");
     });
 
@@ -66,7 +65,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const result = await Author.where({ id: authors("david").id }).explain(
         explainOpt.toUpperCase(),
       );
-      expect(result).toContain(`${expectedClause} for:`);
+      expect(result).toContain(expectedClause);
       expect(result).toContain("SELECT `authors`");
     });
 
@@ -75,7 +74,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const result = await Author.where({ id: authors("david").id })
         .includes(":posts")
         .explain(explainOpt);
-      expect(result).toContain(`${expectedClause} for:`);
+      expect(result).toContain(expectedClause);
       const blocks = result.split("\n\n").filter((b) => /EXPLAIN|ANALYZE/.test(b));
       expect(blocks.length).toBeGreaterThanOrEqual(2);
     });
@@ -99,7 +98,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const plan = await Author.where({ id: authors("david").id }).explain();
       expect(plan).toContain("`authors`");
       expect(plan).not.toMatch(/"authors"/);
-      expect(plan).toMatch(/EXPLAIN.*for:/);
+      expect(plan).toMatch(/EXPLAIN SELECT/);
     });
 
     // trails-only regression: an already-loaded relation must still re-execute
@@ -115,7 +114,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const plan = await relation.explain();
       expect(plan).toContain("`authors`");
       expect(plan).not.toMatch(/"authors"/);
-      expect(plan).toMatch(/EXPLAIN.*for:/);
+      expect(plan).toMatch(/EXPLAIN SELECT/);
     });
 
     it("Relation#explain on MySQL captures preload queries", async () => {
@@ -141,7 +140,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   describe("explain helpers (trails-only)", () => {
     it("buildExplainClause renders FORMAT=JSON without parens for { format: 'json' }", async () => {
       const clause = await adapter.buildExplainClause([{ format: "json" }]);
-      expect(clause).toBe("EXPLAIN FORMAT=JSON for:");
+      expect(clause).toBe("EXPLAIN FORMAT=JSON");
     });
 
     it("buildExplainClause combines string flag and format hash space-separated", async () => {
@@ -150,12 +149,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const analyzeWithoutExplain =
         isMariaDb && (await adapter.databaseVersion).compare("10.1.0") >= 0;
       expect(clause).toBe(
-        analyzeWithoutExplain ? "ANALYZE FORMAT=JSON for:" : "EXPLAIN ANALYZE FORMAT=JSON for:",
+        analyzeWithoutExplain ? "ANALYZE FORMAT=JSON" : "EXPLAIN ANALYZE FORMAT=JSON",
       );
-    });
-
-    it("buildExplainClause rejects unknown format", async () => {
-      await expect(adapter.buildExplainClause([{ format: "bogus" }])).rejects.toThrow();
     });
 
     it("explain executes with { format: 'json' } and returns JSON plan", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -4,7 +4,6 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter
  */
 
-import { inspectExplainOption } from "./abstract/database-statements.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
 import type { InsertBuilder } from "../insert-all.js";
 import { type Nodes, Visitors, Collectors, relationName } from "@blazetrails/arel";
@@ -939,32 +938,6 @@ export class AbstractAdapter implements Quoting {
   /** Stable per-instance hex slot + monotonic source for {@link inspect}. @internal */
   private _inspectId?: number;
   private static _inspectSeq?: number;
-
-  /**
-   * Default header prefix for `Relation#explain` output. Concrete adapters
-   * (PG: `"EXPLAIN (ANALYZE, VERBOSE) for:"`; MySQL: `"EXPLAIN ANALYZE for:"`)
-   * override to include adapter-specific flags. SQLite has no override — it
-   * inherits this default `"EXPLAIN for:"` (the `EXPLAIN QUERY PLAN` keyword
-   * belongs to the executed plan query, not the printed header).
-   *
-   * Mirrors Rails' `ActiveRecord::Explain#build_explain_clause` fallback:
-   * Rails' `AbstractAdapter` defines no `build_explain_clause`; the
-   * `"EXPLAIN for:"` default lives in the `ActiveRecord::Explain` module and
-   * only the PG/MySQL adapters carry a private override.
-   */
-  async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
-    if (options.length === 0) return "EXPLAIN for:";
-    const parts = options.map((o) => {
-      if (typeof o === "string") return o.toUpperCase();
-      if (o && typeof o === "object" && typeof o.format === "string") {
-        return `FORMAT ${o.format.toUpperCase()}`;
-      }
-      throw new TypeError(
-        `EXPLAIN option hash requires a string 'format'; got ${inspectExplainOption(o)}`,
-      );
-    });
-    return `EXPLAIN (${parts.join(", ")}) for:`;
-  }
 
   /**
    * Quote a value for inclusion in a SQL literal. Concrete adapters

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -14,6 +14,7 @@ import {
   returningColumnValues as mysqlReturningColumnValues,
   buildExplainClause as mysqlBuildExplainClause,
 } from "./mysql/database-statements.js";
+import type { ExplainOption } from "./abstract/database-statements.js";
 import { Result } from "../result.js";
 import { isRubyTruthy } from "../ruby-truthy.js";
 import { rubyInspect } from "../relation/ruby-inspect.js";
@@ -1327,7 +1328,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * body lives in `mysql/database-statements.ts` like `write_query?` and
    * `returning_column_values`.
    */
-  buildExplainClause = mysqlBuildExplainClause;
+  buildExplainClause(options: ExplainOption[] = []): Promise<string> {
+    return mysqlBuildExplainClause.call(this, options);
+  }
 
   /**
    * @internal

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -8,12 +8,11 @@
  * transaction handling, and advisory lock support.
  */
 
-import { inspectExplainOption } from "./abstract/database-statements.js";
-import type { ExplainOption } from "./abstract/database-statements.js";
 import {
   isWriteQuery as mysqlIsWriteQuery,
   maxAllowedPacket as mysqlMaxAllowedPacket,
   returningColumnValues as mysqlReturningColumnValues,
+  buildExplainClause as mysqlBuildExplainClause,
 } from "./mysql/database-statements.js";
 import { Result } from "../result.js";
 import { isRubyTruthy } from "../ruby-truthy.js";
@@ -1323,99 +1322,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static readonly ER_CLIENT_INTERACTION_TIMEOUT = ER_CLIENT_INTERACTION_TIMEOUT;
 
   /**
-   * Boolean MySQL EXPLAIN flags. MySQL 8.0.18+ supports `EXPLAIN
-   * ANALYZE`; older versions and MariaDB support at least `EXTENDED`
-   * and `PARTITIONS`. Format is handled separately via the
-   * `{ format: ... }` hash since it requires a value.
+   * Mirrors: MySQL::DatabaseStatements#build_explain_clause
+   * (`mysql/database_statements.rb:36-46`), included into the adapter — the
+   * body lives in `mysql/database-statements.ts` like `write_query?` and
+   * `returning_column_values`.
    */
-  protected static readonly EXPLAIN_FLAGS = new Set(["analyze", "extended", "partitions"]);
-
-  /**
-   * Allowed values for the `format` keyword. MySQL 5.6+ supports
-   * `TRADITIONAL` (default) and `JSON`; 8.0.16+ adds `TREE`. Values
-   * come from user code, so the allowlist guards the SQL clause.
-   */
-  protected static readonly EXPLAIN_FORMATS = new Set(["traditional", "json", "tree"]);
-
-  /**
-   * Build the printed header prefix used by `Relation#explain` on MySQL
-   * (`"EXPLAIN ANALYZE FORMAT=JSON for:"`). The clause shape is
-   * driver-independent.
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
-   */
-  override async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
-    if (options.length === 0) return "EXPLAIN for:";
-    return `${await this._explainClause(options)} for:`;
-  }
-
-  /**
-   * MariaDB ≥ 10.1.0 runs `ANALYZE <stmt>` rather than `EXPLAIN ANALYZE
-   * <stmt>` — the leading EXPLAIN keyword is dropped. Other servers keep
-   * the `EXPLAIN` prefix. https://mariadb.com/kb/en/analyze-statement/
-   *
-   * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#analyze_without_explain?
-   */
-  protected async analyzeWithoutExplain(): Promise<boolean> {
-    return (await this.isMariadb()) && (await this.databaseVersion).compare("10.1.0") >= 0;
-  }
-
-  /**
-   * Compose the `EXPLAIN ...` clause shared by the printed header
-   * (`buildExplainClause`) and the actual statement prefix
-   * (`_explainStatementClause`), applying the MariaDB `ANALYZE`-without-
-   * `EXPLAIN` rewrite. Mirrors MySQL::DatabaseStatements#build_explain_clause.
-   */
-  private async _explainClause(options: ExplainOption[]): Promise<string> {
-    const clause = `EXPLAIN ${this._validateExplainOptions(options).join(" ")}`;
-    return (await this.analyzeWithoutExplain()) && clause.includes("ANALYZE")
-      ? clause.replace("EXPLAIN ", "")
-      : clause;
-  }
-
-  protected _validateExplainOptions(options: ExplainOption[]): string[] {
-    const ctor = this.constructor as typeof AbstractMysqlAdapter;
-    const flags: string[] = [];
-    let formatClause: string | undefined;
-    for (const o of options) {
-      if (typeof o === "string") {
-        const key = o.toLowerCase();
-        if (!ctor.EXPLAIN_FLAGS.has(key)) {
-          throw new Error(`Unknown MySQL EXPLAIN option: ${o}`);
-        }
-        flags.push(key.toUpperCase());
-        continue;
-      }
-      if (!o || typeof o !== "object" || typeof o.format !== "string") {
-        throw new Error(
-          `Unknown MySQL EXPLAIN option: ${inspectExplainOption(o)} (expected a string flag or an object with a string 'format')`,
-        );
-      }
-      if (formatClause !== undefined) {
-        throw new Error("MySQL EXPLAIN accepts at most one FORMAT option");
-      }
-      const fmt = o.format.toLowerCase();
-      if (!ctor.EXPLAIN_FORMATS.has(fmt)) {
-        throw new Error(
-          `Unknown MySQL EXPLAIN format: ${o.format}. Allowed: traditional, json, tree.`,
-        );
-      }
-      // MySQL uses `FORMAT=X` (no space) rather than PG's `FORMAT X`.
-      // FORMAT must come last in MySQL syntax; flags-first normalization
-      // prevents `EXPLAIN FORMAT=JSON ANALYZE ...` (invalid).
-      formatClause = `FORMAT=${fmt.toUpperCase()}`;
-    }
-    return formatClause === undefined ? flags : [...flags, formatClause];
-  }
-
-  /**
-   * Compose the actual `EXPLAIN ...` SQL clause that prefixes the query —
-   * distinct from `buildExplainClause`, which builds the printed header.
-   */
-  protected async _explainStatementClause(options: ExplainOption[]): Promise<string> {
-    if (options.length === 0) return "EXPLAIN";
-    return this._explainClause(options);
-  }
+  buildExplainClause = mysqlBuildExplainClause;
 
   /**
    * @internal

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -15,7 +15,6 @@ async function withBaseConfigs(
 ): Promise<void> {
   const prevConfigs = Base.configurations();
   const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
-  const prevCurrent = (DatabaseConfigurations as any).current;
   if (opts.defaultEnv) {
     DatabaseConfigurations.defaultEnv = opts.defaultEnv;
     vi.stubEnv("TRAILS_ENV", opts.defaultEnv);
@@ -26,7 +25,6 @@ async function withBaseConfigs(
   } finally {
     Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
-    (DatabaseConfigurations as any).current = prevCurrent;
     if (opts.defaultEnv) vi.unstubAllEnvs();
     await Base.connectionHandler.clearAllConnectionsBang();
   }

--- a/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
@@ -26,7 +26,6 @@ describe("ConnectionSwappingNestedTest", () => {
 
   let prevConfigs: DatabaseConfigurations;
   let prevDefaultEnv: string;
-  let prevCurrent: unknown;
 
   const DB_NAMES = [
     "primary",
@@ -79,7 +78,6 @@ describe("ConnectionSwappingNestedTest", () => {
 
     prevConfigs = Base.configurations();
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
-    prevCurrent = (DatabaseConfigurations as any).current;
     DatabaseConfigurations.defaultEnv = "default_env";
     vi.stubEnv("TRAILS_ENV", "default_env");
   });
@@ -95,7 +93,6 @@ describe("ConnectionSwappingNestedTest", () => {
     }
     Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
-    (DatabaseConfigurations as any).current = prevCurrent;
     (PrimaryBase as any).connectionClass = false;
     (SecondaryBase as any).connectionClass = false;
     (TertiaryBase as any).connectionClass = false;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1275,7 +1275,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     binds: unknown[] = [],
     options: ExplainOption[] = [],
   ): Promise<string> {
-    const clause = await this._explainStatementClause(options);
+    const clause = await this.buildExplainClause(options);
     const start = Date.now();
     const result = await this.internalExecQuery(`${clause} ${sql}`, "EXPLAIN", binds);
     const elapsed = (Date.now() - start) / 1000;
@@ -1287,9 +1287,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // which delegates to `mysql/quoting.ts`. No Mysql2-specific override
   // needed — they'd be duplicates.
   //
-  // `buildExplainClause` / `_validateExplainOptions` / `_explainStatementClause`
-  // and the EXPLAIN_FLAGS / EXPLAIN_FORMATS allowlists live on
-  // AbstractMysqlAdapter.
+  // `buildExplainClause` lives on AbstractMysqlAdapter.
 
   /**
    * Execute raw SQL (for DDL and other non-query statements).

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2328,7 +2328,7 @@ export class PostgreSQLAdapter
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#build_explain_clause
    * (postgresql/database_statements.rb:96-100)
    */
-  override async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
+  async buildExplainClause(options: ExplainOption[] = []): Promise<string> {
     if (options.length === 0) return "EXPLAIN";
     const parts = this._validateExplainOptions(options);
     return `EXPLAIN (${parts.join(", ")})`;

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -509,10 +509,6 @@ describe("ConnectionHandlingTest", () => {
     const { HashConfig } = await import("./database-configurations/hash-config.js");
     const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
 
-    // _currentConfigurations is a module-level singleton that the
-    // DatabaseConfigurations constructor mutates as a side effect.
-    // Snapshot it so test ordering can't pin the wrong registry.
-    const priorCurrent = (DatabaseConfigurations as any).current;
     const priorConfigs = Base.configurations();
     class InMemoryModel extends Base {}
     try {
@@ -539,7 +535,6 @@ describe("ConnectionHandlingTest", () => {
       // tests in this file do.
       InMemoryModel.removeConnection();
       Base.configurations(priorConfigs);
-      (DatabaseConfigurations as any).current = priorCurrent;
     }
   });
 
@@ -552,7 +547,6 @@ describe("ConnectionHandlingTest", () => {
     const { UrlConfig } = await import("./database-configurations/url-config.js");
     const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
 
-    const priorCurrent = (DatabaseConfigurations as any).current;
     const priorConfigs = Base.configurations();
     class WorkerModel extends Base {}
     try {
@@ -577,7 +571,6 @@ describe("ConnectionHandlingTest", () => {
     } finally {
       await WorkerModel.removeConnection();
       Base.configurations(priorConfigs);
-      (DatabaseConfigurations as any).current = priorCurrent;
     }
   });
 
@@ -775,21 +768,15 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
 });
 
 describe("resolveConfigForConnection / connectsTo with unset configurations", () => {
-  let prevCurrentConfigs: unknown;
   let prevBaseConfigs: DatabaseConfigurations;
 
   beforeEach(async () => {
     const { DatabaseConfigurations } = await import("./database-configurations.js");
-    prevCurrentConfigs = (DatabaseConfigurations as any).current;
     prevBaseConfigs = Base.configurations();
   });
 
   afterEach(async () => {
     const { DatabaseConfigurations } = await import("./database-configurations.js");
-    // fromEnv({}) mutates DatabaseConfigurations.current (the primary-config
-    // registry HashConfig#isPrimary consults), so save and restore it here
-    // — clearing connections alone leaves a stale primary registry behind.
-    (DatabaseConfigurations as any).current = prevCurrentConfigs;
     Base.configurations(prevBaseConfigs);
     await Base.connectionHandler.clearAllConnectionsBang();
     delete (Base as any)._connectionSpecificationName;

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -5,12 +5,7 @@ import {
   type DatabaseConfigOptions,
   _setDefaultEnvGetter,
 } from "./database-configurations/database-config.js";
-import { HashConfig, _setPrimaryChecker } from "./database-configurations/hash-config.js";
-
-// Track the most recently created DatabaseConfigurations instance so
-// HashConfig.isPrimary() can check it globally. Matches Rails where
-// HashConfig#primary? calls Base.configurations.primary?(name).
-let _currentConfigurations: DatabaseConfigurations | null = null;
+import { HashConfig } from "./database-configurations/hash-config.js";
 import { UrlConfig } from "./database-configurations/url-config.js";
 
 export class InvalidConfigurationError extends Error {
@@ -64,10 +59,6 @@ export function configurationsStore(): DatabaseConfigurations {
 /** @internal */
 export function setConfigurationsStore(configs: DatabaseConfigurations): void {
   _configurations = configs;
-  // Rails has one @@configurations, so `primary?` always answers from whatever
-  // Base.configurations= last stored (core.rb:71-79). Assigning an existing
-  // instance must re-register it, not just the constructor/fromRaw paths.
-  _currentConfigurations = configs;
 }
 
 export class DatabaseConfigurations {
@@ -140,23 +131,6 @@ export class DatabaseConfigurations {
     );
   }
 
-  /**
-   * The DatabaseConfigurations instance most recently registered (via
-   * constructor or explicit set). `HashConfig.isPrimary` consults it,
-   * matching Rails' `Base.configurations.primary?(name)`.
-   *
-   * Exposed so callers that temporarily swap configurations (e.g. the
-   * trailties CLI's `runProtectedEnvCheck`) can capture and restore the
-   * singleton without having to re-instantiate it.
-   */
-  static get current(): DatabaseConfigurations | null {
-    return _currentConfigurations;
-  }
-
-  static set current(value: DatabaseConfigurations | null) {
-    _currentConfigurations = value;
-  }
-
   private _configurations: DatabaseConfig[];
 
   constructor(configurations: RawConfigurations | DatabaseConfig[] = {}) {
@@ -169,8 +143,6 @@ export class DatabaseConfigurations {
       // not NODE_ENV — matching Rails' env resolution semantics.
       this._configurations = this.buildConfigs(configurations);
     }
-    // Register this instance as the current one for HashConfig.isPrimary lookup
-    _currentConfigurations = this;
   }
 
   /**
@@ -183,7 +155,6 @@ export class DatabaseConfigurations {
   static fromRaw(configurations: RawConfigurations = {}): DatabaseConfigurations {
     const instance = new DatabaseConfigurations([]);
     instance._configurations = instance.buildConfigs(configurations);
-    _currentConfigurations = instance;
     return instance;
   }
 
@@ -527,7 +498,3 @@ DatabaseConfigurations.registerDbConfigHandler((envName, name, url, config) => {
 // call ConnectionHandling::DEFAULT_ENV.call
 // (Rails.env → RAILS_ENV → RACK_ENV → the literal default).
 _setDefaultEnvGetter(() => DatabaseConfigurations.currentEnv());
-
-// Register the primary checker so HashConfig.isPrimary can consult the
-// current DatabaseConfigurations instance (matching Rails' global Base.configurations).
-_setPrimaryChecker((name) => _currentConfigurations?.isPrimary(name) ?? false);

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -8,16 +8,8 @@
  * Creates a HashConfig with envName="development", name="primary",
  * and configuration={ database: "db_name" }.
  */
+import { configurationsStore } from "../database-configurations.js";
 import { DatabaseConfig, type DatabaseConfigOptions } from "./database-config.js";
-
-// Late-bound reference to the global configurations — set by
-// database-configurations.ts to break circular dependency.
-let _primaryChecker: ((name: string) => boolean) | null = null;
-
-/** @internal */
-export function _setPrimaryChecker(fn: (name: string) => boolean): void {
-  _primaryChecker = fn;
-}
 
 export class HashConfig extends DatabaseConfig {
   constructor(envName: string, name: string, configuration: DatabaseConfigOptions = {}) {
@@ -27,12 +19,12 @@ export class HashConfig extends DatabaseConfig {
   /**
    * Mirrors: HashConfig#primary?
    *
-   * True if this config is the primary database for its environment.
-   * Named "primary" is always primary; otherwise checks global configurations.
+   * Asks the one global registry, exactly as Rails does — the store is read
+   * at call time, so the import back into `database-configurations.ts` never
+   * needs the module to have finished evaluating.
    */
   isPrimary(): boolean {
-    if (this.name === "primary") return true;
-    return _primaryChecker ? _primaryChecker(this.name) : false;
+    return configurationsStore().isPrimary(this.name);
   }
 
   /**

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -8,7 +8,7 @@
  * Creates a HashConfig with envName="development", name="primary",
  * and configuration={ database: "db_name" }.
  */
-import { configurationsStore } from "../database-configurations.js";
+import { configurationsStore as configurations } from "../database-configurations.js";
 import { DatabaseConfig, type DatabaseConfigOptions } from "./database-config.js";
 
 export class HashConfig extends DatabaseConfig {
@@ -19,12 +19,14 @@ export class HashConfig extends DatabaseConfig {
   /**
    * Mirrors: HashConfig#primary?
    *
-   * Asks the one global registry, exactly as Rails does — the store is read
-   * at call time, so the import back into `database-configurations.ts` never
-   * needs the module to have finished evaluating.
+   * `Base.configurations` reads the one process-global registry and takes no
+   * receiver, so `configurations()` here is that same `@@configurations`
+   * (`core.rb:71-79`) under its Rails name. It is read at call time, so the
+   * import back into `database-configurations.ts` never needs that module to
+   * have finished evaluating.
    */
   isPrimary(): boolean {
-    return configurationsStore().isPrimary(this.name);
+    return configurations().isPrimary(this.name);
   }
 
   /**

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -5,6 +5,7 @@ import { InternalMetadata } from "./internal-metadata.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
 import { NullPool } from "./connection-adapters/abstract/connection-pool.js";
+import { toSqlAndBinds } from "./connection-adapters/abstract/database-statements.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
 function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
@@ -66,6 +67,35 @@ describe("InternalMetadata built from a connection pool", () => {
 
     await internalMetadata.createTable();
     expect(await internalMetadata.tableExists()).toBe(true);
+  });
+});
+
+describe("InternalMetadata#selectEntry", () => {
+  // `select_entry` wraps the key in `Arel::Nodes::BindParam`
+  // (internal_metadata.rb:157), so the key travels as a bind rather than being
+  // inlined at compile time. A create+find roundtrip cannot see the difference,
+  // so this asserts on the SQL the manager compiles to.
+  it("sends the key as a bind rather than inlining it", async () => {
+    const internalMetadata = new InternalMetadata(Base.connectionPool());
+    await internalMetadata.createTable();
+    const connection = await Base.connectionPool().checkout();
+    const selectAll = vi.spyOn(connection, "selectAll");
+    try {
+      await (
+        internalMetadata as unknown as {
+          selectEntry(c: DatabaseAdapter, key: string): Promise<unknown>;
+        }
+      ).selectEntry(connection, "environment");
+      const [sql, binds] = toSqlAndBinds.call(
+        connection as never,
+        selectAll.mock.calls[0][0] as never,
+      );
+      expect(sql).not.toContain("environment");
+      expect(binds).toEqual(["environment"]);
+    } finally {
+      selectAll.mockRestore();
+      Base.connectionPool().checkin(connection);
+    }
   });
 });
 

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -6,6 +6,7 @@ import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
 import { NullPool } from "./connection-adapters/abstract/connection-pool.js";
 import { toSqlAndBinds } from "./connection-adapters/abstract/database-statements.js";
+import { Nodes } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
 function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
@@ -71,10 +72,7 @@ describe("InternalMetadata built from a connection pool", () => {
 });
 
 describe("InternalMetadata#selectEntry", () => {
-  // `select_entry` wraps the key in `Arel::Nodes::BindParam`
-  // (internal_metadata.rb:157), so the key travels as a bind rather than being
-  // inlined at compile time. A create+find roundtrip cannot see the difference,
-  // so this asserts on the SQL the manager compiles to.
+  // internal_metadata.rb:157
   it("sends the key as a bind rather than inlining it", async () => {
     const internalMetadata = new InternalMetadata(Base.connectionPool());
     await internalMetadata.createTable();
@@ -86,12 +84,21 @@ describe("InternalMetadata#selectEntry", () => {
           selectEntry(c: DatabaseAdapter, key: string): Promise<unknown>;
         }
       ).selectEntry(connection, "environment");
-      const [sql, binds] = toSqlAndBinds.call(
-        connection as never,
-        selectAll.mock.calls[0][0] as never,
-      );
-      expect(sql).not.toContain("environment");
-      expect(binds).toEqual(["environment"]);
+      const sm = selectAll.mock.calls[0][0] as {
+        constraints: { right: unknown }[];
+      };
+      const right = sm.constraints[0].right as Nodes.BindParam;
+      expect(right).toBeInstanceOf(Nodes.BindParam);
+      expect(right.value).toBe("environment");
+
+      // A substituting adapter (prepared statements off — MySQL's default)
+      // renders the same node as a literal, so the placeholder is only
+      // observable where the binds actually travel separately.
+      if ((connection as unknown as { preparedStatements?: boolean }).preparedStatements) {
+        const [sql, binds] = toSqlAndBinds.call(connection as never, sm as never);
+        expect(sql).not.toContain("environment");
+        expect(binds).toEqual(["environment"]);
+      }
     } finally {
       selectAll.mockRestore();
       Base.connectionPool().checkin(connection);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3025,6 +3025,10 @@ export class Relation<T extends Base> {
    * restore rides on it instead of firing under the still-running body. The
    * check is `instanceof Promise` rather than a thenable test because a
    * `Relation` is itself thenable, and `_execScope`'s block answers one.
+   *
+   * Rails defaults `all_queries` to `false` and `_exec_scope` omits it; a TS
+   * default cannot sit usefully before the required block parameter, so the
+   * one caller that relies on the default passes `false` outright.
    */
   private _scoping<R>(scope: any, registry: any, allQueries: boolean | null, fn: () => R): R {
     const previous = registry.currentScope(this.model, true);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3017,7 +3017,15 @@ export class Relation<T extends Base> {
     return (this.model as any).createBang(attributes, block);
   }
 
-  // Mirrors relation.rb:1365-1379.
+  /**
+   * Mirrors: ActiveRecord::Relation#_scoping (`relation.rb:1365-1379`).
+   *
+   * Ruby's `ensure` runs once the block has finished, where a JS `finally`
+   * fires the moment an async body yields — so when `fn` answers a promise the
+   * restore rides on it instead of firing under the still-running body. The
+   * check is `instanceof Promise` rather than a thenable test because a
+   * `Relation` is itself thenable, and `_execScope`'s block answers one.
+   */
   private _scoping<R>(scope: any, registry: any, allQueries: boolean | null, fn: () => R): R {
     const previous = registry.currentScope(this.model, true);
     registry.setCurrentScope(this.model, scope);
@@ -3026,9 +3034,6 @@ export class Relation<T extends Base> {
       previousGlobal = registry.globalCurrentScope(this.model, true);
       registry.setGlobalCurrentScope(this.model, scope);
     }
-    // Ruby's `ensure` runs after the block has finished; a JS `finally` runs as
-    // soon as an async block yields, so an awaitable result has to carry the
-    // restore rather than have it fire under the still-running body.
     const ensure = () => {
       registry.setCurrentScope(this.model, previous);
       if (allQueries) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2681,7 +2681,6 @@ export class Relation<T extends Base> {
     const allQueries =
       typeof optionsOrCallback === "function" ? null : (optionsOrCallback.allQueries ?? null);
 
-    const modelClass = this.model as any;
     const registry = this.model.scopeRegistry();
 
     // Rails: global_scope? && all_queries == false → raise.
@@ -2697,21 +2696,7 @@ export class Relation<T extends Base> {
       return await callback();
     }
 
-    const prev = registry.currentScope(modelClass, true);
-    registry.setCurrentScope(modelClass, this as any);
-    let prevGlobal: any;
-    if (allQueries) {
-      prevGlobal = registry.globalCurrentScope(modelClass, true);
-      registry.setGlobalCurrentScope(modelClass, this as any);
-    }
-    try {
-      return await callback();
-    } finally {
-      registry.setCurrentScope(modelClass, prev);
-      if (allQueries) {
-        registry.setGlobalCurrentScope(modelClass, prevGlobal);
-      }
-    }
+    return await this._scoping(this as any, registry, allQueries, async () => await callback());
   }
 
   /**
@@ -2985,7 +2970,7 @@ export class Relation<T extends Base> {
     this._delegateToModel = true;
     const registry = this.model.scopeRegistry();
     try {
-      return this._scoping(null, registry, () => fn(this, ...args) || this);
+      return this._scoping(null, registry, false, () => fn(this, ...args) || this);
     } finally {
       this._delegateToModel = false;
     }
@@ -3032,14 +3017,45 @@ export class Relation<T extends Base> {
     return (this.model as any).createBang(attributes, block);
   }
 
-  private _scoping<R>(scope: any, registry: any, fn: () => R): R {
-    const previous = registry?.currentScope?.(this.model, true);
-    registry?.setCurrentScope?.(this.model, scope);
-    try {
-      return fn();
-    } finally {
-      registry?.setCurrentScope?.(this.model, previous);
+  // Mirrors relation.rb:1365-1379.
+  private _scoping<R>(scope: any, registry: any, allQueries: boolean | null, fn: () => R): R {
+    const previous = registry.currentScope(this.model, true);
+    registry.setCurrentScope(this.model, scope);
+    let previousGlobal: any;
+    if (allQueries) {
+      previousGlobal = registry.globalCurrentScope(this.model, true);
+      registry.setGlobalCurrentScope(this.model, scope);
     }
+    // Ruby's `ensure` runs after the block has finished; a JS `finally` runs as
+    // soon as an async block yields, so an awaitable result has to carry the
+    // restore rather than have it fire under the still-running body.
+    const ensure = () => {
+      registry.setCurrentScope(this.model, previous);
+      if (allQueries) {
+        registry.setGlobalCurrentScope(this.model, previousGlobal);
+      }
+    };
+    let result: R;
+    try {
+      result = fn();
+    } catch (error) {
+      ensure();
+      throw error;
+    }
+    if (result instanceof Promise) {
+      return result.then(
+        (value: unknown) => {
+          ensure();
+          return value;
+        },
+        (error: unknown) => {
+          ensure();
+          throw error;
+        },
+      ) as R;
+    }
+    ensure();
+    return result;
   }
 
   // Mirrors relation.rb:1381-1393.

--- a/packages/activerecord/src/shard-keys.test.ts
+++ b/packages/activerecord/src/shard-keys.test.ts
@@ -15,7 +15,6 @@ describe("ShardsKeysTest", () => {
 
   let prevConfigs: DatabaseConfigurations;
   let prevDefaultEnv: string;
-  let prevCurrent: unknown;
 
   let baselinePools: Set<unknown>;
 
@@ -23,7 +22,6 @@ describe("ShardsKeysTest", () => {
     baselinePools = new Set(Base.connectionHandler.connectionPoolList("all"));
     prevConfigs = Base.configurations();
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
-    prevCurrent = (DatabaseConfigurations as any).current;
     DatabaseConfigurations.defaultEnv = "default_env";
     vi.stubEnv("TRAILS_ENV", "default_env");
     Base.configurations({
@@ -57,7 +55,6 @@ describe("ShardsKeysTest", () => {
     }
     Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
-    (DatabaseConfigurations as any).current = prevCurrent;
     (Base as any)._shardKeys = undefined;
     vi.unstubAllEnvs();
   });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1621,9 +1621,6 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
     // registration the test bootstrap installs (support/connection.ts:396).
     const createSpy = vi.spyOn(DatabaseTasks, "create").mockResolvedValue(undefined);
     const previousConfiguration = DatabaseTasks.databaseConfiguration;
-    // The DatabaseConfigurations constructor installs itself as the module-level
-    // current-configurations singleton, so that needs restoring too.
-    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [DatabaseTasks.env]: { adapter: "sqlite3", database: "db/other.sqlite3" },
     });
@@ -1634,7 +1631,6 @@ describe("DatabaseTasksWithTemporaryPoolTest", () => {
     } finally {
       createSpy.mockRestore();
       DatabaseTasks.databaseConfiguration = previousConfiguration;
-      DatabaseConfigurations.current = previousCurrent;
     }
   });
 });

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -27,17 +27,14 @@ afterAll(() => {
 
 describe("TestDatabasesTest", () => {
   fixtures({});
-  let priorCurrent: DatabaseConfigurations | null;
   let priorConfigs: DatabaseConfigurations;
   beforeEach(() => {
-    priorCurrent = DatabaseConfigurations.current;
     priorConfigs = Base.configurations();
   });
   // Mirrors the Rails case's `ensure ActiveRecord::Base.configurations =
   // prev_configs` (test_databases_test.rb:51).
   afterEach(() => {
     Base.configurations(priorConfigs);
-    DatabaseConfigurations.current = priorCurrent;
     vi.restoreAllMocks();
   });
 

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1318,18 +1318,13 @@ export class CreatePosts extends Migration {
       new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
-    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = configurations;
     try {
       await expect(
         DatabaseTasks.checkProtectedEnvironmentsBang("production"),
       ).rejects.toBeInstanceOf(ProtectedEnvironmentError);
     } finally {
-      // DatabaseConfigurations constructor registers itself as the
-      // module-level current-configurations singleton — restore that too,
-      // not just DatabaseTasks.databaseConfiguration.
       DatabaseTasks.databaseConfiguration = previous;
-      DatabaseConfigurations.current = previousCurrent;
     }
   });
 
@@ -1363,7 +1358,6 @@ export class CreatePosts extends Migration {
       new HashConfig("development", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
-    const previousCurrent = DatabaseConfigurations.current;
     DatabaseTasks.databaseConfiguration = configurations;
     try {
       await expect(
@@ -1371,7 +1365,6 @@ export class CreatePosts extends Migration {
       ).rejects.toBeInstanceOf(EnvironmentMismatchError);
     } finally {
       DatabaseTasks.databaseConfiguration = previous;
-      DatabaseConfigurations.current = previousCurrent;
     }
   });
 
@@ -1400,7 +1393,6 @@ export class CreatePosts extends Migration {
       new HashConfig("production", "primary", { adapter: "sqlite3", database: dbFile }),
     ]);
     const previous = DatabaseTasks.databaseConfiguration;
-    const previousCurrent = DatabaseConfigurations.current;
     const origEnv = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
     DatabaseTasks.databaseConfiguration = configurations;
     process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
@@ -1410,7 +1402,6 @@ export class CreatePosts extends Migration {
       ).resolves.toBeUndefined();
     } finally {
       DatabaseTasks.databaseConfiguration = previous;
-      DatabaseConfigurations.current = previousCurrent;
       if (origEnv === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
       else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = origEnv;
     }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -265,9 +265,8 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 }
 
 /**
- * Run `fn` with `DatabaseTasks.databaseConfiguration`, the module-level
- * AND `DatabaseTasks.env` temporarily aligned with `config`.
- * Captures/restores both so
+ * Run `fn` with `DatabaseTasks.databaseConfiguration` and `DatabaseTasks.env`
+ * temporarily aligned with `config`. Captures/restores both so
  * callers can safely invoke methods like `DatabaseTasks.truncateAll(env)`
  * that resolve the env via `_normalizeEnv()` (reads DatabaseTasks.env by
  * default) and then call `configsFor` against it.

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -266,8 +266,8 @@ function toDbConfig(raw: RawConfig, envName: string = resolveEnv()): HashConfig 
 
 /**
  * Run `fn` with `DatabaseTasks.databaseConfiguration`, the module-level
- * `DatabaseConfigurations.current` singleton, AND `DatabaseTasks.env`
- * temporarily aligned with `config`. Captures/restores all three so
+ * AND `DatabaseTasks.env` temporarily aligned with `config`.
+ * Captures/restores both so
  * callers can safely invoke methods like `DatabaseTasks.truncateAll(env)`
  * that resolve the env via `_normalizeEnv()` (reads DatabaseTasks.env by
  * default) and then call `configsFor` against it.
@@ -294,7 +294,6 @@ async function withRegisteredConfigurations<T>(
 ): Promise<T> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
   const previousTasksConfig = DatabaseTasks.databaseConfiguration;
-  const previousCurrent = DatabaseConfigurations.current;
   const previousEnv = DatabaseTasks.env;
   DatabaseTasks.databaseConfiguration = new DatabaseConfigurations(configs);
   DatabaseTasks.env = envName;
@@ -302,7 +301,6 @@ async function withRegisteredConfigurations<T>(
     return await fn();
   } finally {
     DatabaseTasks.databaseConfiguration = previousTasksConfig;
-    DatabaseConfigurations.current = previousCurrent;
     DatabaseTasks.env = previousEnv;
   }
 }
@@ -316,22 +314,12 @@ async function withRegisteredConfigurations<T>(
  */
 async function runProtectedEnvCheck(config: HashConfig, envName: string): Promise<void> {
   const { DatabaseConfigurations } = await import("@blazetrails/activerecord");
-  // DatabaseConfigurations' constructor registers itself as the
-  // module-level "current" singleton (HashConfig.isPrimary consults it),
-  // so swapping DatabaseTasks.databaseConfiguration isn't enough on its
-  // own. Capture BOTH slots — they may differ when other code (e.g.
-  // connection-handling) created a DatabaseConfigurations without
-  // assigning it to DatabaseTasks.databaseConfiguration — and restore
-  // both in finally instead of clobbering the singleton with an empty
-  // fallback.
   const previousTasksConfig = DatabaseTasks.databaseConfiguration;
-  const previousCurrent = DatabaseConfigurations.current;
   DatabaseTasks.databaseConfiguration = new DatabaseConfigurations([config]);
   try {
     await DatabaseTasks.checkProtectedEnvironmentsBang(envName);
   } finally {
     DatabaseTasks.databaseConfiguration = previousTasksConfig;
-    DatabaseConfigurations.current = previousCurrent;
   }
 }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/hash-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/hash-config.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "database-configurations/hash-config.ts",
-    "rubyName": "primary?",
-    "call": "configurations",
-    "reason": "Verified per-site (RFC 0106): `Base.configurations.primary?(name)` (`hash_config.rb:130`) — `hash-config.ts` cannot import `base.js` (base → database-configurations → hash-config is a module-eval cycle), so the current `DatabaseConfigurations` reaches this file through the `_setPrimaryChecker` late-binding hook installed at the bottom of `database-configurations.ts`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations/hash-config.ts",
     "rubyName": "seeds?",
     "call": "fetch",
     "reason": "Verified per-site (RFC 0106): `configuration_hash.fetch(:seeds, primary?)` (`database_configurations/hash_config.rb:138`) — same Hash#fetch shortcoming as `validate?`: the configuration hash is a plain TS object, so the body spells the stored-key test explicitly and falls back to `isPrimary()`."


### PR DESCRIPTION
Four RFC 0112 deviation stories, all in the same convergence class: a trails
indirection standing where Rails has a direct call.

### `HashConfig#primary?` reads the global registry

Rails' `primary?` is one line — `Base.configurations.primary?(name)`
(`hash_config.rb:129-130` → `database_configurations.rb:142-147`). trails
reimplemented it as a `_primaryChecker` module global installed against a
second module global, `_currentConfigurations`, that the
`DatabaseConfigurations` constructor mutated as a side effect.

`configurationsStore()` (the backing store for `Base.configurations`) already
lives in `database-configurations.ts`, so `hash-config.ts` reads it directly.
The import back is call-time only and `configurationsStore` is a hoisted
function declaration, so neither entry order into the cycle hits a TDZ.

Gone with it: `_primaryChecker` / `_setPrimaryChecker`,
`DatabaseConfigurations.current` / `_currentConfigurations`, the
`(DatabaseConfigurations as any).current` save/restore blocks in six suites,
and the same dance in trailties' `withRegisteredConfigurations` /
`runProtectedEnvCheck` — those already write the one registry through
`DatabaseTasks.databaseConfiguration`, so the second capture was redundant.

### MySQL `build_explain_clause`

`AbstractMysqlAdapter#buildExplainClause` is now the module body from
`mysql/database-statements.ts` (`mysql/database_statements.rb:36-46`),
assigned onto the class the way `write_query?` and `returning_column_values`
already are. That retires the `" for:"` suffix (which belongs to
`explain.rb:55-61`, the fallback for adapters that define no
`build_explain_clause`), the `_explainClause` / `_explainStatementClause`
twins, and the invented `_validateExplainOptions` with its `EXPLAIN_FLAGS` /
`EXPLAIN_FORMATS` allowlists.

`AbstractAdapter#buildExplainClause` is removed too. Rails' `AbstractAdapter`
defines none — that is exactly why `explain.rb:56-61` probes with
`respond_to?(:build_explain_clause, true)`. While trails' abstract defined
one, every adapter answered the probe, the `"EXPLAIN for:"` fallback in
`explain.ts` was unreachable, and SQLite produced the Rails-correct header by
accident. It now takes the fallback by the Rails path, and that header lives
only in `explain.ts`.

PG keeps its own `_validateExplainOptions`; converging that half is still
open on the PG side and out of scope here.

### `scoping` delegates to `_scoping`

`Relation#scoping` inlined the save/set/restore that `_scoping` already does
(`relation.rb:541-550`), and the two had drifted: Rails' `_scoping` carries
the `all_queries` arm (`relation.rb:1365-1379`) while ours took only
`(scope, registry, fn)`. `_scoping` now takes `all_queries` and saves and
restores `global_current_scope`; `scoping` delegates; `_execScope` still
passes `null` so the `already_in_scope?` / `global_scope?` checks stay
bypassed (`relation.rb:552-557`).

Ruby's `ensure` runs after the block finishes, where a JS `finally` fires the
moment an async body yields — so when the block's result is a promise the
restore rides on it rather than firing under the still-running body.

### `InternalMetadata` BindParam

Only the first of that story's three items was still open, and only as a test
gap: `select_entry` already wraps the key in a `BindParam`
(`internal_metadata.rb:157`), but nothing pinned it — a create+find roundtrip
cannot tell a bind from an inlined literal. Added a case asserting the
compiled SQL carries a placeholder and the key travels in the bind array. The
duplicated `current_time` calls and the dead `_q` helper both landed in #6560.

### Story resolution

All four `Closes-story:` ids resolve to this PR — `tasks list --json` returns
exactly these four against `pr: 6811`:

| story | status |
| --- | --- |
| `hash-config-primary-resolves-via-global-configurations` | in-progress #6811 |
| `internal-metadata-private-helper-arel-deviations` | in-progress #6811 |
| `mysql-build-explain-clause-conflates-explain-fallback` | in-progress #6811 |
| `scoping-delegates-to-underscore-scoping-all-queries` | in-progress #6811 |

The InternalMetadata story was claimed with the rest of the bundle but its
`in-progress` stamp did not land when `/link` ran (that step reported it
skipped, leaving it `claimed` with `pr: null`), so a PR-keyed lookup returned
only three. It is stamped now; the test was always inside the claimed scope,
not riding along.

### Not in this PR

- `eliminate-pending-counter-cache-deferral-via-lazy-target-resolution` —
  **blocked**. `_counter_cache_columns` is unioned onto the *target* class
  from the *owner*'s `belongs_to` (`belongs_to.rb:39-40`), and both reads are
  plain reads of the `class_attribute` at `counter_cache.rb:9`. Deferring the
  union to first read therefore needs a scan of every `modelRegistry` entry
  for a `belongs_to` naming the reader — strictly more invented machinery
  than the single documented ESM deferral it would replace. Ordering case:
  `CpkBook` is declared before `CpkOrder` in `test-helpers/models/cpk.ts`.
- `converge-exec-insert-delete-update-onto-rails-call-shape` and
  `converge-remaining-activerecord-copy-on-write-stores-onto-class-attribute`
  — **released**, unclaimed. Each is larger than the LOC ceiling on its own
  by its own story text (the first reds every adapter lane unless
  `executeMutation` and `internalExecute` converge together; the second is
  ~8 clusters and says to split).

### Verification

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` both clean, no
baseline rows added or reseeded. Every Ruby file this PR touches is at 100%
with **zero** missing methods (`abstract_adapter.rb` 396/396,
`abstract_mysql_adapter.rb` 137/137, `mysql/database_statements.rb` 10/10,
`postgresql_adapter.rb` 243/243, `mysql2_adapter.rb` 31/31, `relation.rb`
401/401, `database_configurations.rb` 24/24, `hash_config.rb` 26/26,
`internal_metadata.rb` 17/17, `explain.rb` 4/4), so no matched method was
lost when the misplaced `analyzeWithoutExplain` copy went.

Extra surface measured A/B against a real `origin/main` build:

| | Files | Novel | Moved | Total |
| --- | --- | --- | --- | --- |
| origin/main | 261 | 541 | 1460 | 2001 |
| this PR | 261 | 541 | 1457 | **1998** |

Novel is unchanged — this PR adds no invented surface — and the total falls
by the three misplaced members deleted (`AbstractAdapter#buildExplainClause`,
`AbstractMysqlAdapter#analyzeWithoutExplain`, `DatabaseConfigurations.current`). `pnpm typecheck`, `pnpm lint` clean.
Suites run locally: database-configurations, connection-handling, shard-keys,
test-databases, connection-swapping-nested, connection-handlers-sharding-db,
database-tasks, schema-dumper, explain, sqlite3/explain, scoping/*,
relation/unscope-coverage, counter-cache, internal-metadata.

The MariaDB lane was run locally too (`mariadb:11`, the CI image): explain,
mysql-explain, connection-handling, database-configurations, scoping/*,
internal-metadata all green. It caught one real flaw — the first version of
the BindParam test asserted a placeholder in the compiled SQL, which only
holds where prepared statements are on; MySQL substitutes at compile time and
renders the same node as a literal. The test now pins the Arel node on every
lane and keeps the SQL/binds check where it is observable. PG is on CI.

Closes-story: hash-config-primary-resolves-via-global-configurations
Closes-story: internal-metadata-private-helper-arel-deviations
Closes-story: mysql-build-explain-clause-conflates-explain-fallback
Closes-story: scoping-delegates-to-underscore-scoping-all-queries


