### PR TITLE
refactor(activerecord,trailties): retire appendBang, the nested-attr second pass, the non-Q predicate aliases and the hyphen migration alias; qualify SQLite DROP INDEX

### DIFF
--- a/packages/activerecord/src/active-record.test.ts
+++ b/packages/activerecord/src/active-record.test.ts
@@ -11,12 +11,12 @@ describe("ActiveRecordTest", () => {
   // in-memory SQLite database discards its schema.
   it.skipIf(inMemoryDb())(".disconnect_all! closes all connections", async () => {
     await (await Base.leaseConnection()).connectBang();
-    expect(Base.isConnectedQ()).toBe(true);
+    expect(Base.connectedQ()).toBe(true);
 
     await disconnectAllBang();
-    expect(Base.isConnectedQ()).toBe(false);
+    expect(Base.connectedQ()).toBe(false);
 
     await (await Base.leaseConnection()).connectBang();
-    expect(Base.isConnectedQ()).toBe(true);
+    expect(Base.connectedQ()).toBe(true);
   });
 });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -555,16 +555,21 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
   const inverseRefl = childCtor._reflectOnAssociation?.(inverseName);
   // Rails `BelongsToAssociation#invertible_for?` (belongs_to_association.rb:159):
   // when the inverse is a has_many, wiring is gated on `klass.has_many_inversing`.
-  // Without the flag, Rails does NOT touch the parent collection. Route the
-  // write through the proxy's `_wireInverseTarget` so the in-memory target and
-  // `@replaced_or_added_targets` are maintained in one place (the proxy). This removes the C2 (#2591)
-  // seam that used to reach into `proxy._replacedOrAddedTargets` from here.
+  // Without the flag, Rails does NOT touch the parent collection. With it, the
+  // write is `set_inverse_instance`'s own `inverse.inversed_from(owner)`
+  // (association.rb:132-137, 153-155), whose `self.target = record` reaches
+  // `CollectionAssociation#target=` (collection_association.rb:284-296) and so
+  // `replace_on_target(record, true, replace: true, inversing: true)`.
   if (inverseRefl?.macro === "hasMany") {
     if (!childCtor.hasManyInversing) return;
-    const proxy = association(child, inverseName) as unknown as {
-      _wireInverseTarget: (record: Base) => void;
-    };
-    proxy._wireInverseTarget(owner);
+    // Rails resolves the inverse with a bare `record.association(name)`; in
+    // trails a has_many's canonical target lives on its `CollectionProxy`
+    // (`Base#_associationCache`), so resolving it means materializing that
+    // proxy as well as the association object `inversed_from` is sent to.
+    association(child, inverseName);
+    (
+      child.association(inverseName) as unknown as { inversedFrom(record: Base): void }
+    ).inversedFrom(owner);
     return;
   }
   _cacheSingularTarget(child, inverseName, owner);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -559,13 +559,12 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
   // write is `set_inverse_instance`'s own `inverse.inversed_from(owner)`
   // (association.rb:132-137, 153-155), whose `self.target = record` reaches
   // `CollectionAssociation#target=` (collection_association.rb:284-296) and so
-  // `replace_on_target(record, true, replace: true, inversing: true)`.
+  // `replace_on_target(record, true, replace: true, inversing: true)`. Rails
+  // resolves the inverse with a bare `record.association(name)`; a has_many's
+  // canonical target lives on its `CollectionProxy` here (`_associationCache`),
+  // so resolving it also materializes that proxy.
   if (inverseRefl?.macro === "hasMany") {
     if (!childCtor.hasManyInversing) return;
-    // Rails resolves the inverse with a bare `record.association(name)`; in
-    // trails a has_many's canonical target lives on its `CollectionProxy`
-    // (`Base#_associationCache`), so resolving it means materializing that
-    // proxy as well as the association object `inversed_from` is sent to.
     association(child, inverseName);
     (
       child.association(inverseName) as unknown as { inversedFrom(record: Base): void }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -553,8 +553,10 @@ export function _resolveInverseName(
 export function _wireInverseAssociation(owner: Base, child: Base, inverseName: string): void {
   const childCtor = child.constructor as typeof Base;
   const inverseRefl = childCtor._reflectOnAssociation?.(inverseName);
-  // Rails `BelongsToAssociation#invertible_for?` (belongs_to_association.rb:159):
-  // when the inverse is a has_many, wiring is gated on `klass.has_many_inversing`.
+  // Rails `BelongsToAssociation#invertible_for?` (belongs_to_association.rb:158-161):
+  // when the inverse is a has_many, wiring is gated on `inverse.klass.has_many_inversing`
+  // — the has_many's OWN target class, which is also the class
+  // `CollectionAssociation#target=` reads the flag off.
   // Without the flag, Rails does NOT touch the parent collection. With it, the
   // write is `set_inverse_instance`'s own `inverse.inversed_from(owner)`
   // (association.rb:132-137, 153-155), whose `self.target = record` reaches
@@ -564,7 +566,7 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
   // canonical target lives on its `CollectionProxy` here (`_associationCache`),
   // so resolving it also materializes that proxy.
   if (inverseRefl?.macro === "hasMany") {
-    if (!childCtor.hasManyInversing) return;
+    if (!inverseRefl.klass?.hasManyInversing) return;
     association(child, inverseName);
     (
       child.association(inverseName) as unknown as { inversedFrom(record: Base): void }

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
-import { Base, association, registerModel, RecordInvalid, RecordNotFound } from "../index.js";
+import { Base, association, registerModel, RecordNotFound } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 // Opt this file into the canonical-model autoload index (Zeitwerk analog):
 // `Comment`, `Tagging`, `Tag`, and `Owner` — association targets with no
@@ -22,7 +22,7 @@ import { Tag } from "../test-helpers/models/tag.js";
 import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 import { Pet } from "../test-helpers/models/pet.js";
 import { Toy } from "../test-helpers/models/toy.js";
-import { Firm, Client } from "../test-helpers/models/company.js";
+import { Firm } from "../test-helpers/models/company.js";
 import { Ship } from "../test-helpers/models/ship.js";
 import { ShipPart } from "../test-helpers/models/ship-part.js";
 
@@ -1013,24 +1013,5 @@ describe("CollectionProxy#find — in-memory not-found message fidelity", () => 
         ),
       );
     }
-  });
-});
-
-// `appendBang` is a trails-only bang variant of `push` (Rails' `<<` delegates to
-// the non-raising `concat`). Its "record is persisted but still dirty" arm read
-// `hasChangesToSave` — a getter — through a `typeof … === "function"` guard,
-// which is always `"boolean"`, so the arm never fired and a failed save was
-// swallowed. Company validates presence of `name`, so blanking it makes `save`
-// return false and leaves the persisted record dirty.
-describe("CollectionProxy#appendBang — persisted record left dirty by a failed save", () => {
-  const { companies } = fixtures(["companies", "accounts"]);
-
-  it("raises RecordInvalid when a persisted record still has unsaved changes after push", async () => {
-    const firm = await Firm.find(companies("first_firm").id);
-    const client = await Client.find(companies("second_client").id);
-    client.writeAttribute("name", "");
-    expect(client.isNewRecord()).toBe(false);
-
-    await expect((firm as any).clients.appendBang(client)).rejects.toBeInstanceOf(RecordInvalid);
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -37,7 +37,6 @@ import {
 import type { Nodes } from "@blazetrails/arel";
 import { singularize, camelize, constantize } from "@blazetrails/activesupport";
 import { ConfigurationError, AssociationTypeMismatch } from "../errors.js";
-import { RecordInvalid } from "../validations.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   autoloadModel,
@@ -652,39 +651,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Wire `record` into this collection's target from the inverse side.
-   *
-   * Mirrors the Rails inverse-wiring chain `set_inverse_instance`
-   * (association.rb:132) → `inversed_from` → `self.target =`
-   * (CollectionAssociation#target=, collection_association.rb:285) →
-   * `replace_on_target(record, true, replace: true, inversing: true)`
-   * (the call at collection_association.rb:294), the path Rails takes when a
-   * belongs_to-loaded or preloaded record is folded back into its `has_many`
-   * owner: `skip_callbacks` (no before/after_add — inverse wiring is not a user
-   * `<<`), `replace: true`, and `inversing: true`. The `inversing` arm of that
-   * method's `@replaced_or_added_targets << record if inversing || index ||
-   * record.new_record?` (:476) is what records a *persisted* record here, so a
-   * later `<<`/`push` of the same record replaces in place rather than
-   * appending a duplicate; and because `@_was_loaded` is forced true there we
-   * always append to `@target` — loaded or not. A subsequent real `load()`
-   * merges this in-memory record by primary key (the trails analog of
-   * `merge_target_lists`), so the early append is not double-counted.
-   *
-   * This is the single write entry point for inverse has_many targets. The C2
-   * (#2591) seam, which used to reach into `proxy._replacedOrAddedTargets` from
-   * `associations.ts`, is now internal here. The seeded record lands in
-   * `_target`, which `Base#_associationCache` surfaces to readers (this proxy
-   * is the canonical has_many store).
-   * @internal
-   */
-  _wireInverseTarget(record: T): void {
-    this._collectionAssociation().replaceOnTarget(record, true, {
-      replace: true,
-      inversing: true,
-    }) as Base | null;
-  }
-
-  /**
    * Returns the size of the collection, executing a SELECT COUNT(*) query if
    * the collection hasn't been loaded.
    *
@@ -1279,37 +1245,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   async append(...records: T[]): Promise<Omit<this, "then"> | false> {
     return this.push(...records);
-  }
-
-  /**
-   * Bang version of append — raises RecordInvalid when a target record or join
-   * record is invalid (mirrors Rails' << / save! behavior).
-   *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#<< (bang semantics)
-   */
-  async appendBang(...records: T[]): Promise<void> {
-    this._raiseOnTypeMismatch(records);
-    if (this._assocDef.options.through) {
-      await this._pushThrough(records);
-      return;
-    }
-    // Non-through: push() assigns the FK and calls save() for each record.
-    // After push(), raise RecordInvalid for any record that is still new (save failed)
-    // or still has dirty changes (save returned false without retry — bang raises on
-    // the initial failure rather than attempting a second save).
-    await this.push(...records);
-
-    for (const record of records) {
-      if (record.isNewRecord()) {
-        // New record still unsaved — push()'s save() returned false
-        throw new RecordInvalid(record as unknown as object);
-      }
-      if (record.hasChangesToSave) {
-        // Persisted record still has unsaved changes after push() — raise without retrying
-        throw new RecordInvalid(record as unknown as object);
-      }
-    }
-    return;
   }
 
   /**

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -948,7 +948,7 @@ describe("InverseBelongsToTests", () => {
   });
 
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
-    await withHasManyInversing(Human, async () => {
+    await withHasManyInversing(Interest, async () => {
       const interest = interests("trainspotting");
       const human = (await loadSingularTarget(interest, "human")) as any;
       const cached = human._associationCache("interests")?.target as any[];
@@ -963,7 +963,7 @@ describe("InverseBelongsToTests", () => {
   });
 
   it("with has many inversing should have single record when setting record through attribute in build method", async () => {
-    await withHasManyInversing(Human, async () => {
+    await withHasManyInversing(Interest, async () => {
       const human = await Human.create({});
       association(human, "interests").build({ human });
       expect(await association(human, "interests").size()).toBe(1);
@@ -1190,7 +1190,7 @@ describe("InversePolymorphicBelongsToTests", () => {
   });
 
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
-    await withHasManyInversing(Human, async () => {
+    await withHasManyInversing(Interest, async () => {
       const interest = interests("llama_wrangling");
       const human = (await loadSingularTarget(interest, "polymorphicHuman")) as any;
       const cached = human._associationCache("polymorphicInterests")?.target as any[];

--- a/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
+++ b/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
@@ -9,15 +9,14 @@
  * `@replaced_or_added_targets` only because of the `inversing ||` arm — without
  * it a later add of the same record misses the `:458` index lookup and appends
  * a duplicate instead of replacing in place. This locks that arm: drop
- * `inversing: true` from `CollectionProxy#_wireInverseTarget`'s
- * `_replaceOnTarget` call, or the `inversing ||` factor from the set-add guard,
- * and the second add appends a duplicate.
+ * `inversing: true` from `CollectionAssociation#target=`'s `replaceOnTarget`
+ * call, or the `inversing ||` factor from the set-add guard, and the second add
+ * appends a duplicate.
  */
 import { describe, it, expect } from "vitest";
 import { Base, association } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { loadSingularTarget } from "../test-helpers/load-singular-target.js";
-import { Human } from "../test-helpers/models/human.js";
 import { Interest } from "../test-helpers/models/interest.js";
 
 async function withHasManyInversing(model: typeof Base, fn: () => Promise<void>): Promise<void> {
@@ -35,7 +34,11 @@ describe("replace_on_target inversing (trails)", () => {
   const { interests } = fixtures(["humans", "interests"]);
 
   it("tracks a persisted record added through the inversing path so a later add replaces in place", async () => {
-    await withHasManyInversing(Human, async () => {
+    // `has_many_inversing` is a global `class_attribute` in Rails, and both
+    // gates on this path read it off a different class: the belongs_to's
+    // `invertible_for?` off `Human`, `CollectionAssociation#target=` off
+    // `Human#interests`' own klass, `Interest`. Seat it on `Base`.
+    await withHasManyInversing(Base, async () => {
       const interest = interests("trainspotting") as Base & { id: number };
       const human = (await loadSingularTarget(interest, "human")) as Base & {
         _associationCache(name: string): { target: Base[] } | undefined;

--- a/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
+++ b/packages/activerecord/src/associations/replace-on-target-inversing.trails.test.ts
@@ -34,11 +34,7 @@ describe("replace_on_target inversing (trails)", () => {
   const { interests } = fixtures(["humans", "interests"]);
 
   it("tracks a persisted record added through the inversing path so a later add replaces in place", async () => {
-    // `has_many_inversing` is a global `class_attribute` in Rails, and both
-    // gates on this path read it off a different class: the belongs_to's
-    // `invertible_for?` off `Human`, `CollectionAssociation#target=` off
-    // `Human#interests`' own klass, `Interest`. Seat it on `Base`.
-    await withHasManyInversing(Base, async () => {
+    await withHasManyInversing(Interest, async () => {
       const interest = interests("trainspotting") as Base & { id: number };
       const human = (await loadSingularTarget(interest, "human")) as Base & {
         _associationCache(name: string): { target: Base[] } | undefined;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -638,8 +638,8 @@ function _applyScopeAttributes(
     // `populate_with_current_scope_attributes` runs from `initialize`
     // (scoping.rb:60-66, core.rb:474), which a JS constructor cannot await, so
     // the assignment is parked on the record for `save` to drain — the same
-    // deferral the constructor's nested re-dispatch uses
-    // (`_reapplyNestedAttrSetters`). A scope value naming an association (
+    // deferral the nested-attribute writers use. A scope value naming an
+    // association (
     // `Firm.where(firm: f).new`) is the only one that can still be in flight.
     const pending = (record as any).assignAttributes(toApply) as Promise<void> | void;
     if (pending) _NestedAttributes.parkNestedReaderLoad(record as any, pending);
@@ -732,27 +732,6 @@ function _extractAssociationAttrs(
 }
 
 /**
- * Collect every `<assoc>Attributes` nested-attribute setter key registered on
- * `ctor` and its ancestors (the same registry `_reapplyNestedAttrSetters`
- * walks). Used to hold nested-attribute keys out of the Model constructor's
- * setter-dispatching assignment so they fire post-super, once the association
- * caches exist.
- * @internal
- */
-function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<string> {
-  const keys = new Set<string>();
-  let cls: unknown = ctor;
-  while (cls && cls !== Object) {
-    const own = Object.getOwnPropertyDescriptor(cls, "_nestedAttributeSetterKeys");
-    if (own?.value instanceof Set) {
-      for (const k of own.value as Set<string>) keys.add(k);
-    }
-    cls = Object.getPrototypeOf(cls);
-  }
-  return keys;
-}
-
-/**
  * Route a constructor-form composite primary key through the deferred `id`
  * handling: trails holds the `id` key out of super()'s attribute loop and
  * re-dispatches it here, once `initInternals` has run.
@@ -776,26 +755,23 @@ function _applyCompositePrimaryKey(
 }
 
 /**
- * Keys held out of super()'s setter-dispatching attribute loop and re-applied
- * post-`initInternals`: a composite-PK `id` (→ `_applyCompositePrimaryKey`) and
- * `<assoc>Attributes` nested-attribute keys (→ `_reapplyNestedAttrSetters`).
- * Both dispatch setters that touch state (`id=` the key columns, the nested
- * writer the association caches) which isn't wired until after `super()`.
+ * The one key held out of super()'s setter-dispatching attribute loop and
+ * re-applied post-`initInternals`: a composite-PK `id`
+ * (→ `_applyCompositePrimaryKey`), whose `id=` writes key columns that are not
+ * wired until after `super()`.
  * @internal
  */
 function _withoutDeferredConstructionKeys(
   ctor: typeof Base | undefined,
   attrs: Record<string, unknown>,
 ): Record<string, unknown> {
-  const drop = _collectNestedAttributeSetterKeys(ctor);
   if (
-    Array.isArray((ctor as { primaryKey?: unknown } | undefined)?.primaryKey) &&
-    Object.prototype.hasOwnProperty.call(attrs, "id")
+    !Array.isArray((ctor as { primaryKey?: unknown } | undefined)?.primaryKey) ||
+    !Object.prototype.hasOwnProperty.call(attrs, "id")
   ) {
-    drop.add("id");
+    return attrs;
   }
-  if (drop.size === 0) return attrs;
-  return Object.fromEntries(Object.entries(attrs).filter(([k]) => !drop.has(k)));
+  return Object.fromEntries(Object.entries(attrs).filter(([k]) => k !== "id"));
 }
 
 /**
@@ -1539,8 +1515,7 @@ export class Base extends Model {
   static set connectionSpecificationName(name: string) {
     (this as any)._connectionSpecificationName = name;
   }
-  declare static isConnectedQ: typeof ConnectionHandling.isConnectedQ;
-  declare static isConnected: typeof ConnectionHandling.isConnected;
+  declare static connectedQ: typeof ConnectionHandling.connectedQ;
   declare static readonly connection: DatabaseAdapter;
   declare static isPrimaryClass: typeof ConnectionHandling.isPrimaryClass;
   declare static adapterClass: typeof ConnectionHandling.adapterClass;
@@ -1803,7 +1778,6 @@ export class Base extends Model {
   // --- ReadonlyAttributes mixin (wired via extend() after class) ---
   declare static attrReadonly: typeof ReadonlyAttributes.attrReadonly;
   declare static readonlyAttributeQ: typeof ReadonlyAttributes.readonlyAttributeQ;
-  declare static isReadonlyAttribute: typeof ReadonlyAttributes.readonlyAttributeQ;
 
   /**
    * Return the list of readonly attribute names.
@@ -3217,11 +3191,10 @@ export class Base extends Model {
           );
         }
       }
-      // Hold the composite-PK `id` and any `<assoc>Attributes` nested-attribute
-      // keys out of super()'s setter-dispatching loop: their setters (`id=`, the
-      // nested writer) touch state that isn't wired until after super()
-      // (`initInternals`). Re-dispatched post-super by `_applyCompositePrimaryKey`
-      // and `_reapplyNestedAttrSetters`.
+      // Hold the composite-PK `id` out of super()'s setter-dispatching loop:
+      // `id=` touches key columns that aren't wired until after super()
+      // (`initInternals`). Re-dispatched post-super by
+      // `_applyCompositePrimaryKey`.
       attrsForSuper = _withoutDeferredConstructionKeys(ctor2, attrsForSuper);
       const suppressor2 = ctor2 as typeof ctor2 & { _suppressInitializeCallback?: boolean };
       const hadOwn2 = Object.prototype.hasOwnProperty.call(
@@ -3293,12 +3266,6 @@ export class Base extends Model {
       // dirty state.
       (this as any)._dirty.snapshot((this as any)._attributes);
     }
-    // Dispatch nested-attribute writers (`<assoc>Attributes=`) that the Model
-    // constructor wrote as plain attribute values rather than through their
-    // generated setter, so `new Model({commentsAttributes: [...]})` builds the
-    // associated records in memory — mirroring Rails' `assign_attributes` →
-    // `public_send(setter)` path. No-op for models without nested attributes.
-    _Persistence._reapplyNestedAttrSetters(this.constructor as typeof Base, this, attrs);
   }
 
   // --- Persistence instance predicates (wired via include() after class body) ---
@@ -4321,7 +4288,7 @@ export class Base extends Model {
       return name;
     } else if (this.abstractClass) {
       return `${name}(abstract)`;
-    } else if (!ModelSchema.isSchemaLoaded.call(this as never) && !this.isConnectedQ()) {
+    } else if (!ModelSchema.isSchemaLoaded.call(this as never) && !this.connectedQ()) {
       return `${name} (call '${name}.load_schema' to load schema informations)`;
     }
     // Schema is loaded (or a live connection is available): list the columns'

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -639,8 +639,8 @@ function _applyScopeAttributes(
     // (scoping.rb:60-66, core.rb:474), which a JS constructor cannot await, so
     // the assignment is parked on the record for `save` to drain — the same
     // deferral the nested-attribute writers use. A scope value naming an
-    // association (
-    // `Firm.where(firm: f).new`) is the only one that can still be in flight.
+    // association (`Firm.where(firm: f).new`) is the only one that can still be
+    // in flight.
     const pending = (record as any).assignAttributes(toApply) as Promise<void> | void;
     if (pending) _NestedAttributes.parkNestedReaderLoad(record as any, pending);
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1667,7 +1667,17 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return super.indexName(this._splitTableName(tableName).bare, options);
   }
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#remove_index
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#remove_index
+   * (`sqlite3_adapter.rb:286-292`), with the schema qualifier put back on the
+   * INDEX name for a qualified table — the same fork
+   * `SQLite3::SchemaCreation#visit_CreateIndexDefinition` takes on create, and
+   * ratified in the same place. Rails emits the bare name because it has no
+   * ATTACHed-schema notion; SQLite resolves a bare `DROP INDEX` name across
+   * main, temp and each ATTACHed database in attach order, so two schemas
+   * carrying one index name would otherwise drop whichever it reaches first.
+   * An unqualified table takes the Rails emission untouched.
+   */
   async removeIndex(
     tableName: string,
     columnOrOptions?:
@@ -1692,18 +1702,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
     const indexName = await this.indexNameForRemove(tableName, columnName, options);
 
-    // An unqualified `DROP INDEX` name resolves across main, temp and every
-    // ATTACHed database in attach order, so two schemas carrying the same index
-    // name would have this drop whichever SQLite reaches first. Name the
-    // catalog, the same qualified/unqualified fork
-    // `SQLite3::SchemaCreation#visit_CreateIndexDefinition` takes on create.
     const { schema } = this._splitTableName(tableName);
-    const qualified =
-      schema === ""
-        ? quoteColumnName(indexName)
-        : `${quoteColumnName(schema)}.${quoteColumnName(indexName)}`;
 
-    await this.execQuery(`DROP INDEX ${qualified}`);
+    await this.execQuery(
+      schema === ""
+        ? `DROP INDEX ${quoteColumnName(indexName)}`
+        : `DROP INDEX ${quoteColumnName(schema)}.${quoteColumnName(indexName)}`,
+    );
   }
 
   createSchemaDumper(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1692,7 +1692,18 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
     const indexName = await this.indexNameForRemove(tableName, columnName, options);
 
-    await this.execQuery(`DROP INDEX ${quoteColumnName(indexName)}`);
+    // An unqualified `DROP INDEX` name resolves across main, temp and every
+    // ATTACHed database in attach order, so two schemas carrying the same index
+    // name would have this drop whichever SQLite reaches first. Name the
+    // catalog, the same qualified/unqualified fork
+    // `SQLite3::SchemaCreation#visit_CreateIndexDefinition` takes on create.
+    const { schema } = this._splitTableName(tableName);
+    const qualified =
+      schema === ""
+        ? quoteColumnName(indexName)
+        : `${quoteColumnName(schema)}.${quoteColumnName(indexName)}`;
+
+    await this.execQuery(`DROP INDEX ${qualified}`);
   }
 
   createSchemaDumper(

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts
@@ -298,6 +298,29 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(await adapter.indexExists("aux.customers", ["name"])).toBe(false);
   });
 
+  it("removeIndex drops the index in the named schema, not another attached one", async () => {
+    // An unqualified DROP INDEX name resolves across main, temp and every
+    // ATTACHed database in attach order, so an identically-named index in an
+    // earlier-attached schema would be the one dropped.
+    const onePath = path.join(tmpDir, "one-dup-index.sqlite3");
+    const twoPath = path.join(tmpDir, "two-dup-index.sqlite3");
+    await adapter.executeMutation(`ATTACH DATABASE '${onePath}' AS one`);
+    await adapter.executeMutation(`ATTACH DATABASE '${twoPath}' AS two`);
+    // No teardown: both tables live in per-test ATTACHed database files under
+    // tmpDir, which afterEach removes wholesale.
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await adapter.executeMutation("CREATE TABLE one.customers (id INTEGER PRIMARY KEY, name TEXT)");
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await adapter.executeMutation("CREATE TABLE two.customers (id INTEGER PRIMARY KEY, name TEXT)");
+    await adapter.addIndex("one.customers", ["name"]);
+    await adapter.addIndex("two.customers", ["name"]);
+
+    await adapter.removeIndex("two.customers", ["name"]);
+
+    expect(await adapter.indexExists("two.customers", ["name"])).toBe(false);
+    expect(await adapter.indexExists("one.customers", ["name"])).toBe(true);
+  });
+
   it("copyTableIndexes copies a default-named index on an ATTACHed schema", async () => {
     // The other half of the default-name fix: copy_table_indexes reaches
     // add_index for every index it copies (sqlite3_adapter.rb:668-674), so a

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -308,7 +308,7 @@ describe("ConnectionHandlingTest", () => {
   it("is_connected?", async () => {
     const pool = Base.connectionPool();
     await (await pool.leaseConnection()).verifyBang();
-    expect(Base.isConnectedQ()).toBe(true);
+    expect(Base.connectedQ()).toBe(true);
     pool.releaseConnection();
   });
 
@@ -459,10 +459,6 @@ describe("ConnectionHandlingTest", () => {
     expect(results).toContain("task2: writing");
     expect(currentRole.call(Base)).toBe("writing");
     expect(connectedToStack()).toHaveLength(0);
-  });
-
-  it("#isConnected delegates to isConnectedQ", async () => {
-    expect(Base.isConnected()).toBe(Base.isConnectedQ());
   });
 
   it("#connection leases a connection when none is active", async () => {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -455,15 +455,13 @@ export function retrieveConnection(this: typeof Base): Promise<DatabaseAdapter> 
   });
 }
 
-export function isConnectedQ(this: typeof Base): boolean {
+export function connectedQ(this: typeof Base): boolean {
   const name = connectionSpecificationName.call(this);
   return this.connectionHandler.isConnected(name, {
     role: coreCurrentRole.call(this as any),
     shard: coreCurrentShard.call(this as any),
   });
 }
-
-export const isConnected = isConnectedQ;
 
 const CONNECTION_DEPRECATION_MSG =
   "Called deprecated `ActiveRecord::Base.connection` method. " +
@@ -987,8 +985,7 @@ export const ClassMethods = {
   connectionDbConfig,
   connectionPool,
   retrieveConnection,
-  isConnectedQ,
-  isConnected,
+  connectedQ,
   connection,
   isPrimaryClass,
   adapterClass,

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -824,10 +824,19 @@ export function arelTable(this: CoreHost): Table {
  * hence the `super_()` here, which is the same set of links Ruby reaches, entered
  * from the other end.
  *
+ * `@new_record = true` is `Core#initialize`'s own first line (core.rb:390), two
+ * lines above its `init_internals` call and so before `assign_attributes`
+ * (:394) — which is what lets a `#{name}_attributes=` writer dispatched on that
+ * one pass see `new_record?`. A JS constructor cannot touch `this` before
+ * `super()`, so `Base`'s field initializer runs only after ActiveModel has
+ * already assigned; the flag is raised here instead, at the first seat that
+ * runs before the assignment and in Rails' own order.
+ *
  * @internal
  */
 export function initInternals(
   this: CoreRecord & {
+    _newRecord: boolean;
     _readonly: boolean;
     _previouslyNewRecord: boolean;
     _destroyed: boolean;
@@ -837,6 +846,7 @@ export function initInternals(
   },
   super_: () => void,
 ): void {
+  this._newRecord = true;
   super_();
   this._readonly = false;
   this._previouslyNewRecord = false;

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -148,19 +148,6 @@ describe("MigrationContext filename spellings", () => {
     ]);
   });
 
-  it("loads hyphen-named migrations as a transitional alias", () => {
-    const migrations = found("spellings_hyphen");
-    expect(migrations).toHaveLength(1);
-    expect(migrations[0].version).toBe(20260101000000);
-    expect(migrations[0].name).toBe("CreatePosts");
-  });
-
-  it("collapses hyphen and underscore variants of the same migration, preferring underscore", () => {
-    const migrations = found("spellings_hyphen_and_underscore");
-    expect(migrations).toHaveLength(1);
-    expect(basename(migrations[0].filename!)).toBe("20260101000000_create_posts.ts");
-  });
-
   it("prefers .ts over .js when both exist for the same migration", () => {
     const migrations = found("spellings_ts_and_js");
     expect(migrations).toHaveLength(1);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2238,20 +2238,10 @@ export class MigrationContext<
    * (`migration.rb:1369-1372`).
    *
    * Rails globs `#{paths}/**\/[0-9]*_*.rb`. trails scaffolds migrations in
-   * TypeScript, so the extension set is `ts|js` and the same migration can be
-   * present twice — the source and its compiled output. The two spellings that
-   * survive discovery, and their precedence, are:
-   *
-   * - `<version>_<name>.ts` — the Rails-faithful form, and what trailties
-   *   generates.
-   * - `<version>-<name>.js` / `<version>-<name>.ts` — the pre-1.12c hyphen
-   *   form, kept as a transitional alias so apps generated against earlier
-   *   releases still load.
-   *
-   * A version+name present in more than one spelling is loaded once: `.ts`
-   * beats `.js` (source over compiled output), and at equal extension the
-   * canonical underscore beats the hyphen alias, so renaming a migration
-   * across the 1.12c boundary does not double-load it.
+   * TypeScript, so the extension set is `ts|js` — and that extension set is the
+   * one way a single migration can be present twice, as a `.ts` source beside
+   * the `.js` its build emitted. Rails has no such twin, so it loads once:
+   * `.ts` beats `.js`, source over compiled output.
    */
   private migrationFiles(): string[] {
     const { readdirSync, existsSync } = getFs();
@@ -2263,7 +2253,7 @@ export class MigrationContext<
         const full = join(dir, entry.name);
         if (entry.isDirectory()) {
           collect(full);
-        } else if (/^\d+[_-].*\.(ts|js)$/.test(entry.name)) {
+        } else if (/^\d+_.*\.(ts|js)$/.test(entry.name)) {
           files.push(full);
         }
       }
@@ -2271,18 +2261,13 @@ export class MigrationContext<
     for (const p of this.migrationsPaths) collect(p);
 
     const isTs = (file: string): boolean => file.endsWith(".ts");
-    const isUnderscore = (file: string): boolean => /^\d+_/.test(file.replace(/.*[/\\]/, ""));
     const byBasename = new Map<string, string>();
     for (const file of files.sort()) {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) continue;
       const key = `${parsed[0]}_${parsed[1]}`;
       const kept = byBasename.get(key);
-      if (
-        kept === undefined ||
-        (isTs(file) && !isTs(kept)) ||
-        (isTs(file) === isTs(kept) && isUnderscore(file) && !isUnderscore(kept))
-      ) {
+      if (kept === undefined || (isTs(file) && !isTs(kept))) {
         byBasename.set(key, file);
       }
     }
@@ -2291,16 +2276,14 @@ export class MigrationContext<
 
   /**
    * @internal Mirrors: ActiveRecord::MigrationContext#parse_migration_filename
-   * (`migration.rb:1374-1376`). The name segment is folded to the underscore
-   * form so a hyphen-alias file and its renamed underscore twin parse to the
-   * same name — which is what lets {@link migrationFiles} collapse them and
-   * `Migrator#validate`'s duplicate-name check see one migration.
+   * (`migration.rb:1374-1376`) — Rails'
+   * `/\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/` with `ts|js` for `rb`.
    */
   private parseMigrationFilename(filename: string): [string, string, string] | null {
-    const base = filename.replace(/.*[/\\]/, "").replace(/\.(ts|js)$/, "");
-    const m = base.match(/^(\d+)[_-]([a-z0-9_-]*)(?:\.([a-z0-9_]*))?$/);
+    const base = filename.replace(/.*[/\\]/, "");
+    const m = base.match(/^([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.(?:ts|js)$/);
     if (!m) return null;
-    return [m[1], m[2].replace(/-/g, "_"), m[3] ?? ""];
+    return [m[1], m[2], m[3] ?? ""];
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#validate_timestamp? (`migration.rb:1378-1380`) */

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -554,12 +554,6 @@ export function generateAssociationWriter(
 ): void {
   const modelClass = this;
   const attrName = `${associationName}Attributes`;
-  // Register so persistence.create/createBang can re-dispatch after construction
-  // (the Base constructor routes attrs through writeAttribute, bypassing setters).
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_nestedAttributeSetterKeys")) {
-    (modelClass as any)._nestedAttributeSetterKeys = new Set<string>();
-  }
-  (modelClass as any)._nestedAttributeSetterKeys.add(attrName);
   const assign: (record: Base, name: string, value: any) => Promise<void> | void =
     type === "collection"
       ? assignNestedAttributesForCollectionAssociation
@@ -700,9 +694,9 @@ async function detachDisplacedThenSetNewRecord(
  * Rails reads the existing record with `send(association_name)`
  * (nested_attributes.rb:434), a plain synchronous call; ours is a promise for an
  * unloaded association. The writer itself awaits that load; this is for the one
- * caller that cannot — the constructor re-dispatch in `_reapplyNestedAttrSetters`
- * (persistence.ts). The deferral is a *read*, so no DB state is in flight to
- * race an interim insert.
+ * caller that cannot — `populate_with_current_scope_attributes`, run from a
+ * constructor. The deferral is a *read*, so no DB state is in flight to race an
+ * interim insert.
  * @internal
  */
 export function parkNestedReaderLoad(record: Base, load: Promise<void>): void {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -6,8 +6,6 @@
  */
 
 import { Temporal } from "@blazetrails/date";
-import { camelize } from "@blazetrails/activesupport";
-import { parkNestedReaderLoad } from "./nested-attributes.js";
 import type { Base } from "./base.js";
 import type { CounterCacheCounters } from "./counter-cache.js";
 import {
@@ -879,46 +877,6 @@ export function valuesAt(this: AttributeIO, ...keys: string[]): unknown[] {
   return keys.map((key) => this.readAttribute(key));
 }
 
-/**
- * Re-dispatch any `*Attributes` nested attribute keys that the Base
- * constructor wrote as plain attribute values (via `writeAttribute`) rather
- * than through the generated writer. Called by `create`/`createBang` after
- * construction so that `Model.create({commentsAttributes: [...]})` correctly
- * queues nested attributes for processing on save — mirrors Rails'
- * `new Model(attributes)` → `assign_attributes` → `public_send(setter)` path
- * (activemodel attribute_assignment.rb:35-48), which dispatches by *name*
- * against the `define_method`-generated writer (nested_attributes.rb:582-591).
- *
- * The name is the awaitable `set#{Name}Attributes` writer rather than the
- * `#{name}Attributes=` property setter: it is the one that reproduces Rails'
- * inline timing for the assignments that need I/O, and a JS property setter
- * cannot await. The writer answers a promise only when the assignment owes DB
- * I/O, which a record under construction cannot: it is new, so its has_one never
- * queries (`find_target?` is false) and holds no loaded target. Should one ever
- * arrive, a constructor cannot await it either, so it is parked and drained
- * where the other deferred nested-attributes work is drained — `save`
- * (nested-attributes.ts:182).
- */
-export function _reapplyNestedAttrSetters(
-  ctor: PersistenceHost,
-  record: any,
-  attrs: Record<string, unknown>,
-): void {
-  let cls: any = ctor;
-  while (cls && cls !== Object) {
-    const own = Object.getOwnPropertyDescriptor(cls, "_nestedAttributeSetterKeys");
-    if (own?.value instanceof Set) {
-      for (const k of own.value as Set<string>) {
-        if (Object.prototype.hasOwnProperty.call(attrs, k)) {
-          const pending = record[`set${camelize(k, true)}`](attrs[k]);
-          if (pending) parkNestedReaderLoad(record, pending);
-        }
-      }
-    }
-    cls = Object.getPrototypeOf(cls);
-  }
-}
-
 // ---------------------------------------------------------------------------
 // updateAttribute / updateAttributeBang / updateColumn(s) — single- and
 // multi-column writers. Rails' update_attribute runs callbacks (skips
@@ -1552,7 +1510,7 @@ interface PersistencePrivateHost {
     primaryKey: string | string[];
     currentScope?: unknown | (() => unknown);
     defaultScoped(): { whereClause: { isEmpty(): boolean; ast: unknown } };
-    isReadonlyAttribute?(name: string): boolean;
+    readonlyAttributeQ?(name: string): boolean;
     withConnection?(fn: (conn: unknown) => Promise<void>): Promise<void>;
     connection: { execDelete(sql: string, name: string): Promise<number> };
   };
@@ -1914,7 +1872,7 @@ export async function _createRecord(
 
 /** @internal */
 export function verifyReadonlyAttribute(this: PersistencePrivateHost, name: string): void {
-  if ((this.constructor as any).isReadonlyAttribute?.(name)) {
+  if ((this.constructor as any).readonlyAttributeQ?.(name)) {
     throw new ReadonlyAttributeError(name);
   }
 }

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -570,7 +570,7 @@ describe("QueryCacheTest", () => {
     const originalConnection = Base.removeConnection();
 
     await Base.establishConnection(dbConfig);
-    expect(Task.isConnectedQ()).toBe(false);
+    expect(Task.connectedQ()).toBe(false);
 
     try {
       await Task.cache(async () => {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -112,7 +112,7 @@ export const ClassMethods = {
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
    */
   async cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
-    if (this.isConnected() || !this.configurations().empty) {
+    if (this.connectedQ() || !this.configurations().empty) {
       const pool = this.connectionPool();
       const wasEnabled = pool.queryCacheEnabled;
       try {
@@ -135,7 +135,7 @@ export const ClassMethods = {
     block: () => T | Promise<T>,
     options: { dirties?: boolean } = {},
   ): Promise<T> {
-    if (this.isConnected() || !this.configurations().empty) {
+    if (this.connectedQ() || !this.configurations().empty) {
       return this.connectionPool().disableQueryCache(block, options);
     }
     return Promise.resolve(block());

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -187,5 +187,4 @@ export function _writeAttribute(this: Base, name: string, value: unknown): void 
 export const ClassMethods = {
   attrReadonly,
   readonlyAttributeQ,
-  isReadonlyAttribute: readonlyAttributeQ,
 };

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -50,7 +50,7 @@ export function currentAdapter(...types: AdapterClassName[]): boolean {
 }
 
 function poolConfigurationHash(): Record<string, unknown> {
-  return Base.isConnectedQ()
+  return Base.connectedQ()
     ? (Base.connectionPool().dbConfig.configurationHash as Record<string, unknown>)
     : ambientPoolConfiguration();
 }

--- a/packages/activerecord/src/support/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/support/handler-resolved-adapter.test.ts
@@ -1,6 +1,6 @@
 /**
  * Phase D-0 / D-0a: verify that:
- *   1. Base.connectionHandler is bootstrapped per worker (isConnectedQ)
+ *   1. Base.connectionHandler is bootstrapped per worker (connectedQ)
  *   2. Base.connection resolves the adapter from the handler internally
  *   3. A model with no direct `static { this.adapter = ... }` assignment
  *      resolves its adapter via the Rails-shape handler chain
@@ -50,8 +50,8 @@ describe("handler-resolved adapter (Phase D-0)", () => {
     await Base.connection.dropTable("handler_resolved_comments", { ifExists: true });
   });
 
-  it("isConnectedQ() is true after setupHandlerSuite()", () => {
-    expect(Base.isConnectedQ()).toBe(true);
+  it("connectedQ() is true after setupHandlerSuite()", () => {
+    expect(Base.connectedQ()).toBe(true);
   });
 
   it("bare class extends Base loads schema via lazy reflection without deadlock", async () => {

--- a/packages/activerecord/src/test-helpers/migrations/spellings_hyphen/20260101000000-create-posts.ts
+++ b/packages/activerecord/src/test-helpers/migrations/spellings_hyphen/20260101000000-create-posts.ts
@@ -1,4 +1,0 @@
-// trails-only: the pre-1.12c `<version>-<name>` hyphen alias.
-import { Migration } from "../../../migration.js";
-
-export class CreatePosts extends Migration {}

--- a/packages/activerecord/src/test-helpers/migrations/spellings_hyphen_and_underscore/20260101000000-create-posts.ts
+++ b/packages/activerecord/src/test-helpers/migrations/spellings_hyphen_and_underscore/20260101000000-create-posts.ts
@@ -1,4 +1,0 @@
-// trails-only: the pre-1.12c `<version>-<name>` hyphen alias.
-import { Migration } from "../../../migration.js";
-
-export class CreatePosts extends Migration {}

--- a/packages/activerecord/src/test-helpers/migrations/spellings_hyphen_and_underscore/20260101000000_create_posts.ts
+++ b/packages/activerecord/src/test-helpers/migrations/spellings_hyphen_and_underscore/20260101000000_create_posts.ts
@@ -1,4 +1,0 @@
-// trails-only: the Rails-faithful `<version>_<name>` spelling, in TypeScript.
-import { Migration } from "../../../migration.js";
-
-export class CreatePosts extends Migration {}

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -684,11 +684,11 @@ describe("discoverMigrations", () => {
 
   it("discovers migration files and extracts versions", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-create-users.ts"),
+      path.join(tmpDir, "20260101000000_create_users.ts"),
       `export class CreateUsers { version = "20260101000000"; }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "20260102000000-add-email-to-users.ts"),
+      path.join(tmpDir, "20260102000000_add_email_to_users.ts"),
       `export class AddEmailToUsers { version = "20260102000000"; }`,
     );
     fs.writeFileSync(path.join(tmpDir, "README.md"), "ignore me");
@@ -705,11 +705,11 @@ describe("discoverMigrations", () => {
 
   it("sorts migrations by version", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "20260202000000-second.ts"),
+      path.join(tmpDir, "20260202000000_second.ts"),
       `export class Second { version = "20260202000000"; }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-first.ts"),
+      path.join(tmpDir, "20260101000000_first.ts"),
       `export class First { version = "20260101000000"; }`,
     );
 
@@ -742,7 +742,7 @@ describe("full migration flow", () => {
     await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() {
@@ -803,8 +803,8 @@ export class CreatePosts extends Migration {
     adapter = new BetterSQLite3Adapter(":memory:");
     await establishMigrationConnection(adapter);
 
-    const a = "20260101000000-create-posts.ts";
-    const b = "20260102000000-create-comments.ts";
+    const a = "20260101000000_create_posts.ts";
+    const b = "20260102000000_create_comments.ts";
     fs.writeFileSync(
       path.join(tmpDir, a),
       `import { Migration } from "@blazetrails/activerecord";
@@ -857,7 +857,7 @@ export class CreateComments extends Migration {
     await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -885,7 +885,7 @@ export class CreatePosts extends Migration {
     await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-create-widgets.ts"),
+      path.join(tmpDir, "20260101000000_create_widgets.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateWidgets extends Migration {
   async up() { await this.createTable("widgets", (t) => { t.string("name"); }); }
@@ -937,7 +937,7 @@ export class CreateWidgets extends Migration {
     await establishMigrationConnection(adapter);
 
     fs.writeFileSync(
-      path.join(tmpDir, "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1087,7 +1087,7 @@ describe("db subcommand CLI actions", () => {
 
   it("db abort_if_pending_migrations exits 1 and prints each pending", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1107,7 +1107,7 @@ export class CreatePosts extends Migration {
 
   it("db version reports the highest applied version after migrate", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1141,7 +1141,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1193,7 +1193,7 @@ export class CreatePosts extends Migration {
       ["20260101000002", "authors", "CreateAuthors"],
     ]) {
       fs.writeFileSync(
-        path.join(tmpDir, "db", "migrations", `${version}-create-${table}.ts`),
+        path.join(tmpDir, "db", "migrations", `${version}_create_${table}.ts`),
         `import { Migration } from "@blazetrails/activerecord";
 export class ${cls} extends Migration {
   async up() { await this.createTable(${JSON.stringify(table)}, (t) => { t.string("title"); }); }
@@ -1228,7 +1228,7 @@ export class ${cls} extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1683,7 +1683,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-widgets.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_widgets.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateWidgets extends Migration {
   async up() { await this.createTable("widgets", (t) => { t.string("name"); }); }
@@ -1737,7 +1737,7 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
     );
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1745,7 +1745,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -1824,7 +1824,7 @@ export class CreateDogs extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1832,7 +1832,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_test_env", "20260101000001-create-fixtures.ts"),
+      path.join(tmpDir, "db", "migrations_test_env", "20260101000001_create_fixtures.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateFixtures extends Migration {
   async up() { await this.createTable("fixtures", (t) => { t.string("label"); }); }
@@ -1886,7 +1886,7 @@ export class CreateFixtures extends Migration {
     );
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1894,7 +1894,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2079,7 +2079,7 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
     // Primary migrations in db/migrations; animals in db/migrations_animals.
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2087,7 +2087,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2162,7 +2162,7 @@ export class CreateDogs extends Migration {
     );
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2170,7 +2170,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2210,7 +2210,7 @@ export class CreateDogs extends Migration {
     );
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2218,7 +2218,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2270,19 +2270,19 @@ export class ${cls} extends Migration {
   async down() { await this.dropTable(${JSON.stringify(table)}); }
 }`;
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000001-one-migration.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000001_one_migration.ts"),
       migration("OneMigration", "ones"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000002-two-migration.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000002_two_migration.ts"),
       migration("TwoMigration", "twos"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000003-three-migration.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000003_three_migration.ts"),
       migration("ThreeMigration", "threes"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000004-four-migration.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000004_four_migration.ts"),
       migration("FourMigration", "fours"),
     );
 
@@ -2336,7 +2336,7 @@ export class ${cls} extends Migration {
     );
     fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2344,7 +2344,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001-create-dogs.ts"),
+      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2400,7 +2400,7 @@ export class CreateDogs extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-users.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2408,7 +2408,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, customDir, "20260101000001-create-cats.ts"),
+      path.join(tmpDir, customDir, "20260101000001_create_cats.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateCats extends Migration {
   async up() { await this.createTable("cats", (t) => { t.string("breed"); }); }
@@ -2600,7 +2600,7 @@ export class CreateCats extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-things.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_things.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateThings extends Migration {
   async up() { await this.createTable("things", (t) => { t.string("name"); }); }
@@ -2630,7 +2630,7 @@ export class CreateThings extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-posts.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -2687,7 +2687,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000-create-things.ts"),
+      path.join(tmpDir, "db", "migrations", "20260101000000_create_things.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateThings extends Migration {
   async up() { await this.createTable("things", (t) => { t.string("name"); }); }

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -26,15 +26,13 @@ export function destroyCommand(): Command {
       // Find and remove migration
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (fs.existsSync(migrationsDir)) {
-        // Match both the underscore form (post-1.12c, Rails-faithful)
-        // and the hyphen form (pre-1.12c transitional). Escape the
-        // user-derived tableName so regex metacharacters can't widen
-        // the match.
+        // Escape the user-derived tableName so regex metacharacters can't
+        // widen the match.
         const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         // Anchor to the start of the filename and require the timestamp
         // + separator so names like `..._recreate_posts.ts` cannot match
         // `create_posts.ts`.
-        const pattern = new RegExp(`^\\d+[_-]create[_-]${escaped}\\.(ts|js)$`);
+        const pattern = new RegExp(`^\\d+_create_${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);
@@ -63,14 +61,13 @@ export function destroyCommand(): Command {
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (!fs.existsSync(migrationsDir)) return;
 
-      // Anchor on `^<timestamp>[_-]<name>\.(ts|js)$` so a name like
+      // Anchor on `^<timestamp>_<name>\.(ts|js)$` so a name like
       // `create_posts` does not also match `..._add_create_posts_flag.ts`.
       // Escape first so regex metacharacters in the user-supplied name
       // can't widen the match.
       const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const dashed = dasherize(escaped);
-      const underscored = dashed.replace(/-/g, "_");
-      const pattern = new RegExp(`^\\d+[_-](${dashed}|${underscored})\\.(ts|js)$`);
+      const underscored = dasherize(escaped).replace(/-/g, "_");
+      const pattern = new RegExp(`^\\d+_${underscored}\\.(ts|js)$`);
       for (const f of fs.readdirSync(migrationsDir)) {
         if (pattern.test(f)) {
           removeFile(cwd, `db/migrations/${f}`);
@@ -100,7 +97,7 @@ export function destroyCommand(): Command {
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (fs.existsSync(migrationsDir)) {
         const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const pattern = new RegExp(`^\\d+[_-]create[_-]${escaped}\\.(ts|js)$`);
+        const pattern = new RegExp(`^\\d+_create_${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);

--- a/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
@@ -19,7 +19,7 @@ describe("MigrationGeneratorTest", () => {
       output: () => {},
       name: "add_title_to_posts",
     }).run();
-    expect(files[0]).toMatch(/^db\/migrations\/\d+-add-title-to-posts\.ts$/);
+    expect(files[0]).toMatch(/^db\/migrations\/\d+_add_title_to_posts\.ts$/);
     const content = fs.readFileSync(path.join(tmpDir, files[0]), "utf-8");
     expect(content).toContain("class AddTitleToPosts extends Migration");
     expect(content).toContain("async change(): Promise<void>");

--- a/packages/trailties/src/generators/rails/migration/migration-generator.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.ts
@@ -7,7 +7,7 @@ import {
   tsModule,
 } from "../../../template-builder/index.js";
 import { NamedBase } from "../../named-base.js";
-import { classify, dasherize, migrationTimestamp } from "../../base.js";
+import { classify, migrationTimestamp } from "../../base.js";
 
 // Mirrors railties/lib/rails/generators/rails/migration/migration_generator.rb.
 // hook_for :orm defers to the ORM-provided generator. This skeleton emits a
@@ -55,7 +55,7 @@ export class MigrationGenerator extends NamedBase {
       timestamp = (parseInt(lastTimestamp, 10) + 1).toString();
     }
     lastTimestamp = timestamp;
-    const filename = `db/migrations/${timestamp}-${dasherize(this.fileName)}${this.ext()}`;
+    const filename = `db/migrations/${timestamp}_${this.fileName}${this.ext()}`;
     this.createFile(filename, emitMigrationSource(classify(this.fileName), timestamp));
     return this.getCreatedFiles();
   }

--- a/packages/website/src/lib/frontiers/components/sandbox/FileTree.test.ts
+++ b/packages/website/src/lib/frontiers/components/sandbox/FileTree.test.ts
@@ -23,7 +23,7 @@ function seedFiles() {
   vfs.write("src/app/models/post.ts", "class Post {}");
   vfs.write("src/app/controllers/application-controller.ts", "class AppController {}");
   vfs.write("src/config/routes.ts", "// routes");
-  vfs.write("db/migrations/001-create-users.ts", "migration");
+  vfs.write("db/migrations/001_create_users.ts", "migration");
   vfs.write("package.json", "{}");
 }
 

--- a/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
+++ b/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
@@ -195,7 +195,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("name", "string")');
       expect(content).toContain('this.attribute("bio", "text")');
 
-      const mig = findMigration(artistFiles, /db\/migrations\/.+-create-artists\.ts$/);
+      const mig = findMigration(artistFiles, /db\/migrations\/.+_create_artists\.ts$/);
       expect(mig).toContain('t.string("name")');
       expect(mig).toContain('t.text("bio")');
     });
@@ -207,7 +207,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("artist_id", "integer")');
       expect(content).toContain('this.attribute("release_date", "date")');
 
-      const mig = findMigration(albumFiles, /db\/migrations\/.+-create-albums\.ts$/);
+      const mig = findMigration(albumFiles, /db\/migrations\/.+_create_albums\.ts$/);
       expect(mig).toContain('t.integer("artist_id")');
       expect(mig).toContain('t.date("release_date")');
     });
@@ -219,7 +219,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("track_number", "integer")');
       expect(content).toContain('this.attribute("duration", "integer")');
 
-      const mig = findMigration(trackFiles, /db\/migrations\/.+-create-tracks\.ts$/);
+      const mig = findMigration(trackFiles, /db\/migrations\/.+_create_tracks\.ts$/);
       expect(mig).toContain('t.integer("track_number")');
       expect(mig).toContain('t.integer("duration")');
     });
@@ -229,7 +229,7 @@ describe("generator fixtures", () => {
       const content = readFile("src/app/models/genre.ts");
       expect(content).toContain("class Genre extends Base");
 
-      const mig = findMigration(genreFiles, /db\/migrations\/.+-create-genres\.ts$/);
+      const mig = findMigration(genreFiles, /db\/migrations\/.+_create_genres\.ts$/);
       expect(mig).toContain('t.string("name")');
     });
   });
@@ -272,7 +272,7 @@ describe("generator fixtures", () => {
       expect(content).toContain("class Account extends Base");
       expect(content).toContain('this.attribute("balance", "decimal")');
 
-      const mig = findMigration(accountFiles, /db\/migrations\/.+-create-accounts\.ts$/);
+      const mig = findMigration(accountFiles, /db\/migrations\/.+_create_accounts\.ts$/);
       expect(mig).toContain('t.decimal("balance")');
     });
 
@@ -282,7 +282,7 @@ describe("generator fixtures", () => {
       expect(content).toContain("class Category extends Base");
       expect(content).toContain('this.attribute("parent_id", "integer")');
 
-      const mig = findMigration(categoryFiles, /db\/migrations\/.+-create-categories\.ts$/);
+      const mig = findMigration(categoryFiles, /db\/migrations\/.+_create_categories\.ts$/);
       expect(mig).toContain('t.integer("parent_id")');
     });
 
@@ -294,7 +294,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("account_id", "integer")');
       expect(content).toContain('this.attribute("category_id", "integer")');
 
-      const mig = findMigration(transactionFiles, /db\/migrations\/.+-create-transactions\.ts$/);
+      const mig = findMigration(transactionFiles, /db\/migrations\/.+_create_transactions\.ts$/);
       expect(mig).toContain('t.decimal("amount")');
       expect(mig).toContain('t.integer("account_id")');
       expect(mig).toContain('t.date("date")');
@@ -307,7 +307,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("period_start", "date")');
       expect(content).toContain('this.attribute("period_end", "date")');
 
-      const mig = findMigration(budgetFiles, /db\/migrations\/.+-create-budgets\.ts$/);
+      const mig = findMigration(budgetFiles, /db\/migrations\/.+_create_budgets\.ts$/);
       expect(mig).toContain('t.date("period_start")');
       expect(mig).toContain('t.date("period_end")');
     });

--- a/packages/website/src/lib/frontiers/tutorials/generator-fixtures.ts
+++ b/packages/website/src/lib/frontiers/tutorials/generator-fixtures.ts
@@ -12,7 +12,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/user.ts",
         "test/models/user.test.ts",
-        "db/migrations/*-create-users.ts",
+        "db/migrations/*_create_users.ts",
       ],
     },
     {
@@ -21,7 +21,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/folder.ts",
         "test/models/folder.test.ts",
-        "db/migrations/*-create-folders.ts",
+        "db/migrations/*_create_folders.ts",
       ],
     },
     {
@@ -30,7 +30,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/document.ts",
         "test/models/document.test.ts",
-        "db/migrations/*-create-documents.ts",
+        "db/migrations/*_create_documents.ts",
       ],
     },
   ] satisfies GeneratorFixture[],
@@ -42,7 +42,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/artist.ts",
         "test/models/artist.test.ts",
-        "db/migrations/*-create-artists.ts",
+        "db/migrations/*_create_artists.ts",
       ],
     },
     {
@@ -51,7 +51,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/album.ts",
         "test/models/album.test.ts",
-        "db/migrations/*-create-albums.ts",
+        "db/migrations/*_create_albums.ts",
       ],
     },
     {
@@ -61,7 +61,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/track.ts",
         "test/models/track.test.ts",
-        "db/migrations/*-create-tracks.ts",
+        "db/migrations/*_create_tracks.ts",
       ],
     },
     {
@@ -70,7 +70,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/genre.ts",
         "test/models/genre.test.ts",
-        "db/migrations/*-create-genres.ts",
+        "db/migrations/*_create_genres.ts",
       ],
     },
   ] satisfies GeneratorFixture[],
@@ -82,7 +82,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/account.ts",
         "test/models/account.test.ts",
-        "db/migrations/*-create-accounts.ts",
+        "db/migrations/*_create_accounts.ts",
       ],
     },
     {
@@ -91,7 +91,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/category.ts",
         "test/models/category.test.ts",
-        "db/migrations/*-create-categories.ts",
+        "db/migrations/*_create_categories.ts",
       ],
     },
     {
@@ -101,7 +101,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/transaction.ts",
         "test/models/transaction.test.ts",
-        "db/migrations/*-create-transactions.ts",
+        "db/migrations/*_create_transactions.ts",
       ],
     },
     {
@@ -111,7 +111,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/budget.ts",
         "test/models/budget.test.ts",
-        "db/migrations/*-create-budgets.ts",
+        "db/migrations/*_create_budgets.ts",
       ],
     },
   ] satisfies GeneratorFixture[],

--- a/packages/website/src/routes/dev/filetree/+page.svelte
+++ b/packages/website/src/routes/dev/filetree/+page.svelte
@@ -24,8 +24,8 @@
     v.write("src/app/models/post.ts", 'import { Base } from "@blazetrails/activerecord";\n\nexport class Post extends Base {\n  static {\n    this.attribute("title", "string");\n    this.attribute("body", "text");\n  }\n}');
     v.write("src/app/controllers/application-controller.ts", "class ApplicationController {}");
     v.write("src/app/controllers/posts-controller.ts", "class PostsController {}");
-    v.write("db/migrations/20260401120000-create-users.ts", "class CreateUsers extends Migration {}");
-    v.write("db/migrations/20260401120001-create-posts.ts", "class CreatePosts extends Migration {}");
+    v.write("db/migrations/20260401120000_create_users.ts", "class CreateUsers extends Migration {}");
+    v.write("db/migrations/20260401120001_create_posts.ts", "class CreatePosts extends Migration {}");
     v.write("db/seeds.ts", "// seeds");
     v.write("db/schema.ts", "// schema");
     v.write("test/models/user.test.ts", "// user tests");


### PR DESCRIPTION
Five convergence stories, each retiring a trails-only shape in favour of the Rails seat.

**1. `CollectionProxy#appendBang` / `_wireInverseTarget` (RFC 0114).**
`appendBang` has no Rails counterpart — `collection_proxy.rb:1049-1054` has `<<`
with `push`/`append`/`concat` aliases and nothing bang; its raise-on-invalid
semantics belong to `CollectionAssociation#concat` → `insert_record(record, true)`
(`collection_association.rb:118-131`). Nothing in-repo called it, so it is deleted
outright along with its trails-only test.
`_wireInverseTarget` duplicated the chain `set_inverse_instance` → `inversed_from`
→ `CollectionAssociation#target=` (`association.rb:132-137,153-155`,
`collection_association.rb:284-296`), all of which trails already has;
`_wireInverseAssociation` now sends `inversedFrom(owner)` and the proxy method is
gone. `associations/collection-proxy.ts` drops from 7 moved names to 6.

**2. The nested-attribute second pass (RFC 0115).**
Rails' `initialize` routes the hash straight through `assign_attributes`, so a
`#{name}_attributes=` key dispatches on the one and only pass
(`attribute_assignment.rb:68`). Since #6801 installed the writer under the string
key `"#{name}Attributes="`, `_assignAttribute`'s send reaches it during `super()`,
so the constructor no longer holds those keys back: `_reapplyNestedAttrSetters`
(persistence.ts) and the `_nestedAttributeSetterKeys` registry that fed it are
deleted, and `_withoutDeferredConstructionKeys` is left with the composite-PK `id`
it genuinely must defer.

**3. The non-Q predicate aliases (RFC 0098).**
Rails defines `connected?` (`connection_handling.rb:351`) and
`readonly_attribute?` (`readonly_attributes.rb:43`) once each. Dropped
`export const isConnected = isConnectedQ` and the
`isReadonlyAttribute: readonlyAttributeQ` key on `ClassMethods`, sweeping call
sites onto the Q spelling. Note `isConnectedQ` was itself off-table — the
conventions table produces `isConnected | connected | connectedQ` for `connected?`,
never the stacked `is…Q` — and only the deleted alias was crediting it, so the
export is renamed to `connectedQ` (the spelling `readonlyAttributeQ` already
follows). `parity:api` gains 2 methods.

**4. The hyphen migration filename alias (RFC 0051).**
`migrationFiles`' regex is back to `/^\d+_/` and `parseMigrationFilename`'s to
Rails' `/\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/` with `ts|js` for `rb`
(`migration.rb:1369-1376`). The underscore-over-hyphen half of the dedupe goes
with it; the `.ts`-over-`.js` half stays, now documented as the compiled-twin
rule it is. `rails/migration/migration-generator.ts` was still emitting
`<version>-<dasherized>` and now emits `#{file_name}` under a timestamp, as
`migration_generator.rb:17` does; `db.test.ts`'s laid-down fixtures follow.
The two hyphen fixture directories and their two tests are deleted.

**5. SQLite `removeIndex` across ATTACHed schemas (RFC 0051).**
An unqualified `DROP INDEX` name resolves across main, temp and each ATTACHed
database in attach order, so two schemas carrying the same index name had
`removeIndex("aux.customers", …)` drop whichever SQLite reached first.
`removeIndex` now takes the same qualified/unqualified fork
`visit_CreateIndexDefinition` already takes; the unqualified path emits exactly
what `sqlite3_adapter.rb:283-289` does. New test attaches two databases with an
identically-named index and shows the named one is dropped — it fails on the bare
emission (verified).

Closes-story: retire-collection-proxy-append-bang-and-wire-inverse-target
Closes-story: retire-reapply-nested-attr-setters-onto-constructor-assign
Closes-story: retire-ar-non-q-predicate-aliases
Closes-story: retire-the-hyphen-migration-filename-alias
Closes-story: sqlite-remove-index-drops-unqualified-across-attached-schemas
