### PR TITLE
refactor(activesupport): load the Nokogiri parser at backend-selection time so every XmlMini backend parses synchronously

### DIFF
--- a/packages/activesupport/src/core-ext/hash/conversions.ts
+++ b/packages/activesupport/src/core-ext/hash/conversions.ts
@@ -39,21 +39,9 @@ export class XMLConverter {
   private xml: unknown;
   private disallowedTypes: string[];
 
-  /**
-   * Mirrors: ActiveSupport::XMLConverter#initialize (conversions.rb:151-154).
-   *
-   * Rails' `XmlMini.parse` is synchronous on every backend and so is the
-   * default REXML one here; the Nokogiri backends reach their optional parser
-   * package through a dynamic import, and a TS constructor cannot await one.
-   */
+  /** Mirrors: ActiveSupport::XMLConverter#initialize (conversions.rb:151-154). */
   constructor(xml: string | StringIO | null | undefined, disallowedTypes?: string[] | null) {
-    const parsed = XmlMini.parse(xml);
-    if (typeof (parsed as PromiseLike<unknown> | null)?.then === "function") {
-      throw new RuntimeError(
-        "Hash.fromXml requires a synchronous XmlMini backend; the current backend parses asynchronously",
-      );
-    }
-    this.xml = this.normalizeKeys(parsed as Record<string, unknown>);
+    this.xml = this.normalizeKeys(XmlMini.parse(xml));
     this.disallowedTypes = disallowedTypes ?? DISALLOWED_TYPES;
   }
 

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -352,9 +352,9 @@ describe("ToTagTest", () => {
 
 // Rails' `module REXML end` stand-ins: a backend is anything answering #parse,
 // and these are only ever compared by identity.
-const REXML: XmlMiniBackend = { parse: async () => ({}) };
-const LibXML: XmlMiniBackend = { parse: async () => ({}) };
-const Nokogiri: XmlMiniBackend = { parse: async () => ({}) };
+const REXML: XmlMiniBackend = { parse: () => ({}) };
+const LibXML: XmlMiniBackend = { parse: () => ({}) };
+const Nokogiri: XmlMiniBackend = { parse: () => ({}) };
 
 describe("WithBackendTest", () => {
   let defaultBackend: XmlMiniBackend | null | undefined;

--- a/packages/activesupport/src/xml-mini.trails.test.ts
+++ b/packages/activesupport/src/xml-mini.trails.test.ts
@@ -5,7 +5,9 @@ import {
   _parseHexBinary,
   castBackendNameToModule,
   FileLike,
+  withBackend,
 } from "./xml-mini.js";
+import { fromXml } from "./hash-utils.js";
 import * as XmlMini_REXML from "./xml-mini/rexml.js";
 import * as XmlMini_Nokogiri from "./xml-mini/nokogiri.js";
 
@@ -68,4 +70,22 @@ describe("XmlMini", () => {
       "cannot load such file -- active_support/xml_mini/nosuchengine",
     );
   });
+});
+
+// Rails runs the whole `Hash.from_xml` suite under each backend
+// (hash_ext_test.rb:1024 branches on `XmlMini.backend.name`), which trails
+// cannot mirror while its own suites are backend-agnostic. This covers the
+// property that makes that possible: `Hash.from_xml` calls `XmlMini.parse`
+// straight through (conversions.rb:128-130), so every backend must parse
+// synchronously — the Nokogiri ones load their parser from the file-top
+// `require` seat (nokogiri.rb:3-8), which `with_backend` reaches.
+describe("Hash.from_xml under each XmlMini backend", () => {
+  for (const name of ["REXML", "Nokogiri", "NokogiriSAX"]) {
+    it(`parses synchronously under ${name}`, async () => {
+      const hash = await withBackend(name, () =>
+        fromXml('<product><name>Book</name><price type="integer">10</price></product>'),
+      );
+      expect(hash).toEqual({ product: { name: "Book", price: 10 } });
+    });
+  }
 });

--- a/packages/activesupport/src/xml-mini.trails.test.ts
+++ b/packages/activesupport/src/xml-mini.trails.test.ts
@@ -80,12 +80,20 @@ describe("XmlMini", () => {
 // synchronously — the Nokogiri ones load their parser from the file-top
 // `require` seat (nokogiri.rb:3-8), which `with_backend` reaches.
 describe("Hash.from_xml under each XmlMini backend", () => {
+  const XML = '<product><name>Book</name><price type="integer">10</price></product>';
+  const HASH = { product: { name: "Book", price: 10 } };
+
   for (const name of ["REXML", "Nokogiri", "NokogiriSAX"]) {
     it(`parses synchronously under ${name}`, async () => {
-      const hash = await withBackend(name, () =>
-        fromXml('<product><name>Book</name><price type="integer">10</price></product>'),
-      );
-      expect(hash).toEqual({ product: { name: "Book", price: 10 } });
+      expect(await withBackend(name, () => fromXml(XML))).toEqual(HASH);
     });
   }
+
+  // Ruby cannot name `ActiveSupport::XmlMini_Nokogiri` without having required
+  // its file, which is where `require "nokogiri"` (nokogiri.rb:3) runs, so the
+  // module-object arm of `cast_backend_name_to_module` (xml_mini.rb:200-201) is
+  // as loaded as the name arm.
+  it("parses synchronously when the backend is selected as a module", async () => {
+    expect(await withBackend(XmlMini_Nokogiri, () => fromXml(XML))).toEqual(HASH);
+  });
 });

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -47,18 +47,14 @@ export const FileLike = {
  * `ActiveSupport`; here the module namespace object of
  * `./xml-mini/<name>.js` *is* that module.
  *
- * Rails' backends all return the parsed Hash synchronously, and so does the
- * default REXML one here. The Nokogiri backends are the residue: each loads its
- * optional parser package (`@blazetrails/nokogiri`) through a dynamic import —
- * see `xml-mini/nokogirisax.ts:55` and `xml-mini/nokogiri.ts:99` — so their
- * `parse` returns a Promise, and only the `await XmlMini.parse(...)` path
- * reaches them. `Hash.fromXml`, which Rails calls straight through
- * (conversions.rb:128-130), needs a synchronous backend.
+ * Every backend's `parse` returns the parsed Hash synchronously, as Rails'
+ * do: the Nokogiri backends reach their optional parser package
+ * (`@blazetrails/nokogiri`) from their `_require` hook, which
+ * {@link castBackendNameToModule} awaits at backend-selection time, mirroring
+ * the file-top `require "nokogiri"` Ruby runs there.
  */
 export interface XmlMiniBackend {
-  parse(
-    data: string | StringIO | null | undefined,
-  ): Record<string, unknown> | Promise<Record<string, unknown>>;
+  parse(data: string | StringIO | null | undefined): Record<string, unknown>;
 }
 
 /** The name of a backend, or the backend module itself. */
@@ -292,14 +288,9 @@ let _backend: XmlMiniBackend | null | undefined;
 /**
  * Parse an XML document into a hash through the current backend.
  *
- * Mirrors: `delegate :parse, to: :backend` (xml_mini.rb:99) — the delegation
- * forwards straight to the selected backend, whose result is the Hash itself
- * for a synchronous backend and a Promise for an asynchronous one (see
- * {@link XmlMiniBackend}).
+ * Mirrors: `delegate :parse, to: :backend` (xml_mini.rb:99).
  */
-export function parse(
-  data: string | StringIO | null | undefined,
-): Record<string, unknown> | Promise<Record<string, unknown>> {
+export function parse(data: string | StringIO | null | undefined): Record<string, unknown> {
   return backend()!.parse(data);
 }
 
@@ -731,8 +722,20 @@ const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
   jdom: "JRuby is required to use the JDOM backend for XmlMini",
   libxml: "cannot load such file -- libxml",
   libxmlsax: "cannot load such file -- libxml",
-  nokogiri: () => import("./xml-mini/nokogiri.js"),
-  nokogirisax: () => import("./xml-mini/nokogirisax.js"),
+  // Ruby's `require "active_support/xml_mini/nokogiri"` also runs that file's
+  // own file-top `require "nokogiri"` (nokogiri.rb:3-8); ESM's `import()` only
+  // evaluates the module body, so the loader awaits its `_require` hook here to
+  // reach the optional `@blazetrails/nokogiri` package at the same seat.
+  nokogiri: async () => {
+    const backend = await import("./xml-mini/nokogiri.js");
+    await backend._require();
+    return backend;
+  },
+  nokogirisax: async () => {
+    const backend = await import("./xml-mini/nokogirisax.js");
+    await backend._require();
+    return backend;
+  },
   rexml: () => import("./xml-mini/rexml.js"),
 };
 

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -55,6 +55,16 @@ export const FileLike = {
  */
 export interface XmlMiniBackend {
   parse(data: string | StringIO | null | undefined): Record<string, unknown>;
+
+  /**
+   * The backend file's own file-top `require` of its parser library, which
+   * Ruby runs as part of requiring the file (nokogiri.rb:3, nokogirisax.rb:3)
+   * and {@link castBackendNameToModule} awaits here. Backends whose parser
+   * needs no loading (REXML) do not declare it.
+   *
+   * @internal
+   */
+  _require?(): Promise<void>;
 }
 
 /** The name of a backend, or the backend module itself. */
@@ -722,19 +732,8 @@ const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
   jdom: "JRuby is required to use the JDOM backend for XmlMini",
   libxml: "cannot load such file -- libxml",
   libxmlsax: "cannot load such file -- libxml",
-  // Ruby's `require "active_support/xml_mini/nokogiri"` also runs that file's
-  // own file-top `require "nokogiri"` (nokogiri.rb:3-8); ESM's `import()` only
-  // evaluates the module body, so the `_require` hook is awaited at the same seat.
-  nokogiri: async () => {
-    const backend = await import("./xml-mini/nokogiri.js");
-    await backend._require();
-    return backend;
-  },
-  nokogirisax: async () => {
-    const backend = await import("./xml-mini/nokogirisax.js");
-    await backend._require();
-    return backend;
-  },
+  nokogiri: () => import("./xml-mini/nokogiri.js"),
+  nokogirisax: () => import("./xml-mini/nokogirisax.js"),
   rexml: () => import("./xml-mini/rexml.js"),
 };
 
@@ -747,14 +746,26 @@ const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
  * is a dynamic import here, since the module namespace object of
  * `xml-mini/<name>.js` is the backend module.
  *
+ * Requiring that file also runs its own file-top `require` of the parser
+ * library (nokogiri.rb:3, nokogirisax.rb:3), so in Ruby a backend module cannot
+ * be named at all — by `name` or as the module object this method returns
+ * unchanged — without its parser already being loaded. An ESM `import` only
+ * evaluates the module body and cannot await, so both arms await the backend's
+ * {@link XmlMiniBackend._require} hook to reach the same state.
+ *
  * @internal
  */
 export async function castBackendNameToModule(name: XmlMiniBackendName): Promise<XmlMiniBackend> {
   if (typeof name !== "string") {
+    await name._require?.();
     return name;
   } else {
     const backend = XML_MINI_BACKENDS[name.toLowerCase()];
-    if (typeof backend === "function") return (await backend()) as XmlMiniBackend;
+    if (typeof backend === "function") {
+      const module = (await backend()) as XmlMiniBackend;
+      await module._require?.();
+      return module;
+    }
     // Ruby's counterpart is the core `LoadError` / `RuntimeError` the file's own
     // `require` or guard raises; there is no Rails error class to port here, the
     // same reason `yaml.ts:16` gives for its own LoadError stand-in.

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -724,8 +724,7 @@ const XML_MINI_BACKENDS: Record<string, (() => Promise<unknown>) | string> = {
   libxmlsax: "cannot load such file -- libxml",
   // Ruby's `require "active_support/xml_mini/nokogiri"` also runs that file's
   // own file-top `require "nokogiri"` (nokogiri.rb:3-8); ESM's `import()` only
-  // evaluates the module body, so the loader awaits its `_require` hook here to
-  // reach the optional `@blazetrails/nokogiri` package at the same seat.
+  // evaluates the module body, so the `_require` hook is awaited at the same seat.
   nokogiri: async () => {
     const backend = await import("./xml-mini/nokogiri.js");
     await backend._require();

--- a/packages/activesupport/src/xml-mini/nokogiri.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { parse } from "./nokogiri.js";
+import { describe, it, expect, beforeAll } from "vitest";
+import { parse, _require } from "./nokogiri.js";
+
+// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
+// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
+// direct-import test does the load itself before calling `parse`.
+beforeAll(async () => {
+  await _require();
+});
 
 describe("NokogiriEngineTest", () => {
   it("blank returns empty hash", async () => {
@@ -66,7 +73,7 @@ describe("NokogiriEngineTest", () => {
   });
 
   it("throws on malformed xml", async () => {
-    await expect(parse("<root>")).rejects.toThrow();
+    expect(() => parse("<root>")).toThrow();
   });
 
   it("decodes entities in content", async () => {

--- a/packages/activesupport/src/xml-mini/nokogiri.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { parse, _require } from "./nokogiri.js";
 
-// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
-// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
-// direct-import test does the load itself before calling `parse`.
+// Rails' engine tests load the gem before the suite runs, via
+// `XMLMiniEngineTest.run_with_gem("nokogiri")` (xml_mini_engine_test.rb:8-13).
 beforeAll(async () => {
   await _require();
 });

--- a/packages/activesupport/src/xml-mini/nokogiri.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.ts
@@ -44,9 +44,23 @@ interface NokogiriModule {
 // to resolve at type-check time; the cast pins it to the surface above.
 const NOKOGIRI_PACKAGE = "@blazetrails/nokogiri";
 
-async function loadNokogiri(): Promise<NokogiriModule> {
+let nokogiri: NokogiriModule | undefined;
+
+/**
+ * Mirrors: the file-top `require "nokogiri"` (nokogiri.rb:3-8), which Ruby runs
+ * when `cast_backend_name_to_module` requires this file — i.e. at
+ * backend-selection time, so `parse` itself never loads anything.
+ *
+ * ESM has no synchronous `require`, and a top-level `await import()` breaks the
+ * IIFE/CJS bundles, so the file-top `require` is an awaitable hook the loader
+ * calls after importing this module (`xml-mini.ts`'s `XML_MINI_BACKENDS`).
+ *
+ * @internal
+ */
+export async function _require(): Promise<void> {
+  if (nokogiri !== undefined) return;
   try {
-    return (await import(NOKOGIRI_PACKAGE)) as unknown as NokogiriModule;
+    nokogiri = (await import(NOKOGIRI_PACKAGE)) as unknown as NokogiriModule;
   } catch (e) {
     if (isModuleNotFound(e, "@blazetrails/nokogiri")) {
       throw new Error(
@@ -103,7 +117,7 @@ function nodeToHash(node: XmlNode): XmlHash {
  * `StringIO` is the shim for Ruby's stdlib `StringIO`, and `instanceof
  * StringIO` stands in for `respond_to?(:read)`.
  */
-export async function parse(data: string | StringIO | null | undefined): Promise<XmlHash> {
+export function parse(data: string | StringIO | null | undefined): XmlHash {
   if (!(data instanceof StringIO)) {
     data = new StringIO(data ?? "");
   }
@@ -111,8 +125,7 @@ export async function parse(data: string | StringIO | null | undefined): Promise
   if (data.isEof()) {
     return {};
   } else {
-    const { parseXml } = await loadNokogiri();
-    const doc = parseXml(data);
+    const doc = nokogiri!.parseXml(data);
     try {
       if (doc.errors.length > 0) {
         throw new Error(doc.errors[0].message);

--- a/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
@@ -1,12 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { parse } from "./nokogirisax.js";
-import { parse as parseDom } from "./nokogiri.js";
+import { describe, it, expect, beforeAll } from "vitest";
+import { parse, _require } from "./nokogirisax.js";
+import { parse as parseDom, _require as _requireDom } from "./nokogiri.js";
 import { StringIO } from "../string-io.js";
 
 // trails-only coverage for the readable-IO and `eof?` arms of
 // `XmlMini_NokogiriSAX#parse` (nokogirisax.rb:69-80) and
 // `XmlMini_Nokogiri#parse` (nokogiri.rb:19-31); Rails exercises them through
 // IO-backed request bodies, which have no counterpart in the package's tests.
+
+// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
+// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
+// direct-import test does the load itself before calling `parse`.
+beforeAll(async () => {
+  await _require();
+  await _requireDom();
+});
+
 describe("NokogiriSAX parse readable input", () => {
   it("parses a readable input", async () => {
     const xml = '<products><book type="novel"><title>Dune</title></book></products>';

--- a/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax-readable.trails.test.ts
@@ -8,9 +8,8 @@ import { StringIO } from "../string-io.js";
 // `XmlMini_Nokogiri#parse` (nokogiri.rb:19-31); Rails exercises them through
 // IO-backed request bodies, which have no counterpart in the package's tests.
 
-// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
-// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
-// direct-import test does the load itself before calling `parse`.
+// Rails' engine tests load the gem before the suite runs, via
+// `XMLMiniEngineTest.run_with_gem("nokogiri")` (xml_mini_engine_test.rb:8-13).
 beforeAll(async () => {
   await _require();
   await _requireDom();

--- a/packages/activesupport/src/xml-mini/nokogirisax.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { parse } from "./nokogirisax.js";
-import { parse as parseDom } from "./nokogiri.js";
+import { describe, it, expect, beforeAll } from "vitest";
+import { parse, _require } from "./nokogirisax.js";
+import { parse as parseDom, _require as _requireDom } from "./nokogiri.js";
+
+// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
+// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
+// direct-import test does the load itself before calling `parse`.
+beforeAll(async () => {
+  await _require();
+  await _requireDom();
+});
 
 describe("NokogiriSAXEngineTest", () => {
   it("blank returns empty hash", async () => {
@@ -65,6 +73,6 @@ describe("NokogiriSAXEngineTest", () => {
   });
 
   it("throws on malformed xml", async () => {
-    await expect(parse("<root>")).rejects.toThrow();
+    expect(() => parse("<root>")).toThrow();
   });
 });

--- a/packages/activesupport/src/xml-mini/nokogirisax.test.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { parse, _require } from "./nokogirisax.js";
 import { parse as parseDom, _require as _requireDom } from "./nokogiri.js";
 
-// Ruby's `require "active_support/xml_mini/nokogiri*"` runs the file-top
-// `require "nokogiri"`; `cast_backend_name_to_module` is that seat here, so a
-// direct-import test does the load itself before calling `parse`.
+// Rails' engine tests load the gem before the suite runs, via
+// `XMLMiniEngineTest.run_with_gem("nokogiri")` (xml_mini_engine_test.rb:8-13).
 beforeAll(async () => {
   await _require();
   await _requireDom();

--- a/packages/activesupport/src/xml-mini/nokogirisax.ts
+++ b/packages/activesupport/src/xml-mini/nokogirisax.ts
@@ -36,9 +36,23 @@ interface NokogiriModule {
 // to resolve at type-check time; the cast pins it to the surface above.
 const NOKOGIRI_PACKAGE = "@blazetrails/nokogiri";
 
-async function loadNokogiri(): Promise<NokogiriModule> {
+let nokogiri: NokogiriModule | undefined;
+
+/**
+ * Mirrors: the file-top `require "nokogiri"` (nokogirisax.rb:3-8), which Ruby
+ * runs when `cast_backend_name_to_module` requires this file — i.e. at
+ * backend-selection time, so `parse` itself never loads anything.
+ *
+ * ESM has no synchronous `require`, and a top-level `await import()` breaks the
+ * IIFE/CJS bundles, so the file-top `require` is an awaitable hook the loader
+ * calls after importing this module (`xml-mini.ts`'s `XML_MINI_BACKENDS`).
+ *
+ * @internal
+ */
+export async function _require(): Promise<void> {
+  if (nokogiri !== undefined) return;
   try {
-    return (await import(NOKOGIRI_PACKAGE)) as unknown as NokogiriModule;
+    nokogiri = (await import(NOKOGIRI_PACKAGE)) as unknown as NokogiriModule;
   } catch (e) {
     if (isModuleNotFound(e, "@blazetrails/nokogiri")) {
       throw new Error(
@@ -145,7 +159,7 @@ export function setDocumentClass(klass: new () => HashBuilder): void {
  * `StringIO` is the shim for Ruby's stdlib `StringIO`, and `instanceof
  * StringIO` stands in for `respond_to?(:read)`.
  */
-export async function parse(data: string | StringIO | null | undefined): Promise<XmlHash> {
+export function parse(data: string | StringIO | null | undefined): XmlHash {
   if (!(data instanceof StringIO)) {
     data = new StringIO(data ?? "");
   }
@@ -153,10 +167,8 @@ export async function parse(data: string | StringIO | null | undefined): Promise
   if (data.isEof()) {
     return {};
   } else {
-    const { SAX } = await loadNokogiri();
-
     const document = new (documentClass())();
-    const parser = new SAX.Parser(document);
+    const parser = new nokogiri!.SAX.Parser(document);
     parser.parse(data);
     return document.hash;
   }


### PR DESCRIPTION
Ruby loads a backend's parser with the file-top `require "nokogiri"`
(`activesupport/lib/active_support/xml_mini/nokogiri.rb:3-8`,
`nokogirisax.rb:3-8`), which runs when `cast_backend_name_to_module` requires
the backend file (`xml_mini.rb:200-206`) — i.e. at backend-selection time. So
`XmlMini_Nokogiri#parse` (`nokogiri.rb:19-31`) returns the Hash directly.

trails reached the optional `@blazetrails/nokogiri` package from a per-parse
dynamic `import()` instead, so both Nokogiri backends' `parse` returned a
Promise. `Hash.fromXml` / `fromTrustedXml`, which call `XmlMini.parse` straight
through (`conversions.rb:128-130`), therefore could not be used under a
Nokogiri backend at all — `XMLConverter`'s constructor raised a `RuntimeError`.

## Changes

- `xml-mini/nokogiri.ts`, `xml-mini/nokogirisax.ts`: the package load moves to
  an awaitable `_require` hook that caches the module on the backend module —
  the file-top `require`'s seat. Both `parse` bodies are now plain synchronous
  functions returning the Hash.
- `xml-mini.ts`: `XML_MINI_BACKENDS`' two Nokogiri loaders await `_require`
  after importing the backend module, so `castBackendNameToModule` does what
  Ruby's `require` does. `XmlMiniBackend#parse` returns `Record<string, unknown>`
  — the `Promise` arm is gone, and so is `XmlMini.parse`'s.
- `core-ext/hash/conversions.ts`: the `RuntimeError` guard in `XMLConverter`'s
  constructor is deleted; it is Rails' one-liner again.
- Tests: the direct-import engine tests `await _require()` in a `beforeAll`
  (Rails' `require "active_support/xml_mini/nokogiri"` at the top of its engine
  test files), and a trails-only case asserts `Hash.fromXml` parses under all
  three backends — it fails on baseline for both Nokogiri ones.

Closes-story: converge-nokogiri-backend-parse-to-sync