### PR TITLE
test(activerecord,scripts): converge the root-file assertion tail and count mocha `expects`

### DIFF
--- a/packages/activerecord/src/active-record.test.ts
+++ b/packages/activerecord/src/active-record.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
+import { assertPredicate, assertNotPredicate } from "@blazetrails/activesupport";
 import { Base, disconnectAllBang } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
@@ -11,12 +12,12 @@ describe("ActiveRecordTest", () => {
   // in-memory SQLite database discards its schema.
   it.skipIf(inMemoryDb())(".disconnect_all! closes all connections", async () => {
     await (await Base.leaseConnection()).connectBang();
-    expect(Base.connectedQ()).toBe(true);
+    assertPredicate(Base, (b) => b.connectedQ());
 
     await disconnectAllBang();
-    expect(Base.connectedQ()).toBe(false);
+    assertNotPredicate(Base, (b) => b.connectedQ());
 
     await (await Base.leaseConnection()).connectBang();
-    expect(Base.connectedQ()).toBe(true);
+    assertPredicate(Base, (b) => b.connectedQ());
   });
 });

--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapter_prevent_writes_test.rb
  */
 import { describe, it, expect, beforeEach } from "vitest";
+import { assertPredicate, assertNotPredicate } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import type { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { ReadOnlyError, StatementInvalid } from "./errors.js";
@@ -19,13 +20,13 @@ describe("AdapterPreventWritesTest", () => {
   });
 
   it("preventing writes predicate", async () => {
-    expect(connection.isPreventingWrites()).toBe(false);
+    assertNotPredicate(connection, (c) => c.isPreventingWrites());
 
     await Base.whilePreventingWrites(async () => {
-      expect(connection.isPreventingWrites()).toBe(true);
+      assertPredicate(connection, (c) => c.isPreventingWrites());
     });
 
-    expect(connection.isPreventingWrites()).toBe(false);
+    assertNotPredicate(connection, (c) => c.isPreventingWrites());
   });
 
   it("errors when an insert query is called while preventing writes", async () => {
@@ -69,7 +70,7 @@ describe("AdapterPreventWritesTest", () => {
 
   it("doesnt error when a select query has encoding errors", async () => {
     await Base.whilePreventingWrites(async () => {
-      await expect(connection.selectAll(`SELECT '\xC8'`)).resolves.toBeDefined();
+      await expect(connection.selectAll(`SELECT '\xC8'`)).resolves.not.toThrow();
     });
   });
 

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-fixtures.js";
 import { Post } from "./test-helpers/models/post.js";
+import { assertQueriesMatch } from "./testing/query-assertions.js";
 
 describe("AnnotateTest", () => {
   // `fixtures` wires the handler suite internally, so no separate call.
@@ -14,37 +15,67 @@ describe("AnnotateTest", () => {
   // annotated `select(:id)` relation has data to read back with `.first()`
   // (Rails' `assert posts.first`). The canonical `posts` table comes from the
   // template clone.
-  const { posts } = fixtures(["posts"]);
+  fixtures(["posts"]);
 
   it("annotate wraps content in an inline comment", async () => {
-    const relation = Post.select("id").annotate("foo");
-    expect(relation.toSql()).toMatch(/SELECT .* FROM .* \/\* foo \*\//);
-    expect((await relation.first())?.id).toBe(posts("welcome").id);
+    await assertQueriesMatch(/SELECT .* FROM .* \/\* foo \*\//i, undefined, false, async () => {
+      const relation = Post.select("id").annotate("foo");
+      expect(await relation.first()).toBeTruthy();
+    });
   });
 
   it("annotate is sanitized", async () => {
     // Each annotation is routed through `sanitize_as_sql_comment`, so embedded
     // `*/` / `/*` are spaced apart and can never break out of the wrapping
-    // comment. Asserting the exact sanitized output + running `.first()`
-    // mirrors Rails' `assert_queries_match` regex + `assert posts.first`.
-    const foo = Post.select("id").annotate("*/foo/*");
-    expect(foo.toSql()).toContain("/* * /foo/ * */");
-    expect((await foo.first())?.id).toBe(posts("welcome").id);
+    // comment.
+    await assertQueriesMatch(
+      /SELECT .* FROM .* \/\* \* \/foo\/ \* \*\//i,
+      undefined,
+      false,
+      async () => {
+        const relation = Post.select("id").annotate("*/foo/*");
+        expect(await relation.first()).toBeTruthy();
+      },
+    );
 
-    const slashes = Post.select("id").annotate("**//foo//**");
-    expect(slashes.toSql()).toContain("/* ** //foo// ** */");
-    expect((await slashes.first())?.id).toBe(posts("welcome").id);
+    await assertQueriesMatch(
+      /SELECT .* FROM .* \/\* \*\* \/\/foo\/\/ \*\* \*\//i,
+      undefined,
+      false,
+      async () => {
+        const relation = Post.select("id").annotate("**//foo//**");
+        expect(await relation.first()).toBeTruthy();
+      },
+    );
 
-    const spaced = Post.select("id").annotate("* *//foo//* *");
-    expect(spaced.toSql()).toContain("/* * * //foo// * * */");
-    expect((await spaced.first())?.id).toBe(posts("welcome").id);
+    await assertQueriesMatch(
+      /SELECT .* FROM .* \/\* \* \* \/\/foo\/\/ \* \* \*\//i,
+      undefined,
+      false,
+      async () => {
+        const relation = Post.select("id").annotate("* *//foo//* *");
+        expect(await relation.first()).toBeTruthy();
+      },
+    );
 
-    const chained = Post.select("id").annotate("*/foo/*").annotate("*/bar");
-    expect(chained.toSql()).toContain("/* * /foo/ * */ /* * /bar */");
-    expect((await chained.first())?.id).toBe(posts("welcome").id);
+    await assertQueriesMatch(
+      /SELECT .* FROM .* \/\* \* \/foo\/ \* \*\/ \/\* \* \/bar \*\//i,
+      undefined,
+      false,
+      async () => {
+        const relation = Post.select("id").annotate("*/foo/*").annotate("*/bar");
+        expect(await relation.first()).toBeTruthy();
+      },
+    );
 
-    const hint = Post.select("id").annotate("+ MAX_EXECUTION_TIME(1)");
-    expect(hint.toSql()).toContain("/* + MAX_EXECUTION_TIME(1) */");
-    expect((await hint.first())?.id).toBe(posts("welcome").id);
+    await assertQueriesMatch(
+      /SELECT .* FROM .* \/\* \+ MAX_EXECUTION_TIME\(1\) \*\//i,
+      undefined,
+      false,
+      async () => {
+        const relation = Post.select("id").annotate("+ MAX_EXECUTION_TIME(1)");
+        expect(await relation.first()).toBeTruthy();
+      },
+    );
   });
 });

--- a/packages/activerecord/src/binary.test.ts
+++ b/packages/activerecord/src/binary.test.ts
@@ -49,40 +49,40 @@ describe("BinaryTest", () => {
     // Ported from binary_test.rb:41-70. Rails interleaves two concerns: the
     // Integer-to-String casting of `name`, which ports directly, and assertions
     // that `data` / `data_before_type_cast` carry `Encoding::BINARY` /
-    // `Encoding::UTF_8`. JS has no String encoding attribute, so the encoding
-    // *labels* have no analogue. What `assert_equal Encoding::BINARY,
-    // binary.data.encoding` is asserting in Ruby terms — that the string input
-    // was cast to binary — does port: `data` must be the bytes of "text" at each
-    // phase, which is what `expectTextBytes` pins. The `_before_type_cast`
-    // encoding half stays out: Rails itself notes it is adapter-dependent after
-    // reload (PG returns the bytea_output form).
+    // `Encoding::UTF_8`. JS has no String encoding attribute, so each encoding
+    // assertion ports as the value that the encoding *implies*: a binary-encoded
+    // `data` is the bytes of "text", and a UTF-8 `data_before_type_cast` is
+    // still the JS string it was assigned.
     // `name` is a restricted attribute in trails, hence readAttribute.
     const textBytes = new TextEncoder().encode("text");
-    const expectTextBytes = () => {
-      expect(binary.data).toBeInstanceOf(Uint8Array);
-      expect(new Uint8Array(binary.data)).toEqual(textBytes);
-    };
 
     const binary = Binary.new({ name: 123 as unknown as string, data: "text" });
 
     // Before saving, attribute methods return casted values, but their
     // _before_type_cast still returns the original value. (Integer-to-String
     // conversion used for comparison.)
-    expect(binary.readAttribute("name")).toBe("123");
-    expect(binary.readAttributeBeforeTypeCast("name")).toBe(123);
-    expectTextBytes();
+    expect(binary.readAttribute("name")).toEqual("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toEqual(123);
+    expect(new Uint8Array(binary.data)).toEqual(textBytes);
+    expect(binary.readAttributeBeforeTypeCast("data")).toEqual("text");
 
     await binary.saveBang();
 
     // After saving, casted values appear throughout.
-    expect(binary.readAttribute("name")).toBe("123");
-    expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
-    expectTextBytes();
+    expect(binary.readAttribute("name")).toEqual("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toEqual("123");
+    expect(new Uint8Array(binary.data)).toEqual(textBytes);
+    expect(
+      new Uint8Array((binary.readAttributeBeforeTypeCast("data") as { bytes: Uint8Array }).bytes),
+    ).toEqual(textBytes);
 
     await binary.reload();
 
-    expect(binary.readAttribute("name")).toBe("123");
-    expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
-    expectTextBytes();
+    expect(binary.readAttribute("name")).toEqual("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toEqual("123");
+    // After reloading, data_before_type_cast is adapter-dependent. For
+    // example, PostgreSQL returns the bytea_output encoded representation,
+    // which happens to be UTF-8 — so only `data` itself is asserted here.
+    expect(new Uint8Array(binary.data)).toEqual(textBytes);
   });
 });

--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/date";
+import { assertNotPredicate } from "@blazetrails/activesupport";
 import { describe, it, expect } from "vitest";
 import { Base, StatementInvalid, Relation } from "./index.js";
 import { hexdigest } from "@blazetrails/activesupport";
@@ -232,7 +233,7 @@ describe("CollectionCacheKeyTest", () => {
   it("cache_key with custom timestamp column", async () => {
     const topicsRel = Topic.where("title like ?", "%Topic%");
     const lastTopicTimestamp = expectedUsec(topics("fifth").written_on);
-    expect(await topicsRel.cacheKey("written_on")).toContain(lastTopicTimestamp);
+    expect(await topicsRel.cacheKey("written_on")).toMatch(lastTopicTimestamp);
   });
 
   it("cache_key with unknown timestamp column", async () => {
@@ -270,7 +271,7 @@ describe("CollectionCacheKeyTest", () => {
     const developers = Developer.distinct().order("salary").limit(5);
 
     expect(await developers.cacheKey()).toMatch(/^developers\/query-[0-9a-f]+-\d+-\d+$/);
-    expect(developers.isLoaded).toBe(false);
+    assertNotPredicate(developers, (d) => d.isLoaded);
   });
 
   it("cache_key with a relation having custom select and order", async () => {

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -311,8 +311,8 @@ export class DatabaseConfig {
     return this.configuration.queryCache;
   }
 
-  get replica(): boolean {
-    return this.configuration.replica === true;
+  get replica(): boolean | undefined {
+    return this.configuration.replica;
   }
 
   get migrationsPaths(): string | string[] | undefined {

--- a/packages/activerecord/src/database-configurations/url-config.test.ts
+++ b/packages/activerecord/src/database-configurations/url-config.test.ts
@@ -44,7 +44,7 @@ describe("DatabaseConfigurations", () => {
 
     it("replica parsing", () => {
       let config = new UrlConfig("default_env", "primary", "postgres://localhost/foo", {});
-      expect(config.replica).toBe(false);
+      expect(config.replica).toBeUndefined();
 
       config = new UrlConfig("default_env", "primary", "postgres://localhost/foo?replica=true", {});
       expect(config.replica).toBe(true);

--- a/packages/activerecord/src/encryption/config.test.ts
+++ b/packages/activerecord/src/encryption/config.test.ts
@@ -5,12 +5,10 @@ import { Configuration } from "./errors.js";
 describe("ActiveRecord::Encryption::ConfigTest", () => {
   it("required keys will raise a config error when accessed but not set", () => {
     const config = new Config();
+    config.primaryKey = undefined as never;
     expect(() => config.primaryKey).toThrow(Configuration);
-    expect(() => config.deterministicKey).toThrow(Configuration);
-    expect(() => config.keyDerivationSalt).toThrow(Configuration);
 
-    expect(() => config.primaryKey).toThrow(
-      "Missing Active Record encryption credential: active_record_encryption.primary_key",
-    );
+    config.primaryKey = "some key";
+    expect(() => config.primaryKey).not.toThrow();
   });
 });

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -158,9 +158,8 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
 
     await Contexts.protectingEncryptedData(async () => {
       const found = await (EncryptedBook as any).findBy({ name: "Dune" });
-      // Rails' `assert_equal book, find_by(...)` leans on AR record equality
-      // (`Core#==`, class + id); vitest's toEqual is a structural deep compare,
-      // which the two records' differing dirty/transaction state fails.
+      // `assert_equal book, find_by(...)` leans on AR record equality (`Core#==`,
+      // class + id); vitest's toEqual is a structural deep compare instead.
       expect(found?.id).toEqual(book.id);
     });
   });

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -144,7 +144,7 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     // and still asserts the create-under-NullEncryptor path doesn't raise.
     await expect(
       Contexts.withoutEncryption(() => (EncryptedBook as any).createBang({ name: "Dune" })),
-    ).resolves.toBeDefined();
+    ).resolves.not.toThrow();
   });
 
   it(".protecting_encrypted_data don't decrypt attributes automatically", async () => {
@@ -158,10 +158,10 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
 
     await Contexts.protectingEncryptedData(async () => {
       const found = await (EncryptedBook as any).findBy({ name: "Dune" });
-      // Rails asserts `assert_equal book, find_by(...)`; AR record equality is
-      // class + id, so check both rather than id alone.
-      expect(found).toBeInstanceOf(EncryptedBook);
-      expect(found?.id).toBe(book.id);
+      // Rails' `assert_equal book, find_by(...)` leans on AR record equality
+      // (`Core#==`, class + id); vitest's toEqual is a structural deep compare,
+      // which the two records' differing dirty/transaction state fails.
+      expect(found?.id).toEqual(book.id);
     });
   });
 

--- a/packages/activerecord/src/encryption/derived-secret-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
-import { Encryptor } from "./encryptor.js";
+import { assertEncryptorWorksWith } from "./test-helpers.js";
 import { Configurable } from "./configurable.js";
+import { Message } from "./message.js";
+import { Key } from "./key.js";
+import { KeyProvider } from "./key-provider.js";
+import type { KeyGenerator } from "./key-generator.js";
 
 describe("ActiveRecord::Encryption::DerivedSecretKeyProviderTest", () => {
   let originalSalt: string | undefined;
@@ -16,28 +20,36 @@ describe("ActiveRecord::Encryption::DerivedSecretKeyProviderTest", () => {
     Configurable.config.storeKeyReferences = false;
   });
 
+  // Rails' setup block (derived_secret_key_provider_test.rb:6-10) builds the
+  // shared provider from `build_keys(3)` (encryption/helper.rb:57-63).
+  let keyProvider: KeyProvider;
+  beforeEach(() => {
+    const keys = Array.from(
+      { length: 3 },
+      (_v, index) =>
+        new Key((Configurable.keyGenerator as KeyGenerator).deriveKeyFrom(`some secret ${index}`)),
+    );
+    keyProvider = new KeyProvider(keys);
+  });
+
   it("will derive a key with the right length from the given password", () => {
-    const provider = new DerivedSecretKeyProvider("my-password");
-    const key = provider.encryptionKey();
-    expect(key.secret).toBeTruthy();
-    expect(key.secret.length).toBeGreaterThan(0);
+    const keyProvider = new DerivedSecretKeyProvider("some password");
+    const key = keyProvider.encryptionKey();
+
+    expect([key]).toEqual(keyProvider.decryptionKeys(new Message({ payload: "some secret" })));
+    // Rails' `key.secret.bytesize` counts the raw derived bytes; trails'
+    // KeyGenerator#deriveKeyFrom hands the secret back base64-encoded
+    // (key-generator.ts:35-39), so decode before measuring.
+    expect(Configurable.cipher.keyLength()).toEqual(Buffer.from(key.secret, "base64").byteLength);
   });
 
   it("work with multiple keys when config.store_key_references is false", () => {
     Configurable.config.storeKeyReferences = false;
-    const provider = new DerivedSecretKeyProvider(["password1", "password2"]);
-    const enc = new Encryptor({ compress: false });
-    const encrypted = enc.encrypt("hello", { keyProvider: provider });
-    const decrypted = enc.decrypt(encrypted, { keyProvider: provider });
-    expect(decrypted).toBe("hello");
+    assertEncryptorWorksWith(keyProvider);
   });
 
   it("work with multiple keys when config.store_key_references is true", () => {
     Configurable.config.storeKeyReferences = true;
-    const provider = new DerivedSecretKeyProvider(["password1", "password2"]);
-    const enc = new Encryptor({ compress: false });
-    const encrypted = enc.encrypt("hello", { keyProvider: provider });
-    const decrypted = enc.decrypt(encrypted, { keyProvider: provider });
-    expect(decrypted).toBe("hello");
+    assertEncryptorWorksWith(keyProvider);
   });
 });

--- a/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
+++ b/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
@@ -20,7 +20,7 @@ describe("ActiveRecord::Encryption::EncryptableFixtureTest", () => {
 
   it("fixtures get encrypted automatically", async () => {
     const { encryptedAttribute } = await import("./encryptable-record.js");
-    expect(encryptedAttribute.call(encryptedBooks("awdr"), "name")).toBe(true);
+    expect(encryptedAttribute.call(encryptedBooks("awdr"), "name")).toBeTruthy();
   });
 });
 
@@ -45,8 +45,11 @@ describe("ActiveRecord::Encryption::EncryptableFixtureTest", () => {
 
   it("preserved columns due to ignore_case: true gets encrypted automatically", async () => {
     const book = encryptedBookThatIgnoresCases("rfr");
-    expect((book as any).name).toBe("Ruby for Rails");
+    expect((book as any).name).toEqual("Ruby for Rails");
+    const { assertEncryptedAttribute } = await import("./test-helpers.js");
+    await assertEncryptedAttribute(book, "name", "Ruby for Rails");
+
     const { encryptedAttribute } = await import("./encryptable-record.js");
-    expect(encryptedAttribute.call(book, "name")).toBe(true);
+    expect(encryptedAttribute.call(book, "name")).toBeTruthy();
   });
 });

--- a/packages/activerecord/src/encryption/key.test.ts
+++ b/packages/activerecord/src/encryption/key.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Key } from "./key.js";
+import { Configurable } from "./configurable.js";
+import type { KeyGenerator } from "./key-generator.js";
 
 describe("ActiveRecord::Encryption::KeyTest", () => {
   it("A key can store a secret and public tags", () => {
@@ -10,11 +12,8 @@ describe("ActiveRecord::Encryption::KeyTest", () => {
   });
 
   it(".derive_from instantiates a key with its secret derived from the passed password", () => {
-    const key = Key.deriveFrom("my-password");
-    expect(key).toBeInstanceOf(Key);
-    expect(key.secret).toBeTruthy();
-    expect(key.secret.length).toBeGreaterThan(0);
-    const key2 = Key.deriveFrom("my-password");
-    expect(key2.secret).toBe(key.secret);
+    expect((Configurable.keyGenerator as KeyGenerator).deriveKeyFrom("some password")).toEqual(
+      Key.deriveFrom("some password").secret,
+    );
   });
 });

--- a/packages/activerecord/src/encryption/message.test.ts
+++ b/packages/activerecord/src/encryption/message.test.ts
@@ -28,8 +28,6 @@ describe("ActiveRecord::Encryption::MessageTest", () => {
     // an array stands in for the non-string payload.
     expect(() => new Message({ payload: [] as any })).toThrow(ForbiddenClass);
 
-    // Rails constructs these three bare — a raise would fail the test on its own,
-    // so they carry no assertion of their own.
     new Message();
     new Message({ payload: "" });
     new Message({ payload: "Some payload" });

--- a/packages/activerecord/src/encryption/message.test.ts
+++ b/packages/activerecord/src/encryption/message.test.ts
@@ -27,8 +27,11 @@ describe("ActiveRecord::Encryption::MessageTest", () => {
     // Rails uses Date.new / []; Temporal.PlainDate has no zero-arg analogue, so
     // an array stands in for the non-string payload.
     expect(() => new Message({ payload: [] as any })).toThrow(ForbiddenClass);
-    expect(() => new Message()).not.toThrow();
-    expect(() => new Message({ payload: "" })).not.toThrow();
-    expect(() => new Message({ payload: "Some payload" })).not.toThrow();
+
+    // Rails constructs these three bare — a raise would fail the test on its own,
+    // so they carry no assertion of their own.
+    new Message();
+    new Message({ payload: "" });
+    new Message({ payload: "Some payload" });
   });
 });

--- a/packages/activerecord/src/encryption/null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.test.ts
@@ -14,7 +14,7 @@ describe("ActiveRecord::Encryption::NullEncryptorTest", () => {
 
   it("encrypted? returns false", () => {
     const enc = new NullEncryptor();
-    expect(enc.isEncrypted("Some data")).toBe(false);
+    expect(enc.isEncrypted("Some data")).toBeFalsy();
   });
 
   it("binary? returns false", () => {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -18,6 +18,7 @@ import { type Compressor } from "./config.js";
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { Encryptor as EncryptorImpl } from "./encryptor.js";
+import type { KeyProviderLike } from "./encryptor.js";
 import { type Scheme } from "./scheme.js";
 import { Decryption, Encryption } from "./errors.js";
 import { BinaryData } from "@blazetrails/activemodel";
@@ -693,11 +694,11 @@ export function ciphertextFor(model: any, attrName: string): unknown {
  * (activerecord/test/cases/encryption/helper.rb:50-55) — a round-trip through a
  * fresh Encryptor with the given key provider.
  */
-export function assertEncryptorWorksWith(keyProvider: unknown): void {
+export function assertEncryptorWorksWith(keyProvider: KeyProviderLike): void {
   const encryptor = new EncryptorImpl();
 
-  const encryptedMessage = encryptor.encrypt("some text", { keyProvider } as never);
-  expect(encryptor.decrypt(encryptedMessage, { keyProvider } as never)).toEqual("some text");
+  const encryptedMessage = encryptor.encrypt("some text", { keyProvider });
+  expect(encryptor.decrypt(encryptedMessage, { keyProvider })).toEqual("some text");
 }
 
 /**

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -16,6 +16,7 @@ import { Configurable } from "./configurable.js";
 import { type Compressor } from "./config.js";
 import { Contexts } from "./contexts.js";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
+import { Encryptor as EncryptorImpl } from "./encryptor.js";
 import { type Scheme } from "./scheme.js";
 import { Decryption, Encryption } from "./errors.js";
 import { BinaryData } from "@blazetrails/activemodel";
@@ -684,6 +685,21 @@ export function ciphertextFor(model: any, attrName: string): unknown {
     return type.serialize(value);
   }
   return model.readAttributeBeforeTypeCast(attrName);
+}
+
+/**
+ * Mirrors `assert_encryptor_works_with`
+ * (activerecord/test/cases/encryption/helper.rb:50-55) — a round-trip through a
+ * fresh Encryptor with the given key provider.
+ */
+export function assertEncryptorWorksWith(keyProvider: unknown): void {
+  const encryptor = new EncryptorImpl();
+
+  const encryptedMessage = encryptor.encrypt("some text", { keyProvider } as never);
+  const decrypted = encryptor.decrypt(encryptedMessage, { keyProvider } as never);
+  if (decrypted !== "some text") {
+    throw new Error(`assertEncryptorWorksWith: expected "some text", got ${String(decrypted)}`);
+  }
 }
 
 /**

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -5,6 +5,7 @@
  *          ActiveRecord::Encryption::EncryptionHelpers (assertions).
  */
 
+import { expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
 import { ensureCanonicalTables } from "../support/canonical-table-rebuild.js";
@@ -696,10 +697,7 @@ export function assertEncryptorWorksWith(keyProvider: unknown): void {
   const encryptor = new EncryptorImpl();
 
   const encryptedMessage = encryptor.encrypt("some text", { keyProvider } as never);
-  const decrypted = encryptor.decrypt(encryptedMessage, { keyProvider } as never);
-  if (decrypted !== "some text") {
-    throw new Error(`assertEncryptorWorksWith: expected "some text", got ${String(decrypted)}`);
-  }
+  expect(encryptor.decrypt(encryptedMessage, { keyProvider } as never)).toEqual("some text");
 }
 
 /**

--- a/packages/activerecord/src/errors.test.ts
+++ b/packages/activerecord/src/errors.test.ts
@@ -11,7 +11,7 @@
  * of arguments); in TS it raises TypeError (sources.join is not a function).
  * Different mechanism, same observable outcome: construction fails.
  */
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   SubclassNotFound,
   AssociationTypeMismatch,
@@ -177,14 +177,16 @@ describe("ErrorsTest", () => {
       DeleteRestrictionError,
       TooManyRecords,
     ];
-    for (const errorKlass of errorKlasses) {
-      try {
-        new (errorKlass as any)();
-      } catch {
-        throw new Error(
-          `Instance of ${(errorKlass as any).name} can't be initialized with no arguments`,
-        );
+    expect(() => {
+      for (const errorKlass of errorKlasses) {
+        try {
+          new (errorKlass as any)();
+        } catch {
+          throw new Error(
+            `Instance of ${(errorKlass as any).name} can't be initialized with no arguments`,
+          );
+        }
       }
-    }
+    }).not.toThrow();
   });
 });

--- a/packages/activerecord/src/filter-attributes.test.ts
+++ b/packages/activerecord/src/filter-attributes.test.ts
@@ -154,6 +154,8 @@ describe("FilterAttributesTest", () => {
     const user = new User({ token: "[FILTERED]", auth_token: "[FILTERED]" });
     const output = user.inspect();
     expect(output).toContain("auth_token: [FILTERED]");
+    // Rails' `assert_includes actual, "token: [FILTERED]"` reads PP output, where
+    // the filtered marker is unquoted; trails' `inspect` quotes the string value.
     expect(output).toContain('token: "[FILTERED]"');
   });
 });

--- a/packages/activerecord/src/forbidden-attributes-protection.test.ts
+++ b/packages/activerecord/src/forbidden-attributes-protection.test.ts
@@ -13,6 +13,7 @@
  * against with `dropExisting`.
  */
 import { describe, it, expect } from "vitest";
+import { assertEmpty } from "@blazetrails/activesupport";
 import { ForbiddenAttributesError } from "@blazetrails/activemodel";
 // Side-effect: registers the Relation constructor on Base (the canonical models
 // import only base.js, which doesn't load relation.ts on its own).
@@ -127,7 +128,7 @@ describe("ForbiddenAttributesProtectionTest", () => {
     const remaining = (await Person.where().not(params)).filter(
       (p) => p.readAttribute("first_name") === "Guille",
     );
-    expect(remaining).toHaveLength(0);
+    assertEmpty(remaining);
   });
 
   it("strong params style objects work with singular associations", () => {

--- a/packages/activerecord/src/integration.test.ts
+++ b/packages/activerecord/src/integration.test.ts
@@ -47,10 +47,8 @@ describe("IntegrationTest", () => {
   const { owners, pets } = fixtures(["companies", "developers", "owners", "pets"]);
 
   it("to param should return string", async () => {
-    // Rails `assert_kind_of String, ...`. A JS string primitive is not an
-    // `instanceof String`, so box it — `Object("x")` is a String wrapper and
-    // `Object(1)` is not, which is exactly the discrimination Ruby's kind check
-    // makes.
+    // `assert_kind_of String`: a JS string primitive is not an `instanceof
+    // String`, so box it — `Object("x")` is a String wrapper, `Object(1)` is not.
     expect(Object((await Client.first())!.toParam())).toBeInstanceOf(String);
   });
 

--- a/packages/activerecord/src/integration.test.ts
+++ b/packages/activerecord/src/integration.test.ts
@@ -47,7 +47,11 @@ describe("IntegrationTest", () => {
   const { owners, pets } = fixtures(["companies", "developers", "owners", "pets"]);
 
   it("to param should return string", async () => {
-    expect(typeof (await Client.first())!.toParam()).toBe("string");
+    // Rails `assert_kind_of String, ...`. A JS string primitive is not an
+    // `instanceof String`, so box it — `Object("x")` is a String wrapper and
+    // `Object(1)` is not, which is exactly the discrimination Ruby's kind check
+    // makes.
+    expect(Object((await Client.first())!.toParam())).toBeInstanceOf(String);
   });
 
   it("to param returns nil if not persisted", () => {
@@ -194,7 +198,7 @@ describe("IntegrationTest", () => {
 
     // Rails `travel(1.second) { assert pet.touch }` — Pet `belongs_to :owner,
     // touch: true`, so touching the pet bumps the owner's updated_at.
-    expect(await pet.touch({ time: now.add({ seconds: 1 }) })).toBe(true);
+    expect(await pet.touch({ time: now.add({ seconds: 1 }) })).toBeTruthy();
     await owner.reload();
     expect(owner.cacheKey()).not.toBe(key);
   });

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -355,9 +355,9 @@ describe("LogSubscriberTest", () => {
         type_casted_binds: [1, 2, 3],
       }),
     );
-    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",1\]/);
-    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",2\]/);
-    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(/\["id",3\]/);
+    expect(subscriber.debugs[subscriber.debugs.length - 1]).toMatch(
+      /\["id",1\].*\["id",2\].*\["id",3\]/,
+    );
   });
 
   it("binary data is not logged", () => {

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { Temporal } from "@blazetrails/date";
 import { Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
+
+// Rails' `travel` freezes `Time.now`; vitest's fake timers only patch `Date`,
+// and the timestamp writer reads `Temporal.Now.instant()` off a nanosecond
+// clock, so freeze that too — otherwise `assert_equal Time.now, created_at`
+// compares against a drifting sub-millisecond tail.
+let frozenNow = Temporal.Instant.fromEpochMilliseconds(0);
+const timeNow = () => frozenNow;
 
 describe("TouchTest", () => {
   fixtures([]);
@@ -20,18 +28,21 @@ describe("TouchTest", () => {
 
     const t0 = new Date("2024-01-01T00:00:00.000Z");
     vi.useFakeTimers({ now: t0 });
+    frozenNow = Temporal.Instant.fromEpochMilliseconds(t0.getTime());
+    vi.spyOn(Temporal.Now, "instant").mockImplementation(() => frozenNow);
 
     const stamped = new Mixin();
     expect(stamped.readAttribute("updated_at")).toBeNull();
     expect(stamped.readAttribute("created_at")).toBeNull();
     await stamped.save();
-    const createdAt = stamped.readAttribute("created_at");
-    expect(createdAt).not.toBeNull();
+    expect(stamped.readAttribute("created_at")).toEqual(timeNow());
+    expect(stamped.readAttribute("updated_at")).toEqual(timeNow());
 
     const oldUpdatedAt = stamped.readAttribute("updated_at");
 
     // travel 5 minutes — vi.setSystemTime advances the fake clock without resetting it
     vi.setSystemTime(new Date(t0.getTime() + 5 * 60 * 1000));
+    frozenNow = Temporal.Instant.fromEpochMilliseconds(t0.getTime() + 5 * 60 * 1000);
 
     // Mirror lft_will_change! — force-marks lft dirty without changing its value.
     // Use _attributes.fetchValue (not readAttribute) to match attributeWillChangeBang semantics:
@@ -39,11 +50,10 @@ describe("TouchTest", () => {
     (stamped as any)._dirty.forceChange("lft", (stamped as any)._attributes.fetchValue("lft"));
     await stamped.save();
 
-    const newUpdatedAt = stamped.readAttribute("updated_at");
-    expect(newUpdatedAt).not.toBeNull();
-    expect(newUpdatedAt).not.toEqual(oldUpdatedAt);
-    // created_at does not change on update
-    expect(stamped.readAttribute("created_at")).toEqual(createdAt);
+    expect(stamped.readAttribute("updated_at")).toEqual(timeNow());
+    // created_at does not change on update, so it still reads as the
+    // pre-travel updated_at (mixin_test.rb:46).
+    expect(stamped.readAttribute("created_at")).toEqual(oldUpdatedAt);
   });
 
   it("create turned off", async () => {

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -1,18 +1,13 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { Temporal } from "@blazetrails/date";
+import { currentTimeInstant, freezeTime, travel, travelBack } from "@blazetrails/activesupport";
+import { Duration } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
-
-// Rails' `travel` freezes `Time.now`; vitest's fake timers only patch `Date`,
-// and the timestamp writer reads `Temporal.Now.instant()` off a nanosecond
-// clock, so freeze that too — otherwise `assert_equal Time.now, created_at`
-// compares against a drifting sub-millisecond tail.
-let frozenNow = Temporal.Instant.fromEpochMilliseconds(0);
-const timeNow = () => frozenNow;
 
 describe("TouchTest", () => {
   fixtures([]);
   afterEach(() => {
+    travelBack();
     vi.useRealTimers();
   });
 
@@ -26,23 +21,18 @@ describe("TouchTest", () => {
       }
     }
 
-    const t0 = new Date("2024-01-01T00:00:00.000Z");
-    vi.useFakeTimers({ now: t0 });
-    frozenNow = Temporal.Instant.fromEpochMilliseconds(t0.getTime());
-    vi.spyOn(Temporal.Now, "instant").mockImplementation(() => frozenNow);
+    freezeTime();
 
     const stamped = new Mixin();
     expect(stamped.readAttribute("updated_at")).toBeNull();
     expect(stamped.readAttribute("created_at")).toBeNull();
     await stamped.save();
-    expect(stamped.readAttribute("created_at")).toEqual(timeNow());
-    expect(stamped.readAttribute("updated_at")).toEqual(timeNow());
+    expect(stamped.readAttribute("created_at")).toEqual(currentTimeInstant());
+    expect(stamped.readAttribute("updated_at")).toEqual(currentTimeInstant());
 
     const oldUpdatedAt = stamped.readAttribute("updated_at");
 
-    // travel 5 minutes — vi.setSystemTime advances the fake clock without resetting it
-    vi.setSystemTime(new Date(t0.getTime() + 5 * 60 * 1000));
-    frozenNow = Temporal.Instant.fromEpochMilliseconds(t0.getTime() + 5 * 60 * 1000);
+    travel(Duration.minutes(5));
 
     // Mirror lft_will_change! — force-marks lft dirty without changing its value.
     // Use _attributes.fetchValue (not readAttribute) to match attributeWillChangeBang semantics:
@@ -50,9 +40,7 @@ describe("TouchTest", () => {
     (stamped as any)._dirty.forceChange("lft", (stamped as any)._attributes.fetchValue("lft"));
     await stamped.save();
 
-    expect(stamped.readAttribute("updated_at")).toEqual(timeNow());
-    // created_at does not change on update, so it still reads as the
-    // pre-travel updated_at (mixin_test.rb:46).
+    expect(stamped.readAttribute("updated_at")).toEqual(currentTimeInstant());
     expect(stamped.readAttribute("created_at")).toEqual(oldUpdatedAt);
   });
 

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -236,18 +236,18 @@ describe("MultiDbMigratorTest", () => {
     const migratorA = migratorClass(sensorsA, schemaMigrationA, internalMetadataA);
 
     await schemaMigrationA.dropTable();
-    expect(await schemaMigrationA.tableExists()).toBe(false);
+    expect(await schemaMigrationA.tableExists()).toBeFalsy();
     await migratorA.migrate(1);
-    expect(await schemaMigrationA.tableExists()).toBe(true);
+    expect(await schemaMigrationA.tableExists()).toBeTruthy();
     await migratorA.rollback();
 
     const sensorsB = [sensor(1, "S1"), sensor(2, "S2"), sensor(3, "S3")];
     const migratorB = migratorClass(sensorsB, schemaMigrationB, internalMetadataB);
 
     await schemaMigrationB.dropTable();
-    expect(await schemaMigrationB.tableExists()).toBe(false);
+    expect(await schemaMigrationB.tableExists()).toBeFalsy();
     await migratorB.migrate(1);
-    expect(await schemaMigrationB.tableExists()).toBe(true);
+    expect(await schemaMigrationB.tableExists()).toBeTruthy();
     await migratorB.rollback();
   });
 

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -123,7 +123,8 @@ describe("NormalizedAttributeTest", () => {
   it("finds record by normalized value", async () => {
     expect((aircraft.manufactured_at as Temporal.Instant).equals(noon(time))).toBe(true);
     const found = await NormalizedAircraft.findBy({ manufactured_at: time.toString() });
-    expect(found).not.toBeNull();
+    // Rails' `assert_equal @aircraft, find_by(...)` leans on AR record equality
+    // (`Core#==`, class + id), not a structural compare.
     expect(found!.id).toBe(aircraft.id);
   });
 

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -355,9 +355,7 @@ describe("QueryLogsTest", () => {
   // the comment also confirms no error was raised.
   it.skipIf(adapterType === "postgres")("invalid encoding query", async () => {
     queryLogs.tags = ["application"];
-    await assertQueriesMatch(/\/\*application:active_record\*\//, undefined, false, async () => {
-      await leaseConnection().execute("select 1 as '\uD800'");
-    });
+    await expect(leaseConnection().execute("select 1 as '\uD800'")).resolves.not.toThrow();
   });
 
   it("custom proc context tags", async () => {

--- a/packages/activerecord/src/relation/field-ordered-values.test.ts
+++ b/packages/activerecord/src/relation/field-ordered-values.test.ts
@@ -4,6 +4,7 @@
  * Mirrors: activerecord/test/cases/relation/field_ordered_values_test.rb
  */
 import { describe, it, expect } from "vitest";
+import { assertEmpty } from "@blazetrails/activesupport";
 import { sql as arelSql } from "@blazetrails/arel";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
@@ -28,7 +29,7 @@ describe("FieldOrderedValuesTest", () => {
   it("in order of empty", async () => {
     const posts = Post.inOrderOf("id", []);
 
-    expect(await posts).toEqual([]);
+    assertEmpty(await posts);
   });
 
   it("in order of with enums values", async () => {

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -144,8 +144,7 @@ describe("PredicateBuilderTest", () => {
     // Arel resolves "schema.table" as schema.table identifier, producing:
     // "schema"."table"."column" = ?  (the value is a BindParam, not inlined —
     // Rails parity, see Arel BindParam#toSql).
-    expect(sql).toMatch(/"schema"\."table"\."column"/);
-    expect(sql).toContain("= ?");
+    expect(sql).toMatch(/schema.+table.+column/i);
   });
 
   it("does not mutate", () => {

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -92,12 +92,12 @@ describe("SerializationTest", () => {
 
       const klazz = class extends Base {};
       klazz._tableName = "topics";
-      expect(klazz.includeRootInJson).toBe(true);
+      expect(klazz.includeRootInJson).toBeTruthy();
 
       klazz.includeRootInJson = false;
-      expect(Base.includeRootInJson).toBe(true);
-      expect(klazz.includeRootInJson).toBe(false);
-      expect(new klazz().includeRootInJson).toBe(false);
+      expect(Base.includeRootInJson).toBeTruthy();
+      expect(klazz.includeRootInJson).toBeFalsy();
+      expect(new klazz().includeRootInJson).toBeFalsy();
     } finally {
       Base.includeRootInJson = originalRootInJson;
     }

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -148,7 +148,7 @@ describe("StatementCacheTest", () => {
     // changing the table name should change the query that is not cached.
     Liquid.tableName = "birds";
     try {
-      await expect(Liquid.find(liquid.id)).rejects.toBeInstanceOf(RecordNotFound);
+      await expect(Liquid.find(liquid.id)).rejects.toThrow(RecordNotFound);
     } finally {
       Liquid.tableName = "liquid";
     }

--- a/packages/activerecord/src/table-metadata.test.ts
+++ b/packages/activerecord/src/table-metadata.test.ts
@@ -32,7 +32,7 @@ describe("TableMetadataTest", () => {
 
     const associatedTableMetadata = baseTableMetadata.associatedTable("audit_logs");
 
-    expect(associatedTableMetadata.arelTable.typeForAttribute("message")).toBeInstanceOf(
+    expect(associatedTableMetadata.arelTable.typeForAttribute("message").constructor).toEqual(
       StringType,
     );
   });

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -39,13 +39,9 @@ describe("TestDatabasesTest", () => {
   });
 
   it("databases are created", async () => {
-    const mockReconstructFromSchema = vi
-      .spyOn(DatabaseTasks, "reconstructFromSchema")
-      .mockResolvedValue(undefined);
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
     const connectionHandling = await import("./connection-handling.js");
-    const mockEstablishConnection = vi
-      .spyOn(connectionHandling, "establishConnection")
-      .mockResolvedValue(undefined);
+    vi.spyOn(connectionHandling, "establishConnection").mockResolvedValue(undefined);
 
     const mockConfig: any = {};
     Object.defineProperty(mockConfig, "_database", {
@@ -60,29 +56,17 @@ describe("TestDatabasesTest", () => {
     });
     mockConfig.adapter = "sqlite3";
 
-    const mockConfigurations = stubConfigurations([mockConfig]);
-
-    Base.configurations(mockConfigurations);
+    Base.configurations(stubConfigurations([mockConfig]));
 
     await createAndLoadSchema(2, { envName: "arunit" });
 
     expect(mockConfig.database).toBe("test/db/primary.sqlite3-2");
-    expect(mockReconstructFromSchema).toHaveBeenCalledWith(
-      mockConfig,
-      DatabaseTasks.schemaFormat,
-      undefined,
-    );
-    expect(mockEstablishConnection).toHaveBeenCalledWith(Base, undefined);
   });
 
   it("create databases after fork", async () => {
-    const mockReconstructFromSchema = vi
-      .spyOn(DatabaseTasks, "reconstructFromSchema")
-      .mockResolvedValue(undefined);
+    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
     const connectionHandling = await import("./connection-handling.js");
-    const mockEstablishConnection = vi
-      .spyOn(connectionHandling, "establishConnection")
-      .mockResolvedValue(undefined);
+    vi.spyOn(connectionHandling, "establishConnection").mockResolvedValue(undefined);
 
     const mockConfig: any = {};
     Object.defineProperty(mockConfig, "_database", {
@@ -104,16 +88,21 @@ describe("TestDatabasesTest", () => {
     await createAndLoadSchema(42, { envName: "arunit" });
 
     expect(mockConfig.database).toBe("test/db/primary.sqlite3-42");
-    expect(mockReconstructFromSchema).toHaveBeenCalled();
+    // "Updates the database configuration" — Rails re-reads the registry
+    // (test_databases_test.rb:49); `configsFor` is stubbed to hand back the same
+    // config object, which is the one create_and_load_schema suffixed.
+    expect(mockConfigurations.configsFor({ envName: "arunit", name: "primary" })[0].database).toBe(
+      "test/db/primary.sqlite3-42",
+    );
   });
 
   it("order of configurations isnt changed by test databases", async () => {
     const mockReconstructFromSchema = vi
       .spyOn(DatabaseTasks, "reconstructFromSchema")
       .mockResolvedValue(undefined);
-    const mockEstablishConnection = vi
-      .spyOn(await import("./connection-handling.js"), "establishConnection")
-      .mockResolvedValue(undefined);
+    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
+      undefined,
+    );
 
     const configs = [
       { database: "test/db/primary.sqlite3", adapter: "sqlite3", name: "primary" },
@@ -126,12 +115,10 @@ describe("TestDatabasesTest", () => {
 
     await createAndLoadSchema(42, { envName: "arunit" });
 
-    expect(mockReconstructFromSchema).toHaveBeenCalledTimes(configs.length);
     const reconstructedNames = mockReconstructFromSchema.mock.calls.map(
       (call: any[]) => call[0].name,
     );
     expect(reconstructedNames).toEqual(["primary", "replica"]);
-    expect(mockEstablishConnection).toHaveBeenCalled();
   });
 
   // URL-only configs (no explicit `database`) — e.g. sqlite paths

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -5,6 +5,7 @@
  * Ported from vendor/rails/activerecord/test/cases/touch_later_test.rb.
  */
 import { describe, it, expect } from "vitest";
+import { assertNotPredicate } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 import { travel, travelBack } from "@blazetrails/activesupport";
 import { fixtures } from "./test-fixtures.js";
@@ -39,7 +40,7 @@ describe("TouchLaterTest", () => {
   it("touch later raise if non persisted", async () => {
     const invoice = new Invoice();
     await Invoice.transaction(async () => {
-      expect(invoice.isPersisted()).toBe(false);
+      assertNotPredicate(invoice, (i) => i.isPersisted());
       await expect(invoice.touchLater()).rejects.toThrow(
         "Cannot touch on a new or destroyed record",
       );
@@ -49,7 +50,7 @@ describe("TouchLaterTest", () => {
   it("touch later dont set dirty attributes", async () => {
     const invoice = await Invoice.create();
     await invoice.touchLater();
-    expect(invoice.changed).toBe(false);
+    assertNotPredicate(invoice, (i) => i.changed);
   });
 
   it("touch later respects no touching policy", async () => {

--- a/packages/activerecord/src/type-caster/connection.test.ts
+++ b/packages/activerecord/src/type-caster/connection.test.ts
@@ -16,7 +16,7 @@ describe("ConnectionTest", () => {
 
     const type = typeCaster.typeForAttribute("name");
 
-    expect(type).not.toBeInstanceOf(DeveloperName);
-    expect(type.constructor).toBe(StringType);
+    expect(type.constructor).not.toEqual(DeveloperName);
+    expect(type.constructor).toEqual(StringType);
   });
 });

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { assertPredicate, assertNotPredicate } from "@blazetrails/activesupport";
 import { Author } from "../test-helpers/models/author.js";
 import { fixtures } from "../test-fixtures.js";
 
@@ -25,17 +26,17 @@ const { authors } = fixtures({
 describe("StringTypeTest", () => {
   it("string mutations are detected", async () => {
     const author = await StringTestAuthor.find(authors("sean").id);
-    expect(author.changed).toBe(false);
+    assertNotPredicate(author, (a) => a.changed);
 
     // JS strings are immutable; assignment goes through the setter rather than mutating in place.
     // nameChanged() fires via dirty-tracker change detection, not isChangedInPlace.
     author.name = String(author.name) + " Griffin";
-    expect((author as any).nameChanged()).toBe(true);
+    assertPredicate(author, (a) => (a as any).nameChanged());
 
     await author.save();
     await author.reload();
 
-    expect(author.name).toBe("Sean Griffin");
-    expect(author.changed).toBe(false);
+    expect(author.name).toEqual("Sean Griffin");
+    assertNotPredicate(author, (a) => a.changed);
   });
 });

--- a/packages/activerecord/src/type/type-map.test.ts
+++ b/packages/activerecord/src/type/type-map.test.ts
@@ -121,18 +121,12 @@ describe("HashLookupTypeMapTest", () => {
 
   it("fetch memoizes on args", () => {
     const mapping = new HashLookupTypeMap();
-    let callCount = 0;
     mapping.registerType("foo", undefined, (type: string | number, ...args: unknown[]) => {
-      callCount++;
       return [type, ...args].join("-") as any;
     });
 
-    expect(mapping.fetch("foo", 1, 2, 3, () => [].join("-"))).toBe("foo-1-2-3");
-    expect(mapping.fetch("foo", 1, 2, 3, () => [].join("-"))).toBe("foo-1-2-3");
-    expect(callCount).toBe(1);
-
-    expect(mapping.fetch("foo", 2, 3, 4, () => [].join("-"))).toBe("foo-2-3-4");
-    expect(callCount).toBe(2);
+    expect(mapping.fetch("foo", 1, 2, 3, (...args: unknown[]) => args.join("-"))).toBe("foo-1-2-3");
+    expect(mapping.fetch("foo", 2, 3, 4, (...args: unknown[]) => args.join("-"))).toBe("foo-2-3-4");
   });
 
   it("fetch yields args", () => {

--- a/packages/activerecord/src/unconnected.test.ts
+++ b/packages/activerecord/src/unconnected.test.ts
@@ -25,17 +25,22 @@ describe("TestUnconnectedAdapter", () => {
   });
 
   it("connection no longer established", async () => {
-    await expect(TestRecord.find(1)).rejects.toBeInstanceOf(ConnectionNotDefined);
-    await expect(new TestRecord().save()).rejects.toBeInstanceOf(ConnectionNotDefined);
+    await expect(TestRecord.find(1)).rejects.toThrow(ConnectionNotDefined);
+    await expect(new TestRecord().save()).rejects.toThrow(ConnectionNotDefined);
   });
 
   it("error message when connection not established", async () => {
-    const err = await TestRecord.find(1).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(ConnectionNotDefined);
-    expect((err as ConnectionNotDefined).message).toBe("No database connection defined.");
+    // Rails' `error = assert_raise(...) { ... }` both asserts the raise and hands
+    // back the exception; vitest's `rejects.toThrow` returns nothing, so the
+    // rejection is captured first and re-thrown into the raise assertion.
+    const error = await TestRecord.find(1).catch((e: unknown) => e);
+    expect(() => {
+      throw error;
+    }).toThrow(ConnectionNotDefined);
+    expect((error as ConnectionNotDefined).message).toBe("No database connection defined.");
   });
 
   it("underlying adapter no longer active", async () => {
-    expect(await underlying.active()).toBe(false);
+    expect(await underlying.active()).toBeFalsy();
   });
 });

--- a/packages/activerecord/src/validations/i18n-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-validation.test.ts
@@ -40,9 +40,9 @@ describe("I18nValidationTest", () => {
     const spy = vi.spyOn(ActiveModelError, "generateMessage");
     await topic.save();
     void topic.errors.messages;
-    // Rails' assert_called_with asserts exactly one call with these args.
-    expect(spy).toHaveBeenCalledWith("title", ":taken", topic, { value: "unique!" });
-    expect(spy).toHaveBeenCalledTimes(1);
+    // Rails' assert_called_with asserts exactly one call with these args — one
+    // assertion, so the port folds both halves into the single matcher.
+    expect(spy).toHaveBeenCalledExactlyOnceWith("title", ":taken", topic, { value: "unique!" });
   });
 
   // Rails generates one test per COMMON_CASE via string interpolation; the
@@ -62,9 +62,9 @@ describe("I18nValidationTest", () => {
     const spy = vi.spyOn(ActiveModelError, "generateMessage");
     await topic.isValid();
     void topic.errors.messages;
-    // Rails' assert_called_with asserts exactly one call with these args.
-    expect(spy).toHaveBeenCalledWith("replies", ":invalid", topic, { value: replies });
-    expect(spy).toHaveBeenCalledTimes(1);
+    // Rails' assert_called_with asserts exactly one call with these args — one
+    // assertion, so the port folds both halves into the single matcher.
+    expect(spy).toHaveBeenCalledExactlyOnceWith("replies", ":invalid", topic, { value: replies });
   });
 
   it("validates associated finds custom model key translation", async () => {

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -339,6 +339,9 @@ describe("I18nTest", () => {
     setExceptionHandler(exceptionHandler);
 
     expect(() => transliterate("ąćó")).toThrow(ArgumentError);
+    // Rails writes this first as `I18n.exception_handler.expects(:call)`; mocha
+    // verifies the expectation at teardown, so the port asserts it at the end.
+    expect(exceptionHandler).toHaveBeenCalled();
   });
 
   it("I18n.transliterate raises I18n::ArgumentError exception", () => {
@@ -347,6 +350,8 @@ describe("I18nTest", () => {
     setExceptionHandler(exceptionHandler);
 
     expect(() => transliterate("ąćó", { raise: true })).toThrow(ArgumentError);
+    // `I18n.exception_handler.expects(:call).never`, verified at teardown by mocha.
+    expect(exceptionHandler).not.toHaveBeenCalled();
   });
 
   it("transliterate given an unavailable locale rases an I18n::InvalidLocale", () => {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,18 +21,18 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 312,
+      "assertionCount": 307,
       "kind": 448,
       "value": 59
     },
     "activerecord": {
-      "assertionCount": 1958,
-      "kind": 3971,
-      "value": 39
+      "assertionCount": 1944,
+      "kind": 3927,
+      "value": 38
     },
     "activesupport": {
-      "assertionCount": 888,
-      "kind": 1229,
+      "assertionCount": 882,
+      "kind": 1227,
       "value": 104
     },
     "arel": {
@@ -56,7 +56,7 @@
       "value": 1
     },
     "i18n": {
-      "assertionCount": 6,
+      "assertionCount": 0,
       "kind": 0,
       "value": 0
     },

--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -612,3 +612,61 @@ describe("Ruby extractor assertion-value collection", () => {
     expect(v["recv"]).toEqual(["n:5", "s:hi", "s:sym", null]);
   });
 });
+
+describe("Ruby extractor mocha expectation collection", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-tests.rb");
+
+  function rubyAssertionKinds(
+    fixtures: Record<string, string>,
+  ): Record<string, string[] | undefined> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "assert-rb-mocha-"));
+    try {
+      for (const [rel, src] of Object.entries(fixtures)) {
+        const p = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, src);
+      }
+      const rels = JSON.stringify(Object.keys(fixtures));
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = TestExtractor.new
+        JSON.parse(${JSON.stringify(rels)}).each do |rel|
+          ex.process_file(File.join(${JSON.stringify(dir)}, rel), ${JSON.stringify(dir)})
+        end
+        out = {}
+        ex.test_files.each { |f| f[:testCases].each { |tc| out[tc[:description]] = tc[:assertionKinds] } }
+        puts JSON.generate(out)
+      `;
+      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+      return JSON.parse(stdout);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("counts mocha expects as an assertion and tags the never modifier", () => {
+    const k = rubyAssertionKinds({
+      "cases/mocha_test.rb": `
+        class MochaTest < ActiveSupport::TestCase
+          def test_expects
+            I18n.backend.expects(:translate).with('de', :foo, {})
+            I18n.translate :foo, :locale => 'de'
+          end
+
+          def test_never
+            I18n.exception_handler.expects(:call).never
+            assert_raises(ArgumentError) { I18n.transliterate("x") }
+          end
+
+          def test_stubs_are_not_expectations
+            Transliterator.stubs(:get).raises(ArgumentError)
+          end
+        end
+      `,
+    });
+    expect(k["expects"]).toEqual(["expects"]);
+    expect(k["never"]).toEqual(["expects_never", "assert_raises"]);
+    expect(k["stubs are not expectations"]).toEqual([]);
+  });
+});

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -62,9 +62,20 @@ SKIP_PATTERNS = [
 # (assert_queries_count, assert_no_queries, assert_cycle, …) a whitelist kept
 # missing, the `must_*`/`wont_*` spec forms, and `expect`. The `(_|\z)`/`_`
 # anchors keep look-alikes (`asserted`, `assertion`) out.
+#
+# `expects` is mocha's `Mocha::API#expects` — a mock expectation verified at
+# teardown rather than inline, so minitest's own assertion counter never sees it.
+# It is still an assertion of the test's intent, and the trails ports spell it as
+# an explicit `expect(spy).toHaveBeenCalledWith(...)`, so we count it here to keep
+# the two sides' assertion COUNTS in step. Both sides' kind tokens stay unmapped
+# in assertion-kinds.ts (see `expects-canonical-kind-enrollment`): mapping
+# `toHaveBeenCalled*` onto a canonical kind surfaces ~97 pre-existing port
+# divergences across activerecord/activesupport and is its own burndown.
+# `stubs` is NOT an expectation — it only installs a return value — and stays
+# uncounted.
 def assertion_method?(name)
   return false unless name
-  name == "expect" ||
+  name == "expect" || name == "expects" ||
     name.match?(/\A(assert|refute)(_|\z)/) ||
     name.match?(/\A(must|wont)_/)
 end
@@ -1194,7 +1205,7 @@ class TestExtractor
   def collect_assertion_kinds(node)
     kinds = []
     values = []
-    collect_assertion_kinds_expanded(node, kinds, values, [], 0, nil, @class_stack.dup)
+    collect_assertion_kinds_expanded(node, kinds, values, [], 0, nil, @class_stack.dup, false)
     [kinds, values]
   end
 
@@ -1208,7 +1219,10 @@ class TestExtractor
   # expected value without moving the (lockstep-critical) recording site. The
   # `:command` (`assert_equal 5, foo`) and `:command_call` (`foo.must_equal 5`)
   # forms carry their args on the node directly (node[2] / node[4]).
-  def collect_assertion_kinds_expanded(node, results, values, visiting, depth, pending_args, scope)
+  # `pending_never` threads mocha's `.never` modifier down from the chain's outer
+  # `:call` to the inner `expects`, so `foo.expects(:bar).never` records the
+  # negated kind — the twin of the port's `expect(spy).not.toHaveBeenCalled()`.
+  def collect_assertion_kinds_expanded(node, results, values, visiting, depth, pending_args, scope, pending_never = false)
     return unless node.is_a?(Array)
 
     name = self_call_name(node)
@@ -1217,14 +1231,14 @@ class TestExtractor
         # A parenthesized call `assert_equal(a, b)` is `[:method_add_arg,
         # [:fcall, ...], ...]`; self_call_name matches the inner :fcall, and the
         # recursion below descends into it — so the wrapper is not double-counted.
-        results << name
+        results << (pending_never ? "#{name}_never" : name)
         args = node[0] == :command ? node[2] : pending_args
         values << literal_token(expected_arg(args, name))
       elsif depth < MAX_HELPER_DEPTH && !visiting.include?(name)
         resolved = resolve_helper(name, scope)
         if resolved
           visiting.push(name)
-          collect_assertion_kinds_expanded(resolved[0], results, values, visiting, depth + 1, nil, resolved[1])
+          collect_assertion_kinds_expanded(resolved[0], results, values, visiting, depth + 1, nil, resolved[1], false)
           visiting.pop
         end
       end
@@ -1235,7 +1249,7 @@ class TestExtractor
       # parenthesized `:call` form gets it threaded via `pending_args` from its
       # `:method_add_arg` parent (mirroring the self-call path).
       rname = ident_name(node[3])
-      results << rname
+      results << (pending_never ? "#{rname}_never" : rname)
       args = node[0] == :command_call ? node[4] : pending_args
       values << literal_token(expected_arg(args, rname))
     end
@@ -1244,8 +1258,10 @@ class TestExtractor
     # callee (node[1]) so the value is available at the recording site, then
     # recurse the args normally. Every other node recurses its children unchanged.
     if node[0] == :method_add_arg && node[1].is_a?(Array) && %i[fcall call].include?(node[1][0])
-      collect_assertion_kinds_expanded(node[1], results, values, visiting, depth, node[2], scope)
+      collect_assertion_kinds_expanded(node[1], results, values, visiting, depth, node[2], scope, pending_never)
       collect_assertion_kinds_expanded(node[2], results, values, visiting, depth, nil, scope)
+    elsif node[0] == :call && ident_name(node[3]) == "never"
+      collect_assertion_kinds_expanded(node[1], results, values, visiting, depth, nil, scope, true)
     else
       node.each do |child|
         collect_assertion_kinds_expanded(child, results, values, visiting, depth, nil, scope) if child.is_a?(Array)


### PR DESCRIPTION
Burns down the assertion-parity tail for the activerecord root files (RFC 0105),
and closes the assertion-COUNT half of the mocha-`expects` extractor gap.

## Extractor: mocha `expects` counts as a Rails-side assertion

`scripts/test-compare/extract-ruby-tests.rb`'s `assertion_method?` now accepts
`expects` — mocha's `Mocha::API#expects` is a mock expectation verified at
teardown, so minitest's own counter never sees it, while the trails port spells
the same check as an explicit `expect(spy).toHaveBeenCalledWith(...)`. The
`.never` modifier is threaded down the chain as an `expects_never` token so a
negated expectation stays distinguishable. `stubs` is not an expectation and
stays uncounted.

This takes **i18n to 0 / 0 / 0** on assertions (was 6 assertion-count), and is
pinned by a new case in `extract-ruby-assertions.test.ts` covering all three
shapes (`expects`, `expects(...).never`, and `stubs` staying uncounted).

Both sides' kind tokens stay unmapped in `assertion-kinds.ts`. Enrolling them
(`toHaveBeenCalled*` → a `called` canonical kind) was measured and surfaces ~97
*pre-existing* port divergences — activerecord kind 3970 → 4053, activesupport
1227 → 1240, arel 591 → 592 — which is its own burndown, not a tooling change.
Filed as `0105-ar-deps-test-parity-100/expects-canonical-kind-enrollment`.

## activerecord root files, batches 6a and 6b

All 35 files from the two story tables converge Rails-ward: same assertion kinds,
same counts, same literal values. Highlights:

- `assert_raise` ports as `rejects.toThrow(Klass)`, not `rejects.toBeInstanceOf`.
- `assert_nothing_raised` ports as `not.toThrow()` / `resolves.not.toThrow()`.
- `assert_predicate` / `assert_not_predicate` use the activesupport analogues.
- `assert_encryptor_works_with` (encryption/helper.rb:50-55) now has a trails
  twin in `encryption/test-helpers.ts`, so the two sides agree on the kind.
- `annotate_test.rb` routes through `assertQueriesMatch`, mirroring Rails'
  `assert_queries_match` block-per-annotation shape.
- `mixin_test.rb` now uses activesupport's `freezeTime()` / `travel(...)` — the
  port of Rails' own `travel 5.minutes` — instead of hand-rolled fake timers, so
  `assert_equal Time.now, created_at` compares against the same stubbed clock
  `timestamp.ts` reads.
- `UrlConfig#replica?` returned `configuration_hash[:replica] == true`; Rails
  returns the stored value (`hash_config.rb:46-48`), so the absent case is `nil`,
  not `false`. Fixed in `database-config.ts`.

Three rows are left with a call-site comment explaining why the assertion cannot
be mirrored (a `PP.pp` vs `inspect` quoting difference, and a connection
descriptor that trails names `Base` where Rails names `ActiveRecord::Base` —
that one is a port divergence, not a test one).

`scripts/test-compare/assertion-mismatch-mark.json` lowered on a passing run:

| package | count | kind | value |
| --- | --- | --- | --- |
| activerecord | 1958 → 1944 | 3971 → 3927 | 39 → 38 |
| i18n | 6 → 0 | 0 | 0 |
| activemodel | 312 → 307 | 448 | 59 |
| activesupport | 888 → 882 | 1229 → 1227 | 104 |

No test names changed; `parity:test` percentages are unchanged.

## Not in this PR

`assertions-activesupport-cluster-tail-7` and
`assertions-activesupport-hash-cluster` were bundled but do not fit under the LOC
ceiling alongside the above — they are ~300 divergences of their own. Both have
been released back to the queue untouched.

Closes-story: assertions-tail-root-6a
Closes-story: assertions-tail-root-6b
Closes-story: assertion-extractor-counts-mocha-expects
