### PR TITLE
refactor(activerecord): converge init_internals / initialize_dup onto the prepend super chain

### DIFF
--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
 import { addAggregateReflection, create } from "./reflection.js";
+import { prepend } from "@blazetrails/activesupport";
 
 /**
  * Aggregation cache and composed-of value-object support.
@@ -276,9 +277,8 @@ export function includeAggregations(modelClass: typeof Base): void {
   // Aggregations#reload clears the aggregation cache then calls super. Capture
   // the inherited reload (Ruby `super`) at include time so the delegation walks
   // the real ancestry (Aggregations → AutosaveAssociation → Persistence) rather
-  // than hardcoding a jump straight to Persistence#reload — mirroring the
-  // inheritedInitializeDup capture below. Keeps the autosave hop live for when
-  // AutosaveAssociation#reload is ported.
+  // than hardcoding a jump straight to Persistence#reload. Keeps the autosave hop
+  // live for when AutosaveAssociation#reload is ported.
   const inheritedReload = proto.reload as ReloadFn<Base>;
   Object.defineProperty(proto, "reload", {
     value: reload(inheritedReload),
@@ -287,17 +287,14 @@ export function includeAggregations(modelClass: typeof Base): void {
     enumerable: false,
   });
 
-  const inheritedInitializeDup = proto.initializeDup as
-    | ((this: Base, other: unknown) => void)
-    | undefined;
-  Object.defineProperty(proto, "initializeDup", {
-    value: function (this: Base, other: unknown): void {
+  // Aggregations#initialize_dup copies the aggregation cache, then supers
+  // (aggregations.rb:6-9). `prepend()` is that ancestry splice: the link sits
+  // above the Core → Locking::Optimistic → Timestamp chain base.ts wires.
+  prepend(proto, {
+    initializeDup(this: Base, super_: (other: unknown) => void, other: unknown): void {
       copyAggregationCacheForDup.call(this, other);
-      if (inheritedInitializeDup) inheritedInitializeDup.call(this, other);
+      super_(other);
     },
-    writable: true,
-    configurable: true,
-    enumerable: false,
   });
 }
 
@@ -305,6 +302,7 @@ export function includeAggregations(modelClass: typeof Base): void {
  * @internal
  * Mirrors: ActiveRecord::Aggregations#init_internals
  */
-function initInternals(this: Base): void {
+function initInternals(this: Base, super_: () => void): void {
+  super_();
   (this as any)._aggregationCache = new Map<string, unknown>();
 }

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -287,10 +287,12 @@ export function includeAggregations(modelClass: typeof Base): void {
     enumerable: false,
   });
 
-  // Aggregations#initialize_dup copies the aggregation cache, then supers
-  // (aggregations.rb:6-9). `prepend()` is that ancestry splice: the link sits
-  // above the Core → Locking::Optimistic → Timestamp chain base.ts wires.
+  // Aggregations#init_internals supers then allocates the cache
+  // (aggregations.rb:21-23); Aggregations#initialize_dup copies it, then supers
+  // (aggregations.rb:6-9). `prepend()` is the ancestry splice `include
+  // Aggregations` performs: both links sit above the chains base.ts wires.
   prepend(proto, {
+    initInternals,
     initializeDup(this: Base, super_: (other: unknown) => void, other: unknown): void {
       copyAggregationCacheForDup.call(this, other);
       super_(other);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1960,8 +1960,9 @@ function wrapCollectionProxy<T extends Base = Base>(
  *
  * @internal
  */
-function initInternals(record: Base): void {
-  record._resetAssociationCaches();
+export function initInternals(this: Base, super_: () => void): void {
+  super_();
+  this._resetAssociationCaches();
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -161,7 +161,8 @@ interface DirtyPrivateHost {
 }
 
 /** @internal */
-export function initInternals(this: DirtyPrivateHost): void {
+export function initInternals(this: DirtyPrivateHost, super_: () => void): void {
+  super_();
   this._mutationsBeforeLastSave = null;
   this._mutationsFromDatabase = null;
   this._touchAttrNames = null;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -582,8 +582,14 @@ function propagateErrors(parent: Base, reflectionName: string): void {
   parent.errors.add(underscore(reflectionName));
 }
 
-/** @internal */
-function initInternals(this: AutosaveAssociationHost): void {
+/**
+ * Mirrors `ActiveRecord::AutosaveAssociation#init_internals`
+ * (autosave_association.rb:290-293).
+ *
+ * @internal
+ */
+export function initInternals(this: AutosaveAssociationHost, super_: () => void): void {
+  super_();
   this._alreadyCalled = null;
 }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -87,6 +87,7 @@ import {
   computePrimaryKey as _computePrimaryKey,
   _ensureNoDuplicateErrors as _autosaveEnsureNoDuplicateErrors,
   _registerAssociationBuilderExtension,
+  initInternals as _autosaveInitInternals,
 } from "./autosave-association.js";
 import { Association as AssociationBuilder } from "./associations/builder/association.js";
 import {
@@ -171,11 +172,13 @@ import * as Querying from "./querying.js";
 import * as QueryCacheClassMethods from "./query-cache.js";
 import {
   include,
+  prepend,
   extend,
   classAttribute,
   benchmark as benchmarkable,
   runLoadHooks,
   isBlank as _isBlankValue,
+  type PrependMethod,
   singularize as _singularize,
   type Included,
   type ParameterFilter,
@@ -263,6 +266,7 @@ import {
   filterAttributes as _coreFilterAttributes,
 } from "./core.js";
 import * as _Core from "./core.js";
+import * as _AttributeMethodsDirty from "./attribute-methods/dirty.js";
 import type { AsynchronousQueriesTracker, Session } from "./asynchronous-queries-tracker.js";
 import * as _Persistence from "./persistence.js";
 import * as _EnumModule from "./enum.js";
@@ -315,6 +319,7 @@ import {
   afterCreateCommit as _afterCreateCommit,
   afterUpdateCommit as _afterUpdateCommit,
   afterDestroyCommit as _afterDestroyCommit,
+  initInternals as _transactionsInitInternals,
 } from "./transactions.js";
 
 import {
@@ -330,6 +335,7 @@ import {
   associationInstanceGet as _associationInstanceGet,
   associationInstanceSet as _associationInstanceSet,
   registerModelConstant,
+  initInternals as _associationsInitInternals,
   type AssociationDefinition,
 } from "./associations.js";
 import * as _AttributeAssignment from "./attribute-assignment.js";
@@ -2978,8 +2984,10 @@ export class Base extends Model {
   _previouslyNewRecord = false;
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
-  _strictLoading = false;
-  _strictLoadingMode?: _Core.StrictLoadingMode;
+  // No initializers: `init_internals` (core.rb:834-849) assigns both from the
+  // class during `super()`, and a field initializer here would run afterwards
+  // and clobber them back to the class-less defaults. Declared on the merged
+  // `Base` interface below instead.
   // No Rails counterpart: Rails' strict_loading is tripped by `load_target`
   // alone. Trails keeps the counter only for `loadBelongsTo` / `loadHasOne`
   // (associations/instance-methods.ts) — explicit lazy loads the caller asked
@@ -2994,10 +3002,10 @@ export class Base extends Model {
    *
    * @internal
    */
-  _associationCacheStore: _AssociationCache = createAssociationCache();
-  _collectionProxies: Map<string, unknown> = this._associationCacheStore.proxies;
-  _associationInstances: Map<string, AssociationInstance> = this._associationCacheStore
-    .instances as Map<string, AssociationInstance>;
+  // No initializers, for the same reason as `_strictLoading` above: Rails
+  // allocates `@association_cache` in `init_internals` (associations.rb:75-77),
+  // which now runs during `super()`, and a field initializer here would replace
+  // the store afterwards. `_resetAssociationCaches` is the allocation site.
 
   /**
    * Return the *loaded* cached association object for `name` — callers read
@@ -3069,6 +3077,18 @@ export class Base extends Model {
    * @internal
    */
   _resetAssociationCaches(): void {
+    if (this._associationCacheStore === undefined) {
+      // First call is `init_internals`' `@association_cache = {}`; later calls
+      // (reload/destroy) clear in place so callers holding a facet view keep
+      // seeing the record's cache.
+      this._associationCacheStore = createAssociationCache();
+      this._collectionProxies = this._associationCacheStore.proxies;
+      this._associationInstances = this._associationCacheStore.instances as Map<
+        string,
+        AssociationInstance
+      >;
+      return;
+    }
     this._associationCacheStore.clear();
   }
 
@@ -3144,10 +3164,6 @@ export class Base extends Model {
             ._suppressInitializeCallback;
         }
       }
-      // Mirrors Rails Core#initialize: init_internals runs before
-      // initialize_internals_callback and after_initialize, regardless of
-      // callback suppression (found records run it via `new this()` too).
-      _Core.initInternals.call(this as any);
       _applyCompositePrimaryKey(this as unknown as Base, ctor, attrs);
       executeMultiparameterAssignment(this as any, multiparams);
       // Re-snapshot so mp attrs are part of the initial clean state.
@@ -3228,10 +3244,6 @@ export class Base extends Model {
             ._suppressInitializeCallback;
         }
       }
-      // Mirrors Rails Core#initialize: init_internals runs before
-      // initialize_internals_callback and after_initialize, regardless of
-      // callback suppression (found records run it via `new this()` too).
-      _Core.initInternals.call(this as any);
       _applyCompositePrimaryKey(this as unknown as Base, ctor2, attrs);
       if (!wasSuppressed2) {
         inheritanceInitializeInternalsCallback.call(this as any);
@@ -4352,6 +4364,11 @@ export class Base extends Model {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Base extends Included<typeof AutosaveAssociation> {
+  _strictLoading: boolean;
+  _associationCacheStore: _AssociationCache;
+  _collectionProxies: Map<string, unknown>;
+  _associationInstances: Map<string, AssociationInstance>;
+  _strictLoadingMode?: _Core.StrictLoadingMode;
   association(name: string): AssociationInstance;
   /**
    * Explicitly load a `belongsTo` target and resolve to it.
@@ -4696,32 +4713,34 @@ include(Base, Timestamp.InstanceMethods);
 // composed_of (see aggregations.ts includeAggregations), so models without a
 // composed_of declaration never carry its reload/initialize_dup overrides.
 include(Base, TouchLater.InstanceMethods);
-// Compose the initialize_dup chain. This stays hand-wired (not a last-wins
-// override) because Ruby builds it via module super-calls
-// (Core → Locking::Optimistic → Timestamp); trails has no super chain across
-// mixins, so invoke each module's hook explicitly in that order. Aggregations'
-// initialize_dup slots in above this chain, wired by includeAggregations on
-// composed_of models only.
-//
-// Mirrors ActiveRecord::Core#initialize_dup (core.rb): fire the initialize
-// callbacks against the duped attributes, THEN run the Locking/Timestamp
-// clears. In Rails those modules `super` into Core (which runs the callbacks)
-// and clear only as the stack unwinds (optimistic.rb:72-75, timestamp.rb:50-53),
-// so the hook observes the source's lock_version / timestamps before they are
-// nulled. `initialize` is defined `only: :after`, so runAllCallbacks fires just
-// the after_initialize chain. persistence.ts `dup` calls this after the duped
-// attributes and dirty baseline are in place.
-(Base.prototype as any).initializeDup = function (this: Base, _other: unknown): void {
-  void cbRunAll((this.constructor as typeof Base).prototype, "initialize", this, undefined, {
-    strict: "sync",
-  });
-  if ((this.constructor as typeof Base).lockingEnabled) {
-    LockingOptimistic._clearLockingColumn.call(this as any);
-  }
-  Timestamp.clearTimestampAttributes.call(this as any);
-};
 include(Base, _AttributeAssignment.InstanceMethods);
 include(Base, AutosaveAssociation);
+// The `init_internals` chain (core.rb:834 is the root; every other definition
+// opens with `super`). Prepended in Rails' `include` order (base.rb:299-322), so
+// the last one wired is the outermost link and the stack unwinds into Core —
+// and, below it, into the ActiveModel links `Model.prototype` carries
+// (validations.rb:467, dirty.rb:372).
+prepend(Base.prototype, { initInternals: _Core.initInternals as PrependMethod });
+prepend(Base.prototype, { initInternals: _Persistence.initInternals as PrependMethod });
+prepend(Base.prototype, {
+  initInternals: _AttributeMethodsDirty.initInternals as PrependMethod,
+});
+prepend(Base.prototype, { initInternals: Timestamp.initInternals as PrependMethod });
+prepend(Base.prototype, { initInternals: _associationsInitInternals as PrependMethod });
+prepend(Base.prototype, { initInternals: _autosaveInitInternals as PrependMethod });
+prepend(Base.prototype, { initInternals: _transactionsInitInternals as PrependMethod });
+prepend(Base.prototype, { initInternals: TouchLater.initInternals as PrependMethod });
+// The `initialize_dup` chain, same construction: Core (core.rb:550) fires the
+// initialize callbacks and resets the new-record state, then `super` unwinds
+// through Locking::Optimistic (optimistic.rb:72-75) and Timestamp
+// (timestamp.rb:50-53), whose clears therefore run AFTER the callbacks have seen
+// the source's `lock_version` / timestamps. Aggregations' link (aggregations.rb:6)
+// is prepended above these by `includeAggregations` on composed_of models only.
+// `dup` (persistence.ts) enters the chain once the duped attributes and dirty
+// baseline are in place.
+prepend(Base.prototype, { initializeDup: _Core.initializeDup as PrependMethod });
+prepend(Base.prototype, { initializeDup: LockingOptimistic.initializeDup as PrependMethod });
+prepend(Base.prototype, { initializeDup: Timestamp.initializeDup as PrependMethod });
 _registerAssociationBuilderExtension(AssociationBuilder.extensions);
 // AutosaveAssociation#reload resets marked-for-destruction / destroyed-by-
 // association state, then calls super. Capture the inherited reload (Persistence)

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2984,28 +2984,11 @@ export class Base extends Model {
   _previouslyNewRecord = false;
   private _destroyedByAssociation: unknown = null;
   _transactionAction: "create" | "update" | "destroy" | undefined = undefined;
-  // No initializers: `init_internals` (core.rb:834-849) assigns both from the
-  // class during `super()`, and a field initializer here would run afterwards
-  // and clobber them back to the class-less defaults. Declared on the merged
-  // `Base` interface below instead.
   // No Rails counterpart: Rails' strict_loading is tripped by `load_target`
   // alone. Trails keeps the counter only for `loadBelongsTo` / `loadHasOne`
   // (associations/instance-methods.ts) — explicit lazy loads the caller asked
   // for by name, which Rails has no method to express an exemption for.
   _strictLoadingBypassCount = 0;
-  /**
-   * The single backing slot for this record's association cache — RFC-0022's
-   * fold of the three formerly-separate maps into one store keyed by name (see
-   * `_resetAssociationCaches`). The three public accessors below are
-   * `Map`-compatible facet views onto one field of this shared store, mirroring
-   * Rails' single `@association_cache`.
-   *
-   * @internal
-   */
-  // No initializers, for the same reason as `_strictLoading` above: Rails
-  // allocates `@association_cache` in `init_internals` (associations.rb:75-77),
-  // which now runs during `super()`, and a field initializer here would replace
-  // the store afterwards. `_resetAssociationCaches` is the allocation site.
 
   /**
    * Return the *loaded* cached association object for `name` — callers read
@@ -4364,10 +4347,30 @@ export class Base extends Model {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Base extends Included<typeof AutosaveAssociation> {
+  /**
+   * Assigned by `init_internals` (core.rb:834-849) during `super()`. Declared
+   * here rather than as a class field because a field initializer runs after
+   * `super()` returns and would clobber what the chain just assigned.
+   *
+   * @internal
+   */
   _strictLoading: boolean;
+  /** @internal */
   _strictLoadingMode?: _Core.StrictLoadingMode;
+  /**
+   * The single backing slot for this record's association cache — RFC-0022's
+   * fold of the three formerly-separate maps into one store keyed by name (see
+   * `_resetAssociationCaches`). The two accessors below are `Map`-compatible
+   * facet views onto one field of this shared store, mirroring Rails' single
+   * `@association_cache`, which `Associations#init_internals` allocates
+   * (associations.rb:75-77) — hence no class field here either.
+   *
+   * @internal
+   */
   _associationCacheStore: _AssociationCache;
+  /** @internal */
   _collectionProxies: Map<string, unknown>;
+  /** @internal */
   _associationInstances: Map<string, AssociationInstance>;
   association(name: string): AssociationInstance;
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4365,10 +4365,10 @@ export class Base extends Model {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Base extends Included<typeof AutosaveAssociation> {
   _strictLoading: boolean;
+  _strictLoadingMode?: _Core.StrictLoadingMode;
   _associationCacheStore: _AssociationCache;
   _collectionProxies: Map<string, unknown>;
   _associationInstances: Map<string, AssociationInstance>;
-  _strictLoadingMode?: _Core.StrictLoadingMode;
   association(name: string): AssociationInstance;
   /**
    * Explicitly load a `belongsTo` target and resolve to it.

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -206,3 +206,56 @@ describe("compare", () => {
     expect(reply.compare(first)).toBeUndefined();
   });
 });
+
+describe("init_internals / initialize_dup super chain", () => {
+  fixtures(["topics"]);
+
+  // core.rb:834 is the chain root and every other concern's `init_internals`
+  // opens with `super` (persistence.rb:814, attribute_methods/dirty.rb:196,
+  // timestamp.rb:102, associations.rb:75, autosave_association.rb:290,
+  // transactions.rb:432, touch_later.rb:49). Each hook's fields are only ever
+  // assigned by the chain, so an unwired link leaves its fields `undefined`.
+  it("every concern's init_internals link runs on construction", () => {
+    const topic = new Topic({ title: "Alice" }) as unknown as Record<string, unknown>;
+    // Core (core.rb:834-849)
+    expect(topic._readonly).toBe(false);
+    expect(topic._destroyedByAssociation).toBe(null);
+    // Persistence (persistence.rb:814-818)
+    expect(topic._triggerUpdateCallback).toBe(null);
+    expect(topic._triggerDestroyCallback).toBe(null);
+    // AttributeMethods::Dirty (attribute_methods/dirty.rb:196-201)
+    expect(topic._mutationsBeforeLastSave).toBe(null);
+    expect(topic._mutationsFromDatabase).toBe(null);
+    expect(topic._touchAttrNames).toBe(null);
+    expect(topic._skipDirtyTracking).toBe(null);
+    // Timestamp (timestamp.rb:102-105)
+    expect(topic._touchRecord).toBe(null);
+    // Associations (associations.rb:75-77)
+    expect((topic._associationInstances as Map<string, unknown>).size).toBe(0);
+    // AutosaveAssociation (autosave_association.rb:290-293)
+    expect(topic._alreadyCalled).toBe(null);
+    // Transactions (transactions.rb:432-437)
+    expect(topic._startTransactionState).toBe(null);
+    expect(topic._committedAlreadyCalled).toBe(null);
+    expect(topic._newRecordBeforeLastCommit).toBe(null);
+    // TouchLater (touch_later.rb:49-52)
+    expect(topic._deferTouchAttrs).toBe(null);
+    expect(topic._touchTime).toBe(null);
+  });
+
+  // Core#initialize_dup (core.rb:550-562) runs the initialize callbacks and only
+  // then unwinds through Locking::Optimistic (optimistic.rb:72-75) and Timestamp
+  // (timestamp.rb:50-53), so the hook still observes the source's lock_version
+  // and timestamps; ActiveModel's links (validations.rb:310, dirty.rb:248) sit on
+  // `Model.prototype` and are reached by the same chain rather than shadowed.
+  it("dup runs the whole chain, clearing only after the callbacks", async () => {
+    const topic = await Topic.create({ title: "Alice", content: "Hello" });
+    topic.title = "Bob";
+    const duped = topic.dup();
+
+    expect(duped.errors).not.toBe(topic.errors);
+    expect(duped.title).toBe("Bob");
+    expect(duped.isNewRecord()).toBe(true);
+    expect(duped.id).toBe(null);
+  });
+});

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -246,15 +246,34 @@ describe("init_internals / initialize_dup super chain", () => {
   // Core#initialize_dup (core.rb:550-562) runs the initialize callbacks and only
   // then unwinds through Locking::Optimistic (optimistic.rb:72-75) and Timestamp
   // (timestamp.rb:50-53), so the hook still observes the source's lock_version
-  // and timestamps; ActiveModel's links (validations.rb:310, dirty.rb:248) sit on
-  // `Model.prototype` and are reached by the same chain rather than shadowed.
-  it("dup runs the whole chain, clearing only after the callbacks", async () => {
+  // and timestamps. Below Core sit ActiveModel's links, which `Model.prototype`
+  // carries and an own `Base.prototype` body used to shadow:
+  // Validations#initialize_dup replaces `@errors` (validations.rb:310-313) and
+  // Dirty#initialize_dup gives the copy its own mutation tracker
+  // (dirty.rb:248-251).
+  it("dup runs the whole chain, including the ActiveModel links", async () => {
     const topic = await Topic.create({ title: "Alice", content: "Hello" });
     topic.title = "Bob";
+    topic.errors.add("title", "is invalid");
+    expect(topic.errors.size).toBe(1);
+
     const duped = topic.dup();
 
+    // Validations#initialize_dup: the copy gets a fresh error set rather than
+    // the source's, so the source's errors do not travel with it.
     expect(duped.errors).not.toBe(topic.errors);
+    expect(duped.errors.empty).toBe(true);
+    expect(topic.errors.size).toBe(1);
+
+    // Dirty#initialize_dup: the copy carries the source's pending changes but on
+    // its own tracker, so writing to one no longer marks the other.
     expect(duped.title).toBe("Bob");
+    expect(duped.willSaveChangeToAttribute("title")).toBe(true);
+    duped.content = "Changed";
+    expect(duped.willSaveChangeToAttribute("content")).toBe(true);
+    expect(topic.willSaveChangeToAttribute("content")).toBe(false);
+    expect(topic.content).toBe("Hello");
+
     expect(duped.isNewRecord()).toBe(true);
     expect(duped.id).toBe(null);
   });

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -41,7 +41,7 @@ import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { buildPkWhereNode, columnsHash } from "./model-schema.js";
 import { StatementCache } from "./statement-cache.js";
 import { withConnection } from "./connection-handling.js";
-import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
+import { RangeError as ActiveModelRangeError, runAllCallbacks } from "@blazetrails/activemodel";
 
 /**
  * The Core module interface — methods mixed into every AR model.
@@ -812,7 +812,20 @@ export function arelTable(this: CoreHost): Table {
   return new Table((this as any).tableName, { klass: this as any });
 }
 
-/** @internal */
+/**
+ * The root of the `init_internals` chain — every other concern's hook is
+ * prepended onto `Base.prototype` above it and opens with `super_`
+ * (core.rb:834-849).
+ *
+ * Rails' root has no `super`: `include Core` (base.rb:299) sits below every
+ * later include, so ActiveModel's `Validations`/`Dirty` links (validations.rb:467,
+ * dirty.rb:372) are *above* Core in the MRO. In trails those links are prepended
+ * onto `Model.prototype`, the superclass prototype, so they sit BELOW this one —
+ * hence the `super_()` here, which is the same set of links Ruby reaches, entered
+ * from the other end.
+ *
+ * @internal
+ */
 export function initInternals(
   this: CoreRecord & {
     _readonly: boolean;
@@ -822,7 +835,9 @@ export function initInternals(
     _strictLoading: boolean;
     _strictLoadingMode?: StrictLoadingMode;
   },
+  super_: () => void,
 ): void {
+  super_();
   this._readonly = false;
   this._previouslyNewRecord = false;
   this._destroyed = false;
@@ -830,6 +845,55 @@ export function initInternals(
   const klass = this.constructor as any;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
   this._strictLoadingMode = klass.strictLoadingMode;
+}
+
+/**
+ * Mirrors `ActiveRecord::Core#initialize_dup` (core.rb:550-562). The
+ * `init_attributes(other)` half and the dirty-baseline rebind are performed by
+ * `dup` (persistence.ts) before the chain is entered, because the duplicate is
+ * built by `new ctor({})` rather than Ruby's `Object#dup`; what remains here is
+ * Rails' order — the initialize callbacks run against the duped attributes, the
+ * new-record state is reset, and only then does `super` unwind through
+ * Locking::Optimistic (optimistic.rb:72-75) and Timestamp (timestamp.rb:50-53),
+ * so the hook still observes the source's `lock_version` / timestamps.
+ *
+ * As with {@link initInternals}, Ruby reaches ActiveModel's links from above and
+ * trails from below; `super_` is the receiver-bound link `prepend()` hands the
+ * module.
+ *
+ * @internal
+ */
+export function initializeDup(
+  this: CoreRecord & {
+    _newRecord: boolean;
+    _previouslyNewRecord: boolean;
+    _destroyed: boolean;
+    _startTransactionState: unknown;
+  },
+  super_: (other: unknown) => void,
+  other: unknown,
+): void {
+  // `super_` leads DOWN to ActiveModel's links here, where Ruby reaches them
+  // going up (see initInternals), so it is spelled first to keep Rails'
+  // observable order: `Attributes`/`Validations`/`Dirty` (attributes.rb:111,
+  // validations.rb:310, dirty.rb:248) all sit ABOVE Core in the MRO and have
+  // already replaced `@errors` and the mutation trackers by the time Core runs
+  // the initialize callbacks.
+  super_(other);
+  // `initialize` is registered `only: :after`, so this fires just the
+  // after_initialize chain. strict:"sync" guarantees synchronous completion —
+  // void the settled result.
+  void runAllCallbacks(
+    (this.constructor as { prototype: object }).prototype,
+    "initialize",
+    this,
+    undefined,
+    { strict: "sync" },
+  );
+  this._newRecord = true;
+  this._previouslyNewRecord = false;
+  this._destroyed = false;
+  this._startTransactionState = null;
 }
 
 /** @internal */

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-fixtures.js";
 import { Client } from "./test-helpers/models/company.js";
+import { isFinderNeedsTypeCondition } from "./inheritance.js";
 import { Author } from "./test-helpers/models/author.js";
 
 describe("_instantiate STI dispatch", () => {
@@ -38,5 +39,22 @@ describe("descends_from_active_record? column test", () => {
     }
 
     expect(VirtualTypeAuthor.isDescendsFromActiveRecord()).toBe(true);
+  });
+});
+
+describe("ensure_proper_type on an unreflected subclass", () => {
+  fixtures([]);
+
+  // `ensure_proper_type` writes the STI type unconditionally once
+  // `finder_needs_type_condition?` says so (inheritance.rb:331-336) — no
+  // membership test on the inheritance column. trails carried one because a
+  // strict `_writeAttribute` raises on an attribute the model does not know and
+  // trails reflects lazily; construction now resolves the column itself, so the
+  // guard is gone and a subclass that has never been queried still gets its type.
+  it("writes the sti name without a membership guard", () => {
+    class ColdClient extends Client {}
+
+    expect(isFinderNeedsTypeCondition(ColdClient)).toBe(true);
+    expect(new ColdClient({}).type).toBe("ColdClient");
   });
 });

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -826,11 +826,6 @@ export function ensureProperType(this: Base): void {
   if (!isFinderNeedsTypeCondition(klass)) return;
   const inheritCol = klass.inheritanceColumn;
   if (inheritCol === null) return;
-  // Only write when the model actually carries the column — otherwise the value
-  // wouldn't persist or serialize correctly. Rails needs no such guard: its
-  // `attribute_types` loads the schema synchronously on first touch, so
-  // `_write_attribute` always lands on a known attribute (`inheritance.rb:333`).
-  if (!klass._hasAttribute(inheritCol)) return;
   (this as any)._writeAttribute(inheritCol, stiName(klass));
 }
 

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -334,6 +334,22 @@ export function _clearLockingColumn(this: InstanceLockingHost): void {
 }
 
 /**
+ * Mirrors `ActiveRecord::Locking::Optimistic#initialize_dup`
+ * (optimistic.rb:72-75): `super` first, so the initialize callbacks in
+ * `Core#initialize_dup` still observe the source's `lock_version`.
+ *
+ * @internal
+ */
+export function initializeDup(
+  this: InstanceLockingHost,
+  super_: (other: unknown) => void,
+  other: unknown,
+): void {
+  super_(other);
+  if (this.constructor.lockingEnabled) _clearLockingColumn.call(this);
+}
+
+/**
  * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic#_query_constraints_hash
  */

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1588,14 +1588,15 @@ type PersistenceInstanceChainHost = {
   _writeAttribute(name: string, value: unknown): void;
 };
 
-/** @internal */
-function initInternals(this: PersistencePrivateHost): void {
-  this._newRecord = true;
-  this._destroyed = false;
+/**
+ * Mirrors `ActiveRecord::Persistence#init_internals` (persistence.rb:814-818).
+ *
+ * @internal
+ */
+export function initInternals(this: PersistencePrivateHost, super_: () => void): void {
+  super_();
+  (this as any)._triggerDestroyCallback = (this as any)._triggerUpdateCallback = null;
   this._previouslyNewRecord = false;
-  // Mirrors the Transactions#init_internals super chain — those fields live here too.
-  (this as any)._triggerUpdateCallback = null;
-  (this as any)._triggerDestroyCallback = null;
 }
 
 /** @internal */

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -436,8 +436,25 @@ export function timestampAttributesForUpdate(this: TimestampHost): string[] {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function initInternals(this: TimestampInstanceHost): void {
+export function initInternals(this: TimestampInstanceHost, super_: () => void): void {
+  super_();
   this._touchRecord = null;
+}
+
+/**
+ * Mirrors `ActiveRecord::Timestamp#initialize_dup` (timestamp.rb:50-53): the
+ * clear happens as the `super` stack unwinds, so the initialize callbacks in
+ * `Core#initialize_dup` still see the source's timestamps.
+ *
+ * @internal
+ */
+export function initializeDup(
+  this: TimestampInstanceHost,
+  super_: (other: unknown) => void,
+  other: unknown,
+): void {
+  super_(other);
+  clearTimestampAttributes.call(this);
 }
 
 /** @internal */

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -209,9 +209,10 @@ export const InstanceMethods = {
  *
  * @internal
  */
-export function initInternals(record: any): void {
-  record._deferTouchAttrs = null;
-  record._touchTime = null;
+export function initInternals(this: any, super_: () => void): void {
+  super_();
+  this._deferTouchAttrs = null;
+  this._touchTime = null;
 }
 
 /**

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -554,10 +554,11 @@ export function _triggerDestroyCallback(this: Base): boolean | null {
   return (this as any)._triggerDestroyCallback ?? null;
 }
 
-// Mirrors: ActiveRecord::Transactions#init_internals
+// Mirrors: ActiveRecord::Transactions#init_internals (transactions.rb:432-437)
 /** @internal */
-function initInternals(record: Base): void {
-  const r = record as any;
+export function initInternals(this: Base, super_: () => void): void {
+  super_();
+  const r = this as any;
   r._startTransactionState = null;
   r._committedAlreadyCalled = null;
   r._newRecordBeforeLastCommit = null;


### PR DESCRIPTION
## What

Two convergences in one PR.

### 1. `init_internals` / `initialize_dup` onto the prepend super chain

`Core#init_internals` (`core.rb:834`) is now the chain root, and every concern's
hook is prepended onto `Base.prototype` in Rails' `include` order
(`base.rb:299-322`), each opening with `super_`:

| link | Rails |
| --- | --- |
| Persistence | `persistence.rb:814-818` |
| AttributeMethods::Dirty | `attribute_methods/dirty.rb:196-201` |
| Timestamp | `timestamp.rb:102-105` |
| Associations | `associations.rb:75-77` |
| AutosaveAssociation | `autosave_association.rb:290-293` |
| Transactions | `transactions.rb:432-437` |
| TouchLater | `touch_later.rb:49-52` |

Every one of those existed in trails as a module-private function that nothing
ever called, so their fields were left `undefined` rather than `nil`. base.ts's
two explicit `_Core.initInternals.call(this)` fan-outs are gone.

`initialize_dup` likewise: base.ts no longer assigns an own `Base.prototype`
body, which was shadowing the ActiveModel links `Model.prototype` carries from
#6802 (`validations.rb:310`, `dirty.rb:248`). `Core#initialize_dup`
(`core.rb:550-562`) fires the initialize callbacks and resets the new-record
state, then `super` unwinds through `Locking::Optimistic`
(`optimistic.rb:72-75`) and `Timestamp` (`timestamp.rb:50-53`) — so the
clear-after-callbacks ordering is preserved. `aggregations.ts` drops its
hand-rolled `inheritedInitializeDup` capture in favour of `prepend()`
(`aggregations.rb:6-9`).

Two notes on the shape, both documented at the call site:

- **`super_` direction.** Ruby reaches ActiveModel's links going *up* (Core is
  included first, so it is deepest); trails has them on `Model.prototype`, the
  superclass prototype, so they sit *below*. Core therefore spells `super_`
  where Ruby has none — and in `initializeDup` it spells it **first**, so the
  observable order still matches Rails, where `Attributes`/`Validations`/`Dirty`
  have already replaced `@errors` and the trackers before Core runs the
  callbacks.
- **Class fields.** JS subclass field initializers run *after* `super()`, so
  `_strictLoading`, `_strictLoadingMode` and the association-cache store lost
  their initializers (they would clobber what `init_internals` just assigned)
  and are declared on the merged `Base` interface instead.
  `_resetAssociationCaches` is now the allocation site, which is what
  `@association_cache = {}` is in Rails.

### 2. `ensure_proper_type`'s membership guard

Deleted. `inheritance.rb:331-336` writes the STI type unconditionally once
`finder_needs_type_condition?` says so; the `_has_attribute?` test had no
counterpart. (#6805 had already converged its *reader*, which is what made the
guard inert — so its removal is a no-op at runtime, and the new test covers the
cold-subclass case it was there for.)

## Tests

`core.trails.test.ts` gains a link-by-link `init_internals` assertion (fails on
baseline: every concern field reads `undefined`) and a whole-chain `dup`
assertion. `inheritance.trails.test.ts` covers a never-queried STI subclass
getting its type on `new`.

Green locally: `core`, `dup`, `aggregations`, `timestamp`, `locking`,
`persistence`, `transactions`, `touch-later`, `inheritance` (+ namespaced /
sti-routing / sti-new-gate / encrypted-sti), `associations`,
`autosave-association`, `dirty`, `callbacks`, `base`, `attribute-methods`,
`nested-attributes`, `finder`, `relations`. `parity:api:calls`,
`parity:api:calls:args`, `parity:api:extra`, `lint`, `typecheck` clean.

Closes-story: converge-activerecord-init-internals-and-initialize-dup-super-chain
Closes-story: ensure-proper-type-membership-guard-has-no-rails-counterpart


---

### Note on the dup test's regression value

The dup test now exercises a source record carrying both an error and a pending
change, and asserts the two links' documented effects: the copy gets a fresh
error set rather than the source's (`validations.rb:310-313`) and its own
mutation tracker carrying the source's pending changes (`dirty.rb:248-251`).

It is a **behavioral cover, not a baseline-failing regression test**, and that is
measured, not assumed: checked out against `origin/main` with only this test
file applied, it passes. The reason is structural — trails' `dup`
(persistence.ts) builds the copy with `new ctor({})` rather than Ruby's
`Object#dup`, so the copy already has a fresh `Errors` and a tracker snapshotted
against the duped attribute set before the chain is entered. Both ActiveModel
links therefore re-establish state the copy already had. `initialize_dup` also
cannot be covered by spying: `prepend()` binds `super_` at module-eval, so a spy
installed later is invisible to the chain.

The baseline-failing regression cover for this PR is the `init_internals` test,
which reds on `origin/main` (every concern field reads `undefined`).
