### PR TITLE
refactor(parity,activerecord,activemodel): unblock the call-set migrator, converge attribute_present? and accessed_fields

### DIFF
--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -234,7 +234,8 @@ export abstract class Attribute {
    * and that pass must stay invisible to `accessed_fields`
    * (attribute_methods.rb:460-462 → `AttributeSet#accessed`), which Rails leaves
    * empty on a freshly built record. Dropping the memo with the flag costs one
-   * recomputation on the first real read.
+   * recomputation on the first real read. Story compute-record-dirtiness-lazily
+   * deletes this along with the eager pass.
    *
    * @internal
    */

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -225,6 +225,32 @@ export abstract class Attribute {
   }
 
   /**
+   * Run `fn` and leave `has_been_read?` exactly as it was.
+   *
+   * `Attribute#value` memoizes and flips `@has_been_read` (attribute.rb:41-44),
+   * so Ruby's `changed?` marks the attribute read too — harmlessly, because
+   * Rails only computes dirtiness when someone asks for it. trails computes a
+   * new record's dirtiness EAGERLY, in `DirtyTracker#reinstateNewRecordChanges`,
+   * and that pass must stay invisible to `accessed_fields`
+   * (attribute_methods.rb:460-462 → `AttributeSet#accessed`), which Rails leaves
+   * empty on a freshly built record. Dropping the memo with the flag costs one
+   * recomputation on the first real read.
+   *
+   * @internal
+   */
+  withoutMarkingRead<T>(fn: () => T): T {
+    const hadValue = this._hasValue;
+    try {
+      return fn();
+    } finally {
+      if (!hadValue) {
+        this._hasValue = false;
+        this._value = undefined;
+      }
+    }
+  }
+
+  /**
    * Force-set the memoized cast value without replacing the Attribute or
    * losing valueBeforeTypeCast. Used for post-cast transformations like
    * normalization.

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -494,12 +494,17 @@ export class DirtyTracker {
       // Attribute#changed? already compares value against original_value — for a
       // UserProvidedDefault that original_value is the column default — so defer
       // to it instead of comparing against the model-default snapshot.
-      if (attr.isChanged()) {
-        const wasValue = attr.originalValue ?? null;
-        this._originalAttributes.set(name, wasValue);
-        this._originalHas.add(name);
-        this._changedAttributes.set(name, [wasValue, attr.value ?? null]);
-      }
+      // This whole pass is eager where Rails is lazy, so it asks through
+      // `withoutMarkingRead`: `changed?` and `value` both mark the attribute
+      // read, and a constructed record reports no accessed fields in Rails.
+      attr.withoutMarkingRead(() => {
+        if (attr.isChanged()) {
+          const wasValue = attr.originalValue ?? null;
+          this._originalAttributes.set(name, wasValue);
+          this._originalHas.add(name);
+          this._changedAttributes.set(name, [wasValue, attr.value ?? null]);
+        }
+      });
     }
   }
 

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -494,9 +494,6 @@ export class DirtyTracker {
       // Attribute#changed? already compares value against original_value — for a
       // UserProvidedDefault that original_value is the column default — so defer
       // to it instead of comparing against the model-default snapshot.
-      // This whole pass is eager where Rails is lazy, so it asks through
-      // `withoutMarkingRead`: `changed?` and `value` both mark the attribute
-      // read, and a constructed record reports no accessed fields in Rails.
       attr.withoutMarkingRead(() => {
         if (attr.isChanged()) {
           const wasValue = attr.originalValue ?? null;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1356,7 +1356,6 @@ export class Model {
   }
 
   _attributes: AttributeSet = new AttributeSet();
-  _accessedFields: Set<string> = new Set();
   errors!: Errors<this>;
   _dirty!: DirtyTracker;
 
@@ -1487,11 +1486,18 @@ export class Model {
   /** @internal */
   _writeAttribute(name: string, value: unknown): void {
     this._attributes.writeFromUser(name, value);
-    const newValue = this._attributes.fetchValue(name);
+    const attribute = this._attributes.getAttribute(name);
+    // Rails computes nothing here: `write_from_user` builds a FromUser whose
+    // `@value` stays uncomputed, so `has_been_read?` is false after a write and
+    // `accessed_fields` is empty on a fresh record (attribute_methods_test.rb:1308).
+    // trails' dirty tracker is eager, so it needs the cast value now — take it
+    // from `type_cast` (attribute.rb:100-103, what `value` memoizes) rather than
+    // through `fetchValue`, whose memo is what marks the attribute read.
+    const newValue = attribute.typeCast(attribute.valueBeforeTypeCast);
     // Route through type.isChanged so numeric semantics (equal_nan?,
     // number_to_non_number?) are respected — mirrors the Rails path where dirty
     // tracking ultimately delegates to type.changed? (attribute.rb:155-160).
-    this._dirty.attributeWritten(name, newValue, value, this._attributes.getAttribute(name).type);
+    this._dirty.attributeWritten(name, newValue, value, attribute.type);
   }
 
   /** Mirrors ActiveModel::Serializers::JSON `class_attribute :include_root_in_json` instance reader. */

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1483,16 +1483,21 @@ export class Model {
     this._writeAttribute(name, value);
   }
 
-  /** @internal */
+  /**
+   * Rails computes nothing here: `write_from_user` builds a `FromUser` whose
+   * `@value` stays uncomputed, so `has_been_read?` is false after a write and
+   * `accessed_fields` is empty on a freshly built record
+   * (attribute_methods_test.rb:1308). trails' dirty tracker is eager, so it
+   * needs the cast value now; it comes from `type_cast` (attribute.rb:100-103,
+   * what `value` memoizes) rather than through `fetchValue`, whose memo is what
+   * marks the attribute read. Story compute-record-dirtiness-lazily retires the
+   * eagerness.
+   *
+   * @internal
+   */
   _writeAttribute(name: string, value: unknown): void {
     this._attributes.writeFromUser(name, value);
     const attribute = this._attributes.getAttribute(name);
-    // Rails computes nothing here: `write_from_user` builds a FromUser whose
-    // `@value` stays uncomputed, so `has_been_read?` is false after a write and
-    // `accessed_fields` is empty on a fresh record (attribute_methods_test.rb:1308).
-    // trails' dirty tracker is eager, so it needs the cast value now — take it
-    // from `type_cast` (attribute.rb:100-103, what `value` memoizes) rather than
-    // through `fetchValue`, whose memo is what marks the attribute read.
     const newValue = attribute.typeCast(attribute.valueBeforeTypeCast);
     // Route through type.isChanged so numeric semantics (equal_nan?,
     // number_to_non_number?) are respected — mirrors the Rails path where dirty

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -49,6 +49,12 @@ interface ComposedOfOptions {
  * Configure a composed-of value object on a model.
  *
  * Mirrors: ActiveRecord::Aggregations::ClassMethods#composed_of
+ *
+ * @missingRailsCall include — PERMANENT: aggregations.rb:262 reopens the model
+ *   with `include Aggregations`, and Ruby `include` has no TS equivalent. The
+ *   settled trails idiom (CLAUDE.md "Module mixins") names the mixin helper after
+ *   the module, so the call is `includeAggregations(modelClass)` and the
+ *   `unless self < Aggregations` guard lives inside it.
  */
 export function composedOf(
   modelClass: typeof Base,

--- a/packages/activerecord/src/associations/through-association.ts
+++ b/packages/activerecord/src/associations/through-association.ts
@@ -283,6 +283,13 @@ export const ThroughAssociation = {
   //
   // Mirrors: ActiveRecord::Associations::ThroughAssociation#target_scope
   // (through_association.rb:34-42).
+  /**
+   * @missingRailsCall drop — CONVERGEABLE (story
+   *   port-ruby-array-drop-for-chain-call-sites): Ruby's `Enumerable#drop(1)` over
+   *   `reflection.chain` (through_association.rb:36) is spelled `chain.slice(1)`
+   *   here because trails ports no `Array#drop` yet — the sibling of
+   *   `ruby-empty.ts` / `ruby-first.ts` that story adds.
+   */
   targetScope(this: ThroughAssociationHost): any {
     let scope = super.targetScope();
     if (!scope) return scope;

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -110,11 +110,8 @@ describe("AttributeMethodsTest (trails)", () => {
   });
 
   it("attribute_present? is empty?, not blank?", () => {
-    // attribute_methods.rb:387-392 is `!value.nil? && !(value.respond_to?(:empty?)
-    // && value.empty?)`. Ruby's `" ".empty?` is FALSE, so a whitespace-only
-    // string IS present — where ActiveSupport's `blank?` (which trails read
-    // through before) calls it blank. The alias arm and the `_read_attribute`
-    // read are the same two lines of that body.
+    // attribute_methods.rb:387-392 asks `empty?`, not `blank?`: Ruby's
+    // `" ".empty?` is FALSE, so a whitespace-only string is present.
     class Topic extends Base {
       static {
         this.attribute("title", "string");

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -109,6 +109,25 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(Topic.hasAttribute("missing")).toBe(false);
   });
 
+  it("attribute_present? is empty?, not blank?", () => {
+    // attribute_methods.rb:387-392 is `!value.nil? && !(value.respond_to?(:empty?)
+    // && value.empty?)`. Ruby's `" ".empty?` is FALSE, so a whitespace-only
+    // string IS present — where ActiveSupport's `blank?` (which trails read
+    // through before) calls it blank. The alias arm and the `_read_attribute`
+    // read are the same two lines of that body.
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.attribute("content", "string");
+        this.aliasAttribute("heading", "title");
+      }
+    }
+    const t = new Topic({ title: " ", content: "" });
+    expect(t.attributePresent("title")).toBe(true);
+    expect(t.attributePresent("heading")).toBe(true);
+    expect(t.attributePresent("content")).toBe(false);
+  });
+
   it("readonly attributes are not updated after create", async () => {
     // Rails raises ReadonlyAttributeError on a persisted-record write to an
     // attr_readonly column (readonly_attributes.rb line 49). The test name's

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -43,8 +43,12 @@ export interface AttributeMethods {
 }
 
 interface AttributeRecord {
-  _attributes: { has(name: string): boolean; keys(): Iterable<string>; get(name: string): unknown };
-  _accessedFields: Set<string>;
+  _attributes: {
+    has(name: string): boolean;
+    keys(): Iterable<string>;
+    get(name: string): unknown;
+    accessed(): string[];
+  };
   readAttribute(name: string): unknown;
   /** @internal */
   _readAttribute(name: string): unknown;
@@ -160,7 +164,7 @@ export function attributes(this: AttributeRecord): Record<string, unknown> {
  * Mirrors: ActiveRecord::AttributeMethods#accessed_fields
  */
 export function accessedFields(this: AttributeRecord): string[] {
-  return [...this._accessedFields];
+  return this._attributes.accessed();
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -3,7 +3,8 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods
  */
-import { isBlank, include, Module } from "@blazetrails/activesupport";
+import { include, Module } from "@blazetrails/activesupport";
+import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import {
   MissingAttributeError,
   missingAttribute,
@@ -45,6 +46,8 @@ interface AttributeRecord {
   _attributes: { has(name: string): boolean; keys(): Iterable<string>; get(name: string): unknown };
   _accessedFields: Set<string>;
   readAttribute(name: string): unknown;
+  /** @internal */
+  _readAttribute(name: string): unknown;
 }
 
 /**
@@ -98,12 +101,34 @@ export function hasAttribute(this: AttributeRecord, name: string): boolean {
 }
 
 /**
- * Check whether an attribute is present (not null, not undefined, not empty string).
+ * Check whether an attribute is present.
  *
  * Mirrors: ActiveRecord::AttributeMethods#attribute_present?
+ * (attribute_methods.rb:387-392)
  */
 export function attributePresent(this: AttributeRecord, name: string): boolean {
-  return !isBlank(this.readAttribute(name));
+  let attrName = String(name);
+  attrName =
+    (this.constructor as unknown as { attributeAliases: Record<string, string> }).attributeAliases[
+      attrName
+    ] ?? attrName;
+  const value = this._readAttribute(attrName);
+  return value != null && !(respondsToEmpty(value) && isEmpty(value));
+}
+
+/**
+ * Ruby's `value.respond_to?(:empty?)` (attribute_methods.rb:391): true for the
+ * receivers whose `empty?` {@link isEmpty} answers on — a String, an Array, and
+ * the Hash-like Set/Map/plain object — and false for everything else, so a
+ * `Temporal` timestamp is present rather than an object with no own keys.
+ * TypeScript has no `respond_to?`, so the receiver test is written out.
+ */
+function respondsToEmpty(value: unknown): value is readonly unknown[] | string | object {
+  if (typeof value === "string" || Array.isArray(value)) return true;
+  if (value instanceof Set || value instanceof Map) return true;
+  return (
+    typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype
+  );
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -45,13 +45,11 @@ export function readAttribute(
     this.constructor as unknown as { resolveAttributeName(n: string): string }
   ).resolveAttributeName(String(attrName));
 
-  if (this._attributes.has(name)) this._accessedFields.add(name);
   return this._readAttribute(name, block);
 }
 
 interface ReadAttributeHost {
   _attributes: AttributeSet;
-  _accessedFields: Set<string>;
   _readAttribute(name: string, block?: (name: string) => unknown): unknown;
 }
 
@@ -121,7 +119,6 @@ export function defineMethodAttribute(
 
 interface ReadRecord {
   _attributes: AttributeSet;
-  _accessedFields: Set<string>;
   _readAttribute(n: string, block: (n: string) => unknown): unknown;
   missingAttribute(n: string, stack?: string): never;
 }
@@ -132,7 +129,6 @@ interface ReadRecord {
  * @internal Rails-private helper.
  */
 function readGeneratedAttribute(record: ReadRecord, canonicalName: string): unknown {
-  if (record._attributes.has(canonicalName)) record._accessedFields.add(canonicalName);
   return record._readAttribute(canonicalName, (n) => record.missingAttribute(n));
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -74,6 +74,11 @@ export function quoteColumnName(name: string): string {
  * abstract contract (abstract/quoting.rb:131-133) minus the backslash arm:
  * SQLite treats a backslash as an ordinary character, so only `'` is doubled.
  * **Escape-only** — `quote` adds the surrounding quotes (rb:75-76).
+ *
+ * @missingRailsCall quote — PERMANENT: sqlite3/quoting.rb's `quote_string`
+ *   delegates to the driver's `::SQLite3::Database.quote`; better-sqlite3, the
+ *   trails driver, exposes no such entry point at all, so the port applies that
+ *   driver method's own `''`-doubling rule inline.
  */
 export function quoteString(value: string): string {
   return value.replace(/'/g, "''");

--- a/packages/activerecord/src/filter-attributes.test.ts
+++ b/packages/activerecord/src/filter-attributes.test.ts
@@ -4,6 +4,7 @@ import { AdminUser } from "./test-helpers/models/admin/user.js";
 import { AdminAccount } from "./test-helpers/models/admin/account.js";
 import { User } from "./test-helpers/models/user.js";
 import { fixtures } from "./test-fixtures.js";
+import { pp } from "./pretty-print.js";
 
 // Rails: `fixtures :"admin/users", :"admin/accounts"` + `Admin::User`, `Admin::Account`,
 // `User`. With the YAML store coder implemented, `Admin::User` (which declares
@@ -14,6 +15,15 @@ import { fixtures } from "./test-fixtures.js";
 const { "admin/users": adminUsers } = fixtures(["admin/accounts", "admin/users"]);
 
 describe("FilterAttributesTest", () => {
+  // Rails renders these three through `PP.pp(user, StringIO.new(actual))`
+  // (filter_attributes_test.rb:120-145); trails' port of `PP.pp` is `pp` over
+  // `Core#pretty_print`.
+  async function ppString(obj: unknown): Promise<string> {
+    let out = "";
+    await pp(obj, { write: (s: string) => (out += s) });
+    return out;
+  }
+
   let previousFilterAttributes: (string | RegExp | ((k: string, v: unknown) => unknown))[];
 
   beforeEach(() => {
@@ -134,28 +144,26 @@ describe("FilterAttributesTest", () => {
     expect(user.inspect()).toContain('token: "[FILTERED]"');
   });
 
-  it("filter_attributes on pretty_print", () => {
+  it("filter_attributes on pretty_print", async () => {
     const user = adminUsers("david");
-    const output = user.inspect();
+    const output = await ppString(user);
     expect(output).toContain("name: [FILTERED]");
     expect(output.match(/\[FILTERED\]/g)?.length).toBe(1);
   });
 
-  it("filter_attributes on pretty_print should not filter nil value", () => {
+  it("filter_attributes on pretty_print should not filter nil value", async () => {
     const user = new AdminUser({});
-    const output = user.inspect();
+    const output = await ppString(user);
     expect(output).toContain("name: nil");
     expect(output).not.toContain("name: [FILTERED]");
     expect(output.match(/\[FILTERED\]/g)?.length ?? 0).toBe(0);
   });
 
-  it("filter_attributes on pretty_print should handle [FILTERED] value properly", () => {
+  it("filter_attributes on pretty_print should handle [FILTERED] value properly", async () => {
     User.filterAttributes = ["auth"];
     const user = new User({ token: "[FILTERED]", auth_token: "[FILTERED]" });
-    const output = user.inspect();
+    const output = await ppString(user);
     expect(output).toContain("auth_token: [FILTERED]");
-    // Rails' `assert_includes actual, "token: [FILTERED]"` reads PP output, where
-    // the filtered marker is unquoted; trails' `inspect` quotes the string value.
-    expect(output).toContain('token: "[FILTERED]"');
+    expect(output).toContain("token: [FILTERED]");
   });
 });

--- a/packages/activerecord/src/filter-attributes.test.ts
+++ b/packages/activerecord/src/filter-attributes.test.ts
@@ -15,9 +15,7 @@ import { pp } from "./pretty-print.js";
 const { "admin/users": adminUsers } = fixtures(["admin/accounts", "admin/users"]);
 
 describe("FilterAttributesTest", () => {
-  // Rails renders these three through `PP.pp(user, StringIO.new(actual))`
-  // (filter_attributes_test.rb:120-145); trails' port of `PP.pp` is `pp` over
-  // `Core#pretty_print`.
+  /** `PP.pp(user, StringIO.new(actual))` (filter_attributes_test.rb:120-145). */
   async function ppString(obj: unknown): Promise<string> {
     let out = "";
     await pp(obj, { write: (s: string) => (out += s) });

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -224,6 +224,13 @@ const TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,6})?$/;
  * Mirrors: ActiveRecord::Integration#can_use_fast_cache_version? (private)
  *
  * @internal
+ *
+ * @missingRailsCall with_connection — PERMANENT: integration.rb:181-184 reads
+ *   `self.class.with_connection(&:default_timezone)`. `withConnection` returns a
+ *   Promise in trails and `canUseFastCacheVersion` is a synchronous predicate on
+ *   the `cacheKey` / `cacheVersion` path, so it cannot await one; the port reads
+ *   the global `ActiveRecord.defaultTimezone` instead — which is what Rails' own
+ *   FIXME on that line asks for (do not check out a connection here).
  */
 export function canUseFastCacheVersion(record: Identifiable, timestamp: unknown): boolean {
   if (typeof timestamp !== "string") return false;

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -34,9 +34,8 @@ describe("TouchTest", () => {
 
     travel(Duration.minutes(5));
 
-    // Mirror lft_will_change! — force-marks lft dirty without changing its value.
-    // Use _attributes.fetchValue (not readAttribute) to match attributeWillChangeBang semantics:
-    // fetchValue doesn't add to _accessedFields.
+    // Mirror lft_will_change! — force-marks lft dirty without changing its value,
+    // the way attributeWillChangeBang does.
     (stamped as any)._dirty.forceChange("lft", (stamped as any)._attributes.fetchValue("lft"));
     await stamped.save();
 

--- a/packages/activerecord/src/secure-password.ts
+++ b/packages/activerecord/src/secure-password.ts
@@ -345,6 +345,12 @@ export function hasSecurePassword(
  *
  * Raises an ArgumentError if the set of attributes doesn't contain at
  * least one password and one non-password attribute.
+ *
+ * @missingRailsCall map — PERMANENT:
+ *   `attributes.to_h.partition { ... }.map(&:to_h)`
+ *   (`secure_password.rb:126-128`) — `partition` yields two arrays of pairs that
+ *   `map(&:to_h)` turns back into Hashes; the TS body partitions into two entry
+ *   arrays directly, so there is no pair-array-to-Hash `map` step.
  */
 export async function authenticateBy(
   this: typeof Base,

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -12,6 +12,7 @@ import {
   reconcileFileText,
   renderJsdoc,
   buildExpectations,
+  fileModuleName,
   lowerMarksForDropped,
 } from "./build.js";
 import { serializeBaseline } from "./baseline-json.js";
@@ -150,6 +151,103 @@ const FILE = [
 ].join("\n");
 
 describe("reconcileFileText", () => {
+  /** One expectation under a named owner — the key an artifact row with a
+   *  `tsClass` produces. */
+  const owned = (
+    tsClass: string,
+    tsName: string,
+    calls: Set<string>,
+  ): [string, MethodExpectation] => [
+    expectationKey(tsClass, tsName),
+    { rubyNames: [tsName], tsName, calls },
+  ];
+
+  it("mints a tag on a top-level function keyed under the synthesized file module", () => {
+    // extract-ts-api.ts records a file's top-level functions under a module it
+    // synthesizes from the FILE NAME, so compare.ts keys `quoteString` under
+    // `Quoting` while the AST reports no enclosing class at all.
+    const src = ["export function quoteString(v: string): string {", "  return v;", "}"].join("\n");
+    const expectations = new Map([owned("Quoting", "quoteString", new Set(["quote"]))]);
+    const r = reconcileFileText(
+      "quoting.ts",
+      src,
+      expectations,
+      () => "PERMANENT: no driver quote",
+    );
+    expect(r.unmatched).toEqual([]);
+    expect(r.text!).toContain("@missingRailsCall quote — PERMANENT: no driver quote");
+    expect(r.tagged).toEqual([{ rubyName: "quoteString", call: "quote" }]);
+  });
+
+  it("mints a tag on a method inside a mixin object literal", () => {
+    const src = ["export const ThroughAssociation = {", "  targetScope(): void {}", "};"].join(
+      "\n",
+    );
+    const expectations = new Map([owned("ThroughAssociation", "targetScope", new Set(["drop"]))]);
+    const r = reconcileFileText("through-association.ts", src, expectations, () => "PERMANENT: x");
+    expect(r.unmatched).toEqual([]);
+    expect(r.text!).toContain("@missingRailsCall drop — PERMANENT: x");
+  });
+
+  it("mints a tag on an arrow-function property", () => {
+    const src = [
+      "export class Foo {",
+      "  bar = (): void => {};",
+      "}",
+      "export const helpers = { baz: () => {} };",
+    ].join("\n");
+    const expectations = new Map([
+      owned("Foo", "bar", new Set(["save"])),
+      owned("helpers", "baz", new Set(["reload"])),
+    ]);
+    const r = reconcileFileText("foo.ts", src, expectations, () => "PERMANENT: x");
+    expect(r.unmatched).toEqual([]);
+    expect(r.text!).toContain("@missingRailsCall save — PERMANENT: x");
+    expect(r.text!).toContain("@missingRailsCall reload — PERMANENT: x");
+  });
+
+  it("is idempotent on the newly-supported declaration forms", () => {
+    const src = [
+      "export const ThroughAssociation = {",
+      "  targetScope(): void {}",
+      "};",
+      "export function quoteString(v: string): string {",
+      "  return v;",
+      "}",
+    ].join("\n");
+    const expectations = new Map([
+      owned("ThroughAssociation", "targetScope", new Set(["drop"])),
+      owned("Quoting", "quoteString", new Set(["quote"])),
+    ]);
+    const reason = () => "PERMANENT: x";
+    const first = reconcileFileText("quoting.ts", src, expectations, reason).text!;
+    expect(reconcileFileText("quoting.ts", first, expectations, reason).text).toBeNull();
+  });
+
+  it("lets a class of the file-module's name keep its own key", () => {
+    // `relation.ts` declares `class Relation`, whose name IS the synthesized
+    // file-module name: a top-level function of the same name must not claim
+    // the class's expectation.
+    const src = [
+      "export class Relation {",
+      "  toSql(): string {",
+      '    return "";',
+      "  }",
+      "}",
+      "export function toSql(): string {",
+      '  return "";',
+      "}",
+    ].join("\n");
+    const expectations = new Map([owned("Relation", "toSql", new Set(["arel"]))]);
+    const r = reconcileFileText("relation.ts", src, expectations, () => "PERMANENT: x");
+    const lines = r.text!.split("\n");
+    // The tag lands above the CLASS method, not the top-level function.
+    expect(lines.findIndex((l) => l.includes("@missingRailsCall arel"))).toBeLessThan(
+      lines.findIndex((l) => l.includes("export function toSql")),
+    );
+    expect(r.text!.match(/@missingRailsCall/g)).toHaveLength(1);
+  });
+
   it("reconciles: drops satisfied tags, adds tags, creates missing JSDoc", () => {
     const expectations = new Map([
       anyClass("bar", ["bar"], new Set(["save"])),
@@ -523,5 +621,13 @@ describe("lowerMarksForDropped", () => {
     );
     expect(moved).toEqual([]);
     expect(marks.get("activerecord/relation.json")).toBe(1);
+  });
+});
+
+describe("fileModuleName", () => {
+  it("PascalCases the file basename, as extract-ts-api.ts does", () => {
+    expect(fileModuleName("aggregations.ts")).toBe("Aggregations");
+    expect(fileModuleName("secure-password.ts")).toBe("SecurePassword");
+    expect(fileModuleName("connection-adapters/sqlite3/quoting.ts")).toBe("Quoting");
   });
 });

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -281,7 +281,9 @@ function firstCuratedReason(
  * `composedOf` under `Aggregations` and `secure-password.ts` records
  * `authenticateBy` under `SecurePassword`. compare.ts keys its expectation
  * under that owner, so the migrator has to look there for a declaration the
- * AST reports at the top level.
+ * AST reports at the top level. The fallback yields to any owner a declaration
+ * in the file names for itself — `relation.ts` declares `class Relation`, whose
+ * members keep their own key.
  */
 export function fileModuleName(fileName: string): string {
   const base = (fileName.split("/").at(-1) ?? fileName).replace(/\.ts$/, "");
@@ -390,9 +392,9 @@ export function reconcileFileText(
    *  0083). A tag still carrying the seeded placeholder justifies nothing and
    *  keeps its row: it does not suppress either (see `justifies`). */
   tagged: { rubyName: string; call: string }[];
-  /** Expectation names never seen on a body-bearing declaration (mixin
-   *  host-class duplicates, prototype-patched methods, …) — reported, never
-   *  silently dropped. */
+  /** Expectation names never seen on a declaration this file can tag
+   *  (prototype-patched methods, a name declared only in another file, …) —
+   *  reported, never silently dropped. */
   unmatched: string[];
   /** Every missing call left untagged for want of a curated reason (see
    *  `reconcile`), so a zero-edit run still says how much is waiting on human
@@ -407,76 +409,68 @@ export function reconcileFileText(
   const skipped: string[] = [];
 
   const decls = collectDeclarations(sf);
-  // Every owner a declaration in this file names for itself, so the
-  // synthesized-file-module fallback below never steals a key some class or
-  // mixin object already declares under its own name.
   const declaredKeys = new Set(decls.map((d) => expectationKey(d.owner, d.name)));
   const moduleName = fileModuleName(fileName);
 
   for (const { name, owner, node } of decls) {
-    {
-      const key = expectationKey(owner, name);
-      // A top-level function is recorded by extract-ts-api.ts under the module
-      // it synthesizes from the FILE NAME (`aggregations.ts` → `Aggregations`),
-      // so compare.ts keys its expectation there while the AST says `""`.
-      const moduleKey =
-        owner === "" ? expectationKey(moduleName, name) : expectationKey(owner, name);
-      const anyKey = expectationKey(ANY_CLASS, name);
-      seen.add(key);
-      const useModuleKey = moduleKey !== key && !declaredKeys.has(moduleKey);
-      if (useModuleKey && expectations.has(moduleKey)) seen.add(moduleKey);
-      if (expectations.has(anyKey)) seen.add(anyKey);
-      const exp =
-        expectations.get(key) ??
-        (useModuleKey ? expectations.get(moduleKey) : undefined) ??
-        expectations.get(anyKey);
-      const ranges = ts.getLeadingCommentRanges(text, node.getFullStart()) ?? [];
-      const jsdocRange = ranges.filter((r) => text.slice(r.pos, r.pos + 3) === "/**").at(-1);
-      const comment = jsdocRange ? text.slice(jsdocRange.pos, jsdocRange.end) : null;
-      if (exp || (comment && comment.includes(TAG))) {
-        const lineStart = text.lastIndexOf("\n", node.getStart(sf)) + 1;
-        const indent = text.slice(lineStart, node.getStart(sf)).match(/^\s*/)?.[0] ?? "";
-        const { rest, entries } = parseJsdoc(
-          comment ?? "",
-          jsdocRange
-            ? {
-                fileName,
-                startLine: sf.getLineAndCharacterOfPosition(jsdocRange.pos).line + 1,
-              }
-            : undefined,
-        );
-        const expected = exp?.calls ?? new Set<string>();
-        const r = reconcile(
-          entries,
-          expected,
-          (c) => (exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON),
-          onlyCall,
-        );
-        skipped.push(...r.skipped);
-        if (exp) {
-          for (const e of [...r.kept, ...r.added]) {
-            if (!justifies(e.reason)) continue;
-            for (const rubyName of exp.rubyNames) tagged.push({ rubyName, call: e.call });
-          }
+    const key = expectationKey(owner, name);
+    const fileModuleKey = expectationKey(moduleName, name);
+    const anyKey = expectationKey(ANY_CLASS, name);
+    const useFileModuleKey =
+      owner === "" && fileModuleKey !== key && !declaredKeys.has(fileModuleKey);
+    seen.add(key);
+    if (useFileModuleKey && expectations.has(fileModuleKey)) seen.add(fileModuleKey);
+    if (expectations.has(anyKey)) seen.add(anyKey);
+    const exp =
+      expectations.get(key) ??
+      (useFileModuleKey ? expectations.get(fileModuleKey) : undefined) ??
+      expectations.get(anyKey);
+    const ranges = ts.getLeadingCommentRanges(text, node.getFullStart()) ?? [];
+    const jsdocRange = ranges.filter((r) => text.slice(r.pos, r.pos + 3) === "/**").at(-1);
+    const comment = jsdocRange ? text.slice(jsdocRange.pos, jsdocRange.end) : null;
+    if (exp || (comment && comment.includes(TAG))) {
+      const lineStart = text.lastIndexOf("\n", node.getStart(sf)) + 1;
+      const indent = text.slice(lineStart, node.getStart(sf)).match(/^\s*/)?.[0] ?? "";
+      const { rest, entries } = parseJsdoc(
+        comment ?? "",
+        jsdocRange
+          ? {
+              fileName,
+              startLine: sf.getLineAndCharacterOfPosition(jsdocRange.pos).line + 1,
+            }
+          : undefined,
+      );
+      const expected = exp?.calls ?? new Set<string>();
+      const r = reconcile(
+        entries,
+        expected,
+        (c) => (exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON),
+        onlyCall,
+      );
+      skipped.push(...r.skipped);
+      if (exp) {
+        for (const e of [...r.kept, ...r.added]) {
+          if (!justifies(e.reason)) continue;
+          for (const rubyName of exp.rubyNames) tagged.push({ rubyName, call: e.call });
         }
-        for (const d of r.dropped) {
-          if (!PLACEHOLDER_REASONS.has(d.reason)) harvested.push({ tsName: name, entry: d });
+      }
+      for (const d of r.dropped) {
+        if (!PLACEHOLDER_REASONS.has(d.reason)) harvested.push({ tsName: name, entry: d });
+      }
+      const next = renderJsdoc(comment ? rest : [], [...r.kept, ...r.added], indent);
+      if (comment && jsdocRange) {
+        if (next === null) {
+          // Remove the comment plus its trailing newline + indent.
+          let end = jsdocRange.end;
+          if (text[end] === "\n") end += 1 + indent.length;
+          edits.push({ start: jsdocRange.pos, end, text: "" });
+        } else if (next !== comment) {
+          edits.push({ start: jsdocRange.pos, end: jsdocRange.end, text: next });
         }
-        const next = renderJsdoc(comment ? rest : [], [...r.kept, ...r.added], indent);
-        if (comment && jsdocRange) {
-          if (next === null) {
-            // Remove the comment plus its trailing newline + indent.
-            let end = jsdocRange.end;
-            if (text[end] === "\n") end += 1 + indent.length;
-            edits.push({ start: jsdocRange.pos, end, text: "" });
-          } else if (next !== comment) {
-            edits.push({ start: jsdocRange.pos, end: jsdocRange.end, text: next });
-          }
-        } else if (next !== null) {
-          // Rendered lines already carry the indent; the original declaration
-          // line (starting at lineStart) keeps its own.
-          edits.push({ start: lineStart, end: lineStart, text: next + "\n" });
-        }
+      } else if (next !== null) {
+        // Rendered lines already carry the indent; the original declaration
+        // line (starting at lineStart) keeps its own.
+        edits.push({ start: lineStart, end: lineStart, text: next + "\n" });
       }
     }
   }

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -275,6 +275,104 @@ function firstCuratedReason(
   return DEFAULT_TAG_REASON;
 }
 
+/**
+ * The owner name `extract-ts-api.ts` synthesizes for a file's top-level
+ * functions — the PascalCased file basename, so `aggregations.ts` records
+ * `composedOf` under `Aggregations` and `secure-password.ts` records
+ * `authenticateBy` under `SecurePassword`. compare.ts keys its expectation
+ * under that owner, so the migrator has to look there for a declaration the
+ * AST reports at the top level.
+ */
+export function fileModuleName(fileName: string): string {
+  const base = (fileName.split("/").at(-1) ?? fileName).replace(/\.ts$/, "");
+  return base
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+/** One declaration a `@missingRailsCall` tag can be minted onto: its TS name,
+ *  the owner it is written under (`""` at the top level), and the node whose
+ *  leading JSDoc the tag joins. */
+interface TaggableDecl {
+  name: string;
+  owner: string;
+  node: ts.Node;
+}
+
+/** The owner a declaration is written under: the class it sits in, else the
+ *  `const` an enclosing object literal is assigned to — the settled trails
+ *  mixin idiom (CLAUDE.md "Module mixins"), which extract-ts-api.ts harvests as
+ *  a module of that name — else `""` at the top level. */
+function ownerName(node: ts.Node): string {
+  for (let p = node.parent; p; p = p.parent) {
+    if (ts.isClassDeclaration(p) || ts.isClassExpression(p)) return p.name?.text ?? "";
+    if (
+      ts.isObjectLiteralExpression(p) &&
+      ts.isVariableDeclaration(p.parent) &&
+      ts.isIdentifier(p.parent.name)
+    ) {
+      return p.parent.name.text;
+    }
+  }
+  return "";
+}
+
+/**
+ * Every declaration in one file a tag can be minted onto.
+ *
+ * Beyond the method/function forms, this covers the two shapes the repo's own
+ * conventions produce and the migrator used to report as "no body-bearing
+ * declaration": a method inside a mixin object literal, and a property (class
+ * field or object-literal key) initialized with an arrow function. An overload
+ * SIGNATURE is still skipped — it has no body, and tagging each one duplicates
+ * the block per signature.
+ */
+export function collectDeclarations(sf: ts.SourceFile): TaggableDecl[] {
+  const decls: TaggableDecl[] = [];
+  const visit = (node: ts.Node): void => {
+    let name: string | null = null;
+    let host: ts.Node = node;
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isGetAccessor(node) ||
+        ts.isSetAccessor(node)) &&
+      node.body &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
+      name = node.name.text;
+    } else if (ts.isConstructorDeclaration(node) && node.body) {
+      // Ruby `initialize` matches the TS constructor (artifact tsName
+      // "constructor"), which carries no identifier.
+      name = "constructor";
+    } else if (
+      (ts.isPropertyDeclaration(node) || ts.isPropertyAssignment(node)) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    ) {
+      name = node.name.text;
+    } else if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer)) &&
+      ts.isVariableStatement(node.parent.parent)
+    ) {
+      name = node.name.text;
+      // The JSDoc of `export const foo = () => {}` leads the STATEMENT, not the
+      // declaration inside its declaration list.
+      host = node.parent.parent;
+    }
+    if (name !== null) decls.push({ name, owner: ownerName(node), node: host });
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return decls;
+}
+
 /** Reconcile every named function/method in one source file's text. Returns
  *  the new text (or null if unchanged) plus harvested non-placeholder drops. */
 export function reconcileFileText(
@@ -308,41 +406,30 @@ export function reconcileFileText(
   const seen = new Set<string>();
   const skipped: string[] = [];
 
-  // The class a declaration is written in — `""` at the top level — which is
-  // half of the {@link expectationKey} a tag is minted under.
-  const enclosingClassName = (node: ts.Node): string => {
-    for (let p = node.parent; p; p = p.parent) {
-      if (ts.isClassDeclaration(p) || ts.isClassExpression(p)) return p.name?.text ?? "";
-    }
-    return "";
-  };
+  const decls = collectDeclarations(sf);
+  // Every owner a declaration in this file names for itself, so the
+  // synthesized-file-module fallback below never steals a key some class or
+  // mixin object already declares under its own name.
+  const declaredKeys = new Set(decls.map((d) => expectationKey(d.owner, d.name)));
+  const moduleName = fileModuleName(fileName);
 
-  const visit = (node: ts.Node): void => {
-    let name: string | null = null;
-    // Only body-bearing declarations: overload SIGNATURES (and interface /
-    // ambient members) must not be stamped — tagging each overload duplicates
-    // the block once per signature (found by the activerecord-wide run).
-    if (
-      (ts.isFunctionDeclaration(node) ||
-        ts.isMethodDeclaration(node) ||
-        ts.isGetAccessor(node) ||
-        ts.isSetAccessor(node)) &&
-      node.body &&
-      node.name &&
-      ts.isIdentifier(node.name)
-    ) {
-      name = node.name.text;
-    } else if (ts.isConstructorDeclaration(node) && node.body) {
-      // Ruby `initialize` matches the TS constructor (artifact tsName
-      // "constructor"), which carries no identifier.
-      name = "constructor";
-    }
-    if (name !== null) {
-      const key = expectationKey(enclosingClassName(node), name);
+  for (const { name, owner, node } of decls) {
+    {
+      const key = expectationKey(owner, name);
+      // A top-level function is recorded by extract-ts-api.ts under the module
+      // it synthesizes from the FILE NAME (`aggregations.ts` → `Aggregations`),
+      // so compare.ts keys its expectation there while the AST says `""`.
+      const moduleKey =
+        owner === "" ? expectationKey(moduleName, name) : expectationKey(owner, name);
       const anyKey = expectationKey(ANY_CLASS, name);
       seen.add(key);
+      const useModuleKey = moduleKey !== key && !declaredKeys.has(moduleKey);
+      if (useModuleKey && expectations.has(moduleKey)) seen.add(moduleKey);
       if (expectations.has(anyKey)) seen.add(anyKey);
-      const exp = expectations.get(key) ?? expectations.get(anyKey);
+      const exp =
+        expectations.get(key) ??
+        (useModuleKey ? expectations.get(moduleKey) : undefined) ??
+        expectations.get(anyKey);
       const ranges = ts.getLeadingCommentRanges(text, node.getFullStart()) ?? [];
       const jsdocRange = ranges.filter((r) => text.slice(r.pos, r.pos + 3) === "/**").at(-1);
       const comment = jsdocRange ? text.slice(jsdocRange.pos, jsdocRange.end) : null;
@@ -392,9 +479,7 @@ export function reconcileFileText(
         }
       }
     }
-    ts.forEachChild(node, visit);
-  };
-  visit(sf);
+  }
 
   const unmatched = [...expectations.entries()]
     .filter(([k]) => !seen.has(k))

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/aggregations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/aggregations.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "aggregations.ts",
-    "rubyName": "composed_of",
-    "call": "include",
-    "reason": "aggregations.rb `include Aggregations` — Ruby `include` has no TS equivalent; the settled trails idiom names the mixin helper after the module, so the call is `includeAggregations(modelClass)` (aggregations.ts:50, :262) and the `unless self < Aggregations` guard lives inside it. Language shortcoming."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/through-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/through-association.ts",
-    "rubyName": "target_scope",
-    "call": "drop",
-    "reason": "Ruby's Enumerable#drop(1) over `reflection.chain` (through_association.rb:36) is `chain.slice(1)`: a JS array has no `drop` and ActiveSupport ports no Array#drop."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/quoting.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/quoting.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/quoting.ts",
-    "rubyName": "quote_string",
-    "call": "quote",
-    "reason": "Per-site verified (RFC 0106 wave 4b): sqlite3/quoting.rb's `quote_string` delegates to the driver's `::SQLite3::Database.quote`; better-sqlite3 exposes no such entry point, so trails applies the same `''`-doubling rule inline."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/integration.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/integration.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "integration.ts",
-    "rubyName": "can_use_fast_cache_version?",
-    "call": "with_connection",
-    "reason": "integration.rb:180-183 reads `self.class.with_connection(&:default_timezone)`; `withConnection` is async in trails and `canUseFastCacheVersion` is a synchronous predicate on the cacheKey/cacheVersion path, so the port reads the global `ActiveRecord.defaultTimezone` instead — which is what Rails own FIXME on that line asks for (do not check out a connection here)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/secure-password.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/secure-password.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "secure-password.ts",
-    "rubyName": "authenticate_by",
-    "call": "map",
-    "reason": "Verified per-site (RFC 0106): `attributes.to_h.partition { ... }.map(&:to_h)` (`secure_password.rb:126-128`) — `partition` yields two arrays of pairs that `map(&:to_h)` turns back into Hashes; the TS body partitions into two entry arrays directly, so there is no pair-array-to-Hash `map` step."
-  }
-]

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -26,9 +26,9 @@
       "value": 59
     },
     "activerecord": {
-      "assertionCount": 1944,
-      "kind": 3927,
-      "value": 38
+      "assertionCount": 1943,
+      "kind": 3926,
+      "value": 37
     },
     "activesupport": {
       "assertionCount": 882,


### PR DESCRIPTION
Four related stories, one PR.

## 1. The call-set migrator could not reach mixin / file-module declarations

`parity:api:build` resolved a tag target through body-bearing method and
function declarations under their **enclosing class** only, so six RFC 0106 tail
rows reported `no body-bearing declaration` and could not leave the baseline by
the sanctioned route. The shape behind them is not an exotic declaration form:
`extract-ts-api.ts` records a file's top-level functions under a module it
**synthesizes from the file name** (`aggregations.ts` → `Aggregations`,
`secure-password.ts` → `SecurePassword`), and harvests a mixin object literal
(`export const ThroughAssociation = { … }`, CLAUDE.md "Module mixins") as a
module of that name — so compare.ts keys the expectation under an owner the AST
reports as `""`.

`reconcileFileText` now collects declarations first — adding object-literal
methods and arrow-function properties — then matches each against its owner key,
the synthesized file-module key, and `ANY_CLASS`. The file-module fallback never
claims a key some class or mixin object already declares under its own name
(`relation.ts` declares `class Relation`), which is covered by a test.

Five activerecord rows are migrated and their shards **deleted**; each reason was
reviewed per-site and opened with its permanence claim, which the migrated
baseline prose did not carry. The `drop` row is CONVERGEABLE and names a new
story, `port-ruby-array-drop-for-chain-call-sites`, filed for the `Array#drop`
sibling of `ruby-empty.ts` / `ruby-first.ts`.

## 2. `attribute_present?` used `blank?` where Rails uses `empty?`

`attribute_methods.rb:387-392` is `!value.nil? && !(value.respond_to?(:empty?) &&
value.empty?)`, read through `_read_attribute` after alias resolution. The port
was `!isBlank(this.readAttribute(name))`, and ActiveSupport's `blank?` is true
for a whitespace-only string where Ruby's `" ".empty?` is false — so Rails called
`title = " "` present and trails did not.

## 3. `accessed_fields` converged onto `AttributeSet#accessed`

Rails' body is two lines over a flag `Attribute#value` sets, so every read path
feeds it. trails hand-maintained a `_accessedFields` Set on the record that only
two read paths remembered to add to, and which — being an own enumerable field —
entered `toEqual` structural equality between records.

Two eager computations had to stop forcing the read first:

- `_writeAttribute` took the cast value through `fetchValue`, whose memo is what
  marks the attribute read; it now takes it from `type_cast` (attribute.rb:100-103,
  what `value` memoizes). Rails computes nothing at write time at all.
- `reinstateNewRecordChanges` — a trails-only eager pass where Rails is lazy —
  asks through a new `@internal` `Attribute#withoutMarkingRead`, so a constructed
  record still reports no accessed fields, as in Rails.

`_accessedFields` is then deleted from `model.ts`, `read.ts` and
`attribute-methods.ts`, and the `mixin.test.ts` comment about it is retired.

## 4. `filter_attributes on pretty_print*` rendered through `inspect()`

The three tests rendered through `inspect()` and carried the *sibling* inspect
test's quoted literal. They now render through `pp` over `Core#pretty_print` —
the `PP.pp(user, StringIO.new(actual))` port — and assert Rails' literals
verbatim. `assertion-mismatch-mark.json` lowered on a passing run
(activerecord value 38 → 37, count 1944 → 1943, kind 3927 → 3926).

## Verification

- `pnpm parity:api:calls` — OK (735 baselined, 340 unreviewed, tight)
- `pnpm parity:api:calls:args` — OK; `parity:api:reasons`, `parity:api:detached` — clean
- `parity:api:build` is idempotent on the new forms (second run: zero edits)
- `pnpm parity:test -- --assertions --package activerecord` — `filter_attributes_test.rb` 12/12 ✓, 0 mismatches of any kind
- activemodel suite (2264), relations / dirty / persistence / attributes / base /
  serialization / timestamp / mixin / attribute-methods — green

Closes-story: call-set-migrator-skips-non-body-bearing-declarations
Closes-story: attribute-present-uses-blank-instead-of-empty
Closes-story: converge-accessed-fields-onto-attribute-set-accessed
Closes-story: filter-attributes-pretty-print-test-renders-through-inspect
