### PR TITLE
refactor(arel,activerecord,activesupport): one ToSql#compile, no per-node accept, iso8601/rfc3339 from date parts

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -284,7 +284,7 @@ export function toSql(
   // SubstituteBinds collector). Raw Arel `Node#toSql`/`ToSql#compile` keeps
   // `?` for BindParams (Rails parity); this path substitutes them via the
   // adapter quoter, the same way `Relation#toSql` does. `toSqlAndBinds` uses
-  // `compileWithBinds` for execution (placeholders + bind array).
+  // the Composite collector for execution (placeholders + bind array).
   const visitor = (this as any)?.visitor as Visitors.ToSql | undefined;
   if (visitor && node instanceof Nodes.Node) {
     const [inlinedSql] = compileInlined(visitor, node, this);
@@ -347,8 +347,15 @@ export function toSqlAndBinds(
         const [inlinedSql, inlinedRetryable] = compileInlined(visitor, node, this);
         return [inlinedSql, [], preparable, inlinedRetryable];
       }
-      const [sql, extractedBinds, compiledAllowRetry, compiledPreparable] =
-        visitor.compileWithBinds(node);
+      // Rails builds the collector on the adapter (`collector()`,
+      // abstract_adapter.rb:1176-1188) and compiles through the ONE
+      // `visitor.compile(node, collector)` (database_statements.rb:31-45); the
+      // Composite's `value` is the `[sql, binds]` pair Rails destructures.
+      const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+      collector.retryable = true;
+      const [sql, extractedBinds] = visitor.compile(node, collector);
+      const compiledAllowRetry = collector.retryable;
+      const compiledPreparable = collector.preparable;
       // Rails hands the compiled binds on untouched — `ActiveModel::Attribute`
       // objects survive all the way to the adapter's `type_casted_binds`
       // (abstract/quoting.rb:224), which is where `value_for_database` is
@@ -407,7 +414,8 @@ export function cacheableQuery(
 
   // Prepared path: compile with bind extraction, return Query + raw binds
   if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
-    const [sql, binds] = visitor.compileWithBinds(node);
+    const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+    const [sql, binds] = visitor.compile(node, collector);
     return [klass.query(sql), binds];
   }
 
@@ -416,7 +424,7 @@ export function cacheableQuery(
   // prepared_statements is false.
   if (klass.partialQueryCollector && klass.partialQuery && visitor && node instanceof Nodes.Node) {
     const collector = klass.partialQueryCollector() as { value: [unknown[], unknown[]] };
-    visitor.compileWithCollector(node, collector);
+    visitor.accept(node, collector);
     const [parts, collectedBinds] = collector.value;
     return [klass.partialQuery(parts), collectedBinds];
   }
@@ -1408,7 +1416,7 @@ export const DatabaseStatements = {
     binds = compiledBinds;
     // Rails' select_all passes `prepare: prepared_statements && preparable`
     // (database_statements.rb:73), where `preparable` is the Arel collector's flag
-    // threaded through compileWithBinds → _compileSelectSql → opts.preparable.
+    // threaded through compile → _compileSelectSql → opts.preparable.
     // Callers that don't supply opts.preparable fall back to bind presence, which
     // is correct for every shape that carries binds.
     const preparable = compiledPreparable ?? (binds != null && binds.length > 0);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -236,6 +236,19 @@ export class DatabaseStatementsBase {
 // --- Query conversion ---
 
 /**
+ * Ruby `AbstractAdapter#collector` (abstract_adapter.rb:1176-1188), reached
+ * through the host so a bare visitor stand-in — a host that is not an adapter
+ * and carries no `collector` — still compiles through the prepared-statement
+ * `Composite`.
+ */
+function collectorFor(host: unknown): Collectors.Composite {
+  const collector = (host as { collector?(): unknown } | undefined)?.collector?.();
+  return collector instanceof Collectors.Composite
+    ? collector
+    : new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+}
+
+/**
  * Compile an Arel node to a SQL string with its bind values inlined via the
  * connection's own `quote`. Mirrors Rails' `to_sql` under
  * `unprepared_statement`, which compiles through a `SubstituteBinds` collector
@@ -347,13 +360,10 @@ export function toSqlAndBinds(
         const [inlinedSql, inlinedRetryable] = compileInlined(visitor, node, this);
         return [inlinedSql, [], preparable, inlinedRetryable];
       }
-      // Rails builds the collector on the adapter (`collector()`,
-      // abstract_adapter.rb:1176-1188) and compiles through the ONE
-      // `visitor.compile(node, collector)` (database_statements.rb:31-45); the
-      // Composite's `value` is the `[sql, binds]` pair Rails destructures.
-      const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+      const collector = collectorFor(this);
       collector.retryable = true;
-      const [sql, extractedBinds] = visitor.compile(node, collector);
+      collector.preparable = true;
+      const [sql, extractedBinds] = visitor.compile(node, collector) as [string, unknown[]];
       const compiledAllowRetry = collector.retryable;
       const compiledPreparable = collector.preparable;
       // Rails hands the compiled binds on untouched — `ActiveModel::Attribute`
@@ -414,8 +424,7 @@ export function cacheableQuery(
 
   // Prepared path: compile with bind extraction, return Query + raw binds
   if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
-    const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-    const [sql, binds] = visitor.compile(node, collector);
+    const [sql, binds] = visitor.compile(node, collectorFor(host)) as [string, unknown[]];
     return [klass.query(sql), binds];
   }
 
@@ -424,8 +433,7 @@ export function cacheableQuery(
   // prepared_statements is false.
   if (klass.partialQueryCollector && klass.partialQuery && visitor && node instanceof Nodes.Node) {
     const collector = klass.partialQueryCollector() as { value: [unknown[], unknown[]] };
-    visitor.accept(node, collector);
-    const [parts, collectedBinds] = collector.value;
+    const [parts, collectedBinds] = visitor.compile(node, collector);
     return [klass.partialQuery(parts), collectedBinds];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -103,6 +103,13 @@ export function inspectExplainOption(o: unknown): string {
 export interface DatabaseStatementsHost {
   preparedStatements?: boolean;
   /**
+   * Mixed in from `AbstractAdapter` — Rails' `collector`
+   * (abstract_adapter.rb:1176-1188), the `Composite` under prepared statements
+   * and a `SubstituteBinds` without them.
+   * @internal
+   */
+  collector?(): Collectors.Composite | Collectors.SubstituteBinds;
+  /**
    * Mixed in from `Quoting` — the single Rails `type_casted_binds`
    * (quoting.rb:224). Payload producers must reach it through `this` so the
    * adapter's `type_cast` override applies.
@@ -236,19 +243,6 @@ export class DatabaseStatementsBase {
 // --- Query conversion ---
 
 /**
- * Ruby `AbstractAdapter#collector` (abstract_adapter.rb:1176-1188), reached
- * through the host so a bare visitor stand-in — a host that is not an adapter
- * and carries no `collector` — still compiles through the prepared-statement
- * `Composite`.
- */
-function collectorFor(host: unknown): Collectors.Composite {
-  const collector = (host as { collector?(): unknown } | undefined)?.collector?.();
-  return collector instanceof Collectors.Composite
-    ? collector
-    : new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-}
-
-/**
  * Compile an Arel node to a SQL string with its bind values inlined via the
  * connection's own `quote`. Mirrors Rails' `to_sql` under
  * `unprepared_statement`, which compiles through a `SubstituteBinds` collector
@@ -360,7 +354,7 @@ export function toSqlAndBinds(
         const [inlinedSql, inlinedRetryable] = compileInlined(visitor, node, this);
         return [inlinedSql, [], preparable, inlinedRetryable];
       }
-      const collector = collectorFor(this);
+      const collector = (this as DatabaseStatementsHost).collector!() as Collectors.Composite;
       collector.retryable = true;
       collector.preparable = true;
       const [sql, extractedBinds] = visitor.compile(node, collector) as [string, unknown[]];
@@ -424,7 +418,10 @@ export function cacheableQuery(
 
   // Prepared path: compile with bind extraction, return Query + raw binds
   if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
-    const [sql, binds] = visitor.compile(node, collectorFor(host)) as [string, unknown[]];
+    const [sql, binds] = visitor.compile(node, host.collector!() as Collectors.Composite) as [
+      string,
+      unknown[],
+    ];
     return [klass.query(sql), binds];
   }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -8,7 +8,7 @@
  * Mirrors: ActiveRecord::Calculations
  */
 
-import { Nodes, Table, SelectManager } from "@blazetrails/arel";
+import { Collectors, Nodes, Table, SelectManager } from "@blazetrails/arel";
 import { ArgumentError, BigIntegerType } from "@blazetrails/activemodel";
 import { any, isPresent, many, tryCall } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
@@ -83,7 +83,7 @@ interface AliasingConnection {
 
 interface CalculationConnection {
   adapterName: AdapterName;
-  visitor?: { compile(node: any): string; compileWithBinds?(node: any): [string, unknown[]] };
+  visitor?: { compile(node: any, collector?: any): any };
   toSql(arel: unknown): string;
   quote(value: unknown): string;
   quoteTableName(name: string): string;
@@ -312,7 +312,7 @@ function typeCastCalcBind(b: unknown): unknown {
 
 function compileManagerWithBinds(rel: CalculationRelation, manager: any): [string, unknown[]] {
   const conn = rel._conn() as {
-    visitor?: { compileWithBinds?(ast: unknown): [string, unknown[], boolean, boolean] };
+    visitor?: { compile(ast: unknown, collector: unknown): [string, unknown[]] };
     toSql(m: unknown): string;
     preparedStatements?: boolean;
     bindParamsLength?(): number;
@@ -322,8 +322,9 @@ function compileManagerWithBinds(rel: CalculationRelation, manager: any): [strin
   // the collector is a `SubstituteBinds`, so every value inlines and no binds
   // are sent — not just the over-limit case below.
   if (conn.preparedStatements === false) return [conn.toSql(manager), []];
-  if (visitor?.compileWithBinds) {
-    const [sql, rawBinds] = visitor.compileWithBinds(manager.ast);
+  if (visitor?.compile) {
+    const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+    const [sql, rawBinds] = visitor.compile(manager.ast, collector);
     const binds = rawBinds.map(typeCastCalcBind);
     // Mirrors Rails to_sql_and_binds (database_statements.rb:36-38): when the
     // bind count exceeds the adapter's parameter cap, fall back to an inlined

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -124,7 +124,7 @@ describe("Relation#where — composite-key form", () => {
   it("composite predicate values flow through QueryAttribute (bind params, not inlined Casted)", () => {
     // Regression: an earlier draft used `attribute.eq(rawValue)`,
     // which wraps as Arel::Nodes::Casted and inlines values into SQL.
-    // That breaks compileWithBinds / prepared-statement caching.
+    // That breaks bind extraction / prepared-statement caching.
     // Switching to buildBindAttribute makes each value a
     // QueryAttribute → BindParam at SQL emission. Inspect the node
     // tree: the AND's right-hand sides should be QueryAttribute

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
-import { Table, Visitors, Nodes } from "@blazetrails/arel";
+import { Table, Visitors, Nodes, Collectors } from "@blazetrails/arel";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { WhereClause } from "./where-clause.js";
 import { Substitute } from "../statement-cache.js";
@@ -13,6 +13,11 @@ import { Reply } from "../test-helpers/models/reply.js";
 import { Author } from "../test-helpers/models/author.js";
 import { quoteTableName, escapeRegExp } from "../support/quote-regex.js";
 import { ValueType } from "@blazetrails/activemodel";
+
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
 
 // Same shape as Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50) — a map
 // converting any attribute name to a caster — because `Table#type_for_attribute`
@@ -199,7 +204,7 @@ describe("PredicateBuilderTest", () => {
     it("builds BETWEEN for ranges", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ age: new Range(18, 65) });
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect(sql).toMatch(/BETWEEN \? AND \?/);
       expect(binds.map((b) => (b as { value: unknown }).value)).toEqual([18, 65]);
     });
@@ -212,7 +217,7 @@ describe("PredicateBuilderTest", () => {
     it("does not dereference a plain object literal to its id", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), { id: 5 });
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect(sql).toContain('"posts"."title" = ?');
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
     });
@@ -220,7 +225,7 @@ describe("PredicateBuilderTest", () => {
     it("does not dereference a plain object literal inside an array", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), [{ id: 5 }]);
-      const [, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
     });
 
@@ -241,7 +246,7 @@ describe("PredicateBuilderTest", () => {
     it("handles exclusive ranges", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ age: new Range(18, 65, true) });
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect(sql).toMatch(/>= \?/);
       expect(sql).toMatch(/< \?/);
       expect(binds.map((b) => (b as { value: unknown }).value)).toEqual([18, 65]);
@@ -265,7 +270,7 @@ describe("PredicateBuilderTest", () => {
       const feTable = new Table("posts", { typeCaster: { typeForAttribute: () => forceEqType } });
       const builder = new PredicateBuilder(new TableMetadata(null, feTable));
       const node = builder.build(feTable.get("tags"), [1, 2]);
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect(sql).toContain('"posts"."tags" = ?');
       expect(sql).not.toMatch(/IN \(/);
       expect(binds).toHaveLength(1);
@@ -304,7 +309,7 @@ describe("PredicateBuilderTest", () => {
       // `NOT (age >= 18 AND age < 65)` (And has no invert override).
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = buildInverted(builder, { age: new Range(18, 65, true) });
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
       expect(sql).toMatch(/^NOT \(/);
       expect(sql).toMatch(/>= \?/);
       expect(sql).toMatch(/< \?/);
@@ -349,7 +354,7 @@ describe("PredicateBuilderTest", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), "alice");
       const visitor = new Visitors.ToSql(testConnection);
-      const [sql, binds] = visitor.compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(visitor, node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
     });
@@ -359,7 +364,7 @@ describe("PredicateBuilderTest", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), new Substitute());
       const visitor = new Visitors.ToSql(testConnection);
-      const [sql, binds] = visitor.compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(visitor, node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
       expect((binds[0] as any).valueBeforeTypeCast).toBeInstanceOf(Substitute);
@@ -373,7 +378,7 @@ describe("PredicateBuilderTest", () => {
       // The value is wrapped in a BindParam, so raw Arel compile emits `?`
       // (mirrors Rails); the value is carried as a bind, not inlined.
       expect(visitor.compile(node)).toBe('"users"."name" = ?');
-      const [, binds] = visitor.compileWithBinds(node);
+      const [, binds] = compileWithBinds(visitor, node);
       expect(binds).toHaveLength(1);
     });
   });

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -16,7 +16,7 @@ import { ValueType } from "@blazetrails/activemodel";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 // Same shape as Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50) — a map

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -19,7 +19,7 @@ import { TableMetadata } from "../table-metadata.js";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 // trails-specific regression guard (no Rails counterpart): Base.predicateBuilder

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { IntegerType } from "@blazetrails/activemodel";
-import { Nodes, Table, Visitors } from "@blazetrails/arel";
+import { Nodes, Table, Visitors, Collectors } from "@blazetrails/arel";
 import { fixtures } from "../test-fixtures.js";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -16,6 +16,11 @@ import type { Base } from "../index.js";
 import { escapeRegExp, quoteTableName, quoteColumnName } from "../support/quote-regex.js";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { TableMetadata } from "../table-metadata.js";
+
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
 
 // trails-specific regression guard (no Rails counterpart): Base.predicateBuilder
 // is now TableMetadata-backed, and that metadata is bound to the class. The memo
@@ -56,7 +61,8 @@ describe("PredicateBuilder positive-equality bind typing", () => {
   });
 
   it("leaves an in-range joined equality as a bound predicate", () => {
-    const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
+    const [sql, binds] = compileWithBinds(
+      new Visitors.ToSql(testConnection),
       buildJoinedEquality(7n),
     );
     expect(sql).not.toContain("1=0");

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -209,7 +209,7 @@ export class StatementCache {
       unknown[],
     ];
 
-    // The prepared path (compileWithBinds) already unwraps each collected
+    // The prepared path (the Composite collector) already unwraps each collected
     // BindParam to its `.value`; the unprepared PartialQueryCollector path
     // hands back the raw BindParam nodes. Normalize here so BindMap sees the
     // bound attributes/Substitutes directly — otherwise a concrete bind (e.g.

--- a/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
+++ b/packages/activerecord/src/unprepared-statements-inline-binds.trails.test.ts
@@ -6,7 +6,7 @@
  * inlines during traversal and `binds` comes back empty.
  *
  * Rails cannot regress this — the collector choice *is* the branch. trails
- * compiles through `compileWithBinds` on every path, so the flag has to be
+ * compiles through a `Composite` collector on every path, so the flag has to be
  * consulted explicitly at each compile site; this pins that it is.
  */
 import { describe, it, expect } from "vitest";

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { TimeZone, AmbiguousTime, PeriodNotFound } from "./values/time-zone.js";
+import { ArgumentError } from "./hash-utils.js";
 
 describe("TimeZoneTest", () => {
   it("clear resets the memos", () => {
@@ -165,5 +166,18 @@ describe("TimeZoneLocalPeriodsTest", () => {
     expect(zone().localToUtc(new Date(Date.UTC(2006, 9, 29, 1, 30)))).toEqual(
       new Date(Date.UTC(2006, 9, 29, 5, 30)),
     );
+  });
+
+  it("iso8601 and rfc3339 keep sub-millisecond digits", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    expect(eastern.iso8601("1999-12-31T19:00:00.123456789").nsec).toBe(123456789);
+    expect(eastern.rfc3339("1999-12-31T19:00:00.123456789-05:00").nsec).toBe(123456789);
+  });
+
+  it("iso8601 and rfc3339 raise ArgumentError on an invalid date", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    expect(() => eastern.iso8601(null)).toThrow(ArgumentError);
+    expect(() => eastern.iso8601("foobar")).toThrow(ArgumentError);
+    expect(() => eastern.rfc3339("1999-12-31")).toThrow(ArgumentError);
   });
 });

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -742,6 +742,40 @@ export class Timezone {
   }
 }
 
+/**
+ * Ruby `Time.new`'s fractional-seconds argument (`parts.fetch(:sec, 0) +
+ * parts.fetch(:sec_fraction, 0)`), which Temporal cannot take as a Rational —
+ * it wants the sub-second remainder split across its millisecond / microsecond
+ * / nanosecond components.
+ *
+ * @noRailsEquivalent Ruby's Time carries a Rational sub-second seat; Temporal
+ * carries three integer components. This is the conversion between them.
+ */
+function secFractionToNanosecond(secFraction: DateParts["secFraction"]): number {
+  if (secFraction == null) return 0;
+  return secFraction instanceof Rational
+    ? secFraction.mul(1_000_000_000).toI()
+    : Math.trunc(Number(secFraction) * 1_000_000_000);
+}
+
+/**
+ * Ruby `Time#utc` on a Time built with an explicit `offset` — the instant that
+ * local wall clock names at that offset.
+ *
+ * @noRailsEquivalent Ruby's Time holds its own UTC offset; a
+ * `Temporal.PlainDateTime` does not, so the offset has to be applied here.
+ */
+function utcInstantOf(
+  time: Temporal.PlainDateTime,
+  offset: NonNullable<DateParts["offset"]>,
+): Temporal.Instant {
+  const seconds = offset instanceof Rational ? offset.toF() : Number(offset);
+  return time
+    .toZonedDateTime("UTC")
+    .toInstant()
+    .subtract({ nanoseconds: Math.round(seconds * 1e9) });
+}
+
 export class TimeZone {
   readonly name: string;
   readonly tzinfo: Timezone;
@@ -1068,53 +1102,104 @@ export class TimeZone {
   }
 
   /**
-   * Parse an ISO 8601 string in this timezone.
+   * Mirrors: TimeZone#iso8601 (time_zone.rb:396-433). Ruby's `parts.fetch(:k)`
+   * with no default raises `KeyError`, which the method's own
+   * `rescue Date::Error, KeyError` turns into this `ArgumentError`, so each
+   * missing key is spelled as that raise directly. The `Time.new(...)` build
+   * and the `parts[:offset]` UTC-vs-local wrap at the tail are exactly what
+   * `parts_to_time` (time_zone.rb:585-608) already does, with the same
+   * `fetch` defaults for `:hour`, `:min`, `:sec`, `:sec_fraction` and
+   * `:offset`, so the assembled parts return through it.
    */
   iso8601(str: string | null | undefined): TimeWithZone {
-    if (str == null || str.trim() === "") {
-      throw new Error("invalid date");
-    }
-    const trimmed = str.trim();
+    // Historically `Date._iso8601(nil)` returns `{}`, but in the `date` gem
+    // versions `3.2.1`, `3.1.2`, `3.0.2`, and `2.0.1`, `Date._iso8601(nil)`
+    // raises `TypeError` https://github.com/ruby/date/issues/39
+    // Future `date` releases are expected to revert back to the original behavior.
+    if (str == null) throw new ArgumentError("invalid date");
 
-    // Ordinal date: YYDDD (2-digit year + 3-digit day-of-year)
-    const ordinalMatch = /^(\d{2})(\d{3})$/.exec(trimmed);
-    if (ordinalMatch) {
-      const year = 2000 + parseInt(ordinalMatch[1], 10);
-      const dayOfYear = parseInt(ordinalMatch[2], 10);
-      if (dayOfYear < 1 || dayOfYear > 366) {
-        throw new Error("invalid date");
+    const parts = RubyDate._iso8601(str);
+
+    if (parts.year == null) throw new ArgumentError("invalid date");
+    const year = Number(parts.year);
+
+    let mon: number;
+    let mday: number;
+    if (parts.yday != null) {
+      let ordinalDate: Temporal.PlainDate;
+      try {
+        ordinalDate = RubyDate.ordinal(year, parts.yday);
+      } catch (error) {
+        if (error instanceof RubyDate.Error) throw new ArgumentError("invalid date");
+        throw error;
       }
-      const jan1 = new Date(Date.UTC(year, 0, 1));
-      const target = new Date(jan1.getTime() + (dayOfYear - 1) * 86400000);
-      if (target.getUTCFullYear() !== year) {
-        throw new Error("invalid date");
-      }
-      return this.local(target.getUTCFullYear(), target.getUTCMonth() + 1, target.getUTCDate());
+      mon = ordinalDate.month;
+      mday = ordinalDate.day;
+    } else {
+      if (parts.mon == null || parts.mday == null) throw new ArgumentError("invalid date");
+      mon = parts.mon;
+      mday = parts.mday;
     }
 
-    if (
-      !/^\d{4}-?\d{2}-?\d{2}(T\d{2}:?\d{2}(:?\d{2}([.]\d+)?)?)?([Zz]|[+-]\d{2}:?\d{2})?$/.test(
-        trimmed,
-      )
-    ) {
-      throw new Error("invalid date");
+    // `Time.new(year, month, day, parts.fetch(:hour, 0), parts.fetch(:min, 0),
+    // parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0), parts.fetch(:offset, 0))`
+    // — Temporal takes the sub-second remainder as separate components, which is
+    // how `sec_fraction` keeps its nanosecond resolution here.
+    const nanosecond = secFractionToNanosecond(parts.secFraction);
+    let time: Temporal.PlainDateTime;
+    try {
+      time = Temporal.PlainDateTime.from({
+        year,
+        month: mon,
+        day: mday,
+        hour: parts.hour ?? 0,
+        minute: parts.min ?? 0,
+        second: parts.sec ?? 0,
+        millisecond: Math.trunc(nanosecond / 1_000_000),
+        microsecond: Math.trunc(nanosecond / 1000) % 1000,
+        nanosecond: nanosecond % 1000,
+      });
+    } catch {
+      throw new ArgumentError("argument out of range");
     }
-    return this.parse(trimmed)!;
+
+    if (parts.offset != null) {
+      return new TimeWithZone(utcInstantOf(time, parts.offset), this);
+    }
+    return new TimeWithZone(null, this, time);
   }
 
   /**
-   * Parse an RFC 3339 string in this timezone.
+   * Mirrors: TimeZone#rfc3339 (time_zone.rb:469-484). RFC 3339's zone group is
+   * mandatory, so `Date._rfc3339` either fills every component this reads or
+   * answers an empty hash — which is why Rails' non-defaulting `fetch`es carry
+   * no rescue here, and why the `parts[:offset]` arm of `parts_to_time` is
+   * always the UTC one.
    */
   rfc3339(str: string): TimeWithZone {
-    const trimmed = str?.trim() ?? "";
-    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([.]\d+)?(Z|[+-]\d{2}:\d{2})$/.test(trimmed)) {
-      throw new Error("invalid date");
+    const parts = RubyDate._rfc3339(str);
+
+    if (Object.keys(parts).length === 0) throw new ArgumentError("invalid date");
+
+    const nanosecond = secFractionToNanosecond(parts.secFraction);
+    let time: Temporal.PlainDateTime;
+    try {
+      time = Temporal.PlainDateTime.from({
+        year: Number(parts.year),
+        month: parts.mon!,
+        day: parts.mday!,
+        hour: parts.hour!,
+        minute: parts.min!,
+        second: parts.sec!,
+        millisecond: Math.trunc(nanosecond / 1_000_000),
+        microsecond: Math.trunc(nanosecond / 1000) % 1000,
+        nanosecond: nanosecond % 1000,
+      });
+    } catch {
+      throw new ArgumentError("argument out of range");
     }
-    const date = new Date(trimmed);
-    if (isNaN(date.getTime())) {
-      throw new Error("invalid date");
-    }
-    return new TimeWithZone(instantFrom(date), this);
+
+    return new TimeWithZone(utcInstantOf(time, parts.offset ?? 0), this);
   }
 
   /**
@@ -1292,13 +1377,7 @@ export class TimeZone {
       );
     }
 
-    const secFraction = parts.secFraction;
-    const nanosecond =
-      secFraction == null
-        ? 0
-        : secFraction instanceof Rational
-          ? secFraction.mul(1_000_000_000).toI()
-          : Math.trunc(Number(secFraction) * 1_000_000_000);
+    const nanosecond = secFractionToNanosecond(parts.secFraction);
     let time: Temporal.PlainDateTime;
     try {
       time = Temporal.PlainDateTime.from({
@@ -1317,14 +1396,7 @@ export class TimeZone {
     }
 
     if (parts.offset != null) {
-      const offset = parts.offset instanceof Rational ? parts.offset.toF() : Number(parts.offset);
-      return new TimeWithZone(
-        time
-          .toZonedDateTime("UTC")
-          .toInstant()
-          .subtract({ nanoseconds: Math.round(offset * 1e9) }),
-        this,
-      );
+      return new TimeWithZone(utcInstantOf(time, parts.offset), this);
     }
     return new TimeWithZone(null, this, time);
   }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1102,20 +1102,17 @@ export class TimeZone {
   }
 
   /**
-   * Mirrors: TimeZone#iso8601 (time_zone.rb:396-433). Ruby's `parts.fetch(:k)`
-   * with no default raises `KeyError`, which the method's own
-   * `rescue Date::Error, KeyError` turns into this `ArgumentError`, so each
-   * missing key is spelled as that raise directly. The `Time.new(...)` build
-   * and the `parts[:offset]` UTC-vs-local wrap at the tail are exactly what
-   * `parts_to_time` (time_zone.rb:585-608) already does, with the same
-   * `fetch` defaults for `:hour`, `:min`, `:sec`, `:sec_fraction` and
-   * `:offset`, so the assembled parts return through it.
+   * Mirrors: TimeZone#iso8601 (time_zone.rb:396-433).
+   *
+   * The `str.nil?` guard is Rails' own workaround for the `date` gem versions
+   * where `Date._iso8601(nil)` raises `TypeError` rather than answering `{}`
+   * (https://github.com/ruby/date/issues/39). Ruby's `parts.fetch(:k)` with no
+   * default raises `KeyError`, which this method's `rescue Date::Error,
+   * KeyError` turns into `ArgumentError, "invalid date"` — so each missing key
+   * is spelled as that raise directly. `Time.new`'s seventh argument takes the
+   * fractional seconds Temporal wants split across its sub-second components.
    */
   iso8601(str: string | null | undefined): TimeWithZone {
-    // Historically `Date._iso8601(nil)` returns `{}`, but in the `date` gem
-    // versions `3.2.1`, `3.1.2`, `3.0.2`, and `2.0.1`, `Date._iso8601(nil)`
-    // raises `TypeError` https://github.com/ruby/date/issues/39
-    // Future `date` releases are expected to revert back to the original behavior.
     if (str == null) throw new ArgumentError("invalid date");
 
     const parts = RubyDate._iso8601(str);
@@ -1141,10 +1138,6 @@ export class TimeZone {
       mday = parts.mday;
     }
 
-    // `Time.new(year, month, day, parts.fetch(:hour, 0), parts.fetch(:min, 0),
-    // parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0), parts.fetch(:offset, 0))`
-    // — Temporal takes the sub-second remainder as separate components, which is
-    // how `sec_fraction` keeps its nanosecond resolution here.
     const nanosecond = secFractionToNanosecond(parts.secFraction);
     let time: Temporal.PlainDateTime;
     try {
@@ -1173,8 +1166,7 @@ export class TimeZone {
    * Mirrors: TimeZone#rfc3339 (time_zone.rb:469-484). RFC 3339's zone group is
    * mandatory, so `Date._rfc3339` either fills every component this reads or
    * answers an empty hash — which is why Rails' non-defaulting `fetch`es carry
-   * no rescue here, and why the `parts[:offset]` arm of `parts_to_time` is
-   * always the UTC one.
+   * no rescue here, and why this always takes the `time.utc` arm.
    */
   rfc3339(str: string): TimeWithZone {
     const parts = RubyDate._rfc3339(str);

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1191,7 +1191,7 @@ export class TimeZone {
       throw new ArgumentError("argument out of range");
     }
 
-    return new TimeWithZone(utcInstantOf(time, parts.offset ?? 0), this);
+    return new TimeWithZone(utcInstantOf(time, parts.offset!), this);
   }
 
   /**

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "./test-helpers/connection.js";
-import { Table, Nodes, Visitors } from "./index.js";
+import { Table, Nodes, Visitors, Collectors } from "./index.js";
 
 const users = new Table("users");
 const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
@@ -96,7 +96,7 @@ describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
   // collector.retryable to false.
 
   const collectorIsRetryableAfter = (n: Nodes.Node): boolean =>
-    new Visitors.ToSql(testConnection).compileWithCollector(n).retryable;
+    new Visitors.ToSql(testConnection).accept(n, new Collectors.SQLString()).retryable;
 
   it("Attribute#as keeps the collector retryable", () => {
     expect(collectorIsRetryableAfter(users.attr("id").as("aliased"))).toBe(true);

--- a/packages/arel/src/collectors/substitute-binds.ts
+++ b/packages/arel/src/collectors/substitute-binds.ts
@@ -1,5 +1,3 @@
-import { BindParam } from "../nodes/bind-param.js";
-
 export class SubstituteBinds {
   private quoter: { quote(value: unknown): string };
   private delegate: { append(str: string): unknown; value: string };
@@ -15,11 +13,6 @@ export class SubstituteBinds {
   }
 
   addBind(bind: unknown): this {
-    // A raw Arel BindParam carries its bound value on `.value` (the visitor
-    // pushes the node itself so the Bind collector can render `?` while
-    // `compileWithBinds` unwraps it). When inlining, unwrap to the value so it
-    // can be quoted directly — matching Rails' `add_bind(o.value)`.
-    while (bind instanceof BindParam) bind = bind.value;
     if (bind != null && typeof bind === "object" && "valueForDatabase" in bind) {
       // `valueForDatabase` is a method on a raw Arel attribute but a getter on
       // ActiveModel::Attribute (`get valueForDatabase()`); read the property and

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * Represents a bind parameter placeholder in a prepared statement.
@@ -10,7 +10,7 @@ import { Node, NodeVisitor } from "./node.js";
  * `collector.add_bind(o.value, &bind_block)` where `BIND_BLOCK = proc { "?" }`.
  * So `new BindParam(1).toSql()`, `new BindParam(null).toSql()`, and the
  * valueless `new BindParam().toSql()` are all `"?"`. The value is recorded
- * separately, not inlined; `ToSql#compileWithBinds` returns the SQL with `?`
+ * separately, not inlined; `ToSql#compile` through a `Composite` returns the SQL with `?`
  * markers alongside the extracted bind values. (Casted/Quoted literals do
  * inline via `quote` — only BindParam/Attribute collect a placeholder.)
  */
@@ -61,9 +61,5 @@ export class BindParam extends Node {
   isUnboundable(): 1 | -1 | false {
     const v = this.value as { isUnboundable?: () => 1 | -1 | false } | null | undefined;
     return typeof v?.isUnboundable === "function" ? v.isUnboundable() : false;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/bound-sql-literal.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { BindError } from "../errors.js";
 import { Fragments } from "./fragments.js";
@@ -69,9 +69,5 @@ export class BoundSqlLiteral extends NodeExpression {
       throw new TypeError("Expected Arel node");
     }
     return new Fragments([this, other]);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -7,7 +7,7 @@ import { SelectManager } from "../select-manager.js";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 describe("Arel::Nodes::Quoted", () => {

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "../test-helpers/connection.js";
-import { Table, Nodes, Visitors } from "../index.js";
+import { Table, Nodes, Visitors, Collectors } from "../index.js";
 import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 import { SelectManager } from "../select-manager.js";
+
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
 
 describe("Arel::Nodes::Quoted", () => {
   it("is a Unary subclass (value stored in expr slot)", () => {
@@ -55,7 +60,7 @@ describe("Arel::Nodes.build_quoted", () => {
 
     // compileWithBinds should collect it (not inline it) — matches Rails'
     // visit_ActiveModel_Attribute routing through add_bind.
-    const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+    const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
     expect(sql).toBe("?");
     expect(binds).toEqual([amAttr]);
   });
@@ -137,7 +142,8 @@ describe("Arel::Nodes::Casted#nil?", () => {
     expect(new Nodes.Casted(undefined, attr).isNil()).toBe(true);
     expect(new Nodes.Quoted(undefined).isNil()).toBe(true);
 
-    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(
+    const [sql] = compileWithBinds(
+      new Visitors.ToSql(testConnection),
       users.get("id").eq(undefined),
     );
     expect(sql).toBe('"users"."id" IS NULL');
@@ -147,7 +153,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
   // identically to Casted's, so an undefined-valued Quoted spells IS NULL too.
   it("renders IS NULL for a Quoted(undefined) right-hand side", () => {
     const eq = new Nodes.Equality(users.get("id"), new Nodes.Quoted(undefined));
-    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(eq);
+    const [sql] = compileWithBinds(new Visitors.ToSql(testConnection), eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 
@@ -170,7 +176,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
     const eq = attr.eq(null);
     expect(eq.right).toBeInstanceOf(Nodes.Casted);
     expect((eq.right as Nodes.Casted).attribute).toBe(attr);
-    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(eq);
+    const [sql] = compileWithBinds(new Visitors.ToSql(testConnection), eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 });

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression, registerBuildQuoted } from "./node-expression.js";
 import { Unary } from "./unary.js";
 import type { Attribute } from "../attributes/attribute.js";
@@ -85,10 +85,6 @@ export class Casted extends NodeExpression {
     }
     return this.value;
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
 }
 
 /**
@@ -136,9 +132,5 @@ export class Quoted extends Unary {
 
   get value(): unknown {
     return this.expr;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/comment.ts
+++ b/packages/arel/src/nodes/comment.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * SQL comment: appended as `/* ... *\/` to a query.
@@ -11,9 +11,5 @@ export class Comment extends Node {
   constructor(values: string[]) {
     super();
     this.values = values;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Table } from "../table.js";
@@ -34,9 +34,5 @@ export class Cte extends Binary {
     // (visit_Arel_Table visits a Node name). `Table` types `name` as `string`;
     // a smuggled `SqlLiteral` is cast, matching visit_Arel_Table's convention.
     return new Table(this.name as unknown as string);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * DeleteStatement — DELETE FROM ... WHERE ...
@@ -25,10 +25,6 @@ export class DeleteStatement extends Node {
     this.limit = null;
     this.offset = null;
     this.key = null;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 
   clone(): DeleteStatement {

--- a/packages/arel/src/nodes/false.ts
+++ b/packages/arel/src/nodes/false.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
-export class False extends NodeExpression {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class False extends NodeExpression {}

--- a/packages/arel/src/nodes/full-outer-join.ts
+++ b/packages/arel/src/nodes/full-outer-join.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { Join } from "./binary.js";
 
-export class FullOuterJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class FullOuterJoin extends Join {}

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
 
@@ -28,10 +28,6 @@ export class Function extends NodeExpression {
   as(aliasName: string): this {
     this.alias = aliasName;
     return this;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 
@@ -101,9 +101,5 @@ export class HomogeneousIn extends Node {
   // / parity:api privates coverage.
   protected ivars(): [Node, unknown[], HomogeneousIn["type"]] {
     return [this.attribute, this.values, this.type];
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/inner-join.ts
+++ b/packages/arel/src/nodes/inner-join.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { Join } from "./binary.js";
 
-export class InnerJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class InnerJoin extends Join {}

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * InsertStatement — INSERT INTO ... VALUES ...
@@ -24,10 +24,6 @@ export class InsertStatement extends Node {
     this.columns = [];
     this.values = null;
     this.select = null;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 
   clone(): InsertStatement {

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "../test-helpers/connection.js";
-import { Table, Nodes } from "../index.js";
+import { Table, Nodes, Visitors, Collectors } from "../index.js";
+
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
 
 describe("MatchesTest", () => {
   const users = new Table("users");
@@ -29,7 +34,7 @@ describe("MatchesTest", () => {
       const { Visitors } = await import("../index.js");
       const node = users.get("name").matches("x%", "!");
       const visitor = new Visitors.ToSql(testConnection);
-      const [sql] = visitor.compileWithBinds(node);
+      const [sql] = compileWithBinds(visitor, node);
       expect(sql).toContain("ESCAPE '!'");
       expect(sql).not.toContain("ESCAPE ?");
     });

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -4,7 +4,7 @@ import { Table, Nodes, Visitors, Collectors } from "../index.js";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 describe("MatchesTest", () => {

--- a/packages/arel/src/nodes/nary.ts
+++ b/packages/arel/src/nodes/nary.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
 export class Nary extends NodeExpression {
@@ -27,9 +27,5 @@ export class Nary extends NodeExpression {
       }
       return false;
     });
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -74,10 +74,6 @@ export abstract class Node {
     return false;
   }
 
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-
   /**
    * Ruby-ish equality helper.
    *

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -23,8 +23,6 @@ export const _engine: { current: ArelEngine | null } = { current: null };
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export abstract class Node {
-  abstract accept<T>(visitor: NodeVisitor<T>): T;
-
   not(): Node {
     assertRegistered("Not");
     return new _registry.Not!(this);
@@ -74,6 +72,10 @@ export abstract class Node {
 
   isEquality(): boolean {
     return false;
+  }
+
+  accept<T>(visitor: NodeVisitor<T>): T {
+    return visitor.visit(this);
   }
 
   /**

--- a/packages/arel/src/nodes/outer-join.ts
+++ b/packages/arel/src/nodes/outer-join.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { Join } from "./binary.js";
 
-export class OuterJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class OuterJoin extends Join {}

--- a/packages/arel/src/nodes/regexp.ts
+++ b/packages/arel/src/nodes/regexp.ts
@@ -1,5 +1,4 @@
 import { Binary, NodeOrValue } from "./binary.js";
-import { NodeVisitor } from "./node.js";
 
 /**
  * Represents a regex match: left ~ right.
@@ -11,10 +10,6 @@ export class Regexp extends Binary {
   constructor(left: NodeOrValue, right: NodeOrValue, caseSensitive = true) {
     super(left, right);
     this.caseSensitive = caseSensitive;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 
@@ -28,9 +23,5 @@ export class NotRegexp extends Binary {
   constructor(left: NodeOrValue, right: NodeOrValue, caseSensitive = true) {
     super(left, right);
     this.caseSensitive = caseSensitive;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/right-outer-join.ts
+++ b/packages/arel/src/nodes/right-outer-join.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { Join } from "./binary.js";
 
-export class RightOuterJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class RightOuterJoin extends Join {}

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { JoinSource } from "./join-source.js";
 import type { OptimizerHints } from "./unary.js";
 
@@ -64,9 +64,5 @@ export class SelectCore extends Node {
     c.optimizerHints = this.optimizerHints;
     c.comment = this.comment;
     return c;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/string-join.ts
+++ b/packages/arel/src/nodes/string-join.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { Join } from "./binary.js";
 
-export class StringJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class StringJoin extends Join {}

--- a/packages/arel/src/nodes/terminal.ts
+++ b/packages/arel/src/nodes/terminal.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
-export class Distinct extends NodeExpression {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class Distinct extends NodeExpression {}

--- a/packages/arel/src/nodes/true.ts
+++ b/packages/arel/src/nodes/true.ts
@@ -1,8 +1,3 @@
-import { NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
-export class True extends NodeExpression {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class True extends NodeExpression {}

--- a/packages/arel/src/nodes/update-statement.ts
+++ b/packages/arel/src/nodes/update-statement.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * UpdateStatement — UPDATE ... SET ... WHERE ...
@@ -27,10 +27,6 @@ export class UpdateStatement extends Node {
     this.limit = null;
     this.offset = null;
     this.key = null;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 
   clone(): UpdateStatement {

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -5,7 +5,7 @@ import { Temporal } from "@blazetrails/date";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 describe("PostgresTest", () => {

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { testConnection, postgresqlTestConnection } from "../test-helpers/connection.js";
-import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
+import { Table, star, SelectManager, Nodes, Visitors, Collectors } from "../index.js";
 import { Temporal } from "@blazetrails/date";
+
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
 
 describe("PostgresTest", () => {
   const users = new Table("users");
@@ -135,7 +140,7 @@ describe("PostgresTest", () => {
       const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
       const a = users.get("id").eq(new Nodes.BindParam(42));
       const b = users.get("name").eq(new Nodes.BindParam("alice"));
-      const [sql, binds] = visitor.compileWithBinds(new Nodes.And([a, b]));
+      const [sql, binds] = compileWithBinds(visitor, new Nodes.And([a, b]));
       expect(sql).toContain("$1");
       expect(sql).toContain("$2");
       expect(sql).not.toContain("42");
@@ -147,7 +152,7 @@ describe("PostgresTest", () => {
       const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
       const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
       const node = users.get("created_at").eq(new Nodes.Quoted(d));
-      const [sql, binds] = visitor.compileWithBinds(node);
+      const [sql, binds] = compileWithBinds(visitor, node);
       // Quoted(Date) inlines as a literal — only BindParam/ActiveModel::Attribute produce $N.
       expect(sql).toContain("2020-01-02");
       expect(sql).not.toContain("$1");

--- a/packages/arel/src/visitors/substitute-bound-values.ts
+++ b/packages/arel/src/visitors/substitute-bound-values.ts
@@ -2,7 +2,7 @@
  * Replace each `?` / `$N` placeholder in a compiled SQL string with the text
  * returned by `render(placeholder, index)`, where `index` is the placeholder's
  * left-to-right ordinal (matching the bind array order produced by
- * `ToSql#compileWithBinds`).
+ * `ToSql#compile` through a `Composite` collector).
  *
  * This is the post-traversal bind-inlining step shared by `ToSql#compile` and
  * ActiveRecord's human-readable `toSql` paths. Centralizing the placeholder

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -16,7 +16,7 @@ import { testConnection } from "../test-helpers/connection.js";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
   const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
-  return visitor.compile(node as never, collector);
+  return visitor.compile(node as never, collector) as [string, unknown[]];
 }
 
 describe("the to_sql visitor", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -14,6 +14,11 @@ import {
 import { Attribute as AMAttribute, ValueType, StringType } from "@blazetrails/activemodel";
 import { testConnection } from "../test-helpers/connection.js";
 
+function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
+  const collector = new Collectors.Composite(new Collectors.SQLString(), new Collectors.Bind());
+  return visitor.compile(node as never, collector);
+}
+
 describe("the to_sql visitor", () => {
   const users = new Table("users");
   const posts = new Table("posts");
@@ -70,7 +75,7 @@ describe("the to_sql visitor", () => {
     it("is not preparable when an array", () => {
       const node = users.get("id").notIn([1, 2, 3]);
       const collector = new Collectors.SQLString();
-      new Visitors.ToSql(testConnection).compileWithCollector(node, collector);
+      new Visitors.ToSql(testConnection).accept(node, collector);
       expect(collector.preparable).toBe(false);
     });
 
@@ -441,7 +446,7 @@ describe("the to_sql visitor", () => {
     it("is not preparable when an array", () => {
       const node = users.get("id").notIn([1, 2, 3]);
       const collector = new Collectors.SQLString();
-      new Visitors.ToSql(testConnection).compileWithCollector(node, collector);
+      new Visitors.ToSql(testConnection).accept(node, collector);
       expect(collector.preparable).toBe(false);
     });
   });
@@ -473,7 +478,7 @@ describe("the to_sql visitor", () => {
       });
       const node = new Nodes.HomogeneousIn([1, 2, 3], castedUsers.get("id"), "in");
       const collector = new Collectors.SQLString();
-      new Visitors.ToSql(testConnection).compileWithCollector(node, collector);
+      new Visitors.ToSql(testConnection).accept(node, collector);
       expect(collector.preparable).toBe(false);
     });
   });
@@ -924,37 +929,37 @@ describe("the to_sql visitor", () => {
 
   it("should mark collector as non-retryable if SQL literal is marked as retryable", () => {
     const lit = new Nodes.SqlLiteral("1", { retryable: true });
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(lit);
+    const collector = new Visitors.ToSql(testConnection).accept(lit, new Collectors.SQLString());
     expect(collector.retryable).toBe(true);
   });
 
   it("should mark collector as non-retryable if SQL literal is not retryable", () => {
     const lit = new Nodes.SqlLiteral("1");
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(lit);
+    const collector = new Visitors.ToSql(testConnection).accept(lit, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should mark collector as non-retryable when visiting SQL literal", () => {
     const lit = new Nodes.SqlLiteral("1");
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(lit);
+    const collector = new Visitors.ToSql(testConnection).accept(lit, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should mark collector as non-retryable when visiting bound SQL literal", () => {
     const lit = new Nodes.BoundSqlLiteral("id = ?", [1]);
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(lit);
+    const collector = new Visitors.ToSql(testConnection).accept(lit, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should mark collector as non-retryable when visiting delete statement node", () => {
     const stmt = new DeleteManager().from(users).ast;
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(stmt);
+    const collector = new Visitors.ToSql(testConnection).accept(stmt, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should mark collector as non-retryable when visiting insert statement node", () => {
     const stmt = new InsertManager(users).insert([[users.get("name"), "dean"]]).ast;
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(stmt);
+    const collector = new Visitors.ToSql(testConnection).accept(stmt, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
@@ -1011,19 +1016,19 @@ describe("the to_sql visitor", () => {
 
   it("should mark collector as non-retryable when visiting named function", () => {
     const fn = users.get("name").lower();
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(fn);
+    const collector = new Visitors.ToSql(testConnection).accept(fn, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should mark collector as non-retryable when visiting update statement node", () => {
     const stmt = new UpdateManager().table(users).set([[users.get("name"), "sam"]]).ast;
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(stmt);
+    const collector = new Visitors.ToSql(testConnection).accept(stmt, new Collectors.SQLString());
     expect(collector.retryable).toBe(false);
   });
 
   it("should not change retryable if SQL literal is marked as retryable", () => {
     const lit = new Nodes.SqlLiteral("1", { retryable: true });
-    const collector = new Visitors.ToSql(testConnection).compileWithCollector(lit);
+    const collector = new Visitors.ToSql(testConnection).accept(lit, new Collectors.SQLString());
     expect(collector.retryable).toBe(true);
   });
 
@@ -1079,7 +1084,7 @@ describe("the to_sql visitor", () => {
     it("is not preparable when an array", () => {
       const node = users.get("id").in([1, 2, 3]);
       const collector = new Collectors.SQLString();
-      new Visitors.ToSql(testConnection).compileWithCollector(node, collector);
+      new Visitors.ToSql(testConnection).accept(node, collector);
       expect(collector.preparable).toBe(false);
     });
 
@@ -1220,7 +1225,7 @@ describe("the to_sql visitor", () => {
     const users = new Table("users");
     const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
     const node = users.get("created_at").eq(new Nodes.Quoted(d));
-    const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
+    const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
     // Quoted(Date) inlines per Rails to_sql.rb — _extractBinds was removed by
     // collector threading; only BindParam/ActiveModel::Attribute go to addBind.
     expect(sql).toContain("2020-01-02");
@@ -1424,7 +1429,7 @@ describe("the to_sql visitor", () => {
     const v = new Visitors.ToSql(testConnection);
     const table = new Table("users");
     const mgr = table.project(star).where(table.get("id").eq(new Nodes.BindParam(42)));
-    const [sql, binds] = v.compileWithBinds(mgr.ast);
+    const [sql, binds] = compileWithBinds(v, mgr.ast);
     expect(sql).toContain("?");
     expect(sql).not.toContain("42");
     expect(binds).toEqual([42]);
@@ -1437,7 +1442,7 @@ describe("the to_sql visitor", () => {
       .project(star)
       .where(table.get("name").eq(new Nodes.BindParam("alice")))
       .where(table.get("age").gt(new Nodes.BindParam(21)));
-    const [sql, binds] = v.compileWithBinds(mgr.ast);
+    const [sql, binds] = compileWithBinds(v, mgr.ast);
     expect(sql).toContain("?");
     expect(sql).not.toContain("alice");
     expect(sql).not.toContain("21");
@@ -1447,12 +1452,12 @@ describe("the to_sql visitor", () => {
   it("compileWithBinds with undefined BindParam", () => {
     const v = new Visitors.ToSql(testConnection);
     const node = new Nodes.BindParam();
-    const [sql, binds] = v.compileWithBinds(node);
+    const [sql, binds] = compileWithBinds(v, node);
     expect(sql).toBe("?");
     expect(binds).toHaveLength(1);
   });
 
-  it("compileWithCollector accepts external collector", () => {
+  it("accept accepts external collector", () => {
     const v = new Visitors.ToSql(testConnection);
     const table = new Table("users");
     const mgr = table.project(star).where(table.get("name").eq("alice"));
@@ -1476,7 +1481,7 @@ describe("the to_sql visitor", () => {
       },
     };
 
-    v.compileWithCollector(mgr.ast, collector);
+    v.accept(mgr.ast, collector);
     // Casted values inline their quoted literal directly (mirrors Rails
     // visit_Arel_Nodes_Casted, to_sql.rb:87-88) — no addBind, no placeholder.
     expect(binds).toHaveLength(0);
@@ -1872,7 +1877,8 @@ describe("the to_sql visitor", () => {
       const v = new NumberedVisitor(testConnection);
       // Only BindParam routes through addBind (and therefore bindBlock); Casted
       // and Quoted values inline their quoted literal (Rails to_sql.rb:87-88).
-      const [sql] = v.compileWithBinds(
+      const [sql] = compileWithBinds(
+        v,
         tbl
           .where(tbl.get("id").eq(new Nodes.BindParam(1)))
           .where(tbl.get("name").eq(new Nodes.Casted("hi", tbl.get("name"))))
@@ -2108,7 +2114,7 @@ describe("the to_sql visitor", () => {
     it("Quoted Temporal.Instant binds through unified addBind path under extractBinds", () => {
       const visitor = new Visitors.ToSql(testConnection);
       const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
-      const [sql, binds] = visitor.compileWithBinds(new Nodes.Quoted(instant));
+      const [sql, binds] = compileWithBinds(visitor, new Nodes.Quoted(instant));
       expect(sql).toContain("2026-04-30");
       expect(sql).not.toContain("?");
       expect(binds).toHaveLength(0);
@@ -2120,7 +2126,8 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted string binds raw under extractBinds", () => {
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
+      const [sql, binds] = compileWithBinds(
+        new Visitors.ToSql(testConnection),
         new Nodes.Quoted("hi"),
       );
       expect(sql).toBe("'hi'");
@@ -2128,7 +2135,8 @@ describe("the to_sql visitor", () => {
     });
 
     it("Quoted number binds raw under extractBinds", () => {
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
+      const [sql, binds] = compileWithBinds(
+        new Visitors.ToSql(testConnection),
         new Nodes.Quoted(42),
       );
       expect(sql).toBe("42");
@@ -2137,7 +2145,8 @@ describe("the to_sql visitor", () => {
 
     it("Quoted toISOString-bearing object binds raw under extractBinds", () => {
       const value = Temporal.Instant.from("2026-04-30T00:00:00.000Z");
-      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
+      const [sql, binds] = compileWithBinds(
+        new Visitors.ToSql(testConnection),
         new Nodes.Quoted(value),
       );
       expect(sql).toBe("'2026-04-30 00:00:00'");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1,6 +1,5 @@
 import { Node } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
-import { Bind } from "../collectors/bind.js";
 import { Composite } from "../collectors/composite.js";
 import { SubstituteBinds } from "../collectors/substitute-binds.js";
 import * as Nodes from "../nodes/index.js";
@@ -146,14 +145,15 @@ export class ToSql extends Visitor {
   }
 
   compile(node: Node): string;
+  compile(node: Node | ReadonlyArray<Nodes.NodeOrValue>, collector: Composite): [string, unknown[]];
   compile(
     node: Node | ReadonlyArray<Nodes.NodeOrValue>,
     collector: SQLString | SubstituteBinds,
   ): string;
   compile(
     node: Node | ReadonlyArray<Nodes.NodeOrValue>,
-    collector?: SQLString | SubstituteBinds,
-  ): string {
+    collector?: SQLString | SubstituteBinds | Composite,
+  ): string | [string, unknown[]] {
     // Rails-faithful `compile(node, collector)`: drive the supplied collector
     // (so callers control its bind state) and return the rendered SQL. An array
     // node dispatches to `visit_Array` and renders as a comma-joined list — this
@@ -165,7 +165,7 @@ export class ToSql extends Visitor {
     // of this file does.
     if (collector !== undefined) {
       this.accept(node, collector as unknown as SQLString);
-      return collector.value;
+      return collector.value as string | [string, unknown[]];
     }
     // Mirrors Rails `compile` defaulting to a plain `SQLString` (to_sql.rb:17):
     // Casted/Quoted inline their quoted literal in the visitor, BindParam emits
@@ -1289,12 +1289,9 @@ export class ToSql extends Visitor {
     return collector;
   }
 
+  /** Mirrors Rails: `visit_Arel_Nodes_BindParam` (to_sql.rb:760-762). */
   protected visitArelNodesBindParam(o: Nodes.BindParam, collector: SQLString): SQLString {
-    // Push the node itself (not its value) so `compile` can render `?` while
-    // `compileWithBinds` unwraps to `o.value` for the bind array. Mirrors
-    // Rails' `visit_Arel_Nodes_BindParam`: `collector.add_bind(o.value, &bind_block)`
-    // emits the placeholder and records the value separately.
-    collector.addBind(o, this.bindBlock());
+    collector.addBind(o.value, this.bindBlock());
     return collector;
   }
 
@@ -1778,39 +1775,6 @@ export class ToSql extends Visitor {
       this.visit(child.toCte(), collector);
     });
     return collector;
-  }
-
-  /**
-   * @noRailsEquivalent CONVERGEABLE (story:
-   * arel-to-sql-compile-unification). This is Rails' `Visitor#accept(object,
-   * collector)` (`visitor.rb:8-10`) under a second name — `ToSql` has one
-   * `compile(node, collector = SQLString.new)` (`to_sql.rb:17`) and nothing
-   * else. Retiring it onto `accept` touches ~15 call sites across
-   * `packages/activerecord` and the suites, which is the filed story.
-   */
-  compileWithCollector(node: Node, externalCollector?: unknown): SQLString {
-    return this.visit(node, (externalCollector ?? new SQLString()) as SQLString);
-  }
-
-  /**
-   * Compile an AST node and extract bind values separately.
-   * Returns [sql_with_placeholders, bind_values, retryable].
-   *
-   * @noRailsEquivalent CONVERGEABLE (story:
-   * arel-to-sql-compile-unification). Rails builds the
-   * `Collectors::Composite(SQLString, Bind)` in AR's
-   * `DatabaseStatements#to_sql_and_binds` and compiles through the one
-   * `compile(node, collector)` (`to_sql.rb:17`); trails builds it here instead,
-   * so the collector construction sits on the arel side of the boundary.
-   * Moving it back touches ~40 call sites, which is the filed story.
-   */
-  compileWithBinds(node: Node): [string, unknown[], boolean, boolean] {
-    const sqlCollector = new SQLString();
-    const bindCollector = new Bind();
-    const composite = new Composite(sqlCollector, bindCollector);
-    this.visit(node, composite as unknown as SQLString);
-    const binds = bindCollector.value.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
-    return [sqlCollector.value, binds, sqlCollector.retryable, composite.preparable];
   }
 
   private subselectKey(key: Node): Node {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1,7 +1,5 @@
 import { Node } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
-import { Composite } from "../collectors/composite.js";
-import { SubstituteBinds } from "../collectors/substitute-binds.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { SelectManager } from "../select-manager.js";
@@ -144,35 +142,13 @@ export class ToSql extends Visitor {
     this.connection = connection;
   }
 
-  compile(node: Node): string;
-  compile(node: Node | ReadonlyArray<Nodes.NodeOrValue>, collector: Composite): [string, unknown[]];
+  compile(node: Node | ReadonlyArray<Nodes.NodeOrValue>): string;
+  compile<T>(node: Node | ReadonlyArray<Nodes.NodeOrValue>, collector: { value: T }): T;
   compile(
     node: Node | ReadonlyArray<Nodes.NodeOrValue>,
-    collector: SQLString | SubstituteBinds,
-  ): string;
-  compile(
-    node: Node | ReadonlyArray<Nodes.NodeOrValue>,
-    collector?: SQLString | SubstituteBinds | Composite,
-  ): string | [string, unknown[]] {
-    // Rails-faithful `compile(node, collector)`: drive the supplied collector
-    // (so callers control its bind state) and return the rendered SQL. An array
-    // node dispatches to `visit_Array` and renders as a comma-joined list — this
-    // is what bind_parameter_test's `bind_params` helper relies on to compile a
-    // list of `BindParam` nodes through a single shared collector. The collector
-    // type covers the string-rendering collectors (`SQLString` keeps `?`
-    // placeholders, `SubstituteBinds` inlines quoted values); the visitor's
-    // dispatch is typed against `SQLString`, so cast at the boundary as the rest
-    // of this file does.
-    if (collector !== undefined) {
-      this.accept(node, collector as unknown as SQLString);
-      return collector.value as string | [string, unknown[]];
-    }
-    // Mirrors Rails `compile` defaulting to a plain `SQLString` (to_sql.rb:17):
-    // Casted/Quoted inline their quoted literal in the visitor, BindParam emits
-    // `?` (BIND_BLOCK = proc { "?" }). No post-hoc inlining needed.
-    const sqlCollector = new SQLString();
-    this.accept(node, sqlCollector);
-    return sqlCollector.value;
+    collector: { value: unknown } = new SQLString(),
+  ): unknown {
+    return this.accept(node, collector as unknown as SQLString).value;
   }
 
   protected visitArelNodesDeleteStatement(

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
@@ -9,13 +9,6 @@
   {
     "package": "activesupport",
     "tsFile": "values/time-zone.ts",
-    "rubyName": "iso8601",
-    "call": "ordinal",
-    "reason": "Rails' iso8601 resolves an ordinal date through `Date.ordinal(year, parts.fetch(:yday))` (time_zone.rb:405) after `Date._iso8601` has parsed the string into parts; trails has neither `Date._iso8601` nor `Date.ordinal`, so the ordinal `YYDDD` form is recognised by its own regex arm and converted with day-of-year arithmetic. Blocked on porting `Date._iso8601`/`Date.ordinal`."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "values/time-zone.ts",
     "rubyName": "now",
     "call": "in_time_zone",
     "reason": "Same round trip as the `at` row above: `time_now.utc.in_time_zone(self)` (time_zone.rb:516-518) reaches the same `new TimeWithZone(instant, self)` that this body already performs, and going through `in_time_zone` would close the `values/time-zone` -> `core-ext/date-and-time/zones` import cycle."

--- a/scripts/parity/pipeline/query/diff.ts
+++ b/scripts/parity/pipeline/query/diff.ts
@@ -234,7 +234,7 @@ async function main(): Promise<void> {
       // paramSql and binds are informational-only — excluded from cross-side comparison:
       //   - Rails SQLite inlines datetime values in to_sql() → bound_attributes is empty
       //     → binds = [], paramSql = sql.
-      //   - trails extracts datetime values via compileWithBinds → binds is non-empty,
+      //   - trails extracts datetime values via a Composite collector → binds is non-empty,
       //     paramSql has ? placeholders.
       // This structural asymmetry means cross-side bind comparison would always fail for
       // datetime fixtures regardless of semantic correctness. Both fields remain in the

--- a/scripts/parity/pipeline/query/node/ar_dump.ts
+++ b/scripts/parity/pipeline/query/node/ar_dump.ts
@@ -29,6 +29,7 @@ import { join, resolve, dirname, basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
 import { assertPackagesBuilt } from "./assert-packages-built.js";
+import { Collectors } from "@blazetrails/arel";
 import type { Visitors } from "@blazetrails/arel";
 
 function usage(): never {
@@ -199,7 +200,7 @@ async function main(): Promise<void> {
 
     // 5. Extract SQL — two forms:
     //    a) Inlined: toSql() with all values embedded as literals.
-    //    b) Parameterized: compileWithBinds extracts date values as bind
+    //    b) Parameterized: a Composite collector extracts date values as bind
     //       params (? placeholders), matching the execution path Rails uses
     //       for INSERT/UPDATE and how AR actually passes values to the driver.
     const sqlStr = (result as { toSql(): string }).toSql().trim();
@@ -220,9 +221,15 @@ async function main(): Promise<void> {
           const visitor = (Base.adapter as { visitor?: InstanceType<typeof Visitors.ToSql> })
             .visitor;
           if (visitor == null) throw new Error("connection has no Arel visitor");
+          const collector = new Collectors.Composite(
+            new Collectors.SQLString(),
+            new Collectors.Bind(),
+          );
           const [ps, bs] = (
-            visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
-          ).compileWithBinds((manager as { ast: unknown }).ast);
+            visitor as unknown as {
+              compile(node: unknown, collector: unknown): [string, unknown[]];
+            }
+          ).compile((manager as { ast: unknown }).ast, collector);
           // Resolve QueryAttribute/BindParam wrappers to their DB value first.
           const resolvedBinds = bs.map((b) => {
             if (b != null && typeof b === "object" && "valueForDatabase" in b) {


### PR DESCRIPTION
Three bundled stories.

## `arel-to-sql-compile-unification`

`ToSql#compileWithCollector` and `ToSql#compileWithBinds` are gone; everything
goes through the one Rails-shaped `compile(node, collector)` (`to_sql.rb:17`).

- `compileWithCollector(node, collector)` was `Visitor#accept` (`visitor.rb:10`)
  under a second name — call sites now call `accept` directly.
- `compileWithBinds` built its own `Composite(SQLString, Bind)`. Rails takes that
  collector from the adapter (`AbstractAdapter#collector`,
  `abstract_adapter.rb:1176-1188`) and destructures the Composite's
  `[sql, binds]` value in `to_sql_and_binds` (`database_statements.rb:30-45`)
  and `cacheable_query` (`:56-66`); both callers now do exactly that, and
  `compile` is Rails' one-liner again — `accept(node, collector).value` over a
  defaulted `SQLString`.
- `visit_Arel_Nodes_BindParam` collects `o.value`, not the node
  (`to_sql.rb:760-762`). That was the reason `SubstituteBinds#add_bind` carried
  a `BindParam` unwrap loop Rails does not have (`substitute_binds.rb:19-22`);
  it is deleted.

`visitors/to-sql.ts` extras: the two `compile*` names are gone.
`PostgreSQLWithBinds` does **not** fall out with them — it is a `bind_block`
split, not a `compile` split (Rails' `PostgreSQL` carries the numbered block
unconditionally, `postgresql.rb:81-84`), and retiring it moves every PG SQL-text
assertion from `?` to `$N`. Filed as
`0117-arel-extra-surface-burndown/retire-postgresql-with-binds-onto-postgresql-bind-block`.

## `arel-node-accept-removal-leaves`

Rails' Arel nodes define no `accept` — `grep "def accept"` over
`vendor/rails/activerecord/lib/arel/` hits only `visitors/visitor.rb:10` and
`visitors/dot.rb:28`, and visiting is `Visitor#visit` → `dispatch[object.class]`
(`visitor.rb:28-37`). The invented double-dispatch method is deleted from the 21
leaf node files whose extras row was exactly `MOVED: accept`. Several classes are
now empty bodies, which is what Rails has.

`nodes/node.ts`'s `accept` declaration is deleted outright rather than kept: the
15 node classes the sibling story still owns declare their own `accept` as an
ordinary method and need no base declaration, so `node.ts` matches Rails, which
has no `Node#accept` at all. `accept` leaves that file's `parity:api:extra` row
too (moved 5 -> 4). The `NodeVisitor` type stays for those 15.

## `build-time-zone-iso8601-and-rfc3339-from-date-parts`

`TimeZone#iso8601` (`time_zone.rb:396-433`) and `#rfc3339` (`:469-484`) are built
from `Date._iso8601` / `Date._rfc3339` parts instead of bespoke regexes, in
Rails' branch order and with Rails' guards: `iso8601`'s nil check and its
`:yday` arm through `Date.ordinal`; `rfc3339`'s `parts.empty?` raise and its
always-UTC wrap. Both now raise `ArgumentError("invalid date")` where Rails does,
and `sec_fraction` survives to the nanosecond — `rfc3339` previously inherited
`new Date`'s millisecond floor. The `iso8601` → `ordinal` call-mismatch baseline
row is deleted (converged).

Two module-private helpers carry the pieces Ruby's `Time` has and
`Temporal.PlainDateTime` does not — the Rational sub-second seat and the UTC
offset — shared with the already-ported `parts_to_time` rather than written out
three times.

## Not in this PR

`generate-alias-attributes-from-aliases-by-attribute-name` was claimed with the
bundle and released: its own story file records it as done in PR #6838, which is
still open, so building it here would duplicate and conflict with that branch.

## Checks

`pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
`pnpm parity:api` / `pnpm parity:test` deltas non-negative,
`pnpm vitest run packages/arel` green, plus `packages/activerecord/src/relation`,
`packages/activerecord/src/connection-adapters`, the AR bind-parameter and
statement-cache suites, `scripts/parity/pipeline/query/node`, and the
ActiveSupport time-zone suites — 2882 tests.

Closes-story: arel-to-sql-compile-unification
Closes-story: arel-node-accept-removal-leaves
Closes-story: build-time-zone-iso8601-and-rfc3339-from-date-parts
