### PR TITLE
fix(scripts): alert on stats-sync failure; name the tighten remedy on a rebase-restaled mark

### DIFF
--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -4,7 +4,18 @@ import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { findDuplicateKeys, keyOf, type ExcludeEntry } from "./call-mismatch-baseline.js";
-import { excessByPath, loadMarks, unreviewedCounts } from "./unreviewed-ratchet.js";
+import {
+  excessByPath,
+  loadMarks,
+  renderSlack,
+  slackByPath,
+  tightenCommand,
+  tightenMarks,
+  unreviewedCounts,
+  writeMarks,
+  REBASE_NOTE,
+  type MarkSet,
+} from "./unreviewed-ratchet.js";
 import {
   DEFAULT_REASON,
   bucketFor,
@@ -362,6 +373,7 @@ describe("renderStaleTags", () => {
 // touches. Pins that the shards stay in step with the baseline they measure.
 describe("the committed per-file unreviewed marks", () => {
   const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const MARK_DIR_REL = "scripts/api-compare/call-mismatches-unreviewed";
   const load = async () => ({
     counts: unreviewedCounts(
       await loadSplitBaseline(path.join(HERE, "call-mismatches-exclude")),
@@ -376,15 +388,71 @@ describe("the committed per-file unreviewed marks", () => {
     expect(excessByPath(counts, marks)).toEqual([]);
   });
 
-  // The slack arm of the gate, run without needing a compare artifact.
+  // The slack arm of the gate, run without needing a compare artifact. The
+  // assertion message carries `renderSlack`'s remedy verbatim: this test is the
+  // `Unit Tests` half of a stale mark, and a bare "expected [...] to equal []"
+  // on a two-line diff reads as an unrelated flake (RFC 0106).
   it("are tight — no shard claims more unreviewed rows than the baseline carries", async () => {
     const { counts, marks } = await load();
-    expect([...marks].filter(([rel, max]) => max > (counts.get(rel) ?? 0))).toEqual([]);
+    const slack = slackByPath(counts, marks);
+    expect(slack, slack.length === 0 ? "" : renderSlack(slack, MARK_DIR_REL)).toEqual([]);
   });
 
   it("key every shard to a source the baseline still has entries for", async () => {
     const { counts, marks } = await load();
     expect([...marks.keys()].filter((rel) => !counts.has(rel))).toEqual([]);
+  });
+});
+
+// The rebase case (RFC 0106): a branch deletes an exclude row and tightens, so
+// its mark is LOWER than main's. `main` then advances over the same shard and
+// the rebase takes main's copy with no conflict — the row deletion still
+// stands, so the shard is stale again on a diff that never touched it. The
+// remedy stays manual (the STALE report is also the signal that a row retired),
+// so what is pinned here is that both jobs name it.
+describe("a rebase that restores a higher mark", () => {
+  const SHARD = "activerecord/associations/has-one-association.json";
+  // Post-rebase: the branch's 8 -> 7 tighten is gone, the deletion is not.
+  const counts: MarkSet = new Map([[SHARD, 7]]);
+  const marks: MarkSet = new Map([[SHARD, 8]]);
+
+  it("is reported as a stale high-water mark", () => {
+    expect(slackByPath(counts, marks)).toEqual([{ file: SHARD, count: 7, mark: 8 }]);
+  });
+
+  it("names the exact tighten command and the rebase cause in the report", () => {
+    const out = renderSlack(slackByPath(counts, marks), "scripts/api-compare/x");
+    expect(out).toContain(`pnpm parity:api:calls:tighten ${SHARD}`);
+    expect(out).toContain(REBASE_NOTE);
+  });
+
+  it("lists every stale shard in one command", () => {
+    const two = slackByPath(
+      new Map([["a.json", 0]]),
+      new Map([
+        ["a.json", 1],
+        [SHARD, 2],
+      ]),
+    );
+    expect(tightenCommand(two)).toBe(`  pnpm parity:api:calls:tighten ${SHARD} a.json`);
+  });
+
+  it("tightens back to the branch's own count, and never raises a mark", () => {
+    expect(tightenMarks(counts, marks)).toEqual(new Map([[SHARD, 7]]));
+    // The reverse direction — a count above its mark — is the excess arm's job.
+    expect(tightenMarks(new Map([[SHARD, 9]]), marks)).toEqual(marks);
+  });
+
+  it('deletes a shard that reached 0 rather than writing {"max": 0}', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "marks-"));
+    try {
+      await fs.mkdir(path.dirname(path.join(dir, SHARD)), { recursive: true });
+      await fs.writeFile(path.join(dir, SHARD), '{\n  "max": 8\n}\n');
+      await writeMarks(dir, tightenMarks(new Map([[SHARD, 0]]), marks));
+      expect(await loadMarks(dir)).toEqual(new Map());
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/api-compare/unreviewed-ratchet.ts
+++ b/scripts/api-compare/unreviewed-ratchet.ts
@@ -376,10 +376,34 @@ export function renderSlack(slack: MarkDelta[], markDir: string): string {
     "narrow: this writes ONLY the shards below, never the exclude tree (converging a row and " +
     "retiring it by hand is exactly what lands you here, and a whole-tree reseed would bury " +
     "it):\n" +
-    "  pnpm parity:api:calls:tighten [<shard>...]   (no shard named = every stale one)\n" +
-    slack.map((d) => `  - ${d.file}  mark ${d.mark}, only ${d.count} unreviewed`).join("\n")
+    `${tightenCommand(slack)}\n` +
+    slack.map((d) => `  - ${d.file}  mark ${d.mark}, only ${d.count} unreviewed`).join("\n") +
+    `\n${REBASE_NOTE}`
   );
 }
+
+/**
+ * The copy-pasteable remedy for a slack shard set, naming each shard explicitly
+ * rather than the `[<shard>...]` placeholder: this text is what an author reads
+ * out of a CI log, and a placeholder there costs a round of re-deriving which
+ * shards moved.
+ */
+export function tightenCommand(slack: MarkDelta[]): string {
+  return `  pnpm parity:api:calls:tighten ${slack.map((d) => d.file).join(" ")}`;
+}
+
+/**
+ * A rebase is the second way into a slack shard, and the one that reads as an
+ * unrelated failure: a branch that deleted an exclude row and tightened has a
+ * LOWERED mark, so when `main` advances over the same shard the rebase takes
+ * main's higher copy with no conflict and nothing in its output. The deletion
+ * still stands, so the shard is stale again on a diff that never touched it —
+ * which is why both this gate and the mark unit test say so out loud.
+ */
+export const REBASE_NOTE =
+  "If your branch already ran --tighten, a rebase restored main's copy of the shard " +
+  "(git takes main's side with no conflict when your commit did not touch it) — re-run " +
+  "the command above after every rebase.";
 
 export function renderWriteSummary(
   count: number,

--- a/scripts/sync-stats/cron-wrapper.sh
+++ b/scripts/sync-stats/cron-wrapper.sh
@@ -1,17 +1,29 @@
 #!/usr/bin/env bash
 # Wrapper for cron-triggered stats sync.
-# Runs --latest, retries once on rate-limit failure, emails on failure.
+# Runs --latest, retries once on rate-limit failure, alerts on failure.
+#
+# A failed run used to be indistinguishable from a successful one in the log:
+# the counts block below is appended either way, so both outages of August 2026
+# (stats-sync-20260813, stats-sync-20260821) were noticed only because someone
+# read the log days later, by which point stats.db had a multi-day hole. So
+# every run now closes with an explicit verdict line, and a failing one is a
+# `[cron-wrapper] ... failed ...` line naming the stage and the error — the shape
+# btwhooks' stats watcher matches (`^\[cron-wrapper\] .*fail`) to notify a pane,
+# which is the alerting path that does not require anyone to open the log.
+# A successful run prints one `ok` line and raises nothing.
 #
 # Configuration via environment variables (override in the crontab line):
-#   PROJ_DIR — repo root (default: this script's grandparent directory)
-#   LOG      — path for the sync log file (default: ~/github/blazetrailsdev/stats-sync.log)
-#   EMAIL    — alert recipient (REQUIRED; no default — fail fast)
+#   PROJ_DIR    — repo root (default: this script's grandparent directory)
+#   LOG         — path for the sync log file (default: ~/github/blazetrailsdev/stats-sync.log)
+#   EMAIL       — alert recipient (REQUIRED; no default — fail fast)
+#   STALE_HOURS — flag a gap since the previous run wider than this (default 26)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJ_DIR="${PROJ_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 LOG="${LOG:-$HOME/github/blazetrailsdev/stats-sync.log}"
 EMAIL="${EMAIL:-}"
+STALE_HOURS="${STALE_HOURS:-26}"
 
 if [ -z "$EMAIL" ]; then
   echo "[cron-wrapper] EMAIL env var must be set" >&2
@@ -22,13 +34,80 @@ mkdir -p "$(dirname "$LOG")"
 
 cd "$PROJ_DIR"
 
+# A run that never happens produces no exit code to alert on, so the only
+# evidence of a wrapper that stopped being invoked (crontab edited, host down,
+# pnpm gone) is the gap between this header and the previous one. Report it
+# without the word "failed": this run is fine, and it must not trip the failure
+# matcher.
+report_gap() {
+  local previous
+  previous=$(grep -oE '^=== [0-9]{4}-[0-9]{2}-[0-9]{2}T[^ ]+ ===$' "$LOG" 2>/dev/null | tail -1) || return 0
+  [ -n "$previous" ] || return 0
+  previous=${previous#=== }
+  previous=${previous% ===}
+  local since now hours
+  since=$(date -d "$previous" +%s 2>/dev/null) || return 0
+  now=$(date +%s)
+  hours=$(( (now - since) / 3600 ))
+  if [ "$hours" -ge "$STALE_HOURS" ]; then
+    echo "[cron-wrapper] stale: previous run was ${hours}h ago (expected ~24h) — the sync did not run in between" >> "$LOG"
+  fi
+}
+
+report_gap
 echo "=== $(date -u -Iseconds) ===" >> "$LOG"
 
+# An unreachable mailer must not take the wrapper down with it: under `set -e` a
+# non-zero msmtp would abort the script before it wrote its verdict line or its
+# exit code, turning a triagable failure back into a silent one.
 send_alert() {
   local subject="$1"
   local body="$2"
   printf 'To: %s\nSubject: %s\n\n%s\n' "$EMAIL" "$subject" "$body" \
-    | msmtp "$EMAIL"
+    | msmtp "$EMAIL" \
+    || echo "[cron-wrapper] alert email to $EMAIL could not be sent" >> "$LOG"
+}
+
+# The stage the sync died in, from the `=== Syncing ... ===` banners sync.ts
+# prints; before the first banner the failure is in the build or in startup.
+failing_stage() {
+  local stage
+  stage=$(grep -oE '^=== .+ ===$' "$tmplog" | tail -1) || true
+  if [ -z "$stage" ]; then
+    echo "startup"
+  else
+    stage=${stage#=== }
+    echo "${stage% ===}"
+  fi
+}
+
+# The line worth putting in a notification. pnpm's own `[ELIFECYCLE] Command
+# failed with exit code 1` is the LAST line and says nothing; in both outages the
+# real error sat several lines above it.
+error_line() {
+  local line
+  line=$(grep -m1 -E '^[A-Za-z]*(Error|Exception)\b|^Error:|^error:|^\s*at .*Error' "$tmplog") || true
+  [ -n "$line" ] || line=$(grep -v -e '^\[ELIFECYCLE\]' -e '^$' "$tmplog" | tail -1) || true
+  echo "${line:-no output}"
+}
+
+# One line per failed run, in the shape btwhooks' stats watcher matches, plus
+# the mail. Both carry the stage and the error, not just the exit code.
+report_failure() {
+  local exit_code="$1"
+  local note="$2"
+  local stage error
+  stage=$(failing_stage)
+  error=$(error_line)
+  echo "[cron-wrapper] stats sync failed at stage \"$stage\" (exit $exit_code): $error" >> "$LOG"
+  send_alert "[stats-sync] failed at \"$stage\" (exit $exit_code)" \
+    "$note
+
+Stage: $stage
+Error: $error
+
+Last 30 lines:
+$(tail -30 "$tmplog")"
 }
 
 run_sync() {
@@ -62,21 +141,13 @@ if [ "$exit_code" -ne 0 ] && grep -qi "rate limit\|secondary rate\|abuse detecti
   set -e
   cat "$tmplog" >> "$LOG"
   if [ "$retry_exit" -ne 0 ]; then
-    send_alert "[stats-sync] failed after rate-limit retry (exit $retry_exit)" \
-      "Retry exited $retry_exit after rate-limit cooldown.
-
-Last 30 lines:
-$(tail -30 "$tmplog")"
+    report_failure "$retry_exit" "Retry exited $retry_exit after rate-limit cooldown."
     exit_code=$retry_exit
   else
     exit_code=0
   fi
 elif [ "$exit_code" -ne 0 ]; then
-  send_alert "[stats-sync] failed (exit $exit_code)" \
-    "First run exited $exit_code; no rate-limit signals detected.
-
-Last 30 lines:
-$(tail -30 "$tmplog")"
+  report_failure "$exit_code" "First run exited $exit_code; no rate-limit signals detected."
 fi
 
 # DB path matches sync.ts's DB_PATH: ~/github/blazetrailsdev/stats.db
@@ -88,6 +159,12 @@ if [ -f "$db" ] && command -v sqlite3 >/dev/null 2>&1; then
     SELECT 'Logs: ' || COUNT(*) FROM raw_job_logs;
     SELECT 'Compare: ' || COUNT(DISTINCT merge_commit_sha) FROM test_compare_stats;
   " >> "$LOG"
+fi
+
+# Close every run with a verdict, so a reader (or a parser) never has to infer
+# one from whether the counts above happen to have moved.
+if [ "$exit_code" -eq 0 ]; then
+  echo "[cron-wrapper] ok" >> "$LOG"
 fi
 echo "" >> "$LOG"
 exit "${exit_code}"


### PR DESCRIPTION
## What

Two independent script fixes, both about a failure that currently reaches nobody.

### 1. The nightly stats sync alerts on failure (`scripts/sync-stats/cron-wrapper.sh`)

A failed run was indistinguishable from a successful one in `stats-sync.log`: the closing sqlite3 counts block is appended either way, so both August 2026 outages (`stats-sync-20260813`, `stats-sync-20260821`) were noticed only when a human read the log days later, with a multi-day hole in `stats.db` by then.

- Every run closes with a verdict. A failure writes one
  `[cron-wrapper] stats sync failed at stage "<stage>" (exit N): <error>` line — the shape btwhooks' stats watcher matches (`^\[cron-wrapper\] .*fail`) to notify a pane, i.e. the alerting path that does not require anyone to open the log.
- The stage comes from sync.ts's `=== Syncing ... ===` banners, the error from the first real error line rather than pnpm's `[ELIFECYCLE]` tail, which said nothing in either outage. Both go in the mail too.
- A successful run prints one `ok` line and notifies nobody.
- An unreachable mailer no longer takes the wrapper down with it: under `set -e` a non-zero `msmtp` aborted the script *before* it wrote its verdict or its exit code.
- Staleness: a gap wider than `STALE_HOURS` (default 26) since the previous run header is reported, so a wrapper that stopped being invoked at all — which produces no failing exit code to alert on — is visible on the next run.

No change to the sync itself or to the cron schedule.

Verified by running the wrapper against stub `pnpm`/`msmtp` binaries over the success, first-run-failure, mailer-down and stale-gap paths; `shellcheck` clean.

### 2. A rebase-restaled mark now names its remedy in both jobs (RFC 0106)

A branch that deletes an exclude row and tightens has a *lowered* mark; when `main` advances over the same shard, the rebase takes main's higher copy with no conflict and nothing in its output, so the shard is stale again on a diff that never touched it. That reds `Rails API/Test Comparison` **and** `Unit Tests`, and the unit-test half read as an unrelated flake.

Triage kept the manual step (the STALE report is also the signal that a row retired) and took option 3 in full:

- `renderSlack` prints the exact `pnpm parity:api:calls:tighten <shard>...` command instead of the `[<shard>...]` placeholder, plus a note naming the rebase as the cause.
- The mark unit test carries that same rendered text as its assertion message, so the `Unit Tests` red is self-explanatory.
- New coverage for the rebase-restores-a-higher-mark case: it is reported as slack, tightens back to the branch's own count, never raises a mark, and a shard reaching 0 is deleted rather than written as `{"max": 0}`.

### 3. Already done upstream

`retire-make-constraints-per-link-arel-join-rewalk` was implemented by #6779 (`retire JoinPart#arelJoin`) — `resolvedByIdx`, `walkedLen` and the per-link redistribution are all gone from `makeConstraints`. Marked done against that PR, nothing in this diff.

Closes-story: alert-on-stats-sync-failure
Closes-story: rebase-restales-tightened-mark-reds-unit-tests