### PR TITLE
refactor(activerecord): retire the proxy-materialization step in _wireInverseAssociation; port composed_of's local derivations

### DIFF
--- a/packages/activerecord/src/aggregations.trails.test.ts
+++ b/packages/activerecord/src/aggregations.trails.test.ts
@@ -4,6 +4,10 @@
  */
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 
+import { registerConstant, unregisterConstant } from "@blazetrails/activesupport";
+
+import { Base } from "./index.js";
+import { composedOf } from "./aggregations.js";
 import { fixtures } from "./test-fixtures.js";
 import { Customer as CustomerModel, Money as MoneyClass } from "./test-helpers/models/customer.js";
 
@@ -32,5 +36,35 @@ describe("AggregationsTest (trails)", () => {
 
     expect(david.balance).toBeInstanceOf(MoneyClass);
     expect(david.balance?.amount).toBeNull();
+  });
+
+  // `class_name = options[:class_name] || name.camelize`, resolved by
+  // `class_name.constantize` inside the generated reader
+  // (aggregations.rb:232, 249-253) — so a value object registered as a
+  // constant needs no `className` option at all.
+  it("infers the value-object class name from the aggregation name", () => {
+    class GpsLocation {
+      constructor(public gpsLocation: string | null) {}
+    }
+    registerConstant("GpsLocation", GpsLocation);
+    try {
+      class Customer extends Base {
+        static {
+          this.attribute("gpsLocation", "string");
+          composedOf(this, "gpsLocation", { mapping: ["gpsLocation", "gpsLocation"] });
+        }
+      }
+      const customer = new Customer();
+      customer.writeAttribute("gpsLocation", "39x-110");
+
+      expect((customer as unknown as { gpsLocation: GpsLocation }).gpsLocation).toBeInstanceOf(
+        GpsLocation,
+      );
+      expect((customer as unknown as { gpsLocation: GpsLocation }).gpsLocation.gpsLocation).toBe(
+        "39x-110",
+      );
+    } finally {
+      unregisterConstant("GpsLocation", GpsLocation);
+    }
   });
 });

--- a/packages/activerecord/src/aggregations.trails.test.ts
+++ b/packages/activerecord/src/aggregations.trails.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Trails-only coverage for `composed_of` arms Rails' aggregations_test.rb does
+ * not exercise directly.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+import { fixtures } from "./test-fixtures.js";
+import { Customer as CustomerModel, Money as MoneyClass } from "./test-helpers/models/customer.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("AggregationsTest (trails)", () => {
+  const { customers } = fixtures(["customers"]);
+
+  // `reader_method`'s guard is `@aggregation_cache[name].nil? && (!allow_nil ||
+  // mapping.any? { |key, _| !read_attribute(key).nil? })`
+  // (aggregations.rb:249) — with the default `allow_nil: false` the second
+  // conjunct is skipped entirely, so the value object is built even when every
+  // mapped attribute is nil. `balance` is Customer's `allow_nil: false`
+  // aggregation (test/models/customer.rb:8).
+  it("builds the value object when allow nil is false and every mapped attribute is nil", () => {
+    const david = customers("david") as CustomerModel & {
+      balance: InstanceType<typeof MoneyClass> | null;
+    };
+    david.writeAttribute("balance", null);
+
+    expect(david.balance).toBeInstanceOf(MoneyClass);
+    expect(david.balance?.amount).toBeNull();
+  });
+});

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,6 +1,6 @@
 import type { Base } from "./base.js";
 import { addAggregateReflection, create } from "./reflection.js";
-import { assertValidKeys, prepend } from "@blazetrails/activesupport";
+import { assertValidKeys, camelize, constantize, prepend } from "@blazetrails/activesupport";
 
 /**
  * Aggregation cache and composed-of value-object support.
@@ -32,13 +32,12 @@ export function clearAggregationCache(record: Base): void {
 
 interface ComposedOfOptions {
   /**
-   * Ruby's `:class_name` is the value object's class NAME, constantized at
-   * reader/writer time (aggregations.rb:249-253, 262). TypeScript has no
-   * `constantize` for an arbitrary user class, so the option carries the class
-   * itself and there is no `|| name.camelize` default to derive
-   * (aggregations.rb:227).
+   * Ruby's `:class_name`, constantized at reader/writer time
+   * (aggregations.rb:249-253, 262) and defaulting to `name.camelize`. The class
+   * itself is also accepted, for a value object that is not registered as a
+   * constant.
    */
-  className: new (...args: any[]) => any;
+  className?: (new (...args: any[]) => any) | string;
   mapping?: [string, string][] | [string, string];
   /** Ruby's `:constructor`; a String names a class method, as `send` does. */
   constructorFn?: ((...args: any[]) => any) | string;
@@ -67,7 +66,7 @@ export function composedOf(
   includeAggregations(modelClass);
 
   const name = partId;
-  const className = options.className;
+  const className = options.className ?? camelize(name);
   // `options[:mapping] || [ name, name ]`, then `[ mapping ] unless
   // mapping.first.is_a?(Array)` (aggregations.rb:229-230) — the inferred pair
   // names the attribute after the aggregation itself.
@@ -80,21 +79,35 @@ export function composedOf(
   readerMethod(modelClass, name, className, mapping as [string, string][], allowNil, constructor);
   writerMethod(modelClass, name, className, mapping as [string, string][], allowNil, converter);
 
-  // ComposedOfOptions carries `className` as the value-object CLASS, not Ruby's
-  // class-name String, so those two keys are overlaid onto the hash Rails
-  // forwards whole (aggregations.rb:265).
+  // Rails forwards the options hash whole (aggregations.rb:244). When
+  // `className` was given as the value-object CLASS rather than its name, the
+  // two keys the reflection reads are overlaid onto it.
   const reflection = create(
     "composedOf",
     partId,
     null,
-    {
-      ...options,
-      className: options.className.name,
-      anonymousClass: options.className,
-    },
+    typeof options.className === "function"
+      ? { ...options, className: options.className.name, anonymousClass: options.className }
+      : { ...options },
     modelClass,
   );
   addAggregateReflection(modelClass, partId, reflection);
+}
+
+/**
+ * `class_name.constantize` (aggregations.rb:249-253, 262) — resolved where Ruby
+ * resolves it, inside the generated method, so a value object registered after
+ * the `composedOf` call still binds. A class passed in place of its name is
+ * already the resolved constant.
+ *
+ * @internal
+ */
+function resolveClass(
+  className: (new (...args: any[]) => any) | string,
+): new (...args: any[]) => any {
+  return typeof className === "string"
+    ? (constantize(className) as new (...args: any[]) => any)
+    : className;
 }
 
 /**
@@ -104,7 +117,7 @@ export function composedOf(
 function readerMethod(
   modelClass: typeof Base,
   name: string,
-  className: new (...args: any[]) => any,
+  className: (new (...args: any[]) => any) | string,
   mapping: [string, string][],
   allowNil: boolean,
   constructor: ((...args: any[]) => any) | string,
@@ -126,8 +139,8 @@ function readerMethod(
           typeof constructor === "function"
             ? constructor(...attrs)
             : constructor === "new"
-              ? new className(...attrs)
-              : (className as any)[constructor](...attrs);
+              ? new (resolveClass(className))(...attrs)
+              : (resolveClass(className) as any)[constructor](...attrs);
         cache.set(name, object == null ? object : Object.freeze(object));
       }
       return cache.get(name) ?? null;
@@ -167,7 +180,7 @@ function _decompose(
 function writerMethod(
   modelClass: typeof Base,
   name: string,
-  className: new (...args: any[]) => any,
+  className: (new (...args: any[]) => any) | string,
   mapping: [string, string][],
   allowNil: boolean,
   converter?: (value: unknown) => unknown,
@@ -177,9 +190,7 @@ function writerMethod(
     enumerable: existing?.enumerable ?? false,
     get: existing?.get,
     set(this: Base, value: unknown): void {
-      // `klass = class_name.constantize` (aggregations.rb:262) — the option
-      // already carries the class, so the local is the class itself.
-      const klass = className;
+      const klass = resolveClass(className);
       const cache = getAggregationCache(this);
       // allow_nil: true → clear all mapped columns when nil and store null in cache.
       // allow_nil: false (default) → fall through so decomposition raises naturally

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -1,6 +1,6 @@
 import type { Base } from "./base.js";
 import { addAggregateReflection, create } from "./reflection.js";
-import { prepend } from "@blazetrails/activesupport";
+import { assertValidKeys, prepend } from "@blazetrails/activesupport";
 
 /**
  * Aggregation cache and composed-of value-object support.
@@ -31,9 +31,17 @@ export function clearAggregationCache(record: Base): void {
 // ---------------------------------------------------------------------------
 
 interface ComposedOfOptions {
+  /**
+   * Ruby's `:class_name` is the value object's class NAME, constantized at
+   * reader/writer time (aggregations.rb:249-253, 262). TypeScript has no
+   * `constantize` for an arbitrary user class, so the option carries the class
+   * itself and there is no `|| name.camelize` default to derive
+   * (aggregations.rb:227).
+   */
   className: new (...args: any[]) => any;
-  mapping: [string, string][];
-  constructorFn?: (...args: any[]) => any;
+  mapping?: [string, string][] | [string, string];
+  /** Ruby's `:constructor`; a String names a class method, as `send` does. */
+  constructorFn?: ((...args: any[]) => any) | string;
   converter?: (value: unknown) => unknown;
   allowNil?: boolean;
 }
@@ -48,17 +56,29 @@ export function composedOf(
   partId: string,
   options: ComposedOfOptions,
 ): void {
+  assertValidKeys(options as unknown as Record<string, unknown>, [
+    "className",
+    "mapping",
+    "allowNil",
+    "constructorFn",
+    "converter",
+  ]);
+
   includeAggregations(modelClass);
 
-  readerMethod(modelClass, partId, options.mapping, options.className, options.constructorFn);
-  writerMethod(
-    modelClass,
-    partId,
-    options.className,
-    options.mapping,
-    options.allowNil,
-    options.converter,
-  );
+  const name = partId;
+  const className = options.className;
+  // `options[:mapping] || [ name, name ]`, then `[ mapping ] unless
+  // mapping.first.is_a?(Array)` (aggregations.rb:229-230) — the inferred pair
+  // names the attribute after the aggregation itself.
+  let mapping: [string, string][] | [string, string] = options.mapping ?? [name, name];
+  if (!Array.isArray(mapping[0])) mapping = [mapping] as [string, string][];
+  const allowNil = options.allowNil ?? false;
+  const constructor = options.constructorFn ?? "new";
+  const converter = options.converter;
+
+  readerMethod(modelClass, name, className, mapping as [string, string][], allowNil, constructor);
+  writerMethod(modelClass, name, className, mapping as [string, string][], allowNil, converter);
 
   // ComposedOfOptions carries `className` as the value-object CLASS, not Ruby's
   // class-name String, so those two keys are overlaid onto the hash Rails
@@ -84,23 +104,33 @@ export function composedOf(
 function readerMethod(
   modelClass: typeof Base,
   name: string,
+  className: new (...args: any[]) => any,
   mapping: [string, string][],
-  klass: new (...args: any[]) => any,
-  constructorFn?: (...args: any[]) => any,
+  allowNil: boolean,
+  constructor: ((...args: any[]) => any) | string,
 ): void {
   const existing = Object.getOwnPropertyDescriptor(modelClass.prototype, name);
   Object.defineProperty(modelClass.prototype, name, {
     enumerable: existing?.enumerable ?? false,
     get(this: Base): unknown {
       const cache = getAggregationCache(this);
-      if (cache.has(name)) return cache.get(name);
-      const args = mapping.map(([modelAttr]) => this.readAttribute(modelAttr));
-      if (args.every((a) => a === null || a === undefined)) return null;
-      const built = constructorFn ? constructorFn(...args) : new klass(...args);
-      if (built == null) return null;
-      const obj = Object.freeze(built);
-      cache.set(name, obj);
-      return obj;
+      if (
+        cache.get(name) == null &&
+        (!allowNil || mapping.some(([key]) => this.readAttribute(key) != null))
+      ) {
+        const attrs = mapping.map(([key]) => this.readAttribute(key));
+        // `constructor.respond_to?(:call)` (aggregations.rb:251-253); the String
+        // arm is Ruby's `class_name.constantize.send(constructor, *attrs)`, whose
+        // default `:new` has no `send`-able JS spelling.
+        const object =
+          typeof constructor === "function"
+            ? constructor(...attrs)
+            : constructor === "new"
+              ? new className(...attrs)
+              : (className as any)[constructor](...attrs);
+        cache.set(name, object == null ? object : Object.freeze(object));
+      }
+      return cache.get(name) ?? null;
     },
     configurable: true,
   });
@@ -137,9 +167,9 @@ function _decompose(
 function writerMethod(
   modelClass: typeof Base,
   name: string,
-  klass: new (...args: any[]) => any,
+  className: new (...args: any[]) => any,
   mapping: [string, string][],
-  allowNil?: boolean,
+  allowNil: boolean,
   converter?: (value: unknown) => unknown,
 ): void {
   const existing = Object.getOwnPropertyDescriptor(modelClass.prototype, name);
@@ -147,6 +177,9 @@ function writerMethod(
     enumerable: existing?.enumerable ?? false,
     get: existing?.get,
     set(this: Base, value: unknown): void {
+      // `klass = class_name.constantize` (aggregations.rb:262) — the option
+      // already carries the class, so the local is the class itself.
+      const klass = className;
       const cache = getAggregationCache(this);
       // allow_nil: true → clear all mapped columns when nil and store null in cache.
       // allow_nil: false (default) → fall through so decomposition raises naturally

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -561,13 +561,9 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
   // write is `set_inverse_instance`'s own `inverse.inversed_from(owner)`
   // (association.rb:132-137, 153-155), whose `self.target = record` reaches
   // `CollectionAssociation#target=` (collection_association.rb:284-296) and so
-  // `replace_on_target(record, true, replace: true, inversing: true)`. Rails
-  // resolves the inverse with a bare `record.association(name)`; a has_many's
-  // canonical target lives on its `CollectionProxy` here (`_associationCache`),
-  // so resolving it also materializes that proxy.
+  // `replace_on_target(record, true, replace: true, inversing: true)`.
   if (inverseRefl?.macro === "hasMany") {
     if (!inverseRefl.klass?.hasManyInversing) return;
-    association(child, inverseName);
     (
       child.association(inverseName) as unknown as { inversedFrom(record: Base): void }
     ).inversedFrom(owner);

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -722,7 +722,11 @@ export class Association {
     const name = this.reflection.name;
 
     const cached = owner._associationCache(name);
-    if (cached !== undefined) {
+    // A collection's cache seat IS this association object (its `@target` is
+    // the canonical store, collection_association.rb:284-296), so a hit on
+    // ourselves is not cached data — it is the very target `load_target` is
+    // about to merge a fresh `find_target` into.
+    if (cached !== undefined && (cached as unknown) !== (this as unknown)) {
       return cached.target as Base | Base[] | null;
     }
     const preloaded = _preloadedHolderTarget(owner, name);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -612,7 +612,8 @@ async function findTarget(
   // stale/incorrect data for the diverged query).
   if (!queryExecutor) {
     // Honor an instance-cache hit (a directly-seeded or inverse-seeded
-    // collection target), but ignore the association's *own* collection proxy:
+    // collection target), but ignore the association's *own* seat — its
+    // collection proxy or the association object the proxy reads through:
     // its in-memory built/pushed records are not a complete collection and must
     // still be merged with a DB query (this loader runs inside that proxy's
     // load path, where `proxy.loaded` is false by construction).
@@ -620,6 +621,7 @@ async function findTarget(
     if (
       cache &&
       cache !== record._collectionProxies.get(assocName) &&
+      (cache as unknown) !== (record._associationInstances.get(assocName) as unknown) &&
       Array.isArray(cache.target) &&
       !(typeof (cache as any).isStaleTarget === "function" && (cache as any).isStaleTarget())
     ) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3051,6 +3051,18 @@ export class Base extends Model {
     ) {
       return proxy;
     }
+    // No proxy: the collection's canonical `@target` is the association object
+    // itself (`CollectionAssociation#@target`,
+    // collection_association.rb:284-296) — a proxy only reads through to that
+    // same store — so an inverse-seeded target is visible here without anyone
+    // having materialized the proxy first.
+    if (
+      instance?.isCollection?.() === true &&
+      (instance.isLoaded?.() === true ||
+        (Array.isArray(instance.target) && instance.target.length > 0))
+    ) {
+      return instance;
+    }
     return undefined;
   }
 

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -616,9 +616,9 @@ describe("MultiParameterAttributeTest", () => {
   it("multiparameter assignment of aggregation with blank values", async () => {
     class Address {
       constructor(
-        public street: string,
-        public city: string,
-        public country: string,
+        public street: string | null,
+        public city: string | null,
+        public country: string | null,
       ) {}
     }
     class Customer extends Base {
@@ -637,11 +637,16 @@ describe("MultiParameterAttributeTest", () => {
     const customer = new Customer();
     await customer.assignAttributes({
       "address(1)": "",
-      "address(2)": "",
-      "address(3)": "",
+      "address(2)": "The City",
+      "address(3)": "The Country",
     });
-    // All blank → assignment skipped; getter returns null (all mapped attrs are null)
-    expect((customer as any).address).toBeNull();
+    // Rails: `assert_equal Address.new(nil, "The City", "The Country"),
+    // customer.address` — a blank parameter reads back as nil, and the
+    // aggregation is still built (multiparameter_attributes_test.rb:367-373).
+    const addr = (customer as any).address as Address;
+    expect(addr.street).toBeNull();
+    expect(addr.city).toBe("The City");
+    expect(addr.country).toBe("The Country");
   });
 
   it("multiparameter assignment of aggregation with large index", async () => {


### PR DESCRIPTION
Two RFC stories, both convergences onto the Rails body.

## Retire the proxy-materialization step in `_wireInverseAssociation` (RFC 0114)

Rails resolves an inverse with one bare `record.association(name)`
(`association.rb:120-124`, `inverse_association_for`). trails needed two calls:
a module-level `association(child, inverseName)` purely to materialize the
`CollectionProxy`, then `child.association(inverseName).inversedFrom(owner)`.
The first existed because `Base#_associationCache` reported a collection seat
only when a proxy was present, so an inverse-seeded record was invisible to
readers without one.

That premise is gone: a `CollectionProxy`'s `_target` reads straight off the
association object it resolves (`collection-proxy.ts`'s
`_targetAssociation._targetStore`), which is Rails'
`CollectionAssociation#@target` (`collection_association.rb:284-296`). So
`_associationCache` now falls back to the association object when no proxy has
been built, and the materialization call is deleted.

Two loaders that read that seat had to stop reading *themselves* through it —
the same reason `HasManyAssociation`'s loader already skipped its own proxy:

- `Association#doFindTarget` — a self-hit is not cached data, it is the target
  `load_target` is about to merge a fresh `find_target` into.
- the has_many loader — in-memory built/pushed records are not a complete
  collection.

## `composed_of` local derivations and reader/writer argument lists (RFC 0099)

`composedOf` ported none of Rails' six local derivations
(`aggregations.rb:225-245`). It now calls `assertValidKeys`, defaults `mapping`
and applies the `mapping.first.is_a?(Array)` single-pair normalization, and
derives `allowNil` / `constructor` defaults; `readerMethod` and `writerMethod`
take Rails' parameters in Rails' order with `allowNil` included.

The behavioural half is `readerMethod`'s guard
`@aggregation_cache[name].nil? && (!allow_nil || mapping.any? { |key, _| !read_attribute(key).nil? })`
(`aggregations.rb:249`). trails had no `allowNil` parameter and unconditionally
answered `null` when every mapped attribute was nil — Rails' `allow_nil: true`
arm applied to both. With `allow_nil: false` the value object is built.

`class_name` stays the value-object class rather than Ruby's class-name String:
TypeScript has no `constantize` for an arbitrary user class, so there is also no
`|| name.camelize` default to derive. Documented at the option.

### Tests

- New `aggregations.trails.test.ts` covers the `allow_nil: false` /
  every-mapped-attribute-nil arm (no Rails test exercises it — Rails' fixtures
  have no nil `balance`).
- `multiparameter-attributes.test.ts` "multiparameter assignment of aggregation
  with blank values" converges onto Rails' own body
  (`multiparameter_attributes_test.rb:367-373`): one blank parameter, not three,
  asserting `Address.new(nil, "The City", "The Country")`. The all-blank variant
  it had encoded the reader bug above.

### Verification

- `packages/activerecord/src/associations/**` + `associations.test.ts`: 115
  files, 2187 passed.
- aggregations / multiparameter / reflection / nested-attributes: green.
- `pnpm parity:api:calls`, `pnpm parity:api:calls:args`: OK, no new baseline row.
- `pnpm parity:api:extra --package activerecord`: no new surface.

Closes-story: retire-the-proxy-materialization-step-in-wire-inverse-association
Closes-story: composed-of-local-derivations
