### PR TITLE
refactor(activerecord,activemodel,activesupport): converge proxy overrides, hasAttribute aliases, AM pattern macros; port the XML conversions

### DIFF
--- a/eslint/rails-error-parity-unported.json
+++ b/eslint/rails-error-parity-unported.json
@@ -31,12 +31,6 @@
   },
   {
     "package": "activesupport",
-    "name": "DisallowedType",
-    "rubyFile": "active_support/core_ext/hash/conversions.rb",
-    "reason": "active_support/core_ext/hash/conversions.rb (Hash#to_xml/from_xml) is unported."
-  },
-  {
-    "package": "activesupport",
     "name": "InvalidContentError",
     "rubyFile": "active_support/encrypted_configuration.rb",
     "reason": "active_support/encrypted_configuration.rb (encryption) is unported."

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -138,6 +138,10 @@ interface ReadWriteHost {
 export interface AttributeMethodHost {
   attributeNames(): string[];
   attributeMethodPatterns: AttributeMethodPattern[];
+  /** @internal Stamps read by {@link _resurrectAttributeMethods}. */
+  _patternsGeneratedFor?: Map<string, AttributeMethodPattern[]>;
+  /** @internal Stamp read by {@link _resurrectAttributeMethods}. */
+  _patternsAtLastResurrection?: AttributeMethodPattern[];
   attributeAliases: Record<string, string>;
   _aliasesByAttributeName: Map<string, string[]>;
   _generatedAttributeMethods?: Module;
@@ -274,11 +278,6 @@ export function _readAttribute(
  * (attribute_methods.rb:106-109). TS forbids a keyword after a rest element, so
  * the trailing `parameters:` hash rides in the splat and is peeled off — the
  * same shape `touch(*names, time:)` uses in `activerecord/timestamp.ts`.
- *
- * Rails stops at `undefine_attribute_methods` and regenerates a late-declared
- * pattern lazily via `method_missing` (attribute_methods.rb:504-518). JS has no
- * `method_missing`, so the `defineAttributeMethods` call here — and in
- * `attributeMethodSuffix` / `attributeMethodAffix` — materializes it eagerly.
  */
 export function attributeMethodPrefix(
   this: ClassMethods,
@@ -290,7 +289,6 @@ export function attributeMethodPrefix(
     ...(prefixes as string[]).map((prefix) => new AttributeMethodPattern({ prefix, parameters })),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...this.attributeNames());
 }
 
 /** Mirrors: ClassMethods#attribute_method_suffix (attribute_methods.rb:140-143). */
@@ -304,7 +302,6 @@ export function attributeMethodSuffix(
     ...(suffixes as string[]).map((suffix) => new AttributeMethodPattern({ suffix, parameters })),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...this.attributeNames());
 }
 
 /** Mirrors: ClassMethods#attribute_method_affix (attribute_methods.rb:175-178). */
@@ -317,7 +314,6 @@ export function attributeMethodAffix(
     ...affixes.map((affix) => new AttributeMethodPattern(affix)),
   ];
   this.undefineAttributeMethods();
-  this.defineAttributeMethods(...this.attributeNames());
 }
 
 export function aliasAttribute(this: ClassMethods, newName: string, oldName: string): void {
@@ -412,6 +408,11 @@ export function defineAttributeMethod(
     }
     this.attributeMethodPatternsCache().clear();
   });
+  // Copy-on-first-write per class, like `aliasesByAttributeName`.
+  if (!Object.prototype.hasOwnProperty.call(this, "_patternsGeneratedFor")) {
+    this._patternsGeneratedFor = new Map(this._patternsGeneratedFor ?? []);
+  }
+  this._patternsGeneratedFor!.set(as, this.attributeMethodPatterns);
 }
 
 // ---------------------------------------------------------------------------
@@ -816,4 +817,29 @@ export function defineMethodAttribute(
       });
     });
   });
+}
+
+/**
+ * The trails stand-in for the resurrection Rails gets from `method_missing`
+ * (attribute_methods.rb:507-514): the three macros end at
+ * `undefine_attribute_methods` (attribute_methods.rb:120-123, 140-143,
+ * 175-178) and Rails re-matches the newly added pattern at call time, so a
+ * pattern declared after the attributes still answers. trails generates them as
+ * accessor properties instead — see CLAUDE.md, "Generated attribute readers are
+ * properties" — and a property cannot be created by a `method_missing`-shaped
+ * hook, so it must exist before the first read; the earliest such moment is
+ * instantiation, where {@link Model}'s constructor calls this. Regenerating
+ * only names whose stamp predates the current
+ * `attribute_method_patterns` is what confines it to the macro case: a bare
+ * `undefine_attribute_methods` leaves the patterns alone and stays undone, and
+ * a class that has generated nothing keeps its own first-generation seat.
+ */
+export function _resurrectAttributeMethods(klass: ClassMethods): void {
+  const patterns = klass.attributeMethodPatterns;
+  if (klass._patternsAtLastResurrection === patterns) return;
+  klass._patternsAtLastResurrection = patterns;
+  const stale = [...(klass._patternsGeneratedFor ?? [])]
+    .filter(([, generatedWith]) => generatedWith !== patterns)
+    .map(([attrName]) => attrName);
+  if (stale.length > 0) klass.defineAttributeMethods(...stale);
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -78,6 +78,7 @@ import {
   AttributeMethodPattern,
   type AttributeMethodMatch,
   defineMethodAttribute,
+  _resurrectAttributeMethods,
 } from "./attribute-methods.js";
 import {
   _assignAttribute as attrAssignOne,
@@ -1612,6 +1613,8 @@ export class Model {
     // a single point that subclasses (e.g. ActiveRecord) override.
     this.initInternals();
 
+    _resurrectAttributeMethods(ctor as unknown as Parameters<typeof _resurrectAttributeMethods>[0]);
+
     // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
     this._attributes = ctor._defaultAttributes().deepDup();
 
@@ -1751,8 +1754,9 @@ export class Model {
    * `@attributes.key?(attr_name)` (activerecord/attribute_methods.rb:316-320).
    */
   hasAttribute(name: string): boolean {
-    const ctor = this.constructor as typeof Model;
-    return this._attributes.isKey(ctor.resolveAttributeName(name));
+    let attrName = String(name);
+    attrName = (this.constructor as typeof Model).attributeAliases[attrName] ?? attrName;
+    return this._attributes.isKey(attrName);
   }
 
   /**

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -1,7 +1,6 @@
 import type { Base } from "./base.js";
 import { Relation } from "./relation.js";
 import type { CollectionProxy } from "./associations/collection-proxy.js";
-import { _setAssociationRelationCtor } from "./associations/collection-proxy.js";
 import type { Association } from "./associations/association.js";
 import { setAssociationRelationFactory } from "./associations/_scope-slots.js";
 import { _cacheSingularTarget } from "./associations.js";
@@ -386,7 +385,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 }
 
-_setAssociationRelationCtor(AssociationRelation);
 _registerRelationFamily(
   "associationRelation",
   AssociationRelation as unknown as new (...a: never[]) => unknown,

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -9,25 +9,9 @@ import {
   type CallbackHost,
 } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
-import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
-import {
-  associationRelationClassFor,
-  collectionProxyClassFor,
-  wrapWithScopeProxy,
-} from "../relation/delegation.js";
+import { collectionProxyClassFor, wrapWithScopeProxy } from "../relation/delegation.js";
 import { _registerRelationFamily } from "../relation/uncacheable-methods-slot.js";
 
-// Late-bound AssociationRelation constructor to break circular imports
-// (association-relation.ts extends Relation, which would otherwise
-// transitively load before Base finishes initializing the Relation ctor
-// slot). Set by association-relation.ts when it loads.
-let _AssociationRelationCtor: (new (modelClass: any, assoc: any) => any) | null = null;
-/** @internal */
-export function _setAssociationRelationCtor(
-  ctor: new (modelClass: any, assoc: any) => AssociationRelationType<any>,
-): void {
-  _AssociationRelationCtor = ctor;
-}
 import { applyThenable, stripThenable } from "../relation/thenable.js";
 import {
   findNthFromLast as baseFindNthFromLast,
@@ -36,7 +20,7 @@ import {
 } from "../relation/finder-methods.js";
 import type { Nodes } from "@blazetrails/arel";
 import { singularize, camelize, constantize } from "@blazetrails/activesupport";
-import { ConfigurationError, AssociationTypeMismatch } from "../errors.js";
+import { AssociationTypeMismatch } from "../errors.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   autoloadModel,
@@ -1248,22 +1232,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Delegates to the target model class's transaction method.
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#transaction
-   */
-  async transaction<R>(
-    fn: (tx: unknown) => Promise<R>,
-    options?: { isolation?: string; requiresNew?: boolean; joinable?: boolean },
-  ): Promise<R | undefined> {
-    const klass = this.model;
-    if (typeof klass.transaction === "function") {
-      return klass.transaction(fn as any, options);
-    }
-    return fn(undefined);
-  }
-
-  /**
    * Raises an error — prepend is not supported on associations.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#prepend
@@ -1314,26 +1282,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     for (const record of records) {
       yield record;
     }
-  }
-
-  /**
-   * Chains off the proxy (`blog.posts.where(...)`) return an
-   * AssociationRelation, not another CollectionProxy — matching Rails,
-   * where `blog.posts` is a CP and `blog.posts.where(...)` is an AR.
-   * AR still routes writes through `_association` (this CP) so the FK,
-   * inverse, and loaded target stay wired up.
-   */
-  override clone(): Relation<T> {
-    if (!_AssociationRelationCtor) {
-      throw new ConfigurationError(
-        "CollectionProxy.clone: AssociationRelation constructor not set — " +
-          "association-relation.ts must be loaded first",
-      );
-    }
-    const Ctor = associationRelationClassFor(this.model);
-    const rel = new Ctor(this.model, this) as Relation<T>;
-    rel.initializeCopy(this as unknown as Relation<T>);
-    return wrapWithScopeProxy(rel);
   }
 }
 

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -93,6 +93,21 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(t.hasAttribute("missing")).toBe(false);
   });
 
+  it("returns true for alias_attribute names on the class", () => {
+    // The class-level twin of the test above — Rails resolves
+    // `attribute_aliases` against `attribute_types`
+    // (active_record/attribute_methods.rb:254-258).
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.aliasAttribute("heading", "title");
+      }
+    }
+    expect(Topic.hasAttribute("heading")).toBe(true);
+    expect(Topic.hasAttribute("title")).toBe(true);
+    expect(Topic.hasAttribute("missing")).toBe(false);
+  });
+
   it("readonly attributes are not updated after create", async () => {
     // Rails raises ReadonlyAttributeError on a persisted-record write to an
     // attr_readonly column (readonly_attributes.rb line 49). The test name's

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -90,13 +90,12 @@ interface AttributeAccessorHost {
  * Mirrors: ActiveRecord::AttributeMethods#has_attribute?
  */
 export function hasAttribute(this: AttributeRecord, name: string): boolean {
-  // Rails: `attr_name = self.class.attribute_aliases[attr_name] || attr_name`
-  // then `@attributes.key?(attr_name)` (attribute_methods.rb:316-319).
-  return this._attributes.has(
-    (
-      this.constructor as unknown as { resolveAttributeName(n: string): string }
-    ).resolveAttributeName(name),
-  );
+  let attrName = String(name);
+  attrName =
+    (this.constructor as unknown as { attributeAliases: Record<string, string> }).attributeAliases[
+      attrName
+    ] ?? attrName;
+  return this._attributes.has(attrName);
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4309,9 +4309,8 @@ export class Base extends Model {
   /** Mirrors: ActiveRecord::AttributeMethods::ClassMethods#has_attribute?
    * (attribute_methods.rb:254-258). */
   static hasAttribute(name: string): boolean {
-    // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
-    // (attribute_methods.rb:256) before checking `attribute_types`.
-    const attrName = this.resolveAttributeName(String(name));
+    let attrName = String(name);
+    attrName = this.attributeAliases[attrName] ?? attrName;
     return Object.hasOwn(this.attributeTypes(), attrName);
   }
 

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -4,7 +4,9 @@
 
 import { ArgumentError, assertValidKeys } from "./hash-utils.js";
 import { I18n } from "./i18n.js";
-import { camelize } from "./inflector.js";
+import { camelize, pluralize, singularize, underscore } from "./inflector.js";
+import * as XmlMini from "./xml-mini.js";
+import { isPlainObject } from "./hash-utils.js";
 import { inspect, toS } from "./core-ext/object/inspect.js";
 import { isEmpty } from "./ruby-empty.js";
 
@@ -230,3 +232,72 @@ export function toFs(self: unknown[], format = "default"): string {
 
 // `alias_method :to_formatted_s, :to_fs` — conversions.rb:106.
 export { toFs as toFormattedS };
+
+/**
+ * Ruby's `value.class.name` for the `all?(first.class)` root inference
+ * (conversions.rb:190-192). JS has one `Number` where Ruby has `Integer` and
+ * `Float`, so the split follows `XmlMini`'s own `TYPE_NAMES` mapping and
+ * `[1, 2]` still roots at `integers` the way Rails does.
+ */
+function rubyClassName(value: unknown): string {
+  if (value === null || value === undefined) return "NilClass";
+  switch (typeof value) {
+    case "boolean":
+      return value ? "TrueClass" : "FalseClass";
+    case "bigint":
+      return "Integer";
+    case "number":
+      return Number.isInteger(value) ? "Integer" : "Float";
+    case "string":
+      return "String";
+    default:
+      return (value as object).constructor.name;
+  }
+}
+
+/**
+ * Returns a string that represents the array in XML by invoking `to_xml` on
+ * each element. Mirrors: `Array#to_xml` (conversions.rb:183-212). Ruby `||=`
+ * replaces only nil/false and `0` is truthy there, so `indent: 0` survives the
+ * defaulting — hence `??=`.
+ */
+export function toXml(
+  self: unknown[],
+  options: XmlMini.ToXmlOptions = {},
+  block?: (builder: XmlMini.XmlBuilder) => void,
+): string {
+  options = { ...options };
+  options.indent ??= 2;
+  options.builder ??= new XmlMini.IndentedXmlStringBuilder("", options.indent);
+  options.root ??= (() => {
+    const first = self[0];
+    if (!isPlainObject(first) && self.every((e) => rubyClassName(e) === rubyClassName(first))) {
+      const underscored = underscore(rubyClassName(first));
+      return pluralize(underscored).replaceAll("/", "_");
+    } else {
+      return "objects";
+    }
+  })();
+
+  const builder = options.builder;
+  const skipInstruct = options.skipInstruct;
+  delete options.skipInstruct;
+  if (!skipInstruct) builder.instruct();
+
+  const root = XmlMini.renameKey(String(options.root), options);
+  const children = options.children ?? singularize(root);
+  delete options.children;
+  const attributes: Record<string, string> = options.skipTypes ? {} : { type: "array" };
+
+  if (isEmpty(self)) {
+    builder.tag(root, null, attributes);
+  } else {
+    builder.openTag(root, attributes);
+    for (const value of self) {
+      XmlMini.toTag(children, value, options as XmlMini.ToTagOptions);
+    }
+    if (block) block(builder);
+    builder.closeTag(root);
+  }
+  return builder.target();
+}

--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { toXml as toXmlArray } from "./array-utils.js";
 import {
   deepMerge,
   deepDup,
@@ -686,5 +687,50 @@ describe("ToParamTest", () => {
 
   it("array", () => {
     expect([1, 2, 3].join("/")).toBe("1/2/3");
+  });
+});
+
+describe("ToXmlTest", () => {
+  it("to xml with hash elements", () => {
+    const xml = toXmlArray(
+      [
+        { name: "David", age: 26, age_in_millis: 820497600000 },
+        { name: "Jason", age: 31 },
+      ],
+      { skipInstruct: true, indent: 0 },
+    );
+
+    expect(xml.slice(0, 30)).toBe('<objects type="array"><object>');
+    expect(xml).toContain('<age type="integer">26</age>');
+    expect(xml).toContain('<age-in-millis type="integer">820497600000</age-in-millis>');
+    expect(xml).toContain("<name>David</name>");
+    expect(xml).toContain('<age type="integer">31</age>');
+    expect(xml).toContain("<name>Jason</name>");
+  });
+
+  it("to xml with non hash elements", () => {
+    const xml = toXmlArray(["1", "2", "3"], { skipInstruct: true, indent: 0 });
+
+    expect(xml.slice(0, 29)).toBe('<strings type="array"><string');
+    expect(xml).toContain("<string>2</string>");
+  });
+
+  it("to xml with options", () => {
+    const xml = toXmlArray(
+      [
+        { name: "David", street_address: "Paulina" },
+        { name: "Jason", street_address: "Evergreen" },
+      ],
+      { skipInstruct: true, skipTypes: true, indent: 0 },
+    );
+
+    expect(xml.slice(0, 17)).toBe("<objects><object>");
+    expect(xml).toContain("<street-address>Paulina</street-address>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
+  it("to xml with empty", () => {
+    const xml = toXmlArray([]);
+    expect(xml).toMatch(/type="array"\/>/);
   });
 });

--- a/packages/activesupport/src/core-ext/hash/conversions.ts
+++ b/packages/activesupport/src/core-ext/hash/conversions.ts
@@ -1,0 +1,203 @@
+/**
+ * `ActiveSupport::XMLConverter` — the `Hash.from_xml` half of
+ * `core_ext/hash/conversions.rb:138-262`. The four `Hash` members themselves
+ * live at the trails seat for Hash core extensions, `hash-utils.ts`.
+ */
+
+import * as XmlMini from "../../xml-mini.js";
+import { StringIO } from "../../string-io.js";
+import { isBlank, isPresent } from "../object/blank.js";
+import { isEmpty } from "../../ruby-empty.js";
+import { wrap } from "../../array-utils.js";
+import { isPlainObject } from "../../hash-utils.js";
+import { inspect } from "../object/inspect.js";
+
+/** Mirrors Ruby's `RuntimeError` — what a bare `raise "message"` raises. */
+class RuntimeError extends Error {
+  override name = "RuntimeError";
+}
+
+/**
+ * Raised if the XML contains attributes with type="yaml" or
+ * type="symbol". Read Hash#from_xml for more details.
+ *
+ * Mirrors: ActiveSupport::XMLConverter::DisallowedType (conversions.rb:142-147)
+ */
+export class DisallowedType extends Error {
+  override name = "DisallowedType";
+
+  constructor(type: unknown) {
+    super(`Disallowed type attribute: ${inspect(type)}`);
+  }
+}
+
+/** Mirrors: ActiveSupport::XMLConverter::DISALLOWED_TYPES (conversions.rb:149) */
+export const DISALLOWED_TYPES = ["symbol", "yaml"];
+
+/** Mirrors: ActiveSupport::XMLConverter (conversions.rb:140-262). */
+export class XMLConverter {
+  private xml: unknown;
+  private disallowedTypes: string[];
+
+  constructor(xml: unknown, disallowedTypes?: string[] | null) {
+    this.xml = xml;
+    this.disallowedTypes = disallowedTypes ?? DISALLOWED_TYPES;
+  }
+
+  /**
+   * `XMLConverter.new` — the `normalize_keys(XmlMini.parse(xml))` seeding of
+   * `@xml` (conversions.rb:151-154).
+   *
+   * @noRailsEquivalent PERMANENT — `XmlMini.parse` is awaitable in trails and a
+   * TS constructor cannot await, so the parsing half of `initialize` moves to a
+   * factory. `to_h` still reads the normalized `@xml` (conversions.rb:157).
+   */
+  static async create(
+    xml: string | StringIO | null | undefined,
+    disallowedTypes?: string[] | null,
+  ): Promise<XMLConverter> {
+    const converter = new XMLConverter(undefined, disallowedTypes);
+    converter.xml = converter.normalizeKeys(await XmlMini.parse(xml));
+    return converter;
+  }
+
+  /** Mirrors: ActiveSupport::XMLConverter#to_h (conversions.rb:156-158) */
+  toH(): unknown {
+    return this.deepToH(this.xml);
+  }
+
+  private normalizeKeys(params: unknown): unknown {
+    if (isPlainObject(params)) {
+      return Object.fromEntries(
+        Object.entries(params).map(([k, v]) => [
+          String(k).replaceAll("-", "_"),
+          this.normalizeKeys(v),
+        ]),
+      );
+    } else if (Array.isArray(params)) {
+      return params.map((v) => this.normalizeKeys(v));
+    } else {
+      return params;
+    }
+  }
+
+  private deepToH(value: unknown): unknown {
+    if (isPlainObject(value)) {
+      return this.processHash(value);
+    } else if (Array.isArray(value)) {
+      return this.processArray(value);
+    } else if (typeof value === "string") {
+      return value;
+    } else {
+      throw new RuntimeError(
+        `can't typecast ${value == null ? "NilClass" : (value as object).constructor.name} - ${inspect(value)}`,
+      );
+    }
+  }
+
+  /**
+   * @missingRailsCall try — Language shortcoming: Rails writes
+   * `value["__content__"].try(:empty?)` (conversions.rb:192), but `empty?` is a
+   * real method on every Ruby receiver where trails' `isEmpty` is a free
+   * function — a JS string has no `isEmpty` for `tryCall` to dispatch. The
+   * nil-guard `try` supplies is spelled inline instead.
+   */
+  private processHash(value: Record<string, unknown>): unknown {
+    if (
+      Object.hasOwn(value, "type") &&
+      !isPlainObject(value["type"]) &&
+      this.disallowedTypes.includes(value["type"] as string)
+    ) {
+      throw new DisallowedType(value["type"]);
+    }
+
+    if (this.isBecomeArray(value)) {
+      const [, entries] = wrap(
+        Object.entries(value).find(([, v]) => typeof v !== "string") as unknown[] | undefined,
+      );
+      if (
+        entries === null ||
+        entries === undefined ||
+        (value["__content__"] != null && isEmpty(value["__content__"]))
+      ) {
+        return [];
+      } else if (Array.isArray(entries)) {
+        return entries.map((v) => this.deepToH(v));
+      } else if (isPlainObject(entries)) {
+        return [this.deepToH(entries)];
+      } else {
+        throw new RuntimeError(`can't typecast ${inspect(entries)}`);
+      }
+    } else if (this.isBecomeContent(value)) {
+      return this.processContent(value);
+    } else if (this.isBecomeEmptyString(value)) {
+      return "";
+    } else if (this.isBecomeHash(value)) {
+      const xmlValue: Record<string, unknown> = Object.fromEntries(
+        Object.entries(value).map(([k, v]) => [k, this.deepToH(v)]),
+      );
+
+      // Turn { files: { file: StringIO } } into { files: StringIO } so it is compatible with
+      // how multipart uploaded files from HTML appear
+      return xmlValue["file"] instanceof StringIO ? xmlValue["file"] : xmlValue;
+    }
+    return undefined;
+  }
+
+  private isBecomeContent(value: Record<string, unknown>): boolean {
+    return (
+      value["type"] === "file" ||
+      (value["__content__"] != null &&
+        value["__content__"] !== false &&
+        (Object.keys(value).length === 1 || isPresent(value["__content__"])))
+    );
+  }
+
+  private isBecomeArray(value: Record<string, unknown>): boolean {
+    return value["type"] === "array";
+  }
+
+  private isBecomeEmptyString(value: Record<string, unknown>): boolean {
+    // { "string" => true }
+    // No tests fail when the second term is removed.
+    return value["type"] === "string" && value["nil"] !== "true";
+  }
+
+  private isBecomeHash(value: Record<string, unknown>): boolean {
+    return !this.isNothing(value) && !this.isGarbage(value);
+  }
+
+  private isNothing(value: Record<string, unknown>): boolean {
+    // blank or nil parsed values are represented by nil
+    return isBlank(value) || value["nil"] === "true";
+  }
+
+  private isGarbage(value: Record<string, unknown>): boolean {
+    // If the type is the only element which makes it then
+    // this still makes the value nil, except if type is
+    // an XML node(where type['value'] is a Hash)
+    return (
+      value["type"] != null &&
+      value["type"] !== false &&
+      !isPlainObject(value["type"]) &&
+      Object.keys(value).length === 1
+    );
+  }
+
+  private processContent(value: Record<string, unknown>): unknown {
+    const content = value["__content__"];
+    const parser = XmlMini.PARSING[value["type"] as string];
+    if (parser) {
+      return parser.length === 1
+        ? parser(content)
+        : parser(content, value as Record<string, string>);
+    } else {
+      return content;
+    }
+  }
+
+  private processArray(value: unknown[]): unknown {
+    for (let i = 0; i < value.length; i++) value[i] = this.deepToH(value[i]);
+    return value.length > 1 ? value : value[0];
+  }
+}

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { toXml, fromXml, fromTrustedXml } from "./hash-utils.js";
+import type { ToXmlOptions } from "./xml-mini.js";
+import { DisallowedType } from "./core-ext/hash/conversions.js";
+import { Date as RubyDate } from "@blazetrails/date";
 import { extractBang, sliceBang } from "./core-ext/hash/slice.js";
 import {
   deepMerge,
@@ -594,5 +598,118 @@ describe("HashExtTest", () => {
     const h = Object.freeze({ a: 1, b: 2 });
     const r = except(h as any, "a");
     expect(r).toEqual({ b: 2 });
+  });
+});
+
+describe("HashToXmlTest", () => {
+  const xmlOptions: ToXmlOptions = { root: "person", skipInstruct: true, indent: 0 };
+
+  it("one level", () => {
+    const xml = toXml({ name: "David", street: "Paulina" }, xmlOptions);
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street>Paulina</street>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
+  it("one level dasherize true", () => {
+    const xml = toXml(
+      { name: "David", street_name: "Paulina" },
+      { ...xmlOptions, dasherize: true },
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street-name>Paulina</street-name>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
+  it("one level with types", () => {
+    const xml = toXml(
+      {
+        name: "David",
+        street: "Paulina",
+        age: 26,
+        age_in_millis: 820497600000,
+        moved_on: RubyDate.civil(2005, 11, 15),
+      },
+      xmlOptions,
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street>Paulina</street>");
+    expect(xml).toContain("<name>David</name>");
+    expect(xml).toContain('<age type="integer">26</age>');
+    expect(xml).toContain('<age-in-millis type="integer">820497600000</age-in-millis>');
+    expect(xml).toContain('<moved-on type="date">2005-11-15</moved-on>');
+  });
+
+  it("one level with nils", () => {
+    const xml = toXml({ name: "David", street: "Paulina", age: null }, xmlOptions);
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street>Paulina</street>");
+    expect(xml).toContain("<name>David</name>");
+    expect(xml).toContain('<age nil="true"/>');
+  });
+
+  it("one level with yielding", () => {
+    const xml = toXml({ name: "David", street: "Paulina" }, xmlOptions, (x) => {
+      x.tag("creator", "Rails");
+    });
+
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street>Paulina</street>");
+    expect(xml).toContain("<name>David</name>");
+    expect(xml).toContain("<creator>Rails</creator>");
+  });
+
+  it("two levels with array", () => {
+    const xml = toXml(
+      { name: "David", addresses: [{ street: "Paulina" }, { street: "Evergreen" }] },
+      xmlOptions,
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain('<addresses type="array"><address>');
+    expect(xml).toContain("<address><street>Paulina</street></address>");
+    expect(xml).toContain("<address><street>Evergreen</street></address>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
+  it("from xml raises on disallowed type attributes", async () => {
+    await expect(
+      fromXml('<product><name type="foo">value</name></product>', ["foo"]),
+    ).rejects.toThrow(DisallowedType);
+  });
+
+  it("from xml array one", async () => {
+    expect(await fromXml('<numbers type="Array"><value>1</value></numbers>')).toEqual({
+      numbers: { type: "Array", value: "1" },
+    });
+  });
+
+  it("from trusted xml allows symbol and yaml types", async () => {
+    expect(await fromTrustedXml('<product><name type="symbol">value</name></product>')).toEqual({
+      product: { name: ":value" },
+    });
+  });
+
+  it("escaping to xml", () => {
+    const hash = { bare_string: "First & Last Name", pre_escaped_string: "First &amp; Last Name" };
+
+    const expectedXml =
+      "<person><bare-string>First &amp; Last Name</bare-string><pre-escaped-string>First &amp;amp; Last Name</pre-escaped-string></person>";
+    expect(toXml(hash, xmlOptions)).toBe(expectedXml);
+  });
+
+  it("unescaping from xml", async () => {
+    const xmlString =
+      "<person><bare-string>First &amp; Last Name</bare-string><pre-escaped-string>First &amp;amp; Last Name</pre-escaped-string></person>";
+    const expectedHash = {
+      bare_string: "First & Last Name",
+      pre_escaped_string: "First &amp; Last Name",
+    };
+    expect(((await fromXml(xmlString)) as Record<string, unknown>)["person"]).toEqual(expectedHash);
+  });
+
+  it("to xml dups options", () => {
+    const options = { skipInstruct: true };
+    toXml({}, options);
+    expect(Object.keys(options)).toEqual(["skipInstruct"]);
   });
 });

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -3,6 +3,9 @@
  */
 
 import { isBlank } from "./core-ext/object/blank.js";
+import * as XmlMini from "./xml-mini.js";
+import { XMLConverter } from "./core-ext/hash/conversions.js";
+import type { StringIO } from "./string-io.js";
 
 type AnyObject = Record<string, unknown>;
 
@@ -594,4 +597,57 @@ export function compactBlankBang<T extends AnyObject>(hash: T): T {
     if (isBlank(hash[key])) delete hash[key];
   }
   return hash;
+}
+
+/**
+ * Returns a string containing an XML representation of its receiver.
+ *
+ * Mirrors: `Hash#to_xml` (`core_ext/hash/conversions.rb:74-91`). Ruby `||=`
+ * replaces only nil/false and `0` is truthy there, so `indent: 0` survives the
+ * defaulting — hence `??=`.
+ */
+export function toXml(
+  self: AnyObject,
+  options: XmlMini.ToXmlOptions = {},
+  block?: (builder: XmlMini.XmlBuilder) => void,
+): string {
+  options = { ...options };
+  options.indent ??= 2;
+  options.root ??= "hash";
+  options.builder ??= new XmlMini.IndentedXmlStringBuilder("", options.indent);
+
+  const builder = options.builder;
+  const skipInstruct = options.skipInstruct;
+  delete options.skipInstruct;
+  if (!skipInstruct) builder.instruct();
+
+  const root = XmlMini.renameKey(String(options.root), options);
+
+  builder.openTag(root);
+  for (const [key, value] of Object.entries(self)) {
+    XmlMini.toTag(key, value, options as XmlMini.ToTagOptions);
+  }
+  if (block) block(builder);
+  builder.closeTag(root);
+  return builder.target();
+}
+
+/**
+ * Returns a Hash containing a collection of pairs when the key is the node name
+ * and the value is its content. Mirrors: `Hash.from_xml`
+ * (`core_ext/hash/conversions.rb:128-130`) — awaitable because `XmlMini.parse` is.
+ */
+export function fromXml(
+  xml: string | StringIO | null | undefined,
+  disallowedTypes?: string[] | null,
+): Promise<unknown> {
+  return XMLConverter.create(xml, disallowedTypes).then((converter) => converter.toH());
+}
+
+/**
+ * Builds a Hash from XML just like `Hash.from_xml`, but also allows Symbol and
+ * YAML. Mirrors: `Hash.from_trusted_xml` (conversions.rb:133-135).
+ */
+export function fromTrustedXml(xml: string | StringIO | null | undefined): Promise<unknown> {
+  return fromXml(xml, []);
 }

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -267,7 +267,12 @@ export {
   compactBlank as compactBlankObj,
   compactBlankBang,
   valuesAt,
+  toXml,
+  fromXml,
+  fromTrustedXml,
 } from "./hash-utils.js";
+
+export { XMLConverter, DisallowedType, DISALLOWED_TYPES } from "./core-ext/hash/conversions.js";
 
 export {
   asJson,
@@ -283,6 +288,9 @@ export {
   split,
   extractBang,
   toSentence,
+  // `toXml` is Hash#to_xml above; one ESM namespace cannot hold both, the same
+  // collision `compactBlank as compactBlankObj` resolves.
+  toXml as toXmlArray,
 } from "./array-utils.js";
 
 export {

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -353,6 +353,10 @@ export interface XmlBuilder {
   openTag(name: string, attributes?: Record<string, string>): void;
   /** Emit a closing `</name>`. */
   closeTag(name: string): void;
+  /** Emit the XML declaration. Mirrors: `Builder::XmlMarkup#instruct!`. */
+  instruct(): void;
+  /** The accumulated XML. Mirrors: `Builder::XmlMarkup#target!`. */
+  target(): string;
 }
 
 /**
@@ -483,6 +487,20 @@ function isHash(value: unknown): value is Record<string, unknown> {
  * array/hash values. This is the single per-value funnel that both
  * `Array#to_xml` and `ActiveModel::Serializers::Xml` route every tag through.
  */
+/** `ToTagOptions` plus the keys `to_xml` sets itself (conversions.rb:77-85). */
+export interface ToXmlOptions extends Omit<ToTagOptions, "builder"> {
+  indent?: number;
+  root?: string;
+  builder?: XmlBuilder;
+  /**
+   * @noRailsEquivalent PERMANENT — Ruby's `:skip_instruct` option key is a Hash
+   * key, not a method, so it has no Ruby member for `parity:api` to match. An
+   * options interface is how TS spells an options hash; there is no Ruby name
+   * for it to converge onto.
+   */
+  skipInstruct?: boolean;
+}
+
 export function toTag(key: unknown, value: unknown, options: ToTagOptions): void {
   const { builder } = options;
   const explicitType = options.type;
@@ -770,6 +788,10 @@ export class XmlStringBuilder implements XmlBuilder {
     this.buffer += `</${name}>`;
   }
 
+  instruct(): void {
+    this.buffer = `<?xml version="1.0" encoding="UTF-8"?>` + this.buffer;
+  }
+
   /** The accumulated XML. Mirrors: `Builder::XmlMarkup#target!`. */
   target(): string {
     return this.buffer;
@@ -787,28 +809,41 @@ export class IndentedXmlStringBuilder implements XmlBuilder {
   private buffer = "";
   private depth = 0;
 
-  constructor(private readonly baseIndent = "") {}
+  constructor(
+    private readonly baseIndent = "",
+    private readonly indentWidth = 2,
+  ) {}
 
   private indent(): string {
-    return this.baseIndent + "  ".repeat(this.depth);
+    return this.baseIndent + " ".repeat(this.indentWidth).repeat(this.depth);
+  }
+
+  /** `Builder::XmlMarkup.new(indent: 0)` emits no layout at all. */
+  private newline(): string {
+    return this.indentWidth === 0 ? "" : "\n";
   }
 
   tag(name: string, content?: string | null, attributes: Record<string, string> = {}): void {
     const attrs = attributeString(attributes);
     this.buffer +=
       content == null
-        ? `${this.indent()}<${name}${attrs}/>\n`
-        : `${this.indent()}<${name}${attrs}>${htmlEscape(content).toString()}</${name}>\n`;
+        ? `${this.indent()}<${name}${attrs}/>${this.newline()}`
+        : `${this.indent()}<${name}${attrs}>${htmlEscape(content).toString()}</${name}>${this.newline()}`;
   }
 
   openTag(name: string, attributes: Record<string, string> = {}): void {
-    this.buffer += `${this.indent()}<${name}${attributeString(attributes)}>\n`;
+    this.buffer += `${this.indent()}<${name}${attributeString(attributes)}>${this.newline()}`;
     this.depth += 1;
   }
 
   closeTag(name: string): void {
     this.depth -= 1;
-    this.buffer += `${this.indent()}</${name}>\n`;
+    this.buffer += `${this.indent()}</${name}>${this.newline()}`;
+  }
+
+  instruct(): void {
+    this.buffer =
+      `${this.baseIndent}<?xml version="1.0" encoding="UTF-8"?>${this.newline()}` + this.buffer;
   }
 
   /** The accumulated XML. Mirrors: `Builder::XmlMarkup#target!`. */


### PR DESCRIPTION
Four bundled stories.

**CollectionProxy#transaction / #clone (RFC 0114)** — `collection_proxy.rb`
defines neither. `transaction` is answered by `Relation`'s
`delegate :transaction, ... to: :model` (relation/delegation.rb:106), which is
also what the Rails seat `CollectionAssociation#transaction`
(collection_association.rb:212-214) delegates to; `clone` only existed to carry
seeded proxy relation state, which #6745 removed. Both overrides are gone,
along with the now-dead `_setAssociationRelationCtor` slot they were the only
reader of. Chaining is unaffected: `where`/`spawn` reach `scope()` through the
`collection_proxy.rb:1128-1137` delegation, not through `clone`. Rails'
`association proxy transaction method starts transaction in association class`
still passes on the inherited path; `parity:api:extra` no longer lists either
name for the file, and both call gates have zero rows for it.

**hasAttribute through attributeAliases (RFC 0115)** — the three bodies now
mirror `attribute_methods.rb:316-320` / `:254-258` literally
(`attribute_aliases[attr_name] || attr_name`) instead of routing through
`resolveAttributeName`. **The story's premise that this was a behavioural bug
does not hold**: trails' `resolveAttributeName` is the
`AttributeMethods::ClassMethods` override (attribute_methods.rb:394-396,
`attribute_aliases.fetch(super, &:itself)`), not the
`AttributeRegistration` identity one (attribute_registration.rb:101-103), so the
alias arm already worked — verified against `Topic`'s `heading` alias before
touching anything. This is therefore a pure fidelity convergence with no
behaviour change. The acceptance criterion's "fails on the pre-fix baseline"
half is unsatisfiable by construction; rather than assert that only here, the
criterion has been corrected on the story with the evidence
(blazetrailsdev/tasks@f624c64ca). Coverage: Rails' `has attribute` /
`has attribute with symbol` (base_test.rb:1600-1631, which asserts on Company's
`new_name` alias), the pre-existing
`returns true for alias_attribute names on instances`, and a new class-level
twin `... on the class` for `attribute_methods.rb:254-258`.

**attribute_method_prefix/suffix/affix (RFC 0115)** — all three bodies now end
at `undefineAttributeMethods()`, matching attribute_methods.rb:120-123,
140-143, 175-178 statement for statement, with no helper call. The regeneration
Rails leaves to `method_missing` (attribute_methods.rb:507-514) moved to the
property-existence seat: `defineAttributeMethod` stamps each generated name with
the `attribute_method_patterns` it was generated under, and `Model`'s
constructor regenerates only names whose stamp is stale. That confines it to the
macro case — a bare `undefine_attribute_methods` leaves the patterns alone and
so stays undone (Rails' `#undefine_attribute_methods` semantics), and a class
that has generated nothing keeps its own first-generation seat, so ActiveRecord's
cold schema-load path is untouched.

**The four in-closure XML conversions (RFC 0098)** — per the 2026-08-21 backlog
decision, ported under 0098 rather than reclassified. The disposition is now
recorded in RFC 0098's changelog and RFC 0101's scope statement
(blazetrailsdev/tasks@f624c64ca), so the two no longer contradict each other. XmlMini itself was
already ported, so the slice pulled in is only what these four reach:
`XmlBuilder.instruct()` / `.target()` (the `Builder::XmlMarkup#instruct!` /
`#target!` roles) and an indent width on `IndentedXmlStringBuilder`, so
`indent: 0` produces Builder's unformatted output. New: `Hash#to_xml`,
`Hash.from_xml`, `Hash.from_trusted_xml` (hash-utils.ts), `Array#to_xml`
(array-utils.ts), and `ActiveSupport::XMLConverter` with `DisallowedType` /
`DISALLOWED_TYPES` (core-ext/hash/conversions.ts). AR closure moves
8917/8943 -> 8940/8948; all three Ruby files report matched N/N.

Both call gates green with no new baseline rows, and `parity:api:extra` reports
**zero** novel names added by this PR. Three deviations, each cited at its call
site and language-forced:

- `XMLConverter.create` (`@noRailsEquivalent`) — `XmlMini.parse` is awaitable in
  trails and a TS constructor cannot await, so the parsing half of `initialize`
  moves to a factory. `to_h` still reads the normalized `@xml` verbatim.
- `process_hash`'s `value["__content__"].try(:empty?)` (`@missingRailsCall`) —
  `empty?` is a real method on every Ruby receiver where trails' `isEmpty` is a
  free function, so `tryCall` has nothing to dispatch on a JS string.
- `regenerateForNewPattern` (`@noRailsEquivalent`), above.

Rails' `test_one_level_with_types` passes `resident: :yes` and asserts
`type="symbol"`. That term is left out of the port rather than built on
`XmlMini`'s JS-`Symbol` type inference, which contradicts CLAUDE.md's Symbol
rule; filed as
`0098/converge-xmlmini-symbol-representation-onto-colon-strings`.

### RFC bookkeeping (lives in the tasks repo, not in this diff)

`docs/activerecord/` is frozen and AR work tracking lives in the `tasks` repo
(CLAUDE.md), so RFC and story files cannot appear in a trails diff. The XML
story's bookkeeping is on `blazetrailsdev/tasks@main`:

- `blazetrailsdev/tasks@f624c64ca` — RFC 0098 changelog entry, RFC 0101 scope
  correction, and the corrected has_attribute criterion.
- `blazetrailsdev/tasks@b567db40f` — the require path quoted off
  `ar-closure.ts`'s walk, and all five of the story's acceptance criteria
  ticked. `pnpm tasks show resolve-the-in-closure-xml-conversions` now reports
  them checked.

Quoting the walk turned up a correction worth flagging: the story's Context
claims all four members are in the AR require-closure, and **only
`Array#to_xml` is**, reached in one hop from
`activemodel/lib/active_model/errors.rb:3`. `core_ext/hash/conversions.rb` and
`xml_mini.rb` are absent from `output/ar-closure.json` entirely; the three
`Hash` members score against the AR-closure gap by file attribution, because
`parity:api` anchors `hash-utils.ts` on the in-closure
`core_ext/array/extract_options.rb`. That strengthens the case against option 3
rather than weakening it — `ar-closure.ts` is accurate, so editing it would move
the denominator with no require-graph justification. Both RFCs now say this.

Closes-story: move-collection-proxy-transaction-and-clone-to-their-rails-seats
Closes-story: converge-attribute-method-pattern-macros-onto-undefine-only
Closes-story: resolve-has-attribute-through-attribute-aliases
Closes-story: resolve-the-in-closure-xml-conversions


