### PR TITLE
refactor(activerecord): converge HasManyAssociation#countRecords onto Rails' body

### DIFF
--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -371,14 +371,11 @@ export class HasManyAssociation extends CollectionAssociation {
     if (this.reflection.hasActiveCachedCounter?.()) {
       count = toI((this.owner as any).readAttribute(this.reflection.counterCacheColumn?.()));
     } else {
-      // `:all` keeps a `select` declared on the association off the COUNT.
       count = await (this.scope() as { count(column: string): Promise<number> }).count("all");
     }
 
     if (count === 0) {
-      // Ruby `target.select!(&:new_record?)` — an in-place filter of the same
-      // array object, which the CollectionProxy and any live enumerator share.
-      const target = (this as CollectionAssociation).target;
+      const target = this.target;
       const newRecords = target.filter((record) => record.isNewRecord());
       target.length = 0;
       target.push(...newRecords);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -358,79 +358,37 @@ export class HasManyAssociation extends CollectionAssociation {
   }
 
   /**
-   * Counts the collection's records, applying the counter cache, the
-   * `limit_value` clamp, and the empty-DB loaded side-effect.
-   *
    * Mirrors: ActiveRecord::Associations::HasManyAssociation#count_records
+   * (`has_many_association.rb:80-96`) — the counter cache when active,
+   * otherwise `scope.count(:all)`; when the DB is empty keep only the new
+   * records in the target and mark it loaded (a documented side-effect that
+   * may avoid an extra SELECT), then clamp to
+   * `[association_scope.limit_value, count].compact.min`.
    * @internal
    */
   async countRecords(): Promise<number> {
-    const refl = this.reflection;
-    return countRecords({
-      hasActiveCachedCounter: () => refl.hasActiveCachedCounter?.() ?? false,
-      counterCacheColumn: () => refl.counterCacheColumn?.() ?? null,
-      readCounterAttribute: (col) => (this.owner as any).readAttribute(col),
-      countViaScope: async () => {
-        const rel = (this as any).scope?.();
-        // has_many_association.rb:84 `scope.count(:all)`: `:all` keeps a
-        // `select` declared on the association off the COUNT.
-        return rel && typeof rel.count === "function"
-          ? await rel.count("all")
-          : (this as CollectionAssociation).target.length;
-      },
-      limitValue: () =>
-        ((this as CollectionAssociation).scope() as { limitValue?: number | null })?.limitValue ??
-        null,
-      retainOnlyNewRecords: () => {
-        const self = this as CollectionAssociation;
-        self._writeTargetStore(self.target.filter((r) => r.isNewRecord()));
-      },
-      markLoaded: () => (this as CollectionAssociation).loadedBang(),
-    });
+    let count: number;
+    if (this.reflection.hasActiveCachedCounter?.()) {
+      count = toI((this.owner as any).readAttribute(this.reflection.counterCacheColumn?.()));
+    } else {
+      // `:all` keeps a `select` declared on the association off the COUNT.
+      count = await (this.scope() as { count(column: string): Promise<number> }).count("all");
+    }
+
+    if (count === 0) {
+      // Ruby `target.select!(&:new_record?)` — an in-place filter of the same
+      // array object, which the CollectionProxy and any live enumerator share.
+      const target = (this as CollectionAssociation).target;
+      const newRecords = target.filter((record) => record.isNewRecord());
+      target.length = 0;
+      target.push(...newRecords);
+      this.loadedBang();
+    }
+
+    const limitValue = (this.associationScope() as { limitValue?: number | null } | undefined)
+      ?.limitValue;
+    return Math.min(...[limitValue, count].filter((value) => value != null));
   }
-}
-
-/**
- * Host surface `countRecords` needs, abstracting the OO association and the
- * CollectionProxy (which keep their cardinality in different fields).
- * @internal
- */
-export interface CountRecordsHost {
-  hasActiveCachedCounter(): boolean;
-  counterCacheColumn(): string | null;
-  readCounterAttribute(column: string): unknown;
-  countViaScope(): Promise<number>;
-  limitValue(): number | null;
-  retainOnlyNewRecords(): void;
-  markLoaded(): void;
-}
-
-/**
- * Mirrors ActiveRecord::Associations::HasManyAssociation#count_records
- * (has_many_association.rb): read the counter cache when active, otherwise
- * `scope.count(:all)`; when the DB is empty purge non-new records and mark the
- * target loaded — a documented side-effect that may avoid an extra SELECT —
- * then clamp to `[association_scope.limit_value, count].compact.min`.
- * @internal
- */
-export async function countRecords(host: CountRecordsHost): Promise<number> {
-  let count: number;
-  if (host.hasActiveCachedCounter()) {
-    // has_active_cached_counter? guarantees a counter column, but guard against
-    // a null column anyway — `nil.to_i == 0` in Rails.
-    const column = host.counterCacheColumn();
-    count = column == null ? 0 : toI(host.readCounterAttribute(column));
-  } else {
-    count = await host.countViaScope();
-  }
-
-  if (count === 0) {
-    host.retainOnlyNewRecords();
-    host.markLoaded();
-  }
-
-  const limitValue = host.limitValue();
-  return limitValue == null ? count : Math.min(limitValue, count);
 }
 
 /** Ruby `Object#to_i` semantics: nil → 0, leading-integer parse otherwise. */


### PR DESCRIPTION
Rails `has_many_association.rb:80-96` writes `count_records` as one method ending in `target.select!(&:new_record?)`; trails split it into a `countRecords` free function driven by a `CountRecordsHost` callback object, and replaced the target array instead of filtering it.

- The host object and free function are gone; the body lives in the method, in Rails' order: counter cache or `scope.count(:all)`, the empty-DB `select!` + `loaded!` side-effect, then `[association_scope.limit_value, count].compact.min`.
- The target is filtered **in place** (same array object), matching `select!` — no `_writeTargetStore` replacement.
- `limit_value` now comes from `association_scope`, as in Rails, rather than `scope`.

No baseline row existed for this method; both `parity:api:calls` and `parity:api:calls:args` are green with no new rows.

Closes-story: converge-has-many-count-records-select-bang