### PR TITLE
fix(api-compare): record constructor parameter properties as class members

### DIFF
--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1191,10 +1191,6 @@ describe("extractFileLocalHelpers", () => {
 });
 
 describe("extractClass — constructor parameter properties", () => {
-  // `ExclusionConstraintDefinition = Struct.new(:table_name, :expression, :options)`
-  // (postgresql/schema_definitions.rb:192) generates a reader and a writer per
-  // member; the port spells them as constructor parameter properties
-  // (schema-definitions.ts:108).
   it("records a parameter property as a member of the class", () => {
     const info = extractFromSource(`
       export class Foo {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1190,6 +1190,49 @@ describe("extractFileLocalHelpers", () => {
   });
 });
 
+describe("extractClass — constructor parameter properties", () => {
+  // `ExclusionConstraintDefinition = Struct.new(:table_name, :expression, :options)`
+  // (postgresql/schema_definitions.rb:192) generates a reader and a writer per
+  // member; the port spells them as constructor parameter properties
+  // (schema-definitions.ts:108).
+  it("records a parameter property as a member of the class", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        constructor(
+          readonly tableName: string,
+          public expression: string,
+          options: object,
+        ) {}
+      }
+    `);
+    const names = info.instanceMethods.map((m) => m.name);
+    expect(names).toContain("tableName");
+    expect(names).toContain("expression");
+    expect(names).not.toContain("options");
+    const tableName = info.instanceMethods.find((m) => m.name === "tableName")!;
+    expect(tableName.visibility).toBe("public");
+    expect(tableName.params).toEqual([]);
+    expect(tableName.internal).toBeUndefined();
+  });
+
+  it("tags a `private` / `protected` parameter property with its visibility", () => {
+    const info = extractFromSource(`
+      export class Foo {
+        constructor(
+          private conn: object,
+          protected owner: object,
+        ) {}
+      }
+    `);
+    const conn = info.instanceMethods.find((m) => m.name === "conn")!;
+    expect(conn.visibility).toBe("private");
+    expect(conn.internal).toBe(true);
+    const owner = info.instanceMethods.find((m) => m.name === "owner")!;
+    expect(owner.visibility).toBe("protected");
+    expect(owner.internal).toBe(true);
+  });
+});
+
 describe("extractClass — internal tagging", () => {
   it("emits public members without the internal flag", () => {
     const info = extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2260,12 +2260,6 @@ export function extractClass(
         ...(callArgs !== undefined ? { callArgs } : {}),
         ...(skeleton !== undefined ? { skeleton } : {}),
       });
-      // A constructor parameter property (`constructor(readonly tableName: string)`)
-      // declares a field of the class as surely as a `readonly tableName: string`
-      // in the class body does — it is how the ports spell the members a Ruby
-      // `Struct.new(:table_name, ...)` superclass generates
-      // (postgresql/schema_definitions.rb:192). Record each one as its own member
-      // so the Ruby reader/writer has a counterpart in the file that declares it.
       for (const param of member.parameters) {
         if (!ts.isIdentifier(param.name)) continue;
         const paramVisibility = parameterPropertyVisibility(param);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -2260,6 +2260,26 @@ export function extractClass(
         ...(callArgs !== undefined ? { callArgs } : {}),
         ...(skeleton !== undefined ? { skeleton } : {}),
       });
+      // A constructor parameter property (`constructor(readonly tableName: string)`)
+      // declares a field of the class as surely as a `readonly tableName: string`
+      // in the class body does — it is how the ports spell the members a Ruby
+      // `Struct.new(:table_name, ...)` superclass generates
+      // (postgresql/schema_definitions.rb:192). Record each one as its own member
+      // so the Ruby reader/writer has a counterpart in the file that declares it.
+      for (const param of member.parameters) {
+        if (!ts.isIdentifier(param.name)) continue;
+        const paramVisibility = parameterPropertyVisibility(param);
+        if (paramVisibility === undefined) continue;
+        instanceMethods.push({
+          name: param.name.text,
+          visibility: paramVisibility,
+          params: [],
+          line: param.getSourceFile().getLineAndCharacterOfPosition(param.getStart()).line + 1,
+          file,
+          isStatic: false,
+          ...(paramVisibility !== "public" || hasInternalJsDocTag(param) ? { internal: true } : {}),
+        });
+      }
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
       const calls = extractCalls(member.body);
       const callSeq = extractCallSeq(member.body);
@@ -3672,6 +3692,25 @@ function memberVisibility(member: ts.ClassElement): "public" | "private" | "prot
   if (hasModifier(member, ts.SyntaxKind.ProtectedKeyword)) return "protected";
   if (member.name && ts.isPrivateIdentifier(member.name)) return "private";
   return "public";
+}
+
+/**
+ * The visibility of a constructor parameter property — a parameter carrying an
+ * accessibility modifier or `readonly`, which TypeScript turns into a field of
+ * the class. `undefined` for an ordinary parameter, which declares nothing.
+ */
+function parameterPropertyVisibility(
+  param: ts.ParameterDeclaration,
+): "public" | "private" | "protected" | undefined {
+  if (hasModifier(param, ts.SyntaxKind.PrivateKeyword)) return "private";
+  if (hasModifier(param, ts.SyntaxKind.ProtectedKeyword)) return "protected";
+  if (
+    hasModifier(param, ts.SyntaxKind.PublicKeyword) ||
+    hasModifier(param, ts.SyntaxKind.ReadonlyKeyword)
+  ) {
+    return "public";
+  }
+  return undefined;
 }
 
 function isExported(node: ts.Node): boolean {


### PR DESCRIPTION
`extract-ts-api.ts` walked class members but never the constructor's parameter
properties, so `constructor(readonly tableName: string, ...)` declared a field
the extractor could not see. That is how the ports spell the members a Ruby
`Struct.new(:table_name, :expression, :options)` superclass generates
(`vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:192`,
`:214`; `migration.rb:873`), and once `extract-ruby-api.rb` synthesizes those
accessors (#6878) each one reads as a missing method.

Each parameter carrying `readonly` or an accessibility modifier is now recorded
as an instance member at its own visibility (`private` / `protected` ⇒
`internal: true`, as for a body-declared field); a plain parameter still
declares nothing.

## The writer half

No `setX()` writers were added. A Ruby `name=` writer resolves to the bare camel
accessor first (`scripts/parity/conventions.ts:1554-1570`), so recording the
parameter property answers the Struct's reader and its writer with the one name
the port actually has — and none of these members is ever written in Rails
(`grep '\.table_name = |\.expression = |\.reverting = |\.column = '` over
`activerecord/lib` hits only `CommandRecorder#reverting=` and
`Base.table_name=`, neither of them a Struct member). Adding a mutating setter
no caller uses would be invented surface.

## Result

Measured with #6878's Ruby-side synthesis applied locally, since that is what
surfaces the rows:

- `pnpm parity:api --package activerecord`: 6192/6204 → **6202/6204**, back to
  the pre-RFC-0117 count of 2 missing (`BelongsToAssociation#primary_key`,
  `Preloader::Batch#loaders` — both pre-existing on `main`). The 10 rows that
  clear are `ExclusionConstraintDefinition`'s `table_name` / `expression` /
  `options` (+ writers), `UniqueConstraintDefinition`'s `column` (+ writer), and
  `ReversibleBlockHelper`'s `reverting` (+ writer).
- On this branch alone (`main`'s Ruby extractor): overall matched methods
  13433 → **13437**; extra-surface totals rise where a parameter property is now
  visible surface (activerecord 1986 → 1997), which #6878 is what settles.
- `pnpm vitest run scripts/api-compare` green (1295 tests); `parity:api:calls`
  and `parity:api:calls:args` ratchets OK; extra-surface tag gate exit 0.

Closes-story: struct-member-missing-rows-in-activerecord
