### PR TITLE
refactor(activerecord): converge schemaDefault onto Rails schema_default via the SchemaSource cast-type seam

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
 import { SchemaDumper } from "./schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { IntegerType, DecimalType, BooleanType, StringType } from "@blazetrails/activemodel";
@@ -7,6 +8,7 @@ const emptySource: SchemaSource = {
   tables: () => [],
   columns: () => [],
   indexes: () => [],
+  lookupCastTypeFromColumn: () => new ValueType(),
 };
 
 describe("SchemaDumper", () => {
@@ -77,23 +79,6 @@ describe("SchemaDumper schemaDefault with adapter type deserialize", () => {
       new StringType(),
     );
     expect(result).toContain("uuid()");
-  });
-
-  it("pre-deserialized array default uses typeCastForSchema when deserialize returns null", () => {
-    // Mirrors the PG OID::Array case: column.default is already [] (deserialized by
-    // the adapter) but lookupCastTypeFromColumn returns the scalar element type (e.g.
-    // DecimalType) which cannot deserialize an array — deserialize([]) → null.
-    // schemaDefault must call typeCastForSchema on the original value directly.
-    const rejectingType = {
-      deserialize: () => null,
-      typeCastForSchema: (v: unknown) => JSON.stringify(v),
-    };
-    const adapter = { lookupCastTypeFromColumn: () => rejectingType };
-    const dumper = SchemaDumper.create(adapter as any);
-    const result = (dumper as any).schemaDefault({ hasDefault: true, default: [] }) as
-      | string
-      | undefined;
-    expect(result).toBe("[]");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -170,27 +170,20 @@ export class SchemaDumper extends BaseSchemaDumper {
   // the single `emitTable`/`columnSpec` dispatch. `_adapter` is a trails-only
   // helper on the base (it reaches base-private `_source`).
 
-  /** @internal */
+  /**
+   * Mirrors `def schema_default(column)`
+   * (connection_adapters/abstract/schema_dumper.rb:87-95).
+   * @internal
+   */
   protected schemaDefault(column: Column): string | undefined {
-    if (!column.hasDefault && column.default === undefined) return undefined;
-    if (column.default == null) return this.schemaExpression(column);
-    const adapter = this._adapter();
-    if (adapter?.lookupCastTypeFromColumn) {
-      const type = adapter.lookupCastTypeFromColumn(column);
-      if (type != null && typeof type.deserialize === "function") {
-        const deserialized = type.deserialize(column.default);
-        if (deserialized == null) {
-          // column.default is already non-null (the `== null` guard above
-          // returned early). It may be a pre-deserialized JS value (e.g. []
-          // for a PG OID::Array column) that the scalar element type cannot
-          // deserialize. Apply typeCastForSchema directly on the original.
-          return type.typeCastForSchema(column.default);
-        }
-        return type.typeCastForSchema(deserialized);
-      }
+    if (!column.hasDefault) return undefined;
+    const type = this._adapter().lookupCastTypeFromColumn(column);
+    const default_ = type.deserialize(column.default);
+    if (default_ == null) {
+      return this.schemaExpression(column);
+    } else {
+      return type.typeCastForSchema(default_);
     }
-    if (typeof column.default === "string") return JSON.stringify(column.default);
-    return String(column.default);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
 import { SchemaDumper } from "./schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { Result } from "../../result.js";
 
-const stubSource: SchemaSource = { tables: () => [], columns: () => [], indexes: () => [] };
+const stubSource: SchemaSource = {
+  tables: () => [],
+  columns: () => [],
+  indexes: () => [],
+  lookupCastTypeFromColumn: () => new ValueType(),
+};
 const make = () => SchemaDumper.create(stubSource);
 const col = (
   o: {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Column } from "./column.js";
 import type { SchemaSource } from "../../schema-dumper.js";
@@ -7,6 +8,7 @@ const emptySource: SchemaSource = {
   tables: () => [],
   columns: () => [],
   indexes: () => [],
+  lookupCastTypeFromColumn: () => new ValueType(),
 };
 
 function makeColumn(

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -10,6 +10,7 @@ import { Base } from "./base.js";
 import { fixtures } from "./test-fixtures.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { ValueType } from "@blazetrails/activemodel";
 
 const EMPTY_SOURCE = {
   tables: () => [],
@@ -29,9 +30,16 @@ describe("SchemaDumper trails-only cases", () => {
         // A function default reflects as `default: null` + `defaultFunction`
         // (the literal default is null; the expression rides defaultFunction),
         // which schemaDefault routes through schemaExpression to the arrow form.
-        { name: "token", type: "string", default: null, defaultFunction: "gen_random_uuid()" },
+        {
+          name: "token",
+          type: "string",
+          hasDefault: true,
+          default: null,
+          defaultFunction: "gen_random_uuid()",
+        },
       ],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     expect(output).toContain(`() => "gen_random_uuid()"`);
@@ -62,6 +70,7 @@ describe("SchemaDumper trails-only cases", () => {
         { name: "bv", type: "bitVarying" },
       ],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     for (const helper of [
@@ -98,6 +107,7 @@ describe("SchemaDumper trails-only cases", () => {
         { name: "obj_id", type: "oid" },
       ],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (TopLevelDumper.dump(source) as string[]).join("\n");
     // Regression guard against collapsing to the `enum` fallback. timestamptz/
@@ -348,6 +358,7 @@ describe("SchemaDumperAdapterTest", () => {
       tables: () => ["users"],
       columns: () => [{ name: "id", type: "integer", primaryKey: true }],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     class CommentDumper extends TopLevelDumper {
       protected override fetchTableOptions(_tableName: string): Record<string, unknown> {
@@ -367,6 +378,7 @@ describe("SchemaDumperAdapterTest", () => {
       tables: () => ["t"],
       columns: () => [{ name: "id", type: "integer", primaryKey: true }],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     class MysqlDumper extends TopLevelDumper {
       protected override fetchTableOptions(_t: string): Record<string, unknown> {
@@ -392,6 +404,7 @@ describe("SchemaDumperAdapterTest", () => {
         { name: "account_id", type: "integer", primaryKey: true },
       ],
       indexes: () => [],
+      lookupCastTypeFromColumn: () => new ValueType(),
     };
     const dumper = TopLevelDumper.create(source as any);
     const lines: string[] = [];
@@ -455,6 +468,7 @@ describe("formatColspec", () => {
     tables: () => [],
     columns: () => [],
     indexes: () => [],
+    lookupCastTypeFromColumn: () => new ValueType(),
   });
 
   it("emits values verbatim (Rails format_colspec), not re-quoted", () => {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -25,6 +25,7 @@ import { isBlank } from "@blazetrails/activesupport";
 import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
+import type { Type } from "@blazetrails/activemodel";
 
 let _base: typeof Base | undefined;
 
@@ -64,6 +65,8 @@ export interface ColumnInfo {
   primaryKey?: boolean;
   null?: boolean;
   default?: unknown;
+  /** Rails `Column#has_default?` (connection_adapters/column.rb:30-32). */
+  hasDefault?: boolean;
   defaultFunction?: string | null;
   limit?: number | null;
   precision?: number | null;
@@ -151,6 +154,15 @@ export interface SchemaSource {
   columns(tableName: string): ColumnInfo[] | Promise<ColumnInfo[]>;
   /** @internal */
   indexes(tableName: string): IndexInfo[] | Promise<IndexInfo[]>;
+  /**
+   * Rails' `@connection` in the dumper is always an adapter, so
+   * `schema_default` calls `lookup_cast_type_from_column` unconditionally
+   * (abstract/schema_dumper.rb:89). A `SchemaSource` stands in for that
+   * connection here, so the cast-type lookup is part of the interface rather
+   * than an optional method the dumper has to guard at the call site.
+   * @internal
+   */
+  lookupCastTypeFromColumn(column: ColumnInfo): Type;
 }
 
 export type SchemaDumpLanguage = "ts" | "js";
@@ -257,6 +269,11 @@ class AdapterSchemaSource implements SchemaSource {
     return this._adapter.tables();
   }
 
+  /** @internal */
+  lookupCastTypeFromColumn(column: ColumnInfo): Type {
+    return this._adapter.lookupCastTypeFromColumn(column as { sqlType: string | null }) as Type;
+  }
+
   async columns(tableName: string): Promise<ColumnInfo[]> {
     const cols = await this._adapter.columns(tableName);
     return cols.map((col) => {
@@ -291,6 +308,13 @@ class AdapterSchemaSource implements SchemaSource {
         // is false); clear it so schemaDefault doesn't emit a `default:` alongside
         // the `as:`/`stored:` generation options.
         default: isVirtual ? undefined : col.default,
+        // Rails Column#has_default? (connection_adapters/column.rb:30-32); a
+        // virtual column has none (postgresql/column.rb:33, sqlite3/column.rb).
+        hasDefault: isVirtual
+          ? false
+          : typeof (col as any).hasDefault === "boolean"
+            ? (col as any).hasDefault
+            : col.default != null || (col.defaultFunction ?? null) !== null,
         defaultFunction: col.defaultFunction ?? null,
         limit: col.limit ?? undefined,
         precision: col.precision === undefined ? undefined : col.precision,

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -308,8 +308,7 @@ class AdapterSchemaSource implements SchemaSource {
         // is false); clear it so schemaDefault doesn't emit a `default:` alongside
         // the `as:`/`stored:` generation options.
         default: isVirtual ? undefined : col.default,
-        // Rails Column#has_default? (connection_adapters/column.rb:30-32); a
-        // virtual column has none (postgresql/column.rb:33, sqlite3/column.rb).
+        // Rails Column#has_default? (connection_adapters/column.rb:30-32).
         hasDefault: isVirtual
           ? false
           : typeof (col as any).hasDefault === "boolean"

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -26,6 +26,7 @@ import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
 import type { Type } from "@blazetrails/activemodel";
+import { defaultValue } from "@blazetrails/activemodel";
 
 let _base: typeof Base | undefined;
 
@@ -271,7 +272,17 @@ class AdapterSchemaSource implements SchemaSource {
 
   /** @internal */
   lookupCastTypeFromColumn(column: ColumnInfo): Type {
-    return this._adapter.lookupCastTypeFromColumn(column as { sqlType: string | null }) as Type;
+    // AbstractMysqlAdapter's override returns null for a blank sqlType — a
+    // trails invention it flags itself (abstract-mysql-adapter.ts:1268-1276,
+    // story mysql-native-type-map-converges-onto-type-map). Rails' lookup ends
+    // at TypeMap#lookup, whose miss yields Type.default_value
+    // (activemodel/lib/active_model/type.rb:38-40) and never nil, so the seam
+    // supplies that default rather than handing the dumper a null.
+    return (
+      (this._adapter.lookupCastTypeFromColumn(
+        column as { sqlType: string | null },
+      ) as Type | null) ?? defaultValue()
+    );
   }
 
   async columns(tableName: string): Promise<ColumnInfo[]> {

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -38,13 +38,6 @@ export function benchmark<T>(
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
-/**
- * @missingRailsCall logger — CONVERGEABLE (story
- *   `benchmarkable-should-mix-in-logger-reader`): Rails reads the mixin's
- *   `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared
- *   free function whose host passes the logger in as its first parameter, so
- *   there is no `logger` reader to call.
- */
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,

--- a/packages/trailties/src/schema-source.ts
+++ b/packages/trailties/src/schema-source.ts
@@ -1,3 +1,4 @@
+import { Type } from "@blazetrails/activerecord";
 import type { DatabaseAdapter } from "@blazetrails/activerecord";
 import type { SchemaSource, ColumnInfo, IndexInfo } from "@blazetrails/activerecord";
 
@@ -88,9 +89,14 @@ export class AdapterSchemaSource implements SchemaSource {
   lookupCastTypeFromColumn(
     column: ColumnInfo,
   ): ReturnType<SchemaSource["lookupCastTypeFromColumn"]> {
-    return this.adapter.lookupCastTypeFromColumn(
-      column as { sqlType: string | null },
-    ) as ReturnType<SchemaSource["lookupCastTypeFromColumn"]>;
+    // The MySQL adapter returns null for a blank sqlType; Rails' lookup ends at
+    // Type.default_value (activemodel/lib/active_model/type.rb:38-40) and never
+    // nil, so the seam supplies that default.
+    return (
+      (this.adapter.lookupCastTypeFromColumn(column as { sqlType: string | null }) as ReturnType<
+        SchemaSource["lookupCastTypeFromColumn"]
+      > | null) ?? Type.defaultValue()
+    );
   }
 
   async indexes(tableName: string): Promise<IndexInfo[]> {

--- a/packages/trailties/src/schema-source.ts
+++ b/packages/trailties/src/schema-source.ts
@@ -72,12 +72,25 @@ export class AdapterSchemaSource implements SchemaSource {
       primaryKey: c.primaryKey,
       null: c.null,
       default: c.default,
+      hasDefault:
+        typeof c.hasDefault === "boolean"
+          ? c.hasDefault
+          : c.default != null || (c.defaultFunction ?? null) !== null,
       defaultFunction: c.defaultFunction ?? undefined,
       limit: c.limit ?? undefined,
       precision: c.precision === undefined ? undefined : c.precision,
       scale: c.scale ?? undefined,
       collation: c.collation ?? undefined,
     }));
+  }
+
+  /** The dumper's `schema_default` cast-type lookup, served by the adapter. */
+  lookupCastTypeFromColumn(
+    column: ColumnInfo,
+  ): ReturnType<SchemaSource["lookupCastTypeFromColumn"]> {
+    return this.adapter.lookupCastTypeFromColumn(
+      column as { sqlType: string | null },
+    ) as ReturnType<SchemaSource["lookupCastTypeFromColumn"]>;
   }
 
   async indexes(tableName: string): Promise<IndexInfo[]> {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-dumper.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_default",
-    "call": "order:schemaExpression,lookupCastTypeFromColumn",
-    "reason": "Per-site (RFC 0106): abstract/schema_dumper.rb:87-95 looks the cast type up first and only falls through to `schema_expression(column)` when `type.deserialize(column.default)` is nil; trails short-circuits to `schemaExpression` on a null `column.default` BEFORE the lookup, because the dumper base also runs against hosts that expose no `lookupCastTypeFromColumn` (hence the `adapter?.lookupCastTypeFromColumn` guard on the next line). Real divergence, not equivalence: filed for convergence as 0106-wide-call-set-direct-burndown/converge-schema-default-cast-type-lookup rather than ratified here."
-  }
-]


### PR DESCRIPTION
Converges `AbstractSchemaDumper#schemaDefault` onto Rails' `schema_default`
(`activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb:87-95`).

Before, the port:
- short-circuited to `schemaExpression(column)` on a null `column.default` **before** the cast-type lookup,
- guarded the lookup behind an inline `adapter?.lookupCastTypeFromColumn` optional check,
- added a `typeCastForSchema(column.default)` fallback plus a raw `JSON.stringify` / `String()` tail Rails has no counterpart for.

Now it is the Ruby, line for line: `has_default?` guard → `lookup_cast_type_from_column` → `deserialize` → nil/non-nil branch.

## The host seam

Rails' `@connection` in the dumper is always an adapter, so the lookup is unconditional there. trails' stand-in for that connection is `SchemaSource`, so the resolution lives at that interface rather than at the call site:

- `SchemaSource` now **requires** `lookupCastTypeFromColumn(column)`; both `AdapterSchemaSource` bridges (activerecord + trailties) implement it by delegating to the adapter (`AbstractAdapter#lookupCastTypeFromColumn`, `postgresql/quoting.rb:189-192`).
- `ColumnInfo` carries `hasDefault` (Rails `Column#has_default?`, `connection_adapters/column.rb:30-32`), which the bridges fill from the reflected column — virtual columns report `false` (`postgresql/column.rb:33`, `sqlite3/column.rb`).

## Baseline

`scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-dumper.json` **deleted** — it was the last RFC 0047/0084 seed-placeholder row for `activerecord`. `pnpm parity:api:calls` and `pnpm parity:api:calls:args` are green with no tighten needed.

The one trails test that pinned the removed `typeCastForSchema` fallback (`pre-deserialized array default …`) is dropped: it asserted the divergence. The real PG array case still works — `oid` rides `ColumnInfo`, so the lookup returns `OID::Array`, whose `deserialize` handles an already-parsed array (`oid/array.ts:228-239`).

Closes-story: converge-schema-default-cast-type-lookup


---

## Mechanical exception (unrelated to the story)

`chore(activesupport): drop the stale @missingRailsCall logger tag on benchmark` — #6870 made `benchmark` a `this: Benchmarkable` mixin that reads `this.logger`, so the call the tag excused is now actually made and `pnpm parity:api:calls` reds on the stale justification for **every** PR branched off current main. A justification only shrinks, exactly like a baseline row, and deleting the tag is the remedy the gate itself names. Shipped here as the single mechanical exception rather than left blocking the queue.
