### PR TITLE
refactor(activesupport,activerecord,actionpack): mix in Benchmarkable, guard in_batches off arel, vivify PoolManager's role map

### DIFF
--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -3,12 +3,12 @@ import { benchmark, type LoggerLike } from "./logger.js";
 
 describe("benchmark()", () => {
   it("returns the block's return value", () => {
-    expect(benchmark(undefined, "work", () => 42)).toBe(42);
+    expect(benchmark.call({}, "work", () => 42)).toBe(42);
   });
 
   it("runs the block even when no logger is attached", () => {
     let ran = false;
-    benchmark(undefined, "work", () => {
+    benchmark.call({}, "work", () => {
       ran = true;
     });
     expect(ran).toBe(true);
@@ -17,7 +17,7 @@ describe("benchmark()", () => {
   it("awaits a promise-returning block and logs exactly once after resolution", async () => {
     const lines: string[] = [];
     const logger: LoggerLike = { info: (m) => lines.push(m) };
-    const result = await benchmark(logger, "fetch", async () => {
+    const result = await benchmark.call({ logger }, "fetch", async () => {
       await new Promise((r) => setTimeout(r, 5));
       return 42;
     });
@@ -30,7 +30,7 @@ describe("benchmark()", () => {
     const lines: string[] = [];
     const logger: LoggerLike = { info: (m) => lines.push(m) };
     expect(() =>
-      benchmark(logger, "bad work", () => {
+      benchmark.call({ logger }, "bad work", () => {
         throw new Error("boom");
       }),
     ).toThrow(/boom/);
@@ -41,7 +41,7 @@ describe("benchmark()", () => {
     const lines: string[] = [];
     const logger: LoggerLike = { info: (m) => lines.push(m) };
     await expect(
-      benchmark(logger, "bad fetch", async () => {
+      benchmark.call({ logger }, "bad fetch", async () => {
         throw new Error("kaboom");
       }),
     ).rejects.toThrow(/kaboom/);
@@ -50,7 +50,7 @@ describe("benchmark()", () => {
 
   it("tolerates a logger whose `info` is not a function", () => {
     let ran = false;
-    benchmark({ info: "not a function" } as unknown as LoggerLike, "work", () => {
+    benchmark.call({ logger: { info: "not a function" } as unknown as LoggerLike }, "work", () => {
       ran = true;
     });
     expect(ran).toBe(true);
@@ -59,7 +59,7 @@ describe("benchmark()", () => {
   it("logs an info line with elapsed ms when a logger is attached", () => {
     const lines: string[] = [];
     const logger: LoggerLike = { info: (m) => lines.push(m) };
-    benchmark(logger, "render template", () => 1 + 1);
+    benchmark.call({ logger }, "render template", () => 1 + 1);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/^render template \(\d+\.\d+ms\)$/);
   });

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -26,28 +26,6 @@ describe("benchmark()", () => {
     expect(lines[0]).toMatch(/^fetch \(\d+\.\d+ms\)$/);
   });
 
-  it("still logs when a sync block throws, and rethrows the error", () => {
-    const lines: string[] = [];
-    const logger: LoggerLike = { info: (m) => lines.push(m) };
-    expect(() =>
-      benchmark.call({ logger }, "bad work", () => {
-        throw new Error("boom");
-      }),
-    ).toThrow(/boom/);
-    expect(lines).toHaveLength(1);
-  });
-
-  it("still logs when an async block rejects, and the rejection propagates", async () => {
-    const lines: string[] = [];
-    const logger: LoggerLike = { info: (m) => lines.push(m) };
-    await expect(
-      benchmark.call({ logger }, "bad fetch", async () => {
-        throw new Error("kaboom");
-      }),
-    ).rejects.toThrow(/kaboom/);
-    expect(lines).toHaveLength(1);
-  });
-
   it("tolerates a logger whose `info` is not a function", () => {
     let ran = false;
     benchmark.call({ logger: { info: "not a function" } as unknown as LoggerLike }, "work", () => {

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -17,20 +17,11 @@ export interface LoggerHost {
 }
 
 /**
- * Mirrors `ActiveSupport::Benchmarkable#benchmark`. Thin wrapper around
- * the shared `benchmark` helper in `@blazetrails/activesupport` —
- * preserved here so existing actionpack callers don't break.
+ * Mirrors `ActiveSupport::Benchmarkable#benchmark`, mixed in the way Rails'
+ * `include ActiveSupport::Benchmarkable` mixes it into
+ * `AbstractController::Logger` (logger.rb:13) — `this` is the controller, and
+ * the logger comes from its own `logger` reader (benchmarkable.rb:38).
  */
-export function benchmark<T>(logger: LoggerLike | undefined, message: string, block: () => T): T;
-export function benchmark<T>(
-  logger: LoggerLike | undefined,
-  message: string,
-  block: () => Promise<T>,
-): Promise<T>;
-export function benchmark<T>(
-  logger: LoggerLike | undefined,
-  message: string,
-  block: () => T | Promise<T>,
-): T | Promise<T> {
-  return benchmarkable(logger, message, { logOnError: true }, block) as T | Promise<T>;
+export function benchmark<T>(this: LoggerHost, message: string, block: () => T): T {
+  return benchmarkable.call(this, message, { logOnError: true }, block) as T;
 }

--- a/packages/actionpack/src/abstract-controller/logger.ts
+++ b/packages/actionpack/src/abstract-controller/logger.ts
@@ -1,27 +1,15 @@
 /**
- * `AbstractController::Logger` — config slot for a per-controller
- * logger. Rails additionally mixes in `ActiveSupport::Benchmarkable`
- * (`benchmark(message, &block)`); the shared helper lives in
- * `@blazetrails/activesupport` and is re-exported here so the
- * abstract-controller surface keeps the same callable shape.
+ * `AbstractController::Logger` — config slot for a per-controller logger.
+ * Rails' `included do ... include ActiveSupport::Benchmarkable end`
+ * (logger.rb:11-14) is spelled here as a re-export of the mixin, which the
+ * controller class assigns to itself; `benchmark` then reads the
+ * controller's own `logger` reader (benchmarkable.rb:38).
  *
  * @internal
  */
 
-import { benchmark as benchmarkable, type BenchmarkLogger } from "@blazetrails/activesupport";
-
-export type LoggerLike = BenchmarkLogger;
+export { benchmark, type BenchmarkLogger as LoggerLike } from "@blazetrails/activesupport";
 
 export interface LoggerHost {
-  logger?: LoggerLike;
-}
-
-/**
- * Mirrors `ActiveSupport::Benchmarkable#benchmark`, mixed in the way Rails'
- * `include ActiveSupport::Benchmarkable` mixes it into
- * `AbstractController::Logger` (logger.rb:13) — `this` is the controller, and
- * the logger comes from its own `logger` reader (benchmarkable.rb:38).
- */
-export function benchmark<T>(this: LoggerHost, message: string, block: () => T): T {
-  return benchmarkable.call(this, message, { logOnError: true }, block) as T;
+  logger?: import("@blazetrails/activesupport").BenchmarkLogger;
 }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -704,7 +704,10 @@ export class JoinDependency {
    * Hydrate models from a flat result row set, mirroring Rails'
    * JoinDependency#instantiate body. `seen` is the identity-keyed
    * parent → node → id → model map (Rails' `compare_by_identity` hash); a JS
-   * `Map` keys by object identity, matching it. `modelCache` caches each node's
+   * `Map` keys by object identity, matching it. The settled default-block-Hash
+   * spelling (an inline Proxy `get` trap) cannot express either hash: a trap
+   * only ever sees string and symbol keys, while these are keyed on record and
+   * `JoinPart` objects, so the default block is open-coded on the `Map`. `modelCache` caches each node's
    * instances by id, with the join-root's entry doubling as the parent dedup
    * map (`parents = model_cache[join_root]`).
    *
@@ -730,11 +733,6 @@ export class JoinDependency {
     const baseAliasCols = aliases.columnsForNode(joinRoot);
     const aliasSet = new Set(aliases.columns().map((a) => a.alias));
 
-    // join_dependency.rb:108-114 `Hash.new { ... }.compare_by_identity` /
-    // `Hash.new { |h, klass| h[klass] = {} }`. The settled default-block-Hash
-    // spelling (an inline Proxy `get` trap) vivifies string keys only; these
-    // two hashes are keyed by identity on record and JoinPart objects, so the
-    // default block is open-coded on a `Map` below instead.
     const seen = new Map<any, Map<JoinPart, Map<unknown, any>>>();
     const modelCache = new Map<JoinPart, Map<unknown, any>>();
     const parents = new Map<unknown, any>();

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -730,6 +730,11 @@ export class JoinDependency {
     const baseAliasCols = aliases.columnsForNode(joinRoot);
     const aliasSet = new Set(aliases.columns().map((a) => a.alias));
 
+    // join_dependency.rb:108-114 `Hash.new { ... }.compare_by_identity` /
+    // `Hash.new { |h, klass| h[klass] = {} }`. The settled default-block-Hash
+    // spelling (an inline Proxy `get` trap) vivifies string keys only; these
+    // two hashes are keyed by identity on record and JoinPart objects, so the
+    // default block is open-coded on a `Map` below instead.
     const seen = new Map<any, Map<JoinPart, Map<unknown, any>>>();
     const modelCache = new Map<JoinPart, Map<unknown, any>>();
     const parents = new Map<unknown, any>();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -179,7 +179,6 @@ import {
   singularize as _singularize,
   type Included,
   type ParameterFilter,
-  type BenchmarkLogger,
 } from "@blazetrails/activesupport";
 import {
   hasAttribute as _hasAttribute,
@@ -1671,15 +1670,10 @@ export class Base extends Model {
 
   /**
    * Times the given block and logs the result.
-   * Mirrors: ActiveRecord::Base.benchmark (via ActiveSupport::Benchmarkable)
+   * Mirrors: `extend ActiveSupport::Benchmarkable` (base.rb:285) — the mixin
+   * reads this class's own `logger` reader (benchmarkable.rb:38).
    */
-  static benchmark<T>(
-    message: string,
-    options: { level?: "debug" | "info" | "warn" | "error"; silence?: boolean } = {},
-    fn: () => T | Promise<T>,
-  ): T | Promise<Awaited<T>> {
-    return benchmarkable(this.logger as BenchmarkLogger | null, message, options, fn);
-  }
+  static benchmark = benchmarkable;
 
   // -- Timestamp control --
   static _recordTimestamps = true;

--- a/packages/activerecord/src/connection-adapters/pool-manager.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.test.ts
@@ -132,12 +132,6 @@ describe("PoolManager", () => {
       expect(manager.getPoolConfig("writing", "default")).toBeUndefined();
     });
 
-    it("cleans up empty role maps", () => {
-      manager.setPoolConfig("writing", "default", makePoolConfig("primary"));
-      manager.removePoolConfig("writing", "default");
-      expect(manager.roleNames).toEqual([]);
-    });
-
     it("returns undefined for missing entries", () => {
       expect(manager.removePoolConfig("writing", "default")).toBeUndefined();
     });
@@ -152,13 +146,14 @@ describe("PoolManager", () => {
       expect(manager.poolConfigs("writing")).toEqual([]);
     });
 
-    it("returns false for unknown role", () => {
-      expect(manager.removeRole("unknown")).toBe(false);
+    it("returns undefined for unknown role", () => {
+      expect(manager.removeRole("unknown")).toBeUndefined();
     });
 
-    it("returns true when role existed", () => {
-      manager.setPoolConfig("writing", "default", makePoolConfig("primary"));
-      expect(manager.removeRole("writing")).toBe(true);
+    it("returns the removed shard map when the role existed", () => {
+      const config = makePoolConfig("primary");
+      manager.setPoolConfig("writing", "default", config);
+      expect(manager.removeRole("writing")).toEqual({ default: config });
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/pool-manager.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.ts
@@ -2,6 +2,10 @@
  * Pool manager — manages pool configs per role and shard.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PoolManager
+ *
+ * `@role_to_shard_mapping` is `Hash.new { |h, k| h[k] = {} }`
+ * (pool_manager.rb:7); JS has no Hash default block, so the auto-vivification
+ * is a Proxy `get` trap.
  */
 
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -11,8 +15,6 @@ export class PoolManager {
   private _roleToShardMapping: Record<string, Record<string, PoolConfig>>;
 
   constructor() {
-    // pool_manager.rb:7 `Hash.new { |h, k| h[k] = {} }` — JS has no Hash
-    // default block, so auto-vivification is a Proxy `get` trap.
     this._roleToShardMapping = new Proxy({} as Record<string, Record<string, PoolConfig>>, {
       get(h, k) {
         if (typeof k !== "string") return Reflect.get(h, k);

--- a/packages/activerecord/src/connection-adapters/pool-manager.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.ts
@@ -79,10 +79,11 @@ export class PoolManager {
    * (pool_manager.rb:37) is Ruby `Hash#delete`; over a plain object the JS
    * spelling is the `delete` operator, which is not a call.
    */
-  removeRole(role: string): boolean {
-    if (!Object.hasOwn(this._roleToShardMapping, role)) return false;
+  removeRole(role: string): Record<string, PoolConfig> | undefined {
+    if (!Object.hasOwn(this._roleToShardMapping, role)) return undefined;
+    const shardMap = this._roleToShardMapping[role];
     delete this._roleToShardMapping[role];
-    return true;
+    return shardMap;
   }
 
   /**
@@ -94,7 +95,6 @@ export class PoolManager {
     const shardMap = this._roleToShardMapping[role];
     const poolConfig = shardMap[shard];
     delete shardMap[shard];
-    if (Object.keys(shardMap).length === 0) delete this._roleToShardMapping[role];
     return poolConfig;
   }
 

--- a/packages/activerecord/src/connection-adapters/pool-manager.ts
+++ b/packages/activerecord/src/connection-adapters/pool-manager.ts
@@ -8,36 +8,36 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import type { PoolConfig } from "./pool-config.js";
 
 export class PoolManager {
-  private _roleToShardMapping: Map<string, Map<string, PoolConfig>>;
+  private _roleToShardMapping: Record<string, Record<string, PoolConfig>>;
 
   constructor() {
-    this._roleToShardMapping = new Map();
+    // pool_manager.rb:7 `Hash.new { |h, k| h[k] = {} }` — JS has no Hash
+    // default block, so auto-vivification is a Proxy `get` trap.
+    this._roleToShardMapping = new Proxy({} as Record<string, Record<string, PoolConfig>>, {
+      get(h, k) {
+        if (typeof k !== "string") return Reflect.get(h, k);
+        return (h[k] ??= {});
+      },
+    });
   }
 
   get shardNames(): string[] {
     return [
       ...new Set(
-        [...this._roleToShardMapping.values()].flatMap((shardMap) => [...shardMap.keys()]),
+        Object.values(this._roleToShardMapping).flatMap((shardMap) => Object.keys(shardMap)),
       ),
     ];
   }
 
   get roleNames(): string[] {
-    return [...this._roleToShardMapping.keys()];
+    return Object.keys(this._roleToShardMapping);
   }
 
   poolConfigs(role?: string): PoolConfig[] {
     if (role != null) {
-      const shardMap = this._roleToShardMapping.get(role);
-      return shardMap ? [...shardMap.values()] : [];
+      return Object.values(this._roleToShardMapping[role]);
     }
-    const result: PoolConfig[] = [];
-    for (const shardMap of this._roleToShardMapping.values()) {
-      for (const poolConfig of shardMap.values()) {
-        result.push(poolConfig);
-      }
-    }
-    return result;
+    return Object.values(this._roleToShardMapping).flatMap((shardMap) => Object.values(shardMap));
   }
 
   eachPoolConfig(role: string | undefined, callback: (poolConfig: PoolConfig) => void): void;
@@ -60,36 +60,44 @@ export class PoolManager {
     }
 
     if (role != null) {
-      const shardMap = this._roleToShardMapping.get(role);
-      if (shardMap) {
-        for (const poolConfig of shardMap.values()) {
-          cb(poolConfig);
-        }
+      for (const poolConfig of Object.values(this._roleToShardMapping[role])) {
+        cb(poolConfig);
       }
     } else {
-      for (const shardMap of this._roleToShardMapping.values()) {
-        for (const poolConfig of shardMap.values()) {
+      for (const shardMap of Object.values(this._roleToShardMapping)) {
+        for (const poolConfig of Object.values(shardMap)) {
           cb(poolConfig);
         }
       }
     }
   }
 
+  /**
+   * @missingRailsCall delete — PERMANENT: `@role_to_shard_mapping.delete(role)`
+   * (pool_manager.rb:37) is Ruby `Hash#delete`; over a plain object the JS
+   * spelling is the `delete` operator, which is not a call.
+   */
   removeRole(role: string): boolean {
-    return this._roleToShardMapping.delete(role);
+    if (!Object.hasOwn(this._roleToShardMapping, role)) return false;
+    delete this._roleToShardMapping[role];
+    return true;
   }
 
+  /**
+   * @missingRailsCall delete — PERMANENT: `@role_to_shard_mapping[role].delete(shard)`
+   * (pool_manager.rb:41) is Ruby `Hash#delete`; over a plain object the JS
+   * spelling is the `delete` operator, which is not a call.
+   */
   removePoolConfig(role: string, shard: string): PoolConfig | undefined {
-    const shardMap = this._roleToShardMapping.get(role);
-    if (!shardMap) return undefined;
-    const poolConfig = shardMap.get(shard);
-    shardMap.delete(shard);
-    if (shardMap.size === 0) this._roleToShardMapping.delete(role);
+    const shardMap = this._roleToShardMapping[role];
+    const poolConfig = shardMap[shard];
+    delete shardMap[shard];
+    if (Object.keys(shardMap).length === 0) delete this._roleToShardMapping[role];
     return poolConfig;
   }
 
   getPoolConfig(role: string, shard: string): PoolConfig | undefined {
-    return this._roleToShardMapping.get(role)?.get(shard);
+    return this._roleToShardMapping[role][shard];
   }
 
   setPoolConfig(role: string, shard: string, poolConfig: PoolConfig): void {
@@ -100,11 +108,6 @@ export class PoolManager {
           `pool configuration is provided.`,
       );
     }
-    let shardMap = this._roleToShardMapping.get(role);
-    if (!shardMap) {
-      shardMap = new Map();
-      this._roleToShardMapping.set(role, shardMap);
-    }
-    shardMap.set(shard, poolConfig);
+    this._roleToShardMapping[role][shard] = poolConfig;
   }
 }

--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -25,7 +25,7 @@ describe("PrimaryClassTest", () => {
   // drop every non-default (e.g. :reading) role the connects_to tests
   // established, leaving the writing pool.
   function cleanUpConnectionHandler(): void {
-    const managers: Map<string, { roleNames: string[]; removeRole(role: string): boolean }> = (
+    const managers: Map<string, { roleNames: string[]; removeRole(role: string): unknown }> = (
       Base.connectionHandler as unknown as {
         _connectionNameToPoolManager: Map<string, never>;
       }

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -83,7 +83,7 @@ function poolQueryCacheMaxSize(pool: ConnectionPool): number | null {
 // Mirrors ActiveRecord::TestCase#clean_up_connection_handler: drop every
 // non-default (e.g. :reading) role a test established, leaving the writing pool.
 function cleanUpConnectionHandler(): void {
-  const managers: Map<string, { roleNames: string[]; removeRole(role: string): boolean }> = (
+  const managers: Map<string, { roleNames: string[]; removeRole(role: string): unknown }> = (
     Base.connectionHandler as unknown as {
       _connectionNameToPoolManager: Map<string, never>;
     }

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -157,7 +157,8 @@ export class Batches {
     const ensureValidOptions = () =>
       ensureValidOptionsForBatchingBang(self, cursor, start, finish, (order ?? "asc") as any);
 
-    if (this.orderValues.length > 0) {
+    // batches.rb:263 `if arel.orders.present?`
+    if (this.arel().orders.length > 0) {
       this.actOnIgnoredOrder(errorOnIgnore);
     }
 

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -157,7 +157,6 @@ export class Batches {
     const ensureValidOptions = () =>
       ensureValidOptionsForBatchingBang(self, cursor, start, finish, (order ?? "asc") as any);
 
-    // batches.rb:263 `if arel.orders.present?`
     if (this.arel().orders.length > 0) {
       this.actOnIgnoredOrder(errorOnIgnore);
     }

--- a/packages/activerecord/src/relation/limit-offset-value-string-reads.trails.test.ts
+++ b/packages/activerecord/src/relation/limit-offset-value-string-reads.trails.test.ts
@@ -50,6 +50,6 @@ describe("string limit_value / offset_value read sites", () => {
     await expect(async () => {
       for await (const _batch of Topic.limit("asdfadf").inBatches()) {
       }
-    }).rejects.toThrow(/comparison of String with \d+ failed/);
+    }).rejects.toThrow(/invalid value for Integer\(\): "asdfadf"/);
   });
 });

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -1,7 +1,8 @@
 /**
- * Shared benchmark helper, mirroring `ActiveSupport::Benchmarkable#benchmark`.
- * Used by both `ActionController::Logger`/`AbstractController` and
- * `ActiveRecord::Base.benchmark` so the two stay in lock-step.
+ * `ActiveSupport::Benchmarkable` — mixed into `AbstractController::Logger`
+ * and `ActiveRecord::Base` exactly as Rails' `include Benchmarkable` does
+ * (benchmarkable.rb:4-52). `benchmark` reads the host's `logger` reader
+ * (benchmarkable.rb:38,44,46) rather than taking it as a parameter.
  */
 
 export interface BenchmarkLogger {
@@ -33,21 +34,26 @@ const ERROR_LEVEL = 3;
 
 const monotonicNow = (): number => globalThis.performance?.now() ?? Date.now();
 
+/** The host of `include ActiveSupport::Benchmarkable` — supplies `logger`. */
+export interface Benchmarkable {
+  logger?: BenchmarkLogger | null;
+}
+
 export function benchmark<T>(
-  logger: BenchmarkLogger | null | undefined,
+  this: Benchmarkable,
   message: string,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
 export function benchmark<T>(
-  logger: BenchmarkLogger | null | undefined,
+  this: Benchmarkable,
   message: string,
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
 export function benchmark<T>(
-  logger: BenchmarkLogger | null | undefined,
-  message: string,
-  optionsOrBlock: BenchmarkOptions | (() => T | Promise<T>),
+  this: Benchmarkable,
+  message = "Benchmarking",
+  optionsOrBlock?: BenchmarkOptions | (() => T | Promise<T>),
   maybeBlock?: () => T | Promise<T>,
 ): T | Promise<Awaited<T>> {
   const block = (typeof optionsOrBlock === "function" ? optionsOrBlock : maybeBlock!) as () =>
@@ -57,8 +63,8 @@ export function benchmark<T>(
     typeof optionsOrBlock === "function" ? {} : (optionsOrBlock ?? {});
   const level = options.level ?? "info";
 
+  const logger = this?.logger;
   if (!logger) return block() as T | Promise<Awaited<T>>;
-
   const start = monotonicNow();
   const log = (): void => {
     const fn = (logger as Record<string, unknown>)[level];

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -1,9 +1,11 @@
 /**
  * `ActiveSupport::Benchmarkable` — mixed into `AbstractController::Logger`
- * and `ActiveRecord::Base` exactly as Rails' `include Benchmarkable` does
- * (benchmarkable.rb:4-52). `benchmark` reads the host's `logger` reader
- * (benchmarkable.rb:38,44,46) rather than taking it as a parameter.
+ * (logger.rb:13) and `ActiveRecord::Base` (base.rb:285) the way Rails'
+ * `include`/`extend` mixes it in. `benchmark` reads the host's own `logger`
+ * reader (benchmarkable.rb:38,44,46) rather than taking it as a parameter.
  */
+
+import { assertValidKeys } from "./hash-utils.js";
 
 export interface BenchmarkLogger {
   debug?(message: string): void;
@@ -17,37 +19,24 @@ export interface BenchmarkLogger {
 export interface BenchmarkOptions {
   level?: "debug" | "info" | "warn" | "error";
   silence?: boolean;
-  /**
-   * If true, log the elapsed time even when the block raises/rejects.
-   * Rails' `ActiveSupport::Benchmarkable` does NOT do this — exceptions
-   * propagate without a trailing log line — so this is opt-in. The
-   * actionpack `benchmark()` wrapper enables it for partial-failure
-   * visibility; `ActiveRecord::Base.benchmark` keeps Rails-strict
-   * behavior.
-   */
-  logOnError?: boolean;
 }
-
-// Matches `ActiveSupport::Logger::ERROR` — the level raised by `silence` so
-// in-block info/debug calls are suppressed.
-const ERROR_LEVEL = 3;
-
-const monotonicNow = (): number => globalThis.performance?.now() ?? Date.now();
 
 /** The host of `include ActiveSupport::Benchmarkable` — supplies `logger`. */
 export interface Benchmarkable {
   logger?: BenchmarkLogger | null;
 }
 
+const monotonicNow = (): number => globalThis.performance?.now() ?? Date.now();
+
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,
+  options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,
-  options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
 export function benchmark<T>(
@@ -61,56 +50,40 @@ export function benchmark<T>(
     | Promise<T>;
   const options: BenchmarkOptions =
     typeof optionsOrBlock === "function" ? {} : (optionsOrBlock ?? {});
-  const level = options.level ?? "info";
 
   const logger = this?.logger;
-  if (!logger) return block() as T | Promise<Awaited<T>>;
-  const start = monotonicNow();
-  const log = (): void => {
-    const fn = (logger as Record<string, unknown>)[level];
-    if (typeof fn !== "function") return;
-    const ms = monotonicNow() - start;
-    (fn as (msg: string) => void).call(logger, `${message} (${ms.toFixed(1)}ms)`);
-  };
+  if (logger) {
+    assertValidKeys(options as Record<string, unknown>, ["level", "silence"]);
+    options.level ||= "info";
 
-  const runBlock = (): T | Promise<T> => {
+    let result: T | Promise<T>;
+    const start = monotonicNow();
+    const finish = (): T | Promise<Awaited<T>> => {
+      const ms = monotonicNow() - start;
+      const write = (logger as Record<string, unknown>)[options.level!];
+      if (typeof write === "function") {
+        (write as (msg: string) => void).call(logger, `${message} (${ms.toFixed(1)}ms)`);
+      }
+      return result as Awaited<T>;
+    };
+
     if (options.silence && typeof logger.silence === "function") {
-      // `Logger#silence` is synchronous; raising the level only suppresses
-      // log calls dispatched before the block returns. Async continuations
-      // inside `block` log normally — matches Rails' Ruby behavior.
-      let inner: T | Promise<T>;
-      logger.silence(ERROR_LEVEL, () => {
-        inner = block();
+      logger.silence(undefined, () => {
+        result = block();
       });
-      return inner!;
+    } else {
+      result = block();
     }
-    return block();
-  };
 
-  // Rails' Benchmarkable does not log on raise — exceptions propagate
-  // without a trailing log line. `logOnError: true` opts back into the
-  // log-on-throw contract that the actionpack helper has historically
-  // promised so callers can see partial timings of failing operations.
-  let result: T | Promise<T>;
-  try {
-    result = runBlock();
-  } catch (err) {
-    if (options.logOnError) log();
-    throw err;
-  }
-
-  if (result! instanceof Promise) {
-    return (result as Promise<Awaited<T>>).then(
-      (val) => {
-        log();
+    if (result! instanceof Promise) {
+      return (result as Promise<Awaited<T>>).then((val) => {
+        result = val as T;
+        finish();
         return val;
-      },
-      (err) => {
-        if (options.logOnError) log();
-        throw err;
-      },
-    );
+      });
+    }
+    return finish();
+  } else {
+    return block() as T | Promise<Awaited<T>>;
   }
-  log();
-  return result as Awaited<T>;
 }

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -30,6 +30,10 @@ const monotonicNow = (): number => globalThis.performance?.now() ?? Date.now();
 
 export function benchmark<T>(
   this: Benchmarkable,
+  block: () => T | Promise<T>,
+): T | Promise<Awaited<T>>;
+export function benchmark<T>(
+  this: Benchmarkable,
   message: string,
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
@@ -41,15 +45,22 @@ export function benchmark<T>(
 ): T | Promise<Awaited<T>>;
 export function benchmark<T>(
   this: Benchmarkable,
-  message = "Benchmarking",
+  messageOrBlock: string | (() => T | Promise<T>) = "Benchmarking",
   optionsOrBlock?: BenchmarkOptions | (() => T | Promise<T>),
   maybeBlock?: () => T | Promise<T>,
 ): T | Promise<Awaited<T>> {
-  const block = (typeof optionsOrBlock === "function" ? optionsOrBlock : maybeBlock!) as () =>
-    | T
-    | Promise<T>;
+  const message = typeof messageOrBlock === "function" ? "Benchmarking" : messageOrBlock;
+  const block = (
+    typeof messageOrBlock === "function"
+      ? messageOrBlock
+      : typeof optionsOrBlock === "function"
+        ? optionsOrBlock
+        : maybeBlock!
+  ) as () => T | Promise<T>;
   const options: BenchmarkOptions =
-    typeof optionsOrBlock === "function" ? {} : (optionsOrBlock ?? {});
+    typeof optionsOrBlock === "function" || typeof optionsOrBlock === "undefined"
+      ? {}
+      : optionsOrBlock;
 
   const logger = this?.logger;
   if (logger) {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -401,7 +401,7 @@ export { onLoad, runLoadHooks, resetLoadHooks } from "./lazy-load-hooks.js";
 export type { ClassAttributeOptions } from "./class-attribute.js";
 
 export { benchmark } from "./benchmarkable.js";
-export type { BenchmarkLogger, BenchmarkOptions } from "./benchmarkable.js";
+export type { Benchmarkable, BenchmarkLogger, BenchmarkOptions } from "./benchmarkable.js";
 
 export { Logger, taggedLogging, SimpleFormatter } from "./logger.js";
 export { NullLogger, nullLogger } from "./null-logger.js";

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/relation/batches.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/batches.ts",
-    "rubyName": "in_batches",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/batches.ts",
     "rubyName": "record_cursor_values",
     "call": "slice",
     "reason": "Verified per-site (RFC 0106): `record.attributes.slice(*cursor).values` (batches.rb:409) — Ruby `Hash#slice`, whose TS spelling over the attributes object is a `map` of the cursor names, not a call."

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/benchmarkable.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/benchmarkable.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "benchmarkable.ts",
-    "rubyName": "benchmark",
-    "call": "logger",
-    "reason": "Rails reads the mixin's `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared free function whose host passes the logger in as its first parameter, so there is no `logger` reader to call."
-  }
-]


### PR DESCRIPTION
Bundle of three RFC 0106 call-set convergences.

### `Benchmarkable` mixes in, reads the host's `logger`

`ActiveSupport::Benchmarkable#benchmark` (`benchmarkable.rb:36-51`) takes no
logger — its body calls the mixin host's `logger` reader three times
(`:38,:44,:46`). trails had it as a free function whose first parameter was the
logger. It is now a `this`-typed mixin over a `Benchmarkable` host, with Rails'
parameter list (`message = "Benchmarking"`, `options = {}`, block).

The body now follows `benchmarkable.rb:38-50` branch for branch:
`assert_valid_keys(:level, :silence)`, `options[:level] ||= :info`, measure,
log, return the block's value. The invented `logOnError` option is gone, which
restores Rails' "no log line when the block raises" — the two trails-only tests
asserting the opposite go with it, and `parity:api:extra` for
`benchmarkable.ts` drops from 1 novel name to 0.

Both call sites mix it in instead of passing a logger:

- `ActiveRecord::Base.benchmark` is the mixin assigned to the class, the
  spelling of `extend ActiveSupport::Benchmarkable` (`base.rb:285`).
- `AbstractController::Logger` re-exports the mixin rather than wrapping it,
  the spelling of its `included do ... include ActiveSupport::Benchmarkable`
  (`logger.rb:11-14`).

The `logger` baseline row is deleted (the whole
`call-mismatches-exclude/activesupport/benchmarkable.json` shard goes with it).

### `in_batches` guards off `arel().orders`

`batches.rb:263` reads `arel.orders.present?`; trails read `orderValues`. Since
#6865 folded `toArel` into the `arel` reader, `arel()` is the cheap memoized
reader Rails calls here, so the baseline row's justification no longer held —
the row is deleted (only-shrink, no reseed; no stale mark resulted).

### `PoolManager`'s role→shard map vivifies

`pool_manager.rb:7` is `Hash.new { |h, k| h[k] = {} }`. The port was a `Map` of
`Map`s that open-coded the vivification at each site; it now uses the inline
Proxy spelling settled in #6866, and the method bodies collapse onto Rails'
(`@role_to_shard_mapping[role].values`, `[role][shard] = pool_config`, …).

`remove_pool_config` no longer prunes the emptied role key (`pool_manager.rb:40-42`
deletes the shard only, leaving the vivified `{}` behind), and `remove_role`
returns the removed shard map or `undefined` — Ruby `Hash#delete`'s return
(`pool_manager.rb:36-38`) — rather than a boolean.

Two `@missingRailsCall delete — PERMANENT` tags replace what were `Map#delete`
calls: Ruby `Hash#delete` over a plain object is the JS `delete` operator, which
is not a call. No baseline rows added.

#### The other two sites named by the story

- `join_dependency.rb:108-114` — both hashes are `compare_by_identity` and keyed
  by record / `JoinPart` objects. The Proxy `get` trap only ever sees string and
  symbol keys, so it cannot express them; the `Map` port already open-codes the
  default block, and the site now carries a comment saying so.
- `test_fixtures.rb:123` (`@saved_pool_configs`) — `setup_fixtures` is not
  ported, so there is no site to converge.

Gates: `parity:api:calls`, `:args`, `:reasons`, `:detached` green; batches,
pool-manager, connection-handler, query-cache, base and logger suites green on
SQLite.

Closes-story: benchmarkable-should-mix-in-logger-reader
Closes-story: converge-in-batches-ignored-order-guard-onto-arel
Closes-story: converge-remaining-default-block-hash-sites
