### PR TITLE
fix(parity): let @missingRailsCall suppress order-only flags, audit tag permanence claims

### DIFF
--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -360,14 +360,6 @@ export function resetPrimaryKey(this: PrimaryKeyHost): void {
  * leasing a connection; a cold cache falls through to the "id" convention.
  * `ActiveRecord::Base != self` is carried by the `tableName` guard — `Base`
  * itself has none.
- *
- * @missingRailsCall table_exists? — CONVERGEABLE: `table_exists?` is async in
- * trails, and its sync cache-only view (`cachedTableExists`) leases a connection
- * to reach the cache, which `primary_key` must not do — see `cachedSchemaCacheFor`.
- * A table absent from the schema cache has no cached primary keys either, so the
- * guard is subsumed by the `primaryKeys !== undefined` check.
- * @missingRailsCall primary_keys — CONVERGEABLE: `schema_cache.primary_keys` is
- * async in trails; `getCachedPrimaryKeys` is its lease-free cache-only view.
  */
 export function getPrimaryKey(
   this: PrimaryKeyHost & { primaryKeyPrefixType?: string | null },

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -95,11 +95,6 @@ export function validateAdapterName(adapterName: string): void {
  * Mirrors: ActiveRecord::ConnectionAdapters.resolve
  *
  * Resolves an adapter name to its class.
- *
- * @missingRailsCall join — CONVERGEABLE (story adapter-not-found-message-should-be-built-inline): Rails builds the AdapterNotFound message inline
- *   (connection_adapters.rb:34-39); the port extracts it into the private
- *   `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(", ")`
- *   (connection-adapters.ts:75) is outside the published call-set.
  */
 export async function resolve(adapterName: string): Promise<AdapterClass> {
   const cached = resolved.get(adapterName);

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -45,13 +45,6 @@ export class Reaper {
   private static _pools = new Map<number, WeakRef<ReapablePool>[]>();
   private static _timers = new Map<number, ReturnType<typeof setInterval>>();
 
-  /**
-   * @missingRailsCall spawn_thread — CONVERGEABLE (RFC 0073, the threadless-pool surface): Per-site verified (RFC 0106 wave 4b):
-   *   connection_pool/reaper.rb `spawn_thread` starts a background Thread;
-   *   trails' Reaper drives the same period from a timer, so there is no thread
-   *   to spawn. Tracked with the rest of the threadless pool surface by RFC
-   *   0073.
-   */
   static registerPool(pool: ReapablePool, frequency: number): void {
     if (!frequency || frequency <= 0 || !Number.isFinite(frequency)) return;
     if (pool.isDiscarded?.()) return;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -85,11 +85,6 @@ export class Cidr extends ValueType<IPAddr> {
    *   nil → nil
    *   String → IPAddr.new(value) or nil on ArgumentError
    *   else → value (pass-through for existing IPAddr instances)
-   *
-   * @missingRailsCall new — CONVERGEABLE (story pg-cidr-cast-value-should-build-an-ipaddr): Per-site verified (RFC 0106 wave 4b):
-   *   postgresql/oid/cidr.rb builds an `IPAddr.new(...)`; Ruby's IPAddr has no
-   *   port in trails, so the cast returns the normalized CIDR string. Tracked as
-   *   the PG address-type gap, not a dropped delegation.
    */
   castValue(value: unknown): IPAddr | null {
     if (value == null) return null;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/legacy-point.ts
@@ -25,13 +25,6 @@ export class LegacyPoint extends ValueType<[number, number]> {
     return null;
   }
 
-  /**
-   * @missingRailsCall number_for_point — CONVERGEABLE (story legacy-point-serialize-should-extract-number-for-point): Per-site verified (RFC 0106 wave 4b):
-   *   postgresql/oid/legacy_point.rb's `number_for_point` strips a trailing `.0`
-   *   from each coordinate; trails' serialize formats the pair with the same
-   *   rule inline. The helper is private and one-line in Rails; extracting it
-   *   here would be surface with a single caller.
-   */
   serialize(value: unknown): string | null {
     if (value == null) return null;
     if (globalThis.Array.isArray(value) && value.length === 2) {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2627,7 +2627,18 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     }
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * @missingRailsCall order:columns,createTable — PERMANENT: Per-entry verified
+   *   (RFC 0106 sqlite3 table-rebuild cluster), sqlite3_adapter.rb:602-639:
+   *   Rails calls `columns(from)` INSIDE the `create_table` block.
+   *   `createTable`'s TableDefinition block is synchronous in trails (the
+   *   definition is built, then rendered, with no await point), and `columns()`
+   *   is async, so the reflection is hoisted above the `createTable` call.
+   *   Everything Rails calls is called, once, with the same arguments — only the
+   *   sequence differs, and it is forced by the block being unable to await.
+   */
   private async copyTable(
     from: string,
     to: string,

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -27,14 +27,6 @@ export class TableDefinition extends AbstractTableDefinition {
     return this.references(name, options);
   }
 
-  /**
-   * @missingRailsCall column — CONVERGEABLE (story sqlite3-table-change-column-should-redeclare-the-column): Per-site verified (RFC 0106 wave 4b):
-   *   sqlite3/schema_definitions.rb's `change_column` re-enters
-   *   `column(column_name, type, **options)` on the table definition; trails'
-   *   SQLite Table#changeColumn forwards to the adapter's `changeColumn`, which
-   *   rebuilds the table (copy_table) — the definition-level column
-   *   re-declaration happens inside that rebuild.
-   */
   changeColumn(columnName: string, type: ColumnType, options: ColumnOptions = {}): void {
     const col = this.newColumnDefinition(columnName, type, options);
     const idx = this.columns.findIndex((c) => c.name === columnName);

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -850,13 +850,6 @@ export function ensureProperType(this: Base): void {
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#discriminate_class_for_record
  * @internal Private method, used by persistence to route instantiate() through STI subclasses.
- *
- * @missingRailsCall find_sti_class — CONVERGEABLE (story discriminate-class-for-record-should-call-find-sti-class): inheritance.rb:301
- *   `find_sti_class(record[inheritance_column])` — trails routes through
- *   `findStiClassForRow` (inheritance.ts:867), the registry-safe variant that
- *   matches only within `baseClass`'s tracked subtree; the bare `findStiClass`
- *   is Rails' autoloader analog and is reached from there when STI is explicitly
- *   enabled (inheritance.ts:1075-1078). Documented at inheritance.ts:1050-1059.
  */
 export function discriminateClassForRecord(
   modelClass: typeof Base,

--- a/packages/activerecord/src/middleware/shard-selector.ts
+++ b/packages/activerecord/src/middleware/shard-selector.ts
@@ -32,11 +32,6 @@ export class ShardSelector {
     this.options = options;
   }
 
-  /**
-   * @missingRailsCall new — CONVERGEABLE: shard_selector.rb:41 wraps env in
-   * ActionDispatch::Request.new(env); trails has no ActionDispatch, so call()
-   * receives the request itself and constructs nothing.
-   */
   async call(request: ShardRequest): Promise<unknown> {
     const shard = this.selectedShard(request);
     return this.setShard(shard, () => this.app(request));

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1843,15 +1843,6 @@ export class Relation<T extends Base> {
    * — `_buildEagerOperandManager` is that block, and its manager is rendered
    * through the same connection path (a null manager, e.g. an unresolvable
    * association, falls through to the plain arel).
-   *
-   * @missingRailsCall with_connection — CONVERGEABLE: Rails' non-eager arm is
-   * `model.with_connection { |conn| conn.unprepared_statement { conn.to_sql(arel) } }`
-   * (relation.rb:1217-1219). `withConnection` is a `Promise`-returning checkout
-   * in TypeScript, and `to_sql` renders a string with no `await` in it, so
-   * taking one would make `toSql` async — 412 test and 16 source call sites
-   * treat it as synchronous. The checkout is instead the caller's, read through
-   * `_conn()`, and `unprepared_statement` is applied by hand around the render.
-   * Convergence tracked by RFC 0107 (`converge-sync-eager-builders-async-to-sql`).
    */
   toSql(): string {
     // `unprepared_statement` applied synchronously: `to_sql` is sync here, so

--- a/packages/activerecord/src/schema.ts
+++ b/packages/activerecord/src/schema.ts
@@ -56,12 +56,6 @@ export class Schema extends Current {
     info: SchemaDefineInfo,
     fn: (schema: Schema) => void | Promise<void>,
   ): Promise<void>;
-  /**
-   * @missingRailsCall with_connection — CONVERGEABLE (RFC 0059, the one-schema convergence): `connection_pool.with_connection`
-   *   (schema.rb:54) checks a connection out for the block; the port's
-   *   `Schema.define` is handed the adapter explicitly (schema.ts:51-64), the
-   *   one-schema convergence RFC 0059 tracks.
-   */
   static async define(
     adapter: DatabaseAdapter,
     infoOrFn: SchemaDefineInfo | ((schema: Schema) => void | Promise<void>),

--- a/packages/activesupport/src/number-helper/rounding-helper.ts
+++ b/packages/activesupport/src/number-helper/rounding-helper.ts
@@ -41,9 +41,6 @@ export class RoundingHelper {
    * The literal-shape guard is what `BigDecimal(number.to_s)` does by raising:
    * a string that is not a decimal literal is an `ArgumentError`, not a
    * silently coerced zero.
-   *
-   * @missingRailsCall digit_count — CONVERGEABLE: only the `Rational` arm calls it, to size
-   * the `BigDecimal(number, ndigits)` precision; there is no trails Rational.
    */
   private convertToDecimal(number: unknown): BigDecimal {
     if (number instanceof BigDecimal) return number;

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods/primary-key.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/primary-key.ts",
+    "rubyName": "get_primary_key",
+    "call": "primary_keys",
+    "reason": "`schema_cache.primary_keys` (attribute_methods/primary_key.rb:104) is async in trails; `getCachedPrimaryKeys` is its lease-free cache-only view. Returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit: the async/sync split is convergeable work, so the row is what tracks it."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/primary-key.ts",
+    "rubyName": "get_primary_key",
+    "call": "table_exists?",
+    "reason": "`table_exists?` (attribute_methods/primary_key.rb:103) is async in trails, and its sync cache-only view (`cachedTableExists`) leases a connection to reach the cache, which `primaryKey` must not do — see `cachedSchemaCacheFor`. A table absent from the schema cache has no cached primary keys either, so the guard is subsumed by the `primaryKeys !== undefined` check. Returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters.ts",
+    "rubyName": "resolve",
+    "call": "join",
+    "reason": "Rails builds the AdapterNotFound message inline (connection_adapters.rb:34-39); the port extracts it into the private `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(\", \")` (connection-adapters.ts:75) is outside the published call-set. Tracked by story adapter-not-found-message-should-be-built-inline; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/reaper.ts",
+    "rubyName": "register_pool",
+    "call": "spawn_thread",
+    "reason": "connection_pool/reaper.rb:59 `spawn_thread` starts a background Thread; trails' Reaper drives the same period from a timer, so there is no thread to spawn. Tracked with the rest of the threadless pool surface by RFC 0073; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/cidr.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/cidr.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/cidr.ts",
+    "rubyName": "cast_value",
+    "call": "new",
+    "reason": "postgresql/oid/cidr.rb:31 builds an `IPAddr.new(...)`; Ruby's IPAddr has no port in trails, so the cast returns the normalized CIDR string. Tracked by story pg-cidr-cast-value-should-build-an-ipaddr; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/legacy-point.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/oid/legacy-point.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/oid/legacy-point.ts",
+    "rubyName": "serialize",
+    "call": "number_for_point",
+    "reason": "postgresql/oid/legacy_point.rb:39 `number_for_point` strips a trailing `.0` from each coordinate; trails' serialize formats the pair with the same rule inline. Tracked by story legacy-point-serialize-should-extract-number-for-point; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table",
-    "call": "order:columns,createTable",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 table-rebuild cluster), sqlite3_adapter.rb:602-639: Rails calls `columns(from)` INSIDE the `create_table` block. `createTable`'s TableDefinition block is synchronous in trails (the definition is built, then rendered, with no await point), and `columns()` is async, so the reflection is hoisted above the `createTable` call. Everything Rails calls is called, once, with the same arguments — only the sequence differs, and it is forced by the block being unable to await. Stays a baseline row rather than a `@missingRailsCall` tag: an `order:` flag is keyed on the Ruby name (`copy_table`) while `parity:api:build` writes the tag keyed on the camelCased declaration (`copyTable`), so a migrated `order:` row reads back as both a STALE tag and a NEW mismatch."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "initialize",
     "call": "merge",
     "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:128-132: Rails merges `@config` into `@connection_parameters` because the sqlite3 gem takes the whole config hash as driver options. trails' constructor takes `(filename, options)` — the driver (node:sqlite / better-sqlite3) accepts no config hash — so there is no parameters hash to merge into. Tracked for construction convergence by RFC 0094 (sqlite3-adapter-construction-fidelity)."

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3/schema-definitions.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/schema-definitions.ts",
+    "rubyName": "change_column",
+    "call": "column",
+    "reason": "sqlite3/schema_definitions.rb:14 `change_column` re-enters `column(column_name, type, **options)` on the table definition; trails' SQLite Table#changeColumn forwards to the adapter's `changeColumn`, which rebuilds the table (copy_table) — the definition-level column re-declaration happens inside that rebuild. Tracked by story sqlite3-table-change-column-should-redeclare-the-column; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/inheritance.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
+    "rubyName": "discriminate_class_for_record",
+    "call": "find_sti_class",
+    "reason": "inheritance.rb:301 `find_sti_class(record[inheritance_column])` — trails routes through `findStiClassForRow` (inheritance.ts:867), the registry-safe variant that matches only within `baseClass`'s tracked subtree; the bare `findStiClass` is Rails' autoloader analog and is reached from there when STI is explicitly enabled. Tracked by story discriminate-class-for-record-should-call-find-sti-class; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
     "rubyName": "subclass_from_attributes",
     "call": "find_sti_class",
     "kind": "args",

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "middleware/shard-selector.ts",
+    "rubyName": "call",
+    "call": "new",
+    "reason": "shard_selector.rb:41 wraps env in `ActionDispatch::Request.new(env)`; trails has no ActionDispatch, so `call()` receives the request itself and constructs nothing. Convergeable once ActionDispatch::Request is ported; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -40,5 +40,12 @@
     "rubyName": "to_sql",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "to_sql",
+    "call": "with_connection",
+    "reason": "Rails' non-eager arm is `model.with_connection { |conn| conn.unprepared_statement { conn.to_sql(arel) } }` (relation.rb:1217-1219). `withConnection` is a `Promise`-returning checkout in TypeScript and `toSql` renders synchronously, so the checkout is the caller's, read through `_conn()`, and `unprepared_statement` is applied by hand around the render. Tracked by RFC 0107 (`converge-sync-eager-builders-async-to-sql`); returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "schema.ts",
+    "rubyName": "define",
+    "call": "with_connection",
+    "reason": "`connection_pool.with_connection` (schema.rb:54) checks a connection out for the block; the port's `Schema.define` is handed the adapter explicitly (schema.ts:51-64). Tracked by RFC 0059, the one-schema convergence; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  }
+]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
@@ -2,6 +2,13 @@
   {
     "package": "activesupport",
     "tsFile": "number-helper/rounding-helper.ts",
+    "rubyName": "convert_to_decimal",
+    "call": "digit_count",
+    "reason": "rounding_helper.rb:47 calls `digit_count` from the `Rational` arm alone, to size the `BigDecimal(number, ndigits)` precision; there is no trails Rational. Convergeable with the Rational port; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/rounding-helper.ts",
     "rubyName": "round",
     "call": "fetch",
     "reason": "Ruby Hash#fetch with a default: `options.fetch(:round_mode, :default)` (number_helper/rounding_helper.rb:16) ports to the `\"roundMode\" in this.options` check, which keeps fetch's stored-value-wins semantics that `??` would not."

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -48,6 +48,7 @@ import {
   tsOwnerSeat,
   writerPairedWithReader,
   staleCallTags,
+  applyCallTags,
   suppressTaggedCalls,
   tagsForOwner,
 } from "./compare.js";
@@ -1818,6 +1819,33 @@ describe("suppressTaggedCalls", () => {
       "reload → reload",
     ]);
     expect([...used]).toEqual([]);
+  });
+});
+
+describe("applyCallTags", () => {
+  it("suppresses an order-only flag the declaration tags", () => {
+    const used = new Set<string>();
+    const applied = applyCallTags(
+      ["order:columns,createTable → createTable,columns"],
+      new Map([["order:columns,createTable", "PERMANENT: the block cannot await."]]),
+      used,
+    );
+    expect(applied.kept).toEqual([]);
+    expect(applied.suppressed).toEqual([
+      { call: "order:columns,createTable", reason: "PERMANENT: the block cannot await." },
+    ]);
+    expect([...used]).toEqual(["order:columns,createTable"]);
+  });
+
+  it("suppresses a dropped-call flag and leaves an untagged order flag standing", () => {
+    const used = new Set<string>();
+    const applied = applyCallTags(
+      ["synchronize → synchronize", "order:a,b → b,a"],
+      new Map([["synchronize", "PERMANENT: no threads."]]),
+      used,
+    );
+    expect(applied.kept).toEqual(["order:a,b → b,a"]);
+    expect(applied.suppressed.map((s) => s.call)).toEqual(["synchronize"]);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1383,6 +1383,29 @@ export function suppressTaggedCalls(
   });
 }
 
+/**
+ * Apply one declaration's `@missingRailsCall` tags to EVERY flag its pair
+ * raised — the dropped-call ones and the ORDER-only ones alike — returning what
+ * survives plus the suppressions bought, each with the reason that justified it.
+ *
+ * The order flags used to be appended AFTER suppression ran, so a tag migrated
+ * from an `order:` baseline row suppressed nothing: `parity:api:calls` reported
+ * that one row's call twice at once, as a STALE tag (it never suppressed) and as
+ * a NEW mismatch (the flag came back), and the row could not leave the baseline
+ * (RFC 0106). An order-only divergence is a divergence like any other, so it
+ * takes a receipt like any other.
+ */
+export function applyCallTags(
+  flagged: readonly string[],
+  tags: ReadonlyMap<string, string>,
+  used: Set<string>,
+): { kept: string[]; suppressed: { call: string; reason: string }[] } {
+  const suppressed = flagged
+    .filter((m) => tags.has(callOf(m)))
+    .map((m) => ({ call: callOf(m), reason: tags.get(callOf(m)) ?? "" }));
+  return { kept: suppressTaggedCalls([...flagged], tags, used), suppressed };
+}
+
 /** Every tagged call on a COMPARED (tsFile, tsClass, tsName) that never
  *  suppressed a flag — the tag's stale half. Sorted for a deterministic
  *  artifact. A pair whose owning class stayed unresolved recorded its
@@ -3308,25 +3331,6 @@ export function main() {
           negatedTsCalls,
           rubyOwned?.calls ?? rubyCalls,
         );
-        const tags = tagsForOwner(tsMissingCallTagsByFileName.get(tsFile)?.get(tsName), tsClass);
-        let kept = missing;
-        if (tags !== undefined && tags.size > 0) {
-          const tagKey = callTagKey(tsFile, tsClass ?? "*", tsName);
-          const used = callTagsUsed.get(tagKey) ?? callTagsUsed.set(tagKey, new Set()).get(tagKey)!;
-          kept = suppressTaggedCalls(missing, tags, used);
-          for (const m of missing) {
-            const call = callOf(m);
-            if (tags.has(call))
-              suppressedCalls.push({
-                tsFile,
-                rubyName,
-                tsName,
-                tsClass,
-                call,
-                reason: tags.get(call) ?? "",
-              });
-          }
-        }
         const rubySkeleton = rubySkeletonByName.get(rubyName);
         const tsSkeletons = tsSkeletonByFileName.get(tsFile)?.get(tsName);
         if (rubySkeleton !== undefined && tsSkeletons?.length === 1) {
@@ -3354,7 +3358,17 @@ export function main() {
             ),
           );
         }
-        const flagged = [...kept, ...ordered];
+        const tags = tagsForOwner(tsMissingCallTagsByFileName.get(tsFile)?.get(tsName), tsClass);
+        let flagged = [...missing, ...ordered];
+        if (tags !== undefined && tags.size > 0) {
+          const tagKey = callTagKey(tsFile, tsClass ?? "*", tsName);
+          const used = callTagsUsed.get(tagKey) ?? callTagsUsed.set(tagKey, new Set()).get(tagKey)!;
+          const applied = applyCallTags(flagged, tags, used);
+          flagged = applied.kept;
+          for (const s of applied.suppressed) {
+            suppressedCalls.push({ tsFile, rubyName, tsName, tsClass, ...s });
+          }
+        }
         if (flagged.length === 0) return;
         callMismatches.push({ rubyFile, tsFile, rubyName, tsName, tsClass, missing: flagged });
       };

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -180,7 +180,12 @@ import {
   writeMarks,
 } from "./unreviewed-ratchet.js";
 import { rubyMethodToTsIgnoringSkip, snakeToCamel } from "@blazetrails/parity/conventions";
-import { DEFAULT_REASON, TAG, classifyReason } from "./missing-rails-call-tags.js";
+import {
+  DEFAULT_REASON,
+  TAG,
+  claimsPermanenceButNamesOwner,
+  classifyReason,
+} from "./missing-rails-call-tags.js";
 import type { ApiManifest, ClassInfo, MethodInfo } from "@blazetrails/parity/types";
 
 // The baseline is a directory of per-source-file JSON arrays (see header),
@@ -604,6 +609,14 @@ export function receiptsSection(title: string, receipts: readonly TagReceipt[]):
       `${title} — CONVERGEABLE by file`,
       tally(
         receipts.filter((r) => claim(r) === "convergeable"),
+        (r) => `${r.package}/${r.tsFile} ${r.tsName} ${r.call}`,
+      ),
+    ) +
+    "\n" +
+    section(
+      `${title} — PERMANENT but names a convergence owner`,
+      tally(
+        receipts.filter((r) => claimsPermanenceButNamesOwner(r.reason ?? "")),
         (r) => `${r.package}/${r.tsFile} ${r.tsName} ${r.call}`,
       ),
     )

--- a/scripts/api-compare/missing-rails-call-tags.test.ts
+++ b/scripts/api-compare/missing-rails-call-tags.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   DEFAULT_REASON,
   NARROW_DEFAULT_REASON,
+  claimsPermanenceButNamesOwner,
   suppressedCallsIn,
 } from "./missing-rails-call-tags.js";
 import { ANY_CLASS, expectationKey, reconcileFileText } from "./build.js";
@@ -188,5 +189,39 @@ describe("parity:api:build over a hand-written one-line tag", () => {
   it("makes no further edit on a second run", () => {
     const first = reconcileFileText("foo.ts", src, expectations, () => reason).text!;
     expect(reconcileFileText("foo.ts", first, expectations, () => reason).text).toBeNull();
+  });
+});
+
+describe("claimsPermanenceButNamesOwner", () => {
+  it("flags a PERMANENT reason that hands the deviation to a future owner", () => {
+    expect(
+      claimsPermanenceButNamesOwner(
+        "PERMANENT: connection_pool/reaper.rb spawns a background Thread; trails drives the " +
+          "same period from a timer. Tracked with the rest of the threadless pool surface by RFC 0073.",
+      ),
+    ).toBe(true);
+    expect(claimsPermanenceButNamesOwner("PERMANENT: pending burndown review.")).toBe(true);
+  });
+
+  it("does not flag an RFC cited as the audit that verified the reason", () => {
+    expect(
+      claimsPermanenceButNamesOwner(
+        "PERMANENT: Per-site verified (RFC 0106 wave 4b): `result.rows.first` is `result.rows[0]` " +
+          "on a JS array; `Array#first` is not a ported method name.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag a story cited as the CAUSE of a name-collision false positive", () => {
+    expect(
+      claimsPermanenceButNamesOwner(
+        "PERMANENT: Name-collision false positive (story relation-delegation-rails-named-methods): " +
+          "this unrelated call to String#split is flagged by the name-based wide call-set check.",
+      ),
+    ).toBe(false);
+  });
+
+  it("says nothing about a reason that already claims CONVERGEABLE", () => {
+    expect(claimsPermanenceButNamesOwner("CONVERGEABLE: tracked by RFC 0059.")).toBe(false);
   });
 });

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -289,3 +289,34 @@ export function classifyReason(reason: string): Permanence {
   if (!first) return "unclassified";
   return PERMANENCE_TOKENS[first[1]] ?? "unclassified";
 }
+
+/**
+ * Prose that hands the deviation to a future owner: an RFC, a story, a
+ * follow-up, a burndown wave. A reason resting on such a phrase is describing
+ * work someone will do, which is `CONVERGEABLE` — and, per RFC 0106's rule, a
+ * deviation whose work is still owned belongs in `call-mismatches-exclude/` as
+ * a row rather than at the call site as a receipt, because the row is the thing
+ * tracking it.
+ *
+ * Deliberately NOT a bare `RFC ####` / `story <slug>` match. Most reasons cite
+ * an RFC as the AUDIT that verified them ("Per-site verified (RFC 0106 wave
+ * 4b)"), and one cites the story whose rename CAUSED a name-collision false
+ * positive — neither is a convergence owner, and matching them would drown the
+ * signal in the provenance every reviewed reason carries.
+ */
+const CONVERGENCE_OWNER =
+  /\b(?:tracked (?:by|with|as)|convergence tracked|pending (?:per-cluster|burndown|review)|TODO|follow-?up|will be (?:converged|ported))\b/i;
+
+/**
+ * A tag whose reason claims `PERMANENT` while its prose hands the deviation to
+ * a future owner — the failure the RFC 0080 audit found in 42 of 79
+ * `@noRailsEquivalent` tags, where each reason was factually accurate about its
+ * mechanism and merely drew "therefore permanent" from it. {@link classifyReason}
+ * cannot see it: an unstated claim is countable, a WRONG one is not.
+ *
+ * Reported, never gated: the phrase list is a review prompt, so a false
+ * positive must cost a reviewer a glance rather than a red build.
+ */
+export function claimsPermanenceButNamesOwner(reason: string): boolean {
+  return classifyReason(reason) === "permanent" && CONVERGENCE_OWNER.test(reason);
+}


### PR DESCRIPTION
Bundle of two RFC 0106 stories.

## 1. `order:` rows could not be migrated to a receipt

`parity:api:build` migrates a curated baseline row to a `@missingRailsCall` tag.
An `order:` row did not round-trip: the gate reported the same divergence twice
at once, from both arms.

    call-mismatches ratchet: 1 STALE @missingRailsCall tag(s) whose call is no longer flagged.
      - activerecord  connection-adapters/sqlite3-adapter.ts  copyTable  order:columns,createTable
    call-mismatches ratchet: 1 NEW mismatch(es) not in the baseline.
      + activerecord  connection-adapters/sqlite3-adapter.ts  copy_table  order:columns,createTable

The story diagnosed this as a keying asymmetry (Ruby `copy_table` vs camelCased
`copyTable`). It is not — those are just the two arms' own label columns, and
both name the same call. The real cause is in `compare.ts`'s `checkCalls`: the
order-only flags from `reorderedCalls` were appended **after**
`suppressTaggedCalls` ran (`const flagged = [...kept, ...ordered]`), so a tag
minted from an `order:` row suppressed nothing — it went stale, and its flag came
straight back as NEW. So the fix converges rather than refuses: the composition
moves into `applyCallTags`, which applies a declaration's tags to every flag its
pair raised, dropped-call and order-only alike. An order-only divergence is a
divergence like any other, so it takes a receipt like any other.

Demonstrated end to end: the sqlite3 `copy_table` / `order:columns,createTable`
row is migrated to a call-site tag in this PR and `pnpm parity:api:calls` stays
green (`OK (751 baselined, 340 unreviewed, 124 per-file mark(s) totalling 340
tight)`). Its baselined reason recorded the trap and is now the tag's reason with
that paragraph dropped.

**The `order:`-trap warnings in the RFC 0106 wave-5 follow-up stories
(`wave-5b-head-sweep` … `wave-5-tail-sweep`) can be dropped once this lands** —
an `order:` row migrates like any other row now.

Regression cover: `applyCallTags` in `compare.test.ts`, pinning that an
order-only flag is suppressed by its tag and that an untagged one still stands.

**The story's acceptance criteria do not literally match what shipped, and that
is deliberate.** They ask for the fix and its regression test in `build.ts`,
because the story diagnosed a keying asymmetry there. `build.ts`'s
`expectationKey` / tagging path keys purely on `tsName` and never on `rubyName`,
so no such asymmetry exists — the premise was wrong, and a `build.ts` change
would have been a no-op dressed as a fix. `build.ts` is untouched here on
purpose; a future reader should not go looking for one. What the criteria are
actually *for* — "migrating a shard containing an `order:` row leaves
`parity:api:calls` green" and "a regression test that fails on the current
behaviour" — is met, in `compare.ts` and `compare.test.ts`, where the bug lives.

## 2. `@missingRailsCall` permanence audit

All 112 tags in the tree were read against their reason.

- **95 PERMANENT** — every one rests on a language- or runtime-level fact
  (`Hash#fetch` on a plain object, `Regexp.union`, `Array#first` as an index,
  `define_method` as a property descriptor, no threads, no `process.*`, TS2415,
  the sync/async split RFC 0087 fixes in place). All keep their claim.
- **17 CONVERGEABLE** — each names a future convergence owner, so per RFC 0106's
  rule the baseline row is the thing that should be tracking it. The **12** that
  sit on a compared pair are returned to `call-mismatches-exclude/` as rows
  (written through `serializeBaseline`, sorted, no `--write`, no reseed). The
  remaining 5 (trailties `finisher.ts`, `application.ts`, `engine.ts`) are on
  pairs the call-set gate does not compare, so no row can track them — a baseline
  row for a call that never flags is a STALE row — and they stay as tags.

`claimsPermanenceButNamesOwner` makes the mislabel countable instead of
hand-derived: a reason claiming PERMANENT whose prose hands the deviation to a
future owner ("tracked by/with/as", "convergence tracked", "pending
burndown/review", TODO, follow-up, "will be converged/ported"). It is reported,
never gated — the phrase list is a review prompt, so a false positive costs a
glance, not a red build. Deliberately not a bare `RFC ####` / `story <slug>`
match: most reasons cite an RFC as the *audit* that verified them, and one cites
the story whose rename *caused* a name-collision false positive.

`pnpm parity:api:calls:report` now ends its receipts section with:

    Call-site receipts by permanence claim (1)
      permanent     92
    Call-site receipts by permanence claim — CONVERGEABLE by file (0)
    Call-site receipts by permanence claim — PERMANENT but names a convergence owner (0)

## Verification

- `pnpm parity:api:calls` — OK
- `pnpm parity:api:calls:args` — OK (156 baselined shape rows)
- `pnpm vitest run scripts/api-compare/` — 1285 passed
- `pnpm lint`, `pnpm typecheck` — clean
- 274 LOC (additions + deletions, excluding docs)

Closes-story: api-build-order-row-tag-key-mismatch
Closes-story: audit-missing-rails-call-permanence-claims
