### PR TITLE
refactor(api-compare,activerecord): retire stale @missingRailsCall tags in build; inline add_constraints' loop body

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -705,7 +705,6 @@ export class AssociationScope {
       for (const scopeChainItem of constraints) {
         if (typeof scopeChainItem !== "function") continue;
         const item = this.evalScope(reflection, scopeChainItem, owner);
-        if (!item) continue;
 
         if (scopeChainItem === (chainHead as { scope?: unknown } | undefined)?.scope) {
           // Rails: `scope.merge! item.except(:where, :includes, :unscope, :order)`
@@ -909,7 +908,11 @@ export class AssociationScope {
     const relation = (reflection as unknown as ScopeBuilder).buildScope(
       (reflection as ReflectionProxy).aliasedTable,
     );
-    return invokeScopeLambda(scopeFn as ScopeLambda<unknown>, relation, owner) ?? relation;
+    // Ruby `||` falls back on `false` as well as `nil`, and a scope lambda
+    // ending in a predicate returns one — `?? relation` would hand `false`
+    // back to add_constraints where Rails hands back the relation.
+    const evaluated = invokeScopeLambda(scopeFn as ScopeLambda<unknown>, relation, owner);
+    return evaluated != null && evaluated !== false ? evaluated : relation;
   }
 
   /**

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -664,9 +664,11 @@ export class AssociationScope {
   }
 
   /**
-   * Fold `last_chain_scope` over the chain and merge any user-supplied
-   * `scope` lambdas (reflection.scope / reflection.constraints) into the
-   * relation. PR 1 applies the scope lambda on the tail only.
+   * Fold `last_chain_scope` over the chain, walk the pairs, then merge every
+   * chain entry's scope lambdas into the relation — Rails' one loop body,
+   * inline: `chain.reverse_each` → `reflection.constraints.each` → the
+   * `scope_chain_item == chain_head.scope` / `!item.references_values.empty?`
+   * arms → `all_includes` → `unscope!` / `where_clause +=` / `order_values |`.
    *
    * Mirrors: ActiveRecord::Associations::AssociationScope#add_constraints
    * (association_scope.rb:124-159).
@@ -678,92 +680,213 @@ export class AssociationScope {
   ): unknown {
     const last = chain[chain.length - 1];
     scope = this.lastChainScope(scope, last, owner);
-    // For multi-step chains, walk pairs and add INNER JOINs — Rails'
-    // `chain.each_cons(2) { |r, nr| next_chain_scope(scope, r, nr) }`
+    // Rails: `chain.each_cons(2) { |r, nr| next_chain_scope(scope, r, nr) }`
     // (association_scope.rb:128-130).
     for (let i = 0; i < chain.length - 1; i++) {
       scope = this.nextChainScope(scope, chain[i], chain[i + 1]);
     }
-    // Rails' chain.reverse_each over reflection.constraints (Rails:
-    // association_scope.rb:131-156) merges scope-chain items into the
-    // relation. For each non-head reflection in the chain (in REVERSE
-    // order to match Rails' chain.reverse_each), we apply its scope
-    // lambda to a fresh klass.(unscoped + STI type filter), then push
-    // only the WHERE and ORDER predicates onto the main scope —
-    // matching Rails' `where_clause +=` / `order_values |=` granular
-    // merging (NOT a full Relation#merge, which would let the chain
-    // entry's limit/select/etc override the main scope). It ALSO folds in
-    // the item's joins / left_outer_joins and referenced eager-loads as
-    // OuterJoins (`_mergeReferencedJoins`, Rails' `construct_join_dependency
-    // (associations, Arel::Nodes::OuterJoin)` branch, association_scope.rb:
-    // 138-141) and applies its `unscope!` directives. The head reflection
-    // (chain[0]) is the LAST entry the loop reaches, and its own scope is one
-    // `scope_chain_item` inside the same body — Rails' `if scope_chain_item ==
-    // chain_head.scope` arm (association_scope.rb:137).
-    //
-    // Rails' add_constraints references `Arel::Nodes::OuterJoin` directly (the
-    // eager-load branch above); trails routes that construction through the
-    // `_mergeReferencedJoins` helper, so keep the arel dependency visible on
-    // this method to match Rails' activerecord → arel edge (dep-parity gate).
-    void Nodes.OuterJoin;
-    // Rails: `chain_head = chain.first` (association_scope.rb:131), read by the
-    // one `reverse_each` body that handles every chain position.
+
     const chainHead = chain[0];
     for (let i = chain.length - 1; i >= 0; i--) {
-      scope = this._mergeReflectionScopeChain(scope, chain[i], owner, chainHead);
-    }
-    return scope;
-  }
+      const reflection = chain[i];
+      // Iterate `reflection.constraints()` rather than special-casing
+      // PolymorphicReflection via instanceof. For ordinary
+      // AssociationReflection / ReflectionProxy entries `constraints()`
+      // returns `chain.flatMap(scopes)` — for non-through chain entries that's
+      // just `[self.scope].compact`. For PolymorphicReflection (sourceType
+      // wrapper) `constraints()` ALSO returns the `source_type_scope` lambda
+      // (`where(foreign_type: source_type)`). Iterating handles both cases
+      // without an instanceof check, avoiding a value-import cycle
+      // (reflection → associations → association-scope → reflection).
+      const constraints =
+        (
+          reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
+        ).constraints?.() ?? [];
+      for (const scopeChainItem of constraints) {
+        if (typeof scopeChainItem !== "function") continue;
+        const item = this.evalScope(reflection, scopeChainItem, owner);
+        if (!item) continue;
 
-  /**
-   * Apply one chain entry's scope lambdas — Rails' `chain.reverse_each` loop
-   * body. Rails' add_constraints
-   * does this via `eval_scope` + `scope.where_clause += item.where_clause`
-   * + `scope.order_values = item.order_values | scope.order_values` —
-   * granular per-attribute merging that pushes ONLY where and order
-   * predicates onto the main relation. A through-reflection scope's
-   * limit / select / joins / etc must NOT override the main scope.
-   *
-   * The lambda is evaluated against a fresh
-   * `entry.klass.unscoped` (with STI type_condition re-applied for
-   * subclasses, matching the head-scope path in `scope()`) so its
-   * `where(...)` calls bind to the correct table. We then push the
-   * resulting WHERE predicates onto the main scope and union the
-   * ORDER clauses.
-   *
-   * Mirrors: ActiveRecord::Associations::AssociationScope#add_constraints
-   * (association_scope.rb:131-156).
-   */
-  private _mergeReflectionScopeChain(
-    scope: unknown,
-    reflection: AbstractReflection | ReflectionProxy,
-    owner: Base,
-    chainHead?: AbstractReflection | ReflectionProxy,
-  ): unknown {
-    // Iterate `reflection.constraints()` rather than special-casing
-    // PolymorphicReflection via instanceof. For ordinary
-    // AssociationReflection / ReflectionProxy entries `constraints()`
-    // returns `chain.flatMap(scopes)` — for non-through chain entries
-    // that's just `[self.scope].compact`. For PolymorphicReflection
-    // (sourceType wrapper) `constraints()` ALSO returns the
-    // `source_type_scope` lambda
-    // (`where(foreign_type: source_type)`). Iterating handles both
-    // cases without an instanceof check, avoiding a value-import cycle
-    // (reflection → associations → association-scope → reflection).
-    const constraints =
-      (
-        reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
-      ).constraints?.() ?? [];
-    if (constraints.length === 0) return scope;
-    let merged = scope;
-    for (const c of constraints) {
-      if (typeof c !== "function") continue;
-      const evaluated = this.evalScope(reflection, c, owner);
-      // Rails: `if scope_chain_item == chain_head.scope` (association_scope.rb:137).
-      const isChainHeadScope = c === (chainHead as { scope?: unknown } | undefined)?.scope;
-      merged = this._pushScopeIntoRelation(merged, evaluated, reflection, isChainHeadScope);
+        if (scopeChainItem === (chainHead as { scope?: unknown } | undefined)?.scope) {
+          // Rails: `scope.merge! item.except(:where, :includes, :unscope, :order)`
+          // (association_scope.rb:137-138) — the chain head's own scope merges
+          // every OTHER value (limit, select, joins, …) with Relation#merge's
+          // precedence, and its where / order still reach the relation through
+          // the shared push below, exactly as every other chain item's do.
+          (scope as { mergeBang: (other: unknown) => unknown }).mergeBang(
+            (item as { except: (...skips: string[]) => unknown }).except(
+              "where",
+              "includes",
+              "unscope",
+              "order",
+            ),
+          );
+        } else if (
+          (
+            ((item as { referencesValues?: Array<string | Nodes.SqlLiteral> }).referencesValues ??
+              []) as unknown[]
+          ).length > 0
+        ) {
+          // Rails: `scope.merge! item.only(:joins, :left_outer_joins)`, then
+          // `associations = item.eager_load_values | item.includes_values` and
+          // `scope.joins! item.construct_join_dependency(associations,
+          // OuterJoin)` (association_scope.rb:139-146). A through scope such as
+          // `-> { where("comments.id" => nil).includes(:comments) }` relies on
+          // this to actually JOIN comments; without it the WHERE references a
+          // missing table.
+          //
+          // `merge!` routes the named `joins` / `left_outer_joins` through
+          // Merger#merge_joins / #merge_outer_joins (merger.rb:118-150), which
+          // branch on `other.model == relation.model`: when the item's klass
+          // equals the target scope's klass the names union directly into
+          // `joins_values` / `left_outer_joins_values`; otherwise a cross-klass
+          // JoinDependency is built against the ITEM and stashed. Both branches
+          // are mirrored here (the same split Relation::Merger implements) so a
+          // same-klass entry — e.g. a self-through whose chain entry resolves to
+          // the association's own target — folds its join names in for the
+          // receiver to resolve rather than pre-building a JD.
+          const itemValues = item as {
+            joinsValues?: unknown[];
+            leftOuterJoinsValues?: unknown[];
+            includesValues?: unknown[];
+            eagerLoadValues?: unknown[];
+            _model?: typeof Base;
+          };
+          const target = scope as {
+            joinsValues: unknown[];
+            leftOuterJoinsValues: unknown[];
+            _model?: typeof Base;
+          };
+          const sameKlass = itemValues._model !== undefined && itemValues._model === target._model;
+          // merger.rb:123-126 — `other.joins_values.partition { |join| case join
+          // when Hash, Symbol, Array; true end }`: association specs on one
+          // side, raw SQL / Arel nodes and stashed JoinDependencies on the other.
+          const namedInner: unknown[] = [];
+          const others: unknown[] = [];
+          for (const v of itemValues.joinsValues ?? []) {
+            if (
+              isPlainObject(v) ||
+              Array.isArray(v) ||
+              (typeof v === "string" && v.startsWith(":"))
+            ) {
+              namedInner.push(v);
+            } else {
+              others.push(v);
+            }
+          }
+          for (const v of others) target.joinsValues = [...target.joinsValues, v];
+          if (namedInner.length > 0) {
+            if (sameKlass) {
+              for (const v of namedInner)
+                if (!target.joinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
+                  target.joinsValues = [...target.joinsValues, v];
+            } else {
+              target.joinsValues = [
+                ...target.joinsValues,
+                constructJoinDependency.call(
+                  itemValues as never,
+                  namedInner as never,
+                  Nodes.InnerJoin,
+                ),
+              ];
+            }
+          }
+          const namedLeft = (itemValues.leftOuterJoinsValues ?? []).filter(
+            (v) => !(v instanceof JoinDependency),
+          );
+          const leftDeps = (itemValues.leftOuterJoinsValues ?? []).filter(
+            (v) => v instanceof JoinDependency,
+          );
+          if (namedLeft.length > 0) {
+            if (sameKlass) {
+              for (const v of namedLeft)
+                if (
+                  !target.leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v))
+                )
+                  target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, v];
+            } else {
+              target.leftOuterJoinsValues = [
+                ...target.leftOuterJoinsValues,
+                constructJoinDependency.call(
+                  itemValues as never,
+                  namedLeft as never,
+                  Nodes.OuterJoin,
+                ),
+              ];
+            }
+          }
+          target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, ...leftDeps];
+          // associations = eager_load_values | includes_values → OuterJoin.
+          // Rails' `|` unions with dedup, so an association named in BOTH
+          // eager_load and includes yields a single JoinDependency entry (not a
+          // double join).
+          const associations = [
+            ...new Set([
+              ...(itemValues.eagerLoadValues ?? []),
+              ...(itemValues.includesValues ?? []),
+            ]),
+          ];
+          if (associations.length > 0) {
+            target.leftOuterJoinsValues = [
+              ...target.leftOuterJoinsValues,
+              constructJoinDependency.call(
+                itemValues as never,
+                associations as never,
+                Nodes.OuterJoin,
+              ),
+            ];
+          }
+        }
+
+        // Rails: `reflection.all_includes { scope.includes_values |= item.includes_values }`
+        // (association_scope.rb:148-150). The block yields for the chain HEAD
+        // (`RuntimeReflection#all_includes`, reflection.rb:1279) and NOT for a
+        // `ReflectionProxy` chain entry, so a head scope's `includes(:comments)`
+        // still reaches the relation the head's `except(:includes)` merge withheld.
+        const allIncludes = (
+          reflection as { allIncludes?: (cb: () => void) => unknown } | undefined
+        )?.allIncludes?.bind(reflection);
+        if (allIncludes) {
+          allIncludes(() => {
+            const itemIncludes = (item as { includesValues?: unknown[] }).includesValues ?? [];
+            if (itemIncludes.length === 0) return;
+            const host = scope as { includesValues?: unknown[] };
+            const current = host.includesValues ?? [];
+            host.includesValues = [...current, ...itemIncludes.filter((v) => !current.includes(v))];
+          });
+        }
+        // Rails: `scope.unscope!(*item.unscope_values)` (association_scope.rb:152)
+        // runs BEFORE the item's own where clause is appended, so a
+        // `unscope(where: :skimmer)` chain entry strips the target's
+        // default-scope predicate without dropping the item's additions.
+        const itemUnscope = (item as { unscopeValues?: unknown[] }).unscopeValues ?? [];
+        if (itemUnscope.length > 0) {
+          (scope as { unscopeBang: (...v: unknown[]) => unknown }).unscopeBang(...itemUnscope);
+        }
+        const merged = scope as { whereClause: WhereClause; orderValues?: unknown[] };
+        // Rails: `scope.where_clause += item.where_clause`
+        // (association_scope.rb:153). The assignment matters: the preceding
+        // `unscope!` deletes the `:where` key, and an unset clause reader
+        // returns a fresh `WhereClause.empty()` per call, so appending to the
+        // read value would never reach `@values`.
+        const itemPredicates =
+          (item as { whereClause?: { predicates?: unknown[] } }).whereClause?.predicates ?? [];
+        if (itemPredicates.length > 0) {
+          merged.whereClause = merged.whereClause.plus(
+            new WhereClause(itemPredicates as Nodes.Node[]),
+          );
+        }
+        // Rails: `scope.order_values = item.order_values | scope.order_values`
+        // (association_scope.rb:154). Chain-entry-first + structural dedup.
+        const itemOrders = (item as { orderValues?: unknown[] }).orderValues ?? [];
+        if (itemOrders.length > 0) {
+          merged.orderValues = unionOrderClauses(itemOrders, merged.orderValues ?? []);
+        }
+        scope = merged;
+      }
     }
-    return merged;
+
+    return scope;
   }
 
   /**
@@ -801,190 +924,6 @@ export class AssociationScope {
   private join(table: unknown, constraint: unknown): unknown {
     return new Nodes.LeadingJoin(table as never, new Nodes.On(constraint as never));
   }
-
-  /**
-   * Push ONLY the entry's WHERE predicates and ORDER clauses onto
-   * the main scope — Rails' `where_clause += ...` / `order_values |=`
-   * semantics. A full Relation#merge would let the entry's limit /
-   * select / joins / etc override the main scope, which Rails
-   * explicitly avoids.
-   */
-  protected _pushScopeIntoRelation(
-    scope: unknown,
-    evaluated: unknown,
-    reflection?: AbstractReflection | ReflectionProxy,
-    isChainHeadScope = false,
-  ): unknown {
-    if (!evaluated) return scope;
-    if (isChainHeadScope) {
-      // Rails: `scope.merge! item.except(:where, :includes, :unscope, :order)`
-      // (association_scope.rb:138) — the chain head's own scope merges every
-      // OTHER value (limit, select, joins, …) with Relation#merge's precedence,
-      // and its where / order still reach the relation through the shared push
-      // below, exactly as every other chain item's do.
-      (scope as { mergeBang: (other: unknown) => unknown }).mergeBang(
-        (evaluated as { except: (...skips: string[]) => unknown }).except(
-          "where",
-          "includes",
-          "unscope",
-          "order",
-        ),
-      );
-    } else {
-      // Rails add_constraints' chain.reverse_each folds each item's joins /
-      // left_outer_joins and eager-load-as-join into the main scope when the
-      // item's `where(...)` referenced a joined table (`!item.references_values
-      // .empty?` → `scope.merge! item.only(:joins, :left_outer_joins)` +
-      // `scope.joins! item.construct_join_dependency(eager_load|includes,
-      // OuterJoin)`, association_scope.rb:138-146). A through scope such as
-      // `-> { where("comments.id" => nil).includes(:comments) }` relies on this
-      // to actually JOIN comments; without it the WHERE references a missing
-      // table. `all_includes` does NOT yield for chain entries (ReflectionProxy),
-      // so includes_values themselves are not carried forward — only the join is.
-      this._mergeReferencedJoins(scope, evaluated);
-    }
-    // Rails: `reflection.all_includes { scope.includes_values |= item.includes_values }`
-    // (association_scope.rb:148-150). The block yields for the chain HEAD
-    // (`RuntimeReflection#all_includes`, reflection.rb:1279) and NOT for a
-    // `ReflectionProxy` chain entry, so a head scope's `includes(:comments)`
-    // still reaches the relation the head's `except(:includes)` merge withheld.
-    const allIncludes = (
-      reflection as { allIncludes?: (cb: () => void) => unknown } | undefined
-    )?.allIncludes?.bind(reflection);
-    if (allIncludes) {
-      allIncludes(() => {
-        const itemIncludes = (evaluated as { includesValues?: unknown[] }).includesValues ?? [];
-        if (itemIncludes.length === 0) return;
-        const host = scope as { includesValues?: unknown[] };
-        const current = host.includesValues ?? [];
-        host.includesValues = [...current, ...itemIncludes.filter((v) => !current.includes(v))];
-      });
-    }
-    // Rails: `scope.unscope!(*item.unscope_values)` runs BEFORE the item's own
-    // where clause is appended, so a `unscope(where: :skimmer)` chain entry
-    // strips the target's default-scope predicate without dropping the item's
-    // additions. Apply the item's recorded unscope directives to the main scope.
-    const evalUnscope = (evaluated as { unscopeValues?: unknown[] }).unscopeValues ?? [];
-    if (evalUnscope.length > 0) {
-      (scope as { unscopeBang: (...v: unknown[]) => unknown }).unscopeBang(...evalUnscope);
-    }
-    const evalWhere = (evaluated as { whereClause?: { predicates?: unknown[] } }).whereClause;
-    const evalPredicates = evalWhere?.predicates ?? [];
-    const evalOrders = (evaluated as { orderValues?: unknown[] }).orderValues ?? [];
-    const merged = scope as {
-      whereClause: WhereClause;
-      orderValues?: unknown[];
-    };
-    // Rails: `scope.where_clause += item.where_clause` (association_scope.rb:153).
-    // The assignment matters: the preceding `unscope!` deletes the `:where` key,
-    // and an unset clause reader returns a fresh `WhereClause.empty()` per call,
-    // so appending to the read value would never reach `@values`.
-    if (evalPredicates.length > 0) {
-      merged.whereClause = merged.whereClause.plus(new WhereClause(evalPredicates as Nodes.Node[]));
-    }
-    // Rails: `scope.order_values = item.order_values | scope.order_values`
-    // (association_scope.rb:153). Chain-entry-first + structural dedup.
-    if (evalOrders.length > 0) {
-      merged.orderValues = unionOrderClauses(evalOrders, merged.orderValues ?? []);
-    }
-    return merged;
-  }
-
-  /**
-   * Fold a chain entry's joins / left_outer_joins and any referenced
-   * eager-load associations into the main scope as real JOINs. Mirrors the
-   * `elsif !item.references_values.empty?` branch of Rails' add_constraints
-   * (association_scope.rb:138-146):
-   *
-   *   scope.merge! item.only(:joins, :left_outer_joins)
-   *   associations = item.eager_load_values | item.includes_values
-   *   scope.joins! item.construct_join_dependency(associations, OuterJoin)
-   *
-   * `merge!` routes the named `joins` / `left_outer_joins` through
-   * Merger#merge_joins / #merge_outer_joins (merger.rb:118-150), which branch on
-   * `other.model == relation.model`: when the item's klass equals the target
-   * scope's klass the names union directly into `joins_values` /
-   * `left_outer_joins_values`; otherwise a cross-klass JoinDependency is built
-   * against the ITEM and stashed. Mirror both branches here (the same split
-   * Relation::Merger implements) so a same-klass entry — e.g. a self-through
-   * whose chain entry resolves to the association's own target — folds its join
-   * names in for the receiver to resolve rather than pre-building a JD.
-   */
-  private _mergeReferencedJoins(scope: unknown, evaluated: unknown): void {
-    const item = evaluated as {
-      referencesValues?: Array<string | Nodes.SqlLiteral>;
-      joinsValues?: unknown[];
-      leftOuterJoinsValues?: unknown[];
-      includesValues?: unknown[];
-      eagerLoadValues?: unknown[];
-      _model?: typeof Base;
-    };
-    const refs = item.referencesValues ?? [];
-    if (refs.length === 0) return;
-    const target = scope as {
-      joinsValues: unknown[];
-      leftOuterJoinsValues: unknown[];
-      _model?: typeof Base;
-    };
-    const sameKlass = item._model !== undefined && item._model === target._model;
-    // item.only(:joins, :left_outer_joins) — union named association joins
-    // (same-klass) or build cross-klass JoinDependencies (Merger#merge_joins /
-    // #merge_outer_joins).
-    // merger.rb:123-126 — `other.joins_values.partition { |join| case join when
-    // Hash, Symbol, Array; true end }`: association specs on one side, raw SQL /
-    // Arel nodes and stashed JoinDependencies on the other.
-    const namedInner: unknown[] = [];
-    const others: unknown[] = [];
-    for (const v of item.joinsValues ?? []) {
-      if (isPlainObject(v) || Array.isArray(v) || (typeof v === "string" && v.startsWith(":"))) {
-        namedInner.push(v);
-      } else {
-        others.push(v);
-      }
-    }
-    for (const v of others) target.joinsValues = [...target.joinsValues, v];
-    if (namedInner.length > 0) {
-      if (sameKlass) {
-        for (const v of namedInner)
-          if (!target.joinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
-            target.joinsValues = [...target.joinsValues, v];
-      } else {
-        target.joinsValues = [
-          ...target.joinsValues,
-          constructJoinDependency.call(item as never, namedInner as never, Nodes.InnerJoin),
-        ];
-      }
-    }
-    const namedLeft = (item.leftOuterJoinsValues ?? []).filter(
-      (v) => !(v instanceof JoinDependency),
-    );
-    const leftDeps = (item.leftOuterJoinsValues ?? []).filter((v) => v instanceof JoinDependency);
-    if (namedLeft.length > 0) {
-      if (sameKlass) {
-        for (const v of namedLeft)
-          if (!target.leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
-            target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, v];
-      } else {
-        target.leftOuterJoinsValues = [
-          ...target.leftOuterJoinsValues,
-          constructJoinDependency.call(item as never, namedLeft as never, Nodes.OuterJoin),
-        ];
-      }
-    }
-    target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, ...leftDeps];
-    // associations = eager_load_values | includes_values → OuterJoin. Rails'
-    // `|` unions with dedup, so an association named in BOTH eager_load and
-    // includes yields a single JoinDependency entry (not a double join).
-    const associations = [
-      ...new Set([...(item.eagerLoadValues ?? []), ...(item.includesValues ?? [])]),
-    ];
-    if (associations.length > 0) {
-      target.leftOuterJoinsValues = [
-        ...target.leftOuterJoinsValues,
-        constructJoinDependency.call(item as never, associations as never, Nodes.OuterJoin),
-      ];
-    }
-  }
 }
 
 /**
@@ -1009,8 +948,9 @@ function arelTableEql(a: ArelTable | Nodes.TableAlias, b: ArelTable | Nodes.Tabl
  * `[col, "asc"|"desc"]` tuples). `Array#includes` only does reference
  * equality, so two tuples with equal contents created separately
  * wouldn't match. Rails' `|` operator on order_values is structural.
+ * @internal
  */
-function unionOrderClauses(first: unknown[], second: unknown[]): unknown[] {
+export function unionOrderClauses(first: unknown[], second: unknown[]): unknown[] {
   const result: unknown[] = [];
   const seen = new Set<string>();
   for (const o of [...first, ...second]) {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -318,9 +318,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       ).constraints?.() ?? [];
     for (const scopeChainItem of constraints) {
       if (typeof scopeChainItem !== "function") continue;
-      const item = this.evalScope(reflection, scopeChainItem, owner);
-      if (!item) continue;
-      // Rails: `scope.unscope!(*item.unscope_values)`,
+      const item = this.evalScope(reflection, scopeChainItem, owner); // Rails: `scope.unscope!(*item.unscope_values)`,
       // `scope.where_clause += item.where_clause`,
       // `scope.order_values = item.order_values | scope.order_values`
       // (disable_joins_association_scope.rb:41-47). The join-less variant

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -1,15 +1,17 @@
 import { any } from "@blazetrails/activesupport";
+import { Nodes } from "@blazetrails/arel";
 import type { AliasTracker } from "./alias-tracker.js";
 import {
   AssociationScope,
   ReflectionProxy,
   type AssociationScopeable,
   type ValueTransformation,
+  unionOrderClauses,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { disableJoinsAssociationRelationClassFor } from "../relation/delegation.js";
 import type { Relation } from "../relation.js";
-import type { WhereClause } from "../relation/where-clause.js";
+import { WhereClause } from "../relation/where-clause.js";
 import type { ExceptKey } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
 import type { AbstractReflection } from "../reflection.js";
@@ -314,10 +316,33 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       (
         reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }
       ).constraints?.() ?? [];
-    for (const c of constraints) {
-      if (typeof c !== "function") continue;
-      const evaluated = this.evalScope(reflection, c, owner);
-      scope = this._pushScopeIntoRelation(scope, evaluated);
+    for (const scopeChainItem of constraints) {
+      if (typeof scopeChainItem !== "function") continue;
+      const item = this.evalScope(reflection, scopeChainItem, owner);
+      if (!item) continue;
+      // Rails: `scope.unscope!(*item.unscope_values)`,
+      // `scope.where_clause += item.where_clause`,
+      // `scope.order_values = item.order_values | scope.order_values`
+      // (disable_joins_association_scope.rb:41-47). The join-less variant
+      // merges only those three — no head-scope `merge!`, no referenced-joins
+      // arm, since this path never builds a JOIN.
+      const itemUnscope = (item as { unscopeValues?: unknown[] }).unscopeValues ?? [];
+      if (itemUnscope.length > 0) {
+        (scope as { unscopeBang: (...v: unknown[]) => unknown }).unscopeBang(...itemUnscope);
+      }
+      const merged = scope as { whereClause: WhereClause; orderValues?: unknown[] };
+      const itemPredicates =
+        (item as { whereClause?: { predicates?: unknown[] } }).whereClause?.predicates ?? [];
+      if (itemPredicates.length > 0) {
+        merged.whereClause = merged.whereClause.plus(
+          new WhereClause(itemPredicates as Nodes.Node[]),
+        );
+      }
+      const itemOrders = (item as { orderValues?: unknown[] }).orderValues ?? [];
+      if (itemOrders.length > 0) {
+        merged.orderValues = unionOrderClauses(itemOrders, merged.orderValues ?? []);
+      }
+      scope = merged;
     }
 
     const finalOrd = scope as { orderValues?: unknown[] };

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -14,6 +14,7 @@ import {
   buildExpectations,
   fileModuleName,
   lowerMarksForDropped,
+  staleTagKey,
 } from "./build.js";
 import { serializeBaseline } from "./baseline-json.js";
 import { NARROW_DEFAULT_REASON } from "./missing-rails-call-tags.js";
@@ -325,6 +326,39 @@ describe("reconcileFileText", () => {
     expect(
       reconcileFileText("foo.ts", r.text!, expectations, () => "PERMANENT: x").text,
     ).toBeNull();
+  });
+
+  it("retires a tag compare.ts reports stale, and only that one", () => {
+    // The other half of the #6873 fix: with no expectation the run preserves,
+    // but compare.ts's `staleCallTags` is positive knowledge that the call is
+    // no longer flagged there — that tag goes, its neighbour stays.
+    const src = [
+      "export class Foo {",
+      "  /**",
+      "   * @missingRailsCall logger — PERMANENT: no logger yet.",
+      "   */",
+      "  bar(): void {}",
+      "",
+      "  /**",
+      "   * @missingRailsCall with_raw_connection — PERMANENT: escapes inline.",
+      "   */",
+      "  quoteString(): void {}",
+      "}",
+    ].join("\n");
+    const r = reconcileFileText(
+      "foo.ts",
+      src,
+      new Map(),
+      () => "PERMANENT: x",
+      undefined,
+      new Set([staleTagKey("bar", "logger")]),
+    );
+    expect(r.text!).not.toContain("@missingRailsCall logger");
+    expect(r.text!).toContain("@missingRailsCall with_raw_connection — PERMANENT: escapes inline.");
+    expect(r.harvested.map((h) => [h.tsName, h.entry.call])).toEqual([["bar", "logger"]]);
+    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([
+      ["quoteString", "with_raw_connection"],
+    ]);
   });
 
   it("is idempotent: a second run produces zero edits", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -110,6 +110,17 @@ export interface SuppressedCall {
   call: string;
 }
 
+/** One `@missingRailsCall` tag compare.ts reports STALE: it suppressed nothing
+ *  on the (tsFile, tsName) it is written on, so the call it names is no longer
+ *  flagged there. Confirmation enough to retire the tag even where the
+ *  declaration carries no expectation of its own. */
+export interface StaleTag {
+  package: string;
+  tsFile: string;
+  tsName: string;
+  call: string;
+}
+
 export interface Artifact {
   packages?: string[];
   mismatches: ArtifactMismatch[];
@@ -117,6 +128,10 @@ export interface Artifact {
    *  absent from `mismatches`, so reconciling against that list alone would
    *  drop the very tags that suppressed them. */
   suppressed?: SuppressedCall[];
+  /** Tags whose call compare.ts no longer flags on the declaration they sit on
+   *  (`staleCallTags`). A preserved tag named here is a confirmed convergence,
+   *  so this run retires it instead of preserving it. */
+  staleTags?: StaleTag[];
 }
 
 export interface ReconcileResult {
@@ -379,12 +394,20 @@ export function collectDeclarations(sf: ts.SourceFile): TaggableDecl[] {
 
 /** Reconcile every named function/method in one source file's text. Returns
  *  the new text (or null if unchanged) plus harvested non-placeholder drops. */
+/** Key for one stale-tag row within a file: the tag sits on a (tsName, call)
+ *  site, NOT on the class-qualified expectation key `buildExpectations` builds
+ *  — `staleCallTags` records no class. */
+export function staleTagKey(tsName: string, call: string): string {
+  return `${tsName}\u0000${call}`;
+}
+
 export function reconcileFileText(
   fileName: string,
   text: string,
   expectations: Map<string, MethodExpectation>,
   reasonFor: (rubyName: string, call: string) => string,
   onlyCall?: ReadonlySet<string>,
+  staleTags?: ReadonlySet<string>,
 ): {
   text: string | null;
   /** Tags DROPPED because the call they name is no longer flagged for a
@@ -459,14 +482,28 @@ export function reconcileFileText(
       // A tag that HAS genuinely gone stale is reported by compare.ts's
       // `staleCallTags` (the sanctioned channel), so preserving one here costs a
       // report line rather than a lost receipt.
-      const expected = exp?.calls ?? new Set<string>(entries.map((e) => e.call));
+      // ...unless compare.ts positively reports the tag STALE on this
+      // declaration: that is the same knowledge the gate's "STALE
+      // @missingRailsCall tag(s)" arm reds on, so the writer retires the tag
+      // rather than making a human do it by hand (RFC 0106).
+      const expected =
+        exp?.calls ??
+        new Set<string>(
+          entries.filter((e) => !staleTags?.has(staleTagKey(name, e.call))).map((e) => e.call),
+        );
       const r = reconcile(
         entries,
         expected,
         (c) => (exp ? firstCuratedReason(exp.rubyNames, c, reasonFor) : DEFAULT_TAG_REASON),
         onlyCall,
       );
-      if (!exp) preserved.push(...entries.map((entry) => ({ tsName: name, entry })));
+      if (!exp) {
+        preserved.push(
+          ...entries
+            .filter((entry) => !staleTags?.has(staleTagKey(name, entry.call)))
+            .map((entry) => ({ tsName: name, entry })),
+        );
+      }
       skipped.push(...r.skipped);
       if (exp) {
         for (const e of [...r.kept, ...r.added]) {
@@ -615,6 +652,16 @@ async function main(argv: string[]): Promise<number> {
   }
 
   const byFile = buildExpectations(artifact, pkg, onlyFile);
+  const staleByFile = new Map<string, Set<string>>();
+  for (const t of artifact.staleTags ?? []) {
+    if (t.package !== pkg) continue;
+    if (onlyFile && t.tsFile !== onlyFile) continue;
+    const set = staleByFile.get(t.tsFile) ?? staleByFile.set(t.tsFile, new Set()).get(t.tsFile)!;
+    set.add(staleTagKey(t.tsName, t.call));
+    // A file whose only business this run is a stale tag has no expectation to
+    // put it in `byFile`, and would otherwise never be opened.
+    if (!byFile.has(t.tsFile)) byFile.set(t.tsFile, new Map());
+  }
 
   let changed = 0;
   let skipped = 0;
@@ -639,6 +686,7 @@ async function main(argv: string[]): Promise<number> {
         (rubyName, call) =>
           reasons.get(keyOf({ package: pkg, tsFile, rubyName, call })) ?? DEFAULT_TAG_REASON,
         onlyCall.size > 0 ? onlyCall : undefined,
+        staleByFile.get(tsFile),
       );
     } catch (err) {
       console.error(`parity:api:build: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## parity:api:build retires a tag compare.ts reports stale

PR #6881 made `reconcileFileText` default `expected` to the declaration's own
existing tags when the artifact carries no expectation for it — tag-preserving
where it has nothing to say. That left the other direction open: a tag that HAD
gone stale could not be retired by the writer, only by hand (as
`benchmarkable.ts`'s `@missingRailsCall logger` was in #6881).

`build.ts` now reads the artifact's `staleTags` — the same `StaleCallTag[]`
`compare.ts` already writes via `staleCallTags` and the gate already reds on —
as a third input beside `mismatches` and `suppressed`. Stale rows are keyed by
tag SITE (tsFile + tsName + call), not by the class-qualified expectation key,
so they get their own `staleTagKey`. A preserved tag named there is dropped and
reported on the existing `DROPPED …` line; one with no stale row is preserved
exactly as before (the #6873 shape stays green). A file whose only business is a
stale tag is now opened too — it has no expectation to put it in `byFile`.

## add_constraints is one method again

Rails' `add_constraints` is one method with one loop body
(`association_scope.rb:124-159`); trails split it across four.
`_mergeReflectionScopeChain`, `_pushScopeIntoRelation` and
`_mergeReferencedJoins` are inlined into the single `chain.reverse_each` →
`reflection.constraints.each` body, so `chainHead`, `reflection` and `item` are
ordinary locals and the synthetic `isChainHeadScope` parameter disappears with
the frame that needed it. The `Relation::Merger` same-klass / cross-klass prose
(`merger.rb:118-150`) moved with its code. `evalScope` and `applyScope` stay —
Rails extracts those (:161-172).

`DisableJoinsAssociationScope` was the other `_pushScopeIntoRelation` caller; it
grows its own inject body, which upstream is three lines
(`disable_joins_association_scope.rb:41-47`) — no head-scope `merge!`, no
referenced-joins arm, since that path never builds a JOIN. `unionOrderClauses`
(the trails spelling of Ruby's structural `Array#|` on order values) is now
`@internal`-exported so both bodies share it, mirroring `structuralUnionEq`.

## Verification

- `pnpm vitest run scripts/api-compare/build.test.ts` — 47 passed, including the
  new stale-vs-merely-unmatched regression.
- `pnpm vitest run packages/activerecord/src/associations/` — 115 files, 2045
  passed (SQLite; PG/MariaDB on CI).
- `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green, no new rows.
- `pnpm parity:api:extra --package activerecord`: association-scope.ts and
  disable-joins-association-scope.ts both 0 novel.
- `pnpm typecheck`, `pnpm lint` clean.

Closes-story: api-build-should-retire-tags-compare-reports-stale
Closes-story: add-constraints-split-across-three-invented-helpers