### PR TITLE
refactor(activerecord): converge exec_insert/exec_delete/exec_update and internal_execute onto the Rails call shape

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -152,10 +152,11 @@ async function remoteDisconnect(conn: DatabaseAdapter): Promise<void> {
         internalExecute(
           sql: string,
           name?: string,
+          binds?: unknown[],
           opts?: { materializeTransactions?: boolean },
         ): Promise<unknown>;
       }
-    ).internalExecute("set @@wait_timeout=1", "SQL", { materializeTransactions: false });
+    ).internalExecute("set @@wait_timeout=1", "SQL", [], { materializeTransactions: false });
     await sleep(1200);
   }
 }

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -94,13 +94,13 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   // statements through `_trackPrepared` + `conn.execute`, so an explicit
   // `prepare: true` must land the SQL in the statement pool.
   it("internalExecute prepares when prepare is true", async () => {
-    await adapter.internalExecute("SELECT 1", "SQL", { prepare: true });
+    await adapter.internalExecute("SELECT 1", "SQL", [], { prepare: true });
     const pool = adapter._statementPoolForTest();
     expect(pool?.get("SELECT 1")).toBeTruthy();
   });
 
   it("internalExecute does not prepare when prepare is false", async () => {
-    await adapter.internalExecute("SELECT 2", "SQL", { prepare: false });
+    await adapter.internalExecute("SELECT 2", "SQL", [], { prepare: false });
     const pool = adapter._statementPoolForTest();
     expect(pool?.get("SELECT 2")).toBeFalsy();
   });

--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -95,7 +95,7 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
 
       // materialize:false — the withRawConnection loop's own (suppressed) finally
       // must NOT dirty the parent on the reconnect path.
-      await adapter.internalExecute("SAVEPOINT `sp_clean`", "TRANSACTION", {
+      await adapter.internalExecute("SAVEPOINT `sp_clean`", "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
       });
@@ -105,7 +105,9 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
       // materialize:true (the savepoint default) — the relocated internalExecute
       // finally dirties the parent on the very same reconnect path.
       rawForBlock.mockRejectedValueOnce(new ConnectionFailed("Lost connection to MySQL server"));
-      await adapter.internalExecute("SAVEPOINT `sp_dirty`", "TRANSACTION", { allowRetry: true });
+      await adapter.internalExecute("SAVEPOINT `sp_dirty`", "TRANSACTION", [], {
+        allowRetry: true,
+      });
       expect(reconnect).toHaveBeenCalledTimes(2);
       expect(tm.isRestorable()).toBe(false);
     });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -106,8 +106,7 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     const subscriber = new SQLSubscriber();
     subscriber.start();
     try {
-      await adapter.internalExecute("SELECT $1::integer", "SQL", {
-        binds: [bind],
+      await adapter.internalExecute("SELECT $1::integer", "SQL", [bind], {
         prepare: true,
       });
       const payload = subscriber.payloads.find((p) => p["sql"] === "SELECT $1::integer");
@@ -122,8 +121,7 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     const subscriber = new SQLSubscriber();
     subscriber.start();
     try {
-      await adapter.internalExecute("SELECT $1::integer + 0", "SQL", {
-        binds: [bind],
+      await adapter.internalExecute("SELECT $1::integer + 0", "SQL", [bind], {
         prepare: false,
       });
       const payload = subscriber.payloads.find((p) => p["sql"] === "SELECT $1::integer + 0");

--- a/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
@@ -87,7 +87,7 @@ describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)",
 
       // materialize:false — the withRawConnection loop's own (suppressed) finally
       // must NOT dirty the parent on the reconnect path.
-      await adapter.internalExecute('SAVEPOINT "sp_clean"', "TRANSACTION", {
+      await adapter.internalExecute('SAVEPOINT "sp_clean"', "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
       });
@@ -99,7 +99,9 @@ describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)",
       rawForBlock.mockRejectedValueOnce(
         new ConnectionFailed("server closed the connection unexpectedly"),
       );
-      await adapter.internalExecute('SAVEPOINT "sp_dirty"', "TRANSACTION", { allowRetry: true });
+      await adapter.internalExecute('SAVEPOINT "sp_dirty"', "TRANSACTION", [], {
+        allowRetry: true,
+      });
       expect(reconnect).toHaveBeenCalledTimes(2);
       expect(tm.isRestorable()).toBe(false);
     });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -324,28 +324,35 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   it("internalExecute prepares when prepare is true", async () => {
     const pool = (adapter as unknown as { _statementPool: { get(sql: string): unknown } })
       ._statementPool;
-    await adapter.internalExecute(`SELECT 1`, "SQL", { prepare: true });
+    await adapter.internalExecute(`SELECT 1`, "SQL", [], { prepare: true });
     expect(pool.get(`SELECT 1`)).toBeTruthy();
   });
 
   it("internalExecute does not prepare when prepare is false", async () => {
     const pool = (adapter as unknown as { _statementPool: { get(sql: string): unknown } })
       ._statementPool;
-    await adapter.internalExecute(`SELECT 2`, "SQL", { prepare: false });
+    await adapter.internalExecute(`SELECT 2`, "SQL", [], { prepare: false });
     expect(pool.get(`SELECT 2`)).toBeFalsy();
   });
   it("internalExecute binds through to the driver", async () => {
-    await adapter.internalExecute(`INSERT INTO "pq" ("id", "nick") VALUES (?, ?)`, "SQL", {
-      binds: [7, "bound"],
-    });
+    await adapter.internalExecute(
+      `INSERT INTO "pq" ("id", "nick") VALUES (?, ?)`,
+      "SQL",
+      [7, "bound"],
+      {},
+    );
     expect(await adapter.queryValue(`SELECT "nick" FROM "pq" WHERE "id" = 7`)).toBe("bound");
   });
 
   it("internalExecute binds through to the driver when prepare is true", async () => {
-    await adapter.internalExecute(`INSERT INTO "pq" ("id", "nick") VALUES (?, ?)`, "SQL", {
-      binds: [8, "prepared"],
-      prepare: true,
-    });
+    await adapter.internalExecute(
+      `INSERT INTO "pq" ("id", "nick") VALUES (?, ?)`,
+      "SQL",
+      [8, "prepared"],
+      {
+        prepare: true,
+      },
+    );
     expect(await adapter.queryValue(`SELECT "nick" FROM "pq" WHERE "id" = 8`)).toBe("prepared");
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.test.ts
@@ -267,15 +267,9 @@ describe("DatabaseStatements#insert id extraction", () => {
     }
   }
 
-  it("returns numeric insertId when execInsert returns a number", async () => {
-    const adapter = new InsertTestAdapter() as any;
-    adapter.execInsert = async () => 42;
-    expect(await adapter.insert("INSERT INTO t VALUES (1)")).toBe(42);
-  });
-
   it("respects idValue override when provided, regardless of execInsert return type", async () => {
     const adapter = new InsertTestAdapter() as any;
-    adapter.execInsert = async () => 42;
+    adapter.execInsert = async () => new Result(["id"], [[42]]);
     expect(await adapter.insert("INSERT INTO t VALUES (1)", null, null, 99)).toBe(99);
   });
 
@@ -343,26 +337,6 @@ describe("DatabaseStatements#insert id extraction", () => {
       },
     );
     expect(out).toEqual([null]);
-  });
-
-  it("falls back to [insertId] when returning requested but execInsert returns a number", async () => {
-    const adapter = new InsertTestAdapter() as any;
-    adapter.execInsert = async () => 42;
-    const out = await adapter.insert("INSERT INTO t VALUES (1)", null, "id", undefined, null, [], {
-      returning: ["id"],
-    });
-    expect(out).toEqual([42]);
-  });
-
-  it("falls back to [insertId] when RETURNING yields no value (empty rows)", async () => {
-    const adapter = new InsertTestAdapter() as any;
-    adapter.execInsert = async () => new Result(["id"], []);
-    adapter.returningColumnValues = (result: Result) => result.rows[0]; // undefined for empty rows
-    adapter.lastInsertedId = () => 13;
-    const out = await adapter.insert("INSERT INTO t VALUES (1)", null, "id", undefined, null, [], {
-      returning: ["id"],
-    });
-    expect(out).toEqual([13]);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -683,11 +683,11 @@ export interface AbstractAdapter {
   internalExecute(
     sql: string,
     name?: string,
+    binds?: unknown[],
     opts?: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;
       prepare?: boolean;
-      binds?: unknown[];
     },
   ): Promise<unknown>;
   /** @internal */
@@ -2897,14 +2897,18 @@ function ensureAbstractAdapterMixinsApplied(): void {
   // by a concrete adapter here — they're only defined on AbstractAdapter, and a
   // subclass prototype doesn't yet inherit them when the per-adapter module runs
   // (circular-import load order), so they must be wired on AbstractAdapter. The
-  // OVERRIDDEN write methods (`execInsert`, `execute`,
-  // `rollbackDbTransaction`, `rollbackToSavepoint`, and sqlite's `truncate`) are
+  // OVERRIDDEN write methods (`execute`, `rollbackDbTransaction`,
+  // `rollbackToSavepoint`, and sqlite's `truncate`) are
   // wired on each concrete adapter instead — wiring them here too would leave the
   // override unwrapped. Reads route through `internalExecQuery` and never trip
-  // the wrapper.
+  // the wrapper. `execInsert` is wired here rather than per-adapter: only
+  // PostgreSQL still overrides it (postgresql/database_statements.rb:45), and its
+  // override delegates to `super`, so one wrapper on the shared method clears
+  // exactly once for every adapter.
   dirtiesQueryCache(
     AbstractAdapter,
     "execQuery",
+    "execInsert",
     "execUpdate",
     "execDelete",
     "execInsertAll",

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -624,7 +624,7 @@ export interface AbstractAdapter {
     pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
-  ): Promise<Result | number>;
+  ): Promise<Result>;
   execDelete(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   execUpdate(sql: string, name?: string | null, binds?: unknown[]): Promise<number>;
   isWriteQuery(sql: string): boolean;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -401,8 +401,8 @@ describe("DatabaseStatements", () => {
       const host = {
         log,
         typeCastedBinds,
-        internalExecute: async (sql: string, name: string | null, opts?: { binds?: unknown[] }) =>
-          log(sql, name, opts?.binds ?? [], [], false, async () => {
+        internalExecute: async (sql: string, name: string | null, binds?: unknown[]) =>
+          log(sql, name, binds ?? [], [], false, async () => {
             throw new StatementInvalid("duplicate key value violates unique constraint");
           }),
       } as unknown as DatabaseStatementsHost;
@@ -423,8 +423,8 @@ describe("DatabaseStatements", () => {
       const host = {
         log,
         typeCastedBinds,
-        internalExecute: async (sql: string, name: string | null, opts?: { binds?: unknown[] }) =>
-          log(sql, name, opts?.binds ?? [], [], false, async () => {
+        internalExecute: async (sql: string, name: string | null, binds?: unknown[]) =>
+          log(sql, name, binds ?? [], [], false, async () => {
             throw new StatementInvalid("boom", { sql: "ORIGINAL", binds: [99] });
           }),
       } as unknown as DatabaseStatementsHost;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -782,8 +782,8 @@ describe("execInsert", () => {
     return host;
   }
 
-  it("appends RETURNING via sqlForInsert when adapter supports it", () => {
-    const [sql] = sqlForInsert.call(
+  it("appends RETURNING via sqlForInsert when adapter supports it", async () => {
+    const [sql] = await sqlForInsert.call(
       makeInsertHost(true),
       "INSERT INTO t (x) VALUES (1)",
       "id",
@@ -793,8 +793,8 @@ describe("execInsert", () => {
     expect(sql).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "id"`);
   });
 
-  it("passes sql unchanged when adapter does not support RETURNING", () => {
-    const [sql] = sqlForInsert.call(
+  it("passes sql unchanged when adapter does not support RETURNING", async () => {
+    const [sql] = await sqlForInsert.call(
       makeInsertHost(false),
       "INSERT INTO t (x) VALUES (1)",
       "id",
@@ -804,8 +804,8 @@ describe("execInsert", () => {
     expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
   });
 
-  it("uses explicit returning list when provided", () => {
-    const [sql] = sqlForInsert.call(
+  it("uses explicit returning list when provided", async () => {
+    const [sql] = await sqlForInsert.call(
       makeInsertHost(true),
       "INSERT INTO t (x) VALUES (1)",
       null,
@@ -856,19 +856,25 @@ describe("internal_exec_query is a virtual call", () => {
 });
 
 describe("sqlForInsert", () => {
-  it("returns sql and binds unchanged when adapter does not support RETURNING", () => {
+  it("returns sql and binds unchanged when adapter does not support RETURNING", async () => {
     const host: DatabaseStatementsHost = {
       pool,
       typeCastedBinds,
       log,
       supportsInsertReturning: () => false,
     };
-    const [sql, binds] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", "id", [], null);
+    const [sql, binds] = await sqlForInsert.call(
+      host,
+      "INSERT INTO t (x) VALUES (1)",
+      "id",
+      [],
+      null,
+    );
     expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
     expect(binds).toEqual([]);
   });
 
-  it("appends RETURNING clause when pk is supplied and adapter supports it", () => {
+  it("appends RETURNING clause when pk is supplied and adapter supports it", async () => {
     const host: DatabaseStatementsHost = {
       log,
       pool,
@@ -876,11 +882,11 @@ describe("sqlForInsert", () => {
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
-    const [sql] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", "id", [], null);
+    const [sql] = await sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", "id", [], null);
     expect(sql).toBe(`INSERT INTO t (x) VALUES (1) RETURNING "id"`);
   });
 
-  it("uses explicit returning list when provided", () => {
+  it("uses explicit returning list when provided", async () => {
     const host: DatabaseStatementsHost = {
       log,
       pool,
@@ -888,7 +894,7 @@ describe("sqlForInsert", () => {
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
-    const [sql] = sqlForInsert.call(
+    const [sql] = await sqlForInsert.call(
       host,
       "INSERT INTO t (x) VALUES (1)",
       null,
@@ -898,7 +904,7 @@ describe("sqlForInsert", () => {
     expect(sql).toContain('RETURNING "id", "created_at"');
   });
 
-  it("does NOT append pk-derived RETURNING when pk is false (Rails opt-out)", () => {
+  it("does NOT append pk-derived RETURNING when pk is false (Rails opt-out)", async () => {
     // Mirrors Rails sql_for_insert: pk=false signals the caller does not
     // want any pk-derived RETURNING column. extractTableRefFromInsertSql /
     // primaryKey lookup must be skipped too.
@@ -912,11 +918,11 @@ describe("sqlForInsert", () => {
         throw new Error("primaryKey() must not be called when pk=false");
       },
     };
-    const [sql] = sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", false, [], null);
+    const [sql] = await sqlForInsert.call(host, "INSERT INTO t (x) VALUES (1)", false, [], null);
     expect(sql).toBe("INSERT INTO t (x) VALUES (1)");
   });
 
-  it("still honours explicit returning list when pk=false", () => {
+  it("still honours explicit returning list when pk=false", async () => {
     const host: DatabaseStatementsHost = {
       log,
       pool,
@@ -924,7 +930,7 @@ describe("sqlForInsert", () => {
       supportsInsertReturning: () => true,
       quoteColumnName: (c) => `"${c}"`,
     };
-    const [sql] = sqlForInsert.call(
+    const [sql] = await sqlForInsert.call(
       host,
       "INSERT INTO t (x) VALUES (1)",
       false,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1217,7 +1217,6 @@ export async function internalExecQuery(
     // Thread binds and exec options through so a bound INSERT ... RETURNING
     // reaches the driver and allow_retry / materialize_transactions survive
     // (Rails internal_exec_query(...) → internal_execute(...) → raw_execute).
-    // Ruby's trailing kwargs become the trailing options object.
     const rawResult = await this.internalExecute(sql, name, binds, {
       prepare: options?.prepare,
       allowRetry: options?.allowRetry,
@@ -1369,16 +1368,11 @@ async function insertStatement(
   let sql: string;
   [sql, binds] = toSqlAndBinds.call(this, arel, binds);
   const value = await this.execInsert(sql, name, binds, pk, sequenceName, opts?.returning ?? null);
-  // Rails: `return returning_column_values(value) unless returning.nil?`
-  // (database_statements.rb:203). `returning_column_values` reads the RETURNING
-  // row, which every adapter now produces because `exec_insert` runs
-  // `sql_for_insert` first.
   if (opts?.returning != null) {
-    return (this.returningColumnValues ?? returningColumnValues).call(this, value);
+    return this.returningColumnValues(value);
   }
-  // Rails: `id_value || last_inserted_id(value)` (database_statements.rb:205).
-  // Ruby `||` falls through only on nil/false, so a caller-supplied id of 0 is
-  // kept.
+  // Ruby's `id_value || last_inserted_id(value)` (database_statements.rb:205)
+  // falls through only on nil/false, so a caller-supplied id of 0 is kept.
   if (idValue != null && idValue !== false) return idValue;
   return this.lastInsertedId(value);
 }
@@ -1515,7 +1509,7 @@ export const DatabaseStatements = {
     _sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result> {
-    [sql, binds] = await this.sqlForInsert(sql, pk ?? null, binds, returning ?? null);
+    [sql, binds] = await this.sqlForInsert(sql, pk, binds, returning);
     return this.internalExecQuery(sql, name, binds);
   },
 
@@ -2024,6 +2018,11 @@ function currentTransactionJoinable(host: DatabaseStatementsHost): boolean {
 /**
  * Appends a RETURNING clause when the adapter supports it, then returns [sql, binds].
  *
+ * Async where Ruby is sync: `supports_insert_returning?` and `primary_key` are
+ * plain predicates in Ruby (a constant and a schema-cache read) but both are
+ * async here, and an un-awaited Promise is always truthy — so a sync body would
+ * append RETURNING on every backend.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#sql_for_insert
  * @internal
  */
@@ -2034,10 +2033,6 @@ export async function sqlForInsert(
   binds: unknown[],
   returning: string[] | null | undefined,
 ): Promise<[string, unknown[]]> {
-  // `supports_insert_returning?` and `primary_key` are plain predicates in Ruby;
-  // both are async in trails (a version probe / a schema query), so this body is
-  // async and awaits them. Without the await a Promise is always truthy and the
-  // RETURNING clause would be appended on every backend.
   if (await this.supportsInsertReturning?.()) {
     // Mirrors Rails: `pk == false` is the explicit caller opt-out — skip
     // any pk-derived RETURNING column (caller may still pass `returning:`

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -133,11 +133,11 @@ export interface DatabaseStatementsHost {
   internalExecute?(
     sql: string,
     name?: string | null,
+    binds?: unknown[],
     opts?: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;
       prepare?: boolean;
-      binds?: unknown[];
     },
   ): Promise<unknown>;
   /** @internal */
@@ -196,11 +196,11 @@ export interface DatabaseStatementsHost {
   /** @internal */
   checkIfWriteQuery?(sql: string): void;
   /** @internal */
-  supportsInsertReturning?(): boolean;
+  supportsInsertReturning?(): boolean | Promise<boolean>;
   /** @internal */
   quoteColumnName?(col: string): string;
   /** @internal */
-  primaryKey?(table: string): string | null;
+  primaryKey?(table: string): string | null | Promise<string | null>;
   /** @internal */
   preprocessQuery?(sql: string): string;
   /** @internal */
@@ -486,52 +486,6 @@ export async function query(
  */
 export function execute(_sql: string, _binds?: unknown[], _name?: string | null): Promise<unknown> {
   throw new Error("execute must be implemented by adapter subclass");
-}
-
-/**
- * Shared multi-column RETURNING read-back for exec_insert.
- *
- * Rails' abstract exec_insert runs sql_for_insert then internal_exec_query,
- * returning the full RETURNING row. trails' adapters keep an executeMutation
- * fast path for single-column / no-RETURNING inserts (lastInsertRowid +
- * prepared-statement-cache retry), so this helper handles ONLY the multi-column
- * auto-populated-columns read-back (Rails `_create_record` zips every returning
- * column): it appends the RETURNING columns via sql_for_insert and runs the
- * bound INSERT through the adapter's bind-aware internalExecQuery (which
- * materializes the transaction) to hand back the whole Result, dirtying the
- * transaction as executeMutation would. Returns undefined when the caller should
- * keep its fast path (≤1 returning column, or sql_for_insert produced no
- * RETURNING clause — e.g. MySQL 8, which lacks INSERT ... RETURNING).
- *
- * @internal
- */
-export async function execInsertReturningReadback(
-  this: DatabaseStatementsHost,
-  sql: string,
-  name: string | null,
-  binds: unknown[],
-  pk: string | false | null | undefined,
-  returning: string[] | null | undefined,
-): Promise<Result | undefined> {
-  if (!returning || returning.length <= 1) return undefined;
-  // Gate on the capability flag sql_for_insert itself checks
-  // (supports_insert_returning?) rather than sniffing the generated SQL — on a
-  // backend without INSERT ... RETURNING (MySQL 8) sql_for_insert appends
-  // nothing, so the caller keeps its executeMutation fast path.
-  if (!this.supportsInsertReturning?.()) return undefined;
-  const [returningSql, returningBinds] = sqlForInsert.call(
-    this as never,
-    sql,
-    pk ?? null,
-    binds,
-    returning,
-  );
-  // Dispatch through the instance so SQLite's bind-aware internalExecQuery
-  // override (`.all()`) is used; PG/MySQL fall to the mixed-in default.
-  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
-  const result = await run(returningSql, name, returningBinds);
-  this.dirtyCurrentTransaction?.();
-  return result;
 }
 
 /**
@@ -1263,9 +1217,8 @@ export async function internalExecQuery(
     // Thread binds and exec options through so a bound INSERT ... RETURNING
     // reaches the driver and allow_retry / materialize_transactions survive
     // (Rails internal_exec_query(...) → internal_execute(...) → raw_execute).
-    // trails carries all of them in the opts object rather than positionally.
-    const rawResult = await this.internalExecute(sql, name, {
-      binds,
+    // Ruby's trailing kwargs become the trailing options object.
+    const rawResult = await this.internalExecute(sql, name, binds, {
       prepare: options?.prepare,
       allowRetry: options?.allowRetry,
       materializeTransactions: options?.materializeTransactions,
@@ -1369,6 +1322,26 @@ interface DatabaseStatementsDefaultsHost {
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
+  /** @internal */
+  internalExecute(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: {
+      prepare?: boolean;
+      allowRetry?: boolean;
+      materializeTransactions?: boolean;
+    },
+  ): Promise<unknown>;
+  /** @internal */
+  affectedRows(rawResult: unknown): number;
+  /** @internal */
+  sqlForInsert(
+    sql: string,
+    pk: string | false | null | undefined,
+    binds: unknown[],
+    returning: string[] | null | undefined,
+  ): Promise<[string, unknown[]]>;
 }
 
 /**
@@ -1395,34 +1368,19 @@ async function insertStatement(
 ): Promise<unknown> {
   let sql: string;
   [sql, binds] = toSqlAndBinds.call(this, arel, binds);
-  const result = await this.execInsert(sql, name, binds, pk, sequenceName, opts?.returning ?? null);
-  // execInsert may return a Result (PG/adapter with RETURNING support) or a
-  // number/insertId (MySQL/SQLite via executeMutation). Delegate to the
-  // adapter's lastInsertedId when available; fall back to treating the
-  // result directly as the id (matches executeMutation returning insertId).
-  const insertedId = (): unknown => {
-    if (idValue != null) return idValue;
-    if (this.lastInsertedId && result instanceof Result) return this.lastInsertedId(result);
-    if (result instanceof Result) return lastInsertedId(result);
-    return result; // numeric insertId from executeMutation
-  };
+  const value = await this.execInsert(sql, name, binds, pk, sequenceName, opts?.returning ?? null);
+  // Rails: `return returning_column_values(value) unless returning.nil?`
+  // (database_statements.rb:203). `returning_column_values` reads the RETURNING
+  // row, which every adapter now produces because `exec_insert` runs
+  // `sql_for_insert` first.
   if (opts?.returning != null) {
-    // Adapters that emit a RETURNING clause surface the values via the result
-    // rows; those that can't (MySQL, SQLite < 3.35) fall back to the generated
-    // id so the single PK/auto-populated column is still filled. Returned as an
-    // array to match Rails' `returning_column_values` shape.
-    if (result instanceof Result) {
-      const rv = await (this.returningColumnValues ?? returningColumnValues).call(this, result);
-      // `undefined` first element means no value was extracted (no RETURNING
-      // clause emitted) — fall back to the insert id. A real `null` is a
-      // legitimate RETURNING value and must be preserved, so guard on
-      // `!== undefined`, not `!= null` (Rails has no such guard because its
-      // adapter dispatch never yields the no-value case here).
-      if (rv != null && rv.length > 0 && rv[0] !== undefined) return rv;
-    }
-    return [insertedId()];
+    return (this.returningColumnValues ?? returningColumnValues).call(this, value);
   }
-  return insertedId();
+  // Rails: `id_value || last_inserted_id(value)` (database_statements.rb:205).
+  // Ruby `||` falls through only on nil/false, so a caller-supplied id of 0 is
+  // kept.
+  if (idValue != null && idValue !== false) return idValue;
+  return this.lastInsertedId(value);
 }
 
 export const DatabaseStatements = {
@@ -1552,30 +1510,31 @@ export const DatabaseStatements = {
     this: DatabaseStatementsDefaultsHost,
     sql: string,
     name: string | null = null,
-    binds?: unknown[],
-    _pk?: string | false | null,
+    binds: unknown[] = [],
+    pk?: string | false | null,
     _sequenceName?: string | null,
-    _returning?: string[] | null,
-  ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
+    returning?: string[] | null,
+  ): Promise<Result> {
+    [sql, binds] = await this.sqlForInsert(sql, pk ?? null, binds, returning ?? null);
+    return this.internalExecQuery(sql, name, binds);
   },
 
   async execDelete(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
     name: string | null = null,
-    binds?: unknown[],
+    binds: unknown[] = [],
   ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
+    return this.affectedRows(await this.internalExecute(sql, name, binds));
   },
 
   async execUpdate(
     this: DatabaseStatementsDefaultsHost,
     sql: string,
     name: string | null = null,
-    binds?: unknown[],
+    binds: unknown[] = [],
   ): Promise<number> {
-    return this.executeMutation(sql, binds, name);
+    return this.affectedRows(await this.internalExecute(sql, name, binds));
   },
 
   isWriteQuery(sql: string): boolean {
@@ -1797,13 +1756,12 @@ export function internalExecute(
   this: DatabaseStatementsHost,
   sql: string,
   name: string | null = "SQL",
+  binds: unknown[] = [],
   {
-    binds = [],
     prepare = false,
     allowRetry = false,
     materializeTransactions = true,
   }: {
-    binds?: unknown[];
     prepare?: boolean;
     allowRetry?: boolean;
     materializeTransactions?: boolean;
@@ -2069,21 +2027,25 @@ function currentTransactionJoinable(host: DatabaseStatementsHost): boolean {
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#sql_for_insert
  * @internal
  */
-export function sqlForInsert(
+export async function sqlForInsert(
   this: DatabaseStatementsHost,
   sql: string,
   pk: string | false | null | undefined,
   binds: unknown[],
   returning: string[] | null | undefined,
-): [string, unknown[]] {
-  if (this.supportsInsertReturning?.()) {
+): Promise<[string, unknown[]]> {
+  // `supports_insert_returning?` and `primary_key` are plain predicates in Ruby;
+  // both are async in trails (a version probe / a schema query), so this body is
+  // async and awaits them. Without the await a Promise is always truthy and the
+  // RETURNING clause would be appended on every backend.
+  if (await this.supportsInsertReturning?.()) {
     // Mirrors Rails: `pk == false` is the explicit caller opt-out — skip
     // any pk-derived RETURNING column (caller may still pass `returning:`
     // for an alternate column list).
     let resolvedPk: string | null | undefined = pk === false ? null : pk;
     if (pk !== false && resolvedPk == null) {
       const tableRef = extractTableRefFromInsertSql.call(this, sql);
-      if (tableRef) resolvedPk = this.primaryKey?.(tableRef) ?? null;
+      if (tableRef) resolvedPk = (await this.primaryKey?.(tableRef)) ?? null;
     }
     const returningColumns = returning ?? (resolvedPk != null ? [resolvedPk] : []);
     if (returningColumns.length > 0) {
@@ -2102,7 +2064,7 @@ export function sqlForInsert(
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#last_inserted_id
  * @internal
  */
-function lastInsertedId(result: Result): unknown {
+export function lastInsertedId(result: Result): unknown {
   return singleValueFromRows(result.rows);
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/savepoints.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/savepoints.ts
@@ -31,6 +31,7 @@ export interface SavepointHost {
   internalExecute(
     sql: string,
     name: string,
+    binds?: unknown[],
     opts?: { materializeTransactions?: boolean },
   ): Promise<unknown>;
   currentSavepointName(): string | null;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.internal-execute-cast-result.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.internal-execute-cast-result.trails.test.ts
@@ -57,7 +57,7 @@ describe("Mysql2Adapter#internalExecute → castResult duplicate columns", () =>
   it("preserves duplicate column names via positional array-mode rows", async () => {
     const adapter = makeAdapter();
 
-    const rawResult = (await adapter.internalExecute("SELECT 1 AS a, 2 AS a", "SQL", {
+    const rawResult = (await adapter.internalExecute("SELECT 1 AS a, 2 AS a", "SQL", [], {
       materializeTransactions: false,
     })) as unknown as Mysql2RawResult;
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -4,7 +4,6 @@ import { BigDecimal, KeyError } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
-import { sqlForInsert } from "./abstract/database-statements.js";
 import type { MysqlAdapterOptions } from "./pool-config.js";
 import {
   AbstractMysqlAdapter,
@@ -33,6 +32,7 @@ import { Result } from "../result.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import {
   affectedRows as mysql2AffectedRows,
+  lastInsertedId as mysql2LastInsertedId,
   castResult as mysql2CastResult,
   performQuery as mysql2PerformQuery,
   type Mysql2RawResult,
@@ -589,42 +589,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#perform_query
    * (the `prepare:` keyword routing) + Rails' exec_query tolerating no-result DML.
    */
-  /**
-   * Mirrors Rails' abstract `exec_insert`: `sql_for_insert` first, then
-   * `internal_exec_query` (abstract/database_statements.rb:157-160). MariaDB
-   * supports `INSERT ... RETURNING`, and `sql_for_insert` derives
-   * `returning_columns = returning || Array(pk)` (line 702-713), so an insert
-   * with no explicit `returning:` still gets `RETURNING <pk>` — which the
-   * `executeMutation` primitive cannot carry, since it reports only the
-   * generated id (0 when the PK is trigger-populated rather than
-   * AUTO_INCREMENT). MySQL 8 has no insert returning, so it keeps the
-   * `executeMutation` fast path via `super`, where `sql_for_insert` would append
-   * nothing anyway.
-   */
-  override async execInsert(
-    sql: string,
-    name: string | null = null,
-    binds: unknown[] = [],
-    pk?: string | false | null,
-    sequenceName?: string | null,
-    returning?: string[] | null,
-  ): Promise<Result | number> {
-    const inferredFromPk = pk !== false && pk != null;
-    if ((await this.supportsInsertReturning()) && (returning?.length || inferredFromPk)) {
-      const [returningSql, returningBinds] = sqlForInsert.call(
-        this as never,
-        sql,
-        pk ?? null,
-        binds,
-        returning ?? null,
-      );
-      const result = await this.internalExecQuery(returningSql, name, returningBinds);
-      this.dirtyCurrentTransaction();
-      return result;
-    }
-    return super.execInsert(sql, name, binds, pk, sequenceName, returning);
-  }
-
   // Rails' Mysql2Adapter has no `exec_query` override: the abstract
   // `exec_query` (abstract/database_statements.rb:147-149) funnels into
   // `internal_exec_query`, which is the one we override below.
@@ -926,6 +890,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id
+   * @internal
+   */
+  lastInsertedId(result: Result): Promise<unknown> {
+    return mysql2LastInsertedId.call(this as never, result);
+  }
+
+  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /
@@ -1051,7 +1023,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * `super.materializeBang()` runs after this returns.
    */
   async beginDbTransaction(): Promise<void> {
-    await this.internalExecute("BEGIN", "TRANSACTION", {
+    await this.internalExecute("BEGIN", "TRANSACTION", [], {
       materializeTransactions: false,
       allowRetry: true,
     });
@@ -1090,10 +1062,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const level = transactionIsolationLevels()[isolation];
     if (level === undefined) throw new KeyError(`key not found: :${isolation}`);
     await this.withRawConnection({ allowRetry: true, materializeTransactions: false }, async () => {
-      await this.internalExecute(`SET TRANSACTION ISOLATION LEVEL ${level}`, "TRANSACTION", {
+      await this.internalExecute(`SET TRANSACTION ISOLATION LEVEL ${level}`, "TRANSACTION", [], {
         materializeTransactions: false,
       });
-      await this.internalExecute("BEGIN", "TRANSACTION", { materializeTransactions: false });
+      await this.internalExecute("BEGIN", "TRANSACTION", [], { materializeTransactions: false });
       this._inTransaction = true;
     });
   }
@@ -1153,15 +1125,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   override async internalExecute(
     sql: string,
     name: string | null = "SQL",
+    binds: unknown[] = [],
     {
       materializeTransactions = true,
       allowRetry = false,
-      binds = [],
       prepare: prepareOption,
     }: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;
-      binds?: unknown[];
       prepare?: boolean;
     } = {},
   ): Promise<Mysql2RawResult> {
@@ -1960,13 +1931,13 @@ function isMysql2ConnectionError(e: unknown): boolean {
 // `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails
 // query_cache.rb:13). Overridden methods must be wrapped on the concrete class,
 // not on AbstractAdapter, or the override would run unwrapped. The write methods
-// this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
+// this adapter does NOT override (`execInsert`/`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
 // Each logical write clears the cache exactly once; the still-lower
 // `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
 // through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
-dirtiesQueryCache(Mysql2Adapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
+dirtiesQueryCache(Mysql2Adapter, "rollbackDbTransaction", "rollbackToSavepoint");
 dirtiesQueryCache(Mysql2Adapter, "execute");
 
 // Mirrors `include Mysql2::DatabaseStatements` — `perform_query` is an instance

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -6,9 +6,9 @@
 
 import type { Type } from "@blazetrails/activemodel";
 import type mysql from "mysql2/promise";
-import { NotImplementedError } from "../../errors.js";
 import { Result, type ColumnTypes } from "../../result.js";
 import { combineMultiStatements, type MaxAllowedPacketHost } from "../mysql/database-statements.js";
+import { lastInsertedId as abstractLastInsertedId } from "../abstract/database-statements.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -118,11 +118,20 @@ export function buildColumnTypes(
 /** @internal */
 interface PerformQueryHost {
   _affectedRowsBeforeWarnings?: number;
+  // Ruby reads `@raw_connection.last_id`; node-mysql2's client has no such
+  // accessor, so the value is carried on the adapter instead.
+  _lastId?: number;
   _statements?: Map<string, unknown>;
   handleWarnings?(sql: string): void | Promise<void>;
   verified?(): void;
   _shouldPrepare?(binds: unknown[]): boolean;
   _trackPrepared?(conn: unknown, sql: string): void;
+}
+
+/** @internal */
+interface LastInsertedIdHost {
+  _lastId?: number;
+  supportsInsertReturning(): Promise<boolean>;
 }
 
 /** @internal */
@@ -169,12 +178,22 @@ export async function executeBatch(
   }
 }
 
-/** @internal */
-function lastInsertedId(result: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb:23 cluster=mysql-mysql2-adapter
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id is not implemented",
-  );
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#last_inserted_id
+ * (mysql2/database_statements.rb:22-29)
+ *
+ * Ruby's `@raw_connection&.last_id` reads the driver's own session accessor;
+ * the node mysql2 client exposes the value only on the result header, so
+ * `perform_query` above stashes it as `_lastId` — the same session-scoped
+ * "id of the last INSERT on this connection" the Ruby accessor returns.
+ *
+ * @internal
+ */
+export async function lastInsertedId(this: LastInsertedIdHost, result: Result): Promise<unknown> {
+  if (await this.supportsInsertReturning()) {
+    return abstractLastInsertedId(result);
+  }
+  return this._lastId;
 }
 
 /**
@@ -290,6 +309,7 @@ export async function performQuery(
   }
 
   this._affectedRowsBeforeWarnings = affectedRows;
+  if (insertId !== undefined) this._lastId = insertId;
 
   if (notificationPayload) {
     notificationPayload["affected_rows"] = this._affectedRowsBeforeWarnings;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -118,8 +118,6 @@ export function buildColumnTypes(
 /** @internal */
 interface PerformQueryHost {
   _affectedRowsBeforeWarnings?: number;
-  // Ruby reads `@raw_connection.last_id`; node-mysql2's client has no such
-  // accessor, so the value is carried on the adapter instead.
   _lastId?: number;
   _statements?: Map<string, unknown>;
   handleWarnings?(sql: string): void | Promise<void>;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2486,7 +2486,7 @@ export class PostgreSQLAdapter
     pk?: string | false | null,
     sequenceName?: string | null,
     returning?: string[] | null,
-  ): Promise<Result | number> {
+  ): Promise<Result> {
     // Mirrors Rails' single `if use_insert_returning? || pk == false` arm
     // (postgresql/database_statements.rb:46-47) — `super` is the abstract
     // `sql_for_insert` + `internal_exec_query` pair, which honours the

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -90,8 +90,6 @@ import {
   transactionIsolationLevels,
   preprocessQuery,
   extractTableRefFromInsertSql,
-  sqlForInsert,
-  execInsertReturningReadback,
 } from "./abstract/database-statements.js";
 import { makeGetTypeParser } from "./postgresql/temporal-type-parsers.js";
 
@@ -1231,8 +1229,7 @@ export class PostgreSQLAdapter
       // unreachable: `cast_result` would resolve every pg_type column through
       // `get_oid_type`, re-entering this method. Ruby's PG::Result already
       // yields hash rows; node-pg's array mode needs the field names put back.
-      const result = (await this.internalExecute(query, "SCHEMA", {
-        binds: [],
+      const result = (await this.internalExecute(query, "SCHEMA", [], {
         allowRetry: true,
         materializeTransactions: false,
       })) as { fields?: Array<{ name: string }>; rows?: unknown[][] };
@@ -1552,38 +1549,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * Run a single query on an already-acquired client with the same
-   * instrumentation, exception translation, and warning flushing that
-   * execQuery/executeMutation use. Used when two queries must share a
-   * session (e.g. INSERT + SELECT currval in the returning-disabled path).
-   * @internal
-   */
-  private async _instrumentedQueryOnClient(
-    client: pg.Client,
-    sql: string,
-    name: string | null,
-    binds: unknown[],
-  ): Promise<Result> {
-    const bindArray = this.typeCastedBinds(binds) ?? [];
-    const rewritten = this.rewriteBinds(sql, bindArray);
-    const pgResult = await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
-      try {
-        const r = await this._performQuery(client, rewritten, binds, bindArray, {
-          prepare: this._shouldPrepare(bindArray),
-          notificationPayload: payload,
-          rowMode: "array",
-        });
-        payload.row_count = r.rowCount ?? 0;
-        return r;
-      } catch (e: any) {
-        const translated = this._translateException(e, rewritten, bindArray);
-        throw translated;
-      }
-    });
-    return castResult.call(this, pgResult);
-  }
-
-  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /
@@ -1824,7 +1789,7 @@ export class PostgreSQLAdapter
   async beginDbTransaction(): Promise<void> {
     this._client = await this._acquireFreshClient();
     try {
-      await this.internalExecute("BEGIN", "TRANSACTION", {
+      await this.internalExecute("BEGIN", "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
       });
@@ -1901,7 +1866,7 @@ export class PostgreSQLAdapter
     }
     if (!this._client) throw new ActiveRecordError("No active transaction");
     try {
-      await this.internalExecute("ROLLBACK", "TRANSACTION", {
+      await this.internalExecute("ROLLBACK", "TRANSACTION", [], {
         allowRetry: false,
         materializeTransactions: true,
       });
@@ -1938,7 +1903,7 @@ export class PostgreSQLAdapter
   async execRollbackDbTransaction(): Promise<void> {
     await this._cancelAnyRunningQuery();
     try {
-      await this.internalExecute("ROLLBACK", "TRANSACTION", {
+      await this.internalExecute("ROLLBACK", "TRANSACTION", [], {
         allowRetry: false,
         materializeTransactions: true,
       });
@@ -1997,7 +1962,7 @@ export class PostgreSQLAdapter
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
     await this._cancelAnyRunningQuery();
-    await this.internalExecute("ROLLBACK AND CHAIN", "TRANSACTION", {
+    await this.internalExecute("ROLLBACK AND CHAIN", "TRANSACTION", [], {
       allowRetry: false,
       materializeTransactions: true,
     });
@@ -2157,7 +2122,7 @@ export class PostgreSQLAdapter
     if (level === undefined) throw new KeyError(`key not found: :${isolation}`);
     this._client = await this._acquireFreshClient();
     try {
-      await this.internalExecute(`BEGIN ISOLATION LEVEL ${level}`, "TRANSACTION", {
+      await this.internalExecute(`BEGIN ISOLATION LEVEL ${level}`, "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
       });
@@ -2211,15 +2176,14 @@ export class PostgreSQLAdapter
   override async internalExecute(
     sql: string,
     name: string | null = "SQL",
+    binds: unknown[] = [],
     {
       materializeTransactions = true,
       allowRetry = false,
-      binds = [],
       prepare,
     }: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;
-      binds?: unknown[];
       prepare?: boolean;
     } = {},
   ): Promise<unknown> {
@@ -2501,7 +2465,7 @@ export class PostgreSQLAdapter
   async sessionAuth(user: string): Promise<void> {
     await this.clearCacheBang();
     const quoted = user.toUpperCase() === "DEFAULT" ? "DEFAULT" : pgQuoteColumnName(user);
-    await this.internalExecute(`SET SESSION AUTHORIZATION ${quoted}`, undefined, {
+    await this.internalExecute(`SET SESSION AUTHORIZATION ${quoted}`, undefined, [], {
       materializeTransactions: true,
     });
   }
@@ -2524,61 +2488,10 @@ export class PostgreSQLAdapter
     returning?: string[] | null,
   ): Promise<Result | number> {
     // Mirrors Rails' single `if use_insert_returning? || pk == false` arm
-    // (postgresql/database_statements.rb:46-47).
+    // (postgresql/database_statements.rb:46-47) — `super` is the abstract
+    // `sql_for_insert` + `internal_exec_query` pair, which honours the
+    // `pk == false` opt-out inside `sql_for_insert` itself.
     if (this._useInsertReturning || pk === false) {
-      if (pk === false) {
-        // Explicit caller opt-out: skip the pk-derived RETURNING column.
-        // Cannot delegate to super here — our mixed-in DatabaseStatements
-        // default routes through executeMutation, which auto-appends
-        // `RETURNING id` for bare INSERTs when use_insert_returning is on
-        // (postgresql-adapter.ts:1238-1243). That would defeat the opt-out.
-        // Cannot use execQuery either — it intentionally skips
-        // materializeTransactions / dirtyCurrentTransaction (read-path
-        // optimisation), so an INSERT inside a lazy transaction would
-        // escape rollback. Use the same write-path scaffolding the
-        // pk-non-false branch below uses, just without the currval probe.
-        if (returning && returning.length > 0) {
-          const cols = returning.map((c) => this.quoteColumnName(c)).join(", ");
-          sql = `${sql} RETURNING ${cols}`;
-        }
-        sql = this.preprocessQuery(sql);
-        return this.withRawConnection(async (conn) => {
-          const client = conn as unknown as pg.Client;
-          return this._instrumentedQueryOnClient(client, sql, name, binds);
-        });
-      }
-      // A multi-column RETURNING list is the auto-populated-columns read-back
-      // (Rails `_create_record` zips every returning column). The shared helper
-      // runs it through the bind-aware internalExecQuery (which materializes) and
-      // dirties the transaction, handing back the whole Result — `super`/
-      // `executeMutation` would collapse the row to its first column. A single-
-      // column list falls through to the `super`/`executeMutation` fast path
-      // (scalar id + prepared-statement-cache retry).
-      const readback = await execInsertReturningReadback.call(
-        this as never,
-        sql,
-        name,
-        binds,
-        pk,
-        returning,
-      );
-      if (readback !== undefined) return readback;
-      // When the caller names RETURNING columns (a custom-named serial/identity
-      // PK), append them up front via sql_for_insert so executeMutation reads the
-      // DB-generated value back from the right column instead of falling back to
-      // its auto-appended `RETURNING id` (which errors on tables without an `id`
-      // column and leaves the in-memory PK stale). Mirrors Rails, where the
-      // abstract exec_insert runs sql_for_insert before the query.
-      if (returning && returning.length > 0) {
-        const [sqlWithReturning, resolvedBinds] = sqlForInsert.call(
-          this as never,
-          sql,
-          pk ?? null,
-          binds,
-          returning,
-        );
-        return super.execInsert(sqlWithReturning, name, resolvedBinds, pk, sequenceName, returning);
-      }
       return super.execInsert(sql, name, binds, pk, sequenceName, returning);
     }
     // Rails' else arm (database_statements.rb:48-59). In Rails the whole method
@@ -4946,11 +4859,15 @@ const SERIAL_SEQUENCE_RE = /^nextval\('"?(?<sequenceName>.+_(?<suffix>seq\d*))"?
 // not on AbstractAdapter, or the override would run unwrapped. The write methods
 // this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
+// `execInsert` is wired on AbstractAdapter too, even though this adapter
+// overrides it: the override's `use_insert_returning?` arm delegates to `super`
+// (postgresql/database_statements.rb:46-47), so wiring it here as well would
+// clear the cache twice for one logical insert.
 // Each logical write clears the cache exactly once; the still-lower
 // `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
 // through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
-dirtiesQueryCache(PostgreSQLAdapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
+dirtiesQueryCache(PostgreSQLAdapter, "rollbackDbTransaction", "rollbackToSavepoint");
 dirtiesQueryCache(PostgreSQLAdapter, "execute");
 
 // Rails: `include PostgreSQL::SchemaStatements` (postgresql_adapter.rb:185).

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -33,7 +33,6 @@ import {
   virtualTableExists as sqliteVirtualTableExists,
 } from "./sqlite3/schema-statements.js";
 import { dirtiesQueryCache } from "./abstract/query-cache.js";
-import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   ActiveRecordError,
@@ -726,37 +725,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   /**
-   * Mirrors Rails' abstract `exec_insert` → `sql_for_insert` → `internal_exec_query`
-   * for the multi-column RETURNING read-back. `executeMutation` returns a single
-   * number (the id from `lastInsertRowid` / the changes readback), not the
-   * RETURNING row set, so a multi-column auto-populated-columns list (Rails
-   * `_create_record` zips every returning column) would come back with only the
-   * generated id. Route just that case through the row-returning
-   * `internalExecQuery` (`.all()`, bind-aware, and it materializes the
-   * transaction) and mark the transaction dirty as `executeMutation` would.
-   * Single-column / no-RETURNING inserts keep the `executeMutation` path.
-   */
-  override async execInsert(
-    sql: string,
-    name: string | null = null,
-    binds: unknown[] = [],
-    pk?: string | false | null,
-    _sequenceName?: string | null,
-    returning?: string[] | null,
-  ): Promise<Result | number> {
-    const readback = await execInsertReturningReadback.call(
-      this as never,
-      sql,
-      name,
-      binds,
-      pk,
-      returning,
-    );
-    if (readback !== undefined) return readback;
-    return this.executeMutation(sql, binds, name);
-  }
-
-  /**
    * Begin a transaction.
    */
   private _previousReadUncommitted: unknown = null;
@@ -787,14 +755,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         );
       }
     }
-    await this.internalExecute(`BEGIN ${mode} TRANSACTION`, "TRANSACTION", {
+    await this.internalExecute(`BEGIN ${mode} TRANSACTION`, "TRANSACTION", [], {
       allowRetry: true,
       materializeTransactions: false,
     });
     this._inTransaction = true;
     if (isolation) {
       this._previousReadUncommitted = (await this.queryValue("PRAGMA read_uncommitted")) ?? 0;
-      await this.internalExecute("PRAGMA read_uncommitted=ON", "TRANSACTION", {
+      await this.internalExecute("PRAGMA read_uncommitted=ON", "TRANSACTION", [], {
         allowRetry: true,
         materializeTransactions: false,
       });
@@ -807,6 +775,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       await this.internalExecute(
         `PRAGMA read_uncommitted=${this._previousReadUncommitted}`,
         "TRANSACTION",
+        [],
         { allowRetry: true, materializeTransactions: false },
       );
       this._previousReadUncommitted = null;
@@ -823,14 +792,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override async internalExecute(
     sql: string,
     name: string = "SQL",
+    binds: unknown[] = [],
     {
       materializeTransactions = true,
-      binds = [],
       prepare = false,
       allowRetry = false,
     }: {
       materializeTransactions?: boolean;
-      binds?: unknown[];
       prepare?: boolean;
       allowRetry?: boolean;
     } = {},
@@ -919,7 +887,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * Commit the current transaction.
    */
   async commitDbTransaction(): Promise<void> {
-    await this.internalExecute("COMMIT TRANSACTION", "TRANSACTION", {
+    await this.internalExecute("COMMIT TRANSACTION", "TRANSACTION", [], {
       allowRetry: true,
       materializeTransactions: false,
     });
@@ -935,7 +903,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   async rollbackDbTransaction(): Promise<void> {
     try {
-      await this.internalExecute("ROLLBACK TRANSACTION", "TRANSACTION", {
+      await this.internalExecute("ROLLBACK TRANSACTION", "TRANSACTION", [], {
         allowRetry: true,
         materializeTransactions: false,
       });
@@ -3239,14 +3207,14 @@ function translateException(
 // `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails
 // query_cache.rb:13). Overridden methods must be wrapped on the concrete class,
 // not on AbstractAdapter, or the override would run unwrapped. The write methods
-// this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
+// this adapter does NOT override (`execInsert`/`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncate`/`truncateTables`/`restartDbTransaction`) are wired once on
 // AbstractAdapter.
 // Each logical write clears the cache exactly once; the still-lower
 // `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
 // through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
-dirtiesQueryCache(SQLite3Adapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
+dirtiesQueryCache(SQLite3Adapter, "rollbackDbTransaction", "rollbackToSavepoint");
 dirtiesQueryCache(SQLite3Adapter, "execute");
 
 // Mirrors `include SQLite3::DatabaseStatements` — `perform_query` is an

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -26,6 +26,7 @@ type ExecutableAdapter = {
   internalExecute(
     sql: string,
     name?: string | null,
+    binds?: unknown[],
     options?: { allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<unknown>;
 };
@@ -67,14 +68,14 @@ export async function beginIsolatedDbTransaction(
 }
 
 export async function commitDbTransaction(adapter: ExecutableAdapter): Promise<void> {
-  await adapter.internalExecute("COMMIT TRANSACTION", "TRANSACTION", {
+  await adapter.internalExecute("COMMIT TRANSACTION", "TRANSACTION", [], {
     allowRetry: true,
     materializeTransactions: false,
   });
 }
 
 export async function execRollbackDbTransaction(adapter: ExecutableAdapter): Promise<void> {
-  await adapter.internalExecute("ROLLBACK TRANSACTION", "TRANSACTION", {
+  await adapter.internalExecute("ROLLBACK TRANSACTION", "TRANSACTION", [], {
     allowRetry: true,
     materializeTransactions: false,
   });
@@ -100,6 +101,7 @@ export async function resetIsolationLevel(
     await adapter.internalExecute(
       `PRAGMA read_uncommitted=${previousReadUncommitted}`,
       "TRANSACTION",
+      [],
       { allowRetry: true, materializeTransactions: false },
     );
   }
@@ -109,6 +111,7 @@ interface InternalBeginTransactionHost {
   internalExecute(
     sql: string,
     name?: string | null,
+    binds?: unknown[],
     options?: { allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<unknown>;
   queryValue(sql: string, name?: string): Promise<unknown>;
@@ -174,13 +177,13 @@ export async function internalBeginTransaction(
       );
     }
   }
-  await this.internalExecute(`BEGIN ${mode.toUpperCase()} TRANSACTION`, "TRANSACTION", {
+  await this.internalExecute(`BEGIN ${mode.toUpperCase()} TRANSACTION`, "TRANSACTION", [], {
     allowRetry: true,
     materializeTransactions: false,
   });
   if (isolation) {
     this._previousReadUncommitted = await this.queryValue("PRAGMA read_uncommitted");
-    await this.internalExecute("PRAGMA read_uncommitted=ON", "TRANSACTION", {
+    await this.internalExecute("PRAGMA read_uncommitted=ON", "TRANSACTION", [], {
       allowRetry: true,
       materializeTransactions: false,
     });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -103,7 +103,7 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
     return Result.fromRowHashes(await this.execute(sql, b));
   }
   async execInsert(sql: string, _n?: string | null, b?: unknown[]) {
-    return this.executeMutation(sql, b);
+    return Result.fromRowHashes(await this.execute(sql, b));
   }
   async execDelete(sql: string, _n?: string | null, b?: unknown[]) {
     return this.executeMutation(sql, b);

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -27,8 +27,7 @@ async function captureUpdate(
   const original = conn[key];
   const calls: { sql: string; binds: unknown[] }[] = [];
   conn[key] = function (sql: string, ...rest: unknown[]) {
-    const opts = rest[1] as { binds?: unknown[] } | undefined;
-    calls.push({ sql, binds: opts?.binds ?? (rest[0] as unknown[]) ?? [] });
+    calls.push({ sql, binds: (rest[1] as unknown[]) ?? [] });
     return original.call(this, sql, ...rest);
   };
   try {

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -19,11 +19,16 @@ async function captureUpdate(
   fn: () => Promise<unknown>,
 ): Promise<{ sql: string; binds: unknown[] }> {
   const conn = (rel as { _conn(): Record<string, Mutator> })._conn();
-  const key = conn.executeMutation ? "executeMutation" : "execute";
+  // `update_all` reaches the adapter through `exec_update`, which is
+  // `affected_rows(internal_execute(sql, name, binds))`
+  // (abstract/database_statements.rb:172-174) — so the binds arrive in
+  // `internalExecute`'s options object, not as a positional argument.
+  const key = conn.internalExecute ? "internalExecute" : "execute";
   const original = conn[key];
   const calls: { sql: string; binds: unknown[] }[] = [];
   conn[key] = function (sql: string, ...rest: unknown[]) {
-    calls.push({ sql, binds: (rest[0] as unknown[]) ?? [] });
+    const opts = rest[1] as { binds?: unknown[] } | undefined;
+    calls.push({ sql, binds: opts?.binds ?? (rest[0] as unknown[]) ?? [] });
     return original.call(this, sql, ...rest);
   };
   try {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -2,48 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_delete",
-    "call": "affected_rows",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_delete",
-    "call": "internal_execute",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_insert",
-    "call": "internal_exec_query",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_insert",
-    "call": "sql_for_insert",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_update",
-    "call": "affected_rows",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "exec_update",
-    "call": "internal_execute",
-    "reason": "Surfaced, not introduced, by PR #6772: this file used to define each method twice — a dead file-level `export function` and the live mixin body — and the extractor matched the dead copy, which did make Rails' calls. With the duplication removed the live body is measured, and it routes through trails' `executeMutation` invention instead of Rails' `sql_for_insert`/`internal_exec_query` and `affected_rows(internal_execute(...))` (database_statements.rb:157-174). Converging needs `executeMutation` and `internalExecute`'s signature converged with it — tracked by 0112-one-rails-thing-n-trails-things/converge-exec-insert-delete-update-onto-rails-call-shape."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "initialize",
     "call": "reset_transaction",
     "reason": "Per-site verified (RFC 0106 wave 4b): abstract/database_statements.rb:12 is `reset_transaction` inside `initialize`; trails' DatabaseStatements is a mixin with no constructor of its own — the adapter's own constructor calls `resetTransaction()` (abstract-adapter.ts), so the call happens, just not from a body matched to this Ruby method."


### PR DESCRIPTION
Converges `DatabaseStatements#exec_insert`, `#exec_delete` and `#exec_update`
onto the Rails call shape (`abstract/database_statements.rb:157-174`), and with
them `internal_execute`'s signature.

## What changed

- `execInsert` is now `sqlForInsert(...)` then `internalExecQuery(sql, name, binds)`
  (`database_statements.rb:157-160`). It returns a `Result`, as Rails does.
- `execDelete` / `execUpdate` are `affectedRows(internalExecute(sql, name, binds))`
  (`database_statements.rb:166-174`). Each adapter already had the Rails
  `affected_rows` port (`sqlite3/database_statements.rb:122`,
  `mysql2/database_statements.rb:127`, `postgresql/database_statements.rb:189`);
  they are now reached from the Rails call site instead of `executeMutation`.
- `sqlForInsert` became async. `supports_insert_returning?` and `primary_key` are
  plain predicates in Ruby but async in trails, so the old sync body treated the
  returned Promise as truthy — it would have appended `RETURNING` on every
  backend once called unconditionally.
- `internalExecute`'s signature is now Rails' `(sql, name, binds, **kwargs)`
  (`database_statements.rb:588`) on the abstract file and on all three adapter
  overrides, instead of carrying `binds` inside the options object. This is what
  the story's third acceptance criterion asked for; the call-argument gate was
  flagging it.
- Three `execInsert` overrides are deleted. Rails' SQLite3 and Mysql2 adapters
  have none — SQLite3 gets the RETURNING row from the converged abstract body,
  and Mysql2 instead gets `last_inserted_id`
  (`mysql2/database_statements.rb:22-29`), which was a `NotImplementedError`
  stub. PostgreSQL keeps its override but it is now Rails' two arms verbatim
  (`postgresql/database_statements.rb:45-61`); the `pk == false` special-casing
  it used to carry lives in `sql_for_insert`, where Rails puts it.
- `insert`/`create` converge on `database_statements.rb:200-206`: the
  `returning_column_values` / `id_value || last_inserted_id(value)` pair, with no
  Result-vs-number branching, because `exec_insert` now always yields a Result.
- Deletes two trails inventions the above made dead:
  `execInsertReturningReadback` and PG's `_instrumentedQueryOnClient`.
- `dirties_query_cache` for `execInsert` moves to `AbstractAdapter`. Only
  PostgreSQL still overrides it and its override delegates to `super`, so one
  wrapper on the shared method clears exactly once for every adapter — wiring it
  per-adapter as well would clear twice for one logical insert.

## Baselines

- The six `exec_insert` / `exec_delete` / `exec_update` rows are deleted from
  `call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json`
  by hand. No reseed. That shard is the only baseline this PR touches.
`parity:api:calls`, `parity:api:calls:args`, `pnpm typecheck` and `pnpm lint`
are clean.

Closes-story: converge-exec-insert-delete-update-onto-rails-call-shape
