### PR TITLE
refactor(activesupport): hand the Subscriber object to notifier.subscribe

### DIFF
--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -160,10 +160,6 @@ export class Subscriber {
 
     if (sub.patterns.has(pattern)) return;
 
-    // subscriber.rb:94 passes the Subscriber OBJECT itself; the notifier invokes
-    // it through Ruby's `#call` protocol. `Fanout::Subscribers.new` accepts a
-    // callable object the same way (fanout.rb:325-331), so the object goes
-    // through here too rather than a wrapper lambda.
     const handle = notifier.subscribe(pattern, sub);
     sub.patterns.set(pattern, handle);
   }

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -160,7 +160,11 @@ export class Subscriber {
 
     if (sub.patterns.has(pattern)) return;
 
-    const handle = notifier.subscribe(pattern, (e) => sub.call(e));
+    // subscriber.rb:94 passes the Subscriber OBJECT itself; the notifier invokes
+    // it through Ruby's `#call` protocol. `Fanout::Subscribers.new` accepts a
+    // callable object the same way (fanout.rb:325-331), so the object goes
+    // through here too rather than a wrapper lambda.
+    const handle = notifier.subscribe(pattern, sub);
     sub.patterns.set(pattern, handle);
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/log-subscriber.json
@@ -4,7 +4,7 @@
     "tsFile": "log-subscriber.ts",
     "rubyName": "silenced?",
     "call": "call",
-    "reason": "log_subscriber.rb:143 `@event_levels[event]&.call(logger)` — the stored value is a Ruby Proc invoked through `#call`; the JS callable it ports to is invoked as `check(l)`, so there is no `call` to make. Same substitution as the `cache.ts key_matcher -> call` row. Language shortcoming."
+    "reason": "log_subscriber.rb:143 `@event_levels[event]&.call(logger)` — the stored value is a Ruby Proc invoked through `#call`; the JS callable it ports to is invoked as `check(l)`, so there is no `call` to make. Same substitution as the `cache.ts key_matcher -> call` row. Language shortcoming. Cluster ruling (RFC 0106): where Ruby `#call` is the OBJECT protocol the port converges instead — `subscriber.ts add_event_subscriber` now hands the Subscriber itself to `notifier.subscribe`, since `Fanout::Subscribers.new` accepts a callable object (fanout.rb:325-331). Only Proc-invocation `#call`, as here, stays substituted."
   },
   {
     "package": "activesupport",


### PR DESCRIPTION
## What

`Subscriber.add_event_subscriber` (`activesupport/lib/active_support/subscriber.rb:94`) passes the Subscriber **object** to the notifier:

```ruby
subscriber.patterns[pattern] = notifier.subscribe(pattern, subscriber)
```

trails wrapped it in a lambda (`(e) => sub.call(e)`). That wrapper is unnecessary: trails' `Fanout::Subscribers.new` already implements the callable-object arm of `fanout.rb:325-331` (`CallableListener`, `notifications/fanout.ts:585-612`), and `Notifications.subscribe` already accepts one. So the port now hands `sub` over directly, exactly as Rails does.

## The cluster ruling

RFC 0106 asked for one ruling covering both `subscriber.ts add_event_subscriber -> subscribe` and `log-subscriber.ts silenced? -> call`:

- **Ruby `#call` as the OBJECT protocol converges.** Where Rails passes an object that answers to `#call` and the receiver invokes it, trails passes the object — the contract exists in Notifications/Fanout. That is this PR.
- **Ruby `#call` as Proc invocation stays substituted.** `@event_levels[event]&.call(logger)` (`log_subscriber.rb:143`) invokes a stored Proc; the JS port of a Proc is a function, invoked as `check(l)`. JS `Function.prototype.call` takes a `this` first, so it is not the same call. Genuine language shortcoming, precedent `cache.ts key_matcher -> call`. The existing baseline row now carries the ruling so a future reader does not re-derive it.

The transform_keys half of the cluster converged in #6825.

## Verification

- `pnpm parity:api:calls` — OK (880 baselined, 404 unreviewed); no new rows, no stale marks.
- `pnpm parity:api:calls:args` — OK (160 baselined shape rows).
- `pnpm parity:api:extra --package activesupport` — 0 novel.
- `pnpm vitest run` on subscriber, log-subscriber, notifications (130 tests) — green.

Closes-story: converge-log-subscriber-transform-keys-and-proc