### PR TITLE
fix(api-compare): exempt structural-interface members from extra surface

### DIFF
--- a/packages/activerecord/src/sqlite/libsql.ts
+++ b/packages/activerecord/src/sqlite/libsql.ts
@@ -10,16 +10,11 @@
  * and no name it declares has a Rails method to converge onto. Its sibling
  * subclass `connection-adapters/libsql-adapter.ts` carries the same reason.
  * MOVED-BY-SHORT-NAME: databaseExists, open.
- * Those six score `moved` only because the oracle matches on bare camelized
- * Ruby short names, and the owners it now reports are unrelated: `close`
- * credits `Rack::BodyProxy#close`, `prepare` to `Store::HashAccessor#prepare`,
- * `isOpen` to `Transaction#open?` (abstract/transaction.rb), `open` to
- * `SchemaCache#open` / `MigrationContext#open`, `databaseExists` to
+ * Those two score `moved` only because the oracle matches on bare camelized
+ * Ruby short names, and the owners it reports are unrelated: `open` credits
+ * `SchemaCache#open` / `MigrationContext#open`, and `databaseExists` credits
  * `AbstractAdapter#database_exists?` — which the port already carries on the
- * adapter, at its Rails name, one layer above this driver — and `changes` to
- * `ActiveModel::AttributeMutationTracker#changes`, where this one is
- * `sqlite3_changes()` off the handle, the sqlite3 gem's
- * `SQLite3::Database#changes`.
+ * adapter, at its Rails name, one layer above this driver.
  */
 import Database from "libsql";
 import { getFs } from "@blazetrails/activesupport/fs-adapter";

--- a/packages/activerecord/src/sqlite/libsql.ts
+++ b/packages/activerecord/src/sqlite/libsql.ts
@@ -9,7 +9,7 @@
  * driver object literals and the connection/statement handles behind them —
  * and no name it declares has a Rails method to converge onto. Its sibling
  * subclass `connection-adapters/libsql-adapter.ts` carries the same reason.
- * MOVED-BY-SHORT-NAME: changes, close, databaseExists, isOpen, open, prepare.
+ * MOVED-BY-SHORT-NAME: databaseExists, open.
  * Those six score `moved` only because the oracle matches on bare camelized
  * Ruby short names, and the owners it now reports are unrelated: `close`
  * credits `Rack::BodyProxy#close`, `prepare` to `Store::HashAccessor#prepare`,

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1593,7 +1593,11 @@ describe("buildReport — interface declaration names", () => {
           "ActiveModel::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
           // Declared in a DIFFERENT Rails file: a TS interface of this name in
           // foo.ts is misplaced surface, not an impossible-by-construction shape.
-          "ActiveModel::Quoting": rubyClass({ name: "Quoting", file: "quoting.rb" }),
+          "ActiveModel::Quoting": rubyClass({
+            name: "Quoting",
+            file: "quoting.rb",
+            instance: [method("quoted_table_name")],
+          }),
         },
         modules: {},
       },
@@ -1647,12 +1651,47 @@ describe("buildReport — interface declaration names", () => {
     ]);
   });
 
-  it("still scores an interface's members, which the exemption does not reach", () => {
+  it("exempts the members of an exempt-by-kind interface along with it", () => {
     const report = run(
       ruby,
       tsWith([{ name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] }]),
     );
-    expect(report.packages[0].extraFiles[0].extras).toEqual([
+    expect(report.packages[0].extraFiles).toEqual([]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(2);
+  });
+
+  it("exempts a member of an exempt-by-kind interface that Rails defines elsewhere", () => {
+    // The RFC 0117 case: a structural stand-in's member names a method some
+    // OTHER Ruby class owns, so it scored as moved surface of the `.rb` the
+    // file mirrors purely by sharing the file.
+    const report = run(
+      ruby,
+      tsWith([{ name: "RelationLike", isInterface: true, members: ["quotedTableName"] }]),
+    );
+    expect(report.packages[0].extraFiles).toEqual([]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(2);
+  });
+
+  it("still scores the members of an interface name Rails uses elsewhere", () => {
+    const report = run(
+      ruby,
+      tsWith([{ name: "Quoting", isInterface: true, members: ["tsOnlyHelper"] }]),
+    );
+    expect(report.packages[0].extraFiles[0].extras).toMatchObject([
+      { name: "tsOnlyHelper", kind: "novel" },
+      { name: "Quoting", kind: "moved" },
+    ]);
+    expect(report.packages[0].totalInterfaceExempt).toBe(0);
+  });
+
+  it("does not exempt an interface member a class in the same file also declares", () => {
+    const ts = tsWith([
+      { name: "ConnectionHost", isInterface: true, members: ["tsOnlyHelper"] },
+      { name: "Adapter", members: ["tsOnlyHelper"] },
+    ]);
+    const report = run(ruby, ts);
+    expect(report.packages[0].extraFiles[0].extras).toMatchObject([
+      { name: "Adapter", kind: "novel" },
       { name: "tsOnlyHelper", kind: "novel" },
     ]);
   });

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -717,9 +717,10 @@ interface PackageTotals {
   totalMoved: number;
   totalAllowlisted: number;
   /**
-   * Names dropped by the interface-declaration kind exemption
-   * (`collectInterfaceOnlyNames`). Reported so the exemption stays measurable:
-   * it is the one allowance with no per-declaration tag to count.
+   * Names dropped by the interface kind exemption — declaration names
+   * (`collectInterfaceOnlyNames`) and the members they cover
+   * (`collectInterfaceMemberOnlyNames`). Reported so the exemption stays
+   * measurable: it is the one allowance with no per-declaration tag to count.
    */
   totalInterfaceExempt: number;
   /**
@@ -798,9 +799,10 @@ set — every public name in them is extra. Trees mirroring Rails' test/ code
 extractor reads lib/ only. The NoCntrp column reports that slice separately.
 
 A novel \`interface\` DECLARATION name is exempt by kind and needs no tag: it is a
-type-only shape Ruby leaves to duck typing, so no Ruby counterpart is possible.
-An interface name that does appear in Rails stays scored (as moved) — that is
-the drift case a blanket exemption would hide.
+type-only shape Ruby leaves to duck typing, so no Ruby counterpart is possible,
+and its MEMBERS are exempt with it. An interface name that does appear in Rails
+stays scored (as moved), members included — that is the drift case a blanket
+exemption would hide.
 
 Reasoned exceptions: an extra is allowed by tagging its TS declaration
 \`@noRailsEquivalent <reason>\` in JSDoc. Allowed extras are subtracted from the
@@ -927,6 +929,12 @@ export function collectTsFileNames(
 interface SurfaceName {
   name: string;
   interfaceDeclaration: boolean;
+  /**
+   * The `interface` whose body declares this MEMBER, or `null` for surface
+   * that is not an interface member (a class/namespace member, a top-level
+   * function, or a declaration name — including an interface's own).
+   */
+  interfaceMemberOf: string | null;
 }
 
 /**
@@ -940,14 +948,15 @@ function walkTsFileSurface(
   fileFunctions: MethodInfo[] | undefined,
 ): SurfaceName[] {
   const out: SurfaceName[] = [];
-  const pushMember = (m: MethodInfo): void => {
+  const pushMember = (m: MethodInfo, interfaceMemberOf: string | null): void => {
     if (m.internal === true) return;
     if (m.name.startsWith("_")) return;
-    out.push({ name: m.name, interfaceDeclaration: false });
+    out.push({ name: m.name, interfaceDeclaration: false, interfaceMemberOf });
   };
   for (const c of [...classes, ...modules]) {
     if (c.file !== file) continue;
     const skipForeign = c.synthesizedMixin === true;
+    const declaredByInterface = c.isInterface === true && c.declaredAsNamespace !== true;
     if (!skipForeign && !c.name.startsWith("_")) {
       // `declaredAsNamespace` matters because declaration merging collapses an
       // `interface` and a same-named `namespace` into one entry: the merged
@@ -955,15 +964,24 @@ function walkTsFileSurface(
       // non-interface declaration of the name and must stay scored.
       out.push({
         name: c.name,
-        interfaceDeclaration: c.isInterface === true && c.declaredAsNamespace !== true,
+        interfaceDeclaration: declaredByInterface,
+        interfaceMemberOf: null,
       });
     }
+    // `interfaceMembers` is what tells the two halves of a declaration-merged
+    // `interface`+`namespace` apart: only the names it lists came from the
+    // interface body, so a namespace member is not covered by the interface's
+    // exemption — the same split `collectTaggedEntries` applies to a tagged
+    // interface's members.
+    const interfaceMembers = c.interfaceMembers;
     for (const m of [...c.instanceMethods, ...c.classMethods]) {
       if (skipForeign && m.declaredIn !== undefined) continue;
-      pushMember(m);
+      const fromInterface =
+        c.isInterface === true && (interfaceMembers ? interfaceMembers.includes(m.name) : true);
+      pushMember(m, fromInterface ? c.name : null);
     }
   }
-  for (const fn of fileFunctions ?? []) pushMember(fn);
+  for (const fn of fileFunctions ?? []) pushMember(fn, null);
   return out;
 }
 
@@ -991,6 +1009,9 @@ function walkTsFileSurface(
  * names Rails never uses at all — which therefore cannot be a drifting port of
  * anything — drop out.
  *
+ * The members of an exempt interface go with it — see
+ * `collectInterfaceMemberOnlyNames`.
+ *
  * Names shared with a member or with a class/namespace declaration are NOT
  * exempt — including the `namespace` half of a declaration-merged
  * `interface`+`namespace` pair, which the extractor collapses into one entry
@@ -1016,6 +1037,62 @@ export function collectInterfaceOnlyNames(
   }
   for (const name of others) interfaces.delete(name);
   return interfaces;
+}
+
+/**
+ * Member names a file contributes ONLY through the body of an `interface` —
+ * mapped to the interfaces that declare them.
+ *
+ * RFC 0117, decided here: an `interface` whose declaration name is exempt by
+ * kind (`collectInterfaceOnlyNames` — a structural shape Ruby leaves to duck
+ * typing) covers its MEMBERS too, exactly as a `@noRailsEquivalent` tag on an
+ * interface declaration already does (see `collectTaggedEntries`). The
+ * declaration and its body are one statement about one type: if the type
+ * itself has no Ruby counterpart by construction, neither does any member of
+ * it, and scoring those members against the `.rb` the file happens to mirror
+ * is a category error. `Arel::Attributes::Attribute#relation` is typed
+ * `RelationLike` in `attributes/attribute.ts`, so its `tableAlias` /
+ * `typeForAttribute` — members of `Arel::Table` (`arel/table.rb:26,90`), never
+ * of `Arel::Attributes::Attribute` (`arel/attributes/attribute.rb:5-40`) —
+ * were reported as `attribute.rb`'s moved surface purely because the stand-in
+ * shares its file.
+ *
+ * The exemption is deliberately NOT unconditional on interface members. It
+ * rides on the declaration's verdict, which the scorer applies: an interface
+ * named after something Rails uses may be a real port of a Ruby module's
+ * shape, so its members stay scored and stay tag-able — the drift case a
+ * blanket member exemption would hide.
+ *
+ * A name anything else in the file also contributes — a class member, a
+ * top-level function, any declaration name — is excluded, on the same
+ * reasoning as `collectInterfaceOnlyNames`: the extra set is a flat Set of
+ * bare names, so one name carries one verdict and exempting on the
+ * interface's behalf would silently absolve the other contributor.
+ */
+export function collectInterfaceMemberOnlyNames(
+  file: string,
+  classes: ClassInfo[],
+  modules: ClassInfo[],
+  fileFunctions: MethodInfo[] | undefined,
+): Map<string, string[]> {
+  const members = new Map<string, string[]>();
+  const others = new Set<string>();
+  for (const { name, interfaceMemberOf } of walkTsFileSurface(
+    file,
+    classes,
+    modules,
+    fileFunctions,
+  )) {
+    if (interfaceMemberOf === null) {
+      others.add(name);
+      continue;
+    }
+    const owners = members.get(name);
+    if (owners === undefined) members.set(name, [interfaceMemberOf]);
+    else if (!owners.includes(interfaceMemberOf)) owners.push(interfaceMemberOf);
+  }
+  for (const name of others) members.delete(name);
+  return members;
 }
 
 /**
@@ -1521,6 +1598,12 @@ function buildPackageReport(
     const tsNames = collectTsFileNames(expectedTs, classes, modules, fileFns);
     if (tsNames.size === 0) continue;
     const interfaceOnly = collectInterfaceOnlyNames(expectedTs, classes, modules, fileFns);
+    const interfaceMemberOnly = collectInterfaceMemberOnlyNames(
+      expectedTs,
+      classes,
+      modules,
+      fileFns,
+    );
 
     const allowed =
       rubyFile === null
@@ -1562,6 +1645,20 @@ function buildPackageReport(
       // its own name, so the tag doesn't go stale and the inheritance in
       // `collectTaggedEntries` keeps working.
       if (kind === "novel" && interfaceOnly.has(name)) {
+        interfaceExemptCount++;
+        continue;
+      }
+      // A member of an exempt-by-kind interface inherits its declaration's
+      // verdict — see `collectInterfaceMemberOnlyNames`. Unlike the
+      // declaration exemption this one is not restricted to novel names: a
+      // structural stand-in's member routinely names a method some OTHER Rails
+      // class defines (`Arel::Table#table_alias`), which is exactly the moved
+      // row the wrong `.rb` was being charged for.
+      const memberOwners = interfaceMemberOnly.get(name);
+      if (
+        memberOwners !== undefined &&
+        memberOwners.every((o) => interfaceOnly.has(o) && !globalRubyCandidates.has(o))
+      ) {
         interfaceExemptCount++;
         continue;
       }
@@ -1753,7 +1850,7 @@ function printHumanReport(report: Report, topN: number, maxDetail: number, verbo
   );
   const interfaceExempt = report.packages.reduce((n, pkg) => n + pkg.totalInterfaceExempt, 0);
   console.log(
-    `${p.dim}  Excluded by kind: ${interfaceExempt} novel \`interface\` declaration name(s) — type-only shapes Ruby ` +
+    `${p.dim}  Excluded by kind: ${interfaceExempt} novel \`interface\` declaration name(s) and member(s) — type-only shapes Ruby ` +
       `leaves to duck typing. An interface name Rails DOES use stays scored as moved.${p.reset}`,
   );
   console.log(

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -968,11 +968,6 @@ function walkTsFileSurface(
         interfaceMemberOf: null,
       });
     }
-    // `interfaceMembers` is what tells the two halves of a declaration-merged
-    // `interface`+`namespace` apart: only the names it lists came from the
-    // interface body, so a namespace member is not covered by the interface's
-    // exemption — the same split `collectTaggedEntries` applies to a tagged
-    // interface's members.
     const interfaceMembers = c.interfaceMembers;
     for (const m of [...c.instanceMethods, ...c.classMethods]) {
       if (skipForeign && m.declaredIn !== undefined) continue;
@@ -1063,11 +1058,20 @@ export function collectInterfaceOnlyNames(
  * shape, so its members stay scored and stay tag-able — the drift case a
  * blanket member exemption would hide.
  *
+ * The exemption is deliberately NOT restricted to novel names, as the
+ * declaration one is: a structural stand-in's member routinely names a method
+ * some OTHER Rails class defines (`Arel::Table#table_alias`), which is exactly
+ * the moved row the wrong `.rb` was being charged for.
+ *
  * A name anything else in the file also contributes — a class member, a
  * top-level function, any declaration name — is excluded, on the same
  * reasoning as `collectInterfaceOnlyNames`: the extra set is a flat Set of
  * bare names, so one name carries one verdict and exempting on the
  * interface's behalf would silently absolve the other contributor.
+ * `interfaceMembers` is what tells the two halves of a declaration-merged
+ * `interface`+`namespace` apart — only the names it lists came from the
+ * interface body — the same split `collectTaggedEntries` applies to a tagged
+ * interface's members.
  */
 export function collectInterfaceMemberOnlyNames(
   file: string,
@@ -1648,12 +1652,6 @@ function buildPackageReport(
         interfaceExemptCount++;
         continue;
       }
-      // A member of an exempt-by-kind interface inherits its declaration's
-      // verdict — see `collectInterfaceMemberOnlyNames`. Unlike the
-      // declaration exemption this one is not restricted to novel names: a
-      // structural stand-in's member routinely names a method some OTHER Rails
-      // class defines (`Arel::Table#table_alias`), which is exactly the moved
-      // row the wrong `.rb` was being charged for.
       const memberOwners = interfaceMemberOnly.get(name);
       if (
         memberOwners !== undefined &&


### PR DESCRIPTION
## What

`pnpm parity:api:extra --package arel` reported `attributes/attribute.ts` as
`0 novel, 2 moved` — `tableAlias` and `typeForAttribute`. Neither is a member
of `Arel::Attributes::Attribute`
(`vendor/rails/activerecord/lib/arel/attributes/attribute.rb:5-40`). They are
members of the structural `RelationLike` interface declared in the same TS
file, the duck type `Attribute#relation` is typed against — the Ruby object
that flows through there is an `Arel::Table`, whose `table_alias` /
`type_for_attribute` live in `arel/table.rb`. They were scored against
`attribute.rb` purely by sharing its file.

## Decision

Structural-interface members are excluded from the population, on the
declaration's verdict: an `interface` whose declaration name is already exempt
by kind (RFC 0080 — a novel, interface-only name, a type-only shape Ruby leaves
to duck typing) now covers its **members** too. That is exactly what a
`@noRailsEquivalent` tag on an interface declaration already does
(`collectTaggedEntries`); the declaration and its body are one statement about
one type, so if the type has no Ruby counterpart by construction, neither does
any member of it.

Unlike the declaration exemption, the member half is *not* restricted to novel
names — a stand-in's member routinely names a method some other Rails class
owns (`Arel::Table#table_alias`), which is the moved row the wrong `.rb` was
charged for. The exemption still rides on the declaration: an interface named
after something Rails uses keeps its members scored, so a drifting port of a
Ruby module's shape stays visible. A name anything else in the file also
contributes is excluded, and `interfaceMembers` splits a declaration-merged
`interface`+`namespace` so the namespace half is not absolved.

## Delta

`Excluded by kind` 613 → 2215. Every package's extra-surface total drops or
holds; none regresses.

| package | before (novel/moved/total) | after |
| --- | --- | --- |
| activerecord | 529 / 1447 / 1976 | 388 / 1030 / 1418 |
| activesupport | 419 / 883 / 1302 | 292 / 766 / 1058 |
| actiondispatch | 261 / 397 / 658 | 190 / 204 / 394 |
| trailties | 209 / 213 / 422 | 141 / 122 / 263 |
| activerecord-test-support | 102 / 42 / 144 | 89 / 6 / 95 |
| activemodel | 94 / 174 / 268 | 81 / 141 / 222 |
| actioncontroller | 84 / 152 / 236 | 70 / 77 / 147 |
| actionview | 76 / 184 / 260 | 42 / 109 / 151 |
| rack | 52 / 87 / 139 | 44 / 73 / 117 |
| abstractcontroller | 15 / 68 / 83 | 4 / 41 / 45 |
| i18n | 7 / 87 / 94 | 7 / 84 / 91 |
| **arel** | 7 / 68 / 75 | **7 / 64 / 71** |
| globalid | 6 / 16 / 22 | 5 / 11 / 16 |
| did-you-mean | 0 / 1 / 1 | 0 / 0 / 0 |

`attributes/attribute.ts` no longer appears in the arel report at all.

One consequence, fixed here: `activerecord/src/sqlite/libsql.ts`'s file-level
tag listed `changes, close, isOpen, prepare` in its `MOVED-BY-SHORT-NAME:`
clause; those names are interface members and no longer score moved, so the
run refused the stale clause. The four names are deleted from it (the gate's
own instruction), leaving `databaseExists, open`.

## Verification

- `pnpm vitest run scripts/api-compare` — 1301 passed.
- `pnpm exec tsx scripts/api-compare/extra-surface.ts` exits 0 (the CI form:
  no stale tags, no refused file-level tag).
- `pnpm lint`, `pnpm typecheck` clean.

Out of scope, as the story states: the `[ATTRIBUTE_BRAND]` / `relationName`
novel rows in the same file.

Closes-story: extra-surface-scores-structural-interface-members