### PR TITLE
refactor(arel): retire the root-file and barrel extra-surface residue

### DIFF
--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -26,7 +26,7 @@ describe("Attribute aggregates return typed Function subclasses", () => {
 
 describe("Attribute concat / contains / overlaps return typed infix subclasses", () => {
   it("concat builds a Concat (SQL ||), not a CONCAT(...) function", () => {
-    const c = users.attr("first").concat(users.attr("last"));
+    const c = users.get("first").concat(users.get("last"));
     expect(c).toBeInstanceOf(Nodes.Concat);
     const sql = compile(c);
     expect(sql).toBe('"users"."first" || "users"."last"');
@@ -35,14 +35,14 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
 
   it("contains is a Contains (PostgreSQL @>)", () => {
     const arr = new Nodes.SqlLiteral("ARRAY[1,2]");
-    const c = users.attr("ids").contains(arr);
+    const c = users.get("ids").contains(arr);
     expect(c).toBeInstanceOf(Nodes.Contains);
     expect(compile(c)).toContain("@>");
   });
 
   it("overlaps is an Overlaps (PostgreSQL &&)", () => {
     const arr = new Nodes.SqlLiteral("ARRAY[1,2]");
-    const o = users.attr("ids").overlaps(arr);
+    const o = users.get("ids").overlaps(arr);
     expect(o).toBeInstanceOf(Nodes.Overlaps);
     expect(compile(o)).toContain("&&");
   });
@@ -51,9 +51,9 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
     // Mirrors Rails' Predications#contains/#overlaps which call
     // `quoted_node(other)`. On Attribute that wraps the value in
     // Casted(value, this) so the visitor can apply column type-casting.
-    const c = users.attr("ids").contains([1, 2]);
+    const c = users.get("ids").contains([1, 2]);
     expect(c.right).toBeInstanceOf(Nodes.Casted);
-    const o = users.attr("ids").overlaps([1, 2]);
+    const o = users.get("ids").overlaps([1, 2]);
     expect(o.right).toBeInstanceOf(Nodes.Casted);
   });
 });
@@ -64,7 +64,7 @@ describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
   // becomes Casted(value, this) and keeps the column type-cast path;
   // ActiveModel::Attribute instances become BindParam and raw Nodes pass through.
   it("wraps a scalar in Casted(value, attribute)", () => {
-    const attr = users.attr("id");
+    const attr = users.get("id");
     const out = attr.quotedNode(42);
     expect(out).toBeInstanceOf(Nodes.Casted);
     expect((out as Nodes.Casted).value).toBe(42);
@@ -73,7 +73,7 @@ describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
 
   it("wraps null/undefined in Casted(nil, attribute)", () => {
     for (const nil of [null, undefined]) {
-      const attr = users.attr("id");
+      const attr = users.get("id");
       const out = attr.quotedNode(nil);
       expect(out).toBeInstanceOf(Nodes.Casted);
       expect((out as Nodes.Casted).attribute).toBe(attr);
@@ -83,7 +83,7 @@ describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
 
   it("passes through raw Nodes unchanged", () => {
     const lit = new Nodes.SqlLiteral("CURRENT_TIMESTAMP");
-    expect(users.attr("created_at").quotedNode(lit)).toBe(lit);
+    expect(users.get("created_at").quotedNode(lit)).toBe(lit);
   });
 });
 
@@ -99,11 +99,11 @@ describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
     new Visitors.ToSql(testConnection).accept(n, new Collectors.SQLString()).retryable;
 
   it("Attribute#as keeps the collector retryable", () => {
-    expect(collectorIsRetryableAfter(users.attr("id").as("aliased"))).toBe(true);
+    expect(collectorIsRetryableAfter(users.get("id").as("aliased"))).toBe(true);
   });
 
   it("Binary subclass `as` (via Equality#as) keeps the collector retryable", () => {
-    const eq = new Nodes.Equality(users.attr("id"), new Nodes.SqlLiteral("1", { retryable: true }));
+    const eq = new Nodes.Equality(users.get("id"), new Nodes.SqlLiteral("1", { retryable: true }));
     expect(collectorIsRetryableAfter(eq.as("aliased"))).toBe(true);
   });
 

--- a/packages/arel/src/delete-manager.test.ts
+++ b/packages/arel/src/delete-manager.test.ts
@@ -45,7 +45,7 @@ describe("DeleteManagerTest", () => {
   it("wheres getter returns WHERE conditions", () => {
     const manager = new DeleteManager();
     manager.from(users);
-    manager.where(users.attr("id").eq(1));
+    manager.where(users.get("id").eq(1));
     expect(manager.wheres.length).toBe(1);
   });
 });

--- a/packages/arel/src/errors.ts
+++ b/packages/arel/src/errors.ts
@@ -37,10 +37,3 @@ export class UnsupportedVisitError extends ArelError {
     this.name = "UnsupportedVisitError";
   }
 }
-
-export class NotImplementedError extends ArelError {
-  constructor(message: string) {
-    super(message);
-    this.name = "NotImplementedError";
-  }
-}

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -6,7 +6,7 @@ describe("TestFactoryMethods", () => {
   const users = new Table("users");
   const posts = new Table("posts");
   it("create join", () => {
-    const join = users.createJoin(posts, users.attr("id").eq(posts.attr("user_id")));
+    const join = users.createJoin(posts, users.get("id").eq(posts.get("user_id")));
     expect(join).toBeInstanceOf(Nodes.InnerJoin);
   });
 
@@ -33,7 +33,7 @@ describe("TestFactoryMethods", () => {
   });
 
   it("create on", () => {
-    const on = users.createOn(users.attr("id").eq(posts.attr("user_id")));
+    const on = users.createOn(users.get("id").eq(posts.get("user_id")));
     expect(on).toBeInstanceOf(Nodes.On);
   });
 

--- a/packages/arel/src/nodes/index.ts
+++ b/packages/arel/src/nodes/index.ts
@@ -107,9 +107,3 @@ export { Comment } from "./comment.js";
 export { Cte } from "./cte.js";
 export { UnaryOperation, BitwiseNot } from "./unary-operation.js";
 export { Filter } from "./filter.js";
-
-import { SqlLiteral } from "./sql-literal.js";
-
-export function sql(rawSql: string): SqlLiteral {
-  return new SqlLiteral(rawSql);
-}

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -13,20 +13,20 @@ const users = new Table("users");
 
 describe("Predications.groupingAny / groupingAll", () => {
   it("groupingAny dispatches by method-id and folds with OR (Grouping)", () => {
-    const out = Predications.groupingAny.call(users.attr("id"), "eq", [1, 2, 3]);
+    const out = Predications.groupingAny.call(users.get("id"), "eq", [1, 2, 3]);
     expect(out).toBeInstanceOf(Nodes.Grouping);
     const inner = out.expr as Nodes.Or;
     expect(inner).toBeInstanceOf(Nodes.Or);
   });
 
   it("groupingAll dispatches by method-id and folds with AND", () => {
-    const out = Predications.groupingAll.call(users.attr("id"), "gt", [1, 2]);
+    const out = Predications.groupingAll.call(users.get("id"), "gt", [1, 2]);
     expect(out).toBeInstanceOf(Nodes.Grouping);
     expect(out.expr).toBeInstanceOf(Nodes.And);
   });
 
   it("groupingAny accepts a closure variant (no stringly-typed dispatch)", () => {
-    const attr = users.attr("id");
+    const attr = users.get("id");
     const out = Predications.groupingAny.call(attr, (expr: unknown) => attr.eq(expr), [10, 20]);
     expect(out).toBeInstanceOf(Nodes.Grouping);
   });
@@ -36,7 +36,7 @@ describe("Predications.groupingAny / groupingAll", () => {
     // rerouting: Ruby's `Or.inject` on [] returns nil (rendered `NULL`), and an
     // empty `And` renders `()`. Both must survive the delegation unchanged,
     // since `NULL OR FALSE` is NULL while `FALSE OR FALSE` is FALSE.
-    const attr = users.attr("id");
+    const attr = users.get("id");
     const any = Predications.groupingAny.call(attr, "eq", []);
     expect(any.expr).toBeInstanceOf(Nodes.SqlLiteral);
     expect((any.expr as Nodes.SqlLiteral).value).toBe("NULL");
@@ -53,7 +53,7 @@ describe("Predications.groupingAny / groupingAll", () => {
     // and 155-161 forwards only escape to does_not_match. The extras arm of
     // grouping_any exists for exactly these four callers, so pin that the
     // arguments actually reach the built node.
-    const attr = users.attr("name");
+    const attr = users.get("name");
 
     // matches.rb:11 stores `escape && build_quoted(escape)`, so the arrival
     // shape is a Quoted, not the bare string.
@@ -67,7 +67,7 @@ describe("Predications.groupingAny / groupingAll", () => {
   });
 
   it("groupingAny throws a clear TypeError when the method-id isn't callable", () => {
-    const attr = users.attr("id");
+    const attr = users.get("id");
     expect(() => Predications.groupingAny.call(attr, "noSuchMethod", [1])).toThrowError(
       /noSuchMethod.*Attribute/,
     );
@@ -115,8 +115,8 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
   it("isInfinity does not unwrap Casted, which defines no infinite? in Rails", () => {
     // casted.rb:5-35 — Casted has no `infinite?`, so open_ended?(Casted(INFINITY))
     // is false in Rails and must stay false here.
-    expect(isInfinity(new Nodes.Casted(Infinity, users.attr("id")))).toBe(0);
-    expect(isOpenEnded(new Nodes.Casted(Infinity, users.attr("id")))).toBe(false);
+    expect(isInfinity(new Nodes.Casted(Infinity, users.get("id")))).toBe(0);
+    expect(isOpenEnded(new Nodes.Casted(Infinity, users.get("id")))).toBe(false);
   });
 
   it("isUnboundable duck-types the protocol and yields the sign", () => {
@@ -158,9 +158,9 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
     // between(BindParam(nil), 3) is lteq(3) rather than a Between over a nil bind.
     expect(isOpenEnded(new Nodes.BindParam(null))).toBe(true);
     expect(isOpenEnded(new Nodes.Quoted(null))).toBe(true);
-    expect(isOpenEnded(new Nodes.Casted(null, users.attr("id")))).toBe(true);
+    expect(isOpenEnded(new Nodes.Casted(null, users.get("id")))).toBe(true);
     expect(isOpenEnded(new Nodes.Quoted(3))).toBe(false);
-    expect(isOpenEnded(new Nodes.Casted(3, users.attr("id")))).toBe(false);
+    expect(isOpenEnded(new Nodes.Casted(3, users.get("id")))).toBe(false);
   });
 });
 
@@ -177,13 +177,13 @@ describe("Attribute private helpers (mirror Predications)", () => {
   };
 
   it("groupingAny / groupingAll work via method dispatch on Attribute", () => {
-    const attr = users.attr("id") as AttributePrivates;
+    const attr = users.get("id") as AttributePrivates;
     expect(attr.groupingAny("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
     expect(attr.groupingAll("eq", [1, 2])).toBeInstanceOf(Nodes.Grouping);
   });
 
   it("isInfinity / isUnboundable / isOpenEnded match Predications semantics", () => {
-    const attr = users.attr("id") as AttributePrivates;
+    const attr = users.get("id") as AttributePrivates;
     expect(attr.isInfinity(Infinity)).toBe(1);
     expect(attr.isInfinity(-Infinity)).toBe(-1);
     expect(attr.isInfinity(0)).toBe(0);
@@ -194,7 +194,7 @@ describe("Attribute private helpers (mirror Predications)", () => {
   });
 
   it("isUnboundable duck-types the protocol rather than always returning false", () => {
-    const attr = users.attr("id") as AttributePrivates;
+    const attr = users.get("id") as AttributePrivates;
     expect(attr.isUnboundable({ isUnboundable: () => -1 as const })).toBe(-1);
     expect(attr.isOpenEnded({ isUnboundable: () => 1 as const })).toBe(true);
   });
@@ -221,7 +221,7 @@ describe("between / notBetween self-dispatch (mirror Rails' implicit self)", () 
   });
 
   it("an un-overridden attribute is unaffected", () => {
-    const attr = users.attr("id");
+    const attr = users.get("id");
     expect(attr.between({ begin: 1, end: 2, excludeEnd: false })).toBeInstanceOf(Nodes.Between);
   });
 });
@@ -239,7 +239,7 @@ describe("SelectManager#collapse (Rails-fidelity helper)", () => {
   const mgr = new TestManager(users);
 
   it("returns the single survivor when there's only one non-null expr", () => {
-    const out = mgr.callCollapse([null, users.attr("id").eq(1), undefined]);
+    const out = mgr.callCollapse([null, users.get("id").eq(1), undefined]);
     expect(out).toBeInstanceOf(Nodes.Equality);
   });
 
@@ -250,7 +250,7 @@ describe("SelectManager#collapse (Rails-fidelity helper)", () => {
   });
 
   it("folds multiple exprs into an And via createAnd", () => {
-    const out = mgr.callCollapse([users.attr("id").eq(1), users.attr("name").eq("a")]);
+    const out = mgr.callCollapse([users.get("id").eq(1), users.get("name").eq("a")]);
     expect(out).toBeInstanceOf(Nodes.And);
     expect((out as Nodes.And).children).toHaveLength(2);
   });
@@ -269,7 +269,7 @@ describe("SelectManager#collapse (Rails-fidelity helper)", () => {
 
 describe("HomogeneousIn#ivars (Rails-fidelity helper)", () => {
   it("returns the [attribute, values, type] tuple Rails uses for hash/eql", () => {
-    const attr = users.attr("id");
+    const attr = users.get("id");
     const node = new Nodes.HomogeneousIn([1, 2, 3], attr, "in");
     // ivars is `protected` so cast to access. The point: the tuple
     // shape matches Rails' `[@attribute, @values, @type]`.

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -29,7 +29,7 @@ import { Concat, Contains, Overlaps } from "./nodes/infix-operation.js";
  * `In(this, undefined)`. A `Node` is excluded: it is the `else`-arm value
  * itself, not a manager wrapping one.
  */
-export function isSelectManagerLike(value: unknown): value is { ast: Node } {
+function isSelectManagerLike(value: unknown): value is { ast: Node } {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -59,7 +59,7 @@ export function isSelectManagerLike(value: unknown): value is { ast: Node } {
  *   Hash pair-expansion. This is a decided split, not an accident; both arms
  *   are pinned by tests.
  */
-export function isEnumerable(value: unknown): value is Iterable<unknown> {
+function isEnumerable(value: unknown): value is Iterable<unknown> {
   return typeof value === "object" && value !== null && Symbol.iterator in value;
 }
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -1199,7 +1199,7 @@ describe("SelectManagerTest", () => {
   describe("projections", () => {
     it("reads projections", () => {
       const users = new Table("users");
-      const manager = users.project(users.attr("name"), users.attr("age"));
+      const manager = users.project(users.get("name"), users.get("age"));
       expect(manager.projections.length).toBe(2);
     });
   });
@@ -1207,9 +1207,9 @@ describe("SelectManagerTest", () => {
   describe("projections=", () => {
     it("overwrites projections", () => {
       const users = new Table("users");
-      const manager = users.project(users.attr("name"));
+      const manager = users.project(users.get("name"));
       expect(manager.projections.length).toBe(1);
-      manager.projections = [users.attr("age")];
+      manager.projections = [users.get("age")];
       expect(manager.projections.length).toBe(1);
       const sql = manager.toSql();
       expect(sql).toContain('"age"');
@@ -1222,8 +1222,8 @@ describe("SelectManagerTest", () => {
       const users = new Table("users");
       const manager = users
         .project("*")
-        .where(users.attr("name").eq("Alice"))
-        .where(users.attr("age").gt(18));
+        .where(users.get("name").eq("Alice"))
+        .where(users.get("age").gt(18));
       expect(manager.constraints.length).toBe(2);
     });
   });
@@ -1237,7 +1237,7 @@ describe("SelectManagerTest", () => {
   describe("orders", () => {
     it("returns order clauses", () => {
       const users = new Table("users");
-      const manager = users.project("*").order(users.attr("name").asc());
+      const manager = users.project("*").order(users.get("name").asc());
       expect(manager.orders.length).toBe(1);
     });
   });
@@ -1245,7 +1245,7 @@ describe("SelectManagerTest", () => {
   describe("exists", () => {
     it("can be aliased", () => {
       const users = new Table("users");
-      const subquery = users.project(users.attr("id"));
+      const subquery = users.project(users.get("id"));
       const aliased = subquery.as("sub");
       expect(aliased).toBeInstanceOf(Nodes.TableAlias);
       expect((aliased.name as Nodes.SqlLiteral).value).toBe("sub");
@@ -1261,7 +1261,7 @@ describe("SelectManagerTest", () => {
     const manager = users
       .project("*")
       .join(posts)
-      .on(users.attr("id").eq(posts.attr("user_id")));
+      .on(users.get("id").eq(posts.get("user_id")));
     expect(manager.joinSources().length).toBe(1);
     expect(manager.joinSources()[0]).toBeInstanceOf(Nodes.InnerJoin);
   });
@@ -1271,9 +1271,9 @@ describe("SelectManagerTest", () => {
     const manager = users
       .project("*")
       .join(posts)
-      .on(users.attr("id").eq(posts.attr("user_id")))
+      .on(users.get("id").eq(posts.get("user_id")))
       .outerJoin(comments)
-      .on(posts.attr("id").eq(comments.attr("post_id")));
+      .on(posts.get("id").eq(comments.get("post_id")));
     expect(manager.joinSources().length).toBe(2);
     expect(manager.joinSources()[0]).toBeInstanceOf(Nodes.InnerJoin);
     expect(manager.joinSources()[1]).toBeInstanceOf(Nodes.OuterJoin);

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -211,7 +211,7 @@ describe("TableTest", () => {
   });
 
   it("manufactures an Attribute via attr()", () => {
-    expect(users.attr("email").name).toBe("email");
+    expect(users.get("email").name).toBe("email");
   });
 
   it("accepts :as option for table alias", () => {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -219,10 +219,6 @@ export class Table extends Node {
     return this.typeCaster != null;
   }
 
-  attr(name: string): Attribute {
-    return this.get(name);
-  }
-
   /**
    * The `*` projection for this table — `table.*` after visitor compilation.
    *

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -174,7 +174,7 @@ describe("UpdateManagerTest", () => {
     it("can be set", () => {
       const manager = new UpdateManager();
       manager.table(users);
-      manager.key = users.attr("id").eq(1);
+      manager.key = users.get("id").eq(1);
       expect(manager.ast.key).not.toBeNull();
     });
 
@@ -201,7 +201,7 @@ describe("UpdateManagerTest", () => {
   it("wheres getter returns WHERE conditions", () => {
     const manager = new UpdateManager();
     manager.table(users);
-    manager.where(users.attr("id").eq(1));
+    manager.where(users.get("id").eq(1));
     expect(manager.wheres.length).toBe(1);
   });
 

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -11,7 +11,7 @@ import {
   Nodes,
   Visitors,
 } from "../index.js";
-import { DotNode } from "./dot.js";
+import { Node as DotNode } from "./dot.js";
 
 /**
  * Drive Dot#visit on a bare value (rather than an AST root) and render the

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -1,4 +1,3 @@
-import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
@@ -16,7 +15,7 @@ function isAppendableCollector(c: unknown): c is AppendableCollector {
 }
 
 /** Mirrors `Arel::Visitors::Dot::Node` — a labeled box with side-fields. */
-export class DotNode {
+export class Node {
   readonly name: string;
   readonly id: number;
   readonly fields: string[];
@@ -34,12 +33,12 @@ export class DotNode {
  * `withNode()` call that supplies the destination. `toDot` asserts it's
  * populated by the time the graph is rendered.
  */
-export class DotEdge {
+export class Edge {
   readonly name: string;
-  readonly from: DotNode;
-  to?: DotNode;
+  readonly from: Node;
+  to?: Node;
 
-  constructor(name: string, from: DotNode) {
+  constructor(name: string, from: Node) {
     this.name = name;
     this.from = from;
   }
@@ -55,11 +54,11 @@ export class DotEdge {
  * by multiple node types, mirroring Rails' `alias`.
  */
 export class Dot extends Visitor {
-  private nodes: DotNode[] = [];
-  private edges: DotEdge[] = [];
-  private nodeStack: DotNode[] = [];
-  private edgeStack: DotEdge[] = [];
-  private seen: Map<unknown, DotNode> = new Map();
+  private nodes: Node[] = [];
+  private edges: Edge[] = [];
+  private nodeStack: Node[] = [];
+  private edgeStack: Edge[] = [];
+  private seen: Map<unknown, Node> = new Map();
   private nextId = 0;
 
   /**
@@ -70,7 +69,7 @@ export class Dot extends Visitor {
    */
   private static readonly NIL_SENTINEL = Symbol("Dot.NIL_SENTINEL");
 
-  override accept(object: Node, collector?: unknown): { value: string } {
+  override accept(object: Nodes.Node, collector?: unknown): { value: string } {
     if (!this.dispatch.has(Table)) {
       this.dispatch.set(Table, "visitArelTable");
     }
@@ -173,15 +172,15 @@ export class Dot extends Visitor {
   }
 
   /** Aliased to CurrentRow / Distinct in dispatch (Rails: `alias`). */
-  protected visitNoEdges(_o: Node): void {}
+  protected visitNoEdges(_o: Nodes.Node): void {}
 
   /** Rails: `alias :visit_Arel_Nodes_CurrentRow :visit__no_edges` (dot.rb:104). */
-  protected visitArelNodesCurrentRow(o: Node): void {
+  protected visitArelNodesCurrentRow(o: Nodes.Node): void {
     this.visitNoEdges(o);
   }
 
   /** Rails: `alias :visit_Arel_Nodes_Distinct :visit__no_edges` (dot.rb:105). */
-  protected visitArelNodesDistinct(o: Node): void {
+  protected visitArelNodesDistinct(o: Nodes.Node): void {
     this.visitNoEdges(o);
   }
 
@@ -436,7 +435,7 @@ export class Dot extends Visitor {
     //     NilClass node represents Rails' nil singleton;
     //   - booleans / numbers / bigints / symbols, via typed-prefix keys
     //     so repeated equal scalar edges (e.g. Regexp#caseSensitive) reuse
-    //     one DotNode the way Rails does;
+    //     one Node the way Rails does;
     //   - strings are explicitly excluded — they DON'T dedupe in Ruby
     //     (each String.new gets its own object_id), and a value-based
     //     dedupe would wrongly collapse same-named Tables.
@@ -468,7 +467,7 @@ export class Dot extends Visitor {
     // Mirrors Rails' Dot#visit: every value (including primitives) gets a
     // Node entry whose `name` is the value's class. visit_String / visit_Hash
     // / visit_Array then mutate the new node's fields/edges.
-    const node = new DotNode(this.classNameOf(object), this.nextId++);
+    const node = new Node(this.classNameOf(object), this.nextId++);
     if (seenKey !== undefined) {
       this.seen.set(seenKey, node);
     }
@@ -489,7 +488,7 @@ export class Dot extends Visitor {
 
   /** Mirrors Rails' Dot#edge — push edge, run block, pop. */
   protected edge(name: string, block: () => void): void {
-    const edge = new DotEdge(name, this.nodeStack[this.nodeStack.length - 1]);
+    const edge = new Edge(name, this.nodeStack[this.nodeStack.length - 1]);
     this.edgeStack.push(edge);
     this.edges.push(edge);
     try {
@@ -500,7 +499,7 @@ export class Dot extends Visitor {
   }
 
   /** Mirrors Rails' Dot#with_node — link incoming edge then push node. */
-  protected withNode(node: DotNode, block: () => void): void {
+  protected withNode(node: Node, block: () => void): void {
     const e = this.edgeStack[this.edgeStack.length - 1];
     if (e) e.to = node;
     this.nodeStack.push(node);
@@ -540,7 +539,7 @@ export class Dot extends Visitor {
   }
 
   /** Convenience entry that returns the dot string directly. */
-  compile(node: Node): string {
+  compile(node: Nodes.Node): string {
     return this.accept(node).value;
   }
 

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -3,9 +3,9 @@ export {
   splitSchemaQualifiedName,
   quoteSchemaQualifiedName,
 } from "./split-schema-qualified-name.js";
-export { UnsupportedVisitError, NotImplementedError } from "../errors.js";
+export { UnsupportedVisitError } from "../errors.js";
 export { MySQL } from "./mysql.js";
 export { PostgreSQL } from "./postgresql.js";
 export { SQLite } from "./sqlite.js";
-export { Dot, DotNode, DotEdge } from "./dot.js";
+export { Dot, Node, Edge } from "./dot.js";
 export { Visitor } from "./visitor.js";

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -732,7 +732,7 @@ describe("the to_sql visitor", () => {
       const core = new Nodes.SelectCore();
       core.setQuantifier = new Nodes.DistinctOn(new Nodes.SqlLiteral("aaron"));
       expect(() => new Visitors.ToSql(testConnection).compile(core)).toThrow(
-        Visitors.NotImplementedError,
+        "DISTINCT ON not implemented for this db",
       );
     });
   });
@@ -741,7 +741,7 @@ describe("the to_sql visitor", () => {
     it("raises not implemented error", () => {
       const node = new Nodes.Regexp(users.get("name"), new Nodes.Quoted("foo%"));
       expect(() => new Visitors.ToSql(testConnection).compile(node)).toThrow(
-        Visitors.NotImplementedError,
+        "~ not implemented for this db",
       );
     });
   });
@@ -750,7 +750,7 @@ describe("the to_sql visitor", () => {
     it("raises not implemented error", () => {
       const node = new Nodes.NotRegexp(users.get("name"), new Nodes.Quoted("foo%"));
       expect(() => new Visitors.ToSql(testConnection).compile(node)).toThrow(
-        Visitors.NotImplementedError,
+        "!~ not implemented for this db",
       );
     });
   });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -4,7 +4,7 @@ import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { SelectManager } from "../select-manager.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
-import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors.js";
+import { UnsupportedVisitError, BindError } from "../errors.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 // Mirrors Arel::Visitors::UnsupportedVisitError (defined in to_sql.rb:5
@@ -13,6 +13,19 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 // hierarchy alongside BindError/EmptyJoinError, but re-exports it from
 // here so parity:api finds it where Rails defines it.
 export { UnsupportedVisitError };
+
+/**
+ * Mirrors Ruby's core `NotImplementedError`, which `to_sql.rb` raises from the
+ * three strategy hooks below (:195, :521, :525). Ruby gets the class from the
+ * language, so `arel/errors.rb` declares nothing for it and neither does
+ * `errors.ts`; it stays file-local here, exactly where Rails raises it.
+ */
+class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotImplementedError";
+  }
+}
 
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
@@ -538,9 +551,7 @@ export class ToSql extends Visitor {
 
   protected visitArelNodesDistinctOn(_o: Nodes.DistinctOn, _collector: SQLString): SQLString {
     // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:194 cluster=arel-visitor-strategy
-    throw new NotImplementedError(
-      "DISTINCT ON is not supported by the base ToSql visitor. Use the PostgreSQL visitor instead.",
-    );
+    throw new NotImplementedError("DISTINCT ON not implemented for this db");
   }
 
   private visitArelNodesWith(o: Nodes.With, collector: SQLString): SQLString {
@@ -904,16 +915,12 @@ export class ToSql extends Visitor {
 
   protected visitArelNodesRegexp(_o: Nodes.Regexp, _collector: SQLString): SQLString {
     // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:520 cluster=arel-visitor-strategy
-    throw new NotImplementedError(
-      "Regexp (~ operator) is not supported by the base ToSql visitor. Use a database-specific visitor (e.g. PostgreSQL) instead.",
-    );
+    throw new NotImplementedError("~ not implemented for this db");
   }
 
   protected visitArelNodesNotRegexp(_o: Nodes.NotRegexp, _collector: SQLString): SQLString {
     // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/arel/visitors/to_sql.rb:524 cluster=arel-visitor-strategy
-    throw new NotImplementedError(
-      "NotRegexp (!~ operator) is not supported by the base ToSql visitor. Use a database-specific visitor (e.g. PostgreSQL) instead.",
-    );
+    throw new NotImplementedError("!~ not implemented for this db");
   }
 
   private visitArelNodesStringJoin(o: Nodes.StringJoin, collector: SQLString): SQLString {


### PR DESCRIPTION
Last story of RFC 0117's arel extra-surface burndown. `pnpm parity:api:extra --package arel` goes from **7 novel → 0 novel** for the whole package (`index.ts`, `nodes/index.ts`, `visitors/index.ts` and `arel.ts` all report 0 novel — no earlier story left a dangling re-export).

| retired | why |
| --- | --- |
| `Table#attr` | an alias for `get`, the port of `Arel::Table#[]` (`arel/table.rb:82`). Deleted; the seven test files that used it call `get`. |
| `errors.ts` `NotImplementedError` | a Ruby **builtin** — `arel/errors.rb` declares only `ArelError`/`EmptyJoinError`/`BindError`. Dropped from `errors.ts` and the visitors barrel and redeclared file-local in `visitors/to-sql.ts`, where Rails raises it (`to_sql.rb:195`, `:521`, `:525`), following the same shape `i18n/backend/base.ts` and `actionpack`'s `abstract-store.ts` already use. The three messages now match Rails verbatim (`"DISTINCT ON not implemented for this db"`, `"~ not implemented for this db"`, `"!~ not implemented for this db"`) — the trails strings had drifted. |
| `isEnumerable`, `isSelectManagerLike` | stand-ins for Ruby `is_a?` arms in `predications.rb:65-74` / `:112-121`; no longer exported. |
| `DotNode`, `DotEdge` | these are `Arel::Visitors::Dot::Node` and `::Edge` (`arel/visitors/dot.rb:6`, `:15`) — a naming question, not invented surface. Renamed to `Node` / `Edge`; the arel node type they collided with is now spelled `Nodes.Node`, which is how Ruby spells it (`Arel::Nodes::Node`). |
| `nodes/index.ts` `sql()` | zero callers, and Rails has no `Arel::Nodes.sql` — `Arel.sql` is `arel.rb:52`, already ported in `arel.ts`. It was the barrel's only top-level function, so the synthesized `Index` module row goes with it. |

No new `@noRailsEquivalent` / `@missingRailsCall` tag, and `scripts/parity/conventions.ts` needed no change: `OPERATOR_SPELLING_BY_FQN` already maps `Arel::Table#[]` → `get`, and the nested `Dot::Node`/`Dot::Edge` resolve once the TS names match the Ruby ones.

## Verification

- `pnpm parity:api:extra --package arel` — 0 novel (was 7); 31 files with drift (was 33)
- `pnpm parity:api:calls` — OK (577 baselined, 331 unreviewed); `pnpm parity:api:calls:args` — OK (155 baselined shape rows). No baseline row added.
- `pnpm parity:api` / `pnpm parity:test` deltas non-negative
- `pnpm lint --fix` clean, `pnpm build` clean
- `pnpm vitest run packages/arel` — 76 files, 1453 tests passed

Closes-story: arel-root-and-barrel-tail