### PR TITLE
refactor(arel,activerecord): retire attribute.ts extra surface

### DIFF
--- a/packages/activerecord/src/associations/join-dependency-quoting.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-quoting.test.ts
@@ -14,7 +14,7 @@ import { fixtures } from "../test-fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
 import type { JoinPart } from "./join-dependency/join-part.js";
 import { JoinAssociation } from "./join-dependency/join-association.js";
-import { Nodes, Table, relationName } from "@blazetrails/arel";
+import { Nodes, Table } from "@blazetrails/arel";
 
 /** The tree node a JoinDependency built for a dotted association path. */
 function nodeAt(jd: JoinDependency, path: string): JoinPart {
@@ -29,7 +29,7 @@ function nodeAt(jd: JoinDependency, path: string): JoinPart {
 function joinFor(joins: Nodes.Join[], node: JoinPart): Nodes.Join {
   return joins.find((join) => {
     const rel = join.left as Table | Nodes.TableAlias;
-    return relationName(rel.tableAlias ?? rel.name) === node.effectiveSqlName;
+    return String(rel.tableAlias ?? rel.name) === node.effectiveSqlName;
   })!;
 }
 

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -12,7 +12,7 @@ import { fixtures } from "../test-fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { JoinDependency } from "./join-dependency.js";
 import type { JoinPart } from "./join-dependency/join-part.js";
-import { Nodes, Table, relationName } from "@blazetrails/arel";
+import { Nodes, Table } from "@blazetrails/arel";
 
 /** The tree node a JoinDependency built for a dotted association path. */
 function nodeAt(jd: JoinDependency, path: string): JoinPart {
@@ -28,7 +28,7 @@ function nodeAt(jd: JoinDependency, path: string): JoinPart {
 function joinedTableNames(joins: Nodes.Join[]): string[] {
   return joins.map((join) => {
     const rel = join.left as Table | Nodes.TableAlias;
-    return relationName(rel.tableAlias ?? rel.name);
+    return String(rel.tableAlias ?? rel.name);
   });
 }
 
@@ -40,7 +40,7 @@ function joinedTableNames(joins: Nodes.Join[]): string[] {
 function joinFor(joins: Nodes.Join[], node: JoinPart): Nodes.Join {
   return joins.find((join) => {
     const rel = join.left as Table | Nodes.TableAlias;
-    return relationName(rel.tableAlias ?? rel.name) === node.effectiveSqlName;
+    return String(rel.tableAlias ?? rel.name) === node.effectiveSqlName;
   })!;
 }
 
@@ -66,7 +66,7 @@ describe("JoinDependency has_many :through real-table-name reuse", () => {
 
     expect(joinedTableNames(joins)).toContain("posts");
     const throughJoin = joins.find(
-      (j) => relationName((j.left as Table).tableAlias ?? (j.left as Table).name) === "posts",
+      (j) => String((j.left as Table).tableAlias ?? (j.left as Table).name) === "posts",
     )!;
     expect(throughJoin).toBeInstanceOf(Nodes.OuterJoin);
     expect((throughJoin.left as Table).tableAlias).toBeNull();
@@ -94,13 +94,13 @@ describe("JoinDependency has_many :through real-table-name reuse", () => {
     // Target aliased — Rails encodes this as a `TableAlias` over the real table.
     const targetTable = (joinFor(joins, node) as Nodes.OuterJoin).left as Nodes.TableAlias;
     expect(targetTable.tableName).toBe("comments");
-    expect(relationName(targetTable.tableAlias ?? targetTable.name)).toBe(
+    expect(String(targetTable.tableAlias ?? targetTable.name)).toBe(
       "comments_with_foreign_keys_authors",
     );
 
     // Through still uses real name
     const throughJoin = joins.find(
-      (j) => relationName((j.left as Table).tableAlias ?? (j.left as Table).name) === "posts",
+      (j) => String((j.left as Table).tableAlias ?? (j.left as Table).name) === "posts",
     )!;
     expect(throughJoin).toBeDefined();
     expect((throughJoin.left as Table).tableAlias).toBeNull();
@@ -179,7 +179,7 @@ describe("JoinDependency has_many :through real-table-name reuse", () => {
     expect(target.effectiveSqlName).toBe("commentsWithForeignKey");
     const targetTable = target.arelTable as Nodes.TableAlias;
     expect(targetTable.tableName).toBe("comments");
-    expect(relationName(targetTable.tableAlias ?? targetTable.name)).toBe("commentsWithForeignKey");
+    expect(String(targetTable.tableAlias ?? targetTable.name)).toBe("commentsWithForeignKey");
 
     // The intermediate chain link is internal and never reference-aliased.
     expect(joinedTableNames(jd.joinConstraints([]))).toContain("posts");

--- a/packages/activerecord/src/associations/join-dependency-walk.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-walk.test.ts
@@ -10,7 +10,7 @@ import { Base, registerModel } from "../index.js";
 import { clearReflectionsCache } from "../reflection.js";
 import { fixtures } from "../test-fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
-import { Nodes, Table, relationName } from "@blazetrails/arel";
+import { Nodes, Table } from "@blazetrails/arel";
 
 describe("JoinDependency walk() deduplication", () => {
   // Ride the boot-laid canonical `Base.connection` (single-pool test model)
@@ -182,13 +182,13 @@ describe("JoinDependency walk() deduplication", () => {
     const jd1ReviewsJoin = joins.find((j) => {
       const table = (j as Nodes.OuterJoin).left as Table | Nodes.TableAlias;
       const realName = table instanceof Nodes.TableAlias ? table.tableName : table.name;
-      const alias = relationName(table.tableAlias ?? table.name);
+      const alias = String(table.tableAlias ?? table.name);
       return realName === "comments" && alias !== "comments";
     }) as Nodes.OuterJoin | undefined;
     expect(jd1ReviewsJoin).toBeDefined();
 
     const jd1ReviewsTable = jd1ReviewsJoin!.left as Table | Nodes.TableAlias;
-    const jd1ReviewsAlias = relationName(jd1ReviewsTable.tableAlias ?? jd1ReviewsTable.name);
+    const jd1ReviewsAlias = String(jd1ReviewsTable.tableAlias ?? jd1ReviewsTable.name);
     expect(referencedTables).toContain(jd1ReviewsAlias);
     expect(referencedTables).toContain("likes");
     expect(referencedTables).not.toContain("comments");

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -13,7 +13,7 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "../base.js";
 import type { AssociationSpec } from "../relation/query-methods.js";
-import { Nodes, Table, relationName } from "@blazetrails/arel";
+import { Nodes, Table } from "@blazetrails/arel";
 import { isAssociationCached, _cacheSingularTarget } from "../associations.js";
 import { _reflectOnAssociation } from "../reflection.js";
 import { JoinBase } from "./join-dependency/join-base.js";
@@ -469,8 +469,7 @@ export class JoinDependency {
       if (r instanceof JoinAssociation) {
         const lt = l.table;
         r.table =
-          l.effectiveSqlName ||
-          (typeof lt === "string" ? lt : relationName(lt.tableAlias ?? lt.name));
+          l.effectiveSqlName || (typeof lt === "string" ? lt : String(lt.tableAlias ?? lt.name));
       }
       return this.walk(l, r, joinType);
     });
@@ -540,7 +539,7 @@ export class JoinDependency {
               return root ? name : `${name}_join`;
             },
           );
-          const effectiveName = relationName(table.tableAlias ?? table.name);
+          const effectiveName = String(table.tableAlias ?? table.name);
           const aliased = aliasedArelTableForReflection(
             reflection,
             (reflection as any).tableName,

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Base } from "../../base.js";
-import { Nodes, Table, fetchAttribute, relationName } from "@blazetrails/arel";
+import { Nodes, Table, fetchAttribute } from "@blazetrails/arel";
 import type { AbstractReflection } from "../../reflection.js";
 import { JoinPart } from "./join-part.js";
 import { aliasedArelTableForReflection, type AliasTracker } from "../alias-tracker.js";
@@ -36,13 +36,13 @@ export class JoinAssociation extends JoinPart {
   get table(): string {
     const t = this._table;
     if (!t) return this.reflection.tableName;
-    return relationName(t.tableAlias ?? t.name);
+    return String(t.tableAlias ?? t.name);
   }
 
   set table(value: string) {
     const table = aliasedArelTableForReflection(this.reflection, this.reflection.tableName, value);
     this._table = table;
-    if (!this.tables.some((t) => relationName(t.tableAlias ?? t.name) === value)) {
+    if (!this.tables.some((t) => String(t.tableAlias ?? t.name) === value)) {
       this.tables.push(table);
     }
   }
@@ -98,8 +98,7 @@ export class JoinAssociation extends JoinPart {
       if (!this._table) this._table = table;
       if (
         !this.tables.some(
-          (t) =>
-            relationName(t.tableAlias ?? t.name) === relationName(table.tableAlias ?? table.name),
+          (t) => String(t.tableAlias ?? t.name) === String(table.tableAlias ?? table.name),
         )
       ) {
         this.tables.push(table);
@@ -150,7 +149,7 @@ export class JoinAssociation extends JoinPart {
       if (nodes instanceof Nodes.And) {
         const remaining: Nodes.Node[] = [];
         for (const child of nodes.children) {
-          if (!nodeReferencesTable(child, relationName(table.tableAlias ?? table.name))) {
+          if (!nodeReferencesTable(child, String(table.tableAlias ?? table.name))) {
             others.push(child);
           } else {
             remaining.push(child);
@@ -250,7 +249,7 @@ function nodeReferencesTable(node: Nodes.Node, tableName: string): boolean {
   fetchAttribute(node, (attr: Nodes.Node) => {
     if (attr instanceof Nodes.Attribute) {
       const rel = attr.relation;
-      if (relationName(rel.tableAlias ?? rel.name) === tableName) {
+      if (String(rel.tableAlias ?? rel.name) === tableName) {
         found = true;
         return false;
       }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -6,7 +6,7 @@
 
 import type { ExplainOption } from "./abstract/database-statements.js";
 import type { InsertBuilder } from "../insert-all.js";
-import { type Nodes, Visitors, Collectors, relationName } from "@blazetrails/arel";
+import { type Nodes, Visitors, Collectors } from "@blazetrails/arel";
 import {
   ReadOnlyError,
   ActiveRecordError,
@@ -2720,7 +2720,7 @@ export class AbstractAdapter implements Quoting {
   }): Promise<import("./column.js").Column | undefined> {
     // A `TableAlias` relation may carry a `SqlLiteral` name (set-op / subquery
     // derived table); unwrap to the bare identifier for the schema-cache lookup.
-    const tableName = relationName(attribute.relation.name);
+    const tableName = String(attribute.relation.name);
     // `schemaCache` is Rails' `schema_cache` (abstract_adapter.rb:298): the
     // pool's BoundSchemaReflection, or one bound to this connection when the
     // adapter stands alone on a NullPool.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -5,7 +5,7 @@
  * Mirrors: ActiveRecord::QueryMethods
  */
 import * as Arel from "@blazetrails/arel";
-import { Nodes, SelectManager, Table as ArelTable, relationName } from "@blazetrails/arel";
+import { Nodes, SelectManager, Table as ArelTable } from "@blazetrails/arel";
 import {
   ArgumentError,
   Attribute,
@@ -802,7 +802,7 @@ function orderClauseKey(clause: unknown): string {
   if (typeof clause === "string") return `s:${clause}`;
   if (clause instanceof Nodes.SqlLiteral) return `s:${String((clause as any).value ?? "")}`;
   if (clause instanceof Nodes.Attribute) {
-    return `a:${relationName((clause as any).relation?.name)}.${(clause as any).name}`;
+    return `a:${String((clause as any).relation?.name)}.${(clause as any).name}`;
   }
   if (clause instanceof Nodes.Node && "expr" in (clause as any)) {
     return `${clause.constructor.name}(${orderClauseKey((clause as any).expr)})`;
@@ -2443,11 +2443,11 @@ export function columnReferences(orderArgs: unknown[]): Nodes.SqlLiteral[] {
       const t = extractTableNameFrom(term);
       if (t) refs.push(t);
     } else if (arg instanceof Nodes.Attribute) {
-      refs.push(relationName(arg.relation.name));
+      refs.push(String(arg.relation.name));
     } else if (arg instanceof Nodes.Ordering) {
       const expr = (arg as any).expr;
       if (expr instanceof Nodes.Attribute) {
-        refs.push(relationName(expr.relation.name));
+        refs.push(String(expr.relation.name));
       }
     } else if (arg instanceof Map) {
       // Rails' Hash arm extracts a table only from String/Symbol keys; an Arel

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -8,7 +8,7 @@
  * Mirrors: ActiveRecord::Relation::WhereClause
  */
 
-import { Nodes, fetchAttribute, relationName } from "@blazetrails/arel";
+import { Nodes, fetchAttribute } from "@blazetrails/arel";
 
 export class WhereClause {
   private _predicates: Nodes.Node[];
@@ -154,7 +154,7 @@ export class WhereClause {
     for (const node of equalities(this.predicates, opts.equalityOnly ?? false)) {
       const attr = extractAttribute(node);
       if (attr === null) continue;
-      if (tableName !== undefined && relationName(attr.relation.name) !== tableName) continue;
+      if (tableName !== undefined && String(attr.relation.name) !== tableName) continue;
       result[attr.name] = extractNodeValue((node as any).right);
     }
     return result;
@@ -171,7 +171,7 @@ export class WhereClause {
       if (typeof c === "string") colStrings.add(c);
       else if (c instanceof Nodes.Attribute) {
         attrNodes.push(c);
-        colStrings.add(`${relationName(c.relation.name)}.${c.name}`);
+        colStrings.add(`${String(c.relation.name)}.${c.name}`);
       } else if (c instanceof Nodes.Node) {
         // Non-Attribute expression LHS (e.g. NamedFunction) — Rails' `non_attrs`.
         exprNodes.push(c);
@@ -188,7 +188,7 @@ export class WhereClause {
       }
       if (attrNodes.some((a) => a.eql(attr))) return false;
       if (colStrings.has(attr.name)) return false;
-      const qualified = `${relationName(attr.relation.name)}.${attr.name}`;
+      const qualified = `${String(attr.relation.name)}.${attr.name}`;
       if (colStrings.has(qualified)) return false;
       return true;
     });
@@ -229,7 +229,7 @@ export class WhereClause {
     this.eachAttributes((attr, node) => {
       const key =
         attr instanceof Nodes.Attribute
-          ? `${relationName(attr.relation.name)}.${attr.name}`
+          ? `${String(attr.relation.name)}.${attr.name}`
           : String(attr);
       hash[key] = node;
     });

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "../test-helpers/connection.js";
-import { Table, star, Nodes, Visitors, relationName } from "../index.js";
+import { Table, star, Nodes, Visitors } from "../index.js";
 
 // TS-only coverage for the `when Enumerable` arm of Attribute#in / #notIn
 // (arel/predications.rb:65-74, 112-121). Ruby's Enumerable spans Set, Hash and
@@ -149,27 +149,6 @@ describe("AttributeTest (trails)", () => {
       expect(right).toBeInstanceOf(Nodes.Casted);
       expect((right as Nodes.Casted).attribute).toBe(attr);
       expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"foo"."id" IN (0)');
-    });
-  });
-
-  describe("relationName", () => {
-    it("returns a plain string name unchanged", () => {
-      expect(relationName("users")).toBe("users");
-    });
-
-    it("unwraps a SqlLiteral name to its value", () => {
-      // Unlike Rails (where SqlLiteral < String), trails models SqlLiteral as a
-      // standalone Node, so a TableAlias derived-table alias must be unwrapped
-      // before it flows into any String-typed slot.
-      const alias = new Nodes.TableAlias(new Table("users"), new Nodes.SqlLiteral("derived"));
-      expect(relationName(alias.name)).toBe("derived");
-    });
-
-    it("coerces an attribute on a SqlLiteral-aliased relation to a string name", () => {
-      const alias = new Nodes.TableAlias(new Table("users"), new Nodes.SqlLiteral("derived"));
-      const attr = alias.get("id");
-      const qualified = `${relationName(attr.relation.name)}.${attr.name}`;
-      expect(qualified).toBe("derived.id");
     });
   });
 });

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,6 +1,7 @@
 import { include, type Included } from "@blazetrails/activesupport";
+import { _setAttribute } from "../node-slots.js";
 import { Node } from "../nodes/node.js";
-import { As, ATTRIBUTE_BRAND } from "../nodes/binary.js";
+import { As } from "../nodes/binary.js";
 import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-operation.js";
 import { Count } from "../nodes/count.js";
 import { Sum, Max, Min, Avg } from "../nodes/function.js";
@@ -40,20 +41,8 @@ export interface RelationLike {
   lower: (column: unknown) => NamedFunction;
 }
 
-/**
- * Coerce a relation / table-alias `name` to a plain string, unwrapping a
- * `SqlLiteral`. In Rails `Arel::Nodes::SqlLiteral < String`, so a SqlLiteral
- * name is already a usable string; here `SqlLiteral` is a standalone `Node`, so
- * every string consumer of `RelationLike.name` / `TableAlias.name` must unwrap
- * via this helper rather than letting the object flow into a `String` slot.
- */
-export function relationName(name: string | SqlLiteral): string {
-  return name instanceof SqlLiteral ? name.value : name;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Attribute extends Node {
-  readonly [ATTRIBUTE_BRAND] = true;
   readonly relation: RelationLike;
   readonly name: string;
 
@@ -219,3 +208,5 @@ export interface Attribute extends Omit<
 }
 
 include(Attribute, Predications);
+
+_setAttribute(Attribute);

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -10,7 +10,6 @@ import { TreeManager } from "./tree-manager.js";
 export { TreeManager };
 export type { ArelEngine } from "./nodes/node.js";
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
-export { relationName } from "./attributes/attribute.js";
 export { sql, star, fetchAttribute } from "./arel.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";

--- a/packages/arel/src/node-slots.ts
+++ b/packages/arel/src/node-slots.ts
@@ -69,12 +69,14 @@ export function _setBuildQuoted(fn: (other: any, ctx: any) => any): void {
   _buildQuoted = fn;
 }
 
-// The one non-node slot: `Arel::Attributes::Attribute` is the class Rails
-// narrows on with `is_a?` in `FetchAttribute#fetch_attribute` (binary.rb:33-37)
-// and `Nodes.build_quoted` (casted.rb:48-52). A value import of
-// `attributes/attribute.js` from either reader closes a cycle back through
-// every node module the Attribute mixins reach.
-/** @internal */
+/**
+ * `Arel::Attributes::Attribute` — the class Rails narrows on with `is_a?` in
+ * `FetchAttribute#fetch_attribute` (binary.rb:33-37) and `Nodes.build_quoted`
+ * (casted.rb:48-52). A value import of `attributes/attribute.js` from either
+ * reader closes a cycle back through every node module the Attribute mixins
+ * reach.
+ * @internal
+ */
 export let _Attribute: (new (relation: any, name: string) => any) | undefined;
 /** @internal */
 export function _setAttribute(ctor: new (relation: any, name: string) => any): void {

--- a/packages/arel/src/node-slots.ts
+++ b/packages/arel/src/node-slots.ts
@@ -68,3 +68,15 @@ export let _buildQuoted: ((other: any, ctx: any) => any) | undefined;
 export function _setBuildQuoted(fn: (other: any, ctx: any) => any): void {
   _buildQuoted = fn;
 }
+
+// The one non-node slot: `Arel::Attributes::Attribute` is the class Rails
+// narrows on with `is_a?` in `FetchAttribute#fetch_attribute` (binary.rb:33-37)
+// and `Nodes.build_quoted` (casted.rb:48-52). A value import of
+// `attributes/attribute.js` from either reader closes a cycle back through
+// every node module the Attribute mixins reach.
+/** @internal */
+export let _Attribute: (new (relation: any, name: string) => any) | undefined;
+/** @internal */
+export function _setAttribute(ctor: new (relation: any, name: string) => any): void {
+  _Attribute = ctor;
+}

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,7 +1,7 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import type { Temporal } from "@blazetrails/date";
 import { include } from "@blazetrails/activesupport";
-import { _Equality, _In } from "../node-slots.js";
+import { _Attribute, _Equality, _In } from "../node-slots.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -92,21 +92,14 @@ export type NodeOrValue =
   // whose Rails counterpart has exactly one.
   | null;
 
-export const ATTRIBUTE_BRAND = Symbol.for("arel.Attribute");
-
-function isAttribute(node: unknown): boolean {
-  if (!node || typeof node !== "object") return false;
-  return (node as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true;
-}
-
 /**
  * Mirrors: `module Arel::Nodes::FetchAttribute` (binary.rb:32-40) — mixed
  * into the Binary subclasses whose left or right operand may be an Attribute.
  */
 export const FetchAttribute = {
   fetchAttribute(this: Binary, block: (attr: Node) => unknown): unknown {
-    if (isAttribute(this.left)) return block(this.left as Node);
-    if (isAttribute(this.right)) return block(this.right as Node);
+    if (_Attribute && this.left instanceof _Attribute) return block(this.left as Node);
+    if (_Attribute && this.right instanceof _Attribute) return block(this.right as Node);
     return undefined;
   },
 };

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -27,7 +27,6 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;
   if (other && typeof other === "object") {
-    // Arel::Attributes::Attribute
     if (_Attribute && other instanceof _Attribute) return other as Node;
     // Rails: casted.rb:50-51 — the `when ..., ActiveModel::Attribute` arm
     // returning `other`. Class dispatch, like Rails.

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -1,9 +1,8 @@
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
-import { _setBuildQuoted } from "../node-slots.js";
+import { _Attribute, _setBuildQuoted } from "../node-slots.js";
 import { Unary } from "./unary.js";
 import type { Attribute } from "../attributes/attribute.js";
-import { ATTRIBUTE_BRAND } from "./binary.js";
 import { BindParam } from "./bind-param.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
@@ -28,24 +27,20 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;
   if (other && typeof other === "object") {
-    // Arel::Attributes::Attribute (duck-typed via symbol brand)
-    if ((other as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true) return other as Node;
+    // Arel::Attributes::Attribute
+    if (_Attribute && other instanceof _Attribute) return other as Node;
     // Rails: casted.rb:50-51 — the `when ..., ActiveModel::Attribute` arm
     // returning `other`. Class dispatch, like Rails.
     if (other instanceof ModelAttribute) return new BindParam(other);
     const maybeAst = (other as { ast?: unknown }).ast;
     if (maybeAst instanceof Node) return maybeAst;
   }
-  if (isAttribute(attribute)) return new Casted(other, attribute as Attribute);
+  if (_Attribute && attribute instanceof _Attribute)
+    return new Casted(other, attribute as Attribute);
   return new Quoted(other);
 }
 
 _setBuildQuoted(buildQuoted);
-
-function isAttribute(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  return (value as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true;
-}
 
 /**
  * Casted — a value bound to a specific attribute for type casting.

--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -1,6 +1,6 @@
 ---
 title: "Arel: Deviations from Rails"
-description: How Trails' Arel package differs from Rails Arel — naming, symbol branding, typed generics. No async deviations.
+description: How Trails' Arel package differs from Rails Arel — naming, call-time constant resolution, typed generics. No async deviations.
 ---
 
 # Arel: Deviations from Rails
@@ -10,7 +10,7 @@ description: How Trails' Arel package differs from Rails Arel — naming, symbol
 Arel is the least-deviating package in Trails. It is a pure SQL AST builder
 with no I/O, so JavaScript's async/single-threaded model has almost no impact.
 The deviations here are mostly about Ruby idioms that don't translate
-(symbols, `method_missing`, keyword args) and TypeScript features we use to
+(symbols, `method_missing`, keyword args, call-time constant resolution) and TypeScript features we use to
 add safety Rails can't.
 
 If you know Rails Arel, you already know Trails Arel. The shapes are
@@ -25,19 +25,33 @@ index: [method casing](./index.md#method-casing) (camelCase everywhere) and
 `Arel::Table.new(:users, as: "u")` becomes `new Table("users", { as:
 "u" })`. Nothing Arel-specific about this.
 
-## Symbol branding instead of class checks
+## Call-time constant resolution: the zero-import slot
 
-Rails Arel relies on Ruby's class system (`is_a?`) and duck typing
-(`respond_to?`) to identify node kinds. We can't rely on `instanceof` across
-module boundaries (multiple copies of a class can coexist across bundles), so
-core node types are branded with `Symbol.for(...)` and detected by symbol
-presence.
+Ruby resolves a constant named inside a method body when the method _runs_, and
+Zeitwerk autoloads the file at that moment. So `Arel::Nodes.build_quoted` can
+name `Arel::Attributes::Attribute` (`casted.rb:47-59`) without `casted.rb`
+taking a load-order dependency on it.
 
-- See `packages/arel/src/nodes/binary.ts` for the `ATTRIBUTE_BRAND`
-  pattern. `isAttribute(node)` checks the branded symbol rather than
-  `instanceof Attribute`.
+ESM has no equivalent: every `import` is eager, so naming a class in a method
+body costs a module-evaluation edge — and in Arel those edges close cycles
+whose members all `extend Node` / `extend Binary`, which throws
+`Cannot access 'Binary' before initialization` depending on which module you
+enter the graph through.
 
-This is a pure-TS concern; Rails never needs it.
+Where that happens, the constructor is read through a **zero-import slot
+module**, `packages/arel/src/node-slots.ts`: it imports nothing, so it cannot
+join a cycle, and it exports a mutable binding plus a setter that the defining
+module calls at the bottom of its own body. Readers import the binding and use
+it at call time — exactly where Ruby resolves the constant.
+
+```ts
+// nodes/binary.ts — Rails: left.is_a?(Arel::Attributes::Attribute)
+if (_Attribute && this.left instanceof _Attribute) return block(this.left);
+```
+
+The narrowing itself is plain `instanceof`, the direct equivalent of Ruby's
+`is_a?`; the slot only defers _which module the class arrives from_. This is a
+pure-TS concern; Rails never needs it.
 
 ## No `method_missing`, no Proxy
 

--- a/packages/website/docs/guides/index.md
+++ b/packages/website/docs/guides/index.md
@@ -25,7 +25,7 @@ package. The per-package guides cover the ones specific to each:
 
 - [**Arel**](./arel-rails-deviations.md) — the least-deviating package.
   SQL AST building is purely synchronous; deviations are limited to
-  naming, symbol branding, and added TypeScript generics.
+  naming, call-time constant resolution, and added TypeScript generics.
 - [**ActiveModel**](./activemodel-rails-deviations.md) — generated
   attribute methods instead of `method_missing`, async-capable
   callbacks, encapsulated dirty tracking.


### PR DESCRIPTION
Retires the extra surface `pnpm parity:api:extra --package arel` reports on
`arel/attributes/attribute.ts`: **2 novel → 0**.

(The story text quotes 11 novel; the 9 `multiply`/`divide`/`bitwise*` rows were
already retired by `arel-operator-spellings-in-conventions`, leaving the two
this PR removes.)

## `[ATTRIBUTE_BRAND]` → `instanceof`

Rails narrows on the class itself:
`left.is_a?(Arel::Attributes::Attribute)` in `FetchAttribute#fetch_attribute`
(`arel/nodes/binary.rb:33-37`) and the `when Arel::Attributes::Attribute` arm of
`Nodes.build_quoted` (`arel/nodes/casted.rb:48-52`). No brand needed.

A **value** import of `attributes/attribute.js` from `binary.ts` or `casted.ts`
does close a module cycle — `attribute.ts` reaches `infix-operation`,
`function`, `grouping`, `unary-operation`, … all of which `extend Binary`.
Measured on the built `dist`, a plain-node import of `nodes/binary.js` went from
OK to `Cannot access 'Binary' before initialization`, and the non-test failure
set went 13 → 43 modules.

So the constructor is read through the **existing zero-import slot module**,
`arel/src/node-slots.ts` (`_Attribute` / `_setAttribute`, set at the bottom of
`attribute.ts`) — the shape CLAUDE.md ratifies in "Call-time constant resolution
(Ruby autoload → the zero-import slot)", which is exactly what Ruby does here:
resolve the constant when the method runs. Verified the built-`dist` failure set
is byte-identical to `origin/main`'s (13 modules, all pre-existing
`TableAlias`/`TreeManager` cycles).

## `relationName` → `String(...)`

`relationName` unwrapped a `SqlLiteral` relation/alias name to its text. Rails
has no such helper because `Arel::Nodes::SqlLiteral < String`
(`arel/nodes/sql_literal.rb:5`) — `relation.name` is already a String. Our
`SqlLiteral#toString()` returns the SQL text, so all ~25 call sites in
`activerecord` fold to a plain `String(...)`, the implicit coercion Ruby is
doing. The export is gone from `arel/src/index.ts`, and the trails-only
`describe("relationName")` block that tested the helper is deleted with it.

No new `@noRailsEquivalent` tag.

## Remaining rows on the file: 0 novel, 5 moved

- `relation`, `name`, `constructor` — the `Struct.new :relation, :name` members
  (`arel/attributes/attribute.rb:5`) and its generated `initialize`. The Ruby
  extractor stamps `"superclass": "Struct"` (`extract-ruby-api.rb:550-574`) but
  does not synthesize the accessors, so the TS fields find no counterpart in
  `attribute.rb` and score as *moved*. This is a **matcher** gap — the names
  are already exactly Rails'. Filed as
  `0117-arel-extra-surface-burndown/struct-members-not-extracted-as-ruby-methods`.
- `tableAlias`, `typeForAttribute` — members of the structural `RelationLike`
  interface in the same file, not of `Attribute`; covered by the same story.

## Verification

- `pnpm typecheck` clean; `pnpm vitest run packages/arel` + the three
  `join-dependency*` AR test files: 79 files, 1475 tests, green.
- `pnpm parity:api:calls` OK; `pnpm parity:api:calls:args` OK; no baseline rows
  added.
- 51 insertions, 87 deletions.

Closes-story: arel-attribute-extra-surface


---

## Review round 1

**Finding — stale `packages/website/docs/guides/arel-rails-deviations.md`.** Fixed.
The "Symbol branding instead of class checks" section is replaced by
"Call-time constant resolution: the zero-import slot", which documents what the
code now does (plain `instanceof`, with the constructor arriving through
`node-slots.ts`). The frontmatter `description` and the Arel line in
`docs/guides/index.md` are updated to match — those were the only two other
places that said "symbol branding".

**[style] — the `_Attribute` arm in `buildQuoted` is dead given
`Attribute extends Node`.** Kept deliberately, as fidelity rather than dead code.
In Rails `Arel::Attributes::Attribute < Struct` — it is *not* a `Node` — which
is exactly why `casted.rb:49` has to list it as its own class in the `when`:

```ruby
when Arel::Nodes::Node, Arel::Attributes::Attribute, Arel::Table, Arel::SelectManager, Arel::Nodes::SqlLiteral, ActiveModel::Attribute
```

Dropping the arm would collapse two Rails classes in the `when` list into one TS
check that only happens to cover both because our `Attribute` roots at `Node` for
uniform AST walking (`compare.ts:1677` records that rooting). The `case attribute`
arm below it (`casted.rb:52-54`) is live either way and needs the same slot.
