### PR TITLE
refactor(activerecord,activemodel): move the save-side dirty readers onto AttributeMethods::Dirty

### DIFF
--- a/packages/activemodel/src/attributes-dirty.test.ts
+++ b/packages/activemodel/src/attributes-dirty.test.ts
@@ -69,8 +69,8 @@ describe("AttributesDirtyTest", () => {
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p._writeAttribute("name", "Bob");
-    expect(p.changedAttributeNamesToSave).toContain("name");
-    expect(p.changedAttributeNamesToSave).not.toContain("age");
+    expect(Object.keys(p.changedAttributes)).toContain("name");
+    expect(Object.keys(p.changedAttributes)).not.toContain("age");
   });
 
   it("changes to attribute values", () => {

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -58,8 +58,8 @@ describe("DirtyTest", () => {
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p._writeAttribute("name", "Bob");
-    expect(p.changedAttributeNamesToSave).toContain("name");
-    expect(p.changedAttributeNamesToSave).not.toContain("age");
+    expect(Object.keys(p.changedAttributes)).toContain("name");
+    expect(Object.keys(p.changedAttributes)).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
@@ -176,7 +176,7 @@ describe("DirtyTest", () => {
     class Bare extends Model {}
     const b = new Bare();
     expect(b.changed).toBe(false);
-    expect(b.changedAttributeNamesToSave).toEqual([]);
+    expect(Object.keys(b.changedAttributes)).toEqual([]);
   });
 
   class Person extends Model {
@@ -248,14 +248,14 @@ describe("Dirty Tracking", () => {
   it("not changed initially", () => {
     const p = new Person({ name: "dean", age: 30 });
     expect(p.changed).toBe(false);
-    expect(p.changedAttributeNamesToSave).toEqual([]);
+    expect(Object.keys(p.changedAttributes)).toEqual([]);
   });
 
   it("setting attribute will result in change", () => {
     const p = new Person({ name: "dean" });
     p._writeAttribute("name", "sam");
     expect(p.changed).toBe(true);
-    expect(p.changedAttributeNamesToSave).toContain("name");
+    expect(Object.keys(p.changedAttributes)).toContain("name");
   });
 
   it("attributeWas returns original value", () => {
@@ -368,23 +368,6 @@ describe("attributeBeforeTypeCast", () => {
   });
 });
 
-describe("changedAttributeNamesToSave", () => {
-  it("changedAttributeNamesToSave lists pending changes", () => {
-    class Widget extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("size", "integer");
-      }
-    }
-
-    const w = new Widget({ name: "Test", size: 5 });
-    w.changesApplied();
-    w._writeAttribute("name", "Changed");
-    expect(w.changedAttributeNamesToSave).toContain("name");
-    expect(w.changedAttributeNamesToSave).not.toContain("size");
-  });
-});
-
 describe("clearChangesInformation", () => {
   it("clear_changes_information should reset all changes", () => {
     class Person extends Model {
@@ -420,11 +403,11 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(m.changedAttributeNamesToSave).toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
   });
 });
 
@@ -441,12 +424,12 @@ describe("clearAttributeChanges", () => {
     p.changesApplied();
     p._writeAttribute("name", "Bob");
     p._writeAttribute("age", 31);
-    expect(p.changedAttributeNamesToSave).toContain("name");
-    expect(p.changedAttributeNamesToSave).toContain("age");
+    expect(Object.keys(p.changedAttributes)).toContain("name");
+    expect(Object.keys(p.changedAttributes)).toContain("age");
 
     p.clearAttributeChanges(["name"]);
-    expect(p.changedAttributeNamesToSave).not.toContain("name");
-    expect(p.changedAttributeNamesToSave).toContain("age");
+    expect(Object.keys(p.changedAttributes)).not.toContain("name");
+    expect(Object.keys(p.changedAttributes)).toContain("age");
   });
 });
 
@@ -553,94 +536,6 @@ describe("attributePreviouslyChanged / attributePreviouslyWas", () => {
   });
 });
 
-describe("changesToSave", () => {
-  it("returns the changes hash for unsaved attributes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-    User.attribute("age", "integer");
-
-    const u = new User({ name: "Alice", age: 25 });
-    u._writeAttribute("name", "Bob");
-    const changes = u.changesToSave;
-    expect(changes["name"]).toEqual(["Alice", "Bob"]);
-    expect(changes["age"]).toBeUndefined();
-  });
-
-  it("returns empty object when no changes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-
-    const u = new User({ name: "Alice" });
-    expect(u.changesToSave).toEqual({});
-  });
-});
-
-describe("attributesInDatabase", () => {
-  it("returns database values for changed attributes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-    User.attribute("age", "integer");
-
-    const u = new User({ name: "Alice", age: 25 });
-    u._writeAttribute("name", "Bob");
-    u._writeAttribute("age", 30);
-    const dbValues = u.attributesInDatabase;
-    expect(dbValues["name"]).toBe("Alice");
-    expect(dbValues["age"]).toBe(25);
-  });
-
-  it("returns empty object when no changes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-
-    const u = new User({ name: "Alice" });
-    expect(u.attributesInDatabase).toEqual({});
-  });
-});
-
-describe("hasChangesToSave", () => {
-  it("returns false when no changes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-
-    const u = new User({ name: "Alice" });
-    expect(u.hasChangesToSave).toBe(false);
-  });
-
-  it("returns true when there are unsaved changes", () => {
-    class User extends Model {
-      constructor(attrs: Record<string, unknown> = {}) {
-        super(attrs);
-      }
-    }
-    User.attribute("name", "string");
-
-    const u = new User({ name: "Alice" });
-    u._writeAttribute("name", "Bob");
-    expect(u.hasChangesToSave).toBe(true);
-  });
-});
-
 describe("numeric type.isChanged integration via dirty tracking", () => {
   it("integer attribute set to non-numeric string still appears in changes — number_to_non_number? path", () => {
     class Item extends Model {
@@ -653,7 +548,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 10 });
     item.changesApplied();
     item._writeAttribute("count", "abc");
-    expect(item.changedAttributeNamesToSave).toContain("count");
+    expect(Object.keys(item.changedAttributes)).toContain("count");
   });
 
   it("force-change is cleared by restoreAttributes — forced flag must not survive restore", () => {
@@ -667,11 +562,11 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(m.changedAttributeNamesToSave).toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).toContain("ratio");
 
     m.restoreAttributes();
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
   });
 
   it("force-change is cleared by changesApplied — forced state must not leak across save boundaries", () => {
@@ -685,11 +580,11 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(m.changedAttributeNamesToSave).toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).toContain("ratio");
 
     m.changesApplied();
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
   });
 
   it("force-change survives a subsequent type-equal write — NaN-to-NaN case", () => {
@@ -704,7 +599,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     m.changesApplied();
     m._dirty.forceChange("ratio");
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,
     // not the snapshot original, to preserve Rails' attribute_will_change! semantics.
     expect(m.changes["ratio"]).toEqual([NaN, NaN]);
@@ -721,7 +616,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
     expect(m.changes).not.toHaveProperty("ratio");
   });
 
@@ -736,7 +631,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 1 });
     item.changesApplied();
     item._writeAttribute("count", true);
-    expect(item.changedAttributeNamesToSave).toContain("count");
+    expect(Object.keys(item.changedAttributes)).toContain("count");
   });
 
   it("float attribute NaN → non-NaN → NaN clears dirty state on revert", () => {
@@ -750,9 +645,9 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._writeAttribute("ratio", 1.0);
-    expect(m.changedAttributeNamesToSave).toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).toContain("ratio");
     m._writeAttribute("ratio", NaN);
-    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
+    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
   });
 });
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1750,15 +1750,6 @@ export class Model {
   }
 
   /**
-   * Check if there are any unsaved changes.
-   *
-   * Mirrors: ActiveModel::Dirty#has_changes_to_save?
-   */
-  get hasChangesToSave(): boolean {
-    return this._dirty.changed;
-  }
-
-  /**
    * Map of each changed attribute's name to its old (pre-change) value.
    *
    * Mirrors: ActiveModel::Dirty#changed_attributes
@@ -1795,48 +1786,6 @@ export class Model {
 
   get previousChanges(): Record<string, [unknown, unknown]> {
     return this._dirty.previousChanges;
-  }
-
-  /**
-   * Alias for previousChanges — the changes that were persisted in the last save.
-   *
-   * Mirrors: ActiveModel::Dirty#saved_changes
-   */
-  get savedChanges(): Record<string, [unknown, unknown]> {
-    return this._dirty.previousChanges;
-  }
-
-  /**
-   * Return the list of attribute names that have unsaved changes.
-   *
-   * Mirrors: ActiveModel::Dirty#changed_attribute_names_to_save
-   */
-  get changedAttributeNamesToSave(): string[] {
-    return this._dirty.changedAttributeNames;
-  }
-
-  /**
-   * Return the changes hash that will be saved on the next save.
-   * Same as `changes` — returns { attr: [old, new] } for unsaved attributes.
-   *
-   * Mirrors: ActiveModel::Dirty#changes_to_save
-   */
-  get changesToSave(): Record<string, [unknown, unknown]> {
-    return this.changes;
-  }
-
-  /**
-   * Return a hash of all attributes with their database values
-   * (i.e. the values from before any unsaved changes).
-   *
-   * Mirrors: ActiveModel::Dirty#attributes_in_database
-   */
-  get attributesInDatabase(): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const name of this._dirty.changedAttributeNames) {
-      result[name] = this._dirty.attributeWas(name) ?? this._readAttribute(name);
-    }
-    return result;
   }
 
   /**

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -706,6 +706,6 @@ describe("fromJson", () => {
     u.changesApplied();
     u.fromJson('{"name":"Updated"}');
     expect(u.changed).toBe(true);
-    expect(u.changedAttributeNamesToSave).toContain("name");
+    expect(Object.keys(u.changedAttributes)).toContain("name");
   });
 });

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -861,14 +861,9 @@ import {
   savedChangeToAttribute as _savedChangeToAttribute,
   attributeBeforeLastSave as _attributeBeforeLastSave,
   isSavedChanges as _isSavedChanges,
-  savedChanges as _savedChanges,
   isWillSaveChangeToAttribute as _isWillSaveChangeToAttribute,
   attributeChangeToBeSaved as _attributeChangeToBeSaved,
   attributeInDatabase as _attributeInDatabase,
-  isHasChangesToSave,
-  changesToSave as _changesToSave,
-  changedAttributeNamesToSave as _changedAttributeNamesToSave,
-  attributesInDatabase as _attributesInDatabase,
   attributeNamesForPartialUpdates as _attributeNamesForPartialUpdates,
   attributeNamesForPartialInserts as _attributeNamesForPartialInserts,
 } from "./attribute-methods/dirty.js";
@@ -933,10 +928,6 @@ export function isSavedChanges(this: InstanceMethodHost): boolean {
   return _isSavedChanges(this as any);
 }
 /** @internal */
-export function savedChanges(this: InstanceMethodHost): Record<string, [unknown, unknown]> {
-  return _savedChanges(this as any);
-}
-/** @internal */
 export function isWillSaveChangeToAttribute(
   this: InstanceMethodHost,
   attr: string,
@@ -954,22 +945,6 @@ export function attributeChangeToBeSaved(
 /** @internal */
 export function attributeInDatabase(this: InstanceMethodHost, attr: string): unknown {
   return _attributeInDatabase(this as any, attr);
-}
-/** @internal */
-export function hasChangesToSave(this: InstanceMethodHost): boolean {
-  return isHasChangesToSave(this as any);
-}
-/** @internal */
-export function changesToSave(this: InstanceMethodHost): Record<string, [unknown, unknown]> {
-  return _changesToSave(this as any);
-}
-/** @internal */
-export function changedAttributeNamesToSave(this: InstanceMethodHost): string[] {
-  return _changedAttributeNamesToSave(this as any);
-}
-/** @internal */
-export function attributesInDatabase(this: InstanceMethodHost): Record<string, unknown> {
-  return _attributesInDatabase(this as any);
 }
 /** @internal */
 export function attributeNamesForPartialUpdates(this: InstanceMethodHost): string[] {

--- a/packages/activerecord/src/attribute-methods/dirty-accessor-descriptors.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods/dirty-accessor-descriptors.trails.test.ts
@@ -7,7 +7,7 @@ import { Base } from "../index.js";
 // branch — an object-literal module is read by value and flattens each getter
 // into a data property whose value is the getter's result at include time, so
 // every record would answer the same stale hash. Pin the descriptor kind.
-describe("DirtyTest", () => {
+describe("AttributeMethods::Dirty accessor descriptors", () => {
   const SAVE_SIDE_READERS = [
     "savedChanges",
     "hasChangesToSave",

--- a/packages/activerecord/src/attribute-methods/dirty.test.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
+
+// The save-side readers of AttributeMethods::Dirty are zero-arg Ruby readers,
+// so they port as accessor properties (CLAUDE.md, "Generated attribute readers
+// are properties"). `include()` preserves that only through its class-module
+// branch — an object-literal module is read by value and flattens each getter
+// into a data property whose value is the getter's result at include time, so
+// every record would answer the same stale hash. Pin the descriptor kind.
+describe("DirtyTest", () => {
+  const SAVE_SIDE_READERS = [
+    "savedChanges",
+    "hasChangesToSave",
+    "changesToSave",
+    "changedAttributeNamesToSave",
+    "attributesInDatabase",
+  ] as const;
+
+  it("save-side dirty readers are accessor properties on Base", () => {
+    for (const name of SAVE_SIDE_READERS) {
+      const descriptor = Object.getOwnPropertyDescriptor(Base.prototype, name);
+      expect(descriptor, name).toBeDefined();
+      expect(typeof descriptor!.get, name).toBe("function");
+      expect(descriptor!.value, name).toBeUndefined();
+    }
+  });
+
+  it("save-side dirty readers do not live on ActiveModel", () => {
+    const model = Object.getPrototypeOf(Base.prototype) as object;
+    for (const name of SAVE_SIDE_READERS) {
+      expect(Object.getOwnPropertyDescriptor(model, name), name).toBeUndefined();
+    }
+  });
+});

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -91,15 +91,6 @@ export function isSavedChanges(record: DirtyRecord): boolean {
 }
 
 /**
- * Return all changes from the last save.
- *
- * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_changes
- */
-export function savedChanges(record: DirtyRecord): Record<string, [unknown, unknown]> {
-  return record.previousChanges;
-}
-
-/**
  * Check if a specific attribute will change on the next save.
  *
  * Mirrors: ActiveRecord::AttributeMethods::Dirty#will_save_change_to_attribute?
@@ -137,42 +128,72 @@ export function attributeInDatabase(record: DirtyRecord, attr: string): unknown 
 }
 
 /**
- * Check if there are any unsaved changes.
+ * The half of ActiveRecord::AttributeMethods::Dirty whose Ruby bodies are
+ * zero-arg readers, so they port as accessor properties (CLAUDE.md,
+ * "Generated attribute readers are properties"). A class module rather than a
+ * plain-object one because only `include()`'s class branch copies accessor
+ * descriptors; an object literal is read by value and would flatten each
+ * getter into a data property.
  *
- * Mirrors: ActiveRecord::AttributeMethods::Dirty#has_changes_to_save?
+ * Mirrors: ActiveRecord::AttributeMethods::Dirty
  */
-export function isHasChangesToSave(record: DirtyRecord): boolean {
-  return record.changed;
-}
-
-/**
- * Return all pending changes that will be saved.
- *
- * Mirrors: ActiveRecord::AttributeMethods::Dirty#changes_to_save
- */
-export function changesToSave(record: DirtyRecord): Record<string, [unknown, unknown]> {
-  return record.changes;
-}
-
-/**
- * Return the names of attributes that have unsaved changes.
- *
- * Mirrors: ActiveRecord::AttributeMethods::Dirty#changed_attribute_names_to_save
- */
-export function changedAttributeNamesToSave(record: DirtyRecord): string[] {
-  return Object.keys(record.changes);
-}
-
-/**
- * Returns a hash of original database values for attributes with unsaved changes.
- * Mirrors: ActiveRecord::AttributeMethods::Dirty#attributes_in_database
- */
-export function attributesInDatabase(record: DirtyRecord): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, [oldVal]] of Object.entries(record.changes)) {
-    result[key] = oldVal;
+export class Dirty {
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_changes
+   * (dirty.rb:118-120) — `mutations_before_last_save.changes`.
+   */
+  get savedChanges(): Record<string, [unknown, unknown]> {
+    return (this as unknown as DirtyGetterHost)._dirty.previousChanges;
   }
-  return result;
+
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#has_changes_to_save?
+   * (dirty.rb:169-171) — `mutations_from_database.any_changes?`.
+   */
+  get hasChangesToSave(): boolean {
+    return (this as unknown as DirtyGetterHost)._dirty.changed;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#changes_to_save
+   * (dirty.rb:175-177) — `mutations_from_database.changes`.
+   */
+  get changesToSave(): Record<string, [unknown, unknown]> {
+    return (this as unknown as DirtyGetterHost).changes;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#changed_attribute_names_to_save
+   * (dirty.rb:181-183) — `mutations_from_database.changed_attribute_names`.
+   */
+  get changedAttributeNamesToSave(): string[] {
+    return (this as unknown as DirtyGetterHost)._dirty.changedAttributeNames;
+  }
+
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#attributes_in_database
+   * (dirty.rb:191-193) — `mutations_from_database.changed_values`.
+   */
+  get attributesInDatabase(): Record<string, unknown> {
+    const record = this as unknown as DirtyGetterHost;
+    const result: Record<string, unknown> = {};
+    for (const name of record._dirty.changedAttributeNames) {
+      result[name] = record._dirty.attributeWas(name) ?? record._readAttribute(name);
+    }
+    return result;
+  }
+}
+
+interface DirtyGetterHost {
+  changes: Record<string, [unknown, unknown]>;
+  _dirty: {
+    changed: boolean;
+    changedAttributeNames: string[];
+    previousChanges: Record<string, [unknown, unknown]>;
+    attributeWas(name: string): unknown;
+  };
+  /** @internal */
+  _readAttribute(name: string): unknown;
 }
 
 interface DirtyPrivateHost {

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -159,7 +159,7 @@ export class Dirty {
    * (dirty.rb:175-177) — `mutations_from_database.changes`.
    */
   get changesToSave(): Record<string, [unknown, unknown]> {
-    return (this as unknown as DirtyGetterHost).changes;
+    return (this as unknown as DirtyGetterHost)._dirty.changes;
   }
 
   /**
@@ -175,25 +175,18 @@ export class Dirty {
    * (dirty.rb:191-193) — `mutations_from_database.changed_values`.
    */
   get attributesInDatabase(): Record<string, unknown> {
-    const record = this as unknown as DirtyGetterHost;
-    const result: Record<string, unknown> = {};
-    for (const name of record._dirty.changedAttributeNames) {
-      result[name] = record._dirty.attributeWas(name) ?? record._readAttribute(name);
-    }
-    return result;
+    return (this as unknown as DirtyGetterHost)._dirty.changedAttributes;
   }
 }
 
 interface DirtyGetterHost {
-  changes: Record<string, [unknown, unknown]>;
   _dirty: {
     changed: boolean;
+    changes: Record<string, [unknown, unknown]>;
     changedAttributeNames: string[];
+    changedAttributes: Record<string, unknown>;
     previousChanges: Record<string, [unknown, unknown]>;
-    attributeWas(name: string): unknown;
   };
-  /** @internal */
-  _readAttribute(name: string): unknown;
 }
 
 interface DirtyPrivateHost {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -269,6 +269,7 @@ import {
 } from "./core.js";
 import * as _Core from "./core.js";
 import * as _AttributeMethodsDirty from "./attribute-methods/dirty.js";
+import { Dirty as _Dirty } from "./attribute-methods/dirty.js";
 import type { AsynchronousQueriesTracker, Session } from "./asynchronous-queries-tracker.js";
 import * as _Persistence from "./persistence.js";
 import * as _EnumModule from "./enum.js";
@@ -4387,6 +4388,38 @@ export interface Base extends Included<typeof AutosaveAssociation> {
    */
   loadHasOne(name: string): Promise<Base | null>;
   /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_changes
+   * (attribute_methods/dirty.rb:118-120). A zero-arg Ruby reader, so an
+   * accessor property here — see CLAUDE.md, "Generated attribute readers are
+   * properties". Ported on the `Dirty` class module and mixed in, as
+   * {@link Base.attributeBeforeLastSave} is.
+   */
+  readonly savedChanges: Record<string, [unknown, unknown]>;
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#has_changes_to_save?
+   * (attribute_methods/dirty.rb:169-171). Accessor property and mixed in as
+   * {@link Base.savedChanges} is.
+   */
+  readonly hasChangesToSave: boolean;
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#changes_to_save
+   * (attribute_methods/dirty.rb:175-177). Accessor property and mixed in as
+   * {@link Base.savedChanges} is.
+   */
+  readonly changesToSave: Record<string, [unknown, unknown]>;
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#changed_attribute_names_to_save
+   * (attribute_methods/dirty.rb:181-183). Accessor property and mixed in as
+   * {@link Base.savedChanges} is.
+   */
+  readonly changedAttributeNamesToSave: string[];
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#attributes_in_database
+   * (attribute_methods/dirty.rb:191-193). Accessor property and mixed in as
+   * {@link Base.savedChanges} is.
+   */
+  readonly attributesInDatabase: Record<string, unknown>;
+  /**
    * Mirrors: ActiveRecord::AttributeMethods::Dirty#attribute_before_last_save
    * (attribute_methods/dirty.rb:108-110).
    *
@@ -4721,6 +4754,9 @@ include(Base, {
   storeAccessorFor: _storeAccessorFor,
 });
 include(Base, ModelSchema.InstanceMethods);
+// The accessor-property half of AttributeMethods::Dirty. A class module, so
+// `include()` copies the getter descriptors rather than flattening them.
+include(Base, _Dirty);
 include(Base, _PrimaryKey);
 // Rails includes CompositePrimaryKey into a model when `primary_key=` takes an
 // Array (primary_key.rb:132); each of its bodies opens with the
@@ -4861,10 +4897,9 @@ include(Base, {
     return TouchLater.hasDeferTouchAttrs(this);
   },
   // savedChanges/hasChangesToSave/changesToSave/changedAttributeNamesToSave/
-  // attributesInDatabase — getters on Model.prototype; wiring via include() replaces
-  // the getter descriptor with a data property and breaks behavior. Category A.
-  // savedChangeToAttribute — on Model (returns boolean); AR version returns [T,T]|null
-  // pair — overriding breaks tests. Category A: resolved via Model inheritance.
+  // attributesInDatabase are accessor properties, so they arrive with
+  // `include(Base, _Dirty)` above — this object literal is read by value and
+  // would flatten them into data properties.
   // CounterCache privates
   _foreignKeysEqual: CounterCache._foreignKeysEqual,
   // Associations privates


### PR DESCRIPTION
`vendor/rails/activemodel/lib/active_model/dirty.rb` has no save-side family. `vendor/rails/activerecord/lib/active_record/attribute_methods/dirty.rb` does, and trails defined five of its readers on `ActiveModel::Model`, one package too low:

| trails | Rails |
| --- | --- |
| `savedChanges` | `saved_changes` (dirty.rb:118-120) |
| `hasChangesToSave` | `has_changes_to_save?` (dirty.rb:169-171) |
| `changesToSave` | `changes_to_save` (dirty.rb:175-177) |
| `changedAttributeNamesToSave` | `changed_attribute_names_to_save` (dirty.rb:181-183) |
| `attributesInDatabase` | `attributes_in_database` (dirty.rb:191-193) |

They move to `packages/activerecord/src/attribute-methods/dirty.ts` on a new `Dirty` class module, mixed in beside `_PrimaryKey` with `include(Base, _Dirty)`, in Rails' member order. Each is the single `mutations_from_database` / `mutations_before_last_save` read its Ruby body makes — the `model.ts` versions of `changes_to_save` and `attributes_in_database` reached through the public `changes` getter and hand-looped `changed_values`, and both are folded back onto the tracker reader.

## Why a class module

These are zero-arg Ruby readers, so they port as accessor properties (CLAUDE.md, "Generated attribute readers are properties"), and only `include()`'s class branch copies accessor descriptors. An object-literal module is read by value — each getter would flatten into a data property holding whatever it evaluated to at include time, so every record would answer the same stale hash. This is the hazard `base.ts` had already recorded in a comment; `dirty-accessor-descriptors.trails.test.ts` now pins the descriptor kind so it stays fixed.

## Fallout

- The five `this`-typed delegates for the same names in `attribute-methods.ts` were never wired onto `Base` (nothing imported them); they are dead and go with the move, along with their record-first counterparts in `dirty.ts`.
- The activemodel tests that reached for the AR-only spelling now use the ActiveModel one — `Object.keys(x.changedAttributes)`, which `DirtyTracker` computes identically to `changedAttributeNames`.
- Four describes in `activemodel/src/dirty.test.ts` existed only to exercise the AR-only readers from activemodel (bespoke `class User extends Model`, generic descriptions, no Rails counterpart). They are dropped rather than renamed; the surface they covered is tested from `activerecord/src/dirty.test.ts`.
- The new descriptor test is a `.trails.test.ts`: there is no `activerecord/test/cases/attribute_methods/dirty_test.rb` for it to mirror, and it pins a TypeScript-language-forced property shape rather than a Rails behaviour.

## Notes for the reviewer

The story's inventory listed eleven members at `model.ts:2167-2312`. Six of them — `willSaveChangeToAttribute`, `savedChangeToAttribute`, `attributeBeforeLastSave`, `attributeInDatabase`, and the two trails-invented `*Values` spellings — had already landed in #6821, so only these five remained.

## Gates

- `pnpm parity:api:calls` — OK (745 baselined, 340 unreviewed, 124 marks tight). No new rows, no reseed.
- `pnpm parity:api:calls:args` — OK (156 baselined shape rows).
- `pnpm parity:api:extra --package activerecord` — `attribute-methods/dirty.ts` 0 novel; none of the five surface on `base.ts`. `activemodel/model.ts` loses all five.
- `pnpm parity:api` / `pnpm parity:test` deltas non-negative (the four dropped describes were `extra (TS only)`).
- `pnpm lint` clean, `pnpm typecheck` clean.
- Suites: the new descriptor test, `activemodel/{dirty,attributes-dirty,serialization}.test.ts`, `activerecord/{dirty,persistence,timestamp,locking,transactions,base}.test.ts` — all green.

370 LOC.

Closes-story: move-ar-save-side-dirty-surface-out-of-model