### PR TITLE
fix(activesupport): drop stale @missingRailsCall logger tag on benchmark

### DIFF
--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -38,13 +38,6 @@ export function benchmark<T>(
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
-/**
- * @missingRailsCall logger — CONVERGEABLE (story
- *   `benchmarkable-should-mix-in-logger-reader`): Rails reads the mixin's
- *   `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared
- *   free function whose host passes the logger in as its first parameter, so
- *   there is no `logger` reader to call.
- */
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,


### PR DESCRIPTION
The `Rails API/Test Comparison` job is red on main @4ac7d0f7: the call-mismatches ratchet reports

```
call-mismatches ratchet: 1 STALE @missingRailsCall tag(s) whose call is no longer flagged.
  - activesupport  benchmarkable.ts  benchmark  logger
```

#6870 mixed `Benchmarkable` into its hosts, so `benchmark()` now reads `this?.logger` — the mixin's `logger` reader (`activesupport/lib/active_support/benchmarkable.rb:38,44,46`). The tag's premise (the logger arrives as a parameter, so there is no reader to call) no longer holds, and a justification only shrinks: the tag is deleted rather than reworded.

Verified locally after `pnpm build`:
- `pnpm parity:api:calls` — OK (653 baselined, 331 unreviewed, 122 marks totalling 331 tight)
- `pnpm parity:api:calls:args` — OK (157 baselined shape rows)
- reseed-drift check — clean, no baseline changes

Closes-story: red-4ac7d0f7