### PR TITLE
refactor(activerecord): fold toArel into the arel reader

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -404,7 +404,7 @@ describe("RelationTest", () => {
     }
     // SelectManager#as produces a Nodes.TableAlias — mirrors Rails'
     // `relation.arel.as("ranked")` as the from() argument.
-    const ranked = Book.select("title").toArel().as("ranked");
+    const ranked = Book.select("title").arel().as("ranked");
     const result = Book.from(ranked).where("ranked.title IS NOT NULL").toSql();
     expect(result).toContain("FROM (SELECT");
     expect(result).toContain(") ranked");
@@ -1113,10 +1113,10 @@ describe("lock_value stores the argument", () => {
   // The SQLite visitor drops the LOCK node entirely (arel/visitors/sqlite.rb),
   // so assert against the AST rather than the rendered SQL.
   it("builds the Arel default clause for a bare lock", () => {
-    expect((CanonPost.all().toArel() as any).ast.lock).toBe(null);
-    expect(String((CanonPost.all().lock().toArel() as any).ast.lock.expr)).toBe("FOR UPDATE");
-    expect((CanonPost.all().lock(false).toArel() as any).ast.lock).toBe(null);
-    expect(String((CanonPost.all().lock("FOR SHARE").toArel() as any).ast.lock.expr)).toBe(
+    expect((CanonPost.all().arel() as any).ast.lock).toBe(null);
+    expect(String((CanonPost.all().lock().arel() as any).ast.lock.expr)).toBe("FOR UPDATE");
+    expect((CanonPost.all().lock(false).arel() as any).ast.lock).toBe(null);
+    expect(String((CanonPost.all().lock("FOR SHARE").arel() as any).ast.lock.expr)).toBe(
       "FOR SHARE",
     );
   });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -491,6 +491,11 @@ export class Relation<T extends Base> {
   _seedWherePredicates: readonly unknown[] = [];
   /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
   skipPreloadingValue = false;
+  /**
+   * @internal Rails `@arel` — the memoized `build_arel` manager
+   * (query_methods.rb:1595). Cleared by `reset` (relation.rb:1198).
+   */
+  _arel?: SelectManager;
   private _loaded = false;
   // Rails `@delegate_to_model` (relation.rb:90) — true only while a scope body
   // runs via `_exec_scope`, which is what makes `already_in_scope?` (and hence
@@ -669,6 +674,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reset
    */
   reset(): this {
+    this._arel = undefined;
     this._loaded = false;
     this._delegateToModel = false;
     this._offsets = undefined;
@@ -1113,14 +1119,14 @@ export class Relation<T extends Base> {
           if (relation.isNullRelation()) return Result.empty();
           joinDependency.applyColumnAliases(relation);
           this._joinDependency = joinDependency;
-          return this._conn().selectAll(relation.toArel(), "SQL", [], { async });
+          return this._conn().selectAll(relation.arel(), "SQL", [], { async });
         });
       }
 
       // Mirrors relation.rb:1449 (`_query_by_sql` → querying.rb:67-68). A
       // scheduled FutureResult is a thenable, so the promise this returns
       // settles to the same rows `future.result` yields in `execQueries`.
-      return c.selectAll(this.toArel(), `${this.model.name} Load`, [], { async });
+      return c.selectAll(this.arel(), `${this.model.name} Load`, [], { async });
     });
   }
 
@@ -1637,26 +1643,6 @@ export class Relation<T extends Base> {
   // -- SQL generation --
 
   /**
-   * Return the complete query AST as a SelectManager — projections, joins,
-   * wheres, order, distinct, limit/offset, group, having, lock, hints, from,
-   * CTEs, and annotate() comments. Mirrors Rails `build_arel`
-   * (active_record/relation/query_methods.rb:1750): the single manager Rails
-   * then compiles, so anything consuming `relation.arel()` as a subquery
-   * (`where(id: subrel.arel)`, `from(relation)`) carries the full query rather
-   * than a projection-only fragment.
-   */
-  toArel(aliases?: AliasTracker): SelectManager {
-    // Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
-    // (query_methods.rb:1595), so `build_arel` always has a connection. trails'
-    // `withConnection` is a `Promise`-returning checkout and this reader is
-    // synchronous, so the acquisition is the direct `_conn()` lease rather than
-    // a `with_connection` block; either way `build_arel` never sees a missing
-    // connection, and a model with no established pool raises
-    // `ConnectionNotEstablished` here exactly as Rails' `with_connection` does.
-    return this.buildArel(this._conn(), aliases);
-  }
-
-  /**
    * Mirrors: ActiveRecord::FinderMethods#apply_join_dependency
    * (finder_methods.rb:457-481).
    *
@@ -1761,7 +1747,7 @@ export class Relation<T extends Base> {
       [...new Set([...this.eagerLoadValues, ...this.includesValues])] as any,
       Nodes.OuterJoin,
     );
-    return this._limitedDistinctRelation(jd, basePk).toArel();
+    return this._limitedDistinctRelation(jd, basePk).arel();
   }
 
   /**
@@ -1856,7 +1842,7 @@ export class Relation<T extends Base> {
         const manager = this._buildEagerOperandManager();
         if (manager !== null) return conn.toSql(manager.ast);
       }
-      return conn.toSql(this.toArel().ast);
+      return conn.toSql(this.arel().ast);
     } finally {
       conn.preparedStatements = wasPrepared;
     }
@@ -1921,7 +1907,7 @@ export class Relation<T extends Base> {
           rel = rel.where(this.table.get(column).in(tuples.map((tuple) => tuple[i]) as never));
         });
       } else {
-        const ids = limitedIds ?? this._limitedDistinctRelation(jd, basePk).toArel();
+        const ids = limitedIds ?? this._limitedDistinctRelation(jd, basePk).arel();
         rel = rel.where(this.table.get(basePk).in(ids as never));
       }
       rel.limitValue = null;
@@ -2016,7 +2002,7 @@ export class Relation<T extends Base> {
   ): Promise<unknown[]> {
     const distinctSelect = this._distinctSelectForLimitedIds(basePk);
     const idResult = await this._conn().selectAll(
-      this._limitedDistinctRelation(jd, basePk, distinctSelect).toArel(),
+      this._limitedDistinctRelation(jd, basePk, distinctSelect).arel(),
       "SQL",
     );
     const idRows = idResult.toArray();
@@ -2112,7 +2098,7 @@ export class Relation<T extends Base> {
 
     const eagerRelation = this._applyEagerJoinDependency(jd, basePk);
     jd.applyColumnAliases(eagerRelation);
-    return eagerRelation.toArel();
+    return eagerRelation.arel();
   }
 
   /**
@@ -2863,7 +2849,7 @@ export class Relation<T extends Base> {
       } else {
         const query = collection.unscope("order");
         query.selectValues = [sql(selectValues.replace("%s", column))];
-        arel = query.toArel();
+        arel = query.arel();
       }
 
       [size, timestamp] = first(await c.selectRows(arel, null)) ?? [];

--- a/packages/activerecord/src/relation/arel-reader-connection-acquisition.trails.test.ts
+++ b/packages/activerecord/src/relation/arel-reader-connection-acquisition.trails.test.ts
@@ -1,10 +1,10 @@
 /**
  * Rails' `arel` reader is `with_connection { |c| build_arel(c, aliases) }`
  * (query_methods.rb:1595), so a model with no connection raises out of the
- * reader rather than building Arel against a substitute. trails' `toArel`
+ * reader rather than building Arel against a substitute. trails' `arel`
  * acquires through `_conn()` for the same reason. Rails has no test for this —
  * `with_connection` raising is a property of the pool, not of `arel` — so the
- * pin that `toArel` does not swallow `ConnectionNotEstablished` lives here.
+ * pin that `arel` does not swallow `ConnectionNotEstablished` lives here.
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
@@ -14,7 +14,7 @@ import { ConnectionNotEstablished } from "../errors.js";
 
 registerModel(Post);
 
-describe("Relation#toArel connection acquisition", () => {
+describe("Relation#arel connection acquisition", () => {
   fixtures(["posts"]);
 
   it("raises ConnectionNotEstablished rather than building against a substitute", () => {
@@ -27,7 +27,7 @@ describe("Relation#toArel connection acquisition", () => {
       },
     });
     try {
-      expect(() => relation.toArel()).toThrow(ConnectionNotEstablished);
+      expect(() => relation.arel()).toThrow(ConnectionNotEstablished);
     } finally {
       if (descriptor) Object.defineProperty(Post, "connection", descriptor);
       else delete (Post as unknown as Record<string, unknown>).connection;

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -2,7 +2,7 @@
  * Regression coverage for the unified `build_joins` emitter
  * (RFC 0022 unify-join-emission-build-joins).
  *
- * The live `toSql`/`toArel` path (`buildArel` -> `buildJoins`) and the
+ * The live `toSql`/`arel` path (`buildArel` -> `buildJoins`) and the
  * `from(relation)` subquery path (`build_from` → `buildArel` → `buildJoins`)
  * now delegate to one shared emitter (`emitJoinPlan`), so the left_outer/joins
  * dedup fold (PR #3501 / #3890) lives in a single place and cannot re-drift.

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -234,7 +234,7 @@ interface CalculationRelation {
   /** Mirrors `Relation#ids`. */
   ids(): Promise<unknown[]>;
   /** @internal Rails `build_arel` (query_methods.rb:1750). */
-  toArel(aliases?: unknown): SelectManager;
+  arel(aliases?: unknown): SelectManager;
 }
 
 type AggFn = "count" | "sum" | "average" | "minimum" | "maximum";
@@ -684,7 +684,7 @@ export async function pluck(
     // is what makes a zero-column `pluck` project `table[Arel.star]` via
     // `build_select`'s else arm instead of emitting a projection-less `SELECT FROM`.
     rel.selectValues = columns as any;
-    const manager = rel.toArel();
+    const manager = rel.arel();
 
     // Rails: `select_all(relation.arel, "#{model.name} Pluck")` (calculations.rb:317).
     const result = await this.skipQueryCacheIfNecessary(() =>

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -338,7 +338,7 @@ interface FinderRelation {
   ): Promise<R>;
   /** @internal */
   _materializeDeferredDistinctPkPredicates(): Promise<void>;
-  toArel(): { ast: unknown };
+  arel(): { ast: unknown };
   skipQueryCacheIfNecessary<R>(block: () => R): R;
   withConnection<R>(block: (c: any) => R): R;
 }
@@ -747,8 +747,7 @@ export async function exists(
   if (relation.whereClause.isContradiction()) return false;
   return await this.skipQueryCacheIfNecessary(() =>
     this.withConnection(
-      async (c) =>
-        (await c.selectRows(relation.toArel(), `${this.model.name} Exists?`)).length === 1,
+      async (c) => (await c.selectRows(relation.arel(), `${this.model.name} Exists?`)).length === 1,
     ),
   );
 }

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -494,7 +494,7 @@ export class PredicateBuilder {
   }
 
   private isRelation(value: unknown): boolean {
-    return typeof value === "object" && value !== null && "_model" in value && "toArel" in value;
+    return typeof value === "object" && value !== null && "_model" in value && "arel" in value;
   }
 
   private convertDotNotationToHash(attributes: Record<string, unknown>): Record<string, unknown> {

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.test.ts
@@ -93,7 +93,7 @@ describe("AssociationQueryValue", () => {
       const reselected: string[] = [];
       const fakeRelation = {
         _model: {},
-        toArel() {
+        arel() {
           return null;
         },
         selectValues: [],

--- a/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/association-query-value.ts
@@ -178,6 +178,6 @@ export class AssociationQueryValue {
   }
 
   private isRelation(value: unknown): boolean {
-    return typeof value === "object" && value !== null && "_model" in value && "toArel" in value;
+    return typeof value === "object" && value !== null && "_model" in value && "arel" in value;
   }
 }

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -114,7 +114,7 @@ export class PolymorphicArrayValue {
   /** @internal */
   private klass(value: unknown): unknown {
     if (typeof value !== "object" || value === null) return null;
-    if ("_model" in value && "toArel" in value) return (value as any)._model;
+    if ("_model" in value && "arel" in value) return (value as any)._model;
     return (value as any).constructor ?? null;
   }
 
@@ -122,7 +122,7 @@ export class PolymorphicArrayValue {
   private convertToId(value: unknown): unknown {
     if (value === null || value === undefined) return null;
     if (typeof value === "object" && value !== null) {
-      if ("_model" in value && "toArel" in value) {
+      if ("_model" in value && "arel" in value) {
         const pk = this.primaryKey(value);
         const arelTable = (value as any)._model?.arelTable;
         return (value as any).select(arelTable && !Array.isArray(pk) ? arelTable.get(pk) : pk);

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -30,7 +30,7 @@ export class RelationHandler {
     const deferred = this.deferDistinctPkMaterialization(attribute, value);
     if (deferred) return deferred;
     const relation = this.injectPrimaryKeySelect(attribute, this.applyJoinDependency(value));
-    return attribute.in(relation.toArel());
+    return attribute.in(relation.arel());
   }
 
   // Rails routes an eager-loading subquery with a limit/offset over a collection

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2118,9 +2118,13 @@ export function async(this: QueryMethodsHost): QueryMethodsHost {
   return asyncBang.call((this as any).spawn());
 }
 
-/** @internal */
+/**
+ * Mirrors: ActiveRecord::QueryMethods#assert_modifiable!
+ * (query_methods.rb:1746-1748).
+ * @internal
+ */
 export function assertModifiableBang(this: QueryMethodsHost): void {
-  if ((this as any)._loaded) {
+  if ((this as any)._loaded || (this as any)._arel) {
     throw new UnmodifiableRelation();
   }
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -331,8 +331,12 @@ interface QueryMethodsHost {
   clone(): any;
   /** Mirrors: ActiveRecord::SpawnMethods#spawn (spawn_methods.rb:9-11). */
   spawn(): any;
-  /** Rails `Relation#to_arel` — the built SelectManager (`arel`'s callee). */
-  toArel(aliases?: AliasTracker): any;
+  /**
+   * Mirrors: ActiveRecord::QueryMethods#build_arel (query_methods.rb:1749).
+   *
+   * @internal
+   */
+  buildArel(connection: unknown, aliases?: AliasTracker): any;
   /** Mirrors: `attr_accessor :skip_preloading_value` (relation.rb:72). */
   skipPreloadingValue: boolean;
   _model: typeof import("../base.js").Base;
@@ -1261,14 +1265,14 @@ function rewhere(this: QueryMethodsHost, conditions: Record<string, unknown> | n
  * True for values that PredicateBuilder will route through its
  * RelationHandler (subquery IN/NOT IN). Mirrors the shape check in
  * `PredicateBuilder#isRelation`: a Relation exposes `_model` and a
- * `toArel()` method.
+ * `arel()` method.
  */
 function isRelationLike(value: unknown): boolean {
   return (
     typeof value === "object" &&
     value !== null &&
     "_model" in value &&
-    typeof (value as { toArel?: unknown }).toArel === "function"
+    typeof (value as { arel?: unknown }).arel === "function"
   );
 }
 
@@ -2050,6 +2054,13 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  * already claimed by the caller.
  *
  * Mirrors: ActiveRecord::QueryMethods#arel (query_methods.rb:1594-1596)
+ * @missingRailsCall with_connection — PERMANENT: `with_connection`
+ * (query_methods.rb:1595) is the connection acquisition around `build_arel`.
+ * trails' `Relation#withConnection` is a `Promise`-returning checkout and this
+ * reader is synchronous — every caller reads `relation.arel()` inline while
+ * building a query — so the acquisition is the direct `_conn()` lease, which
+ * hands `build_arel` the same connection and raises the same
+ * `ConnectionNotEstablished` when no pool is established.
  * @internal
  *
  * @missingRailsCall build_arel — CONVERGEABLE: Surfaced by the relation.ts →
@@ -2065,7 +2076,10 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  *   relation.ts with the member (RFC 0107 fan-out).
  */
 export function arel(this: QueryMethodsHost, aliases?: AliasTracker): any {
-  return this.toArel(aliases);
+  // `@arel ||= with_connection { |c| build_arel(c, aliases) }`
+  // (query_methods.rb:1595) — see the `@missingRailsCall` note above for the
+  // synchronous `_conn()` lease standing in for the `with_connection` block.
+  return ((this as any)._arel ??= this.buildArel((this as any)._conn(), aliases));
 }
 
 /**
@@ -2333,12 +2347,12 @@ export function buildSubquery(
   // query_methods.rb:1606: `except(:optimizer_hints).arel.as(subquery_alias)`.
   const relation =
     typeof (this as any).except === "function" ? (this as any).except("optimizerHints") : this;
-  if (typeof relation.toArel !== "function") {
-    throw new ActiveRecordError("Cannot build subquery: relation does not support toArel()");
+  if (typeof relation.arel !== "function") {
+    throw new ActiveRecordError("Cannot build subquery: relation does not support arel()");
   }
   // No identifier gate — the alias is caller-trusted and wrapped verbatim in a
   // `SqlLiteral` by `SelectManager#as`, matching Rails' `build_from`.
-  const subquery = relation.toArel().as(subqueryAlias);
+  const subquery = relation.arel().as(subqueryAlias);
   const sm = new SelectManager(subquery);
   sm.project(selectValue as any);
   const hints: string[] = (this as any).optimizerHintsValues ?? [];
@@ -2978,7 +2992,7 @@ export function buildFrom(this: QueryMethodsHost): unknown {
   const fromClause = (this as any).fromClause;
   const opts = fromClause?.value;
   let name = fromClause?.name;
-  if (opts && typeof opts.toArel === "function") {
+  if (opts && typeof opts.arel === "function") {
     name ??= "subquery";
     const alias = String(name);
     // No identifier gate: Rails' `build_from` stores the caller-provided
@@ -3019,7 +3033,7 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     }
     // Rails build_from wraps `opts.arel.as(name)`, where `arel` is the full
     // `build_arel` — joins, HAVING, nested FROM, LOCK, CTEs, etc. Use the
-    // comprehensive builder rather than the projection-only `toArel`, so the
+    // comprehensive builder rather than the projection-only `arel`, so the
     // subquery stays a live AST: its binds parameterize and its retryability is
     // determined by the actual child nodes (not unconditionally disabled).
     // `build_arel` projects the qualified table star (`"comments".*`) and does
@@ -3030,7 +3044,7 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // the where-subquery path (`relation-handler`); this is intentional, not a
     // shape deviation to converge away. See the
     // `eager-from-subquery-column-alias-projection` story.
-    return resolved.toArel().as(alias);
+    return resolved.arel().as(alias);
   }
   return opts;
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2076,9 +2076,6 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  *   relation.ts with the member (RFC 0107 fan-out).
  */
 export function arel(this: QueryMethodsHost, aliases?: AliasTracker): any {
-  // `@arel ||= with_connection { |c| build_arel(c, aliases) }`
-  // (query_methods.rb:1595) — see the `@missingRailsCall` note above for the
-  // synchronous `_conn()` lease standing in for the `with_connection` block.
   return ((this as any)._arel ??= this.buildArel((this as any)._conn(), aliases));
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2062,18 +2062,6 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  * hands `build_arel` the same connection and raises the same
  * `ConnectionNotEstablished` when no pool is established.
  * @internal
- *
- * @missingRailsCall build_arel — CONVERGEABLE: Surfaced by the relation.ts →
- *   relation/query-methods.ts split (RFC 0107): `arel` and `toArel` are now
- *   cross-file, so the call-set comparer can no longer see through the
- *   delegation to the `build_arel` call inside `toArel`. Folding the memo,
- *   connection acquisition and build_arel call back into `arel` itself is
- *   tracked by story fold-to-arel-into-the-arel-reader (RFC 0107).
- * @missingRailsCall with_connection — CONVERGEABLE: Relation#arel's memo, connection
- *   acquisition and build_arel call all live in `toArel`, which this body
- *   delegates to verbatim; folding them back into `arel` is tracked by story
- *   fold-to-arel-into-the-arel-reader (RFC 0107). Row moved verbatim from
- *   relation.ts with the member (RFC 0107 fan-out).
  */
 export function arel(this: QueryMethodsHost, aliases?: AliasTracker): any {
   return ((this as any)._arel ??= this.buildArel((this as any)._conn(), aliases));
@@ -2326,12 +2314,6 @@ export function buildBoundSqlLiteral(
 /**
  * @internal
  *
- * @missingRailsCall arel — CONVERGEABLE: Confirmed equivalent (RFC 0047): the TS body builds
- *   the Arel manager via _buildArel/toArel (the build_arel port that arel()
- *   delegates to) rather than the memoized arel reader; surfaced when arel()
- *   gained its Rails-faithful aliases param (query_methods.rb:1594). See PR
- *   #4518. Tracked by story query-methods-order-only-call-inversions (RFC
- *   0106).
  * @missingRailsCall empty? — PERMANENT: Verified per-site (RFC 0106):
  *   `optimizer_hints_values.empty?` (query_methods.rb:1609) — `empty?` on a Ruby
  *   Array, whose faithful JS spelling is `xs.length === 0`. That emits no
@@ -3033,9 +3015,8 @@ export function buildFrom(this: QueryMethodsHost): unknown {
       }
     }
     // Rails build_from wraps `opts.arel.as(name)`, where `arel` is the full
-    // `build_arel` — joins, HAVING, nested FROM, LOCK, CTEs, etc. Use the
-    // comprehensive builder rather than the projection-only `arel`, so the
-    // subquery stays a live AST: its binds parameterize and its retryability is
+    // `build_arel` — joins, HAVING, nested FROM, LOCK, CTEs, etc. The subquery
+    // stays a live AST: its binds parameterize and its retryability is
     // determined by the actual child nodes (not unconditionally disabled).
     // `build_arel` projects the qualified table star (`"comments".*`) and does
     // NOT run `JoinDependency#apply_column_aliases` — that column-alias

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -5,6 +5,7 @@ import {
   RecordNotFound,
   RecordInvalid,
   IrreversibleOrderError,
+  UnmodifiableRelation,
   registerModel,
   registerSubclass,
   Base,
@@ -2241,10 +2242,11 @@ describe("RelationTest", () => {
   });
 
   it("relations with cached arel can't be mutated [internal API]", () => {
-    const rel = Post.all();
-    const withWhere = rel.where({ title: "foo" });
-    expect(withWhere).not.toBe(rel);
-    expect(rel.toSql()).not.toContain("foo");
+    const rel = Post.all() as any;
+    rel.arel();
+
+    expect(() => rel.limitBang(5)).toThrow(UnmodifiableRelation);
+    expect(() => rel.whereBang("1 = 2")).toThrow(UnmodifiableRelation);
   });
 
   it("relations show the records in #inspect", async () => {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_main_query",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exec_main_query",
     "call": "wrap",
     "reason": "Verified per-site (RFC 0106): relation.rb:1426 is `FutureResult.wrap([])`, the async arm of the `@none` short-circuit. trails has no FutureResult — `loadAsync` memoizes the load PROMISE itself (relation.ts:753-765) because instantiation/eager-loading/preloading are all awaited inside `execQueries` — so the async arm returns the same `Result.empty()` the sync arm does."
   },
@@ -33,13 +26,6 @@
     "rubyName": "to_sql",
     "call": "apply_join_dependency",
     "reason": "Verified per-site (RFC 0106): relation.rb:1211-1215 renders the eager arm inside an `apply_join_dependency` block. trails' `toSql` is synchronous (relation.ts:1935) while `applyJoinDependency` is async, so the eager arm renders the aliased manager `_buildEagerOperandManager()` returns instead. Retires with the build_arel/apply_join_dependency routing convergence (story relation-arel-build-arel-routing), not here."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "to_sql",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -431,11 +431,11 @@ describe("significantMissingCalls", () => {
       // RFC 0107 — then reddened `to_sql`, `create_or_find_by` and
       // `apply_join_dependency` with no edit to any of their bodies.
       const sameFile = new Map<string, string[]>([
-        ["_buildEagerOperandManager", ["length", "toArel"]],
+        ["_buildEagerOperandManager", ["length", "arel"]],
         ["length", ["toArray"]],
         ["toArray", ["withConnection", "execQueries"]],
       ]);
-      const own = new Set(["_buildEagerOperandManager", "_conn", "toArel"]);
+      const own = new Set(["_buildEagerOperandManager", "_conn", "arel"]);
       const calls = (n: string) => sameFile.get(n);
       // `xs` is a local, so the extractor marks the read foreign for the owner
       // that made it — which is what stops the walk, no name-list needed.

--- a/scripts/parity/pipeline/fixtures/ar-133/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-133/query.ts
@@ -5,6 +5,6 @@ const ranked = Book.select(
   sql('"books".*'),
   sql("ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY pages DESC) AS rn"),
 )
-  .toArel()
+  .arel()
   .as("ranked");
 export default Book.from(ranked).where("ranked.rn = 1").order("ranked.id");

--- a/scripts/parity/pipeline/fixtures/ar-157/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-157/query.ts
@@ -1,4 +1,4 @@
 import { Book } from "./models.js";
-const q1 = Book.where({ status: "active" }).toArel();
-const q2 = Book.where({ status: "featured" }).toArel();
+const q1 = Book.where({ status: "active" }).arel();
+const q2 = Book.where({ status: "featured" }).arel();
 export default Book.from(q1.union(q2).as("all_books")).select("all_books.*").order("all_books.id");

--- a/scripts/parity/pipeline/fixtures/ar-158/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-158/query.ts
@@ -1,9 +1,6 @@
 import { Nodes, sql } from "@blazetrails/arel";
 import { Book, Review } from "./models.js";
-const sub = Review.select("book_id", sql("AVG(rating) AS avg_r"))
-  .group("book_id")
-  .toArel()
-  .as("sub");
+const sub = Review.select("book_id", sql("AVG(rating) AS avg_r")).group("book_id").arel().as("sub");
 const join = new Nodes.InnerJoin(
   sub,
   new Nodes.On(sub.get("book_id").eq(Book.arelTable.get("id"))),

--- a/scripts/parity/pipeline/fixtures/ar-182/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-182/query.ts
@@ -1,6 +1,6 @@
 import { Book } from "./models.js";
 const ids = Book.where({ status: "active" })
   .select("id")
-  .toArel()
-  .union(Book.where({ status: "featured" }).select("id").toArel());
+  .arel()
+  .union(Book.where({ status: "featured" }).select("id").arel());
 export default Book.where(Book.arelTable.get("id").in(ids)).order({ id: "asc" });


### PR DESCRIPTION
`QueryMethods#arel` IS the memo, the connection acquisition and the `build_arel`
call in Rails (`activerecord/lib/active_record/relation/query_methods.rb:1594-1596`):

```ruby
def arel(aliases = nil) # :nodoc:
  @arel ||= with_connection { |c| build_arel(c, aliases) }
end
```

trails' `arel` was a bare delegation to the trails-only `Relation#toArel`, which
held all three. This folds them into `arel` itself, retires `toArel`, and
repoints every caller (relation.ts, calculations, finder-methods,
predicate-builder and its handlers, parity fixtures) at the Rails name.

- `_arel` is the new `@arel` memo; `reset()` clears it, mirroring
  `relation.rb:1198` (`@to_sql = @arel = @loaded = ... = nil`). `clone()`
  allocates a fresh relation, so a spawned relation starts unmemoized exactly
  as Ruby's `initialize_copy` → `reset` leaves it.
- The two `arel` baseline rows (`build_arel`, `with_connection`) are gone.
  `build_arel` is now a real call; `with_connection` carries a
  `@missingRailsCall … PERMANENT` note at the call site — trails'
  `withConnection` is a `Promise`-returning checkout and this reader is
  synchronous, so the direct `_conn()` lease stands in (same connection, same
  `ConnectionNotEstablished` when no pool is established).
- Three further baseline rows converged and were deleted: `relation.ts`
  `exec_main_query`/`to_sql` → `arel`, and `query-methods.ts` `build_subquery`
  → `arel`.

- `assert_modifiable!` is `raise UnmodifiableRelation if @loaded || @arel`
  (`query_methods.rb:1746-1748`). The `@arel` arm becomes load-bearing the moment
  `arel` memoizes, so `assertModifiableBang` now checks `_arel` too, and the
  Rails test `relations with cached arel can't be mutated [internal API]`
  (`relations_test.rb:2099-2105`) is converged to its real assertions.

`pnpm parity:api:calls` and `:args` are green with no new rows;
`pnpm typecheck`, `pnpm lint`, and the relation / relations / relation-dir /
scoping / associations / batches / calculations / finder suites pass locally.

Closes-story: fold-to-arel-into-the-arel-reader