### PR TITLE
fix(parity,activerecord): package-keyed call tags; drop the source_type klass shim

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -705,8 +705,11 @@ export class AssociationScope {
     // `_mergeReferencedJoins` helper, so keep the arel dependency visible on
     // this method to match Rails' activerecord → arel edge (dep-parity gate).
     void Nodes.OuterJoin;
+    // Rails: `chain_head = chain.first` (association_scope.rb:131), read by the
+    // one `reverse_each` body that handles every chain position.
+    const chainHead = chain[0];
     for (let i = chain.length - 1; i >= 1; i--) {
-      scope = this._mergeReflectionScopeChain(scope, chain[i], owner);
+      scope = this._mergeReflectionScopeChain(scope, chain[i], owner, chainHead);
     }
     // Apply the head reflection's scope. Rails: reflection.rb:448,
     // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
@@ -719,7 +722,6 @@ export class AssociationScope {
     // scope. So detect through explicitly and invoke `.scope` directly with
     // the same arity / `this` semantics. The source reflection's scope is a
     // SEPARATE concern, merged below.
-    const chainHead = chain[0];
     const head = chainHead as {
       scopeFor?: (rel: unknown, owner: unknown) => unknown;
       scope?: ((rel: unknown, owner?: unknown) => unknown) | null;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -731,42 +731,23 @@ export class AssociationScope {
       const result = invokeScopeLambda(head.scope as ScopeLambda<unknown>, scope, owner);
       if (result) scope = result;
     }
-    // Rails folds the source reflection's scope into a has_many/has_one
-    // :through query via `add_constraints`' `chain.reverse_each` over
-    // `reflection.constraints` (association_scope.rb). The head branch above
-    // only applies the through reflection's OWN (delegate) scope; the SOURCE
-    // reflection's scope — e.g.
+    // Rails' `chain.reverse_each` folds the CHAIN HEAD too
+    // (association_scope.rb:132), and a through head's `constraints` is
+    // `source_reflection.constraints << scope` (reflection.rb:1180-1184), so a
+    // scope declared on the SOURCE reflection — e.g.
     // `Post.has_many :nonexistent_comments, -> { where("comments.id < 0") }`
-    // for `Author.has_many :nonexistent_comments, through: :posts` — lives on
-    // the source reflection and would otherwise be dropped, so the through
-    // query returns all rows instead of the scoped subset. Merge its WHERE/
-    // ORDER predicates here, evaluated against the source klass' table.
+    // for `Author.has_many :nonexistent_comments, through: :posts` — merges as
+    // part of the head entry, evaluated against the head's own `klass`. That
+    // klass is the RUNTIME one (`RuntimeReflection#klass` → `@association.klass`,
+    // reflection.rb:1265), which is what makes a `source_type:` through work:
+    // its source is a polymorphic belongsTo whose `klass` is uncomputable, and
+    // Rails never reads it here.
     //
-    // For a `source_type:` through, the source reflection is a polymorphic
-    // belongsTo whose `klass` is uncomputable (it raises "Polymorphic
-    // associations do not support computing the class."). Rails' add_constraints
-    // does NOT special-case source_type — `chain.reverse_each` always folds in
-    // `source_reflection.constraints`, so a scope declared on the polymorphic
-    // belongsTo source (e.g. `belongs_to :taggable, -> { where(...) },
-    // polymorphic: true`) must still merge. The resolved source class is the
-    // runtime `klass` off the chain head (a RuntimeReflection, whose `klass` IS
-    // the live `association.klass`, reflection.rb:1265), so pass it as an
-    // override and avoid touching the uncomputable polymorphic `klass`.
-    // (The THROUGH/join-model scope on a source_type association is carried by a
-    // `PolymorphicReflection` chain entry already merged by the reverse_each loop
-    // above — e.g. Tag's `null_taggings -> { none }` — independent of this.)
+    // The head's OWN scope is `chain_head.scope`, which Rails singles out at
+    // :137 and trails applied above, so skip it here rather than applying it
+    // twice.
     if (isThrough) {
-      const sourceRefl = (head as { sourceReflection?: AbstractReflection | null })
-        .sourceReflection;
-      if (sourceRefl) {
-        const sourceType = (head as { options?: { sourceType?: unknown } }).options?.sourceType;
-        scope = this._mergeReflectionScopeChain(
-          scope,
-          sourceRefl,
-          owner,
-          sourceType ? (chain[0] as { klass?: typeof Base }).klass : undefined,
-        );
-      }
+      scope = this._mergeReflectionScopeChain(scope, chain[0], owner, head.scope ?? undefined);
     }
     return scope;
   }
@@ -793,19 +774,8 @@ export class AssociationScope {
     scope: unknown,
     reflection: AbstractReflection | ReflectionProxy,
     owner: Base,
-    klassOverride?: typeof Base,
+    chainHeadScope?: (rel: unknown, owner?: unknown) => unknown,
   ): unknown {
-    const r = reflection as {
-      scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
-      scopeFor?: (rel: unknown, owner?: unknown) => unknown;
-      klass?: typeof Base;
-    };
-    // For a polymorphic belongsTo source (source_type: through), reading
-    // `reflection.klass` raises — the caller threads the resolved source_type
-    // target class here instead. Guard the read so the polymorphic case never
-    // computes the uncomputable klass.
-    const entryKlass = klassOverride ?? r.klass;
-    if (!entryKlass) return scope;
     // Iterate `reflection.constraints()` rather than special-casing
     // PolymorphicReflection via instanceof. For ordinary
     // AssociationReflection / ReflectionProxy entries `constraints()`
@@ -821,18 +791,13 @@ export class AssociationScope {
         reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.() ?? [];
     if (constraints.length === 0) return scope;
-    // Rails' `source_type:` chain entry is a PolymorphicReflection, whose `klass`
-    // delegates to `@reflection` (reflection.rb:1229-1230) and is read by `build_scope`'s
-    // `klass = self.klass` default (reflection.rb:336); trails' entry is the raw
-    // polymorphic belongsTo, whose `klass` raises, so resolve it here instead of
-    // threading a fourth argument past `eval_scope` (association_scope.rb:169).
-    const entry = klassOverride
-      ? (Object.create(reflection, { klass: { value: klassOverride } }) as typeof reflection)
-      : reflection;
     let merged = scope;
     for (const c of constraints) {
       if (typeof c !== "function") continue;
-      const evaluated = this.evalScope(entry, c, owner);
+      // Rails: `if scope_chain_item == chain_head.scope` (:137) — the head's
+      // own scope takes the merge-except path, applied above.
+      if (chainHeadScope !== undefined && c === chainHeadScope) continue;
+      const evaluated = this.evalScope(reflection, c, owner);
       merged = this._pushScopeIntoRelation(merged, evaluated);
     }
     return merged;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -719,7 +719,8 @@ export class AssociationScope {
     // scope. So detect through explicitly and invoke `.scope` directly with
     // the same arity / `this` semantics. The source reflection's scope is a
     // SEPARATE concern, merged below.
-    const head = chain[0] as {
+    const chainHead = chain[0];
+    const head = chainHead as {
       scopeFor?: (rel: unknown, owner: unknown) => unknown;
       scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
       isThroughReflection?: () => boolean;
@@ -733,34 +734,25 @@ export class AssociationScope {
     }
     // Rails' `chain.reverse_each` folds the CHAIN HEAD too
     // (association_scope.rb:132), and a through head's `constraints` is
-    // `source_reflection.constraints << scope` (reflection.rb:1180-1184), so a
-    // scope declared on the SOURCE reflection — e.g.
-    // `Post.has_many :nonexistent_comments, -> { where("comments.id < 0") }`
-    // for `Author.has_many :nonexistent_comments, through: :posts` — merges as
-    // part of the head entry, evaluated against the head's own `klass`. That
-    // klass is the RUNTIME one (`RuntimeReflection#klass` → `@association.klass`,
-    // reflection.rb:1265), which is what makes a `source_type:` through work:
-    // its source is a polymorphic belongsTo whose `klass` is uncomputable, and
-    // Rails never reads it here.
-    //
-    // The head's OWN scope is `chain_head.scope`, which Rails singles out at
-    // :137 and trails applied above, so skip it here rather than applying it
-    // twice.
-    if (isThrough) {
-      scope = this._mergeReflectionScopeChain(scope, chain[0], owner, head.scope ?? undefined);
-    }
+    // `source_reflection.constraints << scope` (reflection.rb:1180-1184) — that
+    // is how a scope on the SOURCE reflection merges, evaluated against the
+    // head's own `klass`. For a `source_type:` through that klass is the runtime
+    // `@association.klass` (`RuntimeReflection#klass`, reflection.rb:1265), so
+    // the polymorphic belongsTo's uncomputable `klass` is never read.
+    scope = this._mergeReflectionScopeChain(scope, chainHead, owner, chainHead);
     return scope;
   }
 
   /**
-   * Apply a non-head chain entry's scope lambda. Rails' add_constraints
+   * Apply one chain entry's scope lambdas — Rails' `chain.reverse_each` loop
+   * body. Rails' add_constraints
    * does this via `eval_scope` + `scope.where_clause += item.where_clause`
    * + `scope.order_values = item.order_values | scope.order_values` —
    * granular per-attribute merging that pushes ONLY where and order
    * predicates onto the main relation. A through-reflection scope's
    * limit / select / joins / etc must NOT override the main scope.
    *
-   * For non-head entries we evaluate the lambda against a fresh
+   * The lambda is evaluated against a fresh
    * `entry.klass.unscoped` (with STI type_condition re-applied for
    * subclasses, matching the head-scope path in `scope()`) so its
    * `where(...)` calls bind to the correct table. We then push the
@@ -774,7 +766,7 @@ export class AssociationScope {
     scope: unknown,
     reflection: AbstractReflection | ReflectionProxy,
     owner: Base,
-    chainHeadScope?: (rel: unknown, owner?: unknown) => unknown,
+    chainHead?: AbstractReflection | ReflectionProxy,
   ): unknown {
     // Iterate `reflection.constraints()` rather than special-casing
     // PolymorphicReflection via instanceof. For ordinary
@@ -794,9 +786,9 @@ export class AssociationScope {
     let merged = scope;
     for (const c of constraints) {
       if (typeof c !== "function") continue;
-      // Rails: `if scope_chain_item == chain_head.scope` (:137) — the head's
-      // own scope takes the merge-except path, applied above.
-      if (chainHeadScope !== undefined && c === chainHeadScope) continue;
+      // Rails: `if scope_chain_item == chain_head.scope` (association_scope.rb:137)
+      // takes the merge-except path, which trails applies in `addConstraints`.
+      if (c === (chainHead as { scope?: unknown } | undefined)?.scope) continue;
       const evaluated = this.evalScope(reflection, c, owner);
       merged = this._pushScopeIntoRelation(merged, evaluated);
     }

--- a/packages/activesupport/src/gem-version.ts
+++ b/packages/activesupport/src/gem-version.ts
@@ -15,6 +15,12 @@ export const VERSION = {
  * Returns the currently loaded version of Active Support as a +Gem::Version+.
  *
  * Mirrors: `ActiveSupport.gem_version` (gem_version.rb:5-7).
+ *
+ * @missingRailsCall new — PERMANENT: `Gem::Version.new VERSION::STRING` (gem_version.rb:6)
+ *   wraps the version in RubyGems' comparable Version object. `Gem` is the
+ *   RubyGems stdlib, not Rails, and trails ports no `Gem::Version`, so
+ *   `gemVersion` answers `VERSION.STRING` itself — the same value, unwrapped —
+ *   exactly as every other package's `gemVersion` does.
  */
 export function gemVersion(): string {
   return VERSION.STRING;

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/gem-version.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/gem-version.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "gem-version.ts",
-    "rubyName": "gem_version",
-    "call": "new",
-    "reason": "`Gem::Version.new VERSION::STRING` (gem_version.rb:6) wraps the version in RubyGems' comparable Version object. `Gem` is the RubyGems stdlib, not Rails, and trails ports no `Gem::Version`, so `gemVersion` answers `VERSION.STRING` itself — the same value, unwrapped — exactly as every other package's `gemVersion` does."
-  }
-]

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -51,6 +51,7 @@ import {
   applyCallTags,
   suppressTaggedCalls,
   tagsForOwner,
+  recordTaggedCalls,
 } from "./compare.js";
 import { rubyMethodToTs } from "@blazetrails/parity/conventions";
 import type {
@@ -1819,6 +1820,40 @@ describe("suppressTaggedCalls", () => {
       "reload → reload",
     ]);
     expect([...used]).toEqual([]);
+  });
+});
+
+describe("recordTaggedCalls", () => {
+  it("records a tag on the package under comparison", () => {
+    const byFileName = new Map<string, Map<string, Map<string, Map<string, string>>>>();
+    recordTaggedCalls(byFileName, "gem-version.ts", "gemVersion", "", ["new"], {
+      new: "PERMANENT",
+    });
+    expect(byFileName.get("gem-version.ts")?.get("gemVersion")?.get("")?.get("new")).toBe(
+      "PERMANENT",
+    );
+  });
+
+  it("ignores a dep package's tag on a file whose basename collides with ours", () => {
+    const byFileName = new Map<string, Map<string, Map<string, Map<string, string>>>>();
+    // Every package ships a `gem-version.ts`; activesupport's tag must not
+    // land under actionpack's same-named file and read as stale there.
+    recordTaggedCalls(
+      byFileName,
+      "gem-version.ts",
+      "gemVersion",
+      "",
+      ["new"],
+      { new: "PERMANENT" },
+      "dep",
+    );
+    expect(byFileName.size).toBe(0);
+    expect(
+      staleCallTags(
+        byFileName,
+        new Map([[callTagKey("gem-version.ts", "*", "gemVersion"), new Set<string>()]]),
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1349,14 +1349,20 @@ export function tagsForOwner(
 /** Record one declaration's tagged calls (call → the reason that justified it,
  *  `""` for an artifact predating the reasons) under (file, name, owner). The
  *  two families are recorded identically, so they share one writer. */
-function recordTaggedCalls(
+export function recordTaggedCalls(
   byFileName: Map<string, Map<string, Map<string, Map<string, string>>>>,
   file: string,
   name: string,
   owner: string,
   calls: string[],
   reasons: Record<string, string> | undefined,
+  scope: "package" | "dep" = "package",
 ): void {
+  // Tags on a DEP package's members are never consulted here — only the
+  // package under comparison has pairs — and the map is keyed by the relative
+  // tsFile alone, so a dep tag on a same-basename file (every package ships a
+  // `gem-version.ts`) would land under this package's file and read as stale.
+  if (scope === "dep") return;
   const byName = byFileName.get(file) ?? new Map<string, Map<string, Map<string, string>>>();
   const byClass = byName.get(name) ?? new Map<string, Map<string, string>>();
   const tagged = byClass.get(owner) ?? new Map<string, string>();
@@ -2728,6 +2734,7 @@ export function main() {
           owner,
           m.missingRailsCalls,
           m.missingRailsCallReasons,
+          scope,
         );
       }
       if (m.missingRailsArgs !== undefined) {
@@ -2738,6 +2745,7 @@ export function main() {
           owner,
           m.missingRailsArgs,
           m.missingRailsArgsReasons,
+          scope,
         );
       }
       if (m.callSeq !== undefined) {


### PR DESCRIPTION
## What

Two related convergence stories.

**1 — `call-tag-population-collides-on-shared-basename`**

`compare.ts` recorded `@missingRailsCall` / `@missingRailsArgs` tags keyed by the
RELATIVE tsFile path alone, across the package under comparison AND its deps.
Every package ships a `gem-version.ts`, so activesupport's tag landed in
`actionpackversion`'s map, was never consumed there, and `staleCallTags` reported
it stale. `recordTaggedCalls` now takes the same `"package" | "dep"` scope the
sibling populations already use and ignores dep-package tags. Regression test in
`scripts/api-compare/compare.test.ts` covers the colliding basename.

With that fixed, `call-mismatches-exclude/activesupport/gem-version.json`
migrates to a `@missingRailsCall new — PERMANENT: …` tag carrying its reviewed
reason (via `parity:api:build`), and the emptied shard is deleted.

**2 — `merge-reflection-scope-chain-injects-a-klass-override-shim`**

`_mergeReflectionScopeChain` took a trails-only `klassOverride` and built its
chain entry with `Object.create(reflection, { klass: … })`, threaded from
`addConstraints`' `options.sourceType` special case.

Rails has no such shim. `add_constraints`' `chain.reverse_each`
(association_scope.rb:132) folds the chain HEAD like any other entry, and a
through head's `constraints` is `source_reflection.constraints << scope`
(reflection.rb:1180-1184) — that is how a scope declared on the SOURCE
reflection merges, evaluated against the head's OWN `klass`. For a `source_type:`
through that klass is the runtime `@association.klass` (`RuntimeReflection#klass`,
reflection.rb:1265), so the polymorphic belongsTo's uncomputable `klass` is never
read.

So `addConstraints` now folds `chain[0]` unconditionally instead of reaching
`head.sourceReflection` with an override, passing `chain_head` so the head's own
scope is skipped — Rails' `if scope_chain_item == chain_head.scope`
(association_scope.rb:137) merge-except case, which trails applies in the head
branch just above. The `Object.create` shim, the `klassOverride` parameter, the
`if (!entryKlass) return scope` guard and the `sourceType` special case are gone.

## Verification

- `pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:reasons`,
  `parity:api:detached` green; no new baseline rows.
- Full `packages/activerecord/src/associations/` suite green on SQLite:
  115 files, 2045 tests (has-many/has-one/nested through, source-type validation,
  polymorphic-sti-through, join-model, disable-joins routing). PG and MySQL via CI.

Closes-story: call-tag-population-collides-on-shared-basename
Closes-story: merge-reflection-scope-chain-injects-a-klass-override-shim