### PR TITLE
refactor(arel,activemodel,activerecord,activesupport): PostgreSQL bind_block, Dirty#changed name array, TimeZone#at nanoseconds

### DIFF
--- a/packages/activemodel/src/attributes-dirty.test.ts
+++ b/packages/activemodel/src/attributes-dirty.test.ts
@@ -63,14 +63,14 @@ describe("AttributesDirtyTest", () => {
   it("setting attribute will result in change", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
   });
 
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p._writeAttribute("name", "Bob");
-    expect(Object.keys(p.changedAttributes)).toContain("name");
-    expect(Object.keys(p.changedAttributes)).not.toContain("age");
+    expect(p.changed).toContain("name");
+    expect(p.changed).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
@@ -89,15 +89,15 @@ describe("AttributesDirtyTest", () => {
   it("setting color to same value should not result in change being recorded", () => {
     const p = new DirtyPerson({ color: "red" });
     p._writeAttribute("color", "red");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("saving should reset model's changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     p.changesApplied();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("saving should preserve previous changes", () => {
@@ -144,7 +144,7 @@ describe("AttributesDirtyTest", () => {
     p.changesApplied();
     p._writeAttribute("name", "Charlie");
     p.clearChangesInformation();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     expect(Object.keys(p.previousChanges).length).toBe(0);
   });
 
@@ -155,15 +155,15 @@ describe("AttributesDirtyTest", () => {
     p.restoreAttributes();
     expect(p._readAttribute("name")).toBe("Alice");
     expect(p._readAttribute("age")).toBe(25);
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     p._writeAttribute("name", "Alice");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
   it("attribute mutation", () => {
     class Person extends Model {
@@ -172,9 +172,9 @@ describe("AttributesDirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     expect(p.changes).toEqual({ name: ["Alice", "Bob"] });
   });
 

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -23,7 +23,7 @@ describe("DirtyTest", () => {
     p._writeAttribute("name", "Bob");
     p.changesApplied();
     expect(p.previousChanges["name"]).toEqual(["Alice", "Bob"]);
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("restore_attributes can restore only some attributes", () => {
@@ -52,14 +52,14 @@ describe("DirtyTest", () => {
   it("setting attribute will result in change", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
   });
 
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p._writeAttribute("name", "Bob");
-    expect(Object.keys(p.changedAttributes)).toContain("name");
-    expect(Object.keys(p.changedAttributes)).not.toContain("age");
+    expect(p.changed).toContain("name");
+    expect(p.changed).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
@@ -83,15 +83,15 @@ describe("DirtyTest", () => {
   it("setting color to same value should not result in change being recorded", () => {
     const p = new DirtyPerson({ color: "red" });
     p._writeAttribute("color", "red");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("saving should reset model's changed status", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     p.changesApplied();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("saving should preserve previous changes", () => {
@@ -150,7 +150,7 @@ describe("DirtyTest", () => {
     p.changesApplied();
     p._writeAttribute("name", "Charlie");
     p.clearChangesInformation();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     expect(Object.keys(p.previousChanges).length).toBe(0);
   });
 
@@ -161,22 +161,22 @@ describe("DirtyTest", () => {
     p.restoreAttributes();
     expect(p._readAttribute("name")).toBe("Alice");
     expect(p._readAttribute("age")).toBe(25);
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new DirtyPerson({ name: "Alice" });
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     p._writeAttribute("name", "Alice");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("model can be dup-ed without Attributes", () => {
     class Bare extends Model {}
     const b = new Bare();
-    expect(b.changed).toBe(false);
-    expect(Object.keys(b.changedAttributes)).toEqual([]);
+    expect(b.isChanged).toBe(false);
+    expect(b.changed).toEqual([]);
   });
 
   class Person extends Model {
@@ -219,9 +219,9 @@ describe("DirtyTest", () => {
       }
     }
     const p = new Person({ name: "Alice" });
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     p._writeAttribute("name", "Bob");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     expect(p.changes).toEqual({ name: ["Alice", "Bob"] });
   });
 
@@ -247,15 +247,15 @@ describe("Dirty Tracking", () => {
 
   it("not changed initially", () => {
     const p = new Person({ name: "dean", age: 30 });
-    expect(p.changed).toBe(false);
-    expect(Object.keys(p.changedAttributes)).toEqual([]);
+    expect(p.isChanged).toBe(false);
+    expect(p.changed).toEqual([]);
   });
 
   it("setting attribute will result in change", () => {
     const p = new Person({ name: "dean" });
     p._writeAttribute("name", "sam");
-    expect(p.changed).toBe(true);
-    expect(Object.keys(p.changedAttributes)).toContain("name");
+    expect(p.isChanged).toBe(true);
+    expect(p.changed).toContain("name");
   });
 
   it("attributeWas returns original value", () => {
@@ -283,15 +283,15 @@ describe("Dirty Tracking", () => {
   it("setting color to same value should not result in change being recorded", () => {
     const p = new Person({ name: "dean" });
     p._writeAttribute("name", "dean");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("resetting attribute", () => {
     const p = new Person({ name: "dean" });
     p._writeAttribute("name", "sam");
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
     p._writeAttribute("name", "dean");
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("changing the same attribute multiple times retains the correct original value", () => {
@@ -308,14 +308,14 @@ describe("Dirty Tracking", () => {
     p.restoreAttributes();
     expect(p._readAttribute("name")).toBe("dean");
     expect(p._readAttribute("age")).toBe(30);
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
   });
 
   it("saving should preserve previous changes", () => {
     const p = new Person({ name: "dean" });
     p._writeAttribute("name", "sam");
     p.changesApplied();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     expect(p.previousChanges).toEqual({ name: ["dean", "sam"] });
   });
 
@@ -336,9 +336,9 @@ describe("Dirty Tracking", () => {
     }
     const s = new Sized({ size: "2" });
     s._writeAttribute("size", "2.3");
-    expect(s.changed).toBe(false);
+    expect(s.isChanged).toBe(false);
     s._writeAttribute("size", "5.1");
-    expect(s.changed).toBe(true);
+    expect(s.isChanged).toBe(true);
   });
 });
 describe("attributeBeforeTypeCast", () => {
@@ -384,10 +384,10 @@ describe("clearChangesInformation", () => {
     expect(Object.keys(p.previousChanges).length).toBeGreaterThan(0);
 
     p._writeAttribute("age", 31);
-    expect(p.changed).toBe(true);
+    expect(p.isChanged).toBe(true);
 
     p.clearChangesInformation();
-    expect(p.changed).toBe(false);
+    expect(p.isChanged).toBe(false);
     expect(Object.keys(p.previousChanges).length).toBe(0);
   });
 });
@@ -403,11 +403,11 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(Object.keys(m.changedAttributes)).toContain("ratio");
+    expect(m.changed).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
+    expect(m.changed).not.toContain("ratio");
   });
 });
 
@@ -424,12 +424,12 @@ describe("clearAttributeChanges", () => {
     p.changesApplied();
     p._writeAttribute("name", "Bob");
     p._writeAttribute("age", 31);
-    expect(Object.keys(p.changedAttributes)).toContain("name");
-    expect(Object.keys(p.changedAttributes)).toContain("age");
+    expect(p.changed).toContain("name");
+    expect(p.changed).toContain("age");
 
     p.clearAttributeChanges(["name"]);
-    expect(Object.keys(p.changedAttributes)).not.toContain("name");
-    expect(Object.keys(p.changedAttributes)).toContain("age");
+    expect(p.changed).not.toContain("name");
+    expect(p.changed).toContain("age");
   });
 });
 
@@ -548,7 +548,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 10 });
     item.changesApplied();
     item._writeAttribute("count", "abc");
-    expect(Object.keys(item.changedAttributes)).toContain("count");
+    expect(item.changed).toContain("count");
   });
 
   it("force-change is cleared by restoreAttributes — forced flag must not survive restore", () => {
@@ -562,11 +562,11 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(Object.keys(m.changedAttributes)).toContain("ratio");
+    expect(m.changed).toContain("ratio");
 
     m.restoreAttributes();
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
+    expect(m.changed).not.toContain("ratio");
   });
 
   it("force-change is cleared by changesApplied — forced state must not leak across save boundaries", () => {
@@ -580,11 +580,11 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio");
-    expect(Object.keys(m.changedAttributes)).toContain("ratio");
+    expect(m.changed).toContain("ratio");
 
     m.changesApplied();
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
+    expect(m.changed).not.toContain("ratio");
   });
 
   it("force-change survives a subsequent type-equal write — NaN-to-NaN case", () => {
@@ -599,7 +599,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     m.changesApplied();
     m._dirty.forceChange("ratio");
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).toContain("ratio");
+    expect(m.changed).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,
     // not the snapshot original, to preserve Rails' attribute_will_change! semantics.
     expect(m.changes["ratio"]).toEqual([NaN, NaN]);
@@ -616,7 +616,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
+    expect(m.changed).not.toContain("ratio");
     expect(m.changes).not.toHaveProperty("ratio");
   });
 
@@ -631,7 +631,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 1 });
     item.changesApplied();
     item._writeAttribute("count", true);
-    expect(Object.keys(item.changedAttributes)).toContain("count");
+    expect(item.changed).toContain("count");
   });
 
   it("float attribute NaN → non-NaN → NaN clears dirty state on revert", () => {
@@ -645,9 +645,9 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._writeAttribute("ratio", 1.0);
-    expect(Object.keys(m.changedAttributes)).toContain("ratio");
+    expect(m.changed).toContain("ratio");
     m._writeAttribute("ratio", NaN);
-    expect(Object.keys(m.changedAttributes)).not.toContain("ratio");
+    expect(m.changed).not.toContain("ratio");
   });
 });
 

--- a/packages/activemodel/src/dirty.trails.test.ts
+++ b/packages/activemodel/src/dirty.trails.test.ts
@@ -28,7 +28,7 @@ describe("Dirty across dup", () => {
     // MRI: t.changes == dup.changes == {"title"=>["A", "B"]}
     expect(duped.changes).toEqual(t.changes);
     expect(duped.changes).toEqual({ title: ["A", "B"] });
-    expect(duped.changed).toBe(true);
+    expect(duped.isChanged).toBe(true);
     expect(duped.attributeWas("title")).toEqual("A");
     // MRI: dup.previous_changes == t.previous_changes
     expect(duped.previousChanges).toEqual(t.previousChanges);
@@ -42,7 +42,7 @@ describe("Dirty across dup", () => {
 
     expect(duped.changes).toEqual({ body: [null, "new"] });
     expect(t.changes).toEqual({});
-    expect(t.changed).toBe(false);
+    expect(t.isChanged).toBe(false);
     expect(t.body).toBeNull();
   });
 
@@ -54,6 +54,6 @@ describe("Dirty across dup", () => {
 
     expect(t.changes).toEqual({ body: [null, "new"] });
     expect(duped.changes).toEqual({});
-    expect(duped.changed).toBe(false);
+    expect(duped.isChanged).toBe(false);
   });
 });

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -10,7 +10,8 @@ import { attributeMissing as attributeMissingDispatch } from "./attribute-method
  * Model implements this interface via DirtyTracker delegation.
  */
 export interface Dirty {
-  readonly changed: boolean;
+  readonly isChanged: boolean;
+  readonly changed: string[];
   readonly changedAttributes: Record<string, unknown>;
   readonly changes: Record<string, [unknown, unknown]>;
   readonly previousChanges: Record<string, [unknown, unknown]>;
@@ -20,7 +21,7 @@ export interface Dirty {
   attributeWas(name: string): unknown;
   attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean;
   attributePreviouslyWas(name: string): unknown;
-  restoreAttributes(): void;
+  restoreAttributes(attrNames?: string[]): void;
   changesApplied(): void;
   clearChangesInformation(): void;
   clearAttributeChanges(attributes: string[]): void;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1745,8 +1745,22 @@ export class Model {
     return duped;
   }
 
-  get changed(): boolean {
+  /**
+   * Returns `true` if any of the attributes has unsaved changes.
+   *
+   * Mirrors: ActiveModel::Dirty#changed? (dirty.rb:285-288)
+   */
+  get isChanged(): boolean {
     return this._dirty.changed;
+  }
+
+  /**
+   * Returns an array with the name of the attributes with unsaved changes.
+   *
+   * Mirrors: ActiveModel::Dirty#changed (dirty.rb:294-297)
+   */
+  get changed(): string[] {
+    return this._dirty.changedAttributeNames;
   }
 
   /**
@@ -1817,8 +1831,13 @@ export class Model {
     return change ? change[0] : this._readAttribute(name);
   }
 
-  restoreAttributes(): void {
-    this._dirty.restore(this._attributes);
+  /**
+   * Restore all previous data of the provided attributes.
+   *
+   * Mirrors: ActiveModel::Dirty#restore_attributes (dirty.rb:319-322)
+   */
+  restoreAttributes(attrNames: string[] = this.changed): void {
+    attrNames.forEach((attrName) => this.restoreAttribute(attrName));
   }
 
   /**

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -705,7 +705,7 @@ describe("fromJson", () => {
     const u = new User({ name: "Original" });
     u.changesApplied();
     u.fromJson('{"name":"Updated"}');
-    expect(u.changed).toBe(true);
-    expect(Object.keys(u.changedAttributes)).toContain("name");
+    expect(u.isChanged).toBe(true);
+    expect(u.changed).toContain("name");
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -515,7 +515,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await x.reload();
       expect(x.hstores).toEqual([{ a: "c" }, { b: "b" }]);
       // Rails: assert_not_predicate x, :changed?
-      expect(x.changed).toBe(false);
+      expect(x.isChanged).toBe(false);
     });
     it("datetime with timezone awareness", async () => {
       const tz = "Pacific Time (US & Canada)";

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -265,7 +265,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await (hstore as any).saveBang();
       await (hstore as any).reload();
       expect((hstore as any).settings["three"]).toBe("four");
-      expect((hstore as any).changed).toBe(false);
+      expect((hstore as any).isChanged).toBe(false);
     });
 
     it("dirty from user equal", async () => {
@@ -273,7 +273,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const hstore = await Hstore.createBang({ settings });
       (hstore as any).settings = { key: "value", alongkey: "anything" };
       expect((hstore as any).settings).toEqual(settings);
-      expect((hstore as any).changed).toBe(false);
+      expect((hstore as any).isChanged).toBe(false);
     });
 
     it("hstore dirty from database equal", async () => {
@@ -282,7 +282,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await (hstore as any).reload();
       expect((hstore as any).settings).toEqual(settings);
       (hstore as any).settings = settings;
-      expect((hstore as any).changed).toBe(false);
+      expect((hstore as any).isChanged).toBe(false);
     });
 
     it("spaces", async () => {

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -127,13 +127,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         cidr_address: "192.168.1.0/24",
       })) as any;
       model.cidr_address = "192.168.1.0/24";
-      expect(model.changed).toBe(false);
+      expect(model.isChanged).toBe(false);
 
       model.cidr_address = "192.168.2.0/24";
-      expect(model.changed).toBe(true);
+      expect(model.isChanged).toBe(true);
 
       model.cidr_address = "192.168.1.0/25";
-      expect(model.changed).toBe(true);
+      expect(model.isChanged).toBe(true);
     });
 
     it("mac address change case does not mark dirty", async () => {
@@ -144,7 +144,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       model.mac_address = (model.mac_address as string).replace(/[a-zA-Z]/g, (c: string) =>
         c === c.toUpperCase() ? c.toLowerCase() : c.toUpperCase(),
       );
-      expect(model.changed).toBe(false);
+      expect(model.isChanged).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -97,7 +97,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       record.single = Infinity;
       record.double = -Infinity;
       // Rails: assert_not_predicate record, :changed?
-      expect(record.changed).toBe(false);
+      expect(record.isChanged).toBe(false);
     });
 
     it("reassigning nan does not mark record as changed", async () => {
@@ -111,7 +111,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       record.single = NaN;
       record.double = NaN;
       // Rails: assert_not_predicate record, :changed?
-      expect(record.changed).toBe(false);
+      expect(record.isChanged).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -985,7 +985,7 @@ export class CollectionAssociation extends Association {
       (this.owner.isStrictLoading() && this.owner.isStrictLoadingAll()) ||
       !!this.reflection.options.strictLoading ||
       this.owner.isNewRecord() ||
-      this.target.some((r) => r.isNewRecord() || r.changed)
+      this.target.some((r) => r.isNewRecord() || r.isChanged)
     );
   }
 

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -646,7 +646,7 @@ async function saveThroughRecord(this: HasManyThroughAssociation, record: Base):
   try {
     const joinRecord = this.buildThroughRecord(record);
     if (!joinRecord) return true;
-    if (!joinRecord.changed) return true;
+    if (!joinRecord.isChanged) return true;
     await (joinRecord as any).saveBang();
     return true;
   } finally {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -867,7 +867,7 @@ describe("HasOneAssociationsTest", () => {
     expect(newShip.isNewRecord()).toBe(true);
     expect(await newShip.isInvalid()).toBe(true);
     expect(origShip.pirate_id).toBeNull();
-    expect(origShip.changed).toBe(false); // check it was saved
+    expect(origShip.isChanged).toBe(false); // check it was saved
   });
 
   it("creation failure replaces existing with dependent option", async () => {
@@ -1043,7 +1043,7 @@ describe("HasOneAssociationsTest", () => {
     await ship.save();
 
     ship.name = "new name";
-    expect(ship.changed).toBe(true);
+    expect(ship.isChanged).toBe(true);
     await assertQueriesCount(3, false, async () => {
       // One query for updating name, not triggering query for updating pirate_id
       await (pirate as any).setShip(ship);

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -450,7 +450,7 @@ describe("CustomPropertiesTest", () => {
     expect((model as any).foo).toBe("lol");
 
     (model as any).foo = "lol";
-    expect(model.changed).toBe(false);
+    expect(model.isChanged).toBe(false);
   });
 
   it("attributes not backed by database columns appear in inspect", () => {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -724,7 +724,7 @@ export async function isAssociationValid(
   if (await record.isValid(context)) return true;
 
   let associatedErrors: any[];
-  if (record.changed || record.isNewRecord() || context) {
+  if (record.isChanged || record.isNewRecord() || context) {
     associatedErrors = record.errors.objects;
   } else {
     associatedErrors = record.errors.objects.filter(

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -56,7 +56,7 @@ describe("bigint model round-trip (all adapters)", () => {
     const m = await Metric.create({ score: BIG, label: "a" });
     const found = await Metric.find(m.id);
     found.score = BIG;
-    expect(found.changed).toBe(false);
+    expect(found.isChanged).toBe(false);
   });
 
   it("dirty tracking: change detected on different bigint", async () => {
@@ -64,7 +64,7 @@ describe("bigint model round-trip (all adapters)", () => {
     const m = await Metric.create({ score: BIG, label: "a" });
     const found = await Metric.find(m.id);
     found.score = BIG + 1n;
-    expect(found.changed).toBe(true);
+    expect(found.isChanged).toBe(true);
     expect(found.changes.score).toEqual([BIG, BIG + 1n]);
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3181,7 +3181,7 @@ export class PostgreSQLAdapter
 
   /** @internal */
   override arelVisitor(): Visitors.ToSql {
-    return new Visitors.PostgreSQLWithBinds(this);
+    return new Visitors.PostgreSQL(this);
   }
 
   supportsDdlTransactions(): boolean {

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -94,7 +94,7 @@ async function withTravel(offsetMs: number, fn: () => Promise<void>): Promise<vo
 
 /** Mirrors Rails' private `check_pirate_after_save_failure(pirate)`. */
 function checkPirateAfterSaveFailure(pirate: Rec): void {
-  expect(pirate.changed).toBe(true);
+  expect(pirate.isChanged).toBe(true);
   expect(pirate.attributeChanged("parrot_id")).toBe(true);
   expect(pirate.changedAttributeNamesToSave).toEqual(["parrot_id"]);
   expect(pirate.attributeWas("parrot_id")).toBeNull();
@@ -377,10 +377,10 @@ describe("DirtyTest", () => {
     pirate.catchphrase = "arrr";
     expect(await pirate.saveBang()).toBeTruthy();
 
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
 
     pirate.parrot_id = "0";
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
   });
 
   it("integer zero to integer zero not marked as changed", async () => {
@@ -389,17 +389,17 @@ describe("DirtyTest", () => {
     pirate.catchphrase = "arrr";
     expect(await pirate.saveBang()).toBeTruthy();
 
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
 
     pirate.parrot_id = 0;
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
   });
 
   it("float zero to string zero not marked as changed", async () => {
     const data = new NumericData({ temperature: 0.0 }) as Rec;
     await data.saveBang();
 
-    expect(data.changed).toBe(false);
+    expect(data.isChanged).toBe(false);
 
     data.temperature = "0";
     expect(data.changes).toEqual({});
@@ -440,18 +440,18 @@ describe("DirtyTest", () => {
 
   it("object should be changed if any attribute is changed", async () => {
     const pirate = new Pirate() as Rec;
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
     expect(pirate.changedAttributeNamesToSave).toEqual([]);
     expect(pirate.changes).toEqual({});
 
     pirate.catchphrase = "arrr";
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     expect(pirate.attributeWas("catchphrase")).toBeNull();
     expect(pirate.changedAttributeNamesToSave).toEqual(["catchphrase"]);
     expect(pirate.changes).toEqual({ catchphrase: [null, "arrr"] });
 
     await pirate.save();
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
     expect(pirate.changedAttributeNamesToSave).toEqual([]);
     expect(pirate.changes).toEqual({});
   });
@@ -482,7 +482,7 @@ describe("DirtyTest", () => {
     const pirate = (await Pirate.createBang({ catchphrase: "jarl" })) as Rec;
     const parrot = await Parrot.createBang({ name: "Lorre" });
     pirate.parrot = parrot;
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     expect(pirate.changedAttributeNamesToSave).toEqual(["parrot_id"]);
   });
 
@@ -601,9 +601,9 @@ describe("DirtyTest", () => {
   it("reload should clear changed attributes", async () => {
     const pirate = (await Pirate.create({ catchphrase: "shiver me timbers" })) as Rec;
     pirate.catchphrase = "*hic*";
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     await pirate.reload();
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
   });
 
   it("dup objects should not copy dirty flag from creator", async () => {
@@ -619,9 +619,9 @@ describe("DirtyTest", () => {
     const phrase = "shiver me timbers";
     const pirate = (await Pirate.create({ catchphrase: phrase })) as Rec;
     pirate.catchphrase = "*hic*";
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     pirate.catchphrase = phrase;
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
   });
 
   it("reverted changes are not dirty after multiple changes", async () => {
@@ -629,23 +629,23 @@ describe("DirtyTest", () => {
     const pirate = (await Pirate.create({ catchphrase: phrase })) as Rec;
     for (let i = 0; i < 10; i++) {
       pirate.catchphrase = "*hic*".repeat(i);
-      expect(pirate.changed).toBe(true);
+      expect(pirate.isChanged).toBe(true);
     }
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     pirate.catchphrase = phrase;
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
   });
 
   it("reverted changes are not dirty going from nil to value and back", async () => {
     const pirate = (await Pirate.create({ catchphrase: "Yar!" })) as Rec;
 
     pirate.parrot_id = 1;
-    expect(pirate.changed).toBe(true);
+    expect(pirate.isChanged).toBe(true);
     expect(pirate.attributeChanged("parrot_id")).toBe(true);
     expect(pirate.attributeChanged("catchphrase")).toBe(false);
 
     pirate.parrot_id = null;
-    expect(pirate.changed).toBe(false);
+    expect(pirate.isChanged).toBe(false);
     expect(pirate.attributeChanged("parrot_id")).toBe(false);
     expect(pirate.attributeChanged("catchphrase")).toBe(false);
   });
@@ -654,15 +654,15 @@ describe("DirtyTest", () => {
     await withPartialWrites(Topic, true, async () => {
       const topic = (await Topic.createBang({ content: { a: "a" } })) as Rec;
 
-      expect(topic.changed).toBe(false);
+      expect(topic.isChanged).toBe(false);
 
       (topic.content as Record<string, string>)["b"] = "b";
 
-      expect(topic.changed).toBe(true);
+      expect(topic.isChanged).toBe(true);
 
       await (topic as unknown as Topic).saveBang();
 
-      expect(topic.changed).toBe(false);
+      expect(topic.isChanged).toBe(false);
       expect((topic.content as Record<string, string>)["b"]).toBe("b");
 
       await (topic as unknown as Topic).reload();
@@ -678,11 +678,11 @@ describe("DirtyTest", () => {
 
     (topic.content as Record<string, string>)["b"] = "b";
 
-    expect(topic.changed).toBe(true);
+    expect(topic.isChanged).toBe(true);
 
     await (topic as unknown as Topic).saveBang();
 
-    expect(topic.changed).toBe(false);
+    expect(topic.isChanged).toBe(false);
     expect(topic.previousChanges).toHaveProperty("content");
     expect(topic.savedChanges).toHaveProperty("content");
     expect((topic.previousChanges["content"][0] as Record<string, string>)["a"]).toBe("a");
@@ -1009,13 +1009,13 @@ describe("DirtyTest", () => {
 
   it("attributes assigned but not selected are dirty", async () => {
     const person = (await Person.select("id").first()) as Rec;
-    expect(person.changed).toBe(false);
+    expect(person.isChanged).toBe(false);
 
     person.first_name = "Sean";
-    expect(person.changed).toBe(true);
+    expect(person.isChanged).toBe(true);
 
     person.first_name = null;
-    expect(person.changed).toBe(true);
+    expect(person.isChanged).toBe(true);
   });
 
   it("attributes not selected are still missing after save", async () => {
@@ -1099,7 +1099,7 @@ describe("DirtyTest", () => {
       static {
         this.tableName = "people";
         this.afterSave(function (record: Rec) {
-          if (record.changed) throw new Error("changed? should be false");
+          if (record.isChanged) throw new Error("changed? should be false");
           if (record.hasChangesToSave) throw new Error("has_changes_to_save? should be false");
           if (!call<boolean>(record, "isSavedChanges"))
             throw new Error("saved_changes? should be true");
@@ -1110,7 +1110,7 @@ describe("DirtyTest", () => {
     };
 
     const person = (await klass.create({ first_name: "Sean" })) as Rec;
-    expect(person.changed).toBe(false);
+    expect(person.isChanged).toBe(false);
   });
 
   it("changed? in around callbacks after yield returns false", async () => {
@@ -1119,7 +1119,7 @@ describe("DirtyTest", () => {
         this.tableName = "people";
         this.aroundCreate(async function (record: Rec, proceed: () => Promise<void>) {
           await proceed();
-          if (record.changed) throw new Error("changed? should be false");
+          if (record.isChanged) throw new Error("changed? should be false");
           if (record.hasChangesToSave) throw new Error("has_changes_to_save? should be false");
           if (!call<boolean>(record, "isSavedChanges"))
             throw new Error("saved_changes? should be true");
@@ -1130,7 +1130,7 @@ describe("DirtyTest", () => {
     };
 
     const person = (await klass.create({ first_name: "Sean" })) as Rec;
-    expect(person.changed).toBe(false);
+    expect(person.isChanged).toBe(false);
   });
 
   it("partial insert off with unchanged default function attribute", async () => {

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -254,7 +254,7 @@ describe("OptimisticLockingTest", () => {
     expect(p1.lock_version).toBe(0);
     await p1.touch();
     expect(p1.lock_version).toBe(1);
-    expect(p1.changed).toBe(false);
+    expect(p1.isChanged).toBe(false);
     expect(Object.keys(p1.savedChanges).sort()).toEqual(["lock_version", "updated_at"]);
   });
 
@@ -365,7 +365,7 @@ describe("OptimisticLockingTest", () => {
     expect(t1.lock_version).toBe(0);
     await t1.touch();
     expect(t1.lock_version).toBe(1);
-    expect(t1.changed).toBe(false);
+    expect(t1.isChanged).toBe(false);
     expect(Object.keys(t1.savedChanges).length).toBeGreaterThan(0);
     expect(Object.keys(t1.savedChanges).sort()).toEqual(
       expect.arrayContaining(["lock_version", "updated_at"]),

--- a/packages/activerecord/src/locking/pessimistic.ts
+++ b/packages/activerecord/src/locking/pessimistic.ts
@@ -16,7 +16,7 @@ import type { Base } from "../base.js";
  */
 export async function lockBang<T extends Base>(this: T, lock: boolean | string = true): Promise<T> {
   if (this.isPersisted()) {
-    if (this.changed) {
+    if (this.isChanged) {
       // Mirrors Rails' squished message order: the save/reload guidance first,
       // then `Changed attributes: #{changed.map(&:inspect).join(', ')}.` last.
       const dirtyAttrs = this.changedAttributeNamesToSave.map((a) => `"${a}"`).join(", ");

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -734,7 +734,7 @@ describe("PersistenceTest", () => {
     await t.updateColumn("title", "super_title");
     expect(t.author_name).toBe("John");
     expect(t.title).toBe("super_title");
-    expect(t.changed).toBe(true);
+    expect(t.isChanged).toBe(true);
     expect(t.attributeChanged("author_name")).toBe(true);
 
     await t.reload();
@@ -749,7 +749,7 @@ describe("PersistenceTest", () => {
     await t.updateColumns({ title: "super_title" });
     expect(t.author_name).toBe("John");
     expect(t.title).toBe("super_title");
-    expect(t.changed).toBe(true);
+    expect(t.isChanged).toBe(true);
     expect(t.attributeChanged("author_name")).toBe(true);
 
     await t.reload();
@@ -1038,7 +1038,7 @@ describe("PersistenceTest", () => {
     const t = (await Topic.first())!;
     await t.updateAttributeBang("title", "super_title");
     expect(t.title).toBe("super_title");
-    expect(t.changed).toBe(false);
+    expect(t.isChanged).toBe(false);
     expect(t.attributeChanged("title")).toBe(false);
     expect(t.attributeChange("title")).toBeNull();
     await t.reload();
@@ -1265,7 +1265,7 @@ describe("PersistenceTest", () => {
     const t = await Topic.create({ title: "a" });
     await t.updateAttribute("title", "super_title");
     expect(t.title).toBe("super_title");
-    expect(t.changed).toBe(false);
+    expect(t.isChanged).toBe(false);
     expect(t.attributeChanged("title")).toBe(false);
     expect(t.attributeChange("title")).toBeNull();
     await t.reload();
@@ -1295,9 +1295,9 @@ describe("PersistenceTest", () => {
   it("update columns should not leave the object dirty", async () => {
     const t = await Topic.create({ title: "old" });
     t.title = "dirty";
-    expect(t.changed).toBe(true);
+    expect(t.isChanged).toBe(true);
     await t.updateColumns({ title: "clean" });
-    expect(t.changed).toBe(false);
+    expect(t.isChanged).toBe(false);
   });
 
   it("update columns returns boolean", async () => {
@@ -1435,11 +1435,11 @@ describe("PersistenceTest", () => {
 
     await topic.reload();
     await topic.updateColumn("content", "--- You too\n...\n");
-    expect(topic.changed).toBe(false);
+    expect(topic.isChanged).toBe(false);
 
     await topic.reload();
     await topic.updateColumn("content", "--- Have a nice day\n...\n");
-    expect(topic.changed).toBe(false);
+    expect(topic.isChanged).toBe(false);
   });
 
   it("update columns", async () => {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -618,7 +618,7 @@ describe("SerializedAttributeTest", () => {
     }
     const topic = await CoderTopic.create({ content: "bar" as any });
     void (topic as any).content; // read to trigger isChangedInPlace check
-    expect(topic.changed).toBe(false);
+    expect(topic.isChanged).toBe(false);
   });
 
   it.skip("serialized attribute works under concurrent initial access", () => {

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -78,7 +78,7 @@ describe("TimestampTest", () => {
     expect(developer.legacy_updated_at).not.toEqual(previouslyUpdatedAt);
     expect(developer.salary).toBe(previousSalary + 10000);
     expect(developer.attributeChanged("salary")).toBe(true);
-    expect(developer.changed).toBe(true);
+    expect(developer.isChanged).toBe(true);
     expect(developer.changedAttributeNamesToSave).toEqual(["salary"]);
     expect((developer as any).isSavedChanges()).toBe(true);
     expect(Object.keys(developer.savedChanges).sort()).toEqual([
@@ -95,7 +95,7 @@ describe("TimestampTest", () => {
     await dev.touch();
 
     expect(dev.legacy_updated_at).not.toEqual(previouslyUpdatedAt);
-    expect(dev.changed).toBe(false);
+    expect(dev.isChanged).toBe(false);
     expect((dev as any).isSavedChanges()).toBe(true);
     expect(Object.keys(dev.savedChanges).sort()).toEqual([
       "legacy_updated_at",
@@ -147,7 +147,7 @@ describe("TimestampTest", () => {
     }
 
     expect(developer.attributeChanged("legacy_created_at")).toBe(false);
-    expect(developer.changed).toBe(false);
+    expect(developer.isChanged).toBe(false);
     expect(developer.legacy_created_at).not.toEqual(previousCreatedAt);
     expect(developer.legacy_updated_at).not.toEqual(previouslyUpdatedAt);
   });
@@ -161,7 +161,7 @@ describe("TimestampTest", () => {
     }
 
     expect(developer.attributeChanged("legacy_updated_at")).toBe(false);
-    expect(developer.changed).toBe(false);
+    expect(developer.isChanged).toBe(false);
     expect(developer.legacy_updated_at).not.toEqual(previouslyUpdatedAt);
   });
 

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -50,7 +50,7 @@ describe("TouchLaterTest", () => {
   it("touch later dont set dirty attributes", async () => {
     const invoice = await Invoice.create();
     await invoice.touchLater();
-    assertNotPredicate(invoice, (i) => i.changed);
+    assertNotPredicate(invoice, (i) => i.isChanged);
   });
 
   it("touch later respects no touching policy", async () => {

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -26,7 +26,7 @@ const { authors } = fixtures({
 describe("StringTypeTest", () => {
   it("string mutations are detected", async () => {
     const author = await StringTestAuthor.find(authors("sean").id);
-    assertNotPredicate(author, (a) => a.changed);
+    assertNotPredicate(author, (a) => a.isChanged);
 
     // JS strings are immutable; assignment goes through the setter rather than mutating in place.
     // nameChanged() fires via dirty-tracker change detection, not isChangedInPlace.
@@ -37,6 +37,6 @@ describe("StringTypeTest", () => {
     await author.reload();
 
     expect(author.name).toEqual("Sean Griffin");
-    assertNotPredicate(author, (a) => a.changed);
+    assertNotPredicate(author, (a) => a.isChanged);
   });
 });

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -250,9 +250,12 @@ describe("TimeZoneTest", () => {
 
   it("at with microseconds", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    const twz = zone.at(946684800);
+    const secs = 946684800.0;
+    const microsecs = 123456.789;
+    const twz = zone.at(secs, microsecs);
     expect(twz.timeZone).toBe(zone);
-    expect(twz.utc().epochMilliseconds).toBe(946684800000);
+    expect(twz.toI()).toBe(secs);
+    expect(twz.nsec).toBe(123456789);
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -183,9 +183,6 @@ describe("TimeZoneLocalPeriodsTest", () => {
   });
 
   it("strptime %Q keeps digits below the millisecond", () => {
-    // `Date._strptime("946684800123456", "%Q")` is `{seconds: (118335600015432/125)}`
-    // — 946684800123.456 seconds — so the instant carries 456 microseconds past
-    // the millisecond that a Float epoch in milliseconds would drop.
     const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = eastern.strptime("946684800123456", "%Q")!;
     expect(twz.toI()).toBe(946684800123);
@@ -195,8 +192,6 @@ describe("TimeZoneLocalPeriodsTest", () => {
   it("at keeps digits below the millisecond", () => {
     const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(eastern.at(946684800, 123456.789).nsec).toBe(123456789);
-    // A Rational is exact, as `Time.at(Rational(946684800123456789, 10**9))`
-    // is in MRI.
     expect(eastern.at(new Rational(946684800123456789n, 1_000_000_000n)).nsec).toBe(123456789);
   });
 });

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { TimeZone, AmbiguousTime, PeriodNotFound } from "./values/time-zone.js";
 import { ArgumentError } from "./hash-utils.js";
+import { Rational } from "@blazetrails/date";
 
 describe("TimeZoneTest", () => {
   it("clear resets the memos", () => {
@@ -179,5 +180,23 @@ describe("TimeZoneLocalPeriodsTest", () => {
     expect(() => eastern.iso8601(null)).toThrow(ArgumentError);
     expect(() => eastern.iso8601("foobar")).toThrow(ArgumentError);
     expect(() => eastern.rfc3339("1999-12-31")).toThrow(ArgumentError);
+  });
+
+  it("strptime %Q keeps digits below the millisecond", () => {
+    // `Date._strptime("946684800123456", "%Q")` is `{seconds: (118335600015432/125)}`
+    // — 946684800123.456 seconds — so the instant carries 456 microseconds past
+    // the millisecond that a Float epoch in milliseconds would drop.
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    const twz = eastern.strptime("946684800123456", "%Q")!;
+    expect(twz.toI()).toBe(946684800123);
+    expect(twz.nsec).toBe(456000000);
+  });
+
+  it("at keeps digits below the millisecond", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    expect(eastern.at(946684800, 123456.789).nsec).toBe(123456789);
+    // A Rational is exact, as `Time.at(Rational(946684800123456789, 10**9))`
+    // is in MRI.
+    expect(eastern.at(new Rational(946684800123456789n, 1_000_000_000n)).nsec).toBe(123456789);
   });
 });

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -749,9 +749,10 @@ export class Timezone {
  * microseconds one. A Float is truncated at the nanosecond, as MRI's
  * `Time.at(946684800.123456789).nsec` is `123456835` rather than `...836`.
  *
- * @noRailsEquivalent Ruby's Numeric tower does this arithmetic exactly at any
- * width; JS needs the accumulation moved onto `bigint` to keep the digits
- * below the millisecond that a Float epoch cannot hold.
+ * @noRailsEquivalent CONVERGEABLE — Ruby's Numeric tower does this arithmetic
+ * exactly at any width, so `Time.at` needs no such scaling; this goes away with
+ * a `Time.at` in `@blazetrails/date` for `at` to delegate to, the gap
+ * `time-helpers-stub-date-and-datetime-clock` records.
  */
 function toNanoseconds(value: number | bigint | Rational, scale: bigint): bigint {
   if (value instanceof Rational) return (value.numerator * scale) / value.denominator;
@@ -984,11 +985,11 @@ export class TimeZone {
    */
   at(
     seconds: number | bigint | Rational,
-    subsecondMicros: number | bigint | Rational = 0,
+    microsecondsWithFrac: number | bigint | Rational = 0,
   ): TimeWithZone {
     return new TimeWithZone(
       Temporal.Instant.fromEpochNanoseconds(
-        toNanoseconds(seconds, 1_000_000_000n) + toNanoseconds(subsecondMicros, 1_000n),
+        toNanoseconds(seconds, 1_000_000_000n) + toNanoseconds(microsecondsWithFrac, 1_000n),
       ),
       this,
     );

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -743,6 +743,24 @@ export class Timezone {
 }
 
 /**
+ * The `Integer`, `Float` or `Rational` a Ruby `Time.at` argument can be, scaled
+ * to a whole number of nanoseconds. `scale` is the nanoseconds one unit of the
+ * argument is worth — `1_000_000_000` for the seconds argument, `1_000` for the
+ * microseconds one. A Float is truncated at the nanosecond, as MRI's
+ * `Time.at(946684800.123456789).nsec` is `123456835` rather than `...836`.
+ *
+ * @noRailsEquivalent Ruby's Numeric tower does this arithmetic exactly at any
+ * width; JS needs the accumulation moved onto `bigint` to keep the digits
+ * below the millisecond that a Float epoch cannot hold.
+ */
+function toNanoseconds(value: number | bigint | Rational, scale: bigint): bigint {
+  if (value instanceof Rational) return (value.numerator * scale) / value.denominator;
+  if (typeof value === "bigint") return value * scale;
+  const whole = Math.trunc(value);
+  return BigInt(whole) * scale + BigInt(Math.trunc((value - whole) * Number(scale)));
+}
+
+/**
  * Ruby `Time.new`'s fractional-seconds argument (`parts.fetch(:sec, 0) +
  * parts.fetch(:sec_fraction, 0)`), which Temporal cannot take as a Rational —
  * it wants the sub-second remainder split across its millisecond / microsecond
@@ -952,11 +970,26 @@ export class TimeZone {
   }
 
   /**
-   * Create a TimeWithZone from a Unix timestamp.
+   * `at(*args)` (time_zone.rb:378-380): `Time.at(*args).utc.in_time_zone(self)`.
+   *
+   *   Time.zone.at(946684800.0)           # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+   *   Time.at(946684800, 123456.789).nsec # => 123456789
+   *
+   * Ruby's `Time.at` takes the seconds as an Integer, Float or Rational and an
+   * optional second argument giving the sub-second part in microseconds, and
+   * carries the result to the nanosecond. `Temporal.Instant` is that same
+   * nanosecond seat, so the total is accumulated as a `bigint` count of
+   * nanoseconds rather than through a Float millisecond, which would drop
+   * every digit below the millisecond.
    */
-  at(secondsSinceEpoch: number): TimeWithZone {
+  at(
+    seconds: number | bigint | Rational,
+    subsecondMicros: number | bigint | Rational = 0,
+  ): TimeWithZone {
     return new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(Math.trunc(secondsSinceEpoch * 1000)),
+      Temporal.Instant.fromEpochNanoseconds(
+        toNanoseconds(seconds, 1_000_000_000n) + toNanoseconds(subsecondMicros, 1_000n),
+      ),
       this,
     );
   }
@@ -1364,9 +1397,7 @@ export class TimeZone {
     if (Object.keys(parts).length === 0) return undefined;
 
     if (parts.seconds != null) {
-      return this.at(
-        parts.seconds instanceof Rational ? parts.seconds.toF() : Number(parts.seconds),
-      );
+      return this.at(parts.seconds);
     }
 
     const nanosecond = secFractionToNanosecond(parts.secFraction);

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -6,7 +6,7 @@ export {
 } from "./split-schema-qualified-name.js";
 export { UnsupportedVisitError, NotImplementedError } from "../errors.js";
 export { MySQL } from "./mysql.js";
-export { PostgreSQL, PostgreSQLWithBinds } from "./postgresql.js";
+export { PostgreSQL } from "./postgresql.js";
 export { SQLite } from "./sqlite.js";
 export { Dot, DotNode, DotEdge } from "./dot.js";
 export { Visitor } from "./visitor.js";

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -128,7 +128,7 @@ describe("PostgresTest", () => {
 
   describe("Nodes::BindParam", () => {
     it("increments each bind param", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
+      const visitor = new Visitors.PostgreSQL(postgresqlTestConnection);
       const a = users.get("id").eq(new Nodes.BindParam());
       const b = users.get("name").eq(new Nodes.BindParam());
       const sql = visitor.compile(new Nodes.And([a, b]));
@@ -137,7 +137,7 @@ describe("PostgresTest", () => {
     });
 
     it("compileWithBinds extracts values with $N placeholders", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
+      const visitor = new Visitors.PostgreSQL(postgresqlTestConnection);
       const a = users.get("id").eq(new Nodes.BindParam(42));
       const b = users.get("name").eq(new Nodes.BindParam("alice"));
       const [sql, binds] = compileWithBinds(visitor, new Nodes.And([a, b]));
@@ -149,7 +149,7 @@ describe("PostgresTest", () => {
     });
 
     it("compileWithBinds uses $N placeholders for Quoted Date values", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
+      const visitor = new Visitors.PostgreSQL(postgresqlTestConnection);
       const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
       const node = users.get("created_at").eq(new Nodes.Quoted(d));
       const [sql, binds] = compileWithBinds(visitor, node);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -3,6 +3,9 @@ import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql } from "./to-sql.js";
 
+/** Mirrors: Arel::Visitors::PostgreSQL::BIND_BLOCK (postgresql.rb:81-82), a private constant. */
+const BIND_BLOCK: (index: number) => string = (i: number) => `$${i}`;
+
 /**
  * PostgreSQL visitor — extends generic ToSql with PostgreSQL-specific features.
  *
@@ -117,6 +120,11 @@ export class PostgreSQL extends ToSql {
     return collector;
   }
 
+  /** Mirrors: Arel::Visitors::PostgreSQL#bind_block (postgresql.rb:81-84). */
+  protected override bindBlock(): (index: number) => string {
+    return BIND_BLOCK;
+  }
+
   /**
    * Mirrors Rails Postgres `grouping_array_or_grouping_element` (postgresql.rb:87).
    * Trails' `GroupingElement` always carries an `expressions: Node[]`
@@ -140,14 +148,5 @@ export class PostgreSQL extends ToSql {
 
   static {
     PostgreSQL.dispatchCache().set(Nodes.Lateral, "visitArelNodesLateral");
-  }
-}
-
-/**
- * PostgreSQL visitor — uses numbered bind parameters ($1, $2, ...).
- */
-export class PostgreSQLWithBinds extends PostgreSQL {
-  protected override bindBlock(): (index: number) => string {
-    return (i: number) => `$${i}`;
   }
 }


### PR DESCRIPTION
Three convergences, one PR.

**`PostgreSQLWithBinds` retired** (RFC 0117). Rails has one PostgreSQL visitor and it carries `BIND_BLOCK = proc { |i| "$#{i}" }` unconditionally (`arel/visitors/postgresql.rb:81-84`). `bindBlock` moves onto `Visitors::PostgreSQL` itself, the subclass and its `visitors/index.ts` export are deleted, and `postgresql-adapter.ts` constructs `Visitors.PostgreSQL`. `parity:api:extra --package arel` for `visitors/postgresql.ts`: novel 1 → 0.

**`Model#changed` returns the name array** (RFC 0115). `changed?` (`dirty.rb:286-288`, boolean) is `isChanged`; `changed` (`dirty.rb:295-297`) is now the `string[]` of unsaved-change attribute names. Every boolean call site was audited (`grep -rn "\.changed\b"`) and moved to `isChanged` — `pessimistic.ts`, `autosave-association.ts`, `collection-association.ts`, `has-many-through-association.ts`, plus the test suites. `restoreAttributes` takes Rails' `attr_names = changed` default (`dirty.rb:319-322`), and the activemodel dirty tests #6858 routed through `Object.keys(x.changedAttributes)` use `x.changed`.

**`TimeZone#at` keeps nanoseconds** (RFC 0098). `at(*args)` (`time_zone.rb:378-380`) is `Time.at(*args).utc.in_time_zone(self)`, so it takes Integer/Float/Rational seconds plus the optional microseconds argument and accumulates a `bigint` nanosecond count through `Temporal.Instant.fromEpochNanoseconds` instead of flooring at the millisecond. `partsToTime`'s `:seconds` arm hands its `Rational` straight through. `at with microseconds` is re-derived against `test_at_with_microseconds` (`time_zone_test.rb:264-272`), and a `%Q` strptime case pins the sub-millisecond digits. A Float is truncated at the nanosecond, matching MRI (`Time.at(946684800.123456789).nsec # => 123456835`).

Story bodies for the wave-5 `order:`-trap warning drop landed in the tasks repo (blazetrailsdev/tasks@a92cf84).

`generate-alias-attributes-from-aliases-by-attribute-name` was released back rather than bundled: its work lives in the still-open PR #6838, whose branch this would duplicate and conflict with.

Closes-story: retire-postgresql-with-binds-onto-postgresql-bind-block
Closes-story: drop-order-row-trap-warnings-from-wave-5-stories
Closes-story: converge-model-changed-onto-the-rails-name-array
Closes-story: time-zone-at-truncates-sub-millisecond-precision