### PR TITLE
chore(activerecord): sweep free-form comments out of relation/

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -735,7 +735,11 @@ export default defineConfig(
   //    widen it a package at a time, after auditing that package's comments,
   //    never ahead of the audit. ──
   {
-    files: ["packages/arel/src/**/*.ts", "packages/activemodel/src/**/*.ts"],
+    files: [
+      "packages/arel/src/**/*.ts",
+      "packages/activemodel/src/**/*.ts",
+      "packages/activerecord/src/relation/**/*.ts",
+    ],
     rules: {
       "blazetrails/no-freeform-comments": "error",
     },

--- a/eslint/no-freeform-comments.mjs
+++ b/eslint/no-freeform-comments.mjs
@@ -16,7 +16,9 @@
  *      constant path. This is the fidelity anchor CLAUDE.md asks for.
  *   3. Tool directives — `eslint-*`, `@ts-*`, `prettier-ignore`, coverage
  *      pragmas, and this repo's own `boundary:` / `@boundary-file:` (read by
- *      `no-native-date`). Deleting these changes what the toolchain does.
+ *      `no-native-date`) and `@nie disposition=` (read by
+ *      `nie-requires-annotation`). Deleting these changes what the toolchain
+ *      does.
  *
  * There is no opt-out marker. The rule shipped with a `keep:` escape hatch and
  * the sweep across arel and activemodel used it zero times, so it was removed:
@@ -59,9 +61,13 @@
  * losing a note. They are matched anywhere in the comment, not just at the
  * start, because `no-native-date` accepts them mid-line
  * (`} /* boundary: *\/ else if (x instanceof Date)`).
+ *
+ * `@nie disposition=` is likewise read by `eslint/nie-requires-annotation.mjs`,
+ * which REQUIRES it on every `throw new NotImplementedError(...)` — deleting
+ * one reds that rule.
  */
 const DIRECTIVE_RE =
-  /^\s*(?:eslint-(?:disable|enable)(?:-next-line|-line)?\b|eslint\s|globals?\s|exported\b|@ts-(?:expect-error|ignore|nocheck)\b|prettier-ignore\b|(?:v8|c8|istanbul|node:coverage)\s+ignore\b|@vitest-environment\b|#!)|\bboundary:|@boundary-file:/iu;
+  /^\s*(?:eslint-(?:disable|enable)(?:-next-line|-line)?\b|eslint\s|globals?\s|exported\b|@ts-(?:expect-error|ignore|nocheck)\b|prettier-ignore\b|(?:v8|c8|istanbul|node:coverage)\s+ignore\b|@vitest-environment\b|#!)|\bboundary:|@boundary-file:|@nie\s+disposition=/iu;
 
 /**
  * A reference to the Rails source. Deliberately generous: a false KEEP costs

--- a/eslint/no-freeform-comments.test.mjs
+++ b/eslint/no-freeform-comments.test.mjs
@@ -113,6 +113,16 @@ tester.run("no-freeform-comments (boundary directives)", rule, {
   invalid: [],
 });
 
+// `@nie disposition=` is required on every `throw new NotImplementedError(...)`
+// by `nie-requires-annotation`, so deleting one reds that rule.
+tester.run("no-freeform-comments (nie disposition directives)", rule, {
+  valid: [
+    { code: `// @nie disposition=TODO\nconst x = 1;\n` },
+    { code: `// @nie disposition=port-real rails=relation.rb:12 cluster=foo\nconst x = 1;\n` },
+  ],
+  invalid: [],
+});
+
 // Rails' OWN comments go too. The Ruby is vendored at `vendor/rails/` and the
 // ported file cites it, so copying its annotations across duplicates them into
 // a second place that rots the moment Rails edits them. A comment that names

--- a/packages/activerecord/src/relation/arel-ast-convergence.test.ts
+++ b/packages/activerecord/src/relation/arel-ast-convergence.test.ts
@@ -31,8 +31,6 @@ import { adapterType } from "../test-adapter.js";
 import { fixtures } from "../test-fixtures.js";
 import { Post as CanonicalPost } from "../test-helpers/models/post.js";
 
-// Establish the primary (boot-laid canonical-schema) pool so the bespoke
-// `Post` model's SQL compiles through `Base.connection`.
 fixtures({});
 
 class Post extends Base {
@@ -51,12 +49,10 @@ function compile(rel: unknown): [string, unknown[]] {
   return [sql, binds];
 }
 
-// Pre-substitution SQL (raw `?` / `$N` placeholders) for the relation.
 function rawSql(rel: unknown): string {
   return compile(rel)[0];
 }
 
-// The single ordered bind array the collector threaded, projected to values.
 function bindValues(rel: unknown): unknown[] {
   return compile(rel)[1].map((b) => (b as { _value?: unknown })?._value ?? b);
 }
@@ -96,8 +92,6 @@ describe("RFC 0022 arel-AST convergence (relation layer)", () => {
     });
   });
 
-  // Cluster 3: from(subquery) threads through the SelectManager (`build_from`)
-  // — a derived table, not a `sql.replace(/FROM …/)` rewrite.
   describe("Relation#from(subquery) on the manager", () => {
     it("renders a derived-table subquery with a qualified projection", () => {
       const sub = Post.where({ author: "alice" });

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -154,9 +154,6 @@ export class Batches {
   ): BatchEnumerator<LoadedRelation<Relation<T>>> | Promise<void> {
     const self = this;
     const cursor = Array(cursorOption ?? this.primaryKey).map(String);
-    // `ensure_valid_options_for_batching!` reaches the schema cache, which is
-    // async here, so the validation runs when the batches are first pulled
-    // rather than at `in_batches` call time.
     const ensureValidOptions = () =>
       ensureValidOptionsForBatchingBang(self, cursor, start, finish, (order ?? "asc") as any);
 
@@ -433,7 +430,6 @@ export function batchOnLoadedRelation(opts: {
   batchLimit: number;
 }): any[] {
   const { relation, cursor, batchLimit } = opts;
-  // relation.records() is async in this codebase; loaded records live on _records.
   let records: any[] = globalThis.Array.isArray(relation._records) ? relation._records : [];
   const order = buildBatchOrders(cursor, opts.order as any).map(([, second]) => second);
 

--- a/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
+++ b/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
@@ -18,8 +18,6 @@ registerModel(Topic);
 const sortedIds = (rows: Array<{ id: unknown }>) =>
   rows.map((r) => Number(r.id)).sort((a, b) => a - b);
 
-// The builders are private instance methods on Relation (relation.ts wrappers
-// that delegate to the query-methods module fns); reach them through this shape.
 type BoundSqlLiteralBuilders = {
   buildBoundSqlLiteral(statement: string, values: unknown[]): Nodes.BoundSqlLiteral;
   buildNamedBoundSqlLiteral(

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -11,8 +11,6 @@ import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, UnmodifiableRelation, registerModel } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 
-// Establish the primary (boot-laid canonical-schema) pool so `Post.connection`
-// and the bespoke da_pets/da_toys models resolve through `Base.connection`.
 fixtures({});
 
 class Post extends Base {
@@ -242,8 +240,6 @@ describe("where-hash key resolves to the referenced join alias", () => {
       .joins(":toys")
       .where({ toys: { name: "Bone" } })
       .toSql();
-    // Identifier quote char differs by adapter (" on sqlite/pg, ` on
-    // mysql/mariadb); strip quotes so the shape assertion holds everywhere.
     const bare = sql.replace(/["`]/g, "");
     expect(bare).toMatch(/INNER JOIN da_toys (?:AS )?toys\b/);
     expect(bare).toMatch(/WHERE toys\.name\b/);

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -16,9 +16,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-fixtures.js";
-// Opt into the canonical-model autoload index so the belongsTo("author") target
-// (`Author`) resolves by name during JoinDependency construction — no manual
-// `registerModel`.
 import "../support/canonical-model-index.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -27,9 +24,6 @@ import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 describe("build_joins from(subquery) dedup", () => {
   fixtures([]);
 
-  // The FROM clause onward — the whole join sequence. Adapter-quoted (MySQL uses
-  // backticks), so a hardcoded `FROM "posts"` would miss there and slice to the
-  // string's tail, leaving the containment assertions vacuously true.
   const fromClause = (sql: string): string => {
     const marker = `FROM ${quoteTableName("posts")}`;
     const at = sql.indexOf(marker);
@@ -59,8 +53,6 @@ describe("build_joins from(subquery) dedup", () => {
       Post.from(Post.leftOuterJoins(":author"), "posts") as unknown as { toSql(): string }
     ).toSql();
     expect((liveSql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(1);
-    // The short-circuited live path emits the exact same LEFT OUTER JOIN clause
-    // as the subquery `from(relation)` path — not just a coincidentally-similar one.
     expect(joinFragment(liveSql)).not.toBe("");
     expect(joinFragment(liveSql)).toBe(joinFragment(subSql));
   });
@@ -75,9 +67,7 @@ describe("build_joins from(subquery) dedup", () => {
     const build = () => Post.leftOuterJoins(":comments").merge(Comment.leftOuterJoins(":post"));
     const liveSql = (build() as unknown as { toSql(): string }).toSql();
     const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
-    // Base `comments` join + the merged cross-klass `post` JoinDependency.
     expect((liveSql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2);
-    // The whole FROM…joins structure of the live path is the subquery's inner query.
     expect(subSql).toContain(fromClause(liveSql));
   });
 
@@ -127,7 +117,6 @@ describe("build_joins from(subquery) dedup", () => {
   it("appends a raw join that trails a named join instead of leading with it", () => {
     const build = () => Post.joins(":comments").joins("CROSS JOIN categories");
     const q = (name: string) => escapeRegExp(quoteTableName(name));
-    // Both halves of the split see the raw-vs-named interleaving, so both append.
     for (const sql of [
       (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql(),
       (build() as unknown as { toSql(): string }).toSql(),
@@ -166,16 +155,11 @@ describe("build_joins from(subquery) dedup", () => {
     expect(liveSql).toMatch(new RegExp(`LEFT OUTER JOIN ${q("authors")} ${q("authors_posts")}`));
   });
 
-  // Live and `from(relation)` subquery paths must emit the same join sequence for
-  // an eager + left-outer + raw-join combination: one shared `build_joins` call
-  // with one AliasTracker on both halves.
   it("emits the same joins for eager_load + left_outer_joins + a raw join on both paths", () => {
     const build = () =>
       Post.joins("CROSS JOIN categories").eagerLoad(":author").leftOuterJoins(":comments");
     const liveSql = (build() as unknown as { toSql(): string }).toSql();
     const subSql = (Post.from(build(), "posts") as unknown as { toSql(): string }).toSql();
-    // The eager live path projects `t0_r*` aliases, so compare from the FROM on:
-    // the whole join sequence of the live query is the subquery's inner query.
     const liveFrom = fromClause(liveSql);
     expect(liveFrom).toContain("CROSS JOIN categories");
     expect(subSql).toContain(liveFrom);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -555,7 +555,6 @@ export async function calculate(
                 ? [...primaryKey]
                 : [primaryKey];
         }
-        // PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
         if (this.groupValues.length === 0) relation.orderValues = [];
       }
 
@@ -575,7 +574,6 @@ export async function pluck(
   this: CalculationRelation,
   ...columnNames: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
 ): Promise<unknown[]> {
-  // `pick` routes through `limit(1).pluck(...)`, so it inherits this rebase.
   if (this.isNullRelation()) return [];
 
   // calculations.rb:300 — a loaded relation whose plucked columns are all
@@ -651,10 +649,6 @@ export async function pluck(
         return /^\w+$/.test(v) && isKnownColumn(v) ? table.get(v) : c;
       }
       if (typeof c !== "string") return c;
-      // Table-qualified ("table.col"), quoted ('"table"."col"'), function expressions,
-      // or comma-separated lists must pass through as raw SQL.
-      // Comma-separated lists are not allowed in a single pluck argument —
-      // each column must be passed as a separate argument for correct result mapping.
       if (hasTopLevelComma(c)) {
         throw argumentError(
           `pluck does not allow comma-separated column lists in a single argument. ` +
@@ -931,7 +925,6 @@ function hasTopLevelComma(s: string): boolean {
         i++;
         continue;
       }
-      // SQL doubled-quote escape ("" or ``)
       if (ch === quote && s[i + 1] === quote) {
         i++;
         continue;
@@ -1227,7 +1220,6 @@ export async function executeGroupedCalculation(
   let associated = false;
   if (groupFields.length === 1 && typeof groupFields[0] === "string") {
     association = (rel.model as any)._reflectOnAssociation?.(groupFields[0]) ?? null;
-    // only count belongs_to associations
     associated = association != null && association.belongsTo?.() === true;
     // calculations.rb:521 — `Array(association.foreign_key)` expands a
     // composite-key belongs_to to every FK column; the rest of the body
@@ -1336,8 +1328,6 @@ export async function executeGroupedCalculation(
       // passes here (calculations.rb:562-563), one-column key included
       // (predicate_builder.rb:87-90).
       const records: any[] = await klass.where(primaryKey, keyIds).toArray();
-      // The composite-PK `id` accessor returns an array, so `index_by(&:id)` is
-      // keyed by the raw per-column attribute values to match the group-key tuple.
       keyRecords = new Map(
         records.map((r) => [keyOf(primaryKey.map((k) => r._readAttribute(k))), r]),
       );
@@ -1491,7 +1481,6 @@ export function typeCastPluckValues(
     joinDependencies ??= buildJoinDependencies.call(rel as any);
     return (
       (lookupCastTypeFromJoinDependencies(rel, name, joinDependencies) as ColumnType | null) ??
-      // Driver OID type (e.g. PostgreSQL) or identity fallback.
       columnType(result, name, i, {})
     );
   });

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -67,7 +67,6 @@ describe("Relation#where — composite-key form", () => {
   it("filters null/undefined-bearing tuples instead of emitting IS NULL (SQL tuple-equality semantics)", async () => {
     await CpkBook.create({ id: [1, 100], title: "valid" });
     await CpkBook.create({ id: [2, 200], title: "also-valid" });
-    // [1, null] is filtered out; [2, 200] remains.
     const matched = await (CpkBook as any)
       .where(
         ["author_id", "id"],
@@ -156,8 +155,6 @@ describe("Relation#where — composite-key form", () => {
       .all()
       .where(["author_id", "id"], [[1, 100]])
       .toSql();
-    // Quote-agnostic (backtick on MySQL/MariaDB, double-quote elsewhere): the
-    // point is the two equalities are ANDed flat, with NO wrapping parens.
     const col = (name: string) => `["\`]?cpk_books["\`]?\\.["\`]?${name}["\`]?`;
     expect(sql).toMatch(new RegExp(`WHERE ${col("author_id")} = 1 AND ${col("id")} = 100`));
     expect(sql).not.toMatch(/\(/);
@@ -205,11 +202,7 @@ describe("Relation#where — composite-key form", () => {
       }
     };
     rel.whereClause.predicates.forEach(walk);
-    // Attribute re-rooted onto the join-only `contracts` table…
     expect(eq.left.relation.name).toBe("contracts");
-    // …and the bind is typed by Contract's `attribute("metadata", "json")`
-    // override (JSON-serialized, quoted), not the raw DB `t.string` column the
-    // generic `TypeCasterConnection` would have used (unquoted `x`).
     expect(eq.right.value.valueForDatabase).toBe('"x"');
   });
 
@@ -221,10 +214,6 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("single-column composite values flow through the column type as binds, not inlined literals", () => {
-    // Regression: the single-column branch used `attribute.in(rawValues)`,
-    // which inlines untyped `Casted` literals — so a string "2" for an
-    // integer column stayed a string and never became a bind (breaking
-    // compileWithBinds / prepared-statement caching).
     const rel = (Post as any).all();
     const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [["1"], ["2"]])[0];
     expect(node.constructor.name).toBe("HomogeneousIn");
@@ -249,9 +238,6 @@ describe("Relation#where — composite-key form", () => {
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
     const rel = (CpkBook as any).all();
     const node = rel.predicateBuilder.buildComposite(["author_id"], [[1], [2], [3]])[0];
-    // The HomogeneousIn node renders as `author_id IN (?, ?, ?)`, which
-    // `toSql` substitutes to `IN (1, 2, 3)`; an OR-chain would render as
-    // `author_id = 1 OR author_id = 2 OR author_id = 3`.
     expect(node.constructor.name).toBe("HomogeneousIn");
     const sql = (CpkBook as any).all().where(node).toSql();
     expect(sql).toMatch(/IN \(1,\s*2,\s*3\)/);
@@ -264,8 +250,6 @@ describe("Relation#where — composite-key form", () => {
     // Grouping(Or([And([eq, eq]), And([eq, eq])])) — the per-tuple Grouping
     // an earlier hand-rolled version added is not part of that shape.
     const rel = (CpkBook as any).all();
-    // Multiple tuples collapse to grouping_queries' single node: one
-    // Grouping(Or([And, And])), returned as a length-1 array.
     const nodes: any = rel.predicateBuilder.buildComposite(
       ["author_id", "id"],
       [
@@ -350,10 +334,6 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("whereNot(mixed-type cols, tuples) routes to sanitize (symmetric with where), not a bogus composite", () => {
-    // The composite form requires an all-strings column list, kept symmetric
-    // with `where`. A non-string element means it is NOT composite cols, so it
-    // routes to the sanitized-conditions path (which surfaces a bind-arity
-    // error) rather than building a predicate off a coerced `5` column.
     expect(() =>
       (CpkBook as any)
         .all()
@@ -366,8 +346,6 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("where([], tuples) is the composite form and raises on the empty column list, not a silent no-op", () => {
-    // The blank short-circuit (`where([])`) applies only to the single-argument
-    // call; a supplied tuples arg keeps this on the composite path.
     expect(() => (CpkBook as any).all().where([], [[1, 2]])).toThrow(/empty column list/);
     expect(() => (CpkBook as any).where([], [[1, 2]])).toThrow(/empty column list/);
   });
@@ -394,8 +372,6 @@ describe("Relation#where — composite-key form", () => {
   it("whereNot(cols, tuples) on all-filtered tuples is a no-op (matches Rails' empty-hash behavior)", async () => {
     await CpkBook.create({ id: [1, 100], title: "a" });
     await CpkBook.create({ id: [2, 200], title: "b" });
-    // All tuples have a null component → filtered out → no predicate
-    // added → all rows returned.
     const matched = await (CpkBook as any)
       .all()
       .where()

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -43,7 +43,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await CpkAuthor.create({ id: 1, name: "Author One" });
     await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 1 });
     await CpkBook.create({ id: [1, 2], title: "Beta", revision: 2 });
-    // Two chapters on book 1 would fan the row count to 3 without DISTINCT.
     await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
     await CpkChapter.create({ id: [1, 11], book_id: 1, title: "ch-2" });
   }
@@ -71,8 +70,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   it("eager_load(:assoc).count(column) counts distinct non-null values of the column", async () => {
     await seedBooksWithChapters();
-    // A specific requested column counts distinctly inline (COUNT(DISTINCT col))
-    // rather than through the pk subquery.
     expect(await CpkBook.eagerLoad("chapters").count("cpk_books.revision")).toBe(2);
   });
 
@@ -85,8 +82,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 5 });
     await CpkBook.create({ id: [1, 2], title: "Beta", revision: 5 });
     await CpkBook.create({ id: [1, 3], title: "Gamma", revision: 9 });
-    // Chapters on book 1 fan the LEFT OUTER JOIN so the DISTINCT-pk id fetch
-    // must de-duplicate.
     await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
     await CpkChapter.create({ id: [1, 11], book_id: 1, title: "ch-2" });
   }
@@ -105,7 +100,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     // `WHERE pk IN (...)` — the two rows both have revision 5, so the answer is 1.
     // Value-bounding (`DISTINCT revision LIMIT 2`) would wrongly return 2.
     expect(count).toBe(2 - 1);
-    // A separate DISTINCT-pk id-materialization query runs before the count.
     const idSql = sqls.find((s) => /DISTINCT.*cpk_books.*author_id/i.test(s) && /LIMIT/i.test(s));
     expect(idSql).toBeTruthy();
     // The recount restricts via per-column IN (author_id IN ... AND id IN ...),
@@ -124,21 +118,12 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await seedBooksDuplicateRevisions();
     let count = 0;
     const sqls = await captureSql(async () => {
-      // Order by a NON-pk column (title) that is NOT in the DISTINCT-pk select
-      // list. Without routing the ordered `SELECT DISTINCT author_id, id ...
-      // ORDER BY title` through the adapter's `columnsForDistinct` hook, PG /
-      // MySQL reject it ("ORDER BY expressions must appear in select list").
-      // titles Alpha(1,rev5) < Beta(2,rev5) < Gamma(3,rev9); limit(2) bounds to
-      // books 1 & 2 → COUNT(DISTINCT revision) over the two rev-5 rows = 1.
       count = (await CpkBook.eagerLoad("chapters")
         .order("cpk_books.title")
         .limit(2)
         .count("cpk_books.revision")) as number;
     });
     expect(count).toBe(1);
-    // The id-materialization query orders by the non-pk column; PG/MySQL alias
-    // it into the select list, sqlite leaves the pk projection unchanged — but
-    // in every case the ordered DISTINCT-pk fetch must run and be valid.
     const idSql = sqls.find((s) => /DISTINCT.*cpk_books.*author_id/i.test(s) && /LIMIT/i.test(s));
     expect(idSql).toBeTruthy();
     expect(idSql).toMatch(/ORDER BY .*title/i);
@@ -146,9 +131,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   it("eager_load(:assoc).offset(n).count(column) bounds ROWS via the id fetch", async () => {
     await seedBooksDuplicateRevisions();
-    // order+offset(1) drops book 1 (rev 5); remaining rows are books 2 (rev 5)
-    // and 3 (rev 9) → COUNT(DISTINCT revision) = 2. Value-bounding would offset
-    // into the distinct value list {5, 9} and (wrongly) return 1.
     const count = await CpkBook.eagerLoad("chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .offset(1)
@@ -165,9 +147,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await CpkBook.create({ id: [1, 3], shop_id: 1, order_id: 200, title: "Gamma" });
   }
 
-  // Re-key a Map<Order record, value> by the order's `id` component, coercing
-  // both key and value to Number so the assertions are adapter-agnostic (MySQL /
-  // PG may hand back the composite-id components / aggregate as strings).
   function byOrderId(result: Map<unknown, unknown>): Map<number | null, number> {
     const out = new Map<number | null, number>();
     for (const [order, n] of result) {
@@ -182,9 +161,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   it("eager_load(:x).group(:composite_fk_belongs_to).count folds the eager JD", async () => {
     await seedBooksWithOrders();
-    // group by the composite-FK belongs_to `order`, eager-loading the same
-    // association: `walk` dedups the coinciding join so the grouped count keys
-    // by the loaded Order records.
     let result!: Map<unknown, unknown>;
     const sqls = await captureSql(async () => {
       // Counted over a named column: with no column Rails' `calculate` installs
@@ -197,8 +173,6 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
         unknown
       >;
     });
-    // The eager `order` JD coincides with the grouped belongs_to; `walk` dedups
-    // it into a single LEFT OUTER JOIN rather than emitting a parallel join.
     const groupSql = sqls.find((s) => /GROUP BY/i.test(s)) ?? "";
     expect(groupSql).toMatch(/LEFT OUTER JOIN .*cpk_orders/i);
     const counts = byOrderId(result);
@@ -213,7 +187,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
       unknown
     >;
     const sums = byOrderId(result);
-    expect(sums.get(100)).toBe(3); // book ids 1 + 2
-    expect(sums.get(200)).toBe(3); // book id 3
+    expect(sums.get(100)).toBe(3);
+    expect(sums.get(200)).toBe(3);
   });
 });

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -74,9 +74,6 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     const outerJoin = joins[0] as Nodes.OuterJoin;
     const on = outerJoin.right as Nodes.On;
     const and = on.expr as Nodes.And;
-    // belongsTo keys target.association_primary_key = source.foreign_key per
-    // column: cpk_orders.shop_id = cpk_books.shop_id AND
-    // cpk_orders.id = cpk_books.order_id.
     expect(and.children).toHaveLength(2);
     type Attr = { name: string; relation: { name: string } };
     const [c0, c1] = and.children as Nodes.Equality[];
@@ -131,10 +128,6 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
 
   it("pluck of a nested-hash spec's inner composite-FK belongsTo joins both segments", async () => {
     await seedBooks();
-    // `{ chapters: "book" }` nests a composite-FK `belongsTo` (`chapters.book`).
-    // Both segments now JOIN: `chapters` keys the composite FK↔PK tuple, and the
-    // inner `book` belongsTo keys `cpk_books.author_id = cpk_chapters.author_id
-    // AND cpk_books.id = cpk_chapters.book_id`.
     const jd = new JoinDependency(
       CpkBook as unknown as typeof Base,
       null,

--- a/packages/activerecord/src/relation/delegation.bench.ts
+++ b/packages/activerecord/src/relation/delegation.bench.ts
@@ -21,7 +21,6 @@ import { Relation } from "../relation.js";
 import { relationClassFor } from "./delegation.js";
 import { Post } from "../test-helpers/models/post.js";
 
-// Warm the per-model subclass so both cases benchmark steady-state `new`.
 const PerModelRelation = relationClassFor(Post);
 
 describe("relation construction hot path", () => {

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -75,18 +75,11 @@ describe("DelegationTest", () => {
       expect(() => guardBaseMethodDelegation(Post as any, "belongsTo")).toThrow(
         NotImplementedError,
       );
-      // `namedExtension` is a real own static defined on `Post` itself (below
-      // `Base` in the static chain), so it is exempt — proving subclass-defined
-      // class members stay delegable.
       expect(Object.prototype.hasOwnProperty.call(Post, "namedExtension")).toBe(true);
       expect(() => guardBaseMethodDelegation(Post as any, "namedExtension")).not.toThrow();
     });
 
     it("delegates Base methods on a relation when allowed (default)", () => {
-      // Production default `true` preserves ordinary
-      // `Post.where(...).<baseMethod>` chains: the call is delegated rather than
-      // raising the guard. (The test harness flips this to `false` suite-wide,
-      // so set it back explicitly here.)
       DelegateCache.delegateBaseMethods = true;
       const relation = Post.all() as any;
       expect(() => relation.belongsTo("author")).not.toThrow(NotImplementedError);
@@ -218,7 +211,7 @@ describe("DelegationTest", () => {
         expect(typeof (Post as any)[method]).toBe("function");
       }
     });
-  }); // QueryingMethodsDelegationTest
+  });
 
   describe("DelegationCachingTest", () => {
     it("delegation doesn't override methods defined in other relation subclasses", () => {
@@ -246,7 +239,7 @@ describe("DelegationTest", () => {
         targetGetter,
       );
     });
-  }); // DelegationCachingTest
+  });
 
   describe("delegateArrayMethod curated list", () => {
     // Rails delegates only the curated `delegate ... to: :records` set plus the
@@ -318,11 +311,9 @@ describe("DelegationTest", () => {
     it("delegates partition to Array", async () => {
       const post = await Post.first();
       const target = (post as any).comments;
-      // Unloaded — partition is still present and loads the rows on call.
       expect(typeof target.partition).toBe("function");
       expect(target.loaded).toBe(false);
 
-      // Predicate value from an independent query so the proxy stays unloaded.
       const someId = (await Comment.first())!.id;
       const [matched, unmatched] = await target.partition((c: any) => c.id === someId);
 
@@ -331,7 +322,6 @@ describe("DelegationTest", () => {
       expect(target.loaded).toBe(true);
       const records: any[] = target.target;
       expect(records.length).toBeGreaterThan(0);
-      // [matched, unmatched] preserve the records' relative order.
       expect(matched.map((c: any) => c.id)).toEqual(
         records.filter((c: any) => c.id === someId).map((c: any) => c.id),
       );
@@ -344,7 +334,6 @@ describe("DelegationTest", () => {
       it(`test_delegates_${method}_to_Array`, async () => {
         const post = await Post.first();
         const target = (post as any).comments;
-        // assert_respond_to: method is present on an *unloaded* proxy.
         expect(target.loaded).toBe(false);
         expect(typeof target[method]).toBe("function");
       });
@@ -365,12 +354,11 @@ describe("DelegationTest", () => {
       const ids = sorted.map((c: any) => c.id);
       expect(ids).toEqual([...ids].sort((a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0)));
     });
-  }); // DelegationAssociationTest
+  });
 
   describe("DelegationRelationTest", () => {
     it("delegates partition to Array", async () => {
       const target = Comment.all();
-      // Unloaded — partition is still present and loads the rows on call.
       expect(typeof (target as any).partition).toBe("function");
 
       const someId = (await Comment.first())!.id;
@@ -378,7 +366,6 @@ describe("DelegationTest", () => {
 
       const records: any[] = await (target as any).toArray();
       expect(records.length).toBeGreaterThan(0);
-      // [matched, unmatched] preserve the records' relative order.
       expect(matched.map((c: any) => c.id)).toEqual(
         records.filter((c: any) => c.id === someId).map((c: any) => c.id),
       );
@@ -390,14 +377,12 @@ describe("DelegationTest", () => {
     for (const method of DELEGATED_ARRAY_METHODS) {
       it(`test_delegates_${method}_to_Array`, () => {
         const target = Comment.all();
-        // assert_respond_to: method is present on an *unloaded* relation.
         expect(typeof (target as any)[method]).toBe("function");
       });
     }
 
     it("delegates sort to Array loading records on call", async () => {
       const target = Comment.all();
-      // sort on an unloaded relation loads via toArray() and returns a sorted copy.
       const sorted = await (target as any).sort((a: any, b: any) =>
         a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
       );
@@ -406,7 +391,7 @@ describe("DelegationTest", () => {
       const ids = sorted.map((c: any) => c.id);
       expect(ids).toEqual([...ids].sort((a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0)));
     });
-  }); // DelegationRelationTest
+  });
 
   // The `delegate ... to: :records` / `to: :model` set exposed under their exact
   // Rails names (delegation.rb:101-106) via DelegationMethods. Each `to: :records`
@@ -414,7 +399,6 @@ describe("DelegationTest", () => {
   // synchronously). Rails generates `test_delegates_<method>_to_Array` per
   // ARRAY_DELEGATES entry as an `assert_respond_to`.
   describe("DelegationNamedMethods", () => {
-    // ruby name → trails camelCase property
     const RECORD_DELEGATES: ReadonlyArray<readonly [string, string]> = [
       ["each", "each"],
       ["join", "join"],
@@ -437,14 +421,11 @@ describe("DelegationTest", () => {
 
     for (const [rubyName, jsName] of RECORD_DELEGATES) {
       it(`test_delegates_${rubyName}_to_Array`, () => {
-        // assert_respond_to: present as a real named method on an unloaded relation.
         expect(typeof (Comment.all() as any)[jsName]).toBe("function");
       });
     }
 
     it("index and rindex locate records by value", async () => {
-      // Same loaded relation, so index()/rindex() see the cached instances and
-      // identity comparison matches.
       const relation = Comment.all();
       const records = await relation;
       const mid = records[Math.floor(records.length / 2)];
@@ -500,8 +481,6 @@ describe("DelegationTest", () => {
     });
 
     it("to_xml serializes the collection with a plural root and singular children", async () => {
-      // Array#to_xml: root reflects the pluralized class name, each record under
-      // root.singularize, and the collection carries `type="array"`.
       const base = Comment.where({ type: "Comment" });
       const xml = await base.toXml();
       expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
@@ -574,7 +553,7 @@ describe("DelegationTest", () => {
     it("delegates name to the model class name", () => {
       expect(Comment.all().name).toBe("Comment");
     });
-  }); // DelegationNamedMethods
+  });
 });
 
 describe("DelegationCachingTest", () => {
@@ -598,9 +577,6 @@ describe("DelegationCachingTest", () => {
     // proxy miss path.
     expect(await (Developer.all() as any).target()).toBe("__target__");
 
-    // The cache must not override CollectionProxy#target: a Developer-typed
-    // collection proxy still resolves its own loaded target accessor, never the
-    // cached "__target__" delegation.
     const project = projects("active_record");
     const proxy = (project as any).developersWithCallbacks;
     await proxy.load();

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -23,9 +23,6 @@ import { Comment } from "../test-helpers/models/comment.js";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { fixtures } from "../test-fixtures.js";
 import { registerModel } from "../index.js";
-// Loading these registers each delegate class with the relation family so the
-// carrier resolvers find their base ctor and `uncacheableMethods()` sees the
-// subclass-only methods (`target`, …).
 import { CollectionProxy } from "../associations/collection-proxy.js";
 import "../association-relation.js";
 import "../disable-joins-association-relation.js";
@@ -38,7 +35,6 @@ describe("generated relation methods — per-model prototype carrier", () => {
     generateRelationMethod(Post as never, "somethingGenerated", fn);
 
     const carrier = relationClassFor(Post as never).prototype as Record<string, unknown>;
-    // Real own property on the carrier prototype — not a WeakMap side-table entry.
     expect(Object.prototype.hasOwnProperty.call(carrier, "somethingGenerated")).toBe(true);
     expect(carrier.somethingGenerated).toBe(fn);
   });
@@ -82,12 +78,9 @@ describe("generated relation methods — per-model prototype carrier", () => {
   });
 
   it("never generates an uncacheable method onto the carrier (gate is load-bearing)", () => {
-    // `Developer.target` is delegated in `DelegationCachingTest`; `target` is
-    // uncacheable (subclass-only), so it must never land on the carrier where it
-    // would shadow `CollectionProxy#target`.
-    expect("target" in CollectionProxy.prototype).toBe(true); // family loaded
+    expect("target" in CollectionProxy.prototype).toBe(true);
     const uncacheable = uncacheableMethods();
-    expect(uncacheable.has("target")).toBe(true); // guard: not a vacuous loop
+    expect(uncacheable.has("target")).toBe(true);
     const carrier = relationClassFor(Post as never).prototype as Record<string, unknown>;
     for (const name of uncacheable) {
       expect(Object.prototype.hasOwnProperty.call(carrier, name)).toBe(false);
@@ -119,9 +112,6 @@ describe("generated relation methods — remaining delegate-class carriers", () 
   });
 
   it("installs already-generated methods when a carrier is created later (includeInto catch-up)", () => {
-    // Generate BEFORE the Comment association/proxy carriers exist: creating them
-    // must back-fill the stored method as a real own property (the `includeInto`
-    // catch-up loop), not miss it.
     generateRelationMethod(Comment as never, "lateCarrierGenerated", () => "late");
     for (const carrier of [
       associationRelationClassFor(Comment as never),
@@ -166,7 +156,6 @@ describe("generated relation methods — remaining delegate-class carriers", () 
     generateRelationMethod(Company as never, "stiOverridden", () => "base");
     const firmCarrier = relationClassFor(Firm as never).prototype as Record<string, unknown>;
     expect((firmCarrier.stiOverridden as () => string)()).toBe("child");
-    // The base carrier (Company) only sees its own module, so it resolves "base".
     const companyCarrier = relationClassFor(Company as never).prototype as Record<string, unknown>;
     expect((companyCarrier.stiOverridden as () => string)()).toBe("base");
   });
@@ -182,7 +171,7 @@ describe("generated relation methods — remaining delegate-class carriers", () 
 
   it("never generates an uncacheable method onto any of the four carriers", () => {
     const uncacheable = uncacheableMethods();
-    expect(uncacheable.has("target")).toBe(true); // guard: not a vacuous loop
+    expect(uncacheable.has("target")).toBe(true);
     for (const carrier of allCarriersFor(Post as never)) {
       const proto = carrier.prototype as Record<string, unknown>;
       for (const name of uncacheable) {
@@ -217,8 +206,6 @@ describe("name delegate — property-reader typing invariant", () => {
   });
 
   it("stays a supertype of `string` so string literals remain assignable at call sites", () => {
-    // The other half: `RelationName` must accept a plain string, so
-    // `expect(relation.name).toBe("Comment")` type-checks without a cast.
     const rel = Comment.all();
     const name: typeof rel.name = "Comment";
     expect(name).toBe("Comment");
@@ -284,9 +271,6 @@ describe("respond_to_missing? — `in` on the dispatch proxies", () => {
   });
 
   it("keeps an own property whose value is undefined off the delegation path", async () => {
-    // `whatAreYou` is a real Comment class method, so the delegation path would
-    // fabricate a callable for it. An own field of the same name holding
-    // `undefined` must win: the property is defined here, it is just unset.
     const rel = Comment.all() as unknown as Record<string, unknown>;
     Object.defineProperty(rel, "whatAreYou", { value: undefined, configurable: true });
     expect(rel.whatAreYou).toBeUndefined();

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -267,9 +267,6 @@ let _uncacheableMethodsCache: Set<string> | undefined;
 let _uncacheableMethodsCacheVersion = -1;
 
 export function uncacheableMethods(): Set<string> {
-  // Recompute only when a relation-family class registers (import-time only);
-  // the version stamp stabilizes before any delegation runs, so this memoizes
-  // permanently without depending on which/how many classes have loaded.
   if (
     _uncacheableMethodsCache &&
     _uncacheableMethodsCacheVersion === _relationFamilyState.version
@@ -305,8 +302,6 @@ export function guardBaseMethodDelegation(modelClass: typeof Base, prop: string)
   while (typeof base === "function" && (base as { name?: string }).name !== "Base") {
     base = Object.getPrototypeOf(base);
   }
-  // No class named `Base` in the chain (e.g. an unexpected hierarchy) — don't
-  // ban; better to under-enforce than to mis-fire on a non-AR class.
   if (typeof base !== "function") return;
   // Reachability check restricted to the static chain at/above `Base`, stopping
   // before `Function.prototype` so its builtins (`call`, `apply`, `bind`, `name`,
@@ -421,8 +416,6 @@ function perModelCarrier(
 ): FamilyCtor {
   let subclass = cache.get(modelClass);
   if (!subclass) {
-    // The family slot is always registered at its class module's init, before
-    // any instance is constructed for that class, so `base` is set here.
     const baseCtor = base as unknown as new (...args: never[]) => object;
     subclass = class extends baseCtor {} as FamilyCtor;
     // A class expression assigned to a `let` infers `.name` from the variable
@@ -632,24 +625,23 @@ export function name(): string {
  */
 const DELEGATED_ARRAY_METHODS = new Set<string>([
   // curated delegate-to-records list (delegation.rb) → JS equivalents
-  "forEach", // each
+  "forEach",
   "join",
   "reverse",
-  "slice", // slice / []
-  "at", // []
-  "indexOf", // index
-  "lastIndexOf", // rindex
-  "concat", // +
-  // Enumerable methods (`Relation` includes Enumerable) with JS analogues
-  "map", // map / collect
-  "filter", // select
-  "find", // detect
-  "some", // any?
-  "every", // all?
-  "includes", // include?
-  "reduce", // inject / reduce
+  "slice",
+  "at",
+  "indexOf",
+  "lastIndexOf",
+  "concat",
+  "map",
+  "filter",
+  "find",
+  "some",
+  "every",
+  "includes",
+  "reduce",
   "sort",
-  "flatMap", // flat_map
+  "flatMap",
 ]);
 
 /**
@@ -782,7 +774,6 @@ export function delegateEnumerableMethod(
       return [matched, unmatched];
     };
   }
-  // DELEGATED_ARRAY_METHODS: async path for unloaded targets.
   return delegateArrayMethodAsync(prop, loadRecords);
 }
 
@@ -1030,11 +1021,6 @@ export function delegateRecordMethodSync(
 }
 
 export class DelegationMethods {
-  // ---- to: :records (Array / Enumerable) ----
-  // Each loads via `records()` (trails has no blocking IO) then applies the
-  // shared `RECORD_DELEGATES` helper — the same pure function the synchronous
-  // loaded-CollectionProxy path (`delegateRecordMethodSync`) uses.
-
   /** `Array#length` — the number of loaded records. */
   async length(this: DelegationHost): Promise<number> {
     return RECORD_DELEGATES.length(await this.records()) as number;
@@ -1185,8 +1171,6 @@ export class DelegationMethods {
     }
     return instruct + builder.target();
   }
-
-  // ---- to: :model ----
 
   /** `delegate :connection, to: :model`. */
   get connection(): DatabaseAdapter {

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -36,7 +36,6 @@ describe("DeleteAllTest", () => {
   it("destroy all", async () => {
     const davids = Author.where({ name: "David" });
 
-    // Force load
     expect(await davids).toEqual([authors("david")]);
     expect(davids.isLoaded).toBe(true);
 
@@ -71,7 +70,6 @@ describe("DeleteAllTest", () => {
   it("delete all loaded", async () => {
     const davids = Author.where({ name: "David" });
 
-    // Force load
     expect(await davids).toEqual([authors("david")]);
     expect(davids.isLoaded).toBe(true);
 

--- a/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
+++ b/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
@@ -46,32 +46,21 @@ registerModel(Interest);
 registerModel(Book);
 registerModel(Citation);
 
-// Strip identifier quotes so assertions hold across adapters (sqlite/postgres
-// double-quote, MySQL/MariaDB backtick).
 const unquoted = (sql: string): string => sql.replace(/["`]/g, "");
 
 describe("_deriveForeignKey inverse_of branches", () => {
   fixtures(["humans", "books"]);
 
-  // has_many :interests, inverse_of: :human — no className. The className-absent
-  // fallback singularizes ("interests" → "Interest"), then the inverse
-  // belongs_to :human derives `human_id`.
   it("has_many inverse_of, no className (plural fallback) derives the inverse FK", () => {
     const sql = unquoted(Human.joins(":interests").toSql());
     expect(sql).toContain("interests.human_id = humans.id");
   });
 
-  // has_one :face, inverse_of: :human — no className. The className-absent
-  // fallback camelizes the name as-is ("face" → "Face"); the inverse
-  // belongs_to :human derives `human_id`.
   it("has_one inverse_of, no className (singular fallback) derives the inverse FK", () => {
     const sql = unquoted(Human.joins(":face").toSql());
     expect(sql).toContain("faces.human_id = humans.id");
   });
 
-  // has_many :citations, inverse_of: :book — no className, no foreignKey. The
-  // inverse belongs_to :book declares foreignKey: "book1_id", so derivation
-  // returns "book1_id" verbatim — NOT the owner-name default "book_id".
   it("uses the inverse belongs_to's explicit foreignKey, not the owner default", () => {
     const sql = unquoted(Book.joins(":citations").toSql());
     expect(sql).toContain("citations.book1_id = books.id");

--- a/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
+++ b/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
@@ -18,9 +18,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-fixtures.js";
-// Opt into the canonical-model autoload index so the `author` association target
-// (`Author`) resolves by name during eager build_joins — no manual
-// `registerModel`.
 import "../support/canonical-model-index.js";
 import { Post } from "../test-helpers/models/post.js";
 
@@ -31,15 +28,9 @@ describe("eager build_joins shared AliasTracker", () => {
     const rel = Post.includes("author")
       .references("author")
       .joins("INNER JOIN authors ON authors.id = posts.author_id");
-    // Strip identifier quoting so the assertions hold across adapters (sqlite /
-    // postgres use `"`, MariaDB/MySQL use backticks).
     const sql = (rel as unknown as { toSql(): string }).toSql().replace(/["`]/g, "");
 
-    // The manual join keeps the real `authors` name; the eager OUTER JOIN
-    // collides against the shared tracker's seed and re-aliases to its
-    // `alias_candidate` (`authors_posts`).
     expect(sql).toContain("LEFT OUTER JOIN authors authors_posts");
-    // Its column-alias projection reads the now-aliased table, not bare `authors`.
     expect(sql).toContain("authors_posts.id AS t1_r0");
     expect(sql).toContain("INNER JOIN authors ON authors.id = posts.author_id");
   });

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -325,10 +325,6 @@ describe("raiseNotFoundSingle", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// findSome — expected_size accounting (Gap 1)
-// ---------------------------------------------------------------------------
-
 const postModelStub = {
   primaryKey: "id",
   name: "Post",
@@ -356,7 +352,6 @@ function makeFindSomeRel(
     primaryKey: postModelStub.primaryKey,
     limitValue: opts.limit ?? null,
     offsetValue: opts.offset ?? null,
-    // ordered=true simulates a relation with ORDER BY (findSome stays in the accounting path)
     orderValues: opts.ordered !== false ? ["id ASC"] : [],
     selectValues: [],
     raiseRecordNotFoundExceptionBang,
@@ -386,7 +381,6 @@ describe("findSome — expected_size respects limit and offset", () => {
   });
 
   it("succeeds when limit clips expected_size and result matches limit", async () => {
-    // 5 ids, limit 3 → expected 3; DB returns 3 rows → no error
     const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const rel = makeFindSomeRel(rows, { limit: 3 });
     const result = await findSome.call(rel, [1, 2, 3, 4, 5]);
@@ -394,7 +388,6 @@ describe("findSome — expected_size respects limit and offset", () => {
   });
 
   it("succeeds when offset + limit produce expected_size=2 from 11 ids", async () => {
-    // 11 ids, limit 3, offset 9 → expected = min(3, 11-9) = 2
     const rows = [{ id: 10 }, { id: 11 }];
     const rel = makeFindSomeRel(rows, { limit: 3, offset: 9 });
     const result = await findSome.call(rel, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
@@ -406,10 +399,6 @@ describe("findSome — expected_size respects limit and offset", () => {
     await expect(findSome.call(rel, [1, 2])).rejects.toBeInstanceOf(RecordNotFound);
   });
 });
-
-// ---------------------------------------------------------------------------
-// findSome — select_values narrowing on ordered path (Story I-followup-2)
-// ---------------------------------------------------------------------------
 
 describe("findSome — narrows to pk column when select_values non-empty (ordered path)", () => {
   it("calls .select(pk) when the relation has select values", async () => {
@@ -439,23 +428,14 @@ describe("findSome — narrows to pk column when select_values non-empty (ordere
   });
 });
 
-// ---------------------------------------------------------------------------
-// findSome → findSomeOrdered dispatch (Story I-followup gap 1)
-// ---------------------------------------------------------------------------
-
 describe("findSome — dispatches to findSomeOrdered when relation has no order values", () => {
   it("returns records in requested id order for an unordered relation", async () => {
-    // DB returns them in arbitrary order; we expect [5, 1, 3] back
     const dbRows = [{ id: 3 }, { id: 5 }, { id: 1 }];
     const rel = makeFindSomeRel(dbRows, { ordered: false });
     const result = await findSome.call(rel, [5, 1, 3]);
     expect(result.map((r: any) => r.id)).toEqual([5, 1, 3]);
   });
 });
-
-// ---------------------------------------------------------------------------
-// findSomeOrdered — id slicing by offset/limit + result ordering (Story I-followup gap 2)
-// ---------------------------------------------------------------------------
 
 function makeFindSomeOrderedRel(
   records: any[],
@@ -495,7 +475,6 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
   });
 
   it("slices to first limit ids when limit is set", async () => {
-    // 50 ids requested but limit 10 → only first 10 ids are queried
     const ids = Array.from({ length: 50 }, (_, i) => i + 1);
     const dbRows = ids.slice(0, 10).map((id) => ({ id }));
     let queriedIds: unknown[] | undefined;
@@ -519,7 +498,6 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
 
   it("slices ids by offset and limit (11 ids, limit 3, offset 9 → 2 records)", async () => {
     const ids = Array.from({ length: 11 }, (_, i) => i + 1);
-    // ids.slice(9, 9+3) = [10, 11]
     const dbRows = [{ id: 11 }, { id: 10 }];
     let queriedIds: unknown[] | undefined;
     const rel = {
@@ -563,14 +541,10 @@ describe("findSomeOrdered — slices ids by offset and limit before querying", (
       },
     };
     const result = await findSomeOrdered.call(rel, [1, 2]);
-    expect(selectArg).toBe("id"); // arelTable.get("id") returns "id" in the mock
+    expect(selectArg).toBe("id");
     expect(result.map((r: any) => r.id)).toEqual([1, 2]);
   });
 });
-
-// ---------------------------------------------------------------------------
-// findTake / findTakeWithLimit — loaded? fast-path (Gap 3)
-// ---------------------------------------------------------------------------
 
 function makeLoadedRel(records: any[]): any {
   return {
@@ -608,10 +582,6 @@ describe("findTakeWithLimit — slices loaded relation without querying", () => 
     expect(spy).not.toHaveBeenCalled();
   });
 });
-
-// ---------------------------------------------------------------------------
-// _orderColumns — implicit_order_column + query_constraints_list (Gap 2)
-// ---------------------------------------------------------------------------
 
 function makeRelForOrder(mc: {
   primaryKey?: string | string[];

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -141,12 +141,8 @@ export function normalizeFindArgs(
     } else {
       ids = compactUniqTuples(expectsArray ? (first as unknown[]) : args);
     }
-    // `find_some` (size > 1) always returns an array; only a deduped size-1
-    // list stays unwrapped when the caller did not pass a tuple list.
     wantArray = expectsArray || ids.length !== 1;
   } else if (rest.length > 0) {
-    // Simple PK: flatten so mixed inputs like `find([1, 2], 3)`
-    // canonicalize to `[1, 2, 3]`.
     ids = compactUniqIds(args.flat(Infinity));
     wantArray = true;
   } else if (Array.isArray(first)) {
@@ -373,11 +369,6 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
     ? ""
     : ` [${this.arel().whereSql(this._model)?.value ?? ""}]`;
 
-  // Composite PK: OR over per-tuple WHERE conditions. The
-  // `Array.isArray(pk)` guard narrows `pk` to `string[]` via
-  // control flow instead of a cast. `tuples !== null` is a
-  // stronger invariant (the normalizer only returns tuples when pk
-  // is composite) but TS can't correlate them, so we check both.
   if (tuples && Array.isArray(pk)) {
     const orConditions = tuples.map((tuple) => buildPkWhere(pk, tuple));
     let rel: any = this.where(orConditions[0]);
@@ -390,10 +381,7 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
     return wantArray ? records : records[0];
   }
 
-  // Simple PK from here on — pk is narrowed to `string`.
   if (Array.isArray(pk)) {
-    // Unreachable: tuples-null + pk-array would mean the normalizer
-    // violated its contract.
     throw new Error("performFind: composite PK without tuples (normalizer invariant violation)");
   }
 
@@ -412,7 +400,6 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
     return wantArray ? [records[0]] : records[0];
   }
 
-  // Simple PK, multiple: find(1, 2, 3) or find([1, 2, 3]).
   const records = await this.where({ [pk]: ids }).toArray();
   if (records.length !== ids.length)
     raiseNotFoundAll(modelName, pk, normalized, records.length, ids.length, conditions);
@@ -698,9 +685,6 @@ export async function performCreateOrFindByBang(
         }),
       { requiresNew: true },
     );
-    // transaction() returns undefined when the block raises Rollback.
-    // Treat that as a persist failure rather than leaking undefined to
-    // the bang caller.
     if (result === undefined) {
       throw new RecordNotSaved(
         `${this._model.name}.createOrFindByBang rolled back before persist`,
@@ -964,7 +948,6 @@ export function constructRelationForExists(this: FinderRelation, conditions: unk
     const [sql, ...binds] = conditions as unknown[];
     if (sql !== undefined) relation = relation.where(sql, ...binds);
   } else if (conditions instanceof Nodes.Node) {
-    // Arel node — pass directly rather than wrapping as a PK value.
     relation = relation.where(conditions);
   } else if (conditions !== null && typeof conditions === "object") {
     // Hash-like: Rails' `when Hash` branch — skip if empty.

--- a/packages/activerecord/src/relation/grouped-composite-assoc-aggregate-alias.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-aggregate-alias.trails.test.ts
@@ -28,7 +28,6 @@ describe("CpkBook grouped calculation over a composite-key belongs_to aliases th
     [CpkBook, CpkOrder, CpkAuthor].forEach((m) => registerModel(m));
   });
 
-  // Three orders in shop 1. Book counts per order: 1 → 1, 2 → 3, 3 → 2.
   async function seedOrders(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
     for (const id of [1, 2, 3]) {

--- a/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
@@ -30,15 +30,6 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
     [CpkBook, CpkOrder, CpkAuthor].forEach((m) => registerModel(m));
   });
 
-  // An aggregate order expression must go through `Arel.sql`: a bare
-  // "COUNT(*) DESC" string is a non-attribute argument, so `disallowRawSql`
-  // rejects it once `allowUnsafeRawSql` is disabled (as it is under the full
-  // suite run).
-  //
-  // Three orders in shop 1. Book counts per order: 1 → 1, 2 → 3, 3 → 2.
-  // Grouping by the composite belongs_to and ordering by COUNT(*) DESC makes
-  // the ordered top-2 orders (2, 3) differ from the unordered/insertion-order
-  // top-2 (1, 2), so a dropped ORDER BY changes the answer.
   async function seedOrders(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
     for (const id of [1, 2, 3]) {
@@ -98,15 +89,11 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
       (order as CpkOrder | null)?.id,
       count,
     ]);
-    // Ordered groups are (2 → 3), (3 → 2), (1 → 1); offset(2) leaves order 1.
     expect(counts).toEqual([[[1, 1], 1]]);
   });
 
   it("group by a composite-key belongs_to with a group-key column order and limit returns the ordered groups", async () => {
     await seedOrders();
-    // A bare column order (rather than an aggregate expression) must resolve
-    // against the model's table: descending order_id makes the top-2 groups
-    // (3, 2) rather than the insertion-order (1, 2).
     const result = (await CpkBook.group("order").order("order_id DESC").limit(2).count()) as Map<
       unknown,
       number

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -15,9 +15,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-fixtures.js";
-// Opt into the canonical-model autoload index so the `posts`/`comments`
-// association targets (`Post`, `Comment`) resolve by name during build_joins —
-// no manual `registerModel`.
 import "../support/canonical-model-index.js";
 import { Author } from "../test-helpers/models/author.js";
 
@@ -40,7 +37,7 @@ describe("join value union structural dedup", () => {
     // so the value survives once — mirroring Rails, not JS reference identity.
     expect(asHost(rel).leftOuterJoinsValues).toHaveLength(1);
     const sql = asHost(rel).toSql();
-    expect((sql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
+    expect((sql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2);
   });
 
   it("emits a single INNER JOIN for a structurally-equal Hash spec joined twice", () => {
@@ -49,12 +46,10 @@ describe("join value union structural dedup", () => {
     const rel = Author.joins({ ":posts": ":comments" }).joins({ ":posts": ":comments" });
     expect(asHost(rel).joinsValues).toHaveLength(1);
     const sql = asHost(rel).toSql();
-    expect((sql.match(/INNER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
+    expect((sql.match(/INNER JOIN/g) ?? []).length).toBe(2);
   });
 
   it("keeps distinct Hash specs as separate joins", () => {
-    // Dedup is by value, not by shape: two hashes with the same key but
-    // different nested target must both survive.
     const rel = Author.leftJoins({ ":posts": ":comments" }).leftJoins({ ":posts": ":author" });
     expect(asHost(rel).leftOuterJoinsValues).toHaveLength(2);
   });

--- a/packages/activerecord/src/relation/limit-offset-value-string-reads.trails.test.ts
+++ b/packages/activerecord/src/relation/limit-offset-value-string-reads.trails.test.ts
@@ -49,7 +49,6 @@ describe("string limit_value / offset_value read sites", () => {
   it("inBatches raises ArgumentError rather than comparing falsely", async () => {
     await expect(async () => {
       for await (const _batch of Topic.limit("asdfadf").inBatches()) {
-        // unreachable
       }
     }).rejects.toThrow(/comparison of String with \d+ failed/);
   });

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -69,10 +69,6 @@ export class Merger {
     const rel = this.relation;
     for (const name of Merger.NORMAL_VALUES) {
       const value = this.values[name];
-      // The unless clause is here mostly for performance reasons (since the `send` call might be
-      // moderately expensive), most of the time the value is going to be `nil` or `.blank?`, the
-      // only catch is that `false.blank?` returns `true`, so there needs to be an extra check so
-      // that explicit `false` values don't fall through the cracks.
       if (value == null || (isBlank(value) && value !== false)) continue;
       const bang = `${name}Bang`;
       if (Array.isArray(value)) rel[bang](...value);
@@ -207,10 +203,8 @@ export class Merger {
   // Mirrors merge_multi_values (merger.rb:154-167).
   private mergeMultiValues(rel: any): void {
     if (this.other.reorderingValue) {
-      // override any order specified in the original relation
       rel.reorderBang(...this.other.orderValues);
     } else if (this.other.orderValues.length > 0) {
-      // merge in order_values from relation
       rel.orderBang(...this.other.orderValues);
     }
 

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -281,10 +281,8 @@ describe("RelationMergingTest", () => {
     // reordered to `[RAW, a, b]`.
     const rawJoin = "INNER JOIN authors ON authors.id = posts.author_id";
     const source = Post.joins(":comments", rawJoin, ":author");
-    // `merge` routes through Merger#mergeJoins...
     const merged = Post.all().merge(source);
     expect(merged.joinsValues).toEqual([":comments", rawJoin, ":author"]);
-    // ...and `mergeBang` folds field-by-field; both must preserve the order.
     const banged = Post.all();
     (banged as any).mergeBang(source);
     expect(banged.joinsValues).toEqual([":comments", rawJoin, ":author"]);

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -128,7 +128,6 @@ describe("RelationMutationTest", () => {
   });
 
   it("#reorder! with symbol prepends the table name", () => {
-    // Same symbol→qualified-attribute analogue as `#order! with symbol`.
     const rel = relation();
     const attr = Post.arelTable.get("title");
     expect(rel.reorderBang(attr)).toBe(rel);
@@ -207,7 +206,6 @@ describe("RelationMutationTest", () => {
   // one for MULTI_VALUE_METHODS (above) and one for SINGLE_VALUE_METHODS (here).
   // The duplicate name is intentional — parity:test matches by description count.
   it("#!", () => {
-    // Every single-value bang returns self and sets its `*_value` scalar.
     const SINGLE: ReadonlyArray<[string, unknown, string, unknown]> = [
       ["limitBang", 5, "limitValue", 5],
       ["offsetBang", 5, "offsetValue", 5],

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -18,9 +18,6 @@ import { Categorization } from "../test-helpers/models/categorization.js";
 // class-name derivation. Rails autoloads it there; trails needs it registered.
 registerModel([Author, Post, SpecialPost, Comment, Paragraph, Categorization]);
 
-// Compare via `<`/`>` (not subtraction): PG round-trips `id` as a BigInt and a
-// BigInt-returning sort comparator throws "Cannot convert a BigInt value to a
-// number" when Array.sort coerces it. `<`/`>` work for both number and BigInt.
 const byId = (records: any[]) =>
   [...records].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
@@ -248,8 +245,6 @@ describe("OrTest", () => {
   });
 });
 
-// The maximum expression tree depth is 1000 by default for SQLite3.
-// https://www.sqlite.org/limits.html#max_expr_depth
 describe("TooManyOrTest", () => {
   fixtures(["paragraphs"]);
 

--- a/packages/activerecord/src/relation/order-blank-arg-compaction.trails.test.ts
+++ b/packages/activerecord/src/relation/order-blank-arg-compaction.trails.test.ts
@@ -23,7 +23,6 @@ describe("order blank arg compaction", () => {
   });
 
   it("raises from the bang method, which does not compact", () => {
-    // orderBang is mixed onto the relation, so it is not on Relation's public type.
     const rel = Post.all() as unknown as { orderBang(arg: string): unknown };
     expect(() => rel.orderBang("")).toThrow(UnknownAttributeReference);
   });

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -3,7 +3,6 @@ import { fixtures } from "../test-fixtures.js";
 import { Customer } from "../test-helpers/models/customer.js";
 import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 
-// Adapter-aware `"customers"."name"` — backticks on MySQL/MariaDB.
 const qualifiedName = escapeRegExp(quoteTableName("customers.name"));
 
 /**

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -214,7 +214,6 @@ describe("PredicateBuilderTest", () => {
       const node = builder.build(table.get("title"), { id: 5 });
       const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
       expect(sql).toContain('"posts"."title" = ?');
-      // The whole object is bound, not the dereferenced `5`.
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
     });
 
@@ -236,8 +235,6 @@ describe("PredicateBuilderTest", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("id"), [new NotARecord(5), new NotARecord(7)]);
       const sql = new Visitors.ToSql(testConnection).compile(node);
-      // The objects flow into HomogeneousIn untouched — they are NOT flattened
-      // to `IN (5, 7)` the way a real AR record would be.
       expect(sql).not.toMatch(/IN \(5, 7\)/);
     });
 
@@ -269,7 +266,6 @@ describe("PredicateBuilderTest", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, feTable));
       const node = builder.build(feTable.get("tags"), [1, 2]);
       const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
-      // Single equality bind, NOT `IN (?, ?)`.
       expect(sql).toContain('"posts"."tags" = ?');
       expect(sql).not.toMatch(/IN \(/);
       expect(binds).toHaveLength(1);
@@ -322,14 +318,10 @@ describe("PredicateBuilderTest", () => {
       // Rails inverts a positively-built, bound predicate, so the value rides a
       // QueryAttribute bind rather than being inlined.
       expect(sql).toContain('"posts"."title" !=');
-      // The whole object is bound, not the dereferenced `5`.
       const bound = (node as unknown as { right: { value: { value: unknown } } }).right.value.value;
       expect(bound).toEqual({ id: 5 });
     });
 
-    // Mirror of the positive ArrayHandler convergence on the inverted path:
-    // non-Base objects carrying an `id` are not collapsed into a
-    // `NOT IN (5, 7)` PK list the way real AR records would be.
     it("does not dereference non-Base objects carrying an id inside a negated array", () => {
       class NotARecord {
         constructor(public id: number) {}
@@ -370,8 +362,6 @@ describe("PredicateBuilderTest", () => {
       const [sql, binds] = visitor.compileWithBinds(node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
-      // The bind is the raw QueryAttribute wrapping the Substitute —
-      // compileWithBinds preserves bind objects for BindMap indexing
       expect((binds[0] as any).valueBeforeTypeCast).toBeInstanceOf(Substitute);
     });
 
@@ -389,16 +379,10 @@ describe("PredicateBuilderTest", () => {
   });
 
   describe("nested table-keyed hash expansion", () => {
-    // Mirror of Post.belongs_to(:author) plus a deliberately-renamed
-    // belongs_to(:writer, class_name: "Author") to exercise the
-    // associated_table aliasing path. Both ride the canonical posts/authors
-    // tables. The canonical Post has no `writer` association, so we build a
-    // throwaway model carrying both.
     class PbTestPost extends Base {
       static {
         this.tableName = "posts";
         this.belongsTo("author");
-        // Association name (writer) deliberately differs from the table (authors).
         this.belongsTo("writer", { className: "Author" });
       }
     }
@@ -451,9 +435,6 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("does not expand when key is a known column on the current table (mirrors Rails !table.has_column? guard)", () => {
-      // products.price is a real canonical column, so a nested hash keyed by it
-      // must NOT be treated as an association — it stays an equality on the
-      // current table.
       class PbTestProduct extends Base {
         static {
           this.tableName = "products";

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -25,12 +25,9 @@ import { TableMetadata } from "../table-metadata.js";
 // structurally by resetting @predicate_builder in `inherited` (core.rb:422-425).
 describe("Base.predicateBuilder STI memoization", () => {
   it("does not leak the parent's builder to an STI subclass", () => {
-    // Warm the parent first: with a prototype-chain memo, this instance would
-    // then be returned for the subclass too.
     const companyPb = Company.predicateBuilder;
     const firmPb = Firm.predicateBuilder;
     expect(firmPb).not.toBe(companyPb);
-    // Idempotent per class.
     expect(Company.predicateBuilder).toBe(companyPb);
     expect(Firm.predicateBuilder).toBe(firmPb);
   });
@@ -117,7 +114,6 @@ describe("association hash expansion grouping shape", () => {
     const rel = CpkOrderWithSingularBookChapters.where({
       chapters: [[1, 2]],
     }) as unknown as HasWhereClause;
-    // One tuple → one query group → predicates spliced flat, one per PK column.
     const preds = rel.whereClause.predicates;
     expect(preds).toHaveLength(2);
     for (const pred of preds) expect(pred).not.toBeInstanceOf(Nodes.Grouping);

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -126,8 +126,6 @@ export class PredicateBuilder {
       const mapped = values.map((object) => extractAggregateAttr(object, aggregateAttr, false));
       return [this.build(this.table.arelTable.get(columnName), mapped)];
     }
-    // Multi-mapping: one AND-group per object over every mapped column, ORed
-    // together (grouping_queries), mirroring expand_from_hash.
     const queryGroups: Nodes.Node[][] = values.map((object) =>
       mapping.map(([fieldAttr, aggregateAttr]) =>
         this.build(
@@ -204,11 +202,9 @@ export class PredicateBuilder {
       // column reference, so no guard beyond this note.
       return assocPb.expandFromHash({ [rawPk as string]: value });
     }
-    // Core non-polymorphic, non-through path.
     const queries = new AssociationQueryValue(associatedTable, value).queries();
     const queryGroups: Nodes.Node[][] = [];
     for (const query of queries) {
-      // Cycle guard: prevents infinite recursion when FK name == association name.
       if (isSameHash(query, attributes)) {
         queryGroups.push([this.build(this.table.arelTable.get(key), value)]);
       } else {
@@ -589,8 +585,6 @@ function extractAggregateAttr(object: unknown, attr: string, tryBang: boolean): 
     const v = (object as Record<string, unknown>)[attr];
     return typeof v === "function" ? (v as (...a: unknown[]) => unknown).call(object) : v;
   }
-  // Multi-mapping (`try!`) surfaces the missing attribute; single-mapping
-  // (`respond_to? ? … : object`) falls back to the scalar passthrough.
   if (tryBang) {
     throw new TypeError(
       `composed_of value ${describeAggregateValue(object)} does not respond to mapped attribute '${attr}'`,

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
@@ -48,7 +48,6 @@ describe("AssociationQueryValue", () => {
         },
         comment,
       );
-      // Single record → one query hash with fk[i] mapped to pk[i] value.
       expect(av.queries()).toEqual([{ blog_id: 11, id: 22 }]);
     });
 
@@ -62,7 +61,6 @@ describe("AssociationQueryValue", () => {
         },
         [c1, c2],
       );
-      // One hash per record — PredicateBuilder OR-groups them.
       expect(av.queries()).toEqual([
         { blog_id: 11, id: 22 },
         { blog_id: 12, id: 33 },
@@ -74,9 +72,8 @@ describe("AssociationQueryValue", () => {
       // `id_value` reads the scalar id column. We mirror via readAttribute('id').
       const record = {
         blog_id: 5,
-        id: [5, 99], // composite-pk id surface
+        id: [5, 99],
         readAttribute(name: string) {
-          // Scalar id column under the surface.
           return name === "id" ? 99 : (this as any)[name];
         },
       };

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -99,9 +99,6 @@ export class AssociationQueryValue {
       const pk = this.primaryKey();
       let relation = value as any;
       if (!Array.isArray(pk) && this.isSelectClause()) {
-        // Select the table-qualified primary key so the subquery's projection
-        // stays unambiguous once its arel carries joins (build_arel
-        // convergence) — matching RelationHandler's `arel_table[primary_key]`.
         const arelTable = relation._model?.arelTable;
         relation = relation.select(arelTable ? arelTable.get(pk) : pk);
       }

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
@@ -31,10 +31,6 @@ export class DeferredDistinctPkIn extends Nodes.In {
     super(attribute, inlineSubquery);
   }
 
-  // Inherited In#invert would build a plain NotIn and drop the deferred
-  // innerRelation, so the load pipeline would never materialize the ids.
-  // `where.not(col: relationWithLimit)` reaches the negated marker through
-  // here (WhereClause#invert over the positively-built predicate).
   invert(): DeferredDistinctPkNotIn {
     return new DeferredDistinctPkNotIn(
       this.left as Nodes.Attribute,
@@ -94,9 +90,6 @@ export class DeferredIdsNotIn extends Nodes.NotIn {
     super(attribute, inlineSubquery);
   }
 
-  // Inherited NotIn#invert would build a plain In carrying only the
-  // display-fallback subquery and drop literalIds/innerRelations, so the load
-  // pipeline would never materialize the ids (see DeferredDistinctPkIn#invert).
   invert(): DeferredIdsIn {
     return new DeferredIdsIn(
       this.left as Nodes.Attribute,

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -123,9 +123,6 @@ export class PolymorphicArrayValue {
     if (value === null || value === undefined) return null;
     if (typeof value === "object" && value !== null) {
       if ("_model" in value && "toArel" in value) {
-        // Select the table-qualified primary key so the subquery's projection
-        // stays unambiguous once its arel carries joins (build_arel
-        // convergence) — matching RelationHandler's `arel_table[primary_key]`.
         const pk = this.primaryKey(value);
         const arelTable = (value as any)._model?.arelTable;
         return (value as any).select(arelTable && !Array.isArray(pk) ? arelTable.get(pk) : pk);

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -48,8 +48,6 @@ export class RelationHandler {
     if (typeof value?._isDeferredDistinctPkSubquery !== "function") return null;
     if (!value._isDeferredDistinctPkSubquery()) return null;
     const inlineSubquery = value._buildDeferredDistinctPkInlineSubquery();
-    // Always positive — `where.not(...)` reaches the negated marker via
-    // `DeferredDistinctPkIn#invert` (WhereClause#invert).
     return new DeferredDistinctPkIn(attribute, inlineSubquery, value);
   }
 

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -120,11 +120,8 @@ describe("QueryAttribute", () => {
     const a = new QueryAttribute("age", "25", intType);
     const b = new QueryAttribute("age", "25", intType);
     const d = new QueryAttribute("name", "25", intType);
-    // Same type instance → equal
     expect(a.equals(b)).toBe(true);
-    // Different name → not equal
     expect(a.equals(d)).toBe(false);
-    // Different instances of same Type class → equal (constructor-based)
     const intType2 = new IntType();
     const e = new QueryAttribute("age", "25", intType2);
     expect(a.equals(e)).toBe(true);
@@ -144,7 +141,6 @@ describe("QueryAttribute", () => {
     expect(new QueryAttribute("id", -(2 ** 40), int4).isUnboundable()).toBe(-1);
     expect(new QueryAttribute("id", 5, int4).isUnboundable()).toBe(false);
 
-    // The #4433 bignum path: a bigint column is Integer(limit: 8).
     const int8 = new IntegerType({ limit: 8 });
     expect(new QueryAttribute("id", 2n ** 63n, int8).isUnboundable()).toBe(1);
     expect(new QueryAttribute("id", -(2n ** 63n) - 1n, int8).isUnboundable()).toBe(-1);
@@ -180,7 +176,6 @@ describe("QueryAttribute", () => {
     const int4 = new IntegerType({ limit: 4 });
     expect(new QueryAttribute("id", Infinity, int4).isUnboundable()).toBe(false);
     expect(new QueryAttribute("id", -Infinity, int4).isUnboundable()).toBe(false);
-    // isInfinite reads value_before_type_cast, so it still reports the sign.
     expect(new QueryAttribute("id", Infinity, int4).isInfinite()).toBe(1);
     expect(new QueryAttribute("id", -Infinity, int4).isInfinite()).toBe(-1);
   });

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -71,11 +71,6 @@ export class QueryAttribute extends Attribute {
     return super.valueForDatabase;
   }
 
-  // A query bind may hold an un-cast raw value (StatementCache substitution binds
-  // via `withCastValue` without casting), so serialize through the FULL `serialize`
-  // path — which, for a NormalizedValueType, casts+normalizes the raw value before
-  // serializing (mirroring `type_for_attribute(name).serialize`). The base
-  // `_valueForDatabase` fast-path is only correct for already-cast persisted values.
   protected override _valueForDatabase(): unknown {
     return this.type.serialize(this.value);
   }
@@ -139,8 +134,6 @@ export class QueryAttribute extends Attribute {
     return this._unboundable;
   }
 }
-
-// private
 
 /**
  * Mirrors: ActiveRecord::Relation::QueryAttribute#infinity? (query_attribute.rb:53-55)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -75,7 +75,6 @@ export class WhereChain<R = any> {
             | QueryMethodsHost["_model"]
             | null,
       );
-      // Empty/all-filtered → NOT (no rows) = ALL rows = no predicate added.
       if (nodes.length > 0) {
         scope.whereClause = scope.whereClause.plus(new WhereClause(nodes).invert());
       }
@@ -289,10 +288,6 @@ export type OrderArg =
   // -argument guard compact_blanks it away before it reaches the bang variant.
   | null;
 
-// ---------------------------------------------------------------------------
-// Host interface: the shape of `this` for bang methods mixed into Relation.
-// Uses TS `private` keyword fields which are accessible at runtime.
-// ---------------------------------------------------------------------------
 interface QueryMethodsHost {
   /** Rails `delegate :primary_key, to: :model` (delegation.rb:106). */
   primaryKey: string | string[];
@@ -346,10 +341,6 @@ interface QueryMethodsHost {
   table: ArelTable;
   predicateBuilder: import("./predicate-builder.js").PredicateBuilder;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Bang variants — mutate `this` in place, return `this`.
@@ -752,8 +743,6 @@ function inOrderOf(
   const arelColumn: any =
     column instanceof Nodes.SqlLiteral ? column : orderColumn.call(this, String(column));
 
-  // The Arel CASE node is pushed as a node (not pre-rendered SQL) so its embedded
-  // bind values thread through the outer collector when the statement is compiled.
   let scope = orderBang.call(
     this.spawn(),
     buildCaseForValuePosition.call(this, arelColumn, values, { filter }) as any,
@@ -2031,7 +2020,6 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // the (rare) no-load path; eager materialization here would require an async
   // `excluding`, breaking the chainable contract.
   const attribute = this.predicateBuilder.table.arelTable.get(pk);
-  // Mirror the array handler's `x.is_a?(Base) ? x.id : x` deref.
   const literalIds = literalRecords.map((r) => (isBaseInstance(r) ? (r as any).id : r));
   // Build the positive `IN (subquery)` (Rails builds positively and inverts);
   // only its subquery `right` is needed for the marker's display fallback.
@@ -2352,9 +2340,6 @@ export function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): 
     );
   }
   return orderQuery.flatMap((o) => {
-    // Use reverse() when available (Ascending, Descending, NullsFirst, NullsLast),
-    // fall back to desc() for other Arel nodes (Attribute, NodeExpression, etc.).
-    // Guard instanceof Nodes.Node to avoid matching arrays which also have reverse().
     if (o instanceof Nodes.Node) {
       if (typeof (o as any).reverse === "function") return [(o as any).reverse()];
       if (typeof (o as any).desc === "function") return [(o as any).desc()];
@@ -2438,7 +2423,6 @@ export function columnReferences(orderArgs: unknown[]): Nodes.SqlLiteral[] {
     } else if (isPlainObject(arg)) {
       for (const [key, value] of Object.entries(arg)) {
         if (isPlainObject(value)) {
-          // Nested hash { table: { col: dir } } — key is the table name.
           refs.push(key);
         } else {
           const t = extractTableNameFrom(String(key));
@@ -2570,9 +2554,6 @@ export function resolveArelAttributes(this: QueryMethodsHost, attrs: unknown[]):
   });
 }
 
-// ---------------------------------------------------------------------------
-// Module export — all bang variants as a single object for `include()`.
-// ---------------------------------------------------------------------------
 /**
  * `QueryMethods.public_instance_methods(false)` — the members Ruby defines
  * above the first `protected` (query_methods.rb:1604). `CollectionProxy`
@@ -2746,10 +2727,6 @@ export const QueryMethodBangs = {
   ...QueryMethodsPrivateInstanceMethods,
 } as const;
 
-// ---------------------------------------------------------------------------
-// PR 2a private helpers — column resolution, select/from/with building.
-// ---------------------------------------------------------------------------
-
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -2823,7 +2800,7 @@ export function arelColumn(
 /** @internal */
 export function arelColumns(this: QueryMethodsHost, columns: unknown[]): unknown[] {
   return columns.flatMap((field) => {
-    if (field instanceof Nodes.Node) return [field]; // Arel nodes pass through directly
+    if (field instanceof Nodes.Node) return [field];
     if (typeof field === "string") return [arelColumn.call(this, field)];
     if (typeof field === "function") return [field()];
     if (isPlainObject(field)) return arelColumnsFromHash.call(this, field);
@@ -3001,9 +2978,6 @@ export function buildFrom(this: QueryMethodsHost): unknown {
   return opts;
 }
 
-// A table's `.*` projection. `Table#star` is a getter; a table ALIAS
-// (Nodes.TableAlias) has no such helper, but `get("*")` yields the equivalent
-// `<alias>.*` Attribute (the "*" sentinel skips column-name quoting either way).
 function tableStar(table: any): unknown {
   return table.star ?? table.get("*");
 }
@@ -3526,8 +3500,6 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
   // query_methods.rb:1882 — `return if joins_values.empty? && left_outer_joins_values.empty?`.
   if (this.joinsValues.length === 0 && this.leftOuterJoinsValues.length === 0) return;
 
-  // Buckets fold eager into stashed_join. Delegate emission to the shared
-  // `build_joins` port.
   const [buckets, joinType] = buildJoinBuckets.call(this);
   const leadingJoins = buckets.leading_join as Nodes.Join[];
   const joinNodes = buckets.join_node as Nodes.Join[];

--- a/packages/activerecord/src/relation/ruby-inspect.test.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.test.ts
@@ -50,8 +50,6 @@ describe("rubyInspect", () => {
     expect(rubyInspect("cr\r\n")).toBe('"cr\\r\\n"');
     expect(rubyInspect("null\0char")).toBe('"null\\0char"');
     expect(rubyInspect("esc\x1bseq")).toBe('"esc\\eseq"');
-    // Output stays single-line so an EXPLAIN header can't span
-    // multiple lines based on bind contents.
     expect(rubyInspect("a\nb")).not.toContain("\n");
   });
 

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -23,24 +23,12 @@ import { Person } from "../test-helpers/models/person.js";
 import { Friendship } from "../test-helpers/models/friendship.js";
 import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 
-// Person self-registers on import; Friendship does not, but `followers`
-// (through friendships, source follower) needs it in the registry.
 registerModel(Friendship);
 
 describe("SELECT * column collision in joined relations", () => {
-  // `fixtures` wires the handler suite + transactional fixtures +
-  // fixture seeding in one call; the canonical `people` / `friendships` tables
-  // come from the template clone.
   const { people } = fixtures(["people", "friendships"]);
 
   it("hydrates the target's columns, not the join table's, when ids collide", async () => {
-    // friendships("Connection 1"): id=1, friend_id=michael(1), follower_id=david(2).
-    // michael.followers joins friendships (friend_id = michael.id=1) to its
-    // follower (david, people.id=2). The friendship's id=1 collides with
-    // michael's own id=1, so a bare `*` projection would hydrate id=1 (michael)
-    // instead of david. Reading `michael.followers` exercises the public
-    // CollectionProxy path, which routes this non-nested through association
-    // through AssociationScope — the same JOIN/projection path used in production.
     const michael = people("michael");
     const followers = await michael.followers;
     expect(followers.map((p) => ({ id: p.id, first_name: p.first_name }))).toEqual([

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -238,10 +238,6 @@ describe("SelectTest", () => {
     // string it was before extra-select columns were cast by column type).
     const foo = post.readAttribute("foo");
     expect(Number(foo)).toBe(1.1);
-    // On PG (`numeric`) and MySQL (`NEWDECIMAL`) the column_types map casts the
-    // extra select to a BigDecimal — asserting that here pins the type fidelity
-    // the bare `Number(...)` coercion above would otherwise mask (the raw mysql2
-    // driver string "1.1" also numeric-equals 1.1).
     const adapterName = (Post.connection as unknown as { adapterName: string }).adapterName;
     const expectsBigDecimal = adapterName === "postgres" || adapterName === "mysql2";
     expect(foo instanceof BigDecimal).toBe(expectsBigDecimal);

--- a/packages/activerecord/src/relation/single-pk-eager-count-limit-id-subquery-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/single-pk-eager-count-limit-id-subquery-applies-order.trails.test.ts
@@ -34,16 +34,10 @@ describe("Post single-PK eager count limit id subquery applies order", () => {
     [Post, Comment].forEach((m) => registerModel(m as unknown as typeof Base));
   });
 
-  // Order by title ascending picks a different top-2 than pk order:
-  //   pk order (1, 2)  → tags_count {5, 7} → COUNT(DISTINCT) = 2
-  //   title order (A=2, B=3) → tags_count {7, 7} → COUNT(DISTINCT) = 1
-  // So a limited id set that ignores the order would (wrongly) count 2.
   async function seedPosts(): Promise<void> {
     await Post.create({ id: 1, title: "C", body: "b", tags_count: 5 });
     await Post.create({ id: 2, title: "A", body: "b", tags_count: 7 });
     await Post.create({ id: 3, title: "B", body: "b", tags_count: 7 });
-    // Two comments on post 2 fan the LEFT OUTER JOIN, so the DISTINCT-pk id
-    // fetch must de-duplicate.
     await Comment.create({ post_id: 2, body: "c1" });
     await Comment.create({ post_id: 2, body: "c2" });
     await Comment.create({ post_id: 1, body: "c3" });
@@ -64,7 +58,6 @@ describe("Post single-PK eager count limit id subquery applies order", () => {
     // have tags_count 7, so the answer is 1. An unordered top-2 (posts 1 & 2)
     // would wrongly return 2.
     expect(count).toBe(1);
-    // The id-materialization subquery carries the ORDER BY title.
     const idSql = sqls.find((s) => /DISTINCT/i.test(s) && /ORDER BY/i.test(s) && /LIMIT/i.test(s));
     expect(idSql).toBeTruthy();
     expect(idSql).toMatch(/ORDER BY.*title/i);
@@ -72,9 +65,6 @@ describe("Post single-PK eager count limit id subquery applies order", () => {
 
   it("eager_load(:comments).order(:title).offset(n).count(column) counts over the ordered rows after the offset", async () => {
     await seedPosts();
-    // title order: A=2, B=3, C=1. offset(1) drops post 2, leaving posts 3 & 1
-    // → tags_count {7, 5} → COUNT(DISTINCT) = 2. An unordered offset could drop
-    // a different row and diverge.
     const count = await Post.eagerLoad("comments")
       .order("title")
       .offset(1)

--- a/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
+++ b/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
@@ -70,29 +70,21 @@ describe("SpawnAlreadyInScopeTest", () => {
   });
 
   test("spawn inside a scope body re-derives model.all instead of cloning", async () => {
-    // The discriminating case: the current scope is a *different* relation from
-    // the receiver. `clone` would keep the receiver's `title` condition;
-    // `model.all` re-derives from the current scope and carries `type` instead.
     const currentScope = model.where({ type: "SpecialPost" });
     let spawned: ScopeInternals | undefined;
 
     defineAndCallScope("spawnsInsideBody", (rel) => {
       withCurrentScope(currentScope, () => {
-        // Drive spawn on `rel` itself, which `_execScope` marked
-        // delegate-to-model — a clone would not carry the flag.
         spawned = rel.spawn();
       });
       return rel;
     });
 
-    // `spawn` re-derived `model.all` (the current scope) rather than cloning
-    // the receiver, so it carries the current scope's condition.
     expect(await spawned!.toSql()).toMatch(/SpecialPost/);
   });
 
   test("already in scope requires both the flag and a current scope", () => {
     const outside = model.where({ type: "Post" });
-    // Flag unset (not in a scope body) — a current scope alone is not enough.
     withCurrentScope(outside, (registry) => {
       expect(outside.isAlreadyInScope(registry)).toBe(false);
     });
@@ -105,7 +97,6 @@ describe("SpawnAlreadyInScopeTest", () => {
     defineAndCallScope("checksBothConditions", (rel) => {
       bodyRelation = rel;
       const registry = model.scopeRegistry();
-      // `_exec_scope` nils the current scope, so the flag alone is not enough.
       flagWithoutScope = rel.isAlreadyInScope(registry);
       withCurrentScope(rel, (reg) => {
         flagWithScope = rel.isAlreadyInScope(reg);
@@ -119,7 +110,6 @@ describe("SpawnAlreadyInScopeTest", () => {
 
     expect(flagWithoutScope).toBe(false);
     expect(flagWithScope).toBe(true);
-    // The flag is cleared once `_execScope` returns.
     expect(flagAfterBody).toBe(false);
   });
 
@@ -140,9 +130,6 @@ describe("SpawnAlreadyInScopeTest", () => {
     expect(clonedFlag).toBe(false);
   });
 
-  // A plain composition sanity check on the `_execScope` rewiring — it does not
-  // discriminate the clone-flag leak, since `_exec_scope` nils the current scope
-  // for the duration of the body (the test above covers the leak).
   test("chaining inside a scope body accumulates conditions", async () => {
     const scoped = defineAndCallScope("chainedInBody", (rel) =>
       rel.where({ type: "Post" }).where({ title: "Welcome to the weblog" }),

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -87,7 +87,6 @@ async function recordsIntersection(rel: any, other: readonly unknown[]): Promise
  * merge algorithm; `merge` (performMerge) reaches it via `spawn.merge!`.
  */
 export function mergeBang(this: any, other: any): any {
-  // A bare Relation is detected by its `whereClause`.
   if (other && typeof other === "object" && "whereClause" in other) {
     return new Merger(this, other).merge();
   }

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -124,8 +124,6 @@ describe("Thenable", () => {
     const second = await davids.load();
     expect(second).toBe(first);
 
-    // The view is not a copy: loading through it marked the original loaded,
-    // and both read the same records.
     expect(davids.isLoaded).toBe(true);
     expect(await first.toArray()).toEqual(await davids);
   });

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -84,11 +84,6 @@ describe("UpdateAllTest", () => {
     "cpkOrders",
     "cpkOrderAgreements",
   ]);
-  // "update all doesnt ignore order" deliberately raises a DB error to test
-  // ORDER BY semantics; on PG this aborts the transaction. It still runs
-  // transactionally because the fixture teardown skips its redundant DELETEs
-  // while the pinned transaction is open, so the abort no longer poisons the
-  // rollback.
 
   it("update all with scope", async () => {
     const tag = tags("general");
@@ -139,8 +134,6 @@ describe("UpdateAllTest", () => {
     expect(await petsScope.updateAll({ name: "Bob" })).toBe(countBefore);
   });
 
-  // TRACKED DEVIATION: includes + where referencing included table should switch to JOIN strategy.
-  // Trails `includes` does a separate SELECT so toys.name is not available in the WHERE clause.
   it("update all with includes", async () => {
     const petsScope = Pet.includes("toys").where({ toys: { name: "Bone" } });
 
@@ -285,7 +278,6 @@ describe("UpdateAllTest", () => {
     await topic2.reload();
     expect(topic1.title).toBe("adequaterecord");
     expect(topic2.title).toBe("adequaterecord");
-    // before_update set author_name = "David" when blank
     expect(topic1.author_name).toBe("David");
     expect(topic2.author_name).toBe("David");
   });

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -114,8 +114,6 @@ describe("update_all value substitution", () => {
     const rel = Topic.where({ id: 1 });
     try {
       const { binds } = await captureUpdate(rel, () => rel.updateAll({ title: "x" }));
-      // Cast exactly once, on the RAW value — the bind must preserve the result
-      // rather than casting it a second time.
       expect(casts).toEqual(["x"]);
       expect(binds[0]).toBe("cast(x)");
     } finally {

--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -99,13 +99,9 @@ describe("Relation value accessor Rails semantics", () => {
   });
 
   it("order_values stores a raw SQL bind ordering as an Arel SqlLiteral node", () => {
-    // Bind-array form [Arel.sql("... ?"), bind]: the interpolated raw SQL is
-    // stored as a SqlLiteral node directly, so the reader returns it by
-    // reference (no on-read normalization).
     const rel = relation().order([new Nodes.SqlLiteral("id = ?"), 1]);
     expect(rel.orderValues).toBe(internals(rel).orderValues);
     expect(rel.orderValues[0]).toBeInstanceOf(Nodes.SqlLiteral);
-    // Bind is interpolated (quoting is adapter-specific, so match loosely).
     expect((rel.orderValues[0] as Nodes.SqlLiteral).value).toMatch(/^id = '?1'?$/);
   });
 

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -43,7 +43,6 @@ describe("WhereChainTest", () => {
     "books",
   ]);
 
-  // david is author 1, mary is author 2.
   const davidPostsCount = async (): Promise<number> =>
     (await ((await Author.find(1)) as any).posts.toArray()).length;
 
@@ -54,11 +53,6 @@ describe("WhereChainTest", () => {
     expect(includesRecord(relation, posts("authorless"))).toBe(false);
   });
 
-  // Self-join `children`: where.associated / where.missing route the join through
-  // JoinDependency (`joins!` / `left_outer_joins!`), which aliases the added
-  // `Comment.children` self-join. The `:class_name` predicate is keyed by the
-  // association name so it resolves to that same aliased join table rather than
-  // the always-present owner PK, so childless rows filter correctly.
   it("associated with child association", async () => {
     const relation = await Comment.all().where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
@@ -200,23 +194,18 @@ describe("WhereChainTest", () => {
     expect((first as any).id).toBe(((await Author.find(2)) as any).id);
   });
 
-  // Prior inner `joins("children")` supplies the JoinDependency self-join;
-  // `joins!` unions with it so there is one join and the predicate dedups onto
-  // it. See the self-join note above.
   it("associated with add joins before", async () => {
     const relation = await Comment.joins(":children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
   });
 
-  // Self-join `children` — see the self-join note above.
   it("associated with add left joins before", async () => {
     const relation = await Comment.leftJoins(":children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
   });
 
-  // Self-join `children` — see the self-join note above.
   it("associated with add left outer joins before", async () => {
     const relation = await Comment.leftOuterJoins(":children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
@@ -234,7 +223,6 @@ describe("WhereChainTest", () => {
     expect(ids(relation)).toEqual([posts("authorless").id]);
   });
 
-  // Self-join `children` — see the self-join note above.
   it("missing with child association", async () => {
     const relation = await Comment.all().where().missing("children");
     expect(includesRecord(relation, comments("more_greetings"))).toBe(true);

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -38,7 +38,6 @@ describe("WhereChain associated join guard (trails)", () => {
     const sql = Post.joins(":author").where().associated("author").toSql();
     expect(authorsJoinCount(sql)).toBe(1);
     expect(sql).toMatch(/INNER JOIN/i);
-    // The IS NOT NULL predicate still lands on the (unaliased) target table.
     expect(sql).toMatch(/["`]?authors["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
   });
 
@@ -50,11 +49,6 @@ describe("WhereChain associated join guard (trails)", () => {
     expect(sql).toMatch(/["`]?authors["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
   });
 
-  // Self-join (Comment#children): routing the join through JoinDependency
-  // (`joins!`) unions the pending join-value with the where-join, so there is
-  // still exactly one join. The `:class_name` self-join predicate is keyed by
-  // the association name (`self.not(children => …)`), so it resolves to the
-  // same aliased join table (`children`) rather than the owner PK.
   it("does not duplicate a self-join already in joins_values", () => {
     const inner = Comment.joins(":children").where().associated("children").toSql();
     expect(joinCount(inner)).toBe(1);
@@ -77,8 +71,6 @@ describe("WhereChain not inversion shapes (trails)", () => {
     const relation = Post.where().not({
       title: [null, "Welcome to the weblog", "So I was thinking"],
     });
-    // Positive ArrayHandler shape `(title IN (...) OR title IS NULL)`, inverted
-    // once at the clause level — not the threaded `NOT IN ... AND IS NOT NULL`.
     expect(relation.toSql()).toMatch(/NOT \(.*IN \(.*\).*OR.*IS NULL\)/is);
     const posts = await relation;
     expect(posts.length).toBeGreaterThan(0);
@@ -91,13 +83,9 @@ describe("WhereChain not inversion shapes (trails)", () => {
   it("inverts a multi-column aggregate group as one NOT over the AND group", async () => {
     const david = await Customer.find(1);
     const relation = Customer.where().not({ address: david.address });
-    // expand_from_hash builds the three mapped-column equalities positively;
-    // WhereClause#invert wraps them in a single NOT(...) group.
     expect(relation.toSql()).toMatch(
       /NOT \(.*address_street.*AND.*address_city.*AND.*address_country.*\)/is,
     );
-    // The flat positive predicates invert via NOT(ast) — no per-branch
-    // Grouping double-wrap (`NOT ((...))`) like the old negation threading.
     expect(relation.toSql()).not.toMatch(/NOT \(\(/);
     const customers = await relation;
     expect(customers.length).toBeGreaterThan(0);
@@ -105,9 +93,6 @@ describe("WhereChain not inversion shapes (trails)", () => {
   });
 
   it("inverts an exclusive range as NOT over the positive bound pair", () => {
-    // Arel builds `gteq(begin) AND lt(end)`; And has no invert override, so
-    // Node#invert yields `NOT (id >= 1 AND id < 5)` — not a re-derived
-    // `(id < 1 OR id >= 5)`.
     const sql = Post.where()
       .not({ id: new Range(1, 5, true) })
       .toSql();
@@ -125,9 +110,6 @@ describe("WhereChain not inversion shapes (trails)", () => {
   });
 });
 
-// Routing the join through JoinDependency (`joins!` / `left_outer_joins!`) makes
-// through-association shapes work for free — the bespoke resolver threw for them.
-// `Author has_many :comments, through: :posts` emits both intermediate joins.
 describe("WhereChain through association (trails)", () => {
   fixtures(["authors", "posts", "comments", "authorAddresses"]);
 
@@ -136,7 +118,6 @@ describe("WhereChain through association (trails)", () => {
     expect(relation.toSql()).toMatch(
       /INNER JOIN\s+["`]?posts["`]?.*INNER JOIN\s+["`]?comments["`]?.*["`]?comments["`]?\.["`]?id["`]?\s+IS NOT NULL/is,
     );
-    // Authors 1 and 2 have comments through their posts; author 3 has none.
     const authors = await relation.distinct();
     expect(ids(authors)).toEqual([1, 2]);
   });
@@ -146,7 +127,6 @@ describe("WhereChain through association (trails)", () => {
     expect(relation.toSql()).toMatch(
       /LEFT OUTER JOIN\s+["`]?posts["`]?.*LEFT OUTER JOIN\s+["`]?comments["`]?.*["`]?comments["`]?\.["`]?id["`]?\s+IS NULL/is,
     );
-    // Author 3 has no comments through posts, so it is reported missing.
     const authors = await relation.distinct();
     expect(ids(authors)).toContain(3);
   });

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -150,7 +150,6 @@ describe("ActiveRecord::Relation", () => {
         { length: 10 },
         (_, i) => new WhereClause([t.get(`id${i}`).eq(bindParam(i))]),
       );
-      // wcs[0] + wcs[1] + wcs[2].or(wcs[3]) + wcs[4] + wcs[5] + wcs[6].or(wcs[7]) + wcs[8] + wcs[9]
       const wc = [
         wcs[1],
         wcs[2].or(wcs[3]),
@@ -160,7 +159,6 @@ describe("ActiveRecord::Relation", () => {
         wcs[8],
         wcs[9],
       ].reduce((acc, c) => acc.plus(c), wcs[0]);
-      // wcs[0] + wcs[2].or(wcs[3]) + wcs[5] + wcs[6].or(wcs[7]) + wcs[9]
       const expected = [wcs[2].or(wcs[3]), wcs[5], wcs[6].or(wcs[7]), wcs[9]].reduce(
         (acc, c) => acc.plus(c),
         wcs[0],

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -171,9 +171,6 @@ export class WhereClause {
       if (typeof c === "string") colStrings.add(c);
       else if (c instanceof Nodes.Attribute) {
         attrNodes.push(c);
-        // Also register as qualified "table.column" so cross-model merges work
-        // even when two Table instances for the same table have different klass/
-        // typeCaster (and thus different stableSerialize outputs, breaking eql).
         colStrings.add(`${relationName(c.relation.name)}.${c.name}`);
       } else if (c instanceof Nodes.Node) {
         // Non-Attribute expression LHS (e.g. NamedFunction) — Rails' `non_attrs`.
@@ -191,7 +188,6 @@ export class WhereClause {
       }
       if (attrNodes.some((a) => a.eql(attr))) return false;
       if (colStrings.has(attr.name)) return false;
-      // Match qualified "table.column" strings against the attribute's relation + name
       const qualified = `${relationName(attr.relation.name)}.${attr.name}`;
       if (colStrings.has(qualified)) return false;
       return true;
@@ -240,10 +236,6 @@ export class WhereClause {
     return hash;
   }
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 /** @internal */
 function invertPredicate(node: Nodes.Node): Nodes.Node {
@@ -333,13 +325,13 @@ function wrapSqlLiteral(node: Nodes.SqlLiteral): Nodes.Node {
 function extractAttribute(node: Nodes.Node): Nodes.Attribute | null {
   let attrNode: Nodes.Attribute | null = null;
   fetchAttribute(node, (attr: Nodes.Node) => {
-    if (!(attr instanceof Nodes.Attribute)) return true; // not an attribute — keep traversing
+    if (!(attr instanceof Nodes.Attribute)) return true;
     if (attrNode !== null && !attrNode.eql(attr)) {
       attrNode = null;
-      return false; // conflict: multiple different attributes — stop
+      return false;
     }
     attrNode = attr;
-    return true; // found a match — keep traversing (Nary may have more children)
+    return true;
   });
   return attrNode;
 }

--- a/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
+++ b/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
@@ -27,7 +27,6 @@ describe("where value defer-to-bind casting", () => {
     await first.update({ parent_id: 0 });
     const rel = Topic.where().not({ parent_id: "not-a-number" });
     expect(rel.toSql()).not.toMatch(/IS NOT NULL/i);
-    // `parent_id != NULL` matches nothing — including rows whose parent_id IS NULL.
     expect(await rel).toHaveLength(0);
   });
 
@@ -38,15 +37,12 @@ describe("where value defer-to-bind casting", () => {
   });
 
   it("having with an un-castable string binds it instead of IS NULL", async () => {
-    // Select only the grouped column — PG rejects an ungrouped `topics.*`.
     const rel = Topic.select("parent_id").group("parent_id").having({ parent_id: "not-a-number" });
     expect(rel.toSql()).not.toMatch(/IS NULL/i);
     expect(await rel).toHaveLength(0);
   });
 
   it("non-string scalars for a numeric column take the same bind path as strings", async () => {
-    // The retired pre-cast only touched `typeof value === "string"`; a raw
-    // number and its string spelling must compile to the same predicate shape.
     const numeric = Topic.where({ parent_id: 1 }).toSql();
     const stringy = Topic.where({ parent_id: "1" }).toSql();
     expect(stringy).toBe(numeric);

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -231,9 +231,6 @@ describe("WhereTest", () => {
   it("array first arg discards extra positional rest", () => {
     const withStray = (Post.all().where as any)(["id = ?", 1], 2);
     const withoutStray = (Post.all().where as any)(["id = ?", 1]);
-    // The stray 2 is dropped: the SQL is identical to the no-rest call, which
-    // binds only the array's own tail (1) — never the extra positional. (An
-    // appended 2 would emit a second bind and diverge the SQL.)
     expect(withStray.toSql()).toEqual(withoutStray.toSql());
   });
 
@@ -493,9 +490,6 @@ describe("WhereTest", () => {
   });
 
   it("where with blank conditions", async () => {
-    // `where([])` now short-circuits as blank (`opts.blank?` → no-op),
-    // matching `{}` / `null` / `""` — see relation.ts#where. (RFC 0023
-    // finder-array-conditions-composite-ambiguity.)
     for (const blank of [[], {}, null, ""]) {
       const result = await Edge.where(blank as any).order("sink_id");
       expect(result).toHaveLength(4);
@@ -627,8 +621,6 @@ describe("WhereTest", () => {
   });
 
   it("to sql with large number", async () => {
-    // The out-of-range bind is dropped from the generated SQL (not bound as a
-    // value the column can't hold), so replaying it via findBySql matches [bob].
     const bob = authors("bob") as any;
     const sql1 = Author.where({ id: [3, 9223372036854775808n] }).toSql();
     expect(ids(await Author.findBySql(sql1))).toStrictEqual([bob.id]);

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -111,9 +111,6 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     ).toEqual(POSTS_WITH_COMMENTS.length);
   });
 
-  // Regression: the CTE body and the outer WHERE both carry a bound parameter,
-  // so prependCtes must thread the CTE-body bind ahead of the body binds and
-  // renumber the body's PG `$N` placeholders past it (instead of inlining).
   it("count after with call with bound conditions", async () => {
     const relation = Post.with({ typed_posts: Post.where({ type: "Post" }) })
       .from("typed_posts AS posts")
@@ -143,7 +140,7 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     const relation = Post.with({
       posts_with_special_type_or_tags_or_comments: [
         Post.where({ type: "SpecialPost" }),
-        arelSql("SELECT * FROM posts WHERE tags_count > 0") as any, // arel node on purpose
+        arelSql("SELECT * FROM posts WHERE tags_count > 0") as any,
         Post.where("legacy_comments_count > 0"),
       ],
     }).from("posts_with_special_type_or_tags_or_comments AS posts");
@@ -211,8 +208,6 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
       }).joins(":commented_posts") as unknown as { toSql(): string }
     ).toSql();
 
-    // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
-    // MariaDB/MySQL), so the quote char is optional in the match.
     const q = `["\`]?`;
     expect(sql).toMatch(
       new RegExp(
@@ -229,7 +224,6 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
 
     const records = await relation.order("id");
 
-    // Make sure we load all records (thus, left outer join is used)
     expect(records.length).toEqual(await Post.count());
     expect(
       records
@@ -258,8 +252,6 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
 
     const sql = (relation as unknown as { toSql(): string }).toSql();
 
-    // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
-    // MariaDB/MySQL), so the quote char is optional in the match.
     const q = `["\`]?`;
     expect(sql).toMatch(
       new RegExp(


### PR DESCRIPTION
Slice 1 of the activerecord free-form-comment sweep: `packages/activerecord/src/relation/**`.

`blazetrails/no-freeform-comments` (trails#6822) was registered for `arel` and
`activemodel` only. This adds `packages/activerecord/src/relation/**/*.ts` to the
rule's `files` and applies the autofix — **256 blocks / 494 lines deleted**.
JSDoc, comments that point at the Ruby, and tool directives are untouched.

The rule's `files` list is the gate, so it extends one directory at a time and
stays green in between; the remaining activerecord directories are filed as their
own slice stories (see below).

## Rule change

`@nie disposition=` is now recognised as a tool directive. `nie-requires-annotation`
*requires* it on every `throw new NotImplementedError(...)`, so deleting one
(three sites in `relation/`) would have red-lit that rule. Covered by a new case in
`eslint/no-freeform-comments.test.mjs`.

## Stories filed

A comment recording deferred work becomes a story, not a better comment:

- `0023-surfaced-deviations/update-all-includes-join-strategy` — the
  `TRACKED DEVIATION` note on `UpdateAllTest#update all with includes`
  (`relation/update-all.test.ts:137`): trails' `includes` runs a separate SELECT,
  so a `where` referencing the included table does not switch to Rails'
  eager-JOIN strategy. The story cites the exact Rails lines:
  `relation.rb:1238` (`eager_loading?`), `relation.rb:1474`
  (`references_eager_loaded_tables?`), `relation.rb:605` (`update_all`'s
  `eager_loading? ? apply_join_dependency.arel : build_arel(c)` branch) and
  `relation/finder_methods.rb:457` (`apply_join_dependency`), plus the trails
  seat at `relation.ts:1273` (`updateAll`).

Follow-on slices:

- `strip-freeform-comments-ar-root` (3714 lines / 1749 blocks)
- `strip-freeform-comments-ar-connection-adapters` (1580 / 719)
- `strip-freeform-comments-ar-associations` (1512 / 657)
- `strip-freeform-comments-ar-support` (634 / 211)
- `strip-freeform-comments-ar-adapters` (624 / 340)
- `strip-freeform-comments-ar-remaining-dirs` (everything else)

## Verification

- `pnpm eslint packages/activerecord/src/relation` clean; a second `--fix` is a no-op.
- `pnpm typecheck` clean.
- `pnpm vitest run packages/activerecord/src/relation/` — 62 files, 781 passed.
- `pnpm vitest run eslint/no-freeform-comments.test.mjs` — 28 passed.

Closes-story: strip-freeform-comments-activerecord



## Note on main's red Lint

An earlier revision of this PR carried a one-line fix for
`@typescript-eslint/no-unnecessary-type-assertion` at
`connection-adapters/postgresql-adapter.exec-query.test.ts:390`. That is out of
this story's slice, and it has since been fixed on `main` independently, so the
commit is dropped and the branch rebased onto `ff023ccf0`. This PR is again
comment-sweep-only.

The rebase swept 12 further comment lines that landed in `relation/` on main
after this branch was cut (`with.test.ts`), which is the rule doing its job.
