### PR TITLE
feat(date,activerecord): Time.new/Time.now take in:/precision:; drop the { format } EXPLAIN arm

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -138,13 +138,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   // members of the MySQLExplainTest class. These exercise the adapter directly
   // (no DB rows), so they need no fixtures.
   describe("explain helpers (trails-only)", () => {
-    it("buildExplainClause renders FORMAT=JSON without parens for { format: 'json' }", async () => {
-      const clause = await adapter.buildExplainClause([{ format: "json" }]);
+    it("buildExplainClause renders a format flag without parens", async () => {
+      const clause = await adapter.buildExplainClause(["format=json"]);
       expect(clause).toBe("EXPLAIN FORMAT=JSON");
     });
 
-    it("buildExplainClause combines string flag and format hash space-separated", async () => {
-      const clause = await adapter.buildExplainClause(["analyze", { format: "json" }]);
+    it("buildExplainClause joins its flags space-separated", async () => {
+      const clause = await adapter.buildExplainClause(["analyze", "format=json"]);
       // MariaDB >= 10.1 drops the EXPLAIN prefix for ANALYZE (analyze_without_explain?).
       const analyzeWithoutExplain =
         isMariaDb && (await adapter.databaseVersion).compare("10.1.0") >= 0;
@@ -153,8 +153,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       );
     });
 
-    it("explain executes with { format: 'json' } and returns JSON plan", async () => {
-      const result = await adapter.explain("SELECT 1", [], [{ format: "json" }]);
+    it("explain executes with a format flag and returns JSON plan", async () => {
+      const result = await adapter.explain("SELECT 1", [], ["format=json"]);
       expect(typeof result).toBe("string");
       expect(result.length).toBeGreaterThan(0);
     });

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -54,16 +54,16 @@ function baseClass(): typeof Base {
 }
 
 /**
- * A single entry in `Relation#explain`'s options list. Either a bare
- * flag name (`"analyze"`, `"verbose"`) or a keyword hash (`{ format:
- * "json" }`) — mirrors Rails' `explain(*options)` where options can
- * be a mix of Symbols and a single Hash. Each adapter decides which
- * flags / keys it supports and throws on unknown ones.
+ * A single entry in `Relation#explain`'s options list: a Ruby Symbol or String
+ * flag (`":analyze"`, `"verbose"`). Rails' adapters render the list with a bare
+ * `options.join` (`mysql/database_statements.rb:39`,
+ * `postgresql/database_statements.rb:99`), so a Hash there would render as
+ * `{:format=>"json"}.to_s.upcase` — a format is asked for as one more flag.
  *
  * Mirrors: the `options` array shape used by Rails'
  * `ActiveRecord::Relation#explain` and its adapter `build_explain_clause`.
  */
-export type ExplainOption = string | { format: string };
+export type ExplainOption = string;
 
 /**
  * Host interface for DatabaseStatements mixin methods that need adapter context.

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -71,7 +71,7 @@ export async function buildExplainClause(
   options: ExplainOption[] = [],
 ): Promise<string> {
   if (options.length === 0) return "EXPLAIN";
-  const clause = `EXPLAIN ${options.map((o) => (typeof o === "string" ? o.toUpperCase() : `FORMAT=${(o as { format: string }).format.toUpperCase()}`)).join(" ")}`;
+  const clause = `EXPLAIN ${options.join(" ").toUpperCase()}`;
   if ((await isAnalyzeWithoutExplain.call(this)) && clause.includes("ANALYZE")) {
     return clause.replace("EXPLAIN ", "");
   }

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -341,18 +341,6 @@ describe("ExplainTest", () => {
     expect(rendered).toBe('[[nil, "raw"], [nil, 42]]');
   });
 
-  it("rejects multiple hash options (Rails extract_options! semantics)", () => {
-    expect(() => Car.all().explain({ format: "json" }, { format: "xml" } as never)).toThrow(
-      /at most one option hash/,
-    );
-  });
-
-  it("rejects a non-trailing hash option", () => {
-    expect(() => Car.all().explain({ format: "json" } as never, "analyze")).toThrow(
-      /last argument/,
-    );
-  });
-
   it("isolates concurrent explain() calls via AsyncLocalStorage scopes", async () => {
     // Two parallel explain() calls must not trample each other's
     // collected queries. Without async-context isolation a global

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -140,30 +140,6 @@ function takeLimit(limitValue: number | string | null): number {
   return Math.min(limitValue, 11);
 }
 
-function validateExplainOptions(options: ExplainOption[]): void {
-  let seenHash = false;
-  for (let i = 0; i < options.length; i++) {
-    const o = options[i];
-    if (typeof o === "string") {
-      if (seenHash) {
-        throw new Error(
-          "EXPLAIN option hash must be the last argument (Rails' extract_options! semantics)",
-        );
-      }
-      continue;
-    }
-    if (!o || typeof o !== "object") {
-      throw new TypeError(
-        `EXPLAIN option must be a string flag or an options hash; got ${String(o)}`,
-      );
-    }
-    if (seenHash) {
-      throw new Error("EXPLAIN accepts at most one option hash");
-    }
-    seenHash = true;
-  }
-}
-
 /**
  * Relation — the lazy, chainable query interface.
  *
@@ -1236,19 +1212,16 @@ export class Relation<T extends Base> {
    * COUNT query and `await .explain()` (the proxy's `inspect`) explains the main
    * SELECT plus every query run as a side effect of it (eager loads, preloads).
    *
-   * `options` is a mix of flag strings and an optional trailing keyword
-   * hash, and what each adapter does with them is the adapter's own
-   * `build_explain_clause`. PG joins them and upcases the result
-   * (`postgresql/database_statements.rb:96-100`), so it takes flag strings
-   * only — `FORMAT JSON` is one of them, exactly as Rails' own
+   * `options` are the Symbols/Strings Rails hands to the adapter's own
+   * `build_explain_clause`, which upcases and joins them — `", "` on PG
+   * (`postgresql/database_statements.rb:96-100`), `" "` on MySQL
+   * (`mysql/database_statements.rb:36-46`) — and validates nothing; SQLite
+   * ignores them entirely. A Hash among them would render as its own
+   * stringification, the garbage Ruby's `Array#join` produces, so a format is
+   * asked for as one more flag, exactly as Rails' own
    * `test_explain_with_options_as_strings` passes it
-   * (`postgresql/explain_test.rb:29-33`) — and a keyword hash there renders
-   * as its own stringification, the same garbage Ruby's `Array#join` would
-   * produce. MySQL's body does read the hash
-   * (`mysql/database_statements.rb:36-46`); SQLite ignores options entirely.
-   * Ruby's `extract_options!` allows at most one trailing Hash; we enforce
-   * the same shape here so MySQL's order-sensitive SQL
-   * (`EXPLAIN FORMAT=JSON ANALYZE` is invalid) can't be produced by accident.
+   * (`postgresql/explain_test.rb:29-33`). Each flag is therefore spelled the
+   * way that adapter's EXPLAIN spells it, in the order it receives them.
    * Examples:
    *
    *     await Post.all().explain("analyze", "verbose")
@@ -1257,13 +1230,12 @@ export class Relation<T extends Base> {
    *     await Post.all().explain("analyze", "format json")
    *     // → EXPLAIN (ANALYZE, FORMAT JSON) SELECT …        (PG)
    *
-   *     await Post.all().explain("analyze", { format: "json" })
+   *     await Post.all().explain("analyze", "format=json")
    *     // → EXPLAIN ANALYZE FORMAT=JSON SELECT …           (MySQL)
    *
    * Mirrors: ActiveRecord::Relation#explain
    */
   explain(...options: ExplainOption[]): ExplainProxy<T> {
-    validateExplainOptions(options);
     return new ExplainProxy(this, options);
   }
 

--- a/packages/activesupport/src/time-travel.test.ts
+++ b/packages/activesupport/src/time-travel.test.ts
@@ -38,6 +38,7 @@ describe("TimeTravelTest", () => {
     expect(Time.now().toS()).toEqual(expectedTime.toS());
     expect(Time.new().toS()).toEqual(expectedTime.toS());
     expect(Time.new(2004, 11, 25).toS()).not.toEqual(expectedTime.toS());
+    expect(Time.new({ precision: 3 }).toS()).not.toEqual(expectedTime.toS());
     expect(RubyDate.today().toString()).toEqual(new RubyDate(2004, 11, 24).toDate().toString());
     expect(DateTime.now().toString()).toEqual(expectedTime.toDatetime().toString());
     expect(currentTime().getUTCFullYear()).toBe(2004);
@@ -49,6 +50,7 @@ describe("TimeTravelTest", () => {
     travelTo(expectedTime, {}, () => {
       expect(Time.now().toS()).toEqual(expectedTime.toS());
       expect(Time.new().toS()).toEqual(expectedTime.toS());
+      expect(Time.new({ precision: 3 }).toS()).not.toEqual(expectedTime.toS());
       expect(Time.new(2004, 11, 25).toS()).not.toEqual(expectedTime.toS());
       expect(RubyDate.today().toString()).toEqual(new RubyDate(2004, 11, 24).toDate().toString());
       expect(DateTime.now().toString()).toEqual(expectedTime.toDatetime().toString());

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -42,6 +42,42 @@ describe("Time", () => {
     expect(time.strftime("%Y-%m-%d %H:%M:%S %z %Z")).toBe("2008-03-01 06:00:00 -0500 ");
   });
 
+  it("Time.new takes the zone as MRI's `in:` keyword", () => {
+    // MRI 3.3:
+    //   Time.new(2020, 1, 1, in: "+05:00").to_s       #=> "2020-01-01 00:00:00 +0500"
+    //   Time.new(2020, 1, 1, in: "+05:00").utc_offset #=> 18000
+    //   Time.now(in: "+05:00").utc_offset             #=> 18000
+    //   Time.new(2020, 1, in: "+05:00").to_s          #=> "2020-01-01 00:00:00 +0500"
+    //   Time.new(2020, 1, 1, 5, in: "+05:00").to_s    #=> "2020-01-01 05:00:00 +0500"
+    expect(Time.new(2020, 1, 1, { in: "+05:00" }).toS()).toBe("2020-01-01 00:00:00 +0500");
+    expect(Time.new(2020, 1, 1, { in: "+05:00" }).utcOffset).toBe(18000);
+    expect(Time.new(2020, 1, 1, 0, 0, 0, { in: "+05:00" }).utcOffset).toBe(18000);
+    expect(Time.now({ in: "+05:00" }).utcOffset).toBe(18000);
+    expect(Time.new(2020, 1, { in: "+05:00" }).toS()).toBe("2020-01-01 00:00:00 +0500");
+    expect(Time.new(2020, 1, 1, 5, { in: "+05:00" }).toS()).toBe("2020-01-01 05:00:00 +0500");
+  });
+
+  it("Time.new takes the zone as MRI's seventh positional", () => {
+    // MRI 3.3:
+    //   Time.new(2020, 1, 1, 0, 0, 0, "+05:00").utc_offset #=> 18000
+    //   Time.new(2020, 1, 1, 0, 0, 0, 3600).utc_offset     #=> 3600
+    //   Time.new(2020, 1, 1, 0, 0, 0, "+05:00", in: "+06:00")
+    //     #=> ArgumentError: timezone argument given as positional and keyword arguments
+    expect(Time.new(2020, 1, 1, 0, 0, 0, "+05:00").utcOffset).toBe(18000);
+    expect(Time.new(2020, 1, 1, 0, 0, 0, 3600).utcOffset).toBe(3600);
+    expect(() => Time.new(2020, 1, 1, 0, 0, 0, "+05:00", { in: "+06:00" })).toThrow(
+      "timezone argument given as positional and keyword arguments",
+    );
+  });
+
+  it("Time.new takes MRI's `precision:` keyword, which trims only a string argument", () => {
+    // MRI 3.3 applies `precision:` to the STRING form alone:
+    //   Time.new(2020, 1, 1, 0, 0, 0.56789, precision: 3).nsec #=> 567890000
+    // and `Time.new(precision: 3)` is just the current time.
+    expect(Time.new(2020, 1, 1, 0, 0, 0.56789, { precision: 3 }).nsec).toBe(567890000);
+    expect(Time.new({ precision: 3 })).toBeInstanceOf(Time);
+  });
+
   it("Time.new takes an offset in seconds, as Rails passes", () => {
     expect(new Time(2008, 3, 1, 6, 0, 0, 3600).utcOffset).toBe(3600);
     expect(new Time(2008, 3, 1, 6, 0, 0, 0).strftime("%z %Z")).toBe("+0000 ");

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -303,6 +303,36 @@ function validateVtmRange(mem: string, value: number, b: number, e: number): voi
 }
 
 /**
+ * MRI's `rb_scan_args_kw` splits the keyword hash off an argument list before
+ * binding the positionals, so `Time.new`'s keywords may follow any number of
+ * them — `Time.new(2020, 1, 1, in: "+05:00")` is a three-positional call, not a
+ * fourth positional. `Rational` is the one object a positional itself takes
+ * (`sec`), so it is not a keyword hash.
+ */
+function isTimeNewOptions(arg: unknown): arg is TimeNewOptions {
+  return typeof arg === "object" && arg !== null && !(arg instanceof Rational);
+}
+
+/** The defaults `Time.new`'s positionals fall back to once a keyword hash is
+ *  lifted out of the slot one of them would have bound. */
+const TIME_NEW_DEFAULTS = [undefined, 1, 1, 0, 0, 0, null];
+
+/**
+ * The keywords MRI's `Time.new` takes beside its positionals (`time.c`
+ * `time_s_init`): `in:` names the zone — the keyword spelling of the older
+ * seventh positional — and `precision:` the sub-second digits kept off a
+ * STRING argument.
+ *
+ * @noRailsEquivalent PERMANENT — the trails spelling of Ruby kwargs on a Ruby
+ * core method. Rails never defines `::Time`, so there is no Rails counterpart
+ * for the keyword bag either.
+ */
+export interface TimeNewOptions {
+  in?: string | number | null;
+  precision?: number | null;
+}
+
+/**
  * @noRailsEquivalent PERMANENT — Ruby core `::Time`. Rails never defines the
  * class, only reopens it in `core_ext/time/*.rb`, so there is no Rails
  * counterpart for a port to converge on. trails carries only the members a
@@ -357,27 +387,86 @@ export class Time {
     return (this.#utcOffsetMemo ??= Number(this.#zoned!.offsetNanoseconds) / 1_000_000_000);
   }
 
-  /** Ruby `Time.now`, the current time in the local zone. */
-  static now(): Time {
-    return Time.#atInstant(Temporal.Now.instant());
+  /**
+   * Ruby `Time.now(in: nil)` (`timev.rb` `Time.now`), the current time — in the
+   * zone `in:` names, or the local one. MRI takes no `precision:` here:
+   * `Time.now(precision: 3)` is `ArgumentError: unknown keyword: :precision`,
+   * because the keyword only trims the sub-second a STRING argument spells and
+   * `now` takes none.
+   */
+  static now({ in: inZone = null }: { in?: string | number | null } = {}): Time {
+    return Time.#atInstant(Temporal.Now.instant(), inZone);
   }
 
   /**
    * Ruby `Time.new(year = nil, month = nil, day = nil, hour = nil, min = nil,
-   * sec = nil)` (`time.c` `time_s_init`): with no arguments it answers the
-   * current time in the local zone, and with them it lands on the same seat
-   * `Time.local` does. MRI's `in:` zone keyword is not carried.
+   * sec = nil, zone = nil, in: nil, precision: nil)` (`time.c` `time_s_init`):
+   * with no arguments it answers the current time in the local zone, and with
+   * them it lands on the same seat `Time.local` does. `in:` is the keyword
+   * spelling of the seventh positional's zone; both routes reach the
+   * constructor's `zone`, and giving both is MRI's `ArgumentError: timezone
+   * argument given as positional and keyword arguments`.
+   *
+   * `precision:` trims the sub-second of the STRING form —
+   * `Time.new("2000-12-31 23:59:59.56789", precision: 3)` is
+   * `Time.new("2000-12-31 23:59:59.567")` — and MRI applies it to nothing else:
+   * `Time.new(2020, 1, 1, 0, 0, 0.56789, precision: 3).nsec` is `567890000`,
+   * the untrimmed value. trails does not port the string form yet, so the
+   * keyword is taken and, as in MRI without a string, changes nothing. Taking
+   * it is what `travel_to`'s `Time.new` stub reads: it forwards to the original
+   * method whenever it is handed anything at all (`time_helpers.rb:180-187`),
+   * so `Time.new(precision: 3)` answers the real current time, not the
+   * travelled one.
+   *
+   * The keywords are spelled as a trailing object and, as in MRI, may follow
+   * any number of positionals — `Time.new({ precision: 3 })`,
+   * `Time.new(2020, 1, 1, { in: "+05:00" })` — because `rb_scan_args_kw` lifts
+   * the hash out before the positionals bind (see {@link isTimeNewOptions}).
+   *
+   * The no-argument path reads the clock straight rather than through
+   * {@link Time.now}, as `time_s_init` does: `travel_to` stubs both, and going
+   * through `Time.now` let its stub answer a `Time.new` call the `Time.new`
+   * stub had just forwarded to the original method.
    */
   static new(
-    year?: number | string,
-    month: number | string | null = 1,
-    day: number | string | null = 1,
-    hour: number | string | null = 0,
-    min: number | string | null = 0,
-    sec: number | string | Rational | null = 0,
+    year?: number | string | TimeNewOptions,
+    month: number | string | TimeNewOptions | null = 1,
+    day: number | string | TimeNewOptions | null = 1,
+    hour: number | string | TimeNewOptions | null = 0,
+    min: number | string | TimeNewOptions | null = 0,
+    sec: number | string | Rational | TimeNewOptions | null = 0,
+    zone: string | number | TimeNewOptions | null = null,
+    options: TimeNewOptions = {},
   ): Time {
-    if (year === undefined) return Time.now();
-    return Time.mktime(year, month, day, hour, min, sec);
+    const given = [year, month, day, hour, min, sec, zone];
+    const kwargsAt = given.findIndex(isTimeNewOptions);
+    if (kwargsAt !== -1) {
+      options = given[kwargsAt] as TimeNewOptions;
+      given[kwargsAt] = TIME_NEW_DEFAULTS[kwargsAt];
+    }
+    [year, month, day, hour, min, sec, zone] = given as [
+      typeof year,
+      typeof month,
+      typeof day,
+      typeof hour,
+      typeof min,
+      typeof sec,
+      typeof zone,
+    ];
+    const { in: inZone = null } = options;
+    if (zone != null && inZone != null) {
+      throw new ArgumentError("timezone argument given as positional and keyword arguments");
+    }
+    if (year === undefined) return Time.#atInstant(Temporal.Now.instant(), inZone);
+    return new Time(
+      year as number | string,
+      month as number | string | null,
+      day as number | string | null,
+      hour as number | string | null,
+      min as number | string | null,
+      sec as number | string | Rational | null,
+      (zone as string | number | null) ?? inZone,
+    );
   }
 
   /**


### PR DESCRIPTION
Two stories. The bundle's third —
`missing-rails-call-tag-inert-on-top-level-function` — was **landed by #6898**
while this PR was open, so it is dropped from the diff and marked done against
that PR rather than this one. See "What #6898 and #6890 took" below.

## 1. `Time.new` / `Time.now` take MRI's `in:` and `precision:`

Verified against `ruby 3.3.11` on PATH rather than derived:

- `Time.new(2020, 1, 1, in: "+05:00").utc_offset` → `18000`; `Time.now(in:)` too.
- The keywords may follow **any number** of positionals, because
  `rb_scan_args_kw` lifts the keyword hash out before the positionals bind:
  `Time.new(2020, 1, 1, in: "+05:00")` is a three-positional call, not a fourth
  positional. Confirmed for the one-, two-, three- and six-positional spellings.
- The seventh positional zone MRI has always taken is carried alongside it
  (`Time.new(2020,1,1,0,0,0,"+05:00")`, `…, 3600`), and giving both spellings is
  MRI's `ArgumentError: timezone argument given as positional and keyword
  arguments`.
- `precision:` trims the sub-second of the **string** form only —
  `Time.new("2000-12-31 23:59:59.56789", precision: 3) ==
  Time.new("2000-12-31 23:59:59.567")`, while
  `Time.new(2020,1,1,0,0,0.56789, precision: 3).nsec` is `567890000`,
  untrimmed. trails does not port the string form, so the keyword is taken and,
  as in MRI without a string, changes nothing.
- `Time.now(precision: 3)` is `ArgumentError: unknown keyword: :precision`, so
  `Time.now` takes `in:` alone. (The story text asked for both; MRI disagrees.)

Taking the keywords is what `travel_to`'s `Time.new` stub reads — it forwards
anything non-empty to the original method (`time_helpers.rb:180-187`) — so the
two `assert_not_equal expected_time, Time.new(precision: 3)` arms
(`time_travel_test.rb:70,86`) come back off skip.

The no-argument path now reads the clock directly instead of calling
`Time.now`, as `time_s_init` does; otherwise the sibling `Time.now` stub
reached a `Time.new` its own stub had forwarded.

## 2. The `{ format }` EXPLAIN option arm

Rails renders `build_explain_clause`'s options with a bare join —
`"EXPLAIN #{options.join(" ").upcase}"` (`mysql/database_statements.rb:39`) and
`"EXPLAIN (#{options.join(", ").upcase})"`
(`postgresql/database_statements.rb:99`). A Ruby Hash there renders as
`{:format=>"json"}.to_s.upcase`, so Rails' options are only Symbols/Strings and
a format is one more flag.

`ExplainOption` becomes `string`; MySQL's body drops its per-option `map` for
Rails' `join`; `relation.ts`'s `validateExplainOptions` (Rails' `explain` is two
lines and validates nothing) goes with the arm it served, and its JSDoc tracks
the change.

**On the "extra-surface total falls" criterion:** it already did. #6890 landed
the PG half of this story and deleted `inspectExplainOption`, the only
*exported* name the arm carried, so `parity:api:extra --package activerecord`
is 1424 both before and after this diff. What is left here is the type, the
MySQL body and the `relation.ts` validator — none of them exported surface.

## What #6898 and #6890 took

- **#6898** fixed `@missingRailsCall` on a top-level function, independently and
  with a narrower mechanism than the one this PR carried: `usedForAnyOwner()`
  credits a `""`-owner tag (which is what a top-level function records under)
  with every owner's suppressions, where this PR grouped owners by call-set
  identity. Theirs is the tighter rule — it cannot mask a sibling class at all,
  rather than relying on distinct call-sets to keep them apart — so this PR's
  version is dropped rather than merged, and the story is marked done against
  #6898.
- **#6890** landed `pg-explain-option-validation-has-no-rails-counterpart`,
  which is the PG half of story 2 above. The overlap this PR's earlier revision
  flagged resolved itself in that direction; the MySQL half and the type were
  untouched there and remain here.

## Gates

`parity:api:calls` OK (464 baselined / 323 unreviewed, 119 marks tight),
`parity:api:calls:args` OK (146 shape rows), `parity:api:extra:gate` OK
(arel novel 0/0, total 63/63), `parity:test:assertions` OK, `pnpm lint` clean.
`parity:api` methods 13514/15423 and `parity:api:extra --package activerecord`
1422 both unmoved by this diff. 8 files, +164/-77.

Closes-story: time-new-takes-in-and-precision-kwargs
Closes-story: explain-format-hash-option-is-invented-surface
