### PR TITLE
refactor(activerecord,scripts,trailties): attributes_before_type_cast method, readonly write_attribute super, Core#relation, multi-call tag guard

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-boolean.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-boolean.test.ts
@@ -63,13 +63,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
       let boolean = await BooleanType.createBang({ archived: true, published: true } as any);
       await (boolean as any).reload();
-      let attributes = (boolean as any).attributesBeforeTypeCast;
+      let attributes = (boolean as any).attributesBeforeTypeCast();
       expect(attributes["archived"]).toBe(1);
       expect(attributes["published"]).toBe("1");
 
       boolean = await BooleanType.createBang({ archived: false, published: false } as any);
       await (boolean as any).reload();
-      attributes = (boolean as any).attributesBeforeTypeCast;
+      attributes = (boolean as any).attributesBeforeTypeCast();
       expect(attributes["archived"]).toBe(0);
       expect(attributes["published"]).toBe("0");
 
@@ -82,13 +82,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
       let boolean = await BooleanType.createBang({ archived: true, published: true } as any);
       await (boolean as any).reload();
-      let attributes = (boolean as any).attributesBeforeTypeCast;
+      let attributes = (boolean as any).attributesBeforeTypeCast();
       expect(attributes["archived"]).toBe(1);
       expect(attributes["published"]).toBe("1");
 
       boolean = await BooleanType.createBang({ archived: false, published: false } as any);
       await (boolean as any).reload();
-      attributes = (boolean as any).attributesBeforeTypeCast;
+      attributes = (boolean as any).attributesBeforeTypeCast();
       expect(attributes["archived"]).toBe(0);
       expect(attributes["published"]).toBe("0");
 

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -256,7 +256,7 @@ export class AssociationScope {
     // bypasses default_scope but STILL applies the STI `type_condition`
     // because `relation()` adds it for `finder_needs_type_condition?`
     // classes (`core.rb:431-435`). `Base.unscoped` now wires STI through
-    // `_buildUnscopedRelation`, so no compensation is needed here.
+    // `relation`, so no compensation is needed here.
     const scopeRelation = klass.unscoped() as {
       aliasTracker: () => AliasTracker;
     };
@@ -874,7 +874,7 @@ export class AssociationScope {
    * Build a fresh scope for evaluating a chain entry's lambda. Mirrors
    * `entryKlass.unscoped` — Rails' `unscoped` retains the STI type filter
    * via `relation()` (core.rb:431-435), and `Base.unscoped` now wires that
-   * through `_buildUnscopedRelation`, so no compensation is needed here.
+   * through `relation`, so no compensation is needed here.
    */
   protected _buildEntryScope(entryKlass: typeof Base, aliasedTable?: unknown): unknown {
     // Build the entry relation against the chain entry's alias so the scope
@@ -887,9 +887,9 @@ export class AssociationScope {
     // the table when the tracker produced a real alias; otherwise keep
     // `unscoped()` so non-aliased SQL is byte-identical.
     if (aliasedTable) {
-      return (
-        entryKlass as unknown as { _buildUnscopedRelation: (t: unknown) => unknown }
-      )._buildUnscopedRelation(aliasedTable);
+      return (entryKlass as unknown as { relation: (t: unknown) => unknown }).relation(
+        aliasedTable,
+      );
     }
     return (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
   }

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -729,7 +729,7 @@ describe("AttributeMethodsTest", () => {
   it("read attributes_before_type_cast", () => {
     const { Post } = makeModel();
     const p = new Post({ title: "raw", score: "99" });
-    const raw = p.attributesBeforeTypeCast;
+    const raw = p.attributesBeforeTypeCast();
     expect(raw.score).toBe("99");
     expect(p.score).toBe(99);
   });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -509,13 +509,4 @@ describe("ActiveRecord attribute read/write surface lives on Base, not Model", (
     read(t);
     expect(t.accessedFields()).toEqual(["title"]);
   });
-
-  it("keeps attributesBeforeTypeCast a getter rather than a data property", () => {
-    // before_type_cast.rb:82 is a zero-arg reader, so it ports as an accessor
-    // property; include() copies an object literal by value and would flatten
-    // it into a data property holding the getter's one-time result.
-    const descriptor = Object.getOwnPropertyDescriptor(Base.prototype, "attributesBeforeTypeCast")!;
-    expect(typeof descriptor.get).toBe("function");
-    expect("value" in descriptor).toBe(false);
-  });
 });

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -854,7 +854,7 @@ export function readAttributeForDatabase(this: InstanceMethodHost, attrName: str
 }
 /** @internal */
 export function attributesBeforeTypeCast(this: InstanceMethodHost): Record<string, unknown> {
-  return _attributesBeforeTypeCast(this as any);
+  return _attributesBeforeTypeCast.call(this as any);
 }
 /** @internal */
 export function attributesForDatabase(this: InstanceMethodHost): Record<string, unknown> {

--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -35,12 +35,10 @@ export function readAttributeBeforeTypeCast(
  * Return all attribute values before type casting.
  *
  * Mirrors: ActiveRecord::AttributeMethods::BeforeTypeCast#attributes_before_type_cast
- * (before_type_cast.rb:82-84). Ruby's zero-arg reader is an accessor property
- * here — see CLAUDE.md, "Generated attribute readers are properties" — so
- * base.ts installs it with `Object.defineProperty` rather than `include()`.
+ * (before_type_cast.rb:82-84).
  */
-export function attributesBeforeTypeCast(record: BeforeTypeCastRecord): Record<string, unknown> {
-  return record._attributes.valuesBeforeTypeCast();
+export function attributesBeforeTypeCast(this: BeforeTypeCastRecord): Record<string, unknown> {
+  return this._attributes.valuesBeforeTypeCast();
 }
 
 interface DatabaseRecord extends AttributeOwner {

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -47,13 +47,13 @@ export function writeAttribute(this: Model, attrName: string, value: unknown): v
   //   table has a real `id` column (e.g. cpk_books). Mirror that raise here
   //   rather than writing the scalar `id`. (Composite `id=` assignment flows
   //   through the per-column `_writeAttribute` path, not this one.)
+  // The `_initializingAttributes` guard on that arm has no Rails counterpart:
+  // during `new X(…)` it must stay quiet, because Ruby builds the attribute set
+  // before any writer runs.
   const pk = (this.constructor as unknown as { primaryKey: string | string[] | null }).primaryKey;
   if (name === "id" && pk != null) {
     if (typeof pk === "string") {
       name = pk;
-      // `_initializingAttributes` has no Rails counterpart: during `new X(…)`
-      // this arm must stay quiet, because Ruby builds the attribute set before
-      // any writer runs.
     } else if (!this._initializingAttributes) {
       // Rails calls `write_from_user(@primary_key, …)` with the PK array, so the
       // Null attribute's name — and the interpolated message (attribute.rb:236) —
@@ -64,12 +64,9 @@ export function writeAttribute(this: Model, attrName: string, value: unknown): v
   }
 
   // write.rb:36 — `@attributes.write_from_user(name, value)`. `Model`'s
-  // `_writeAttribute` is that call plus trails' dirty bookkeeping; going
-  // through `this._writeAttribute` would instead re-enter
+  // `_writeAttribute` is that call plus trails' dirty bookkeeping; going through
+  // `this._writeAttribute` would instead re-enter
   // `HasReadonlyAttributes#_write_attribute`, a guard Rails does not run twice.
-  // Writing an unknown attribute raises `MissingAttributeError` from
-  // `AttributeSet#writeFromUser`; mass assignment routes through here too but
-  // rescues it (attribute-assignment.ts), so `new X({unknown: 1})` stays lenient.
   Model.prototype._writeAttribute.call(this, name, value);
 }
 

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -1,16 +1,19 @@
 /**
  * Attribute writing methods.
  *
- * `writeAttribute` here is the base `Write#write_attribute`. `Base.prototype`
- * currently receives `HasReadonlyAttributes#write_attribute`
- * (readonly-attributes.ts), which inlines this body behind its guards instead
- * of reaching it the way Ruby's `super` (readonly_attributes.rb:54) does —
- * tracked by the `converge-readonly-write-attribute-onto-write-super` story.
+ * `writeAttribute` here is the base `Write#write_attribute`, reached from
+ * `HasReadonlyAttributes#write_attribute` (readonly-attributes.ts) where Ruby
+ * writes `super` (readonly_attributes.rb:54).
  *
  * Mirrors: ActiveRecord::AttributeMethods::Write
  */
 
-import { Model, AttrNames, buildMangledName } from "@blazetrails/activemodel";
+import {
+  Model,
+  MissingAttributeError,
+  AttrNames,
+  buildMangledName,
+} from "@blazetrails/activemodel";
 import type { CodeGenerator } from "@blazetrails/activesupport";
 import { completeHalfAccessor } from "./read.js";
 
@@ -30,11 +33,44 @@ export interface Write {
  * Mirrors: ActiveRecord::AttributeMethods::Write#write_attribute (write.rb:31-38)
  */
 export function writeAttribute(this: Model, attrName: string, value: unknown): void {
-  const name = (
+  let name = (
     this.constructor as unknown as { resolveAttributeName(n: string): string }
   ).resolveAttributeName(String(attrName));
 
-  this._writeAttribute(name, value);
+  // write.rb:35 — `name = @primary_key if name == "id" && @primary_key`, where
+  // `@primary_key` is `klass.primary_key` (core.rb:844).
+  // - Scalar custom PK: `@primary_key` is a string, so `id` remaps to the real
+  //   PK column (a standard `id` PK remaps to itself, a no-op).
+  // - Composite PK: `@primary_key` is the array, so Rails calls
+  //   `write_from_user([...], v)`; the array key misses the attribute hash and
+  //   resolves to a `Null` attribute → `MissingAttributeError` — even when the
+  //   table has a real `id` column (e.g. cpk_books). Mirror that raise here
+  //   rather than writing the scalar `id`. (Composite `id=` assignment flows
+  //   through the per-column `_writeAttribute` path, not this one.)
+  const pk = (this.constructor as unknown as { primaryKey: string | string[] | null }).primaryKey;
+  if (name === "id" && pk != null) {
+    if (typeof pk === "string") {
+      name = pk;
+      // `_initializingAttributes` has no Rails counterpart: during `new X(…)`
+      // this arm must stay quiet, because Ruby builds the attribute set before
+      // any writer runs.
+    } else if (!this._initializingAttributes) {
+      // Rails calls `write_from_user(@primary_key, …)` with the PK array, so the
+      // Null attribute's name — and the interpolated message (attribute.rb:236) —
+      // is the array in Ruby `#inspect` form, e.g. `["author_id", "id"]`.
+      const arrayName = `[${pk.map((c) => `"${c}"`).join(", ")}]`;
+      throw new MissingAttributeError(`can't write unknown attribute \`${arrayName}\``);
+    }
+  }
+
+  // write.rb:36 — `@attributes.write_from_user(name, value)`. `Model`'s
+  // `_writeAttribute` is that call plus trails' dirty bookkeeping; going
+  // through `this._writeAttribute` would instead re-enter
+  // `HasReadonlyAttributes#_write_attribute`, a guard Rails does not run twice.
+  // Writing an unknown attribute raises `MissingAttributeError` from
+  // `AttributeSet#writeFromUser`; mass assignment routes through here too but
+  // rescues it (attribute-assignment.ts), so `new X({unknown: 1})` stays lenient.
+  Model.prototype._writeAttribute.call(this, name, value);
 }
 
 /**

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -11,6 +11,7 @@ import { registerSubclass } from "./inheritance.js";
 import { Type } from "@blazetrails/activemodel";
 import { fixtures } from "./test-fixtures.js";
 import { reconcileVirtualAttributes, loadSchema } from "./model-schema.js";
+import { Firm } from "./test-helpers/models/company.js";
 
 describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => {
   function makeModel() {
@@ -131,6 +132,23 @@ describe("_applyScopeAttributes — a scope that sets type wins over the STI def
         ),
       );
     });
+  });
+});
+
+describe("Base.relation with a cleared inheritance column (trails)", () => {
+  fixtures(["companies"]);
+
+  it("skips the type condition when the inheritance column is gone", async () => {
+    await Firm.loadSchema();
+    expect(Firm.isFinderNeedsTypeCondition()).toBe(true);
+
+    const previous = Firm.inheritanceColumn;
+    Firm.inheritanceColumn = null;
+    try {
+      expect(() => (Firm as unknown as { relation(): unknown }).relation()).not.toThrow();
+    } finally {
+      Firm.inheritanceColumn = previous;
+    }
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2188,6 +2188,12 @@ export class Base extends Model {
     const relation = Relation.create(this, { table });
 
     if (isFinderNeedsTypeCondition(this) && !isIgnoreDefaultScope.call(this)) {
+      // `finder_needs_type_condition?` memoizes on first call (inheritance.rb:92),
+      // so clearing `inheritance_column` afterwards leaves it answering true.
+      // Rails' `type_condition` then builds `table[nil]` (inheritance.rb:322);
+      // trails' `typeCondition` raises instead, so skip the arm rather than
+      // turning a Rails no-op into an error.
+      if (this.inheritanceColumn === null) return relation;
       return relation.whereBang(typeCondition(this, table));
     } else {
       return relation;
@@ -2195,7 +2201,7 @@ export class Base extends Model {
   }
 
   private static _buildDefaultRelation(allQueries?: boolean | null): any {
-    // default.rb:36 — `default_scoped(scope = relation, all_queries: nil)`: the
+    // named.rb:45 — `default_scoped(scope = relation, all_queries: nil)`: the
     // base relation, STI condition and all, is built BEFORE `build_default_scope`
     // arms the recursion guard, and the default scope merges into it.
     return (

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -40,16 +40,12 @@ import {
 import { setCurrentAdapterResolver } from "./type.js";
 import { Table, DeleteManager, Nodes } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import type { Relation } from "./relation.js";
+import { Relation } from "./relation.js";
 // Side-effect import: relation.ts registers the `Relation` family slot that
 // `relationClassFor` builds every per-model relation subclass from. relation.ts
 // no longer imports base.js for its value, so this edge is one-way.
 import "./relation.js";
-import {
-  wrapWithScopeProxy,
-  relationClassFor,
-  generatedRelationMethods as _generatedRelationMethods,
-} from "./relation/delegation.js";
+import { generatedRelationMethods as _generatedRelationMethods } from "./relation/delegation.js";
 import { _registerBase as _registerBaseWithQueryCache } from "./query-cache.js";
 import { _registerBase as _registerBaseWithSchemaMigration } from "./schema-migration.js";
 import { _registerBase as _registerBaseWithInternalMetadata } from "./internal-metadata.js";
@@ -65,6 +61,7 @@ import {
   subclasses as inheritanceSubclasses,
   descendants as inheritanceDescendants,
   isFinderNeedsTypeCondition,
+  typeCondition,
   primaryAbstractClass,
   applicationRecordClassQ as _applicationRecordClassQ,
   stiClassFor,
@@ -203,6 +200,7 @@ import {
   pkAttribute as _pkAttribute,
   readAttributeBeforeTypeCast as _readAttributeBeforeTypeCast,
   readAttributeForDatabase as _readAttributeForDatabase,
+  attributesBeforeTypeCast as _attributesBeforeTypeCast,
   attributesForDatabase as _attributesForDatabase,
   attributeBeforeTypeCast as _attributeBeforeTypeCast,
   attributeForDatabase as _attributeForDatabase,
@@ -238,10 +236,7 @@ import {
   defineMethodAttribute as _defineMethodAttribute,
 } from "./attribute-methods/read.js";
 import { setDefineMethodAttribute as _setDefineMethodAttribute } from "./attribute-methods/write.js";
-import {
-  attributeCameFromUser as _attributeCameFromUser,
-  attributesBeforeTypeCast as _attributesBeforeTypeCastFn,
-} from "./attribute-methods/before-type-cast.js";
+import { attributeCameFromUser as _attributeCameFromUser } from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
   _queryAttribute as _queryAttributeFn,
@@ -327,6 +322,7 @@ import {
 
 import {
   Default as DefaultScoping,
+  isIgnoreDefaultScope,
   defaultScope as _defaultScope,
   isScopeAttributes as _isScopeAttributes,
   unscoped as _unscoped,
@@ -395,15 +391,6 @@ export type PrimaryKeyScalar = string | number | bigint | null | undefined;
  * Mirrors: the value returned by `ActiveRecord::Base#id`.
  */
 export type PrimaryKeyValue = PrimaryKeyScalar | PrimaryKeyScalar[];
-
-/**
- * @internal The per-model `Relation` subclass ctor (Rails' `relation_class_for`).
- * Base relations are constructed from the per-model subclass so generated
- * relation methods resolve as real methods via its prototype carrier.
- */
-function _relationCtorFor(this: void, model: typeof Base): new (m: typeof Base, t?: any) => any {
-  return relationClassFor(model) as new (m: typeof Base, t?: any) => any;
-}
 
 /**
  * Rails' `persistence.rb#update` / `#update!` dispatch on the first arg:
@@ -2186,51 +2173,35 @@ export class Base extends Model {
     return this._buildDefaultRelation();
   }
 
-  /** @internal Build a scope-proxy-wrapped Relation with no default scope
-   *  applied. Used by `unscoped()` in scoping/default.ts. Mirrors Rails'
-   *  `relation` (core.rb:431-435): `unscoped` bypasses the default scope but
-   *  STILL applies the STI `type_condition` for `finder_needs_type_condition?`
-   *  classes, so callers like `AssociationScope` get a type-filtered base
-   *  without re-adding the condition themselves. */
-  static _buildUnscopedRelation(table?: any): any {
-    // `table` lets callers build the relation against a specific Arel table
-    // (e.g. an association-scope chain entry's aliased table). Passing it to
-    // the ctor means the STI `type_condition` that `_applyStiTypeCondition`
-    // adds below is qualified by that same table — so a self-referential
-    // through doesn't end up with the STI predicate on the FROM table and
-    // the source-type predicate on the alias.
-    const rel = new (_relationCtorFor(this))(this, table);
-    return this._applyStiTypeCondition(wrapWithScopeProxy(rel));
-  }
+  /**
+   * Mirrors: ActiveRecord::Core::ClassMethods#relation (core.rb:431-435).
+   *
+   * The `table` argument has no Rails counterpart: `AbstractReflection#build_scope`
+   * (reflection.rb:336-338) and `AssociationScope` build against a possibly-aliased
+   * Arel table, and passing it here qualifies the STI `type_condition` by that same
+   * table — so a self-referential through doesn't end up with the STI predicate on
+   * the FROM table and the source-type predicate on the alias.
+   *
+   * @internal Rails-private (core.rb:408 `private`).
+   */
+  static relation(table?: any): any {
+    const relation = Relation.create(this, { table });
 
-  /** @internal Re-apply the STI `type_condition` WHERE for subclasses.
-   *  Rails bakes this into `relation()` so both `unscoped` and the
-   *  default-scoped path carry it; we layer it onto the base relation. */
-  private static _applyStiTypeCondition(rel: any): any {
-    // Rails gates the finder type-condition on `finder_needs_type_condition?`
-    // (hierarchical + inheritance-column presence), not on an explicit
-    // `inheritanceColumn` assignment — so any non-abstract subclass over a
-    // `type`-bearing table scopes
-    // by type. The column resolves on the subclass itself (default "type").
-    if (isFinderNeedsTypeCondition(this)) {
-      const col = this.inheritanceColumn;
-      if (col === null) return rel;
-      // Rails: `([self] + descendants).map(&:sti_name)` (inheritance.rb#type_condition)
-      // — `sti_name` honors `store_full_sti_class` / overrides, not the bare class name.
-      const stiNames = [stiName(this), ...this.descendants.map((d: typeof Base) => stiName(d))];
-      return rel.where({ [col]: stiNames.length === 1 ? stiNames[0] : stiNames });
+    if (isFinderNeedsTypeCondition(this) && !isIgnoreDefaultScope.call(this)) {
+      return relation.whereBang(typeCondition(this, table));
+    } else {
+      return relation;
     }
-    return rel;
   }
 
   private static _buildDefaultRelation(allQueries?: boolean | null): any {
-    const buildBase = () => {
-      const r = new (_relationCtorFor(this))(this);
-      return wrapWithScopeProxy(r);
-    };
-    const rel =
-      DefaultScoping.buildDefaultScope.call(this, buildBase(), { allQueries }) ?? buildBase();
-    return this._applyStiTypeCondition(rel);
+    // default.rb:36 — `default_scoped(scope = relation, all_queries: nil)`: the
+    // base relation, STI condition and all, is built BEFORE `build_default_scope`
+    // arms the recursion guard, and the default scope merges into it.
+    return (
+      DefaultScoping.buildDefaultScope.call(this, this.relation(), { allQueries }) ??
+      this.relation()
+    );
   }
 
   // Scope extension methods: scope name -> Record of extra methods
@@ -2393,7 +2364,7 @@ export class Base extends Model {
       if (scope._model === this) {
         return scope.clone();
       }
-      return this._buildUnscopedRelation().mergeBang(scope);
+      return this.relation().mergeBang(scope);
     }
     return this.defaultScoped({ allQueries: options?.allQueries });
   }
@@ -3838,7 +3809,7 @@ export class Base extends Model {
   declare hasAttribute: (name: string) => boolean;
   declare attributePresent: (name: string) => boolean;
   declare readAttributeBeforeTypeCast: (name: string) => unknown;
-  declare readonly attributesBeforeTypeCast: Record<string, unknown>;
+  declare attributesBeforeTypeCast: () => Record<string, unknown>;
   declare columnForAttribute: (name: string) => any;
   declare toKey: () => unknown[] | null;
   declare accessedFields: () => string[];
@@ -4760,16 +4731,6 @@ include(Base, {
   writeStoreAttribute: _writeStoreAttribute,
   storeAccessorFor: _storeAccessorFor,
 });
-// before_type_cast.rb:82 — a Ruby zero-arg reader ports as an accessor property
-// (CLAUDE.md, "Generated attribute readers are properties"), and include()
-// copies the object literal by value, which would flatten the getter into a
-// data property. Install the descriptor directly instead.
-Object.defineProperty(Base.prototype, "attributesBeforeTypeCast", {
-  get(this: Base) {
-    return _attributesBeforeTypeCastFn(this as never);
-  },
-  configurable: true,
-});
 include(Base, ModelSchema.InstanceMethods);
 include(Base, _PrimaryKey);
 // Rails includes CompositePrimaryKey into a model when `primary_key=` takes an
@@ -4887,6 +4848,7 @@ include(Base, {
   formatForInspect: _formatForInspect,
   pkAttribute: _pkAttribute,
   readAttributeForDatabase: _readAttributeForDatabase,
+  attributesBeforeTypeCast: _attributesBeforeTypeCast,
   attributesForDatabase: _attributesForDatabase,
   attributeBeforeTypeCast: _attributeBeforeTypeCast,
   attributeForDatabase: _attributeForDatabase,

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,7 +1,8 @@
 import type { Base } from "./base.js";
-import { Model, MissingAttributeError } from "@blazetrails/activemodel";
+import { Model } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
 import { ActiveRecord } from "./ar-config.js";
+import { writeAttribute as _writeAttributeSuper } from "./attribute-methods/write.js";
 
 /**
  * Raised when a persisted record attempts to write to a column declared
@@ -78,79 +79,50 @@ export function readonlyAttributeQ(this: typeof Base, attribute: string): boolea
 }
 
 /**
- * AR's `write_attribute` override — Rails' `HasReadonlyAttributes` mixin in
- * readonly_attributes.rb (line 49). Adds two guards before delegating to the
- * base Model implementation:
+ * Rails' `HasReadonlyAttributes#write_attribute` (readonly_attributes.rb:49-55):
+ * a readonly guard, then `super` into `AttributeMethods::Write#write_attribute`
+ * (write.rb:31-38), which resolves the alias, remaps `"id"` to the primary key
+ * and writes.
  *
- *   - frozen record: raises `Cannot modify a frozen X`.
- *   - readonly column on a persisted record: raises `ReadonlyAttributeError`
- *     when the guard was armed at declaration time (`_readonlyAttributesRaise`,
- *     captured from `raise_on_assign_to_attr_readonly` when `attrReadonly` ran);
- *     otherwise the write falls through to `super` and the value is written in
- *     memory (Rails leaves HasReadonlyAttributes uninstalled in that case).
+ * Two trails-only details ride along:
  *
- * During construction the `_newRecord` field initializer on `Base` hasn't
- * run yet when `Model`'s constructor invokes `writeAttribute` — gate the
- * readonly check on the definitively-persisted state (`_newRecord === false`)
- * rather than `!isNewRecord()` so initial assignments during `new X(...)`
- * aren't mistakenly blocked.
+ *   - the frozen-record guard, which Rails does not have in this module: it
+ *     raises `Cannot modify a frozen X` before anything else.
+ *   - `_readonlyAttributesRaise`. Rails includes `HasReadonlyAttributes` only
+ *     when `raise_on_assign_to_attr_readonly` was true at `attr_readonly`
+ *     declaration time (readonly_attributes.rb:33); trails always installs the
+ *     method, so the flag captured there stands in for the absent module and
+ *     the write falls through to `super` when it is false — the value IS
+ *     written in memory, and persist-time exclusion of readonly columns
+ *     (attributesForUpdate) keeps it out of the UPDATE.
+ *
+ * During construction the `_newRecord` field initializer on `Base` hasn't run
+ * yet when `Model`'s constructor invokes `writeAttribute` — gate the readonly
+ * check on the definitively-persisted state (`_newRecord === false`) rather
+ * than `!isNewRecord()` so initial assignments during `new X(...)` aren't
+ * mistakenly blocked.
  *
  * `Base.prototype.writeAttribute` installed via include() in base.ts.
  *
  * Mirrors: ActiveRecord::HasReadonlyAttributes#write_attribute
  */
-export function writeAttribute(this: Base, name: string, value: unknown): void {
+export function writeAttribute(this: Base, attrName: string, value: unknown): void {
   if (this._attributes.isFrozen()) {
     throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
   }
   const ctor = this.constructor as typeof Base;
-  // Rails' `write_attribute` resolves `attribute_aliases[name]` before the
-  // chain runs, so HasReadonlyAttributes' check sees the canonical name and
-  // writing via an alias cannot bypass readonly enforcement.
-  let canonical = ctor.resolveAttributeName(String(name));
-  // Rails `write_attribute` remaps the `id` literal to the primary key before
-  // `write_from_user` (write.rb:35: `name = @primary_key if name == "id" &&
-  // @primary_key`), where `@primary_key` is `klass.primary_key` (core.rb:844).
-  // - Scalar custom PK: `@primary_key` is a string, so `id` remaps to the real
-  //   PK column (a standard `id` PK remaps to itself, a no-op).
-  // - Composite PK: `@primary_key` is the array, so Rails calls
-  //   `write_from_user([...], v)`; the array key misses the attribute hash and
-  //   resolves to a `Null` attribute → `MissingAttributeError` — even when the
-  //   table has a real `id` column (e.g. cpk_books). Mirror that raise here
-  //   rather than writing the scalar `id`. (Composite `id=` assignment flows
-  //   through the per-column `_writeAttribute` path, not this one.)
-  const pk = ctor.primaryKey;
-  if (canonical === "id" && pk != null) {
-    if (typeof pk === "string") {
-      canonical = pk;
-    } else if (!(this as { _initializingAttributes?: boolean })._initializingAttributes) {
-      // Rails calls `write_from_user(@primary_key, …)` with the PK array, so the
-      // Null attribute's name — and the interpolated message (attribute.rb:236) —
-      // is the array in Ruby `#inspect` form, e.g. `["author_id", "id"]`.
-      const arrayName = `[${pk.map((c) => `"${c}"`).join(", ")}]`;
-      throw new MissingAttributeError(`can't write unknown attribute \`${arrayName}\``);
-    }
-  }
-  // Rails only installs this guard when `raise_on_assign_to_attr_readonly` was
-  // true at `attr_readonly` declaration time (captured in `_readonlyAttributesRaise`).
-  // When it was false the guard is absent, so the write falls straight through to
-  // `super` — the value IS written in memory; persist-time exclusion of readonly
-  // columns (attributesForUpdate) keeps it out of the UPDATE.
+  // readonly_attributes.rb:50 checks the RAW `attr_name` and lets `super`
+  // resolve the alias afterwards, so an aliased write escapes the guard in
+  // Rails too.
   if (
     this._newRecord === false &&
     ctor._readonlyAttributesRaise &&
-    ctor.readonlyAttributeQ(canonical)
+    ctor.readonlyAttributeQ(String(attrName))
   ) {
-    throw new ReadonlyAttributeError(canonical);
+    throw new ReadonlyAttributeError(String(attrName));
   }
-  // Mirrors Rails `write_attribute` → `write_from_user`: writing an unknown
-  // attribute raises MissingAttributeError. The raise originates in
-  // `AttributeSet#writeFromUser` (the schema cache is always warm, so an absent
-  // name is definitively unknown). Mass assignment routes through here too but
-  // rescues it (attribute-assignment.ts), so `new X({unknown: 1})` stays lenient.
-  // `super` — route through Model's _writeAttribute with the already-resolved
-  // canonical name, matching Rails' `super` into the underscore path.
-  Model.prototype._writeAttribute.call(this, canonical, value);
+
+  _writeAttributeSuper.call(this as never, attrName, value);
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -89,11 +89,11 @@ export class Default {
    *
    * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#unscoped
    * (default.rb:17-26) — `block_given? ? relation.scoping(&block) : relation`.
-   * trails spells Rails' `relation` `_buildUnscopedRelation` (see named.ts).
+   * `relation` is Rails' `Core::ClassMethods#relation` (core.rb:431-435).
    * @internal
    */
   static unscoped(this: any, block?: () => any): any {
-    return block ? this._buildUnscopedRelation().scoping(block) : this._buildUnscopedRelation();
+    return block ? this.relation().scoping(block) : this.relation();
   }
 }
 
@@ -244,7 +244,7 @@ function isExecuteScope(
  * one recursion guard, and WITHOUT `skip_inherited_scope`.
  * @internal
  */
-function isIgnoreDefaultScope(this: any): boolean {
+export function isIgnoreDefaultScope(this: any): boolean {
   return !!ScopeRegistry.ignoreDefaultScope(this.baseClass);
 }
 

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -26,8 +26,8 @@ import { Default } from "./default.js";
 /**
  * Mirrors `ActiveRecord::AttributeMethods::ClassMethods::RESTRICTED_CLASS_METHODS`
  * (`%w(private public protected allocate new name superclass)`), plus `relation`:
- * Rails reserves the private `AR::Base#relation`, which trails names
- * `_buildUnscopedRelation`, so the public `relation` name stays reserved here.
+ * Rails reserves the private `AR::Base#relation` (core.rb:431), so a scope may
+ * not shadow it.
  */
 const RESTRICTED_CLASS_METHODS = new Set([
   "private",
@@ -144,7 +144,7 @@ interface NamedHost {
   // Rails' `relation` (core.rb) — a pristine Relation with the STI type
   // condition but neither current_scope nor default_scope applied. It is the
   // default `scope` argument for both methods below.
-  _buildUnscopedRelation?(): any;
+  relation?(): any;
 }
 
 /**
@@ -154,7 +154,7 @@ interface NamedHost {
  * current_scope is itself an empty scope.
  */
 export function scopeForAssociation(this: NamedHost, scope?: any): any {
-  const rel = scope ?? this._buildUnscopedRelation?.();
+  const rel = scope ?? this.relation?.();
   if (this.currentScope?.()?.isEmptyScope) {
     return rel;
   }
@@ -183,7 +183,7 @@ export function defaultScoped(
   // Relation instance.
   const kwargsOnly =
     scopeOrOptions != null && Object.getPrototypeOf(scopeOrOptions) === Object.prototype;
-  const scope = (kwargsOnly ? undefined : scopeOrOptions) ?? this._buildUnscopedRelation?.();
+  const scope = (kwargsOnly ? undefined : scopeOrOptions) ?? this.relation?.();
   const opts = kwargsOnly ? (scopeOrOptions as { allQueries?: boolean | null }) : options;
   return Default.buildDefaultScope.call(this, scope, { allQueries: opts?.allQueries }) ?? scope;
 }

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -155,12 +155,15 @@ export class Application extends Engine {
    * Mirrors `Engine#app` (`engine.rb:516-524`) — builds the middleware
    * stack once and wraps the endpoint in it.
    *
-   * @missingRailsCall build_middleware, merge_into — CONVERGEABLE: Rails merges
+   * @missingRailsCall build_middleware — CONVERGEABLE: Rails merges
    * `config.app_middleware + config.middleware` (both
    * `MiddlewareStackProxy`s) into the default stack. `MiddlewareStackProxy`
    * is not ported (`trailtie/configuration.ts:87` — `appMiddleware()`
    * returns undefined), so there are no queued operations to merge and the
    * default stack is assigned to `config.middleware` directly.
+   * @missingRailsCall merge_into — CONVERGEABLE: same gap, the other half of
+   * `engine.rb:519` — with no `MiddlewareStackProxy` there is nothing to merge
+   * the default stack into.
    */
   app(): RackApp {
     if (this._app) return this._app;

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -145,9 +145,12 @@ Finisher.initializer("run_prepare_callbacks", function (this: FinisherHost) {
  * Mirrors `Finisher`'s `set_routes_reloader_hook` initializer
  * (`finisher.rb:158-179`).
  *
- * @missingRailsCall reloaders, to_run — CONVERGEABLE: `Application#reloaders` and
- * `ActiveSupport::Reloader#to_run` are not ported, so the reloader is only
- * executed once here instead of being re-run on every reload.
+ * @missingRailsCall reloaders — CONVERGEABLE: `Application#reloaders` is not
+ * ported, so the reloader is never registered on the reloaders collection
+ * (`finisher.rb:162`).
+ * @missingRailsCall to_run — CONVERGEABLE: `ActiveSupport::Reloader#to_run` is
+ * not ported, so the reloader is only executed once here instead of being
+ * re-run on every reload (`finisher.rb:164-177`).
  */
 Finisher.initializer("set_routes_reloader_hook", async function (this: FinisherHost) {
   const reloader = this.routesReloader();

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -45,6 +45,14 @@ describe("suppressedCallsIn", () => {
     );
   });
 
+  it("throws on a tag naming several comma-separated calls", () => {
+    expect(() =>
+      suppressedCallsIn(
+        block("@missingRailsCall reloaders, to_run — PERMANENT: neither is ported."),
+      ),
+    ).toThrow(/needs a call/);
+  });
+
   it("throws on a call-less one-line tag", () => {
     expect(() => suppressedCallsIn("/** @missingRailsCall */")).toThrow(/needs a call/);
   });

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -66,8 +66,11 @@ export interface JsdocOrigin {
  *  rather than growing a near-copy of it. */
 const tagLine = (tag: string): RegExp =>
   new RegExp(`^\\s*\\*?\\s*${tag}\\s+(\\S+)(?:\\s+—\\s?(.*))?$`);
-const callLessTagLine = (tag: string): RegExp =>
-  new RegExp(`^\\s*\\*?\\s*${tag}(?:\\s+—(?:\\s.*)?)?\\s*$`);
+/** A line that OPENS the tag, whatever follows it. Anything matching this and
+ *  not `tagLine` is malformed — the bare tag, one going straight to the
+ *  em-dash, or one naming several comma-separated calls — and is a hard error
+ *  rather than prose the parser walks past (RFC 0099). */
+const tagLineStart = (tag: string): RegExp => new RegExp(`^\\s*\\*?\\s*${tag}\\b`);
 // A line opening a NEW JSDoc tag: at most one space after the `*`. Curated
 // reasons can contain Ruby ivar names (`@primary_key`), and the wrapper's
 // hang indent (`*   `) can place one at line start — deeper-indented `@`
@@ -125,12 +128,15 @@ function toCommentLines(comment: string, tag: string): CommentLine[] {
  *  and its `@missingRailsCall` entries. Continuation lines (not starting a new
  *  `@` tag) attach to the preceding entry.
  *
- *  A tag with NO call at all — the bare tag, or one going straight to the
- *  em-dash — is a hard error too, distinguished from the empty-reason one by
- *  "needs a call". It matches no other rule here, so before RFC 0083 it was
- *  read as prose: no suppression, no stale-tag report, no empty-reason error.
- *  That was the last way to write a tag the parser ignores without complaint,
- *  the same quiet-direction hazard as the one-line form one level up.
+ *  A tag line that opens the tag and does not parse is a hard error too,
+ *  distinguished from the empty-reason one by "needs a call": the bare tag, one
+ *  going straight to the em-dash, and — the shape RFC 0099 closed — one naming
+ *  several comma-separated calls, which `tagLine` cannot match past the first
+ *  token. Each matched no other rule here and so was read as prose: no
+ *  suppression, no stale-tag report, no empty-reason error, and invisible to
+ *  the permanence gate. That was the last way to write a tag the parser ignores
+ *  without complaint, the same quiet-direction hazard as the one-line form one
+ *  level up.
  *
  *  An empty reason is a hard error, matching `@noRailsEquivalent` (RFC 0080):
  *  every tag in the tree is written with a reason — the generator only emits a
@@ -151,13 +157,14 @@ export function parseJsdoc(
   const at = (sourceIndex: number): string =>
     origin ? ` ${origin.fileName}:${origin.startLine + sourceIndex}` : "";
   for (const { text: line, sourceIndex, synthetic } of toCommentLines(comment, tag)) {
-    if (callLessTagLine(tag).test(line)) {
+    const m = line.match(tagLine(tag));
+    if (!m && tagLineStart(tag).test(line)) {
       throw new Error(
-        `${tag} needs a call:${at(sourceIndex)} — name the Rails call that is ` +
-          `not made here, as \`${tag} <ruby_call> — <reason>\`.`,
+        `${tag} needs a call:${at(sourceIndex)} — name ONE Rails call that is ` +
+          `not made here, as \`${tag} <ruby_call> — <reason>\`. Several calls take ` +
+          `one tag each; a comma-separated list matches nothing and would suppress nothing.`,
       );
     }
-    const m = line.match(tagLine(tag));
     if (m) {
       // Trimmed at capture: `tagLine` absorbs only one space after the
       // em-dash, so trailing whitespace would otherwise read as a non-empty


### PR DESCRIPTION
Bundle of five stories.

## 1. `pnpm lint` red on main (RFC 0061) — already fixed

The redundant `as Promise<Result>` at
`postgresql-adapter.exec-query.test.ts:396` was removed by #6844 as an
`eslint --fix` drive-by (its PR body says so). `pnpm lint:files` on that file
is clean; the story is marked done against #6844 and is not part of this diff.

The scope gap the story asked about is real and is by design: `ci.yml`'s Lint
job lints only the files a PR changed (`lint_files`, ci.yml:313-323), with
`LINT_ALL_RE` widening to the whole tree only when a rule *input* changes. A
type-driven redundancy like this one is introduced by editing a DIFFERENT file
(#6663 narrowed `execInsert`'s return type), so the test file is never
re-linted and CI stays green. Closing it means a full-tree lint on every PR;
not taken here.

## 2. `attributes_before_type_cast` is a getter (RFC 0115)

`before_type_cast.rb:82-84` is a plain zero-arg method, and its sibling
`attributes_for_database` (`:86-89`) is already ported as one. The accessor
property is gone: `attributesBeforeTypeCast` is `this`-typed in
`attribute-methods/before-type-cast.ts` and wired through `include()` in
base.ts beside `attributesForDatabase`. The `Object.defineProperty` block and
its `keeps attributesBeforeTypeCast a getter` test are deleted; the six call
sites take `()`. CLAUDE.md's "generated attribute readers are properties" rule
covers generated readers, not a hand-written method — `attributes_for_database`
is the proof.

## 3. `HasReadonlyAttributes#write_attribute` → `super` (RFC 0115)

`readonly_attributes.rb:49-55` is a guard plus `super`. `readonly-attributes.ts`
inlined `Write#write_attribute` instead, leaving `attribute-methods/write.ts`'s
`writeAttribute` (added by #6846, the Rails home) exported and unreachable.

- the alias resolution, the `"id"` → `@primary_key` remap and the composite-PK
  `MissingAttributeError` move to `write.ts`, which is where write.rb:33-36
  writes them;
- `readonly-attributes.ts` is now the guard plus a call to it in `super`'s
  place;
- the guard checks the RAW `attr_name` (readonly_attributes.rb:50) and lets
  `super` resolve the alias, where trails resolved first. An aliased write now
  escapes the guard exactly as it does in Rails.

The frozen-record guard and `_readonlyAttributesRaise` (trails' stand-in for
Rails only *including* the module when `raise_on_assign_to_attr_readonly` was
true at declaration time) are re-cited at their new site.

## 4. Comma-separated `@missingRailsCall` is a silent no-op (RFC 0099)

`tagLine` matches one call token, so a two-call tag matched nothing and was
read as prose: no suppression, no stale-tag report, no empty-reason error,
invisible to the permanence gate. `callLessTagLine` is replaced by
`tagLineStart` — any line that OPENS the tag and does not parse is the
existing "needs a call" hard error, which subsumes the bare and em-dash-only
shapes it used to catch. Both live instances now carry one classified tag per
call: `application.ts:158` (`build_middleware`, `merge_into`, engine.rb:519)
and `application/finisher.ts:148` (`reloaders` finisher.rb:162, `to_run`
finisher.rb:164-177).

Turning the guard on also surfaced four pre-existing unclassified `enum.ts`
tags that landed with #6844 (after #6840 added the permanence gate); those were
fixed on main in parallel and are not in this diff.

## 5. `Base._buildUnscopedRelation` → `Core#relation` (RFC 0112)

`Base.relation(table?)` is now Rails' body at the Rails name (core.rb:431-435):
`Relation.create(this, { table })`, then `type_condition` under Rails' own
`finder_needs_type_condition? && !ignore_default_scope?` guard. Both trails
inventions are gone — `_buildUnscopedRelation` and the private
`_applyStiTypeCondition`, whose hand-rolled `where({ col: stiNames })` is
replaced by `inheritance.ts`'s `typeCondition`, and `_relationCtorFor`, which
had no callers left. `_buildDefaultRelation` builds its base from
`relation()`, matching default.rb:36's `default_scoped(scope = relation, …)`:
the STI condition is on the base BEFORE `build_default_scope` merges, and
before the recursion guard arms.

The `table` parameter has no Rails counterpart — it is what
`AbstractReflection#build_scope` and `AssociationScope` need to qualify the STI
predicate by an aliased table — and is documented at the definition.

`isIgnoreDefaultScope` is exported from `scoping/default.ts` (it is already at
its Rails name and home) so `relation()` can spell its guard.

## Verification

- `pnpm parity:api:calls` — OK (808 baselined, 340 unreviewed); no new rows
- `pnpm parity:api:calls:args` — OK (156 baselined shape rows)
- `pnpm parity:api:extra --package activerecord` — base.ts loses two novel
  names, gains none
- `pnpm typecheck`, `pnpm lint` on the changed files — clean
- green: `associations/` (116 files), `scoping/`, `inheritance`,
  `attribute-methods{,.trails}`, `readonly`, `attribute-methods/write`,
  `dirty`, `base`, `persistence`, `relations`, `enum`, `scripts/api-compare`
  (39 files), all of `packages/trailties` (82 files)

Closes-story: lint-red-on-main-unnecessary-type-assertion-pg-exec-query
Closes-story: attributes-before-type-cast-is-a-getter-not-a-method
Closes-story: converge-readonly-write-attribute-onto-write-super
Closes-story: multi-call-missing-rails-call-tag-is-a-silent-noop
Closes-story: converge-build-unscoped-relation-onto-core-relation
