### PR TITLE
chore(ci): drop stale hardcoded LOC figure from attribution-scan comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
           # The pulls/{n}/commits endpoint caps at 250 commits even with
           # --paginate, so a >250-commit PR would leave its tail unscanned. Fail
           # closed in that case rather than passing on a partial scan — this repo
-          # squashes and has a 500-LOC ceiling, so 250 commits never happens
+          # squashes and PRs are size-capped, so 250 commits never happens
           # legitimately; if it does, squash/rebase before re-running.
           count=$(scripts/ci/gh-api-retry.sh "repos/$REPO/pulls/$PR_NUMBER" --jq '.commits')
           if [ "$count" -gt 250 ]; then


### PR DESCRIPTION
The Preflight attribution-scan comment justified failing closed on the 250-commit API cap by citing "a 500-LOC ceiling". That number isn't authoritative anywhere — CLAUDE.md is explicit that the PR size ceiling comes from the agent prompt's "Hard rules" block, filled from `PR_MAX_LOC` so it can be retuned without editing files. A hardcoded 500 here is a second, unmaintained source of truth, and an agent has already read it out of this file and passed it on as a hard rule.

Reworded to "PRs are size-capped". The reasoning is unchanged; no workflow logic touched.

Swept for other instances: the only remaining hits are two lines in `docs/html-sanitizer-plan.md` recording a past one-off approval to exceed the ceiling as it stood then. Those are historical records of a decision, not a live statement of the current limit, so left alone.