### PR TITLE
refactor(activesupport): migrate 14 call-set baseline rows to @missingRailsCall tags

### DIFF
--- a/packages/activesupport/src/actionable-error.ts
+++ b/packages/activesupport/src/actionable-error.ts
@@ -60,6 +60,14 @@ export class ActionableError extends Error {
     return {};
   }
 
+  /**
+   * @missingRailsCall fetch — PERMANENT: actionable_error.rb:30
+   *   `actions(error).fetch(name).call` — Ruby Hash#fetch raises KeyError, which
+   *   the method's own `rescue KeyError` turns into NonActionable; JS object
+   *   indexing cannot raise, so the port spells the same pair as an explicit
+   *   `name in actions` guard (key presence, exactly as fetch tests it) plus the
+   *   NonActionable throw. Language shortcoming.
+   */
   static dispatch(error: any, name: string): void {
     const actions = this.actions(error);
     if (!(name in actions)) {

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -44,6 +44,13 @@ export function benchmark<T>(
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
+/**
+ * @missingRailsCall logger — CONVERGEABLE (story
+ *   `benchmarkable-should-mix-in-logger-reader`): Rails reads the mixin's
+ *   `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared
+ *   free function whose host passes the logger in as its first parameter, so
+ *   there is no `logger` reader to call.
+ */
 export function benchmark<T>(
   logger: BenchmarkLogger | null | undefined,
   message: string,

--- a/packages/activesupport/src/broadcast-logger.ts
+++ b/packages/activesupport/src/broadcast-logger.ts
@@ -31,6 +31,12 @@ export class BroadcastLogger extends Logger {
     return this;
   }
 
+  /**
+   * @missingRailsCall delete — PERMANENT: Ruby Array#delete removes by value:
+   *   `@broadcasts.delete(logger)` (broadcast_logger.rb:105) ports to the
+   *   `filter`ed reassignment in stopBroadcastingTo — JS arrays have no
+   *   delete-by-value.
+   */
   stopBroadcastingTo(logger: Logger): this {
     this.broadcasts = this.broadcasts.filter((l) => l !== logger);
     return this;

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -38,6 +38,12 @@ export class MemoryStore extends Store implements CacheStore {
   private cacheSize: number;
   private _pruning = false;
 
+  /**
+   * @missingRailsCall new — PERMANENT: memory_store.rb:83 `@monitor = Monitor.new` — Ruby's
+   *   Monitor is a reentrant mutex guarding the store against other THREADS. JS
+   *   has one thread and the store's mutations are synchronous, so there is
+   *   nothing to construct and nothing to lock. Language shortcoming.
+   */
   constructor(options?: {
     size?: number;
     maxPruneTime?: number;

--- a/packages/activesupport/src/configuration-file.ts
+++ b/packages/activesupport/src/configuration-file.ts
@@ -18,6 +18,12 @@ export class ConfigurationFile {
     this.content = this.read(contentPath);
   }
 
+  /**
+   * @missingRailsCall load — PERMANENT: configuration_file.rb:26-28 `YAML.unsafe_load_file`
+   *   / `YAML.load_file` — Ruby's YAML/Psych is stdlib with no port; trails
+   *   reads the file through the async fs adapter and hands the source to its
+   *   own YAML parser, so no `load` call exists to make.
+   */
   static parse(
     contentPath: string,
     options: { context?: Record<string, unknown>; [option: string]: unknown } = {},
@@ -43,6 +49,11 @@ export class ConfigurationFile {
    * instances or Symbols, so there is nothing to permit), and `freeze:` (no
    * deep-freeze pass). Everything else — `merge:`, `version:`, `schema:`,
    * `maxAliasCount:` — reaches the loader.
+   *
+   * @missingRailsCall load — PERMANENT: configuration_file.rb:26-28 `YAML.unsafe_load_file`
+   *   / `YAML.load_file` — Ruby's YAML/Psych is stdlib with no port; trails
+   *   reads the file through the async fs adapter and hands the source to its
+   *   own YAML parser, so no `load` call exists to make.
    */
   parse({
     context,

--- a/packages/activesupport/src/error-reporter.ts
+++ b/packages/activesupport/src/error-reporter.ts
@@ -235,6 +235,12 @@ export class ErrorReporter {
   /**
    * Report an error directly to subscribers. You can use this method when the
    * block-based #handle and #record methods are not suitable.
+   *
+   * @missingRailsCall merge — PERMANENT: error_reporter.rb:263
+   *   `ActiveSupport::ExecutionContext.to_h.merge(context)` — Ruby Hash#merge
+   *   returning a new hash is JS object spread (`{ ...ExecutionContext.toH(),
+   *   ...context }`); there is no Hash object to call `merge` on. Same
+   *   substitution as the `cache.ts merged_options -> merge` row.
    */
   report(
     error: Error,

--- a/packages/activesupport/src/message-pack/serializer.ts
+++ b/packages/activesupport/src/message-pack/serializer.ts
@@ -54,6 +54,12 @@ export class Serializer {
    * @internal Memoizes extension install + handler registration, then returns
    * the factory. Ruby builds and freezes a packer/unpacker pool here; with no
    * threads to pool against, the factory itself plays the role of the pool.
+   *
+   * @missingRailsCall fetch — PERMANENT: message_pack/serializer.rb:54
+   *   `message_pack_factory.pool(ENV.fetch("RAILS_MAX_THREADS", 5).to_i)` — the
+   *   fetch reads the thread count for a Ruby connection pool of packers. JS has
+   *   one thread, so trails holds a single factory rather than a pool, and there
+   *   is no thread count to read. Language shortcoming.
    */
   protected messagePackPool(): Factory {
     if (!this.installed) {

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -129,6 +129,12 @@ export class MessageVerifier extends Codec {
     }
   }
 
+  /**
+   * @missingRailsCall hexdigest — PERMANENT: Rails calls `OpenSSL::HMAC.hexdigest`; trails
+   *   routes every HMAC through the crypto adapter
+   *   (`createHmac(...).digest("hex")`), which is the same digest by a different
+   *   call.
+   */
   private generateDigest(data: string): string {
     return getCrypto().createHmac(this.digest, this.secret).update(data).digest("hex");
   }

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -388,6 +388,12 @@ export class Fanout {
     }
   }
 
+  /**
+   * @missingRailsCall transform_values — PERMANENT: Ruby Hash#transform_values:
+   *   `group_by(&:group_class).transform_values { |s| s.map(&:delegate) }`
+   *   (notifications/fanout.rb:189-191) is folded into the local groupBy helper,
+   *   which emits the delegate lists directly.
+   */
   groupsFor(name: string): Map<GroupClass, Delegate[]> {
     let groups = this.groupsForCache.get(name);
     if (!groups) {

--- a/packages/activesupport/src/number-helper/rounding-helper.ts
+++ b/packages/activesupport/src/number-helper/rounding-helper.ts
@@ -20,6 +20,13 @@ export class RoundingHelper {
     this.options = options;
   }
 
+  /**
+   * @missingRailsCall fetch — PERMANENT: Ruby Hash#fetch with a default:
+   *   `options.fetch(:round_mode, :default)`
+   *   (number_helper/rounding_helper.rb:16) ports to the `"roundMode" in
+   *   this.options` check, which keeps fetch's stored-value-wins semantics that
+   *   `??` would not.
+   */
   round(number: unknown): unknown {
     const precision = this.absolutePrecision(number);
     if (precision == null) return number;

--- a/packages/activesupport/src/testing/method-call-assertions.ts
+++ b/packages/activesupport/src/testing/method-call-assertions.ts
@@ -66,6 +66,9 @@ export function assertCalled<T extends object>(
  * runs.
  *
  * @internal
+ *
+ * @missingRailsCall new — PERMANENT: `Minitest::Mock.new`; minitest is not ported, so the
+ *   mock is the recorded-call list `assertMock` compares against `args`.
  */
 export function assertCalledWith<T extends object>(
   object: T,

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -138,6 +138,11 @@ export function travel(
  * errors with external services, like MySQL (which will round instead of floor,
  * leading to off-by-one-second errors), unless the `withUsec` argument is set
  * to `true`.
+ *
+ * @missingRailsCall at — CONVERGEABLE (story
+ *   `travel-to-should-stub-rails-time-receivers`): `Time.at(now)` builds the
+ *   stubbed Time; the trails clock method takes a `Temporal.Instant` directly,
+ *   so there is no `at` constructor to call.
  */
 export function travelTo(
   dateOrTime: Temporal.PlainDate | Date | Temporal.Instant | string,

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -509,6 +509,13 @@ export interface ToXmlOptions extends Omit<ToTagOptions, "builder"> {
   skipInstruct?: boolean;
 }
 
+/**
+ * @missingRailsCall call — PERMANENT: to_tag ports XmlMini.to_tag: Rails'
+ *   Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms
+ *   (immutable `{ ...options }` spread instead of merge, destructured
+ *   `options.type` instead of delete, direct function invocation, and
+ *   String()/keyToString()) — no behavioral omission.
+ */
 export function toTag(key: unknown, value: unknown, options: ToTagOptions): void {
   const { builder } = options;
   const explicitType = options.type;

--- a/packages/activesupport/src/xml-mini/nokogiri.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.ts
@@ -116,6 +116,9 @@ function nodeToHash(node: XmlNode): XmlHash {
  * Mirrors: ActiveSupport::XmlMini_Nokogiri#parse (nokogiri.rb:19-31) —
  * `StringIO` is the shim for Ruby's stdlib `StringIO`, and `instanceof
  * StringIO` stands in for `respond_to?(:read)`.
+ *
+ * @missingRailsCall first — PERMANENT: Ruby core Enumerable#first on the parsed document
+ *   (xml_mini/nokogiri.rb:19-30), not a ported trails method.
  */
 export function parse(data: string | StringIO | null | undefined): XmlHash {
   if (!(data instanceof StringIO)) {

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/actionable-error.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/actionable-error.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "actionable-error.ts",
-    "rubyName": "dispatch",
-    "call": "fetch",
-    "reason": "actionable_error.rb:30 `actions(error).fetch(name).call` — Ruby Hash#fetch raises KeyError, which the method's own `rescue KeyError` turns into NonActionable; JS object indexing cannot raise, so the port spells the same pair as an explicit `name in actions` guard (key presence, exactly as fetch tests it) plus the NonActionable throw. Language shortcoming."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/benchmarkable.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/benchmarkable.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "benchmarkable.ts",
-    "rubyName": "benchmark",
-    "call": "logger",
-    "reason": "Rails reads the mixin's `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared free function whose host passes the logger in as its first parameter, so there is no `logger` reader to call."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/broadcast-logger.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/broadcast-logger.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "broadcast-logger.ts",
-    "rubyName": "stop_broadcasting_to",
-    "call": "delete",
-    "reason": "Ruby Array#delete removes by value: `@broadcasts.delete(logger)` (broadcast_logger.rb:105) ports to the `filter`ed reassignment in stopBroadcastingTo — JS arrays have no delete-by-value."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/cache/memory-store.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "cache/memory-store.ts",
-    "rubyName": "initialize",
-    "call": "new",
-    "reason": "memory_store.rb:83 `@monitor = Monitor.new` — Ruby's Monitor is a reentrant mutex guarding the store against other THREADS. JS has one thread and the store's mutations are synchronous, so there is nothing to construct and nothing to lock. Language shortcoming."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/configuration-file.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/configuration-file.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "configuration-file.ts",
-    "rubyName": "parse",
-    "call": "load",
-    "reason": "configuration_file.rb:26-28 `YAML.unsafe_load_file` / `YAML.load_file` — Ruby's YAML/Psych is stdlib with no port; trails reads the file through the async fs adapter and hands the source to its own YAML parser, so no `load` call exists to make."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/error-reporter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/error-reporter.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "error-reporter.ts",
-    "rubyName": "report",
-    "call": "merge",
-    "reason": "error_reporter.rb:263 `ActiveSupport::ExecutionContext.to_h.merge(context)` — Ruby Hash#merge returning a new hash is JS object spread (`{ ...ExecutionContext.toH(), ...context }`); there is no Hash object to call `merge` on. Same substitution as the `cache.ts merged_options -> merge` row."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/message-pack/serializer.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/message-pack/serializer.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "message-pack/serializer.ts",
-    "rubyName": "message_pack_pool",
-    "call": "fetch",
-    "reason": "message_pack/serializer.rb:54 `message_pack_factory.pool(ENV.fetch(\"RAILS_MAX_THREADS\", 5).to_i)` — the fetch reads the thread count for a Ruby connection pool of packers. JS has one thread, so trails holds a single factory rather than a pool, and there is no thread count to read. Language shortcoming."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/message-verifier.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/message-verifier.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "message-verifier.ts",
-    "rubyName": "generate_digest",
-    "call": "hexdigest",
-    "reason": "Rails calls `OpenSSL::HMAC.hexdigest`; trails routes every HMAC through the crypto adapter (`createHmac(...).digest(\"hex\")`), which is the same digest by a different call."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/notifications/fanout.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/notifications/fanout.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "notifications/fanout.ts",
-    "rubyName": "groups_for",
-    "call": "transform_values",
-    "reason": "Ruby Hash#transform_values: `group_by(&:group_class).transform_values { |s| s.map(&:delegate) }` (notifications/fanout.rb:189-191) is folded into the local groupBy helper, which emits the delegate lists directly."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
@@ -5,12 +5,5 @@
     "rubyName": "convert_to_decimal",
     "call": "digit_count",
     "reason": "rounding_helper.rb:47 calls `digit_count` from the `Rational` arm alone, to size the `BigDecimal(number, ndigits)` precision; there is no trails Rational. Convergeable with the Rational port; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/rounding-helper.ts",
-    "rubyName": "round",
-    "call": "fetch",
-    "reason": "Ruby Hash#fetch with a default: `options.fetch(:round_mode, :default)` (number_helper/rounding_helper.rb:16) ports to the `\"roundMode\" in this.options` check, which keeps fetch's stored-value-wins semantics that `??` would not."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/method-call-assertions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/method-call-assertions.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "testing/method-call-assertions.ts",
-    "rubyName": "assert_called_with",
-    "call": "new",
-    "reason": "`Minitest::Mock.new`; minitest is not ported, so the mock is the recorded-call list `assertMock` compares against `args`."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/testing/time-helpers.json
@@ -3,13 +3,6 @@
     "package": "activesupport",
     "tsFile": "testing/time-helpers.ts",
     "rubyName": "travel_to",
-    "call": "at",
-    "reason": "`Time.at(now)` builds the stubbed Time; the trails clock method takes a `Temporal.Instant` directly, so there is no `at` constructor to call."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "testing/time-helpers.ts",
-    "rubyName": "travel_to",
     "call": "stub_object",
     "kind": "args",
     "rubyArgs": [

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "xml-mini.ts",
-    "rubyName": "to_tag",
-    "call": "call",
-    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/xml-mini/nokogiri.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "xml-mini/nokogiri.ts",
-    "rubyName": "parse",
-    "call": "first",
-    "reason": "Ruby core Enumerable#first on the parsed document (xml_mini/nokogiri.rb:19-30), not a ported trails method."
-  }
-]


### PR DESCRIPTION
Continues the RFC 0106 tail sweep into **activesupport**. Each single-row `kind: "set"` shard under `scripts/api-compare/call-mismatches-exclude/activesupport/` moves its existing reviewed, Rails-anchored reason to a `@missingRailsCall` tag at the call site, via `pnpm parity:api:build --package activesupport --file <f> --call <c>`. Emptied shards are deleted, not committed as `[]`. No `--write`, no reseed. No method body is touched — JSDoc only.

Migrated (14):

| file | call |
| --- | --- |
| `actionable-error.ts` | `fetch` |
| `benchmarkable.ts` | `logger` |
| `broadcast-logger.ts` | `delete` |
| `cache/memory-store.ts` | `new` |
| `configuration-file.ts` | `load` |
| `error-reporter.ts` | `merge` |
| `message-pack/serializer.ts` | `fetch` |
| `message-verifier.ts` | `hexdigest` |
| `notifications/fanout.ts` | `transform_values` |
| `number-helper/rounding-helper.ts` | `fetch` |
| `testing/method-call-assertions.ts` | `new` |
| `testing/time-helpers.ts` | `at` |
| `xml-mini.ts` | `call` |
| `xml-mini/nokogiri.ts` | `first` |

### Permanence claims

`suppressedCallsIn` (`scripts/api-compare/missing-rails-call-tags.ts:219-231`) requires every tag reason to open with `PERMANENT` or `CONVERGEABLE`, which the baseline rows did not carry. Twelve are **PERMANENT** — Ruby stdlib with no trails port (Psych, minitest), a single-threaded runtime (`Monitor.new`, `ENV.fetch("RAILS_MAX_THREADS")`), or a Ruby Hash/Array method with no JS receiver (`Hash#fetch`'s KeyError, `Array#delete`-by-value, `Hash#merge`, `Hash#transform_values`).

Two are **CONVERGEABLE** and name a new story rather than ratifying the deviation:

- `benchmarkable.ts` `logger` — trails ports `Benchmarkable#benchmark` as a free function taking the logger as its first parameter instead of a mixin reading the host's `logger` reader (`benchmarkable.rb:38,44,46`). trails has a settled mixin idiom, so this is not a language shortcoming → `benchmarkable-should-mix-in-logger-reader`.
- `testing/time-helpers.ts` `at` — `travelTo` stubs a single internal `clock` rather than the four receivers Rails stubs (`time_helpers.rb:178-190`), which is also what the two remaining `kind: "args"` rows on that method record → `travel-to-should-stub-rails-time-receivers`.

### One row deferred: `gem-version.ts` `new`

Minting its tag reds `pnpm parity:api:calls`:

```
call-mismatches ratchet: 1 STALE @missingRailsCall tag(s) whose call is no longer flagged.
  - actionpackversion  gem-version.ts  gemVersion  new
```

`compare.ts` keys the tag population (`tsMissingCallTagsByFileName`, `compare.ts:2602`, filled by `recordTaggedCalls` at :2722) by the relative tsFile path alone, over a population spanning the package **and its deps**. `actionpack` depends on `activesupport` and both ship a `gem-version.ts`, so activesupport's tag lands in `actionpackversion`'s map, goes unconsumed, and `staleCallTags` (:4000) reports it stale. Every package in the repo ships a `gem-version.ts`, so this bites any same-basename file across a dep edge. The row stays baselined and the tooling fix is filed as `call-tag-population-collides-on-shared-basename`.

### Gates

- `pnpm parity:api:calls` — OK (691 baselined, 331 unreviewed, 122 marks totalling 331 tight)
- `pnpm parity:api:calls:args` — OK (157 baselined shape rows)
- `pnpm parity:api:reasons` — 3418 files, every tag carries a reason
- `pnpm parity:api:detached` — 3993 files, no detached tag blocks
- `pnpm lint`, `pnpm typecheck` — clean

209 LOC (87+/122-).

Closes-story: wave-5b-tail-sweep
