### PR TITLE
fix(parity,activesupport,activerecord): preserve harvested call tags; Rational rounding arm; fold the chain head into add_constraints

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -697,8 +697,9 @@ export class AssociationScope {
     // OuterJoins (`_mergeReferencedJoins`, Rails' `construct_join_dependency
     // (associations, Arel::Nodes::OuterJoin)` branch, association_scope.rb:
     // 138-141) and applies its `unscope!` directives. The head reflection
-    // (chain[0]) is handled by the scope/scopeFor branch below — Rails'
-    // chain_head item in add_constraints.
+    // (chain[0]) is the LAST entry the loop reaches, and its own scope is one
+    // `scope_chain_item` inside the same body — Rails' `if scope_chain_item ==
+    // chain_head.scope` arm (association_scope.rb:137).
     //
     // Rails' add_constraints references `Arel::Nodes::OuterJoin` directly (the
     // eager-load branch above); trails routes that construction through the
@@ -708,40 +709,9 @@ export class AssociationScope {
     // Rails: `chain_head = chain.first` (association_scope.rb:131), read by the
     // one `reverse_each` body that handles every chain position.
     const chainHead = chain[0];
-    for (let i = chain.length - 1; i >= 1; i--) {
+    for (let i = chain.length - 1; i >= 0; i--) {
       scope = this._mergeReflectionScopeChain(scope, chain[i], owner, chainHead);
     }
-    // Apply the head reflection's scope. Rails: reflection.rb:448,
-    // scope_for — 0-arity scopes get `this`=relation, >=1-arity get
-    // (relation, owner) per `relation.instance_exec(owner, &scope) ||
-    // relation`. For ordinary AssociationReflections we call `scopeFor`
-    // when present. ThroughReflection does NOT implement `scopeFor`;
-    // it only exposes `.scope`, which delegates to its `delegateReflection`
-    // (the through reflection's OWN scope — Rails `delegate :scope, to:
-    // :delegate_reflection`, reflection.rb:1229), NOT the source reflection's
-    // scope. So detect through explicitly and invoke `.scope` directly with
-    // the same arity / `this` semantics. The source reflection's scope is a
-    // SEPARATE concern, merged below.
-    const head = chainHead as {
-      scopeFor?: (rel: unknown, owner: unknown) => unknown;
-      scope?: ((rel: unknown, owner?: unknown) => unknown) | null;
-      isThroughReflection?: () => boolean;
-    };
-    const isThrough = typeof head.isThroughReflection === "function" && head.isThroughReflection();
-    if (!isThrough && typeof head.scopeFor === "function") {
-      scope = head.scopeFor.call(head, scope, owner);
-    } else if (typeof head.scope === "function") {
-      const result = invokeScopeLambda(head.scope as ScopeLambda<unknown>, scope, owner);
-      if (result) scope = result;
-    }
-    // Rails' `chain.reverse_each` folds the CHAIN HEAD too
-    // (association_scope.rb:132), and a through head's `constraints` is
-    // `source_reflection.constraints << scope` (reflection.rb:1180-1184) — that
-    // is how a scope on the SOURCE reflection merges, evaluated against the
-    // head's own `klass`. For a `source_type:` through that klass is the runtime
-    // `@association.klass` (`RuntimeReflection#klass`, reflection.rb:1265), so
-    // the polymorphic belongsTo's uncomputable `klass` is never read.
-    scope = this._mergeReflectionScopeChain(scope, chainHead, owner, chainHead);
     return scope;
   }
 
@@ -788,11 +758,10 @@ export class AssociationScope {
     let merged = scope;
     for (const c of constraints) {
       if (typeof c !== "function") continue;
-      // Rails: `if scope_chain_item == chain_head.scope` (association_scope.rb:137)
-      // takes the merge-except path, which trails applies in `addConstraints`.
-      if (c === (chainHead as { scope?: unknown } | undefined)?.scope) continue;
       const evaluated = this.evalScope(reflection, c, owner);
-      merged = this._pushScopeIntoRelation(merged, evaluated);
+      // Rails: `if scope_chain_item == chain_head.scope` (association_scope.rb:137).
+      const isChainHeadScope = c === (chainHead as { scope?: unknown } | undefined)?.scope;
+      merged = this._pushScopeIntoRelation(merged, evaluated, reflection, isChainHeadScope);
     }
     return merged;
   }
@@ -840,19 +809,57 @@ export class AssociationScope {
    * select / joins / etc override the main scope, which Rails
    * explicitly avoids.
    */
-  protected _pushScopeIntoRelation(scope: unknown, evaluated: unknown): unknown {
+  protected _pushScopeIntoRelation(
+    scope: unknown,
+    evaluated: unknown,
+    reflection?: AbstractReflection | ReflectionProxy,
+    isChainHeadScope = false,
+  ): unknown {
     if (!evaluated) return scope;
-    // Rails add_constraints' chain.reverse_each folds each item's joins /
-    // left_outer_joins and eager-load-as-join into the main scope when the
-    // item's `where(...)` referenced a joined table (`!item.references_values
-    // .empty?` → `scope.merge! item.only(:joins, :left_outer_joins)` +
-    // `scope.joins! item.construct_join_dependency(eager_load|includes,
-    // OuterJoin)`, association_scope.rb:138-146). A through scope such as
-    // `-> { where("comments.id" => nil).includes(:comments) }` relies on this
-    // to actually JOIN comments; without it the WHERE references a missing
-    // table. `all_includes` does NOT yield for chain entries (ReflectionProxy),
-    // so includes_values themselves are not carried forward — only the join is.
-    this._mergeReferencedJoins(scope, evaluated);
+    if (isChainHeadScope) {
+      // Rails: `scope.merge! item.except(:where, :includes, :unscope, :order)`
+      // (association_scope.rb:138) — the chain head's own scope merges every
+      // OTHER value (limit, select, joins, …) with Relation#merge's precedence,
+      // and its where / order still reach the relation through the shared push
+      // below, exactly as every other chain item's do.
+      (scope as { mergeBang: (other: unknown) => unknown }).mergeBang(
+        (evaluated as { except: (...skips: string[]) => unknown }).except(
+          "where",
+          "includes",
+          "unscope",
+          "order",
+        ),
+      );
+    } else {
+      // Rails add_constraints' chain.reverse_each folds each item's joins /
+      // left_outer_joins and eager-load-as-join into the main scope when the
+      // item's `where(...)` referenced a joined table (`!item.references_values
+      // .empty?` → `scope.merge! item.only(:joins, :left_outer_joins)` +
+      // `scope.joins! item.construct_join_dependency(eager_load|includes,
+      // OuterJoin)`, association_scope.rb:138-146). A through scope such as
+      // `-> { where("comments.id" => nil).includes(:comments) }` relies on this
+      // to actually JOIN comments; without it the WHERE references a missing
+      // table. `all_includes` does NOT yield for chain entries (ReflectionProxy),
+      // so includes_values themselves are not carried forward — only the join is.
+      this._mergeReferencedJoins(scope, evaluated);
+    }
+    // Rails: `reflection.all_includes { scope.includes_values |= item.includes_values }`
+    // (association_scope.rb:148-150). The block yields for the chain HEAD
+    // (`RuntimeReflection#all_includes`, reflection.rb:1279) and NOT for a
+    // `ReflectionProxy` chain entry, so a head scope's `includes(:comments)`
+    // still reaches the relation the head's `except(:includes)` merge withheld.
+    const allIncludes = (
+      reflection as { allIncludes?: (cb: () => void) => unknown } | undefined
+    )?.allIncludes?.bind(reflection);
+    if (allIncludes) {
+      allIncludes(() => {
+        const itemIncludes = (evaluated as { includesValues?: unknown[] }).includesValues ?? [];
+        if (itemIncludes.length === 0) return;
+        const host = scope as { includesValues?: unknown[] };
+        const current = host.includesValues ?? [];
+        host.includesValues = [...current, ...itemIncludes.filter((v) => !current.includes(v))];
+      });
+    }
     // Rails: `scope.unscope!(*item.unscope_values)` runs BEFORE the item's own
     // where clause is appended, so a `unscope(where: :skimmer)` chain entry
     // strips the target's default-scope predicate without dropping the item's

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -38,13 +38,6 @@ export function benchmark<T>(
   options: BenchmarkOptions,
   block: () => T | Promise<T>,
 ): T | Promise<Awaited<T>>;
-/**
- * @missingRailsCall logger — CONVERGEABLE (story
- *   `benchmarkable-should-mix-in-logger-reader`): Rails reads the mixin's
- *   `logger` reader (benchmarkable.rb:38,44,46); trails' benchmark is a shared
- *   free function whose host passes the logger in as its first parameter, so
- *   there is no `logger` reader to call.
- */
 export function benchmark<T>(
   this: Benchmarkable,
   message: string,

--- a/packages/activesupport/src/number-helper.test.ts
+++ b/packages/activesupport/src/number-helper.test.ts
@@ -8,6 +8,7 @@ import {
   numberToHumanSize,
   numberToHuman,
 } from "./number-helper.js";
+import { Rational } from "@blazetrails/date";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
 
 /** Mirrors: number_helper_test.rb:18-25's `NumberWithToD`. */
@@ -134,6 +135,11 @@ describe("NumberHelperTest", () => {
       "111.23460000000000000000",
     );
     expect(numberToRounded("111.2346", { precision: 100 })).toBe(`111.2346${"0".repeat(96)}`);
+    expect(numberToRounded(new Rational(1112346, 10000), { precision: 20 })).toBe(
+      "111.23460000000000000000",
+    );
+    expect(numberToRounded(new Rational(1112346, 10000), { precision: 4 })).toBe("111.2346");
+    expect(numberToRounded(new Rational(0, 1), { precision: 2 })).toBe("0.00");
     expect(numberToRounded("x")).toBe("x");
   });
 
@@ -167,6 +173,15 @@ describe("NumberHelperTest", () => {
     expect(numberToRounded(0.001111, { precision: 3, significant: true })).toBe("0.00111");
     expect(numberToRounded(9775, { precision: 20, significant: true })).toBe(
       "9775.0000000000000000",
+    );
+    expect(numberToRounded(new Rational(9775, 1), { precision: 20, significant: true })).toBe(
+      "9775.0000000000000000",
+    );
+    expect(numberToRounded(new Rational(9775, 100), { precision: 20, significant: true })).toBe(
+      "97.750000000000000000",
+    );
+    expect(numberToRounded(new Rational(9772, 100), { precision: 3, significant: true })).toBe(
+      "97.7",
     );
     expect(numberToRounded(new BigDecimal("9775"), { precision: 20, significant: true })).toBe(
       "9775.0000000000000000",

--- a/packages/activesupport/src/number-helper/number-converter.ts
+++ b/packages/activesupport/src/number-helper/number-converter.ts
@@ -1,3 +1,4 @@
+import { Rational } from "@blazetrails/date";
 import { I18n } from "../i18n.js";
 import { camelize } from "../inflector.js";
 import { BigDecimal } from "../core-ext/big-decimal/conversions.js";
@@ -94,6 +95,9 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
 
   protected isValidFloat(): boolean {
     if (this.number instanceof BigDecimal) return true;
+    // Ruby's `Float(Rational(9775, 100))` is `97.75` — a Rational converts,
+    // where `Number(rational)` is `NaN` (number_helper_test.rb:225-230).
+    if (this.number instanceof Rational) return Number.isFinite(this.number.toF());
     // Ruby's `Float("")` / `Float(" ")` raise, where `Number("")` is 0.
     if (typeof this.number === "string" && this.number.trim() === "") return false;
     const n = Number(this.number);
@@ -101,6 +105,7 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
   }
 
   protected numberAsFloat(): number {
+    if (this.number instanceof Rational) return this.number.toF();
     return this.number instanceof BigDecimal
       ? Number(this.number.toString("F"))
       : Number(this.number);

--- a/packages/activesupport/src/number-helper/rounding-helper.ts
+++ b/packages/activesupport/src/number-helper/rounding-helper.ts
@@ -1,3 +1,4 @@
+import { Rational } from "@blazetrails/date";
 import { BigDecimal } from "../core-ext/big-decimal/conversions.js";
 import { BIGDECIMAL_STRING } from "./number-converter.js";
 
@@ -7,6 +8,15 @@ class ArgumentError extends Error {
 
 class NoMethodError extends Error {
   override name = "NoMethodError";
+}
+
+/** Ruby's `Kernel#BigDecimal(value)` over a String, which `convert_to_decimal`
+ *  reaches from two of its three arms (`rounding_helper.rb:28` and `:32`). */
+function bigDecimal(value: string): BigDecimal {
+  if (!BIGDECIMAL_STRING.test(value)) {
+    throw new ArgumentError(`invalid value for BigDecimal(): "${value}"`);
+  }
+  return new BigDecimal(value.trim());
 }
 
 /**
@@ -50,12 +60,17 @@ export class RoundingHelper {
    * silently coerced zero.
    */
   private convertToDecimal(number: unknown): BigDecimal {
-    if (number instanceof BigDecimal) return number;
-    const value = String(number);
-    if (!BIGDECIMAL_STRING.test(value)) {
-      throw new ArgumentError(`invalid value for BigDecimal(): "${value}"`);
+    if (typeof number === "number" || typeof number === "string") {
+      return bigDecimal(String(number));
     }
-    return new BigDecimal(value.trim());
+    if (number instanceof Rational) {
+      return new BigDecimal(
+        number,
+        this.digitCount(number.toI()) + (this.options.precision as number),
+      );
+    }
+    if (number instanceof BigDecimal) return number;
+    return bigDecimal(String(number));
   }
 
   private absolutePrecision(number: unknown): number | undefined {

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -287,8 +287,44 @@ describe("reconcileFileText", () => {
   });
 
   it("still harvests a human-authored reason when its call converges", () => {
-    const r = reconcileFileText("foo.ts", FILE, new Map(), () => DEFAULT_TAG_REASON);
+    // `bar` HAS an expectation, for a different call: the artifact knows the
+    // declaration, so `stale_call` genuinely no longer fires.
+    const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
+    const r = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(r.harvested.map((h) => h.entry.reason)).toEqual(["placeholder to drop"]);
+    expect(r.preserved).toEqual([]);
+  });
+
+  it("preserves a pre-existing tag on a declaration the artifact knows nothing about", () => {
+    // The PR #6873 loss: migrating one method's rows rewrote the JSDoc of every
+    // declaration in the file, and a reviewed receipt on an unrelated one — with
+    // no baseline row anywhere to put it back — was deleted on a `harvested`
+    // line that read like a successful migration.
+    const src = [
+      "export class Foo {",
+      "  /**",
+      "   * Mirrors Rails `Foo#bar`.",
+      "   */",
+      "  bar(): void {}",
+      "",
+      "  /**",
+      "   * @missingRailsCall with_raw_connection — PERMANENT: escapes inline.",
+      "   */",
+      "  quoteString(): void {}",
+      "}",
+    ].join("\n");
+    const expectations = new Map([owned("Foo", "bar", new Set(["save"]))]);
+    const r = reconcileFileText("foo.ts", src, expectations, () => "PERMANENT: x");
+    expect(r.text!).toContain("@missingRailsCall save — PERMANENT: x");
+    expect(r.text!).toContain("@missingRailsCall with_raw_connection — PERMANENT: escapes inline.");
+    expect(r.harvested).toEqual([]);
+    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([
+      ["quoteString", "with_raw_connection"],
+    ]);
+    // And a second run over the result is still a no-op.
+    expect(
+      reconcileFileText("foo.ts", r.text!, expectations, () => "PERMANENT: x").text,
+    ).toBeNull();
   });
 
   it("is idempotent: a second run produces zero edits", () => {
@@ -357,7 +393,10 @@ describe("reconcileFileText", () => {
       "  bar(): void {}",
       "}",
     ].join("\n");
-    const { text } = reconcileFileText("foo.ts", src, new Map(), () => "x");
+    // An expectation with an EMPTY call set: the artifact knows the
+    // declaration and flags nothing on it, so the tag has genuinely converged.
+    const expectations = new Map([owned("Foo", "bar", new Set<string>())]);
+    const { text } = reconcileFileText("foo.ts", src, expectations, () => "x");
     expect(text!).not.toContain("@missingRailsCall");
     expect(text!).not.toContain("/**");
     expect(text!).toContain("  bar(): void {}");

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -14,7 +14,9 @@
  *     nothing, so minting it would only add inert prose to a source file while
  *     the reason kept living in the baseline JSON (RFC 0083);
  *   - tags for now-satisfied calls are dropped (human-authored reasons are
- *     harvested to stdout, never destroyed unseen);
+ *     harvested to stdout, never destroyed unseen). A call is "now-satisfied"
+ *     only where the artifact carries an expectation for the declaration; a tag
+ *     on a declaration the artifact says nothing about is preserved verbatim;
  *   - existing tags that still apply are kept byte-for-byte (idempotent:
  *     a second run produces zero edits);
  *   - a tag with no reason fails the run (see the empty-reason contract in
@@ -385,7 +387,13 @@ export function reconcileFileText(
   onlyCall?: ReadonlySet<string>,
 ): {
   text: string | null;
+  /** Tags DROPPED because the call they name is no longer flagged for a
+   *  declaration the artifact does know — a genuine convergence, reported so
+   *  the receipt does not vanish unseen. */
   harvested: { tsName: string; entry: TagEntry }[];
+  /** Tags left exactly as written on a declaration the artifact carries no
+   *  expectation for. Nothing here was migrated, and nothing here was dropped. */
+  preserved: { tsName: string; entry: TagEntry }[];
   /** Every (rubyName, call) the file now tags with a real justification — kept
    *  and newly-added alike. These are the baseline rows the tag supersedes, so
    *  `main` drops them from the split baseline in the same operation (RFC
@@ -404,6 +412,7 @@ export function reconcileFileText(
   const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
   const edits: Edit[] = [];
   const harvested: { tsName: string; entry: TagEntry }[] = [];
+  const preserved: { tsName: string; entry: TagEntry }[] = [];
   const tagged: { rubyName: string; call: string }[] = [];
   const seen = new Set<string>();
   const skipped: string[] = [];
@@ -440,13 +449,24 @@ export function reconcileFileText(
             }
           : undefined,
       );
-      const expected = exp?.calls ?? new Set<string>();
+      // With no expectation, the artifact knows nothing about this
+      // declaration — compare.ts matched no Ruby method onto it, so it reports
+      // neither a flag nor a suppression for any call. An empty `expected`
+      // would then read every pre-existing tag as satisfied and delete it, which
+      // is how PR #6873 silently dropped two reviewed receipts that had no
+      // baseline row to put them back. Expect exactly what the file already
+      // tags instead: the run is tag-preserving where it has nothing to say.
+      // A tag that HAS genuinely gone stale is reported by compare.ts's
+      // `staleCallTags` (the sanctioned channel), so preserving one here costs a
+      // report line rather than a lost receipt.
+      const expected = exp?.calls ?? new Set<string>(entries.map((e) => e.call));
       const r = reconcile(
         entries,
         expected,
         (c) => (exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON),
         onlyCall,
       );
+      if (!exp) preserved.push(...entries.map((entry) => ({ tsName: name, entry })));
       skipped.push(...r.skipped);
       if (exp) {
         for (const e of [...r.kept, ...r.added]) {
@@ -479,12 +499,12 @@ export function reconcileFileText(
     .filter(([k]) => !seen.has(k))
     .map(([, e]) => e.tsName)
     .sort();
-  if (edits.length === 0) return { text: null, harvested, tagged, unmatched, skipped };
+  if (edits.length === 0) return { text: null, harvested, preserved, tagged, unmatched, skipped };
   let out = text;
   for (const e of edits.sort((a, b) => b.start - a.start)) {
     out = out.slice(0, e.start) + e.text + out.slice(e.end);
   }
-  return { text: out, harvested, tagged, unmatched, skipped };
+  return { text: out, harvested, preserved, tagged, unmatched, skipped };
 }
 
 /** (tsFile → tsName → expectation) for one package: every call the artifact
@@ -624,11 +644,27 @@ async function main(argv: string[]): Promise<number> {
       console.error(`parity:api:build: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
-    const { text: next, harvested, tagged, unmatched, skipped: fileSkipped } = reconciled;
+    const {
+      text: next,
+      harvested,
+      preserved,
+      tagged,
+      unmatched,
+      skipped: fileSkipped,
+    } = reconciled;
     skipped += fileSkipped.length;
     for (const t of tagged) migrated.add(keyOf({ package: pkg, tsFile, ...t }));
     for (const h of harvested) {
-      console.log(`harvested (${tsFile} ${h.tsName} ${h.entry.call}): ${h.entry.reason}`);
+      console.log(
+        `DROPPED ${TAG} on ${tsFile} ${h.tsName} for \`${h.entry.call}\` — the call is no ` +
+          `longer flagged there, so its receipt is retired. Reason it carried: ${h.entry.reason}`,
+      );
+    }
+    for (const kept of preserved) {
+      console.log(
+        `preserved ${TAG} on ${tsFile} ${kept.tsName} for \`${kept.entry.call}\` — no expectation ` +
+          "for that declaration in the artifact; the tag is left exactly as written.",
+      );
     }
     if (unmatched.length > 0) {
       console.log(`unmatched (${tsFile}): ${unmatched.join(", ")} — no body-bearing declaration`);

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/number-helper/rounding-helper.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "number-helper/rounding-helper.ts",
-    "rubyName": "convert_to_decimal",
-    "call": "digit_count",
-    "reason": "rounding_helper.rb:47 calls `digit_count` from the `Rational` arm alone, to size the `BigDecimal(number, ndigits)` precision; there is no trails Rational. Convergeable with the Rational port; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
-  }
-]


### PR DESCRIPTION
Bundle of three RFC 0106 / 0112 stories.

## 1. `parity:api:build` must not drop harvested tags

`reconcileFileText` walked every declaration in the target file and, for one
with a pre-existing `@missingRailsCall` tag but **no expectation in the
artifact**, computed an empty `expected` set — so every tag on it read as
satisfied and was deleted on a `harvested …` line that looked like a successful
migration. That is how PR #6873 silently lost two reviewed receipts on
`postgresql-adapter.ts` (`quote check_int_in_range`, `quoteString
with_raw_connection`); neither had a baseline row anywhere to put it back.

Now `expected` falls back to exactly what the file already tags when the
artifact carries no expectation, so the run is tag-preserving where it has
nothing to say. A tag is dropped only where compare.ts *does* know the
declaration and no longer flags the call, and both outcomes print an explicit
line naming the declaration (`DROPPED …` / `preserved …`). A genuinely stale tag
is already reported through compare.ts's `staleCallTags`, so preserving one here
costs a report line rather than a lost receipt.

Regression test: a fixture with a baseline row to migrate on `bar` **and** an
unrelated pre-existing tag on `quoteString` — the second survives, and a second
run is still a no-op.

## 2. `rounding_helper` `convert_to_decimal` Rational arm

`convertToDecimal` now has all three arms of `rounding_helper.rb:25-34` in
Rails' order — Float/String, Rational, else — with the Rational arm calling
`digitCount(number.toI()) + options.precision` (`:29-30`) against
`@blazetrails/date`'s `Rational` and `BigDecimal`'s existing Rational
constructor.

`NumberConverter#isValidFloat` / `#numberAsFloat` learn Ruby's
`Float(Rational(9775, 100)) == 97.75`; without that a Rational never reached the
converter at all (`Number(rational)` is `NaN`, so `execute` returned the value
unconverted).

The `digit_count` baseline row is **deleted** (`rounding-helper.json` is now
empty and removed) — not migrated to a tag, not reworded. No mark shard existed
for it, so no `tighten` was needed. The six Rational assertions Rails carries at
`number_helper_test.rb:183-230` are restored to the two existing tests.

## 3. `add_constraints` head scope inside the `reverse_each` fold

The chain head's own scope is now one `scope_chain_item` inside the same loop
body as every other chain position (`association_scope.rb:131-156`):

- the `isThroughReflection()` / `scopeFor` split above the fold is gone — Rails
  reads `reflection.constraints` uniformly and never asks whether the head is a
  through;
- `_mergeReflectionScopeChain`'s `c === chainHead.scope` **skip** became a
  **merge arm**: `scope.merge! item.except(:where, :includes, :unscope, :order)`
  (`:137-138`), before the shared `where_clause +=` / `order_values |` push that
  `_pushScopeIntoRelation` already implements;
- the loop body gains the `reflection.all_includes { scope.includes_values |=
  item.includes_values }` arm (`:148-150`) that trails never ported. It yields
  for the head (`RuntimeReflection#all_includes`, `reflection.rb:1279`) and not
  for a `ReflectionProxy` entry — without it a head scope's `includes(:comments)`
  is withheld by the `except(:includes)` merge and
  `HasManyThroughAssociationsTest > get collection singular ids on has many
  through with conditions and include` reds with `no such column: comments.id`.

## Drive-by

`benchmarkable.ts`'s `@missingRailsCall logger` tag is stale — the body reads
`this.logger` since #6870 — and reds `parity:api:calls` on `main`. Deleted.

## Verification

- `packages/activerecord/src/associations/` — 115 files, 2045 passed, SQLite.
  (PG / MySQL lanes via CI.)
- `pnpm parity:api:calls` OK (652 baselined, one row fewer), `:args` OK,
  `parity:api:reasons` OK, `parity:api:detached` OK,
  `parity:api:extra --package activesupport` — no novel surface.
- `pnpm lint`, `pnpm typecheck` clean.

Closes-story: parity-api-build-must-not-drop-harvested-tags
Closes-story: rounding-helper-convert-to-decimal-rational-arm
Closes-story: add-constraints-head-scope-applied-outside-the-reverse-each-fold
