### PR TITLE
refactor(activerecord): pass klass to Preloader::Association#associationKeyName

### DIFF
--- a/packages/activerecord/src/associations/preloader-polymorphic-composite-key-name.trails.test.ts
+++ b/packages/activerecord/src/associations/preloader-polymorphic-composite-key-name.trails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `Preloader::Association#association_key_name` resolves the associated key
+ * against the CONCRETE class of the records being preloaded:
+ *
+ *   def association_key_name
+ *     reflection.join_primary_key(klass)
+ *   end
+ *
+ * (`preloader/association.rb:160-162`), and `join_primary_key(klass = nil)` is
+ * `polymorphic? ? association_primary_key(klass) : association_primary_key`
+ * (`reflection.rb:944-946`). Dropping the `klass` argument makes a polymorphic
+ * preload key on the reflection's own guess instead of the target's real
+ * primary key — for `Cpk::Post` (`primary_key: [:title, :author]`,
+ * schema.rb:263) that is the difference between the composite key and a
+ * non-existent `id` column.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import type { CpkPost } from "../test-helpers/models/cpk.js";
+
+describe("Preloader::Association#associationKeyName — polymorphic CPK target", () => {
+  fixtures([]);
+
+  beforeAll(async () => {
+    const cpk = await import("../test-helpers/models/cpk.js");
+    registerModel("CpkPost", cpk.CpkPost);
+    registerModel("CpkComment", cpk.CpkComment);
+  });
+
+  it("preloads a polymorphic belongs_to whose target has a composite primary key", async () => {
+    const cpk = await import("../test-helpers/models/cpk.js");
+    const post = await cpk.CpkPost.create({
+      title: "cpk polymorphic post",
+      author: "the_author",
+    });
+    await cpk.CpkComment.create({
+      commentable_title: post.title,
+      commentable_author: post.author,
+      commentable_type: cpk.CpkPost.polymorphicName(),
+      text: "great post!",
+    });
+
+    const comments = await cpk.CpkComment.where({
+      commentable_title: post.title,
+    }).includes(":commentable");
+
+    expect(comments.length).toBe(1);
+    const commentable = comments[0].commentable as CpkPost | null;
+    expect(commentable).not.toBeNull();
+    expect(commentable!.title).toBe(post.title);
+    expect(commentable!.author).toBe(post.author);
+  });
+});

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -104,8 +104,9 @@ export class Association {
     return this._preloadedRecords!;
   }
 
+  /** The name of the key on the associated records */
   get associationKeyName(): string | string[] {
-    return (this.reflection as any).joinPrimaryKey;
+    return this.reflection.joinPrimaryKeyFor(this.klass);
   }
 
   loaderQuery(): LoaderQuery {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1034,8 +1034,12 @@ export class AssociationReflection extends MacroReflection {
     return this.foreignType;
   }
 
-  get joinPrimaryKey(): string | string[] {
+  joinPrimaryKeyFor(_klass?: typeof Base): string | string[] {
     return this.foreignKey;
+  }
+
+  get joinPrimaryKey(): string | string[] {
+    return this.joinPrimaryKeyFor();
   }
 
   get joinPrimaryType(): string | null {
@@ -1384,13 +1388,6 @@ export class BelongsToReflection extends AssociationReflection {
   }
 
   get joinPrimaryKey(): string | string[] {
-    if (this.isPolymorphic()) {
-      const pk = this.options.primaryKey;
-      if (pk !== undefined) {
-        return Array.isArray(pk) ? pk.map(String) : String(pk);
-      }
-      return "id";
-    }
     return this.joinPrimaryKeyFor();
   }
 


### PR DESCRIPTION
`Preloader::Association#association_key_name` is
`reflection.join_primary_key(klass)`
(`activerecord/lib/active_record/associations/preloader/association.rb:160-162`);
trails read the `joinPrimaryKey` getter and passed no klass. Since
`join_primary_key(klass = nil)` is
`polymorphic? ? association_primary_key(klass) : association_primary_key`
(`reflection.rb:944-946`), a polymorphic preload must resolve its key against
the concrete class being preloaded.

- `associationKeyName` now calls `reflection.joinPrimaryKeyFor(this.klass)`.
- `joinPrimaryKeyFor(klass)` — Rails' `join_primary_key(klass)` — now exists on
  `AssociationReflection` (`foreignKey`, reflection.rb:606) and
  `PolymorphicReflection` (delegated, reflection.rb:1229-1230), alongside the
  existing `BelongsToReflection` / `ThroughReflection` / `RuntimeReflection`
  ones; every `joinPrimaryKey` getter is now just `joinPrimaryKeyFor()`.
- The `BelongsToReflection#joinPrimaryKey` polymorphic arm's hardcoded `"id"`
  fallback is gone — it diverged from `association_primary_key(klass)`.
- `ThroughReflection#joinPrimaryKeyFor` is now Rails' one-line body
  (`source_reflection.join_primary_key(klass)`, reflection.rb:1093-1095).

Regression coverage: preloading `Cpk::Comment#commentable` (polymorphic
belongs_to onto `cpk_posts`, whose PK is `[:title, :author]`, schema.rb:263).
On baseline it fails with `no such column: id`.

No baseline row existed for this call on main, so nothing to delete;
`parity:api:calls` and `parity:api:calls:args` are both OK.

Closes-story: converge-preloader-association-key-name-klass-argument
