### PR TITLE
fix(activerecord): claim permanence on enum.ts @missingRailsCall reasons

### DIFF
--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -412,7 +412,7 @@ export class EnumMethods {
    * the predicate `is{Name}`, the persisting bang `{name}Bang`, the positive
    * scope `{name}`, and the auto negative scope `not{Name}`.
    *
-   * @missingRailsCall define_method — enum.rb:306,310 emit the predicate and
+   * @missingRailsCall define_method — PERMANENT. enum.rb:306,310 emit the predicate and
    * bang with `define_method`. A generated member has to be installed with
    * `Object.defineProperty` in trails: it carries a descriptor, and the reader
    * half of the enum surface is a property, not a callable (see CLAUDE.md,
@@ -522,7 +522,7 @@ export { enumMethod as enum };
  *
  * Mirrors: ActiveRecord::Enum#_enum (private)
  *
- * @missingRailsCall define_method — enum.rb:232
+ * @missingRailsCall define_method — PERMANENT. enum.rb:232
  * `singleton_class.define_method(name.pluralize) { enum_values }` defines the
  * class-level values reader. trails installs it with `Object.defineProperty` on
  * the class object, the JS spelling of `singleton_class.define_method` (see
@@ -846,7 +846,7 @@ const _enumMethodsModuleRegistry = new WeakMap<typeof import("./base.js").Base, 
  *
  * Mirrors: ActiveRecord::Enum#_enum_methods_module (private)
  *
- * @missingRailsCall include — enum.rb:329 `include mod` splices the freshly
+ * @missingRailsCall include — PERMANENT. enum.rb:329 `include mod` splices the freshly
  * built module into the class's ancestors. trails does that splice with
  * `getOrCreateModuleCarrier` (from `EnumMethods.carrier()`), which interposes a
  * prototype between the model prototype and its parent — the JS spelling of the
@@ -870,7 +870,7 @@ export function _enumMethodsModule(this: typeof import("./base.js").Base): EnumM
  *
  * Mirrors: ActiveRecord::Enum#detect_enum_conflict! (private)
  *
- * @missingRailsCall method_defined_within? — enum.rb:377 and enum.rb:383 both
+ * @missingRailsCall method_defined_within? — PERMANENT. enum.rb:377 and enum.rb:383 both
  * spell their check as `method_defined_within?`. Neither arm can route through
  * the port of it: `isMethodDefinedWithin` resolves a method's owner by walking
  * the CONSTRUCTOR chain (`instanceMethodOwner`), which never reaches


### PR DESCRIPTION
Main went red on `Rails API/Test Comparison` at ff023ccf:

```
Error: @missingRailsCall needs a permanence claim in packages/activerecord/src/enum.ts
 — open the reason for `define_method` with PERMANENT ... or CONVERGEABLE ...
```

Cross-PR collision: #6840 made an unclassified `@missingRailsCall` reason a hard error in `extract-ts-api`, while #6844 landed four new `enum.ts` tags in parallel whose reasons open with prose. Each of the four is a language-level fact, so each reason now opens with `PERMANENT`:

- `define_method` (enum.rb:306,310 and :232) — `Object.defineProperty` is the JS `define_method`; the generated reader is a property.
- `include` (enum.rb:329) — the interposed carrier prototype is the JS ancestor splice.
- `method_defined_within?` (enum.rb:377,383) — `isMethodDefinedWithin` walks the constructor chain and never reaches `Object.prototype`.

Comment prose only; no behavior change. `pnpm exec tsx scripts/api-compare/extract-ts-api.ts` now completes.

Closes-story: red-ff023ccf