### PR TITLE
refactor(activerecord,activesupport): converge records_by_owner control flow, retire PoolConfig#adapterFactory, port the remaining to_xml tests

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -64,19 +64,13 @@ export class ThroughAssociation extends Association {
         continue;
       }
 
-      // Ruby's `through_records_by_owner` / `source_records_by_owner` are
-      // memoized hash reads forced on first use inside the loop; ours are
-      // memoized async methods, so awaiting them here is the same laziness —
-      // an all-owners-loaded preload never forces either and issues no query.
       let throughRecords = (await this.throughRecordsByOwner()).get(owner) ?? [];
 
       if (this.owners[0].association(this.throughReflection!.name).loaded) {
-        const sourceType = (this.reflection as any).options?.sourceType;
+        const sourceType = this.reflection.options.sourceType;
         if (sourceType) {
-          const foreignType =
-            (this.reflection as any).foreignType ?? (this.sourceReflection as any)?.foreignType;
           throughRecords = throughRecords.filter(
-            (record) => (record as any)._readAttribute(foreignType) === sourceType,
+            (record) => record.readAttribute(this.reflection.foreignType!) === sourceType,
           );
         }
       }
@@ -84,7 +78,7 @@ export class ThroughAssociation extends Association {
       const sourceRecordsByOwner = await this.sourceRecordsByOwner();
       let records = throughRecords.flatMap((record) => sourceRecordsByOwner.get(record) ?? []);
 
-      records = records.filter((r) => r != null);
+      records = records.filter((record) => record != null);
       if (this.scope?.orderValues?.length > 0) {
         const preloadIndex = await this.preloadIndex();
         records.sort((a, b) => (preloadIndex.get(a) ?? 0) - (preloadIndex.get(b) ?? 0));

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -51,44 +51,12 @@ export class ThroughAssociation extends Association {
     return this._throughPreloadedRecords;
   }
 
+  /** Mirrors: Preloader::ThroughAssociation#records_by_owner
+   *  (`preloader/through_association.rb:11-37`). */
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
     if (this._recordsByOwner !== undefined) return this._recordsByOwner;
 
     const result = new Map<Base, Base[]>();
-
-    // When every owner already carries this association loaded — e.g. an outer
-    // through query eager-loaded this source sub-chain via `includes!`/
-    // `references!`, so the middle records arrive with their source association
-    // populated — return those targets directly. This is the hoisted
-    // loop-invariant of Rails' `records_by_owner`
-    // (preloader/through_association.rb:11-15): if every owner is loaded, every
-    // iteration takes the early `next`, so `through_records_by_owner` /
-    // `source_records_by_owner` are never forced and no fetch happens. The
-    // per-owner `isLoaded` check inside our loop only avoids re-associating, not
-    // the unconditional fetch above it, so the guard must be hoisted here.
-    if (this.owners.length > 0 && this.owners.every((owner) => this.isLoaded(owner))) {
-      for (const owner of this.owners) {
-        result.set(owner, this.targetFor(owner));
-      }
-      this._recordsByOwner = result;
-      return result;
-    }
-
-    const throughRecordsByOwner = await this.throughRecordsByOwner();
-    const sourceRecordsByOwner = await this.sourceRecordsByOwner();
-
-    const throughRefl = this.throughReflection;
-    const firstOwner = this.owners[0] as any;
-    const throughLoadedOnFirst =
-      throughRefl != null &&
-      firstOwner != null &&
-      (() => {
-        try {
-          return !!firstOwner.association?.(throughRefl.name)?.loaded;
-        } catch {
-          return false;
-        }
-      })();
 
     for (const owner of this.owners) {
       if (this.isLoaded(owner)) {
@@ -96,38 +64,39 @@ export class ThroughAssociation extends Association {
         continue;
       }
 
-      let throughRecords = throughRecordsByOwner.get(owner) ?? [];
+      // Ruby's `through_records_by_owner` / `source_records_by_owner` are
+      // memoized hash reads forced on first use inside the loop; ours are
+      // memoized async methods, so awaiting them here is the same laziness —
+      // an all-owners-loaded preload never forces either and issues no query.
+      let throughRecords = (await this.throughRecordsByOwner()).get(owner) ?? [];
 
-      if (throughLoadedOnFirst) {
+      if (this.owners[0].association(this.throughReflection!.name).loaded) {
         const sourceType = (this.reflection as any).options?.sourceType;
-        const foreignType =
-          (this.reflection as any).foreignType ?? (this.sourceReflection as any)?.foreignType;
-        if (sourceType && foreignType) {
+        if (sourceType) {
+          const foreignType =
+            (this.reflection as any).foreignType ?? (this.sourceReflection as any)?.foreignType;
           throughRecords = throughRecords.filter(
             (record) => (record as any)._readAttribute(foreignType) === sourceType,
           );
         }
       }
 
-      let records = throughRecords.flatMap((tr) => sourceRecordsByOwner.get(tr) ?? []);
+      const sourceRecordsByOwner = await this.sourceRecordsByOwner();
+      let records = throughRecords.flatMap((record) => sourceRecordsByOwner.get(record) ?? []);
+
       records = records.filter((r) => r != null);
-
-      // Preserve scope ordering via preload index
       if (this.scope?.orderValues?.length > 0) {
-        const index = await this.preloadIndex();
-        records.sort((a, b) => (index.get(a) ?? 0) - (index.get(b) ?? 0));
+        const preloadIndex = await this.preloadIndex();
+        records.sort((a, b) => (preloadIndex.get(a) ?? 0) - (preloadIndex.get(b) ?? 0));
       }
-
-      // Apply distinct
       if (this.scope?.distinctValue) {
         const seen = new Set<Base>();
-        records = records.filter((r) => {
-          if (seen.has(r)) return false;
-          seen.add(r);
+        records = records.filter((rhs) => {
+          if (seen.has(rhs)) return false;
+          seen.add(rhs);
           return true;
         });
       }
-
       result.set(owner, records);
     }
 

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -20,8 +20,8 @@ const adapters = new Map<string, AdapterLoader>();
 // (like Rails' adapter registry). Cleared when a name is re-registered.
 const resolved = new Map<string, Promise<AdapterClass>>();
 // Sync mirror of `resolved`, populated when each promise settles. Lets
-// sync entry points (like `connectsTo`) hand the pool a sync
-// `adapterFactory` once async adapter loading has completed at least once.
+// `db_config.new_connection` name the adapter class synchronously, as Ruby's
+// `require` lets it, once async adapter loading has completed at least once.
 const resolvedSyncCache = new Map<string, AdapterClass>();
 // Mirror of resolution rejections. Surfaces from `resolveSyncError` so the
 // sync auto-resolve path can re-throw the original loader error (unknown
@@ -31,8 +31,7 @@ const resolveErrors = new Map<string, unknown>();
 /**
  * Synchronous companion to `resolve(name)`. Returns the adapter class if it
  * has been resolved at least once (via `resolve()`), or null. Used by
- * `connectsTo` to build a sync `adapterFactory` without changing its
- * signature.
+ * `db_config.new_connection`, which is synchronous as Rails' is.
  *
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -160,7 +160,6 @@ export class ConnectionHandler {
       role?: string;
       shard?: string;
       clobber?: boolean;
-      adapterFactory?: () => DatabaseAdapter;
     } = {},
   ): ConnectionPool {
     // `owner_name: Base` (connection_handler.rb:115). `_base` is unset only
@@ -182,9 +181,6 @@ export class ConnectionHandler {
     const clobber = options.clobber ?? false;
 
     const poolConfig = this.resolvePoolConfig(config, ownerName, role, shard);
-    if (options.adapterFactory) {
-      poolConfig.adapterFactory = options.adapterFactory;
-    }
 
     const poolManager = this.setPoolManager(poolConfig.connectionDescriptor);
 
@@ -218,12 +214,12 @@ export class ConnectionHandler {
 
     Notifications.instrument("!connection.active_record", payload);
 
-    // Mirrors connectsTo: when no explicit adapterFactory is given, kick off
-    // an async load so the synchronous adapter cache is warm by the time the
-    // pool first calls newConnection(). Callers that need to await this can
+    // ESM's `import()` is async where Ruby's `require` is not, so kick the
+    // adapter load off here and let the synchronous cache be warm by the time
+    // the pool first calls newConnection(). Callers that need to await this can
     // read `pool.adapterReady`. Detached `.catch` so unhandled-rejection
     // warnings don't fire when callers never await it.
-    if (!options.adapterFactory && poolConfig.dbConfig.adapter) {
+    if (poolConfig.dbConfig.adapter) {
       const adapterReady = resolveConnectionAdapter(poolConfig.dbConfig.adapter);
       adapterReady.catch(() => {});
       poolConfig.pool.adapterReady = adapterReady;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -391,8 +391,8 @@ export class ConnectionPool implements ReapablePool {
    * Resolves once the adapter class for this pool has been loaded by the
    * async ConnectionAdapters resolver. Set by sync entry points like
    * `connectsTo` so callers can await preload before issuing real queries;
-   * defaults to a resolved promise for pools whose adapterFactory is
-   * supplied directly.
+   * defaults to a resolved promise until `establish_connection` kicks the
+   * async adapter resolve off.
    *
    * @internal Adapter-loading plumbing, not a Rails surface: Rails' `require` is
    * synchronous, so `establish_connection` returns with the adapter class
@@ -1337,15 +1337,9 @@ export class ConnectionPool implements ReapablePool {
    *     connection
    *   end
    *
-   * Falls back to `poolConfig.adapterFactory` when one is given (trails-
-   * specific extension for tests that need to inject a specific adapter
-   * instance), but the default path now delegates to `dbConfig.newConnection`
-   * just like Rails.
    */
   newConnection(): DatabaseAdapter {
-    const conn = this.poolConfig.adapterFactory
-      ? this.poolConfig.adapterFactory()
-      : (this.dbConfig.newConnection() as DatabaseAdapter);
+    const conn = this.dbConfig.newConnection() as DatabaseAdapter;
     // Set the back-reference so AbstractAdapter#schemaCache can reach
     // pool.poolConfig.schemaCache to share the raw SchemaCache across
     // every connection in this pool. Rails' AbstractAdapter has the

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -128,8 +128,8 @@ export function parseSqliteUrl(url: string): string {
  *  - PG/MySQL: `[config]` — single config object (or URL string).
  *
  * Mirrors the inline normalization in `connectsTo` / `establishWithConfig`
- * and is the resolver used by {@link ConnectionPool#newConnection} when no
- * `adapterFactory` is provided.
+ * and is the resolver {@link ConnectionPool#newConnection} builds every
+ * connection through.
  */
 export function buildAdapterArg(
   adapterName: string,
@@ -156,6 +156,7 @@ export function buildAdapterArg(
       driver,
       pragmas,
       strict,
+      foreignKeys,
       timeout,
       retries,
       statementLimit,
@@ -169,6 +170,9 @@ export function buildAdapterArg(
     if (driver !== undefined) options.driver = driver;
     if (pragmas !== undefined) options.pragmas = pragmas;
     if (strict !== undefined) options.strict = strict;
+    // `DEFAULT_PRAGMAS["foreign_keys"]` (sqlite3_adapter.rb:84-85) — a config
+    // key the adapter reads, so it belongs in the options it is built with.
+    if (foreignKeys !== undefined) options.foreignKeys = foreignKeys;
     // Rails' SQLite3Adapter reads `@config[:timeout]` and applies it as the
     // driver's busy timeout (sqlite3_adapter.rb:821-826); `config.example.yml:84`
     // sets it on both arunit entries.

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -5,7 +5,6 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { Base } from "../base.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations, type RawConfigurations } from "../database-configurations.js";
-import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { currentRole, connectedToStack } from "../core.js";
 
 async function withBaseConfigs(
@@ -205,7 +204,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
           database: databases[name],
           ...(replica ? { replica: true } : {}),
         }),
-        { ownerName: "Base", role, shard, adapterFactory: () => new BetterSQLite3Adapter() },
+        { ownerName: "Base", role, shard },
       );
 
     try {
@@ -492,7 +491,6 @@ describe("ConnectionHandlersShardingDbTest", () => {
           ownerName: owner,
           role: "writing",
           shard,
-          adapterFactory: () => new BetterSQLite3Adapter(),
         },
       );
 
@@ -554,7 +552,6 @@ describe("ConnectionHandlersShardingDbTest", () => {
           ownerName: "SecondaryBase",
           role: "writing",
           shard,
-          adapterFactory: () => new BetterSQLite3Adapter(),
         },
       );
 

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -33,16 +33,6 @@ export class PoolConfig {
   readonly role: string;
   readonly shard: string;
   readonly dbConfig: DatabaseConfig;
-  /**
-   * @noRailsEquivalent CONVERGEABLE — story
-   * `0099-call-argument-convergence/remove-pool-config-adapter-factory`. Ruby
-   * requires the adapter class named by `db_config.adapter` at connect time, so
-   * `connection_handler.rb:279` passes no factory. ESM has no autoloaded
-   * constant lookup, so a caller that cannot await `resolveConnectionAdapter`
-   * hands the pool a ready-made factory. Assigned rather than taken as a fifth
-   * `PoolConfig.new` argument, so that call site keeps Rails' argument list.
-   */
-  adapterFactory?: () => DatabaseAdapter;
   private _pool: ConnectionPool | null = null;
   private _connectionDescriptor!: ConnectionDescriptor;
   private _schemaReflection: SchemaReflection | null = null;
@@ -53,15 +43,11 @@ export class PoolConfig {
     dbConfig: DatabaseConfig,
     role: string = "writing",
     shard: string = "default",
-    options: {
-      adapterFactory?: () => DatabaseAdapter;
-    } = {},
   ) {
     this.connectionDescriptor = connectionClass;
     this.dbConfig = dbConfig;
     this.role = role;
     this.shard = shard;
-    this.adapterFactory = options.adapterFactory;
 
     const ref = new WeakRef(this);
     INSTANCES.add(ref);

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -117,10 +117,6 @@ export function connectsTo(
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
       const dbConfig = resolveConfigForConnection.call(this, dbKey);
-      // `establish_connection` resolves the adapter class from
-      // `db_config.adapter` (connection_handler.rb:110-137); trails' resolve is
-      // async, so it hands the pool back an `adapterReady` promise callers can
-      // await before issuing real queries.
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         ownerName: this.connectionClassForSelf(),
         role,
@@ -844,12 +840,11 @@ async function establishWithConfig(
   config?: Record<string, unknown>,
   dbConfigOverride?: DatabaseConfig,
 ): Promise<void> {
-  // Pass the original adapter name to the registry so caller overrides
-  // like register("mysql2", ...) aren't shadowed by normalization. Called for
-  // its effect: Ruby's `require` is synchronous, so `db_config.new_connection`
-  // (`database_configurations/database_config.rb`) can name the adapter class
-  // without a preceding load; warming the sync cache here is what lets
-  // `ConnectionPool#new_connection` stay synchronous like Rails'.
+  // No Rails counterpart: Ruby's `require` is synchronous, so
+  // `db_config.new_connection` names the adapter class with no preceding load.
+  // Warming the sync cache here is what keeps `ConnectionPool#new_connection`
+  // synchronous. The original (un-normalized) name goes to the registry so a
+  // caller override like `register("mysql2", ...)` is not shadowed.
   await _loadAdapter(adapterName);
 
   // Mirror Rails' db_config_handler (database_configurations.rb:65-70):

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -9,22 +9,9 @@ import {
   DatabaseConfig,
   _setConfigurationHash,
 } from "./database-configurations/database-config.js";
-import {
-  resolve as resolveConnectionAdapter,
-  resolveSync as resolveConnectionAdapterSync,
-} from "./connection-adapters.js";
-import {
-  adapterNameFromUrl,
-  buildAdapterArg,
-  normalizeAdapterName,
-  parseSqliteUrl,
-} from "./connection-adapters/adapter-args.js";
-import {
-  AdapterNotSpecified,
-  ConnectionNotEstablished,
-  NotImplementedError,
-  ActiveRecordError,
-} from "./errors.js";
+import { resolve as resolveConnectionAdapter } from "./connection-adapters.js";
+import { adapterNameFromUrl } from "./connection-adapters/adapter-args.js";
+import { AdapterNotSpecified, NotImplementedError, ActiveRecordError } from "./errors.js";
 import { ActiveRecord } from "./ar-config.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import {
@@ -130,42 +117,15 @@ export function connectsTo(
   for (const [shard, dbKeys] of Object.entries(shardEntries)) {
     for (const [role, dbKey] of Object.entries(dbKeys)) {
       const dbConfig = resolveConfigForConnection.call(this, dbKey);
-      const adapterName = dbConfig.adapter ?? "";
-      const adapterArg = buildAdapterArg(adapterName, dbConfig.configuration);
-      // Kick off async load so the sync adapter cache is populated by the
-      // time the pool first asks for a connection. The returned promise is
-      // attached to the pool as `adapterReady` so callers running real
-      // queries can await it before leaseConnection(). Capture any
-      // rejection in `loadError` so the sync factory below can surface the
-      // real cause (AdapterNotFound, loader import error, ...) instead of
-      // a generic "not preloaded" message — and swallow the rejection on a
-      // detached `.catch` so callers that never await `adapterReady` don't
-      // trip an unhandled-promise warning.
-      let loadError: unknown = null;
-      const adapterReady: Promise<unknown> = adapterName
-        ? resolveConnectionAdapter(adapterName).catch((err) => {
-            loadError = err;
-            throw err;
-          })
-        : Promise.resolve(null);
-      adapterReady.catch(() => {});
+      // `establish_connection` resolves the adapter class from
+      // `db_config.adapter` (connection_handler.rb:110-137); trails' resolve is
+      // async, so it hands the pool back an `adapterReady` promise callers can
+      // await before issuing real queries.
       const pool = this.connectionHandler.establishConnection(dbConfig, {
         ownerName: this.connectionClassForSelf(),
         role,
         shard,
-        adapterFactory: () => {
-          if (loadError) throw loadError;
-          const AdapterClass = resolveConnectionAdapterSync(adapterName);
-          if (!AdapterClass) {
-            throw new ConnectionNotEstablished(
-              `Adapter ${adapterName || "(missing)"} for ${this.name} pool not preloaded; ` +
-                `await the pool's \`adapterReady\` promise after \`connectsTo\` returns.`,
-            );
-          }
-          return new AdapterClass(...adapterArg);
-        },
       });
-      pool.adapterReady = adapterReady;
       connections.push(pool);
     }
   }
@@ -884,22 +844,13 @@ async function establishWithConfig(
   config?: Record<string, unknown>,
   dbConfigOverride?: DatabaseConfig,
 ): Promise<void> {
-  const normalized = normalizeAdapterName(adapterName);
   // Pass the original adapter name to the registry so caller overrides
-  // like register("mysql2", ...) aren't shadowed by normalization.
-  const AdapterClass = await _loadAdapter(adapterName);
-
-  // For SQLite, preserve adapter options (pragmas, strict, readonly, driver,
-  // etc.) by routing through buildAdapterArg whenever a config hash is given;
-  // bare-URL inputs fall through to the simple filename path.
-  let adapterArgs: unknown[];
-  if (config) {
-    adapterArgs = buildAdapterArg(adapterName, config);
-  } else if (normalized === "sqlite") {
-    adapterArgs = [parseSqliteUrl(url || ":memory:")];
-  } else {
-    adapterArgs = [url];
-  }
+  // like register("mysql2", ...) aren't shadowed by normalization. Called for
+  // its effect: Ruby's `require` is synchronous, so `db_config.new_connection`
+  // (`database_configurations/database_config.rb`) can name the adapter class
+  // without a preceding load; warming the sync cache here is what lets
+  // `ConnectionPool#new_connection` stay synchronous like Rails'.
+  await _loadAdapter(adapterName);
 
   // Mirror Rails' db_config_handler (database_configurations.rb:65-70):
   // `url ? UrlConfig.new(env, name, url, config) : HashConfig.new(...)`.
@@ -943,8 +894,6 @@ async function establishWithConfig(
     ownerName: modelClass.connectionClassForSelf(),
     role,
     shard,
-    adapterFactory: () =>
-      new (AdapterClass as new (...args: unknown[]) => DatabaseAdapter)(...adapterArgs),
   });
 }
 

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -119,10 +119,6 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   }
 }
 
-// Rails reaches a bespoke adapter class through `ConnectionAdapters.register`
-// (`connection_adapters.rb:9-13`) and `db_config.new_connection`, never by
-// handing the pool a ready-made connection. `resolve` warms the sync cache the
-// way Ruby's `require` does, so `new_connection` stays synchronous.
 register("transaction_aware_test", async () => TransactionAwareTestAdapter);
 await resolve("transaction_aware_test");
 

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -7,7 +7,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaCache, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { ambientPoolConfiguration } from "./test-adapter.js";
+import { ambientPoolConfiguration, rawTestAdapterConfiguration } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type {
@@ -26,7 +26,7 @@ interface AmbientPoolOptions {
 
 function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfig {
   return new HashConfig("test", "primary", {
-    ...ambientPoolConfiguration(),
+    ...rawTestAdapterConfiguration(),
     checkoutTimeout: 0.2,
     reapingFrequency: null,
     ...overrides,

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -7,7 +7,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaCache, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter, ambientPoolConfiguration } from "./test-adapter.js";
+import { ambientPoolConfiguration } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type {
@@ -17,11 +17,11 @@ import type {
 import { Result } from "./result.js";
 import { Base } from "./base.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
+import { register, resolve } from "./connection-adapters.js";
 
 interface AmbientPoolOptions {
   role?: string;
   shard?: string;
-  adapterFactory?: () => DatabaseAdapter;
 }
 
 function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfig {
@@ -35,18 +35,13 @@ function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfi
 
 function makeAmbientPool(
   overrides: Record<string, unknown> = {},
-  {
-    role = "writing",
-    shard = "default",
-    adapterFactory = newRawTestAdapter,
-  }: AmbientPoolOptions = {},
+  { role = "writing", shard = "default" }: AmbientPoolOptions = {},
 ): ConnectionPool {
   const pc = new PoolConfig(
     new ConnectionDescriptor("primary"),
     makeAmbientDbConfig(overrides),
     role,
     shard,
-    { adapterFactory },
   );
   return new ConnectionPool(pc);
 }
@@ -124,11 +119,15 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   }
 }
 
+// Rails reaches a bespoke adapter class through `ConnectionAdapters.register`
+// (`connection_adapters.rb:9-13`) and `db_config.new_connection`, never by
+// handing the pool a ready-made connection. `resolve` warms the sync cache the
+// way Ruby's `require` does, so `new_connection` stays synchronous.
+register("transaction_aware_test", async () => TransactionAwareTestAdapter);
+await resolve("transaction_aware_test");
+
 function makeTransactionAwarePool(size: number = 5): ConnectionPool {
-  return makeAmbientPool(
-    { pool: size },
-    { adapterFactory: () => new TransactionAwareTestAdapter() },
-  );
+  return makeAmbientPool({ adapter: "transaction_aware_test", pool: size });
 }
 
 it("checkout after close", async () => {

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -25,7 +25,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter, ambientPoolConfiguration, adapterType } from "./test-adapter.js";
+import { ambientPoolConfiguration, adapterType } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import type { LeasedTestAdapter } from "./test-adapter.js";
 import { fixtures } from "./test-fixtures.js";
@@ -54,12 +54,10 @@ function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfi
   });
 }
 
-/** Build a pool-under-test from the ambient lane config + adapter factory. */
+/** Build a pool-under-test from the ambient lane config. */
 function makeAmbientPool(overrides: Record<string, unknown> = {}): ConnectionPool {
   const dbConfig = makeAmbientDbConfig(overrides);
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-    adapterFactory: newRawTestAdapter,
-  });
+  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default");
   return new ConnectionPool(pc);
 }
 
@@ -771,7 +769,6 @@ describe("ConnectionPool schema cache", () => {
         dbConfig,
         "writing",
         "default",
-        { adapterFactory: newRawTestAdapter },
       );
       expect(
         (pc.schemaReflection as unknown as { _cachePath: string | null })._cachePath,
@@ -794,7 +791,6 @@ describe("ConnectionPool schema cache", () => {
         dbConfig,
         "writing",
         "default",
-        { adapterFactory: newRawTestAdapter },
       );
       const cachePath = (pc.schemaReflection as unknown as { _cachePath: string | null })
         ._cachePath;
@@ -810,9 +806,7 @@ describe("ConnectionPool schema cache", () => {
     // (or defaultSchemaCachePath fallback), which the reflection
     // remembers for its first on-disk load.
     const dbConfig = makeAmbientDbConfig({ schemaCachePath: "db/custom_cache.json" });
-    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-      adapterFactory: newRawTestAdapter,
-    });
+    const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default");
     const reflection = pc.schemaReflection;
     expect(reflection).toBeInstanceOf(SchemaReflection);
     // Internal state check: the cache path reached the reflection.
@@ -1072,7 +1066,6 @@ describe("ConnectionPoolConfiguration query cache", () => {
         dbConfig,
         "writing",
         "default",
-        { adapterFactory: newRawTestAdapter },
       );
       const pool = new ConnectionPool(pc);
       const max = (pool.queryCache as unknown as { _maxSize: number })._maxSize;

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -25,7 +25,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { ambientPoolConfiguration, adapterType } from "./test-adapter.js";
+import { adapterType, rawTestAdapterConfiguration } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import type { LeasedTestAdapter } from "./test-adapter.js";
 import { fixtures } from "./test-fixtures.js";
@@ -47,7 +47,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
  */
 function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfig {
   return new HashConfig("test", "primary", {
-    ...ambientPoolConfiguration(),
+    ...rawTestAdapterConfiguration(),
     checkoutTimeout: 0.2,
     reapingFrequency: null,
     ...overrides,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -27,6 +27,10 @@ export type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 export type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 export type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 export { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
+// `ActiveRecord::ConnectionAdapters` itself — `register` / `resolve`
+// (`connection_adapters.rb:9-27`) are how a host application points
+// `db_config.adapter` at an adapter class Rails would otherwise `require`.
+export * as ConnectionAdapters from "./connection-adapters.js";
 export { Migration, MigrationContext } from "./migration.js";
 export {
   TableDefinition,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -27,9 +27,11 @@ export type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 export type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 export type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 export { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
-// `ActiveRecord::ConnectionAdapters` itself — `register` / `resolve`
-// (`connection_adapters.rb:9-27`) are how a host application points
-// `db_config.adapter` at an adapter class Rails would otherwise `require`.
+/**
+ * Mirrors: `ActiveRecord::ConnectionAdapters` (`connection_adapters.rb:9-27`) —
+ * `register` / `resolve` point `db_config.adapter` at an adapter class Rails
+ * would otherwise `require`.
+ */
 export * as ConnectionAdapters from "./connection-adapters.js";
 export { Migration, MigrationContext } from "./migration.js";
 export {

--- a/packages/activerecord/src/pooled-connections.test.ts
+++ b/packages/activerecord/src/pooled-connections.test.ts
@@ -3,12 +3,12 @@ import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.j
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { ambientPoolConfiguration } from "./test-adapter.js";
+import { rawTestAdapterConfiguration } from "./test-adapter.js";
 import { ConnectionTimeoutError } from "./errors.js";
 
 function establishConnection(poolSize: number, checkoutTimeout: number): ConnectionPool {
   const dbConfig = new HashConfig("test", "primary", {
-    ...ambientPoolConfiguration(),
+    ...rawTestAdapterConfiguration(),
     pool: poolSize,
     checkoutTimeout,
     reapingFrequency: null,

--- a/packages/activerecord/src/pooled-connections.test.ts
+++ b/packages/activerecord/src/pooled-connections.test.ts
@@ -3,20 +3,17 @@ import { ConnectionPool } from "./connection-adapters/abstract/connection-pool.j
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter } from "./test-adapter.js";
+import { ambientPoolConfiguration } from "./test-adapter.js";
 import { ConnectionTimeoutError } from "./errors.js";
 
 function establishConnection(poolSize: number, checkoutTimeout: number): ConnectionPool {
   const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
+    ...ambientPoolConfiguration(),
     pool: poolSize,
     checkoutTimeout,
     reapingFrequency: null,
   });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-    adapterFactory: newRawTestAdapter,
-  });
+  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default");
   return new ConnectionPool(pc);
 }
 

--- a/packages/activerecord/src/sqlite-adapter.test.ts
+++ b/packages/activerecord/src/sqlite-adapter.test.ts
@@ -12,10 +12,6 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import type { SqliteConnection, SqliteDriver } from "./sqlite-adapter.js";
 import { register, resolve } from "./connection-adapters.js";
 
-// Rails reaches a bespoke adapter through `ConnectionAdapters.register`
-// (`connection_adapters.rb:9-13`) and `db_config.new_connection`, not by handing
-// the pool a ready-made connection. `resolve` warms the sync cache the same way
-// Ruby's `require` does, so `ConnectionPool#new_connection` stays synchronous.
 let registeredTestAdapters = 0;
 async function registerTestAdapter(build: () => DatabaseAdapter): Promise<string> {
   const adapter = `sqlite3_test_${(registeredTestAdapters += 1)}`;

--- a/packages/activerecord/src/sqlite-adapter.test.ts
+++ b/packages/activerecord/src/sqlite-adapter.test.ts
@@ -10,6 +10,25 @@ import { HashConfig } from "./database-configurations/hash-config.js";
 import { betterSqlite3Driver } from "./sqlite/better-sqlite3.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { SqliteConnection, SqliteDriver } from "./sqlite-adapter.js";
+import { register, resolve } from "./connection-adapters.js";
+
+// Rails reaches a bespoke adapter through `ConnectionAdapters.register`
+// (`connection_adapters.rb:9-13`) and `db_config.new_connection`, not by handing
+// the pool a ready-made connection. `resolve` warms the sync cache the same way
+// Ruby's `require` does, so `ConnectionPool#new_connection` stays synchronous.
+let registeredTestAdapters = 0;
+async function registerTestAdapter(build: () => DatabaseAdapter): Promise<string> {
+  const adapter = `sqlite3_test_${(registeredTestAdapters += 1)}`;
+  register(
+    adapter,
+    async () =>
+      function () {
+        return build();
+      } as unknown as new () => DatabaseAdapter,
+  );
+  await resolve(adapter);
+  return adapter;
+}
 
 // Async-only drivers (no `openSync()`) exercising the async construction path
 // the way expo-sqlite / WASM drivers do, backed by better-sqlite3 so they run
@@ -232,18 +251,16 @@ describe("SQLite adapter driver binding", () => {
     // End-to-end: ConnectionPool#checkout is synchronous and hands back the
     // freshly-constructed (still-pending) adapter without awaiting the open.
     // The first query on the checked-out connection must complete it.
-    const dbConfig = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    const adapter = await registerTestAdapter(
+      () =>
+        new SQLite3Adapter(":memory:", { driver: asyncOnlyDriver }) as unknown as DatabaseAdapter,
+    );
+    const dbConfig = new HashConfig("test", "primary", { adapter });
     const poolConfig = new PoolConfig(
       new ConnectionDescriptor("primary"),
       dbConfig,
       "writing",
       "default",
-      {
-        adapterFactory: () =>
-          new SQLite3Adapter(":memory:", {
-            driver: asyncOnlyDriver,
-          }) as unknown as DatabaseAdapter,
-      },
     );
     const pool = new ConnectionPool(poolConfig);
     const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
@@ -286,16 +303,15 @@ describe("SQLite adapter driver binding", () => {
         },
       });
     });
-    const dbConfig = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    const adapter = await registerTestAdapter(
+      () => new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
+    );
+    const dbConfig = new HashConfig("test", "primary", { adapter });
     const poolConfig = new PoolConfig(
       new ConnectionDescriptor("primary"),
       dbConfig,
       "writing",
       "default",
-      {
-        adapterFactory: () =>
-          new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
-      },
     );
     const pool = new ConnectionPool(poolConfig);
     const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
@@ -313,18 +329,18 @@ describe("SQLite adapter driver binding", () => {
   it("pool disconnect no-ops to a resolved promise for a sync driver", async () => {
     // better-sqlite3 closes synchronously inside disconnectBang(); the drain
     // contributes nothing and disconnect() still resolves.
-    const dbConfig = new HashConfig("test", "primary", { adapter: "sqlite3" });
+    const adapter = await registerTestAdapter(
+      () =>
+        new SQLite3Adapter(":memory:", {
+          driver: betterSqlite3Driver,
+        }) as unknown as DatabaseAdapter,
+    );
+    const dbConfig = new HashConfig("test", "primary", { adapter });
     const poolConfig = new PoolConfig(
       new ConnectionDescriptor("primary"),
       dbConfig,
       "writing",
       "default",
-      {
-        adapterFactory: () =>
-          new SQLite3Adapter(":memory:", {
-            driver: betterSqlite3Driver,
-          }) as unknown as DatabaseAdapter,
-      },
     );
     const pool = new ConnectionPool(poolConfig);
     const conn = (await pool.checkout()) as unknown as SQLite3Adapter;
@@ -370,20 +386,17 @@ describe("SQLite adapter driver binding", () => {
     return { driver, release: () => resolveClose(), isClosed: () => closed };
   };
 
-  const makePoolConfig = (adapterFactory: () => DatabaseAdapter): PoolConfig =>
+  const makePoolConfig = async (build: () => DatabaseAdapter): Promise<PoolConfig> =>
     new PoolConfig(
       new ConnectionDescriptor("primary"),
-      new HashConfig("test", "primary", {
-        adapter: "sqlite3",
-      }),
+      new HashConfig("test", "primary", { adapter: await registerTestAdapter(build) }),
       "writing",
       "default",
-      { adapterFactory },
     );
 
   it("pool clearReloadableConnections drains an in-flight async-only close", async () => {
     const { driver, release, isClosed } = gatedCloseDriver();
-    const poolConfig = makePoolConfig(
+    const poolConfig = await makePoolConfig(
       () =>
         new Proxy(new SQLite3Adapter(":memory:", { driver }), {
           get(target, prop, receiver) {
@@ -410,7 +423,7 @@ describe("SQLite adapter driver binding", () => {
   it("pool flushBang drains an in-flight async-only close", async () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     const pool = new ConnectionPool(
-      makePoolConfig(
+      await makePoolConfig(
         () => new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
       ),
     );
@@ -429,7 +442,7 @@ describe("SQLite adapter driver binding", () => {
   it("pool discardBang drains an in-flight async-only close", async () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     const pool = new ConnectionPool(
-      makePoolConfig(
+      await makePoolConfig(
         () => new SQLite3Adapter(":memory:", { driver }) as unknown as DatabaseAdapter,
       ),
     );
@@ -452,7 +465,7 @@ describe("SQLite adapter driver binding", () => {
     const { driver, release, isClosed } = gatedCloseDriver();
     let failCheckout = false;
     const pool = new ConnectionPool(
-      makePoolConfig(
+      await makePoolConfig(
         () =>
           new Proxy(new SQLite3Adapter(":memory:", { driver }), {
             get(target, prop, receiver) {
@@ -486,7 +499,7 @@ describe("SQLite adapter driver binding", () => {
     // better-sqlite3 closes synchronously inside disconnectBang(); each async
     // seam variant contributes nothing and resolves immediately.
     const pool = new ConnectionPool(
-      makePoolConfig(
+      await makePoolConfig(
         () =>
           new SQLite3Adapter(":memory:", {
             driver: betterSqlite3Driver,

--- a/packages/activerecord/src/support/pooled-sqlite-adapter.ts
+++ b/packages/activerecord/src/support/pooled-sqlite-adapter.ts
@@ -1,9 +1,9 @@
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
-import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { PoolConfig } from "../connection-adapters/pool-config.js";
 import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
+import { resolve as resolveConnectionAdapter } from "../connection-adapters.js";
 
 /**
  * A standalone SQLite pool for tests that need an adapter of their own rather
@@ -16,20 +16,22 @@ import { HashConfig } from "../database-configurations/hash-config.js";
  * (`alter_table`, and so `add_foreign_key` / `remove_column`) ends there, so
  * those tests check their adapter out of a real pool.
  */
+// `db_config.new_connection` (`database_config.rb`) names the adapter class
+// Ruby's `require` has already loaded. ESM's `import()` is async, so warm the
+// registry's sync cache once at module load and keep `new_connection`
+// synchronous, exactly as Rails' is.
+await resolveConnectionAdapter("sqlite3");
+
 export function newSqlitePool(
   database = ":memory:",
   options?: ConstructorParameters<typeof BetterSQLite3Adapter>[1],
 ): ConnectionPool {
+  const dbConfig = new HashConfig("test", "primary", {
+    adapter: "sqlite3",
+    database,
+    ...options,
+  });
   return new ConnectionPool(
-    new PoolConfig(
-      new ConnectionDescriptor("primary"),
-      new HashConfig("test", "primary", { adapter: "sqlite3", database }),
-      "writing",
-      "default",
-      {
-        adapterFactory: () =>
-          new BetterSQLite3Adapter(database, options) as unknown as AbstractAdapter,
-      },
-    ),
+    new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default"),
   );
 }

--- a/packages/activerecord/src/support/pooled-sqlite-adapter.ts
+++ b/packages/activerecord/src/support/pooled-sqlite-adapter.ts
@@ -16,10 +16,6 @@ import { resolve as resolveConnectionAdapter } from "../connection-adapters.js";
  * (`alter_table`, and so `add_foreign_key` / `remove_column`) ends there, so
  * those tests check their adapter out of a real pool.
  */
-// `db_config.new_connection` (`database_config.rb`) names the adapter class
-// Ruby's `require` has already loaded. ESM's `import()` is async, so warm the
-// registry's sync cache once at module load and keep `new_connection`
-// synchronous, exactly as Rails' is.
 await resolveConnectionAdapter("sqlite3");
 
 export function newSqlitePool(

--- a/packages/activerecord/src/support/second-connection.ts
+++ b/packages/activerecord/src/support/second-connection.ts
@@ -34,12 +34,12 @@ export async function withSecondAdapter<T>(
     url,
     pool: 1,
   });
+  await dbConfig.loadAdapter();
   const poolConfig = new PoolConfig(
     new ConnectionDescriptor("primary"),
     dbConfig,
     "writing",
     "default",
-    { adapterFactory: () => new PostgreSQLAdapter(url) as unknown as DatabaseAdapter },
   );
   const pool = new ConnectionPool(poolConfig);
   try {

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -17,8 +17,6 @@ import pg from "pg";
 import mysql from "mysql2/promise";
 import "../sqlite/better-sqlite3.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
-import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { ConnectionDescriptor } from "../connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "../connection-adapters/pool-config.js";
@@ -73,15 +71,14 @@ function slotCount(): number {
 // the primary test connection (`connection.ts`, `config.example.yml`).
 async function pooledTemplateAdapter(
   configurationHash: Record<string, unknown>,
-  adapterFactory: () => DatabaseAdapter,
 ): Promise<{ adapter: DatabaseAdapter; pool: ConnectionPool }> {
   const dbConfig = new HashConfig("arunit", "primary", configurationHash);
+  await dbConfig.loadAdapter();
   const poolConfig = new PoolConfig(
     new ConnectionDescriptor("primary"),
     dbConfig,
     "writing",
     "default",
-    { adapterFactory },
   );
   const pool = new ConnectionPool(poolConfig);
   return { adapter: await pool.leaseConnection(), pool };
@@ -145,10 +142,10 @@ const sqliteAdapter: DbTemplateAdapter = {
     const runToken = newRunToken();
     const templatePath = await templatePathFor(runToken);
 
-    const { adapter, pool } = await pooledTemplateAdapter(
-      { adapter: "sqlite3", database: templatePath },
-      () => new BetterSQLite3Adapter(templatePath) as unknown as DatabaseAdapter,
-    );
+    const { adapter, pool } = await pooledTemplateAdapter({
+      adapter: "sqlite3",
+      database: templatePath,
+    });
     await buildTemplateSchema(adapter, runToken, async () => {
       pool.releaseConnection();
       await pool.disconnectBang();
@@ -219,14 +216,11 @@ const pgAdapter: DbTemplateAdapter = {
     await admin.query(`CREATE DATABASE ${quotePgDatabaseName(templateDb)}`);
 
     const templateSettings = withDatabase(settings, templateDb);
-    const { adapter, pool } = await pooledTemplateAdapter(
-      { adapter: "postgresql", ...driverConfig(templateSettings) },
-      () =>
-        new PostgreSQLAdapter({
-          connectionString: settingsUrl("postgres", templateSettings),
-          max: 1,
-        }) as unknown as DatabaseAdapter,
-    );
+    const { adapter, pool } = await pooledTemplateAdapter({
+      adapter: "postgresql",
+      ...driverConfig(templateSettings),
+      max: 1,
+    });
     try {
       await loadSchema(adapter);
       // Stamp ar_internal_metadata so every slot cloned from this template
@@ -349,15 +343,12 @@ const mysqlAdapter: DbTemplateAdapter = {
     await Promise.all(
       Array.from({ length: n }, (_, i) => i + 1).map(async (slot) => {
         const slotSettings = withDatabase(settings, slotDatabaseName(baseDb, runToken, slot));
-        const { adapter, pool } = await pooledTemplateAdapter(
-          { adapter: "mysql2", ...driverConfig(slotSettings) },
-          () =>
-            new Mysql2Adapter({
-              ...driverConfig(slotSettings),
-              connectionLimit: 1,
-              flags: ["FOUND_ROWS"],
-            }) as unknown as DatabaseAdapter,
-        );
+        const { adapter, pool } = await pooledTemplateAdapter({
+          adapter: "mysql2",
+          ...driverConfig(slotSettings),
+          connectionLimit: 1,
+          flags: ["FOUND_ROWS"],
+        });
         await buildTemplateSchema(adapter, runToken, async () => {
           pool.releaseConnection();
           await pool.disconnectBang();

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1308,8 +1308,8 @@ export class DatabaseTasks {
         clobber,
       });
       // Deviation: ESM cannot import synchronously, so the handler resolves the
-      // adapter class through a dynamic `import()` when given no adapterFactory
-      // (connection-handler.ts:181-186) and the pool is not leasable until it
+      // adapter class through a dynamic `import()`
+      // (connection-handler.ts:178-186) and the pool is not leasable until it
       // settles. Ruby resolves the constant inline at :543.
       await pool.adapterReady;
       return await fn(pool);

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -89,10 +89,6 @@ const _primaryConfiguration: Record<string, unknown> = {
  *
  * @internal
  */
-// The per-connection driver caps the lane wiring below applies to a raw test
-// adapter, as configuration-hash entries. A pool builds its connections through
-// `db_config.new_connection` (`connection_pool.rb`), so a test-local pool caps
-// its connections the same way by carrying these in its `db_config`.
 let rawTestAdapterCaps: Record<string, unknown> = {};
 
 export function ambientPoolConfiguration(): Record<string, unknown> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -89,16 +89,22 @@ const _primaryConfiguration: Record<string, unknown> = {
  *
  * @internal
  */
+// The per-connection driver caps the lane wiring below applies to a raw test
+// adapter, as configuration-hash entries. A pool builds its connections through
+// `db_config.new_connection` (`connection_pool.rb`), so a test-local pool caps
+// its connections the same way by carrying these in its `db_config`.
+let rawTestAdapterCaps: Record<string, unknown> = {};
+
 export function ambientPoolConfiguration(): Record<string, unknown> {
-  return { ..._primaryConfiguration };
+  return { ..._primaryConfiguration, ...rawTestAdapterCaps };
 }
 
 /**
  * Synchronous factory that creates a fresh underlying adapter on the PRIMARY
  * lane database — the same database `Base.connection` rides (on the file-backed
  * sqlite lane its connections share the worker DB, exactly like Rails'
- * file-backed `arunit`). This is the `adapterFactory` for a test-local
- * {@link ConnectionPool} — Rails' `ConnectionPool#new_connection`
+ * file-backed `arunit`). This is the raw counterpart of a test-local
+ * {@link ConnectionPool}'s `ConnectionPool#new_connection`
  * (`connection_pool.rb`) — and nothing else: the adapter it returns still
  * carries the constructor's `NullPool` seed (`abstract_adapter.rb:153`) until a
  * pool adopts it. A test that wants a pool-owned adapter calls
@@ -136,9 +142,10 @@ const { ConnectionDescriptor } =
  * (`abstract_adapter.rb:153`) answers none of them — in Ruby it raises
  * `NoMethodError`, and only trails' cast hides that.
  *
- * {@link newRawTestAdapter} is the pool's `adapterFactory`, so the driver-level
- * cap of one server connection per raw adapter (max: 1 / connectionLimit: 1) is
- * untouched, and `pool: 1` says the same thing at the pool layer. One pool per
+ * The pool builds its connection through `db_config.new_connection` from a
+ * config hash carrying the same driver-level cap of one server connection per
+ * adapter (max: 1 / connectionLimit: 1), and `pool: 1` says the same thing at
+ * the pool layer. One pool per
  * raw adapter, not one shared pool, so each keeps the independent schema
  * reflection a standalone adapter has.
  *
@@ -160,6 +167,7 @@ export async function checkoutRawTestAdapter(): Promise<{
 }> {
   const dbConfig = new HashConfig(_primaryEnvConfig.envName, _primaryEnvConfig.name, {
     ..._primaryConfiguration,
+    ...rawTestAdapterCaps,
     pool: 1,
   });
   const poolConfig = new PoolConfig(
@@ -167,7 +175,6 @@ export async function checkoutRawTestAdapter(): Promise<{
     dbConfig,
     "writing",
     "default",
-    { adapterFactory: newRawTestAdapter },
   );
   const pool = new RealConnectionPool(poolConfig);
   return { adapter: await pool.leaseConnection(), pool };
@@ -178,6 +185,7 @@ if (adapterType === "postgres") {
   const [config] = adapterArgs as [Record<string, unknown>];
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
+  rawTestAdapterCaps = { max: 1 };
   newRawTestAdapter = () =>
     new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
 } else if (adapterType === "mysql") {
@@ -185,6 +193,7 @@ if (adapterType === "postgres") {
   // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   const [config] = adapterArgs as [Record<string, unknown>];
+  rawTestAdapterCaps = { connectionLimit: 1, flags: ["FOUND_ROWS"] };
   newRawTestAdapter = () =>
     new Mysql2Adapter({
       ...config,
@@ -227,6 +236,7 @@ async function buildInTestPool(): Promise<ConnectionPool> {
   // exactly like connection_pool_test.rb derives from `Base.connection_pool.db_config`.
   const dbConfig = new HashConfig(src.envName, src.name, {
     ...src.configurationHash,
+    ...rawTestAdapterCaps,
     checkoutTimeout: 0.2,
   });
 
@@ -235,7 +245,6 @@ async function buildInTestPool(): Promise<ConnectionPool> {
     dbConfig,
     "writing",
     "default",
-    { adapterFactory: newRawTestAdapter },
   );
   return new ConnectionPool(poolConfig);
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -89,10 +89,25 @@ const _primaryConfiguration: Record<string, unknown> = {
  *
  * @internal
  */
+export function ambientPoolConfiguration(): Record<string, unknown> {
+  return { ..._primaryConfiguration };
+}
+
+// The per-connection driver caps the lane wiring below applies to a raw test
+// adapter (PG `max`, MySQL `connectionLimit`/`flags`). Not part of the primary
+// lane's own configuration hash, which is why they live here and not in
+// `ambientPoolConfiguration`.
 let rawTestAdapterCaps: Record<string, unknown> = {};
 
-export function ambientPoolConfiguration(): Record<string, unknown> {
-  return { ..._primaryConfiguration, ...rawTestAdapterCaps };
+/**
+ * {@link ambientPoolConfiguration} plus those caps: the configuration hash a
+ * pool-under-test builds its connections from, so each of its connections maps
+ * to exactly one server connection the way {@link newRawTestAdapter} does.
+ *
+ * @internal
+ */
+export function rawTestAdapterConfiguration(): Record<string, unknown> {
+  return { ...ambientPoolConfiguration(), ...rawTestAdapterCaps };
 }
 
 /**
@@ -162,8 +177,7 @@ export async function checkoutRawTestAdapter(): Promise<{
   pool: ConnectionPool;
 }> {
   const dbConfig = new HashConfig(_primaryEnvConfig.envName, _primaryEnvConfig.name, {
-    ..._primaryConfiguration,
-    ...rawTestAdapterCaps,
+    ...rawTestAdapterConfiguration(),
     pool: 1,
   });
   const poolConfig = new PoolConfig(

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -188,8 +188,8 @@ if (lane === "mysql") {
 }
 
 // Pre-warm the sync adapter-class cache for the active test environment so
-// ConnectionPool.newConnection() can auto-resolve from `dbConfig.adapter`
-// without an explicit `adapterFactory`. Mirrors how Rails' autoload makes
+// ConnectionPool.newConnection() can resolve from `dbConfig.adapter`.
+// Mirrors how Rails' autoload makes
 // adapter classes synchronously available to ConnectionPool#new_connection.
 {
   const { resolve: resolveAdapter } = await import("./connection-adapters.js");

--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -729,8 +729,43 @@ describe("ToXmlTest", () => {
     expect(xml).toContain("<name>David</name>");
   });
 
+  it("to xml with dedicated name", () => {
+    const xml = toXmlArray(
+      [
+        { name: "David", age: 26, age_in_millis: 820497600000 },
+        { name: "Jason", age: 31 },
+      ],
+      { skipInstruct: true, indent: 0, root: "people" },
+    );
+
+    expect(xml.slice(0, 29)).toBe('<people type="array"><person>');
+  });
+
+  it("to xml with indent set", () => {
+    const xml = toXmlArray(
+      [
+        { name: "David", street_address: "Paulina" },
+        { name: "Jason", street_address: "Evergreen" },
+      ],
+      { skipInstruct: true, skipTypes: true, indent: 4 },
+    );
+
+    expect(xml.slice(0, 22)).toBe("<objects>\n    <object>");
+    expect(xml).toContain("\n        <street-address>Paulina</street-address>");
+    expect(xml).toContain("\n        <name>David</name>");
+    expect(xml).toContain("\n        <street-address>Evergreen</street-address>");
+    expect(xml).toContain("\n        <name>Jason</name>");
+  });
+
   it("to xml with empty", () => {
     const xml = toXmlArray([]);
     expect(xml).toMatch(/type="array"\/>/);
+  });
+
+  it("to xml dups options", () => {
+    const options = { skipInstruct: true };
+    toXmlArray([], options);
+    // :builder, etc, shouldn't be added to options
+    expect(options).toEqual({ skipInstruct: true });
   });
 });

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -611,6 +611,16 @@ describe("HashToXmlTest", () => {
     expect(xml).toContain("<name>David</name>");
   });
 
+  it("one level dasherize false", () => {
+    const xml = toXml(
+      { name: "David", street_name: "Paulina" },
+      { ...xmlOptions, dasherize: false },
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street_name>Paulina</street_name>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
   it("one level dasherize true", () => {
     const xml = toXml(
       { name: "David", street_name: "Paulina" },
@@ -618,6 +628,23 @@ describe("HashToXmlTest", () => {
     );
     expect(xml.slice(0, 8)).toBe("<person>");
     expect(xml).toContain("<street-name>Paulina</street-name>");
+    expect(xml).toContain("<name>David</name>");
+  });
+
+  it("one level camelize true", () => {
+    const xml = toXml({ name: "David", street_name: "Paulina" }, { ...xmlOptions, camelize: true });
+    expect(xml.slice(0, 8)).toBe("<Person>");
+    expect(xml).toContain("<StreetName>Paulina</StreetName>");
+    expect(xml).toContain("<Name>David</Name>");
+  });
+
+  it("one level camelize lower", () => {
+    const xml = toXml(
+      { name: "David", street_name: "Paulina" },
+      { ...xmlOptions, camelize: "lower" },
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<streetName>Paulina</streetName>");
     expect(xml).toContain("<name>David</name>");
   });
 
@@ -648,6 +675,17 @@ describe("HashToXmlTest", () => {
     expect(xml).toContain('<age nil="true"/>');
   });
 
+  it("one level with skipping types", () => {
+    const xml = toXml(
+      { name: "David", street: "Paulina", age: null },
+      { ...xmlOptions, skipTypes: true },
+    );
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<street>Paulina</street>");
+    expect(xml).toContain("<name>David</name>");
+    expect(xml).toContain('<age nil="true"/>');
+  });
+
   it("one level with yielding", () => {
     const xml = toXml({ name: "David", street: "Paulina" }, xmlOptions, (x) => {
       x.tag("creator", "Rails");
@@ -657,6 +695,13 @@ describe("HashToXmlTest", () => {
     expect(xml).toContain("<street>Paulina</street>");
     expect(xml).toContain("<name>David</name>");
     expect(xml).toContain("<creator>Rails</creator>");
+  });
+
+  it("two levels", () => {
+    const xml = toXml({ name: "David", address: { street: "Paulina" } }, xmlOptions);
+    expect(xml.slice(0, 8)).toBe("<person>");
+    expect(xml).toContain("<address><street>Paulina</street></address>");
+    expect(xml).toContain("<name>David</name>");
   });
 
   it("two levels with array", () => {
@@ -671,6 +716,14 @@ describe("HashToXmlTest", () => {
     expect(xml).toContain("<name>David</name>");
   });
 
+  it("three levels with array", () => {
+    const xml = toXml(
+      { name: "David", addresses: [{ streets: [{ name: "Paulina" }, { name: "Paulina" }] }] },
+      xmlOptions,
+    );
+    expect(xml).toContain('<addresses type="array"><address><streets type="array"><street><name>');
+  });
+
   it("from xml raises on disallowed type attributes", async () => {
     await expect(
       fromXml('<product><name type="foo">value</name></product>', ["foo"]),
@@ -680,6 +733,24 @@ describe("HashToXmlTest", () => {
   it("from xml array one", async () => {
     expect(await fromXml('<numbers type="Array"><value>1</value></numbers>')).toEqual({
       numbers: { type: "Array", value: "1" },
+    });
+  });
+
+  it("from xml disallows symbol and yaml types by default", async () => {
+    await expect(fromXml('<product><name type="symbol">value</name></product>')).rejects.toThrow(
+      DisallowedType,
+    );
+
+    await expect(fromXml('<product><name type="yaml">value</name></product>')).rejects.toThrow(
+      DisallowedType,
+    );
+  });
+
+  it("from xml array many", async () => {
+    expect(
+      await fromXml('<numbers type="Array"><value>1</value><value>2</value></numbers>'),
+    ).toEqual({
+      numbers: { type: "Array", value: ["1", "2"] },
     });
   });
 
@@ -705,6 +776,14 @@ describe("HashToXmlTest", () => {
       pre_escaped_string: "First &amp; Last Name",
     };
     expect(((await fromXml(xmlString)) as Record<string, unknown>)["person"]).toEqual(expectedHash);
+  });
+
+  it("roundtrip to xml from xml", async () => {
+    const hash = { bare_string: "First & Last Name", pre_escaped_string: "First &amp; Last Name" };
+
+    expect(((await fromXml(toXml(hash, xmlOptions))) as Record<string, unknown>)["person"]).toEqual(
+      hash,
+    );
   });
 
   it("to xml dups options", () => {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -59,10 +59,6 @@ async function establishMigrationConnection(
   extra: Record<string, unknown> = {},
 ): Promise<void> {
   const { Base, HashConfig, ConnectionAdapters } = await import("@blazetrails/activerecord");
-  // Rails reaches a caller-supplied adapter class through
-  // `ConnectionAdapters.register` (`connection_adapters.rb:9-13`) and
-  // `db_config.new_connection`, never by handing the pool a connection. The
-  // `resolve` warms the sync cache the way Ruby's `require` does.
   const adapterName = `sqlite3_migration_${(migrationAdapters += 1)}`;
   ConnectionAdapters.register(
     adapterName,

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -52,21 +52,34 @@ import * as os from "node:os";
 // (migration.rb:1036-1038, 1488-1491) — nothing pins an adapter to the
 // Migrator any more — so a case that drives a hand-built adapter has to
 // establish it as the migration pool's connection for the duration.
+let migrationAdapters = 0;
 async function establishMigrationConnection(
   adapter: unknown,
   database = ":memory:",
   extra: Record<string, unknown> = {},
 ): Promise<void> {
-  const { Base, HashConfig } = await import("@blazetrails/activerecord");
+  const { Base, HashConfig, ConnectionAdapters } = await import("@blazetrails/activerecord");
+  // Rails reaches a caller-supplied adapter class through
+  // `ConnectionAdapters.register` (`connection_adapters.rb:9-13`) and
+  // `db_config.new_connection`, never by handing the pool a connection. The
+  // `resolve` warms the sync cache the way Ruby's `require` does.
+  const adapterName = `sqlite3_migration_${(migrationAdapters += 1)}`;
+  ConnectionAdapters.register(
+    adapterName,
+    async () =>
+      function () {
+        return adapter;
+      } as never,
+  );
+  await ConnectionAdapters.resolve(adapterName);
   const config = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
+    adapter: adapterName,
     database,
     ...extra,
   });
   const pool = Base.connectionHandler.establishConnection(config, {
     ownerName: Base,
     clobber: true,
-    adapterFactory: () => adapter as never,
   });
   // Lease eagerly so the adapter's `pool` back-reference is in place before the
   // caller reads or overrides it (`record_environment` goes through

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -16,15 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/through-association.ts",
-    "rubyName": "records_by_owner",
-    "call": "loaded?",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "RFC 0099 bucket (c) tooling noise, verified at associations/preloader/through_association.rb:13 `if loaded?(owner)` and :20 `owners.first.association(through_reflection.name).loaded?`: the body calls `loaded?` twice — once with an owner argument, once on a receiver — and the comparator paired the port's single `loaded(owner)` against the receiverless occurrence."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "source_preloaders",
     "call": "scope",
     "reason": "Deliberate: the source Preloader is handed a scope derived from `reflectionScope`/`preloadScope` rather than `scope`, because `throughScope` may already have eager-loaded the source (see the block comment at the call site)."


### PR DESCRIPTION
Three of a four-story bundle. The fourth,
`wave-4c-ar-core-residue-attributes-remainder-part-3`, was released unstarted —
its 63 call-set rows do not fit alongside these three under the LOC ceiling, and
its own acceptance criteria anticipate the split.

## `Preloader::ThroughAssociation#records_by_owner` (RFC 0099)

`recordsByOwner` now has Rails' statement and branch order
(`preloader/through_association.rb:11-37`):

- the hoisted `owners.every(isLoaded)` pre-check is deleted; the per-owner
  `isLoaded(owner)` arm with its `continue` is the only loaded check, matching
  `:13-16`;
- `throughRecordsByOwner()` / `sourceRecordsByOwner()` are consulted lazily
  inside the loop, the way Ruby's memoized hash reads are, so the all-loaded
  case issues no query without the hoist that used to justify it;
- the `owners.first.association(through_reflection.name).loaded?` check is back
  inside the loop at `:20`, with no `try/catch` Rails does not have.

The `records_by_owner -> loaded?()` call-args baseline row went stale and is
deleted by hand.

## `PoolConfig#adapterFactory` (RFC 0099)

Gone, along with the `PoolConfig` constructor's fifth options parameter and
`establish_connection`'s `adapterFactory` option. Every pool now builds its
connections through `db_config.new_connection` (`connection_pool.rb`), as Rails
does. The one genuinely ESM-only step — warming the sync adapter-class cache
where Ruby's `require` is synchronous — stays where it already lived, in
`establish_connection`'s `adapterReady` and `DatabaseConfig#loadAdapter`; no new
`@noRailsEquivalent` was added anywhere.

Callers that used to inject a ready-made adapter now go through Rails' own
`ConnectionAdapters.register` (`connection_adapters.rb:9-13`) plus a
`db_config.adapter` pointing at the registered name. That is why
`ConnectionAdapters` is exported from the package root — no new members, just
the namespace Rails already has.

`buildAdapterArg` now forwards SQLite's `foreign_keys` config key
(`sqlite3_adapter.rb:84-85`), which the retired factory path used to carry past
it.

## Rails `HashToXmlTest` / `ToXmlTest` remainder (RFC 0098)

Ports the tests trails#6818 left behind, each under its Rails name with Rails'
own assertions and the existing `xmlOptions` setup: `one level dasherize false`,
`camelize true`, `camelize lower`, `with skipping types`, `two levels`,
`three levels with array`, `from xml disallows symbol and yaml types by
default`, `from xml array many`, `roundtrip to xml from xml`, and the array
side's `to xml with dedicated name`, `with indent set`, `dups options`.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args`
green; `pnpm parity:api:extra --package activerecord` reports no new novel
surface. Locally green on SQLite: the AS xml suites, the preloader / through /
eager / nested-through suites, and the whole
`connection-adapters/`, `adapters/sqlite3/`, `support/`, `tasks/` trees plus the
pool, sharding and trailties `db` suites. PG and MariaDB ride CI.

Closes-story: converge-through-association-records-by-owner-control-flow
Closes-story: remove-pool-config-adapter-factory
Closes-story: port-the-remaining-hash-and-array-to-xml-tests
