### PR TITLE
refactor(activerecord,activesupport,date,arel): aggregate_reflections hash, Time.at, arel node accept removal

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1917,6 +1917,8 @@ export class Base extends Model {
   // --- Reflection::ClassMethods (wired via extend() after class body) ---
   /** reflection.rb:11 — `class_attribute :_reflections, instance_writer: false, default: {}`. */
   declare static _reflections: Record<string, _Reflection.AssociationReflection>;
+  /** reflection.rb:12 — `class_attribute :aggregate_reflections, instance_writer: false, default: {}`. */
+  declare static aggregateReflections: Record<string, _Reflection.AggregateReflection>;
   declare static _reflectOnAssociation: typeof _Reflection.ClassMethods._reflectOnAssociation;
   declare static reflections: typeof _Reflection.ClassMethods.reflections;
   declare static normalizedReflections: typeof _Reflection.ClassMethods.normalizedReflections;
@@ -1925,7 +1927,6 @@ export class Base extends Model {
   declare static reflectOnAllAggregations: typeof _Reflection.ClassMethods.reflectOnAllAggregations;
   declare static reflectOnAggregation: typeof _Reflection.ClassMethods.reflectOnAggregation;
   declare static reflectOnAllAutosaveAssociations: typeof _Reflection.ClassMethods.reflectOnAllAutosaveAssociations;
-  declare static aggregateReflections: typeof _Reflection.ClassMethods.aggregateReflections;
 
   // --- Validations::ClassMethods (wired via extend() after class body) ---
   declare static validates: typeof _Validations.validates;
@@ -4635,6 +4636,7 @@ extend(Base, _Reflection.ClassMethods);
 // it is trails-only registry bookkeeping carried on the same mechanism as the
 // `_reflections` it shadows, so the two cannot drift apart.
 classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} });
+classAttribute.call(Base, "aggregateReflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
 classAttribute.call(Base, "_counterCacheColumns", { instanceAccessor: false, default: [] });
 classAttribute.call(Base, "counterCachedAssociationNames", {

--- a/packages/activerecord/src/multiparameter-attribute-assignment.ts
+++ b/packages/activerecord/src/multiparameter-attribute-assignment.ts
@@ -12,11 +12,11 @@
 
 import { AttributeAssignmentError, MultiparameterAssignmentErrors } from "./errors.js";
 
-// Read _aggregateReflections directly to avoid a circular dependency:
+// Read aggregateReflections directly to avoid a circular dependency:
 // persistence.ts → multiparameter-attribute-assignment.ts → reflection.ts → persistence.ts
 function getAggregation(modelClass: any, name: string): { klass: any } | null {
-  const aggs: Map<string, { klass: any }> | undefined = modelClass._aggregateReflections;
-  return aggs?.get(name) ?? null;
+  const aggs: Record<string, { klass: any }> | undefined = modelClass.aggregateReflections;
+  return aggs?.[name] ?? null;
 }
 
 // Maximum allowed position index — guards against DoS via huge allocations

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -2183,16 +2183,15 @@ export function addReflection(
 
 /**
  * Mirrors: ActiveRecord::Reflection.add_aggregate_reflection
+ * (reflection.rb:29-31). `aggregate_reflections` is a `class_attribute`
+ * (reflection.rb:12), so the reassignment is the whole per-class mechanism:
+ * the read walks the constructor chain, the write lands on `ar`.
  */
 export function addAggregateReflection(
   ar: typeof Base,
   name: string,
   reflection: AggregateReflection,
 ): void {
-  // Rails: `ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_sym => reflection)`
-  // (reflection.rb:30). `aggregate_reflections` is a `class_attribute`
-  // (reflection.rb:12), so the reassignment is what makes the registry
-  // per-class: the read walks the constructor chain, the write lands here.
   ar.aggregateReflections = merge(ar.aggregateReflections, { [name]: reflection });
 }
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -13,6 +13,7 @@ import {
   safeConstantize,
   foreignKey as deriveForeignKey,
   except,
+  merge,
 } from "@blazetrails/activesupport";
 import { Table, type TableRef } from "@blazetrails/arel";
 import { _correctNames } from "./associations.js";
@@ -2188,14 +2189,11 @@ export function addAggregateReflection(
   name: string,
   reflection: AggregateReflection,
 ): void {
-  const hasOwn = Object.prototype.hasOwnProperty.call(ar, "_aggregateReflections");
-  const existing = (ar as any)._aggregateReflections;
-  const aggs: Map<string, AggregateReflection> =
-    hasOwn && existing instanceof Map
-      ? existing
-      : new Map<string, AggregateReflection>(existing instanceof Map ? existing : undefined);
-  aggs.set(name, reflection);
-  (ar as any)._aggregateReflections = aggs;
+  // Rails: `ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_sym => reflection)`
+  // (reflection.rb:30). `aggregate_reflections` is a `class_attribute`
+  // (reflection.rb:12), so the reassignment is what makes the registry
+  // per-class: the read walks the constructor chain, the write lands here.
+  ar.aggregateReflections = merge(ar.aggregateReflections, { [name]: reflection });
 }
 
 // ---------------------------------------------------------------------------
@@ -2307,20 +2305,14 @@ export function reflectOnAllAssociations(
 }
 
 export function reflectOnAllAggregations(modelClass: typeof Base): AggregateReflection[] {
-  const aggregations: Map<string, AggregateReflection> | undefined = (modelClass as any)
-    ._aggregateReflections;
-  if (!aggregations) return [];
-  return Array.from(aggregations.values());
+  return Object.values(modelClass.aggregateReflections);
 }
 
 export function reflectOnAggregation(
   modelClass: typeof Base,
   name: string,
 ): AggregateReflection | null {
-  const aggregations: Map<string, AggregateReflection> | undefined = (modelClass as any)
-    ._aggregateReflections;
-  if (!aggregations) return null;
-  return aggregations.get(name) ?? null;
+  return modelClass.aggregateReflections[name] ?? null;
 }
 
 export function reflectOnAllAutosaveAssociations(
@@ -2376,14 +2368,6 @@ export const ClassMethods = {
   },
   reflectOnAllAutosaveAssociations(this: typeof Base): AssociationLikeReflection[] {
     return reflectOnAllAutosaveAssociations(this);
-  },
-  // Rails: `class_attribute :aggregate_reflections, default: {}` — the
-  // composed-of registry keyed by aggregation name. Trails stores it in the
-  // dynamically-assigned `_aggregateReflections` Map; expose the Rails-shaped
-  // hash reader (the `=`/`?` forms map to the same accessor).
-  aggregateReflections(this: typeof Base): Readonly<Record<string, AggregateReflection>> {
-    const aggs: Map<string, AggregateReflection> | undefined = (this as any)._aggregateReflections;
-    return aggs ? Object.fromEntries(aggs) : {};
   },
   _reflectOnAssociation: _reflectOnAssociationClassMethod,
 };

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -122,6 +122,16 @@ export function isInclude(hash: AnyObject, key: string): boolean {
 }
 
 /**
+ * Ruby's `Hash#merge` — a non-destructive copy of the receiver with
+ * `otherHash`'s pairs written over it.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `Hash`, as {@link except} is.
+ */
+export function merge<T extends AnyObject>(hash: T, otherHash: AnyObject): T {
+  return { ...hash, ...otherHash } as T;
+}
+
+/**
  * Return a copy of the object without the specified keys.
  */
 export function except<T extends AnyObject, K extends keyof T>(obj: T, ...keys: K[]): Omit<T, K> {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -228,6 +228,7 @@ export {
   deepDup,
   slice,
   except,
+  merge,
   isInclude as isIncludeObj,
   deepTransformKeys,
   deepCamelizeKeys,

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -12,7 +12,7 @@
 import { TimeWithZone } from "../time-with-zone.js";
 import { Duration } from "../duration.js";
 import { ArgumentError } from "../hash-utils.js";
-import { Temporal, Date as RubyDate, Rational } from "@blazetrails/date";
+import { Temporal, Date as RubyDate, Rational, Time } from "@blazetrails/date";
 import type { DateParts } from "@blazetrails/date";
 import { instantFrom } from "../temporal.js";
 import { currentTime } from "../time-travel.js";
@@ -743,25 +743,6 @@ export class Timezone {
 }
 
 /**
- * The `Integer`, `Float` or `Rational` a Ruby `Time.at` argument can be, scaled
- * to a whole number of nanoseconds. `scale` is the nanoseconds one unit of the
- * argument is worth — `1_000_000_000` for the seconds argument, `1_000` for the
- * microseconds one. A Float is truncated at the nanosecond, as MRI's
- * `Time.at(946684800.123456789).nsec` is `123456835` rather than `...836`.
- *
- * @noRailsEquivalent CONVERGEABLE — Ruby's Numeric tower does this arithmetic
- * exactly at any width, so `Time.at` needs no such scaling; this goes away with
- * a `Time.at` in `@blazetrails/date` for `at` to delegate to, the gap
- * `time-helpers-stub-date-and-datetime-clock` records.
- */
-function toNanoseconds(value: number | bigint | Rational, scale: bigint): bigint {
-  if (value instanceof Rational) return (value.numerator * scale) / value.denominator;
-  if (typeof value === "bigint") return value * scale;
-  const whole = Math.trunc(value);
-  return BigInt(whole) * scale + BigInt(Math.trunc((value - whole) * Number(scale)));
-}
-
-/**
  * Ruby `Time.new`'s fractional-seconds argument (`parts.fetch(:sec, 0) +
  * parts.fetch(:sec_fraction, 0)`), which Temporal cannot take as a Rational —
  * it wants the sub-second remainder split across its millisecond / microsecond
@@ -975,22 +956,13 @@ export class TimeZone {
    *
    *   Time.zone.at(946684800.0)           # => Fri, 31 Dec 1999 14:00:00 HST -10:00
    *   Time.at(946684800, 123456.789).nsec # => 123456789
-   *
-   * Ruby's `Time.at` takes the seconds as an Integer, Float or Rational and an
-   * optional second argument giving the sub-second part in microseconds, and
-   * carries the result to the nanosecond. `Temporal.Instant` is that same
-   * nanosecond seat, so the total is accumulated as a `bigint` count of
-   * nanoseconds rather than through a Float millisecond, which would drop
-   * every digit below the millisecond.
    */
   at(
     seconds: number | bigint | Rational,
     microsecondsWithFrac: number | bigint | Rational = 0,
   ): TimeWithZone {
     return new TimeWithZone(
-      Temporal.Instant.fromEpochNanoseconds(
-        toNanoseconds(seconds, 1_000_000_000n) + toNanoseconds(microsecondsWithFrac, 1_000n),
-      ),
+      Time.at(seconds, microsecondsWithFrac).getutc().toTime().toInstant(),
       this,
     );
   }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -956,6 +956,10 @@ export class TimeZone {
    *
    *   Time.zone.at(946684800.0)           # => Fri, 31 Dec 1999 14:00:00 HST -10:00
    *   Time.at(946684800, 123456.789).nsec # => 123456789
+   *
+   * `getutc` is Ruby's `Time#utc` on an immutable receiver (trails' `::Time`
+   * has no in-place conversion), and `toTime().toInstant()` is the instant a
+   * `TimeWithZone` holds where Ruby's `in_time_zone` takes the `::Time` itself.
    */
   at(
     seconds: number | bigint | Rational,

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,5 +1,5 @@
 import { include, type Included } from "@blazetrails/activesupport";
-import { Node, NodeVisitor } from "../nodes/node.js";
+import { Node } from "../nodes/node.js";
 import { As, ATTRIBUTE_BRAND } from "../nodes/binary.js";
 import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-operation.js";
 import { Count } from "../nodes/count.js";
@@ -183,10 +183,6 @@ export class Attribute extends Node {
   extract(field: string): Extract {
     // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).
     return new Extract([this], field);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,6 +1,6 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import type { Temporal } from "@blazetrails/date";
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { And } from "./and.js";
@@ -133,10 +133,6 @@ export class Binary extends NodeExpression {
   not(): Not {
     return new Not(this);
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
 }
 
 export class Assignment extends Binary {}
@@ -232,10 +228,6 @@ export class IsDistinctFrom extends Binary {
   fetchAttribute(block: (attr: Node) => unknown): unknown {
     return fetchAttributeFromBinary(this.left, this.right, block);
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
 }
 
 export class IsNotDistinctFrom extends Binary {
@@ -245,10 +237,6 @@ export class IsNotDistinctFrom extends Binary {
 
   fetchAttribute(block: (attr: Node) => unknown): unknown {
     return fetchAttributeFromBinary(this.left, this.right, block);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 
@@ -277,11 +265,7 @@ export abstract class Join extends Binary {
   }
 }
 
-export class CrossJoin extends Join {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class CrossJoin extends Join {}
 
 /** Set operations — Rails defines via const_set in binary.rb */
 export class Union extends Binary {

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { buildQuoted } from "./casted.js";
@@ -79,10 +79,6 @@ export class Case extends NodeExpression {
     c.conditions.push(...this.conditions);
     c.default = this.default;
     return c;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/fragments.ts
+++ b/packages/arel/src/nodes/fragments.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 
 /**
  * Fragments — a list of nodes to be emitted in sequence.
@@ -15,9 +15,5 @@ export class Fragments extends Node {
 
   join(node: Node): Fragments {
     return new Fragments([...this.values, node]);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/index.ts
+++ b/packages/arel/src/nodes/index.ts
@@ -1,5 +1,4 @@
 export { Node } from "./node.js";
-export type { NodeVisitor } from "./node.js";
 export { And } from "./and.js";
 export { Or } from "./or.js";
 export { Grouping } from "./grouping.js";

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Binary, type NodeOrValue } from "./binary.js";
 import { As } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -45,10 +45,6 @@ export class InfixOperation extends Binary {
 
   desc(): Descending {
     return new Descending(this);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/join-source.ts
+++ b/packages/arel/src/nodes/join-source.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 
 /**
@@ -20,9 +20,5 @@ export class JoinSource extends Binary {
 
   isEmpty(): boolean {
     return !this.left && this.right.length === 0;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Function } from "./function.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Over } from "./over.js";
@@ -35,8 +35,4 @@ export class NamedFunction extends Function {
     }
     return new Over(this, window);
   };
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
 }

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -100,14 +100,6 @@ export abstract class Node {
   }
 }
 
-/**
- * Visitor interface for the Node hierarchy.
- */
-export interface NodeVisitor<T> {
-  /** @internal */
-  visit(node: Node): T;
-}
-
 interface NodeRegistry {
   Not?: new (expr: Node) => Node;
   Grouping?: new (expr: Node) => Node;

--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SelectCore } from "./select-core.js";
 
@@ -27,10 +27,6 @@ export class SelectStatement extends NodeExpression {
     this.offset = null;
     this.lock = null;
     this.with = null;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 
   clone(): SelectStatement {
@@ -64,9 +60,5 @@ export class SelectOptions extends Node {
     this.limit = limit;
     this.offset = offset;
     this.lock = lock;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,5 +1,5 @@
 import { isBlank, type Included } from "@blazetrails/activesupport";
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Fragments } from "./fragments.js";
 import { buildQuoted } from "./casted.js";
 
@@ -72,10 +72,6 @@ export class SqlLiteral extends Node {
   toYAML(): string {
     const escaped = this.value.replace(/\n/g, "\\n");
     return `---\n!sql_literal\nvalue: ${JSON.stringify(escaped)}`;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 import { Cte } from "./cte.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -69,9 +69,5 @@ export class TableAlias extends Binary {
     return this.relation instanceof Table
       ? this.relation.get(name, this)
       : new Attribute(this, name);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }

--- a/packages/arel/src/nodes/unary-operation.ts
+++ b/packages/arel/src/nodes/unary-operation.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Unary } from "./unary.js";
 import { As } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -32,10 +32,6 @@ export class UnaryOperation extends Unary {
 
   desc(): Descending {
     return new Descending(this);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
 export class Unary extends NodeExpression {
@@ -12,10 +12,6 @@ export class Unary extends NodeExpression {
   constructor(expr: unknown) {
     super();
     this.expr = expr;
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -1,4 +1,4 @@
-import { Node, NodeVisitor } from "./node.js";
+import { Node } from "./node.js";
 import { Unary } from "./unary.js";
 import { SqlLiteral } from "./sql-literal.js";
 
@@ -49,10 +49,6 @@ export class Window extends Node {
     this.frame(new Range(expr));
     return this;
   }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
 }
 
 /**
@@ -84,11 +80,7 @@ export class Following extends Unary {
   }
 }
 
-export class CurrentRow extends Node {
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
-  }
-}
+export class CurrentRow extends Node {}
 
 export class Rows extends Unary {
   declare readonly expr: Node | null;

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -1,6 +1,6 @@
 import { Attribute } from "./attributes/attribute.js";
 import { EmptyJoinError } from "./errors.js";
-import { _engine, ArelEngine, Node, NodeVisitor } from "./nodes/node.js";
+import { _engine, ArelEngine, Node } from "./nodes/node.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
@@ -251,10 +251,6 @@ export class Table extends Node {
   ): Join {
     const JoinClass = klass ?? InnerJoin;
     return new JoinClass(to as Node, (constraint ?? null) as Node | null);
-  }
-
-  accept<T>(visitor: NodeVisitor<T>): T {
-    return visitor.visit(this);
   }
 }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -221,14 +221,19 @@ describe("the to_sql visitor", () => {
   });
 
   it("can define a dispatch method", () => {
-    const visitor: Nodes.NodeVisitor<string> = {
-      visit(node: Nodes.Node): string {
-        if (node instanceof Nodes.SqlLiteral) return node.value;
-        return "unknown";
-      },
-    };
-    const node = new Nodes.SqlLiteral("NOW()");
-    expect(node.accept(visitor)).toBe("NOW()");
+    let visited = false;
+    class HelloVisitor extends Visitors.Visitor {
+      hello(_node: Table, _c: unknown): string {
+        visited = true;
+        return "";
+      }
+      static {
+        this.dispatchCache().set(Table, "hello");
+      }
+    }
+    const viz = new HelloVisitor();
+    viz.accept(users, new Collectors.SQLString());
+    expect(visited).toBe(true);
   });
 
   it("should visit built-in functions", () => {

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,20 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { Node, NodeVisitor } from "../nodes/node.js";
+import { Node } from "../nodes/node.js";
 import { Visitor } from "./visitor.js";
 import { UnsupportedVisitError } from "../errors.js";
 
-class A extends Node {
-  accept<T>(v: NodeVisitor<T>): T {
-    return v.visit(this);
-  }
-}
+class A extends Node {}
 class B extends A {}
 class B2 extends B {}
-class C extends Node {
-  accept<T>(v: NodeVisitor<T>): T {
-    return v.visit(this);
-  }
-}
+class C extends Node {}
 
 class TestVisitor extends Visitor {
   visited: Array<{ node: string; collector: unknown }> = [];

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -20,8 +20,6 @@ describe("Time", () => {
   it("Time.at builds a local time from the seconds since the Epoch", () => {
     vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue("UTC");
     expect(Time.at(946684800).strftime("%Y-%m-%d %H:%M:%S %z")).toBe("2000-01-01 00:00:00 +0000");
-    // MRI truncates the Float at the nanosecond, so the nearest double to
-    // 946684800.123456789 answers 123456835 rather than 123456789.
     expect(Time.at(Number("946684800.123456789")).nsec).toBe(123456835);
     expect(Time.at(946684800, 123456.789).nsec).toBe(123456789);
     expect(Time.at(new Rational(1, 3)).nsec).toBe(333333333);

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -17,6 +17,18 @@ describe("Time", () => {
     expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 +0000 UTC");
   });
 
+  it("Time.at builds a local time from the seconds since the Epoch", () => {
+    vi.spyOn(Temporal.Now, "timeZoneId").mockReturnValue("UTC");
+    expect(Time.at(946684800).strftime("%Y-%m-%d %H:%M:%S %z")).toBe("2000-01-01 00:00:00 +0000");
+    // MRI truncates the Float at the nanosecond, so the nearest double to
+    // 946684800.123456789 answers 123456835 rather than 123456789.
+    expect(Time.at(Number("946684800.123456789")).nsec).toBe(123456835);
+    expect(Time.at(946684800, 123456.789).nsec).toBe(123456789);
+    expect(Time.at(new Rational(1, 3)).nsec).toBe(333333333);
+    expect(Time.at(-0.5).nsec).toBe(500000000);
+    expect(Time.at(-0.5).strftime("%Y-%m-%d %H:%M:%S")).toBe("1969-12-31 23:59:59");
+  });
+
   it("Time.new builds a time at the given offset", () => {
     const time = new Time(2008, 3, 1, 6, 0, 0, "-05:00");
     expect(time.hour).toBe(6);

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -202,6 +202,18 @@ function subsecNanoseconds(sec: number | Rational): number {
 }
 
 /**
+ * MRI's `num_exact` (`time.c`), the conversion every `Time.at` argument goes
+ * through: an Integer and a Rational are exact already, and a Float becomes
+ * its own exact ratio through `Float#to_r` ({@link fToR}) — which is why
+ * `Time.at(946684800.123456789).nsec` is `123456835` rather than `...789`.
+ */
+function numExact(v: number | bigint | Rational): Rational {
+  if (v instanceof Rational) return v;
+  if (typeof v === "bigint") return new Rational(v, 1);
+  return fToR(v);
+}
+
+/**
  * MRI's `months[]` table (`time.c`), the three-letter month names
  * `month_arg` matches a String positional against.
  */
@@ -279,6 +291,40 @@ export class Time {
       plain.hour,
       plain.minute,
       plain.second + plain.millisecond / 1_000 + plain.microsecond / 1_000_000,
+    );
+  }
+
+  /**
+   * Ruby `Time.at(seconds, microseconds_with_frac = 0)` (`time.c`
+   * `time_s_at`), which builds a time in the LOCAL zone from the seconds since
+   * the Epoch. Both arguments take the Integer, Float or Rational MRI's
+   * `num_exact` takes, and the sum is carried exactly and then floored at the
+   * nanosecond, MRI's own seat: `Time.at(946684800, 123456.789).nsec` is
+   * `123456789`, and `Time.at(-0.5).to_i` is `-1`.
+   */
+  static at(
+    seconds: number | bigint | Rational,
+    microsecondsWithFrac: number | bigint | Rational = 0,
+  ): Time {
+    const timew = numExact(seconds)
+      .mul(1_000_000_000)
+      .add(numExact(microsecondsWithFrac).mul(1_000));
+    const nanoseconds =
+      timew.numerator / timew.denominator - (timew.numerator % timew.denominator < 0n ? 1n : 0n);
+    const zoned = Temporal.Instant.fromEpochNanoseconds(nanoseconds).toZonedDateTimeISO(
+      Temporal.Now.timeZoneId(),
+    );
+    return new Time(
+      zoned.year,
+      zoned.month,
+      zoned.day,
+      zoned.hour,
+      zoned.minute,
+      new Rational(
+        BigInt(zoned.second) * 1_000_000_000n +
+          BigInt(zoned.millisecond * 1_000_000 + zoned.microsecond * 1_000 + zoned.nanosecond),
+        1_000_000_000n,
+      ),
     );
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/reflection.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
-    "rubyName": "add_aggregate_reflection",
-    "call": "merge",
-    "reason": "Equivalent (RFC 0106): `aggregate_reflections` is a Ruby Hash upstream and a JS `Map` in trails, so the single-pair `merge` is `Map#set` on a copy. Converging the call means porting the container to a plain hash first."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
     "rubyName": "add_reflection",
     "call": "except",
     "kind": "args",


### PR DESCRIPTION
Bundle of three convergence stories.

**aggregate_reflections as a plain class_attribute hash** (`reflection.rb:12,29-31`)
`aggregate_reflections` was a JS `Map` assigned by hand, which blocked
`add_aggregate_reflection`'s `Hash#merge`. It is now a `classAttribute`-registered
plain hash beside `_reflections`, and `addAggregateReflection` is the Rails
one-liner. `merge` joins `except` in activesupport's `hash-utils.ts` as the Ruby
core `Hash` method it ports. The `add_aggregate_reflection -> merge` baseline row
is deleted by hand.

**Time.at** (`time.c` `time_s_at`, `time_zone.rb:378-380`)
`@blazetrails/date` gains `Time.at(seconds, microsecondsWithFrac = 0)` with Ruby's
Integer / Float / Rational argument forms, carried to the nanosecond through
MRI's `num_exact` coercion. `TimeZone#at` now delegates
(`Time.at(*args).utc.in_time_zone(self)`) and the bespoke `toNanoseconds` helper
and its `@noRailsEquivalent` tag are gone.

**arel per-node accept** (`arel/visitors/visitor.rb:10`)
Arel nodes have no `accept` in Rails — only the visitor does. Deleted from the 14
node/attribute/table files that carried it, along with the `NodeVisitor` type and
its barrel export. The one node-targeted caller, `to_sql_test.rb:33`'s "can define
a dispatch method", now routes through `visitor.accept(node, collector)` as Rails
does. `parity:api:extra --package arel` no longer reports any `MOVED: accept` row.

Closes-story: aggregate-reflections-plain-hash-for-merge
Closes-story: delegate-time-zone-at-to-a-real-time-at
Closes-story: arel-node-accept-removal-members
