### PR TITLE
docs(website): skip the internal binary.ts fragment in guides typecheck

### DIFF
--- a/packages/website/docs/guides/arel-rails-deviations.md
+++ b/packages/website/docs/guides/arel-rails-deviations.md
@@ -44,6 +44,8 @@ join a cycle, and it exports a mutable binding plus a setter that the defining
 module calls at the bottom of its own body. Readers import the binding and use
 it at call time — exactly where Ruby resolves the constant.
 
+<!-- typecheck:skip -->
+
 ```ts
 // nodes/binary.ts — Rails: left.is_a?(Arel::Attributes::Attribute)
 if (_Attribute && this.left instanceof _Attribute) return block(this.left);


### PR DESCRIPTION
Fixes the **Guides Code Type Check** red on `main` @18aae5fcf.

The "Call-time constant resolution: the zero-import slot" snippet added to
`packages/website/docs/guides/arel-rails-deviations.md` by #6877 is a fragment
quoted out of `packages/arel/src/nodes/binary.ts:101`:

```
if (_Attribute && this.left instanceof _Attribute) return block(this.left);
```

`_Attribute` is a package-internal binding from `arel/src/node-slots.ts`, `this`
is `Binary`, and the `return` is outside a function body — so `pnpm guides:typecheck`
fails it with TS2304 ×2, TS2532, TS1108.

It is illustrative quoted source, not user-facing example code, so it gets the
existing marker for exactly that case, `<!-- typecheck:skip -->` (precedent:
`activerecord-rails-deviations.md:309`).

## Verification

`pnpm build && pnpm guides:typecheck` — was 4 errors, now
`✓ All 17 code blocks type-check cleanly.` (2 skipped).

Closes-story: red-18aae5fc