### PR TITLE
refactor(activerecord,ci): converge readonly write guards, default_scoped and relation; full-tree lint on non-PR events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,10 @@ jobs:
       # `__ALL__` means "couldn't compute a reliable diff, check everything".
       prettier_files: ${{ steps.filter.outputs.prettier_files }}
       # Same shape as prettier_files, narrowed to the extensions ESLint is
-      # configured for. `__ALL__` additionally covers the case where a changed
-      # file feeds a rule's inputs rather than being linted itself — see
-      # LINT_ALL_RE below.
+      # configured for. `__ALL__` additionally covers every non-PR event (a
+      # type-aware rule can break a file no PR touched) and the case where a
+      # changed file feeds a rule's inputs rather than being linted itself —
+      # see LINT_ALL_RE below.
       lint_files: ${{ steps.filter.outputs.lint_files }}
     steps:
       - uses: actions/checkout@v5
@@ -176,7 +177,19 @@ jobs:
             else
               echo "prettier_files=__ALL__" >> "$GITHUB_OUTPUT"
             fi
-            if echo "$files" | grep -qE "$LINT_ALL_RE"; then
+            # A type-aware rule (no-unnecessary-type-assertion &c.) reads
+            # declarations in OTHER files, so narrowing a return type in one PR
+            # can make an assertion in a file NO PR touched redundant. That file
+            # is never re-linted, CI stays green, and `main` carries a lint error
+            # every agent then hits locally. Lint the whole tree on every non-PR
+            # event — the push to main that landed it, the weekly sweep,
+            # workflow_dispatch — so the break surfaces with its file and rule in
+            # the run itself. The per-PR changed-files scope is deliberately
+            # untouched; a full-tree lint on every PR is what the scope exists to
+            # avoid.
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+              echo "lint_files=__ALL__" >> "$GITHUB_OUTPUT"
+            elif echo "$files" | grep -qE "$LINT_ALL_RE"; then
               echo "lint_files=__ALL__" >> "$GITHUB_OUTPUT"
             elif lfiles=$(git diff --name-only --diff-filter=ACMR "$base"..."$head" 2>/dev/null); then
               {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -76,6 +76,13 @@ export interface AssociationScopeable {
  * a reflection plus `attr_reader :aliased_table` and
  * `def all_includes; nil; end`.)
  */
+/** The `Relation` surface `_buildEntryScope` needs off `build_scope`. */
+type AliasedScope = { where(predicate: unknown): AliasedScope };
+
+type ScopeBuilder = {
+  buildScope(table?: unknown, predicateBuilder?: unknown, klass?: typeof Base): AliasedScope;
+};
+
 export class ReflectionProxy {
   // AbstractReflection rather than AssociationReflection because chain
   // entries can be ThroughReflection / PolymorphicReflection wrappers;
@@ -162,12 +169,8 @@ export class ReflectionProxy {
    * (reflection.rb:336-338) — the Rails seat for a relation built against a
    * possibly-aliased Arel table.
    */
-  buildScope(table?: unknown, predicateBuilder?: unknown, klass?: typeof Base): unknown {
-    return (
-      this.reflection as unknown as {
-        buildScope(t?: unknown, pb?: unknown, k?: typeof Base): unknown;
-      }
-    ).buildScope(table, predicateBuilder, klass);
+  buildScope(table?: unknown, predicateBuilder?: unknown, klass?: typeof Base): AliasedScope {
+    return (this.reflection as unknown as ScopeBuilder).buildScope(table, predicateBuilder, klass);
   }
 
   constraints(): Array<(...args: unknown[]) => unknown> {
@@ -887,39 +890,30 @@ export class AssociationScope {
   }
 
   /**
-   * Build a fresh scope for evaluating a chain entry's lambda. Without an
-   * alias this is `entryKlass.unscoped` — Rails' `unscoped` retains the STI
-   * type filter via `relation()` (core.rb:431-435), and `Base.unscoped` wires
-   * that through `relation`, so no compensation is needed there.
+   * Build a fresh scope for evaluating a chain entry's lambda.
+   *
+   * Aliased entries go through `AbstractReflection#build_scope`
+   * (reflection.rb:336-338), the seat Rails' `association_scope.rb:169` calls
+   * with `reflection.aliased_table`, and take their STI predicate on that same
+   * alias the way `join_scope` does (reflection.rb:285-286) — a
+   * self-referential through must filter the joined-in alias, not the FROM
+   * table. Without an alias this is `entryKlass.unscoped`, whose `relation()`
+   * (core.rb:431-435) carries the type condition already, so the non-aliased
+   * SQL stays byte-identical.
    */
   protected _buildEntryScope(
     entryKlass: typeof Base,
     aliasedTable?: unknown,
     reflection?: AbstractReflection | ReflectionProxy,
   ): unknown {
-    // Rails: `reflection.build_scope(reflection.aliased_table)`
-    // (association_scope.rb:169) — `AbstractReflection#build_scope`
-    // (reflection.rb:336-338) is the seat that takes a table, so the scope
-    // lambda's `where(...)` predicates qualify by the alias. The STI predicate
-    // is layered on the same aliased table the way reflection.rb:285-286 does
-    // in `join_scope`: for a self-referential through (a repeated table) it
-    // must land on the joined-in alias, not the FROM table. We only take this
-    // path when the tracker produced a real alias; otherwise keep `unscoped()`
-    // so non-aliased SQL is byte-identical.
     if (aliasedTable && reflection) {
-      let scope = (
-        reflection as unknown as {
-          buildScope(t?: unknown, pb?: unknown, k?: typeof Base): { where(v: unknown): unknown };
-        }
-      ).buildScope(aliasedTable, undefined, entryKlass);
-      if (
-        (
-          entryKlass as unknown as { isFinderNeedsTypeCondition(): boolean }
-        ).isFinderNeedsTypeCondition()
-      ) {
-        scope = scope.where(typeCondition(entryKlass, aliasedTable as never)) as {
-          where(v: unknown): unknown;
-        };
+      const scope = (reflection as unknown as ScopeBuilder).buildScope(
+        aliasedTable,
+        undefined,
+        entryKlass,
+      );
+      if (entryKlass.isFinderNeedsTypeCondition()) {
+        return scope.where(typeCondition(entryKlass, aliasedTable as never));
       }
       return scope;
     }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,6 +1,7 @@
 import { isPlainObject } from "@blazetrails/activesupport";
 import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
+import { typeCondition } from "../inheritance.js";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
 import { RuntimeReflection } from "../reflection.js";
@@ -154,6 +155,19 @@ export class ReflectionProxy {
         }
       ).scopeFor?.(relation, owner) ?? relation
     );
+  }
+
+  /**
+   * SimpleDelegator forwarding of `AbstractReflection#build_scope`
+   * (reflection.rb:336-338) — the Rails seat for a relation built against a
+   * possibly-aliased Arel table.
+   */
+  buildScope(table?: unknown, predicateBuilder?: unknown, klass?: typeof Base): unknown {
+    return (
+      this.reflection as unknown as {
+        buildScope(t?: unknown, pb?: unknown, k?: typeof Base): unknown;
+      }
+    ).buildScope(table, predicateBuilder, klass);
   }
 
   constraints(): Array<(...args: unknown[]) => unknown> {
@@ -819,7 +833,8 @@ export class AssociationScope {
    * from its klass. Rails: `relation = reflection.build_scope(reflection
    * .aliased_table); relation.instance_exec(owner, &scope)`
    * (association_scope.rb:169-172). We build the relation via
-   * `_buildEntryScope` (= `klass.unscoped`, which carries the STI
+   * `_buildEntryScope` (`reflection.build_scope(aliased_table)` when the
+   * chain entry is aliased, else `klass.unscoped`, which carries the STI
    * type_condition) and invoke with `invokeScopeLambda`'s arity / `this`
    * semantics: 0-arg → `call(relation)`; 1+-arg → `call(relation, relation,
    * owner)`. The common 0-arg form Rails uses for scope_for_association /
@@ -853,6 +868,7 @@ export class AssociationScope {
     const relation = this._buildEntryScope(
       entryKlass,
       aliased instanceof Nodes.TableAlias ? aliased : undefined,
+      reflection,
     );
     return invokeScopeLambda(scopeFn as ScopeLambda<unknown>, relation, owner);
   }
@@ -871,25 +887,41 @@ export class AssociationScope {
   }
 
   /**
-   * Build a fresh scope for evaluating a chain entry's lambda. Mirrors
-   * `entryKlass.unscoped` — Rails' `unscoped` retains the STI type filter
-   * via `relation()` (core.rb:431-435), and `Base.unscoped` now wires that
-   * through `relation`, so no compensation is needed here.
+   * Build a fresh scope for evaluating a chain entry's lambda. Without an
+   * alias this is `entryKlass.unscoped` — Rails' `unscoped` retains the STI
+   * type filter via `relation()` (core.rb:431-435), and `Base.unscoped` wires
+   * that through `relation`, so no compensation is needed there.
    */
-  protected _buildEntryScope(entryKlass: typeof Base, aliasedTable?: unknown): unknown {
-    // Build the entry relation against the chain entry's alias so the scope
-    // lambda's `where(...)` predicates — AND any STI `type_condition` — qualify
-    // by the alias (Rails' `build_scope(reflection.aliased_table)`,
-    // reflection.rb:336). For a self-referential through (repeated table) the
-    // source-type filter must land on the joined-in alias, not the FROM table.
-    // The `TableAlias` node delegates `typeForAttribute` / `typeCastForDatabase`
-    // to the underlying table, so attribute casting is preserved. We only feed
-    // the table when the tracker produced a real alias; otherwise keep
-    // `unscoped()` so non-aliased SQL is byte-identical.
-    if (aliasedTable) {
-      return (entryKlass as unknown as { relation: (t: unknown) => unknown }).relation(
-        aliasedTable,
-      );
+  protected _buildEntryScope(
+    entryKlass: typeof Base,
+    aliasedTable?: unknown,
+    reflection?: AbstractReflection | ReflectionProxy,
+  ): unknown {
+    // Rails: `reflection.build_scope(reflection.aliased_table)`
+    // (association_scope.rb:169) — `AbstractReflection#build_scope`
+    // (reflection.rb:336-338) is the seat that takes a table, so the scope
+    // lambda's `where(...)` predicates qualify by the alias. The STI predicate
+    // is layered on the same aliased table the way reflection.rb:285-286 does
+    // in `join_scope`: for a self-referential through (a repeated table) it
+    // must land on the joined-in alias, not the FROM table. We only take this
+    // path when the tracker produced a real alias; otherwise keep `unscoped()`
+    // so non-aliased SQL is byte-identical.
+    if (aliasedTable && reflection) {
+      let scope = (
+        reflection as unknown as {
+          buildScope(t?: unknown, pb?: unknown, k?: typeof Base): { where(v: unknown): unknown };
+        }
+      ).buildScope(aliasedTable, undefined, entryKlass);
+      if (
+        (
+          entryKlass as unknown as { isFinderNeedsTypeCondition(): boolean }
+        ).isFinderNeedsTypeCondition()
+      ) {
+        scope = scope.where(typeCondition(entryKlass, aliasedTable as never)) as {
+          where(v: unknown): unknown;
+        };
+      }
+      return scope;
     }
     return (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4639,8 +4639,7 @@ extend(Base, {
 });
 
 include(Base, {
-  // AttributeMethods::Write — `HasReadonlyAttributes`' overrides are included
-  // per-class by `attrReadonly` (readonly_attributes.rb:33).
+  // AttributeMethods::Write
   writeAttribute: _writeAttributeMethod,
   // Persistence
   isNewRecord: _Persistence.isNewRecord,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -235,7 +235,11 @@ import {
   _readAttribute as _readAttributeFn,
   defineMethodAttribute as _defineMethodAttribute,
 } from "./attribute-methods/read.js";
-import { setDefineMethodAttribute as _setDefineMethodAttribute } from "./attribute-methods/write.js";
+import {
+  setDefineMethodAttribute as _setDefineMethodAttribute,
+  writeAttribute as _writeAttributeMethod,
+  _writeAttribute as _writeAttributeLowLevel,
+} from "./attribute-methods/write.js";
 import { attributeCameFromUser as _attributeCameFromUser } from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
@@ -321,7 +325,6 @@ import {
 } from "./transactions.js";
 
 import {
-  Default as DefaultScoping,
   isIgnoreDefaultScope,
   defaultScope as _defaultScope,
   isScopeAttributes as _isScopeAttributes,
@@ -1756,17 +1759,6 @@ export class Base extends Model {
   // -- Readonly attributes --
   static _readonlyAttributes: Set<string> = new Set();
 
-  // Whether the readonly write guards (Rails' HasReadonlyAttributes mixin) are
-  // active for this class. Rails decides at `attr_readonly` declaration time
-  // whether to `include HasReadonlyAttributes` — only when
-  // `raise_on_assign_to_attr_readonly` is true at that moment. Once included it
-  // raises unconditionally regardless of later flag flips; when not included a
-  // write to a readonly attr goes straight through (value written in memory,
-  // persist-time exclusion keeps it out of the UPDATE). We capture the flag
-  // value when `attrReadonly` runs into this own-property, inherited down the
-  // prototype chain like Ruby's include. (readonly_attributes.rb:33)
-  static _readonlyAttributesRaise = false;
-
   // Suppresses after_initialize in the constructor when set by _instantiate /
   // directInstantiate (inheritance.ts) so we can fire after_find first, then
   // after_initialize — matching Rails' init_with_attributes call order.
@@ -2170,22 +2162,16 @@ export class Base extends Model {
 
   /** @internal Like all() but skips currentScope — used by the preloader. */
   static _allForPreload(): any {
-    return this._buildDefaultRelation();
+    return this.defaultScoped();
   }
 
   /**
    * Mirrors: ActiveRecord::Core::ClassMethods#relation (core.rb:431-435).
    *
-   * The `table` argument has no Rails counterpart: `AbstractReflection#build_scope`
-   * (reflection.rb:336-338) and `AssociationScope` build against a possibly-aliased
-   * Arel table, and passing it here qualifies the STI `type_condition` by that same
-   * table — so a self-referential through doesn't end up with the STI predicate on
-   * the FROM table and the source-type predicate on the alias.
-   *
    * @internal Rails-private (core.rb:408 `private`).
    */
-  static relation(table?: any): any {
-    const relation = Relation.create(this, { table });
+  static relation(): any {
+    const relation = Relation.create(this);
 
     if (isFinderNeedsTypeCondition(this) && !isIgnoreDefaultScope.call(this)) {
       // `finder_needs_type_condition?` memoizes on first call (inheritance.rb:92),
@@ -2194,20 +2180,10 @@ export class Base extends Model {
       // trails' `typeCondition` raises instead, so skip the arm rather than
       // turning a Rails no-op into an error.
       if (this.inheritanceColumn === null) return relation;
-      return relation.whereBang(typeCondition(this, table));
+      return relation.whereBang(typeCondition(this));
     } else {
       return relation;
     }
-  }
-
-  private static _buildDefaultRelation(allQueries?: boolean | null): any {
-    // named.rb:45 — `default_scoped(scope = relation, all_queries: nil)`: the
-    // base relation, STI condition and all, is built BEFORE `build_default_scope`
-    // arms the recursion guard, and the default scope merges into it.
-    return (
-      DefaultScoping.buildDefaultScope.call(this, this.relation(), { allQueries }) ??
-      this.relation()
-    );
   }
 
   // Scope extension methods: scope name -> Record of extra methods
@@ -3337,7 +3313,7 @@ export class Base extends Model {
 
   declare static collectionCacheKey: typeof _collectionCacheKey;
 
-  declare writeAttribute: typeof ReadonlyAttributes.writeAttribute;
+  declare writeAttribute: typeof _writeAttributeMethod;
 
   declare id: PrimaryKeyValue;
 
@@ -4663,8 +4639,9 @@ extend(Base, {
 });
 
 include(Base, {
-  // ReadonlyAttributes
-  writeAttribute: ReadonlyAttributes.writeAttribute,
+  // AttributeMethods::Write — `HasReadonlyAttributes`' overrides are included
+  // per-class by `attrReadonly` (readonly_attributes.rb:33).
+  writeAttribute: _writeAttributeMethod,
   // Persistence
   isNewRecord: _Persistence.isNewRecord,
   isPersisted: _Persistence.isPersisted,
@@ -4736,7 +4713,7 @@ include(Base, {
   set: _set,
   _queryAttribute: _queryAttributeFn,
   _readAttribute: _readAttributeFn,
-  _writeAttribute: ReadonlyAttributes._writeAttribute,
+  _writeAttribute: _writeAttributeLowLevel,
   // PrimaryKey
   toKey: _toKey,
   // Store (private instance helpers)

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -2,6 +2,7 @@ import type { Base } from "./base.js";
 import { Model } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
 import { ActiveRecord } from "./ar-config.js";
+import { include } from "@blazetrails/activesupport";
 import { writeAttribute as _writeAttributeSuper } from "./attribute-methods/write.js";
 
 /**
@@ -48,14 +49,13 @@ export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
   for (const attr of attributes) {
     (this as any)._readonlyAttributes.add(attr);
   }
-  // Rails reads `raise_on_assign_to_attr_readonly` HERE, at declaration time
-  // (readonly_attributes.rb:33), and only `include HasReadonlyAttributes` — the
-  // write guards — when it is true. Capture that decision per-class: a later
-  // flip of the live flag does not retroactively arm (or disarm) the guards on
-  // an already-declared model. `include` is idempotent and one-way, so we never
-  // clear the flag once set.
+  // readonly_attributes.rb:33 — Rails reads `raise_on_assign_to_attr_readonly`
+  // HERE, at declaration time, and only `include HasReadonlyAttributes` — the
+  // write guards — when it is true. `include` is idempotent and one-way, so a
+  // later flip of the live flag neither arms nor disarms an already-declared
+  // model.
   if (ActiveRecord.raiseOnAssignToAttrReadonly) {
-    this._readonlyAttributesRaise = true;
+    include(this as unknown as new (...args: any[]) => any, HasReadonlyAttributes);
   }
 }
 
@@ -82,19 +82,8 @@ export function readonlyAttributeQ(this: typeof Base, attribute: string): boolea
  * Rails' `HasReadonlyAttributes#write_attribute` (readonly_attributes.rb:49-55):
  * a readonly guard, then `super` into `AttributeMethods::Write#write_attribute`
  * (write.rb:31-38), which resolves the alias, remaps `"id"` to the primary key
- * and writes.
- *
- * Two trails-only details ride along:
- *
- *   - the frozen-record guard, which Rails does not have in this module: it
- *     raises `Cannot modify a frozen X` before anything else.
- *   - `_readonlyAttributesRaise`. Rails includes `HasReadonlyAttributes` only
- *     when `raise_on_assign_to_attr_readonly` was true at `attr_readonly`
- *     declaration time (readonly_attributes.rb:33); trails always installs the
- *     method, so the flag captured there stands in for the absent module and
- *     the write falls through to `super` when it is false — the value IS
- *     written in memory, and persist-time exclusion of readonly columns
- *     (attributesForUpdate) keeps it out of the UPDATE.
+ * and writes. A frozen record raises from the attribute set itself, as it does
+ * in Ruby, so there is no frozen guard here.
  *
  * During construction the `_newRecord` field initializer on `Base` hasn't run
  * yet when `Model`'s constructor invokes `writeAttribute` — gate the readonly
@@ -102,23 +91,17 @@ export function readonlyAttributeQ(this: typeof Base, attribute: string): boolea
  * than `!isNewRecord()` so initial assignments during `new X(...)` aren't
  * mistakenly blocked.
  *
- * `Base.prototype.writeAttribute` installed via include() in base.ts.
+ * Mixed onto a class by `attrReadonly` above, the way readonly_attributes.rb:33
+ * `include`s the module.
  *
  * Mirrors: ActiveRecord::HasReadonlyAttributes#write_attribute
  */
 export function writeAttribute(this: Base, attrName: string, value: unknown): void {
-  if (this._attributes.isFrozen()) {
-    throw new Error(`Cannot modify a frozen ${(this.constructor as typeof Base).name}`);
-  }
   const ctor = this.constructor as typeof Base;
   // readonly_attributes.rb:50 checks the RAW `attr_name` and lets `super`
   // resolve the alias afterwards, so an aliased write escapes the guard in
   // Rails too.
-  if (
-    this._newRecord === false &&
-    ctor._readonlyAttributesRaise &&
-    ctor.readonlyAttributeQ(String(attrName))
-  ) {
+  if (this._newRecord === false && ctor.readonlyAttributeQ(String(attrName))) {
     throw new ReadonlyAttributeError(String(attrName));
   }
 
@@ -126,17 +109,12 @@ export function writeAttribute(this: Base, attrName: string, value: unknown): vo
 }
 
 /**
- * Low-level write that checks readonly but bypasses the frozen-record guard.
- *
  * Mirrors: ActiveRecord::HasReadonlyAttributes#_write_attribute
+ * (readonly_attributes.rb:57-62).
  */
 export function _writeAttribute(this: Base, name: string, value: unknown): void {
   const ctor = this.constructor as typeof Base;
-  if (
-    this._newRecord === false &&
-    ctor._readonlyAttributesRaise &&
-    ctor.readonlyAttributeQ(String(name))
-  ) {
+  if (this._newRecord === false && ctor.readonlyAttributeQ(String(name))) {
     throw new ReadonlyAttributeError(String(name));
   }
   // Mirrors Rails `_write_attribute`: skip alias resolution, unlike the public
@@ -146,6 +124,16 @@ export function _writeAttribute(this: Base, name: string, value: unknown): void 
   // `_writeAttribute(@primary_key=null, value)`).
   Model.prototype._writeAttribute.call(this, name, value);
 }
+
+/**
+ * The instance half of Rails' `HasReadonlyAttributes`
+ * (readonly_attributes.rb:47-63), `include`d onto a class by `attrReadonly`
+ * only when `raise_on_assign_to_attr_readonly` is true at declaration time.
+ */
+export const HasReadonlyAttributes = {
+  writeAttribute,
+  _writeAttribute,
+};
 
 /**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -462,7 +462,7 @@ function stiCarrierChain(modelClass: typeof Base): (typeof Base)[] {
 
 /**
  * Per-model prototype carrier for the `Relation` delegate class. Relations
- * built for `modelClass` (via `Base._buildDefaultRelation` &c.) are constructed
+ * built for `modelClass` (via `Base.defaultScoped` &c.) are constructed
  * from this subclass.
  *
  * Mirrors: ActiveRecord::Delegation::ClassMethods#relation_class_for

--- a/packages/activerecord/src/scoping/default-scoped-sti.trails.test.ts
+++ b/packages/activerecord/src/scoping/default-scoped-sti.trails.test.ts
@@ -1,0 +1,24 @@
+/**
+ * TS-only coverage for the evaluation ORDER inside `default_scoped`
+ * (named.rb:45-47). Ruby's `scope = relation` is a DEFAULT ARGUMENT, so the
+ * base relation — STI `type_condition` and all — is built BEFORE
+ * `build_default_scope` arms its recursion guard. Hoisting `relation()` out of
+ * the default would drop the type condition on an STI subclass whose default
+ * scope re-enters the relation, which no ported Rails test isolates.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { fixtures } from "../test-fixtures.js";
+import { SpecialComment } from "../test-helpers/models/comment.js";
+
+describe("defaultScoped on an STI subclass", () => {
+  fixtures([]);
+
+  it("keeps the type condition alongside the default scope", () => {
+    const sql = SpecialComment.defaultScoped().toSql();
+
+    expect(sql).toMatch(/["`]type["`]\s+IN\s*\(/i);
+    expect(sql).toContain("SpecialComment");
+    expect(sql).toMatch(/["`]deleted_at["`]\s+IS\s+NULL/i);
+  });
+});

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -791,6 +791,26 @@ describe("CI runs every tooling test suite", () => {
     }
   });
 
+  // LINT_ALL_RE only covers a rule's declared INPUTS. A TYPE-AWARE rule's real
+  // input is the whole program: narrowing a return type in one file can make an
+  // assertion in a file no PR touched redundant, and the changed-files scope
+  // can never see it. The standing coverage for that class is a full-tree lint
+  // on every non-PR event, so `main` goes red in the run that landed the break
+  // instead of only on an agent's laptop.
+  it("lints the whole tree on every non-pull_request event", async () => {
+    const yml = await readFile(CI_YML, "utf8");
+
+    expect(yml).toContain(
+      `if [ "\${{ github.event_name }}" != "pull_request" ]; then
+` + `              echo "lint_files=__ALL__" >> "$GITHUB_OUTPUT"`,
+    );
+
+    const wf = parseYaml(yml) as { on: Record<string, unknown> };
+    expect(Object.keys(wf.on)).toContain("schedule");
+    expect(Object.keys(wf.on)).toContain("workflow_dispatch");
+    expect((wf.on.push as { branches: string[] }).branches).toContain("main");
+  });
+
   it("keeps the lint file filter to extensions eslint is configured for", async () => {
     const yml = await readFile(CI_YML, "utf8");
     const lintable = gateRegex(yml, "LINTABLE_RE");


### PR DESCRIPTION
Four bundled convergence stories.

**`HasReadonlyAttributes` is included conditionally** (readonly_attributes.rb:33, :47-63). `attrReadonly` now `include()`s the module's `writeAttribute` / `_writeAttribute` onto the class only when `raise_on_assign_to_attr_readonly` is true at declaration time, exactly as Ruby's conditional `include` does. `Base.prototype` carries `AttributeMethods::Write`'s writers as its default. That retires `_readonlyAttributesRaise` and both of its conjuncts, so `writeAttribute` is readonly_attributes.rb:49-55 and nothing else. The trails-only frozen guard (and its bespoke `Cannot modify a frozen X` message) is gone: a frozen record raises `FrozenError` from the attribute set itself, where Ruby raises it.

**`Base._buildDefaultRelation` is gone.** `_allForPreload` reads `defaultScoped`, which already carries named.rb:45-47's body at the Rails name with Rails' parameter names and defaults. `relation()` is still evaluated as the default argument — before `buildDefaultScope` arms the recursion guard — and a new trails test pins it (an STI subclass with a default scope keeps its type condition).

**`Base.relation()` is 0-arg**, matching core.rb:431-435. The one caller that passed a table, `AssociationScope#_buildEntryScope`, now goes through `AbstractReflection#build_scope` (reflection.rb:336-338) — the Rails seat for a relation against a possibly-aliased table — and layers the STI condition on that alias the way reflection.rb:285-286 does in `join_scope`. The self-referential-through invariant is already pinned by association-scope.test.ts (`children_imageables`), which stays green.

**CI lints the whole tree on every non-`pull_request` event.** A type-aware rule reads declarations in other files, so narrowing a return type in one PR can make an assertion in a file no PR touched redundant; that file is never re-linted, CI stays green, and `main` carries a lint error every agent then hits locally. Now the push to main that lands the break — plus the weekly sweep and `workflow_dispatch` — runs `pnpm lint` over the tree and reports the file and rule. The per-PR changed-files scope is deliberately unchanged; a coverage test in `scripts/ci-suite-coverage.test.ts` pins both halves.

Closes-story: ci-lint-scope-misses-cross-file-type-driven-breaks
Closes-story: readonly-write-attribute-carries-two-non-rails-guards
Closes-story: build-default-relation-is-a-trails-seat-for-default-scoped
Closes-story: relation-takes-a-table-argument-rails-does-not