### PR TITLE
refactor(activerecord,activemodel): converge the dirty predicates onto is*, declare dirty.rb:54

### DIFF
--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -187,8 +187,7 @@ export class DirtyTracker {
    * `attribute_changed?` conjoined with the `from:`/`to:` comparisons.
    */
   attributeChanged(name: string, options?: DirtyOptions): boolean {
-    if (!(this._changedAttributes.has(name) || this._isInPlaceMutableChange(name))) return false;
-    return this.isChanged(this.changes, name, options);
+    return this.isChanged(this.mutationsFromDatabase, name, options);
   }
 
   /**
@@ -196,7 +195,7 @@ export class DirtyTracker {
    * (attribute_mutation_tracker.rb:44-48) over `mutations_before_last_save`.
    */
   attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
-    return this.isChanged(this.previousChanges, name, options);
+    return this.isChanged(this.mutationsBeforeLastSave, name, options);
   }
 
   /**
@@ -206,7 +205,7 @@ export class DirtyTracker {
    * `saved_change_to_attribute?` / `will_save_change_to_attribute?` reader
    * delegates to.
    *
-   * @missingRailsArgs changed? — CONVERGEABLE: Rails picks the change set by picking one of its two tracker INSTANCES (`mutations_from_database` / `mutations_before_last_save`); trails has a single DirtyTracker holding both sets, so the set Ruby chose by receiver is a leading argument here. It converges when DirtyTracker splits into two AttributeMutationTracker instances (story `0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments` owns that split).
+   * @missingRailsArgs changed? — CONVERGEABLE: Rails picks the change set by picking one of its two tracker INSTANCES (`mutations_from_database` / `mutations_before_last_save`); trails has a single DirtyTracker holding both sets, so the set Ruby chose by receiver is a leading argument here. It converges when DirtyTracker splits into two AttributeMutationTracker instances (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers` owns that split).
    */
   isChanged(
     changes: Record<string, [unknown, unknown]>,

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -2,6 +2,12 @@ import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
 import { attributeMissing as attributeMissingDispatch } from "./attribute-methods.js";
 
+/** Rails' `**options` on `AttributeMutationTracker#changed?` (attribute_mutation_tracker.rb:44). */
+export interface DirtyOptions {
+  from?: unknown;
+  to?: unknown;
+}
+
 /**
  * Dirty mixin contract — tracks attribute changes on a model.
  *
@@ -17,9 +23,9 @@ export interface Dirty {
   readonly previousChanges: Record<string, [unknown, unknown]>;
   readonly mutationsFromDatabase: Record<string, [unknown, unknown]>;
   readonly mutationsBeforeLastSave: Record<string, [unknown, unknown]>;
-  attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean;
+  attributeChanged(name: string, options?: DirtyOptions): boolean;
   attributeWas(name: string): unknown;
-  attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean;
+  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean;
   attributePreviouslyWas(name: string): unknown;
   restoreAttributes(attrNames?: string[]): void;
   changesApplied(): void;
@@ -175,9 +181,44 @@ export class DirtyTracker {
     return this._hasInPlaceMutableChange();
   }
 
-  attributeChanged(name: string): boolean {
-    if (this._changedAttributes.has(name)) return true;
-    return this._isInPlaceMutableChange(name);
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed?
+   * (attribute_mutation_tracker.rb:44-48) over `mutations_from_database` —
+   * `attribute_changed?` conjoined with the `from:`/`to:` comparisons.
+   */
+  attributeChanged(name: string, options?: DirtyOptions): boolean {
+    if (!(this._changedAttributes.has(name) || this._isInPlaceMutableChange(name))) return false;
+    return this.isChanged(this.changes, name, options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed?
+   * (attribute_mutation_tracker.rb:44-48) over `mutations_before_last_save`.
+   */
+  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
+    return this.isChanged(this.previousChanges, name, options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed?
+   * (attribute_mutation_tracker.rb:44-48) — the one body every
+   * `attribute_changed?` / `attribute_previously_changed?` /
+   * `saved_change_to_attribute?` / `will_save_change_to_attribute?` reader
+   * delegates to.
+   *
+   * @missingRailsArgs changed? — CONVERGEABLE: Rails picks the change set by picking one of its two tracker INSTANCES (`mutations_from_database` / `mutations_before_last_save`); trails has a single DirtyTracker holding both sets, so the set Ruby chose by receiver is a leading argument here. It converges when DirtyTracker splits into two AttributeMutationTracker instances (story `0023-surfaced-deviations/construction-time-dirty-baseline-hides-ctor-assignments` owns that split).
+   */
+  isChanged(
+    changes: Record<string, [unknown, unknown]>,
+    name: string,
+    options?: DirtyOptions,
+  ): boolean {
+    if (!Object.hasOwn(changes, name)) return false;
+    if (!options) return true;
+    const change = changes[name];
+    if ("from" in options && change[0] !== options.from) return false;
+    if ("to" in options && change[1] !== options.to) return false;
+    return true;
   }
 
   attributeWas(name: string): unknown {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -68,6 +68,7 @@ export type { Mutable } from "./type/helpers/mutable.js";
 export { ModelName } from "./naming.js";
 export type { ModelLike } from "./naming.js";
 export { DirtyTracker } from "./dirty.js";
+export type { DirtyOptions } from "./dirty.js";
 export {
   _registerCallbackOnProto,
   hasCallbackOnProto,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -39,6 +39,7 @@ import { AttributeSet } from "./attribute-set.js";
 import { ModelLike, ModelName } from "./naming.js";
 import {
   DirtyTracker,
+  type DirtyOptions,
   initInternals as dirtyInitInternals,
   initializeDup as dirtyInitializeDup,
 } from "./dirty.js";
@@ -1776,15 +1777,15 @@ export class Model {
     return this._dirty.changes;
   }
 
-  attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    name = (this.constructor as typeof Model).resolveAttributeName(name);
-    if (!this._dirty.attributeChanged(name)) return false;
-    if (!options) return true;
-    const change = this._dirty.attributeChange(name);
-    if (!change) return false;
-    if ("from" in options && change[0] !== options.from) return false;
-    if ("to" in options && change[1] !== options.to) return false;
-    return true;
+  /**
+   * Mirrors: ActiveModel::Dirty#attribute_changed? (dirty.rb:300-302) —
+   * `mutations_from_database.changed?(attr_name.to_s, **options)`.
+   */
+  attributeChanged(name: string, options?: DirtyOptions): boolean {
+    return this._dirty.attributeChanged(
+      (this.constructor as typeof Model).resolveAttributeName(name),
+      options,
+    );
   }
 
   attributeWas(name: string): unknown {
@@ -1808,15 +1809,11 @@ export class Model {
    *
    * Mirrors: ActiveModel::Dirty#attribute_previously_changed?
    */
-  attributePreviouslyChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
-    name = (this.constructor as typeof Model).resolveAttributeName(name);
-    const changes = this._dirty.previousChanges;
-    if (!(name in changes)) return false;
-    if (!options) return true;
-    const change = changes[name];
-    if ("from" in options && change[0] !== options.from) return false;
-    if ("to" in options && change[1] !== options.to) return false;
-    return true;
+  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
+    return this._dirty.attributePreviouslyChanged(
+      (this.constructor as typeof Model).resolveAttributeName(name),
+      options,
+    );
   }
 
   /**

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -222,7 +222,7 @@ export class BelongsToAssociation extends SingularAssociation {
   }
 
   isSavedChangeToTarget(): boolean {
-    return this.foreignKeyNames().some((fk) => this.owner.savedChangeToAttribute(fk));
+    return this.foreignKeyNames().some((fk) => this.owner.isSavedChangeToAttribute(fk));
   }
 
   // --- Protected ---

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -46,7 +46,7 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
 
   override isSavedChangeToTarget(): boolean {
     return (
-      super.isSavedChangeToTarget() || this.owner.savedChangeToAttribute(this.foreignTypeName())
+      super.isSavedChangeToTarget() || this.owner.isSavedChangeToAttribute(this.foreignTypeName())
     );
   }
 

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -12,6 +12,7 @@ import {
   isInstanceMethodAlreadyImplemented as _amInstanceMethodAlreadyImplemented,
   defineAttributeMethods as amDefineAttributeMethods,
   type InstanceHost as AttributeMethodsInstanceHost,
+  type DirtyOptions,
 } from "@blazetrails/activemodel";
 import { DangerousAttributeError } from "./errors.js";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
@@ -898,7 +899,6 @@ import { queryCastAttribute as _queryCastAttribute } from "./attribute-methods/q
 // import from it here (cycle). These 5 delegates are inlined the same way
 // toKey/id are inlined above (see comment near line 12).
 import {
-  type DirtyOptions,
   isSavedChangeToAttribute as _isSavedChangeToAttribute,
   savedChangeToAttribute as _savedChangeToAttribute,
   attributeBeforeLastSave as _attributeBeforeLastSave,

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -10,13 +10,13 @@
 import { Temporal } from "@blazetrails/date";
 import type { DirtyOptions } from "@blazetrails/activemodel";
 
-export type { DirtyOptions };
-
 interface DirtyRecord {
   changed: boolean;
   changedAttributes: Record<string, unknown>;
   changes: Record<string, [unknown, unknown]>;
   previousChanges: Record<string, [unknown, unknown]>;
+  mutationsFromDatabase: Record<string, [unknown, unknown]>;
+  mutationsBeforeLastSave: Record<string, [unknown, unknown]>;
   readAttribute(name: string): unknown;
   /** @internal */
   _dirty: {
@@ -35,14 +35,14 @@ interface DirtyRecord {
  * (dirty.rb:86-88) — `mutations_before_last_save.changed?(attr_name.to_s,
  * **options)`.
  *
- * @missingRailsArgs changed? — CONVERGEABLE: trails' single DirtyTracker holds both of Ruby's tracker instances' change sets, so the set Ruby names by receiver is `changed?`'s leading argument here. See `DirtyTracker#isChanged`.
+ * @missingRailsArgs changed? — CONVERGEABLE: trails' single DirtyTracker holds both of Ruby's tracker instances' change sets, so the set Ruby names by receiver is `changed?`'s leading argument here. Story: `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`.
  */
 export function isSavedChangeToAttribute(
   record: DirtyRecord,
   attr: string,
   options?: DirtyOptions,
 ): boolean {
-  return record._dirty.isChanged(record.previousChanges, attr, options);
+  return record._dirty.isChanged(record.mutationsBeforeLastSave, attr, options);
 }
 
 /**
@@ -90,7 +90,7 @@ export function isWillSaveChangeToAttribute(
   attr: string,
   options?: DirtyOptions,
 ): boolean {
-  return record._dirty.isChanged(record.changes, attr, options);
+  return record._dirty.isChanged(record.mutationsFromDatabase, attr, options);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -8,12 +8,9 @@
  */
 
 import { Temporal } from "@blazetrails/date";
+import type { DirtyOptions } from "@blazetrails/activemodel";
 
-/** Rails' `**options` for the two `changed?`-backed predicates (dirty.rb:86, 138). */
-export interface DirtyOptions {
-  from?: unknown;
-  to?: unknown;
-}
+export type { DirtyOptions };
 
 interface DirtyRecord {
   changed: boolean;
@@ -21,27 +18,14 @@ interface DirtyRecord {
   changes: Record<string, [unknown, unknown]>;
   previousChanges: Record<string, [unknown, unknown]>;
   readAttribute(name: string): unknown;
-}
-
-/**
- * Mirrors: ActiveModel::AttributeMutationTracker#changed?
- * (attribute_mutation_tracker.rb:44-48) — the one body
- * `saved_change_to_attribute?` and `will_save_change_to_attribute?` share, over
- * `mutations_before_last_save` and `mutations_from_database` respectively.
- * Rails' `type_cast(attr_name, …)` of each option happens on `Base`, where the
- * enum registry is reachable.
- */
-function changed(
-  changes: Record<string, [unknown, unknown]>,
-  attr: string,
-  options?: DirtyOptions,
-): boolean {
-  if (!Object.prototype.hasOwnProperty.call(changes, attr)) return false;
-  if (!options) return true;
-  const change = changes[attr];
-  if ("from" in options && change[0] !== options.from) return false;
-  if ("to" in options && change[1] !== options.to) return false;
-  return true;
+  /** @internal */
+  _dirty: {
+    isChanged(
+      changes: Record<string, [unknown, unknown]>,
+      name: string,
+      options?: DirtyOptions,
+    ): boolean;
+  };
 }
 
 /**
@@ -50,13 +34,15 @@ function changed(
  * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_change_to_attribute?
  * (dirty.rb:86-88) — `mutations_before_last_save.changed?(attr_name.to_s,
  * **options)`.
+ *
+ * @missingRailsArgs changed? — CONVERGEABLE: trails' single DirtyTracker holds both of Ruby's tracker instances' change sets, so the set Ruby names by receiver is `changed?`'s leading argument here. See `DirtyTracker#isChanged`.
  */
 export function isSavedChangeToAttribute(
   record: DirtyRecord,
   attr: string,
   options?: DirtyOptions,
 ): boolean {
-  return changed(record.previousChanges, attr, options);
+  return record._dirty.isChanged(record.previousChanges, attr, options);
 }
 
 /**
@@ -96,13 +82,15 @@ export function isSavedChanges(record: DirtyRecord): boolean {
  * Mirrors: ActiveRecord::AttributeMethods::Dirty#will_save_change_to_attribute?
  * (dirty.rb:138-140) — `mutations_from_database.changed?(attr_name.to_s,
  * **options)`.
+ *
+ * @missingRailsArgs changed? — CONVERGEABLE: same single-tracker reason as `isSavedChangeToAttribute` above.
  */
 export function isWillSaveChangeToAttribute(
   record: DirtyRecord,
   attr: string,
   options?: DirtyOptions,
 ): boolean {
-  return changed(record.changes, attr, options);
+  return record._dirty.isChanged(record.changes, attr, options);
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -11,10 +11,6 @@ import { Temporal } from "@blazetrails/date";
 import type { DirtyOptions } from "@blazetrails/activemodel";
 
 interface DirtyRecord {
-  changed: boolean;
-  changedAttributes: Record<string, unknown>;
-  changes: Record<string, [unknown, unknown]>;
-  previousChanges: Record<string, [unknown, unknown]>;
   mutationsFromDatabase: Record<string, [unknown, unknown]>;
   mutationsBeforeLastSave: Record<string, [unknown, unknown]>;
   readAttribute(name: string): unknown;
@@ -54,7 +50,7 @@ export function savedChangeToAttribute(
   record: DirtyRecord,
   attr: string,
 ): [unknown, unknown] | null {
-  return record.previousChanges[attr] ?? null;
+  return record.mutationsBeforeLastSave[attr] ?? null;
 }
 
 /**
@@ -73,7 +69,7 @@ export function attributeBeforeLastSave(record: DirtyRecord, attr: string): unkn
  * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_changes?
  */
 export function isSavedChanges(record: DirtyRecord): boolean {
-  return Object.keys(record.previousChanges).length > 0;
+  return Object.keys(record.mutationsBeforeLastSave).length > 0;
 }
 
 /**
@@ -102,7 +98,7 @@ export function attributeChangeToBeSaved(
   record: DirtyRecord,
   attr: string,
 ): [unknown, unknown] | null {
-  return record.changes[attr] ?? null;
+  return record.mutationsFromDatabase[attr] ?? null;
 }
 
 /**

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -789,8 +789,8 @@ export function is_recordChanged(reflection: any, record: any, key: any[]): bool
     (typeof record.isNewRecord === "function" ? record.isNewRecord() : false) ||
     isAssociationForeignKeyChanged(reflection, record, key) ||
     isInversePolymorphicAssociationChanged(reflection, record) ||
-    (typeof record.willSaveChangeToAttribute === "function"
-      ? fkCols.some((col) => record.willSaveChangeToAttribute(col))
+    (typeof record.isWillSaveChangeToAttribute === "function"
+      ? fkCols.some((col) => record.isWillSaveChangeToAttribute(col))
       : false)
   );
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4878,10 +4878,9 @@ include(Base, {
   // with `include(Base, _PrimaryKey)` / `include(Base, _CompositePrimaryKey)`
   // above: the readers are accessor properties, and only those calls copy
   // descriptors — this object literal is read by value and would flatten them.
-  // `isSavedChangeToAttribute` / `isWillSaveChangeToAttribute` are defined in
-  // the class body above (they carry the alias + enum type_cast step), so they
-  // are deliberately absent here — this literal is assigned onto the prototype
-  // after the class and would otherwise clobber them.
+  // `isSavedChangeToAttribute` / `isWillSaveChangeToAttribute` are absent on
+  // purpose: this literal lands on the prototype after the class body and would
+  // clobber the overrides there that carry the alias + enum type_cast step.
   savedChangeToAttribute: _savedChangeToAttribute,
   attributeBeforeLastSave: _attributeBeforeLastSave,
   attributeChangeToBeSaved: _attributeChangeToBeSaved,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -131,6 +131,7 @@ import {
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
+  type DirtyOptions,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
 import * as Inheritance from "./inheritance.js";
@@ -206,6 +207,7 @@ import {
   attributeForDatabase as _attributeForDatabase,
   queryCastAttribute as _queryCastAttribute,
   isSavedChangeToAttribute as _isSavedChangeToAttribute,
+  savedChangeToAttribute as _savedChangeToAttribute,
   attributeBeforeLastSave as _attributeBeforeLastSave,
   isWillSaveChangeToAttribute as _isWillSaveChangeToAttribute,
   attributeChangeToBeSaved as _attributeChangeToBeSaved,
@@ -1721,12 +1723,13 @@ export class Base extends Model {
    * The `class_attribute` writer gives Active Record its own array rather than
    * mutating ActiveModel's.
    *
-   * dirty.rb:54's `attribute_method_prefix("saved_change_to_",
-   * parameters: false)` has no entry: Ruby tells the array-returning
-   * `saved_change_to_name` from the predicate `saved_change_to_name?` by the
-   * `?`, which the camel spelling drops, so both would generate
-   * `savedChangeToName`. Story:
-   * 0096-naming-identifier-burndown/saved-change-to-attribute-values-generated-half.
+   * Ruby tells the predicate `saved_change_to_name?` (dirty.rb:53) from the
+   * array-returning `saved_change_to_name` (dirty.rb:54) by the trailing `?`,
+   * which the camel spelling drops; the `is*` prefix
+   * (docs/ruby-ts-conventions.md) is where TypeScript puts the same
+   * distinction, so it goes in the pattern's own prefix and the derived
+   * `${prefix}Attribute${suffix}` proxy target (attribute_methods.rb:481)
+   * lands on `isSavedChangeToAttribute` unchanged.
    */
   static {
     this.attributeMethodPatterns = [
@@ -1734,9 +1737,10 @@ export class Base extends Model {
       new AttributeMethodPattern({ suffix: "BeforeTypeCast", parameters: false }),
       new AttributeMethodPattern({ suffix: "ForDatabase", parameters: false }),
       new AttributeMethodPattern({ suffix: "CameFromUser", parameters: false }),
-      new AttributeMethodPattern({ prefix: "savedChangeTo", parameters: "**options" }),
+      new AttributeMethodPattern({ prefix: "isSavedChangeTo", parameters: "**options" }),
+      new AttributeMethodPattern({ prefix: "savedChangeTo", parameters: false }),
       new AttributeMethodPattern({ suffix: "BeforeLastSave", parameters: false }),
-      new AttributeMethodPattern({ prefix: "willSaveChangeTo", parameters: "**options" }),
+      new AttributeMethodPattern({ prefix: "isWillSaveChangeTo", parameters: "**options" }),
       new AttributeMethodPattern({ suffix: "ChangeToBeSaved", parameters: false }),
       new AttributeMethodPattern({ suffix: "InDatabase", parameters: false }),
     ];
@@ -1954,7 +1958,7 @@ export class Base extends Model {
   // Cast `from:`/`to:` options through the enum mapping before comparison.
   // Rails normalises these via AttributeMutationTracker#type_cast (which calls
   // type.cast on the attribute's EnumType); we mirror it here for both live
-  // changes (attributeChanged) and persisted changes (savedChangeToAttribute).
+  // changes (attributeChanged) and persisted changes (isSavedChangeToAttribute).
   // All enums are label-stored via the registered EnumType with their mapping
   // in the single `_enums` registry.
   override attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
@@ -1976,16 +1980,8 @@ export class Base extends Model {
    * (attribute_mutation_tracker.rb:44-48) and trails cannot: alias resolution
    * and the `type_cast(attr_name, …)` of each option through the attribute's
    * `EnumType`, both of which need the class, not the record.
-   *
-   * The NAME is forced: a generated `savedChangeToName` reaches its target
-   * through the derived `${prefix}attribute${suffix}` join
-   * (attribute_methods.rb:481), and Ruby tells the predicate from the value
-   * reader by a TRAILING `?` where TypeScript's convention is a LEADING `is` —
-   * so no pattern can derive `isSavedChangeToAttribute`, the spelling the port
-   * carries. Story:
-   * 0096-naming-identifier-burndown/converge-ar-dirty-generic-names-onto-dirty-ts.
    */
-  savedChangeToAttribute(name: string, options?: { from?: unknown; to?: unknown }): boolean {
+  isSavedChangeToAttribute(name: string, options?: DirtyOptions): boolean {
     const ctor = this.constructor as typeof Base;
     if (options) {
       const canonical = (ctor as any).attributeAliases?.[name] ?? name;
@@ -1996,10 +1992,10 @@ export class Base extends Model {
 
   /**
    * Mirrors: ActiveRecord::AttributeMethods::Dirty#will_save_change_to_attribute?
-   * (attribute_methods/dirty.rb:138-140). Same split and the same forced
-   * spelling as {@link Base.savedChangeToAttribute}.
+   * (attribute_methods/dirty.rb:138-140). Same split as
+   * {@link Base.isSavedChangeToAttribute}.
    */
-  willSaveChangeToAttribute(name: string, options?: { from?: unknown; to?: unknown }): boolean {
+  isWillSaveChangeToAttribute(name: string, options?: DirtyOptions): boolean {
     const ctor = this.constructor as typeof Base;
     if (options) {
       const canonical = (ctor as any).attributeAliases?.[name] ?? name;
@@ -3557,7 +3553,7 @@ export class Base extends Model {
           // use valueForDatabase (user-set value as expected DB version → stale if mismatch).
           // Otherwise use originalValueForDatabase() so NULL-in-DB → IS NULL.
           const lockAttr = this._attributes.getAttribute(lockCol);
-          const lockWhereValue = this.willSaveChangeToAttribute(lockCol)
+          const lockWhereValue = this.isWillSaveChangeToAttribute(lockCol)
             ? lockAttr.valueForDatabase
             : lockAttr.originalValueForDatabase();
           if (lockWhereValue == null) {
@@ -4882,9 +4878,12 @@ include(Base, {
   // with `include(Base, _PrimaryKey)` / `include(Base, _CompositePrimaryKey)`
   // above: the readers are accessor properties, and only those calls copy
   // descriptors — this object literal is read by value and would flatten them.
-  isSavedChangeToAttribute: _isSavedChangeToAttribute,
+  // `isSavedChangeToAttribute` / `isWillSaveChangeToAttribute` are defined in
+  // the class body above (they carry the alias + enum type_cast step), so they
+  // are deliberately absent here — this literal is assigned onto the prototype
+  // after the class and would otherwise clobber them.
+  savedChangeToAttribute: _savedChangeToAttribute,
   attributeBeforeLastSave: _attributeBeforeLastSave,
-  isWillSaveChangeToAttribute: _isWillSaveChangeToAttribute,
   attributeChangeToBeSaved: _attributeChangeToBeSaved,
   attributeInDatabase: _attributeInDatabase,
   attributeNamesForPartialUpdates: _attributeNamesForPartialUpdates,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1961,7 +1961,7 @@ export class Base extends Model {
   // changes (attributeChanged) and persisted changes (isSavedChangeToAttribute).
   // All enums are label-stored via the registered EnumType with their mapping
   // in the single `_enums` registry.
-  override attributeChanged(name: string, options?: { from?: unknown; to?: unknown }): boolean {
+  override attributeChanged(name: string, options?: DirtyOptions): boolean {
     if (options) {
       const ctor = this.constructor as typeof Base;
       const canonical = (ctor as any).attributeAliases?.[name] ?? name;

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -268,10 +268,10 @@ describe("init_internals / initialize_dup super chain", () => {
     // Dirty#initialize_dup: the copy carries the source's pending changes but on
     // its own tracker, so writing to one no longer marks the other.
     expect(duped.title).toBe("Bob");
-    expect(duped.willSaveChangeToAttribute("title")).toBe(true);
+    expect(duped.isWillSaveChangeToAttribute("title")).toBe(true);
     duped.content = "Changed";
-    expect(duped.willSaveChangeToAttribute("content")).toBe(true);
-    expect(topic.willSaveChangeToAttribute("content")).toBe(false);
+    expect(duped.isWillSaveChangeToAttribute("content")).toBe(true);
+    expect(topic.isWillSaveChangeToAttribute("content")).toBe(false);
     expect(topic.content).toBe("Hello");
 
     expect(duped.isNewRecord()).toBe(true);

--- a/packages/activerecord/src/dirty-generated-methods.trails.test.ts
+++ b/packages/activerecord/src/dirty-generated-methods.trails.test.ts
@@ -16,8 +16,9 @@ interface Generated {
   changesApplied(): void;
   readonly nameInDatabase: unknown;
   readonly nameBeforeLastSave: unknown;
-  savedChangeToName(): boolean;
-  willSaveChangeToName(): boolean;
+  isSavedChangeToName(): boolean;
+  readonly savedChangeToName: [unknown, unknown] | null;
+  isWillSaveChangeToName(): boolean;
 }
 
 describe("DirtyGeneratedMethods", () => {
@@ -47,11 +48,20 @@ describe("DirtyGeneratedMethods", () => {
     const p = Person.new({}) as unknown as Generated;
     p.changesApplied();
     p.name = "Bob";
-    expect(p.willSaveChangeToName()).toBe(true);
-    expect(p.savedChangeToName()).toBe(false);
+    expect(p.isWillSaveChangeToName()).toBe(true);
+    expect(p.isSavedChangeToName()).toBe(false);
     p.changesApplied();
-    expect(p.willSaveChangeToName()).toBe(false);
-    expect(p.savedChangeToName()).toBe(true);
+    expect(p.isWillSaveChangeToName()).toBe(false);
+    expect(p.isSavedChangeToName()).toBe(true);
+  });
+
+  it("savedChangeTo<Attr> returns the last save's [old, new] pair", () => {
+    const p = Person.new({ name: "Alice" }) as unknown as Generated;
+    p.changesApplied();
+    expect(p.savedChangeToName).toEqual([null, "Alice"]);
+    p.name = "Bob";
+    p.changesApplied();
+    expect(p.savedChangeToName).toEqual(["Alice", "Bob"]);
   });
 });
 
@@ -74,8 +84,8 @@ describe("willSaveChangeToAttribute", () => {
     const w = new Widget({ name: "Test", size: 5 });
     w.changesApplied();
     w.writeAttribute("name", "Changed");
-    expect(w.willSaveChangeToAttribute("name")).toBe(true);
-    expect(w.willSaveChangeToAttribute("size")).toBe(false);
+    expect(w.isWillSaveChangeToAttribute("name")).toBe(true);
+    expect(w.isWillSaveChangeToAttribute("size")).toBe(false);
   });
 
   it("attributeChangeToBeSaved returns [old, new]", () => {
@@ -100,8 +110,8 @@ describe("willSaveChangeToAttribute", () => {
     const u = new User({ name: "Alice" });
     u.changesApplied();
     u.writeAttribute("name", "Bob");
-    expect(u.willSaveChangeToAttribute("name", { from: "Alice", to: "Bob" })).toBe(true);
-    expect(u.willSaveChangeToAttribute("name", { from: "Wrong" })).toBe(false);
+    expect(u.isWillSaveChangeToAttribute("name", { from: "Alice", to: "Bob" })).toBe(true);
+    expect(u.isWillSaveChangeToAttribute("name", { from: "Wrong" })).toBe(false);
   });
 });
 
@@ -143,8 +153,8 @@ describe("attributeInDatabase / attributeBeforeLastSave", () => {
     u.changesApplied();
     u.writeAttribute("name", "Bob");
     u.changesApplied();
-    expect(u.savedChangeToAttribute("name", { from: "Alice", to: "Bob" })).toBe(true);
-    expect(u.savedChangeToAttribute("name", { from: "Alice", to: "Wrong" })).toBe(false);
-    expect(u.savedChangeToAttribute("name", { from: "Wrong", to: "Bob" })).toBe(false);
+    expect(u.isSavedChangeToAttribute("name", { from: "Alice", to: "Bob" })).toBe(true);
+    expect(u.isSavedChangeToAttribute("name", { from: "Alice", to: "Wrong" })).toBe(false);
+    expect(u.isSavedChangeToAttribute("name", { from: "Wrong", to: "Bob" })).toBe(false);
   });
 });

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -1028,14 +1028,14 @@ describe("DirtyTest", () => {
   it("saved_change_to_attribute? returns whether a change occurred in the last save", async () => {
     const person = (await Person.create({ first_name: "Sean" })) as Rec;
 
-    expect(person.savedChangeToAttribute("first_name")).toBe(true);
-    expect(person.savedChangeToAttribute("gender")).toBe(false);
-    expect(person.savedChangeToAttribute("first_name", { from: null, to: "Sean" })).toBe(true);
-    expect(person.savedChangeToAttribute("first_name", { from: null })).toBe(true);
-    expect(person.savedChangeToAttribute("first_name", { to: "Sean" })).toBe(true);
-    expect(person.savedChangeToAttribute("first_name", { from: "Jim", to: "Sean" })).toBe(false);
-    expect(person.savedChangeToAttribute("first_name", { from: "Jim" })).toBe(false);
-    expect(person.savedChangeToAttribute("first_name", { to: "Jim" })).toBe(false);
+    expect(person.isSavedChangeToAttribute("first_name")).toBe(true);
+    expect(person.isSavedChangeToAttribute("gender")).toBe(false);
+    expect(person.isSavedChangeToAttribute("first_name", { from: null, to: "Sean" })).toBe(true);
+    expect(person.isSavedChangeToAttribute("first_name", { from: null })).toBe(true);
+    expect(person.isSavedChangeToAttribute("first_name", { to: "Sean" })).toBe(true);
+    expect(person.isSavedChangeToAttribute("first_name", { from: "Jim", to: "Sean" })).toBe(false);
+    expect(person.isSavedChangeToAttribute("first_name", { from: "Jim" })).toBe(false);
+    expect(person.isSavedChangeToAttribute("first_name", { to: "Jim" })).toBe(false);
   });
 
   it("saved_change_to_attribute returns the change that occurred in the last save", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2064,7 +2064,7 @@ describe("PersistenceTest", () => {
   it("update attribute in before validation respects callback chain", async () => {
     let counter = 0;
     const callOnce = (record: any) => {
-      if (record.savedChangeToAuthor_name()) counter += 1;
+      if (record.isSavedChangeToAuthor_name()) counter += 1;
     };
     class TrackingTopic extends Topic {
       static {
@@ -2076,7 +2076,7 @@ describe("PersistenceTest", () => {
           callOnce(this);
         });
         self.afterUpdate(function (this: any) {
-          if (this.savedChangeToAuthor_name()) callOnce(this);
+          if (this.isSavedChangeToAuthor_name()) callOnce(this);
         });
       }
     }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1536,7 +1536,7 @@ type PersistenceInstanceChainHost = {
   _attributes: any;
   _dirty: { reinstateNewRecordChanges(attributes: unknown, skip: Set<string>): void };
   readAttribute(name: string): unknown;
-  willSaveChangeToAttribute(name: string): boolean;
+  isWillSaveChangeToAttribute(name: string): boolean;
   _readAttribute(name: string): unknown;
   _writeAttribute(name: string, value: unknown): void;
 };

--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -169,8 +169,8 @@ describe("StoreTest", () => {
 
     await john.save();
     expect((john as any).partner_nameChange()).toBeNull();
-    expect((john as any).savedChangeToPartner_name()).toBe(true);
-    expect((john as any).savedChangeToPartner_nameValues()).toEqual(["Dallas", "Lena"]);
+    expect((john as any).isSavedChangeToPartner_name()).toBe(true);
+    expect((john as any).savedChangeToPartner_name()).toEqual(["Dallas", "Lena"]);
     expect((john as any).partner_nameBeforeLastSave()).toBe("Dallas");
   });
 
@@ -181,8 +181,8 @@ describe("StoreTest", () => {
 
     await john.save();
     expect((john as any).enableFriendRequestsChange()).toBeNull();
-    expect((john as any).savedChangeToEnableFriendRequests()).toBe(true);
-    expect((john as any).savedChangeToEnableFriendRequestsValues()).toEqual([null, true]);
+    expect((john as any).isSavedChangeToEnableFriendRequests()).toBe(true);
+    expect((john as any).savedChangeToEnableFriendRequests()).toEqual([null, true]);
     (john as any).enableFriendRequests = false;
     await john.save();
     expect((john as any).enableFriendRequestsBeforeLastSave()).toBe(true);

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -390,20 +390,21 @@ export function storeAccessor(
       const [prevStore] = this.changes[storeAttribute] ?? [undefined];
       return dig(prevStore, key) ?? null;
     });
-    // Matches `Base`'s `savedChangeToAttribute(name)` predicate shape; the value
-    // form is exposed as `savedChangeTo<X>Values()`.
-    define(`savedChangeTo${cap}`, function (this) {
-      if (!this.savedChangeToAttribute?.(storeAttribute)) return false;
+    // store.rb:164-175 — `saved_change_to_#{accessor_key}?` and
+    // `saved_change_to_#{accessor_key}`, the predicate/array pair the `?`
+    // separates in Ruby and the `is*` prefix separates here.
+    define(`isSavedChangeTo${cap}`, function (this) {
+      if (!this.isSavedChangeToAttribute?.(storeAttribute)) return false;
       const [prevStore, newStore] = this.savedChanges?.[storeAttribute] ?? [undefined, undefined];
       return dig(prevStore, key) !== dig(newStore, key);
     });
-    define(`savedChangeTo${cap}Values`, function (this) {
-      if (!this.savedChangeToAttribute?.(storeAttribute)) return null;
+    define(`savedChangeTo${cap}`, function (this) {
+      if (!this.isSavedChangeToAttribute?.(storeAttribute)) return null;
       const [prevStore, newStore] = this.savedChanges?.[storeAttribute] ?? [undefined, undefined];
       return [dig(prevStore, key) ?? null, dig(newStore, key) ?? null];
     });
     define(`${accessorKey}BeforeLastSave`, function (this) {
-      if (!this.savedChangeToAttribute?.(storeAttribute)) return null;
+      if (!this.isSavedChangeToAttribute?.(storeAttribute)) return null;
       const [prevStore] = this.savedChanges?.[storeAttribute] ?? [undefined];
       return dig(prevStore, key) ?? null;
     });
@@ -422,7 +423,7 @@ export function storeAccessor(
 
 interface StoreDirtyHost {
   attributeChanged(name: string): boolean;
-  savedChangeToAttribute(name: string): boolean;
+  isSavedChangeToAttribute(name: string): boolean;
   changes: Record<string, [unknown, unknown]>;
   savedChanges: Record<string, [unknown, unknown]>;
 }

--- a/packages/activerecord/src/test-helpers/models/topic.ts
+++ b/packages/activerecord/src/test-helpers/models/topic.ts
@@ -175,7 +175,7 @@ export class Topic extends Base {
 
   /** @internal */
   private setEmailAddress() {
-    if (!this.isPersisted() && !this.willSaveChangeToAttribute("author_email_address")) {
+    if (!this.isPersisted() && !this.isWillSaveChangeToAttribute("author_email_address")) {
       this.writeAttribute("author_email_address", "test@test.com");
     }
   }

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -283,7 +283,7 @@ interface TimestampInstanceHost {
   readAttribute?(name: string): unknown;
   _readAttribute?(name: string): unknown;
   _writeAttribute?(name: string, val: unknown): void;
-  willSaveChangeToAttribute?(name: string): boolean;
+  isWillSaveChangeToAttribute?(name: string): boolean;
   clearAttributeChange?(name: string): void;
   hasChangesToSave?: boolean;
   id?: unknown;
@@ -503,7 +503,7 @@ export async function recordUpdateTimestamps<T>(
   if (this._touchRecord && shouldRecordTimestamps.call(this)) {
     const currentTime = currentTimeFromProperTimezone();
     for (const column of timestampAttributesForUpdateInModel.call(this.constructor)) {
-      if (!this.willSaveChangeToAttribute?.(column)) {
+      if (!this.isWillSaveChangeToAttribute?.(column)) {
         this._writeAttribute?.(column, currentTime);
       }
     }


### PR DESCRIPTION
Converges the two ActiveRecord dirty predicates onto the names the ports already
carry, and declares the one `attribute_method_prefix` that name was blocking.

## The name

`saved_change_to_attribute?` / `will_save_change_to_attribute?`
(`activerecord/lib/active_record/attribute_methods/dirty.rb:86-88`, `:138-140`)
are predicates. `docs/ruby-ts-conventions.md` spells a Ruby trailing `?` as a
leading `is`, so `Base` now carries `isSavedChangeToAttribute` /
`isWillSaveChangeToAttribute` — the spelling
`packages/activerecord/src/attribute-methods/dirty.ts` was already using — and
the two class-side steps stay with them: alias resolution and the enum
`type_cast(attr_name, …)` Rails does inside `AttributeMutationTracker#changed?`
(`attribute_mutation_tracker.rb:44-48`).

No `AttributeMethodPattern` escape hatch was needed. The predicate pattern's
prefix is `isSavedChangeTo`, so Ruby's derived `${prefix}attribute${suffix}`
proxy target (`activemodel/lib/active_model/attribute_methods.rb:481`) joins to
`isSavedChangeToAttribute` on its own — the `is` goes where Ruby's `?` went, in
the affix.

## The generated half

That frees the un-prefixed name, so `dirty.rb:54`'s
`attribute_method_prefix("saved_change_to_", parameters: false)` is now declared
in `Base._attributeMethodPatterns` and the comment explaining its absence is
gone. It generates `savedChangeTo<Attr>` over
`attribute-methods/dirty.ts`'s `savedChangeToAttribute`, which until now was
reachable from neither `Base.prototype` nor any pattern; it is mixed onto the
prototype here. `store_accessor` gets the matching pair
(`activerecord/lib/active_record/store.rb:164-175`): `isSavedChangeTo<Key>` and
`savedChangeTo<Key>`, retiring the invented `…Values` spelling.

## The shared body

The `changed?` compare the two predicates duplicated moves onto `DirtyTracker`
(`packages/activemodel/src/dirty.ts`) where Rails puts it, so
`attribute_changed?` (`activemodel/dirty.rb:300-302`) and
`attribute_previously_changed?` (`:310-312`) stop repeating the from/to test.
Every reader now names Rails' own receiver for the set it reads —
`record.mutationsBeforeLastSave` / `record.mutationsFromDatabase`
(`activemodel/dirty.rb:274-284`) — so each body reads as its Ruby line does.

Rails picks the change set by picking one of its two tracker *instances*; trails
has a single `DirtyTracker` holding both sets, so the set is `isChanged`'s
leading argument — carried by a `@missingRailsArgs … CONVERGEABLE` tag at each
call site rather than a baseline row. Filed as
`0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`:
a faithful `AttributeMutationTracker` port already exists and is unused, and
wiring `DirtyTracker` to hold two of them retires the argument and all three
tags.

## Gates

- `pnpm parity:api` totals unchanged vs `origin/main` (13508/15417, files
  896/1050, arity 8327/8413), `parity:api:extra` per-package totals unchanged.
- `pnpm parity:api:calls`: OK — call mismatches 472 → **470** (both dirty
  predicates converged; zero rows added).
- `pnpm parity:api:calls:args`: OK, zero rows added.
- 284 LOC.

Closes-story: converge-ar-dirty-generic-names-onto-dirty-ts
Closes-story: saved-change-to-attribute-values-generated-half
