### PR TITLE
refactor(activerecord): spell build_join_buckets' default-block Hash as a Proxy

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3354,13 +3354,6 @@ export function selectInnerNamedJoins(
  *   unrelated `ActiveRecord::Result.empty`, which takes arguments since it
  *   gained Rails' `async:` kwarg (result.rb:94-100) — nothing in the TS body was
  *   dropped.
- * @missingRailsCall order:selectNamedJoins,constructor — CONVERGEABLE: Re-keyed by the
- *   accessor-pair fix to the ported-with-args gate (compare.ts `tsWriterSigs`):
- *   the SAME pre-existing order-only divergence this body already carried,
- *   reported at a different first inversion now that a `set` accessor's
- *   signature no longer opens the gate for its reader. The row it replaces was
- *   deleted from this file in the same commit. Tracked by story
- *   query-methods-order-only-call-inversions (RFC 0106).
  */
 export function buildJoinBuckets(
   this: QueryMethodsHost,

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3365,12 +3365,16 @@ export function selectInnerNamedJoins(
 export function buildJoinBuckets(
   this: QueryMethodsHost,
 ): [Record<string, unknown[]>, typeof Nodes.InnerJoin | typeof Nodes.OuterJoin] {
-  const buckets: Record<string, unknown[]> = {
-    leading_join: [],
-    join_node: [],
-    stashed_join: [],
-    named_join: [],
-  };
+  // query_methods.rb:1826 — `buckets = Hash.new { |h, k| h[k] = [] }`. JS has no
+  // Hash default block, so the auto-vivifying read is spelled as a Proxy `get`
+  // trap: a missing string key stores and returns a fresh array, exactly as the
+  // Ruby block does. Non-string keys (symbol protocol lookups) fall through.
+  const buckets = new Proxy({} as Record<string, unknown[]>, {
+    get(h, k) {
+      if (typeof k !== "string") return Reflect.get(h, k);
+      return (h[k] ??= []);
+    },
+  });
 
   const joinsValues = this.joinsValues;
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3365,10 +3365,8 @@ export function selectInnerNamedJoins(
 export function buildJoinBuckets(
   this: QueryMethodsHost,
 ): [Record<string, unknown[]>, typeof Nodes.InnerJoin | typeof Nodes.OuterJoin] {
-  // query_methods.rb:1826 — `buckets = Hash.new { |h, k| h[k] = [] }`. JS has no
-  // Hash default block, so the auto-vivifying read is spelled as a Proxy `get`
-  // trap: a missing string key stores and returns a fresh array, exactly as the
-  // Ruby block does. Non-string keys (symbol protocol lookups) fall through.
+  // query_methods.rb:1826 `Hash.new { |h, k| h[k] = [] }` — JS has no Hash
+  // default block, so auto-vivification is a Proxy `get` trap.
   const buckets = new Proxy({} as Record<string, unknown[]>, {
     get(h, k) {
       if (typeof k !== "string") return Reflect.get(h, k);


### PR DESCRIPTION
Ruby's `buckets = Hash.new { |h, k| h[k] = [] }` (`activerecord/lib/active_record/relation/query_methods.rb:1826`) was ported as a pre-seeded object literal with the four bucket keys. That emits no constructor, so the shard's first TS constructor was the `new Nodes.StringJoin` further down and the call-set gate reported `order:selectNamedJoins,constructor`.

JS has no Hash default block — a genuine language gap. The settled spelling is a `Proxy` `get` trap: a missing string key stores and returns a fresh array, exactly as the Ruby block does; non-string (symbol protocol) keys fall through to `Reflect.get`. It sits at the same position as `Hash.new`, adds no exported surface, and is the natural JS spelling for the other three instances (`join_dependency.rb:108-114`, `pool_manager.rb:7`, `test_fixtures.rb:123`) when they are converged.

The `build_join_buckets` / `order:selectNamedJoins,constructor` baseline row is deleted; `pnpm parity:api:calls` and `pnpm parity:api:calls:args` are green with no stale mark.

Closes-story: build-join-buckets-default-hash-idiom

## Review reply — why the Proxy stays inline rather than a shared helper

The settled spelling **is** the inline Proxy, and deliberately so.

Ruby has no helper here either: every one of the four sites spells the literal
`Hash.new { |h, k| h[k] = [] }` in place (`query_methods.rb:1826`,
`join_dependency.rb:108-114`, `pool_manager.rb:7`, `test_fixtures.rb:123`).
A trails `hashWithDefault` / `defaultHash` in activesupport would be a public
name with no Ruby counterpart — exactly what `pnpm parity:api:extra` measures
and what CLAUDE.md's "no abstraction Rails does not have" rule forbids; it
would ship as a `@noRailsEquivalent` receipt, i.e. new debt, to converge a
different piece of debt. It would also read as an indirection a Rails dev does
not find in the Ruby, which is the fidelity bar this repo is held to.

So the answer to the open question is: each remaining site inlines the same
two-line trap, mirroring its own Ruby `Hash.new` line the way this one mirrors
`query_methods.rb:1826`. The shape is three tokens wide (`new Proxy`, a
string-key guard, `h[k] ??= <default>`) and is now precedent in the tree for
the RFC 0106 stories that convert the other three; "subtly different" is a
review question at those sites, not a reason to add surface Rails lacks.


## Rebase note (2026-08-22)

#6862 landed while this was in review and migrated the whole
`call-mismatches-exclude/activerecord/relation/query-methods.json` shard to
per-site `@missingRailsCall` tags, so the row this PR deleted now lives as a
`@missingRailsCall order:selectNamedJoins,constructor — CONVERGEABLE` tag on
`buildJoinBuckets`. The Proxy makes the call the gate was missing, so the tag is
stale — it is deleted here instead of the baseline row (same only-shrink
contract, same convergence). `pnpm parity:api:calls` is green: 738 → 708
baselined, no stale tag, no stale mark.
