### PR TITLE
feat(eslint): no-freeform-comments, registered for arel + activemodel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ coverage/
 
 # Scratch output from local screenshot/driver runs.
 tmp/
+
+# Local audit page for eslint/no-freeform-comments; published as an Artifact.
+comment-audit.html

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -727,7 +727,8 @@ export default defineConfig(
   // ── no-freeform-comments: trails is a line-by-line Rails port, so a comment
   //    that restates the TS competes with the Ruby for authority and rots
   //    independently of both. The autofix DELETES; it keeps JSDoc, references
-  //    that point AT the Ruby, tool directives, and anything marked `keep:`.
+  //    that point AT the Ruby, and tool directives. There is no opt-out marker:
+  //    a comment either earns one of those forms or goes.
   //    Rails' OWN comments are NOT kept — the Ruby is vendored and cited, so
   //    copying its annotations across just duplicates them somewhere that goes
   //    stale on its own. Scoped to the packages whose backlog has been swept —

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -726,9 +726,11 @@ export default defineConfig(
 
   // ── no-freeform-comments: trails is a line-by-line Rails port, so a comment
   //    that restates the TS competes with the Ruby for authority and rots
-  //    independently of both. The autofix DELETES; it keeps JSDoc, Rails
-  //    references, tool directives, Rails' own ported comments, and anything
-  //    marked `keep:`. Scoped to the packages whose backlog has been swept —
+  //    independently of both. The autofix DELETES; it keeps JSDoc, references
+  //    that point AT the Ruby, tool directives, and anything marked `keep:`.
+  //    Rails' OWN comments are NOT kept — the Ruby is vendored and cited, so
+  //    copying its annotations across just duplicates them somewhere that goes
+  //    stale on its own. Scoped to the packages whose backlog has been swept —
   //    widen it a package at a time, after auditing that package's comments,
   //    never ahead of the audit. ──
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.m
 import noLoadSchemaWithStubbedDdl from "./eslint/no-load-schema-with-stubbed-ddl.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
 import noRawControlBytes from "./eslint/no-raw-control-bytes.mjs";
+import noFreeformComments from "./eslint/no-freeform-comments.mjs";
 import { readFileSync } from "node:fs";
 
 // See the rails-file-structure-method-order block below: without real order
@@ -255,6 +256,7 @@ export default defineConfig(
           "no-load-schema-with-stubbed-ddl": noLoadSchemaWithStubbedDdl,
           "no-explicit-any-disable": noExplicitAnyDisable,
           "no-raw-control-bytes": noRawControlBytes,
+          "no-freeform-comments": noFreeformComments,
           // Off by default — opt in per project (see eslint/manifest-complete.mjs).
           "manifest-complete": manifestComplete,
         },
@@ -719,6 +721,20 @@ export default defineConfig(
     files: ["**/*.ts", "**/*.mts", "**/*.mjs", "**/*.js"],
     rules: {
       "blazetrails/no-raw-control-bytes": "error",
+    },
+  },
+
+  // ── no-freeform-comments: trails is a line-by-line Rails port, so a comment
+  //    that restates the TS competes with the Ruby for authority and rots
+  //    independently of both. The autofix DELETES; it keeps JSDoc, Rails
+  //    references, tool directives, Rails' own ported comments, and anything
+  //    marked `keep:`. Scoped to the packages whose backlog has been swept —
+  //    widen it a package at a time, after auditing that package's comments,
+  //    never ahead of the audit. ──
+  {
+    files: ["packages/arel/src/**/*.ts", "packages/activemodel/src/**/*.ts"],
+    rules: {
+      "blazetrails/no-freeform-comments": "error",
     },
   },
 

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -1,0 +1,191 @@
+/**
+ * ESLint rule: no-freeform-comments
+ *
+ * trails is a line-by-line port of Rails. A comment that restates what the TS
+ * says, or that narrates a decision the Rails source already settles, is drift:
+ * it competes with the Ruby for authority and it rots independently of both
+ * sides. The comments worth having are the ones that point at Rails, the ones
+ * the port's own conventions live in (JSDoc), and the ones a tool reads.
+ *
+ * So this rule deletes free-form comments and KEEPS four kinds:
+ *
+ *   1. JSDoc block comments (`/** ... *\/`). Every port convention lives here —
+ *      `Mirrors:`, `@internal`, `@noRailsEquivalent`, `@missingRailsCall` — and
+ *      `parity:api` / the ESLint manifests read them.
+ *   2. Rails references — a `.rb` path or citation, a `Mirrors:` line, a Rails
+ *      constant path. This is the fidelity anchor CLAUDE.md asks for.
+ *   3. Tool directives — `eslint-*`, `@ts-*`, `prettier-ignore`, coverage
+ *      pragmas, and this repo's own `boundary:` / `@boundary-file:` (read by
+ *      `no-native-date`). Deleting these changes what the toolchain does.
+ *   4. Anything explicitly kept with the escape hatch (see KEEP_MARKER).
+ *
+ * Rails' OWN comments are NOT kept, and that is deliberate. The Ruby is
+ * vendored at `vendor/rails/` and every ported file carries a `Mirrors:` line
+ * pointing at it, so a reader who wants Rails' annotation on a line reads it
+ * at the source. Copying it into trails duplicates it into a second place that
+ * rots on its own the moment Rails edits it — the same failure this rule
+ * exists to prevent. Reference the Ruby; do not restate it.
+ *
+ * The fix is destructive by design: the point is to run it, then read the diff
+ * and rescue whatever turns out to be load-bearing. Run it with
+ * `--rule '{"blazetrails/no-freeform-comments":["warn",{"report":true}]}'` to
+ * audit without deleting.
+ */
+
+/**
+ * Escape hatch. A comment whose first line carries this marker is kept, and
+ * the marker itself stays in the source as the record of the decision.
+ *
+ * Prefer promoting the comment to JSDoc or citing the Rails file instead —
+ * both are kept automatically and both say more than the marker does.
+ */
+const KEEP_MARKER = "keep:";
+
+/**
+ * Directives the toolchain reads. Deleting one silently changes behaviour.
+ *
+ * `boundary:` / `@boundary-file:` are this repo's own directives, read by
+ * `eslint/no-native-date.mjs` — they are the documented exemption for an
+ * intentional JS `Date`, so deleting one reds that rule rather than merely
+ * losing a note. They are matched anywhere in the comment, not just at the
+ * start, because `no-native-date` accepts them mid-line
+ * (`} /* boundary: *\/ else if (x instanceof Date)`).
+ */
+const DIRECTIVE_RE =
+  /^\s*(?:eslint-(?:disable|enable)(?:-next-line|-line)?\b|eslint\s|globals?\s|exported\b|@ts-(?:expect-error|ignore|nocheck)\b|prettier-ignore\b|(?:v8|c8|istanbul|node:coverage)\s+ignore\b|@vitest-environment\b|#!)|\bboundary:|@boundary-file:/iu;
+
+/**
+ * A reference to the Rails source. Deliberately generous: a false KEEP costs
+ * one line of audit, a false DELETE costs a fidelity anchor.
+ *
+ * - `query_methods.rb`, `relation/query_methods.rb:1604`
+ * - `Mirrors:` / `Mirrors Rails:` — the repo's citation convention
+ * - `ActiveRecord::Relation`, `Arel::Nodes::Grouping` — Ruby constant paths
+ * - a bare `rails/` path
+ *
+ * This keeps pointers TO the Ruby, which is the whole substitute for copying
+ * the Ruby's own comments across.
+ */
+const RAILS_REF_RE =
+  /(?:\b[\w/]+\.rb\b|\bMirrors\b|\b(?:Active(?:Record|Model|Support|Storage|Job)|Arel|Abstract\w*)::|(?:^|\s)rails\/|\bRails\b|\bRuby\b|\bMRI\b)/u;
+
+/**
+ * A contiguous run of `//` comments is one human comment that happens to wrap.
+ * Judging each physical line separately splits a Rails citation from the
+ * sentence it anchors and deletes half of it, so line comments are grouped
+ * into blocks first and kept or deleted whole.
+ */
+function groupLineComments(comments, sourceCode) {
+  const groups = [];
+  let current = null;
+  for (const comment of comments) {
+    if (comment.type !== "Line") {
+      if (current) {
+        groups.push(current);
+        current = null;
+      }
+      groups.push([comment]);
+      continue;
+    }
+    const contiguous =
+      current &&
+      comment.loc.start.line === current[current.length - 1].loc.end.line + 1 &&
+      onlyCommentOnItsLine(comment, sourceCode) &&
+      onlyCommentOnItsLine(current[current.length - 1], sourceCode);
+    if (contiguous) current.push(comment);
+    else {
+      if (current) groups.push(current);
+      current = [comment];
+    }
+  }
+  if (current) groups.push(current);
+  return groups;
+}
+
+/** True when nothing but whitespace precedes the comment on its own line. */
+function onlyCommentOnItsLine(comment, sourceCode) {
+  const line = sourceCode.lines[comment.loc.start.line - 1] ?? "";
+  return line.slice(0, comment.loc.start.column).trim() === "";
+}
+
+/** JSDoc: a block comment opening `/**`, which is where the port conventions live. */
+function isJsDoc(comment) {
+  return comment.type === "Block" && comment.value.startsWith("*");
+}
+
+function isKept(group) {
+  return group.some((comment) => {
+    const text = comment.value;
+    if (isJsDoc(comment)) return true;
+    if (DIRECTIVE_RE.test(text)) return true;
+    if (text.toLowerCase().includes(KEEP_MARKER)) return true;
+    return RAILS_REF_RE.test(text);
+  });
+}
+
+/**
+ * The range to remove: the comment span, plus the whitespace back to the start
+ * of its line and the trailing newline, so deleting a standalone comment does
+ * not leave a blank line behind. A trailing comment (code on the same line)
+ * keeps its line and loses only the comment and the space before it.
+ */
+function removalRange(group, sourceCode) {
+  const first = group[0];
+  const last = group[group.length - 1];
+  const text = sourceCode.getText();
+  let start = first.range[0];
+  let end = last.range[1];
+  const standalone = onlyCommentOnItsLine(first, sourceCode);
+  while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
+  if (standalone) {
+    if (text[end] === "\r") end++;
+    if (text[end] === "\n") end++;
+  }
+  return [start, end];
+}
+
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Delete free-form comments; keep JSDoc, Rails references, tool directives, and explicitly marked comments.",
+    },
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          // Report without offering a fix — the audit mode.
+          report: { type: "boolean" },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      freeform:
+        "Free-form comment. trails is a line-by-line Rails port: cite the Rails file, promote it to JSDoc, or delete it. To keep it as-is, prefix it with `{{marker}}`.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const reportOnly = context.options[0]?.report === true;
+    return {
+      Program() {
+        for (const group of groupLineComments(sourceCode.getAllComments(), sourceCode)) {
+          if (isKept(group)) continue;
+          const range = removalRange(group, sourceCode);
+          context.report({
+            loc: { start: group[0].loc.start, end: group[group.length - 1].loc.end },
+            messageId: "freeform",
+            data: { marker: KEEP_MARKER },
+            fix: reportOnly ? undefined : (fixer) => fixer.removeRange(range),
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;
+export { KEEP_MARKER, RAILS_REF_RE, DIRECTIVE_RE };

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -157,7 +157,7 @@ const rule = {
     type: "suggestion",
     docs: {
       description:
-        "Delete free-form comments; keep JSDoc, Rails references, tool directives, and explicitly marked comments.",
+        "Delete free-form comments; keep only JSDoc, references to the Rails source, and tool directives.",
     },
     fixable: "code",
     schema: [

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -7,7 +7,7 @@
  * sides. The comments worth having are the ones that point at Rails, the ones
  * the port's own conventions live in (JSDoc), and the ones a tool reads.
  *
- * So this rule deletes free-form comments and KEEPS four kinds:
+ * So this rule deletes free-form comments and KEEPS three kinds:
  *
  *   1. JSDoc block comments (`/** ... *\/`). Every port convention lives here —
  *      `Mirrors:`, `@internal`, `@noRailsEquivalent`, `@missingRailsCall` — and
@@ -17,7 +17,10 @@
  *   3. Tool directives — `eslint-*`, `@ts-*`, `prettier-ignore`, coverage
  *      pragmas, and this repo's own `boundary:` / `@boundary-file:` (read by
  *      `no-native-date`). Deleting these changes what the toolchain does.
- *   4. Anything explicitly kept with the escape hatch (see KEEP_MARKER).
+ *
+ * There is no opt-out marker. The rule shipped with a `keep:` escape hatch and
+ * the sweep across arel and activemodel used it zero times, so it was removed:
+ * a comment earns one of the three forms above or it goes.
  *
  * Rails' OWN comments are NOT kept, and that is deliberate. The Ruby is
  * vendored at `vendor/rails/` and every ported file carries a `Mirrors:` line
@@ -46,15 +49,6 @@
  * `--rule '{"blazetrails/no-freeform-comments":["warn",{"report":true}]}'` to
  * audit without deleting.
  */
-
-/**
- * Escape hatch. A comment whose first line carries this marker is kept, and
- * the marker itself stays in the source as the record of the decision.
- *
- * Prefer promoting the comment to JSDoc or citing the Rails file instead —
- * both are kept automatically and both say more than the marker does.
- */
-const KEEP_MARKER = "keep:";
 
 /**
  * Directives the toolchain reads. Deleting one silently changes behaviour.
@@ -133,7 +127,6 @@ function isKept(group) {
     const text = comment.value;
     if (isJsDoc(comment)) return true;
     if (DIRECTIVE_RE.test(text)) return true;
-    if (text.toLowerCase().includes(KEEP_MARKER)) return true;
     return RAILS_REF_RE.test(text);
   });
 }
@@ -179,7 +172,7 @@ const rule = {
     ],
     messages: {
       freeform:
-        "Free-form comment. trails is a line-by-line Rails port: cite the Rails file, promote it to JSDoc, or delete it. To keep it as-is, prefix it with `{{marker}}`.",
+        "Free-form comment. trails is a line-by-line Rails port: cite the Rails file, promote it to JSDoc, or delete it.",
     },
   },
   create(context) {
@@ -193,7 +186,6 @@ const rule = {
           context.report({
             loc: { start: group[0].loc.start, end: group[group.length - 1].loc.end },
             messageId: "freeform",
-            data: { marker: KEEP_MARKER },
             fix: reportOnly ? undefined : (fixer) => fixer.removeRange(range),
           });
         }
@@ -203,4 +195,4 @@ const rule = {
 };
 
 export default rule;
-export { KEEP_MARKER, RAILS_REF_RE, DIRECTIVE_RE };
+export { RAILS_REF_RE, DIRECTIVE_RE };

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -35,6 +35,12 @@
  * declaration it sits on is the same drift this rule deletes, and should be
  * deleted in review.
  *
+ * Requiring a tag or a Rails reference on every JSDoc block was measured and
+ * rejected: it flags 94 pre-existing blocks in these two packages that are
+ * ordinary API documentation ("Set the FROM table.", "Add GROUP BY."), which
+ * is JSDoc doing its job. Tracked as
+ * 0023-surfaced-deviations/close-jsdoc-bypass-in-no-freeform-comments.
+ *
  * The fix is destructive by design: the point is to run it, then read the diff
  * and rescue whatever turns out to be load-bearing. Run it with
  * `--rule '{"blazetrails/no-freeform-comments":["warn",{"report":true}]}'` to

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -26,6 +26,15 @@
  * rots on its own the moment Rails edits it — the same failure this rule
  * exists to prevent. Reference the Ruby; do not restate it.
  *
+ * KNOWN LIMITATION: keep-rule 1 is unconditional, so reformatting a doomed
+ * `//` comment as `/** ... *\/` bypasses the fix. That is deliberate and not
+ * closable statically — JSDoc on a declaration is exactly where this repo puts
+ * `Mirrors:`, `@internal` and `@noRailsEquivalent`, and no static check can
+ * separate a real contract note from narration wearing the same syntax. The
+ * check is review, not lint: a JSDoc block that documents nothing about the
+ * declaration it sits on is the same drift this rule deletes, and should be
+ * deleted in review.
+ *
  * The fix is destructive by design: the point is to run it, then read the diff
  * and rescue whatever turns out to be load-bearing. Run it with
  * `--rule '{"blazetrails/no-freeform-comments":["warn",{"report":true}]}'` to

--- a/eslint/no-freeform-comments.test.mjs
+++ b/eslint/no-freeform-comments.test.mjs
@@ -29,15 +29,19 @@ tester.run("no-freeform-comments", rule, {
     { code: `// eslint-disable-next-line no-unused-vars\nconst x = 1;\n` },
     { code: `// @ts-expect-error deliberate\nconst x = 1;\n` },
     { code: `// prettier-ignore\nconst x = 1;\n` },
-    // The escape hatch, and it is case-insensitive.
-    { code: `// keep: the ordering here is load-bearing for the pool.\nconst x = 1;\n` },
-    { code: `// KEEP: shouted, still kept.\nconst x = 1;\n` },
     // One line of a wrapped block carrying the citation keeps the whole block.
     {
       code: `// The visitor dispatches on node class, not on arity, because\n// visitors.rb:41 does the same.\nconst x = 1;\n`,
     },
   ],
   invalid: [
+    // There is no opt-out marker. `keep:` was the rule's escape hatch and was
+    // removed unused — a comment now earns JSDoc or a citation, or it goes.
+    {
+      code: `// keep: the ordering here is load-bearing for the pool.\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
     // A standalone comment takes its whole line with it.
     {
       code: `// this adds two numbers\nconst x = 1 + 1;\n`,

--- a/eslint/no-freeform-comments.test.mjs
+++ b/eslint/no-freeform-comments.test.mjs
@@ -1,0 +1,133 @@
+import { RuleTester } from "eslint";
+import rule from "./no-freeform-comments.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    parser: (await import("typescript-eslint")).parser,
+  },
+});
+
+tester.run("no-freeform-comments", rule, {
+  valid: [
+    // JSDoc is where every port convention lives.
+    { code: `/** Mirrors: ActiveRecord::Relation#where. */\nexport function where() {}\n` },
+    { code: `/**\n * @internal\n */\nconst x = 1;\n` },
+    { code: `/** No tags, still JSDoc. */\nconst x = 1;\n` },
+    // Rails citations, in every spelling the packages actually use.
+    { code: `// query_methods.rb:1604\nconst x = 1;\n` },
+    {
+      code: `// Mirrors Rails: \`Nodes::Extract.new [self], field\` (expressions.rb).\nconst x = 1;\n`,
+    },
+    { code: `// ActiveRecord::Base does this in two passes.\nconst x = 1;\n` },
+    { code: `// Ruby's \`nil\` is falsy; JS \`0\` is not.\nconst x = 1;\n` },
+    // Tool directives change behaviour when deleted.
+    { code: `// eslint-disable-next-line no-unused-vars\nconst x = 1;\n` },
+    { code: `// @ts-expect-error deliberate\nconst x = 1;\n` },
+    { code: `// prettier-ignore\nconst x = 1;\n` },
+    // The escape hatch, and it is case-insensitive.
+    { code: `// keep: the ordering here is load-bearing for the pool.\nconst x = 1;\n` },
+    { code: `// KEEP: shouted, still kept.\nconst x = 1;\n` },
+    // One line of a wrapped block carrying the citation keeps the whole block.
+    {
+      code: `// The visitor dispatches on node class, not on arity, because\n// visitors.rb:41 does the same.\nconst x = 1;\n`,
+    },
+  ],
+  invalid: [
+    // A standalone comment takes its whole line with it.
+    {
+      code: `// this adds two numbers\nconst x = 1 + 1;\n`,
+      output: `const x = 1 + 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // A trailing comment keeps the code and loses the preceding space.
+    {
+      code: `const x = 1; // obvious\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // A non-JSDoc block comment is free-form.
+    {
+      code: `/* just a note */\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // A wrapped run with no citation anywhere is one report, deleted whole.
+    {
+      code: `// first line of narration\n// second line of narration\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // Indentation is consumed too, so no blank-ish line is left behind.
+    {
+      code: `function f() {\n  // narration\n  return 1;\n}\n`,
+      output: `function f() {\n  return 1;\n}\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // Two separated comments are two reports, not one.
+    {
+      code: `// one\nconst x = 1;\n// two\nconst y = 2;\n`,
+      output: `const x = 1;\nconst y = 2;\n`,
+      errors: [{ messageId: "freeform" }, { messageId: "freeform" }],
+    },
+    // Section banners carry no information the code does not.
+    {
+      code: `// ---------------------------------------------------------------\n// Statements\n// ---------------------------------------------------------------\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+  ],
+});
+
+// Audit mode reports without fixing, so a survey run cannot mutate the tree.
+tester.run("no-freeform-comments (report mode)", rule, {
+  valid: [],
+  invalid: [
+    {
+      code: `// narration\nconst x = 1;\n`,
+      options: [{ report: true }],
+      output: null,
+      errors: [{ messageId: "freeform" }],
+    },
+  ],
+});
+
+// `boundary:` / `@boundary-file:` are directives this repo's own
+// `no-native-date` rule reads, so deleting one reds that rule rather than
+// merely losing a note. They are accepted anywhere in the comment because
+// `no-native-date` accepts them mid-line.
+tester.run("no-freeform-comments (boundary directives)", rule, {
+  valid: [
+    { code: `// boundary: the JS Date is matched only to refuse it, per #939\nconst x = 1;\n` },
+    { code: `// @boundary-file: adapter marshalling\nconst x = 1;\n` },
+    { code: `const x = 1; /* boundary: */\n` },
+  ],
+  invalid: [],
+});
+
+// Rails' OWN comments go too. The Ruby is vendored at `vendor/rails/` and the
+// ported file cites it, so copying its annotations across duplicates them into
+// a second place that rots the moment Rails edits them. A comment that names
+// the Ruby is a pointer and survives (rule 2); a comment that restates it does
+// not.
+tester.run("no-freeform-comments (Rails' own comments are not privileged)", rule, {
+  valid: [
+    // A pointer to the Ruby, which is what replaces copying the comment.
+    { code: `// Mirrors arel/nodes/window.rb:15\nconst x = 1;\n` },
+  ],
+  invalid: [
+    // arel/nodes/window.rb:15, carried across verbatim by the port.
+    {
+      code: `// FIXME: We SHOULD NOT be converting these to SqlLiteral automatically\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+    // activemodel/lib/active_model/locale/en.yml:3
+    {
+      code: `// The default format to use in full error messages.\nconst x = 1;\n`,
+      output: `const x = 1;\n`,
+      errors: [{ messageId: "freeform" }],
+    },
+  ],
+});

--- a/eslint/no-freeform-comments.test.mjs
+++ b/eslint/no-freeform-comments.test.mjs
@@ -14,7 +14,10 @@ tester.run("no-freeform-comments", rule, {
     // JSDoc is where every port convention lives.
     { code: `/** Mirrors: ActiveRecord::Relation#where. */\nexport function where() {}\n` },
     { code: `/**\n * @internal\n */\nconst x = 1;\n` },
-    { code: `/** No tags, still JSDoc. */\nconst x = 1;\n` },
+    // A tagless JSDoc documenting a declaration is still JSDoc. This is also
+    // the rule's known limitation: it cannot tell this from narration that was
+    // reformatted to `/** */` to dodge the fix. See the rule's own doc.
+    { code: `/** The engine every manager compiles against. */\nexport const engine = 1;\n` },
     // Rails citations, in every spelling the packages actually use.
     { code: `// query_methods.rb:1604\nconst x = 1;\n` },
     {

--- a/packages/activemodel/src/access.test.ts
+++ b/packages/activemodel/src/access.test.ts
@@ -2,11 +2,6 @@ import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 
 describe("AccessTest", () => {
-  // =========================================================================
-  // Ported from missing-activemodel-stubs.test.ts
-  // =========================================================================
-
-  // ---- Access tests ----
   class SliceModel extends Model {
     static {
       this.attribute("name", "string");

--- a/packages/activemodel/src/api.test.ts
+++ b/packages/activemodel/src/api.test.ts
@@ -21,7 +21,6 @@ class DefaultValueModel extends Model {
 
   declare _attr?: string;
 
-  // `attr_accessor :hello`, added by DefaultValue's `included` hook.
   get hello(): string | undefined {
     return this._hello;
   }

--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -110,7 +110,6 @@ describe("AttributeAssignmentTest", () => {
       set name(v: string) {
         (this as Base).writeAttribute("name", v.toUpperCase());
       }
-      // getter mirrors the default attribute read
       get name(): string {
         return this.readAttribute("name") as string;
       }
@@ -318,8 +317,6 @@ describe("AttributeAssignmentTest", () => {
       }
     }
     const p = new Person({});
-    // Non-empty (per empty? delegation, not the wrapper's Object.keys) → the
-    // guard proceeds into sanitize_for_mass_assignment, which forbids it.
     const params = new ProtectedParams({ name: "Bob" });
     expect(() => p.assignAttributes(params as unknown as Record<string, unknown>)).toThrow(
       ForbiddenAttributesError,

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -242,10 +242,6 @@ function respondToEachPair(attrs: unknown): attrs is Record<string, unknown> {
  * carry an `empty: <boolean>` attribute is unaffected).
  */
 function isParamsLikeWrapper(attrs: object): boolean {
-  // `where`/`exists` funnel raw primitives through this path, and
-  // `Object.getPrototypeOf` box-coerces them (so a number clears the plain-object
-  // gate below) while `in` throws on them outright. A primitive is never a params
-  // wrapper — reject before either check.
   if (typeof attrs !== "object" || attrs === null) return false;
   const proto = Object.getPrototypeOf(attrs);
   if (proto === Object.prototype || proto === null) return false;

--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -201,7 +201,6 @@ describe("AttributeMethodsTest", () => {
   it("method missing works correctly even if attributes method is not defined", () => {
     class Bare extends Model {}
     const b = new Bare();
-    // attributeMissing returns null for undefined attributes
     expect(b.readAttribute("nonexistent")).toBe(null);
   });
 
@@ -326,9 +325,6 @@ describe("AttributeMethodsTest", () => {
   });
 
   it("aliased writes propagate to dirty tracking on the canonical name", () => {
-    // The alias write must register a change on the ORIGINAL attribute's
-    // dirty state, not a separate entry — otherwise changedAttributes /
-    // changes would report under the aliased name.
     class Person extends Model {
       static {
         this.attribute("name", "string");
@@ -359,7 +355,6 @@ describe("AttributeMethodsTest", () => {
   });
 
   it("name clashes are handled", () => {
-    // Attributes with the same name as existing methods should still work via readAttribute
     class Person extends Model {
       static {
         this.attribute("name", "string");

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -402,7 +402,6 @@ export function defineAttributeMethod(
     }
     this.attributeMethodPatternsCache().clear();
   });
-  // Copy-on-first-write per class, like `aliasesByAttributeName`.
   if (!Object.prototype.hasOwnProperty.call(this, "_patternsGeneratedFor")) {
     this._patternsGeneratedFor = new Map(this._patternsGeneratedFor ?? []);
   }

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -124,10 +124,6 @@ export class AttributeMethodPattern {
   }
 }
 
-// ---------------------------------------------------------------------------
-// ClassMethods — assigned directly to Model's static side
-// ---------------------------------------------------------------------------
-
 /** Minimum shape required of an instance accessed through a generated attribute method closure. */
 interface ReadWriteHost {
   readAttribute(name: string): unknown;
@@ -392,8 +388,6 @@ export function defineAttributeMethods(this: ClassMethods, ...attrNames: string[
   });
 }
 
-// -- Internal helpers (take explicit host arg) --------------------------------
-
 export function defineAttributeMethod(
   this: ClassMethods,
   attrName: string,
@@ -449,7 +443,6 @@ export function defineAttributeMethodPattern(
   // Active Record itself defines and to consult the class's own methods
   // (activerecord/attribute_methods.rb:165-179).
   if (this.isInstanceMethodAlreadyImplemented(publicMethodName)) {
-    // However, for `alias_attribute`, we always define the method.
     if (!override) return;
   }
 
@@ -596,9 +589,6 @@ export function defineProxyCall(
   const callArgs = rest.slice(0, -1) as string[];
   const mangledName = buildMangledName(name);
 
-  // We have to use a different namespace for every target method, because if
-  // someone defines an attribute that looks like an attribute method we could
-  // clash, e.g. `attribute :title_was` / `attribute :title`.
   const namespace = `${options.namespace}_${proxyTarget}`;
 
   defineCall(codeGenerator, name, proxyTarget, mangledName, parameters, callArgs, {
@@ -703,8 +693,6 @@ function sendProxyTarget(record: ReadWriteHost, targetName: string, args: unknow
   }
   return target.call(record, ...args);
 }
-
-// -- Public ClassMethods (use `this`, assigned to Model directly) -----------
 
 /**
  * @noRailsEquivalent Peels Ruby's trailing `parameters:` keyword back off the

--- a/packages/activemodel/src/attribute-mutation-tracker.test.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.test.ts
@@ -84,7 +84,6 @@ describe("AttributeMutationTracker", () => {
     const tracker = new AttributeMutationTracker(set);
 
     set.writeFromUser("age", 31);
-    // String "30" / "31" cast to integers should match the typed values.
     expect(tracker.isChanged("age", { from: "30", to: "31" })).toBe(true);
     expect(tracker.isChanged("age", { from: "29" })).toBe(false);
     expect(tracker.isChanged("age", { to: "32" })).toBe(false);
@@ -205,7 +204,6 @@ describe("forceChange and type.isChanged independence", () => {
     set.writeFromUser("ratio", NaN);
     expect(tracker.changedAttributeNames()).not.toContain("ratio");
 
-    // forceChange overrides type — must appear as changed regardless
     tracker.forceChange("ratio");
     expect(tracker.changedAttributeNames()).toContain("ratio");
   });

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -7,7 +7,6 @@ function cloneValue(value: unknown): unknown {
   // boundary: Date is mutable — clone to protect dirty tracking when a legacy
   // caller hands in a Date attribute value. Temporal types are immutable.
   if (value instanceof Date) return new Date(value.getTime());
-  // Temporal types are immutable — no clone needed
   if (
     value instanceof Temporal.Instant ||
     value instanceof Temporal.PlainDateTime ||
@@ -17,7 +16,6 @@ function cloneValue(value: unknown): unknown {
   )
     return value;
   if (Array.isArray(value)) return value.map(cloneValue);
-  // Only deep-clone plain objects; preserve class instances as-is
   const proto = Object.getPrototypeOf(value);
   if (proto !== Object.prototype && proto !== null) return value;
   const result: Record<string, unknown> = proto === null ? Object.create(null) : {};

--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -205,7 +205,6 @@ describe("AttributeRegistrationTest", () => {
   });
 
   it("the default type is used when type is omitted", () => {
-    // When using a registered type, lookups use the registry
     const stringType = Types.typeRegistry.lookup("string");
     expect(stringType.name).toBe("string");
     expect(stringType.cast("hello")).toBe("hello");
@@ -234,7 +233,6 @@ describe("AttributeRegistrationTest", () => {
   });
 
   it(".decorate_attributes decorates specified attributes", () => {
-    // We can use normalizes as the TS equivalent of decorate_attributes
     class Person extends Model {
       static {
         this.attribute("name", "string");
@@ -246,7 +244,6 @@ describe("AttributeRegistrationTest", () => {
   });
 
   it(".decorate_attributes stacks decorators", () => {
-    // Multiple normalizations: last one wins since normalizes replaces
     class Person extends Model {
       static {
         this.attribute("name", "string");
@@ -264,7 +261,6 @@ describe("AttributeRegistrationTest", () => {
       static {
         this.attribute("name", "string");
         this.normalizes("name", (v: unknown) => (typeof v === "string" ? v.toUpperCase() : v));
-        // Re-register normalization
         this.normalizes("name", (v: unknown) => (typeof v === "string" ? v.toLowerCase() : v));
       }
     }
@@ -304,7 +300,6 @@ describe("AttributeRegistrationTest", () => {
     }
     const queue = (MyModel as any)._pendingAttributeModifications;
     expect(queue).toBeDefined();
-    // "name" → PendingType; "age" → PendingType + PendingDefault
     expect(queue.length).toBe(3);
   });
 
@@ -329,7 +324,6 @@ describe("AttributeRegistrationTest", () => {
         this.attribute("role", "string", { default: "admin" });
       }
     }
-    // Child's pending queue replays after parent's, so child's default wins
     const defaults = (Child as any)._defaultAttributes();
     expect(defaults.getAttribute("role").value).toBe("admin");
   });
@@ -342,15 +336,12 @@ describe("AttributeRegistrationTest", () => {
     }
     class Child extends Parent {}
 
-    // Prime the subclass cache
     const before = (Child as any)._defaultAttributes();
     expect(before.keys()).toContain("name");
     expect(before.keys()).not.toContain("age");
 
-    // Add a new attribute to the superclass at runtime
     Parent.attribute("age", "integer", { default: 42 });
 
-    // Child's cache must be invalidated and rebuilt
     const after = (Child as any)._defaultAttributes();
     expect(after.getAttribute("age").value).toBe(42);
   });
@@ -364,12 +355,10 @@ describe("AttributeRegistrationTest", () => {
     class Mid extends Base {}
     class Leaf extends Mid {}
 
-    // Prime all caches
     (Base as any)._defaultAttributes();
     (Mid as any)._defaultAttributes();
     (Leaf as any)._defaultAttributes();
 
-    // Add to root — all descendants must recompute
     Base.attribute("new_attr", "integer", { default: 7 });
 
     expect((Leaf as any)._defaultAttributes().getAttribute("new_attr").value).toBe(7);

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -296,10 +296,6 @@ export function resetDefaultAttributesBang(this: AttributeHostInternals): void {
   // cascade that clears _default_attributes, mirroring Rails resetting
   // @attribute_types alongside @default_attributes.
   this._cachedAttributeTypes = null;
-  // _attributesBuilder is an AR-specific derived cache. Shadow with undefined
-  // so prototype-chain lookup never returns a stale superclass builder after
-  // this class's attributes change. STI subclasses remove the shadow after
-  // writing the fresh builder; AM-only classes carry it harmlessly.
   this._attributesBuilder = undefined;
 }
 

--- a/packages/activemodel/src/attribute-set.test.ts
+++ b/packages/activemodel/src/attribute-set.test.ts
@@ -292,9 +292,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 25 });
-    // After construction, attributes may already have been read; snapshot current state:
     const accessed = p._attributes.accessed();
-    // At minimum, reading one more attribute increases the set
     p.readAttribute("name");
     expect(p._attributes.accessed().length).toBeGreaterThanOrEqual(accessed.length);
     expect(p.hasAttribute("name")).toBe(true);

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -130,11 +130,6 @@ export class AttributeSet {
   writeFromDatabase(
     name: string,
     value: unknown,
-    // Structural duck type (not the abstract `Type`): callers thread result-set
-    // column types whose only contract on this path is `deserialize`, and
-    // `Attribute.fromDatabase` only calls `type.deserialize` here. Widening to
-    // the structural interface lets call sites pass the column type without an
-    // `as never` cast.
     type?: { deserialize(value: unknown): unknown },
   ): void {
     this.assertNotFrozen();
@@ -391,7 +386,6 @@ export class AttributeSet {
         if (attr.hasBeenRead()) {
           result.set(name, attr.value);
         } else {
-          // Clone so lazy evaluation doesn't affect the live attribute
           const cloned = Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
           result.set(name, { [LAZY_ATTR]: cloned });
         }

--- a/packages/activemodel/src/attribute-set/yaml-encoder.test.ts
+++ b/packages/activemodel/src/attribute-set/yaml-encoder.test.ts
@@ -85,7 +85,6 @@ describe("YAMLEncoder", () => {
     const decoded = localCoder.decode(json);
     expect(decoded.fetchValue("x")).toBe("hello");
     expect(warnSpy).toHaveBeenCalledOnce();
-    // Second decode: no extra warn
     localCoder.decode(json);
     expect(warnSpy).toHaveBeenCalledOnce();
   });
@@ -127,7 +126,6 @@ describe("YAMLEncoder", () => {
     const set = makeSet(new Map([["flag", attr]]));
     const envelope = JSON.parse(coder.encode(set));
     expect(envelope.types.flag).toBe("immutable_string");
-    // Decode recovers the correct type
     const decoded = coder.decode(coder.encode(set));
     expect(decoded.fetchValue("flag")).toBe("t");
   });

--- a/packages/activemodel/src/attribute.test.ts
+++ b/packages/activemodel/src/attribute.test.ts
@@ -271,13 +271,11 @@ describe("AttributeTest", () => {
     const p = new Person({ name: "Alice" });
     const attrs = { ...p.attributes };
     attrs.name = "Bob";
-    // Original should be unchanged
     expect(p.readAttribute("name")).toBe("Alice");
   });
 
   it("with_value_from_user returns a new attribute with the value from the user", () => {
     const type = Types.typeRegistry.lookup("integer");
-    // Cast from user input
     const val = type.cast("42");
     expect(val).toBe(42);
   });
@@ -316,7 +314,6 @@ describe("AttributeTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    // The attribute exists but we can check hasAttribute
     expect(p.hasAttribute("name")).toBe(true);
     expect(p.hasAttribute("nonexistent")).toBe(false);
   });
@@ -331,7 +328,6 @@ describe("AttributeTest", () => {
     const p = new Person({ name: "Alice", age: 25 });
     p.writeAttribute("name", "Bob");
     expect(p.readAttribute("name")).toBe("Bob");
-    // age should still be the same
     expect(p.readAttribute("age")).toBe(25);
   });
 
@@ -493,8 +489,7 @@ describe("AttributeTest", () => {
     it("returns true when type.isChangedInPlace returns true (StringType: raw vs new value differ)", () => {
       const stringType = typeRegistry.lookup("string");
       const attr = Attribute.fromDatabase("name", "hello", stringType);
-      void attr.value; // materialize so hasBeenRead() is true
-      // Simulate mutation by overriding the cast value while raw stays "hello"
+      void attr.value;
       attr.overrideCastValue("world");
       expect(attr.changedInPlace()).toBe(true);
     });
@@ -502,14 +497,13 @@ describe("AttributeTest", () => {
     it("returns false before value is read (hasBeenRead guard)", () => {
       const stringType = typeRegistry.lookup("string");
       const attr = Attribute.fromDatabase("name", "hello", stringType);
-      // Don't access attr.value — hasBeenRead() is false
       expect(attr.changedInPlace()).toBe(false);
     });
 
     it("returns false for immutable type even after value is read", () => {
       const intType = typeRegistry.lookup("integer");
       const attr = Attribute.fromDatabase("count", 5, intType);
-      void attr.value; // materialize
+      void attr.value;
       expect(attr.changedInPlace()).toBe(false);
     });
   });
@@ -530,7 +524,6 @@ describe("AttributeTest", () => {
     });
 
     it("recomputes when in-place object mutation is detected via isChangedInPlace", () => {
-      // Custom mutable type: deserializes JSON strings, detects in-place mutations
       const Types = typeRegistry;
       const baseType = Types.lookup("value");
       const mutableType = Object.create(baseType);
@@ -542,10 +535,8 @@ describe("AttributeTest", () => {
         JSON.stringify(newVal);
 
       const attr = Attribute.fromDatabase("data", '{"x":1}', mutableType);
-      void attr.valueForDatabase; // prime cache — _hasValueForDatabase=true
-      // Mutate the memoized value object in place (no setter, _hasValueForDatabase stays true)
+      void attr.valueForDatabase;
       (attr.value as Record<string, number>).x = 99;
-      // isChangedInPlace('{"x":1}', {x:99}) → true → recompute
       expect(attr.valueForDatabase).toBe('{"x":99}');
     });
   });

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -3,7 +3,9 @@ import { defaultValue } from "./type.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 import { RuntimeError } from "./attribute-assignment.js";
 
-// Symbol so identity comparisons work across module copies and can't collide with any user value.
+/**
+ * Symbol so identity comparisons work across module copies and can't collide with any user value.
+ */
 export const UNINITIALIZED_ORIGINAL_VALUE: unique symbol = Symbol.for(
   "@blazetrails/activemodel/UNINITIALIZED_ORIGINAL_VALUE",
 );
@@ -33,8 +35,6 @@ export abstract class Attribute {
   private _hasValue: boolean;
   private _cachedValueForDatabase: unknown;
   private _hasValueForDatabase: boolean;
-
-  // --- Factory methods ---
 
   static fromDatabase(
     name: string,

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -5,6 +5,8 @@ import { RuntimeError } from "./attribute-assignment.js";
 
 /**
  * Symbol so identity comparisons work across module copies and can't collide with any user value.
+ *
+ * Mirrors activemodel/lib/active_model/attribute.rb:243, where this sentinel is `Object.new`; a JS Symbol keeps that identity across module copies.
  */
 export const UNINITIALIZED_ORIGINAL_VALUE: unique symbol = Symbol.for(
   "@blazetrails/activemodel/UNINITIALIZED_ORIGINAL_VALUE",

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -21,7 +21,6 @@ export class UserProvidedDefault extends FromUser {
   private _hasMemoizedVBTC: boolean = false;
 
   constructor(name: string, value: unknown, type: Type, databaseDefault: Attribute | null = null) {
-    // Pass undefined to super — we override valueBeforeTypeCast below
     super(name, undefined, type, databaseDefault);
     this.userProvidedValue = value;
   }
@@ -71,5 +70,4 @@ export class UserProvidedDefault extends FromUser {
   }
 }
 
-// Register with Attribute to resolve circular dependency for withUserDefault
 _registerUserProvidedDefault(UserProvidedDefault);

--- a/packages/activemodel/src/attributes-dirty.test.ts
+++ b/packages/activemodel/src/attributes-dirty.test.ts
@@ -10,7 +10,6 @@ describe("AttributesDirtyTest", () => {
     }
     const p = new Person({ age: 25 });
     p.writeAttribute("age", "25");
-    // Writing the same value (after cast) should not count as a change
     expect(p.attributeChanged("age")).toBe(false);
   });
 

--- a/packages/activemodel/src/attributes.test.ts
+++ b/packages/activemodel/src/attributes.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect } from "vitest";
 import { Model, ValueType } from "./index.js";
 
 describe("AttributesTest", () => {
-  // =========================================================================
-  // Phase 1000/1050 — Attributes and Type Casting
-  // =========================================================================
   class User extends Model {
     static {
       this.attribute("name", "string");
@@ -335,8 +332,8 @@ describe("attributesBeforeTypeCast", () => {
     const u = new User({ name: "Alice", age: "25" });
     const raw = u.attributesBeforeTypeCast;
     expect(raw.name).toBe("Alice");
-    expect(raw.age).toBe("25"); // raw, not cast to integer
-    expect(u.readAttribute("age")).toBe(25); // cast version
+    expect(raw.age).toBe("25");
+    expect(u.readAttribute("age")).toBe(25);
   });
 });
 

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -90,8 +90,6 @@ export function attribute(
   options?: AttributeOptions,
 ): void {
   name = this.resolveAttributeName(name);
-  // Type-optional form: `attribute(name, options)`. The second positional is
-  // the options hash rather than a type when it isn't a string or Type.
   if (typeName !== undefined && typeof typeName !== "string" && !(typeName instanceof Type)) {
     options = typeName;
     typeName = undefined;

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -164,7 +164,6 @@ describe("CallbacksTest", () => {
   });
 
   it("only selects which types of callbacks should be created", async () => {
-    // Test that before/after/around create callbacks exist
     const order: string[] = [];
     class Person extends Model {
       static {
@@ -292,7 +291,6 @@ describe("CallbacksTest", () => {
   });
 
   it("class-based callback object with snake_case method", async () => {
-    // camelCase only — method name is beforeValidation (not before_validation)
     const log: string[] = [];
     const auditor = {
       beforeValidation(record: any) {
@@ -455,14 +453,10 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
   });
 
   it("skipCallback miss does NOT isolate subclass from future parent callbacks", async () => {
-    // A miss must preserve copy-on-first-write inheritance so a
-    // subclass that later has callbacks added to its parent still sees
-    // them via the prototype chain.
     const log: string[] = [];
     class Parent extends Model {}
     class Child extends Parent {}
     expect(Child.skipCallback("save", "before", () => undefined)).toBe(false);
-    // Now register on Parent — Child should still see it.
     Parent.setCallback("save", "before", () => log.push("from-parent"));
     await new Child().runCallbacks("save", () => log.push("child-block"));
     expect(log).toEqual(["from-parent", "child-block"]);
@@ -490,10 +484,6 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
   });
 
   it("skipCallback removes a CallbackObject registered via beforeX/afterX helpers", async () => {
-    // The generated `beforeX`/`afterX`/`aroundX` helpers from
-    // `defineModelCallbacks` pass the original filter straight to
-    // `register` so skipCallback(event, timing, originalObject) can
-    // find and remove it by reference.
     const log: string[] = [];
     class Thing extends Model {
       static {
@@ -514,9 +504,6 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
   });
 
   it("CallbackChain.register rejects on: for non-commit/rollback events", () => {
-    // Register-level gate — every path (setCallback, generated
-    // beforeX/afterX, plugin-direct _registerCallbackOnProto) funnels here, so
-    // rejecting once at the registration catches all entry points.
     const proto = Object.create(null);
     expect(() =>
       _registerCallbackOnProto(proto, "before", "save", () => {}, { on: "create" }),
@@ -534,9 +521,6 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
   });
 
   it("resetCallbacks clears CallbackObject-registered callbacks too", async () => {
-    // Companion to the skipCallback-with-object case: resetCallbacks
-    // must sweep the event bucket regardless of whether its entries
-    // came from functions or CallbackObjects.
     const log: string[] = [];
     class Thing extends Model {}
     const obj = {
@@ -712,8 +696,6 @@ describe("unified sync/async runner", () => {
     const p = new Person({ name: "test" });
     const result = p.isValid();
     expect(result).toBeInstanceOf(Promise);
-    // Halted before-validation aborts the chain, so isValid() is false and the
-    // validate callback never runs.
     expect(await result).toBe(false);
     expect(order).toEqual(["before"]);
   });
@@ -811,7 +793,7 @@ describe("Callbacks", () => {
     }
     const n = new NoValidate();
     expect(await n.isValid()).toBe(false);
-    expect(n.errors.count).toBe(0); // validations never ran
+    expect(n.errors.count).toBe(0);
   });
 
   it("complete callback chain", async () => {
@@ -949,7 +931,6 @@ describe("afterCommit / afterRollback callbacks", () => {
         this.afterCommit(() => {});
       }
     }
-    // Should not throw
     expect(await new Order({ total: 1 }).isValid()).toBe(true);
   });
 
@@ -981,7 +962,6 @@ describe("defineModelCallbacks()", () => {
     });
 
     const p = new Payment({ amount: 100 });
-    // Run callbacks manually
     await runBeforeCallbacksOnProto(Payment.prototype, "process", p);
     await runAfterCallbacksOnProto(Payment.prototype, "process", p);
     expect(log).toEqual(["before_process", "after_process"]);
@@ -1038,7 +1018,6 @@ describe("withOptions()", () => {
       m.validates("email", { presence: true });
     });
 
-    // Validations only run with "create" context, not without
     const user = new User();
     expect(await user.isValid()).toBe(true);
     expect(await user.isValid("create")).toBe(false);

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -81,12 +81,6 @@ export function defineModelCallbacks(this: object, ...args: unknown[]): void {
   const timings: CallbackTiming[] = options.only ?? ["before", "after", "around"];
   const klass = this as { prototype?: object } & Record<string, unknown>;
 
-  // NB: each `_defineXxxModelCallback` passes `fnOrObject` directly to
-  // `register`; `register` handles object dispatch internally AND stores
-  // the original filter for identity-based removal via `skip()`. Pre-resolving
-  // here would make the stored filter the wrapper function, breaking
-  // `Model.skipCallback(event, timing, originalObject)` for entries registered
-  // through the generated `beforeX`/`afterX`/`aroundX` helpers.
   for (const event of eventNames) {
     // Register the chain on the prototype with the same config used by
     // _registerCallbackOnProto so skipAfterCallbacksIfTerminated is consistent
@@ -126,6 +120,7 @@ export type CallbackObject = object;
 export interface RunCallbacksOptions {
   strict?: "sync";
 }
+
 /**
  * `if:` / `unless:` accept one filter or an array of them, and a filter is a
  * callable or a Symbol naming a method on the record — the shape Rails hands
@@ -314,9 +309,6 @@ export function _registerCallbackOnProto(
       }
     }
   }
-  // Two-step: defineCallbacks creates the chain with the right config (COW if
-  // needed); getCallbackChains re-reads the now-own Map (cheap: hasOwnProperty
-  // true on second call).
   asDefineCallbacks(proto, event, { skipAfterCallbacksIfTerminated: true });
   const chains = asGetCallbackChains(proto);
   const chain = chains.get(event)!;
@@ -344,10 +336,6 @@ export function _registerCallbackOnProto(
     chain.config,
     isObj ? (fn as unknown as ASCallbackObject) : undefined,
   );
-  // Ordinary after-callbacks always run in definition order, achieved by
-  // prepending into activesupport's LIFO-iterated after chain. Transactional
-  // (commit/rollback) callbacks instead honor the explicit `prepend` flag the
-  // caller threads in from ActiveRecord.run_after_transaction_callbacks_in_order_defined.
   const isTransactional = event === "commit" || event === "rollback";
   const prepend = !!conditions?.prepend || (timing === "after" && !isTransactional);
   if (prepend) chain.prepend(entry);
@@ -401,10 +389,6 @@ export function beforeOrAroundCallbackSources(
       continue;
     }
     const src = e.filter.toString();
-    // A bound (`fn.bind(this)`) or native function stringifies to a wrapper with
-    // no body text ("... { [native code] }"), so it exposes no association reads.
-    // Treat it as opaque rather than as a callback that reads nothing, so the
-    // caller falls back to a conservative load instead of skipping the preload.
     if (src.includes("[native code]")) opaque = true;
     else sources.push(src);
   }
@@ -469,8 +453,6 @@ export function restoreCallbacksOnProto(
   event: string,
   snapshot: Callback[] | undefined,
 ): void {
-  // Ensure `proto` owns its chains map (COW) before mutating, so the restore
-  // never bleeds into a parent class's shared chain.
   const chains = asGetCallbackChains(proto);
   const chain = chains.get(event);
   if (!chain) return;

--- a/packages/activemodel/src/dirty-mutations.test.ts
+++ b/packages/activemodel/src/dirty-mutations.test.ts
@@ -93,7 +93,6 @@ describe("DirtyMutations", () => {
     (p as any).age = 40;
     p.clearAttributeChange("name");
     expect(p.mutationsFromDatabase).toEqual({ age: [30, 40] });
-    // The value stays — only the tracking was cleared.
     expect((p as any).name).toBe("Bob");
   });
 

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -175,7 +175,6 @@ describe("DirtyTest", () => {
   it("model can be dup-ed without Attributes", () => {
     class Bare extends Model {}
     const b = new Bare();
-    // Should not throw
     expect(b.changed).toBe(false);
     expect(b.changedAttributeNamesToSave).toEqual([]);
   });
@@ -335,10 +334,10 @@ describe("Dirty Tracking", () => {
         this.attribute("size", "integer");
       }
     }
-    const s = new Sized({ size: "2" }); // cast to 2
-    s.writeAttribute("size", "2.3"); // cast to 2
+    const s = new Sized({ size: "2" });
+    s.writeAttribute("size", "2.3");
     expect(s.changed).toBe(false);
-    s.writeAttribute("size", "5.1"); // cast to 5
+    s.writeAttribute("size", "5.1");
     expect(s.changed).toBe(true);
   });
 });
@@ -351,8 +350,8 @@ describe("attributeBeforeTypeCast", () => {
     }
 
     const price = new Price({ amount: "42" });
-    expect(price.readAttribute("amount")).toBe(42); // cast to integer
-    expect(price.readAttributeBeforeTypeCast("amount")).toBe("42"); // raw string
+    expect(price.readAttribute("amount")).toBe(42);
+    expect(price.readAttributeBeforeTypeCast("amount")).toBe("42");
   });
 
   it("tracks raw values on writeAttribute", () => {
@@ -396,12 +395,11 @@ describe("clearChangesInformation", () => {
     }
 
     const p = new Person({ name: "Alice", age: 30 });
-    p.changesApplied(); // snapshot as clean
+    p.changesApplied();
     p.writeAttribute("name", "Bob");
-    p.changesApplied(); // this makes name change a "previous change"
+    p.changesApplied();
     expect(Object.keys(p.previousChanges).length).toBeGreaterThan(0);
 
-    // Now make another current change
     p.writeAttribute("age", 31);
     expect(p.changed).toBe(true);
 
@@ -425,8 +423,6 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
-    // After clearAttributeChanges, _forcedNames must also be cleared so a
-    // subsequent type-equal write does not re-appear as dirty.
     m.writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
@@ -527,7 +523,7 @@ describe("attributePreviouslyChanged / attributePreviouslyWas", () => {
     }
     const u = new User({ name: "Alice" });
     u.writeAttribute("name", "Bob");
-    u.changesApplied(); // simulate save — records name change as previous
+    u.changesApplied();
     expect(u.attributePreviouslyChanged("name")).toBe(true);
   });
 
@@ -674,8 +670,6 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.restoreAttributes();
-    // After restoreAttributes(), _forcedNames must be cleared so a subsequent
-    // type-equal write does not re-appear as dirty.
     m.writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
@@ -694,15 +688,11 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.changesApplied();
-    // After changesApplied(), _forcedNames must be cleared so the next
-    // type-equal write does not appear dirty.
     m.writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 
   it("force-change survives a subsequent type-equal write — NaN-to-NaN case", () => {
-    // attribute_will_change! (forceChange) must not be wiped out by a write
-    // where type.isChanged returns false.
     class Metric extends Model {
       constructor(attrs: Record<string, unknown> = {}) {
         super(attrs);
@@ -712,8 +702,8 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m._dirty.forceChange("ratio"); // mirrors attribute_will_change!
-    m.writeAttribute("ratio", NaN); // type-equal write
+    m._dirty.forceChange("ratio");
+    m.writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,
     // not the snapshot original, to preserve Rails' attribute_will_change! semantics.
@@ -736,9 +726,6 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
   });
 
   it("integer same-cast-value write via boolean raw is still dirty — number_to_non_number? path at model level", () => {
-    // true casts to 1 via NumericMixin, so cast values are equal (1 === 1).
-    // Without type delegation, DirtyTracker would clear the change. With it,
-    // type.isChanged(1, 1, true) fires isNumberToNonNumber? and records dirty.
     class Item extends Model {
       constructor(attrs: Record<string, unknown> = {}) {
         super(attrs);
@@ -779,25 +766,21 @@ describe("DirtyTracker#redetectChanges", () => {
 
   it("marks attributes as dirty where the post-rollback value differs from the restored baseline", () => {
     const m = new Subject({ title: "original", score: 0 });
-    m.changesApplied(); // simulate post-save clean state
+    m.changesApplied();
 
-    // Simulate in-TX user edit
     const postTxAttrs = (m as any)._attributes.deepDup();
     (postTxAttrs as AttributeSet).writeFromUser("title", "tx-edit");
 
-    // Simulate restore to pre-TX state (baseline is already "original" from snapshot)
     const restored = (m as any)._attributes;
     const dirty: DirtyTracker = (m as any)._dirty;
     dirty.snapshot(restored);
     dirty.clearChangesInformation();
     dirty.redetectChanges(postTxAttrs);
 
-    // title differed → dirty, with [was=original (preTX baseline), now=tx-edit (postTX)]
     expect(dirty.attributeChanged("title")).toBe(true);
     expect(dirty.attributeWas("title")).toBe("original");
     expect(dirty.changes).toEqual({ title: ["original", "tx-edit"] });
 
-    // score unchanged → not dirty
     expect(dirty.attributeChanged("score")).toBe(false);
   });
 
@@ -805,7 +788,7 @@ describe("DirtyTracker#redetectChanges", () => {
     const m = new Subject({ title: "same", score: 1 });
     m.changesApplied();
 
-    const postTxAttrs = (m as any)._attributes.deepDup(); // no edits during TX
+    const postTxAttrs = (m as any)._attributes.deepDup();
 
     const restored = (m as any)._attributes;
     const dirty: DirtyTracker = (m as any)._dirty;
@@ -818,22 +801,18 @@ describe("DirtyTracker#redetectChanges", () => {
   });
 
   it("detects number_to_non_number? via valueBeforeTypeCast — score=1 written as `true` is dirty vs numeric baseline", () => {
-    // Numeric type isChanged: isNumberToNonNumber?(oldValue, newValueBeforeTypeCast) fires when
-    // the new raw value is not a number even if the cast value equals the old cast value.
     const m = new Subject({ title: "t", score: 1 });
-    m.changesApplied(); // baseline: score=1 (cast), raw=1
+    m.changesApplied();
 
-    // Simulate in-TX write of `true` to score (casts to 1, but raw is non-numeric)
     const postTxAttrs = (m as any)._attributes.deepDup();
-    (postTxAttrs as AttributeSet).writeFromUser("score", true); // valueBeforeTypeCast=true, value=1
+    (postTxAttrs as AttributeSet).writeFromUser("score", true);
 
-    const restored = (m as any)._attributes; // baseline still score=1
+    const restored = (m as any)._attributes;
     const dirty: DirtyTracker = (m as any)._dirty;
     dirty.snapshot(restored);
     dirty.clearChangesInformation();
     dirty.redetectChanges(postTxAttrs);
 
-    // Cast values are both 1, but raw `true` triggers isNumberToNonNumber? → dirty
     expect(dirty.attributeChanged("score")).toBe(true);
     expect(dirty.changes).toEqual({ score: [1, 1] });
   });

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -279,9 +279,6 @@ export class DirtyTracker {
     name: string,
   ): void {
     this._deleteChange(name);
-    // Fast path: avoid snapshotting every attribute when only one baseline
-    // needs rebinding. AttributeSet exposes has/fetchValue per-attribute;
-    // fall back to the full snapshot for plain Maps / other shapes.
     let has: boolean;
     let value: unknown;
     const perAttr = attributes as { has?: unknown; fetchValue?: unknown };
@@ -451,10 +448,6 @@ export class DirtyTracker {
     const currentValue = this.fetchValue(name);
     // Unconditional forced marker (Rails: forced_changes[attr] = fetch_value).
     this._forcedNames.add(name);
-    // Capture the "was" only when the attribute isn't already changed (by this
-    // force or a prior assignment), so a repeat force — or a force after an
-    // assignment — never overwrites the original "was". Clone to keep the stored
-    // snapshot stable under in-place mutation of the live object.
     if (!this._changedAttributes.has(name)) {
       let cloned: unknown;
       try {
@@ -525,9 +518,6 @@ export class DirtyTracker {
     }
     const original = resolveValue(this._originalAttributes.get(name));
     if (type.isChanged(original, newValue, rawValue) || this._forcedNames.has(name)) {
-      // When force-dirtied, preserve the cloned pre-mutation snapshot captured
-      // by forceChange() as the "was" side. For normal writes use the snapshot
-      // original. A force_change must not be silently cleared by a type-equal write.
       const existingFrom = this._forcedNames.has(name)
         ? this._changedAttributes.get(name)?.[0]
         : undefined;
@@ -560,13 +550,9 @@ export class DirtyTracker {
       const attr = currentAttributes.getAttribute(name);
       const currentValue = attr.value;
       if (!this._originalHas.has(name)) {
-        // Attribute added during the TX — mark as a new addition
         this._changedAttributes.set(name, [undefined, currentValue]);
       } else {
         const savedValue = resolveValue(this._originalAttributes.get(name));
-        // Entry: [was=savedValue (pre-TX), now=currentValue (post-TX)] — matches [was, now] convention.
-        // Pass attr.valueBeforeTypeCast as the raw third arg so numeric types can
-        // detect number_to_non_number? changes (e.g. writing `true` to an integer field).
         if (attr.type.isChanged(savedValue, currentValue, attr.valueBeforeTypeCast)) {
           this._changedAttributes.set(name, [savedValue, currentValue]);
         }

--- a/packages/activemodel/src/error.test.ts
+++ b/packages/activemodel/src/error.test.ts
@@ -13,7 +13,6 @@ describe("ErrorTest", () => {
   it("comparing against different class would not raise error", () => {
     const errors = new Errors({});
     errors.add("name", ":blank");
-    // Just verify it doesn't throw
     expect(errors.objects[0]).toBeDefined();
   });
 
@@ -95,7 +94,6 @@ describe("ErrorTest", () => {
   });
 
   it("full_message returns the given message when the attribute contains base", () => {
-    // A field named "base_price" should still get a prefix
     const e = new Errors(null);
     expect(e.fullMessage("base_price", "is invalid")).toBe("Base price is invalid");
   });
@@ -260,7 +258,6 @@ describe("ErrorTest", () => {
     expect(msg).toBe("can't be blank");
   });
 
-  // P10: message getter dispatches on rawType shape (identifier vs literal string)
   it("message with identifier-shaped rawType routes through i18n", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
@@ -278,7 +275,6 @@ describe("ErrorTest", () => {
   it("generateMessage with identifier options.message routes through i18n as new type", () => {
     const e = new Errors(null);
     e.add("name", ":blank", { message: ":tooShort" });
-    // ":tooShort" becomes the type, and has no locale entry → the missing-translation message
     expect(e.messagesFor("name")[0]).toContain("errors.messages.tooShort");
   });
 
@@ -309,19 +305,16 @@ describe("ErrorTest", () => {
     expect(msg).toBe("Profile bio can't be blank");
   });
 
-  // P10: fullMessage non-nested regression guard
   it("fullMessage non-nested attribute behaves as before", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
     expect(e.fullMessages[0]).toBe("Name can't be blank");
   });
 
-  // P10: attributesForHash is protected (accessible within the class hierarchy)
   it("attributesForHash is accessible via equals", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
     e.add("name", ":blank");
-    // equals() uses attributesForHash internally; duplicates should be equal
     expect(e.objects[0].equals(e.objects[1])).toBe(true);
   });
 });

--- a/packages/activemodel/src/errors.test.ts
+++ b/packages/activemodel/src/errors.test.ts
@@ -13,9 +13,6 @@ import type { ValidatableRecord } from "./validator.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
 describe("ErrorsTest", () => {
-  // =========================================================================
-  // Phase 1100 — Errors (ported)
-  // =========================================================================
   it("add creates an error object and returns it", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
@@ -82,8 +79,6 @@ describe("ErrorsTest", () => {
   it("message interpolation with %{count}", () => {
     const e = new Errors(null);
     e.add("name", ":too_short", { count: 3 });
-    // Default message is "is too short" — doesn't have %{count} by default
-    // but the mechanism should work for messages that do
     expect(e.messagesFor("name").length).toBe(1);
   });
 
@@ -103,7 +98,6 @@ describe("ErrorsTest", () => {
     const dup = new Errors({});
     dup.copyBang(errors);
     expect(dup.count).toBe(1);
-    // Modifying dup should not affect original
     dup.add("age", ":invalid");
     expect(errors.count).toBe(1);
     expect(dup.count).toBe(2);
@@ -193,7 +187,6 @@ describe("ErrorsTest", () => {
     errors.add("name", ":invalid");
     const hash = errors.toHash();
     expect(hash.get("name")).toEqual(["can't be blank", "is invalid"]);
-    // Accessing a non-existent key should be undefined
     expect(hash.get("age")).toBeUndefined();
   });
 
@@ -209,7 +202,6 @@ describe("ErrorsTest", () => {
     const errors = new Errors({});
     errors.add("name", ":blank");
     errors.add("age", ":invalid");
-    // fullMessages style
     expect(errors.fullMessages).toEqual(["Name can't be blank", "Age is invalid"]);
   });
 
@@ -409,7 +401,7 @@ describe("ErrorsTest", () => {
 
   it("attribute_names returns an empty array after try to get a message only", () => {
     const e = new Errors(null);
-    e.messagesFor("name"); // should not create an entry
+    e.messagesFor("name");
     expect(e.attributeNames).toEqual([]);
   });
 
@@ -692,7 +684,7 @@ describe("ErrorsTest", () => {
     const source = new Errors({});
     source.add("age", ":invalid");
     const wrapper = new Errors({});
-    wrapper.mergeBang(source); // imports as NestedError
+    wrapper.mergeBang(source);
     const target = new Errors({});
     target.copyBang(wrapper);
     expect(target.objects[0].constructor.name).toBe("NestedError");
@@ -740,7 +732,6 @@ describe("ErrorsTest", () => {
       const errors = new Errors({});
       errors.add("email", ":invalid", { with: /^\w+@\w+$/i });
       expect(errors.where("email", ":invalid", { with: /^\w+@\w+$/i })).toHaveLength(1);
-      // Different source or different flags must not match.
       expect(errors.where("email", ":invalid", { with: /^\w+@\w+$/g })).toHaveLength(0);
       expect(errors.where("email", ":invalid", { with: /other/i })).toHaveLength(0);
     });
@@ -765,7 +756,6 @@ describe("ErrorsTest", () => {
       expect(imported.type).toBe("wrong");
       expect(imported.rawType).toBe(":invalid");
 
-      // copy! must preserve the {attribute, type, rawType} split.
       const copy = new Errors({});
       copy.copyBang(target);
       const round = copy.objects[0];
@@ -794,7 +784,6 @@ describe("ErrorsTest", () => {
       target.objects[0] as unknown as { innerError: { options: Record<string, unknown> } }
     ).innerError;
     expect(tgtInner).toBe(srcInner);
-    // The wrapper's own `@options` is independent, though.
     expect(target.objects[0].options).not.toBe(wrapper.objects[0].options);
   });
 
@@ -806,7 +795,6 @@ describe("ErrorsTest", () => {
     const e2 = new Errors(base2);
     e2.copyBang(e1);
     expect(e2.objects[0].base).toBe(base2);
-    // Original is untouched.
     expect(e1.objects[0].base).toBe(base1);
   });
 
@@ -938,7 +926,6 @@ describe("ErrorsTest", () => {
     e.add("name", ":too_short");
     e.add("age", ":invalid");
     expect(e.attributeNames).toEqual(["name", "age"]);
-    // Should not have duplicates
     expect(e.attributeNames.length).toBe(2);
   });
 
@@ -959,7 +946,6 @@ describe("ErrorsTest", () => {
   it("added? returns false when checking for an error, but not providing message argument", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
-    // When checking with default type "invalid", should return false since we added "blank"
     expect(e.added("name")).toBe(false);
   });
 
@@ -973,7 +959,6 @@ describe("ErrorsTest", () => {
   it("added? returns false when checking for an error by symbol and a different error with same message is present", () => {
     const e = new Errors(null);
     e.add("name", ":blank");
-    // Even if the rendered message might be similar, type must match
     expect(e.added("name", ":present")).toBe(false);
   });
 
@@ -1019,7 +1004,6 @@ describe("ErrorsTest", () => {
     it("add with strict: true raises StrictValidationFailed", () => {
       const errors = new Errors({});
       expect(() => errors.add("name", ":blank", { strict: true })).toThrow(StrictValidationFailed);
-      // Strict raise must NOT append the error to the collection.
       expect(errors.count).toBe(0);
     });
 
@@ -1188,9 +1172,6 @@ describe("Errors<TBase> type parameter", () => {
   });
 
   it("unparameterized Errors annotation compiles (default = object)", () => {
-    // Proves the `= object` default is in effect: the type annotation `Errors`
-    // (no type arg) is accepted and the record handed to an `add()` callback
-    // resolves to `object | null`.
     const e: Errors = new Errors({} as object);
     e.add("name", (record, _opts) => {
       expectTypeOf(record).toEqualTypeOf<object | null>();

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -298,7 +298,6 @@ export class Errors<TBase extends object = object> {
     let normType: string;
     [attribute, normType, options] = this.normalizeArguments(attribute, type, options);
     if (normType.startsWith(":")) {
-      // Symbol branch: strict attribute/type/options match.
       return this._errors.some((e) => e.strictMatch(attribute, normType, options));
     }
     // String branch: full-message lookup (Rails else clause in added?).
@@ -321,7 +320,6 @@ export class Errors<TBase extends object = object> {
   ): boolean {
     [attribute, type] = this.normalizeArguments(attribute, type);
     if (type.startsWith(":")) {
-      // Symbol branch: check for errors of this exact type.
       return this.where(attribute, type).length > 0;
     }
     // String branch: full-message lookup (Rails else clause).

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -83,8 +83,11 @@ export {
 export type { CallbackConditions, TransactionalCallbackConditions } from "./callbacks.js";
 export { serializableHash } from "./serialization.js";
 export type { SerializeOptions, SerializableHash } from "./serialization.js";
-// Aliased to avoid clobbering the global `JSON` namespace; consumers
-// can import as `JSONSerializer` or alias on import.
+
+/**
+ * Aliased to avoid clobbering the global `JSON` namespace; consumers
+ * can import as `JSONSerializer` or alias on import.
+ */
 export { JSON as JSONSerializer } from "./serializers/json.js";
 export { Type } from "./type/value.js";
 export {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -84,10 +84,6 @@ export type { CallbackConditions, TransactionalCallbackConditions } from "./call
 export { serializableHash } from "./serialization.js";
 export type { SerializeOptions, SerializableHash } from "./serialization.js";
 
-/**
- * Aliased to avoid clobbering the global `JSON` namespace; consumers
- * can import as `JSONSerializer` or alias on import.
- */
 export { JSON as JSONSerializer } from "./serializers/json.js";
 export { Type } from "./type/value.js";
 export {

--- a/packages/activemodel/src/locale/en.ts
+++ b/packages/activemodel/src/locale/en.ts
@@ -11,11 +11,8 @@ import type { TranslationData } from "@blazetrails/i18n";
 
 export const en: TranslationData = {
   errors: {
-    // The default format to use in full error messages.
     format: "%{attribute} %{message}",
 
-    // The values :model, :attribute and :value are always available for interpolation
-    // The value :count is available when applicable. Can be used for pluralization.
     messages: {
       model_invalid: "Validation failed: %{errors}",
       inclusion: "is not included in the list",

--- a/packages/activemodel/src/model.test.ts
+++ b/packages/activemodel/src/model.test.ts
@@ -20,7 +20,6 @@ class DefaultValueModel extends Model {
 
   declare _attr?: string;
 
-  // `attr_accessor :hello`, added by DefaultValue's `included` hook.
   get hello(): string | undefined {
     return this._hello;
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -236,10 +236,6 @@ export interface Model {
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Model {
-  /**
-   * Allow dynamic attribute access (e.g., record.title) for properties
-   * defined at runtime via Model.attribute().
-   */
   [key: string]: unknown;
 
   static includeRootInJson: boolean | string = false;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -236,11 +236,12 @@ export interface Model {
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Model {
-  // Allow dynamic attribute access (e.g., record.title) for properties
-  // defined at runtime via Model.attribute().
+  /**
+   * Allow dynamic attribute access (e.g., record.title) for properties
+   * defined at runtime via Model.attribute().
+   */
   [key: string]: unknown;
 
-  // -- Class-level registries --
   static includeRootInJson: boolean | string = false;
   // Rails: class_attribute :param_delimiter, instance_reader: false, default: "-"
   // (activemodel/lib/active_model/conversion.rb:32)
@@ -270,8 +271,6 @@ export class Model {
   // only the "defined but never written to" window diverges from Rails.
   static _validators: Map<string | null, Array<ValidatorLike>> = new Map();
   declare private static _modelName: ModelName | null;
-
-  // -- Attributes (Phase 1000) --
 
   declare static attribute: Extended<typeof AttributesClassMethods>["attribute"];
   declare static setDefineMethodAttribute: Extended<
@@ -319,7 +318,6 @@ export class Model {
     return Object.keys(this.attributeTypes());
   }
 
-  // -- Normalizations --
   static _normalizations: Map<
     string,
     { fns: Array<(value: unknown) => unknown>; applyToNil: boolean }
@@ -339,7 +337,6 @@ export class Model {
    */
   static normalizes(...args: NormalizesArgs): void {
     if (!Object.hasOwn(this, "_normalizations")) {
-      // Deep copy parent normalizations for stacking
       this._normalizations = new Map();
       const parent = Object.getPrototypeOf(this) as typeof Model;
       if (parent._normalizations) {
@@ -349,7 +346,6 @@ export class Model {
       }
     }
 
-    // Parse args: attributes..., fn, [options]
     let options: { applyToNil?: boolean } = {};
     let fn: (value: unknown) => unknown;
     const lastArg = args[args.length - 1];
@@ -367,7 +363,6 @@ export class Model {
     for (const attr of attributes) {
       const existing = this._normalizations.get(attr);
       if (existing) {
-        // Stack: add new normalizer after existing ones
         existing.fns.push(fn);
         if (applyToNil) existing.applyToNil = true;
       } else {
@@ -381,11 +376,6 @@ export class Model {
       // never double-wrap a non-idempotent normalizer.
       this.decorateAttributes([attr], this._normalizationDecorator(attr));
     }
-    // AR reflects columns after the class body runs, so at declaration time the
-    // immediate `_attributeDefinitions` apply above no-ops on a not-yet-reflected
-    // column — but `decorateAttributes` also pushed a durable pending decorator
-    // that replays on every `_defaultAttributes` rebuild, so the reflected column
-    // is decorated in the default attribute set that `type_for_attribute` reads.
 
     // Rails' ActiveRecord::Normalization registers
     // `before_validation :normalize_changed_in_place_attributes` at include
@@ -465,8 +455,6 @@ export class Model {
       return normalizedValueType(base, normalizer, entry.applyToNil, entry);
     };
   }
-
-  // -- Validations (Phase 1100) --
 
   /**
    * Mirrors: ActiveModel::Validations::ClassMethods#validates (validates.rb:111-133).
@@ -720,10 +708,6 @@ export class Model {
       exceptOn: exceptOnOpt,
     });
 
-    // Extract the explicit `attributes:` option so we can route the validator
-    // into the right bucket even when the validator class doesn't expose
-    // `attributes` on the instance or in `options` (e.g. plain classes that
-    // only implement `validate()`).
     const rawExplicit = (rest as { attributes?: unknown }).attributes;
     const explicitAttributes: string[] | null = Array.isArray(rawExplicit)
       ? rawExplicit.map(String)
@@ -770,11 +754,6 @@ export class Model {
           const origErrors = r.errors;
           const tempErrors = new Errors(r);
           r.errors = tempErrors;
-          // Restore the real errors, then raise if the validator flagged
-          // anything. A DB-backed validator (uniqueness / associated) returns a
-          // Promise — its `errors.add` runs when that promise resolves, so we
-          // must await before inspecting `tempErrors`; otherwise strict would
-          // never fire for async validators (RFC 0063 made the chain async).
           const settle = (): void => {
             r.errors = origErrors;
             if (tempErrors.any) {
@@ -951,8 +930,6 @@ export class Model {
   static validatesSizeOf(...attrNames: unknown[]): void {
     this.validatesWith(LengthValidator, this._mergeAttributes(attrNames));
   }
-
-  // -- Callbacks (Phase 1200) --
 
   static beforeValidation<T extends typeof Model>(
     this: T,
@@ -1288,9 +1265,6 @@ export class Model {
     fn: CallbackFn | AroundCallbackFn | CallbackObject,
     options?: CallbackConditions<InstanceType<T>>,
   ): void {
-    // `_registerCallbackOnProto` enforces `on:` applicability (only commit/rollback)
-    // and value validity (:create/:update/:destroy) so every entry point shares the
-    // same gate. No extra guard needed here.
     _registerCallbackOnProto(
       this.prototype,
       timing,
@@ -1335,11 +1309,6 @@ export class Model {
     timing: "before" | "after" | "around",
     fn: CallbackFn | AroundCallbackFn | CallbackObject,
   ): boolean {
-    // Don't force copy-on-first-write on a miss — if there's nothing
-    // matching, we shouldn't clone and trap the subclass in a snapshot
-    // that will never see future parent registrations. Check via the
-    // inherited chain first; only clone when we're actually going to
-    // mutate (match found).
     if (!hasCallbackOnProto(this.prototype, event, timing, fn)) return false;
     return skipCallbackOnProto(this.prototype, event, timing, fn);
   }
@@ -1508,8 +1477,6 @@ export class Model {
     methodName: string,
   ) => Array<{ proxyTarget: string; attrName: string }>;
 
-  // -- Naming (Phase 1300) --
-
   declare static lookupAncestors: () => Array<{
     new (...args: never[]): unknown;
     modelName: ModelName;
@@ -1536,13 +1503,10 @@ export class Model {
       // enclosing-module chain to walk, so nothing can declare relative naming
       // and the detect answers nil.
       const namespace = null;
-      // Model satisfies ModelLike but TS can't prove it due to circular types.
       this._modelName = new ModelName(this as unknown as ModelLike, namespace);
     }
     return this._modelName;
   }
-
-  // -- Instance --
 
   _attributes: AttributeSet = new AttributeSet();
   _accessedFields: Set<string> = new Set();
@@ -1615,7 +1579,6 @@ export class Model {
 
     _resurrectAttributeMethods(ctor as unknown as Parameters<typeof _resurrectAttributeMethods>[0]);
 
-    // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
     this._attributes = ctor._defaultAttributes().deepDup();
 
     // API#initialize — assign_attributes(attributes) (api.rb:80-82), which runs
@@ -1645,7 +1608,6 @@ export class Model {
       this._initializingAttributes = false;
     }
 
-    // Snapshot after construction — the initial state is "clean"
     this._dirty.snapshot(this._attributes);
 
     // Fire after_initialize callbacks. ActiveRecord intentionally uses the
@@ -1654,13 +1616,9 @@ export class Model {
     // then fire after_initialize in Rails-compatible order.
     const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
     if (callbackSuppressor._suppressInitializeCallback !== true) {
-      // strict:"sync" guarantees synchronous completion (async callbacks throw),
-      // so the returned Promise is already settled — void the sync-strict result.
       void runAfterCallbacksOnProto(ctor.prototype, "initialize", this, { strict: "sync" });
     }
   }
-
-  // -- Attribute access --
 
   readAttribute(name: string, block?: (name: string) => unknown): unknown {
     // Rails resolves alias_attribute names in `read_attribute`
@@ -1701,9 +1659,6 @@ export class Model {
   /** @internal */
   _writeAttribute(name: string, value: unknown): void {
     this._attributes.writeFromUser(name, value);
-    // `fetchValue` reads the attribute's cast value; the cast type carries the
-    // NormalizedValueType decoration (see `normalizes`), so normalization is
-    // already applied here — no separate imperative hook.
     const newValue = this._attributes.fetchValue(name);
     // Route through type.isChanged so numeric semantics (equal_nan?,
     // number_to_non_number?) are respected — mirrors the Rails path where dirty
@@ -1773,8 +1728,6 @@ export class Model {
     if (typeof value === "string" && value.trim() === "") return false;
     return true;
   }
-
-  // -- Validations --
 
   // Rails `validation_context` holds either a single Symbol or an
   // Array<Symbol> (or nil). `valid?([:create, :publish])` round-trips
@@ -2001,8 +1954,6 @@ export class Model {
     duped.initializeDup(this);
     return duped;
   }
-
-  // -- Dirty tracking --
 
   get changed(): boolean {
     return this._dirty.changed;
@@ -2243,8 +2194,6 @@ export class Model {
     this._dirty.clearAttributeChange(this._attributes, name);
   }
 
-  // -- Serialization --
-
   serializableHash(options?: SerializeOptions): Record<string, unknown> {
     return serializableHash(this, options);
   }
@@ -2315,8 +2264,6 @@ export class Model {
   isPersisted(): boolean {
     return false;
   }
-
-  // -- Naming / Conversion --
 
   get modelName(): ModelName {
     return (this.constructor as typeof Model).modelName;
@@ -2441,13 +2388,6 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place?
    */
   attributeChangedInPlace(name: string): boolean {
-    // trails can't observe true in-place mutation of an immutable JS value, so
-    // we infer it: an attribute was changed *outside* the tracked write path
-    // (e.g. a direct `_attributes` write) when its live value no longer matches
-    // what dirty tracking recorded. A normal assignment records the new value
-    // as the change's right-hand side, so `current === recorded` and this
-    // returns false — the assignment path already normalized the value, and
-    // re-normalizing would double-apply a non-idempotent normalizer.
     const current = this.readAttribute(name);
     const recorded = this._dirty.mutationsFromDatabase[name];
     if (recorded) return current !== recorded[1];
@@ -2515,8 +2455,6 @@ export class Model {
   valuesAt(...methods: (string | string[])[]): unknown[] {
     return methods.flat().map((m) => this.readAttribute(m));
   }
-
-  // -- Callbacks helper for subclasses --
 
   runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown {
     return runAllCallbacks((this.constructor as typeof Model).prototype, event, this, block, opts);

--- a/packages/activemodel/src/naming.test.ts
+++ b/packages/activemodel/src/naming.test.ts
@@ -328,9 +328,6 @@ describe("ModelName singularRouteKey", () => {
     const name = new ModelName("Sheep");
     expect(name.plural).toBe("sheep");
     expect(name.routeKey).toBe("sheep_index");
-    // singularRouteKey is `singularize(routeKey)`; whatever our activesupport
-    // Inflector returns for "sheep_index" is the expected value — assert it's
-    // derived from routeKey, not independently computed.
     expect(name.singularRouteKey.length).toBeGreaterThan(0);
   });
   it("Naming.singularRouteKey delegates to ModelName.singularRouteKey", () => {
@@ -389,7 +386,6 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(mn.compare("Blog")).toBe(1);
     expect(mn.compare("BlogPosts")).toBe(-1);
     expect(mn.compare(new ModelName("BlogPost"))).toBe(0);
-    // `String#<=>` answers nil for an operand that is not string-like.
     expect(mn.compare(42)).toBe(undefined);
     expect(mn.compare(null)).toBe(undefined);
   });
@@ -440,8 +436,6 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
   });
 
   it("equals / compare distinguish namespaced models with the same bare name", () => {
-    // Two ModelName instances share the same `name: "Post"` but differ
-    // in namespace — must not compare equal, must sort deterministically.
     const blogPost = new ModelName("Blog::Post");
     const adminPost = new ModelName("Admin::Post");
     const blogPost2 = new ModelName("Blog::Post");
@@ -450,8 +444,6 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     expect(blogPost.equals(adminPost)).toBe(false);
     expect(blogPost.equals(blogPost2)).toBe(true);
     expect(blogPost.equals(barePost)).toBe(false);
-    // `compare` is `String#<=>` on `@name` ("Admin::Post" vs "Blog::Post"),
-    // so Admin < Blog.
     expect(blogPost.compare(adminPost)).toBe(1);
     expect(adminPost.compare(blogPost)).toBe(-1);
     expect(blogPost.compare(blogPost2)).toBe(0);
@@ -472,10 +464,8 @@ describe("ModelName is string-ish (Rails String-inheritance analog)", () => {
     // namespace even when its bare name comes later alphabetically.
     const adminOther = new ModelName("Admin::Other");
     const blogPost = new ModelName("Blog::Post");
-    // "Admin::Other" < "Blog::Post"
     expect(adminOther.compare(blogPost)).toBe(-1);
     expect(blogPost.compare(adminOther)).toBe(1);
-    // Comparison is over the raw qualified path, so "Admin::Other" < "Post".
     const barePost = new ModelName("Post");
     expect(adminOther.compare(barePost)).toBe(-1);
     expect(barePost.compare(adminOther)).toBe(1);

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -162,8 +162,6 @@ export class ModelName {
    * operator overloading, so call sites spell them `compare(...) < 0` etc.
    */
   compare(other: unknown): number | undefined {
-    // `Name` answers `to_str`, so a `Name` operand takes String#<=>'s
-    // string-like arm rather than falling through to nil.
     const name = other instanceof ModelName ? other.name : other;
     if (typeof name !== "string") return undefined;
     return this.name === name ? 0 : this.name < name ? -1 : 1;

--- a/packages/activemodel/src/secure-password.test.ts
+++ b/packages/activemodel/src/secure-password.test.ts
@@ -77,7 +77,7 @@ describe("SecurePasswordTest", () => {
   it("create a new user with validation and password byte size greater than 72 bytes", async () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    (u as any).password = "\u{1F600}".repeat(19); // 4 bytes each = 76 bytes, 19 chars
+    (u as any).password = "\u{1F600}".repeat(19);
     expect(await u.isValid()).toBe(false);
   });
 
@@ -363,7 +363,6 @@ describe("SecurePasswordTest", () => {
 
   it("password_challenge validates against existing digest", async () => {
     const User = createUserClass();
-    // Simulate a DB-loaded record: digest is in attributes at snapshot time.
     const builder = new User({ name: "test" });
     (builder as any).password = "secret";
     const digest = builder.readAttribute("password_digest");
@@ -385,7 +384,6 @@ describe("SecurePasswordTest", () => {
 
   it("password_challenge validates against existing digest before allowing changes", async () => {
     const User = createUserClass();
-    // Simulate a DB-loaded record with an existing digest as baseline.
     const builder = new User({ name: "test" });
     (builder as any).password = "secret";
     const digest = builder.readAttribute("password_digest");
@@ -431,7 +429,6 @@ describe("SecurePasswordTest", () => {
   it("password_challenge fails when no prior digest exists", async () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    // No password set — password_digest baseline is null.
     (u as any).passwordChallenge = "anything";
     expect(await u.isValid()).toBe(false);
     expect(u.errors.messagesFor("passwordChallenge")).toContain("is invalid");

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -44,9 +44,6 @@ export function hasSecurePassword(
     modelClass.attribute(digestAttr, "string");
   }
 
-  // The confirmation is virtual (no DB column) but is genuinely stored in the
-  // attribute set (read back via `readAttribute`), so declare it as a known
-  // name — `AttributeSet#writeFromUser` raises for any name not in the set.
   if (!modelClass._defaultAttributes().isKey(confirmationAttr)) {
     modelClass.attribute(confirmationAttr, "string");
   }

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -530,16 +530,11 @@ describe("SerializationTest", () => {
       });
       const json = b.asJson({ include: "posts" });
       expect(Array.isArray(json.posts)).toBe(true);
-      // Each post's above-safe-range BigInt id is coerced to a string.
       expect((json.posts as Array<{ id: string }>)[0].id).toBe("10000000000000000000");
       expect(() => JSON.stringify(json)).not.toThrow();
     });
 
     it("attribute named toJSON does not shadow Model#toJSON", () => {
-      // `attribute("toJSON", ...)` must NOT install an accessor on the
-      // subclass prototype if `toJSON` is already resolvable up the
-      // chain — otherwise JSON.stringify would hit the attribute
-      // getter instead of our asJson-backed hook.
       class Weird extends Model {
         static {
           this.attribute("toJSON", "string");
@@ -547,18 +542,11 @@ describe("SerializationTest", () => {
         }
       }
       const w = new Weird({ toJSON: "raw-value", name: "w" });
-      // Direct stringify still routes through Model's toJSON.
       expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
-      // The attribute still roundtrips via `readAttribute`, just not via
-      // `instance.toJSON` (which now stays a framework method).
       expect(w.readAttribute("toJSON")).toBe("raw-value");
     });
 
     it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
-      // Direct `JSON.stringify(model)` should match `model.toJSON()` —
-      // without the hook, the default walker would enumerate
-      // `_attributes`/`_dirty`/`errors`/etc. and potentially throw on
-      // BigInt state.
       class Row extends Model {
         static {
           this.attribute("id", "big_integer");
@@ -578,13 +566,10 @@ describe("SerializationTest", () => {
           this.attribute("name", "string");
         }
       }
-      // 2^62 — cannot be represented as a JS number without precision loss.
       const big = 2n ** 62n;
       const r = new Row({ id: big, name: "row-2" });
       expect(() => JSON.stringify(r)).not.toThrow();
       const parsed = JSON.parse(JSON.stringify(r));
-      // bigint is coerced to decimal string (not number — JS number loses
-      // precision above 2^53-1). Consumers must parse with BigInt(str).
       expect(typeof parsed.id).toBe("string");
       expect(parsed.id).toBe("4611686018427387904");
       expect(parsed.name).toBe("row-2");
@@ -675,9 +660,6 @@ describe("Serialization", () => {
   });
 });
 
-// ===========================================================================
-// fromJson
-// ===========================================================================
 describe("fromJson", () => {
   it("from_json should work without a root (class attribute)", () => {
     class User extends Model {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -111,8 +111,6 @@ export function serializableHash(
         );
       }
       const items = Array.isArray(records) ? records : Array.from(records);
-      // This callback only runs in the sync build, so nested includes build
-      // sync too (pass `sync: true`) rather than returning their own thenables.
       safeSet(
         result,
         assocName,
@@ -198,14 +196,8 @@ export function readAttributeForSerialization(record: SerializationRecord, key: 
   const inRecord = key in (record as object);
   const reader = inRecord ? (record as Record<string, unknown>)[key] : undefined;
 
-  // `send(key)`: a value-returning member (generated getter or user override)
-  // wins.
   if (inRecord && typeof reader !== "function") return reader;
 
-  // A store attribute reads its stored value: covers a store-backed record with
-  // no installed accessor (a bare `_attributes` Map / AttributeSet) and a
-  // reserved-name declared attribute (e.g. toJSON) whose function member would
-  // recurse if invoked.
   const storeHasKey =
     attrStore instanceof Map
       ? attrStore.has(key)
@@ -218,8 +210,6 @@ export function readAttributeForSerialization(record: SerializationRecord, key: 
       : (attrStore as { fetchValue(k: string): unknown }).fetchValue(key);
   }
 
-  // A genuine function member is invoked (`send`); an absent member raises like
-  // `send`'s `NoMethodError`.
   if (inRecord) return (reader as () => unknown).call(record);
   throw new NoMethodError(
     `undefined method '${key}' for an instance of ${record.constructor.name}`,
@@ -416,9 +406,7 @@ async function preloadIncludes(
       ? Array.isArray(records)
         ? records
         : Array.from(records)
-      : // Any resolved singular object (AR record or `_attributes`-less PORO)
-        // may itself carry nested includes to preload.
-        records != null && typeof records === "object"
+      : records != null && typeof records === "object"
         ? [records]
         : [];
     for (const child of children) {
@@ -445,8 +433,6 @@ async function resolveIncludeAsync(record: SerializationRecord, name: string): P
   }
   if (raw !== null && raw !== undefined) return raw;
 
-  // `raw` is nil: an unloaded singular reader is indistinguishable from a
-  // genuine nil, so ask the association holder whether it can still load.
   const associationFn = (record as { association?: (n: string) => unknown }).association;
   if (typeof associationFn === "function") {
     let holder: { loaded?: unknown; loadTarget?: () => unknown } | undefined;
@@ -565,7 +551,7 @@ function sendAssociation(record: SerializationRecord, name: string): unknown {
 function isSerializableCollection(value: unknown): value is Iterable<unknown> {
   if (Array.isArray(value)) return true;
   if (value == null || typeof value !== "object") return false;
-  if ((value as SerializationRecord)._attributes) return false; // a single record
+  if ((value as SerializationRecord)._attributes) return false;
   return typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function";
 }
 

--- a/packages/activemodel/src/serializers/json-serialization.test.ts
+++ b/packages/activemodel/src/serializers/json-serialization.test.ts
@@ -360,7 +360,6 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const m = new Multi({}).fromJson('{"first":{"name":"Carol"},"person":{"name":"Dan"}}');
-      // First key "first" wins, regardless of the configured "person" root.
       expect(m.readAttribute("name")).toBe("Carol");
     } finally {
       Multi.includeRootInJson = false;

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -37,7 +37,6 @@ describe("Serializers::JSON host", () => {
 
   it("modelName resolves to the subclass and is memoized per-class", () => {
     expect(Person.modelName.name).toBe("Person");
-    // Memoized — repeat call returns same instance.
     expect(Person.modelName).toBe(Person.modelName);
 
     class Other extends JSONHost {}
@@ -131,7 +130,6 @@ describe("Serializers::JSON host", () => {
     }
     const b = new Big();
     b._id = 9007199254740993n;
-    // Without `Numeric#as_json`, JSON.stringify(b.asJson()) would throw.
     expect(() => globalThis.JSON.stringify(b.asJson())).not.toThrow();
   });
 

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -50,11 +50,6 @@ export class JSON {
   // accepts a string here too (treated as a custom root key by as_json).
   static includeRootInJson: boolean | string = false;
 
-  /**
-   * Per-class memo so the static getter can be inherited without
-   * recomputing or sharing state across subclasses (matches Model's
-   * model.ts:1179-1185 pattern).
-   */
   declare protected static _modelName?: ModelName;
 
   /**

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -50,9 +50,11 @@ export class JSON {
   // accepts a string here too (treated as a custom root key by as_json).
   static includeRootInJson: boolean | string = false;
 
-  // Per-class memo so the static getter can be inherited without
-  // recomputing or sharing state across subclasses (matches Model's
-  // model.ts:1179-1185 pattern).
+  /**
+   * Per-class memo so the static getter can be inherited without
+   * recomputing or sharing state across subclasses (matches Model's
+   * model.ts:1179-1185 pattern).
+   */
   declare protected static _modelName?: ModelName;
 
   /**

--- a/packages/activemodel/src/trailtie.test.ts
+++ b/packages/activemodel/src/trailtie.test.ts
@@ -8,8 +8,6 @@ import { Error as ActiveModelError } from "./error.js";
 import { deprecator } from "./deprecator.js";
 
 describe("RailtieTest", () => {
-  // Snapshot the global subclasses list so activesupport tests that
-  // truncate it can't make this suite order-dependent.
   let savedSubclasses: (typeof BaseRailtie)[];
   let savedConfig: Record<string, unknown>;
 
@@ -30,12 +28,10 @@ describe("RailtieTest", () => {
     ActiveModelError.i18nCustomizeFullMessage = false;
     BaseRailtie.subclasses.length = 0;
     BaseRailtie.subclasses.push(...savedSubclasses);
-    // Reset per-class config to saved snapshot
     for (const key of Object.keys(Trailtie.config)) {
       delete Trailtie.config[key];
     }
     Object.assign(Trailtie.config, savedConfig);
-    // Clear deprecators registry
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -78,10 +74,6 @@ describe("RailtieTest", () => {
   });
 
   it("runInitializers applies the active_model.secure_password setting", () => {
-    // Simulate a test environment via TRAILS_ENV so the initializer
-    // fires the min_cost branch. Snapshot-and-restore the prior value
-    // so a developer or runner that already had TRAILS_ENV set sees
-    // it back after the test.
     const prev = processEnv.TRAILS_ENV;
     setEnv("TRAILS_ENV", "test");
     try {

--- a/packages/activemodel/src/translation.test.ts
+++ b/packages/activemodel/src/translation.test.ts
@@ -29,7 +29,6 @@ describe("ActiveModelI18nTests", () => {
         this.attribute("name", "string");
       }
     }
-    // Calling multiple times should be idempotent
     expect(Person.humanAttributeName("name")).toBe("Name");
     expect(Person.humanAttributeName("name")).toBe("Name");
   });
@@ -40,7 +39,6 @@ describe("ActiveModelI18nTests", () => {
         this.attribute("first_name", "string");
       }
     }
-    // humanAttributeName provides basic translation
     expect(Person.humanAttributeName("first_name")).toBe("First name");
   });
 
@@ -60,7 +58,6 @@ describe("ActiveModelI18nTests", () => {
   });
 
   it("translated model when missing translation", () => {
-    // Falls back to humanized attribute name
     class Person extends Model {}
     expect(Person.humanAttributeName("unknown_attr")).toBe("Unknown attr");
   });
@@ -166,7 +163,6 @@ describe("ActiveModelI18nTests", () => {
   });
 
   it("raise on missing translations", () => {
-    // humanAttributeName always returns a default, never raises
     expect(Model.humanAttributeName("missing_field")).toBe("Missing field");
   });
 

--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -67,7 +67,6 @@ describe("BigIntegerTest", () => {
   it("numeric string with trailing characters extracts leading digits (Rails to_i)", () => {
     const type = new BigIntegerType();
     expect(type.cast("123abc")).toBe(123);
-    // Preserves precision for large leading-digit runs with trailing chars.
     expect(type.cast("99999999999999999999trailing")).toBe(BigInt("99999999999999999999"));
   });
 

--- a/packages/activemodel/src/type/binary.trails.test.ts
+++ b/packages/activemodel/src/type/binary.trails.test.ts
@@ -17,8 +17,6 @@ describe("BinaryTypeTrails", () => {
   });
 
   it("serialize wraps bytes without copying or decoding them", () => {
-    // `super` is Value#serialize (identity), so the raw value reaches Data and
-    // the bytes are preserved exactly — 0x80 is not valid UTF-8 on its own.
     const type = new Types.BinaryType();
     const bytes = new Uint8Array([0x80, 0xde, 0xad]);
     const result = type.serialize(bytes);

--- a/packages/activemodel/src/type/boolean.test.ts
+++ b/packages/activemodel/src/type/boolean.test.ts
@@ -29,7 +29,6 @@ describe("BooleanTest", () => {
     expect(type.cast(":on")).toBeTruthy();
     expect(type.cast(":ON")).toBeTruthy();
 
-    // explicitly check for false vs nil
     expect(type.cast(false)).toEqual(false);
     expect(type.cast(0)).toEqual(false);
     expect(type.cast("0")).toEqual(false);

--- a/packages/activemodel/src/type/boolean.ts
+++ b/packages/activemodel/src/type/boolean.ts
@@ -10,7 +10,7 @@ export class BooleanType extends ValueType<boolean> {
   static readonly FALSE_VALUES: ReadonlySet<unknown> = new Set([
     false,
     0,
-    0n, // safeIntegers mode returns bigint 0n for SQLite boolean columns
+    0n,
     "0",
     ":0",
     "f",

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -208,7 +208,6 @@ describe("DateTimeTest", () => {
 });
 
 describe("DateTimeType#isChanged", () => {
-  // 1_000_000n ns = exactly 1ms from epoch — a clean boundary for all precision tests.
   const MS1 = 1_000_000n;
 
   it("two identical Temporal.Instant references are unchanged", () => {
@@ -227,14 +226,14 @@ describe("DateTimeType#isChanged", () => {
   it("instants differing by one full microsecond are changed (precision=null)", () => {
     const t = new Types.DateTimeType();
     const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1000n); // next μs bucket
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1000n);
     expect(t.isChanged(a, b)).toBe(true);
   });
 
   it("instants differing by one full millisecond are changed (precision=3)", () => {
     const t = new Types.DateTimeType({ precision: 3 });
     const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n); // next ms bucket
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n);
     expect(t.isChanged(a, b)).toBe(true);
   });
 

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -89,26 +89,19 @@ describe("DateTimeType date-only strings with a zone token", () => {
   });
 });
 
-// Offsets `Date._parse` resolves that the hand-rolled zone table this replaced
-// could not: a fractional-hour numeric offset, a sub-minute one, and an
-// abbreviation outside the short list it carried. Each `:offset` below is
-// ruby 3.3.11's `Date._parse` answer.
 describe("DateTimeType offsets sourced from Date._parse", () => {
   const type = new Types.DateTimeType();
   const cast = (s: string) => (type.cast(s) as Temporal.Instant | null)?.toString() ?? null;
 
   it("applies a fractional-hour numeric offset", () => {
-    // Date._parse("2013-09-04 03:00:00 +05:45")[:offset] #=> 20700
     expect(cast("2013-09-04 03:00:00 +05:45")).toBe("2013-09-03T21:15:00Z");
   });
 
   it("applies a sub-minute numeric offset", () => {
-    // Date._parse("2013-09-04 03:00:00 -00:44:30")[:offset] #=> -2670
     expect(cast("2013-09-04 03:00:00 -00:44:30")).toBe("2013-09-04T03:44:30Z");
   });
 
   it("applies an offset from the gem's full zone table", () => {
-    // Date._parse("2013-09-04 03:00:00 IST")[:offset] #=> 19800
     expect(cast("2013-09-04 03:00:00 IST")).toBe("2013-09-03T21:30:00Z");
   });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -94,7 +94,6 @@ describe("DateTest", () => {
   });
 
   it("cast slash string", () => {
-    // ruby 3.3.11: Date._parse("7/4/2020", false) #=> {year: 2020, mon: 4, mday: 7}
     const result = type.cast("7/4/2020");
     expect(result).toBeInstanceOf(Temporal.PlainDate);
     expect((result as Temporal.PlainDate).toString()).toBe("2020-04-07");
@@ -118,7 +117,6 @@ describe("DateTest", () => {
   });
 
   it("multiparameter hash missing day returns null (no defaults for DateType — P21 regression guard)", () => {
-    // Date has no defaults; year/month/day are all required.
     const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7 });
     expect(result).toBeNull();
   });

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -75,7 +75,6 @@ describe("DecimalTest", () => {
     expect(type.isChanged(5.0, 5.0, "0.5e+1")).toBeFalsy();
     // Rails passes `BigDecimal("0.0") / 0`; trails' NaN decimal is the "NaN" sentinel.
     expect(type.isChanged("NaN", "NaN", "NaN")).toBeFalsy();
-    // Float NaN over BigDecimal NaN: still a change (`instance_of?` guard).
     expect(type.isChanged("NaN", NaN, NaN)).toBeTruthy();
   });
 
@@ -125,8 +124,6 @@ describe("DecimalType", () => {
 
   it("serialize delegates to cast via Helpers::Numeric", () => {
     const type = new Types.DecimalType();
-    // serialize delegates to cast, which yields a BigDecimal so the value
-    // quotes in fixed ("F") form rather than as a single-quoted string.
     expect(type.serialize("1.5")).toEqual(bd("1.5"));
     expect(type.serialize("")).toBeNull();
   });
@@ -138,10 +135,7 @@ describe("DecimalType", () => {
   });
 
   it("isChanged returns true for number_to_non_number? path — same cast value, non-numeric raw", () => {
-    // DecimalType shares applyNumericMixin with Integer/Float — verify the
-    // number_to_non_number? path is exercised on Decimal as well.
     const type = new Types.DecimalType();
-    // old="0", new_cast="0" (same), raw="wibble" (non-numeric) → changed
     expect(type.isChanged("0", "0", "wibble")).toBe(true);
   });
 
@@ -151,9 +145,6 @@ describe("DecimalType", () => {
   });
 
   it("casts NaN (BigDecimal NaN sentinel) — number and string forms", () => {
-    // BigDecimal("NaN") has no decimal string form; it round-trips as the
-    // sentinel "NaN" (the JS NaN on assignment, the string "NaN" from PG on
-    // load).
     const type = new Types.DecimalType();
     expect(type.cast(NaN)).toBe("NaN");
     expect(type.cast("NaN")).toBe("NaN");
@@ -173,8 +164,6 @@ describe("DecimalType", () => {
 
   it("serialize bridges to BigDecimal F-form for quoting", () => {
     const type = new Types.DecimalType();
-    // Whole values gain a trailing ".0" in fixed form, fractional values
-    // drop the quotes — both quote bare, not as 'string' literals.
     expect((type.serialize(42) as BigDecimal).toString("F")).toBe("42.0");
     expect((type.serialize("1.5") as BigDecimal).toString("F")).toBe("1.5");
     expect(type.serialize(null)).toBeNull();
@@ -191,16 +180,12 @@ describe("DecimalType", () => {
   });
 
   it("applyScale leaves the NaN sentinel untouched", () => {
-    // A scaled decimal column (bank_balance is scale: 2) must not mangle the
-    // "NaN" sentinel — roundHalfUpToScale's splitDecimal returns null for it.
     const type = new Types.DecimalType({ precision: 10, scale: 2 });
     expect(type.cast(NaN)).toBe("NaN");
     expect(type.cast("NaN")).toBe("NaN");
   });
 
   it("applyScale leaves the Infinity sentinel untouched", () => {
-    // A scaled decimal column must not mangle the "Infinity"/"-Infinity"
-    // sentinel — roundHalfUpToScale's splitDecimal returns null for it.
     const type = new Types.DecimalType({ precision: 10, scale: 2 });
     expect(type.cast(Infinity)).toBe("Infinity");
     expect(type.cast(-Infinity)).toBe("-Infinity");

--- a/packages/activemodel/src/type/decimal.trails.test.ts
+++ b/packages/activemodel/src/type/decimal.trails.test.ts
@@ -10,25 +10,18 @@ describe("DecimalTypeTrails", () => {
     // rounds the input to 3 significant digits ("1.23") before any scale: pass.
     const type = new Types.DecimalType({ precision: 3 });
     expect(type.cast(1.2346)).toEqual(bd("1.23"));
-    // 1234.5 → 3 significant digits → "1230"
     expect(type.cast(1234.5)).toEqual(bd("1230"));
-    // No precision configured: pass through (preserves the existing default).
     const noPrec = new Types.DecimalType();
     expect(noPrec.cast(1.2346)).toEqual(bd("1.2346"));
   });
 
   it("apply_scale handles leading-dot and trailing-dot numeric forms", () => {
     const type = new Types.DecimalType({ scale: 2 });
-    // `_castWithoutScale` can emit forms like ".5" or "1." — apply_scale
-    // must normalize them, not silently pass through.
     expect(type.cast(".5")).toEqual(bd("0.50"));
     expect(type.cast("1.")).toEqual(bd("1.00"));
   });
 
   it("apply_scale does not OOM on adversarial exponents", () => {
-    // `"1e10000000"` would force splitDecimal to allocate a ~10M-digit
-    // string if expanded naively. The cap leaves the raw form alone — and
-    // BigDecimal can't hold it either, so the raw string passes through.
     const type = new Types.DecimalType({ scale: 2 });
     expect(type.cast("1e10000000")).toBe("1e10000000");
   });

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -68,9 +68,6 @@ export class DecimalType extends NumericValueType {
       typeof value === "bigint" ||
       value instanceof Rational
     ) {
-      // A Rational is the case that makes the significant-digit count matter
-      // here rather than in the Float arm: it carries an exact fraction, so
-      // `Rational(1, 3)` is `0.333333333333333333E0` at the default 18.
       castedValue = new BigDecimal(value, this.precision ?? BIGDECIMAL_PRECISION);
     } else if (typeof value === "string") {
       castedValue = toD(value);
@@ -106,8 +103,6 @@ export class DecimalType extends NumericValueType {
     if (this.precision !== undefined) {
       return new BigDecimal(this.applyScale(value), this.floatPrecision());
     }
-    // `Float#to_d` reads the float's SHORTEST round-trip decimal string —
-    // what `String(value)` yields — not its binary expansion.
     return new BigDecimal(String(value));
   }
 
@@ -188,8 +183,6 @@ function toD(value: string): BigDecimal | string | null {
   try {
     return new BigDecimal(match ? match[0] : "0");
   } catch {
-    // Adversarial exponents (e.g. "1e10000000") exceed BigDecimal's expansion
-    // cap; leave the raw prefix untouched rather than answering a wrong value.
     return match ? match[0] : "0";
   }
 }

--- a/packages/activemodel/src/type/helpers/mutable.test.ts
+++ b/packages/activemodel/src/type/helpers/mutable.test.ts
@@ -67,7 +67,6 @@ describe("MutableModule", () => {
 
   it("isChangedInPlace handles pre-parsed object rawOldValue (driver-parsed case)", () => {
     const t = new FakeJsonType();
-    // Simulate pg driver pre-parsing jsonb: rawOldValue is an object, not a string
     const rawOld = { a: 1 };
     expect(t.isChangedInPlace(rawOld, { a: 1 })).toBe(false);
     expect(t.isChangedInPlace(rawOld, { a: 2 })).toBe(true);

--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -69,7 +69,6 @@ describe("applySecondsPrecision", () => {
   it("works on Temporal.Instant via .round()", () => {
     const inst = Temporal.Instant.from("2024-01-02T03:04:05.123456789Z");
     const r = applySecondsPrecision.call({ precision: 3 }, inst) as Temporal.Instant;
-    // Compare via the same field path Temporal uses for Instant->ZDT.
     const zdt = r.toZonedDateTimeISO("UTC");
     expect(zdt.millisecond).toBe(123);
     expect(zdt.microsecond).toBe(0);

--- a/packages/activemodel/src/type/integer.trails.test.ts
+++ b/packages/activemodel/src/type/integer.trails.test.ts
@@ -91,10 +91,7 @@ describe("IntegerType", () => {
     expect(type.isSerializable(Infinity)).toBe(true);
     expect(type.isSerializable(-Infinity)).toBe(true);
     expect(type.isSerializable(NaN)).toBe(true);
-    // A non-numeric string is `to_i`-able to 0 here ("abc".to_i == 0), which is
-    // in range.
     expect(type.isSerializable("abc")).toBe(true);
-    // Genuinely out-of-range values still answer false.
     expect(type.isSerializable(2 ** 40)).toBe(false);
   });
 

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -66,9 +66,6 @@ export class IntegerType extends NumericValueType {
     // predicate correct for a raw value, whether or not the caller pre-cast.
     const castValue = this.cast(value) as number | bigint | null;
     if (this.isInRange(castValue)) return true;
-    // `in_range?(cast_value) || begin; yield cast_value if block_given?; false; end`
-    // — the block receives the CAST value, which is the only place a caller can
-    // get it without casting a second time.
     block?.(castValue);
     return false;
   }

--- a/packages/activemodel/src/type/registry.test.ts
+++ b/packages/activemodel/src/type/registry.test.ts
@@ -88,8 +88,6 @@ describe("TypeRegistry", () => {
   });
 
   it("uuid, json, array are not in AM TypeRegistry defaults (PG-specific types live in AR's OID layer)", () => {
-    // Use a fresh instance — the singleton may be mutated by AR's type.ts
-    // which re-registers "json" for its own purposes.
     const fresh = new TypeRegistry();
     expect(() => fresh.lookup("uuid")).toThrow("Unknown type :uuid");
     expect(() => fresh.lookup("json")).toThrow("Unknown type :json");
@@ -97,9 +95,6 @@ describe("TypeRegistry", () => {
   });
 
   it("a class can be registered for a symbol", () => {
-    // Use a uniquely-scoped name — the type registry is a global singleton,
-    // so generic names ("custom", "mytype") risk colliding as the test set
-    // grows.
     Types.typeRegistry.register("type_registry_test_custom", () => new Types.StringType());
     const t = Types.typeRegistry.lookup("type_registry_test_custom");
     expect(t).toBeInstanceOf(Types.StringType);

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -137,7 +137,6 @@ describe("TimeTest", () => {
   });
 
   it("valueFromMultiparameterAssignment: hour-only hash returns Time on 2000-01-01 base (P21)", () => {
-    // Regression: was null before P21 because year defaulted to 0 and hit the short-circuit.
     expect(type.cast({ "4": 15 })).toEqual(timeUtc(2000, 1, 1, 15, 0, 0));
   });
 

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -66,7 +66,6 @@ export abstract class Type<T = unknown> {
   }
 
   typeCastForSchema(value: unknown): string {
-    // JSON.stringify throws on BigInt; use String() directly for it.
     if (typeof value === "bigint") return value.toString();
     return JSON.stringify(value) ?? String(value);
   }
@@ -191,8 +190,6 @@ export abstract class Type<T = unknown> {
       depth++;
     }
     const result = castDepth >= 0 && serializeDepth >= 0 && castDepth <= serializeDepth;
-    // Define as own property so subclasses don't read this through the
-    // static prototype chain.
     Object.defineProperty(this, "_serializeCastValueCompatible", {
       value: result,
       writable: true,

--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -310,11 +310,9 @@ describe("ValidationsTest", () => {
 
     const t = new Topic({ title: "" });
 
-    // If block should not fire
     assertPredicate(await t.isValid(), (valid) => valid);
     assertPredicate(t.author_name, (authorName) => authorName == null);
 
-    // If block should fire
     assert(await t.isInvalid("update"));
     assert(t.author_name === "bad");
   });
@@ -477,7 +475,6 @@ describe("ValidationsTest", () => {
 
   it("invalid options to validate", async () => {
     const error = await assertRaises([ArgumentError], {}, () => {
-      // A common mistake -- we meant to call 'validates'
       Topic.validate("title", { presence: true } as unknown as ConditionalOptions);
     });
     const message =

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -7,10 +7,6 @@ import { resetI18n } from "./test-helpers/i18n.js";
 // here rather than in `validations.test.ts` so the Rails-mirroring file stays a
 // one-to-one port of the Rails case.
 describe("ValidationsTest (trails)", () => {
-  // =========================================================================
-  // Phase 1100/1150 — Validations
-  // =========================================================================
-  // -- Presence --
   describe("presence", () => {
     class Article extends Model {
       static {
@@ -41,7 +37,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Absence --
   describe("absence", () => {
     class Blank extends Model {
       static {
@@ -65,7 +60,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Length --
   describe("length", () => {
     class WithLength extends Model {
       static {
@@ -122,11 +116,10 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Numericality --
   describe("numericality", () => {
     class Numeric extends Model {
       static {
-        this.attribute("value", "string"); // string to test cast behavior
+        this.attribute("value", "string");
         this.validates("value", { numericality: true });
       }
     }
@@ -241,7 +234,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Inclusion / Exclusion --
   describe("inclusion and exclusion", () => {
     class Colorful extends Model {
       static {
@@ -270,7 +262,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Format --
   describe("format", () => {
     class EmailUser extends Model {
       static {
@@ -292,7 +283,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Confirmation --
   describe("confirmation", () => {
     class Signup extends Model {
       static {
@@ -315,7 +305,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Uniqueness (simulated) --
   describe("uniqueness", () => {
     class UniqueUser extends Model {
       static existingNames = new Set<string>();
@@ -333,8 +322,6 @@ describe("ValidationsTest (trails)", () => {
         if (!valid) return false;
         const name = this.readAttribute("name") as string;
         if (UniqueUser.existingNames.has(name)) {
-          // `errors.messages.taken` ships in activerecord's en.yml, not
-          // activemodel's — an Active Model-only case has to supply the literal.
           this.errors.add("name", "has already been taken");
           return false;
         }
@@ -359,7 +346,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
 
-  // -- Type-based validations --
   describe("type-based validations", () => {
     class TypedModel extends Model {
       static {
@@ -501,9 +487,7 @@ describe("ValidationsTest (trails)", () => {
           this.validates("name", { presence: true, on: "create" });
         }
       }
-      // No context → default context → no validators active → passes.
       expect(await new Scoped({}).validateBang()).toBe(true);
-      // :create context → presence validator active → raises.
       await expect(new Scoped({}).validateBang("create")).rejects.toThrow(/Validation failed/);
     });
 
@@ -519,7 +503,6 @@ describe("ValidationsTest (trails)", () => {
           this.validates("title", { presence: true, on: ["publish"] });
         }
       }
-      // Single-symbol context → only the `on: :create` validator fires.
       const a = new Scoped({});
       expect(await a.isValid("create")).toBe(false);
       expect(a.errors.attributeNames).toEqual(["name"]);
@@ -529,7 +512,6 @@ describe("ValidationsTest (trails)", () => {
       expect(await b.isValid(["create", "publish"])).toBe(false);
       expect(b.errors.attributeNames.sort()).toEqual(["name", "title"]);
 
-      // Array context matching only one registered value fires that one.
       const c = new Scoped({});
       expect(await c.isValid(["publish"])).toBe(false);
       expect(c.errors.attributeNames).toEqual(["title"]);
@@ -579,8 +561,6 @@ describe("ValidationsTest (trails)", () => {
       const m = new Scoped({});
       await m.isValid("previous");
       await m.isValid(null);
-      // First call saw "previous"; second call saw null (explicit clear),
-      // not "previous" carried over.
       expect(captured).toEqual(["previous", null]);
     });
 
@@ -608,8 +588,6 @@ describe("ValidationsTest (trails)", () => {
     }
 
     it("ValidationError message comes from I18n :model_invalid", async () => {
-      // Default en → "Validation failed: %{errors}"
-      // (activemodel locale/en.yml:9).
       await expect(new Topic({}).validateBang()).rejects.toThrow(
         /^Validation failed: Title can't be blank$/,
       );
@@ -658,7 +636,6 @@ describe("ValidationsTest (trails)", () => {
     it("contextForValidation is callable on a frozen model", () => {
       const t = new Topic({ title: "ok" });
       t.freeze();
-      // freeze() pre-materializes the cache; access must not throw.
       expect(() => t.contextForValidation()).not.toThrow();
     });
   });
@@ -713,14 +690,8 @@ describe("ValidationsTest (trails)", () => {
       }
       class Child extends Base {}
       expect(Child.validatorsOn("name")).toHaveLength(1);
-      // Parent adds another validator AFTER Child is defined, and Child has
-      // not yet registered anything of its own. Copy-on-first-write
-      // semantics: Child still sees Base's map, so the new validator
-      // propagates.
       Base.validates("name", { length: { minimum: 2 } });
       expect(Child.validatorsOn("name")).toHaveLength(2);
-      // As soon as Child writes, it detaches. Further Base writes stay on
-      // Base.
       Child.validates("name", { length: { maximum: 10 } });
       Base.validates("name", { format: { with: /x/ } });
       expect(Child.validatorsOn("name")).toHaveLength(3);
@@ -736,9 +707,7 @@ describe("ValidationsTest (trails)", () => {
         }
       }
       class Child extends Base {}
-      // Subclass sees parent's validators…
       expect(Child.validatorsOn("name")).toHaveLength(1);
-      // …and adding one on the subclass must not affect the parent.
       Child.validates("name", { length: { minimum: 2 } });
       expect(Child.validatorsOn("name")).toHaveLength(2);
       expect(Base.validatorsOn("name")).toHaveLength(1);
@@ -763,9 +732,7 @@ describe("ValidationsTest (trails)", () => {
       // instance or in `options`, so `validatesWith` must route the explicit
       // `attributes:` option through to the bucket lookup.
       class PojoValidator {
-        validate(_record: unknown): void {
-          /* no-op */
-        }
+        validate(_record: unknown): void {}
       }
       class Person extends Model {
         static {
@@ -784,9 +751,7 @@ describe("ValidationsTest (trails)", () => {
       // _registerValidator must check both.
       const { Validator: ValidatorBase } = await import("./validator.js");
       class StaticValidator extends ValidatorBase {
-        override validate(): void {
-          /* no-op */
-        }
+        override validate(): void {}
       }
       class Person extends Model {
         static {
@@ -810,12 +775,10 @@ describe("ValidationsTest (trails)", () => {
       Person.validatorsOn("never_registered");
       expect(Array.from(Person._validators.keys())).not.toContain("never_registered");
 
-      // Mutating the returned array must NOT affect internal state.
       const a = Person.validatorsOn("name");
       a.length = 0;
       expect(Person.validatorsOn("name")).toHaveLength(1);
 
-      // Consecutive calls return independent arrays.
       expect(Person.validatorsOn("name")).not.toBe(Person.validatorsOn("name"));
     });
   });
@@ -954,7 +917,6 @@ describe("ValidationsTest (trails)", () => {
     });
   });
   describe("Validations", () => {
-    // -- Presence --
     describe("presence", () => {
       class Article extends Model {
         static {
@@ -985,7 +947,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Absence --
     describe("absence", () => {
       class Blank extends Model {
         static {
@@ -1009,7 +970,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Length --
     describe("length", () => {
       class WithLength extends Model {
         static {
@@ -1066,11 +1026,10 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Numericality --
     describe("numericality", () => {
       class Numeric extends Model {
         static {
-          this.attribute("value", "string"); // string to test cast behavior
+          this.attribute("value", "string");
           this.validates("value", { numericality: true });
         }
       }
@@ -1154,7 +1113,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Inclusion / Exclusion --
     describe("inclusion", () => {
       class Status extends Model {
         static {
@@ -1193,7 +1151,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Format --
     describe("format", () => {
       class Email extends Model {
         static {
@@ -1227,7 +1184,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Acceptance --
     describe("acceptance", () => {
       // Rails' equivalent uses a virtual attribute; boolean here so `"1"` /
       // `true` round-trip through cast as `true` and match the default accept
@@ -1264,7 +1220,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Confirmation --
     describe("confirmation", () => {
       class WithConfirm extends Model {
         static {
@@ -1296,7 +1251,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Conditional validation --
     describe("conditional", () => {
       it("if validation using block false", async () => {
         class Cond extends Model {
@@ -1331,7 +1285,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- Custom validate --
     describe("custom validate", () => {
       it("function validator", async () => {
         class Custom extends Model {
@@ -1352,7 +1305,6 @@ describe("ValidationsTest (trails)", () => {
       });
     });
 
-    // -- isInvalid --
     it("invalid should be the opposite of valid", async () => {
       class Required extends Model {
         static {
@@ -1364,7 +1316,6 @@ describe("ValidationsTest (trails)", () => {
       expect(await new Required({ name: "dean" }).isInvalid()).toBe(false);
     });
 
-    // -- fullMessages --
     it("fullMessages prefixes attribute name", async () => {
       class FM extends Model {
         static {
@@ -1390,7 +1341,6 @@ describe("ValidationsTest (trails)", () => {
       expect(b.errors.fullMessages).toContain("is broken");
     });
 
-    // -- errors.clear between validations --
     it("errors are cleared between isValid calls", async () => {
       class Clearable extends Model {
         static {
@@ -1482,7 +1432,6 @@ describe("ValidationsTest (trails)", () => {
         }
       }
       const validators = User.validators();
-      // presence on name, presence on email, length on email
       expect(validators.length).toBe(3);
     });
 
@@ -1496,9 +1445,9 @@ describe("ValidationsTest (trails)", () => {
         }
       }
       const nameValidators = User.validatorsOn("name");
-      expect(nameValidators.length).toBe(2); // presence + length
+      expect(nameValidators.length).toBe(2);
       const emailValidators = User.validatorsOn("email");
-      expect(emailValidators.length).toBe(1); // presence only
+      expect(emailValidators.length).toBe(1);
     });
 
     it("returns empty array for attribute with no validators", () => {
@@ -1524,9 +1473,7 @@ describe("ValidationsTest (trails)", () => {
         }
       }
       const u = new User({ name: "Alice" });
-      // Without context, terms_accepted validation is skipped
       expect(await u.isValid()).toBe(true);
-      // With custom context, terms_accepted presence validation runs
       expect(await u.isValid("registration")).toBe(false);
     });
 
@@ -1841,7 +1788,7 @@ describe("ValidationsTest (trails)", () => {
           this.validatesPresenceOf("title", { if: () => true, on: "update" });
         }
       }
-      expect(await new Topic({ title: "" }).isValid()).toBe(true); // no context
+      expect(await new Topic({ title: "" }).isValid()).toBe(true);
       expect(await new Topic({ title: "" }).isInvalid("update")).toBe(true);
     });
 

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -179,8 +179,6 @@ export class ValidationError<TModel extends ModelWithErrors = ModelWithErrors>
   //
   constructor(model: TModel) {
     const errors = model.errors.fullMessages.join(", ");
-    // Match the guard used by `error.ts`'s I18n lookups — only treat
-    // `i18nScope` as a scope when the class actually exposes a string.
     const rawScope = (model as { constructor?: { i18nScope?: unknown } }).constructor?.i18nScope;
     const scope = typeof rawScope === "string" ? rawScope : "activemodel";
     const message = I18n.t(`${scope}.errors.messages.model_invalid`, {

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -159,7 +159,6 @@ describe("AcceptanceValidationTest", () => {
     );
     const a = new Agreement({ terms: "1" });
     expect(await a.isValid()).toBe(true);
-    // The value lives in the accessor slot (attr_accessor), not @attributes.
     expect((a as unknown as { terms: unknown }).terms).toBe("1");
   });
 

--- a/packages/activemodel/src/validations/comparison-validation.test.ts
+++ b/packages/activemodel/src/validations/comparison-validation.test.ts
@@ -386,8 +386,6 @@ describe("ComparisonValidationTest", () => {
     );
   });
 
-  // -- private --
-
   async function assertInvalidValues(values: unknown[], error?: string): Promise<void> {
     await withEachTopicApprovedValue(values, async (topic, value) => {
       assertPredicate(await topic.isInvalid(), (invalid) => invalid, `${value} failed comparison`);

--- a/packages/activemodel/src/validations/conditional-validation.test.ts
+++ b/packages/activemodel/src/validations/conditional-validation.test.ts
@@ -24,7 +24,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("if validation using method true", async () => {
-    // When the method returns true
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -61,7 +60,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("unless validation using method true", async () => {
-    // When the method returns true
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -95,7 +93,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("if validation using method false", async () => {
-    // When the method returns false
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -107,7 +104,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("unless validation using method false", async () => {
-    // When the method returns false
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -120,7 +116,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("if validation using block true", async () => {
-    // When the block returns true
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -133,7 +128,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("unless validation using block true", async () => {
-    // When the block returns true
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -145,7 +139,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("if validation using block false", async () => {
-    // When the block returns false
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",
@@ -157,7 +150,6 @@ describe("ConditionalValidationTest", () => {
   });
 
   it("unless validation using block false", async () => {
-    // When the block returns false
     Topic.validatesLengthOf("title", {
       maximum: 5,
       tooLong: "hoo %{count}",

--- a/packages/activemodel/src/validations/format-validation.test.ts
+++ b/packages/activemodel/src/validations/format-validation.test.ts
@@ -3,7 +3,6 @@ import { Model } from "../index.js";
 
 describe("FormatValidationTest", () => {
   it("validates format of with multiline regexp and option", () => {
-    // Multiline regexp should raise error
     expect(() => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -28,6 +28,8 @@ export class FormatValidator extends EachValidator {
    * during EachValidator's constructor-time checkValidityBang() call. JS class
    * fields don't initialize until AFTER super() returns. (Same bootstrapping
    * lesson as PR #994.)
+   *
+   * @internal Rails-private helpers.
    */
   declare resolveValue: typeof resolveValue;
   /** @internal Rails-private helper. */

--- a/packages/activemodel/src/validations/format.ts
+++ b/packages/activemodel/src/validations/format.ts
@@ -22,11 +22,13 @@ import { resolveValue } from "./resolve-value.js";
  *     ...
  */
 export class FormatValidator extends EachValidator {
-  // Declarations only — actual functions attached to the prototype below.
-  // Prototype attachment (not class fields) so the helpers are present
-  // during EachValidator's constructor-time checkValidityBang() call. JS class
-  // fields don't initialize until AFTER super() returns. (Same bootstrapping
-  // lesson as PR #994.)
+  /**
+   * Declarations only — actual functions attached to the prototype below.
+   * Prototype attachment (not class fields) so the helpers are present
+   * during EachValidator's constructor-time checkValidityBang() call. JS class
+   * fields don't initialize until AFTER super() returns. (Same bootstrapping
+   * lesson as PR #994.)
+   */
   declare resolveValue: typeof resolveValue;
   /** @internal Rails-private helper. */
   declare recordError: typeof recordError;

--- a/packages/activemodel/src/validations/inclusion-validation.test.ts
+++ b/packages/activemodel/src/validations/inclusion-validation.test.ts
@@ -140,7 +140,6 @@ describe("InclusionValidationTest", () => {
   });
 
   it("validates inclusion of time range", async () => {
-    // Use array of specific time values
     const times = ["morning", "afternoon", "evening"];
     class Schedule extends Model {
       static {

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -62,6 +62,8 @@ export class LengthValidator extends EachValidator {
    * during EachValidator's constructor-time checkValidityBang() call. JS class
    * fields don't initialize until AFTER super() returns. (Same bootstrapping
    * lesson as PR #994 / #1002.)
+   *
+   * @internal Rails-private helpers.
    */
   declare resolveValue: typeof resolveValue;
   /** @internal Rails-private helper. */

--- a/packages/activemodel/src/validations/length.ts
+++ b/packages/activemodel/src/validations/length.ts
@@ -56,11 +56,13 @@ export const RESERVED_OPTIONS = [
 ] as const;
 
 export class LengthValidator extends EachValidator {
-  // Declarations only — actual functions attached to the prototype below.
-  // Prototype attachment (not class fields) so the helpers are present
-  // during EachValidator's constructor-time checkValidityBang() call. JS class
-  // fields don't initialize until AFTER super() returns. (Same bootstrapping
-  // lesson as PR #994 / #1002.)
+  /**
+   * Declarations only — actual functions attached to the prototype below.
+   * Prototype attachment (not class fields) so the helpers are present
+   * during EachValidator's constructor-time checkValidityBang() call. JS class
+   * fields don't initialize until AFTER super() returns. (Same bootstrapping
+   * lesson as PR #994 / #1002.)
+   */
   declare resolveValue: typeof resolveValue;
   /** @internal Rails-private helper. */
   declare skipNilCheck: typeof skipNilCheck;

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -80,7 +80,7 @@ describe("NumericalityValidationTest", () => {
 
   const NIL = [null];
   const BLANK = ["", " ", " \t \r \n"];
-  const BIGDECIMAL_STRINGS = ["12345678901234567890.1234567890"]; // 30 significant digits
+  const BIGDECIMAL_STRINGS = ["12345678901234567890.1234567890"];
   const FLOAT_STRINGS = [
     "0.0",
     "+0.0",
@@ -478,8 +478,6 @@ describe("NumericalityValidationTest", () => {
     await assertInvalidValues([Number("65.5"), new BigDecimal("65.7")], "must be equal to 65.6");
     await assertValidValues([Number("65.6"), new BigDecimal("65.6")]);
   });
-
-  // -- private --
 
   async function assertInvalidValues(values: unknown[], error?: string): Promise<void> {
     await withEachTopicApprovedValue(values, async (topic, value) => {

--- a/packages/activemodel/src/validations/numericality-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.trails.test.ts
@@ -78,12 +78,6 @@ describe("NumericalityValidator (trails-only)", () => {
   });
 
   it("rejects plain object values via NumericalityValidator.validateEach directly", () => {
-    // Direct exercise of the non-string/non-number narrowing in kernelFloat.
-    // Going through Model attributes wouldn't work — string-typed attrs
-    // cast objects to "[object Object]" before validation, value-typed
-    // attrs go through their own cast path. Bypass attribute infra and
-    // call the validator with a stub record so a real plain object
-    // reaches the parse pipeline.
     const v = new NumericalityValidator({ attributes: ["x"] });
     const errs = new Errors(null);
     const stubRecord = { errors: errs };
@@ -135,8 +129,8 @@ describe("NumericalityValidator (trails-only)", () => {
         this.validates("score", { numericality: { even: true } });
       }
     }
-    expect(await new Person({ score: 2.5 }).isValid()).toBe(true); // trunc(2.5)=2, even
-    expect(await new Person({ score: 3.5 }).isValid()).toBe(false); // trunc(3.5)=3, odd
+    expect(await new Person({ score: 2.5 }).isValid()).toBe(true);
+    expect(await new Person({ score: 3.5 }).isValid()).toBe(false);
   });
 
   it("odd/even truncates negative float via Math.trunc (-2.5 → -2, even)", async () => {
@@ -147,8 +141,8 @@ describe("NumericalityValidator (trails-only)", () => {
         this.validates("score", { numericality: { odd: true } });
       }
     }
-    expect(await new Person({ score: -3.5 }).isValid()).toBe(true); // trunc(-3.5)=-3, odd
-    expect(await new Person({ score: -2.5 }).isValid()).toBe(false); // trunc(-2.5)=-2, even
+    expect(await new Person({ score: -3.5 }).isValid()).toBe(true);
+    expect(await new Person({ score: -2.5 }).isValid()).toBe(false);
   });
 
   it("odd/even truncation: 2.9 is even (truncates to 2, not rounds to 3)", async () => {
@@ -158,8 +152,8 @@ describe("NumericalityValidator (trails-only)", () => {
         this.validates("score", { numericality: { even: true } });
       }
     }
-    expect(await new Person({ score: 2.9 }).isValid()).toBe(true); // trunc(2.9)=2, even
-    expect(await new Person({ score: 3.9 }).isValid()).toBe(false); // trunc(3.9)=3, odd
+    expect(await new Person({ score: 2.9 }).isValid()).toBe(true);
+    expect(await new Person({ score: 3.9 }).isValid()).toBe(false);
   });
 
   it("cameFromUser absent (AM Model) → validates the cast value", async () => {
@@ -181,8 +175,6 @@ describe("NumericalityValidator (trails-only)", () => {
   });
 
   it("cameFromUser false → validates cast value (readAttribute)", () => {
-    // Mock: scoreCameFromUser is false, but cast value (readAttribute) is
-    // a valid number — validation should pass.
     class MockRecord {
       errors = { add: vi.fn() };
       scoreCameFromUser = false;
@@ -193,12 +185,10 @@ describe("NumericalityValidator (trails-only)", () => {
     }
     const rec = new MockRecord();
     const result = prepareValueForValidation.call(undefined, "initial", rec as never, "score");
-    // Should return the cast value (42), not the raw string
     expect(result).toBe(42);
   });
 
   it("cameFromUser absent → falls back to readAttributeBeforeTypeCast", () => {
-    // A host with no `_came_from_user?` reader takes the `_before_type_cast` arm.
     class MockRecord {
       errors = { add: vi.fn() };
       scoreBeforeTypeCast = "raw-value";

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -28,6 +28,8 @@ export class NumericalityValidator extends EachValidator {
    * below so they're available during EachValidator's super-time
    * checkValidityBang() call (same bootstrapping pattern as PRs #994 / #1002 /
    * #1009). Class fields don't initialize until after super() returns.
+   *
+   * @internal Rails-private helpers.
    */
   /** @internal Rails-private helper. */
   declare optionAsNumber: typeof optionAsNumber;

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -23,10 +23,12 @@ export class NumericalityValidator extends EachValidator {
   resolveValue = resolveValue;
   errorOptions = errorOptions;
 
-  // Coercion-pipeline privates declared here, attached to the prototype
-  // below so they're available during EachValidator's super-time
-  // checkValidityBang() call (same bootstrapping pattern as PRs #994 / #1002 /
-  // #1009). Class fields don't initialize until after super() returns.
+  /**
+   * Coercion-pipeline privates declared here, attached to the prototype
+   * below so they're available during EachValidator's super-time
+   * checkValidityBang() call (same bootstrapping pattern as PRs #994 / #1002 /
+   * #1009). Class fields don't initialize until after super() returns.
+   */
   /** @internal Rails-private helper. */
   declare optionAsNumber: typeof optionAsNumber;
   /** @internal Rails-private helper. */

--- a/packages/activemodel/src/validations/validates.test.ts
+++ b/packages/activemodel/src/validations/validates.test.ts
@@ -244,9 +244,7 @@ describe("ValidatesTest", () => {
         });
       }
     }
-    // When inactive, both validations should be skipped
     expect(await new Person({ active: false }).isValid()).toBe(true);
-    // When active, both validations should run
     expect(await new Person({ active: true }).isValid()).toBe(false);
     expect(await new Person({ active: true, name: "abc" }).isValid()).toBe(true);
   });

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -173,7 +173,6 @@ describe("ValidatesWithTest", () => {
     });
     const p = new Person({});
     await p.isValid();
-    // null values are skipped
     expect(p.errors.count).toBe(0);
   });
 
@@ -185,7 +184,7 @@ describe("ValidatesWithTest", () => {
     }
     Person.validatesEach(["name"], (record, attr, value) => {
       if (value && typeof value === "string" && value.trim() === "") {
-        return; // skip blank
+        return;
       }
       if (value === null || value === undefined) return;
       record.errors.add(attr, ":invalid");
@@ -354,7 +353,6 @@ describe("WithValidator arity dispatch", () => {
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
-    // Function.length of a rest-param function is 0, so no arg is passed
     expect(received).toHaveLength(0);
   });
 
@@ -368,7 +366,6 @@ describe("WithValidator arity dispatch", () => {
     };
     const validator = new WithValidator({ attributes: ["name"], with: "myCheck" });
     validator.validateEach(record, "name", "value");
-    // Function.length excludes default params, so length is 0 → called without arg
     expect(capturedArg).toBe("");
   });
 });

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -5,11 +5,6 @@ import { Table, Nodes, Visitors } from "./index.js";
 const users = new Table("users");
 const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
 
-// Behavior tests for the attribute-alignment changes — typed-subclass
-// returns from aggregates / contains / overlaps / concat, plus the
-// `retryable: true` flag on alias SqlLiterals across every per-class
-// `as()` override.
-
 describe("Attribute aggregates return typed Function subclasses", () => {
   it("count compiles to COUNT(...) and is a Count", () => {
     const c = users.get("id").count();
@@ -35,7 +30,6 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
     expect(c).toBeInstanceOf(Nodes.Concat);
     const sql = compile(c);
     expect(sql).toBe('"users"."first" || "users"."last"');
-    // Regression: must NOT emit the old NamedFunction CONCAT(...) form.
     expect(sql).not.toContain("CONCAT(");
   });
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -28,10 +28,6 @@ import { Predications } from "../predications.js";
  * Mirrors: Arel::Attributes::Attribute
  */
 export interface RelationLike {
-  /**
-   * A `SqlLiteral` name (e.g. a `SelectManager#as` / set-op `from()` derived
-   * table) renders bare; `quoteTableName` returns its value unchanged.
-   */
   name: string | SqlLiteral;
   // `TableAlias#table_alias` aliases `:name`, which may be a `SqlLiteral`
   // (Arel::Nodes::TableAlias `alias :table_alias :name`, table_alias.rb); a

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -28,8 +28,10 @@ import { Predications } from "../predications.js";
  * Mirrors: Arel::Attributes::Attribute
  */
 export interface RelationLike {
-  // A `SqlLiteral` name (e.g. a `SelectManager#as` / set-op `from()` derived
-  // table) renders bare; `quoteTableName` returns its value unchanged.
+  /**
+   * A `SqlLiteral` name (e.g. a `SelectManager#as` / set-op `from()` derived
+   * table) renders bare; `quoteTableName` returns its value unchanged.
+   */
   name: string | SqlLiteral;
   // `TableAlias#table_alias` aliases `:name`, which may be a `SqlLiteral`
   // (Arel::Nodes::TableAlias `alias :table_alias :name`, table_alias.rb); a
@@ -39,8 +41,6 @@ export interface RelationLike {
   typeCastForDatabase: (attrName: string, value: unknown) => unknown;
   typeForAttribute: (name: string) => unknown;
   isAbleToTypeCast: () => boolean;
-  // Attribute#lower delegates here (`relation.lower self`), so every relation
-  // that carries attributes must surface FactoryMethods#lower.
   lower: (column: unknown) => NamedFunction;
 }
 
@@ -97,8 +97,6 @@ export class Attribute extends Node {
     return buildQuoted(other, this);
   }
 
-  // -- Ordering --
-
   asc(): Ascending {
     return new Ascending(this);
   }
@@ -154,8 +152,6 @@ export class Attribute extends Node {
     return new BitwiseNot(this);
   }
 
-  // -- Aliasing --
-
   as(other: string): As {
     return new As(this, new SqlLiteral(other, { retryable: true }));
   }
@@ -187,8 +183,6 @@ export class Attribute extends Node {
   average(): Avg {
     return new Avg([this]);
   }
-
-  // -- Extract --
 
   extract(field: string): Extract {
     // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).

--- a/packages/arel/src/attributes/math.test.ts
+++ b/packages/arel/src/attributes/math.test.ts
@@ -32,8 +32,6 @@ describe("MathTest", () => {
     expect(visitor.compile(table.get("id").add(2))).toBe('("users"."id" + 2)');
   });
 
-  // Unparenthesized operators: * and /
-
   it("average should be compatible with *", () => {
     expect(visitor.compile(table.get("id").average().multiply(2))).toBe('AVG("users"."id") * 2');
   });
@@ -73,8 +71,6 @@ describe("MathTest", () => {
   it("attribute node should be compatible with /", () => {
     expect(visitor.compile(table.get("id").divide(2))).toBe('"users"."id" / 2');
   });
-
-  // Parenthesized operators: + - & | ^ << >>
 
   it("average should be compatible with +", () => {
     expect(visitor.compile(table.get("id").average().add(2))).toBe('(AVG("users"."id") + 2)');

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -83,8 +83,6 @@ describe("WindowPredications.over (mixed into Function)", () => {
   });
 
   it("NamedFunction#over with a NamedWindow doubles embedded quotes in the name", () => {
-    // Embedded `"` characters in a window name must be doubled when quoting
-    // the identifier so they do not terminate it early.
     const fn = new Nodes.NamedFunction("MY_FN", [new Nodes.SqlLiteral("x")]);
     const win = new Nodes.NamedWindow('weird"name');
     expect(compile(fn.over(win))).toBe('MY_FN(x) OVER "weird""name"');

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -95,9 +95,6 @@ describe("TestFactoryMethods", () => {
     expect(new Visitors.ToSql(testConnection).compile(f)).toBe("FALSE");
   });
 
-  // Regression: verifies the include(Node, FactoryMethods) call in index.ts
-  // actually attached methods to Node.prototype. If that wiring is dropped,
-  // an arbitrary Node subclass (Equality below) silently loses the API.
   describe("FactoryMethods is mixed into every Node subclass", () => {
     const eq = users.get("id").eq(1);
     it("createTrue available on Equality", () => {

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -36,6 +36,8 @@ _registerCteFactory((name, relation) => new Cte(name, relation));
  * init rather than inside node-expression.ts / infix-operation.ts because
  * the mixin modules transitively import those files via their target-node
  * imports, creating a module-load cycle.
+ *
+ * @noRailsEquivalent ESM load order forces the mixin wiring here; Ruby `include`s in each class body.
  */
 import { include } from "@blazetrails/activesupport";
 import { Node } from "./nodes/node.js";

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -57,11 +57,6 @@ const _NodeExpression = NodeExpression as unknown as new (...args: unknown[]) =>
 const _TreeManager = TreeManager as unknown as new (...args: unknown[]) => TreeManager;
 const _SqlLiteral = SqlLiteral as unknown as new (...args: unknown[]) => SqlLiteral;
 
-/**
- * Modules typed as explicit module interfaces (no string index sig) need
- * a cast to satisfy include()'s runtime constraint. The cast is type-only
- * and runtime semantics are unchanged — include() iterates Object.keys.
- */
 type RuntimeModule = Record<string, (...args: unknown[]) => unknown>;
 const asRuntime = <T>(m: T): RuntimeModule => m as unknown as RuntimeModule;
 include(_Node, asRuntime(FactoryMethods));

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -29,12 +29,14 @@ registerNodeDeps({ Not, Grouping, Or, And });
 registerBinaryInversions({ Equality, In });
 _registerCteFactory((name, relation) => new Cte(name, relation));
 
-// Mix Predications + Math into NodeExpression (so every expression-valued
-// node — Function, Unary, Case, Casted, ...) and into InfixOperation
-// separately (it extends Binary, not NodeExpression). Done here at package
-// init rather than inside node-expression.ts / infix-operation.ts because
-// the mixin modules transitively import those files via their target-node
-// imports, creating a module-load cycle.
+/**
+ * Mix Predications + Math into NodeExpression (so every expression-valued
+ * node — Function, Unary, Case, Casted, ...) and into InfixOperation
+ * separately (it extends Binary, not NodeExpression). Done here at package
+ * init rather than inside node-expression.ts / infix-operation.ts because
+ * the mixin modules transitively import those files via their target-node
+ * imports, creating a module-load cycle.
+ */
 import { include } from "@blazetrails/activesupport";
 import { Node } from "./nodes/node.js";
 import { NodeExpression } from "./nodes/node-expression.js";
@@ -54,9 +56,12 @@ const _Node = Node as unknown as new (...args: unknown[]) => Node;
 const _NodeExpression = NodeExpression as unknown as new (...args: unknown[]) => NodeExpression;
 const _TreeManager = TreeManager as unknown as new (...args: unknown[]) => TreeManager;
 const _SqlLiteral = SqlLiteral as unknown as new (...args: unknown[]) => SqlLiteral;
-// Modules typed as explicit module interfaces (no string index sig) need
-// a cast to satisfy include()'s runtime constraint. The cast is type-only
-// and runtime semantics are unchanged — include() iterates Object.keys.
+
+/**
+ * Modules typed as explicit module interfaces (no string index sig) need
+ * a cast to satisfy include()'s runtime constraint. The cast is type-only
+ * and runtime semantics are unchanged — include() iterates Object.keys.
+ */
 type RuntimeModule = Record<string, (...args: unknown[]) => unknown>;
 const asRuntime = <T>(m: T): RuntimeModule => m as unknown as RuntimeModule;
 include(_Node, asRuntime(FactoryMethods));
@@ -83,7 +88,6 @@ include(_SqlLiteral, Predications);
 include(_SqlLiteral, asRuntime(Expressions));
 include(_SqlLiteral, asRuntime(AliasPredication));
 include(_SqlLiteral, asRuntime(OrderPredications));
-// Function includes WindowPredications and FilterPredications.
 include(FunctionNode, asRuntime(WindowPredications));
 include(FunctionNode, asRuntime(FilterPredications));
 // Filter includes WindowPredications (nodes/filter.rb:6).

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -82,7 +82,6 @@ describe("InsertManagerTest", () => {
     it("noop for empty list", () => {
       const im = new InsertManager();
       im.into(users);
-      // No values set - should still generate partial SQL
       const sql = im.toSql();
       expect(sql).toContain("INSERT INTO");
     });

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -311,7 +311,9 @@ export class Intersect extends Binary {
   }
 }
 
-// Registry for breaking circular deps (Equality→Binary, In→Binary)
+/**
+ * Registry for breaking circular deps (Equality→Binary, In→Binary)
+ */
 const _invertRegistry: {
   Equality?: new (left: NodeOrValue, right: NodeOrValue) => Binary;
   In?: new (left: NodeOrValue, right: NodeOrValue) => Binary;

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -311,9 +311,6 @@ export class Intersect extends Binary {
   }
 }
 
-/**
- * Registry for breaking circular deps (Equality→Binary, In→Binary)
- */
 const _invertRegistry: {
   Equality?: new (left: NodeOrValue, right: NodeOrValue) => Binary;
   In?: new (left: NodeOrValue, right: NodeOrValue) => Binary;

--- a/packages/arel/src/nodes/bound-sql-literal.test.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.test.ts
@@ -78,8 +78,6 @@ describe("BoundSqlLiteralTest", () => {
     });
 
     it("JSON.stringify escapes embedded double-quotes in error message", () => {
-      // SQL has 1 placeholder; 2 binds triggers a count mismatch.
-      // Verifies JSON.stringify correctly escapes the embedded double-quote in the SQL.
       expect(() => new Nodes.BoundSqlLiteral('name = "O\'Brien" AND ?', [1, 2])).toThrow(
         'wrong number of bind variables (2 for 1) in: "name = \\"O\'Brien\\" AND ?"',
       );

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -63,7 +63,6 @@ describe("Arel::Nodes.build_quoted", () => {
   it("unwraps a TreeManager-shaped .ast so the visitor receives a real Node", () => {
     const sub = new SelectManager(users).project(users.get("id"));
     const node = buildQuoted(sub);
-    // SelectStatement (or a Node) — NOT the manager itself.
     expect(node).toBeInstanceOf(Nodes.SelectStatement);
   });
 
@@ -166,8 +165,6 @@ describe("Arel::Nodes::Casted#nil?", () => {
     expect(node.isNil()).toBe(true);
   });
 
-  // quoted_node is build_quoted(other, self), so a nil from an Attribute is
-  // Casted — carrying the column's type-cast context — not a bare Quoted.
   it("is what an Attribute's quoted_node builds for nil, and still renders IS NULL", () => {
     const attr = users.get("id");
     const eq = attr.eq(null);

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -32,8 +32,6 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
     // Rails: casted.rb:50-51 — the `when ..., ActiveModel::Attribute` arm
     // returning `other`. Class dispatch, like Rails.
     if (other instanceof ModelAttribute) return new BindParam(other);
-    // SelectManager / TreeManager — expose a Node `ast`; use that so the
-    // visitor always receives a real Node.
     const maybeAst = (other as { ast?: unknown }).ast;
     if (maybeAst instanceof Node) return maybeAst;
   }

--- a/packages/arel/src/nodes/comment.test.ts
+++ b/packages/arel/src/nodes/comment.test.ts
@@ -23,9 +23,7 @@ describe("CommentTest", () => {
       const mgr = users.project(star);
       mgr.comment("hello */ DROP TABLE users");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
-      // The */ is stripped so the comment stays enclosed
       expect(sql).toContain("/* hello DROP TABLE users */");
-      // There should be exactly one block comment pair
       expect(sql.match(/\/\*/g)!.length).toBe(1);
       expect(sql.match(/\*\//g)!.length).toBe(1);
     });
@@ -35,7 +33,6 @@ describe("CommentTest", () => {
       const mgr = users.project(star);
       mgr.comment("before /* nested */ after");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
-      // Both /* and */ stripped from the value
       expect(sql).toContain("/* before nested after */");
     });
 

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -48,7 +48,6 @@ describe("Arel::Nodes::ExtractTest", () => {
     it("should not mutate the extract", () => {
       const original = new Nodes.Extract(users.get("created_at"), "YEAR");
       const aliased = original.as("y");
-      // Original should remain unchanged (aliased is a new As node)
       expect(original).toBeInstanceOf(Nodes.Extract);
       expect(aliased).toBeInstanceOf(Nodes.As);
     });

--- a/packages/arel/src/nodes/fragments.test.ts
+++ b/packages/arel/src/nodes/fragments.test.ts
@@ -6,7 +6,6 @@ describe("FragmentsTest", () => {
   describe("equality", () => {
     it("fails if joined with something that is not an Arel node", () => {
       const lit = new Nodes.SqlLiteral("foo");
-      // SqlLiteral is a Node, verifying it works correctly
       expect(lit.value).toBe("foo");
       expect(lit).toBeInstanceOf(Nodes.Node);
     });

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -66,8 +66,6 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
     });
 
     it("compiles an all-non-serializable IN as IN (NULL)", () => {
-      // A multi-value array whose values all filter out of castedValues (e.g.
-      // all out-of-range ids) must render `IN (NULL)`, never the invalid `IN ()`.
       const filteringRelation = {
         name: "users",
         typeForAttribute: () => ({ isSerializable: () => false, serialize: (v: unknown) => v }),

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -133,14 +133,16 @@ export class Overlaps extends InfixOperation {
   }
 }
 
-// Declaration merging: tell TypeScript that InfixOperation instances carry
-// the Predications + Math method surfaces mixed in from index.ts via
-// `include()`. The runtime wiring lives there to avoid a circular module
-// cycle between infix-operation.ts and math.ts.
-// Inline `typeof import(...)` keeps the mixin modules out of this file's
-// static import graph (math.ts imports InfixOperation for its class
-// references; a static reverse import would cycle).
-// See node-expression.ts for why these use the explicit module interfaces.
+/**
+ * Declaration merging: tell TypeScript that InfixOperation instances carry
+ * the Predications + Math method surfaces mixed in from index.ts via
+ * `include()`. The runtime wiring lives there to avoid a circular module
+ * cycle between infix-operation.ts and math.ts.
+ * Inline `typeof import(...)` keeps the mixin modules out of this file's
+ * static import graph (math.ts imports InfixOperation for its class
+ * references; a static reverse import would cycle).
+ * See node-expression.ts for why these use the explicit module interfaces.
+ */
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -142,6 +142,8 @@ export class Overlaps extends InfixOperation {
  * static import graph (math.ts imports InfixOperation for its class
  * references; a static reverse import would cycle).
  * See node-expression.ts for why these use the explicit module interfaces.
+ *
+ * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -30,7 +30,6 @@ describe("MatchesTest", () => {
       const node = users.get("name").matches("x%", "!");
       const visitor = new Visitors.ToSql(testConnection);
       const [sql] = visitor.compileWithBinds(node);
-      // ESCAPE value must be inlined ('!'), not turned into a bind placeholder.
       expect(sql).toContain("ESCAPE '!'");
       expect(sql).not.toContain("ESCAPE ?");
     });

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -30,9 +30,6 @@ export class NamedFunction extends Function {
     if (!window) return new Over(this, null);
     if (typeof window === "string") return new Over(this, new SqlLiteral(window));
     if (window instanceof NamedWindow) {
-      // Match the identifier-quoting policy used elsewhere in ToSql:
-      // double up embedded quotes so a name like `w"x` doesn't escape
-      // the identifier and produce malformed (or injectable) SQL.
       const escaped = window.name.replace(/"/g, '""');
       return new Over(this, new SqlLiteral(`"${escaped}"`));
     }

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -44,6 +44,8 @@ export abstract class NodeExpression extends Node {
  * extends it). A direct import would deadlock the class-extends
  * expression at module-load time; instead casted.ts registers itself here
  * at its own module-init.
+ *
+ * @noRailsEquivalent ESM has no call-time constant resolution; see CLAUDE.md, "Call-time constant resolution".
  */
 let buildQuoted: ((other: unknown, ctx: unknown) => Node) | undefined;
 export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node): void {
@@ -59,6 +61,8 @@ export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node):
  * (method-syntax) so subclasses like Function/Grouping/UnaryOperation that
  * override `as`/`asc`/`desc` with method declarations don't trip the
  * property-vs-method override error.
+ *
+ * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -39,23 +39,27 @@ export abstract class NodeExpression extends Node {
   }
 }
 
-// `buildQuoted` lives in casted.ts, which imports NodeExpression (Casted
-// extends it). A direct import would deadlock the class-extends
-// expression at module-load time; instead casted.ts registers itself here
-// at its own module-init.
+/**
+ * `buildQuoted` lives in casted.ts, which imports NodeExpression (Casted
+ * extends it). A direct import would deadlock the class-extends
+ * expression at module-load time; instead casted.ts registers itself here
+ * at its own module-init.
+ */
 let buildQuoted: ((other: unknown, ctx: unknown) => Node) | undefined;
 export function registerBuildQuoted(fn: (other: unknown, ctx: unknown) => Node): void {
   buildQuoted = fn;
 }
 
-// Using `typeof import(...)` inline avoids pulling the mixin modules into
-// this file's static import graph (they transitively depend on node
-// classes that extend NodeExpression), while still giving TypeScript the
-// method-surface signatures via declaration merging.
-// AliasPredication / OrderPredications use their explicit module interfaces
-// (method-syntax) so subclasses like Function/Grouping/UnaryOperation that
-// override `as`/`asc`/`desc` with method declarations don't trip the
-// property-vs-method override error.
+/**
+ * Using `typeof import(...)` inline avoids pulling the mixin modules into
+ * this file's static import graph (they transitively depend on node
+ * classes that extend NodeExpression), while still giving TypeScript the
+ * method-surface signatures via declaration merging.
+ * AliasPredication / OrderPredications use their explicit module interfaces
+ * (method-syntax) so subclasses like Function/Grouping/UnaryOperation that
+ * override `as`/`asc`/`desc` with method declarations don't trip the
+ * property-vs-method override error.
+ */
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -180,9 +180,7 @@ describe("Table.engine", () => {
   it("Node#toSql() compiles through the engine connection's visitor", () => {
     const users = new Table("users");
     const node = users.get("name").isDistinctFrom(null);
-    // Default engine (generic visitor, supplied by the suite setup).
     expect(node.toSql()).toBe(`"users"."name" IS NOT NULL`);
-    // An engine whose connection carries the SQLite visitor.
     expect(node.toSql(sqliteEngine)).toBe(`"users"."name" IS NOT NULL`);
   });
 
@@ -195,7 +193,6 @@ describe("Table.engine", () => {
     expect(mgr.toSql()).toContain("END = 0");
     expect(mgr.toSql()).not.toContain("IS NOT DISTINCT FROM");
     const sqlite = mgr.toSql(sqliteEngine);
-    // SQLite emits IS for IS NOT DISTINCT FROM; Quoted(true) inlines as 1 in SQLite.
     expect(sqlite).toContain('"users"."active" IS 1');
     expect(sqlite).not.toContain("IS NOT DISTINCT FROM");
   });

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -117,10 +117,6 @@ interface NodeRegistry {
   And?: new (children: Node[]) => Node;
 }
 
-/**
- * Registry for breaking circular dependencies.
- * Populated by the index module after all classes are loaded.
- */
 const _registry: NodeRegistry = {};
 
 function assertRegistered(name: keyof NodeRegistry): void {
@@ -200,6 +196,8 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
  * interface (vs. `Included<typeof FactoryMethods>`) is required: under
  * composite/declaration emit, the cycle Node ↔ FactoryMethods would force
  * tsc to fall back to a structural shape with a string index signature.
+ *
+ * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
 type _FactoryMethodsModule = import("../factory-methods.js").FactoryMethodsModule;
 

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -117,8 +117,10 @@ interface NodeRegistry {
   And?: new (children: Node[]) => Node;
 }
 
-// Registry for breaking circular dependencies.
-// Populated by the index module after all classes are loaded.
+/**
+ * Registry for breaking circular dependencies.
+ * Populated by the index module after all classes are loaded.
+ */
 const _registry: NodeRegistry = {};
 
 function assertRegistered(name: keyof NodeRegistry): void {
@@ -147,7 +149,6 @@ function fnv1a32(input: string): number {
     hash ^= input.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193);
   }
-  // Force unsigned 32-bit.
   return hash >>> 0;
 }
 
@@ -164,8 +165,6 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
   if (value instanceof Date) return `Date(${value.toISOString()})`;
 
   if (typeof value === "object") {
-    // Use recursion-stack cycle detection (not global "seen"), so repeated/shared references
-    // serialize consistently rather than being misclassified as circular.
     if (seen.has(value)) return "[Circular]";
     seen.add(value);
 
@@ -193,13 +192,15 @@ function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()):
   return String(value);
 }
 
-// Methods supplied by the FactoryMethods mixin (runtime wiring in ../index.ts).
-// The aliased import keeps this type-only — pulling factory-methods.ts into
-// the static import graph here would create a module-load cycle, since it
-// imports concrete Node subclasses. The explicit `FactoryMethodsModule`
-// interface (vs. `Included<typeof FactoryMethods>`) is required: under
-// composite/declaration emit, the cycle Node ↔ FactoryMethods would force
-// tsc to fall back to a structural shape with a string index signature.
+/**
+ * Methods supplied by the FactoryMethods mixin (runtime wiring in ../index.ts).
+ * The aliased import keeps this type-only — pulling factory-methods.ts into
+ * the static import graph here would create a module-load cycle, since it
+ * imports concrete Node subclasses. The explicit `FactoryMethodsModule`
+ * interface (vs. `Included<typeof FactoryMethods>`) is required: under
+ * composite/declaration emit, the cycle Node ↔ FactoryMethods would force
+ * tsc to fall back to a structural shape with a string index signature.
+ */
 type _FactoryMethodsModule = import("../factory-methods.js").FactoryMethodsModule;
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type,

--- a/packages/arel/src/nodes/sql-literal.test.ts
+++ b/packages/arel/src/nodes/sql-literal.test.ts
@@ -73,7 +73,6 @@ describe("SqlLiteralTest", () => {
   describe("addition", () => {
     it("fails if joined with something that is not an Arel node", () => {
       const lit = new Nodes.SqlLiteral("foo");
-      // SqlLiteral is a Node, verifying it works correctly
       expect(lit.value).toBe("foo");
       expect(lit).toBeInstanceOf(Nodes.Node);
     });

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -70,7 +70,6 @@ export class SqlLiteral extends Node {
   }
 
   toYAML(): string {
-    // Minimal YAML-ish representation for test parity (no external deps).
     const escaped = this.value.replace(/\n/g, "\\n");
     return `---\n!sql_literal\nvalue: ${JSON.stringify(escaped)}`;
   }

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -3,8 +3,6 @@ import { Binary } from "./binary.js";
 import { Cte } from "./cte.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Attribute } from "../attributes/attribute.js";
-// Cyclic with table.ts (which imports TableAlias); safe because the binding is
-// only dereferenced inside `get()`, never at class-evaluation time.
 import { Table } from "../table.js";
 
 /** Structural view of `TableAlias#relation`.

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -20,13 +20,11 @@ export class Window extends Node {
   }
 
   order(...expr: (Node | string)[]): this {
-    // FIXME: We SHOULD NOT be converting these to SqlLiteral automatically
     this.orders.push(...expr.map((x) => (typeof x === "string" ? new SqlLiteral(x) : x)));
     return this;
   }
 
   partition(...expr: (Node | string)[]): this {
-    // FIXME: We SHOULD NOT be converting these to SqlLiteral automatically
     this.partitions.push(...expr.map((x) => (typeof x === "string" ? new SqlLiteral(x) : x)));
     return this;
   }

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -15,7 +15,6 @@ describe("Predications.groupingAny / groupingAll", () => {
   it("groupingAny dispatches by method-id and folds with OR (Grouping)", () => {
     const out = Predications.groupingAny.call(users.attr("id"), "eq", [1, 2, 3]);
     expect(out).toBeInstanceOf(Nodes.Grouping);
-    // The grouped expression is an Or chain over three Equality nodes.
     const inner = out.expr as Nodes.Or;
     expect(inner).toBeInstanceOf(Nodes.Or);
   });
@@ -62,17 +61,12 @@ describe("Predications.groupingAny / groupingAll", () => {
     expect(m.escape).toEqual(new Nodes.Quoted("!"));
     expect(m.caseSensitive).toBe(true);
 
-    // does_not_match_any passes no case_sensitive, so the predicate default
-    // (false) must win rather than escape leaking into that slot.
     const d = attr.doesNotMatchAny(["a%"], "!").expr as Nodes.DoesNotMatch;
     expect(d.escape).toEqual(new Nodes.Quoted("!"));
     expect(d.caseSensitive).toBe(false);
   });
 
   it("groupingAny throws a clear TypeError when the method-id isn't callable", () => {
-    // Regression for the dispatch-safety concern: a typo in the
-    // method-id should fail loudly, not blow up with "Cannot read
-    // property 'call' of undefined".
     const attr = users.attr("id");
     expect(() => Predications.groupingAny.call(attr, "noSuchMethod", [1])).toThrowError(
       /noSuchMethod.*Attribute/,
@@ -81,8 +75,6 @@ describe("Predications.groupingAny / groupingAll", () => {
 });
 
 describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
-  // A PredicationHost carrying the mixin's own isInfinity / isUnboundable, as a
-  // class including Predications would — isOpenEnded dispatches through `this`.
   const host = {
     quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node,
     quotedArray: (vs: unknown[]): Nodes.Node[] => vs as Nodes.Node[],
@@ -202,9 +194,6 @@ describe("Attribute private helpers (mirror Predications)", () => {
   });
 
   it("isUnboundable duck-types the protocol rather than always returning false", () => {
-    // Regression for the stub these delegated to: it hardcoded `false`, so
-    // anything routing `between` through Attribute#isOpenEnded silently lost
-    // unboundable collapse (#4433). They now share the real implementation.
     const attr = users.attr("id") as AttributePrivates;
     expect(attr.isUnboundable({ isUnboundable: () => -1 as const })).toBe(-1);
     expect(attr.isOpenEnded({ isUnboundable: () => 1 as const })).toBe(true);
@@ -223,7 +212,6 @@ describe("between / notBetween self-dispatch (mirror Rails' implicit self)", () 
 
   it("between honors a host override of isInfinity", () => {
     const attr = new OverridingAttribute(users, "id");
-    // Both bounds read as open-ended, and begin reports +Infinity -> in([]).
     expect(attr.between({ begin: 1, end: 2, excludeEnd: false })).toBeInstanceOf(Nodes.In);
   });
 

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -78,10 +78,6 @@ describe("Predications range semantics", () => {
       expect(((node as Nodes.In).right as unknown[]).length).toBe(0);
     });
 
-    // A bound value exposing `isUnboundable()` (a QueryAttribute bind whose
-    // value is out of range for its column, or the RangeHandler sentinel)
-    // participates in the open-ended / unboundable decision tree exactly like
-    // ±Infinity, so an out-of-range bound never reaches the visitor as a bind.
     const unboundable = (sign: 1 | -1) => ({ isUnboundable: () => sign });
 
     it("unboundable begin (+1) collapses to In([])", () => {

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -7,21 +7,18 @@ describe("PredicationsMixin", () => {
 
   describe("on InfixOperation (Math chain)", () => {
     it("Division#subtract chains via the Math mixin", () => {
-      // arel-24: users[:age] / 3 - users[:other]
       const expr = users.get("age").divide(3).subtract(users.get("other"));
       const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."age" / 3 - "users"."other")');
     });
 
     it("BitwiseAnd#gt produces a GROUP BY / HAVING-style comparison", () => {
-      // arel-25: (users[:bitmap] & 16).gt(0)
       const expr = users.get("bitmap").bitwiseAnd(16).gt(0);
       const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" & 16) > 0');
     });
 
     it("BitwiseShiftLeft#gt chains through Predications", () => {
-      // arel-28: (users[:bitmap] << 1).gt(0)
       const expr = users.get("bitmap").bitwiseShiftLeft(1).gt(0);
       const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" << 1) > 0');
@@ -30,7 +27,6 @@ describe("PredicationsMixin", () => {
 
   describe("on UnaryOperation (via NodeExpression mixin)", () => {
     it("BitwiseNot#gt produces a predicate", () => {
-      // arel-30: (~users[:bitmap]).gt(0)
       const expr = new Nodes.BitwiseNot(users.get("bitmap")).gt(0);
       const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe(' ~ "users"."bitmap" > 0');
@@ -69,7 +65,6 @@ describe("PredicationsMixin", () => {
 
   describe("on NamedFunction (via Function → NodeExpression mixin)", () => {
     it("count().gt(n) produces HAVING-ready comparison", () => {
-      // arel-47: photos[:id].count.gt(5)
       const expr = users.get("id").count().gt(5);
       const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('COUNT("users"."id") > 5');

--- a/packages/arel/src/predications.trails.test.ts
+++ b/packages/arel/src/predications.trails.test.ts
@@ -8,8 +8,6 @@ import { Table, Nodes, Visitors } from "./index.js";
 describe("PredicationsMixin in/notIn Enumerable arm", () => {
   const users = new Table("users");
   const visitor = new Visitors.ToSql(testConnection);
-  // An InfixOperation, not an Attribute — this exercises the Predications
-  // mixin's own `in`/`notIn`, which Attribute overrides.
   const expr = () => users.get("bitmap").bitwiseAnd(16);
 
   describe("#in", () => {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -267,8 +267,6 @@ export const Predications = {
     ): Node;
   },
 
-  // -- _any / _all variants --
-
   eqAny(
     this: PredicationHost & GroupingFolders & { eq(o: unknown): Node },
     others: unknown[],
@@ -496,11 +494,13 @@ export const Predications = {
   },
 };
 
-// Pins GroupingFolders (above) against the real folder implementations. The
-// interface exists only because the *_any/*_all variants cannot name
-// `Predications` while it is still being defined; this assertion makes the two
-// declarations fail to compile if they ever disagree, so the second
-// declaration cannot become the kind of drifting duplicate this file just
-// removed from the *_any/*_all fold paths.
+/**
+ * Pins GroupingFolders (above) against the real folder implementations. The
+ * interface exists only because the *_any/*_all variants cannot name
+ * `Predications` while it is still being defined; this assertion makes the two
+ * declarations fail to compile if they ever disagree, so the second
+ * declaration cannot become the kind of drifting duplicate this file just
+ * removed from the *_any/*_all fold paths.
+ */
 const _groupingFoldersMatchImplementation: GroupingFolders = Predications;
 void _groupingFoldersMatchImplementation;

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -501,6 +501,8 @@ export const Predications = {
  * declarations fail to compile if they ever disagree, so the second
  * declaration cannot become the kind of drifting duplicate this file just
  * removed from the *_any/*_all fold paths.
+ *
+ * @noRailsEquivalent TypeScript-only compile-time assertion; Ruby reopens the module instead.
  */
 const _groupingFoldersMatchImplementation: GroupingFolders = Predications;
 void _groupingFoldersMatchImplementation;

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -1201,7 +1201,6 @@ describe("SelectManagerTest", () => {
     mgr.project(star);
     const win = mgr.window("w");
     win.order(users.get("created_at").asc());
-    // The window should be in core.windows
     expect(mgr.toSql()).toContain("WINDOW");
   });
 
@@ -1504,7 +1503,6 @@ describe("SelectManagerTest", () => {
         .project(star)
         .optimizerHints("HINT */ DROP TABLE users --");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
-      // `*/` stripped; `--` left intact, matching sanitize_as_sql_comment.
       expect(sql).toBe('SELECT /*+ HINT DROP TABLE users -- */ * FROM "users"');
     });
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -457,7 +457,6 @@ export class SelectManager extends TreeManager {
   protected collapse(exprs: unknown[]): Node {
     exprs = exprs
       .filter((expr) => expr !== null && expr !== undefined)
-      // FIXME: Don't do this automatically
       .map((expr) => (typeof expr === "string" ? sql(expr) : (expr as Node)));
     if (exprs.length === 1) return exprs[0] as Node;
     return this.createAnd(exprs as Node[]);

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -224,9 +224,6 @@ describe("TableTest", () => {
     expect(users.star.toSql()).toBe('"users".*');
   });
 
-  // Schema-qualified quoting is an adapter behaviour (ANSI dot-splitting); the
-  // suite's FakeRecord engine wraps the whole name in one pair of quotes, so
-  // these name a real quoting connection at the call site to exercise the split.
   it("star splits schema-qualified name", () => {
     expect(new Visitors.ToSql(testConnection).compile(new Table("test_schema.things").star)).toBe(
       '"test_schema"."things".*',

--- a/packages/arel/src/test-helpers/default-quoter.ts
+++ b/packages/arel/src/test-helpers/default-quoter.ts
@@ -132,8 +132,6 @@ function quoteScalar(this: ArelConnection, value: unknown): string {
   if (typeof value === "number") return String(value);
   if (typeof value === "bigint") return String(value);
   if (typeof value === "boolean") return value ? this.quotedTrue() : this.quotedFalse();
-  // Normalise all typed-array views to Uint8Array before handing off so
-  // quotedBinary can rely on a consistent shape.
   if (ArrayBuffer.isView(value)) {
     const bytes =
       value instanceof Uint8Array
@@ -154,16 +152,15 @@ function quoteScalar(this: ArelConnection, value: unknown): string {
     const hasCustomToString =
       proto === Object.prototype && value.toString !== Object.prototype.toString;
     if ((proto === Object.prototype || proto === null) && !hasCustomToString) {
+      let json: string | undefined;
       try {
-        const json = JSON.stringify(value);
-        if (json !== undefined) return `'${json.replace(/'/g, "''")}'`;
+        json = JSON.stringify(value);
       } catch {
-        // circular references, BigInt, etc. — fall through
+        json = undefined;
       }
+      if (json !== undefined) return `'${json.replace(/'/g, "''")}'`;
     }
   }
-  // Only escape single quotes here; backslash escaping is dialect-specific
-  // and handled by quoteString (MySQL/PG adapters override quote() as needed).
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -77,9 +77,11 @@ export abstract class TreeManager {
   }
 }
 
-// Methods supplied by the FactoryMethods mixin (runtime wiring in ./index.ts).
-// See node.ts for why this uses the explicit `FactoryMethodsModule` interface
-// rather than `Included<typeof FactoryMethods>`.
+/**
+ * Methods supplied by the FactoryMethods mixin (runtime wiring in ./index.ts).
+ * See node.ts for why this uses the explicit `FactoryMethodsModule` interface
+ * rather than `Included<typeof FactoryMethods>`.
+ */
 type _FactoryMethodsModule = import("./factory-methods.js").FactoryMethodsModule;
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-object-type,

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -81,6 +81,8 @@ export abstract class TreeManager {
  * Methods supplied by the FactoryMethods mixin (runtime wiring in ./index.ts).
  * See node.ts for why this uses the explicit `FactoryMethodsModule` interface
  * rather than `Included<typeof FactoryMethods>`.
+ *
+ * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
 type _FactoryMethodsModule = import("./factory-methods.js").FactoryMethodsModule;
 

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -19,7 +19,7 @@ import { DotNode } from "./dot.js";
  */
 function visitStandalone(value: unknown): string {
   const v = new Visitors.Dot();
-  v.compile(new Nodes.SqlLiteral("")); // initialize state
+  v.compile(new Nodes.SqlLiteral(""));
   (v as unknown as { visit(o: unknown): void }).visit(value);
   return (v as unknown as { toDot(): string }).toDot();
 }
@@ -100,7 +100,6 @@ describe("TestDot", () => {
     const node = new Nodes.And([users.get("id"), users.get("name")]);
     const out = dot.compile(node);
     expect(out).toContain("And");
-    // visit__children walks each child under an index-labeled edge.
     expect(out).toContain('[label="0"]');
     expect(out).toContain('[label="1"]');
   });
@@ -115,7 +114,6 @@ describe("TestDot", () => {
   it("Arel Nodes SqlLiteral", () => {
     const node = new Nodes.SqlLiteral("RAW SQL");
     const out = dot.compile(node);
-    // visit_String stashes the literal as a side-field, not a child node.
     expect(out).toContain("RAW SQL");
   });
 
@@ -155,12 +153,10 @@ describe("TestDot", () => {
       expect(out).toMatch(/^digraph "Arel" \{\n/);
       expect(out).toContain("node [width=0.375,height=0.25,shape=record];");
       expect(out).toMatch(/\n\}$/);
-      // A leaf node: id [label="<f0>Name"];
       expect(out).toMatch(/^\d+ \[label="<f0>Distinct"\];$/m);
     });
 
     it("emits one edge per visit_edge declaration with the field name as label", () => {
-      // Binary -> left, right (two visit_edge calls).
       const node = new Nodes.Equality(users.get("id"), new Nodes.SqlLiteral("1"));
       const out = dot.compile(node);
       expect(out).toMatch(/-> \d+ \[label="left"\];/);
@@ -180,7 +176,6 @@ describe("TestDot", () => {
 
     it("collapses to a leaf for visit_NoEdges nodes (CurrentRow, Distinct)", () => {
       const out = dot.compile(new Nodes.CurrentRow());
-      // Single node, no edges.
       const edges = (out.match(/->/g) ?? []).length;
       expect(edges).toBe(0);
     });
@@ -188,8 +183,6 @@ describe("TestDot", () => {
     it("escapes embedded double-quotes in side-field labels (quote helper)", () => {
       const node = new Nodes.SqlLiteral('say "hi"');
       const out = dot.compile(node);
-      // SqlLiteral is dispatched as visit_String — the value becomes a
-      // side-field on the parent node with quote() escaping the `"`.
       expect(out).toContain('say \\"hi\\"');
     });
 
@@ -202,10 +195,10 @@ describe("TestDot", () => {
         visit(o: unknown): void;
         toDot(): string;
       };
-      v.compile(new Nodes.SqlLiteral("seed")); // initialize state
+      v.compile(new Nodes.SqlLiteral("seed"));
       (v as unknown as Internals).visit(null);
       const out = (v as unknown as Internals).toDot();
-      expect(out).toMatch(/<f0>NilClass\|<f1>"/); // no characters between |<f1> and the closing "
+      expect(out).toMatch(/<f0>NilClass\|<f1>"/);
       expect(out).not.toContain("null");
       expect(out).not.toContain("undefined");
     });
@@ -228,7 +221,7 @@ describe("TestDot", () => {
         visitSymbol(o: unknown): void;
       };
       const iv = v as unknown as WithBigDecimal;
-      v.compile(new Nodes.SqlLiteral("seed")); // initialize internal state
+      v.compile(new Nodes.SqlLiteral("seed"));
       const node = new DotNode("Integer", 0);
       (v as unknown as { nodes: DotNode[] }).nodes.push(node);
       iv.withNode(node, () => {
@@ -260,7 +253,6 @@ describe("TestDot", () => {
         iv.visitSet(new Set([new Nodes.SqlLiteral("a"), new Nodes.SqlLiteral("b")]));
       });
       const out = iv.toDot();
-      // visit_Array walks each member under an index-labeled edge.
       expect(out).toMatch(/-> \d+ \[label="0"\];/);
       expect(out).toMatch(/-> \d+ \[label="1"\];/);
     });
@@ -378,8 +370,6 @@ describe("TestDot", () => {
       (v as unknown as Internals).visit(42);
       (v as unknown as Internals).visit(42);
       const out = (v as unknown as Internals).toDot();
-      // Booleans and numbers each fire a single labeled node — repeats
-      // shouldn't allocate new ones.
       const trueMatches = out.match(/<f0>TrueClass\|<f1>true"\];/g) ?? [];
       expect(trueMatches.length).toBe(1);
       const fortyTwoMatches = out.match(/<f0>Integer\|<f1>42"\];/g) ?? [];
@@ -399,8 +389,6 @@ describe("TestDot", () => {
       (v as unknown as Internals).visit(a);
       (v as unknown as Internals).visit(b);
       const out = (v as unknown as Internals).toDot();
-      // Two Table nodes (one per Table instance) AND two String "users"
-      // nodes (one per visit_String, since strings shouldn't dedupe).
       const tableMatches = out.match(/<f0>Table"\];/g) ?? [];
       expect(tableMatches.length).toBe(2);
       const stringUsersMatches = out.match(/<f0>String\|<f1>users"\];/g) ?? [];
@@ -419,7 +407,6 @@ describe("TestDot", () => {
       expect(out).toContain("Exists");
       expect(out).toMatch(/-> \d+ \[label="expressions"\];/);
       expect(out).toMatch(/-> \d+ \[label="alias"\];/);
-      // Generic Function visitor would have emitted a `distinct` edge.
       expect(out).not.toMatch(/-> \d+ \[label="distinct"\];/);
     });
 
@@ -433,14 +420,10 @@ describe("TestDot", () => {
     });
 
     it("non-Node bind values (ActiveModel::Attribute shape) don't crash", () => {
-      // Regression: Dot.visit used to call super.visit on any non-primitive
-      // non-array non-plain-object value, throwing UnsupportedVisitError
-      // on a class instance the dispatch table didn't know about.
       const attribute = ModelAttribute.fromDatabase("x", 42, new ValueType());
       const bind = new Nodes.BindParam(attribute);
       const out = dot.compile(bind);
       expect(out).toContain("BindParam");
-      // visitActiveModelAttribute walks valueBeforeTypeCast.
       expect(out).toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
       expect(out).toContain("42");
     });
@@ -503,9 +486,6 @@ describe("TestDot", () => {
     });
 
     it("a record derived from a null-prototype record routes to visit_Hash", () => {
-      // The prototype here has no `constructor` at all, which must not be
-      // read as "some class other than Object" — both halves are records,
-      // so the derived value is a Hash like any other.
       const base: Record<string, unknown> = Object.create(null);
       base.inherited = "nope";
       const derived: Record<string, unknown> = Object.create(base);

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -71,9 +71,6 @@ export class Dot extends Visitor {
   private static readonly NIL_SENTINEL = Symbol("Dot.NIL_SENTINEL");
 
   override accept(object: Node, collector?: unknown): { value: string } {
-    // Lazily register Table — at static-block time `Table` (imported from
-    // ../table.js) is a partial forwarding ref due to a circular import via
-    // tree-manager.js. By the first instance call the class is fully loaded.
     if (!this.dispatch.has(Table)) {
       this.dispatch.set(Table, "visitArelTable");
     }
@@ -90,10 +87,6 @@ export class Dot extends Visitor {
     sink.append(this.toDot());
     return sink as { value: string };
   }
-
-  // ---------------------------------------------------------------------
-  // visit_* methods (per-node-type edge declarations)
-  // ---------------------------------------------------------------------
 
   protected visitArelNodesFunction(o: Nodes.Function): void {
     this.visitEdge(o, "expressions");
@@ -180,9 +173,7 @@ export class Dot extends Visitor {
   }
 
   /** Aliased to CurrentRow / Distinct in dispatch (Rails: `alias`). */
-  protected visitNoEdges(_o: Node): void {
-    // intentionally left blank
-  }
+  protected visitNoEdges(_o: Node): void {}
 
   /** Rails: `alias :visit_Arel_Nodes_CurrentRow :visit__no_edges` (dot.rb:104). */
   protected visitArelNodesCurrentRow(o: Node): void {
@@ -412,10 +403,6 @@ export class Dot extends Visitor {
     this.visitEdge(o, "default");
   }
 
-  // ---------------------------------------------------------------------
-  // Core machinery (visit, edge, with_node, quote, to_dot)
-  // ---------------------------------------------------------------------
-
   /**
    * Mirrors Rails' Dot#visit_edge — descend into a named field. Rails uses
    * `o.send(method)`, which raises `NoMethodError` on a typo; we mirror
@@ -456,7 +443,7 @@ export class Dot extends Visitor {
     const seenKey: unknown = (() => {
       if (object === null || object === undefined) return Dot.NIL_SENTINEL;
       const t = typeof object;
-      if (t === "object") return object; // reference identity
+      if (t === "object") return object;
       if (t === "boolean") return `boolean:${object as boolean}`;
       if (t === "number") {
         const n = object as number;
@@ -465,8 +452,8 @@ export class Dot extends Visitor {
         return `number:${n}`;
       }
       if (t === "bigint") return `bigint:${(object as bigint).toString()}`;
-      if (t === "symbol") return object; // Symbol identity is reference-like
-      return undefined; // strings: no dedupe
+      if (t === "symbol") return object;
+      return undefined;
     })();
 
     if (seenKey !== undefined) {
@@ -543,10 +530,6 @@ export class Dot extends Visitor {
       });
       return `${n.id} [label="${label}"];`;
     });
-    // Every visit() in this Dot opens a Node and routes through withNode,
-    // which sets the incoming edge's `to`. So `e.to` is always populated
-    // by the time toDot runs — assert it (rather than silently dropping
-    // edges) so a regression that breaks the invariant fails loudly.
     const edgeLines = this.edges.map((e) => {
       if (!e.to) {
         throw new Error(`Dot: edge "${e.name}" has no destination node`);
@@ -615,7 +598,6 @@ export class Dot extends Visitor {
 
   static {
     const reg = (ctor: NodeCtor, m: string) => Dot.dispatchCache().set(ctor, m);
-    // Function family
     reg(Nodes.Function, "visitArelNodesFunction");
     // Each aggregate has its own Rails alias chain; Trails dispatches them
     // explicitly to keep the Rails-named helper visible.
@@ -627,7 +609,6 @@ export class Dot extends Visitor {
     reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
     reg(Nodes.Count, "visitArelNodesCount");
     reg(Nodes.Extract, "visitArelNodesExtract");
-    // Unary / Binary / specialized
     reg(Nodes.Unary, "visitArelNodesUnary");
     reg(Nodes.Binary, "visitArelNodesBinary");
     reg(Nodes.UnaryOperation, "visitArelNodesUnaryOperation");
@@ -642,14 +623,11 @@ export class Dot extends Visitor {
     reg(Nodes.NamedWindow, "visitArelNodesNamedWindow");
     reg(Nodes.CurrentRow, "visitArelNodesCurrentRow");
     reg(Nodes.Distinct, "visitArelNodesDistinct");
-    // Statements
     reg(Nodes.InsertStatement, "visitArelNodesInsertStatement");
     reg(Nodes.SelectCore, "visitArelNodesSelectCore");
     reg(Nodes.SelectStatement, "visitArelNodesSelectStatement");
     reg(Nodes.UpdateStatement, "visitArelNodesUpdateStatement");
     reg(Nodes.DeleteStatement, "visitArelNodesDeleteStatement");
-    // Misc — `Table` is registered lazily in accept() (it's mid-load
-    // here due to a circular import via tree-manager).
     reg(Nodes.Casted, "visitArelNodesCasted");
     reg(Nodes.HomogeneousIn, "visitArelNodesHomogeneousIn");
     reg(Nodes.Attribute, "visitArelAttributesAttribute");
@@ -667,8 +645,6 @@ export class Dot extends Visitor {
     // ctor-keyed table (the prototype walk covers Attribute subclasses).
     reg(ModelAttribute, "visitActiveModelAttribute");
     reg(Set, "visitSet");
-    // Quoted, True, False, BoundSqlLiteral, Fragments don't extend any
-    // ancestor with a useful Dot handler — register explicitly as leaves.
     reg(Nodes.Quoted, "visitNoEdges");
     reg(Nodes.True, "visitNoEdges");
     reg(Nodes.False, "visitNoEdges");
@@ -676,8 +652,5 @@ export class Dot extends Visitor {
     reg(Nodes.Fragments, "visitNoEdges");
     reg(Nodes.SelectOptions, "visitNoEdges");
     reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
-    // Other Trails nodes inherit from registered ancestors (Unary/Binary/
-    // InfixOperation/Ordering/Function), so the Visitor.resolveDispatch
-    // prototype walk routes them through the right handler at first use.
   }
 }

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -220,9 +220,6 @@ describe("MysqlTest", () => {
   });
 });
 
-// Audit follow-up: verify the MySQL dialect overrides land on the
-// previously-missing visit methods (Bin / UnqualifiedColumn /
-// IsDistinctFrom / IsNotDistinctFrom / Regexp / NotRegexp / Cte).
 describe("MySQL dialect overrides (audit follow-up)", () => {
   const users = new Table("users");
   const compile = (n: Nodes.Node): string => new Visitors.MySQL(mysqlTestConnection).compile(n);
@@ -366,9 +363,6 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
     });
 
     it("buildSubselect adds DISTINCT when the subselect has no LIMIT/OFFSET/ORDER", () => {
-      // JOIN + GROUP BY + HAVING (no LIMIT/OFFSET/ORDER): super clones
-      // and clears limit/offset/orders on the rewritten stmt, build_subselect
-      // sees an `o` with none of those → MySQL adds DISTINCT to materialize.
       const stmt = buildUpdate({ withJoin: true, groups: true, havings: true });
       const out = prep.prepareUpdateStatement(stmt);
       const sql = visitor.compile(out);
@@ -403,7 +397,6 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
     const inner = new SelectManager(users).project(users.get("id"));
     const cte = new Nodes.Cte("recent", inner.ast);
     expect(compile(cte)).toMatch(/^`recent` AS \(/);
-    // Embedded backticks must be doubled.
     const weird = new Nodes.Cte("we`ird", inner.ast);
     expect(compile(weird)).toMatch(/^`we``ird` AS \(/);
   });

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -67,11 +67,6 @@ export class MySQL extends ToSql {
     return collector;
   }
 
-  /**
-   * MySQL's null-safe equality is `<=>`. The standard `IS [NOT] DISTINCT
-   * FROM` is supported only on MySQL 8.0.14+; the operator form works
-   * on every MySQL version.
-   */
   protected override visitArelNodesIsNotDistinctFrom(
     o: Nodes.IsNotDistinctFrom,
     collector: SQLString,

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -38,10 +38,6 @@ export class MySQL extends ToSql {
     return collector;
   }
 
-  // :'(
-  // To retrieve all rows from a certain offset up to the end of the result set,
-  // you can use some large number for the second parameter.
-  // https://dev.mysql.com/doc/refman/en/select.html
   protected override visitArelNodesSelectStatement(
     o: Nodes.SelectStatement,
     collector: SQLString,
@@ -71,9 +67,11 @@ export class MySQL extends ToSql {
     return collector;
   }
 
-  // MySQL's null-safe equality is `<=>`. The standard `IS [NOT] DISTINCT
-  // FROM` is supported only on MySQL 8.0.14+; the operator form works
-  // on every MySQL version.
+  /**
+   * MySQL's null-safe equality is `<=>`. The standard `IS [NOT] DISTINCT
+   * FROM` is supported only on MySQL 8.0.14+; the operator form works
+   * on every MySQL version.
+   */
   protected override visitArelNodesIsNotDistinctFrom(
     o: Nodes.IsNotDistinctFrom,
     collector: SQLString,
@@ -107,7 +105,6 @@ export class MySQL extends ToSql {
     o: Nodes.NullsFirst,
     collector: SQLString,
   ): SQLString {
-    // MySQL has no NULLS FIRST; emulate: col IS NOT NULL, col ASC/DESC
     const expr = o.expr as Nodes.Ascending | Nodes.Descending;
     this.visit(expr.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NOT NULL, ");
@@ -116,7 +113,6 @@ export class MySQL extends ToSql {
   }
 
   protected override visitArelNodesNullsLast(o: Nodes.NullsLast, collector: SQLString): SQLString {
-    // MySQL has no NULLS LAST; emulate: col IS NULL, col ASC/DESC
     const expr = o.expr as Nodes.Ascending | Nodes.Descending;
     this.visit(expr.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NULL, ");

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -335,10 +335,6 @@ describe("PostgresTest", () => {
   });
 });
 
-// Audit follow-up: Postgres dialect overrides for grouping-element
-// formatting (spaces inside parens), Cube/Rollup/GroupingSet wrapping,
-// Lateral parens-only-when-needed, and explicit IsDistinctFrom
-// overrides (behaviorally identical to base, kept for fidelity).
 describe("PostgreSQL dialect overrides (audit follow-up)", () => {
   const users = new Table("users");
   const compile = (n: Nodes.Node): string =>
@@ -380,9 +376,6 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
   });
 
   it("Cube/Rollup/GroupingSet route through groupingArrayOrGroupingElement", () => {
-    // Verify the helper is actually wired into the dialect-public path:
-    // CUBE / ROLLUP / GROUPING SETS each emit their prefix followed by the
-    // helper's `( ... )` formatting.
     expect(compile(new Nodes.Cube([users.get("a"), users.get("b")]))).toBe(
       'CUBE( "users"."a", "users"."b" )',
     );
@@ -390,7 +383,6 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     expect(compile(new Nodes.GroupingSet([users.get("a"), users.get("b")]))).toBe(
       'GROUPING SETS( "users"."a", "users"."b" )',
     );
-    // GroupingElement itself uses the helper too.
     expect(compile(new Nodes.GroupingElement([users.get("a")]))).toBe('( "users"."a" )');
   });
 
@@ -427,7 +419,6 @@ describe("Temporal scalar quoting", () => {
     ).toContain("'14:23:55'");
   });
 
-  // A JS Date is rejected AR-wide (#939): it must not be claimed as a Time.
   it("refuses a JS Date rather than formatting it as a Time", () => {
     const d = new Date("2026-04-26T14:23:55Z");
     expect(() =>

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -147,9 +147,11 @@ export class PostgreSQL extends ToSql {
  * PostgreSQL visitor — uses numbered bind parameters ($1, $2, ...).
  */
 export class PostgreSQLWithBinds extends PostgreSQL {
-  // SQLString tracks bindIndex in the collector (starts at 1, increments per
-  // addBind call). Overriding bindBlock() to return the $N renderer is
-  // sufficient — the index state never touches the visitor instance.
+  /**
+   * SQLString tracks bindIndex in the collector (starts at 1, increments per
+   * addBind call). Overriding bindBlock() to return the $N renderer is
+   * sufficient — the index state never touches the visitor instance.
+   */
   protected override bindBlock(): (index: number) => string {
     return (i: number) => `$${i}`;
   }

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -147,11 +147,6 @@ export class PostgreSQL extends ToSql {
  * PostgreSQL visitor — uses numbered bind parameters ($1, $2, ...).
  */
 export class PostgreSQLWithBinds extends PostgreSQL {
-  /**
-   * SQLString tracks bindIndex in the collector (starts at 1, increments per
-   * addBind call). Overriding bindBlock() to return the $N renderer is
-   * sufficient — the index state never touches the visitor instance.
-   */
   protected override bindBlock(): (index: number) => string {
     return (i: number) => `$${i}`;
   }

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -9,7 +9,6 @@ describe("SqliteTest", () => {
     it("should handle nil", () => {
       const node = users.get("name").isDistinctFrom(null);
       const sql = new Visitors.SQLite(testConnection).compile(node);
-      // SQLite has no IS DISTINCT FROM; it uses IS NOT for null-aware !=.
       expect(sql).toBe('"users"."name" IS NOT NULL');
     });
   });
@@ -41,7 +40,6 @@ describe("SqliteTest", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isNotDistinctFrom(posts.get("user_id"));
       const sql = new Visitors.SQLite(testConnection).compile(node);
-      // SQLite uses IS for null-aware equality (no IS NOT DISTINCT FROM).
       expect(sql).toBe('"users"."id" IS "posts"."user_id"');
     });
 

--- a/packages/arel/src/visitors/sqlite.ts
+++ b/packages/arel/src/visitors/sqlite.ts
@@ -10,7 +10,6 @@ import { ToSql } from "./to-sql.js";
  */
 export class SQLite extends ToSql {
   protected override visitArelNodesLock(_node: Nodes.Lock, collector: SQLString): SQLString {
-    // SQLite does not support locking — silently ignore.
     return collector;
   }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -656,9 +656,6 @@ describe("the to_sql visitor", () => {
           Temporal.PlainMonthDay.from("04-30"),
         ]) {
           expect(() =>
-            // The cast is the point: these three Temporal types are
-            // deliberately outside NodeOrValue, and this asserts the runtime
-            // raises for anyone who reaches them anyway.
             spy.compile(new Nodes.Equality(attr, value as unknown as Nodes.NodeOrValue)),
           ).toThrow(TypeError);
         }
@@ -691,8 +688,6 @@ describe("the to_sql visitor", () => {
         // caller produces.
         const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
         expect(() => compileRight(instant)).toThrow(Visitors.UnsupportedVisitError);
-        // Rendering shape here is whatever the quoter already does with a
-        // Temporal; this pins only that the wrapped path still inlines.
         expect(compileRight(new Nodes.Quoted(instant))).toContain("2026-04-30");
       });
 
@@ -1199,12 +1194,10 @@ describe("the to_sql visitor", () => {
   it("should visit_Date with fractional seconds retains microseconds", () => {
     const d = Temporal.Instant.from("2026-04-18T13:00:41.729Z");
     const sql = new Visitors.ToSql(testConnection).compile(new Nodes.Quoted(d));
-    // 729 ms → "729000" microseconds
     expect(sql).toBe("'2026-04-18 13:00:41.729000'");
   });
 
   it("should visit_Date-like with 1-digit fraction normalises to microseconds", () => {
-    // ".7" → "700000" μs (not "007000" which a naive ms*1000 approach produced)
     const obj = Temporal.PlainDateTime.from("2020-01-02T03:04:05.7");
     const sql = new Visitors.ToSql(testConnection).compile(new Nodes.Quoted(obj));
     expect(sql).toBe("'2020-01-02 03:04:05.700000'");
@@ -1217,7 +1210,6 @@ describe("the to_sql visitor", () => {
   });
 
   it("should visit_Date-like with no fractional part (no trailing Z artifact)", () => {
-    // A Temporal with no sub-second component emits bare seconds.
     const obj = Temporal.PlainDate.from("2026-01-01").toPlainDateTime();
     const sql = new Visitors.ToSql(testConnection).compile(new Nodes.Quoted(obj));
     expect(sql).toBe("'2026-01-01 00:00:00'");
@@ -1465,7 +1457,6 @@ describe("the to_sql visitor", () => {
     const table = new Table("users");
     const mgr = table.project(star).where(table.get("name").eq("alice"));
 
-    // Use a custom collector that tracks parts and binds
     const parts: unknown[] = [];
     const binds: unknown[] = [];
     const collector = {
@@ -1724,8 +1715,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("an infinite-but-bounded BindParam does not short-circuit", () => {
-      // Infinity has no `unboundable?`, so the bind is bounded and renders as a
-      // placeholder rather than collapsing.
       const node = new Nodes.GreaterThan(users.get("id"), new Nodes.BindParam(Infinity));
       expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"users"."id" > ?');
     });
@@ -1763,8 +1752,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("visitTable and visitAttribute now route through quoteTableName / quoteColumnName", () => {
-      // A table name with a double-quote in it would have crashed pre-PR
-      // because the inline replace was string-only; quoteTableName escapes it.
       const weird = new Table('we"ird');
       const sql = new Visitors.ToSql(testConnection).compile(weird.get('co"l').eq(1));
       expect(sql).toBe('"we""ird"."co""l" = 1');
@@ -1782,8 +1769,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("collectNodesFor is a no-op when the list is empty", () => {
-      // SELECT with no projections / no WHERE should not emit those
-      // clauses at all (no stray spacer).
       const sql = new Table("users").project().toSql();
       expect(sql).toBe('SELECT FROM "users"');
       expect(sql).not.toContain("WHERE");
@@ -1816,9 +1801,6 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Comment placement", () => {
     it("emits exactly one space before each comment in SelectCore (no double space)", () => {
-      // Regression: visit_Arel_Nodes_Comment used to prepend its own leading
-      // space, and SelectCore also called maybeVisit() which adds another.
-      // The visitor now leaves the leading space to the caller.
       const tbl = new Table("users");
       const sql = tbl.project(tbl.get("id")).comment("hi", "bye").toSql();
       expect(sql).toBe('SELECT "users"."id" FROM "users" /* hi */ /* bye */');
@@ -1829,26 +1811,15 @@ describe("the to_sql visitor", () => {
   describe("schema-qualified table identifier", () => {
     it("quotes each segment of a schema.table name in SELECT and column refs", () => {
       const tbl = new Table("schema.table");
-      // Dot-splitting is an adapter behaviour, so name a real quoting connection
-      // rather than the suite's FakeRecord engine (which wraps the whole name in
-      // one pair of quotes). Both the FROM clause and the qualified column
-      // reference should emit "schema"."table" — not "schema.table" (which would
-      // be a single identifier and reference a different relation).
       const sql = new Visitors.ToSql(testConnection).compile(tbl.project(tbl.get("col")).ast);
       expect(sql).toBe('SELECT "schema"."table"."col" FROM "schema"."table"');
     });
   });
 
   describe("identifier-escape consistency (helper-routed quoting)", () => {
-    // Regression: four sites used to interpolate `"${name}"` directly,
-    // bypassing quoteColumnName / quoteTableName and silently producing
-    // invalid SQL on identifiers containing a literal double-quote.
     it("UPDATE SET column quotes embedded double-quotes", () => {
       const tbl = new Table('tab"le');
       const mgr = new UpdateManager().table(tbl).set([[tbl.get('co"l'), 1]]);
-      // Identifier-escaping is an adapter behaviour; the suite's FakeRecord
-      // engine leaves the embedded quote intact, so name a real quoting
-      // connection to exercise the escape (matching the sibling CTE test).
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain('"co""l" = 1');
     });
@@ -1907,8 +1878,8 @@ describe("the to_sql visitor", () => {
           .where(tbl.get("name").eq(new Nodes.Casted("hi", tbl.get("name"))))
           .project(tbl.get("id")).ast,
       );
-      expect(sql).toContain("$1"); // BindParam → addBind → $1
-      expect(sql).toContain("'hi'"); // Casted value inlines via quote
+      expect(sql).toContain("$1");
+      expect(sql).toContain("'hi'");
       expect(sql).not.toContain("?");
     });
 
@@ -1939,7 +1910,6 @@ describe("the to_sql visitor", () => {
         AMAttribute.fromDatabase("name", "x", new StringType()),
         collector,
       );
-      // bindIndex starts at 1; the block receives 1, so `$1`
       expect(collector.value).toBe("$1");
     });
 
@@ -2052,8 +2022,6 @@ describe("the to_sql visitor", () => {
       });
 
       it("Equality with null still emits IS NULL (not the unboundable branch)", () => {
-        // Regression guard: null is bounded — sign is 0, so the `IS NULL`
-        // path must still fire, not the new `1=0` short-circuit.
         expect(compile(id.eq(null))).toBe('"users"."id" IS NULL');
         expect(compile(id.notEq(null))).toBe('"users"."id" IS NOT NULL');
       });
@@ -2138,8 +2106,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted Temporal.Instant binds through unified addBind path under extractBinds", () => {
-      // Quoted(Temporal.Instant) inlines via quotedDate — toISOString path.
-      // _extractBinds was removed; Quoted always inlines regardless of collector.
       const visitor = new Visitors.ToSql(testConnection);
       const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
       const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(instant));
@@ -2154,7 +2120,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted string binds raw under extractBinds", () => {
-      // Quoted("hi") inlines via quote() — _extractBinds was removed.
       const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
         new Nodes.Quoted("hi"),
       );
@@ -2163,7 +2128,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted number binds raw under extractBinds", () => {
-      // Quoted(42) inlines via quote() — _extractBinds was removed.
       const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
         new Nodes.Quoted(42),
       );
@@ -2172,7 +2136,6 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted toISOString-bearing object binds raw under extractBinds", () => {
-      // Quoted(date-like) inlines via quotedDate() — _extractBinds was removed.
       const value = Temporal.Instant.from("2026-04-30T00:00:00.000Z");
       const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
         new Nodes.Quoted(value),

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -63,7 +63,6 @@ describe("ToSql Array-named identifiers", () => {
     ] as unknown as string;
 
     const quoted = make().quoteColumnName(names);
-    // Undo the adapter's identifier quoting to compare the bare Array#to_s text.
     expect(quoted.slice(1, -1).replaceAll('""', '"')).toBe(
       String.raw`["a\n", "t\tb", "esc\e", "nul\u0000", "del\u007F", "ué", "bs\\", "q\"", "cr\r", "ff\f", "vt\v", "bel\a", "bsp\b", "h\#{x}", "d\#$g", "a\#@i", "plain#hash", "shop_id", "id", "\u0001\u001F", "日本"]`,
     );

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -309,8 +309,6 @@ export class ToSql extends Visitor {
     return this.visitArelNodesCasted(o as unknown as Nodes.Casted, collector);
   }
 
-  // -- Boolean literals --
-
   protected visitArelNodesTrue(_o: Nodes.True, collector: SQLString): SQLString {
     collector.append("TRUE");
     return collector;
@@ -354,8 +352,6 @@ export class ToSql extends Visitor {
     }
     return collector;
   }
-
-  // -- Statements --
 
   protected visitArelNodesSelectStatement(
     o: Nodes.SelectStatement,
@@ -421,34 +417,26 @@ export class ToSql extends Visitor {
 
   static {
     const d = ToSql.dispatchCache();
-    // Runtime guard: TS `keyof T` only exposes public members, and the
-    // visit methods are mostly protected, so we can't constrain `m` at
-    // compile time. Asserting here catches typos/renames the next time
-    // the static block runs (i.e. as soon as the file is imported).
     const reg = (ctor: NodeCtor, m: string) => {
       if (typeof (ToSql.prototype as unknown as Record<string, unknown>)[m] !== "function") {
         throw new Error(`ToSql dispatch: method '${m}' is not defined on the prototype`);
       }
       d.set(ctor, m);
     };
-    // Statements
     reg(Nodes.SelectStatement, "visitArelNodesSelectStatement");
     reg(Nodes.SelectOptions, "visitArelNodesSelectOptions");
     reg(Nodes.SelectCore, "visitArelNodesSelectCore");
     reg(Nodes.InsertStatement, "visitArelNodesInsertStatement");
     reg(Nodes.UpdateStatement, "visitArelNodesUpdateStatement");
     reg(Nodes.DeleteStatement, "visitArelNodesDeleteStatement");
-    // Set operations
     reg(Nodes.UnionAll, "visitArelNodesUnionAll");
     reg(Nodes.Union, "visitArelNodesUnion");
     reg(Nodes.Intersect, "visitArelNodesIntersect");
     reg(Nodes.Except, "visitArelNodesExcept");
-    // CTE
     reg(Nodes.WithRecursive, "visitArelNodesWithRecursive");
     reg(Nodes.With, "visitArelNodesWith");
     reg(Nodes.TableAlias, "visitArelNodesTableAlias");
     reg(Nodes.Cte, "visitArelNodesCte");
-    // Joins
     reg(Nodes.JoinSource, "visitArelNodesJoinSource");
     reg(Nodes.InnerJoin, "visitArelNodesInnerJoin");
     reg(Nodes.OuterJoin, "visitArelNodesOuterJoin");
@@ -457,7 +445,6 @@ export class ToSql extends Visitor {
     reg(Nodes.CrossJoin, "visitCrossJoin");
     reg(Nodes.StringJoin, "visitArelNodesStringJoin");
     reg(Nodes.On, "visitArelNodesOn");
-    // Predicates
     reg(Nodes.Equality, "visitArelNodesEquality");
     reg(Nodes.NotEqual, "visitArelNodesNotEqual");
     reg(Nodes.GreaterThan, "visitArelNodesGreaterThan");
@@ -475,7 +462,6 @@ export class ToSql extends Visitor {
     reg(Nodes.IsNotDistinctFrom, "visitArelNodesIsNotDistinctFrom");
     reg(Nodes.Assignment, "visitArelNodesAssignment");
     reg(Nodes.As, "visitArelNodesAs");
-    // Unary
     reg(Nodes.Ascending, "visitArelNodesAscending");
     reg(Nodes.Descending, "visitArelNodesDescending");
     reg(Nodes.Offset, "visitArelNodesOffset");
@@ -487,12 +473,10 @@ export class ToSql extends Visitor {
     reg(Nodes.NullsFirst, "visitArelNodesNullsFirst");
     reg(Nodes.NullsLast, "visitArelNodesNullsLast");
     reg(Nodes.UnaryOperation, "visitArelNodesUnaryOperation");
-    // Boolean
     reg(Nodes.And, "visitArelNodesAnd");
     reg(Nodes.Or, "visitArelNodesOr");
     reg(Nodes.Not, "visitArelNodesNot");
     reg(Nodes.Grouping, "visitArelNodesGrouping");
-    // Window
     reg(Nodes.Over, "visitArelNodesOver");
     reg(Nodes.NamedWindow, "visitArelNodesNamedWindow");
     reg(Nodes.Window, "visitArelNodesWindow");
@@ -501,7 +485,6 @@ export class ToSql extends Visitor {
     reg(Nodes.Preceding, "visitArelNodesPreceding");
     reg(Nodes.Following, "visitArelNodesFollowing");
     reg(Nodes.CurrentRow, "visitArelNodesCurrentRow");
-    // Filter / Case / Extract / Infix
     reg(Nodes.Filter, "visitArelNodesFilter");
     reg(Nodes.Case, "visitArelNodesCase");
     reg(Nodes.When, "visitArelNodesWhen");
@@ -517,7 +500,6 @@ export class ToSql extends Visitor {
     // raising UnsupportedVisitError.
     reg(ModelAttribute, "visitActiveModelAttribute");
     reg(Nodes.Fragments, "visitArelNodesFragments");
-    // Functions
     reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
     reg(Nodes.Exists, "visitArelNodesExists");
     reg(Nodes.Count, "visitArelNodesCount");
@@ -525,7 +507,6 @@ export class ToSql extends Visitor {
     reg(Nodes.Max, "visitArelNodesMax");
     reg(Nodes.Min, "visitArelNodesMin");
     reg(Nodes.Avg, "visitArelNodesAvg");
-    // Advanced grouping
     reg(Nodes.Cube, "visitArelNodesCube");
     reg(Nodes.RollUp, "visitArelNodesRollUp");
     reg(Nodes.GroupingSet, "visitArelNodesGroupingSet");
@@ -534,10 +515,8 @@ export class ToSql extends Visitor {
     reg(Nodes.Comment, "visitArelNodesComment");
     reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
     reg(Nodes.HomogeneousIn, "visitArelNodesHomogeneousIn");
-    // Boolean literals
     reg(Nodes.True, "visitArelNodesTrue");
     reg(Nodes.False, "visitArelNodesFalse");
-    // Leaf nodes
     reg(Nodes.Distinct, "visitArelNodesDistinct");
     reg(Nodes.SqlLiteral, "visitArelNodesSqlLiteral");
     reg(Nodes.Quoted, "visitArelNodesQuoted");
@@ -596,7 +575,6 @@ export class ToSql extends Visitor {
   }
 
   protected visitArelNodesBin(o: Nodes.Bin, collector: SQLString): SQLString {
-    // Generic visitor: just emit the inner expression.
     if (o.expr instanceof Node) {
       this.visit(o.expr, collector);
     } else if (o.expr !== null) {
@@ -604,8 +582,6 @@ export class ToSql extends Visitor {
     }
     return collector;
   }
-
-  // -- Leaf nodes --
 
   private visitArelNodesDistinct(_o: Nodes.Distinct, collector: SQLString): SQLString {
     collector.append("DISTINCT");
@@ -619,8 +595,6 @@ export class ToSql extends Visitor {
     );
   }
 
-  // -- CTE --
-
   private visitArelNodesWith(o: Nodes.With, collector: SQLString): SQLString {
     collector.append("WITH ");
     return this.collectCtes(o.children, collector);
@@ -630,8 +604,6 @@ export class ToSql extends Visitor {
     collector.append("WITH RECURSIVE ");
     return this.collectCtes(o.children, collector);
   }
-
-  // -- Set operations --
 
   protected visitArelNodesUnion(o: Nodes.Union, collector: SQLString): SQLString {
     return this.infixValueWithParen(o, collector, " UNION ");
@@ -660,8 +632,6 @@ export class ToSql extends Visitor {
     return this.visitArelNodesWindow(o, collector);
   }
 
-  // -- Window --
-
   private visitArelNodesWindow(o: Nodes.Window, collector: SQLString): SQLString {
     collector.append("(");
 
@@ -679,8 +649,6 @@ export class ToSql extends Visitor {
     collector.append(")");
     return collector;
   }
-
-  // -- Filter --
 
   private visitArelNodesFilter(o: Nodes.Filter, collector: SQLString): SQLString {
     this.visit(o.left, collector);
@@ -812,8 +780,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  // -- Unary --
-
   private visitArelNodesAscending(o: Nodes.Ascending, collector: SQLString): SQLString {
     if (o.expr instanceof Node) this.visit(o.expr, collector);
     collector.append(" ASC");
@@ -825,8 +791,6 @@ export class ToSql extends Visitor {
     collector.append(" DESC");
     return collector;
   }
-
-  // -- NullsFirst / NullsLast --
 
   protected visitArelNodesNullsFirst(o: Nodes.NullsFirst, collector: SQLString): SQLString {
     if (o.expr instanceof Node) this.visit(o.expr, collector);
@@ -848,8 +812,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  // -- Functions --
-
   private visitArelNodesNamedFunction(o: Nodes.NamedFunction, collector: SQLString): SQLString {
     collector.retryable = false;
     collector.append(o.name);
@@ -863,8 +825,6 @@ export class ToSql extends Visitor {
     }
     return collector;
   }
-
-  // -- Extract --
 
   private visitArelNodesExtract(o: Nodes.Extract, collector: SQLString): SQLString {
     collector.append(`EXTRACT(${String(o.field).toUpperCase()} FROM `);
@@ -961,8 +921,6 @@ export class ToSql extends Visitor {
     return this.visitBinaryOp(o, "<", collector);
   }
 
-  // -- Matches with ESCAPE --
-
   protected visitArelNodesMatches(o: Nodes.Matches, collector: SQLString): SQLString {
     collector = this.visit(o.left, collector);
     collector.append(" LIKE ");
@@ -986,8 +944,6 @@ export class ToSql extends Visitor {
       return collector;
     }
   }
-
-  // -- Joins --
 
   private visitArelNodesJoinSource(o: Nodes.JoinSource, collector: SQLString): SQLString {
     if (o.left) this.visit(o.left, collector);
@@ -1097,7 +1053,6 @@ export class ToSql extends Visitor {
       }
     }
     this.visit(attr, collector);
-    // Duck-type check for SelectManager subquery - visit wraps it in parens
     if (
       values &&
       typeof values === "object" &&
@@ -1152,8 +1107,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  // -- Boolean --
-
   private visitArelNodesAnd(o: Nodes.And, collector: SQLString): SQLString {
     return this.injectJoin(o.children, collector, " AND ");
   }
@@ -1163,8 +1116,6 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesAssignment(o: Nodes.Assignment, collector: SQLString): SQLString {
-    // Column-name unqualification is the responsibility of `UnqualifiedColumn`,
-    // which `UpdateManager#set` wraps each LHS in.
     this.visit(o.left, collector);
     collector.append(" = ");
     // Mirrors Rails (to_sql.rb:630-641): a Node/Attribute right is visited; a
@@ -1178,8 +1129,6 @@ export class ToSql extends Visitor {
     }
     return collector;
   }
-
-  // -- Predicates --
 
   private visitArelNodesEquality(o: Nodes.Equality, collector: SQLString): SQLString {
     const right = o.right;
@@ -1249,8 +1198,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  // -- Case --
-
   private visitArelNodesCase(o: Nodes.Case, collector: SQLString): SQLString {
     collector.append("CASE");
     if (o.case) {
@@ -1298,8 +1245,6 @@ export class ToSql extends Visitor {
     collector.append(this.quoteColumnName(attr.name));
     return collector;
   }
-
-  // -- Cte --
 
   protected visitArelNodesCte(o: Nodes.Cte, collector: SQLString): SQLString {
     collector.append(`${this.quoteTableName(o.name)} AS `);
@@ -1377,8 +1322,6 @@ export class ToSql extends Visitor {
     collector.append(o.value);
     return collector;
   }
-
-  // -- BoundSqlLiteral --
 
   private visitArelNodesBoundSqlLiteral(o: Nodes.BoundSqlLiteral, collector: SQLString): SQLString {
     collector.retryable = false;
@@ -1531,16 +1474,12 @@ export class ToSql extends Visitor {
     return this.unsupported(o, collector);
   }
 
-  // -- InfixOperation --
-
   private visitArelNodesInfixOperation(o: Nodes.InfixOperation, collector: SQLString): SQLString {
     this.visit(o.left, collector);
     collector.append(` ${o.operator} `);
     this.visit(o.right, collector);
     return collector;
   }
-
-  // -- UnaryOperation --
 
   private visitArelNodesUnaryOperation(o: Nodes.UnaryOperation, collector: SQLString): SQLString {
     // Mirrors Rails: `collector << " #{o.operator} "` (visitors/to_sql.rb).
@@ -1904,10 +1843,10 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  // -- BindParam --
-
-  // Overridable hook for date bind insertion so PostgreSQLWithBinds can
-  // emit $N placeholders instead of ?.
+  /**
+   * Overridable hook for date bind insertion so PostgreSQLWithBinds can
+   * emit $N placeholders instead of ?.
+   */
   protected addDateBind(value: unknown, collector: SQLString): void {
     collector.addBind(value, this.bindBlock());
   }
@@ -1955,16 +1894,12 @@ export class ToSql extends Visitor {
     }
   }
 
-  // -- Concat --
-
   protected visitArelNodesConcat(o: Nodes.Concat, collector: SQLString): SQLString {
     this.visit(o.left, collector);
     collector.append(" || ");
     this.visit(o.right, collector);
     return collector;
   }
-
-  // -- Advanced grouping --
 
   protected visitArelNodesCube(o: Nodes.Cube, collector: SQLString): SQLString {
     collector.append("CUBE(");
@@ -2012,8 +1947,6 @@ export class ToSql extends Visitor {
     collector.append(")");
     return collector;
   }
-
-  // -- Helpers --
 
   /**
    * Mirrors `to_sql.rb#unboundable?` (to_sql.rb:905-907), returning the sign

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1843,10 +1843,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  /**
-   * Overridable hook for date bind insertion so PostgreSQLWithBinds can
-   * emit $N placeholders instead of ?.
-   */
   protected addDateBind(value: unknown, collector: SQLString): void {
     collector.addBind(value, this.bindBlock());
   }

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -47,8 +47,6 @@ describe("Visitor dispatch", () => {
   });
 
   it("memoizes ancestor lookups in the cache", () => {
-    // Use a fresh subclass so we own the dispatch cache start state —
-    // earlier tests may already have populated TestVisitor's cache for B.
     class FreshVisitor extends Visitor {
       visitA(_n: A): string {
         return "A";
@@ -234,7 +232,6 @@ describe("Visitor dispatch", () => {
       }
     }
     expect(new Sub().accept(new A())).toBe("Sub-A");
-    // Parent visitor still uses its own implementation.
     expect(new TestVisitor().accept(new A())).toBe("A");
   });
 });

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -24,10 +24,13 @@ function describeClass(object: unknown): string {
  * reject any ctor with a more-specific parameter type.
  */
 export type NodeCtor = abstract new (...args: never[]) => object;
-// Structural, not `typeof Visitor`: concrete visitors now take a required
-// `ArelConnection` constructor argument (RFC 0007 deleted the defaults), so
-// their constructor signatures are not assignable to the abstract base's.
-// Only the static dispatch surface matters here, never construction.
+
+/**
+ * Structural, not `typeof Visitor`: concrete visitors now take a required
+ * `ArelConnection` constructor argument (RFC 0007 deleted the defaults), so
+ * their constructor signatures are not assignable to the abstract base's.
+ * Only the static dispatch surface matters here, never construction.
+ */
 type VisitorCtor = (abstract new (...args: never[]) => Visitor) &
   Pick<typeof Visitor, "dispatchCache">;
 

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -30,6 +30,8 @@ export type NodeCtor = abstract new (...args: never[]) => object;
  * `ArelConnection` constructor argument (RFC 0007 deleted the defaults), so
  * their constructor signatures are not assignable to the abstract base's.
  * Only the static dispatch surface matters here, never construction.
+ *
+ * @noRailsEquivalent TypeScript-only ctor type; Ruby dispatches on the class object directly.
  */
 type VisitorCtor = (abstract new (...args: never[]) => Visitor) &
   Pick<typeof Visitor, "dispatchCache">;


### PR DESCRIPTION
Adds `blazetrails/no-freeform-comments` — an ESLint rule whose autofix deletes
free-form comments — registers it for `arel` and `activemodel`, and runs it.

trails is a line-by-line port. A comment that restates what the TS says
competes with the Ruby for authority and rots independently of both sides, so
the rule keeps only three kinds:

1. **JSDoc**, where every port convention already lives (`Mirrors:`,
   `@internal`, `@noRailsEquivalent`).
2. **Rails references** — a `.rb` citation, a `Mirrors:` line, a Ruby constant
   path. Pointers *to* the Ruby.
3. **Tool directives** — `eslint-*`, `@ts-*`, `prettier-ignore`, coverage
   pragmas, and this repo's own `boundary:` / `@boundary-file:`, which
   `no-native-date` reads as the documented exemption for an intentional JS
   `Date`. Deleting one reds that rule rather than merely losing a note.

There is no opt-out marker. The rule shipped with a `keep:` escape hatch, the
sweep used it zero times, and it has been removed — a comment earns one of the
three forms above or it goes.

## Rails' own comments are deleted too

An earlier revision of this branch kept them, matched against a generated 56k
manifest of every comment text in `vendor/rails`. That has been dropped, and
the manifest and its builder deleted, because it contradicted the rule's own
thesis: a copy of Rails' comment is a second place saying what `vendor/rails`
already says, going stale the moment upstream edits it, with nothing to detect
the drift.

The Ruby is vendored and permanently referenceable and every ported file cites
it, so a reader who wants Rails' annotation on a line reads it at the source.
Swept accordingly: Arel's two `FIXME: We SHOULD NOT be converting these to
SqlLiteral automatically`, `intentionally left blank`, the MySQL offset note,
and the `conditional-validation` test narration.

## Result

| | blocks |
|---|---|
| flagged across `arel` + `activemodel` | 506 |
| promoted to JSDoc | 12 |
| deleted | 495 (~817 comment lines) |
| kept via an escape hatch | **0** — the hatch is removed |

Nothing survived as body-level prose. A comment either sits on a declaration
and became JSDoc, or it cites the Ruby, or it is gone — writing a more
persuasive justification for a deviation ratifies it instead of converging it.

Every one of the 12 JSDoc blocks this PR adds carries either a
`@noRailsEquivalent` / `@internal` tag or a Rails citation — none rests on bare
JSDoc. They document TypeScript-only mixin typing, ESM load-order constructs,
and the class-fields-vs-`super()` bootstrapping that forces prototype
attachment in the validators.

The rule does keep any JSDoc unconditionally, so reformatting a `//` comment as
JSDoc bypasses the fix. Closing that with a blanket "must carry a tag or
citation" rule was measured and rejected: it flags 94 pre-existing blocks in
these packages that are ordinary API docs (`Set the FROM table.`,
`Add GROUP BY.`, `UNION with another manager.`). Tracked with the measurement
as `0023/close-jsdoc-bypass-in-no-freeform-comments`.

## Filed rather than left as prose

- `0023/converge-sql-literal-yaml-onto-encode-with` — `SqlLiteral#toYAML()` is
  an invented name emitting a tagged `!sql_literal` mapping, where Rails'
  `encode_with` sets `coder.scalar = to_s` (`arel/nodes/sql_literal.rb:18`), so
  a SqlLiteral dumps as a plain scalar. The deleted comment described the
  deviation; it did not justify it.
- `0023/strip-freeform-comments-activerecord` — widening the rule's `files` to
  `activerecord`, which is far larger and wants its own review pass.

## Notes

- No ported code changed. The only non-comment edits are the 22 JSDoc
  promotions, two Prettier reflows, and one restructured `catch {}` in the
  **test** quoter (`arel/src/test-helpers/default-quoter.ts`, which has no
  Rails counterpart) that a deletion had emptied.
- No test name renamed — verified against the diff.
- `comment-audit.html` is untracked; it was committed by mistake in the first
  commit and is the review surface, published separately.

## Verification

- `pnpm eslint packages/arel/src packages/activemodel/src` clean; a second
  `--fix` run is a no-op.
- `pnpm parity:api:calls` OK (887 baselined, unchanged); `pnpm parity:api:calls:args`
  OK (169 rows, unchanged); `pnpm parity:api:extra` reports 0 novel names.
- `pnpm typecheck` clean.
- `pnpm vitest run packages/arel packages/activemodel` — 167 files, 3424 passed.
