### PR TITLE
refactor(activerecord,activesupport,scripts): receiver-form min, HABTM through_model fold, receipt permanence report

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -22,7 +22,6 @@ import { qualifiedName } from "./inheritance.js";
 // callers don't need to import the slot module directly.
 export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 
-import { ConfigurationError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementCache } from "./statement-cache.js";
 import { HasManyThroughAssociationNotFoundError } from "./associations/errors.js";
@@ -33,14 +32,9 @@ import {
 import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
-import { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
 export { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
 import {
   underscore,
-  singularize,
-  pluralize,
-  camelize,
-  foreignKey as deriveForeignKey,
   constantize,
   registerConstant,
   unregisterConstant,
@@ -824,12 +818,7 @@ export class Associations {
       name,
       scope as ((...args: any[]) => any) | null,
       options as Record<string, unknown>,
-      {
-        defaultJoinTableName,
-        singleFk,
-        createHabtmJoinModel,
-        modelRegistry,
-      },
+      { modelRegistry },
     );
     // Rails registers the autosave-association callbacks for every HABTM
     // (the underlying has_many :through is built via the standard
@@ -1577,178 +1566,6 @@ export function _inlinePolymorphicKeys(
   // here rather than delegating.
   const scalarOwnerKey = Array.isArray(primaryKey) ? "id" : primaryKey;
   return { fkCols: [scalarFk], ownerKeyCols: [scalarOwnerKey] };
-}
-
-/**
- * Compute the default join table name for HABTM.
- * Uses the two table names in alphabetical order, joined by underscore.
- */
-/** Coerce a foreignKey option to a single string. HABTM doesn't support composite keys. */
-/**
- * Create an anonymous join model class for HABTM associations.
- * The join model has two belongsTo associations (left side and target),
- * delegates its adapter to the declaring model, and uses the specified
- * join table name.
- *
- * Mirrors: ActiveRecord::Associations::Builder::HasAndBelongsToMany#through_model
- */
-function createHabtmJoinModel(
-  lhsModel: typeof Base,
-  joinModelName: string,
-  joinTableNameResolver: () => string,
-  ownerFk: string,
-  targetFk: string,
-  targetClassName: string,
-  sourceName: string,
-): typeof Base {
-  // Walk up to the root AR Base class to avoid inheriting domain callbacks/validations.
-  // Stop at the last class that still has `create` (i.e., the AR Base class).
-  let BaseClass: typeof Base = lhsModel;
-  let parent = Object.getPrototypeOf(BaseClass);
-  while (parent && parent !== Function.prototype && typeof parent.create === "function") {
-    BaseClass = parent;
-    parent = Object.getPrototypeOf(BaseClass);
-  }
-  const JoinModel = class extends BaseClass {} as typeof Base;
-  Object.defineProperty(JoinModel, "name", {
-    value: joinModelName,
-    writable: false,
-    configurable: true,
-  });
-
-  // Mirrors `through_model`'s `@table_name ||= table_name_resolver.call`
-  // (has_and_belongs_to_many.rb:24-27): the name resolves on first read, not at
-  // declaration time, because the RHS class might not have been loaded yet.
-  // The composite PK is trails': HABTM join tables typically have no id column,
-  // so the join model uses [ownerFk, targetFk] to support delete/destroy
-  // operations that issue PK-based WHERE clauses.
-  let joinTableName: string | null = null;
-  Object.defineProperty(JoinModel, "_tableName", {
-    get(): string {
-      return (joinTableName ??= joinTableNameResolver());
-    },
-    set(value: string | null) {
-      joinTableName = value;
-    },
-    configurable: true,
-  });
-  JoinModel.primaryKey = [ownerFk, targetFk];
-
-  // Carry the declaring model's Ruby module path onto the anonymous join model
-  // so its source `belongsTo` resolves an unqualified target class name
-  // (e.g. "Article") namespace-relative to the owner (→ "Publisher::Article").
-  // Without this, the join model's `activeRecord` is the bare `HABTM_*` class
-  // and the compute_type walk has no nesting to try.
-  if ((lhsModel as { moduleName?: string }).moduleName) {
-    (JoinModel as { moduleName?: string }).moduleName = (
-      lhsModel as { moduleName?: string }
-    ).moduleName;
-  }
-
-  // Delegate connection to the left (declaring) model. The join model is rooted
-  // at the AR Base class (to shed domain callbacks), so it would otherwise
-  // resolve to the primary pool. Delegating the connection-spec name keeps writes
-  // (and the threaded-connection check in `threadedConnectionFor`) on the owner's
-  // pool — required when the owner lives in an alternate database.
-  Object.defineProperty(JoinModel, "connection", {
-    get() {
-      return lhsModel.connection;
-    },
-    configurable: true,
-  });
-  // `connectionPool` resolves via `connectionSpecificationName`, which reads the
-  // `_connectionSpecificationName` backing field (own-property check + accessor).
-  // Delegating that field — not just the public static accessor — is what routes
-  // the pool lookup to the owner's database.
-  Object.defineProperty(JoinModel, "_connectionSpecificationName", {
-    get() {
-      return lhsModel.connectionSpecificationName;
-    },
-    set(_v: unknown) {
-      /* no-op: always delegates to lhs */
-    },
-    configurable: true,
-  });
-  Object.defineProperty(JoinModel, "adapter", {
-    get() {
-      return lhsModel.connection;
-    },
-    set(_v: unknown) {
-      /* no-op: always delegates to lhs */
-    },
-    configurable: true,
-  });
-
-  // Mirrors `Builder::HasAndBelongsToMany#add_left_association` /
-  // `#add_right_association` (has_and_belongs_to_many.rb:53-63).
-  (JoinModel as any).belongsTo("leftSide", {
-    required: false,
-    className: lhsModel.name,
-    foreignKey: ownerFk,
-  });
-  (JoinModel as any).belongsTo(sourceName, {
-    required: false,
-    className: targetClassName,
-    foreignKey: targetFk,
-  });
-
-  // `required: false` is hardcoded on both sides in Rails, so
-  // `belongs_to_required_by_default` never reaches the implicit join model
-  // (see project.rb:21-26 and the "usable with belongs to required by default"
-  // test).
-
-  return JoinModel;
-}
-
-function singleFk(fk: string | string[] | undefined, fallback: string): string {
-  if (Array.isArray(fk)) {
-    throw new ConfigurationError("HABTM associations do not support composite foreign keys");
-  }
-  return fk ?? fallback;
-}
-
-/**
- * Compute the default HABTM join-table name.
- *
- * Mirrors ActiveRecord::Associations::Builder::HasAndBelongsToMany#table_name:
- * sort both side table names, then collapse a shared `[._]`-terminated prefix
- * so `b30_posts` + `b30_tags` → `b30_posts_tags` (not `b30_posts_b30_tags`).
- */
-function defaultJoinTableName(
-  model1: typeof Base,
-  assocName: string,
-  options?: { className?: string },
-): string {
-  const lhsTable = (model1 as any).tableName ?? fallbackTableName(model1.name);
-  const className = options?.className ?? camelize(singularize(assocName));
-  const targetModel = modelRegistry.get(className);
-  const rhsTable = (targetModel as any)?.tableName ?? fallbackTableName(className);
-  return joinHabtmTableNames(lhsTable, rhsTable);
-}
-
-// Mirrors builder/has-and-belongs-to-many.ts#_fallbackTableName: namespaced
-// class names (`Admin::Tag`) underscore to `admin/tag`, which would leak a
-// `/` into the join-table name. Rails' `klass.table_name` normalizes to
-// underscores, so do the same when the target model isn't registered yet.
-function fallbackTableName(name: string): string {
-  return underscore(pluralize(name)).replace(/\//g, "_");
-}
-
-/**
- * Compute the target-side FK for a HABTM. Mirrors Rails
- * Builder::HasAndBelongsToMany#belongs_to_options:
- *   1. explicit `associationForeignKey` override
- *   2. `class_name.foreign_key` (demodulize+underscore+"_id")
- *   3. default belongs_to: singularized association name + "_id"
- * @internal
- */
-export function habtmTargetFk(
-  assocName: string,
-  options: { className?: unknown; associationForeignKey?: unknown },
-): string {
-  if (options.associationForeignKey) return String(options.associationForeignKey);
-  if (options.className) return deriveForeignKey(String(options.className));
-  return `${underscore(singularize(assocName))}_id`;
 }
 
 /**

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.trails.test.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.trails.test.ts
@@ -38,7 +38,6 @@ describe("Builder::HasAndBelongsToMany#throughModel", () => {
     expect(joinModel.leftModel).toBe(Developer);
     expect(joinModel.leftReflection.name).toBe("leftSide");
     expect(joinModel.rightReflection.name).toBe("project");
-    // A join table has no id column, so the join keys are the primary key.
     expect(joinModel.primaryKey).toEqual(["developer_id", "project_id"]);
   });
 });

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.trails.test.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.trails.test.ts
@@ -38,5 +38,7 @@ describe("Builder::HasAndBelongsToMany#throughModel", () => {
     expect(joinModel.leftModel).toBe(Developer);
     expect(joinModel.leftReflection.name).toBe("leftSide");
     expect(joinModel.rightReflection.name).toBe("project");
+    // A join table has no id column, so the join keys are the primary key.
+    expect(joinModel.primaryKey).toEqual(["developer_id", "project_id"]);
   });
 });

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -8,7 +8,8 @@ import {
   privateConstant,
 } from "@blazetrails/activesupport";
 import * as Reflection from "../../reflection.js";
-import { habtmTargetFk, joinHabtmTableNames } from "../../associations.js";
+import { joinHabtmTableNames } from "../../associations.js";
+import { ConfigurationError } from "../../errors.js";
 import { CollectionAssociation as CollectionAssociationBuilder } from "./collection-association.js";
 import { HasMany } from "./has-many.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
@@ -104,6 +105,15 @@ export class HasAndBelongsToMany {
       }
     };
 
+    // `Class.new(ActiveRecord::Base)` inherits Base's whole environment; a JS
+    // subclass of the walked-up root inherits none of it, so the trails-only
+    // seats below (connection delegation, module path, the composite primary
+    // key a join table with no id column needs) sit on this class.
+    const ownerFk = this.options.foreignKey;
+    if (Array.isArray(ownerFk)) {
+      throw new ConfigurationError("HABTM associations do not support composite foreign keys");
+    }
+
     Object.defineProperty(joinModel, "name", {
       value: `HABTM_${camelize(this.associationName)}`,
       writable: true,
@@ -112,8 +122,45 @@ export class HasAndBelongsToMany {
     joinModel.tableNameResolver = () => builder._tableName();
     joinModel.leftModel = lhsModel;
 
-    joinModel.addLeftAssociation("leftSide", { anonymousClass: lhsModel });
+    // The module path Ruby gets from the join model's lexical nesting under the
+    // owner: without it the source `belongsTo` cannot resolve an unqualified
+    // "Article" to "Publisher::Article".
+    if (lhsModel.moduleName) {
+      joinModel.moduleName = lhsModel.moduleName;
+    }
+    // `connection_pool` above is all Ruby needs; JS resolves the pool through
+    // `_connectionSpecificationName` and reads `connection` / `adapter`
+    // directly, so those delegate too — required for an alternate database.
+    Object.defineProperty(joinModel, "connection", {
+      get: () => lhsModel.connection,
+      configurable: true,
+    });
+    Object.defineProperty(joinModel, "_connectionSpecificationName", {
+      get: () => lhsModel.connectionSpecificationName,
+      set: () => {},
+      configurable: true,
+    });
+    Object.defineProperty(joinModel, "adapter", {
+      get: () => lhsModel.connection,
+      set: () => {},
+      configurable: true,
+    });
+
+    // Rails passes `anonymous_class:` alone and lets the belongs_to derive
+    // `left_side_id`, which no query reads: the through join uses the MIDDLE
+    // has_many's key, derived from `lhs_model.name.demodulize`. A trails class
+    // name is flattened (`Publisher::Article` → `PublisherArticle`), so the
+    // owner key is resolved here off the Ruby leaf name instead.
+    joinModel.addLeftAssociation("leftSide", {
+      anonymousClass: lhsModel,
+      foreignKey:
+        ownerFk ?? `${underscore(demodulize(lhsModel._demodulizedName ?? lhsModel.name))}_id`,
+    });
     joinModel.addRightAssociation(this.associationName, this.belongsToOptions(this.options));
+    joinModel.primaryKey = [
+      joinModel.leftReflection.foreignKey,
+      joinModel.rightReflection.foreignKey,
+    ];
     return joinModel;
   }
 
@@ -130,6 +177,12 @@ export class HasAndBelongsToMany {
     middleOptions.className = `${this.lhsModel.name}::${joinModel.name}`;
     if (this.options.foreignKey) {
       middleOptions.foreignKey = this.options.foreignKey;
+    } else {
+      // Rails stops here and lets the middle has_many derive the owner key from
+      // `lhs_model.name.demodulize`; a flattened JS class name cannot be
+      // demodulized, so the key the join model already resolved is passed on
+      // (see `through_model`'s `add_left_association`).
+      middleOptions.foreignKey = joinModel.leftReflection.foreignKey;
     }
     return middleOptions;
   }
@@ -182,9 +235,6 @@ export class HasAndBelongsToMany {
     scope: ((...args: any[]) => any) | null,
     options: Record<string, unknown>,
     deps: {
-      defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
-      singleFk: (fk: string | string[] | undefined, fallback: string) => string;
-      createHabtmJoinModel: (...args: any[]) => any;
       modelRegistry: Map<string, any>;
     },
   ): void {
@@ -193,9 +243,6 @@ export class HasAndBelongsToMany {
 
   private _build(
     deps: {
-      defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
-      singleFk: (fk: string | string[] | undefined, fallback: string) => string;
-      createHabtmJoinModel: (...args: any[]) => any;
       modelRegistry: Map<string, any>;
     },
     scope: ((...args: any[]) => any) | null = null,
@@ -204,73 +251,30 @@ export class HasAndBelongsToMany {
     const name = this.associationName;
     const options = this.options;
 
-    const targetClassName = (options.className as string) ?? camelize(singularize(name));
-    let memoizedJoinTableName: string | undefined;
-    const joinTableNameResolver = (): string =>
-      (memoizedJoinTableName ??=
-        (options.joinTable as string) ??
-        deps.defaultJoinTableName(model, name, {
-          className: options.className as string | undefined,
-        }));
-    // Rails derives the owner join key from the demodulized class name, so a
-    // namespaced owner like `Publisher::Article` yields `article_id`, not
-    // `publisher_article_id`. `_demodulizedName` carries the Ruby leaf name for
-    // models whose flattened JS class name differs; fall back to `model.name`.
-    const ownerLeafName = model._demodulizedName ?? model.name;
-    const ownerFk = deps.singleFk(
-      options.foreignKey as string | string[] | undefined,
-      `${underscore(demodulize(ownerLeafName))}_id`,
-    );
-    const targetFk = habtmTargetFk(name, options);
+    const joinModel = this.throughModel();
 
-    const joinModelName = `HABTM_${camelize(name)}`;
-    const registryKey = `${model.name}::${joinModelName}`;
-    // Rails' `add_right_association` always names the join-model `belongs_to`
-    // from the association name via `name.to_s.singularize` — even when
-    // `class_name:` is set (e.g. `other_posts, class_name: "Post"` yields
-    // `belongs_to :other_post, class_name: "Post", foreign_key: "post_id"`).
-    // `source_reflection_names` then resolves the through `source:` via the same
-    // `singularize(assoc_name)`. The class-name-derived foreign key (`post_id`)
-    // is carried by `targetFk` (`habtmTargetFk`), passed to the join model below.
-    const sourceName = singularize(name);
-    const JoinModel = deps.createHabtmJoinModel(
-      model,
-      joinModelName,
-      joinTableNameResolver,
-      ownerFk,
-      targetFk,
-      targetClassName,
-      sourceName,
-    );
-
-    deps.modelRegistry.set(registryKey, JoinModel);
+    // `const_set join_model.name, join_model` + `private_constant`
+    // (associations.rb:1868-1869): trails has no constant table, so the join
+    // model is registered under the same `Owner::HABTM_Name` path.
+    const registryKey = `${model.name}::${joinModel.name}`;
+    deps.modelRegistry.set(registryKey, joinModel);
     privateConstant(registryKey);
 
-    const middleName = [pluralize(model.name.toLowerCase()), name].sort().join("_");
-    const middleOptions: Record<string, unknown> = {
-      className: registryKey,
-      // DEVIATION (trails-only, tracked by converge-constantize-ignores-private-constants):
-      // Rails sets only `class_name` here (has_and_belongs_to_many.rb:73) and
-      // resolves the join model straight back out of the constant table —
-      // `private_constant` blocks only a literal `A::B` reference, never
-      // `const_get`, so `Object.const_get("Category::HABTM_Posts")` succeeds in
-      // Ruby (verified on 3.3.11). trails' `constantize` raises for a private
-      // name, which it should not; until that is fixed, hold the join model
-      // directly so `klass` short-circuits before any name lookup. `className`
-      // stays exactly as Rails spells it.
-      anonymousClass: JoinModel,
-      foreignKey: ownerFk,
-      dependent: "delete",
-    };
-    model._associations = [
-      ...model._associations,
-      { type: "hasMany", name: middleName, options: middleOptions },
-    ];
-    const middleReflection = Reflection.create("hasMany", middleName, null, middleOptions, model);
+    const middleReflection = this.middleReflection(joinModel);
+    const middleName = middleReflection.name;
+    // DEVIATION (trails-only, tracked by converge-constantize-ignores-private-constants):
+    // Rails resolves the join model straight back out of the constant table —
+    // `private_constant` blocks only a literal `A::B` reference, never
+    // `const_get`, so `Object.const_get("Category::HABTM_Posts")` succeeds in
+    // Ruby (verified on 3.3.11). trails' `constantize` raises for a private
+    // name, which it should not; until that is fixed, hold the join model
+    // directly so `klass` short-circuits before any name lookup.
+    middleReflection.options.anonymousClass = joinModel;
+    middleReflection.options.dependent = "delete";
     // Rails: `Builder::HasMany.define_callbacks self, middle_reflection`
     // (associations.rb:1878); AutosaveAssociation is one of its extensions.
     addAutosaveAssociationCallbacks.call(model, middleReflection);
-    Reflection.addReflection(model, middleName, middleReflection as any);
+    Reflection.addReflection(model, middleName, middleReflection);
 
     // Mirrors Rails associations.rb:1886-1894 — instead of registering a
     // bare `before_destroy` callback per HABTM, Rails includes an anonymous
@@ -369,7 +373,7 @@ export class HasAndBelongsToMany {
     // the generated join model and join SQL is a follow-up.
     const habtmOptions: Record<string, unknown> = {
       through: middleName,
-      source: (options.source as string) ?? sourceName,
+      source: (options.source as string) ?? joinModel.rightReflection.name,
     };
     if (options.joinTable != null) habtmOptions.joinTable = options.joinTable;
     for (const k of HABTM_FORWARDED_KEYS) {
@@ -405,7 +409,7 @@ export class HasAndBelongsToMany {
     // — the through middle is owned by the public HABTM reflection. Some
     // reflection-walking code paths (e.g. nested-through resolution and
     // inverse lookup) inspect this link.
-    (middleReflection as any).parentReflection = habtmReflection;
+    middleReflection.parentReflection = habtmReflection;
     CollectionAssociationBuilder.defineAccessors(model, habtmReflection);
   }
 }

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -165,7 +165,10 @@ export class HasAndBelongsToMany {
 
   middleReflection(joinModel: any): any {
     const lhsModelName = this.lhsModel.name.toLowerCase();
-    const middleName = [pluralize(lhsModelName), this.associationName].sort().join("_");
+    const middleName = [pluralize(lhsModelName), this.associationName]
+      .sort()
+      .join("_")
+      .replace(/::/g, "_");
     const middleOptions = this.middleOptions(joinModel);
 
     return HasMany.createReflection(this.lhsModel, middleName, null, middleOptions);

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -37,8 +37,7 @@ export class HasAndBelongsToMany {
    *
    * Rails writes `Class.new(ActiveRecord::Base)`; this builder cannot import
    * `Base` without closing an import cycle, so the root AR class is reached by
-   * walking up from the left model — the same walk `createHabtmJoinModel`
-   * (associations.ts) does, landing on the same class.
+   * walking up from the left model, landing on the same class.
    *
    * @missingRailsCall call — Language shortcoming: Rails invokes the resolver
    * lambda as `table_name_resolver.call`; JS functions have no `call`-named
@@ -105,10 +104,6 @@ export class HasAndBelongsToMany {
       }
     };
 
-    // `Class.new(ActiveRecord::Base)` inherits Base's whole environment; a JS
-    // subclass of the walked-up root inherits none of it, so the trails-only
-    // seats below (connection delegation, module path, the composite primary
-    // key a join table with no id column needs) sit on this class.
     const ownerFk = this.options.foreignKey;
     if (Array.isArray(ownerFk)) {
       throw new ConfigurationError("HABTM associations do not support composite foreign keys");
@@ -122,15 +117,17 @@ export class HasAndBelongsToMany {
     joinModel.tableNameResolver = () => builder._tableName();
     joinModel.leftModel = lhsModel;
 
-    // The module path Ruby gets from the join model's lexical nesting under the
-    // owner: without it the source `belongsTo` cannot resolve an unqualified
-    // "Article" to "Publisher::Article".
+    // `Class.new(ActiveRecord::Base)` inherits Base's whole environment and the
+    // join model's lexical nesting under the owner; a JS subclass of the
+    // walked-up root inherits neither, so the module path (without which the
+    // source `belongsTo` cannot resolve "Article" to "Publisher::Article") and
+    // the connection seats below are set here.
     if (lhsModel.moduleName) {
       joinModel.moduleName = lhsModel.moduleName;
     }
     // `connection_pool` above is all Ruby needs; JS resolves the pool through
     // `_connectionSpecificationName` and reads `connection` / `adapter`
-    // directly, so those delegate too — required for an alternate database.
+    // directly, so those delegate too.
     Object.defineProperty(joinModel, "connection", {
       get: () => lhsModel.connection,
       configurable: true,
@@ -157,6 +154,8 @@ export class HasAndBelongsToMany {
         ownerFk ?? `${underscore(demodulize(lhsModel._demodulizedName ?? lhsModel.name))}_id`,
     });
     joinModel.addRightAssociation(this.associationName, this.belongsToOptions(this.options));
+    // A join table has no id column, and trails' delete/destroy issue PK-based
+    // WHERE clauses where Rails' `delete_all(:delete_all)` builds its own.
     joinModel.primaryKey = [
       joinModel.leftReflection.foreignKey,
       joinModel.rightReflection.foreignKey,
@@ -253,9 +252,8 @@ export class HasAndBelongsToMany {
 
     const joinModel = this.throughModel();
 
-    // `const_set join_model.name, join_model` + `private_constant`
-    // (associations.rb:1868-1869): trails has no constant table, so the join
-    // model is registered under the same `Owner::HABTM_Name` path.
+    // `const_set` + `private_constant` (associations.rb:1868-1869) against the
+    // registry that stands in for Ruby's constant table.
     const registryKey = `${model.name}::${joinModel.name}`;
     deps.modelRegistry.set(registryKey, joinModel);
     privateConstant(registryKey);

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -186,6 +186,16 @@ export class HasAndBelongsToMany {
       // (see `through_model`'s `add_left_association`).
       middleOptions.foreignKey = joinModel.leftReflection.foreignKey;
     }
+    // DEVIATION (trails-only, tracked by converge-constantize-ignores-private-constants):
+    // Rails resolves the join model straight back out of the constant table —
+    // `private_constant` blocks only a literal `A::B` reference, never
+    // `const_get`, so `Object.const_get("Category::HABTM_Posts")` succeeds in
+    // Ruby (verified on 3.3.11). trails' `constantize` raises for a private
+    // name, so the join model is held directly and `klass` short-circuits
+    // before any name lookup. `dependent` stands in for the
+    // `delete_all(:delete_all)` Rails writes into `destroy_associations`.
+    middleOptions.anonymousClass = joinModel;
+    middleOptions.dependent = "delete";
     return middleOptions;
   }
 
@@ -263,15 +273,6 @@ export class HasAndBelongsToMany {
 
     const middleReflection = this.middleReflection(joinModel);
     const middleName = middleReflection.name;
-    // DEVIATION (trails-only, tracked by converge-constantize-ignores-private-constants):
-    // Rails resolves the join model straight back out of the constant table —
-    // `private_constant` blocks only a literal `A::B` reference, never
-    // `const_get`, so `Object.const_get("Category::HABTM_Posts")` succeeds in
-    // Ruby (verified on 3.3.11). trails' `constantize` raises for a private
-    // name, which it should not; until that is fixed, hold the join model
-    // directly so `klass` short-circuits before any name lookup.
-    middleReflection.options.anonymousClass = joinModel;
-    middleReflection.options.dependent = "delete";
     // Rails: `Builder::HasMany.define_callbacks self, middle_reflection`
     // (associations.rb:1878); AutosaveAssociation is one of its extensions.
     addAutosaveAssociationCallbacks.call(model, middleReflection);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -399,9 +399,6 @@ export class HasManyAssociation extends CollectionAssociation {
         limitValue?: number | null;
       } | null
     )?.limitValue;
-    // `[association_scope.limit_value, count].compact.min`
-    // (has_many_association.rb:95) — `compact` drops the nil limit, so `count`
-    // is always present and the receiver is never empty.
     return min([limitValue, count].filter((value) => value != null))!;
   }
 }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -34,6 +34,7 @@ import { compositeQueryConstraintsList, queryConstraintsList } from "../persiste
 import {
   camelize,
   eachSlice,
+  min,
   selectBang,
   singularize,
   underscore,
@@ -398,7 +399,10 @@ export class HasManyAssociation extends CollectionAssociation {
         limitValue?: number | null;
       } | null
     )?.limitValue;
-    return limitValue == null ? count : Math.min(limitValue, count);
+    // `[association_scope.limit_value, count].compact.min`
+    // (has_many_association.rb:95) — `compact` drops the nil limit, so `count`
+    // is always present and the receiver is never empty.
+    return min([limitValue, count].filter((value) => value != null))!;
   }
 }
 

--- a/packages/activesupport/src/array-utils.ts
+++ b/packages/activesupport/src/array-utils.ts
@@ -210,6 +210,30 @@ export function selectBang<T>(array: T[], predicate: (item: T) => boolean): T[] 
 }
 
 /**
+ * The smallest element of `collection`, or `undefined` when it is empty —
+ * Ruby's `Enumerable#min` in its no-argument RECEIVER form, which
+ * `HasManyAssociation#count_records` (`has_many_association.rb:95`) calls as
+ * `[association_scope.limit_value, count].compact.min`.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `Enumerable`, not Rails, exactly as
+ * `selectBang` above is Ruby core `Array`. JS spells the same operation
+ * `Math.min(...values)`, which is a different shape (the values are arguments,
+ * not a receiver) and is numbers-only, so the receiver form is spelled here for
+ * the ports that consume it.
+ */
+export function min<T>(collection: readonly T[]): T | undefined {
+  let result: T | undefined;
+  let seen = false;
+  for (const item of collection) {
+    if (!seen || item < (result as T)) {
+      result = item;
+      seen = true;
+    }
+  }
+  return result;
+}
+
+/**
  * Remove elements from `array` that match `predicate`, returning the removed elements.
  *
  * Mirrors: `Array#extract!` (core_ext/array/extract.rb:10-20). Ruby's no-block

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -287,6 +287,7 @@ export {
   inGroups,
   split,
   extractBang,
+  min,
   selectBang,
   toSentence,
   // `toXml` is Hash#to_xml above; one ESM namespace cannot hold both, the same

--- a/scripts/api-compare/call-args-baseline.ts
+++ b/scripts/api-compare/call-args-baseline.ts
@@ -14,7 +14,12 @@
  * Hard rules: no node:* imports, no process.*, async fs only.
  */
 
-import { type CallMismatchKey, compareShardKeys, shardKeyOf } from "./call-mismatch-baseline.js";
+import {
+  type CallMismatchKey,
+  type TagReceipt,
+  compareShardKeys,
+  shardKeyOf,
+} from "./call-mismatch-baseline.js";
 
 /** One flagged call site at the grain the baseline records. `rubyArgs` is part
  *  of the key: one call in one method can be wrong two ways at two sites. */
@@ -45,6 +50,10 @@ export interface CallArgArtifact {
   /** `@missingRailsArgs` tags (RFC 0099) on a COMPARED pair that suppressed no
    *  mismatch. Absent on an artifact predating the field. */
   staleTags?: { package: string; tsFile: string; tsName: string; call: string }[];
+  /** The mismatches `@missingRailsArgs` tags DID suppress, each with its reason
+   *  (RFC 0099) — grouped by permanence claim in the report. Absent on an
+   *  artifact predating the field. */
+  suppressed?: TagReceipt[];
 }
 
 /** The rows the gate ratchets: `shape` only. */

--- a/scripts/api-compare/call-mismatch-baseline.ts
+++ b/scripts/api-compare/call-mismatch-baseline.ts
@@ -119,6 +119,21 @@ export interface Artifact {
    *  (RFC 0083). Optional so an artifact predating the field still loads; the
    *  gate fails on a non-empty list, the tag's only-shrink half. */
   staleTags?: StaleTag[];
+  /** The flags `@missingRailsCall` tags DID suppress, each with the reason that
+   *  justified it (RFC 0099). Optional so an artifact predating the field still
+   *  loads; the report groups them by permanence claim. */
+  suppressed?: TagReceipt[];
+}
+
+/** One suppression a call-site receipt bought: the tagged declaration, the Ruby
+ *  call it justifies, and the tag's reason — whose leading `PERMANENT` /
+ *  `CONVERGEABLE` token is the population split the report prints. */
+export interface TagReceipt {
+  package: string;
+  tsFile: string;
+  tsName: string;
+  call: string;
+  reason?: string;
 }
 
 export interface StaleTag {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-many-association.json
@@ -2,15 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
-    "rubyName": "count_records",
-    "call": "min",
-    "kind": "args",
-    "rubyArgs": [],
-    "reason": "has_many_association.rb:95 `[association_scope.limit_value, count].compact.min` — Ruby's Enumerable#min is a RECEIVER method taking no arguments; JS's is `Math.min(...values)`, which takes the values as arguments. Same values, same result, and the only spellings that would report zero args (an Array.prototype extension, or a receiver-shaped helper named `min`) are surface trails does not add. Language shortcoming."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
     "call": "fetch",
     "reason": "Ruby `options.fetch(:ensuring_owner_was, nil)` (has_many_association.rb:52); a JS object has no `fetch`, so the stored-nil semantics are spelled as an own-key check at the call site."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1825,7 +1825,20 @@ describe("staleCallTags", () => {
   const tags = new Map([
     [
       "relation.ts",
-      new Map([["load", new Map([["Relation", new Set(["synchronize", "reload"])]])]]),
+      new Map([
+        [
+          "load",
+          new Map([
+            [
+              "Relation",
+              new Map([
+                ["synchronize", "PERMANENT — receipt."],
+                ["reload", "PERMANENT — receipt."],
+              ]),
+            ],
+          ]),
+        ],
+      ]),
     ],
   ]);
 
@@ -1851,8 +1864,18 @@ describe("staleCallTags", () => {
 
   it("keys tags to their own file, so a same-named method elsewhere is untouched", () => {
     const twoFiles = new Map([
-      ["relation.ts", new Map([["load", new Map([["Relation", new Set(["synchronize"])]])]])],
-      ["core.ts", new Map([["load", new Map([["Core", new Set(["synchronize"])]])]])],
+      [
+        "relation.ts",
+        new Map([
+          ["load", new Map([["Relation", new Map([["synchronize", "PERMANENT — receipt."]])]])],
+        ]),
+      ],
+      [
+        "core.ts",
+        new Map([
+          ["load", new Map([["Core", new Map([["synchronize", "PERMANENT — receipt."]])]])],
+        ]),
+      ],
     ]);
     const used = new Map([[callTagKey("core.ts", "Core", "load"), new Set<string>()]]);
     expect(staleCallTags(twoFiles, used)).toEqual([
@@ -1868,8 +1891,8 @@ describe("staleCallTags", () => {
           [
             "checkout",
             new Map([
-              ["ConnectionPool", new Set(["synchronize"])],
-              ["NullPool", new Set(["synchronize"])],
+              ["ConnectionPool", new Map([["synchronize", "PERMANENT — receipt."]])],
+              ["NullPool", new Map([["synchronize", "PERMANENT — receipt."]])],
             ]),
           ],
         ]),
@@ -2221,22 +2244,29 @@ describe("writerPairedWithReader", () => {
 
 describe("tagsForOwner", () => {
   const byClass = new Map([
-    ["ConnectionPool", new Set(["synchronize"])],
-    ["NullPool", new Set(["reload"])],
+    ["ConnectionPool", new Map([["synchronize", "PERMANENT — no monitor in JS."]])],
+    ["NullPool", new Map([["reload", "CONVERGEABLE — see story."]])],
   ]);
 
   it("reads only the resolved owner's tags", () => {
-    expect([...tagsForOwner(byClass, "ConnectionPool")!]).toEqual(["synchronize"]);
+    expect([...tagsForOwner(byClass, "ConnectionPool")!.keys()]).toEqual(["synchronize"]);
   });
 
   it("gives an owner with no tags of its own nothing from its siblings", () => {
-    expect(tagsForOwner(new Map([["NullPool", new Set(["synchronize"])]]), "ConnectionPool")).toBe(
-      undefined,
-    );
+    expect(
+      tagsForOwner(
+        new Map([["NullPool", new Map([["synchronize", "PERMANENT — x."]])]]),
+        "ConnectionPool",
+      ),
+    ).toBe(undefined);
   });
 
   it("falls back to the union when the owner is unresolved", () => {
-    expect([...tagsForOwner(byClass, undefined)!].sort()).toEqual(["reload", "synchronize"]);
+    expect([...tagsForOwner(byClass, undefined)!.keys()].sort()).toEqual(["reload", "synchronize"]);
+  });
+
+  it("carries each tag's reason, so the report can read its permanence claim", () => {
+    expect(tagsForOwner(byClass, "NullPool")!.get("reload")).toBe("CONVERGEABLE — see story.");
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1019,6 +1019,10 @@ export interface SuppressedCall {
   /** See `CallMismatch.tsClass`. */
   tsClass?: string;
   call: string;
+  /** The tag's reason, carried so the report can group the receipts by the
+   *  permanence claim it opens with (RFC 0099). `""` when the artifact the
+   *  entry was read from predates the reasons. */
+  reason?: string;
 }
 
 /** Identity of the declaration a `@missingRailsCall` tag is written on. Keyed
@@ -1331,15 +1335,35 @@ export function writerPairedWithReader(
  *  silence a flag raised against this one. With no owner resolved the tags of
  *  the file's single tagged class — or, ambiguously, their union — apply. */
 export function tagsForOwner(
-  byClass: ReadonlyMap<string, ReadonlySet<string>> | undefined,
+  byClass: ReadonlyMap<string, ReadonlyMap<string, string>> | undefined,
   owner: string | undefined,
-): ReadonlySet<string> | undefined {
+): ReadonlyMap<string, string> | undefined {
   if (!byClass || byClass.size === 0) return undefined;
   if (owner !== undefined) return byClass.get(owner);
   if (byClass.size === 1) return [...byClass.values()][0];
-  const union = new Set<string>();
-  for (const calls of byClass.values()) for (const c of calls) union.add(c);
+  const union = new Map<string, string>();
+  for (const calls of byClass.values()) for (const [c, reason] of calls) union.set(c, reason);
   return union;
+}
+
+/** Record one declaration's tagged calls (call → the reason that justified it,
+ *  `""` for an artifact predating the reasons) under (file, name, owner). The
+ *  two families are recorded identically, so they share one writer. */
+function recordTaggedCalls(
+  byFileName: Map<string, Map<string, Map<string, Map<string, string>>>>,
+  file: string,
+  name: string,
+  owner: string,
+  calls: string[],
+  reasons: Record<string, string> | undefined,
+): void {
+  const byName = byFileName.get(file) ?? new Map<string, Map<string, Map<string, string>>>();
+  const byClass = byName.get(name) ?? new Map<string, Map<string, string>>();
+  const tagged = byClass.get(owner) ?? new Map<string, string>();
+  for (const c of calls) tagged.set(c, reasons?.[c] ?? "");
+  byClass.set(owner, tagged);
+  byName.set(name, byClass);
+  byFileName.set(file, byName);
 }
 
 /** Drop the flagged calls a tag on this declaration justifies, recording each
@@ -1348,7 +1372,7 @@ export function tagsForOwner(
  *  name. */
 export function suppressTaggedCalls(
   missing: string[],
-  tags: ReadonlySet<string>,
+  tags: ReadonlyMap<string, string> | ReadonlySet<string>,
   used: Set<string>,
 ): string[] {
   return missing.filter((m) => {
@@ -1364,7 +1388,7 @@ export function suppressTaggedCalls(
  *  artifact. A pair whose owning class stayed unresolved recorded its
  *  suppressions under the `"*"` class, so both keys are consulted. */
 export function staleCallTags(
-  tagsByFileName: Map<string, Map<string, Map<string, Set<string>>>>,
+  tagsByFileName: Map<string, Map<string, Map<string, Map<string, string>>>>,
   used: Map<string, Set<string>>,
 ): StaleCallTag[] {
   const out: StaleCallTag[] = [];
@@ -1375,7 +1399,7 @@ export function staleCallTags(
           used.get(callTagKey(tsFile, tsClass, tsName)) ??
           used.get(callTagKey(tsFile, "*", tsName));
         if (hit === undefined) continue;
-        for (const call of calls) {
+        for (const call of calls.keys()) {
           if (!hit.has(call)) out.push({ tsFile, tsName, call });
         }
       }
@@ -1485,6 +1509,9 @@ interface CallArgsResult {
   /** `@missingRailsArgs` tags on a COMPARED pair that suppressed nothing —
    *  the tag's only-shrink half, read by lint-call-args.ts. */
   staleTags: StaleCallTag[];
+  /** The mismatches those tags DID suppress, each with its reason — the
+   *  permanence report's population (RFC 0099). */
+  suppressed: SuppressedCall[];
 }
 
 function emptySkipTally(): Record<CallArgSkipReason, number> {
@@ -2549,10 +2576,16 @@ export function main() {
     const tsCallArgsByFileNameOwner = new Map<string, Map<string, Map<string, CallSite[][]>>>();
     // (file → name → declaring class → tagged calls), so a tag on one class
     // never speaks for a same-named sibling; a top-level function is `""`.
-    const tsMissingCallTagsByFileName = new Map<string, Map<string, Map<string, Set<string>>>>();
+    const tsMissingCallTagsByFileName = new Map<
+      string,
+      Map<string, Map<string, Map<string, string>>>
+    >();
     // The call-ARGUMENT twin (RFC 0099): the `@missingRailsArgs` tags, keyed
     // identically, read by `checkCallArgs`.
-    const tsMissingArgTagsByFileName = new Map<string, Map<string, Map<string, Set<string>>>>();
+    const tsMissingArgTagsByFileName = new Map<
+      string,
+      Map<string, Map<string, Map<string, string>>>
+    >();
     // (file → name → every class declaring it), `resolveTsOwner`'s population.
     const tsOwnersByFileName = new Map<string, Map<string, Set<string>>>();
     // The same population split by the SEAT each owner declares the name on
@@ -2665,24 +2698,24 @@ export function main() {
         }
       }
       if (m.missingRailsCalls !== undefined) {
-        const byName =
-          tsMissingCallTagsByFileName.get(file) ?? new Map<string, Map<string, Set<string>>>();
-        const byClass = byName.get(m.name) ?? new Map<string, Set<string>>();
-        const tagged = byClass.get(owner) ?? new Set<string>();
-        for (const c of m.missingRailsCalls) tagged.add(c);
-        byClass.set(owner, tagged);
-        byName.set(m.name, byClass);
-        tsMissingCallTagsByFileName.set(file, byName);
+        recordTaggedCalls(
+          tsMissingCallTagsByFileName,
+          file,
+          m.name,
+          owner,
+          m.missingRailsCalls,
+          m.missingRailsCallReasons,
+        );
       }
       if (m.missingRailsArgs !== undefined) {
-        const byName =
-          tsMissingArgTagsByFileName.get(file) ?? new Map<string, Map<string, Set<string>>>();
-        const byClass = byName.get(m.name) ?? new Map<string, Set<string>>();
-        const tagged = byClass.get(owner) ?? new Set<string>();
-        for (const c of m.missingRailsArgs) tagged.add(c);
-        byClass.set(owner, tagged);
-        byName.set(m.name, byClass);
-        tsMissingArgTagsByFileName.set(file, byName);
+        recordTaggedCalls(
+          tsMissingArgTagsByFileName,
+          file,
+          m.name,
+          owner,
+          m.missingRailsArgs,
+          m.missingRailsArgsReasons,
+        );
       }
       if (m.callSeq !== undefined) {
         const byName = tsCallSeqByFileName.get(file) ?? new Map<string, string[][]>();
@@ -2999,6 +3032,9 @@ export function main() {
     // mismatch is STALE, the only-shrink half `@missingRailsCall` already has.
     const argTagsUsed = new Map<string, Set<string>>();
     const suppressedCalls: SuppressedCall[] = [];
+    // The call-ARGUMENT twin, reported in that artifact for the same reason:
+    // its receipts carry a permanence claim and are a population of their own.
+    const suppressedArgCalls: SuppressedCall[] = [];
     const callSkeletons: CallSkeleton[] = [];
     let callArgsCompared = 0;
     const callArgsSkipped = emptySkipTally();
@@ -3280,7 +3316,15 @@ export function main() {
           kept = suppressTaggedCalls(missing, tags, used);
           for (const m of missing) {
             const call = callOf(m);
-            if (tags.has(call)) suppressedCalls.push({ tsFile, rubyName, tsName, tsClass, call });
+            if (tags.has(call))
+              suppressedCalls.push({
+                tsFile,
+                rubyName,
+                tsName,
+                tsClass,
+                call,
+                reason: tags.get(call) ?? "",
+              });
           }
         }
         const rubySkeleton = rubySkeletonByName.get(rubyName);
@@ -3399,6 +3443,14 @@ export function main() {
             (argTagsUsed.get(tagKey) ?? argTagsUsed.set(tagKey, new Set()).get(tagKey)!).add(
               ruby.name,
             );
+            suppressedArgCalls.push({
+              tsFile,
+              rubyName,
+              tsName,
+              tsClass,
+              call: ruby.name,
+              reason: argTags.get(ruby.name) ?? "",
+            });
             continue;
           }
           callArgMismatches.push({
@@ -3941,6 +3993,7 @@ export function main() {
         skipped: callArgsSkipped,
         mismatches: callArgMismatches,
         staleTags: staleCallTags(tsMissingArgTagsByFileName, argTagsUsed),
+        suppressed: suppressedArgCalls,
       },
       bodyHashes: bodyHashRecords,
     });
@@ -4090,6 +4143,9 @@ export function main() {
     const staleArgTagsFlat = results.flatMap((r) =>
       r.callArgs.staleTags.map((t) => ({ package: r.package, ...t })),
     );
+    const suppressedArgsFlat = results.flatMap((r) =>
+      r.callArgs.suppressed.map((c) => ({ package: r.package, ...c })),
+    );
     fs.writeFileSync(
       callArgsPath,
       JSON.stringify(
@@ -4107,6 +4163,7 @@ export function main() {
           ),
           mismatches: callArgsFlat,
           staleTags: staleArgTagsFlat,
+          suppressed: suppressedArgsFlat,
         },
         null,
         2,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -68,8 +68,16 @@ import {
 import { extractorSchemaToken } from "./extractor-schema.js";
 import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
 import { FOREIGN_READ_PREFIX, NEGATED_CALL_PREFIX } from "./enumerable-idioms.js";
-import { TAG as MISSING_RAILS_CALL_TAG, suppressedCallsIn } from "./missing-rails-call-tags.js";
-import { TAG as MISSING_RAILS_ARGS_TAG, suppressedArgCallsIn } from "./missing-rails-args-tags.js";
+import {
+  TAG as MISSING_RAILS_CALL_TAG,
+  suppressedCallReasonsIn,
+  suppressedCallsIn,
+} from "./missing-rails-call-tags.js";
+import {
+  TAG as MISSING_RAILS_ARGS_TAG,
+  suppressedArgCallsIn,
+  suppressedArgReasonsIn,
+} from "./missing-rails-args-tags.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
 // takes ~16s; only a handful of packages typically change between
@@ -711,6 +719,8 @@ export function extractFromProgram(
         const noRailsEquivalent = noRailsEquivalentReason(node);
         const fnMissingRailsCalls = missingRailsCallTags(node);
         const fnMissingRailsArgs = missingRailsArgsTags(node);
+        const fnMissingRailsCallReasons = missingRailsCallTagReasons(node);
+        const fnMissingRailsArgsReasons = missingRailsArgsTagReasons(node);
         fileFunctions.push({
           name: node.name.text,
           visibility: "public",
@@ -727,6 +737,12 @@ export function extractFromProgram(
           ...(fnSkeleton !== undefined ? { skeleton: fnSkeleton } : {}),
           ...(fnMissingRailsCalls !== undefined ? { missingRailsCalls: fnMissingRailsCalls } : {}),
           ...(fnMissingRailsArgs !== undefined ? { missingRailsArgs: fnMissingRailsArgs } : {}),
+          ...(fnMissingRailsCallReasons !== undefined
+            ? { missingRailsCallReasons: fnMissingRailsCallReasons }
+            : {}),
+          ...(fnMissingRailsArgsReasons !== undefined
+            ? { missingRailsArgsReasons: fnMissingRailsArgsReasons }
+            : {}),
         });
       } else if (ts.isVariableStatement(node) && isExported(node)) {
         // Capture `export const X = { method() {...}, foo, bar: ... }`
@@ -1625,6 +1641,31 @@ export function missingRailsArgsTags(node: ts.Node): string[] | undefined {
   );
 }
 
+/**
+ * The reasons behind {@link missingRailsCallTags}' suppressions, keyed by Ruby
+ * call — the artifact half of the permanence report (RFC 0099): a receipt's
+ * `PERMANENT` / `CONVERGEABLE` claim is only separable downstream if the reason
+ * that makes it travels with the suppression.
+ */
+export function missingRailsCallTagReasons(node: ts.Node): Record<string, string> | undefined {
+  return taggedReasonsOn(
+    node,
+    MISSING_RAILS_CALL_TAG,
+    fileHasMissingRailsCallTag,
+    suppressedCallReasonsIn,
+  );
+}
+
+/** The call-ARGUMENT twin of {@link missingRailsCallTagReasons}. */
+export function missingRailsArgsTagReasons(node: ts.Node): Record<string, string> | undefined {
+  return taggedReasonsOn(
+    node,
+    MISSING_RAILS_ARGS_TAG,
+    fileHasMissingRailsArgsTag,
+    suppressedArgReasonsIn,
+  );
+}
+
 /** The shared read: the last leading `/** ... *\/` comment, parsed by the
  *  family's parser, with a per-file fast path off the tag's raw text. */
 function taggedCallsOn(
@@ -1633,6 +1674,31 @@ function taggedCallsOn(
   seen: WeakMap<ts.SourceFile, boolean>,
   parse: (comment: string, origin: { fileName: string; startLine: number }) => string[],
 ): string[] | undefined {
+  const calls = taggedCommentOf(node, tag, seen, parse);
+  return calls !== undefined && calls.length > 0 ? calls : undefined;
+}
+
+/** {@link taggedCallsOn} for the call → reason map; empty means untagged. */
+function taggedReasonsOn(
+  node: ts.Node,
+  tag: string,
+  seen: WeakMap<ts.SourceFile, boolean>,
+  parse: (
+    comment: string,
+    origin: { fileName: string; startLine: number },
+  ) => Record<string, string>,
+): Record<string, string> | undefined {
+  const reasons = taggedCommentOf(node, tag, seen, parse);
+  return reasons !== undefined && Object.keys(reasons).length > 0 ? reasons : undefined;
+}
+
+/** Find the declaration's tag-bearing JSDoc and hand it to `parse`. */
+function taggedCommentOf<T>(
+  node: ts.Node,
+  tag: string,
+  seen: WeakMap<ts.SourceFile, boolean>,
+  parse: (comment: string, origin: { fileName: string; startLine: number }) => T,
+): T | undefined {
   const sf = node.getSourceFile();
   let present = seen.get(sf);
   if (present === undefined) {
@@ -1645,11 +1711,10 @@ function taggedCallsOn(
   if (!range) return undefined;
   const comment = sf.text.slice(range.pos, range.end);
   if (!comment.includes(tag)) return undefined;
-  const calls = parse(comment, {
+  return parse(comment, {
     fileName: sf.fileName,
     startLine: sf.getLineAndCharacterOfPosition(range.pos).line + 1,
   });
-  return calls.length > 0 ? calls : undefined;
 }
 
 /**
@@ -1899,6 +1964,8 @@ export function harvestObjectLiteralMethods(
     let noRailsEquivalent = noRailsEquivalentReason(prop);
     const propMissingRailsCalls = missingRailsCallTags(prop);
     const propMissingRailsArgs = missingRailsArgsTags(prop);
+    const propMissingRailsCallReasons = missingRailsCallTagReasons(prop);
+    const propMissingRailsArgsReasons = missingRailsArgsTagReasons(prop);
     if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
@@ -1965,6 +2032,12 @@ export function harvestObjectLiteralMethods(
       ...(callArgs !== undefined ? { callArgs } : {}),
       ...(propMissingRailsCalls !== undefined ? { missingRailsCalls: propMissingRailsCalls } : {}),
       ...(propMissingRailsArgs !== undefined ? { missingRailsArgs: propMissingRailsArgs } : {}),
+      ...(propMissingRailsCallReasons !== undefined
+        ? { missingRailsCallReasons: propMissingRailsCallReasons }
+        : {}),
+      ...(propMissingRailsArgsReasons !== undefined
+        ? { missingRailsArgsReasons: propMissingRailsArgsReasons }
+        : {}),
       ...(writer ? { writer: true } : {}),
     });
   }
@@ -2100,12 +2173,20 @@ export function extractClass(
     const noRailsEquivalent = noRailsEquivalentReason(member);
     const memberMissingRailsCalls = missingRailsCallTags(member);
     const memberMissingRailsArgs = missingRailsArgsTags(member);
+    const memberMissingRailsCallReasons = missingRailsCallTagReasons(member);
+    const memberMissingRailsArgsReasons = missingRailsArgsTagReasons(member);
     const tagged = {
       ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
       ...(memberMissingRailsCalls !== undefined
         ? { missingRailsCalls: memberMissingRailsCalls }
         : {}),
       ...(memberMissingRailsArgs !== undefined ? { missingRailsArgs: memberMissingRailsArgs } : {}),
+      ...(memberMissingRailsCallReasons !== undefined
+        ? { missingRailsCallReasons: memberMissingRailsCallReasons }
+        : {}),
+      ...(memberMissingRailsArgsReasons !== undefined
+        ? { missingRailsArgsReasons: memberMissingRailsArgsReasons }
+        : {}),
     };
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);
     const line = member.getSourceFile().getLineAndCharacterOfPosition(member.getStart()).line + 1;

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -83,6 +83,8 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "noRailsEquivalent",
   "missingRailsCalls",
   "missingRailsArgs",
+  "missingRailsCallReasons",
+  "missingRailsArgsReasons",
   "recv",
   "writer",
 ] as const;

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -129,6 +129,7 @@ import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import {
   type Artifact,
   type CallMismatchKey,
+  type TagReceipt,
   type ExcludeEntry,
   compareKeys,
   compareShardKeys,
@@ -179,7 +180,7 @@ import {
   writeMarks,
 } from "./unreviewed-ratchet.js";
 import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "@blazetrails/parity/conventions";
-import { DEFAULT_REASON, TAG } from "./missing-rails-call-tags.js";
+import { DEFAULT_REASON, TAG, classifyReason } from "./missing-rails-call-tags.js";
 import type { ApiManifest, ClassInfo, MethodInfo } from "@blazetrails/parity/types";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
@@ -355,7 +356,7 @@ export function bucketFor(key: CallMismatchKey, index: TsMemberIndex): CauseBuck
     : "same-file zero-arg member";
 }
 
-export function tally<T>(items: T[], keyFn: (item: T) => string): [string, number][] {
+export function tally<T>(items: readonly T[], keyFn: (item: T) => string): [string, number][] {
   const counts = new Map<string, number>();
   for (const item of items) {
     const k = keyFn(item);
@@ -583,11 +584,40 @@ export function unreviewedCount(entries: ExcludeEntry[]): number {
   return unreviewedEntries(entries, DEFAULT_REASON).length;
 }
 
+/**
+ * The call-site receipts (`@missingRailsCall` / `@missingRailsArgs`), grouped
+ * by the permanence claim their reason opens with — the report half of the
+ * receipt contract (RFC 0099).
+ *
+ * A receipt takes its deviation off the baseline, so it leaves the row count
+ * the baselines are measured by. Without this section a CONVERGEABLE receipt is
+ * as invisible as a PERMANENT one and never surfaces as work again, which is
+ * exactly the failure `parity:api:extra` fixed for `@noRailsEquivalent` by
+ * printing its own permanence tally (extra-surface.ts).
+ */
+export function receiptsSection(title: string, receipts: readonly TagReceipt[]): string {
+  return (
+    section(
+      title,
+      tally(receipts, (r) => classifyReason(r.reason ?? "")),
+    ) +
+    "\n" +
+    section(
+      `${title} — CONVERGEABLE by file`,
+      tally(
+        receipts.filter((r) => classifyReason(r.reason ?? "") === "convergeable"),
+        (r) => `${r.package}/${r.tsFile} ${r.tsName} ${r.call}`,
+      ),
+    )
+  );
+}
+
 export function renderReport(
   entries: ExcludeEntry[],
   index: TsMemberIndex | undefined,
   top: number,
   mark?: number,
+  receipts: readonly TagReceipt[] = [],
 ): string {
   const files = new Set(entries.map((e) => `${e.package} ${e.tsFile}`)).size;
   const parts = [
@@ -609,6 +639,7 @@ export function renderReport(
       top,
     ),
   ];
+  parts.push(receiptsSection("Call-site receipts by permanence claim", receipts));
   parts.push(
     index === undefined
       ? `\nBy cause bucket: SKIPPED — ${path.relative(ROOT_DIR, TS_API_PATH)} is missing ` +
@@ -848,6 +879,7 @@ async function reportMain(top: number, unreviewedOnly: boolean): Promise<number>
       manifest && indexTsMembers(manifest),
       top,
       totalMark(await loadMarks(MARK_DIR)),
+      artifact?.suppressed ?? [],
     ),
   );
   return 0;

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -596,16 +596,14 @@ export function unreviewedCount(entries: ExcludeEntry[]): number {
  * printing its own permanence tally (extra-surface.ts).
  */
 export function receiptsSection(title: string, receipts: readonly TagReceipt[]): string {
+  const claim = (r: TagReceipt): string => classifyReason(r.reason ?? "");
   return (
-    section(
-      title,
-      tally(receipts, (r) => classifyReason(r.reason ?? "")),
-    ) +
+    section(title, tally(receipts, claim)) +
     "\n" +
     section(
       `${title} — CONVERGEABLE by file`,
       tally(
-        receipts.filter((r) => classifyReason(r.reason ?? "") === "convergeable"),
+        receipts.filter((r) => claim(r) === "convergeable"),
         (r) => `${r.package}/${r.tsFile} ${r.tsName} ${r.call}`,
       ),
     )

--- a/scripts/api-compare/missing-rails-args-tags.test.ts
+++ b/scripts/api-compare/missing-rails-args-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { suppressedArgCallsIn, TAG } from "./missing-rails-args-tags.js";
+import { suppressedArgCallsIn, suppressedArgReasonsIn, TAG } from "./missing-rails-args-tags.js";
 
 const block = (body: string): string => `/**\n * ${body}\n */`;
 
@@ -36,5 +36,17 @@ describe("suppressedArgCallsIn", () => {
     expect(
       suppressedArgCallsIn(block(`${TAG} where — CONVERGEABLE: pending the scope port.`)),
     ).toEqual(["where"]);
+  });
+});
+
+describe("suppressedArgReasonsIn", () => {
+  it("maps each suppressed call to the reason that justified it", () => {
+    expect(
+      suppressedArgReasonsIn(block(`${TAG} new — PERMANENT: a JS Map takes no capacity.`)),
+    ).toEqual({ new: "PERMANENT: a JS Map takes no capacity." });
+  });
+
+  it("returns nothing for an untagged comment", () => {
+    expect(suppressedArgReasonsIn(block("Just prose."))).toEqual({});
   });
 });

--- a/scripts/api-compare/missing-rails-args-tags.ts
+++ b/scripts/api-compare/missing-rails-args-tags.ts
@@ -34,6 +34,7 @@ import {
   classifyReason,
   justifies,
   parseJsdoc,
+  suppressedCallReasonsIn,
 } from "./missing-rails-call-tags.js";
 
 export const TAG = "@missingRailsArgs";
@@ -54,4 +55,13 @@ export function suppressedArgCallsIn(comment: string, origin?: JsdocOrigin): str
     );
   }
   return [...new Set(entries.filter((e) => justifies(e.reason)).map((e) => e.call))].sort();
+}
+
+/** The call-ARGUMENT twin of `suppressedCallReasonsIn`: each suppressed call
+ *  mapped to its reason, for the permanence report (RFC 0099). */
+export function suppressedArgReasonsIn(
+  comment: string,
+  origin?: JsdocOrigin,
+): Record<string, string> {
+  return suppressedCallReasonsIn(comment, origin, TAG);
 }

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -211,6 +211,25 @@ export function suppressedCallsIn(comment: string, origin?: JsdocOrigin): string
   return [...new Set(justified.map((e) => e.call))].sort();
 }
 
+/** The same suppressions as {@link suppressedCallsIn}, each mapped to the
+ *  REASON that justified it, so a consumer can group the receipts by the
+ *  permanence claim {@link classifyReason} reads off that reason (RFC 0099).
+ *  Two tags for one call on one comment keep the first reason, matching the
+ *  dedup {@link suppressedCallsIn} already does. */
+export function suppressedCallReasonsIn(
+  comment: string,
+  origin?: JsdocOrigin,
+  tag: string = TAG,
+): Record<string, string> {
+  const { entries } = parseJsdoc(comment, origin, tag);
+  const reasons: Record<string, string> = {};
+  for (const entry of entries) {
+    if (!justifies(entry.reason)) continue;
+    reasons[entry.call] ??= entry.reason;
+  }
+  return reasons;
+}
+
 /**
  * The permanence claim a tag's reason makes about itself.
  *

--- a/scripts/api-compare/receiver-as-first-arg.ts
+++ b/scripts/api-compare/receiver-as-first-arg.ts
@@ -115,4 +115,9 @@ export const RECEIVER_AS_FIRST_ARG = new Set([
   // call, so activerecord's `ruby-first.ts` exports it as `first(collection)`
   // and the Ruby receiver is TS argument 1.
   "first",
+  // Ruby core `Enumerable#min` in its no-argument receiver form —
+  // `[limit_value, count].compact.min`. JS's `Math.min(...values)` takes the
+  // values as ARGUMENTS and is numbers-only, so @blazetrails/activesupport
+  // exports `min(collection)` and the Ruby receiver is TS argument 1.
+  "min",
 ]);

--- a/scripts/api-compare/report-call-args.test.ts
+++ b/scripts/api-compare/report-call-args.test.ts
@@ -56,6 +56,35 @@ describe("renderReport", () => {
     expect(out).toMatch(/opaqueRubyArg\s+7/);
   });
 
+  it("groups the call-site receipts by permanence claim", () => {
+    const out = renderReport(
+      {
+        ...artifact,
+        suppressed: [
+          {
+            package: "arel",
+            tsFile: "visitors/to-sql.ts",
+            tsName: "visit",
+            call: "new",
+            reason: "PERMANENT: a JS Map takes no capacity.",
+          },
+          {
+            package: "activerecord",
+            tsFile: "relation.ts",
+            tsName: "where",
+            call: "where",
+            reason: "CONVERGEABLE: pending the scope port.",
+          },
+        ],
+      },
+      20,
+    );
+    expect(out).toContain("Call-site receipts by permanence claim (2)");
+    expect(out).toMatch(/permanent\s+1/);
+    expect(out).toMatch(/convergeable\s+1/);
+    expect(out).toContain("activerecord/relation.ts where where");
+  });
+
   it("truncates a grouping to --top", () => {
     expect(renderReport(artifact, 1)).toContain("By file (top 1 of 2)");
   });

--- a/scripts/api-compare/report-call-args.ts
+++ b/scripts/api-compare/report-call-args.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "url";
 import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import type { CallArgArtifact } from "./call-args-baseline.js";
 
-import { parseTop, section, tally } from "./lint-call-mismatches.js";
+import { parseTop, receiptsSection, section, tally } from "./lint-call-mismatches.js";
 import { classifyRow, NAMING_CLASSES } from "./naming-taxonomy.js";
 
 export { parseTop };
@@ -97,6 +97,7 @@ export function renderReport(
       "Naming residue by class",
       tally(naming, (r) => namingLabel(r)),
     ),
+    receiptsSection("Call-site receipts by permanence claim", artifact.suppressed ?? []),
     section(
       "Naming residue by package",
       tally(naming, (r) => `${r.package}  ${namingLabel(r).replace(/^.*\(|\)$/g, "")}`),

--- a/scripts/parity/types.ts
+++ b/scripts/parity/types.ts
@@ -120,6 +120,18 @@ export interface MethodInfo {
    */
   missingRailsArgs?: string[];
   /**
+   * TS-side only (RFC 0099): the REASON behind each `@missingRailsCall`
+   * suppression above, keyed by Ruby call. Carried so a receipt's permanence
+   * claim — `PERMANENT` / `CONVERGEABLE`, read by `classifyReason` — survives
+   * into the artifact and the suppressions can be reported as the two separate
+   * populations they are, the way `parity:api:extra` already reports
+   * `@noRailsEquivalent`.
+   */
+  missingRailsCallReasons?: Record<string, string>;
+  /** TS-side only (RFC 0099): the `@missingRailsArgs` twin of
+   *  {@link missingRailsCallReasons}. */
+  missingRailsArgsReasons?: Record<string, string>;
+  /**
    * Normalized digest of the Ruby method BODY (source-hash pinning, RFC 0025).
    * Whitespace/comment-insensitive, body-only; changes when the ported code
    * changes upstream. Ruby-side only (the TS extractor does not emit it); used


### PR DESCRIPTION
Three RFC 0106 / RFC 0099 convergence stories.

### 1. Receiver-form `Enumerable#min` (`converge-enumerable-min-receiver-call-shape`)

`[association_scope.limit_value, count].compact.min` (`has_many_association.rb:95`)
is a no-argument RECEIVER call; the port spelled it `Math.min(limitValue, count)`,
so the call-argument gate read two arguments against Ruby's zero. Adds the
receiver-shaped `min` to `array-utils.ts` beside `selectBang` (Ruby core
`Enumerable`, `@noRailsEquivalent PERMANENT`), lists it in
`RECEIVER_AS_FIRST_ARG`, and deletes the `args` baseline row.

(An earlier revision of this branch also deleted the stale `subscriber.ts`
`subscribe` args row, which was red on `main` at the time. #6833 has since landed
that same fix, so after the rebase onto `f1c6178` the only baseline change here
is the `min` row this story asks for.)

### 2. HABTM `_build` folds into `throughModel` / `middleReflection` (`fold-createhabtmjoinmodel-into-through-model`)

`Builder::HasAndBelongsToMany#build` is ONE Rails method (`associations.rb:1866-1900`):
`through_model`, `const_set`, `middle_reflection`, callbacks. trails had
`throughModel()` / `middleReflection()` mirroring Rails AND a second
implementation, `createHabtmJoinModel` (associations.ts) — and only the second
was reachable. `_build` now calls the two Rails methods; the trails-only extras
the duplicate carried (composite PK, `connection` / `_connectionSpecificationName`
delegation, `moduleName` propagation) sit on the subclass `throughModel` already
builds, each justified where it sits. `createHabtmJoinModel`,
`defaultJoinTableName`, `singleFk` and `habtmTargetFk` — which only fed it — are
deleted; the join table name now comes from the builder's own `_tableName`
(Rails' private `table_name`) and the source name from
`join_model.right_reflection.name`, as Rails spells it.

### 3. Receipts by permanence claim (`report-call-site-receipts-by-permanence-claim`)

`@missingRailsArgs` / `@missingRailsCall` suppressions leave the baseline row
counts entirely, so a CONVERGEABLE receipt was as invisible as a PERMANENT one
and never surfaced as work again. Each suppression's reason now travels with it
— extractor (`missingRailsCallReasons` / `missingRailsArgsReasons`) → both
artifacts → report — and `parity:api:calls:report` /
`parity:api:calls:args:report` group the receipts by permanence claim, plus the
CONVERGEABLE ones by file. Current state: 3 permanent (args), 27 unclassified
(`@missingRailsCall`, which has no permanence token yet).

### Review notes

On the middle association's `_associations` backing entry: it is still appended,
by `Builder::Association.createReflection` (`builder/association.ts:140-148`),
which `middleReflection` reaches through `HasMany.createReflection` — the inline
path used to append it by hand because it built the reflection with a bare
`Reflection.create` instead. Probed on the canonical `Developer`: the
`developers_projects` entry is present after declaration and
`developer.association("developers_projects")` resolves, and the HABTM destroy
tests exercise the override at line 313.

That probe did surface a real adjacent defect, now fixed: `createReflection`
snapshots `{...options}` into the `_associations` entry, so setting
`anonymousClass` / `dependent` on the reflection AFTER it was built left the two
copies disagreeing. Both keys now go into `middleOptions` before the reflection
is created, which also puts the whole trails-only deviation in one place.

### Size

783 LOC by the check command, over the 700 ceiling: 315 of it is deletion, 178 of
those the duplicate `createHabtmJoinModel` and the three helpers that fed
it, which story 2 exists to remove. Net additions are 463 across three stories.

Verified: `has-and-belongs-to-many-associations`, `has-many-associations`,
`associations`, `habtm`, `reflection`, `callbacks`, `autosave-association`,
`fixtures`, `reserved-word`, `eager-singularization`, `loader-methods` and the
api-compare script suites all green; `parity:api:calls` and
`parity:api:calls:args` both OK.

Closes-story: converge-enumerable-min-receiver-call-shape
Closes-story: fold-createhabtmjoinmodel-into-through-model
Closes-story: report-call-site-receipts-by-permanence-claim
