### PR TITLE
refactor(activerecord): migrate the single-row call-set baseline tail to @missingRailsCall tags

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -23,6 +23,10 @@ export class BelongsToAssociation extends SingularAssociation {
   /**
    * Handle dependent destruction/deletion of the target record.
    * Called by the owner's before_destroy callback.
+   *
+   * @missingRailsCall fetch — PERMANENT: Ruby `options.fetch(:ensuring_owner_was, nil)`
+   *   (belongs_to_association.rb:34); a JS object has no `fetch`, so the
+   *   stored-nil semantics are spelled as an own-key check at the call site.
    */
   async handleDependency(): Promise<void> {
     const target = await this.loadTarget();

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -147,6 +147,10 @@ export class HasOneAssociation extends SingularAssociation {
   /**
    * Delete the associated record using the given method.
    * Supports: delete, destroy, nullify.
+   *
+   * @missingRailsCall fetch — PERMANENT: Ruby `options.fetch(:ensuring_owner_was, nil)`
+   *   (has_one_association.rb:51); a JS object has no `fetch`, so the stored-nil
+   *   semantics are spelled as an own-key check at the call site.
    */
   async delete(
     method: string | undefined = this.reflection.options.dependent as string | undefined,

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -254,6 +254,15 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * returns, matching Rails' assignment-time `create_through_record`. Only the
    * new-owner / `save: false` build arms leave it for the owner's next save,
    * which is Rails' own shape (has_one_through_association.rb:33-37).
+   *
+   * @missingRailsCall create_through_record — PERMANENT: Verified per-site (RFC 0106):
+   *   `create_through_record(record, save)`
+   *   (has_one_through_association.rb:10-12) writes the join row, so it is async
+   *   in trails. `replace` cannot be — it is reached from the synchronous
+   *   `writer`/`setNewRecord` path that RFC 0087 requires to stay sync — so the
+   *   body queues `_pendingReplace` and `persistReplace`/`autosaveHasOne` awaits
+   *   `createThroughRecord` one frame later. Same sync-setter shortcoming as the
+   *   `setX()` idiom.
    */
   protected override replace(record: Base | null, save = true): void {
     if (record) (this as any).raiseOnTypeMismatchBang(record);

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -291,6 +291,14 @@ export class SingularAssociation extends Association {
    * `setTarget` refusing a replacement that lands mid-query rather than losing
    * it silently. `Association#_findTarget` handles the complementary case the
    * raise cannot see — a bare FK change that never touches the holder.
+   *
+   * @missingRailsCall first — PERMANENT: Rails' `super.then(&:first)` is Array#first over
+   *   the array Association#find_target already loaded, not Relation#first;
+   *   take() (unordered LIMIT 1) is the SQL-level equivalent — Relation#first
+   *   would route through ordered_relation and add the ORDER BY that
+   *   has_one_associations_test `test_has_one_does_not_use_order_by` forbids.
+   *   The statement-cache branch's literal .first() lives in the extracted
+   *   _loadSingularViaStatementCache helper (associations.ts).
    */
   protected override async findTarget(): Promise<Base | null> {
     this._loaderWritebackSuppressed++;

--- a/packages/activerecord/src/asynchronous-queries-tracker.ts
+++ b/packages/activerecord/src/asynchronous-queries-tracker.ts
@@ -52,6 +52,16 @@ export class AsynchronousQueriesTracker {
     asynchronousQueriesTracker.finalizeSession();
   }
 
+  /**
+   * @missingRailsCall last — PERMANENT: Verified per-site (RFC 0106): `@stack.last or raise
+   *   ActiveRecordError` (`asynchronous_queries_tracker.rb:50`) — the TS body
+   *   reads `this.#stack[this.#stack.length - 1]` and raises the same error with
+   *   the same message. `first`/`last`/`size` are positional/property idioms
+   *   with no JS call form, deliberately left uncredited by RFC 0092
+   *   (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment)
+   *   so the reason-text route is the sanctioned one; nothing was dropped from
+   *   the TS body.
+   */
   get currentSession(): Session {
     const session = this.#stack[this.#stack.length - 1];
     if (!session)

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -855,7 +855,15 @@ export function _ensureNoDuplicateErrors(this: AutosaveAssociationHost): void {
   if (typeof this.errors?.uniqBang === "function") this.errors.uniqBang();
 }
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @missingRailsCall define_method — PERMANENT: autosave_association.rb:162
+ *   `define_method(name) do |*args| ... end` — Ruby's `define_method` is a
+ *   prototype assignment in JS (`klass.prototype[name] = function ...`,
+ *   autosave-association.ts:863); there is no `define_method` to call. Language
+ *   shortcoming.
+ */
 export function defineNonCyclicMethod(this: any, name: string, fn: (this: any) => any): void {
   const klass = this;
   // Rails passes a Symbol here and `define_method` names the method after it;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2513,6 +2513,13 @@ export class Base extends Model {
    *   `composite_primary_key? ? id.first.is_a?(Array) : id.is_a?(Array)`
    * so a plain tuple on a composite-PK model is treated as ONE record,
    * not N.
+   *
+   * @missingRailsCall with_transaction_returning_status — PERMANENT: File-mapping artifact:
+   *   `base.ts`'s `destroy` is the instance-method table entry `destroy:
+   *   _Persistence.destroy` (base.ts:4609), not a body. Rails'
+   *   `Transactions#destroy` (transactions.rb:356-358) maps to persistence.ts
+   *   `destroy`, which does call `withTransactionReturningStatus`
+   *   (persistence.ts:855).
    */
   static async destroy<T extends typeof Base>(
     this: T,

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -95,6 +95,11 @@ export function validateAdapterName(adapterName: string): void {
  * Mirrors: ActiveRecord::ConnectionAdapters.resolve
  *
  * Resolves an adapter name to its class.
+ *
+ * @missingRailsCall join — CONVERGEABLE (story adapter-not-found-message-should-be-built-inline): Rails builds the AdapterNotFound message inline
+ *   (connection_adapters.rb:34-39); the port extracts it into the private
+ *   `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(", ")`
+ *   (connection-adapters.ts:75) is outside the published call-set.
  */
 export async function resolve(adapterName: string): Promise<AdapterClass> {
   const cached = resolved.get(adapterName);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -120,6 +120,11 @@ export class ConnectionHandler {
     return [...this._connectionNameToPoolManager.keys()];
   }
 
+  /**
+   * @missingRailsCall map — PERMANENT: Per-site verified (RFC 0106 wave 4b): the inner
+   *   `map` of connection_handler.rb:75-79 is the same Ruby-Enumerable idiom,
+   *   spelled as the body of trails' explicit `for..of` accumulation.
+   */
   connectionPoolList(role?: string | null): ConnectionPool[] {
     const effectiveRole = role === "all" ? null : role;
     const pools: ConnectionPool[] = [];

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -260,6 +260,12 @@ export class Queue {
     return undefined;
   }
 
+  /**
+   * @missingRailsCall size — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   connection_pool/queue.rb `@queue.size > @num_waiting`; trails' queue holds
+   *   its entries in a JS array whose `.length` is the same quantity —
+   *   `Array#size` is not a ported method name.
+   */
   private canRemoveNoWait(): boolean {
     return this._queue.length > this._numWaiting;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -45,6 +45,13 @@ export class Reaper {
   private static _pools = new Map<number, WeakRef<ReapablePool>[]>();
   private static _timers = new Map<number, ReturnType<typeof setInterval>>();
 
+  /**
+   * @missingRailsCall spawn_thread — CONVERGEABLE (RFC 0073, the threadless-pool surface): Per-site verified (RFC 0106 wave 4b):
+   *   connection_pool/reaper.rb `spawn_thread` starts a background Thread;
+   *   trails' Reaper drives the same period from a timer, so there is no thread
+   *   to spawn. Tracked with the rest of the threadless pool surface by RFC
+   *   0073.
+   */
   static registerPool(pool: ReapablePool, frequency: number): void {
     if (!frequency || frequency <= 0 || !Number.isFinite(frequency)) return;
     if (pool.isDiscarded?.()) return;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -220,6 +220,14 @@ export interface DatabaseStatementsHost {
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements (initialize)
  */
 export class DatabaseStatementsBase {
+  /**
+   * @missingRailsCall reset_transaction — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   abstract/database_statements.rb:12 is `reset_transaction` inside
+   *   `initialize`; trails' DatabaseStatements is a mixin with no constructor of
+   *   its own — the adapter's own constructor calls `resetTransaction()`
+   *   (abstract-adapter.ts), so the call happens, just not from a body matched
+   *   to this Ruby method.
+   */
   constructor() {
     (this as any)._transactionManager = new TransactionManager(this as any);
   }

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -106,7 +106,13 @@ export function defaultInsertValue(column: AutoIncrementColumnHost): Nodes.SqlLi
   return abstractDefaultInsertValue(column);
 }
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @missingRailsCall first — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+ *   mysql/database_statements.rb's `result.rows.first` is `result.rows[0]` on a
+ *   JS array; `Array#first` is not a ported method name.
+ */
 export async function returningColumnValues(
   this: SupportsInsertReturningHost | void,
   result: Result,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -396,6 +396,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * is stashed for promotion. Prefer the config-hash / URI-string form.
    */
   constructor(rawConnection: mysql.Connection, deprecatedConfig?: Record<string, unknown> | null);
+  /**
+   * @missingRailsCall push — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   mysql2_adapter.rb:61-66 pushes onto `@config[:flags]` (a Ruby Array) while
+   *   building the client flags; trails composes the mysql2 driver options
+   *   object instead — the node driver takes named booleans, not a FLAGS array,
+   *   so there is no array to push onto.
+   */
   constructor(
     config: string | (mysql.PoolOptions & MysqlAdapterOptions) | mysql.Connection,
     deprecatedConfig?: Record<string, unknown> | null,

--- a/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
@@ -20,6 +20,11 @@ export class ExplainPrettyPrinter {
    *      ->  Seq Scan on posts  (cost=0.00..28.88 rows=8 width=4)
    *            Filter: (posts.user_id = 1)
    *   (6 rows)
+   *
+   * @missingRailsCall first — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/explain_pretty_printer.rb's `result.rows.map(&:first)` /
+   *   `.first` is index-0 access on a JS array; `Array#first` is not a ported
+   *   method name.
    */
   pp(result: Result): string {
     const header = result.columns[0];

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -85,6 +85,11 @@ export class Cidr extends ValueType<IPAddr> {
    *   nil → nil
    *   String → IPAddr.new(value) or nil on ArgumentError
    *   else → value (pass-through for existing IPAddr instances)
+   *
+   * @missingRailsCall new — CONVERGEABLE (story pg-cidr-cast-value-should-build-an-ipaddr): Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/oid/cidr.rb builds an `IPAddr.new(...)`; Ruby's IPAddr has no
+   *   port in trails, so the cast returns the normalized CIDR string. Tracked as
+   *   the PG address-type gap, not a dropped delegation.
    */
   castValue(value: unknown): IPAddr | null {
     if (value == null) return null;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -38,6 +38,11 @@ export class DateTime extends DateTimeType {
    * handles the nil short-circuit and dispatches here, so we fall
    * through to the parent's `castValue` (NOT `cast`) to avoid the
    * virtual-dispatch loop that would re-enter this method.
+   *
+   * @missingRailsCall format — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/oid/date_time.rb's `value.format` is Ruby's DateTime
+   *   formatting; trails' cast returns a Temporal value formatted through
+   *   Temporal's own API, which has no `format` method.
    */
   override castValue(value: unknown): PgDateTimeResult | null {
     if (value === null || value === undefined) return null;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date.ts
@@ -31,6 +31,11 @@ export class Date extends DateType {
    * the nil short-circuit and dispatches here, so we fall through to
    * the parent's `castValue` (NOT `cast`) to avoid the virtual-dispatch
    * loop that would re-enter this method.
+   *
+   * @missingRailsCall format — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/oid/date.rb's `value.format` is Ruby's Date formatting; trails'
+   *   cast returns a Temporal.PlainDate and formats through Temporal's own API,
+   *   which has no `format` method.
    */
   override castValue(
     value: unknown,

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/hstore.ts
@@ -48,6 +48,11 @@ export class Hstore extends ValueType<Record<string, string | null>> {
     return this.deserialize(serialized);
   }
 
+  /**
+   * @missingRailsCall new — PERMANENT: Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/oid/hstore.rb's scanner allocates a `Hash.new`; trails
+   *   accumulates into an object literal, which is not a `new` expression.
+   */
   override deserialize(value: unknown): Record<string, string | null> | null {
     if (value == null) return null;
     if (typeof value !== "string") {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -25,6 +25,13 @@ export class LegacyPoint extends ValueType<[number, number]> {
     return null;
   }
 
+  /**
+   * @missingRailsCall number_for_point — CONVERGEABLE (story legacy-point-serialize-should-extract-number-for-point): Per-site verified (RFC 0106 wave 4b):
+   *   postgresql/oid/legacy_point.rb's `number_for_point` strips a trailing `.0`
+   *   from each coordinate; trails' serialize formats the pair with the same
+   *   rule inline. The helper is private and one-line in Rails; extracting it
+   *   here would be surface with a single caller.
+   */
   serialize(value: unknown): string | null {
     if (value == null) return null;
     if (globalThis.Array.isArray(value) && value.length === 2) {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.ts
@@ -153,6 +153,14 @@ export class RangeType extends ValueType<Range> {
     return isInfinity(value) ? value : this.subtype.serialize(this.subtype.cast(value));
   }
 
+  /**
+   * @missingRailsCall split — PERMANENT: Name-collision false positive (story
+   *   relation-delegation-rails-named-methods): exposing the `delegate ... to:
+   *   :records` set under Rails names made `split`/`reverse`/`rindex` recognized
+   *   ported method names, so this unrelated call to String#split /
+   *   Array#reverse / String#rindex on a non-Relation receiver is flagged by the
+   *   name-based wide call-set check.
+   */
   private extractBounds(value: string): {
     from: unknown;
     to: unknown;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -129,13 +129,13 @@ export class ExclusionConstraintDefinition {
   }
 
   /**
-   * @missingRailsCall match? — CONVERGEABLE (story pg-export-name-ignores-dumper-patterns): Per-entry verified (RFC 0032 wide-entry
-   *   verification): Rails postgresql/schema_definitions.rb:209-211/231-233
-   *   filter via SchemaDumper.excl_ignore_pattern/unique_ignore_pattern.match?;
-   *   trails schema-definitions.ts:98-100/134-136 return `this.name != null`
-   *   only — the ignore-pattern filtering (patterns exist at
-   *   schema-dumper.ts:346-348) is unported. Omission tracked in story
-   *   pg-export-name-ignores-dumper-patterns.
+   * @missingRailsCall match? — PERMANENT: Rails
+   *   postgresql/schema_definitions.rb:209-211 is
+   *   `!ActiveRecord::SchemaDumper.excl_ignore_pattern.match?(name) if name`,
+   *   which this body mirrors — the pattern IS applied. `Regexp#match?` has no
+   *   JS call spelling: a JS RegExp answers `test`, and `test` is stateful on a
+   *   `/g` pattern, so the port routes through `statelessTest`
+   *   (schema-dumper.ts:349) to get Ruby's stateless semantics.
    */
   exportNameOnSchemaDump(): boolean {
     return this.name != null && !statelessTest(SchemaDumper.exclIgnorePattern, this.name);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -128,6 +128,15 @@ export class ExclusionConstraintDefinition {
     return this.options.deferrable;
   }
 
+  /**
+   * @missingRailsCall match? — CONVERGEABLE (story pg-export-name-ignores-dumper-patterns): Per-entry verified (RFC 0032 wide-entry
+   *   verification): Rails postgresql/schema_definitions.rb:209-211/231-233
+   *   filter via SchemaDumper.excl_ignore_pattern/unique_ignore_pattern.match?;
+   *   trails schema-definitions.ts:98-100/134-136 return `this.name != null`
+   *   only — the ignore-pattern filtering (patterns exist at
+   *   schema-dumper.ts:346-348) is unported. Omission tracked in story
+   *   pg-export-name-ignores-dumper-patterns.
+   */
   exportNameOnSchemaDump(): boolean {
     return this.name != null && !statelessTest(SchemaDumper.exclIgnorePattern, this.name);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/utils.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/utils.ts
@@ -6,6 +6,8 @@
  */
 
 export class Name {
+  static readonly SEPARATOR = ".";
+
   readonly schema: string | null;
   readonly identifier: string;
 
@@ -15,10 +17,7 @@ export class Name {
   }
 
   toString(): string {
-    if (this.schema) {
-      return `${this.schema}.${this.identifier}`;
-    }
-    return this.identifier;
+    return this.parts().join(Name.SEPARATOR);
   }
 
   quoted(): string {

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -27,6 +27,14 @@ export class TableDefinition extends AbstractTableDefinition {
     return this.references(name, options);
   }
 
+  /**
+   * @missingRailsCall column — CONVERGEABLE (story sqlite3-table-change-column-should-redeclare-the-column): Per-site verified (RFC 0106 wave 4b):
+   *   sqlite3/schema_definitions.rb's `change_column` re-enters
+   *   `column(column_name, type, **options)` on the table definition; trails'
+   *   SQLite Table#changeColumn forwards to the adapter's `changeColumn`, which
+   *   rebuilds the table (copy_table) — the definition-level column
+   *   re-declaration happens inside that rebuild.
+   */
   changeColumn(columnName: string, type: ColumnType, options: ColumnOptions = {}): void {
     const col = this.newColumnDefinition(columnName, type, options);
     const idx = this.columns.findIndex((c) => c.name === columnName);

--- a/packages/activerecord/src/database-configurations/url-config.ts
+++ b/packages/activerecord/src/database-configurations/url-config.ts
@@ -12,6 +12,11 @@ import { inferAdapterNameFromUrl } from "../connection-adapters/adapter-args.js"
 export class UrlConfig extends HashConfig {
   readonly url: string;
 
+  /**
+   * @missingRailsCall merge — PERMANENT: Verified per-site (RFC 0106):
+   *   `@configuration_hash.merge(build_url_hash)` (`url_config.rb:43`) — a
+   *   non-mutating Hash merge is an object spread in TS.
+   */
   constructor(
     envName: string,
     name: string,

--- a/packages/activerecord/src/encryption/auto-filtered-parameters.ts
+++ b/packages/activerecord/src/encryption/auto-filtered-parameters.ts
@@ -67,6 +67,12 @@ export class AutoFilteredParameters {
     );
   }
 
+  /**
+   * @missingRailsCall new — PERMANENT: `Concurrent::Array.new`
+   *   (auto_filtered_parameters.rb:48): the per-class attribute list is an array
+   *   literal in TS, which emits no constructor call, and Concurrent::
+   *   thread-safe collections have no analogue on a single-threaded event loop.
+   */
   private collectForLater(klass: any, attribute: string): void {
     if (!this._attributesByClass.has(klass)) {
       this._attributesByClass.set(klass, []);

--- a/packages/activerecord/src/encryption/configurable.ts
+++ b/packages/activerecord/src/encryption/configurable.ts
@@ -139,6 +139,12 @@ export class Configurable {
     }
   }
 
+  /**
+   * @missingRailsCall new — PERMANENT: `Concurrent::Array.new` (configurable.rb:48): the
+   *   lazily-allocated listener list is `_listeners ??= []` in TS, an array
+   *   literal with no constructor call, and Concurrent:: collections have no
+   *   analogue on a single-threaded event loop.
+   */
   static onEncryptedAttributeDeclared(callback: (klass: any, name: string) => void): () => void {
     // Mirrors Rails' `self.encrypted_attribute_declaration_listeners ||= ...`
     // (configurable.rb:48) — lazily allocate on first registration.

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -124,7 +124,13 @@ export class Contexts {
     return this.currentCustomContext ?? this.defaultContext;
   }
 
-  /** Mirrors: ActiveRecord::Encryption::Contexts#current_custom_context (contexts.rb:66-68) */
+  /**
+   * Mirrors: ActiveRecord::Encryption::Contexts#current_custom_context (contexts.rb:66-68)
+   *
+   * @missingRailsCall last — PERMANENT: `custom_contexts&.last` (contexts.rb:67) on a plain
+   *   Array — the faithful port is index access, which emits no call name
+   *   (compare.ts's `first`/`last` note).
+   */
   static get currentCustomContext(): Context | null {
     return customContexts.length > 0 ? customContexts[customContexts.length - 1] : null;
   }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -234,7 +234,13 @@ export class EncryptedAttributeType extends ValueType {
       this.isFixed() && this.previousTypesWithoutCleanText().length > 0);
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * @missingRailsCall first — PERMANENT: `previous_types.first`
+   *   (encrypted_attribute_type.rb:127) on a plain Array — the faithful port is
+   *   index access, which emits no call name (compare.ts's `first`/`last` note).
+   */
   private serializeWithOldest(value: unknown): unknown {
     // Mirrors Rails' previous_types.first — the first of the previous types (which are
     // built from previousSchemesIncludingCleanText, so the clean-text entry, if any, is

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -24,6 +24,13 @@ export class ExtendedDeterministicUniquenessValidator {
    *
    * Mirrors: Rails' ExtendedDeterministicUniquenessValidator.install_support which
    * prepends EncryptedUniquenessValidator into ActiveRecord::Validations::UniquenessValidator.
+   *
+   * @missingRailsCall prepend — PERMANENT: Rails prepends `EncryptedUniquenessValidator`
+   *   into the validator class
+   *   (extended_deterministic_uniqueness_validator.rb:7); trails swaps
+   *   `validateEach` on the prototype directly because `resetSupport` has to
+   *   hand the original method back for test teardown, which the `prepend()`
+   *   shim's wrapper cannot expose.
    */
   static installSupport({
     UniquenessValidator,

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -19,6 +19,11 @@ export class KeyProvider {
     this._keys = Array.isArray(keys) ? keys : [keys];
   }
 
+  /**
+   * @missingRailsCall last — PERMANENT: `@keys.last` (key_provider.rb:21) on a plain Array
+   *   — the faithful port is index access, which emits no call name
+   *   (compare.ts's `first`/`last` note).
+   */
   encryptionKey(): Key {
     if (!this._encryptionKey) {
       const key = this._keys[this._keys.length - 1];

--- a/packages/activerecord/src/encryption/key.ts
+++ b/packages/activerecord/src/encryption/key.ts
@@ -18,6 +18,12 @@ export class Key {
     this.publicTags = new Properties();
   }
 
+  /**
+   * @missingRailsCall first — PERMANENT: `Digest::SHA1.hexdigest(secret).first(4)`
+   *   (key.rb:24) is ActiveSupport's String#first, whose faithful JS spelling is
+   *   `String#slice(0, 4)` — a differently-named native call the gate cannot
+   *   credit.
+   */
   get id(): string {
     return getCrypto().createHash("sha1").update(this.secret).digest("hex").slice(0, 4);
   }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -850,6 +850,13 @@ export function ensureProperType(this: Base): void {
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#discriminate_class_for_record
  * @internal Private method, used by persistence to route instantiate() through STI subclasses.
+ *
+ * @missingRailsCall find_sti_class — CONVERGEABLE (story discriminate-class-for-record-should-call-find-sti-class): inheritance.rb:301
+ *   `find_sti_class(record[inheritance_column])` — trails routes through
+ *   `findStiClassForRow` (inheritance.ts:867), the registry-safe variant that
+ *   matches only within `baseClass`'s tracked subtree; the bare `findStiClass`
+ *   is Rails' autoloader analog and is reached from there when STI is explicitly
+ *   enabled (inheritance.ts:1075-1078). Documented at inheritance.ts:1050-1059.
  */
 export function discriminateClassForRecord(
   modelClass: typeof Base,

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -98,6 +98,13 @@ export class LogSubscriber extends BaseLogSubscriber {
     });
   }
 
+  /**
+   * @missingRailsCall any? — PERMANENT: Verified per-site (RFC 0106):
+   *   `payload[:binds]&.any?` (`log_subscriber.rb:120`) — a blockless
+   *   `Array#any?` is the emptiness test, whose faithful JS spelling is `length
+   *   > 0`. The gate flags it only because `any?` maps onto the unrelated
+   *   `Relation#any?`.
+   */
   sql(event: Event): void {
     const payload = event.payload;
 

--- a/packages/activerecord/src/middleware/database-selector/resolver/session.ts
+++ b/packages/activerecord/src/middleware/database-selector/resolver/session.ts
@@ -34,6 +34,12 @@ export class Session {
     return time.epochMilliseconds;
   }
 
+  /**
+   * @missingRailsCall at — PERMANENT: Verified per-site (RFC 0106): `Time.at(timestamp /
+   *   1000, (timestamp % 1000) * 1000)` (`resolver/session.rb:25`) — trails'
+   *   time type is `Temporal.Instant`, whose epoch constructor is
+   *   `fromEpochMilliseconds`; there is no `at` to call.
+   */
   static convertTimestampToTime(timestamp: number | undefined): Temporal.Instant {
     return Temporal.Instant.fromEpochMilliseconds(timestamp ?? 0);
   }

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -62,6 +62,13 @@ export class ShardSelector {
     return this.resolver(request);
   }
 
+  /**
+   * @missingRailsCall fetch — PERMANENT: Verified per-site (RFC 0106):
+   *   `options.fetch(:lock, true)` (`shard_selector.rb:66`) — the options hash
+   *   is a plain TS object, so the stored-key test `Hash#fetch` performs is
+   *   spelled `"lock" in this.options ? ... : true`. `fetch` has no TS call
+   *   spelling.
+   */
   private async setShard<T>(shard: string, block: () => T | Promise<T>): Promise<T> {
     return Base.connectedTo({ shard }, () =>
       // `options.fetch(:lock, true)` (shard_selector.rb:66) returns the STORED

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -530,6 +530,11 @@ export class PredicateBuilder {
     return converted;
   }
 
+  /**
+   * @missingRailsCall last — PERMANENT: Verified per-site (RFC 0106): `@handlers.detect {
+   *   ... }.last` (predicate_builder.rb:186) — Ruby `Array#last` on the matched
+   *   `[klass, handler]` pair, spelled `[1]` in TS (predicate-builder.ts:543).
+   */
   private handlerFor(object: unknown): { call(attr: Nodes.Attribute, value: any): Nodes.Node } {
     // Rails: `@handlers.detect { |klass, _| klass === object }.last` — BasicObject
     // matches every value, so the detect never comes back nil.

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -144,6 +144,15 @@ export class AssociationQueryValue {
     return !(type in hash);
   }
 
+  /**
+   * @missingRailsCall empty? — PERMANENT: Verified per-site (RFC 0106):
+   *   `value.select_values.empty?` (association_query_value.rb:52) — `empty?` on
+   *   a Ruby Array, whose faithful JS spelling is `xs.length === 0`. That emits
+   *   no callee, so no TS call can ever credit the Ruby one. The gate flags it
+   *   only because `empty?` maps onto the unrelated
+   *   `ActiveRecord::Result.empty`, which takes arguments since it gained Rails'
+   *   `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped.
+   */
   private isSelectClause(): boolean {
     const sv = (this.value as any).selectValues;
     if (typeof sv === "function") return sv.call(this.value).length === 0;

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -42,6 +42,15 @@ export class PolymorphicArrayValue {
     return this._values;
   }
 
+  /**
+   * @missingRailsCall empty? — PERMANENT: Verified per-site (RFC 0106): `values.empty?`
+   *   (polymorphic_array_value.rb:12) — `empty?` on a Ruby Array, whose faithful
+   *   JS spelling is `xs.length === 0`. That emits no callee, so no TS call can
+   *   ever credit the Ruby one. The gate flags it only because `empty?` maps
+   *   onto the unrelated `ActiveRecord::Result.empty`, which takes arguments
+   *   since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the
+   *   TS body was dropped.
+   */
   queries(): Record<string, unknown>[] {
     const fk = this.associatedTable.joinForeignKey;
     if (this.values.length === 0) {

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -17,6 +17,15 @@ import { DeferredDistinctPkIn } from "./deferred-distinct-pk-in.js";
  *     → author_id IN (SELECT authors.id FROM authors WHERE active = true)
  */
 export class RelationHandler {
+  /**
+   * @missingRailsCall empty? — PERMANENT: Verified per-site (RFC 0106):
+   *   `value.select_values.empty?` (relation_handler.rb:11) — `empty?` on a Ruby
+   *   Array, whose faithful JS spelling is `xs.length === 0`. That emits no
+   *   callee, so no TS call can ever credit the Ruby one. The gate flags it only
+   *   because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`,
+   *   which takes arguments since it gained Rails' `async:` kwarg
+   *   (result.rb:94-100) — nothing in the TS body was dropped.
+   */
   call(attribute: Nodes.Attribute, value: any): Nodes.Node {
     const deferred = this.deferDistinctPkMaterialization(attribute, value);
     if (deferred) return deferred;

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -56,6 +56,12 @@ export class Schema extends Current {
     info: SchemaDefineInfo,
     fn: (schema: Schema) => void | Promise<void>,
   ): Promise<void>;
+  /**
+   * @missingRailsCall with_connection — CONVERGEABLE (RFC 0059, the one-schema convergence): `connection_pool.with_connection`
+   *   (schema.rb:54) checks a connection out for the block; the port's
+   *   `Schema.define` is handed the adapter explicitly (schema.ts:51-64), the
+   *   one-schema convergence RFC 0059 tracks.
+   */
   static async define(
     adapter: DatabaseAdapter,
     infoOrFn: SchemaDefineInfo | ((schema: Schema) => void | Promise<void>),

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -125,6 +125,11 @@ export class UniquenessValidator extends EachValidator {
    *
    * Validates options: :conditions must be callable, :scope must be
    * strings. Extracts :class option for finder resolution.
+   *
+   * @missingRailsCall all? — PERMANENT: Verified per-site (RFC 0106):
+   *   `Array(options[:scope]).all? { |s| s.respond_to?(:to_sym) }`
+   *   (`uniqueness.rb:11`) — `Array#all?` is `Array#every` in JS. The gate flags
+   *   it only because `all?` maps onto the unrelated `Relation#all`.
    */
   constructor(options: Record<string, unknown> = {}) {
     if (options.conditions != null && typeof options.conditions !== "function") {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/belongs-to-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "handle_dependency",
-    "call": "fetch",
-    "reason": "Ruby `options.fetch(:ensuring_owner_was, nil)` (belongs_to_association.rb:34); a JS object has no `fetch`, so the stored-nil semantics are spelled as an own-key check at the call site."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "delete",
-    "call": "fetch",
-    "reason": "Ruby `options.fetch(:ensuring_owner_was, nil)` (has_one_association.rb:51); a JS object has no `fetch`, so the stored-nil semantics are spelled as an own-key check at the call site."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/has-one-through-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "replace",
-    "call": "create_through_record",
-    "reason": "Verified per-site (RFC 0106): `create_through_record(record, save)` (has_one_through_association.rb:10-12) writes the join row, so it is async in trails. `replace` cannot be — it is reached from the synchronous `writer`/`setNewRecord` path that RFC 0087 requires to stay sync — so the body queues `_pendingReplace` and `persistReplace`/`autosaveHasOne` awaits `createThroughRecord` one frame later. Same sync-setter shortcoming as the `setX()` idiom."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/singular-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/singular-association.ts",
-    "rubyName": "find_target",
-    "call": "first",
-    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; take() (unordered LIMIT 1) is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/asynchronous-queries-tracker.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/asynchronous-queries-tracker.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "asynchronous-queries-tracker.ts",
-    "rubyName": "current_session",
-    "call": "last",
-    "reason": "Verified per-site (RFC 0106): `@stack.last or raise ActiveRecordError` (`asynchronous_queries_tracker.rb:50`) — the TS body reads `this.#stack[this.#stack.length - 1]` and raises the same error with the same message. `first`/`last`/`size` are positional/property idioms with no JS call form, deliberately left uncredited by RFC 0092 (`positional-idiom-analogues`, see JS_ENUMERABLE_ALIASES' header comment) so the reason-text route is the sanctioned one; nothing was dropped from the TS body."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/autosave-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "define_non_cyclic_method",
-    "call": "define_method",
-    "reason": "autosave_association.rb:162 `define_method(name) do |*args| ... end` — Ruby's `define_method` is a prototype assignment in JS (`klass.prototype[name] = function ...`, autosave-association.ts:863); there is no `define_method` to call. Language shortcoming."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/base.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "destroy",
-    "call": "with_transaction_returning_status",
-    "reason": "File-mapping artifact: `base.ts`'s `destroy` is the instance-method table entry `destroy: _Persistence.destroy` (base.ts:4609), not a body. Rails' `Transactions#destroy` (transactions.rb:356-358) maps to persistence.ts `destroy`, which does call `withTransactionReturningStatus` (persistence.ts:855)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters.ts",
-    "rubyName": "resolve",
-    "call": "join",
-    "reason": "Rails builds the AdapterNotFound message inline (connection_adapters.rb:34-39); the port extracts it into the private `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(\", \")` (connection-adapters.ts:75) is outside the published call-set."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "connection_pool_list",
-    "call": "map",
-    "reason": "Per-site verified (RFC 0106 wave 4b): the inner `map` of connection_handler.rb:75-79 is the same Ruby-Enumerable idiom, spelled as the body of trails' explicit `for..of` accumulation."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
-    "rubyName": "can_remove_no_wait?",
-    "call": "size",
-    "reason": "Per-site verified (RFC 0106 wave 4b): connection_pool/queue.rb `@queue.size > @num_waiting`; trails' queue holds its entries in a JS array whose `.length` is the same quantity — `Array#size` is not a ported method name."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool/reaper.ts",
-    "rubyName": "register_pool",
-    "call": "spawn_thread",
-    "reason": "Per-site verified (RFC 0106 wave 4b): connection_pool/reaper.rb `spawn_thread` starts a background Thread; trails' Reaper drives the same period from a timer, so there is no thread to spawn. Tracked with the rest of the threadless pool surface by RFC 0073."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "initialize",
-    "call": "reset_transaction",
-    "reason": "Per-site verified (RFC 0106 wave 4b): abstract/database_statements.rb:12 is `reset_transaction` inside `initialize`; trails' DatabaseStatements is a mixin with no constructor of its own — the adapter's own constructor calls `resetTransaction()` (abstract-adapter.ts), so the call happens, just not from a body matched to this Ruby method."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql/database-statements.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/database-statements.ts",
-    "rubyName": "returning_column_values",
-    "call": "first",
-    "reason": "Per-site verified (RFC 0106 wave 4b): mysql/database_statements.rb's `result.rows.first` is `result.rows[0]` on a JS array; `Array#first` is not a ported method name."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/mysql2-adapter.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "initialize",
-    "call": "push",
-    "reason": "Per-site verified (RFC 0106 wave 4b): mysql2_adapter.rb:61-66 pushes onto `@config[:flags]` (a Ruby Array) while building the client flags; trails composes the mysql2 driver options object instead — the node driver takes named booleans, not a FLAGS array, so there is no array to push onto."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/explain-pretty-printer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/explain-pretty-printer.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/explain-pretty-printer.ts",
-    "rubyName": "pp",
-    "call": "first",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/explain_pretty_printer.rb's `result.rows.map(&:first)` / `.first` is index-0 access on a JS array; `Array#first` is not a ported method name."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/cidr.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/cidr.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/cidr.ts",
-    "rubyName": "cast_value",
-    "call": "new",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/oid/cidr.rb builds an `IPAddr.new(...)`; Ruby's IPAddr has no port in trails, so the cast returns the normalized CIDR string. Tracked as the PG address-type gap, not a dropped delegation."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/date-time.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/date-time.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/date-time.ts",
-    "rubyName": "cast_value",
-    "call": "format",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/oid/date_time.rb's `value.format` is Ruby's DateTime formatting; trails' cast returns a Temporal value formatted through Temporal's own API, which has no `format` method."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/date.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/date.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/date.ts",
-    "rubyName": "cast_value",
-    "call": "format",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/oid/date.rb's `value.format` is Ruby's Date formatting; trails' cast returns a Temporal.PlainDate and formats through Temporal's own API, which has no `format` method."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/hstore.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/hstore.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/hstore.ts",
-    "rubyName": "deserialize",
-    "call": "new",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/oid/hstore.rb's scanner allocates a `Hash.new`; trails accumulates into an object literal, which is not a `new` expression."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/legacy-point.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/legacy-point.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/legacy-point.ts",
-    "rubyName": "serialize",
-    "call": "number_for_point",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/oid/legacy_point.rb's `number_for_point` strips a trailing `.0` from each coordinate; trails' serialize formats the pair with the same rule inline. The helper is private and one-line in Rails; extracting it here would be surface with a single caller."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/range.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/range.ts",
-    "rubyName": "extract_bounds",
-    "call": "split",
-    "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/schema-definitions.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
-    "rubyName": "export_name_on_schema_dump?",
-    "call": "match?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/schema_definitions.rb:209-211/231-233 filter via SchemaDumper.excl_ignore_pattern/unique_ignore_pattern.match?; trails schema-definitions.ts:98-100/134-136 return `this.name != null` only — the ignore-pattern filtering (patterns exist at schema-dumper.ts:346-348) is unported. Omission tracked in story pg-export-name-ignores-dumper-patterns."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/utils.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/utils.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/utils.ts",
-    "rubyName": "to_s",
-    "call": "join",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/utils.rb:18-20 is `parts.join(SEPARATOR)`; trails utils.ts:17-22 toString template-joins schema and identifier explicitly."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-definitions.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-definitions.ts",
-    "rubyName": "change_column",
-    "call": "column",
-    "reason": "Per-site verified (RFC 0106 wave 4b): sqlite3/schema_definitions.rb's `change_column` re-enters `column(column_name, type, **options)` on the table definition; trails' SQLite Table#changeColumn forwards to the adapter's `changeColumn`, which rebuilds the table (copy_table) — the definition-level column re-declaration happens inside that rebuild."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/url-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/url-config.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations/url-config.ts",
-    "rubyName": "initialize",
-    "call": "merge",
-    "reason": "Verified per-site (RFC 0106): `@configuration_hash.merge(build_url_hash)` (`url_config.rb:43`) — a non-mutating Hash merge is an object spread in TS."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/auto-filtered-parameters.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/auto-filtered-parameters.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/auto-filtered-parameters.ts",
-    "rubyName": "collect_for_later",
-    "call": "new",
-    "reason": "`Concurrent::Array.new` (auto_filtered_parameters.rb:48): the per-class attribute list is an array literal in TS, which emits no constructor call, and Concurrent:: thread-safe collections have no analogue on a single-threaded event loop."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/configurable.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/configurable.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/configurable.ts",
-    "rubyName": "on_encrypted_attribute_declared",
-    "call": "new",
-    "reason": "`Concurrent::Array.new` (configurable.rb:48): the lazily-allocated listener list is `_listeners ??= []` in TS, an array literal with no constructor call, and Concurrent:: collections have no analogue on a single-threaded event loop."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/contexts.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/contexts.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/contexts.ts",
-    "rubyName": "current_custom_context",
-    "call": "last",
-    "reason": "`custom_contexts&.last` (contexts.rb:67) on a plain Array — the faithful port is index access, which emits no call name (compare.ts's `first`/`last` note)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encrypted-attribute-type.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encrypted-attribute-type.ts",
-    "rubyName": "serialize_with_oldest",
-    "call": "first",
-    "reason": "`previous_types.first` (encrypted_attribute_type.rb:127) on a plain Array — the faithful port is index access, which emits no call name (compare.ts's `first`/`last` note)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/extended-deterministic-uniqueness-validator.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/extended-deterministic-uniqueness-validator.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/extended-deterministic-uniqueness-validator.ts",
-    "rubyName": "install_support",
-    "call": "prepend",
-    "reason": "Rails prepends `EncryptedUniquenessValidator` into the validator class (extended_deterministic_uniqueness_validator.rb:7); trails swaps `validateEach` on the prototype directly because `resetSupport` has to hand the original method back for test teardown, which the `prepend()` shim's wrapper cannot expose."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-provider.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key-provider.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/key-provider.ts",
-    "rubyName": "encryption_key",
-    "call": "last",
-    "reason": "`@keys.last` (key_provider.rb:21) on a plain Array — the faithful port is index access, which emits no call name (compare.ts's `first`/`last` note)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/key.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/key.ts",
-    "rubyName": "id",
-    "call": "first",
-    "reason": "`Digest::SHA1.hexdigest(secret).first(4)` (key.rb:24) is ActiveSupport's String#first, whose faithful JS spelling is `String#slice(0, 4)` — a differently-named native call the gate cannot credit."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "discriminate_class_for_record",
-    "call": "find_sti_class",
-    "reason": "inheritance.rb:301 `find_sti_class(record[inheritance_column])` — trails routes through `findStiClassForRow` (inheritance.ts:867), the registry-safe variant that matches only within `baseClass`'s tracked subtree; the bare `findStiClass` is Rails' autoloader analog and is reached from there when STI is explicitly enabled (inheritance.ts:1075-1078). Documented at inheritance.ts:1050-1059."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "subclass_from_attributes",
     "call": "find_sti_class",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/log-subscriber.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "sql",
-    "call": "any?",
-    "reason": "Verified per-site (RFC 0106): `payload[:binds]&.any?` (`log_subscriber.rb:120`) — a blockless `Array#any?` is the emptiness test, whose faithful JS spelling is `length > 0`. The gate flags it only because `any?` maps onto the unrelated `Relation#any?`."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver/session.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/database-selector/resolver/session.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/database-selector/resolver/session.ts",
-    "rubyName": "convert_timestamp_to_time",
-    "call": "at",
-    "reason": "Verified per-site (RFC 0106): `Time.at(timestamp / 1000, (timestamp % 1000) * 1000)` (`resolver/session.rb:25`) — trails' time type is `Temporal.Instant`, whose epoch constructor is `fromEpochMilliseconds`; there is no `at` to call."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/shard-selector.ts",
-    "rubyName": "set_shard",
-    "call": "fetch",
-    "reason": "Verified per-site (RFC 0106): `options.fetch(:lock, true)` (`shard_selector.rb:66`) — the options hash is a plain TS object, so the stored-key test `Hash#fetch` performs is spelled `\"lock\" in this.options ? ... : true`. `fetch` has no TS call spelling."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "handler_for",
-    "call": "last",
-    "reason": "Verified per-site (RFC 0106): `@handlers.detect { ... }.last` (predicate_builder.rb:186) — Ruby `Array#last` on the matched `[klass, handler]` pair, spelled `[1]` in TS (predicate-builder.ts:543)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/association-query-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/association-query-value.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/association-query-value.ts",
-    "rubyName": "select_clause?",
-    "call": "empty?",
-    "reason": "Verified per-site (RFC 0106): `value.select_values.empty?` (association_query_value.rb:52) — `empty?` on a Ruby Array, whose faithful JS spelling is `xs.length === 0`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "queries",
-    "call": "empty?",
-    "reason": "Verified per-site (RFC 0106): `values.empty?` (polymorphic_array_value.rb:12) — `empty?` on a Ruby Array, whose faithful JS spelling is `xs.length === 0`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/relation-handler.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/predicate-builder/relation-handler.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/relation-handler.ts",
-    "rubyName": "call",
-    "call": "empty?",
-    "reason": "Verified per-site (RFC 0106): `value.select_values.empty?` (relation_handler.rb:11) — `empty?` on a Ruby Array, whose faithful JS spelling is `xs.length === 0`. That emits no callee, so no TS call can ever credit the Ruby one. The gate flags it only because `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes arguments since it gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "schema.ts",
-    "rubyName": "define",
-    "call": "with_connection",
-    "reason": "`connection_pool.with_connection` (schema.rb:54) checks a connection out for the block; the port's `Schema.define` is handed the adapter explicitly (schema.ts:51-64), the one-schema convergence RFC 0059 tracks."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/validations/uniqueness.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "initialize",
-    "call": "all?",
-    "reason": "Verified per-site (RFC 0106): `Array(options[:scope]).all? { |s| s.respond_to?(:to_sym) }` (`uniqueness.rb:11`) — `Array#all?` is `Array#every` in JS. The gate flags it only because `all?` maps onto the unrelated `Relation#all`."
-  }
-]


### PR DESCRIPTION
RFC 0106's tail sweep, activerecord half.

Every shard under `scripts/api-compare/call-mismatches-exclude/activerecord/**`
carrying exactly **one** `kind: "set"` row whose reason is already reviewed,
per-site and Rails-anchored leaves the baseline via

    pnpm parity:api:build --package activerecord --file <tsFile> --call <ruby_call>

which writes that reason as a `@missingRailsCall <ruby_call> — <reason>` tag on
the declaration and drops the baseline row. **42 rows migrated, 42 shards
deleted**, plus one row **converged** rather than tagged. `--call` was passed per
row, so no migration was name-keyed or bulk.

Population: 447 `kind: "set"` rows / 157 files → **405 / 114** for
activerecord + arel + activesupport.

## Not just a tag shuffle

- **`postgresql/utils.ts` `Name#toString` is converged**, not tagged. Rails
  (`postgresql/utils.rb:18-20`) is `parts.join SEPARATOR`; the port
  template-joined schema and identifier by hand. It now declares
  `SEPARATOR = "."` and calls the `parts()` that already existed. Verified
  against the built dist: `public.posts`, `posts`, `a.b.c d` — byte-identical to
  the previous body on every input, and now the same body Rails has. Its shard
  is deleted.
- **Every tag carries the permanence claim main now enforces.** A sibling landed
  the `PERMANENT` / `CONVERGEABLE` requirement on `@missingRailsCall` reasons
  while this branch was open; all 42 reasons were classified per-site, and each
  `CONVERGEABLE` one names the story that will retire it (RFC 0073, RFC 0059, and
  the five filed below).
- **Fixes a main red as a driveby.** That same enforcement left four
  pre-existing `enum.ts` tags unclassified, which aborts
  `parity:api --calls` on `main` today. All four are language-level facts
  (`Object.defineProperty` *is* the JS `define_method`; the module carrier *is*
  the ancestor splice) and are now marked `PERMANENT`. Not otherwise touched.

## Deliberately left as baseline rows

- **`order:` rows** (`abstract/schema-dumper`, `mysql/schema-statements`,
  `postgresql/oid/type-map-initializer`) — the flag is keyed on the **Ruby** name
  while the migrator keys the tag on the camelCased declaration, so a migrated
  `order:` row reads back as a STALE tag AND a NEW mismatch.
- **RFC 0047/0084 seed placeholders** (`attribute-methods/time-zone-conversion`,
  `coders/column-serializer`, `type-caster/connection`, `type/serialized`) — the
  migrator refuses a placeholder by design (RFC 0083); these need convergence or
  a real per-site reason first.
- **Five rows the migrator cannot reach** — it reports `no body-bearing
  declaration` for `aggregations.ts` (`composedOf`),
  `associations/through-association.ts` (`targetScope`),
  `connection-adapters/sqlite3/quoting.ts` (`quoteString`), `integration.ts`
  (`canUseFastCacheVersion`) and `secure-password.ts` (`authenticateBy`). The
  common shape is the `this`-typed-function mixin idiom CLAUDE.md mandates,
  which is exactly what `build.ts` cannot key a tag onto.
- **`associations/disable-joins-association-scope.ts`** — deferred to `main`,
  which improved that tag under this branch; re-migrating it would have fought a
  sibling's wording.

## Filed rather than ratified

Five deviations were `CONVERGEABLE`, so each got a story with the Rails
`file:line` rather than a comfortable reason:

- `adapter-not-found-message-should-be-built-inline` — `resolve` extracts a
  private helper Rails inlines (`connection_adapters.rb:34-39`).
- `legacy-point-serialize-should-extract-number-for-point` — Rails extracts the
  helper; the port inlines it. "Surface with one caller" is a preference, not a
  language shortcoming.
- `pg-cidr-cast-value-should-build-an-ipaddr` — `castValue` returns a string
  where Rails returns an `IPAddr`.
- `sqlite3-table-change-column-should-redeclare-the-column` — the definition-level
  `column(...)` re-entry never happens.
- `discriminate-class-for-record-should-call-find-sti-class` — routes through the
  trails-invented `findStiClassForRow` (`inheritance.rb:301`).

Plus the sweep's own continuation, each with its exact file list and both traps
written down: `wave-5b-tail-sweep` (the activesupport single-row tail, staged and
verified green here then reverted purely for the LOC ceiling),
`wave-5c-tail-sweep` (the 2- and 3-row shards),
`call-set-migrator-skips-non-body-bearing-declarations`, and
`module-ext-delegate-should-call-delegation-generate` (`delegate` inlines what
Rails delegates to `ActiveSupport::Delegation.generate`, delegation.rb:280 — a
port, not a tag migration).

## Verification

    pnpm parity:api:calls        call-mismatches ratchet: OK (766 baselined, 340 unreviewed, 124 marks totalling 340 tight)
    pnpm parity:api:calls:args   call-args ratchet: OK (156 baselined shape row(s))
    pnpm parity:api:reasons      3418 file(s) checked, every @missingRailsCall carries a reason
    pnpm parity:api:detached     3993 file(s) checked, no detached tag blocks
    pnpm typecheck               clean
    eslint                       clean (lint-staged, all 85 files)

`parity:api` / `parity:test` deltas are non-negative and `parity:api:extra` is
unmoved by construction: apart from `utils.ts`, **every changed `.ts` line in
this diff is a JSDoc comment line** —

    git diff origin/main...HEAD -- '*.ts' | grep -E '^[+-]' | grep -v '^[+-][+-]' \
      | grep -vE '^[+-]\s*(\*|/\*\*|\*/)'

returns only the five `utils.ts` lines. No stubs, no new public names.

Size: 667 LOC (279+/388-), under the 700 ceiling.

Closes-story: wave-5-tail-sweep
