### PR TITLE
refactor(activesupport,activemodel,activerecord): converge parse-string-in-zone onto user_input_in_time_zone

### DIFF
--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Rational, Temporal } from "@blazetrails/date";
-import { useZone } from "@blazetrails/activesupport";
+import { TimeWithZone, useZone } from "@blazetrails/activesupport";
 import {
   applySecondsPrecision,
   fastStringToTime,
@@ -151,17 +151,42 @@ describe("fastStringToTime", () => {
 // (time_value.rb:42-44) — `value.in_time_zone`, whose else arm with no
 // Time.zone set is a bare `to_time` (date_and_time/zones.rb:20-27).
 describe("userInputInTimeZone", () => {
-  it("answers a zoneless value when Time.zone is unset", () => {
+  it("answers String#to_time when Time.zone is unset", () => {
     const result = userInputInTimeZone("2024-06-15 14:30:00");
-    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
-    expect(result?.toString()).toBe("2024-06-15T14:30:00");
+    expect(result).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect((result as Temporal.ZonedDateTime).toPlainDateTime().toString()).toBe(
+      "2024-06-15T14:30:00",
+    );
   });
 
-  it("anchors to Time.zone when one is set", () => {
+  it("parses in Time.zone when one is set", () => {
     useZone("Eastern Time (US & Canada)", () => {
-      const result = userInputInTimeZone("2024-06-15 14:30:00");
-      expect(result).toBeInstanceOf(Temporal.ZonedDateTime);
-      expect((result as Temporal.ZonedDateTime).timeZoneId).toBe("America/New_York");
+      const result = userInputInTimeZone("2024-06-15 14:30:00") as TimeWithZone;
+      expect(result).toBeInstanceOf(TimeWithZone);
+      expect(result.timeZone.name).toBe("Eastern Time (US & Canada)");
+      expect(result.hour).toBe(14);
+    });
+  });
+
+  it("keeps sub-millisecond precision through the zone parse", () => {
+    useZone("Eastern Time (US & Canada)", () => {
+      const result = userInputInTimeZone("2024-06-15 14:30:00.123456789") as TimeWithZone;
+      expect(result.utc().epochNanoseconds % 1_000_000_000n).toBe(123456789n);
+    });
+  });
+
+  it("honours an explicit offset in the string", () => {
+    useZone("Eastern Time (US & Canada)", () => {
+      const result = userInputInTimeZone("2024-06-15T10:30:00Z") as TimeWithZone;
+      expect(result.hour).toBe(6);
+    });
+  });
+
+  it("reads a date-only string as midnight in the zone", () => {
+    useZone("Eastern Time (US & Canada)", () => {
+      const result = userInputInTimeZone("2024-06-15") as TimeWithZone;
+      expect(result.hour).toBe(0);
+      expect(result.day).toBe(15);
     });
   });
 });

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -4,7 +4,12 @@
  * Mirrors: ActiveModel::Type::Helpers::TimeValue
  */
 import { Rational, Temporal } from "@blazetrails/date";
-import { toFs, zone } from "@blazetrails/activesupport";
+import {
+  TimeWithZone,
+  inTimeZone as stringInTimeZone,
+  toFs,
+  zone,
+} from "@blazetrails/activesupport";
 
 import { isUtc } from "./timezone.js";
 
@@ -114,36 +119,34 @@ export function typeCastForSchema(value: unknown): string {
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::TimeValue#user_input_in_time_zone
- * (time_value.rb:42-44) — `value.in_time_zone`, whose zone is the thread-local
- * `Time.zone`.
+ * (time_value.rb:42-44)
  *
- * With no zone set at all Ruby takes `in_time_zone`'s else arm and answers a
- * bare `to_time` (`date_and_time/zones.rb:20-27`) — a value with no zone
- * attached. `Temporal.PlainDateTime` is that zoneless value, so the else arm
- * is answered as one rather than anchored to a zone Ruby never picked.
+ *   def user_input_in_time_zone(value)
+ *     value.in_time_zone
+ *   end
+ *
+ * Ruby picks `in_time_zone` off the receiver's class, and the two definitions
+ * that matter here do different things: `String#in_time_zone`
+ * (`core_ext/string/zones.rb:8-14`) is `Time.find_zone!(zone).parse(self)`,
+ * falling back to `String#to_time` with no zone set, while a `Time`'s is
+ * `DateAndTime::Zones#in_time_zone` (`core_ext/date_and_time/zones.rb:20-27`).
+ * A TS free function has no receiver to dispatch on, so the arm is chosen from
+ * the value's type — and each arm calls the ported core-ext, so no parsing
+ * lives here.
  */
 export function userInputInTimeZone(
   value: unknown,
-): Temporal.ZonedDateTime | Temporal.PlainDateTime | null {
+): TimeWithZone | Temporal.ZonedDateTime | Temporal.Instant | null {
   if (value === null || value === undefined) return null;
+  if (value instanceof TimeWithZone) return value.inTimeZone();
   if (value instanceof Temporal.ZonedDateTime) return value;
-  const str = String(value).trim();
-  if (str === "") return null;
-  if (str.includes("[")) {
-    try {
-      return Temporal.ZonedDateTime.from(str);
-    } catch {
-      return null;
-    }
-  }
-  try {
+  if (value instanceof Temporal.Instant) {
+    // `DateAndTime::Zones#in_time_zone` (zones.rb:20-27) on the `Time` arm:
+    // `time_with_zone(self, time_zone)` when a zone resolves, else `self`.
     const timeZone = zone();
-    const time = Temporal.PlainDateTime.from(str.replace(" ", "T"));
-    if (timeZone) return time.toZonedDateTime(timeZone.tzinfo.identifier);
-    return time;
-  } catch {
-    return null;
+    return timeZone ? new TimeWithZone(value, timeZone) : value;
   }
+  return stringInTimeZone(String(value)) ?? null;
 }
 
 /**

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -132,7 +132,9 @@ export function typeCastForSchema(value: unknown): string {
  * `DateAndTime::Zones#in_time_zone` (`core_ext/date_and_time/zones.rb:20-27`).
  * A TS free function has no receiver to dispatch on, so the arm is chosen from
  * the value's type — and each arm calls the ported core-ext, so no parsing
- * lives here.
+ * lives here. The `Temporal.Instant` arm is `zones.rb:22-27` inline:
+ * `time_with_zone(self, time_zone)` when a zone resolves, else the time
+ * itself.
  */
 export function userInputInTimeZone(
   value: unknown,
@@ -141,8 +143,6 @@ export function userInputInTimeZone(
   if (value instanceof TimeWithZone) return value.inTimeZone();
   if (value instanceof Temporal.ZonedDateTime) return value;
   if (value instanceof Temporal.Instant) {
-    // `DateAndTime::Zones#in_time_zone` (zones.rb:20-27) on the `Time` arm:
-    // `time_with_zone(self, time_zone)` when a zone resolves, else `self`.
     const timeZone = zone();
     return timeZone ? new TimeWithZone(value, timeZone) : value;
   }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -54,6 +54,15 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return resolveIsUtc(this._subtype);
   }
 
+  /**
+   * Mirrors: `TimeZoneConverter#cast` (time_zone_conversion.rb:19-32).
+   *
+   * Rails gives `String` an `in_time_zone` through CoreExt, so a string takes
+   * the `respond_to?(:in_time_zone)` arm — `super(user_input_in_time_zone(value))
+   * || super` (`:24`), whose `user_input_in_time_zone` is
+   * `Helpers::TimeValue`'s (time_value.rb:42-44), reached through the
+   * `DelegateClass` hop to the subtype.
+   */
   override cast(value: unknown): unknown {
     if (value == null) return null;
     // Hash (multiparameter attributes): cast via subtype, then treat wall-clock
@@ -81,12 +90,6 @@ export class TimeZoneConverter extends ValueType<unknown> {
       const instant = value.toZonedDateTime(zoneForIsUtc(this._subtypeIsUtc)).toInstant();
       return setTimeZoneWithoutConversion(instant, this._subtypeIsUtc);
     }
-    // Strings: Rails gives String an `in_time_zone` via CoreExt, so a string
-    // takes the `respond_to?(:in_time_zone)` arm —
-    // `super(user_input_in_time_zone(value)) || super`
-    // (time_zone_conversion.rb:24). `user_input_in_time_zone` is
-    // `Helpers::TimeValue`'s (time_value.rb:42-44), reached through the
-    // DelegateClass hop to the subtype.
     if (typeof value === "string") {
       return (
         this._subtype.cast((this._subtype as TimeValueSubtype).userInputInTimeZone(value)) ??

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -3,10 +3,18 @@
  */
 import type { Type } from "@blazetrails/activemodel";
 import { ValueType } from "@blazetrails/activemodel";
-import { TimeWithZone, TimeZone, zone as timeZone } from "@blazetrails/activesupport";
+import { TimeWithZone, zone as timeZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 import { isUtc } from "../type/internal/timezone.js";
 type ValueTypeInstance = InstanceType<typeof ValueType>;
+
+/**
+ * The `Helpers::TimeValue` member Rails reaches on the wrapped subtype through
+ * `DelegateClass(Type::Value)` — `user_input_in_time_zone` (time_value.rb:42-44).
+ */
+interface TimeValueSubtype extends Type {
+  userInputInTimeZone(value: unknown): unknown;
+}
 
 export interface TimeZoneConversion {
   timeZoneAwareAttributes: boolean;
@@ -73,23 +81,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
       const instant = value.toZonedDateTime(zoneForIsUtc(this._subtypeIsUtc)).toInstant();
       return setTimeZoneWithoutConversion(instant, this._subtypeIsUtc);
     }
-    // Strings: Rails gives String an in_time_zone method via CoreExt, so strings
-    // take the respond_to?(:in_time_zone) branch and are parsed as local to
-    // Time.zone (user_input_in_time_zone = value.in_time_zone = zone.parse(value)).
-    // Without this, subtype would interpret the string in default_timezone and
-    // convertTimeToTimeZone would only shift display — wrong underlying instant.
-    // Parse inline (not via zone.parse()) to preserve full nanosecond precision.
+    // Strings: Rails gives String an `in_time_zone` via CoreExt, so a string
+    // takes the `respond_to?(:in_time_zone)` arm —
+    // `super(user_input_in_time_zone(value)) || super`
+    // (time_zone_conversion.rb:24). `user_input_in_time_zone` is
+    // `Helpers::TimeValue`'s (time_value.rb:42-44), reached through the
+    // DelegateClass hop to the subtype.
     if (typeof value === "string") {
-      const zone = timeZone();
-      if (zone) {
-        // Mirrors Rails' `super(user_input_in_time_zone(value)) || super`:
-        // parse in the current zone; fall back to subtype cast if the format
-        // isn't recognized (preserves support for formats parseStringInZone
-        // doesn't handle, e.g. non-standard strings the subtype accepts).
-        const parsed = parseStringInZone(value, zone);
-        if (parsed !== null) return parsed;
-        return this.convertTimeToTimeZone(this._subtype.cast(value));
-      }
+      return (
+        this._subtype.cast((this._subtype as TimeValueSubtype).userInputInTimeZone(value)) ??
+        this._subtype.cast(value)
+      );
     }
     // Rails: `map(super) { |v| cast(v) }` (time_zone_conversion.rb:31) — the
     // DelegateClass hop to the subtype's own `map` hook, which rebuilds an
@@ -272,51 +274,6 @@ function setTimeZoneWithoutConversion(value: unknown, subtypeIsUtc?: boolean): u
     return value.inTimeZone(zone);
   }
   return value;
-}
-
-/** @internal */
-function parseStringInZone(value: string, zone: TimeZone): TimeWithZone | null {
-  try {
-    const trimmed = value.trim();
-    if (trimmed === "") return null;
-    // Normalize space separator → T first (e.g. "2024-06-15 10:30:00-04:00").
-    const withT = trimmed.replace(" ", "T");
-    // Detect offset: Z/z, ±HH:MM, ±HHMM, or short ±HH (without minutes).
-    if (/[Zz]$|[+-]\d{2}(?::?\d{2})?$/.test(withT)) {
-      // Normalize to a form Temporal.Instant.from() accepts (RFC 3339: no spaces,
-      // colon-separated offset). TimeWithZone#toString() emits "YYYY-MM-DD HH:MM:SS ±HHMM";
-      // after the space→T step the offset remains " ±HHMM" — strip the space and insert
-      // the colon. Also handles: ±HH:MM (already canonical), ±HHMM (add colon), ±HH (add :00).
-      const normalized = withT
-        .replace(/\s*([-+])(\d{2}):?(\d{2})$/, "$1$2:$3")
-        .replace(/\s*([-+]\d{2})$/, "$1:00");
-      return new TimeWithZone(Temporal.Instant.from(normalized), zone);
-    }
-    // No offset → wall-clock components local to the current zone.
-    // Date-only strings ("YYYY-MM-DD") → midnight, matching Rails' in_time_zone behavior.
-    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(withT);
-    const datetimeStr = isDateOnly ? `${withT}T00:00:00` : withT;
-    const pdt = Temporal.PlainDateTime.from(datetimeStr, { overflow: "reject" });
-    // zone.local() gives correct DST disambiguation at millisecond precision;
-    // add back sub-millisecond precision (microseconds + nanoseconds) separately.
-    const base = zone.local(
-      pdt.year,
-      pdt.month,
-      pdt.day,
-      pdt.hour,
-      pdt.minute,
-      pdt.second,
-      pdt.millisecond,
-    );
-    const subMs = pdt.microsecond * 1000 + pdt.nanosecond;
-    if (subMs === 0) return base;
-    return new TimeWithZone(
-      Temporal.Instant.fromEpochNanoseconds(base.utc().epochNanoseconds + BigInt(subMs)),
-      zone,
-    );
-  } catch {
-    return null;
-  }
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -61,7 +61,9 @@ export class TimeZoneConverter extends ValueType<unknown> {
    * the `respond_to?(:in_time_zone)` arm — `super(user_input_in_time_zone(value))
    * || super` (`:24`), whose `user_input_in_time_zone` is
    * `Helpers::TimeValue`'s (time_value.rb:42-44), reached through the
-   * `DelegateClass` hop to the subtype.
+   * `DelegateClass` hop to the subtype. That `||` falls through on `nil` and
+   * `false` only, so it is spelled as the explicit falsy check rather than a
+   * `??` (which keeps a `false`) or a bare truthiness test (which drops a `0`).
    */
   override cast(value: unknown): unknown {
     if (value == null) return null;
@@ -91,10 +93,10 @@ export class TimeZoneConverter extends ValueType<unknown> {
       return setTimeZoneWithoutConversion(instant, this._subtypeIsUtc);
     }
     if (typeof value === "string") {
-      return (
-        this._subtype.cast((this._subtype as TimeValueSubtype).userInputInTimeZone(value)) ??
-        this._subtype.cast(value)
+      const casted = this._subtype.cast(
+        (this._subtype as TimeValueSubtype).userInputInTimeZone(value),
       );
+      return casted != null && casted !== false ? casted : this._subtype.cast(value);
     }
     // Rails: `map(super) { |v| cast(v) }` (time_zone_conversion.rb:31) — the
     // DelegateClass hop to the subtype's own `map` hook, which rebuilds an

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -177,7 +177,7 @@ export function travelTo(
   } else if (typeof dateOrTime === "string") {
     // Without a `Time.zone` set there is no zone to parse through.
     const zone = timeZone();
-    now = zone ? zone.parse(dateOrTime).toTime() : Temporal.Instant.from(dateOrTime);
+    now = zone ? zone.parse(dateOrTime)!.toTime() : Temporal.Instant.from(dateOrTime);
   } else if (dateOrTime instanceof Date) {
     now = Temporal.Instant.fromEpochMilliseconds(dateOrTime.getTime());
   } else {

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -42,14 +42,14 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("creates from TimeZone.parse() with ISO string", () => {
-    const twz = eastern.parse("2024-06-15T12:00:00Z");
+    const twz = eastern.parse("2024-06-15T12:00:00Z")!;
     // 12:00 UTC = 8:00 EDT
     expect(twz.hour).toBe(8);
     expect(twz.day).toBe(15);
   });
 
   it("parses a string without timezone info as local to the zone", () => {
-    const twz = eastern.parse("2024-06-15 12:00:00");
+    const twz = eastern.parse("2024-06-15 12:00:00")!;
     expect(twz.hour).toBe(12);
     expect(twz.day).toBe(15);
   });

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -371,7 +371,7 @@ describe("TimeZoneTest", () => {
   // ---------------------------------------------------------------------------
   it("parse", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("1999-12-31 19:00:00");
+    const twz = zone.parse("1999-12-31 19:00:00")!;
     expect(twz.hour).toBe(19);
     expect(twz.day).toBe(31);
     expect(twz.month).toBe(12);
@@ -382,45 +382,46 @@ describe("TimeZoneTest", () => {
 
   it("parse string with timezone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2024-01-15T12:00:00Z");
+    const twz = zone.parse("2024-01-15T12:00:00Z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
     expect(twz.hour).toBe(7);
   });
 
   it("parse with old date", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("1883-07-01 00:00:00");
+    const twz = zone.parse("1883-07-01 00:00:00")!;
     expect(twz.year).toBe(1883);
   });
 
   it("parse far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2050-01-01T00:00:00-05:00");
+    const twz = zone.parse("2050-01-01T00:00:00-05:00")!;
     expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
   });
 
   it("parse returns nil when string without date information is passed in", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    expect(() => zone.parse("foobar")).toThrow();
+    expect(zone.parse("foobar")).toBeUndefined();
+    expect(zone.parse("   ")).toBeUndefined();
   });
 
   it("parse with incomplete date", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2000-01-01");
+    const twz = zone.parse("2000-01-01")!;
     expect(twz.year).toBe(2000);
     expect(twz.hour).toBe(0);
   });
 
   it("parse with day omitted", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2005-02-01");
+    const twz = zone.parse("2005-02-01")!;
     expect(twz.year).toBe(2005);
     expect(twz.month).toBe(2);
   });
 
   it("parse should not black out system timezone dst jump", () => {
     const zone = TimeZone.find("Pacific Time (US & Canada)")!;
-    const twz = zone.parse("2012-03-25 03:29:00");
+    const twz = zone.parse("2012-03-25 03:29:00")!;
     expect(twz.hour).toBe(3);
     expect(twz.min).toBe(29);
     expect(twz.day).toBe(25);
@@ -430,7 +431,7 @@ describe("TimeZoneTest", () => {
 
   it("parse should black out app timezone dst jump", () => {
     const zone = TimeZone.find("Pacific Time (US & Canada)")!;
-    const twz = zone.parse("2012-03-11 02:29:00");
+    const twz = zone.parse("2012-03-11 02:29:00")!;
     expect(twz.hour).toBe(3);
     expect(twz.min).toBe(29);
     expect(twz.day).toBe(11);
@@ -440,38 +441,38 @@ describe("TimeZoneTest", () => {
 
   it("parse with missing time components", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("1999-12-31");
+    const twz = zone.parse("1999-12-31")!;
     expect(twz.hour).toBe(0);
     expect(twz.min).toBe(0);
   });
 
   it("parse with javascript date", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2013-01-01T00:00:00");
+    const twz = zone.parse("2013-01-01T00:00:00")!;
     expect(twz.year).toBe(2013);
   });
 
   it("parse doesnt use local dst", () => {
     const zone = TimeZone.find("UTC")!;
-    const twz = zone.parse("2013-03-10 02:00:00");
+    const twz = zone.parse("2013-03-10 02:00:00")!;
     expect(twz.hour).toBe(2);
     expect(twz.day).toBe(10);
   });
 
   it("parse handles dst jump", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.parse("2006-04-02 02:00:00");
+    const twz = zone.parse("2006-04-02 02:00:00")!;
     expect(twz.hour).toBe(3);
   });
 
   it("parse with invalid date", () => {
-    const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    expect(() => zone.parse("")).toThrow();
+    const zone = TimeZone.find("UTC")!;
+    expect(() => zone.parse("9000")).toThrow("argument out of range");
   });
 
   it("parse with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
-    const twz = zone.parse("2014-10-26 01:00:00");
+    const twz = zone.parse("2014-10-26 01:00:00")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
@@ -549,7 +550,7 @@ describe("TimeZoneTest", () => {
   // ---------------------------------------------------------------------------
   it("strptime", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
+    const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
@@ -557,7 +558,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with nondefault time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S");
+    const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
@@ -565,7 +566,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with explicit time zone as abbrev", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z");
+    const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
@@ -573,7 +574,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with explicit time zone as h offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z");
+    const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
@@ -581,7 +582,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with explicit time zone as hm offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z");
+    const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
@@ -589,7 +590,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with explicit time zone as hms offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z");
+    const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
@@ -597,7 +598,7 @@ describe("TimeZoneTest", () => {
 
   it("strptime with almost explicit time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z");
+    const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
@@ -606,13 +607,13 @@ describe("TimeZoneTest", () => {
   it("strptime with day omitted", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const base = zone.local(2000, 1, 1);
-    expect(zone.strptime("Feb", "%b", base).month).toBe(2);
-    expect(zone.strptime("Feb", "%b", base).day).toBe(1);
-    expect(zone.strptime("Feb 2005", "%b %Y", base).year).toBe(2005);
-    expect(zone.strptime("Feb 2005", "%b %Y", base).month).toBe(2);
-    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base).day).toBe(2);
-    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base).month).toBe(2);
-    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base).year).toBe(2005);
+    expect(zone.strptime("Feb", "%b", base)!.month).toBe(2);
+    expect(zone.strptime("Feb", "%b", base)!.day).toBe(1);
+    expect(zone.strptime("Feb 2005", "%b %Y", base)!.year).toBe(2005);
+    expect(zone.strptime("Feb 2005", "%b %Y", base)!.month).toBe(2);
+    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base)!.day).toBe(2);
+    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base)!.month).toBe(2);
+    expect(zone.strptime("2 Feb 2005", "%e %b %Y", base)!.year).toBe(2005);
   });
 
   it("strptime with malformed string", () => {
@@ -622,19 +623,19 @@ describe("TimeZoneTest", () => {
 
   it("strptime with timestamp seconds", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1470272280", "%s");
+    const twz = zone.strptime("1470272280", "%s")!;
     expect(twz.toI()).toBe(1470272280);
   });
 
   it("strptime with timestamp milliseconds", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.strptime("1470272280000", "%Q");
+    const twz = zone.strptime("1470272280000", "%Q")!;
     expect(twz.toI()).toBe(1470272280);
   });
 
   it("strptime with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
-    const twz = zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S");
+    const twz = zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S")!;
     expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -12,7 +12,8 @@
 import { TimeWithZone } from "../time-with-zone.js";
 import { Duration } from "../duration.js";
 import { ArgumentError } from "../hash-utils.js";
-import { Temporal } from "@blazetrails/date";
+import { Temporal, Date as RubyDate, Rational } from "@blazetrails/date";
+import type { DateParts } from "@blazetrails/date";
 import { instantFrom } from "../temporal.js";
 import { currentTime } from "../time-travel.js";
 import { utcToLocalReturnsUtcOffsetTimes } from "../core-ext/date-and-time/compatibility.js";
@@ -901,277 +902,19 @@ export class TimeZone {
   }
 
   /**
-   * Parse a string into a TimeWithZone in this timezone.
+   * `parse(str, now = now())` (time_zone.rb:453-455):
+   * `parts_to_time(Date._parse(str, false), now)`.
    */
-  parse(str: string): TimeWithZone {
-    const trimmed = str.trim();
-
-    // If string has no timezone info, parse components manually to avoid
-    // system timezone interference, then treat as local to this zone
-    if (!/[Zz]|[+-]\d{2}:?\d{2}$/.test(trimmed)) {
-      // Try to extract date/time components directly
-      const match = trimmed.match(
-        /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T\s](\d{1,2}):(\d{1,2})(?::(\d{1,2})(?:\.(\d+))?)?)?$/,
-      );
-      if (match) {
-        const y = parseInt(match[1], 10);
-        const m = parseInt(match[2], 10);
-        const d = parseInt(match[3], 10);
-        const h = match[4] ? parseInt(match[4], 10) : 0;
-        const min = match[5] ? parseInt(match[5], 10) : 0;
-        const s = match[6] ? parseInt(match[6], 10) : 0;
-        let ms = 0;
-        if (match[7]) {
-          ms = parseInt(match[7].padEnd(3, "0").slice(0, 3), 10);
-        }
-        return this.local(y, m, d, h, min, s, ms);
-      }
-
-      // Fall back to Date parser for other formats
-      const date = new Date(str);
-      if (isNaN(date.getTime())) {
-        throw new Error(`Could not parse time: "${str}"`);
-      }
-      const y = date.getFullYear();
-      const m = date.getMonth() + 1;
-      const d = date.getDate();
-      const h = date.getHours();
-      const min = date.getMinutes();
-      const s = date.getSeconds();
-      const ms = date.getMilliseconds();
-      return this.local(y, m, d, h, min, s, ms);
-    }
-
-    // String has timezone info — parse and convert the UTC instant to this zone
-    const date = new Date(str);
-    if (isNaN(date.getTime())) {
-      throw new Error(`Could not parse time: "${str}"`);
-    }
-    return new TimeWithZone(instantFrom(date), this);
+  parse(str: string, now: TimeWithZone = this.now()): TimeWithZone | undefined {
+    return this.partsToTime(RubyDate._parse(str, false), now);
   }
 
   /**
-   * Parse a time string using a strftime-style format.
-   * The parsed time is interpreted in this timezone unless the format
-   * extracts an explicit timezone offset from the string.
+   * `strptime(str, format, now = now())` (time_zone.rb:487-489):
+   * `parts_to_time(DateTime._strptime(str, format), now)`.
    */
-  strptime(str: string, format: string, base?: TimeWithZone): TimeWithZone {
-    const now = base ?? this.now();
-    let year = now.year;
-    let month = now.month;
-    let day = now.day;
-    let hour = 0;
-    let minute = 0;
-    let second = 0;
-    const ms = 0;
-    let explicitOffsetSeconds: number | null = null;
-    let epochMs: number | null = null;
-
-    // Build a regex from the format string and extract components
-    let pos = 0;
-    let strPos = 0;
-
-    while (pos < format.length) {
-      if (format[pos] === "%" && pos + 1 < format.length) {
-        // Check for escaped %
-        if (format[pos + 1] === "%") {
-          if (str[strPos] !== "%") {
-            throw new Error(`ArgumentError: strptime: input does not match format`);
-          }
-          strPos++;
-          pos += 2;
-          continue;
-        }
-
-        // Handle optional : prefix for zone formats
-        let spec = format[pos + 1];
-        let specLen = 2;
-        if (spec === ":" && pos + 2 < format.length) {
-          if (
-            format[pos + 2] === ":" &&
-            pos + 3 < format.length &&
-            format[pos + 3] === ":" &&
-            pos + 4 < format.length &&
-            format[pos + 4] === "z"
-          ) {
-            spec = ":::z";
-            specLen = 5;
-          } else if (
-            format[pos + 2] === ":" &&
-            pos + 3 < format.length &&
-            format[pos + 3] === "z"
-          ) {
-            spec = "::z";
-            specLen = 4;
-          } else if (format[pos + 2] === "z") {
-            spec = ":z";
-            specLen = 3;
-          }
-        }
-
-        switch (spec) {
-          case "Y": {
-            const m = str.slice(strPos).match(/^(\d{4})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            year = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "m": {
-            const m = str.slice(strPos).match(/^(\d{1,2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            month = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "b": {
-            const m = str
-              .slice(strPos)
-              .match(/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/i);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            const months: Record<string, number> = {
-              jan: 1,
-              feb: 2,
-              mar: 3,
-              apr: 4,
-              may: 5,
-              jun: 6,
-              jul: 7,
-              aug: 8,
-              sep: 9,
-              oct: 10,
-              nov: 11,
-              dec: 12,
-            };
-            month = months[m[1].toLowerCase()];
-            strPos += m[1].length;
-            break;
-          }
-          case "d":
-          case "e": {
-            const m = str.slice(strPos).match(/^\s*(\d{1,2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            day = parseInt(m[1], 10);
-            strPos += m[0].length;
-            break;
-          }
-          case "H": {
-            const m = str.slice(strPos).match(/^(\d{1,2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            hour = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "M": {
-            const m = str.slice(strPos).match(/^(\d{1,2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            minute = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "S": {
-            const m = str.slice(strPos).match(/^(\d{1,2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            second = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "s": {
-            const m = str.slice(strPos).match(/^(\d+)/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            epochMs = parseInt(m[1], 10) * 1000;
-            strPos += m[1].length;
-            break;
-          }
-          case "Q": {
-            const m = str.slice(strPos).match(/^(\d+)/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            epochMs = parseInt(m[1], 10);
-            strPos += m[1].length;
-            break;
-          }
-          case "Z": {
-            // Timezone abbreviation like PST, EST
-            const m = str.slice(strPos).match(/^([A-Z]{3,5})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            const abbrevOffsets: Record<string, number> = {
-              PST: -8 * 3600,
-              PDT: -7 * 3600,
-              MST: -7 * 3600,
-              MDT: -6 * 3600,
-              CST: -6 * 3600,
-              CDT: -5 * 3600,
-              EST: -5 * 3600,
-              EDT: -4 * 3600,
-              UTC: 0,
-              GMT: 0,
-            };
-            if (m[1] in abbrevOffsets) {
-              explicitOffsetSeconds = abbrevOffsets[m[1]];
-            }
-            strPos += m[1].length;
-            break;
-          }
-          case ":z": {
-            // +HH:MM
-            const m = str.slice(strPos).match(/^([+-])(\d{2}):(\d{2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            const sign = m[1] === "+" ? 1 : -1;
-            explicitOffsetSeconds = sign * (parseInt(m[2], 10) * 3600 + parseInt(m[3], 10) * 60);
-            strPos += m[0].length;
-            break;
-          }
-          case "::z": {
-            // +HH:MM:SS
-            const m = str.slice(strPos).match(/^([+-])(\d{2}):(\d{2}):(\d{2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            const sign = m[1] === "+" ? 1 : -1;
-            explicitOffsetSeconds =
-              sign * (parseInt(m[2], 10) * 3600 + parseInt(m[3], 10) * 60 + parseInt(m[4], 10));
-            strPos += m[0].length;
-            break;
-          }
-          case ":::z": {
-            // +HH (minimal)
-            const m = str.slice(strPos).match(/^([+-])(\d{2})/);
-            if (!m) throw new Error("ArgumentError: strptime: input does not match format");
-            const sign = m[1] === "+" ? 1 : -1;
-            explicitOffsetSeconds = sign * parseInt(m[2], 10) * 3600;
-            strPos += m[0].length;
-            break;
-          }
-          default:
-            throw new Error(`ArgumentError: strptime: unsupported format directive %${spec}`);
-        }
-        pos += specLen;
-      } else {
-        // Literal character
-        if (str[strPos] !== format[pos]) {
-          throw new Error("ArgumentError: strptime: input does not match format");
-        }
-        strPos++;
-        pos++;
-      }
-    }
-
-    // Verify remaining input was consumed (allow trailing whitespace)
-    if (strPos < str.length && str.slice(strPos).trim().length > 0) {
-      throw new Error("ArgumentError: strptime: input does not match format");
-    }
-
-    if (epochMs !== null) {
-      return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(epochMs), this);
-    }
-
-    if (explicitOffsetSeconds !== null) {
-      // The parsed time was in an explicit offset — convert to UTC then to this zone
-      const utcMs =
-        Date.UTC(year, month - 1, day, hour, minute, second, ms) - explicitOffsetSeconds * 1000;
-      return new TimeWithZone(Temporal.Instant.fromEpochMilliseconds(utcMs), this);
-    }
-
-    // No explicit offset — interpret as local time in this zone
-    return this.local(year, month, day, hour, minute, second, ms);
+  strptime(str: string, format: string, now: TimeWithZone = this.now()): TimeWithZone | undefined {
+    return this.partsToTime(RubyDate._strptime(str, format), now);
   }
 
   /**
@@ -1270,6 +1013,95 @@ export class TimeZone {
    * memoizes (time_with_zone.rb:72-74) and reads `dst?` /
    * `observed_utc_offset` / `abbreviation` off.
    */
+  /**
+   * `parts_to_time(parts, now)` (time_zone.rb:585-608).
+   *
+   *   def parts_to_time(parts, now)
+   *     raise ArgumentError, "invalid date" if parts.nil?
+   *     return if parts.empty?
+   *
+   *     if parts[:seconds]
+   *       time = Time.at(parts[:seconds])
+   *     else
+   *       time = Time.new(
+   *         parts.fetch(:year, now.year),
+   *         parts.fetch(:mon, now.month),
+   *         parts.fetch(:mday, parts[:year] || parts[:mon] ? 1 : now.day),
+   *         parts.fetch(:hour, 0),
+   *         parts.fetch(:min, 0),
+   *         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
+   *         parts.fetch(:offset, 0)
+   *       )
+   *     end
+   *
+   *     if parts[:offset] || parts[:seconds]
+   *       TimeWithZone.new(time.utc, self)
+   *     else
+   *       TimeWithZone.new(nil, self, time)
+   *     end
+   *   end
+   *
+   * Ruby's `Time.new(..., offset)` defaults its offset to `0`, so the
+   * no-offset arm builds the wall clock as a UTC-flagged `::Time` and hands it
+   * to the LOCAL seat of the `TimeWithZone` constructor, which resolves it
+   * through `period_for_local` — that is where the DST-gap and ambiguity
+   * policy lives. `Temporal.PlainDateTime` is that wall clock here, and it
+   * carries the `sec_fraction` down to the nanosecond, which `TimeZone#local`
+   * (millisecond arguments) cannot.
+   */
+  private partsToTime(parts: DateParts | null, now: TimeWithZone): TimeWithZone | undefined {
+    if (parts == null) throw new ArgumentError("invalid date");
+    if (Object.keys(parts).length === 0) return undefined;
+
+    if (parts.seconds != null) {
+      // Ruby's `Time.at(parts[:seconds])` followed by the
+      // `TimeWithZone.new(time.utc, self)` arm below is what `TimeZone#at`
+      // (time_zone.rb:378-380) already is: `Time.at(*args).utc.in_time_zone(self)`.
+      return this.at(
+        parts.seconds instanceof Rational ? parts.seconds.toF() : Number(parts.seconds),
+      );
+    }
+
+    const secFraction = parts.secFraction;
+    const nanosecond =
+      secFraction == null
+        ? 0
+        : secFraction instanceof Rational
+          ? secFraction.mul(1_000_000_000).toI()
+          : Math.trunc(Number(secFraction) * 1_000_000_000);
+    // Ruby's `Time.new` raises `ArgumentError, "argument out of range"` for
+    // out-of-range components (`Date._parse("9000", false)` is
+    // `{mon: 90, mday: 0}`); Temporal answers a `RangeError` for the same.
+    let time: Temporal.PlainDateTime;
+    try {
+      time = Temporal.PlainDateTime.from({
+        year: Number("year" in parts ? parts.year : now.year),
+        month: "mon" in parts ? parts.mon! : now.month,
+        day: "mday" in parts ? parts.mday! : parts.year != null || parts.mon != null ? 1 : now.day,
+        hour: "hour" in parts ? parts.hour! : 0,
+        minute: "min" in parts ? parts.min! : 0,
+        second: "sec" in parts ? parts.sec! : 0,
+        millisecond: Math.trunc(nanosecond / 1_000_000),
+        microsecond: Math.trunc(nanosecond / 1000) % 1000,
+        nanosecond: nanosecond % 1000,
+      });
+    } catch {
+      throw new ArgumentError("argument out of range");
+    }
+
+    if (parts.offset != null) {
+      const offset = parts.offset instanceof Rational ? parts.offset.toF() : Number(parts.offset);
+      return new TimeWithZone(
+        time
+          .toZonedDateTime("UTC")
+          .toInstant()
+          .subtract({ nanoseconds: Math.round(offset * 1e9) }),
+        this,
+      );
+    }
+    return new TimeWithZone(null, this, time);
+  }
+
   periodForUtc(date: Date | Temporal.Instant): TimezonePeriod {
     return this.tzinfo.periodForUtc(date);
   }
@@ -1356,7 +1188,7 @@ export class TimeZone {
     ) {
       throw new Error("invalid date");
     }
-    return this.parse(trimmed);
+    return this.parse(trimmed)!;
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1013,95 +1013,6 @@ export class TimeZone {
    * memoizes (time_with_zone.rb:72-74) and reads `dst?` /
    * `observed_utc_offset` / `abbreviation` off.
    */
-  /**
-   * `parts_to_time(parts, now)` (time_zone.rb:585-608).
-   *
-   *   def parts_to_time(parts, now)
-   *     raise ArgumentError, "invalid date" if parts.nil?
-   *     return if parts.empty?
-   *
-   *     if parts[:seconds]
-   *       time = Time.at(parts[:seconds])
-   *     else
-   *       time = Time.new(
-   *         parts.fetch(:year, now.year),
-   *         parts.fetch(:mon, now.month),
-   *         parts.fetch(:mday, parts[:year] || parts[:mon] ? 1 : now.day),
-   *         parts.fetch(:hour, 0),
-   *         parts.fetch(:min, 0),
-   *         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
-   *         parts.fetch(:offset, 0)
-   *       )
-   *     end
-   *
-   *     if parts[:offset] || parts[:seconds]
-   *       TimeWithZone.new(time.utc, self)
-   *     else
-   *       TimeWithZone.new(nil, self, time)
-   *     end
-   *   end
-   *
-   * Ruby's `Time.new(..., offset)` defaults its offset to `0`, so the
-   * no-offset arm builds the wall clock as a UTC-flagged `::Time` and hands it
-   * to the LOCAL seat of the `TimeWithZone` constructor, which resolves it
-   * through `period_for_local` — that is where the DST-gap and ambiguity
-   * policy lives. `Temporal.PlainDateTime` is that wall clock here, and it
-   * carries the `sec_fraction` down to the nanosecond, which `TimeZone#local`
-   * (millisecond arguments) cannot.
-   */
-  private partsToTime(parts: DateParts | null, now: TimeWithZone): TimeWithZone | undefined {
-    if (parts == null) throw new ArgumentError("invalid date");
-    if (Object.keys(parts).length === 0) return undefined;
-
-    if (parts.seconds != null) {
-      // Ruby's `Time.at(parts[:seconds])` followed by the
-      // `TimeWithZone.new(time.utc, self)` arm below is what `TimeZone#at`
-      // (time_zone.rb:378-380) already is: `Time.at(*args).utc.in_time_zone(self)`.
-      return this.at(
-        parts.seconds instanceof Rational ? parts.seconds.toF() : Number(parts.seconds),
-      );
-    }
-
-    const secFraction = parts.secFraction;
-    const nanosecond =
-      secFraction == null
-        ? 0
-        : secFraction instanceof Rational
-          ? secFraction.mul(1_000_000_000).toI()
-          : Math.trunc(Number(secFraction) * 1_000_000_000);
-    // Ruby's `Time.new` raises `ArgumentError, "argument out of range"` for
-    // out-of-range components (`Date._parse("9000", false)` is
-    // `{mon: 90, mday: 0}`); Temporal answers a `RangeError` for the same.
-    let time: Temporal.PlainDateTime;
-    try {
-      time = Temporal.PlainDateTime.from({
-        year: Number("year" in parts ? parts.year : now.year),
-        month: "mon" in parts ? parts.mon! : now.month,
-        day: "mday" in parts ? parts.mday! : parts.year != null || parts.mon != null ? 1 : now.day,
-        hour: "hour" in parts ? parts.hour! : 0,
-        minute: "min" in parts ? parts.min! : 0,
-        second: "sec" in parts ? parts.sec! : 0,
-        millisecond: Math.trunc(nanosecond / 1_000_000),
-        microsecond: Math.trunc(nanosecond / 1000) % 1000,
-        nanosecond: nanosecond % 1000,
-      });
-    } catch {
-      throw new ArgumentError("argument out of range");
-    }
-
-    if (parts.offset != null) {
-      const offset = parts.offset instanceof Rational ? parts.offset.toF() : Number(parts.offset);
-      return new TimeWithZone(
-        time
-          .toZonedDateTime("UTC")
-          .toInstant()
-          .subtract({ nanoseconds: Math.round(offset * 1e9) }),
-        this,
-      );
-    }
-    return new TimeWithZone(null, this, time);
-  }
-
   periodForUtc(date: Date | Temporal.Instant): TimezonePeriod {
     return this.tzinfo.periodForUtc(date);
   }
@@ -1326,6 +1237,96 @@ export class TimeZone {
       return zones;
     }, {});
     return zonesMapMemo;
+  }
+
+  /**
+   * `parts_to_time(parts, now)` (time_zone.rb:585-608).
+   *
+   *   def parts_to_time(parts, now)
+   *     raise ArgumentError, "invalid date" if parts.nil?
+   *     return if parts.empty?
+   *
+   *     if parts[:seconds]
+   *       time = Time.at(parts[:seconds])
+   *     else
+   *       time = Time.new(
+   *         parts.fetch(:year, now.year),
+   *         parts.fetch(:mon, now.month),
+   *         parts.fetch(:mday, parts[:year] || parts[:mon] ? 1 : now.day),
+   *         parts.fetch(:hour, 0),
+   *         parts.fetch(:min, 0),
+   *         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
+   *         parts.fetch(:offset, 0)
+   *       )
+   *     end
+   *
+   *     if parts[:offset] || parts[:seconds]
+   *       TimeWithZone.new(time.utc, self)
+   *     else
+   *       TimeWithZone.new(nil, self, time)
+   *     end
+   *   end
+   *
+   * Ruby's `Time.new(..., offset)` defaults its offset to `0`, so the
+   * no-offset arm builds the wall clock as a UTC-flagged `::Time` and hands it
+   * to the LOCAL seat of the `TimeWithZone` constructor, which resolves it
+   * through `period_for_local` — that is where the DST-gap and ambiguity
+   * policy lives. `Temporal.PlainDateTime` is that wall clock here, and it
+   * carries the `sec_fraction` down to the nanosecond, which `TimeZone#local`
+   * (millisecond arguments) cannot.
+   *
+   * `Time.at(parts[:seconds])` followed by that `TimeWithZone.new(time.utc,
+   * self)` arm is what `TimeZone#at` (time_zone.rb:378-380) already is —
+   * `Time.at(*args).utc.in_time_zone(self)` — so the `:seconds` arm returns
+   * through it. And `Time.new` raises `ArgumentError, "argument out of range"`
+   * for out-of-range components (`Date._parse("9000", false)` is `{mon: 90,
+   * mday: 0}`), where Temporal answers a `RangeError`.
+   */
+  private partsToTime(parts: DateParts | null, now: TimeWithZone): TimeWithZone | undefined {
+    if (parts == null) throw new ArgumentError("invalid date");
+    if (Object.keys(parts).length === 0) return undefined;
+
+    if (parts.seconds != null) {
+      return this.at(
+        parts.seconds instanceof Rational ? parts.seconds.toF() : Number(parts.seconds),
+      );
+    }
+
+    const secFraction = parts.secFraction;
+    const nanosecond =
+      secFraction == null
+        ? 0
+        : secFraction instanceof Rational
+          ? secFraction.mul(1_000_000_000).toI()
+          : Math.trunc(Number(secFraction) * 1_000_000_000);
+    let time: Temporal.PlainDateTime;
+    try {
+      time = Temporal.PlainDateTime.from({
+        year: Number("year" in parts ? parts.year : now.year),
+        month: "mon" in parts ? parts.mon! : now.month,
+        day: "mday" in parts ? parts.mday! : parts.year != null || parts.mon != null ? 1 : now.day,
+        hour: "hour" in parts ? parts.hour! : 0,
+        minute: "min" in parts ? parts.min! : 0,
+        second: "sec" in parts ? parts.sec! : 0,
+        millisecond: Math.trunc(nanosecond / 1_000_000),
+        microsecond: Math.trunc(nanosecond / 1000) % 1000,
+        nanosecond: nanosecond % 1000,
+      });
+    } catch {
+      throw new ArgumentError("argument out of range");
+    }
+
+    if (parts.offset != null) {
+      const offset = parts.offset instanceof Rational ? parts.offset.toF() : Number(parts.offset);
+      return new TimeWithZone(
+        time
+          .toZonedDateTime("UTC")
+          .toInstant()
+          .subtract({ nanoseconds: Math.round(offset * 1e9) }),
+        this,
+      );
+    }
+    return new TimeWithZone(null, this, time);
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/time-zone-conversion.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/time-zone-conversion.ts",
-    "rubyName": "cast",
-    "call": "user_input_in_time_zone",
-    "reason": "Verified per-site (RFC 0106 wave 4g): `super(user_input_in_time_zone(value)) || super` (time_zone_conversion.rb:24). trails parses the string arm through the file-local `parseStringInZone` (time-zone-conversion.ts:82-92, :278-320) rather than the shared `TimeValue#userInputInTimeZone` (activemodel/type/helpers/time-value.ts:125), because that helper does not yet handle explicit offsets, DST disambiguation via `zone.local`, or date-only strings. Routing the call through it today would regress those. Convergence tracked in story `converge-parse-string-in-zone-onto-user-input-in-time-zone`."
-  }
-]


### PR DESCRIPTION
`TimeZoneConverter#cast`'s string arm is Rails
`super(user_input_in_time_zone(value)) || super`
(`activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb:24`),
but trails parsed the string through a file-local `parseStringInZone`
instead. Routing the Rails call through the shared
`Helpers::TimeValue#user_input_in_time_zone` as it stood would have regressed
explicit offsets, DST disambiguation, date-only strings and sub-millisecond
precision — because that helper was an under-port of `Object#in_time_zone`.

So the fix is in the shared helper, not the call site.

## What changed

- **`TimeZone#parse`** is now Rails' `parts_to_time(Date._parse(str, false), now)`
  (`time_zone.rb:453-455`), over a new private `partsToTime`
  (`time_zone.rb:585-608`). The no-offset arm builds the wall clock as a
  `Temporal.PlainDateTime` and hands it to the LOCAL seat of the `TimeWithZone`
  constructor, which is where `period_for_local` resolves DST — and it carries
  `sec_fraction` down to the nanosecond, which `TimeZone#local` (millisecond
  arguments) cannot. The `parts[:seconds]` arm is `TimeZone#at`, which is
  exactly Ruby's `Time.at(...)` + `TimeWithZone.new(time.utc, self)` pair.
- **`TimeZone#strptime`** follows as
  `parts_to_time(DateTime._strptime(str, format), now)` (`time_zone.rb:487-489`),
  retiring 218 lines of bespoke directive handling.
- **`userInputInTimeZone`** is `value.in_time_zone` (`time_value.rb:42-44`),
  dispatched by receiver type to the ported core-exts: `String#in_time_zone`
  (`core_ext/string/zones.rb:8-14`) and `DateAndTime::Zones#in_time_zone`
  (`core_ext/date_and_time/zones.rb:20-27`). No parsing lives in it.
- **`TimeZoneConverter#cast`**'s string arm calls the subtype's
  `userInputInTimeZone` and then `super`; `parseStringInZone` is deleted.

Both `parse` and `strptime` now return `TimeWithZone | undefined`, matching
Rails' `return if parts.empty?`, and out-of-range components raise
`ArgumentError("argument out of range")` as `Time.new` does. Two trails test
bodies were corrected to the Rails bodies they are named after
(`test_parse_returns_nil_when_string_without_date_information_is_passed_in`
asserts nil, not a raise; `test_parse_with_invalid_date` uses `"9000"`).

## Gates

- `pnpm parity:api:calls` — OK; call mismatches 673 → 671, baseline row and
  its unreviewed mark shard deleted.
- `pnpm parity:api:calls:args` — OK.
- `pnpm parity:api:extra` — no new public surface (`partsToTime` is private).
- `pnpm typecheck`, `pnpm lint` clean.
- activesupport + activemodel suites: 6629 passed / 0 failed.
- activerecord attribute-methods, PG oid, base, date-time, timestamp,
  precision suites green.

Closes-story: converge-parse-string-in-zone-onto-user-input-in-time-zone