### PR TITLE
test(activerecord): select_entry case leases the pool connection instead of checking out a second

### DIFF
--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -76,33 +76,36 @@ describe("InternalMetadata#selectEntry", () => {
   it("sends the key as a bind rather than inlining it", async () => {
     const internalMetadata = new InternalMetadata(Base.connectionPool());
     await internalMetadata.createTable();
-    const connection = await Base.connectionPool().checkout();
-    const selectAll = vi.spyOn(connection, "selectAll");
-    try {
-      await (
-        internalMetadata as unknown as {
-          selectEntry(c: DatabaseAdapter, key: string): Promise<unknown>;
-        }
-      ).selectEntry(connection, "environment");
-      const sm = selectAll.mock.calls[0][0] as {
-        constraints: { right: unknown }[];
-      };
-      const right = sm.constraints[0].right as Nodes.BindParam;
-      expect(right).toBeInstanceOf(Nodes.BindParam);
-      expect(right.value).toBe("environment");
+    // `withConnection` rather than a second `checkout()`: on the
+    // `ARCONN=sqlite3_mem` lane every connection owns its own private database,
+    // so a freshly checked-out one has never seen the table just created.
+    await Base.connectionPool().withConnection(async (connection) => {
+      const selectAll = vi.spyOn(connection, "selectAll");
+      try {
+        await (
+          internalMetadata as unknown as {
+            selectEntry(c: DatabaseAdapter, key: string): Promise<unknown>;
+          }
+        ).selectEntry(connection, "environment");
+        const sm = selectAll.mock.calls[0][0] as {
+          constraints: { right: unknown }[];
+        };
+        const right = sm.constraints[0].right as Nodes.BindParam;
+        expect(right).toBeInstanceOf(Nodes.BindParam);
+        expect(right.value).toBe("environment");
 
-      // A substituting adapter (prepared statements off — MySQL's default)
-      // renders the same node as a literal, so the placeholder is only
-      // observable where the binds actually travel separately.
-      if ((connection as unknown as { preparedStatements?: boolean }).preparedStatements) {
-        const [sql, binds] = toSqlAndBinds.call(connection as never, sm as never);
-        expect(sql).not.toContain("environment");
-        expect(binds).toEqual(["environment"]);
+        // A substituting adapter (prepared statements off — MySQL's default)
+        // renders the same node as a literal, so the placeholder is only
+        // observable where the binds actually travel separately.
+        if ((connection as unknown as { preparedStatements?: boolean }).preparedStatements) {
+          const [sql, binds] = toSqlAndBinds.call(connection as never, sm as never);
+          expect(sql).not.toContain("environment");
+          expect(binds).toEqual(["environment"]);
+        }
+      } finally {
+        selectAll.mockRestore();
       }
-    } finally {
-      selectAll.mockRestore();
-      Base.connectionPool().checkin(connection);
-    }
+    });
   });
 });
 


### PR DESCRIPTION
The `InternalMetadata#selectEntry` BindParam case added in #6811 creates the metadata table through the pool's leased connection, then ran its probe against a connection it checked out separately.

On `ARCONN=sqlite3_mem` — the only lane where `in_memory_db?` is true — every SQLite connection owns its own private database, so the freshly checked-out connection had never seen the table and the probe raised `StatementInvalid: no such table: ar_internal_metadata`. That reds `Active Record SQLite :memory: Tests` on main @ab4189dc; every other lane shares one file-backed database and passes.

The probe now runs inside `Base.connectionPool().withConnection(...)`, which hands back the same leased connection `createTable` used. Assertions are unchanged, and the `checkin` in the old `finally` goes away with the manual checkout.

### Verification

`pnpm vitest run packages/activerecord/src/internal-metadata.trails.test.ts` green on both the default lane and `ARCONN=sqlite3_mem` (7/7 each); the latter fails on baseline with the CI error.

Closes-story: red-ab4189dc