### PR TITLE
fix(api-compare): synthesize Struct.new member accessors and initialize

### DIFF
--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -38,13 +38,6 @@ export function benchmark<T>(
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
-/**
- * @missingRailsCall logger — CONVERGEABLE (story
- *   `benchmarkable-should-mix-in-logger-reader`): Rails reads the mixin's
- *   `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared
- *   free function whose host passes the logger in as its first parameter, so
- *   there is no `logger` reader to call.
- */
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -572,6 +572,7 @@ class ApiExtractor
           fqn = current_fqn
           @classes[fqn] ||= new_class_info(const_name_str, fqn)
           @classes[fqn][:superclass] = "Struct"
+          synthesize_struct_members(fqn, struct_call)
           walk_body(body)
           @visibility_stack.pop
           @namespace_stack.pop
@@ -623,6 +624,7 @@ class ApiExtractor
     fqn = current_fqn
     @classes[fqn] ||= new_class_info(name, fqn)
     @classes[fqn][:superclass] = superclass if superclass
+    synthesize_struct_members(fqn, node[2]) if superclass == "Struct"
 
     body = node[3] || node[2]
     @attr_names_stack.push(collect_attr_declarations(body))
@@ -632,6 +634,43 @@ class ApiExtractor
     @module_function_stack.pop
     @visibility_stack.pop
     @namespace_stack.pop
+  end
+
+  # `class Attribute < Struct.new :relation, :name` (arel/attributes/attribute.rb:5)
+  # generates a reader and a writer per member plus an `initialize` taking the
+  # members positionally, none of which appear in the source as `def`s. Without
+  # them the ported TS fields have no Ruby counterpart in the same file and score
+  # as extra/moved surface.
+  def synthesize_struct_members(fqn, struct_new_node)
+    target = @classes[fqn]
+    return unless target
+    names = extract_symbol_args(struct_new_node)
+    return if names.empty?
+
+    names.each do |name|
+      target[:instanceMethods] << {
+        name: name,
+        visibility: "public",
+        params: [],
+        file: @current_file,
+        line: @current_line,
+        reader: true,
+      }
+      target[:instanceMethods] << {
+        name: "#{name}=",
+        visibility: "public",
+        params: [{ name: "value", kind: "required" }],
+        file: @current_file,
+        line: @current_line,
+      }
+    end
+    target[:instanceMethods] << {
+      name: "initialize",
+      visibility: "public",
+      params: names.map { |name| { name: name, kind: "optional" } },
+      file: @current_file,
+      line: @current_line,
+    }
   end
 
   def process_sclass(node)

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -663,11 +663,13 @@ class ApiExtractor
         line: @current_line,
       }
     end
+    # Both arms are optional: `Struct.new(:a, :b).new` and its keyword_init
+    # twin both accept zero arguments, leaving the members nil.
     kind = keyword_init?(struct_new_node) ? "keyword" : "optional"
     target[:instanceMethods] << {
       name: "initialize",
       visibility: "public",
-      params: names.map { |name| { name: name, kind: kind } },
+      params: names.map { |name| { name: name, kind: kind, default: "..." } },
       file: @current_file,
       line: @current_line,
     }

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -637,10 +637,9 @@ class ApiExtractor
   end
 
   # `class Attribute < Struct.new :relation, :name` (arel/attributes/attribute.rb:5)
-  # generates a reader and a writer per member plus an `initialize` taking the
-  # members positionally, none of which appear in the source as `def`s. Without
-  # them the ported TS fields have no Ruby counterpart in the same file and score
-  # as extra/moved surface.
+  # generates a reader and a writer per member, plus an `initialize` taking the
+  # members positionally (by keyword under `keyword_init: true`). None of them
+  # appear in the source as `def`s.
   def synthesize_struct_members(fqn, struct_new_node)
     target = @classes[fqn]
     return unless target
@@ -664,13 +663,27 @@ class ApiExtractor
         line: @current_line,
       }
     end
+    kind = keyword_init?(struct_new_node) ? "keyword" : "optional"
     target[:instanceMethods] << {
       name: "initialize",
       visibility: "public",
-      params: names.map { |name| { name: name, kind: "optional" } },
+      params: names.map { |name| { name: name, kind: kind } },
       file: @current_file,
       line: @current_line,
     }
+  end
+
+  # True for `Struct.new(:a, :b, keyword_init: true)`, whose generated
+  # `initialize` takes the members as keywords rather than positionally.
+  def keyword_init?(node)
+    return false unless node.is_a?(Array)
+    if node[0] == :assoc_new && node[1].is_a?(Array) && node[1][0] == :@label &&
+       node[1][1] == "keyword_init:"
+      value = node[2]
+      return value.is_a?(Array) && value[0] == :var_ref &&
+             value[1].is_a?(Array) && value[1][1] == "true"
+    end
+    node.any? { |child| child.is_a?(Array) && keyword_init?(child) }
   end
 
   def process_sclass(node)

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1534,6 +1534,56 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     expect(urlHelpers.params.map((p) => p.kind)).toEqual(["optional"]);
   });
 
+  // `class Attribute < Struct.new :relation, :name`
+  // (activerecord/lib/arel/attributes/attribute.rb:5) generates the member
+  // accessors and an `initialize`; none of them appear in the source as `def`s.
+  it("synthesizes the accessors and initialize a Struct.new superclass generates", () => {
+    const m = metaMethods(`
+      module Arel
+        class Attribute < Struct.new :relation, :name
+          def type_caster
+            relation.type_for_attribute(name)
+          end
+        end
+      end
+    `);
+    expect(m["Arel::Attribute"].map((x) => x.name).sort()).toEqual([
+      "initialize",
+      "name",
+      "name=",
+      "relation",
+      "relation=",
+      "type_caster",
+    ]);
+    const init = m["Arel::Attribute"].find((x) => x.name === "initialize")!;
+    expect(init.params).toEqual([
+      { name: "relation", kind: "optional" },
+      { name: "name", kind: "optional" },
+    ]);
+    const reader = m["Arel::Attribute"].find((x) => x.name === "relation")!;
+    expect(reader.params).toEqual([]);
+  });
+
+  it("synthesizes the accessors a `CONST = Struct.new(...) do ... end` generates", () => {
+    const m = metaMethods(`
+      module Arel
+        Edge = Struct.new(:name, :from) do
+          def to_s
+            name
+          end
+        end
+      end
+    `);
+    expect(m["Arel::Edge"].map((x) => x.name).sort()).toEqual([
+      "from",
+      "from=",
+      "initialize",
+      "name",
+      "name=",
+      "to_s",
+    ]);
+  });
+
   it("unrolls a literal-array each loop that interpolates the loop variable", () => {
     const m = metaMethods(`
       module ClassMethods

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1534,9 +1534,6 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     expect(urlHelpers.params.map((p) => p.kind)).toEqual(["optional"]);
   });
 
-  // `class Attribute < Struct.new :relation, :name`
-  // (activerecord/lib/arel/attributes/attribute.rb:5) generates the member
-  // accessors and an `initialize`; none of them appear in the source as `def`s.
   it("synthesizes the accessors and initialize a Struct.new superclass generates", () => {
     const m = metaMethods(`
       module Arel
@@ -1562,6 +1559,20 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     ]);
     const reader = m["Arel::Attribute"].find((x) => x.name === "relation")!;
     expect(reader.params).toEqual([]);
+  });
+
+  it("synthesizes keyword params for a keyword_init Struct's initialize", () => {
+    const m = metaMethods(`
+      module ActiveSupport
+        class Report < Struct.new(:error, :severity, keyword_init: true)
+        end
+      end
+    `);
+    const init = m["ActiveSupport::Report"].find((x) => x.name === "initialize")!;
+    expect(init.params).toEqual([
+      { name: "error", kind: "keyword" },
+      { name: "severity", kind: "keyword" },
+    ]);
   });
 
   it("synthesizes the accessors a `CONST = Struct.new(...) do ... end` generates", () => {

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -1554,8 +1554,8 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     ]);
     const init = m["Arel::Attribute"].find((x) => x.name === "initialize")!;
     expect(init.params).toEqual([
-      { name: "relation", kind: "optional" },
-      { name: "name", kind: "optional" },
+      { name: "relation", kind: "optional", default: "..." },
+      { name: "name", kind: "optional", default: "..." },
     ]);
     const reader = m["Arel::Attribute"].find((x) => x.name === "relation")!;
     expect(reader.params).toEqual([]);
@@ -1570,8 +1570,8 @@ describe("Ruby extractor metaprogrammed method surface", () => {
     `);
     const init = m["ActiveSupport::Report"].find((x) => x.name === "initialize")!;
     expect(init.params).toEqual([
-      { name: "error", kind: "keyword" },
-      { name: "severity", kind: "keyword" },
+      { name: "error", kind: "keyword", default: "..." },
+      { name: "severity", kind: "keyword", default: "..." },
     ]);
   });
 


### PR DESCRIPTION
`class Attribute < Struct.new :relation, :name` (`vendor/rails/activerecord/lib/arel/attributes/attribute.rb:5`) generates a reader and a writer per member plus an `initialize`, and none of them appear in the source as `def`s. `extract-ruby-api.rb` already resolved the superclass to `Struct` but recorded no members, so `attribute.ts`'s `relation` / `name` / `constructor` matched some other .rb file and scored as *moved* extra surface.

The extractor now synthesizes those members for both Struct shapes it already recognizes: `class X < Struct.new(...)` and `CONST = Struct.new(...) do ... end`.

## Result

`pnpm parity:api:extra --package arel`, `attributes/attribute.ts`: **2 novel, 5 moved → 2 novel, 2 moved**. `relation`, `name` and `constructor` are gone; the two remaining moved rows (`tableAlias`, `typeForAttribute`) are members of the structural `RelationLike` interface in the same file, not of `Attribute`.

Per-package extra-surface totals (before → after), all downward:

| Package | Novel | Moved | Total |
| --- | --- | --- | --- |
| activerecord | 264 → 264 | 532 → 529 | 1986 → 1974 |
| activesupport | 123 → 122 | 420 → 420 | 1303 → 1302 |
| trailties | 94 → 94 | 211 → 209 | 422 → 421 |
| activerecord-test-support | 32 → 32 | 103 → 102 | 144 → 144 |
| activemodel | 50 → 50 | 94 → 94 | 269 → 268 |
| actioncontroller | 39 → 39 | 84 → 84 | 239 → 236 |
| rack | 19 → 18 | 52 → 52 | 141 → 139 |
| arel | 34 → 34 | 10 → 10 | 83 → 78 |

`pnpm parity:api` matched methods rise (13433 → 13480 overall; arel 952/952 → 957/957). The extractor also surfaces 12 previously invisible *missing* rows in activerecord (data layer 100% → 99.8%): the Struct members of `ExclusionConstraintDefinition` / `UniqueConstraintDefinition`, `ReversibleBlockHelper#reverting`, `BelongsToAssociation#primary_key`, `Preloader::Batch#loaders`. Those are real gaps in two flavours — `extract-ts-api.ts` does not record TS constructor parameter properties (`constructor(readonly tableName: string, …)`, `schema-definitions.ts:108`), and the writer half is absent where the TS field is `readonly`. Out of scope here; filed as `0117-arel-extra-surface-burndown/struct-member-missing-rows-in-activerecord`.

`pnpm vitest run scripts/api-compare` green (1295 tests); `parity:api:calls` and `parity:api:calls:args` ratchets OK.

Closes-story: struct-members-not-extracted-as-ruby-methods

## Notes

- Verified against MRI (`ruby -e 'S=Struct.new(:a,:b); p S.instance_methods(false)'` → `[:a, :a=, :b, :b=]`), so the reader/writer pair per member is synthesized, not just the reader.
- `Struct.new(:a, :b, keyword_init: true)` (`activesupport/lib/active_support/testing/error_reporter_assertions.rb:10`) generates an `initialize` taking the members as keywords; that arm is handled too.
- One modelling choice: MRI reports the generated `initialize` as `[[:rest]]` (a C function with arity -1). It is recorded here as one optional positional param per member — the documented member API, and the shape the arity check can actually compare against (`arel` arity stays 100%, 694/694 → 695/695).


## Review round 1

- **Keyword-init members are optional, not required** (reviewer finding on `extract-ruby-api.rb:666`). Confirmed against MRI: `ruby -e 'S=Struct.new(:a,:b,keyword_init:true); p S.new'` → `#<struct S a=nil, b=nil>`. Both arms now carry `default: "..."`, the file's own optional-param shape (`extract-ruby-api.rb:130-136`), so `arity.ts:251` no longer reads them as required. `arel` arity stays 695/695 (100%); the ratchets and `pnpm vitest run scripts/api-compare` (1298) are green.
- Rebased on current `main` and dropped the now-stale `@missingRailsCall logger` tag in `benchmarkable.ts` (landed by #6873): `benchmark` reads `this?.logger`, so the call is no longer flagged and the tag reds the call-mismatches ratchet on `main` as it stands. Deleting it is the remedy the gate prescribes; the deviation story it cited stays open.
