### PR TITLE
refactor(activerecord): eval_scope drops the klassOverride param and undefined guard

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -821,10 +821,19 @@ export class AssociationScope {
         reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.() ?? [];
     if (constraints.length === 0) return scope;
+    // Rails' chain entry for a `source_type:` through is a PolymorphicReflection
+    // whose own `klass` already resolves (reflection.rb:1265), which is what
+    // `build_scope`'s `klass = self.klass` default (reflection.rb:336) reads.
+    // trails' entry here is the raw polymorphic belongsTo, whose `klass` raises,
+    // so resolve the source_type target onto the entry rather than threading a
+    // fourth argument past `eval_scope` (association_scope.rb:169-172).
+    const entry = klassOverride
+      ? (Object.create(reflection, { klass: { value: klassOverride } }) as typeof reflection)
+      : reflection;
     let merged = scope;
     for (const c of constraints) {
       if (typeof c !== "function") continue;
-      const evaluated = this.evalScope(reflection, c, owner, entryKlass);
+      const evaluated = this.evalScope(entry, c, owner);
       merged = this._pushScopeIntoRelation(merged, evaluated);
     }
     return merged;
@@ -846,22 +855,9 @@ export class AssociationScope {
     reflection: AbstractReflection | ReflectionProxy,
     scopeFn: (...args: unknown[]) => unknown,
     owner: Base,
-    klassOverride?: typeof Base,
   ): unknown {
-    // `klassOverride` carries the resolved source_type target for a polymorphic
-    // belongsTo source, whose `reflection.klass` would otherwise raise.
-    const entryKlass = klassOverride ?? (reflection as { klass?: typeof Base }).klass;
-    if (!entryKlass) return undefined;
-    // Rails: `relation = reflection.build_scope(reflection.aliased_table)`
-    // (association_scope.rb:169) — the chain entry's scope lambda binds its
-    // `where(...)` predicates to the ALIASED table. For a self-referential
-    // polymorphic through (a repeated table) the entry's `imageable_type`
-    // source-type filter must qualify the joined-in alias
-    // (`children_imageables`), not the FROM table.
     const relation = (reflection as unknown as ScopeBuilder).buildScope(
       (reflection as ReflectionProxy).aliasedTable,
-      undefined,
-      entryKlass,
     );
     return invokeScopeLambda(scopeFn as ScopeLambda<unknown>, relation, owner) ?? relation;
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -821,12 +821,11 @@ export class AssociationScope {
         reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.() ?? [];
     if (constraints.length === 0) return scope;
-    // Rails' chain entry for a `source_type:` through is a PolymorphicReflection
-    // whose own `klass` already resolves (reflection.rb:1265), which is what
-    // `build_scope`'s `klass = self.klass` default (reflection.rb:336) reads.
-    // trails' entry here is the raw polymorphic belongsTo, whose `klass` raises,
-    // so resolve the source_type target onto the entry rather than threading a
-    // fourth argument past `eval_scope` (association_scope.rb:169-172).
+    // Rails' `source_type:` chain entry is a PolymorphicReflection whose own
+    // `klass` resolves (reflection.rb:1265) and is read by `build_scope`'s
+    // `klass = self.klass` default (reflection.rb:336); trails' entry is the raw
+    // polymorphic belongsTo, whose `klass` raises, so resolve it here instead of
+    // threading a fourth argument past `eval_scope` (association_scope.rb:169).
     const entry = klassOverride
       ? (Object.create(reflection, { klass: { value: klassOverride } }) as typeof reflection)
       : reflection;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -821,8 +821,8 @@ export class AssociationScope {
         reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.() ?? [];
     if (constraints.length === 0) return scope;
-    // Rails' `source_type:` chain entry is a PolymorphicReflection whose own
-    // `klass` resolves (reflection.rb:1265) and is read by `build_scope`'s
+    // Rails' `source_type:` chain entry is a PolymorphicReflection, whose `klass`
+    // delegates to `@reflection` (reflection.rb:1229-1230) and is read by `build_scope`'s
     // `klass = self.klass` default (reflection.rb:336); trails' entry is the raw
     // polymorphic belongsTo, whose `klass` raises, so resolve it here instead of
     // threading a fourth argument past `eval_scope` (association_scope.rb:169).


### PR DESCRIPTION
`AssociationScope#eval_scope` (`association_scope.rb:169-172`) is three
parameters and two statements in Rails, with no falsy path. trails carried a
fourth `klassOverride` parameter and an early `return undefined`; the latter let
`_pushScopeIntoRelation`'s `if (!evaluated) return scope` swallow a chain
entry's constraints silently and bypassed the `|| relation` fallback ported in
#6862.

The `source_type:` polymorphic target is now resolved onto the chain entry
before `evalScope` is reached, mirroring Rails, where the entry is a
`PolymorphicReflection` whose own `klass` resolves (`reflection.rb:1265`) and
`build_scope`'s `klass = self.klass` default (`reflection.rb:336`) does the
rest.

Verified: `packages/activerecord/src/associations/**` (116 files, 2189 tests)
green on SQLite; `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green
with no new baseline rows.

The bundled story `port-delegation-generate-module-and-reserved-receivers` is
**not** in this PR: it edits `Delegation.generate`'s receiver computation in
`packages/activesupport/src/delegation.ts`, which open PR #6863 rewrites
(+123 LOC) and has not merged. It is `pnpm tasks block`ed on #6863 rather than
landed here as a conflicting duplicate.

Closes-story: eval-scope-carries-a-klass-override-param-and-nil-guard