### PR TITLE
refactor(arel,activerecord): fold select-manager join/union variants, drop _buildEntryScope

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,7 +1,6 @@
 import { isPlainObject } from "@blazetrails/activesupport";
 import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
-import { typeCondition } from "../inheritance.js";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
 import { RuntimeReflection } from "../reflection.js";
@@ -76,7 +75,7 @@ export interface AssociationScopeable {
  * a reflection plus `attr_reader :aliased_table` and
  * `def all_includes; nil; end`.)
  */
-/** The `Relation` surface `_buildEntryScope` needs off `build_scope`. */
+/** The `Relation` surface `evalScope` needs off `build_scope`. */
 type AliasedScope = { where(predicate: unknown): AliasedScope };
 
 type ScopeBuilder = {
@@ -835,11 +834,8 @@ export class AssociationScope {
    * Evaluate a chain entry's scope lambda against a fresh relation built
    * from its klass. Rails: `relation = reflection.build_scope(reflection
    * .aliased_table); relation.instance_exec(owner, &scope)`
-   * (association_scope.rb:169-172). We build the relation via
-   * `_buildEntryScope` (`reflection.build_scope(aliased_table)` when the
-   * chain entry is aliased, else `klass.unscoped`, which carries the STI
-   * type_condition) and invoke with `invokeScopeLambda`'s arity / `this`
-   * semantics: 0-arg → `call(relation)`; 1+-arg → `call(relation, relation,
+   * (association_scope.rb:169-172), and invoke with `invokeScopeLambda`'s
+   * arity / `this` semantics: 0-arg → `call(relation)`; 1+-arg → `call(relation, relation,
    * owner)`. The common 0-arg form Rails uses for scope_for_association /
    * source_type_scope (`function () { return this.where(...) }`) relies on
    * `this` being the relation. Unlike Rails we omit the `|| relation`
@@ -864,14 +860,11 @@ export class AssociationScope {
     // `where(...)` predicates to the ALIASED table. For a self-referential
     // polymorphic through (a repeated table) the entry's `imageable_type`
     // source-type filter must qualify the joined-in alias
-    // (`children_imageables`), not the FROM table. Only repoint when the
-    // tracker actually produced an alias (a `TableAlias` node); the
-    // non-aliased case keeps `klass.arelTable` so SQL is byte-identical.
-    const aliased = (reflection as ReflectionProxy).aliasedTable;
-    const relation = this._buildEntryScope(
+    // (`children_imageables`), not the FROM table.
+    const relation = (reflection as unknown as ScopeBuilder).buildScope(
+      (reflection as ReflectionProxy).aliasedTable,
+      undefined,
       entryKlass,
-      aliased instanceof Nodes.TableAlias ? aliased : undefined,
-      reflection,
     );
     return invokeScopeLambda(scopeFn as ScopeLambda<unknown>, relation, owner);
   }
@@ -887,37 +880,6 @@ export class AssociationScope {
    */
   private join(table: unknown, constraint: unknown): unknown {
     return new Nodes.LeadingJoin(table as never, new Nodes.On(constraint as never));
-  }
-
-  /**
-   * Build a fresh scope for evaluating a chain entry's lambda.
-   *
-   * Aliased entries go through `AbstractReflection#build_scope`
-   * (reflection.rb:336-338), the seat Rails' `association_scope.rb:169` calls
-   * with `reflection.aliased_table`, and take their STI predicate on that same
-   * alias the way `join_scope` does (reflection.rb:285-286) — a
-   * self-referential through must filter the joined-in alias, not the FROM
-   * table. Without an alias this is `entryKlass.unscoped`, whose `relation()`
-   * (core.rb:431-435) carries the type condition already, so the non-aliased
-   * SQL stays byte-identical.
-   */
-  protected _buildEntryScope(
-    entryKlass: typeof Base,
-    aliasedTable?: unknown,
-    reflection?: AbstractReflection | ReflectionProxy,
-  ): unknown {
-    if (aliasedTable && reflection) {
-      const scope = (reflection as unknown as ScopeBuilder).buildScope(
-        aliasedTable,
-        undefined,
-        entryKlass,
-      );
-      if (entryKlass.isFinderNeedsTypeCondition()) {
-        return scope.where(typeCondition(entryKlass, aliasedTable as never));
-      }
-      return scope;
-    }
-    return (entryKlass as unknown as { unscoped: () => unknown }).unscoped();
   }
 
   /**

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -310,7 +310,12 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       ).constraints?.() ?? [];
     for (const c of constraints) {
       if (typeof c !== "function") continue;
-      const entryScope = this._buildEntryScope(klass);
+      const entryScope = (
+        reflection as unknown as {
+          buildScope(table?: unknown, predicateBuilder?: unknown, klass?: typeof Base): unknown;
+          aliasedTable?: unknown;
+        }
+      ).buildScope((reflection as { aliasedTable?: unknown }).aliasedTable, undefined, klass);
       const evaluated =
         c.length === 0
           ? (c as () => unknown).call(entryScope)

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3426,7 +3426,7 @@ export interface JoinEmissionPlan {
  * @internal
  */
 export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmissionPlan): void {
-  if (plan.leadingJoins.length > 0) manager.prependJoinNodes(...plan.leadingJoins);
+  if (plan.leadingJoins.length > 0) manager.joinSources().push(...plan.leadingJoins);
 
   // One AliasTracker shared across every JoinDependency, mirroring Rails' single
   // `build_joins` `alias_tracker(leading_joins + join_nodes, aliases)`
@@ -3463,8 +3463,9 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   const joinType = plan.joinType;
   if (namedJoins.length > 0 || plan.stashedJoins.length > 0) {
     const jd = constructJoinDependency.call(this, namedJoins, joinType);
-    for (const node of jd.joinConstraints(plan.stashedJoins, sharedTracker(), references))
-      manager.appendJoinNode(node);
+    manager
+      .joinSources()
+      .push(...jd.joinConstraints(plan.stashedJoins, sharedTracker(), references));
   }
 
   // `build_joins` concats `buckets[:join_node]` once (query_methods.rb:1899);
@@ -3472,7 +3473,7 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // the `while joins.first.is_a?(Arel::Nodes::Join)` loop
   // (query_methods.rb:1856-1863) before the CTE nodes the select_named_joins
   // block appends (query_methods.rb:1865-1873).
-  for (const node of plan.joinNodes) manager.appendJoinNode(node);
+  if (plan.joinNodes.length > 0) manager.joinSources().push(...plan.joinNodes);
 
   // When a tracker was threaded in (Rails passes the alias HASH itself to
   // `join_scope.arel(alias_tracker.aliases)`, so claims made while building this

--- a/packages/arel/src/nodes/binary.test.ts
+++ b/packages/arel/src/nodes/binary.test.ts
@@ -26,7 +26,7 @@ describe("NodesTest", () => {
 
     it("UnionAll is a Binary", () => {
       const sm = new SelectManager(users);
-      const unionAll = sm.unionAll(new SelectManager(users));
+      const unionAll = sm.union(":all", new SelectManager(users));
       expect(unionAll).toBeInstanceOf(Nodes.Binary);
     });
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -323,7 +323,7 @@ describe("SelectManagerTest", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
       const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(q1.unionAll(q2))).toContain("UNION ALL");
+      expect(visitor.compile(q1.union(":all", q2))).toContain("UNION ALL");
     });
   });
 
@@ -1176,7 +1176,7 @@ describe("SelectManagerTest", () => {
   it("rightOuterJoin generates RIGHT OUTER JOIN", () => {
     const mgr = new SelectManager(users);
     mgr.project(star);
-    mgr.rightOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
+    mgr.join(posts, Nodes.RightOuterJoin).on(users.get("id").eq(posts.get("user_id")));
     expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
     expect(mgr.toSql()).toContain('"posts"');
   });
@@ -1184,14 +1184,14 @@ describe("SelectManagerTest", () => {
   it("fullOuterJoin generates FULL OUTER JOIN", () => {
     const mgr = new SelectManager(users);
     mgr.project(star);
-    mgr.fullOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
+    mgr.join(posts, Nodes.FullOuterJoin).on(users.get("id").eq(posts.get("user_id")));
     expect(mgr.toSql()).toContain("FULL OUTER JOIN");
   });
 
   it("crossJoin generates CROSS JOIN", () => {
     const mgr = new SelectManager(users);
     mgr.project(star);
-    mgr.crossJoin(posts);
+    mgr.join(posts, Nodes.CrossJoin);
     expect(mgr.toSql()).toContain("CROSS JOIN");
     expect(mgr.toSql()).toContain('"posts"');
   });
@@ -1202,27 +1202,6 @@ describe("SelectManagerTest", () => {
     const win = mgr.window("w");
     win.order(users.get("created_at").asc());
     expect(mgr.toSql()).toContain("WINDOW");
-  });
-
-  it("rightOuterJoin with string table name", () => {
-    const mgr = new SelectManager(users);
-    mgr.project(star);
-    mgr.rightOuterJoin("posts", users.get("id").eq(new Nodes.SqlLiteral("posts.user_id")));
-    expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
-  });
-
-  it("fullOuterJoin with string table name", () => {
-    const mgr = new SelectManager(users);
-    mgr.project(star);
-    mgr.fullOuterJoin("posts", users.get("id").eq(new Nodes.SqlLiteral("posts.user_id")));
-    expect(mgr.toSql()).toContain("FULL OUTER JOIN");
-  });
-
-  it("crossJoin with string table name", () => {
-    const mgr = new SelectManager(users);
-    mgr.project(star);
-    mgr.crossJoin("posts");
-    expect(mgr.toSql()).toContain("CROSS JOIN");
   });
 
   describe("projections", () => {
@@ -1353,7 +1332,8 @@ describe("SelectManagerTest", () => {
     it("takes the full outer join class", () => {
       const mgr = users
         .project(star)
-        .fullOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
+        .join(posts, Nodes.FullOuterJoin)
+        .on(users.get("id").eq(posts.get("user_id")));
       expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.FullOuterJoin);
       expect(mgr.toSql()).toContain("FULL OUTER JOIN");
     });
@@ -1361,7 +1341,8 @@ describe("SelectManagerTest", () => {
     it("takes the right outer join class", () => {
       const mgr = users
         .project(star)
-        .rightOuterJoin(posts, users.get("id").eq(posts.get("user_id")));
+        .join(posts, Nodes.RightOuterJoin)
+        .on(users.get("id").eq(posts.get("user_id")));
       expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.RightOuterJoin);
       expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
     });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -5,11 +5,9 @@ import { SelectCore } from "./nodes/select-core.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Distinct } from "./nodes/terminal.js";
 import { Offset, Limit, Lock, On, DistinctOn, Group, OptimizerHints } from "./nodes/unary.js";
-import { CrossJoin, Join } from "./nodes/binary.js";
+import { Join } from "./nodes/binary.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
-import { RightOuterJoin } from "./nodes/right-outer-join.js";
-import { FullOuterJoin } from "./nodes/full-outer-join.js";
 import { StringJoin } from "./nodes/string-join.js";
 import { EmptyJoinError } from "./errors.js";
 import { Union, UnionAll, Intersect, Except } from "./nodes/binary.js";
@@ -27,6 +25,11 @@ import { Lateral } from "./nodes/unary.js";
 import { And } from "./nodes/and.js";
 import { JoinSource } from "./nodes/join-source.js";
 import { InsertManager } from "./insert-manager.js";
+
+const UNION_NODE_CLASSES: Record<
+  string,
+  new (left: SelectStatement, right: SelectStatement) => Union
+> = { UnionAll };
 
 /**
  * SelectManager — the chainable API for building SELECT queries.
@@ -364,10 +367,30 @@ export class SelectManager extends TreeManager {
 
   /**
    * UNION with another manager.
+   *
+   * Mirrors: Arel::SelectManager#union (select_manager.rb:187-196). The
+   * one-argument form is `union(other)`; `union(":all", other)` produces a
+   * `Nodes::UnionAll`. A Ruby Symbol is a colon-prefixed string here (see
+   * CLAUDE.md), and `UNION_NODE_CLASSES` stands in for
+   * `Nodes.const_get("Union#{operation.to_s.capitalize}")`, which JS has no
+   * equivalent of.
    */
-  union(other: SelectManager | SelectStatement): Union {
+  union(
+    operation: string | SelectManager | SelectStatement,
+    other: SelectManager | SelectStatement | null = null,
+  ): Union {
+    let nodeClass: new (left: SelectStatement, right: SelectStatement) => Union;
+    if (other) {
+      const name = String(operation).slice(1);
+      const capitalized = name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
+      nodeClass = UNION_NODE_CLASSES[`Union${capitalized}`];
+    } else {
+      other = operation as SelectManager | SelectStatement;
+      nodeClass = Union;
+    }
+
     const otherAst = other instanceof SelectManager ? other.ast : other;
-    return new Union(this.ast, otherAst);
+    return new nodeClass(this.ast, otherAst);
   }
 
   /**
@@ -467,48 +490,11 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * RIGHT OUTER JOIN.
-   */
-  rightOuterJoin(table: Node | string, onCondition?: Node): this {
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
-    const onNode = onCondition ? new On(onCondition) : null;
-    this.core.source.right.push(new RightOuterJoin(tableNode, onNode));
-    return this;
-  }
-
-  /**
-   * FULL OUTER JOIN.
-   */
-  fullOuterJoin(table: Node | string, onCondition?: Node): this {
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
-    const onNode = onCondition ? new On(onCondition) : null;
-    this.core.source.right.push(new FullOuterJoin(tableNode, onNode));
-    return this;
-  }
-
-  /**
-   * CROSS JOIN.
-   */
-  crossJoin(table: Node | string): this {
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
-    this.core.source.right.push(new CrossJoin(tableNode, null));
-    return this;
-  }
-
-  /**
    * Set WITH RECURSIVE.
    */
   withRecursive(...ctes: Node[]): this {
     this.ast.with = new WithRecursive(ctes);
     return this;
-  }
-
-  /**
-   * UNION ALL with another manager.
-   */
-  unionAll(other: SelectManager | SelectStatement): UnionAll {
-    const otherAst = other instanceof SelectManager ? other.ast : other;
-    return new UnionAll(this.ast, otherAst);
   }
 
   /**
@@ -581,40 +567,6 @@ export class SelectManager extends TreeManager {
     if (groupValuesColumns.length > 0) dm.group(groupValuesColumns);
     if (havingClause !== null) dm.having(havingClause);
     return dm;
-  }
-
-  /**
-   * Append a raw-SQL join fragment (a StringJoin) to the FROM sources.
-   * Use this instead of reaching into `core.source.right` directly when
-   * you need to add a pre-built JOIN string (e.g. `LEFT OUTER JOIN … ON …`).
-   *
-   * Mirrors: the join_sources mutation pattern in Rails' JoinDependency
-   * (relation.joins!(join_dependency) calls join_constraints which pushes
-   * StringJoin nodes onto the Arel manager's join_sources).
-   */
-  appendStringJoin(sql: string): this {
-    this.core.source.right.push(new StringJoin(new SqlLiteral(sql), null));
-    return this;
-  }
-
-  /**
-   * Insert existing Arel join nodes at the front of join_sources, preserving
-   * their relative order. Mirrors the leading_join bucket in Rails' build_joins,
-   * which places LeadingJoin nodes before any alias-tracker-generated joins.
-   */
-  prependJoinNodes(...nodes: Join[]): this {
-    this.core.source.right.unshift(...nodes);
-    return this;
-  }
-
-  /**
-   * Append an existing Arel join node to join_sources.
-   *
-   * Mirrors: join_sources.concat(join_nodes) in Rails build_joins.
-   */
-  appendJoinNode(node: Join): this {
-    this.core.source.right.push(node);
-    return this;
   }
 }
 

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -47,7 +47,7 @@ describe("TableTest", () => {
       const onClause = new Nodes.On(users.get("id").eq(posts.get("user_id")));
       const join = users.createJoin(posts, onClause, Nodes.OuterJoin);
       const mgr = users.project(star);
-      mgr.appendJoinNode(join);
+      mgr.joinSources().push(join);
       const sql = mgr.toSql();
       expect(sql).toContain('LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"');
     });


### PR DESCRIPTION
Two RFC stories, both pure convergence — no new surface, no new baseline rows.

## `arel/select-manager.ts` — novel extra surface 7 → 0 (RFC 0117)

Rails' `Arel::SelectManager` takes the join **class** as `join`'s second
argument (`select_manager.rb:102-113`) and the union operation as `union`'s
first (`:187-196`); trails had a convenience method per variant.

- `union(operation, other = nil)` ported at Rails' signature.
  `union(":all", other)` resolves `Nodes::UnionAll` the way
  `Nodes.const_get("Union#{operation.to_s.capitalize}")` does (a Ruby Symbol
  is a colon-prefixed string, per CLAUDE.md). `unionAll` deleted.
- `rightOuterJoin` / `fullOuterJoin` / `crossJoin` deleted — callers pass
  `join(relation, Nodes.RightOuterJoin)` and chain `.on(...)`.
- `appendStringJoin` / `prependJoinNodes` / `appendJoinNode` deleted. Rails
  mutates `join_sources` directly (`join_sources.concat(...)`,
  `query_methods.rb:1891/1896/1899`), which `emitJoinPlan` now does. `arel.join_sources`
  is empty when `build_joins` runs (`query_methods.rb:1752-1753`), so the
  leading-join `concat` is Rails' append, not the old `unshift`.

The three `*OuterJoin with string table name` tests are dropped: Rails' `join`
promotes a String to a `StringJoin`, so a string is never a join *table* there —
behaviour those tests asserted that Rails does not have. The other six tests
keep their names and now exercise the Rails-shaped call.

## `AssociationScope#eval_scope` — `_buildEntryScope` gone (RFC 0112)

`association_scope.rb:169-172` has no branch:

```ruby
relation = reflection.build_scope(reflection.aliased_table)
```

trails routed through a trails-only `_buildEntryScope` that took the Rails
path only when the alias tracker produced a `Nodes.TableAlias` and otherwise
fell back to `entryKlass.unscoped()` (whose `relation()` STI gate is not
`build_scope`'s). Both arms and the helper are gone; the disable-joins
constraint loop reaches `build_scope` directly, mirroring its inherited
`eval_scope` call (`disable_joins_association_scope.rb:42`).

No SQL moved: all 116 association test files pass unchanged.

## Verification

- `pnpm parity:api:extra --package arel` — `select-manager.ts` 0 novel, 13 moved.
- `pnpm parity:api:calls` OK (744 baselined), `pnpm parity:api:calls:args` OK — no new rows.
- `pnpm vitest run packages/arel` — 1462 passed.
- `pnpm vitest run packages/activerecord/src/relation` — 1215 passed.
- `pnpm vitest run packages/activerecord/src/associations` — 2189 passed.
- `pnpm typecheck`, `eslint` clean.

## Bundle note

The bundle also carried `converge-lazy-alias-attribute-method-generation` and
`generate-alias-attributes-from-aliases-by-attribute-name`. Both are the work of
**open** PR #6838 (whose body already carries the second `Closes-story` trailer)
— their story "Resolution" sections describe that branch, not `main`. Building
them here would have duplicated an unmerged sibling in the same file, so both
were released back to the queue.

Closes-story: arel-select-manager-join-variants
Closes-story: build-entry-scope-branches-where-rails-always-calls-build-scope