### PR TITLE
refactor(activerecord,activesupport): converge five copy-on-write stores onto classAttribute(); NumberConverter#execute returns nil/number unconverted

### DIFF
--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -80,10 +80,10 @@ export function numberToHuman(number: NumberLike, options: NumberHelperOptions =
 
 /** @internal */
 export function delegateNumberHelperMethod(
-  method: (n: unknown, o: Record<string, unknown>) => string,
+  method: (n: unknown, o: Record<string, unknown>) => unknown,
   number: NumberLike,
   options: NumberHelperOptions,
-): string | SafeBuffer | null {
+): unknown {
   if (number == null) return null;
   const { raise: raiseOnInvalid, ...rest } = escapeUnsafeOptions(options);
   return wrapWithOutputSafetyHandling(
@@ -122,11 +122,13 @@ export function escapeUnits(units: Record<string, string | SafeBuffer>): Record<
 export function wrapWithOutputSafetyHandling(
   number: unknown,
   raiseOnInvalid: boolean,
-  formatted: string,
-): string | SafeBuffer {
+  formatted: unknown,
+): unknown {
   const valid = validFloat(number);
   if (raiseOnInvalid && !valid) throw new InvalidNumberError(number);
-  return valid || isHtmlSafe(number) ? htmlSafe(formatted) : formatted;
+  // On the `valid_float` arm `execute` took its `convert` arm, so
+  // `formatted_number` (number_helper.rb:148) is a String.
+  return valid || isHtmlSafe(number) ? htmlSafe(formatted as string) : formatted;
 }
 
 /** @internal */

--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -118,7 +118,13 @@ export function escapeUnits(units: Record<string, string | SafeBuffer>): Record<
   return escaped;
 }
 
-/** @internal */
+/**
+ * Mirrors: `wrap_with_output_safety_handling` (number_helper.rb:141-152). On the
+ * `valid_float` arm `NumberConverter#execute` took its `convert` arm, so
+ * `formatted_number` (number_helper.rb:148) is a String.
+ *
+ * @internal
+ */
 export function wrapWithOutputSafetyHandling(
   number: unknown,
   raiseOnInvalid: boolean,
@@ -126,8 +132,6 @@ export function wrapWithOutputSafetyHandling(
 ): unknown {
   const valid = validFloat(number);
   if (raiseOnInvalid && !valid) throw new InvalidNumberError(number);
-  // On the `valid_float` arm `execute` took its `convert` arm, so
-  // `formatted_number` (number_helper.rb:148) is a String.
   return valid || isHtmlSafe(number) ? htmlSafe(formatted as string) : formatted;
 }
 

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -35,7 +35,7 @@ class Topic extends Model {
     this._price = value;
   }
 
-  get price(): string | null {
+  get price(): unknown {
     return NumberHelper.numberToCurrency(this._price as number);
   }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1366,14 +1366,13 @@ export class CollectionAssociation extends Association {
 
         const memAttributeNames = new Set(memRecord.attributeNames());
         const changedAttributeNamesToSave = new Set(memRecord.changedAttributeNamesToSave);
-        const attrReadonly: ReadonlySet<string> =
-          (memRecord.constructor as unknown as { _readonlyAttributes?: ReadonlySet<string> })
-            ._readonlyAttributes ?? new Set<string>();
+        const attrReadonly = (memRecord.constructor as unknown as { _attrReadonly: string[] })
+          ._attrReadonly;
         for (const name of record
           .attributeNames()
           .filter((name) => memAttributeNames.has(name))
           .filter((name) => !changedAttributeNamesToSave.has(name))
-          .filter((name) => !attrReadonly.has(name))) {
+          .filter((name) => !attrReadonly.includes(name))) {
           memRecord._writeAttribute(name, record.get(name));
         }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -294,7 +294,6 @@ import {
   globalCurrentScope as _globalCurrentScope,
   setGlobalCurrentScope as _setGlobalCurrentScope,
   scopeAttributes,
-  defaultScopeOverride as _defaultScopeOverride,
   populateWithCurrentScopeAttributes as _populateWithCurrentScopeAttributes,
 } from "./scoping.js";
 import {
@@ -955,14 +954,14 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion.skip_time_zone_conversion_for_attributes
    */
-  static skipTimeZoneConversionForAttributes: string[] = [];
+  declare static skipTimeZoneConversionForAttributes: string[];
 
   /**
    * Column types eligible for time-zone conversion.
    *
    * Mirrors: ActiveRecord::AttributeMethods::TimeZoneConversion.time_zone_aware_types
    */
-  static timeZoneAwareTypes: string[] = ["datetime", "time"];
+  declare static timeZoneAwareTypes: string[];
 
   static get protectedEnvironments(): string[] {
     return ModelSchema.protectedEnvironments.call(this);
@@ -1753,9 +1752,6 @@ export class Base extends Model {
     ModelSchema.ignoredColumns.call(this, columns);
   }
 
-  // -- Readonly attributes --
-  static _readonlyAttributes: Set<string> = new Set();
-
   // Suppresses after_initialize in the constructor when set by _instantiate /
   // directInstantiate (inheritance.ts) so we can fire after_find first, then
   // after_initialize — matching Rails' init_with_attributes call order.
@@ -1783,9 +1779,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.nested_attributes_options
    */
-  static get nestedAttributesOptions(): Readonly<Record<string, unknown>> {
-    return _NestedAttributes.nestedAttributesOptions.call(this);
-  }
+  declare static nestedAttributesOptions: Record<
+    string,
+    import("./nested-attributes.js").NestedAttributeOptions
+  >;
 
   /**
    * Declare that this model accepts nested attributes for an association.
@@ -1806,20 +1803,6 @@ export class Base extends Model {
 
   static set verboseQueryLogs(value: boolean) {
     _setVerboseQueryLogs(value);
-  }
-
-  /**
-   * Whether this model defines its own default_scope (vs only inheriting it).
-   * Nil until `build_default_scope` first memoizes it (Rails class_attribute).
-   *
-   * Mirrors: ActiveRecord::Base.default_scope_override
-   */
-  static get defaultScopeOverride(): boolean | null {
-    return _defaultScopeOverride.call(this);
-  }
-
-  static set defaultScopeOverride(value: boolean | null) {
-    (this as { _defaultScopeOverride?: boolean | null })._defaultScopeOverride = value;
   }
 
   /**
@@ -1909,6 +1892,16 @@ export class Base extends Model {
   }
 
   // --- Reflection::ClassMethods (wired via extend() after class body) ---
+  /** encryptable_record.rb:11 — `class_attribute :encrypted_attributes` (no default). */
+  declare static encryptedAttributes: Set<string> | undefined;
+  /** The `class_attribute` predicate `encrypted_attributes?`. */
+  declare static readonly isEncryptedAttributes: boolean;
+  /** readonly_attributes.rb:11 — `class_attribute :_attr_readonly, instance_accessor: false, default: []`. */
+  declare static _attrReadonly: string[];
+  /** default.rb:19 — `class_attribute :default_scopes, instance_writer: false, instance_predicate: false, default: []`. */
+  declare static defaultScopes: import("./scoping/default.js").DefaultScope[];
+  /** default.rb:20 — `class_attribute :default_scope_override, ... default: nil`. */
+  declare static defaultScopeOverride: boolean | null;
   /** reflection.rb:11 — `class_attribute :_reflections, instance_writer: false, default: {}`. */
   declare static _reflections: Record<string, _Reflection.AssociationReflection>;
   /** reflection.rb:12 — `class_attribute :aggregate_reflections, instance_writer: false, default: {}`. */
@@ -2151,8 +2144,6 @@ export class Base extends Model {
 
   // -- Scopes registry (used by Relation) --
   static _scopes: Map<string, (rel: any, ...args: any[]) => any> = new Map();
-  /** Accumulated default_scope declarations. @internal */
-  static defaultScopes: import("./scoping/default.js").DefaultScope[] = [];
 
   // --- Default scope (wired via extend() after class body) ---
   declare static defaultScope: typeof _defaultScope;
@@ -4633,6 +4624,35 @@ classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} }
 classAttribute.call(Base, "aggregateReflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
 classAttribute.call(Base, "_counterCacheColumns", { instanceAccessor: false, default: [] });
+// readonly_attributes.rb:11 — `class_attribute :_attr_readonly,
+// instance_accessor: false, default: []`.
+classAttribute.call(Base, "_attrReadonly", { instanceAccessor: false, default: [] });
+// default.rb:19-20 — `default_scope_override` stays nil until
+// `build_default_scope` memoizes it.
+classAttribute.call(Base, "defaultScopes", {
+  instanceWriter: false,
+  instancePredicate: false,
+  default: [],
+});
+classAttribute.call(Base, "defaultScopeOverride", {
+  instanceWriter: false,
+  instancePredicate: false,
+  default: null,
+});
+// time_zone_conversion.rb:61-62.
+classAttribute.call(Base, "skipTimeZoneConversionForAttributes", {
+  instanceWriter: false,
+  default: [],
+});
+classAttribute.call(Base, "timeZoneAwareTypes", {
+  instanceWriter: false,
+  default: ["datetime", "time"],
+});
+// nested_attributes.rb:15.
+classAttribute.call(Base, "nestedAttributesOptions", { instanceWriter: false, default: {} });
+// encryptable_record.rb:11 — `class_attribute :encrypted_attributes`, with no
+// `default:` on purpose (see the comment at encryptable_record.rb:50).
+classAttribute.call(Base, "encryptedAttributes");
 classAttribute.call(Base, "counterCachedAssociationNames", {
   instanceWriter: false,
   default: [],

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4624,11 +4624,7 @@ classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} }
 classAttribute.call(Base, "aggregateReflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
 classAttribute.call(Base, "_counterCacheColumns", { instanceAccessor: false, default: [] });
-// readonly_attributes.rb:11 — `class_attribute :_attr_readonly,
-// instance_accessor: false, default: []`.
 classAttribute.call(Base, "_attrReadonly", { instanceAccessor: false, default: [] });
-// default.rb:19-20 — `default_scope_override` stays nil until
-// `build_default_scope` memoizes it.
 classAttribute.call(Base, "defaultScopes", {
   instanceWriter: false,
   instancePredicate: false,
@@ -4639,7 +4635,6 @@ classAttribute.call(Base, "defaultScopeOverride", {
   instancePredicate: false,
   default: null,
 });
-// time_zone_conversion.rb:61-62.
 classAttribute.call(Base, "skipTimeZoneConversionForAttributes", {
   instanceWriter: false,
   default: [],
@@ -4648,10 +4643,7 @@ classAttribute.call(Base, "timeZoneAwareTypes", {
   instanceWriter: false,
   default: ["datetime", "time"],
 });
-// nested_attributes.rb:15.
 classAttribute.call(Base, "nestedAttributesOptions", { instanceWriter: false, default: {} });
-// encryptable_record.rb:11 — `class_attribute :encrypted_attributes`, with no
-// `default:` on purpose (see the comment at encryptable_record.rb:50).
 classAttribute.call(Base, "encryptedAttributes");
 classAttribute.call(Base, "counterCachedAssociationNames", {
   instanceWriter: false,

--- a/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
+++ b/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
@@ -34,7 +34,7 @@ class ReflectedEncryptedCompany extends Company {}
 const defTypeFor = (klass: typeof Company, name: string) => klass.typeForAttribute(name);
 
 const encryptedAttributesOf = (klass: typeof Company) =>
-  (klass as unknown as { _encryptedAttributes?: Set<string> })._encryptedAttributes ??
+  (klass as unknown as { encryptedAttributes?: Set<string> }).encryptedAttributes ??
   new Set<string>();
 
 describe("STI subclass encrypts", () => {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -91,6 +91,9 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
     }
   }
 
+  // encryptable_record.rb:50 — `self.encrypted_attributes ||= Set.new`.
+  klass.encryptedAttributes ??= new Set<string>();
+
   for (const name of names) {
     encryptAttribute.call(klass, name, options);
   }
@@ -115,7 +118,7 @@ export function applyPendingEncryptions(klass: any): void {
   // so subclasses that have already snapped their callback chain don't miss it —
   // if a subclass registered callbacks before the parent installed this
   // validator, `in` would suppress installation even though the subclass lacks it.
-  // The validator reads `record.constructor._encryptedAttributes` at call time,
+  // The validator reads `record.constructor.encryptedAttributes` at call time,
   // so it correctly handles STI subclasses with different encrypted attribute sets.
   if (
     !Object.prototype.hasOwnProperty.call(klass, "_frozenEncryptionValidatorInstalled") &&

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -91,7 +91,6 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
     }
   }
 
-  // encryptable_record.rb:50 — `self.encrypted_attributes ||= Set.new`.
   klass.encryptedAttributes ??= new Set<string>();
 
   for (const name of names) {

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -34,7 +34,6 @@ import {
   decryptAttributes,
   deterministicEncryptedAttributes,
   encryptAttributes,
-  encryptedAttributes,
   encrypts,
   validateEncryptionAllowed,
 } from "./encryptable-record.js";
@@ -216,9 +215,9 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Author = makeEncryptedAuthor(await freshAdapter());
     new Post();
     new Author();
-    expect(encryptedAttributes.call(Post)).toEqual(new Set(["title", "body"]));
-    expect(encryptedAttributes.call(Author)).toEqual(new Set(["name"]));
-    expect(encryptedAttributes.call(Post)).not.toEqual(encryptedAttributes.call(Author));
+    expect(Post.encryptedAttributes).toEqual(new Set(["title", "body"]));
+    expect(Author.encryptedAttributes).toEqual(new Set(["name"]));
+    expect(Post.encryptedAttributes).not.toEqual(Author.encryptedAttributes);
   });
 
   it("deterministic_encrypted_attributes returns the list of deterministic encrypted attributes in a model (each record class holds their own list)", async () => {
@@ -991,7 +990,7 @@ describe("EncryptableRecord.encryptAttribute — scheme-based ignore_case wiring
   it("wires the case-preserving original_<name> column when ignoreCase is set", () => {
     const modelClass = makeMockModel(["name", "original_name"]);
     encrypts.call(modelClass, "name", { deterministic: true, ignoreCase: true });
-    const encrypted = encryptedAttributes.call(modelClass);
+    const encrypted = modelClass.encryptedAttributes;
     expect(encrypted.has("name")).toBe(true);
     expect(encrypted.has("original_name")).toBe(true);
   });
@@ -999,7 +998,7 @@ describe("EncryptableRecord.encryptAttribute — scheme-based ignore_case wiring
   it("does not wire original_<name> when ignoreCase is absent", () => {
     const modelClass = makeMockModel(["name"]);
     encrypts.call(modelClass, "name", { deterministic: true });
-    expect(encryptedAttributes.call(modelClass).has("original_name")).toBe(false);
+    expect(modelClass.encryptedAttributes.has("original_name")).toBe(false);
   });
 
   it("raises when the original_<name> column is missing and supportUnencryptedData is false", () => {

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -14,7 +14,7 @@ import {
   EncryptedBook,
   UnencryptedBook,
 } from "../test-helpers/models/book-encrypted.js";
-import { EncryptableRecord, deterministicEncryptedAttributes } from "./encryptable-record.js";
+import { deterministicEncryptedAttributes } from "./encryptable-record.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { applyPendingEncryptions } from "../encryption.js";
 import { Serialized } from "../type/serialized.js";
@@ -182,10 +182,10 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
  */
 describe("ActiveRecord::Encryption::EncryptableRecord.encrypted_attributes? (trails)", () => {
   it("is true once a model has declared an encrypted attribute", () => {
-    expect(EncryptableRecord.isEncryptedAttributes(EncryptedBook)).toBe(true);
+    expect(EncryptedBook.isEncryptedAttributes).toBe(true);
   });
 
   it("is false for a model that never assigned the class_attribute", () => {
-    expect(EncryptableRecord.isEncryptedAttributes(UnencryptedBook)).toBe(false);
+    expect(UnencryptedBook.isEncryptedAttributes).toBe(false);
   });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -69,19 +69,6 @@ const ORIGINAL_ATTRIBUTE_PREFIX = "original_";
  *   EncryptableRecord.encrypts(User, "email", { deterministic: true })
  */
 export class EncryptableRecord {
-  /**
-   * `class_attribute :encrypted_attributes` (encryptable_record.rb:11) also
-   * generates the predicate, whose body is `!!encrypted_attributes` — true once
-   * the slot has been assigned (`self.encrypted_attributes ||= Set.new`,
-   * encryptable_record.rb:50), including for an assigned-but-empty Set. That is
-   * NOT `has_encrypted_attributes?`, which is `present?` and so false when the
-   * Set is empty (encryptable_record.rb:204-206). The reader's `?? new Set()`
-   * default can't answer it, so read the slot directly.
-   */
-  static isEncryptedAttributes(modelClass: any): boolean {
-    return modelClass._encryptedAttributes != null;
-  }
-
   static sourceAttributeFromPreservedAttribute(attributeName: string): string | undefined {
     return attributeName.startsWith(ORIGINAL_ATTRIBUTE_PREFIX)
       ? attributeName.slice(ORIGINAL_ATTRIBUTE_PREFIX.length)
@@ -231,7 +218,7 @@ export class EncryptableRecord {
 
   /** @internal */
   static addLengthValidationForEncryptedColumns(modelClass: any): void {
-    const attrs: Set<string> = modelClass._encryptedAttributes ?? new Set<string>();
+    const attrs: Set<string> = modelClass.encryptedAttributes ?? new Set<string>();
     for (const name of attrs) {
       validateColumnSize.call(modelClass, name);
     }
@@ -244,8 +231,7 @@ export class EncryptableRecord {
     const names =
       attributeNames ??
       (typeof record.attributeNames === "function" ? record.attributeNames() : []);
-    const encryptedAttrs: Set<string> =
-      record.constructor._encryptedAttributes ?? new Set<string>();
+    const encryptedAttrs: Set<string> = record.constructor.encryptedAttributes ?? new Set<string>();
     const merged = [...new Set<string>([...names, ...[...encryptedAttrs].map(String)])];
     return record._createRecord?.(merged);
   }
@@ -253,7 +239,7 @@ export class EncryptableRecord {
   /** @internal */
   static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
     const klass = record.constructor;
-    const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
+    const encryptedAttrs: Set<string> = klass.encryptedAttributes ?? new Set();
     // changedAttributeNamesToSave is the string[] of changed attribute names.
     // Iterate changed once and check Set membership — O(n+m) vs O(n×m).
     const changed: string[] = Array.isArray(record.changedAttributeNamesToSave)
@@ -297,19 +283,14 @@ export function encrypts(this: any, ...namesAndOptions: unknown[]): void {
     }
   }
 
-  // `encryptAttribute` own-property-guards `_encryptedAttributes` itself.
+  // encryptable_record.rb:50 — `self.encrypted_attributes ||= Set.new`; the
+  // comment there says the Set is deliberately NOT a `class_attribute` default
+  // because the instance would then be shared across classes.
+  this.encryptedAttributes ??= new Set<string>();
+
   for (const name of names) {
     encryptAttribute.call(this, name, options);
   }
-}
-
-/**
- * The `class_attribute :encrypted_attributes` reader (encryptable_record.rb:11).
- * `this` is the model class; the slot is inherited through the prototype chain,
- * matching `class_attribute`'s subclass visibility.
- */
-export function encryptedAttributes(this: any): Set<string> {
-  return this._encryptedAttributes ?? new Set<string>();
 }
 
 /**
@@ -324,7 +305,7 @@ export function deterministicEncryptedAttributes(this: any): Set<string> {
     return this._deterministicEncryptedAttributes;
   }
   const result = new Set<string>();
-  for (const attributeName of encryptedAttributes.call(this)) {
+  for (const attributeName of this.encryptedAttributes ?? new Set<string>()) {
     const type = encryptedTypeOf(this.typeForAttribute(attributeName));
     if (type?.deterministic) {
       result.add(attributeName);
@@ -342,7 +323,7 @@ export function deterministicEncryptedAttributes(this: any): Set<string> {
  */
 export function encryptedAttribute(this: any, attributeName: string): boolean {
   const name = this.constructor.attributeAliases?.[attributeName] ?? attributeName;
-  if (!encryptedAttributes.call(this.constructor).has(name)) return false;
+  if (!(this.constructor.encryptedAttributes ?? new Set<string>()).has(name)) return false;
   // `encryptedTypeOf` unwraps the resolved type: unlike Ruby's DelegateClass,
   // a TS `Serialized(Encrypted(...))` does not forward `encrypted?`.
   const type = encryptedTypeOf(this.constructor.typeForAttribute(name));
@@ -429,7 +410,7 @@ export function validateEncryptionAllowed(this: any): void {
  * @internal
  */
 export function hasEncryptedAttributes(this: any): boolean {
-  return encryptedAttributes.call(this.constructor).size > 0;
+  return (this.constructor.encryptedAttributes ?? new Set<string>()).size > 0;
 }
 
 /**
@@ -439,7 +420,7 @@ export function hasEncryptedAttributes(this: any): boolean {
  */
 export function buildEncryptAttributeAssignments(this: any): Record<string, unknown> {
   const result: Record<string, unknown> = {};
-  for (const attributeName of encryptedAttributes.call(this.constructor)) {
+  for (const attributeName of this.constructor.encryptedAttributes ?? new Set<string>()) {
     result[attributeName] =
       typeof this.readAttribute === "function"
         ? this.readAttribute(attributeName)
@@ -455,7 +436,7 @@ export function buildEncryptAttributeAssignments(this: any): Record<string, unkn
  */
 export function buildDecryptAttributeAssignments(this: any): Record<string, unknown> {
   const result: Record<string, unknown> = {};
-  for (const attributeName of encryptedAttributes.call(this.constructor)) {
+  for (const attributeName of this.constructor.encryptedAttributes ?? new Set<string>()) {
     const type = this.constructor.typeForAttribute(attributeName) as {
       deserialize: (v: unknown) => unknown;
     };
@@ -478,12 +459,10 @@ export function buildDecryptAttributeAssignments(this: any): Record<string, unkn
  */
 export function encryptAttribute(this: any, name: string, options: SchemeOptions = {}): void {
   const modelClass = this;
-  // Own-property guard mirrors Rails' `class_attribute` semantics — a subclass
-  // encrypting a new attribute must not mutate the parent's (or a sibling's) Set.
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_encryptedAttributes")) {
-    modelClass._encryptedAttributes = new Set<string>(modelClass._encryptedAttributes ?? []);
-  }
-  modelClass._encryptedAttributes.add(name);
+  // `encrypted_attributes << name.to_sym` (encryptable_record.rb:85) — an
+  // in-place add, the way Rails does it; `encrypts` has already seeded this
+  // class's own Set.
+  modelClass.encryptedAttributes.add(name);
   delete modelClass._deterministicEncryptedAttributes;
 
   const pending: PendingEncryption = {
@@ -529,7 +508,7 @@ export function preserveOriginalEncrypted(this: any, name: string): void {
   // (`requireOriginalColumnsAfterReflection`, driven from schema reflection)
   // can re-run the missing-column check against the authoritative DB column
   // set — closing the fail-open gap when the adapter isn't connected at
-  // declaration time. Own-property guarded like `_encryptedAttributes` so a
+  // declaration time. Own-property guarded so a
   // subclass declaring ignoreCase doesn't mutate the parent's Set.
   if (!Object.prototype.hasOwnProperty.call(modelClass, "_ignoreCasePreservedAttributes")) {
     modelClass._ignoreCasePreservedAttributes = new Set<string>(

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -270,6 +270,10 @@ export function validateColumnSize(this: any, attributeName: string): void {
  * Mirrors: ActiveRecord::Encryption::EncryptableRecord::ClassMethods#encrypts
  * (encryptable_record.rb:49-55). `this` is the model class, the receiver Ruby's
  * `class_methods do` block gives the method.
+ *
+ * `self.encrypted_attributes ||= Set.new` (encryptable_record.rb:50) seeds this
+ * class's own Set; the comment there records why it is deliberately not a
+ * `class_attribute` `default:` — that instance would be shared across classes.
  */
 export function encrypts(this: any, ...namesAndOptions: unknown[]): void {
   let options: SchemeOptions = {};
@@ -283,9 +287,6 @@ export function encrypts(this: any, ...namesAndOptions: unknown[]): void {
     }
   }
 
-  // encryptable_record.rb:50 — `self.encrypted_attributes ||= Set.new`; the
-  // comment there says the Set is deliberately NOT a `class_attribute` default
-  // because the instance would then be shared across classes.
   this.encryptedAttributes ??= new Set<string>();
 
   for (const name of names) {
@@ -451,6 +452,9 @@ export function buildDecryptAttributeAssignments(this: any): Record<string, unkn
  * (via encryption.ts#encrypts) and direct callers route through here, mirroring
  * Rails' single `encrypt_attribute`.
  *
+ * `encrypted_attributes << name.to_sym` (encryptable_record.rb:85) adds to this
+ * class's own Set in place, which `encrypts` has already seeded.
+ *
  * The scheme is built by `schemeFor` — Rails' one `scheme_for` — inside the
  * `PendingEncryption` getter, because Rails calls `scheme_for` inside the
  * `decorate_attributes` block (encryptable_record.rb:85-88).
@@ -459,9 +463,6 @@ export function buildDecryptAttributeAssignments(this: any): Record<string, unkn
  */
 export function encryptAttribute(this: any, name: string, options: SchemeOptions = {}): void {
   const modelClass = this;
-  // `encrypted_attributes << name.to_sym` (encryptable_record.rb:85) — an
-  // in-place add, the way Rails does it; `encrypts` has already seeded this
-  // class's own Set.
   modelClass.encryptedAttributes.add(name);
   delete modelClass._deterministicEncryptedAttributes;
 
@@ -508,8 +509,8 @@ export function preserveOriginalEncrypted(this: any, name: string): void {
   // (`requireOriginalColumnsAfterReflection`, driven from schema reflection)
   // can re-run the missing-column check against the authoritative DB column
   // set — closing the fail-open gap when the adapter isn't connected at
-  // declaration time. Own-property guarded so a
-  // subclass declaring ignoreCase doesn't mutate the parent's Set.
+  // declaration time. Own-property guarded so a subclass declaring ignoreCase
+  // doesn't mutate the parent's Set.
   if (!Object.prototype.hasOwnProperty.call(modelClass, "_ignoreCasePreservedAttributes")) {
     modelClass._ignoreCasePreservedAttributes = new Set<string>(
       modelClass._ignoreCasePreservedAttributes ?? [],

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -292,7 +292,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::EncryptedQuery
       }),
     });
     return {
-      _encryptedAttributes: new Set(["email"]),
+      encryptedAttributes: new Set(["email"]),
       typeForAttribute: () => type,
     };
   }
@@ -358,7 +358,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const avPrev = new AdditionalValue("plain@example.com", prevType);
 
     const model = {
-      _encryptedAttributes: new Set(["email"]),
+      encryptedAttributes: new Set(["email"]),
       typeForAttribute: () => type,
     };
     const relation = {
@@ -376,7 +376,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
   it("leaves attributes alone when whereValuesHash has no matching entry", () => {
     const type = makeType(true);
     const model = {
-      _encryptedAttributes: new Set(["email"]),
+      encryptedAttributes: new Set(["email"]),
       typeForAttribute: () => type,
     };
     const relation = { model, whereValuesHash: () => ({}) };
@@ -391,7 +391,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
     const type = makeType(false);
     const av = new AdditionalValue("enc", type);
     const model = {
-      _encryptedAttributes: new Set(["body"]),
+      encryptedAttributes: new Set(["body"]),
       typeForAttribute: () => type,
     };
     const relation = { model, whereValuesHash: () => ({ body: [av] }) };
@@ -403,7 +403,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
   it("ignores scalar (non-array) where values", () => {
     const type = makeType(true);
     const model = {
-      _encryptedAttributes: new Set(["email"]),
+      encryptedAttributes: new Set(["email"]),
       typeForAttribute: () => type,
     };
     const relation = {
@@ -439,7 +439,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
         this.attribute("email", "string");
       }
     }
-    (Contact as any)._encryptedAttributes = new Set(["email"]);
+    (Contact as any).encryptedAttributes = new Set(["email"]);
     (Contact as any).decorateAttributes(["email"], () => type);
 
     const avCurrent = new AdditionalValue("plain@example.com", type);
@@ -517,7 +517,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
         }),
       });
       const model = {
-        _encryptedAttributes: new Set(["email"]),
+        encryptedAttributes: new Set(["email"]),
         typeForAttribute: () => type,
       };
       const rel = new (targets.Relation as any)(model);
@@ -541,7 +541,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       });
       const av = new AdditionalValue("plain@x", type);
       const model = {
-        _encryptedAttributes: new Set(["email"]),
+        encryptedAttributes: new Set(["email"]),
         typeForAttribute: () => type,
       };
       const rel = new (targets.Relation as any)(model);
@@ -564,7 +564,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
         }),
       });
       class Contact extends (targets.Base as any) {
-        static _encryptedAttributes = new Set(["email"]);
+        static encryptedAttributes = new Set(["email"]);
         static typeForAttribute = () => type;
       }
       (Contact as any).findBy({ email: "x" });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -118,7 +118,7 @@ export class EncryptedQuery {
     checkForAdditionalValues: boolean,
   ): unknown[] {
     const model = owner._model ?? owner;
-    const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
+    const encryptedAttrs = model.encryptedAttributes as Set<string> | undefined;
     if (!encryptedAttrs?.size) return args;
 
     if (!Array.isArray(args) || args.length === 0) return args;
@@ -220,7 +220,7 @@ export class RelationQueries {
     originalScopeForCreate: (...args: any[]) => unknown,
   ): Record<string, unknown> {
     const model = this.model ?? this;
-    const encryptedAttrs = model._encryptedAttributes as Set<string> | undefined;
+    const encryptedAttrs = model.encryptedAttributes as Set<string> | undefined;
     if (!encryptedAttrs?.size) return originalScopeForCreate.call(this) as Record<string, unknown>;
 
     const scopeAttrs = originalScopeForCreate.call(this) as Record<string, unknown>;

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
@@ -33,7 +33,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     });
 
     const klass = {
-      _encryptedAttributes: new Set(["email"]),
+      encryptedAttributes: new Set(["email"]),
       typeForAttribute: () => type,
     };
     const record = { constructor: klass };
@@ -78,7 +78,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
       scheme: new Scheme({ deterministic: false, encryptor: encryptorA }),
     });
     const klass = {
-      _encryptedAttributes: new Set(["body"]),
+      encryptedAttributes: new Set(["body"]),
       typeForAttribute: () => type,
     };
     const record = { constructor: klass };

--- a/packages/activerecord/src/fixtures.ts
+++ b/packages/activerecord/src/fixtures.ts
@@ -21,7 +21,7 @@ import type { Quoting } from "./connection-adapters/abstract/quoting.js";
 import { currentTimeFromProperTimezone } from "./timestamp.js";
 import { isPresent, singularize, underscore } from "@blazetrails/activesupport";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
-import { EncryptableRecord, encryptedAttributes } from "./encryption/encryptable-record.js";
+import { EncryptableRecord } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { defaultValue, type Type } from "@blazetrails/activemodel";
 
@@ -743,7 +743,7 @@ async function checkAllForeignKeysValidBang(conn: DatabaseAdapter): Promise<void
  * produced here is compatible with what the reloaded record will decrypt.
  */
 function encryptFixtureRows(ModelClass: BaseClass, rows: FixtureAttrs[]): void {
-  const encryptedAttrs = encryptedAttributes.call(ModelClass);
+  const encryptedAttrs = ModelClass.encryptedAttributes ?? new Set<string>();
   // Build a name→EncryptedAttributeType map from _pendingEncryptions. This lets
   // us serialize even before loadSchemaFromAdapter has run (the scheme is
   // already recorded, while `type_for_attribute` still answers the fallback
@@ -1255,7 +1255,7 @@ export async function prepareModelFixtures(
   // serialize each encrypted column value to ciphertext before insert so the DB stores
   // encrypted data (not cleartext), and populate original_* preserve-columns for ignoreCase.
   // Mirrors: ActiveRecord::Railtie `Fixture.prepend EncryptedFixtures if config.encrypt_fixtures`
-  if (Configurable.config.encryptFixtures && isPresent(encryptedAttributes.call(ModelClass))) {
+  if (Configurable.config.encryptFixtures && isPresent(ModelClass.encryptedAttributes)) {
     encryptFixtureRows(ModelClass, rows);
   }
 

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -88,22 +88,15 @@ describe("TestNestedAttributesInGeneral", () => {
   }
 
   it("base should have an empty nested attributes options", () => {
-    // A model that never declared accepts_nested_attributes_for has no configs
-    // of its own (Rails asserts ActiveRecord::Base.nested_attributes_options == {}).
     class Plain extends Base {}
-    const configs = (Plain as any)._nestedAttributeConfigs;
-    expect(configs === undefined || (Array.isArray(configs) && configs.length === 0)).toBe(true);
+    expect(Plain.nestedAttributesOptions).toEqual({});
   });
 
   it("should add a proc to nested attributes options", () => {
-    const configs = (Pirate as any)._nestedAttributeConfigs;
-    const rejectAllBlank = configs.find(
-      (c: any) => c.associationName === "birdsWithRejectAllBlank",
-    );
-    expect(rejectAllBlank.options.rejectIf).toBe(REJECT_ALL_BLANK_PROC);
+    const options = Pirate.nestedAttributesOptions;
+    expect(options.birdsWithRejectAllBlank.rejectIf).toBe(REJECT_ALL_BLANK_PROC);
     for (const name of ["parrots", "birds"]) {
-      const cfg = configs.find((c: any) => c.associationName === name);
-      expect(typeof cfg.options.rejectIf).toBe("function");
+      expect(typeof options[name].rejectIf).toBe("function");
     }
   });
 

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -220,17 +220,10 @@ describe("nested attributes assignment ordering (trails-only)", () => {
   // attributes are already set — even when the nested key sits first in the
   // literal.
   it("assigns nested parameter hashes after the base attributes", async () => {
-    const config = (
-      Pirate as unknown as {
-        _nestedAttributeConfigs: {
-          associationName: string;
-          options: { rejectIf?: unknown };
-        }[];
-      }
-    )._nestedAttributeConfigs.find((c) => c.associationName === "ship")!;
-    const originalRejectIf = config.options.rejectIf;
+    const config = Pirate.nestedAttributesOptions.ship;
+    const originalRejectIf = config.rejectIf;
     const observed: unknown[] = [];
-    config.options.rejectIf = async (_attrs: Record<string, unknown>, record: Base) => {
+    config.rejectIf = (_attrs: Record<string, unknown>, record: Base) => {
       observed.push((record as Pirate).catchphrase);
       return false;
     };
@@ -242,7 +235,7 @@ describe("nested attributes assignment ordering (trails-only)", () => {
         catchphrase: "Aye",
       });
     } finally {
-      config.options.rejectIf = originalRejectIf;
+      config.rejectIf = originalRejectIf;
     }
 
     expect(observed).toEqual(["Aye"]);
@@ -349,12 +342,8 @@ describe("nested attributes assignment ordering (trails-only)", () => {
       events.push("remove_target!:end");
     };
 
-    const config = (
-      Pirate as unknown as {
-        _nestedAttributeConfigs: { associationName: string; options: { rejectIf?: unknown } }[];
-      }
-    )._nestedAttributeConfigs.find((c) => c.associationName === "parrots")!;
-    config.options.rejectIf = () => {
+    const config = Pirate.nestedAttributesOptions.parrots;
+    config.rejectIf = () => {
       events.push("parrots");
       return false;
     };
@@ -391,12 +380,8 @@ describe("nested attributes assignment ordering (trails-only)", () => {
       events.push("remove_target!:end");
     };
 
-    const config = (
-      Pirate as unknown as {
-        _nestedAttributeConfigs: { associationName: string; options: { rejectIf?: unknown } }[];
-      }
-    )._nestedAttributeConfigs.find((c) => c.associationName === "parrots")!;
-    config.options.rejectIf = () => {
+    const config = Pirate.nestedAttributesOptions.parrots;
+    config.rejectIf = () => {
       events.push("parrots");
       return false;
     };

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -59,6 +59,9 @@ export interface NestedAttributeOptions {
 /**
  * Configure nested attributes for an association.
  *
+ * The registry write is nested_attributes.rb:361-363 — dup the hash, assign the
+ * key, write the whole hash back through the `class_attribute` writer.
+ *
  * Mirrors: ActiveRecord::Base.accepts_nested_attributes_for
  *
  * Usage:
@@ -120,8 +123,6 @@ export function acceptsNestedAttributesFor(
   // nested_attributes.rb. We mirror that in
   // assignNestedAttributesForOneToOneAssociation.
 
-  // nested_attributes.rb:361-363 — dup the hash, assign the key, write the
-  // whole hash back through the `class_attribute` writer.
   const nestedAttributesOptions = { ...modelClass.nestedAttributesOptions };
   nestedAttributesOptions[associationName] = options;
   modelClass.nestedAttributesOptions = nestedAttributesOptions;

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -44,7 +44,7 @@ export function _destroy(this: Base): boolean {
 export const REJECT_ALL_BLANK_PROC = (attributes: Record<string, unknown>): boolean =>
   Object.entries(attributes).every(([key, value]) => key === "_destroy" || isBlank(value));
 
-interface NestedAttributeOptions {
+export interface NestedAttributeOptions {
   allowDestroy?: boolean;
   // The owner record is passed as a second argument so method-style predicates
   // (Rails `reject_if: :some_method`) can consult the owner (e.g. `persisted?`).
@@ -54,29 +54,6 @@ interface NestedAttributeOptions {
   // A string limit names a method/attribute on the owner (Rails `limit: :symbol`).
   limit?: number | string | ((...args: unknown[]) => number);
   updateOnly?: boolean;
-}
-
-interface NestedAttributeConfig {
-  associationName: string;
-  options: NestedAttributeOptions;
-}
-
-/**
- * Rails: `class_attribute :nested_attributes_options, default: {}` — the
- * per-model map of `associationName => options` populated by
- * `accepts_nested_attributes_for`. Trails records the same data in the
- * dynamically-assigned `_nestedAttributeConfigs` array; expose the Rails-shaped
- * hash reader (the `=`/`?` forms map to the same accessor).
- *
- * Mirrors: ActiveRecord::NestedAttributes#nested_attributes_options
- */
-export function nestedAttributesOptions(
-  this: typeof Base,
-): Readonly<Record<string, NestedAttributeOptions>> {
-  const configs: NestedAttributeConfig[] = (this as any)._nestedAttributeConfigs ?? [];
-  const out: Record<string, NestedAttributeOptions> = {};
-  for (const c of configs) out[c.associationName] = c.options;
-  return out;
 }
 
 /**
@@ -143,20 +120,11 @@ export function acceptsNestedAttributesFor(
   // nested_attributes.rb. We mirror that in
   // assignNestedAttributesForOneToOneAssociation.
 
-  // Store config on the class
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_nestedAttributeConfigs")) {
-    (modelClass as any)._nestedAttributeConfigs = [];
-  }
-  // Upsert: replace existing entry for this association (mirrors Rails'
-  // nested_attributes_options[name] = options hash-assignment).
-  const configs: NestedAttributeConfig[] = (modelClass as any)._nestedAttributeConfigs;
-  const existingIdx = configs.findIndex((c) => c.associationName === associationName);
-  const entry: NestedAttributeConfig = { associationName, options };
-  if (existingIdx >= 0) {
-    configs[existingIdx] = entry;
-  } else {
-    configs.push(entry);
-  }
+  // nested_attributes.rb:361-363 — dup the hash, assign the key, write the
+  // whole hash back through the `class_attribute` writer.
+  const nestedAttributesOptions = { ...modelClass.nestedAttributesOptions };
+  nestedAttributesOptions[associationName] = options;
+  modelClass.nestedAttributesOptions = nestedAttributesOptions;
 
   const type =
     assocExists.type === "hasMany" || assocExists.type === "hasAndBelongsToMany"
@@ -215,9 +183,8 @@ export function assignNestedAttributes(
   // is exceeded — mirror that here so callers see the misconfiguration
   // at assign time, not at save time.
   const ctor = record.constructor as typeof Base;
-  const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
-  const config = configs.find((c) => c.associationName === associationName);
-  const resolvedLimit = resolveNestedLimit(config?.options.limit, record);
+  const options = ctor.nestedAttributesOptions[associationName];
+  const resolvedLimit = resolveNestedLimit(options?.limit, record);
   if (resolvedLimit !== undefined && attrs.length > resolvedLimit) {
     throw new TooManyRecords(
       `Maximum ${resolvedLimit} records are allowed. ` + `Got ${attrs.length} records instead.`,
@@ -240,10 +207,9 @@ async function processNestedAttributes(record: Base): Promise<void> {
   if (!pending) return;
 
   const ctor = record.constructor as typeof Base;
-  const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
 
   for (const [assocName, attrsList] of pending) {
-    const config = configs.find((c) => c.associationName === assocName);
+    const config = ctor.nestedAttributesOptions[assocName];
     if (!config) continue;
 
     const associations: any[] = (ctor as any)._associations ?? [];
@@ -328,7 +294,7 @@ async function processNestedAttributes(record: Base): Promise<void> {
       assertNestedAttributesAreKnown(targetModel, childAttrs);
 
       // Check _destroy before rejectIf — destroy should work regardless of rejectIf
-      if (_destroy && config.options.allowDestroy) {
+      if (_destroy && config.allowDestroy) {
         // Destroy existing record
         if (pkValue) {
           const existing = await (targetModel as any).find(pkValue);
@@ -340,7 +306,7 @@ async function processNestedAttributes(record: Base): Promise<void> {
       // Check rejectIf only for create/update, not destroy. The `"all_blank"`
       // symbol is resolved to a proc at declaration time, so this is always a
       // function here.
-      const rejectIf = config.options.rejectIf;
+      const rejectIf = config.rejectIf;
       if (typeof rejectIf === "function" && rejectIf(attrs, record)) {
         continue;
       }
@@ -430,8 +396,8 @@ export function hasDestroyFlag(hash: Record<string, unknown>): boolean {
 
 /** @internal */
 export function isAllowDestroy(this: Base, associationName: string): boolean {
-  const configs: NestedAttributeConfig[] = (this.constructor as any)._nestedAttributeConfigs ?? [];
-  return configs.find((c) => c.associationName === associationName)?.options.allowDestroy ?? false;
+  const ctor = this.constructor as typeof Base;
+  return ctor.nestedAttributesOptions[associationName]?.allowDestroy ?? false;
 }
 
 /** @internal */
@@ -450,8 +416,8 @@ export function callRejectIf(
   attributes: Record<string, unknown>,
 ): boolean {
   if (isWillBeDestroyed.call(this, associationName, attributes)) return false;
-  const configs: NestedAttributeConfig[] = (this.constructor as any)._nestedAttributeConfigs ?? [];
-  const rejectIf = configs.find((c) => c.associationName === associationName)?.options.rejectIf;
+  const ctor = this.constructor as typeof Base;
+  const rejectIf = ctor.nestedAttributesOptions[associationName]?.rejectIf;
   // `"all_blank"` is resolved to a proc in acceptsNestedAttributesFor, so a
   // stored rejectIf is always a function here.
   return typeof rejectIf === "function" ? rejectIf(attributes, this) : false;
@@ -784,8 +750,7 @@ export function assignNestedAttributesForOneToOneAssociation(
   }
 
   const ctor = record.constructor as typeof Base;
-  const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
-  const options = configs.find((c) => c.associationName === associationName)?.options ?? {};
+  const options = ctor.nestedAttributesOptions[associationName] ?? {};
   const updateOnly = options.updateOnly ?? false;
   const hasId = hasNestedId(attributes);
 
@@ -897,8 +862,7 @@ export function assignNestedAttributesForCollectionAssociation(
     );
   }
   const ctor = record.constructor as typeof Base;
-  const configs: NestedAttributeConfig[] = (ctor as any)._nestedAttributeConfigs ?? [];
-  const config = configs.find((c) => c.associationName === associationName);
+  const config = ctor.nestedAttributesOptions[associationName];
 
   let attrs: Record<string, unknown>[];
   if (Array.isArray(attributesCollection)) {
@@ -915,7 +879,7 @@ export function assignNestedAttributesForCollectionAssociation(
     }
   }
 
-  checkRecordLimitBang(resolveNestedLimit(config?.options.limit, record), attrs);
+  checkRecordLimitBang(resolveNestedLimit(config?.limit, record), attrs);
 
   // Rails `assign_nested_attributes_for_collection_association` marks matching
   // records for destruction *in memory* at assign time, so validations run
@@ -934,7 +898,7 @@ export function assignNestedAttributesForCollectionAssociation(
   // against nor marked here. The DB rows are still correctly destroyed by the
   // post-save flush; only the pre-save size-validation interaction is skipped
   // for the unloaded case (not exercised by any test).
-  if (config?.options.allowDestroy) {
+  if (config?.allowDestroy) {
     const loaded = loadedCollectionTarget(record, associationName);
     if (loaded.length > 0) {
       const targetModel = resolveCollectionTargetModel(record, associationName);

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -40,16 +40,15 @@ export class ReadonlyAttributeError extends ActiveRecordError {
  * Declare attributes as readonly. Once a record is persisted, these
  * attributes cannot be changed via update/save.
  *
+ * `self._attr_readonly |= attributes.map(&:to_s)` (readonly_attributes.rb:30) —
+ * `Array#|` is union-with-dedup, and the assignment (not a mutation of the
+ * inherited Array) is what keeps the write local to this class.
+ *
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#attr_readonly
  */
 export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
-  // `self._attr_readonly |= attributes.map(&:to_s)` (readonly_attributes.rb:30):
-  // `Array#|` is union-with-dedup, and the assignment is what makes the write
-  // local to this class — `_attrReadonly` is a `classAttribute`.
-  const attrReadonly = (this as any)._attrReadonly as string[];
   (this as any)._attrReadonly = [
-    ...attrReadonly,
-    ...attributes.map(String).filter((attr) => !attrReadonly.includes(attr)),
+    ...new Set([...((this as any)._attrReadonly as string[]), ...attributes.map(String)]),
   ];
   // readonly_attributes.rb:33 — Rails reads `raise_on_assign_to_attr_readonly`
   // HERE, at declaration time, and only `include HasReadonlyAttributes` — the

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -43,12 +43,14 @@ export class ReadonlyAttributeError extends ActiveRecordError {
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#attr_readonly
  */
 export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
-  if (!Object.prototype.hasOwnProperty.call(this, "_readonlyAttributes")) {
-    (this as any)._readonlyAttributes = new Set((this as any)._readonlyAttributes);
-  }
-  for (const attr of attributes) {
-    (this as any)._readonlyAttributes.add(attr);
-  }
+  // `self._attr_readonly |= attributes.map(&:to_s)` (readonly_attributes.rb:30):
+  // `Array#|` is union-with-dedup, and the assignment is what makes the write
+  // local to this class — `_attrReadonly` is a `classAttribute`.
+  const attrReadonly = (this as any)._attrReadonly as string[];
+  (this as any)._attrReadonly = [
+    ...attrReadonly,
+    ...attributes.map(String).filter((attr) => !attrReadonly.includes(attr)),
+  ];
   // readonly_attributes.rb:33 — Rails reads `raise_on_assign_to_attr_readonly`
   // HERE, at declaration time, and only `include HasReadonlyAttributes` — the
   // write guards — when it is true. `include` is idempotent and one-way, so a
@@ -65,7 +67,7 @@ export function attrReadonly(this: typeof Base, ...attributes: string[]): void {
  * Mirrors: ActiveRecord::ReadonlyAttributes::ClassMethods#readonly_attributes
  */
 export function readonlyAttributes(this: typeof Base): string[] {
-  return Array.from((this as any)._readonlyAttributes ?? []);
+  return (this as any)._attrReadonly;
 }
 
 /**
@@ -75,7 +77,7 @@ export function readonlyAttributes(this: typeof Base): string[] {
  * (The `Q` suffix mirrors Ruby's `?` predicate convention.)
  */
 export function readonlyAttributeQ(this: typeof Base, attribute: string): boolean {
-  return ((this as any)._readonlyAttributes as Set<string> | undefined)?.has(attribute) ?? false;
+  return ((this as any)._attrReadonly as string[]).includes(attribute);
 }
 
 /**

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -183,17 +183,3 @@ export function setGlobalCurrentScope(this: ScopingClassHost, scope: any): void 
 export function scopeRegistry(): ScopeRegistry {
   return ScopeRegistry.instance();
 }
-
-/**
- * Rails: `class_attribute :default_scope_override` (default nil) — whether the
- * model defines its own `default_scope`. Like Rails, this stays nil until
- * `build_default_scope` first runs and memoizes the boolean into the
- * `_defaultScopeOverride` class field (see scoping/default.ts); reading it
- * before then returns nil, not an eagerly-computed boolean.
- *
- * Mirrors: ActiveRecord::Scoping#default_scope_override
- */
-export function defaultScopeOverride(this: ScopingClassHost): boolean | null {
-  const value = (this as any)._defaultScopeOverride;
-  return value == null ? null : value;
-}

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -168,8 +168,9 @@ export function defaultScope<T extends typeof Base>(
       : (optionsOrAllQueries?.allQueries ?? false);
 
   const scopeObj = new DefaultScope(scope as (rel: any) => any, allQueries);
-  const existing: DefaultScope[] = (this as any).defaultScopes ?? [];
-  (this as any).defaultScopes = [...existing, scopeObj];
+  // `self.default_scopes += [default_scope]` (default.rb:142) — the
+  // reassignment is what makes the write local to this class.
+  (this as any).defaultScopes = [...(this as any).defaultScopes, scopeObj];
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -168,8 +168,6 @@ export function defaultScope<T extends typeof Base>(
       : (optionsOrAllQueries?.allQueries ?? false);
 
   const scopeObj = new DefaultScope(scope as (rel: any) => any, allQueries);
-  // `self.default_scopes += [default_scope]` (default.rb:142) — the
-  // reassignment is what makes the write local to this class.
   (this as any).defaultScopes = [...(this as any).defaultScopes, scopeObj];
 }
 

--- a/packages/activerecord/src/test-helpers/models/price-estimate.ts
+++ b/packages/activerecord/src/test-helpers/models/price-estimate.ts
@@ -19,7 +19,7 @@ export class PriceEstimate extends Base {
   }
 
   // Rails overrides the `price` reader with `number_to_currency(super)`.
-  get price(): string {
+  get price(): unknown {
     return NumberHelper.numberToCurrency(this.readAttribute("price"));
   }
 }

--- a/packages/activesupport/src/core-ext/numeric/conversions.ts
+++ b/packages/activesupport/src/core-ext/numeric/conversions.ts
@@ -31,6 +31,10 @@ export namespace NumericWithFormat {
    * which this parameter type excludes, so the `when Symbol` fallback to `to_s`
    * is the last arm here. `to_s(format)` dispatches on the receiver:
    * `BigDecimal#to_s` takes a format string, `Integer#to_s` a base.
+   *
+   * `self` is always a Numeric, so `NumberConverter#execute`
+   * (number_converter.rb:130-137) always takes its `convert` arm and every
+   * helper below answers a String.
    */
   export function toFs(
     self: number | BigDecimal,
@@ -45,9 +49,6 @@ export namespace NumericWithFormat {
         : self.toString(format as number);
     }
 
-    // `self` is always a Numeric here, so `NumberConverter#execute`
-    // (number_converter.rb:130-137) always takes its `convert` arm and every
-    // helper below answers a String.
     switch (format) {
       case ":phone":
         return NumberHelper.numberToPhone(self, options ?? {}) as string;

--- a/packages/activesupport/src/core-ext/numeric/conversions.ts
+++ b/packages/activesupport/src/core-ext/numeric/conversions.ts
@@ -45,21 +45,24 @@ export namespace NumericWithFormat {
         : self.toString(format as number);
     }
 
+    // `self` is always a Numeric here, so `NumberConverter#execute`
+    // (number_converter.rb:130-137) always takes its `convert` arm and every
+    // helper below answers a String.
     switch (format) {
       case ":phone":
-        return NumberHelper.numberToPhone(self, options ?? {});
+        return NumberHelper.numberToPhone(self, options ?? {}) as string;
       case ":currency":
-        return NumberHelper.numberToCurrency(self, options ?? {});
+        return NumberHelper.numberToCurrency(self, options ?? {}) as string;
       case ":percentage":
-        return NumberHelper.numberToPercentage(self, options ?? {});
+        return NumberHelper.numberToPercentage(self, options ?? {}) as string;
       case ":delimited":
-        return NumberHelper.numberToDelimited(self, options ?? {});
+        return NumberHelper.numberToDelimited(self, options ?? {}) as string;
       case ":rounded":
-        return NumberHelper.numberToRounded(self, options ?? {});
+        return NumberHelper.numberToRounded(self, options ?? {}) as string;
       case ":human":
-        return NumberHelper.numberToHuman(self, options ?? {});
+        return NumberHelper.numberToHuman(self, options ?? {}) as string;
       case ":human_size":
-        return NumberHelper.numberToHumanSize(self, options ?? {});
+        return NumberHelper.numberToHumanSize(self, options ?? {}) as string;
       default:
         return self.toString();
     }

--- a/packages/activesupport/src/number-helper.test.ts
+++ b/packages/activesupport/src/number-helper.test.ts
@@ -295,13 +295,13 @@ describe("NumberHelperTest", () => {
   });
 
   it("number helpers should return nil when given nil", () => {
-    // null is not numeric, so helpers return the string representation
-    expect(numberToPhone(null as unknown as number)).toBe("null");
-    expect(numberToCurrency(null as unknown as number)).toBe("null");
-    expect(numberToDelimited(null as unknown as number)).toBe("null");
-    expect(numberToRounded(null as unknown as number)).toBe("null");
-    expect(numberToHumanSize(null as unknown as number)).toBe("null");
-    expect(numberToHuman(null as unknown as number)).toBe("null");
+    expect(numberToPhone(null)).toBeNull();
+    expect(numberToCurrency(null)).toBeNull();
+    expect(numberToPercentage(null)).toBeNull();
+    expect(numberToDelimited(null)).toBeNull();
+    expect(numberToRounded(null)).toBeNull();
+    expect(numberToHumanSize(null)).toBeNull();
+    expect(numberToHuman(null)).toBeNull();
   });
 
   it("number helpers do not mutate options hash", () => {

--- a/packages/activesupport/src/number-helper.ts
+++ b/packages/activesupport/src/number-helper.ts
@@ -82,7 +82,7 @@ export interface NumberToHumanOptions {
   roundMode?: string;
 }
 
-export function numberToPhone(number: unknown, options: NumberToPhoneOptions = {}): string {
+export function numberToPhone(number: unknown, options: NumberToPhoneOptions = {}): unknown {
   return NumberToPhoneConverter.convert(number, options);
 }
 
@@ -95,7 +95,7 @@ export function numberToPhone(number: unknown, options: NumberToPhoneOptions = {
 export function numberToDelimited(
   number: unknown,
   options: NumberWithDelimiterOptions = {},
-): string {
+): unknown {
   return NumberToDelimitedConverter.convert(number, options);
 }
 
@@ -107,30 +107,33 @@ export function numberToDelimited(
 export function numberWithDelimiter(
   number: unknown,
   options: NumberWithDelimiterOptions = {},
-): string {
+): unknown {
   return numberToDelimited(number, options);
 }
 
-export function numberToRounded(number: unknown, options: NumberToRoundedOptions = {}): string {
+export function numberToRounded(number: unknown, options: NumberToRoundedOptions = {}): unknown {
   return NumberToRoundedConverter.convert(number, options);
 }
 
-export function numberToCurrency(number: unknown, options: NumberToCurrencyOptions = {}): string {
+export function numberToCurrency(number: unknown, options: NumberToCurrencyOptions = {}): unknown {
   return NumberToCurrencyConverter.convert(number, options);
 }
 
 export function numberToPercentage(
   number: unknown,
   options: NumberToPercentageOptions = {},
-): string {
+): unknown {
   return NumberToPercentageConverter.convert(number, options);
 }
 
-export function numberToHumanSize(number: unknown, options: NumberToHumanSizeOptions = {}): string {
+export function numberToHumanSize(
+  number: unknown,
+  options: NumberToHumanSizeOptions = {},
+): unknown {
   return NumberToHumanSizeConverter.convert(number, options);
 }
 
-export function numberToHuman(number: unknown, options: NumberToHumanOptions = {}): string {
+export function numberToHuman(number: unknown, options: NumberToHumanOptions = {}): unknown {
   return NumberToHumanConverter.convert(number, options);
 }
 

--- a/packages/activesupport/src/number-helper/number-converter.ts
+++ b/packages/activesupport/src/number-helper/number-converter.ts
@@ -75,7 +75,7 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
 
   static namespace: string | undefined;
 
-  static convert(number: unknown, options?: any): string {
+  static convert(number: unknown, options?: any): any {
     return new (this as any)(number, options ?? {}).execute();
   }
 
@@ -84,9 +84,15 @@ export abstract class NumberConverter<TOptions extends NumberFormatOptions = Num
     this.opts = options;
   }
 
-  execute(): string {
-    if (this.number === null || this.number === undefined) return String(this.number);
-    if (this.validateFloat && !this.validBigdecimal()) return String(this.number);
+  /**
+   * Mirrors: `NumberConverter#execute` (number_converter.rb:130-137). The
+   * first two arms answer `nil` and the unconverted `number` — a `String`
+   * comes back out of `number_to_human("x")` only because the input already
+   * was one.
+   */
+  execute(): unknown {
+    if (this.number == null || this.number === false) return null;
+    if (this.validateFloat && !this.validBigdecimal()) return this.number;
     return this.convert();
   }
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/encryption/encryptable-record.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypt_attribute",
-    "call": "order:constructor,schemeFor",
-    "reason": "Rails calls `scheme_for` then `EncryptedAttributeType.new` inside the `decorate_attributes` block (encryptable_record.rb:88-91); trails builds the pending decorator first and hangs `schemeFor` off a lazy `scheme` getter on it, so the constructor is recorded ahead of `schemeFor`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "override_accessors_to_preserve_original",
     "call": "encrypted_attribute?",
     "reason": "Rails' reader lives in an anonymous `Module.new` that is `include`d so its body can call `super()` (encryptable_record.rb:110-118), and the `encrypted_attribute?` guard only exists to decide between that `super()` value and the original column; TS has no ancestor chain to `super()` into from a mixin, so trails redefines the prototype accessor to read the original attribute directly and the guard has nothing to guard."


### PR DESCRIPTION
RFC 0112. Two bundled stories.

## 1. Copy-on-write stores → `classAttribute()`

Five of bucket B's stores now go through `classAttribute()` from
`@blazetrails/activesupport` instead of a hand-rolled `hasOwnProperty`
copy-on-first-write guard or a prototype-chain walk:

| Rails | what went away |
| --- | --- |
| `readonly_attributes.rb:11` `_attr_readonly` | the `Set`-valued `_readonlyAttributes` and its own-property guard — also picks up the Rails **name** and Array shape, so `attr_readonly` is `self._attr_readonly \|= attributes.map(&:to_s)` (readonly_attributes.rb:30) and `collection_association.rb:341`'s `mem_record.class._attr_readonly` reads the same field Rails reads |
| `default.rb:19-20` `default_scopes` / `default_scope_override` | the `_defaultScopeOverride` shadow field, its `base.ts` getter/setter pair, and `scoping.ts`'s hand-written reader |
| `time_zone_conversion.rb:61-62` `skip_time_zone_conversion_for_attributes` / `time_zone_aware_types` | plain unguarded `static` arrays |
| `nested_attributes.rb:15` `nested_attributes_options` | the trails-only `_nestedAttributeConfigs` array (a `{associationName, options}[]` scanned with `.find` at 7 sites); writes are now nested_attributes.rb:361-363's dup-assign-write-back |
| `encryptable_record.rb:11` `encrypted_attributes` | the own-property copy guard in `encryptAttribute`, the hand-written reader, and `EncryptableRecord.isEncryptedAttributes` — which the generated `class_attribute` predicate replaces at its own name |

The encryption one is a small behavior change *toward* Rails: `encrypts` seeds
this class's Set with `||=` (encryptable_record.rb:50, whose comment explains
why it is deliberately not a `default:`) and `encrypt_attribute` then adds in
place (encryptable_record.rb:85), so a subclass declaring `encrypts` on a
parent that already has a Set mutates the parent's — as it does upstream. The
STI cover still passes: an STI base with no Set of its own is untouched, which
is the case that test exercises.

Two bucket-B clusters were left for their own PRs rather than blowing the LOC
ceiling, filed with the Rails line numbers already in hand:

- `converge-token-for-class-attribute-stores` — `token_for.rb:10-11`, two WeakMap
  registries plus chain walks; the wrinkle is the boot-time verifier
  (`railtie.rb:328-334`), which has no post-chain fallback once the attribute is
  a `classAttribute` on `Base`.
- `converge-test-fixtures-class-attribute-stores` — `test_fixtures.rb:31-38`.

## 2. `NumberConverter#execute`

`execute` returned a `string` in every arm — the String `"null"` for a nil
number, `String(number)` for an unparseable one. Per number_converter.rb:130-137
the three arms are `nil`, the unconverted `number`, and `convert`; the
`number_helper.rb` wrappers and the ActionView / `Numeric#to_fs` consumers
follow. The first arm is Ruby's `if !number`, so `false` takes it too.

`number helpers should return nil when given nil` was asserting `"null"`;
it now asserts nil, and picks up the `number_to_percentage` line it was missing
(number_helper_test.rb:406-416).

## Gates

`pnpm parity:api:calls` OK (one baseline row deleted, not reseeded — the
`order:constructor,schemeFor` row for `encrypt_attribute`, whose `new Set(...)`
the converged body no longer makes). `pnpm parity:api:calls:args` OK.
`parity:api:extra` adds nothing. `pnpm lint`, `pnpm typecheck` clean.
Ran locally: encryption (38 files), scoping, nested-attributes, number-helper,
readonly/locking/write, dup, base, has-many, insert-all, fixtures.

Closes-story: converge-remaining-activerecord-copy-on-write-stores-onto-class-attribute
Closes-story: number-converter-execute-returns-string-in-every-arm