### PR TITLE
refactor(activerecord,activemodel): move the AR attribute read/write surface out of activemodel/model.ts

### DIFF
--- a/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
+++ b/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
@@ -21,7 +21,7 @@ describe("MassAssignmentEmptyParametersTest", () => {
     expect(() => {
       record = new Account(params as unknown as Record<string, unknown>);
     }).not.toThrow();
-    expect(record!.readAttribute("name")).toBeNull();
+    expect(record!._readAttribute("name")).toBeNull();
   });
 
   it("non-empty Parameters proceeds past the empty-bag guard at construction", () => {
@@ -55,6 +55,6 @@ describe("ParametersForbiddenAttributesTest", () => {
     const params = new Parameters({ name: "Bob" }).permitAll();
     expect(params.permitted).toBe(true);
     const record = new Account(params as unknown as Record<string, unknown>);
-    expect(record.readAttribute("name")).toBe("Bob");
+    expect(record._readAttribute("name")).toBe("Bob");
   });
 });

--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -43,7 +43,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "Bob" });
-    expect(p.readAttribute("name")).toBe("Bob");
+    expect(p._readAttribute("name")).toBe("Bob");
   });
 
   it("assign non-existing attribute", () => {
@@ -86,7 +86,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "private_val" });
-    expect(p.readAttribute("name")).toBe("private_val");
+    expect(p._readAttribute("name")).toBe("private_val");
   });
 
   it("does not swallow errors raised in an attribute writer", () => {
@@ -108,10 +108,10 @@ describe("AttributeAssignmentTest", () => {
         this.attribute("name", "string");
       }
       set name(v: string) {
-        (this as Base).writeAttribute("name", v.toUpperCase());
+        (this as Base)._writeAttribute("name", v.toUpperCase());
       }
       get name(): string {
-        return this.readAttribute("name") as string;
+        return this._readAttribute("name") as string;
       }
     }
     class Child extends Base {
@@ -123,7 +123,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const c = new Child({});
     void c.assignAttributes({ name: "bob" });
-    expect(c.readAttribute("name")).toBe("BOB");
+    expect(c._readAttribute("name")).toBe("BOB");
   });
 
   it("routes through instance-own setter (JS singleton method)", () => {
@@ -137,13 +137,13 @@ describe("AttributeAssignmentTest", () => {
     Object.defineProperty(p, "name", {
       set(v: string) {
         seen.push(v);
-        (this as Person).writeAttribute("name", v.toUpperCase());
+        (this as Person)._writeAttribute("name", v.toUpperCase());
       },
       configurable: true,
     });
     void p.assignAttributes({ name: "bob" });
     expect(seen).toEqual(["bob"]);
-    expect(p.readAttribute("name")).toBe("BOB");
+    expect(p._readAttribute("name")).toBe("BOB");
   });
 
   it("routes through user-defined setter if present", () => {
@@ -152,12 +152,12 @@ describe("AttributeAssignmentTest", () => {
         this.attribute("name", "string");
       }
       set name(v: string) {
-        super.writeAttribute("name", v.trim().toUpperCase());
+        super._writeAttribute("name", v.trim().toUpperCase());
       }
     }
     const p = new Person({});
     void p.assignAttributes({ name: "  bob  " });
-    expect(p.readAttribute("name")).toBe("BOB");
+    expect(p._readAttribute("name")).toBe("BOB");
   });
 
   it("an ArgumentError is raised if a non-hash-like object is passed", () => {
@@ -197,8 +197,8 @@ describe("AttributeAssignmentTest", () => {
     }
     const params = new ProtectedParams({ name: "Guille", description: "desc" }).permitBang();
     const p = new Person(params as unknown as Record<string, unknown>);
-    expect(p.readAttribute("name")).toBe("Guille");
-    expect(p.readAttribute("description")).toBe("desc");
+    expect(p._readAttribute("name")).toBe("Guille");
+    expect(p._readAttribute("description")).toBe("desc");
   });
 
   it("assigning no attributes should not raise, even if the hash is un-permitted", () => {
@@ -219,7 +219,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    expect(p._readAttribute("name")).toBe("test");
   });
 
   it("simple assignment", () => {
@@ -231,8 +231,8 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "Alice", age: 30 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(30);
   });
 
   it("regular hash should still be used for mass assignment", () => {
@@ -243,7 +243,7 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "Bob" });
-    expect(p.readAttribute("name")).toBe("Bob");
+    expect(p._readAttribute("name")).toBe("Bob");
   });
 
   it("subclass override of _assignAttributes is called by assignAttributes", () => {
@@ -261,7 +261,7 @@ describe("AttributeAssignmentTest", () => {
     void p.assignAttributes({ name: "Carol" });
     expect(called).toHaveLength(1);
     expect(called[0]).toEqual({ name: "Carol" });
-    expect(p.readAttribute("name")).toBe("Carol");
+    expect(p._readAttribute("name")).toBe("Carol");
   });
 
   it("subclass override of sanitizeForMassAssignment is called by assignAttributes", () => {
@@ -277,8 +277,8 @@ describe("AttributeAssignmentTest", () => {
     }
     const p = new Person({});
     void p.assignAttributes({ name: "Dave", role: "admin" });
-    expect(p.readAttribute("name")).toBe("Dave");
-    expect(p.readAttribute("role")).toBeNull();
+    expect(p._readAttribute("name")).toBe("Dave");
+    expect(p._readAttribute("role")).toBeNull();
   });
 
   it("empty params wrapper is a no-op on assignAttributes (empty? delegation)", () => {
@@ -293,7 +293,7 @@ describe("AttributeAssignmentTest", () => {
     // ForbiddenAttributesError despite the wrapper being unpermitted.
     const params = new ProtectedParams({});
     expect(() => p.assignAttributes(params as unknown as Record<string, unknown>)).not.toThrow();
-    expect(p.readAttribute("name")).toBeNull();
+    expect(p._readAttribute("name")).toBeNull();
   });
 
   it("empty params wrapper is a no-op at construction (empty? delegation)", () => {
@@ -307,7 +307,7 @@ describe("AttributeAssignmentTest", () => {
     expect(() => {
       record = new Person(params as unknown as Record<string, unknown>);
     }).not.toThrow();
-    expect(record!.readAttribute("name")).toBeNull();
+    expect(record!._readAttribute("name")).toBeNull();
   });
 
   it("non-empty unpermitted params wrapper still raises (empty? delegation)", () => {
@@ -339,6 +339,6 @@ describe("AttributeAssignmentTest", () => {
     void p.assignAttributes({ name: "Eve", age: 5 });
     expect(seen).toContainEqual(["name", "Eve"]);
     expect(seen).toContainEqual(["age", 5]);
-    expect(p.readAttribute("name")).toBe("Eve");
+    expect(p._readAttribute("name")).toBe("Eve");
   });
 });

--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -62,7 +62,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    expect(p._readAttribute("name")).toBe("test");
   });
 
   it("#define_attribute_method generates attribute method with invalid identifier characters", () => {
@@ -72,7 +72,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    expect(p._readAttribute("name")).toBe("test");
   });
 
   it("#define_attribute_methods works passing multiple arguments", () => {
@@ -83,8 +83,8 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 30 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(30);
   });
 
   it("#define_attribute_methods generates attribute methods", () => {
@@ -94,7 +94,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("#alias_attribute generates attribute_aliases lookup hash", () => {
@@ -116,7 +116,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ first_name: "Alice" });
-    expect(p.readAttribute("first_name")).toBe("Alice");
+    expect(p._readAttribute("first_name")).toBe("Alice");
   });
 
   it("#alias_attribute works with attributes with spaces in their names", () => {
@@ -162,7 +162,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    expect(p._readAttribute("name")).toBe("test");
   });
 
   it("should not interfere with respond_to? if the attribute has a private/protected method", () => {
@@ -172,7 +172,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.respondTo("readAttribute")).toBe(true);
+    expect(p.respondTo("_readAttribute")).toBe(true);
   });
 
   it("alias attribute respects user defined method", () => {
@@ -201,7 +201,7 @@ describe("AttributeMethodsTest", () => {
   it("method missing works correctly even if attributes method is not defined", () => {
     class Bare extends Model {}
     const b = new Bare();
-    expect(b.readAttribute("nonexistent")).toBe(null);
+    expect(b._readAttribute("nonexistent")).toBe(null);
   });
 
   it("unrelated classes should not share attribute method matchers", () => {
@@ -242,7 +242,7 @@ describe("AttributeMethodsTest", () => {
     const p = new Person({ name: "Alice" });
     expect((p as any).full_name).toBe("Alice");
     (p as any).full_name = "Bob";
-    expect(p.readAttribute("name")).toBe("Bob");
+    expect(p._readAttribute("name")).toBe("Bob");
   });
 
   it("#undefine_attribute_methods removes attribute methods", () => {
@@ -281,7 +281,7 @@ describe("AttributeMethodsTest", () => {
     }
     const p = new Person({ name: "Alice" });
     expect(p.customName()).toBe("custom");
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("should use attribute_missing to dispatch a missing attribute", () => {
@@ -307,53 +307,6 @@ describe("AttributeMethodsTest", () => {
     expect(match.proxyTarget).toBe("attributeTest");
   });
 
-  it("readAttribute / writeAttribute resolve alias_attribute names transparently", () => {
-    // Rails `read_attribute(name)` does `attribute_aliases[name] || name`
-    // (activemodel attribute_methods.rb) so callers can pass either the
-    // aliased or canonical name and hit the same underlying attribute.
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.aliasAttribute("nickname", "name");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("nickname")).toBe("Alice");
-    p.writeAttribute("nickname", "Ally");
-    expect(p.readAttribute("name")).toBe("Ally");
-    expect(p.readAttribute("nickname")).toBe("Ally");
-  });
-
-  it("aliased writes propagate to dirty tracking on the canonical name", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.aliasAttribute("nickname", "name");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    p.changesApplied();
-    p.writeAttribute("nickname", "Ally");
-    expect(p.changedAttributeNamesToSave).toEqual(["name"]);
-    expect(p.changes).toEqual({ name: ["Alice", "Ally"] });
-  });
-
-  it("hasAttribute and readAttributeBeforeTypeCast resolve alias names", () => {
-    // Rails `has_attribute?` and `read_attribute_before_type_cast` both go
-    // through `attribute_aliases[name] || name` (attribute_methods.rb).
-    class Person extends Model {
-      static {
-        this.attribute("age", "integer");
-        this.aliasAttribute("years", "age");
-      }
-    }
-    const p = new Person({ age: "42" });
-    expect(p.hasAttribute("years")).toBe(true);
-    expect(p.hasAttribute("age")).toBe(true);
-    expect(p.hasAttribute("nope")).toBe(false);
-    expect(p.readAttributeBeforeTypeCast("years")).toBe("42");
-  });
-
   it("name clashes are handled", () => {
     class Person extends Model {
       static {
@@ -361,22 +314,7 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("name")).toBe("Alice");
-  });
-});
-describe("hasAttribute", () => {
-  it("returns true for defined attributes", () => {
-    class Widget extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("size", "integer");
-      }
-    }
-
-    const w = new Widget({ name: "Test" });
-    expect(w.hasAttribute("name")).toBe(true);
-    expect(w.hasAttribute("size")).toBe(true);
-    expect(w.hasAttribute("unknown")).toBe(false);
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 });
 describe("attribute method prefix/suffix/affix", () => {
@@ -387,7 +325,7 @@ describe("attribute method prefix/suffix/affix", () => {
         this.attributeMethodPrefix("clear_");
       }
       clear_attribute(attr: string): unknown {
-        return this.readAttribute(attr);
+        return this._readAttribute(attr);
       }
     }
     const u = new User({ name: "Alice" });
@@ -401,7 +339,7 @@ describe("attribute method prefix/suffix/affix", () => {
         this.attributeMethodSuffix("_before_type_cast");
       }
       attribute_before_type_cast(attr: string): unknown {
-        return this.readAttribute(attr);
+        return this._readAttribute(attr);
       }
     }
     const u = new User({ name: "Alice" });
@@ -415,7 +353,7 @@ describe("attribute method prefix/suffix/affix", () => {
         this.attributeMethodAffix({ prefix: "reset_", suffix: "_to_default" });
       }
       reset_attribute_to_default(attr: string): unknown {
-        return this.readAttribute(attr);
+        return this._readAttribute(attr);
       }
     }
     const u = new User({ name: "Alice" });
@@ -431,7 +369,7 @@ describe("respondTo", () => {
       }
     }
     const u = new User({ name: "Alice" });
-    expect(u.respondTo("readAttribute")).toBe(true);
+    expect(u.respondTo("_readAttribute")).toBe(true);
     expect(u.respondTo("isValid")).toBe(true);
   });
 
@@ -466,7 +404,7 @@ describe("attributeMissing", () => {
     User.attribute("name", "string");
 
     const u = new User({ name: "Alice" });
-    expect(u.readAttribute("nonexistent")).toBeNull();
+    expect(u._readAttribute("nonexistent")).toBeNull();
   });
 
   it("can be overridden to provide custom behavior", () => {
@@ -492,7 +430,7 @@ describe("attributeMissing", () => {
     );
     // Plain attribute reads still work normally — readAttribute is not
     // routed through attribute_missing in either Rails or trails.
-    expect(u.readAttribute("name")).toBe("Alice");
+    expect(u._readAttribute("name")).toBe("Alice");
   });
 });
 

--- a/packages/activemodel/src/attribute-methods.trails.test.ts
+++ b/packages/activemodel/src/attribute-methods.trails.test.ts
@@ -34,7 +34,7 @@ describe("AttributeMethodsTest (trails)", () => {
         this.attributeMethodSuffix("Short");
       }
       attributeShort(attrName: string): string {
-        return String(this.readAttribute(attrName)).slice(0, 3);
+        return String(this._readAttribute(attrName)).slice(0, 3);
       }
       nicknameShort(): string {
         return "parent";
@@ -71,7 +71,7 @@ describe("AttributeMethodsTest (trails)", () => {
     const person = new Person({ name: "Alexander" });
     expect(person.name).toBe("Alexander");
     person.name = "Bob";
-    expect(person.readAttribute("name")).toBe("Bob");
+    expect(person._readAttribute("name")).toBe("Bob");
   });
 
   it("alias_attribute and attribute_method_suffix write only the declaring class", () => {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -11,8 +11,6 @@
 import { camelize, CodeGenerator, include, Module } from "@blazetrails/activesupport";
 
 export interface AttributeMethods {
-  hasAttribute(name: string): boolean;
-  attributePresent(name: string): boolean;
   attributeMissing(match: AttributeMethodMatch, ...args: unknown[]): unknown;
   respondTo(method: string): boolean;
 }
@@ -126,8 +124,10 @@ export class AttributeMethodPattern {
 
 /** Minimum shape required of an instance accessed through a generated attribute method closure. */
 interface ReadWriteHost {
-  readAttribute(name: string): unknown;
-  writeAttribute(name: string, value: unknown): void;
+  /** @internal */
+  _readAttribute(name: string): unknown;
+  /** @internal */
+  _writeAttribute(name: string, value: unknown): void;
   [key: string]: unknown;
 }
 
@@ -801,10 +801,10 @@ export function defineMethodAttribute(
               `missing attribute '${canonicalName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
             );
           }
-          return this.readAttribute(canonicalName);
+          return this._readAttribute(canonicalName);
         },
         set(this: ReadWriteHost, value: unknown) {
-          this.writeAttribute(canonicalName, value);
+          this._writeAttribute(canonicalName, value);
         },
         configurable: true,
       });

--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -61,7 +61,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const m = new MyModel({ count: "5" });
-    expect(m.readAttribute("count")).toBe(5);
+    expect(m._readAttribute("count")).toBe(5);
   });
 
   it("default value can be specified", () => {
@@ -71,7 +71,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("status")).toBe("pending");
+    expect(m._readAttribute("status")).toBe("pending");
   });
 
   it("default value can be nil", () => {
@@ -81,7 +81,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("name")).toBeNull();
+    expect(m._readAttribute("name")).toBeNull();
   });
 
   it(".type_for_attribute returns the default type when an unregistered attribute is specified", () => {
@@ -183,7 +183,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const c = new Child({ name: "5" });
-    expect(c.readAttribute("name")).toBe(5);
+    expect(c._readAttribute("name")).toBe(5);
   });
 
   it("superclass attributes can be overridden", () => {
@@ -198,7 +198,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const c = new Child({});
-    expect(c.readAttribute("name")).toBe("child");
+    expect(c._readAttribute("name")).toBe("child");
   });
 
   it("superclass default values can be overridden", () => {
@@ -213,7 +213,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const c = new Child({});
-    expect(c.readAttribute("status")).toBe("inactive");
+    expect(c._readAttribute("status")).toBe("inactive");
   });
 
   it(".decorate_attributes decorates specified attributes", () => {
@@ -327,7 +327,7 @@ describe("AttributeRegistrationTest", () => {
       }
     }
     const p = new Person({ age: "25" });
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it(".attribute_types reflects registered attribute types", () => {

--- a/packages/activemodel/src/attribute-set.test.ts
+++ b/packages/activemodel/src/attribute-set.test.ts
@@ -13,8 +13,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: "25" });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it("building with custom types", () => {
@@ -24,7 +24,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ active: "true" });
-    expect(p.readAttribute("active")).toBe(true);
+    expect(p._readAttribute("active")).toBe(true);
   });
 
   it("[] returns a null object", () => {
@@ -34,7 +34,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.readAttribute("name")).toBe(null);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("duping creates a new hash, but does not dup the attributes", () => {
@@ -46,7 +46,7 @@ describe("AttributeSetTest", () => {
     const p = new Person({ name: "Alice" });
     const attrs = p.attributes;
     attrs.name = "Bob";
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("deep_duping creates a new hash and dups each attribute", () => {
@@ -58,7 +58,7 @@ describe("AttributeSetTest", () => {
     const p = new Person({ name: "Alice" });
     const attrs = { ...p.attributes };
     attrs.name = "Bob";
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("freezing cloned set does not freeze original", () => {
@@ -69,8 +69,8 @@ describe("AttributeSetTest", () => {
     }
     const p = new Person({ name: "Alice" });
     const attrs = Object.freeze({ ...p.attributes });
-    p.writeAttribute("name", "Bob");
-    expect(p.readAttribute("name")).toBe("Bob");
+    p._writeAttribute("name", "Bob");
+    expect(p._readAttribute("name")).toBe("Bob");
     expect(attrs.name).toBe("Alice");
   });
 
@@ -107,8 +107,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ age: "25" });
-    expect(p.readAttributeBeforeTypeCast("age")).toBe("25");
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._attributes.getAttribute("age").valueBeforeTypeCast).toBe("25");
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it("known columns are built with uninitialized attributes", () => {
@@ -118,8 +118,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.hasAttribute("name")).toBe(true);
-    expect(p.readAttribute("name")).toBe(null);
+    expect(p._attributes.isKey("name")).toBe(true);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("uninitialized attributes are not included in the attributes hash", () => {
@@ -129,8 +129,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.attributePresent("name")).toBe(false);
-    expect(p.readAttribute("name")).toBe(null);
+    expect(p._readAttribute("name")).toBe(null);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("uninitialized attributes are not included in keys", () => {
@@ -141,7 +141,7 @@ describe("AttributeSetTest", () => {
     }
     const p = new Person({});
     expect(p.attributeNames()).toContain("name");
-    expect(p.attributePresent("name")).toBe(false);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("uninitialized attributes return false for key?", () => {
@@ -151,8 +151,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.hasAttribute("name")).toBe(true);
-    expect(p.attributePresent("name")).toBe(false);
+    expect(p._attributes.isKey("name")).toBe(true);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("unknown attributes return false for key?", () => {
@@ -162,7 +162,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.hasAttribute("unknown")).toBe(false);
+    expect(p._attributes.isKey("unknown")).toBe(false);
   });
 
   it("fetch_value returns the value for the given initialized attribute", () => {
@@ -172,7 +172,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("fetch_value returns nil for unknown attributes", () => {
@@ -182,7 +182,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.readAttribute("unknown")).toBe(null);
+    expect(p._readAttribute("unknown")).toBe(null);
   });
 
   it("fetch_value returns nil for unknown attributes when types has a default", () => {
@@ -192,7 +192,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.readAttribute("missing")).toBe(null);
+    expect(p._readAttribute("missing")).toBe(null);
   });
 
   it("fetch_value uses the given block for uninitialized attributes", () => {
@@ -202,7 +202,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    const value = p.readAttribute("name") ?? "default";
+    const value = p._readAttribute("name") ?? "default";
     expect(value).toBe("default");
   });
 
@@ -213,7 +213,7 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.readAttribute("name")).toBe(null);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("the primary_key is always initialized", () => {
@@ -234,8 +234,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    p.writeAttribute("age", "42");
-    expect(p.readAttribute("age")).toBe(42);
+    p._writeAttribute("age", "42");
+    expect(p._readAttribute("age")).toBe(42);
   });
 
   it("write_from_user sets the attribute with user typecasting", () => {
@@ -245,8 +245,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({});
-    p.writeAttribute("age", "25");
-    expect(p.readAttribute("age")).toBe(25);
+    p._writeAttribute("age", "25");
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it("values_for_database", () => {
@@ -257,8 +257,8 @@ describe("AttributeSetTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: "25" });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it("freezing doesn't prevent the set from materializing", () => {
@@ -293,9 +293,9 @@ describe("AttributeSetTest", () => {
     }
     const p = new Person({ name: "Alice", age: 25 });
     const accessed = p._attributes.accessed();
-    p.readAttribute("name");
+    p._readAttribute("name");
     expect(p._attributes.accessed().length).toBeGreaterThanOrEqual(accessed.length);
-    expect(p.hasAttribute("name")).toBe(true);
+    expect(p._attributes.isKey("name")).toBe(true);
   });
 
   it("#map returns a new attribute set with the changes applied", () => {
@@ -307,7 +307,7 @@ describe("AttributeSetTest", () => {
     const p = new Person({ name: "Alice" });
     const mapped = p._attributes.map((attr) => attr.withCastValue("Bob"));
     expect(mapped.fetchValue("name")).toBe("Bob");
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("comparison for equality is correctly implemented", () => {

--- a/packages/activemodel/src/attribute.test.ts
+++ b/packages/activemodel/src/attribute.test.ts
@@ -13,8 +13,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("count")).toBe(0);
-    expect(m.readAttribute("count")).toBe(0);
+    expect(m._readAttribute("count")).toBe(0);
+    expect(m._readAttribute("count")).toBe(0);
   });
 
   it("from_user + value_for_database type casts from the user to the database", () => {
@@ -24,7 +24,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ age: "25" });
-    expect(m.readAttribute("age")).toBe(25);
+    expect(m._readAttribute("age")).toBe(25);
   });
 
   it("from_user + value_for_database uses serialize_cast_value when possible", () => {
@@ -34,7 +34,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ age: "25" });
-    expect(m.readAttribute("age")).toBe(25);
+    expect(m._readAttribute("age")).toBe(25);
   });
 
   it("value_for_database is memoized", () => {
@@ -44,8 +44,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    expect(m.readAttribute("name")).toBe("test");
-    expect(m.readAttribute("name")).toBe("test");
+    expect(m._readAttribute("name")).toBe("test");
+    expect(m._readAttribute("name")).toBe("test");
   });
 
   it("value_for_database is recomputed when value changes in place", () => {
@@ -55,8 +55,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    m.writeAttribute("name", "changed");
-    expect(m.readAttribute("name")).toBe("changed");
+    m._writeAttribute("name", "changed");
+    expect(m._readAttribute("name")).toBe("changed");
   });
 
   it("duping does not dup the value if it is not dupable", () => {
@@ -66,7 +66,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ count: 5 });
-    expect(m.readAttribute("count")).toBe(5);
+    expect(m._readAttribute("count")).toBe(5);
   });
 
   it("duping does not eagerly type cast if we have not yet type cast", () => {
@@ -76,7 +76,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("name")).toBeNull();
+    expect(m._readAttribute("name")).toBeNull();
   });
 
   it("uninitialized attributes yield their name if a block is given to value", () => {
@@ -86,7 +86,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("name")).toBeNull();
+    expect(m._readAttribute("name")).toBeNull();
   });
 
   it("attributes do not equal attributes with different names", () => {
@@ -97,8 +97,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test", title: "test" });
-    expect(m.readAttribute("name")).toBe("test");
-    expect(m.readAttribute("title")).toBe("test");
+    expect(m._readAttribute("name")).toBe("test");
+    expect(m._readAttribute("title")).toBe("test");
   });
 
   it("attributes do not equal attributes with different types", () => {
@@ -109,8 +109,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ age: 25, name: "25" });
-    expect(m.readAttribute("age")).toBe(25);
-    expect(m.readAttribute("name")).toBe("25");
+    expect(m._readAttribute("age")).toBe(25);
+    expect(m._readAttribute("name")).toBe("25");
   });
 
   it("attributes do not equal attributes with different values", () => {
@@ -121,7 +121,7 @@ describe("AttributeTest", () => {
     }
     const m1 = new MyModel({ name: "Alice" });
     const m2 = new MyModel({ name: "Bob" });
-    expect(m1.readAttribute("name")).not.toBe(m2.readAttribute("name"));
+    expect(m1._readAttribute("name")).not.toBe(m2._readAttribute("name"));
   });
 
   it("attributes do not equal attributes of other classes", () => {
@@ -147,7 +147,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    expect(m.readAttribute("name")).toBe("test");
+    expect(m._readAttribute("name")).toBe("test");
   });
 
   it("an attribute is not changed if it hasn't been assigned or mutated", () => {
@@ -167,7 +167,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    m.writeAttribute("name", "changed");
+    m._writeAttribute("name", "changed");
     expect(m.attributeChanged("name")).toBe(true);
   });
 
@@ -178,7 +178,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    m.writeAttribute("name", "test");
+    m._writeAttribute("name", "test");
     expect(m.attributeChanged("name")).toBe(false);
   });
 
@@ -199,7 +199,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    m.writeAttribute("name", "mutated");
+    m._writeAttribute("name", "mutated");
     expect(m.attributeChanged("name")).toBe(true);
   });
 
@@ -210,7 +210,7 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({ name: "test" });
-    m.writeAttribute("name", "changed");
+    m._writeAttribute("name", "changed");
     expect(m.attributeChanged("name")).toBe(true);
     m.clearChangesInformation();
     expect(m.attributeChanged("name")).toBe(false);
@@ -224,7 +224,7 @@ describe("AttributeTest", () => {
     }
     const m = new MyModel({ name: "test" });
     m.clearChangesInformation();
-    expect(m.readAttribute("name")).toBe("test");
+    expect(m._readAttribute("name")).toBe("test");
   });
 
   it("with_value_from_user validates the value", () => {
@@ -234,8 +234,8 @@ describe("AttributeTest", () => {
       }
     }
     const m = new MyModel({});
-    m.writeAttribute("age", "25");
-    expect(m.readAttribute("age")).toBe(25);
+    m._writeAttribute("age", "25");
+    expect(m._readAttribute("age")).toBe(25);
   });
 
   it("from_database + read type casts from database", () => {
@@ -271,7 +271,7 @@ describe("AttributeTest", () => {
     const p = new Person({ name: "Alice" });
     const attrs = { ...p.attributes };
     attrs.name = "Bob";
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("with_value_from_user returns a new attribute with the value from the user", () => {
@@ -293,7 +293,7 @@ describe("AttributeTest", () => {
       }
     }
     const p = new Person();
-    expect(p.readAttribute("name")).toBe(null);
+    expect(p._readAttribute("name")).toBe(null);
   });
 
   it("attributes equal other attributes with the same constructor arguments", () => {
@@ -314,8 +314,8 @@ describe("AttributeTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.hasAttribute("name")).toBe(true);
-    expect(p.hasAttribute("nonexistent")).toBe(false);
+    expect(p._attributes.isKey("name")).toBe(true);
+    expect(p._attributes.isKey("nonexistent")).toBe(false);
   });
 
   it("with_type preserves mutations", () => {
@@ -326,9 +326,9 @@ describe("AttributeTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
-    expect(p.readAttribute("name")).toBe("Bob");
-    expect(p.readAttribute("age")).toBe(25);
+    p._writeAttribute("name", "Bob");
+    expect(p._readAttribute("name")).toBe("Bob");
+    expect(p._readAttribute("age")).toBe(25);
   });
 
   it("value_before_type_cast returns the given value", () => {
@@ -338,8 +338,8 @@ describe("AttributeTest", () => {
       }
     }
     const p = new Person({ age: "42" });
-    expect(p.readAttributeBeforeTypeCast("age")).toBe("42");
-    expect(p.readAttribute("age")).toBe(42);
+    expect(p._attributes.getAttribute("age").valueBeforeTypeCast).toBe("42");
+    expect(p._readAttribute("age")).toBe(42);
   });
 
   it("#serializable? delegates to the type", () => {

--- a/packages/activemodel/src/attributes-dirty.test.ts
+++ b/packages/activemodel/src/attributes-dirty.test.ts
@@ -9,7 +9,7 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ age: 25 });
-    p.writeAttribute("age", "25");
+    p._writeAttribute("age", "25");
     expect(p.attributeChanged("age")).toBe(false);
   });
 
@@ -20,7 +20,7 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changes["name"]).toEqual(["Alice", "Bob"]);
   });
 
@@ -31,7 +31,7 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.previousChanges["name"]).toEqual(["Alice", "Bob"]);
     expect(p.attributeChanged("name")).toBe(false);
@@ -45,8 +45,8 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("age", 30);
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("age", 30);
     p.clearAttributeChanges(["name"]);
     expect(p.attributeChanged("name")).toBe(false);
     expect(p.attributeChanged("age")).toBe(true);
@@ -62,39 +62,39 @@ describe("AttributesDirtyTest", () => {
 
   it("setting attribute will result in change", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
   });
 
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changedAttributeNamesToSave).toContain("name");
     expect(p.changedAttributeNamesToSave).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChange("name")).toEqual(["Alice", "Bob"]);
   });
 
   it("checking if an attribute has changed to a particular value", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChanged("name", { to: "Bob" })).toBe(true);
     expect(p.attributeChanged("name", { to: "Charlie" })).toBe(false);
   });
 
   it("setting color to same value should not result in change being recorded", () => {
     const p = new DirtyPerson({ color: "red" });
-    p.writeAttribute("color", "red");
+    p._writeAttribute("color", "red");
     expect(p.changed).toBe(false);
   });
 
   it("saving should reset model's changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
     p.changesApplied();
     expect(p.changed).toBe(false);
@@ -102,47 +102,47 @@ describe("AttributesDirtyTest", () => {
 
   it("saving should preserve previous changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
   });
 
   it("setting new attributes should not affect previous changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
   });
 
   it("saving should preserve model's previous changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.attributePreviouslyChanged("name")).toBe(true);
   });
 
   it("previous value is preserved when changed after save", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
     expect(p.changes).toEqual({ name: ["Bob", "Charlie"] });
   });
 
   it("changing the same attribute multiple times retains the correct original value", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Charlie");
     expect(p.attributeChange("name")).toEqual(["Alice", "Charlie"]);
   });
 
   it("clear_changes_information should reset all changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     p.clearChangesInformation();
     expect(p.changed).toBe(false);
     expect(Object.keys(p.previousChanges).length).toBe(0);
@@ -150,19 +150,19 @@ describe("AttributesDirtyTest", () => {
 
   it("restore_attributes should restore all previous data", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("age", 30);
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("age", 30);
     p.restoreAttributes();
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(25);
     expect(p.changed).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
-    p.writeAttribute("name", "Alice");
+    p._writeAttribute("name", "Alice");
     expect(p.changed).toBe(false);
   });
   it("attribute mutation", () => {
@@ -173,7 +173,7 @@ describe("AttributesDirtyTest", () => {
     }
     const p = new Person({ name: "Alice" });
     expect(p.changed).toBe(false);
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
     expect(p.changes).toEqual({ name: ["Alice", "Bob"] });
   });
@@ -185,7 +185,7 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChanged("name")).toBe(true);
     expect(p.attributeWas("name")).toBe("Alice");
   });

--- a/packages/activemodel/src/attributes.test.ts
+++ b/packages/activemodel/src/attributes.test.ts
@@ -13,57 +13,57 @@ describe("AttributesTest", () => {
 
   it("initializes with defaults", () => {
     const u = new User();
-    expect(u.readAttribute("name")).toBe(null);
-    expect(u.readAttribute("age")).toBe(0);
-    expect(u.readAttribute("active")).toBe(true);
+    expect(u._readAttribute("name")).toBe(null);
+    expect(u._readAttribute("age")).toBe(0);
+    expect(u._readAttribute("active")).toBe(true);
   });
 
   it("initializes with provided values", () => {
     const u = new User({ name: "dean", age: 30 });
-    expect(u.readAttribute("name")).toBe("dean");
-    expect(u.readAttribute("age")).toBe(30);
+    expect(u._readAttribute("name")).toBe("dean");
+    expect(u._readAttribute("age")).toBe(30);
   });
 
   it("casts string to integer", () => {
     const u = new User({ age: "25" });
-    expect(u.readAttribute("age")).toBe(25);
+    expect(u._readAttribute("age")).toBe(25);
   });
 
   it("integer truncates floats", () => {
     const u = new User({ age: 25.9 });
-    expect(u.readAttribute("age")).toBe(25);
+    expect(u._readAttribute("age")).toBe(25);
   });
 
   it("casts string to float", () => {
     const u = new User({ score: "9.5" });
-    expect(u.readAttribute("score")).toBe(9.5);
+    expect(u._readAttribute("score")).toBe(9.5);
   });
 
   it("casts string to boolean", () => {
     // Rails BooleanType: only FALSE_VALUES coerce to false; "yes"/"no"
     // are both truthy (not in FALSE_VALUES).
-    expect(new User({ active: "false" }).readAttribute("active")).toBe(false);
-    expect(new User({ active: "true" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "yes" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "no" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "1" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "0" }).readAttribute("active")).toBe(false);
-    expect(new User({ active: 1 }).readAttribute("active")).toBe(true);
-    expect(new User({ active: 0 }).readAttribute("active")).toBe(false);
+    expect(new User({ active: "false" })._readAttribute("active")).toBe(false);
+    expect(new User({ active: "true" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "yes" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "no" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "1" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "0" })._readAttribute("active")).toBe(false);
+    expect(new User({ active: 1 })._readAttribute("active")).toBe(true);
+    expect(new User({ active: 0 })._readAttribute("active")).toBe(false);
   });
 
   it("casts null to null for all types", () => {
     const u = new User({ name: null, age: null, score: null, active: null });
-    expect(u.readAttribute("name")).toBe(null);
-    expect(u.readAttribute("age")).toBe(null);
-    expect(u.readAttribute("score")).toBe(null);
-    expect(u.readAttribute("active")).toBe(null);
+    expect(u._readAttribute("name")).toBe(null);
+    expect(u._readAttribute("age")).toBe(null);
+    expect(u._readAttribute("score")).toBe(null);
+    expect(u._readAttribute("active")).toBe(null);
   });
 
   it("writeAttribute casts the value", () => {
     const u = new User();
-    u.writeAttribute("age", "42");
-    expect(u.readAttribute("age")).toBe(42);
+    u._writeAttribute("age", "42");
+    expect(u._readAttribute("age")).toBe(42);
   });
 
   it("returns all attributes as a hash", () => {
@@ -74,22 +74,6 @@ describe("AttributesTest", () => {
       score: null,
       active: true,
     });
-  });
-
-  it("attributePresent checks for non-blank values", () => {
-    const u = new User({ name: "dean" });
-    expect(u.attributePresent("name")).toBe(true);
-    expect(u.attributePresent("score")).toBe(false);
-  });
-
-  it("attributePresent returns false for empty string", () => {
-    const u = new User({ name: "" });
-    expect(u.attributePresent("name")).toBe(false);
-  });
-
-  it("attributePresent returns false for whitespace-only string", () => {
-    const u = new User({ name: "   " });
-    expect(u.attributePresent("name")).toBe(false);
   });
 
   it("attributeNames returns declared names", () => {
@@ -103,8 +87,8 @@ describe("AttributesTest", () => {
         this.attribute("token", "string", { default: () => `tok_${++counter}` });
       }
     }
-    expect(new WithLambda().readAttribute("token")).toBe("tok_1");
-    expect(new WithLambda().readAttribute("token")).toBe("tok_2");
+    expect(new WithLambda()._readAttribute("token")).toBe("tok_1");
+    expect(new WithLambda()._readAttribute("token")).toBe("tok_2");
   });
 
   it("inheritance: children inherit parent attributes", () => {
@@ -114,8 +98,8 @@ describe("AttributesTest", () => {
       }
     }
     const admin = new Admin({ name: "dean" });
-    expect(admin.readAttribute("name")).toBe("dean");
-    expect(admin.readAttribute("role")).toBe("admin");
+    expect(admin._readAttribute("name")).toBe("dean");
+    expect(admin._readAttribute("role")).toBe("admin");
     expect(Admin.attributeNames()).toContain("name");
     expect(Admin.attributeNames()).toContain("role");
   });
@@ -132,8 +116,8 @@ describe("AttributesTest", () => {
     }
     const a = new ModelA({ name: "Alice" });
     const b = new ModelB({ name: "Bob" });
-    expect(a.readAttribute("name")).toBe("Alice");
-    expect(b.readAttribute("name")).toBe("Bob");
+    expect(a._readAttribute("name")).toBe("Alice");
+    expect(b._readAttribute("name")).toBe("Bob");
   });
 
   it("nonexistent attribute", () => {
@@ -143,7 +127,7 @@ describe("AttributesTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("nonexistent")).toBeNull();
+    expect(m._readAttribute("nonexistent")).toBeNull();
   });
 
   it("attributes with proc defaults can be marshalled", () => {
@@ -153,7 +137,7 @@ describe("AttributesTest", () => {
       }
     }
     const m = new MyModel({});
-    expect(m.readAttribute("tags")).toBe("default");
+    expect(m._readAttribute("tags")).toBe("default");
   });
 
   it("can't modify attributes if frozen", () => {
@@ -201,8 +185,8 @@ describe("AttributesTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 30 });
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(30);
   });
 
   it("reading attributes", () => {
@@ -239,8 +223,8 @@ describe("AttributesTest", () => {
         this.attribute("name", "string", { default: "child" });
       }
     }
-    expect(new Child().readAttribute("name")).toBe("child");
-    expect(new Parent().readAttribute("name")).toBe("parent");
+    expect(new Child()._readAttribute("name")).toBe("child");
+    expect(new Parent()._readAttribute("name")).toBe("parent");
   });
 
   it("attributes can be dup-ed", () => {
@@ -252,7 +236,7 @@ describe("AttributesTest", () => {
     const p = new Person({ name: "Alice" });
     const attrs = { ...p.attributes };
     attrs.name = "Bob";
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("children inherit attributes", () => {
@@ -263,7 +247,7 @@ describe("AttributesTest", () => {
     }
     class Child extends Parent {}
     const data = new Child({ integer_field: "4.4" });
-    expect(data.readAttribute("integer_field")).toBe(4);
+    expect(data._readAttribute("integer_field")).toBe(4);
   });
 
   it("unknown type error is raised", () => {
@@ -285,39 +269,10 @@ describe("attributesBeforeTypeCast", () => {
       }
     }
     const u = new User({ name: "Alice", age: "25" });
-    const raw = u.attributesBeforeTypeCast;
+    const raw = u._attributes.valuesBeforeTypeCast();
     expect(raw.name).toBe("Alice");
     expect(raw.age).toBe("25");
-    expect(u.readAttribute("age")).toBe(25);
-  });
-});
-
-describe("columnForAttribute()", () => {
-  it("returns type info for defined attribute", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const u = new User({ name: "Alice", age: 25 });
-    const col = u.columnForAttribute("name");
-    expect(col).not.toBeNull();
-    expect(col!.name).toBe("name");
-
-    const ageCol = u.columnForAttribute("age");
-    expect(ageCol).not.toBeNull();
-    expect(ageCol!.name).toBe("age");
-  });
-
-  it("returns null for unknown attribute", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const u = new User({ name: "Alice" });
-    expect(u.columnForAttribute("nonexistent")).toBeNull();
+    expect(u._readAttribute("age")).toBe(25);
   });
 });
 
@@ -345,56 +300,56 @@ describe("Attributes", () => {
 
   it("initializes with defaults", () => {
     const u = new User();
-    expect(u.readAttribute("name")).toBe(null);
-    expect(u.readAttribute("age")).toBe(0);
-    expect(u.readAttribute("active")).toBe(true);
+    expect(u._readAttribute("name")).toBe(null);
+    expect(u._readAttribute("age")).toBe(0);
+    expect(u._readAttribute("active")).toBe(true);
   });
 
   it("initializes with provided values", () => {
     const u = new User({ name: "dean", age: 30 });
-    expect(u.readAttribute("name")).toBe("dean");
-    expect(u.readAttribute("age")).toBe(30);
+    expect(u._readAttribute("name")).toBe("dean");
+    expect(u._readAttribute("age")).toBe(30);
   });
 
   it("casts string to integer", () => {
     const u = new User({ age: "25" });
-    expect(u.readAttribute("age")).toBe(25);
+    expect(u._readAttribute("age")).toBe(25);
   });
 
   it("integer truncates floats", () => {
     const u = new User({ age: 25.9 });
-    expect(u.readAttribute("age")).toBe(25);
+    expect(u._readAttribute("age")).toBe(25);
   });
 
   it("casts string to float", () => {
     const u = new User({ score: "9.5" });
-    expect(u.readAttribute("score")).toBe(9.5);
+    expect(u._readAttribute("score")).toBe(9.5);
   });
 
   it("casts string to boolean", () => {
     // Rails BooleanType: "yes"/"no" both truthy (neither in FALSE_VALUES).
-    expect(new User({ active: "false" }).readAttribute("active")).toBe(false);
-    expect(new User({ active: "true" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "yes" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "no" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "1" }).readAttribute("active")).toBe(true);
-    expect(new User({ active: "0" }).readAttribute("active")).toBe(false);
-    expect(new User({ active: 1 }).readAttribute("active")).toBe(true);
-    expect(new User({ active: 0 }).readAttribute("active")).toBe(false);
+    expect(new User({ active: "false" })._readAttribute("active")).toBe(false);
+    expect(new User({ active: "true" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "yes" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "no" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "1" })._readAttribute("active")).toBe(true);
+    expect(new User({ active: "0" })._readAttribute("active")).toBe(false);
+    expect(new User({ active: 1 })._readAttribute("active")).toBe(true);
+    expect(new User({ active: 0 })._readAttribute("active")).toBe(false);
   });
 
   it("casts null to null for all types", () => {
     const u = new User({ name: null, age: null, score: null, active: null });
-    expect(u.readAttribute("name")).toBe(null);
-    expect(u.readAttribute("age")).toBe(null);
-    expect(u.readAttribute("score")).toBe(null);
-    expect(u.readAttribute("active")).toBe(null);
+    expect(u._readAttribute("name")).toBe(null);
+    expect(u._readAttribute("age")).toBe(null);
+    expect(u._readAttribute("score")).toBe(null);
+    expect(u._readAttribute("active")).toBe(null);
   });
 
   it("writeAttribute casts the value", () => {
     const u = new User();
-    u.writeAttribute("age", "42");
-    expect(u.readAttribute("age")).toBe(42);
+    u._writeAttribute("age", "42");
+    expect(u._readAttribute("age")).toBe(42);
   });
 
   it("returns all attributes as a hash", () => {
@@ -405,22 +360,6 @@ describe("Attributes", () => {
       score: null,
       active: true,
     });
-  });
-
-  it("attributePresent checks for non-blank values", () => {
-    const u = new User({ name: "dean" });
-    expect(u.attributePresent("name")).toBe(true);
-    expect(u.attributePresent("score")).toBe(false);
-  });
-
-  it("attributePresent returns false for empty string", () => {
-    const u = new User({ name: "" });
-    expect(u.attributePresent("name")).toBe(false);
-  });
-
-  it("attributePresent returns false for whitespace-only string", () => {
-    const u = new User({ name: "   " });
-    expect(u.attributePresent("name")).toBe(false);
   });
 
   it("attributeNames returns declared names", () => {
@@ -434,8 +373,8 @@ describe("Attributes", () => {
         this.attribute("token", "string", { default: () => `tok_${++counter}` });
       }
     }
-    expect(new WithLambda().readAttribute("token")).toBe("tok_1");
-    expect(new WithLambda().readAttribute("token")).toBe("tok_2");
+    expect(new WithLambda()._readAttribute("token")).toBe("tok_1");
+    expect(new WithLambda()._readAttribute("token")).toBe("tok_2");
   });
 
   it("inheritance: children inherit parent attributes", () => {
@@ -445,8 +384,8 @@ describe("Attributes", () => {
       }
     }
     const admin = new Admin({ name: "dean" });
-    expect(admin.readAttribute("name")).toBe("dean");
-    expect(admin.readAttribute("role")).toBe("admin");
+    expect(admin._readAttribute("name")).toBe("dean");
+    expect(admin._readAttribute("role")).toBe("admin");
     expect(Admin.attributeNames()).toContain("name");
     expect(Admin.attributeNames()).toContain("role");
   });

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -276,7 +276,7 @@ describe("CallbacksTest", () => {
     const log: string[] = [];
     const auditor = {
       beforeValidation(record: any) {
-        log.push(`auditing ${record.readAttribute("name")}`);
+        log.push(`auditing ${record._readAttribute("name")}`);
       },
     };
     class Person extends Model {
@@ -333,7 +333,7 @@ describe("CallbacksTest", () => {
     const log: string[] = [];
     const observer = {
       beforeProcess(record: any) {
-        log.push(`processing ${record.readAttribute("name")}`);
+        log.push(`processing ${record._readAttribute("name")}`);
       },
     };
     class Job extends Model {
@@ -911,7 +911,7 @@ describe("Callbacks (extended)", () => {
         this.validate("validateCustom");
       }
       validateCustom() {
-        if (this.readAttribute("value") === 0) {
+        if (this._readAttribute("value") === 0) {
           this.errors.add("value", ":invalid", { message: "cannot be zero" });
         }
       }

--- a/packages/activemodel/src/conversion.test.ts
+++ b/packages/activemodel/src/conversion.test.ts
@@ -8,7 +8,7 @@ class Contact extends Model {
     this.attribute("id");
   }
   override isPersisted(): boolean {
-    return this.readAttribute("id") != null;
+    return this._readAttribute("id") != null;
   }
 }
 

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -9,7 +9,7 @@ describe("DirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changes["name"]).toEqual(["Alice", "Bob"]);
   });
 
@@ -20,7 +20,7 @@ describe("DirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.previousChanges["name"]).toEqual(["Alice", "Bob"]);
     expect(p.changed).toBe(false);
@@ -34,8 +34,8 @@ describe("DirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("age", 30);
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("age", 30);
     p.clearAttributeChanges(["name"]);
     expect(p.attributeChanged("name")).toBe(false);
     expect(p.attributeChanged("age")).toBe(true);
@@ -51,20 +51,20 @@ describe("DirtyTest", () => {
 
   it("setting attribute will result in change", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
   });
 
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changedAttributeNamesToSave).toContain("name");
     expect(p.changedAttributeNamesToSave).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChange("name")).toEqual(["Alice", "Bob"]);
   });
 
@@ -75,20 +75,20 @@ describe("DirtyTest", () => {
 
   it("checking if an attribute has changed to a particular value", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChanged("name", { to: "Bob" })).toBe(true);
     expect(p.attributeChanged("name", { to: "Charlie" })).toBe(false);
   });
 
   it("setting color to same value should not result in change being recorded", () => {
     const p = new DirtyPerson({ color: "red" });
-    p.writeAttribute("color", "red");
+    p._writeAttribute("color", "red");
     expect(p.changed).toBe(false);
   });
 
   it("saving should reset model's changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
     p.changesApplied();
     expect(p.changed).toBe(false);
@@ -96,29 +96,29 @@ describe("DirtyTest", () => {
 
   it("saving should preserve previous changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
   });
 
   it("setting new attributes should not affect previous changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
   });
 
   it("saving should preserve model's previous changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.attributePreviouslyChanged("name")).toBe(true);
   });
 
   it("checking if an attribute was previously changed to a particular value", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.attributePreviouslyChanged("name", { from: "Alice", to: "Bob" })).toBe(true);
     expect(p.attributePreviouslyChanged("name", { to: "Charlie" })).toBe(false);
@@ -127,11 +127,11 @@ describe("DirtyTest", () => {
   it("previous value is preserved when changed after save", () => {
     const p = new DirtyPerson({ name: "Alice" });
     expect(p.changedAttributes).toEqual({});
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     // Rails asserts `changed_attributes` — a name->old-value hash.
     expect(p.changedAttributes).toEqual({ name: "Alice" });
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     expect(p.changedAttributes).toEqual({ name: "Bob" });
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
     expect(p.changes).toEqual({ name: ["Bob", "Charlie"] });
@@ -139,16 +139,16 @@ describe("DirtyTest", () => {
 
   it("changing the same attribute multiple times retains the correct original value", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Charlie");
     expect(p.attributeChange("name")).toEqual(["Alice", "Charlie"]);
   });
 
   it("clear_changes_information should reset all changes", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
-    p.writeAttribute("name", "Charlie");
+    p._writeAttribute("name", "Charlie");
     p.clearChangesInformation();
     expect(p.changed).toBe(false);
     expect(Object.keys(p.previousChanges).length).toBe(0);
@@ -156,19 +156,19 @@ describe("DirtyTest", () => {
 
   it("restore_attributes should restore all previous data", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("age", 30);
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("age", 30);
     p.restoreAttributes();
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(25);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(25);
     expect(p.changed).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new DirtyPerson({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
-    p.writeAttribute("name", "Alice");
+    p._writeAttribute("name", "Alice");
     expect(p.changed).toBe(false);
   });
 
@@ -206,7 +206,7 @@ describe("DirtyTest", () => {
 
   it("to_json should work on model after save", () => {
     const p = new Person({ name: "Alice", age: 25 });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     const json = p.toJSON();
     expect(JSON.parse(json)).toEqual({ name: "Bob", age: 25 });
@@ -220,7 +220,7 @@ describe("DirtyTest", () => {
     }
     const p = new Person({ name: "Alice" });
     expect(p.changed).toBe(false);
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.changed).toBe(true);
     expect(p.changes).toEqual({ name: ["Alice", "Bob"] });
   });
@@ -232,7 +232,7 @@ describe("DirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     expect(p.attributeChanged("name")).toBe(true);
     expect(p.attributeWas("name")).toBe("Alice");
   });
@@ -253,27 +253,27 @@ describe("Dirty Tracking", () => {
 
   it("setting attribute will result in change", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     expect(p.changed).toBe(true);
     expect(p.changedAttributeNamesToSave).toContain("name");
   });
 
   it("attributeWas returns original value", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     expect(p.attributeWas("name")).toBe("dean");
   });
 
   it("changes to attribute values", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     expect(p.attributeChange("name")).toEqual(["dean", "sam"]);
   });
 
   it("list of changed attribute keys", () => {
     const p = new Person({ name: "dean", age: 30 });
-    p.writeAttribute("name", "sam");
-    p.writeAttribute("age", 31);
+    p._writeAttribute("name", "sam");
+    p._writeAttribute("age", 31);
     expect(p.changes).toEqual({
       name: ["dean", "sam"],
       age: [30, 31],
@@ -282,38 +282,38 @@ describe("Dirty Tracking", () => {
 
   it("setting color to same value should not result in change being recorded", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "dean");
+    p._writeAttribute("name", "dean");
     expect(p.changed).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     expect(p.changed).toBe(true);
-    p.writeAttribute("name", "dean");
+    p._writeAttribute("name", "dean");
     expect(p.changed).toBe(false);
   });
 
   it("changing the same attribute multiple times retains the correct original value", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
-    p.writeAttribute("name", "bob");
+    p._writeAttribute("name", "sam");
+    p._writeAttribute("name", "bob");
     expect(p.attributeChange("name")).toEqual(["dean", "bob"]);
   });
 
   it("restore_attributes should restore all previous data", () => {
     const p = new Person({ name: "dean", age: 30 });
-    p.writeAttribute("name", "sam");
-    p.writeAttribute("age", 99);
+    p._writeAttribute("name", "sam");
+    p._writeAttribute("age", 99);
     p.restoreAttributes();
-    expect(p.readAttribute("name")).toBe("dean");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("dean");
+    expect(p._readAttribute("age")).toBe(30);
     expect(p.changed).toBe(false);
   });
 
   it("saving should preserve previous changes", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     p.changesApplied();
     expect(p.changed).toBe(false);
     expect(p.previousChanges).toEqual({ name: ["dean", "sam"] });
@@ -321,9 +321,9 @@ describe("Dirty Tracking", () => {
 
   it("setting new attributes should not affect previous changes", () => {
     const p = new Person({ name: "dean" });
-    p.writeAttribute("name", "sam");
+    p._writeAttribute("name", "sam");
     p.changesApplied();
-    p.writeAttribute("name", "bob");
+    p._writeAttribute("name", "bob");
     expect(p.previousChanges).toEqual({ name: ["dean", "sam"] });
     expect(p.changes).toEqual({ name: ["sam", "bob"] });
   });
@@ -335,9 +335,9 @@ describe("Dirty Tracking", () => {
       }
     }
     const s = new Sized({ size: "2" });
-    s.writeAttribute("size", "2.3");
+    s._writeAttribute("size", "2.3");
     expect(s.changed).toBe(false);
-    s.writeAttribute("size", "5.1");
+    s._writeAttribute("size", "5.1");
     expect(s.changed).toBe(true);
   });
 });
@@ -350,8 +350,8 @@ describe("attributeBeforeTypeCast", () => {
     }
 
     const price = new Price({ amount: "42" });
-    expect(price.readAttribute("amount")).toBe(42);
-    expect(price.readAttributeBeforeTypeCast("amount")).toBe("42");
+    expect(price._readAttribute("amount")).toBe(42);
+    expect(price._attributes.getAttribute("amount").valueBeforeTypeCast).toBe("42");
   });
 
   it("tracks raw values on writeAttribute", () => {
@@ -362,9 +362,9 @@ describe("attributeBeforeTypeCast", () => {
     }
 
     const price = new Price({ amount: 10 });
-    price.writeAttribute("amount", "99");
-    expect(price.readAttribute("amount")).toBe(99);
-    expect(price.readAttributeBeforeTypeCast("amount")).toBe("99");
+    price._writeAttribute("amount", "99");
+    expect(price._readAttribute("amount")).toBe(99);
+    expect(price._attributes.getAttribute("amount").valueBeforeTypeCast).toBe("99");
   });
 });
 
@@ -379,7 +379,7 @@ describe("changedAttributeNamesToSave", () => {
 
     const w = new Widget({ name: "Test", size: 5 });
     w.changesApplied();
-    w.writeAttribute("name", "Changed");
+    w._writeAttribute("name", "Changed");
     expect(w.changedAttributeNamesToSave).toContain("name");
     expect(w.changedAttributeNamesToSave).not.toContain("size");
   });
@@ -396,11 +396,11 @@ describe("clearChangesInformation", () => {
 
     const p = new Person({ name: "Alice", age: 30 });
     p.changesApplied();
-    p.writeAttribute("name", "Bob");
+    p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(Object.keys(p.previousChanges).length).toBeGreaterThan(0);
 
-    p.writeAttribute("age", 31);
+    p._writeAttribute("age", 31);
     expect(p.changed).toBe(true);
 
     p.clearChangesInformation();
@@ -423,7 +423,7 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 });
@@ -439,8 +439,8 @@ describe("clearAttributeChanges", () => {
 
     const p = new Person({ name: "Alice", age: 30 });
     p.changesApplied();
-    p.writeAttribute("name", "Bob");
-    p.writeAttribute("age", 31);
+    p._writeAttribute("name", "Bob");
+    p._writeAttribute("age", 31);
     expect(p.changedAttributeNamesToSave).toContain("name");
     expect(p.changedAttributeNamesToSave).toContain("age");
 
@@ -459,7 +459,7 @@ describe("attributeChanged with from/to options", () => {
     }
     const u = new User({ name: "Alice" });
     u.changesApplied();
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.attributeChanged("name", { from: "Alice", to: "Bob" })).toBe(true);
   });
 
@@ -471,7 +471,7 @@ describe("attributeChanged with from/to options", () => {
     }
     const u = new User({ name: "Alice" });
     u.changesApplied();
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.attributeChanged("name", { from: "Charlie", to: "Bob" })).toBe(false);
   });
 
@@ -483,7 +483,7 @@ describe("attributeChanged with from/to options", () => {
     }
     const u = new User({ name: "Alice" });
     u.changesApplied();
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.attributeChanged("name", { from: "Alice", to: "Charlie" })).toBe(false);
   });
 
@@ -495,7 +495,7 @@ describe("attributeChanged with from/to options", () => {
     }
     const u = new User({ name: "Alice" });
     u.changesApplied();
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.attributeChanged("name", { from: "Alice" })).toBe(true);
     expect(u.attributeChanged("name", { from: "Wrong" })).toBe(false);
   });
@@ -508,7 +508,7 @@ describe("attributeChanged with from/to options", () => {
     }
     const u = new User({ name: "Alice" });
     u.changesApplied();
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.attributeChanged("name", { to: "Bob" })).toBe(true);
     expect(u.attributeChanged("name", { to: "Wrong" })).toBe(false);
   });
@@ -522,7 +522,7 @@ describe("attributePreviouslyChanged / attributePreviouslyWas", () => {
       }
     }
     const u = new User({ name: "Alice" });
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     u.changesApplied();
     expect(u.attributePreviouslyChanged("name")).toBe(true);
   });
@@ -534,7 +534,7 @@ describe("attributePreviouslyChanged / attributePreviouslyWas", () => {
       }
     }
     const u = new User({ name: "Alice" });
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     u.changesApplied();
     expect(u.attributePreviouslyChanged("name", { from: "Alice", to: "Bob" })).toBe(true);
     expect(u.attributePreviouslyChanged("name", { to: "Charlie" })).toBe(false);
@@ -547,7 +547,7 @@ describe("attributePreviouslyChanged / attributePreviouslyWas", () => {
       }
     }
     const u = new User({ name: "Alice" });
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     u.changesApplied();
     expect(u.attributePreviouslyWas("name")).toBe("Alice");
   });
@@ -564,7 +564,7 @@ describe("changesToSave", () => {
     User.attribute("age", "integer");
 
     const u = new User({ name: "Alice", age: 25 });
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     const changes = u.changesToSave;
     expect(changes["name"]).toEqual(["Alice", "Bob"]);
     expect(changes["age"]).toBeUndefined();
@@ -594,8 +594,8 @@ describe("attributesInDatabase", () => {
     User.attribute("age", "integer");
 
     const u = new User({ name: "Alice", age: 25 });
-    u.writeAttribute("name", "Bob");
-    u.writeAttribute("age", 30);
+    u._writeAttribute("name", "Bob");
+    u._writeAttribute("age", 30);
     const dbValues = u.attributesInDatabase;
     expect(dbValues["name"]).toBe("Alice");
     expect(dbValues["age"]).toBe(25);
@@ -636,7 +636,7 @@ describe("hasChangesToSave", () => {
     User.attribute("name", "string");
 
     const u = new User({ name: "Alice" });
-    u.writeAttribute("name", "Bob");
+    u._writeAttribute("name", "Bob");
     expect(u.hasChangesToSave).toBe(true);
   });
 });
@@ -652,7 +652,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const item = new Item({ count: 10 });
     item.changesApplied();
-    item.writeAttribute("count", "abc");
+    item._writeAttribute("count", "abc");
     expect(item.changedAttributeNamesToSave).toContain("count");
   });
 
@@ -670,7 +670,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.restoreAttributes();
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 
@@ -688,7 +688,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.changesApplied();
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 
@@ -703,7 +703,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,
     // not the snapshot original, to preserve Rails' attribute_will_change! semantics.
@@ -720,7 +720,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
     expect(m.changes).not.toHaveProperty("ratio");
   });
@@ -735,7 +735,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const item = new Item({ count: 1 });
     item.changesApplied();
-    item.writeAttribute("count", true);
+    item._writeAttribute("count", true);
     expect(item.changedAttributeNamesToSave).toContain("count");
   });
 
@@ -749,9 +749,9 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
 
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
-    m.writeAttribute("ratio", 1.0);
+    m._writeAttribute("ratio", 1.0);
     expect(m.changedAttributeNamesToSave).toContain("ratio");
-    m.writeAttribute("ratio", NaN);
+    m._writeAttribute("ratio", NaN);
     expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1467,16 +1467,6 @@ export class Model {
     }
   }
 
-  readAttribute(name: string, block?: (name: string) => unknown): unknown {
-    // Rails resolves alias_attribute names in `read_attribute`
-    // (attribute_aliases[name] || name, read.rb:31-34); `_read_attribute`
-    // skips it. Resolved against the loaded attribute set so the trails
-    // camelCase-key bridge cannot displace a name the record already owns.
-    const resolved = (this.constructor as typeof Model).resolveAttributeName(name);
-    if (this._attributes.has(resolved)) this._accessedFields.add(resolved);
-    return this._attributes.fetchValue(resolved, block) ?? null;
-  }
-
   /**
    * @internal
    * Mirrors AR `_read_attribute(attr_name, &block)` — reads directly from the
@@ -1494,15 +1484,6 @@ export class Model {
     this._writeAttribute(name, value);
   }
 
-  writeAttribute(name: string, value: unknown): void {
-    // Alias-resolve on the public write path; aliased writes land on the
-    // canonical attribute's dirty state (Rails `write_attribute`,
-    // write.rb:31-34). Resolved against the loaded attribute set to stay
-    // coherent with `readAttribute` / `hasAttribute`.
-    const resolved = (this.constructor as typeof Model).resolveAttributeName(name);
-    this._writeAttribute(resolved, value);
-  }
-
   /** @internal */
   _writeAttribute(name: string, value: unknown): void {
     this._attributes.writeFromUser(name, value);
@@ -1513,52 +1494,9 @@ export class Model {
     this._dirty.attributeWritten(name, newValue, value, this._attributes.getAttribute(name).type);
   }
 
-  /**
-   * Read the raw (uncast) value of an attribute.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_before_type_cast
-   */
-  readAttributeBeforeTypeCast(name: string): unknown {
-    const resolved = (this.constructor as typeof Model).resolveAttributeName(name);
-    return this._attributes.getAttribute(resolved).valueBeforeTypeCast ?? null;
-  }
-
   /** Mirrors ActiveModel::Serializers::JSON `class_attribute :include_root_in_json` instance reader. */
   get includeRootInJson(): boolean | string {
     return (this.constructor as typeof Model).includeRootInJson;
-  }
-
-  /**
-   * Get all attributes before type cast as a plain object.
-   *
-   * Mirrors: ActiveModel::Attributes#attributes_before_type_cast
-   */
-  get attributesBeforeTypeCast(): Record<string, unknown> {
-    return this._attributes.valuesBeforeTypeCast();
-  }
-
-  /**
-   * Get the type/metadata for an attribute.
-   *
-   * Mirrors: ActiveRecord::Base.column_for_attribute
-   */
-  columnForAttribute(name: string): { name: string; type: Type } | null {
-    const klass = this.constructor as typeof Model;
-    if (!Object.hasOwn(klass.attributeTypes(), name)) return null;
-    return { name, type: klass.typeForAttribute(name) };
-  }
-
-  /**
-   * Check if this model has the given attribute defined.
-   *
-   * Mirrors: ActiveRecord::AttributeMethods#has_attribute? — `attr_name =
-   * self.class.attribute_aliases[attr_name] || attr_name` then
-   * `@attributes.key?(attr_name)` (activerecord/attribute_methods.rb:316-320).
-   */
-  hasAttribute(name: string): boolean {
-    let attrName = String(name);
-    attrName = (this.constructor as typeof Model).attributeAliases[attrName] ?? attrName;
-    return this._attributes.isKey(attrName);
   }
 
   /**
@@ -1568,13 +1506,6 @@ export class Model {
    * methods and cannot carry an accessor's type across the mixin.
    */
   declare attributes: Record<string, unknown>;
-
-  attributePresent(name: string): boolean {
-    const value = this.readAttribute(name);
-    if (value === null || value === undefined) return false;
-    if (typeof value === "string" && value.trim() === "") return false;
-    return true;
-  }
 
   // Rails `validation_context` holds either a single Symbol or an
   // Array<Symbol> (or nil). `valid?([:create, :publish])` round-trips
@@ -1892,7 +1823,7 @@ export class Model {
   get attributesInDatabase(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const name of this._dirty.changedAttributeNames) {
-      result[name] = this._dirty.attributeWas(name) ?? this.readAttribute(name);
+      result[name] = this._dirty.attributeWas(name) ?? this._readAttribute(name);
     }
     return result;
   }
@@ -1923,7 +1854,7 @@ export class Model {
   attributePreviouslyWas(name: string): unknown {
     name = (this.constructor as typeof Model).resolveAttributeName(name);
     const change = this._dirty.previousChanges[name];
-    return change ? change[0] : this.readAttribute(name);
+    return change ? change[0] : this._readAttribute(name);
   }
 
   restoreAttributes(): void {
@@ -2098,7 +2029,7 @@ export class Model {
       }
     }
     for (const [key, value] of Object.entries(attrs)) {
-      this.writeAttribute(key, value);
+      this._writeAttribute(key, value);
     }
     return this;
   }
@@ -2236,7 +2167,9 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place?
    */
   attributeChangedInPlace(name: string): boolean {
-    const current = this.readAttribute(name);
+    const current = this._readAttribute(
+      (this.constructor as typeof Model).resolveAttributeName(name),
+    );
     const recorded = this._dirty.mutationsFromDatabase[name];
     if (recorded) return current !== recorded[1];
     const original = this._dirty.attributeWas(name);
@@ -2253,7 +2186,7 @@ export class Model {
   toKey(): unknown[] | null {
     // conversion.rb:67-70 — `key = respond_to?(:id) && id; key ? Array(key) : nil`.
     // `Array(key)` is what keeps a composite `id` from being double-wrapped.
-    const key = this.respondTo("id") ? this.readAttribute("id") : false;
+    const key = this.respondTo("id") ? this._readAttribute("id") : false;
     return key != null && key !== false ? wrap(key) : null;
   }
 
@@ -2290,7 +2223,7 @@ export class Model {
   slice(...methods: (string | string[])[]): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const m of methods.flat()) {
-      result[m] = this.readAttribute(m);
+      result[m] = this._readAttribute((this.constructor as typeof Model).resolveAttributeName(m));
     }
     return result;
   }
@@ -2301,7 +2234,9 @@ export class Model {
    * Mirrors: ActiveModel::Access#values_at
    */
   valuesAt(...methods: (string | string[])[]): unknown[] {
-    return methods.flat().map((m) => this.readAttribute(m));
+    return methods
+      .flat()
+      .map((m) => this._readAttribute((this.constructor as typeof Model).resolveAttributeName(m)));
   }
 
   runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown {

--- a/packages/activemodel/src/nested-error.test.ts
+++ b/packages/activemodel/src/nested-error.test.ts
@@ -39,7 +39,7 @@ describe("NestedErrorTest", () => {
   it("message", () => {
     const topic = new Topic({ author_name: "Bruce" });
     const innerError = new ActiveModelError(topic, "title", ":not_enough", {
-      message: (model: Topic) => `not good enough for ${model.readAttribute("author_name")}`,
+      message: (model: Topic) => `not good enough for ${model._readAttribute("author_name")}`,
     });
     const reply = new Reply({ author_name: "Mark" });
     const error = new NestedError(reply, innerError);
@@ -50,7 +50,7 @@ describe("NestedErrorTest", () => {
   it("full message", () => {
     const topic = new Topic({ author_name: "Bruce" });
     const innerError = new ActiveModelError(topic, "title", ":not_enough", {
-      message: (model: Topic) => `not good enough for ${model.readAttribute("author_name")}`,
+      message: (model: Topic) => `not good enough for ${model._readAttribute("author_name")}`,
     });
     const reply = new Reply({ author_name: "Mark" });
     const error = new NestedError(reply, innerError);

--- a/packages/activemodel/src/secure-password.test.ts
+++ b/packages/activemodel/src/secure-password.test.ts
@@ -108,9 +108,9 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    expect(u.readAttribute("password_digest")).not.toBe(null);
+    expect(u._readAttribute("password_digest")).not.toBe(null);
     (u as any).password = null;
-    expect(u.readAttribute("password_digest")).toBe(null);
+    expect(u._readAttribute("password_digest")).toBe(null);
   });
 
   it("update an existing user with validation and no change in password", async () => {
@@ -118,7 +118,7 @@ describe("SecurePasswordTest", () => {
     const u = new User({ name: "test" });
     (u as any).password = "secret";
     expect(await u.isValid()).toBe(true);
-    expect(u.readAttribute("password_digest")).not.toBe(null);
+    expect(u._readAttribute("password_digest")).not.toBe(null);
   });
 
   it("update an existing user with validations and valid password/confirmation", async () => {
@@ -133,7 +133,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test", password_digest: "$2a$04$existing" });
     (u as any).password = "";
-    expect(u.readAttribute("password_digest")).toBe("$2a$04$existing");
+    expect(u._readAttribute("password_digest")).toBe("$2a$04$existing");
   });
 
   it("updating an existing user with validation and a spaces only password", async () => {
@@ -148,7 +148,7 @@ describe("SecurePasswordTest", () => {
     const u = new User({ name: "test", password_digest: "$2a$04$existing" });
     (u as any).password = "";
     (u as any).passwordConfirmation = "";
-    expect(u.readAttribute("password_digest")).toBe("$2a$04$existing");
+    expect(u._readAttribute("password_digest")).toBe("$2a$04$existing");
   });
 
   it("updating an existing user with validation and a nil password", () => {
@@ -156,7 +156,7 @@ describe("SecurePasswordTest", () => {
     const u = new User({ name: "test" });
     (u as any).password = "secret";
     (u as any).password = null;
-    expect(u.readAttribute("password_digest")).toBe(null);
+    expect(u._readAttribute("password_digest")).toBe(null);
   });
 
   it("updating an existing user with validation and password length greater than 72", async () => {
@@ -228,14 +228,14 @@ describe("SecurePasswordTest", () => {
   it("updating an existing user with validation and a blank password digest", async () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    u.writeAttribute("password_digest", "");
+    u._writeAttribute("password_digest", "");
     expect(await u.isValid()).toBe(false);
   });
 
   it("updating an existing user with validation and a nil password digest", async () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    u.writeAttribute("password_digest", null);
+    u._writeAttribute("password_digest", null);
     expect(await u.isValid()).toBe(false);
   });
 
@@ -243,9 +243,9 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    const digest = u.readAttribute("password_digest");
+    const digest = u._readAttribute("password_digest");
     (u as any).password = "";
-    expect(u.readAttribute("password_digest")).toBe(digest);
+    expect(u._readAttribute("password_digest")).toBe(digest);
   });
 
   it("setting a nil password should clear an existing password", () => {
@@ -253,7 +253,7 @@ describe("SecurePasswordTest", () => {
     const u = new User({ name: "test" });
     (u as any).password = "secret";
     (u as any).password = null;
-    expect(u.readAttribute("password_digest")).toBe(null);
+    expect(u._readAttribute("password_digest")).toBe(null);
   });
 
   it("override secure password attribute", () => {
@@ -266,7 +266,7 @@ describe("SecurePasswordTest", () => {
     hasSecurePassword(User, "token");
     const u = new User({ name: "test" });
     (u as any).token = "mytoken";
-    expect(u.readAttribute("token_digest")).not.toBe(null);
+    expect(u._readAttribute("token_digest")).not.toBe(null);
     expect((u as any).authenticateToken("mytoken")).toBe(u);
     expect((u as any).authenticateToken("wrong")).toBe(false);
   });
@@ -289,7 +289,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    const digest = u.readAttribute("password_digest") as string;
+    const digest = u._readAttribute("password_digest") as string;
     const salt = digest.slice(0, 29);
     expect(salt).toMatch(/^\$2[aby]?\$\d{2}\$[./A-Za-z0-9]{22}$/);
   });
@@ -298,13 +298,13 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     expect((u as any).password).toBe(null);
-    expect(u.readAttribute("password_digest")).toBe(null);
+    expect(u._readAttribute("password_digest")).toBe(null);
   });
 
   it("password_salt should return nil when password digest is nil", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    expect(u.readAttribute("password_digest")).toBe(null);
+    expect(u._readAttribute("password_digest")).toBe(null);
   });
 
   it("Password digest cost defaults to bcrypt default cost when min_cost is false", () => {
@@ -312,7 +312,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    const digest = u.readAttribute("password_digest") as string;
+    const digest = u._readAttribute("password_digest") as string;
     expect(digest).toMatch(/\$12\$/);
   });
 
@@ -321,7 +321,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    const digest = u.readAttribute("password_digest") as string;
+    const digest = u._readAttribute("password_digest") as string;
     expect(digest).toMatch(/\$12\$/);
     expect((u as any).authenticate("secret")).toBe(u);
   });
@@ -331,7 +331,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    const digest = u.readAttribute("password_digest") as string;
+    const digest = u._readAttribute("password_digest") as string;
     expect(digest).toContain("$04$");
   });
 
@@ -339,7 +339,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    expect(u.readAttribute("password_digest")).not.toBe(null);
+    expect(u._readAttribute("password_digest")).not.toBe(null);
     (u as any).password = "newpassword";
     expect((u as any).authenticate("newpassword")).toBe(u);
     expect((u as any).authenticate("secret")).toBe(false);
@@ -348,7 +348,7 @@ describe("SecurePasswordTest", () => {
   it("constructor mass-assignment hashes password and removes plaintext", () => {
     const User = createUserClass();
     const u = new User({ name: "test", password: "secret" });
-    expect(u.readAttribute("password_digest")).not.toBe(null);
+    expect(u._readAttribute("password_digest")).not.toBe(null);
     expect(u.attributes.password).toBeUndefined();
     expect((u as any).authenticate("secret")).toBe(u);
   });
@@ -357,7 +357,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
     (u as any).password = "secret";
-    expect(u.readAttribute("password_digest")).not.toBe(null);
+    expect(u._readAttribute("password_digest")).not.toBe(null);
     expect((u as any).authenticate("secret")).toBe(u);
   });
 
@@ -365,7 +365,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const builder = new User({ name: "test" });
     (builder as any).password = "secret";
-    const digest = builder.readAttribute("password_digest");
+    const digest = builder._readAttribute("password_digest");
     const u = new User({ name: "test", password_digest: digest });
     expect(await u.isValid()).toBe(true);
     (u as any).passwordChallenge = "secret";
@@ -386,7 +386,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const builder = new User({ name: "test" });
     (builder as any).password = "secret";
-    const digest = builder.readAttribute("password_digest");
+    const digest = builder._readAttribute("password_digest");
     const u = new User({ name: "test", password_digest: digest });
     expect(await u.isValid()).toBe(true);
     (u as any).password = "newpassword";
@@ -419,7 +419,7 @@ describe("SecurePasswordTest", () => {
     const User = createUserClass();
     const builder = new User({ name: "test" });
     (builder as any).password = "secret";
-    const digest = builder.readAttribute("password_digest");
+    const digest = builder._readAttribute("password_digest");
     const u = new User({ name: "test", password_digest: digest });
     (u as any).passwordChallenge = "wrong";
     expect(await u.isValid()).toBe(false);
@@ -454,7 +454,7 @@ describe("SecurePasswordTest", () => {
   it("whitespace-only password digest treated as blank", async () => {
     const User = createUserClass();
     const u = new User({ name: "test" });
-    u.writeAttribute("password_digest", "   ");
+    u._writeAttribute("password_digest", "   ");
     expect(await u.isValid()).toBe(false);
     expect(u.errors.messagesFor("password")).toContain("can't be blank");
   });

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -63,10 +63,10 @@ export function hasSecurePassword(
 
   Object.defineProperty(modelClass.prototype, confirmationAttr, {
     get(this: Model) {
-      return this.readAttribute(confirmationAttr);
+      return this._readAttribute(confirmationAttr);
     },
     set(this: Model, value: unknown) {
-      this.writeAttribute(confirmationAttr, value);
+      this._writeAttribute(confirmationAttr, value);
     },
     configurable: true,
   });
@@ -85,7 +85,7 @@ export function hasSecurePassword(
   const saltMethodName = `${attribute}Salt`;
   Object.defineProperty(modelClass.prototype, saltMethodName, {
     get(this: Model) {
-      const digest = this.readAttribute(digestAttr) as string | null;
+      const digest = this._readAttribute(digestAttr) as string | null;
       if (!digest) return null;
       return bcrypt.getSalt(digest);
     },
@@ -98,7 +98,7 @@ export function hasSecurePassword(
   Object.defineProperty(modelClass.prototype, authMethodName, {
     value: function (this: Model, unencryptedPassword: unknown) {
       if (typeof unencryptedPassword !== "string" || !unencryptedPassword) return false;
-      const digest = this.readAttribute(digestAttr) as string | null;
+      const digest = this._readAttribute(digestAttr) as string | null;
       if (!digest) return false;
       return bcrypt.compareSync(unencryptedPassword, digest) ? this : false;
     },
@@ -108,7 +108,7 @@ export function hasSecurePassword(
 
   modelClass.afterInitialize((record: Model) => {
     if (record._attributes.has(attribute)) {
-      const plaintext = record.readAttribute(attribute);
+      const plaintext = record._readAttribute(attribute);
       record._attributes.delete(attribute);
       setPassword(record, plaintext, attribute, digestAttr, passwordCache);
     }
@@ -117,7 +117,7 @@ export function hasSecurePassword(
   if (validations) {
     modelClass.validate((record: Model) => {
       const pwd = passwordCache.get(record);
-      const digest = record.readAttribute(digestAttr);
+      const digest = record._readAttribute(digestAttr);
 
       if (isBlank(digest) && (pwd === undefined || pwd === null)) {
         record.errors.add(attribute, ":blank");
@@ -142,7 +142,7 @@ export function hasSecurePassword(
         const humanAttr = modelClass.humanAttributeName
           ? modelClass.humanAttributeName(attribute)
           : humanize(attribute);
-        const confirmation = record.readAttribute(confirmationAttr);
+        const confirmation = record._readAttribute(confirmationAttr);
         if (confirmation !== undefined && confirmation !== null && pwd !== confirmation) {
           record.errors.add(attribute, ":confirmation", { attribute: humanAttr });
         }
@@ -160,7 +160,7 @@ function setPassword(
 ) {
   if (value === null || value === undefined) {
     passwordCache.set(instance, null);
-    instance.writeAttribute(digestAttr, null);
+    instance._writeAttribute(digestAttr, null);
     return;
   }
   const str = String(value);
@@ -169,7 +169,7 @@ function setPassword(
   }
   passwordCache.set(instance, str);
   const cost = SecurePassword.minCost ? MIN_COST : DEFAULT_COST;
-  instance.writeAttribute(digestAttr, bcrypt.hashSync(str, cost));
+  instance._writeAttribute(digestAttr, bcrypt.hashSync(str, cost));
 }
 
 /**

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -52,7 +52,7 @@ describe("SerializationTest", () => {
         this.attribute("name", "string");
       }
       get name(): string {
-        return "OVERRIDE:" + (this.readAttribute("name") as string);
+        return "OVERRIDE:" + (this._readAttribute("name") as string);
       }
     }
     const p = new Person({ name: "Bob" });
@@ -116,7 +116,7 @@ describe("SerializationTest", () => {
         this.attribute("name", "string");
       }
       greeting(): string {
-        return "Hi " + (this.readAttribute("name") as string);
+        return "Hi " + (this._readAttribute("name") as string);
       }
     }
     const p = new Person({ name: "Bob" });
@@ -339,7 +339,7 @@ describe("SerializationTest", () => {
       this.attribute("email", "string");
     }
     get greeting(): string {
-      return `Hi ${this.readAttribute("name")}`;
+      return `Hi ${this._readAttribute("name")}`;
     }
   }
 
@@ -543,7 +543,7 @@ describe("SerializationTest", () => {
       }
       const w = new Weird({ toJSON: "raw-value", name: "w" });
       expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
-      expect(w.readAttribute("toJSON")).toBe("raw-value");
+      expect(w._readAttribute("toJSON")).toBe("raw-value");
     });
 
     it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
@@ -596,7 +596,7 @@ describe("Serialization", () => {
     }
 
     get summary(): string {
-      return String(this.readAttribute("title")).slice(0, 10);
+      return String(this._readAttribute("title")).slice(0, 10);
     }
   }
 
@@ -670,8 +670,8 @@ describe("fromJson", () => {
     }
     const u = new User({});
     u.fromJson('{"name":"Alice","age":30}');
-    expect(u.readAttribute("name")).toBe("Alice");
-    expect(u.readAttribute("age")).toBe(30);
+    expect(u._readAttribute("name")).toBe("Alice");
+    expect(u._readAttribute("age")).toBe(30);
   });
 
   it("returns this for chaining", () => {
@@ -693,7 +693,7 @@ describe("fromJson", () => {
     }
     const u = new User({});
     u.fromJson('{"user":{"name":"Charlie"}}', true);
-    expect(u.readAttribute("name")).toBe("Charlie");
+    expect(u._readAttribute("name")).toBe("Charlie");
   });
 
   it("marks attributes as changed via dirty tracking", () => {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -7,7 +7,6 @@ export interface SerializationRecord {
   [key: string]: unknown;
   _attributes?: unknown;
   attributes?: Record<string, unknown>;
-  readAttribute?: (key: string) => unknown;
   constructor: { name: string };
 }
 

--- a/packages/activemodel/src/serializers/json-serialization.test.ts
+++ b/packages/activemodel/src/serializers/json-serialization.test.ts
@@ -42,7 +42,7 @@ describe("JsonSerializationTest", () => {
         this.attribute("name", "string");
       }
       greeting() {
-        return `Hello ${this.readAttribute("name")}`;
+        return `Hello ${this._readAttribute("name")}`;
       }
     }
     const p = new Person({ name: "Alice" });
@@ -59,8 +59,8 @@ describe("JsonSerializationTest", () => {
     }
     const p = new Person();
     p.fromJson('{"name":"Bob","age":30}');
-    expect(p.readAttribute("name")).toBe("Bob");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("Bob");
+    expect(p._readAttribute("age")).toBe(30);
   });
 
   it("as_json should work with root option set to string", () => {
@@ -195,14 +195,14 @@ describe("JsonSerializationTest", () => {
   it("from_json should work without a root (class attribute)", () => {
     const p = new JsonPerson({});
     p.fromJson('{"name":"Alice","age":30}');
-    expect(p.readAttribute("name")).toBe("Alice");
-    expect(p.readAttribute("age")).toBe(30);
+    expect(p._readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("age")).toBe(30);
   });
 
   it("from_json should work with a root (method parameter)", () => {
     const p = new JsonPerson({});
     p.fromJson('{"json_person":{"name":"Alice","age":30}}', true);
-    expect(p.readAttribute("name")).toBe("Alice");
+    expect(p._readAttribute("name")).toBe("Alice");
   });
 
   it("should include root in JSON if include_root_in_json is true", () => {
@@ -360,7 +360,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const m = new Multi({}).fromJson('{"first":{"name":"Carol"},"person":{"name":"Dan"}}');
-      expect(m.readAttribute("name")).toBe("Carol");
+      expect(m._readAttribute("name")).toBe("Carol");
     } finally {
       Multi.includeRootInJson = false;
     }
@@ -403,7 +403,7 @@ describe("JsonSerializationTest", () => {
     }
     try {
       const w = new Wrapped({}).fromJson('{"wrapped":{"name":"Alice"}}');
-      expect(w.readAttribute("name")).toBe("Alice");
+      expect(w._readAttribute("name")).toBe("Alice");
     } finally {
       Wrapped.includeRootInJson = false;
     }

--- a/packages/activemodel/src/type/decimal.trails.test.ts
+++ b/packages/activemodel/src/type/decimal.trails.test.ts
@@ -50,7 +50,7 @@ describe("DecimalTypeTrails", () => {
       }
     }
     const m = new MyModel({ price: "1.0" });
-    m.writeAttribute("price", "1.0");
+    m._writeAttribute("price", "1.0");
     expect(m.attributeChanged("price")).toBe(false);
   });
 });

--- a/packages/activemodel/src/type/float.trails.test.ts
+++ b/packages/activemodel/src/type/float.trails.test.ts
@@ -9,8 +9,8 @@ describe("FloatType (trails)", () => {
       }
     }
     const m = new MyModel({ value: 1.5 });
-    m.writeAttribute("value", 2.5);
-    expect(m.readAttribute("value")).toBe(2.5);
+    m._writeAttribute("value", 2.5);
+    expect(m._readAttribute("value")).toBe(2.5);
     expect(m.attributeChanged("value")).toBe(true);
   });
 

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -320,7 +320,7 @@ describe("ValidationsTest (trails)", () => {
       override async isValid(): Promise<boolean> {
         const valid = await super.isValid();
         if (!valid) return false;
-        const name = this.readAttribute("name") as string;
+        const name = this._readAttribute("name") as string;
         if (UniqueUser.existingNames.has(name)) {
           this.errors.add("name", "has already been taken");
           return false;
@@ -378,7 +378,7 @@ describe("ValidationsTest (trails)", () => {
         this.attribute("first", "string");
       }
       get fullName(): string {
-        return (this.readAttribute("first") as string) ?? "";
+        return (this._readAttribute("first") as string) ?? "";
       }
     }
     Person.validatesEach(["fullName"], (record, attr, value) => {
@@ -823,7 +823,7 @@ describe("ValidationsTest (trails)", () => {
             },
             {
               if: (record) =>
-                (record as unknown as { readAttribute(a: string): unknown }).readAttribute(
+                (record as unknown as { _readAttribute(a: string): unknown })._readAttribute(
                   "price",
                 ) !== null,
             },
@@ -840,7 +840,7 @@ describe("ValidationsTest (trails)", () => {
     it("validation with class that adds errors", async () => {
       class EvenValidator {
         validate(record: any) {
-          const val = record.readAttribute("count");
+          const val = record._readAttribute("count");
           if (typeof val === "number" && val % 2 !== 0) {
             record.errors.add("count", ":invalid", { message: "must be even" });
           }
@@ -869,7 +869,7 @@ describe("ValidationsTest (trails)", () => {
           this.threshold = options.threshold ?? 10;
         }
         validate(record: any) {
-          const val = record.readAttribute("score");
+          const val = record._readAttribute("score");
           if (typeof val === "number" && val < this.threshold) {
             record.errors.add("score", ":invalid", {
               message: `must be at least ${this.threshold}`,
@@ -904,7 +904,7 @@ describe("ValidationsTest (trails)", () => {
         static {
           this.attribute("active", "boolean");
           this.validatesWith(AlwaysInvalidValidator, {
-            if: (r: any) => r.readAttribute("active") === true,
+            if: (r: any) => r._readAttribute("active") === true,
           });
         }
       }
@@ -1259,7 +1259,7 @@ describe("ValidationsTest (trails)", () => {
             this.attribute("requireName", "boolean", { default: false });
             this.validates("name", {
               presence: {
-                if: (r: any) => r.readAttribute("requireName") === true,
+                if: (r: any) => r._readAttribute("requireName") === true,
               },
             });
           }
@@ -1275,7 +1275,7 @@ describe("ValidationsTest (trails)", () => {
             this.attribute("optional", "boolean", { default: false });
             this.validates("name", {
               presence: {
-                unless: (r: any) => r.readAttribute("optional") === true,
+                unless: (r: any) => r._readAttribute("optional") === true,
               },
             });
           }
@@ -1291,7 +1291,7 @@ describe("ValidationsTest (trails)", () => {
           static {
             this.attribute("value", "integer");
             this.validate(function (record: any) {
-              const val = record.readAttribute("value");
+              const val = record._readAttribute("value");
               if (val !== null && (val as number) % 2 !== 0) {
                 record.errors.add("value", ":even", { message: "must be even" });
               }
@@ -1351,7 +1351,7 @@ describe("ValidationsTest (trails)", () => {
       const c = new Clearable();
       await c.isValid();
       expect(c.errors.count).toBeGreaterThan(0);
-      c.writeAttribute("name", "dean");
+      c._writeAttribute("name", "dean");
       await c.isValid();
       expect(c.errors.count).toBe(0);
     });
@@ -1609,7 +1609,7 @@ describe("ValidationsTest (trails)", () => {
           this.attribute("requires_name", "boolean");
           this.validates("name", {
             presence: true,
-            if: (record: any) => record.readAttribute("requires_name") === true,
+            if: (record: any) => record._readAttribute("requires_name") === true,
           });
         }
       }
@@ -1624,7 +1624,7 @@ describe("ValidationsTest (trails)", () => {
           this.attribute("requires_name", "boolean");
           this.validates("name", {
             presence: true,
-            if: (record: any) => record.readAttribute("requires_name") === true,
+            if: (record: any) => record._readAttribute("requires_name") === true,
           });
         }
       }
@@ -1639,7 +1639,7 @@ describe("ValidationsTest (trails)", () => {
           this.attribute("skip_validation", "boolean");
           this.validates("name", {
             presence: true,
-            unless: (record: any) => record.readAttribute("skip_validation") === true,
+            unless: (record: any) => record._readAttribute("skip_validation") === true,
           });
         }
       }
@@ -1654,7 +1654,7 @@ describe("ValidationsTest (trails)", () => {
           this.attribute("skip_validation", "boolean");
           this.validates("name", {
             presence: true,
-            unless: (record: any) => record.readAttribute("skip_validation") === true,
+            unless: (record: any) => record._readAttribute("skip_validation") === true,
           });
         }
       }

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -46,7 +46,7 @@ describe("AcceptanceValidationTest", () => {
       }
     }
     const p = new Person({});
-    expect(p.hasAttribute("terms")).toBe(true);
+    expect(p._attributes.isKey("terms")).toBe(true);
   });
 
   it("terms of service agreement no acceptance", async () => {

--- a/packages/activemodel/src/validations/callbacks.test.ts
+++ b/packages/activemodel/src/validations/callbacks.test.ts
@@ -277,7 +277,7 @@ describe("CallbacksWithMethodNamesShouldBeCalled", () => {
           (_r: any) => {
             log.push("before");
           },
-          { if: (r: any) => r.readAttribute("name") === "trigger" },
+          { if: (r: any) => r._readAttribute("name") === "trigger" },
         );
       }
     }

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -33,7 +33,7 @@ export class ConfirmationValidator extends EachValidator {
     const confirmationAttr = `${attribute}Confirmation`;
     const rec = record as unknown as Record<string, unknown>;
     const confirmed =
-      (rec.readAttribute as ((a: string) => unknown) | undefined)?.(confirmationAttr) ??
+      (rec._readAttribute as ((a: string) => unknown) | undefined)?.(confirmationAttr) ??
       rec[confirmationAttr];
     if (confirmed == null) return;
     if (!this.isConfirmationValueEqual(record, attribute, value, confirmed)) {

--- a/packages/activemodel/src/validations/length-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/length-validation.trails.test.ts
@@ -38,7 +38,7 @@ describe("LengthValidator (trails)", () => {
   it("resolves a Proc maximum against the record", async () => {
     // Rails length.rb:55 — `check_value = resolve_value(record, check_value)`.
     Person.validatesLengthOf("title", {
-      maximum: (r: Person) => r.readAttribute("limit") as number,
+      maximum: (r: Person) => r._readAttribute("limit") as number,
     });
     expect(await new Person({ title: "abc", limit: 5 }).isValid()).toBe(true);
     expect(await new Person({ title: "abcdef", limit: 5 }).isValid()).toBe(false);

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -51,7 +51,7 @@ class Topic extends Model {
   // suffix, reading the ivar directly.
   attributeBeforeTypeCast(attr: string): unknown {
     if (attr === "price") return this._price;
-    return this.readAttributeBeforeTypeCast(attr);
+    return this._attributes.getAttribute(attr).valueBeforeTypeCast;
   }
 }
 

--- a/packages/activemodel/src/validations/numericality-validation.trails.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.trails.test.ts
@@ -94,7 +94,7 @@ describe("NumericalityValidator (trails-only)", () => {
       errors = { add: vi.fn() };
       scoreCameFromUser = true;
       scoreBeforeTypeCast = "abc";
-      readAttribute(_name: string) {
+      _readAttribute(_name: string) {
         return 0;
       }
     }
@@ -179,7 +179,7 @@ describe("NumericalityValidator (trails-only)", () => {
       errors = { add: vi.fn() };
       scoreCameFromUser = false;
       scoreBeforeTypeCast = "not-a-number-string";
-      readAttribute(_name: string) {
+      _readAttribute(_name: string) {
         return 42;
       }
     }
@@ -202,7 +202,7 @@ describe("NumericalityValidator (trails-only)", () => {
     class MockRecord {
       errors = { add: vi.fn() };
       scoreCameFromUser = false;
-      readAttribute(_name: string) {
+      _readAttribute(_name: string) {
         return 99;
       }
     }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -432,8 +432,8 @@ export function prepareValueForValidation(
   if (cameFromUser in r) {
     if (r[cameFromUser]) {
       rawValue = r[`${attrName}BeforeTypeCast`];
-    } else if (typeof r.readAttribute === "function") {
-      rawValue = r.readAttribute(attrName);
+    } else if (typeof r._readAttribute === "function") {
+      rawValue = r._readAttribute(attrName);
     }
   } else {
     const beforeTypeCast = `${attrName}BeforeTypeCast`;
@@ -449,7 +449,7 @@ export function prepareValueForValidation(
 
 interface RecordWithRawAttribute {
   attributeChangedInPlace?: (name: string) => boolean;
-  readAttribute?: (name: string) => unknown;
+  _readAttribute?: (name: string) => unknown;
   [key: string]: unknown;
 }
 

--- a/packages/activemodel/src/validations/validates.test.ts
+++ b/packages/activemodel/src/validations/validates.test.ts
@@ -147,7 +147,7 @@ describe("ValidatesTest", () => {
         this.attribute("active", "boolean");
         this.validates("name", {
           presence: true,
-          if: (r: any) => r.readAttribute("active") === true,
+          if: (r: any) => r._readAttribute("active") === true,
         });
       }
     }
@@ -162,7 +162,7 @@ describe("ValidatesTest", () => {
         this.attribute("skip", "boolean");
         this.validates("name", {
           presence: true,
-          unless: (r: any) => r.readAttribute("skip") === true,
+          unless: (r: any) => r._readAttribute("skip") === true,
         });
       }
     }
@@ -173,7 +173,7 @@ describe("ValidatesTest", () => {
   it("validates with validator class", async () => {
     class MyValidator {
       validate(record: any) {
-        if (!record.readAttribute("name")) {
+        if (!record._readAttribute("name")) {
           record.errors.add("name", ":blank", { message: "must be present" });
         }
       }
@@ -193,7 +193,7 @@ describe("ValidatesTest", () => {
     const Validators = {
       NameValidator: class {
         validate(record: any) {
-          if (!record.readAttribute("name")) {
+          if (!record._readAttribute("name")) {
             record.errors.add("name", ":blank", { message: "is required" });
           }
         }
@@ -240,7 +240,7 @@ describe("ValidatesTest", () => {
         this.validates("name", {
           presence: true,
           length: { minimum: 3 },
-          if: (r: any) => r.readAttribute("active") === true,
+          if: (r: any) => r._readAttribute("active") === true,
         });
       }
     }
@@ -271,7 +271,7 @@ describe("ValidatesTest", () => {
         this.min = options.minimum ?? 0;
       }
       validate(record: any) {
-        const val = record.readAttribute("name");
+        const val = record._readAttribute("name");
         if (typeof val === "string" && val.length < this.min) {
           record.errors.add("name", ":too_short", { message: "is too short" });
         }

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -12,7 +12,7 @@ describe("ValidatesWithTest", () => {
         this.minLength = options.minLength ?? 3;
       }
       validate(record: any) {
-        const name = record.readAttribute("name");
+        const name = record._readAttribute("name");
         if (typeof name === "string" && name.length < this.minLength) {
           record.errors.add("name", ":invalid", { message: "too short" });
         }
@@ -33,14 +33,14 @@ describe("ValidatesWithTest", () => {
   it("with multiple classes", async () => {
     class V1 {
       validate(record: any) {
-        if (!record.readAttribute("name")) {
+        if (!record._readAttribute("name")) {
           record.errors.add("name", ":blank");
         }
       }
     }
     class V2 {
       validate(record: any) {
-        if (!record.readAttribute("age")) {
+        if (!record._readAttribute("age")) {
           record.errors.add("age", ":blank");
         }
       }
@@ -61,7 +61,7 @@ describe("ValidatesWithTest", () => {
   it("validates_with preserves standard options", async () => {
     class CustomValidator {
       validate(record: any) {
-        if (!record.readAttribute("name")) {
+        if (!record._readAttribute("name")) {
           record.errors.add("name", ":blank");
         }
       }
@@ -200,7 +200,7 @@ describe("ValidatesWithTest", () => {
         this.attribute("name", "string");
       }
       customValidation() {
-        if (!this.readAttribute("name")) {
+        if (!this._readAttribute("name")) {
           this.errors.add("name", ":blank");
         }
       }
@@ -217,7 +217,7 @@ describe("ValidatesWithTest", () => {
         this.attribute("name", "string");
       }
       checkName() {
-        if (!this.readAttribute("name")) {
+        if (!this._readAttribute("name")) {
           this.errors.add("name", ":blank");
         }
       }
@@ -250,7 +250,7 @@ describe("ValidatesWithTest", () => {
   it("validation with class that adds errors", async () => {
     class CustomValidator {
       validate(record: any) {
-        const val = record.readAttribute("name");
+        const val = record._readAttribute("name");
         if (!val || val === "") {
           record.errors.add("name", ":blank");
         }
@@ -290,7 +290,7 @@ describe("ValidatesWithTest", () => {
         this.min = opts.minimum ?? 0;
       }
       validate(record: any) {
-        const val = record.readAttribute("name");
+        const val = record._readAttribute("name");
         if (typeof val === "string" && val.length < this.min) {
           record.errors.add("name", ":too_short");
         }

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -112,8 +112,8 @@ export class EachValidator<TBase extends object = object> extends Validator<TBas
     if (typeof rec.readAttributeForValidation === "function") {
       return (rec.readAttributeForValidation as (a: string) => unknown)(attribute);
     }
-    if (typeof rec.readAttribute === "function") {
-      return (rec.readAttribute as (a: string) => unknown)(attribute);
+    if (typeof rec._readAttribute === "function") {
+      return (rec._readAttribute as (a: string) => unknown)(attribute);
     }
     return rec[attribute];
   }

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -465,6 +465,18 @@ describe("define_attribute_methods abstract gate (trails)", () => {
   });
 });
 
+class AccessTopic extends Base {
+  static {
+    this.attribute("title", "string");
+    this.attribute("body", "string");
+  }
+}
+type TrackingTopic = InstanceType<typeof AccessTopic> & {
+  title: string;
+  slice(...names: string[]): Record<string, unknown>;
+  valuesAt(...names: string[]): unknown[];
+};
+
 describe("ActiveRecord attribute read/write surface lives on Base, not Model", () => {
   it("defines the ActiveRecord-only members on Base.prototype", () => {
     for (const name of [
@@ -481,20 +493,20 @@ describe("ActiveRecord attribute read/write surface lives on Base, not Model", (
     }
   });
 
-  it("marks the field accessed when read through readAttribute", () => {
-    // Rails tracks the read inside `fetch_value` (activemodel/attribute.rb:44-47),
-    // which `read_attribute` reaches at read.rb:33, so a public read counts
-    // toward `accessed_fields` (attribute_methods.rb:460). trails keeps the
-    // marker on the record, so `readAttribute` has to set it itself.
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-        this.attribute("body", "string");
-      }
-    }
-    const t = Topic.new({ title: "access-test", body: "hello" });
+  // Rails marks a read on the Attribute itself, inside `fetch_value`
+  // (activemodel/attribute.rb:41-44), so every public read path feeds
+  // `accessed_fields` (attribute_methods.rb:460). trails keeps the marker on the
+  // record, so each of these paths has to set it; `slice` and `valuesAt` are
+  // Base's own (persistence.ts), which read through `readAttribute`.
+  it.each([
+    ["readAttribute", (t: TrackingTopic) => t.readAttribute("title")],
+    ["the generated reader", (t: TrackingTopic) => t.title],
+    ["slice", (t: TrackingTopic) => t.slice("title")],
+    ["valuesAt", (t: TrackingTopic) => t.valuesAt("title")],
+  ] as const)("marks the field accessed when read through %s", (_label, read) => {
+    const t = AccessTopic.new({ title: "access-test", body: "hello" }) as TrackingTopic;
     expect(t.accessedFields()).toEqual([]);
-    t.readAttribute("title");
+    read(t);
     expect(t.accessedFields()).toEqual(["title"]);
   });
 

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { Base, DangerousAttributeError, ReadonlyAttributeError, registerModel } from "./index.js";
+import { Model } from "@blazetrails/activemodel";
 import { GeneratedAttributeMethods, isMethodDefinedWithin } from "./attribute-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
 import { registerSubclass } from "./inheritance.js";
@@ -461,5 +462,31 @@ describe("define_attribute_methods abstract gate (trails)", () => {
     expect("author_name" in ConcreteTopic.prototype).toBe(true);
     expect("author_nameBeforeTypeCast" in ConcreteTopic.prototype).toBe(true);
     expect("author_nameForDatabase" in ConcreteTopic.prototype).toBe(true);
+  });
+});
+
+describe("ActiveRecord attribute read/write surface lives on Base, not Model", () => {
+  it("defines the ActiveRecord-only members on Base.prototype", () => {
+    for (const name of [
+      "readAttribute",
+      "writeAttribute",
+      "readAttributeBeforeTypeCast",
+      "attributesBeforeTypeCast",
+      "columnForAttribute",
+      "hasAttribute",
+      "attributePresent",
+    ]) {
+      expect(Object.getOwnPropertyDescriptor(Base.prototype, name)).toBeDefined();
+      expect(Object.getOwnPropertyDescriptor(Model.prototype, name)).toBeUndefined();
+    }
+  });
+
+  it("keeps attributesBeforeTypeCast a getter rather than a data property", () => {
+    // before_type_cast.rb:82 is a zero-arg reader, so it ports as an accessor
+    // property; include() copies an object literal by value and would flatten
+    // it into a data property holding the getter's one-time result.
+    const descriptor = Object.getOwnPropertyDescriptor(Base.prototype, "attributesBeforeTypeCast")!;
+    expect(typeof descriptor.get).toBe("function");
+    expect("value" in descriptor).toBe(false);
   });
 });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -481,6 +481,23 @@ describe("ActiveRecord attribute read/write surface lives on Base, not Model", (
     }
   });
 
+  it("marks the field accessed when read through readAttribute", () => {
+    // Rails tracks the read inside `fetch_value` (activemodel/attribute.rb:44-47),
+    // which `read_attribute` reaches at read.rb:33, so a public read counts
+    // toward `accessed_fields` (attribute_methods.rb:460). trails keeps the
+    // marker on the record, so `readAttribute` has to set it itself.
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("body", "string");
+      }
+    }
+    const t = Topic.new({ title: "access-test", body: "hello" });
+    expect(t.accessedFields()).toEqual([]);
+    t.readAttribute("title");
+    expect(t.accessedFields()).toEqual(["title"]);
+  });
+
   it("keeps attributesBeforeTypeCast a getter rather than a data property", () => {
     // before_type_cast.rb:82 is a zero-arg reader, so it ports as an accessor
     // property; include() copies an object literal by value and would flatten

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -17,7 +17,6 @@ import {
   attributeForInspect as _attrForInspect,
   initializeGeneratedModules as _coreInitializeGeneratedModules,
 } from "./core.js";
-import { writeAttribute as _writeAttribute } from "./readonly-attributes.js";
 import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js";
 // toKey/id: inline to avoid a circular dependency (primary-key.ts imports
 // dangerousAttributeMethods from this file)
@@ -727,20 +726,6 @@ export function attributeForInspect(this: InstanceMethodHost, attr: string): str
   return _attrForInspect.call(this as any, attr);
 }
 
-/** Mirrors: ActiveRecord::AttributeMethods#read_attribute (read.rb:31-34) */
-export function readAttribute(
-  this: InstanceMethodHost,
-  name: string,
-  block?: (name: string) => unknown,
-): unknown {
-  return this._readAttribute(
-    (
-      this.constructor as unknown as { resolveAttributeName(n: string): string }
-    ).resolveAttributeName(name),
-    block,
-  );
-}
-
 /**
  * Mirrors: ActiveRecord::AttributeMethods#[] (attribute_methods.rb:415-417)
  *
@@ -763,17 +748,6 @@ export function get(this: InstanceMethodHost, attrName: string): unknown {
  */
 export function set(this: InstanceMethodHost, attrName: string, value: unknown): void {
   this.writeAttribute(attrName, value);
-}
-
-/** Mirrors: ActiveRecord::AttributeMethods#write_attribute (write.rb:31-34) */
-export function writeAttribute(this: InstanceMethodHost, name: string, value: unknown): void {
-  _writeAttribute.call(
-    this as any,
-    (
-      this.constructor as unknown as { resolveAttributeName(n: string): string }
-    ).resolveAttributeName(name),
-    value,
-  );
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#query_attribute */

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -10,7 +10,9 @@
  */
 
 interface BeforeTypeCastRecord extends AttributeOwner {
-  readonly attributesBeforeTypeCast: Record<string, unknown>;
+  _attributes: AttributeOwner["_attributes"] & {
+    valuesBeforeTypeCast(): Record<string, unknown>;
+  };
 }
 
 /**
@@ -22,18 +24,23 @@ export function readAttributeBeforeTypeCast(
   record: BeforeTypeCastRecord,
   attrName: string,
 ): unknown {
-  const name = record.constructor.attributeAliases?.[attrName] ?? attrName;
+  const name = (
+    record.constructor as unknown as { resolveAttributeName(n: string): string }
+  ).resolveAttributeName(String(attrName));
 
-  return attributeBeforeTypeCast.call(record, name);
+  return attributeBeforeTypeCast.call(record, name) ?? null;
 }
 
 /**
  * Return all attribute values before type casting.
  *
  * Mirrors: ActiveRecord::AttributeMethods::BeforeTypeCast#attributes_before_type_cast
+ * (before_type_cast.rb:82-84). Ruby's zero-arg reader is an accessor property
+ * here — see CLAUDE.md, "Generated attribute readers are properties" — so
+ * base.ts installs it with `Object.defineProperty` rather than `include()`.
  */
 export function attributesBeforeTypeCast(record: BeforeTypeCastRecord): Record<string, unknown> {
-  return record.attributesBeforeTypeCast;
+  return record._attributes.valuesBeforeTypeCast();
 }
 
 interface DatabaseRecord extends AttributeOwner {

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -27,10 +27,12 @@ interface AttributeHolder {
  * been type cast.
  *
  * Rails marks the read on the Attribute itself, inside `fetch_value`
- * (activemodel/attribute.rb:44-47), so `read_attribute` (read.rb:33) feeds
+ * (activemodel/attribute.rb:41-44), so `read_attribute` (read.rb:33) feeds
  * `accessed_fields` (attribute_methods.rb:460) like every other read path.
- * trails keeps that marker on the record instead — see
- * {@link readGeneratedAttribute} — so each public read path sets it itself.
+ * trails keeps that marker on the record, so each public read path sets it
+ * itself — see {@link readGeneratedAttribute}, and the
+ * `converge-accessed-fields-onto-attribute-set-accessed` story for why the
+ * marker cannot yet move to the Attribute.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Read#read_attribute (read.rb:29-34)
  */

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -1,10 +1,6 @@
 /**
  * Attribute reading methods.
  *
- * The actual readAttribute implementation lives on Model (from
- * @blazetrails/activemodel). This module exists to match the Rails
- * file structure for ActiveRecord::AttributeMethods::Read.
- *
  * Mirrors: ActiveRecord::AttributeMethods::Read
  */
 
@@ -24,6 +20,28 @@ export interface Read {
 
 interface AttributeHolder {
   _attributes: AttributeSet;
+}
+
+/**
+ * Returns the value of the attribute identified by `attrName` after it has
+ * been type cast.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::Read#read_attribute (read.rb:29-34)
+ */
+export function readAttribute(
+  this: ReadAttributeHost,
+  attrName: string,
+  block?: (name: string) => unknown,
+): unknown {
+  const name = (
+    this.constructor as unknown as { resolveAttributeName(n: string): string }
+  ).resolveAttributeName(String(attrName));
+
+  return this._readAttribute(name, block);
+}
+
+interface ReadAttributeHost {
+  _readAttribute(name: string, block?: (name: string) => unknown): unknown;
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -26,6 +26,12 @@ interface AttributeHolder {
  * Returns the value of the attribute identified by `attrName` after it has
  * been type cast.
  *
+ * Rails marks the read on the Attribute itself, inside `fetch_value`
+ * (activemodel/attribute.rb:44-47), so `read_attribute` (read.rb:33) feeds
+ * `accessed_fields` (attribute_methods.rb:460) like every other read path.
+ * trails keeps that marker on the record instead — see
+ * {@link readGeneratedAttribute} — so each public read path sets it itself.
+ *
  * Mirrors: ActiveRecord::AttributeMethods::Read#read_attribute (read.rb:29-34)
  */
 export function readAttribute(
@@ -37,10 +43,13 @@ export function readAttribute(
     this.constructor as unknown as { resolveAttributeName(n: string): string }
   ).resolveAttributeName(String(attrName));
 
+  if (this._attributes.has(name)) this._accessedFields.add(name);
   return this._readAttribute(name, block);
 }
 
 interface ReadAttributeHost {
+  _attributes: AttributeSet;
+  _accessedFields: Set<string>;
   _readAttribute(name: string, block?: (name: string) => unknown): unknown;
 }
 

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -1,10 +1,10 @@
 /**
  * Attribute writing methods.
  *
- * The actual writeAttribute implementation lives on Model (from
- * @blazetrails/activemodel), with Base adding encryption and frozen
- * checks. This module exists to match the Rails file structure for
- * ActiveRecord::AttributeMethods::Write.
+ * `writeAttribute` here is the base `Write#write_attribute`; `Base.prototype`
+ * receives `HasReadonlyAttributes#write_attribute` (readonly-attributes.ts),
+ * which adds the frozen / readonly guards and reaches this shape through its
+ * own `super` call.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */
@@ -21,6 +21,19 @@ import { completeHalfAccessor } from "./read.js";
 export interface Write {
   writeAttribute(name: string, value: unknown): void;
   _writeAttribute(name: string, value: unknown): void;
+}
+
+/**
+ * Updates the attribute identified by `attrName` using the specified `value`.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::Write#write_attribute (write.rb:31-38)
+ */
+export function writeAttribute(this: Model, attrName: string, value: unknown): void {
+  const name = (
+    this.constructor as unknown as { resolveAttributeName(n: string): string }
+  ).resolveAttributeName(String(attrName));
+
+  this._writeAttribute(name, value);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -1,10 +1,11 @@
 /**
  * Attribute writing methods.
  *
- * `writeAttribute` here is the base `Write#write_attribute`; `Base.prototype`
- * receives `HasReadonlyAttributes#write_attribute` (readonly-attributes.ts),
- * which adds the frozen / readonly guards and reaches this shape through its
- * own `super` call.
+ * `writeAttribute` here is the base `Write#write_attribute`. `Base.prototype`
+ * currently receives `HasReadonlyAttributes#write_attribute`
+ * (readonly-attributes.ts), which inlines this body behind its guards instead
+ * of reaching it the way Ruby's `super` (readonly_attributes.rb:54) does —
+ * tracked by the `converge-readonly-write-attribute-onto-write-super` story.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -201,6 +201,7 @@ import {
   attributesWithValues as _attributesWithValues,
   formatForInspect as _formatForInspect,
   pkAttribute as _pkAttribute,
+  readAttributeBeforeTypeCast as _readAttributeBeforeTypeCast,
   readAttributeForDatabase as _readAttributeForDatabase,
   attributesForDatabase as _attributesForDatabase,
   attributeBeforeTypeCast as _attributeBeforeTypeCast,
@@ -232,11 +233,15 @@ import {
   isCompositePrimaryKey as _isCompositePrimaryKey,
 } from "./attribute-methods/primary-key.js";
 import {
+  readAttribute as _readAttribute,
   _readAttribute as _readAttributeFn,
   defineMethodAttribute as _defineMethodAttribute,
 } from "./attribute-methods/read.js";
 import { setDefineMethodAttribute as _setDefineMethodAttribute } from "./attribute-methods/write.js";
-import { attributeCameFromUser as _attributeCameFromUser } from "./attribute-methods/before-type-cast.js";
+import {
+  attributeCameFromUser as _attributeCameFromUser,
+  attributesBeforeTypeCast as _attributesBeforeTypeCastFn,
+} from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
   _queryAttribute as _queryAttributeFn,
@@ -3842,6 +3847,9 @@ export class Base extends Model {
 
   declare hasAttribute: (name: string) => boolean;
   declare attributePresent: (name: string) => boolean;
+  declare readAttributeBeforeTypeCast: (name: string) => unknown;
+  declare readonly attributesBeforeTypeCast: Record<string, unknown>;
+  declare columnForAttribute: (name: string) => any;
   declare toKey: () => unknown[] | null;
   declare accessedFields: () => string[];
   declare queryAttribute: (name: string) => boolean;
@@ -4744,6 +4752,15 @@ include(Base, {
   // Serialization
   serializableHash: Serialization.serializableHash,
   // AttributeMethods
+  readAttribute: _readAttribute,
+  readAttributeBeforeTypeCast: _readAttributeBeforeTypeCast,
+  // model_schema.rb:183 — `delegate :type_for_attribute, :column_for_attribute,
+  // to: :class`. The class-side method is ModelSchema.columnForAttribute; the
+  // delegate is inlined here so it does not become a second exported symbol
+  // for the same Ruby name.
+  columnForAttribute(this: Base, name: string) {
+    return (this.constructor as typeof Base).columnForAttribute(name);
+  },
   hasAttribute: _hasAttribute,
   attributePresent: _attributePresent,
   accessedFields: _accessedFields,
@@ -4759,6 +4776,16 @@ include(Base, {
   readStoreAttribute: _readStoreAttribute,
   writeStoreAttribute: _writeStoreAttribute,
   storeAccessorFor: _storeAccessorFor,
+});
+// before_type_cast.rb:82 — a Ruby zero-arg reader ports as an accessor property
+// (CLAUDE.md, "Generated attribute readers are properties"), and include()
+// copies the object literal by value, which would flatten the getter into a
+// data property. Install the descriptor directly instead.
+Object.defineProperty(Base.prototype, "attributesBeforeTypeCast", {
+  get(this: Base) {
+    return _attributesBeforeTypeCastFn(this as never);
+  },
+  configurable: true,
 });
 include(Base, _PrimaryKey);
 include(Base, LockingPessimistic.InstanceMethods);
@@ -4893,10 +4920,6 @@ include(Base, {
   hasDeferTouchAttrs(this: Base) {
     return TouchLater.hasDeferTouchAttrs(this);
   },
-  // readAttributeBeforeTypeCast/attributesBeforeTypeCast — inherited from Model.prototype
-  // (readAttributeBeforeTypeCast is a method, attributesBeforeTypeCast is a getter).
-  // The re-exports in before-type-cast.ts call record.<methodName>(), so wiring
-  // them would create cycles. Category A: inherited, extractor limitation.
   // savedChanges/hasChangesToSave/changesToSave/changedAttributeNamesToSave/
   // attributesInDatabase — getters on Model.prototype; wiring via include() replaces
   // the getter descriptor with a data property and breaks behavior. Category A.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4754,13 +4754,6 @@ include(Base, {
   // AttributeMethods
   readAttribute: _readAttribute,
   readAttributeBeforeTypeCast: _readAttributeBeforeTypeCast,
-  // model_schema.rb:183 — `delegate :type_for_attribute, :column_for_attribute,
-  // to: :class`. The class-side method is ModelSchema.columnForAttribute; the
-  // delegate is inlined here so it does not become a second exported symbol
-  // for the same Ruby name.
-  columnForAttribute(this: Base, name: string) {
-    return (this.constructor as typeof Base).columnForAttribute(name);
-  },
   hasAttribute: _hasAttribute,
   attributePresent: _attributePresent,
   accessedFields: _accessedFields,
@@ -4787,6 +4780,7 @@ Object.defineProperty(Base.prototype, "attributesBeforeTypeCast", {
   },
   configurable: true,
 });
+include(Base, ModelSchema.InstanceMethods);
 include(Base, _PrimaryKey);
 include(Base, LockingPessimistic.InstanceMethods);
 include(Base, LockingOptimistic.InstanceMethods);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1675,6 +1675,19 @@ export const ClassMethods = {
   loadSchemaFromAdapter,
 };
 
+/**
+ * Mirrors: `delegate :type_for_attribute, :column_for_attribute, to: :class`
+ * (model_schema.rb:183). Only `column_for_attribute` is here — the instance
+ * `type_for_attribute` delegate still lives on `ActiveModel::Model`.
+ */
+export const InstanceMethods = {
+  columnForAttribute(this: { constructor: unknown }, name: string): unknown {
+    return (this.constructor as { columnForAttribute(n: string): unknown }).columnForAttribute(
+      name,
+    );
+  },
+};
+
 /** @internal */
 function initializeLoadSchemaMonitor(this: SchemaHost): void {
   // no-op: JS is single-threaded; no Monitor/Mutex needed


### PR DESCRIPTION
Seven `Model` instance members had no ActiveModel counterpart — every one was
ActiveRecord surface parked on `ActiveModel::Model` because `Base extends Model`.
Each now lives in its Rails-counterpart `activerecord` file, at its Rails name:

| member | new home | Rails |
| --- | --- | --- |
| `readAttribute` | `attribute-methods/read.ts` | `attribute_methods/read.rb:29-34` |
| `writeAttribute` | `attribute-methods/write.ts` | `attribute_methods/write.rb:31-38` |
| `readAttributeBeforeTypeCast` | `attribute-methods/before-type-cast.ts` | `before_type_cast.rb:48-53` |
| `attributesBeforeTypeCast` | `attribute-methods/before-type-cast.ts` | `before_type_cast.rb:82-84` |
| `columnForAttribute` | `model-schema.ts` `InstanceMethods` | `model_schema.rb:183` (`delegate … to: :class`) |
| `hasAttribute` | `attribute-methods.ts` (already there) | `attribute_methods.rb:316-320` |
| `attributePresent` | `attribute-methods.ts` (already there) | `attribute_methods.rb:387-392` |

ActiveModel keeps `_readAttribute` (`attribute_methods.rb:556`) and
`_writeAttribute` (`attributes.rb:156`) — the underscore pair is the only one
Rails actually defines there. The un-underscored public pair is ActiveRecord's,
and `vendor/rails/activemodel` defines none of the seven.

`readAttribute` / `writeAttribute` were already implemented in
`activerecord/src/attribute-methods.ts`; they move to `read.ts` / `write.ts`,
their Rails homes, and `readAttribute` is now wired onto `Base.prototype`
instead of being shadowed by the inherited `Model` one.

### The getter hazard

`attributesBeforeTypeCast` is a zero-arg Ruby reader, so it ports as an accessor
property (CLAUDE.md, *Generated attribute readers are properties*). `include()`
reads its object literal by value and would flatten the getter into a data
property holding one stale snapshot, so `base.ts` installs it with
`Object.defineProperty`. `attribute-methods.trails.test.ts` asserts the
**descriptor kind**, not just the value, plus that all seven are own properties
of `Base.prototype` and none of `Model.prototype`.

`base.ts`'s Category-A comment block (*"inherited from Model.prototype … extractor
limitation"*) is deleted with the arrangement it described.

### ActiveModel consumers

`secure-password.ts`, `validator.ts`, `validations/{confirmation,numericality}.ts`
and the ActiveModel generated-accessor closure move onto `_readAttribute` /
`_writeAttribute` — which is what Rails' own generated reader does
(`attributes.rb:92` → `attribute(…)` → `_read_attribute`). The ActiveModel test
suite follows. A handful of trails-invented ActiveModel tests that existed only
to exercise the AR-only members (`columnForAttribute`, `attributePresent`,
`has_attribute?` alias resolution) are dropped; each has AR-side coverage.

### Verification

- `pnpm typecheck`, `eslint` on every changed file: clean.
- ActiveModel suite: 1911 passed, 1 skipped.
- ActiveRecord: attribute-methods (+ `read`/`write`/`query`/tz), dirty,
  attributes, readonly, base, persistence, serialization, serialized-attribute,
  enum, timestamp, integration, primary-keys, validations, secure-password,
  multiparameter, store, normalized-attribute, nested-attributes,
  json-serialization, locking, finder, relations, inheritance, aggregations,
  callbacks, encryption/**, validations/**, actionpack parameters — all green.
- `pnpm parity:api` `13424` and `pnpm parity:test` `15739` unchanged vs a clean
  `origin/main` measurement; `parity:test` extra (TS-only) drops 3609 → 3597.
- `pnpm parity:api:extra --package activemodel`: all seven gone from `model.ts`.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK — no new rows, no reseed.

### `accessedFields` tracking

Rails marks a read on the Attribute itself, inside `fetch_value`
(`activemodel/attribute.rb:41-44`), so every read path feeds `accessed_fields`
(`attribute_methods.rb:460`). trails keeps that marker in a record-side
`_accessedFields` set that each read path maintains by hand, so `readAttribute`
sets it itself. `attribute-methods.trails.test.ts` covers all four paths a
`Base` instance reads through — `readAttribute`, the generated reader, `slice`,
`valuesAt` — and each case fails with the tracking line removed.

The six `Model` methods that switched from `readAttribute` to `_readAttribute`
change no `accessedFields()` result on an AR record:

- `toKey`, `slice`, `valuesAt` — `Base` overrides all three (`base.ts:4717`,
  `:4718`, `:4767`); `Persistence.slice`/`valuesAt` read through
  `readAttribute` and `PrimaryKey.toKey` reads `this.id`, so Model's copies
  never run on a `Base` instance.
- `attributesInDatabase`, `attributePreviouslyWas`, `attributeChangedInPlace` —
  Rails reads `mutations_from_database` / `mutations_before_last_save`
  (`attribute_methods/dirty.rb`) and never `read_attribute`, so the trails
  fallback marking a field accessed was the deviation.

Moving the marker into `_readAttribute` so every path feeds it — the convergent
fix — was tried and reverted: it reds
`relations.test.ts > RelationTest > loading with one association`, because
`toEqual` walks own enumerable properties and `_accessedFields` is one, so two
records holding the same row via different read paths stop comparing equal.
Rails' counterpart (`relations_test.rb:751`) compares with `Core#==`, which is
`comparison_object.id == id`. Recorded on the convergence story below.

### Adjacent deviations found, filed not propagated

- `converge-readonly-write-attribute-onto-write-super` — `readonly-attributes.ts`
  inlines `Write#write_attribute` behind its guards instead of calling it the
  way `readonly_attributes.rb:54`'s `super` does, which is why write.ts's
  `writeAttribute` is exported but unreachable. Noted in write.ts's header.
- `converge-accessed-fields-onto-attribute-set-accessed` — `accessedFields`
  should be Rails' `@attributes.accessed` (`attribute_methods.rb:461`), deleting
  the hand-maintained set. trails already has `AttributeSet#accessed` and
  `Attribute#hasBeenRead()`; two blockers documented on the story.
- `attribute-present-uses-blank-instead-of-empty` — `attributePresent` uses
  ActiveSupport `blank?` where `attribute_methods.rb:391` uses
  `respond_to?(:empty?) && empty?`, so a whitespace-only string reads as absent
  in trails and present in Rails. Pre-existing on both copies; unchanged here.

### On `write.ts`'s `writeAttribute`

It is not wired onto `Base.prototype` — `ReadonlyAttributes.writeAttribute` is.
That is not new unused surface: on `origin/main` the same function was equally
unwired in `attribute-methods.ts` (`base.ts` there wires only
`ReadonlyAttributes.writeAttribute`), so the count is unchanged and this PR just
puts it at its Rails home, which the story's acceptance criterion asks for.
Wiring it is `converge-readonly-write-attribute-onto-write-super`, because it
means relocating the `"id"` → primary-key remap and the composite-PK
`MissingAttributeError` out of `readonly-attributes.ts` into `write.ts` (their
Rails home, `write.rb:35`) and reducing readonly's body to Rails' two-line guard
plus `super`.

### Size

1146 LOC, over the 700 ceiling. It cannot be split without stacking: the
definitions cannot leave `Model` until every ActiveModel consumer is off them,
and ~90% of the diff is the mechanical `readAttribute` → `_readAttribute`
rename across the ActiveModel test suite (22 files, one identifier).

Closes-story: move-ar-attribute-read-write-surface-out-of-model
