### PR TITLE
refactor(activerecord,activesupport): colon-spell includes/preload in relation+preloader+test-helpers; travel_to builds a Time

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1837,7 +1837,7 @@ describe("AssociationsTest", () => {
   it("association with references", async () => {
     const firm = companies("first_firm");
     const scope = association(firm, "associationWithReferences").scope();
-    expect(scope.referencesValues).toEqual(["foo"]);
+    expect(scope.referencesValues).toEqual([":foo"]);
   });
 
   it("force reload", async () => {

--- a/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
+++ b/packages/activerecord/src/relation/aliased-table-attr-reader.trails.test.ts
@@ -64,7 +64,7 @@ describe("Relation on an aliased table", () => {
   });
 
   it("roots the limited-id subquery on the alias", () => {
-    const sql = aliased().eagerLoad("comments").limit(1).toSql();
+    const sql = aliased().eagerLoad(":comments").limit(1).toSql();
     expect(sql).toContain(`${aliasQ}.${idQ}`);
     expect(sql).not.toMatch(new RegExp(`SELECT DISTINCT ${escapeRegExp(`${baseQ}.${idQ}`)}`));
   });
@@ -75,13 +75,13 @@ describe("Relation on an aliased table", () => {
       undefined,
       false,
       async () => {
-        await aliased().eagerLoad("comments").limit(1);
+        await aliased().eagerLoad(":comments").limit(1);
       },
     );
   });
 
   it("projects the eager load's base columns off the alias", async () => {
-    const posts = await aliased().eagerLoad("comments").limit(1);
+    const posts = await aliased().eagerLoad(":comments").limit(1);
     expect(posts.length).toBe(1);
     expect(posts[0].id).toBeDefined();
   });

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -51,7 +51,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await seedBooksWithChapters();
     let count = 0;
     const sqls = await captureSql(async () => {
-      count = (await CpkBook.eagerLoad("chapters").count()) as number;
+      count = (await CpkBook.eagerLoad(":chapters").count()) as number;
     });
     // Rails folds the eager JD into a LEFT OUTER JOIN and de-duplicates via a
     // DISTINCT-pk-columns subquery; 2 chapters on book 1 fan to 3 joined rows,
@@ -65,12 +65,12 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
   it("eager_load(:assoc).count matches the un-joined count", async () => {
     await seedBooksWithChapters();
     // Rails: Cpk::Book.count == Cpk::Book.includes(:chapters).references(:chapters).count
-    expect(await CpkBook.eagerLoad("chapters").count()).toBe(await CpkBook.count());
+    expect(await CpkBook.eagerLoad(":chapters").count()).toBe(await CpkBook.count());
   });
 
   it("eager_load(:assoc).count(column) counts distinct non-null values of the column", async () => {
     await seedBooksWithChapters();
-    expect(await CpkBook.eagerLoad("chapters").count("cpk_books.revision")).toBe(2);
+    expect(await CpkBook.eagerLoad(":chapters").count("cpk_books.revision")).toBe(2);
   });
 
   async function seedBooksDuplicateRevisions(): Promise<void> {
@@ -90,7 +90,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await seedBooksDuplicateRevisions();
     let count = 0;
     const sqls = await captureSql(async () => {
-      count = (await CpkBook.eagerLoad("chapters")
+      count = (await CpkBook.eagerLoad(":chapters")
         .order("cpk_books.author_id", "cpk_books.id")
         .limit(2)
         .count("cpk_books.revision")) as number;
@@ -118,7 +118,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await seedBooksDuplicateRevisions();
     let count = 0;
     const sqls = await captureSql(async () => {
-      count = (await CpkBook.eagerLoad("chapters")
+      count = (await CpkBook.eagerLoad(":chapters")
         .order("cpk_books.title")
         .limit(2)
         .count("cpk_books.revision")) as number;
@@ -131,7 +131,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   it("eager_load(:assoc).offset(n).count(column) bounds ROWS via the id fetch", async () => {
     await seedBooksDuplicateRevisions();
-    const count = await CpkBook.eagerLoad("chapters")
+    const count = await CpkBook.eagerLoad(":chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .offset(1)
       .count("cpk_books.revision");
@@ -168,7 +168,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
       // grouped calculation has no count-subquery arm, so the composite key
       // would reach Arel as the multi-column `COUNT(DISTINCT author_id, id)`
       // SQLite and PostgreSQL reject.
-      result = (await CpkBook.eagerLoad("order").group("order").count("cpk_books.id")) as Map<
+      result = (await CpkBook.eagerLoad(":order").group("order").count("cpk_books.id")) as Map<
         unknown,
         unknown
       >;
@@ -182,7 +182,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   it("eager_load(:x).group(:composite_fk_belongs_to).sum folds the eager JD", async () => {
     await seedBooksWithOrders();
-    const result = (await CpkBook.eagerLoad("order").group("order").sum("id")) as Map<
+    const result = (await CpkBook.eagerLoad(":order").group("order").sum("id")) as Map<
       unknown,
       unknown
     >;

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -91,7 +91,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
 
   it("pluck over eagerLoad('chapters') joins the composite-FK collection", async () => {
     await seedBooks();
-    const titles = await CpkBook.eagerLoad("chapters")
+    const titles = await CpkBook.eagerLoad(":chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .pluck("title");
     expect(titles).toEqual(["Alpha", "Beta", "Gamma"]);
@@ -99,7 +99,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
 
   it("pluck over eagerLoad('chapters') can project the joined table's column", async () => {
     await seedBooks();
-    const chapterTitles = await CpkBook.eagerLoad("chapters")
+    const chapterTitles = await CpkBook.eagerLoad(":chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .pluck("cpk_chapters.title");
     expect(chapterTitles).toEqual(["ch-1", null, null]);
@@ -107,7 +107,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
 
   it("pluck over multiple eager specs joins both", async () => {
     await seedBooks();
-    const titles = await CpkBook.eagerLoad("author", "chapters")
+    const titles = await CpkBook.eagerLoad(":author", ":chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .pluck("title");
     expect(titles).toEqual(["Alpha", "Beta", "Gamma"]);
@@ -119,7 +119,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     // (distinct_relation_for_primary_key, schema_statements.rb:1429) and
     // re-queries with one `IN` per key column, so the LIMIT bounds PARENTS —
     // not the fanned-out joined rows.
-    const titles = await CpkBook.eagerLoad("chapters")
+    const titles = await CpkBook.eagerLoad(":chapters")
       .order("cpk_books.author_id", "cpk_books.id")
       .limit(2)
       .pluck("title");
@@ -137,7 +137,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     const nodes = (jd as unknown as { nodes: { assocName: string }[] }).nodes;
     expect(nodes.map((n) => n.assocName)).toEqual(["chapters", "chapters.book"]);
 
-    const titles = await CpkBook.eagerLoad({ chapters: "book" })
+    const titles = await CpkBook.eagerLoad({ ":chapters": ":book" })
       .order("cpk_books.author_id", "cpk_books.id")
       .pluck("cpk_chapters.title");
     expect(titles).toEqual(["ch-1", null, null]);

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -129,7 +129,7 @@ describe("DeleteAllTest", () => {
   });
 
   it("delete all with includes", async () => {
-    const pets = Pet.includes("toys").where({ toys: { name: "Bone" } });
+    const pets = Pet.includes(":toys").where({ toys: { name: "Bone" } });
 
     expect(await pets.exists()).toBe(true);
     const countBefore = await pets.count();

--- a/packages/activerecord/src/relation/eager-load-under-cte-and-from.trails.test.ts
+++ b/packages/activerecord/src/relation/eager-load-under-cte-and-from.trails.test.ts
@@ -26,7 +26,7 @@ describeIfSupports("common_table_expressions", "eager load under a CTE / FROM ov
   it("emits the aliased eager JOIN alongside the CTE", async () => {
     const relation = Post.with({
       posts_with_comments: Post.where("legacy_comments_count > 0"),
-    }).eagerLoad("comments");
+    }).eagerLoad(":comments");
 
     const sql = relation.toSql();
     expect(sql).toMatch(/WITH\s+/i);
@@ -37,7 +37,7 @@ describeIfSupports("common_table_expressions", "eager load under a CTE / FROM ov
   });
 
   it("emits the aliased eager JOIN alongside a FROM override", async () => {
-    const relation = Post.from("posts AS posts").eagerLoad("comments");
+    const relation = Post.from("posts AS posts").eagerLoad(":comments");
 
     expect(relation.toSql()).toMatch(/LEFT OUTER JOIN/i);
 

--- a/packages/activerecord/src/relation/eager-loading-memo.trails.test.ts
+++ b/packages/activerecord/src/relation/eager-loading-memo.trails.test.ts
@@ -15,7 +15,7 @@ describe("Relation eager_loading? memo", () => {
   fixtures(["posts", "comments"]);
 
   it("memoizes a truthy result instead of recomputing it", () => {
-    const relation = Post.eagerLoad("comments");
+    const relation = Post.eagerLoad(":comments");
     expect(relation.isEagerLoading).toBe(true);
 
     relation.eagerLoadValues = [];
@@ -32,7 +32,7 @@ describe("Relation eager_loading? memo", () => {
   });
 
   it("clears the memo in reset", () => {
-    const relation = Post.eagerLoad("comments");
+    const relation = Post.eagerLoad(":comments");
     expect(relation.isEagerLoading).toBe(true);
 
     relation.eagerLoadValues = [];

--- a/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
+++ b/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
@@ -25,8 +25,8 @@ describe("eager build_joins shared AliasTracker", () => {
   fixtures([]);
 
   it("aliases the eager OUTER JOIN when an explicit joins already claims the table", () => {
-    const rel = Post.includes("author")
-      .references("author")
+    const rel = Post.includes(":author")
+      .references(":author")
       .joins("INNER JOIN authors ON authors.id = posts.author_id");
     const sql = (rel as unknown as { toSql(): string }).toSql().replace(/["`]/g, "");
 

--- a/packages/activerecord/src/relation/limited-ids-subquery-sanitizers.trails.test.ts
+++ b/packages/activerecord/src/relation/limited-ids-subquery-sanitizers.trails.test.ts
@@ -17,13 +17,13 @@ describe("Relation limited ids subquery sanitizers", () => {
 
   it("raises for a non-numeric limit, as the plain build_arel path does", async () => {
     await expect(
-      (async () => Post.eagerLoad("comments").limit("asdfadf").toSql())(),
+      (async () => Post.eagerLoad(":comments").limit("asdfadf").toSql())(),
     ).rejects.toThrow(/invalid value for Integer/);
   });
 
   it("truncates a string offset through to_i", async () => {
-    const eager = await Post.eagerLoad("comments").order("posts.id").limit(2).offset("1").toSql();
-    const plain = await Post.eagerLoad("comments").order("posts.id").limit(2).offset(1).toSql();
+    const eager = await Post.eagerLoad(":comments").order("posts.id").limit(2).offset("1").toSql();
+    const plain = await Post.eagerLoad(":comments").order("posts.id").limit(2).offset(1).toSql();
     expect(eager).toBe(plain);
   });
 });

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -224,8 +224,8 @@ describe("RelationMergingTest", () => {
 
   it("relation merging with eager load", async () => {
     const relations = [
-      Post.order("comments.id DESC").merge(Post.eagerLoad("lastComment")).merge(Post.all()),
-      Post.eagerLoad("lastComment").merge(Post.order("comments.id DESC")).merge(Post.all()),
+      Post.order("comments.id DESC").merge(Post.eagerLoad(":lastComment")).merge(Post.all()),
+      Post.eagerLoad(":lastComment").merge(Post.order("comments.id DESC")).merge(Post.all()),
     ];
 
     // `lastComment` is a lazy hasOne: on a freshly-found record it returns a
@@ -249,8 +249,8 @@ describe("RelationMergingTest", () => {
 
   it("relation merging with preload", async () => {
     const relations = [
-      Post.all().merge(Post.preload("author")),
-      Post.preload("author").merge(Post.all()),
+      Post.all().merge(Post.preload(":author")),
+      Post.preload(":author").merge(Post.all()),
     ];
     for (const posts of relations) {
       await assertQueriesCount(2, false, async () => {

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -20,7 +20,7 @@ describe("OrderTest", () => {
 
   const ids = async (rel: any): Promise<unknown[]> => (await rel.toArray()).map((b: any) => b.id);
   const incOrder = (...args: any[]): Promise<unknown[]> =>
-    ids(Book.includes("author").order(...args));
+    ids(Book.includes(":author").order(...args));
 
   it("order asc", async () => {
     const z = (await Book.create({ name: "Zulu", author: authors("david") })) as any;

--- a/packages/activerecord/src/relation/single-pk-eager-count-limit-id-subquery-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/single-pk-eager-count-limit-id-subquery-applies-order.trails.test.ts
@@ -48,7 +48,7 @@ describe("Post single-PK eager count limit id subquery applies order", () => {
     await seedPosts();
     let count = 0;
     const sqls = await captureSql(async () => {
-      count = (await Post.eagerLoad("comments")
+      count = (await Post.eagerLoad(":comments")
         .order("title")
         .limit(2)
         .count("posts.tags_count")) as number;
@@ -65,7 +65,7 @@ describe("Post single-PK eager count limit id subquery applies order", () => {
 
   it("eager_load(:comments).order(:title).offset(n).count(column) counts over the ordered rows after the offset", async () => {
     await seedPosts();
-    const count = await Post.eagerLoad("comments")
+    const count = await Post.eagerLoad(":comments")
       .order("title")
       .offset(1)
       .count("posts.tags_count");

--- a/packages/activerecord/src/relation/symbol-references-eager-load.trails.test.ts
+++ b/packages/activerecord/src/relation/symbol-references-eager-load.trails.test.ts
@@ -18,14 +18,14 @@ describe("a leading-colon references value", () => {
   fixtures(["posts", "comments"]);
 
   it("is subtracted from the joined tables like the bare string", () => {
-    expect(Post.includes("comments").references(":posts").toSql()).toBe(
-      Post.includes("comments").references("posts").toSql(),
+    expect(Post.includes(":comments").references(":posts").toSql()).toBe(
+      Post.includes(":comments").references("posts").toSql(),
     );
   });
 
   it("promotes includes to an eager join like the bare string", () => {
-    expect(Post.includes("comments").references(":comments").toSql()).toBe(
-      Post.includes("comments").references("comments").toSql(),
+    expect(Post.includes(":comments").references(":comments").toSql()).toBe(
+      Post.includes(":comments").references("comments").toSql(),
     );
   });
 });

--- a/packages/activerecord/src/relation/unscope-coverage.test.ts
+++ b/packages/activerecord/src/relation/unscope-coverage.test.ts
@@ -44,26 +44,26 @@ describe("Relation#unscope — full Rails key coverage", () => {
   it("unscope('preload') clears preload only — leaves includes / eagerLoad alone", () => {
     const rel = (UscAuthor as any)
       .all()
-      .preload("uscPosts")
-      .includes("uscPosts")
-      .eagerLoad("uscPosts");
-    expect(rel.preloadValues).toEqual(["uscPosts"]);
+      .preload(":uscPosts")
+      .includes(":uscPosts")
+      .eagerLoad(":uscPosts");
+    expect(rel.preloadValues).toEqual([":uscPosts"]);
     const cleared = rel.unscope("preload");
     expect(cleared.preloadValues).toEqual([]);
-    expect(cleared.includesValues).toEqual(["uscPosts"]);
-    expect(cleared.eagerLoadValues).toEqual(["uscPosts"]);
+    expect(cleared.includesValues).toEqual([":uscPosts"]);
+    expect(cleared.eagerLoadValues).toEqual([":uscPosts"]);
   });
 
   it("unscope('eagerLoad') clears eagerLoad only — leaves includes / preload alone", () => {
     const rel = (UscAuthor as any)
       .all()
-      .preload("uscPosts")
-      .includes("uscPosts")
-      .eagerLoad("uscPosts");
+      .preload(":uscPosts")
+      .includes(":uscPosts")
+      .eagerLoad(":uscPosts");
     const cleared = rel.unscope("eagerLoad");
     expect(cleared.eagerLoadValues).toEqual([]);
-    expect(cleared.includesValues).toEqual(["uscPosts"]);
-    expect(cleared.preloadValues).toEqual(["uscPosts"]);
+    expect(cleared.includesValues).toEqual([":uscPosts"]);
+    expect(cleared.preloadValues).toEqual([":uscPosts"]);
   });
 
   it("unscope('includes') clears includes only — leaves preload / eagerLoad alone (Rails-faithful)", () => {
@@ -71,12 +71,12 @@ describe("Relation#unscope — full Rails key coverage", () => {
     // eagerLoad. Rails' query_methods.rb scopes each key independently.
     const rel = (UscAuthor as any)
       .all()
-      .preload("uscPosts")
-      .includes("uscPosts")
-      .eagerLoad("uscPosts");
+      .preload(":uscPosts")
+      .includes(":uscPosts")
+      .eagerLoad(":uscPosts");
     const cleared = rel.unscope("includes");
     expect(cleared.includesValues).toEqual([]);
-    expect(cleared.preloadValues).toEqual(["uscPosts"]);
-    expect(cleared.eagerLoadValues).toEqual(["uscPosts"]);
+    expect(cleared.preloadValues).toEqual([":uscPosts"]);
+    expect(cleared.eagerLoadValues).toEqual([":uscPosts"]);
   });
 });

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -135,7 +135,7 @@ describe("UpdateAllTest", () => {
   });
 
   it("update all with includes", async () => {
-    const petsScope = Pet.includes("toys").where({ toys: { name: "Bone" } });
+    const petsScope = Pet.includes(":toys").where({ toys: { name: "Bone" } });
 
     expect(await petsScope.exists()).toBe(true);
     const countBefore = await petsScope.count();

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -145,7 +145,7 @@ describe("RelationTest", () => {
     // Car.incl_engines.incl_tyres). Rails' includes! unions (`|=`), so a repeat
     // of the SAME include folds to one — only distinct ones accumulate.
     const relation = (Car.inclEngines() as any).inclTyres();
-    expect(relation.includesValues.map(String)).toEqual(["engines", "tyres"]);
+    expect(relation.includesValues.map(String)).toEqual([":engines", ":tyres"]);
   });
 
   it("dynamic finder", () => {

--- a/packages/activerecord/src/test-helpers/models/car.ts
+++ b/packages/activerecord/src/test-helpers/models/car.ts
@@ -66,8 +66,8 @@ export class Car extends Base {
 
     this.hasMany("priceEstimates", { as: "estimateOf" });
 
-    this.scope("inclTyres", (q: any) => q.includes("tyres"));
-    this.scope("inclEngines", (q: any) => q.includes("engines"));
+    this.scope("inclTyres", (q: any) => q.includes(":tyres"));
+    this.scope("inclEngines", (q: any) => q.includes(":engines"));
     this.scope("orderUsingNewStyle", (q: any) => q.order("name asc"));
 
     this.attribute("wheels_owned_at", "datetime", { default: () => Temporal.Now.instant() });

--- a/packages/activerecord/src/test-helpers/models/category.ts
+++ b/packages/activerecord/src/test-helpers/models/category.ts
@@ -38,7 +38,7 @@ export class Category extends Base {
     this.hasAndBelongsToMany("otherPosts", { className: "Post" });
     this.hasAndBelongsToMany(
       "postsWithAuthorsSortedByAuthorId",
-      (q: any) => q.includes("authors").order("authors.id"),
+      (q: any) => q.includes(":authors").order("authors.id"),
       { className: "Post" },
     );
     this.hasAndBelongsToMany(

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -218,7 +218,7 @@ export class CommentWithDefaultScopeReferencesAssociation extends Comment {
 
   static {
     this.defaultScope((q: any) =>
-      q.includes(":developer").order("developers.name").references("developer"),
+      q.includes(":developer").order("developers.name").references(":developer"),
     );
     this.belongsTo("developer");
   }

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -294,7 +294,7 @@ export class Firm extends Company {
       autosave: false,
     });
 
-    this.hasMany("associationWithReferences", (q: any) => q.references("foo"), {
+    this.hasMany("associationWithReferences", (q: any) => q.references(":foo"), {
       className: "Client",
     });
 

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -41,7 +41,7 @@ export class Owner extends Base {
           ) as last_pet_id
         `,
         )
-        .includes("lastPet"),
+        .includes(":lastPet"),
     );
     this.afterCommit(async (owner: Owner) => {
       await owner.executeBlocks();

--- a/packages/activerecord/src/test-helpers/models/person.ts
+++ b/packages/activerecord/src/test-helpers/models/person.ts
@@ -81,7 +81,7 @@ export class Person extends Base {
     this.hasMany("securePosts", { through: "secureReaders" });
     this.hasMany(
       "postsWithNoComments",
-      (q: any) => q.includes(":comments").where("comments.id is null").references("comments"),
+      (q: any) => q.includes(":comments").where("comments.id is null").references(":comments"),
       { through: "readers", source: "post" },
     );
 

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../time-zone-config.js";
 import { inTimeZone } from "./date-and-time/zones.js";
 import { current } from "../time-ext.js";
+import { setPreserveTimezone } from "./date-and-time/compatibility.js";
 
 describe("TimeWithZoneTest", () => {
   let eastern: TimeZone;
@@ -27,6 +28,10 @@ describe("TimeWithZoneTest", () => {
     eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     pacific = TimeZone.find("Pacific Time (US & Canada)")!;
     utcZone = TimeZone.find("UTC")!;
+  });
+
+  afterEach(() => {
+    setPreserveTimezone(null);
   });
 
   // @twz = 2000-01-01 00:00:00 UTC in Eastern = 1999-12-31 19:00:00 EST
@@ -880,34 +885,51 @@ describe("TimeWithZoneTest", () => {
   });
 
   it("to time with preserve timezone using zone", () => {
+    setPreserveTimezone(":zone");
     const twz = maketwz();
-    const time = twz.utc();
-    expect(time).toBeInstanceOf(Temporal.Instant);
-    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    const time = twz.toTime();
+    expect(time).toBeInstanceOf(RubyTime);
+    expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(time.utcOffset).toBe(-18000);
+    expect(time.zone).toBe("EST");
   });
 
   it("to time with preserve timezone using offset", () => {
+    setPreserveTimezone(":offset");
     const twz = maketwz();
-    const time = twz.utc();
-    expect(time.epochMilliseconds).toBe(twz.getTime());
+    const time = twz.toTime();
+    expect(time).toBeInstanceOf(RubyTime);
+    expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(time.utcOffset).toBe(-18000);
+    expect(time.zone).toBeNull();
   });
 
   it("to time with preserve timezone using true", () => {
+    setPreserveTimezone(true);
     const twz = maketwz();
-    const time = twz.utc();
-    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    const time = twz.toTime();
+    expect(time).toBeInstanceOf(RubyTime);
+    expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(time.utcOffset).toBe(-18000);
+    expect(time.zone).toBeNull();
   });
 
   it("to time without preserve timezone", () => {
+    setPreserveTimezone(false);
     const twz = maketwz();
-    const time = twz.utc();
-    expect(time).toBeInstanceOf(Temporal.Instant);
+    const time = twz.toTime();
+    expect(time).toBeInstanceOf(RubyTime);
+    expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(time.zone).not.toBeNull();
   });
 
   it("to time without preserve timezone configured", () => {
+    setPreserveTimezone(null);
     const twz = maketwz();
-    const time = twz.utc();
-    expect(time.epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    const time = twz.toTime();
+    expect(time).toBeInstanceOf(RubyTime);
+    expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(time.zone).not.toBeNull();
   });
 
   it("method missing with time return value", () => {

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -4,7 +4,7 @@ import { TimeWithZone } from "../time-with-zone.js";
 import { TimeZone } from "../values/time-zone.js";
 import { travelTo } from "../testing/time-helpers.js";
 import { instantFromDate } from "../testing/temporal-helpers.js";
-import { Temporal } from "@blazetrails/date";
+import { Temporal, Time as RubyTime } from "@blazetrails/date";
 import {
   zone as timeZone,
   setZone,
@@ -88,7 +88,7 @@ describe("TimeWithZoneTest", () => {
   it("localtime", () => {
     const twz = maketwz();
     const local = twz.localtime();
-    expect(local).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(local).toBeInstanceOf(RubyTime);
   });
 
   it("localtime with offset", () => {
@@ -96,12 +96,12 @@ describe("TimeWithZoneTest", () => {
     // -7h offset → wall-clock 1999-12-31 17:00:00.
     const twz = maketwz();
     const local = twz.localtime(-7 * 3600);
-    expect(local).toBeInstanceOf(Temporal.PlainDateTime);
+    expect(local).toBeInstanceOf(RubyTime);
     expect(local.year).toBe(1999);
     expect(local.month).toBe(12);
     expect(local.day).toBe(31);
     expect(local.hour).toBe(17);
-    expect(local.minute).toBe(0);
+    expect(local.min).toBe(0);
     // getlocal alias mirrors localtime
     const aliased = twz.getlocal(-7 * 3600);
     expect(aliased.toString()).toBe(local.toString());

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -182,8 +182,6 @@ export function travelTo(
       ? zone.parse(dateOrTime)!.toTime()
       : Time.at(new Rational(Temporal.Instant.from(dateOrTime).epochNanoseconds, 1_000_000_000n));
   } else {
-    // `now.to_time unless now.is_a?(Time)` — a JS `Date` and a
-    // `Temporal.Instant` are both the instant a Ruby `to_time` seats.
     now =
       dateOrTime instanceof Time
         ? dateOrTime

--- a/packages/activesupport/src/testing/time-helpers.ts
+++ b/packages/activesupport/src/testing/time-helpers.ts
@@ -7,6 +7,7 @@ import { Duration } from "../duration.js";
 import { clock, currentTimeInstant } from "../time-travel.js";
 import { zone as timeZone } from "../time-zone-config.js";
 import { midnight } from "../core-ext/date/calculations.js";
+import { change } from "../time-ext.js";
 import { isEmpty } from "../ruby-empty.js";
 
 /** Mirrors Ruby's `RuntimeError` — what a bare `raise "message"` raises. */
@@ -171,30 +172,36 @@ export function travelTo(
     throw new RuntimeError(travelToNestedBlockCall);
   }
 
-  let instant: Temporal.Instant;
+  let now: Time;
   if (dateOrTime instanceof Temporal.PlainDate) {
-    instant = midnight(dateOrTime).toTime();
+    now = midnight(dateOrTime).toTime();
   } else if (typeof dateOrTime === "string") {
     // Without a `Time.zone` set there is no zone to parse through.
     const zone = timeZone();
-    instant = zone ? zone.parse(dateOrTime)!.toTime() : Temporal.Instant.from(dateOrTime);
-  } else if (dateOrTime instanceof globalThis.Date) {
-    instant = Temporal.Instant.fromEpochMilliseconds(dateOrTime.getTime());
-  } else if (dateOrTime instanceof Time) {
-    instant = dateOrTime.toTime().toInstant();
+    now = zone
+      ? zone.parse(dateOrTime)!.toTime()
+      : Time.at(new Rational(Temporal.Instant.from(dateOrTime).epochNanoseconds, 1_000_000_000n));
   } else {
-    instant = dateOrTime;
+    // `now.to_time unless now.is_a?(Time)` — a JS `Date` and a
+    // `Temporal.Instant` are both the instant a Ruby `to_time` seats.
+    now =
+      dateOrTime instanceof Time
+        ? dateOrTime
+        : Time.at(
+            new Rational(
+              dateOrTime instanceof globalThis.Date
+                ? BigInt(dateOrTime.getTime()) * 1_000_000n
+                : dateOrTime.epochNanoseconds,
+              1_000_000_000n,
+            ),
+          );
   }
 
-  if (!withUsec) {
-    instant = Temporal.Instant.fromEpochMilliseconds(
-      Math.floor(instant.epochMilliseconds / 1000) * 1000,
-    );
-  }
+  if (!withUsec) now = change(now, { usec: 0 });
 
   // `now` must be in local system timezone, because `Time.at(now)`
   // and `now.to_date` (see stubs below) will use `now`'s timezone too!
-  const now = Time.at(new Rational(instant.epochNanoseconds, 1_000_000_000n));
+  now = now.getlocal();
 
   const stubs = simpleStubs();
   const stubbedTime = stubs.stubbing(Time, "now") ? Time.now() : undefined;
@@ -223,7 +230,7 @@ export function travelTo(
   // Ruby has no fifth receiver: production code reads the clock through
   // `currentTimeInstant()` because `Time.now()` costs ~70x a bare
   // `Temporal.Now.instant()` and sits on every `TimeWithZone` construction.
-  stubs.stubObject(clock, "now", () => instant);
+  stubs.stubObject(clock, "now", () => now.toTime().toInstant());
 
   if (block) {
     try {

--- a/packages/activesupport/src/time-ext.trails.test.ts
+++ b/packages/activesupport/src/time-ext.trails.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Temporal, Time as RubyTime } from "@blazetrails/date";
 import { toTime } from "./core-ext/time/compatibility.js";
+import { change } from "./time-ext.js";
 import { offsetInSeconds, secondsSinceUnixEpoch } from "./core-ext/date-time/conversions.js";
 import { setPreserveTimezone } from "./core-ext/date-and-time/compatibility.js";
 
@@ -75,5 +76,23 @@ describe("DateTime's private conversion helpers", () => {
         Temporal.PlainDateTime.from("2005-02-21T10:11:12").toZonedDateTime("+05:00"),
       ),
     ).toBe(Date.UTC(2005, 1, 21, 5, 11, 12) / 1000);
+  });
+});
+
+describe("change over a ::Time receiver", () => {
+  it("returns a ::Time, cascading the reset from the largest option given", () => {
+    const t = RubyTime.utc(2012, 8, 29, 22, 35, 30);
+    const changed = change(t, { hour: 0 });
+    expect(changed).toBeInstanceOf(RubyTime);
+    expect([changed.year, changed.mon, changed.day]).toEqual([2012, 8, 29]);
+    expect([changed.hour, changed.min, changed.sec]).toEqual([0, 0, 0]);
+    expect(changed.isUtc()).toBe(true);
+  });
+
+  it("usec: 0 drops the sub-second and leaves the rest alone", () => {
+    const t = RubyTime.utc(2012, 8, 29, 22, 35, 30, 123456);
+    const changed = change(t, { usec: 0 });
+    expect(changed.nsec).toBe(0);
+    expect([changed.hour, changed.min, changed.sec]).toEqual([22, 35, 30]);
   });
 });

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -9,7 +9,7 @@
  *   `toDate`). Predicates (`isPast`, `isFuture`) accept `Date | Temporal.Instant`.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Rational, Temporal, Time as RubyTime } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
 import { ArgumentError } from "./hash-utils.js";
 import { zone as timeZone } from "./time-zone-config.js";
@@ -444,10 +444,37 @@ export function change(
   options: ChangeOptions,
 ): Temporal.ZonedDateTime;
 export function change(date: Date, options: ChangeOptions): Temporal.Instant;
+export function change(date: RubyTime, options: ChangeOptions): RubyTime;
 export function change(
-  date: Date | Temporal.ZonedDateTime,
+  date: Date | RubyTime | Temporal.ZonedDateTime,
   options: ChangeOptions,
-): Temporal.Instant | Temporal.ZonedDateTime {
+): Temporal.Instant | RubyTime | Temporal.ZonedDateTime {
+  // A `::Time` receiver answers a `::Time`, as `change` does in Ruby; the
+  // components it reads are the ones its `to_time` carries, so the change runs
+  // through the shared arm below and is reseated. `Time`'s constructor takes an
+  // offset rather than a zone id, so a zoned receiver comes back carrying its
+  // offset — Rails' own `elsif zone` arm rebuilds through `::Time.local`, which
+  // reseats in the system zone rather than the receiver's, so neither keeps a
+  // foreign zone's abbreviation.
+  if (date instanceof RubyTime) {
+    const changed = change(date.toTime(), options);
+    return new RubyTime(
+      changed.year,
+      changed.month,
+      changed.day,
+      changed.hour,
+      changed.minute,
+      new Rational(
+        BigInt(changed.second) * 1_000_000_000n +
+          BigInt(
+            changed.millisecond * 1_000_000 + changed.microsecond * 1_000 + changed.nanosecond,
+          ),
+        1_000_000_000n,
+      ),
+      date.isUtc() ? "UTC" : changed.offset,
+    );
+  }
+
   // Ruby reads the components off the receiver; a JS `Date` spells those readers
   // differently, and reads them in the system's local zone, so widen it to the
   // one shape both arms below share.

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -444,18 +444,20 @@ export function change(
   options: ChangeOptions,
 ): Temporal.ZonedDateTime;
 export function change(date: Date, options: ChangeOptions): Temporal.Instant;
+/**
+ * A `::Time` receiver answers a `::Time`, as `change` does in Ruby. The
+ * components it reads are the ones its `to_time` carries, so the change runs
+ * through the shared `ZonedDateTime` arm and is reseated. `Time`'s constructor
+ * takes an offset rather than a zone id, so a zoned receiver comes back
+ * carrying its offset — Rails' own `elsif zone` arm rebuilds through
+ * `::Time.local`, which reseats in the system zone rather than the receiver's,
+ * so neither keeps a foreign zone's abbreviation.
+ */
 export function change(date: RubyTime, options: ChangeOptions): RubyTime;
 export function change(
   date: Date | RubyTime | Temporal.ZonedDateTime,
   options: ChangeOptions,
 ): Temporal.Instant | RubyTime | Temporal.ZonedDateTime {
-  // A `::Time` receiver answers a `::Time`, as `change` does in Ruby; the
-  // components it reads are the ones its `to_time` carries, so the change runs
-  // through the shared arm below and is reseated. `Time`'s constructor takes an
-  // offset rather than a zone id, so a zoned receiver comes back carrying its
-  // offset — Rails' own `elsif zone` arm rebuilds through `::Time.local`, which
-  // reseats in the system zone rather than the receiver's, so neither keeps a
-  // foreign zone's abbreviation.
   if (date instanceof RubyTime) {
     const changed = change(date.toTime(), options);
     return new RubyTime(

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -520,28 +520,18 @@ export class TimeWithZone {
   }
 
   /**
-   * Returns the local wall-clock time as a Temporal.PlainDateTime.
-   * If `utcOffsetOverride` is provided (in seconds), the result is the wall-clock
-   * time at that offset from UTC.
-   *
-   * @missingRailsCall getlocal — PERMANENT: `utc.getlocal(utc_offset)`
-   *   (time_with_zone.rb:83-85) is Ruby `Time#getlocal`; trails' `utc()` answers
-   *   a `Temporal.Instant`, which has no `getlocal` — the shifted wall clock is
-   *   built with `toZonedDateTimeISO("UTC").toPlainDateTime()`, and `getlocal`
-   *   is the alias of THIS method, not a call it can make.
+   * Mirrors: `ActiveSupport::TimeWithZone#localtime(utc_offset = nil)`
+   * (time_with_zone.rb:83-85) — `utc.getlocal(utc_offset)`, a `::Time` at the
+   * given offset or zone, or in the system zone when none is given. trails'
+   * `utc` answers the instant rather than the `::Time` Rails' does, so the
+   * `::Time` `getlocal` is called on is seated from that instant here.
    */
-  localtime(utcOffsetOverride?: number): Temporal.PlainDateTime {
-    if (utcOffsetOverride !== undefined) {
-      const shifted = Temporal.Instant.fromEpochMilliseconds(
-        Math.trunc(this._epochMs + utcOffsetOverride * 1000),
-      );
-      return shifted.toZonedDateTimeISO("UTC").toPlainDateTime();
-    }
-    return this._zoned.toPlainDateTime();
+  localtime(utcOffset: string | number | null = null): Time {
+    return Time.at(new Rational(this.utc().epochNanoseconds, 1_000_000_000n)).getlocal(utcOffset);
   }
 
-  /** Alias for localtime() */
-  getlocal(utcOffset?: number): Temporal.PlainDateTime {
+  /** `alias_method :getlocal, :localtime` (time_with_zone.rb:86). */
+  getlocal(utcOffset: string | number | null = null): Time {
     return this.localtime(utcOffset);
   }
 
@@ -551,12 +541,21 @@ export class TimeWithZone {
   }
 
   /**
-   * Mirrors: `ActiveSupport::TimeWithZone#to_time` (time_with_zone.rb:493-501),
-   * which answers a `::Time` — `getlocal`, the same instant in the system zone,
-   * for the default `preserve_timezone`.
+   * Mirrors: `ActiveSupport::TimeWithZone#to_time` (time_with_zone.rb:493-501).
+   * Rails hands `getlocal` the `TimeZone` object itself for the `:zone` arm,
+   * which `::Time` reads through `utc_to_local`; `@blazetrails/date`'s `Time`
+   * seats a zone by its IANA identifier, which is the same zone spelled the way
+   * that constructor takes it. The three `@to_time_with_*` memos Rails keeps are
+   * not carried — the value is recomputed rather than cached.
    */
   toTime(): Time {
-    return Time.at(new Rational(this.utc().epochNanoseconds, 1_000_000_000n));
+    if (this.preserveTimezone() === ":zone") {
+      return this.getlocal(this.timeZone.tzinfo.identifier);
+    } else if (this.preserveTimezone()) {
+      return this.getlocal(this.utcOffset);
+    } else {
+      return this.getlocal();
+    }
   }
 
   /** Unix timestamp in seconds */

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -13,7 +13,7 @@ import { currentTime } from "./time-travel.js";
 import { zone as timeZone, findZoneBang } from "./time-zone-config.js";
 import { Temporal } from "@blazetrails/date";
 import { instantFrom } from "./temporal.js";
-import { Rational, cCivilToJd, strftime } from "@blazetrails/date";
+import { Rational, Time, cCivilToJd, strftime } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 import { DATE_FORMATS, toFs } from "./core-ext/time/conversions.js";
 import {
@@ -551,16 +551,12 @@ export class TimeWithZone {
   }
 
   /**
-   * Returns the UTC instant.
-   *
-   * @missingRailsCall getlocal — PERMANENT: Rails' `to_time` returns a `::Time` re-seated
-   *   by `getlocal` per `preserve_timezone` (time_with_zone.rb:493-501); trails'
-   *   `toTime()` answers the UTC `Temporal.Instant`, which carries its own
-   *   offset and has no `getlocal`. The `preserve_timezone` three-arm split is a
-   *   separate unported behaviour, not a dropped call.
+   * Mirrors: `ActiveSupport::TimeWithZone#to_time` (time_with_zone.rb:493-501),
+   * which answers a `::Time` — `getlocal`, the same instant in the system zone,
+   * for the default `preserve_timezone`.
    */
-  toTime(): Temporal.Instant {
-    return this.utc();
+  toTime(): Time {
+    return Time.at(new Rational(this.utc().epochNanoseconds, 1_000_000_000n));
   }
 
   /** Unix timestamp in seconds */

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -293,4 +293,25 @@ describe("Time", () => {
       );
     });
   });
+
+  describe("Time#getlocal", () => {
+    it("answers the same instant in the local system zone", () => {
+      const t = Time.utc(2020, 1, 1, 12, 0, 0);
+      const local = t.getlocal();
+      expect(local.toTime().epochNanoseconds).toBe(t.toTime().epochNanoseconds);
+      expect(local.utcOffset).toBe(
+        Number(
+          Temporal.Instant.fromEpochMilliseconds(946728000000).toZonedDateTimeISO(
+            Temporal.Now.timeZoneId(),
+          ).offsetNanoseconds,
+        ) / 1_000_000_000,
+      );
+    });
+
+    it("seats the instant at an explicit utc_offset", () => {
+      const t = Time.utc(2020, 1, 1, 12, 0, 0);
+      expect(t.getlocal("+05:00").utcOffset).toBe(18000);
+      expect(t.getlocal("+05:00").hour).toBe(17);
+    });
+  });
 });

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -312,6 +312,21 @@ describe("Time", () => {
       const t = Time.utc(2020, 1, 1, 12, 0, 0);
       expect(t.getlocal("+05:00").utcOffset).toBe(18000);
       expect(t.getlocal("+05:00").hour).toBe(17);
+      expect(t.getlocal(18000).utcOffset).toBe(18000);
+    });
+
+    it("an offset-built time has no zone, as MRI's has none", () => {
+      const t = Time.utc(2020, 1, 1, 12, 0, 0);
+      expect(t.getlocal("+05:00").zone).toBeNull();
+      expect(t.getlocal("+05:00").strftime("%Z")).toBe("");
+      expect(t.getlocal("+05:00").toS()).toBe("2020-01-01 17:00:00 +0500");
+    });
+
+    it("a zone identifier stands in for MRI's zone object argument", () => {
+      const t = Time.utc(2020, 1, 1, 12, 0, 0);
+      const eastern = t.getlocal("America/New_York");
+      expect(eastern.utcOffset).toBe(-18000);
+      expect(eastern.zone).toBe("EST");
     });
   });
 });

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -49,6 +49,16 @@ export function resetLocalTimeZoneId(): void {
 }
 
 /**
+ * Whether a string names a zone rather than spelling a `utc_offset`. MRI's
+ * `Time#getlocal` takes only the offset spellings — a leading sign, or one of
+ * the military letters — plus a zone OBJECT, which a zone identifier stands in
+ * for here.
+ */
+function isZoneIdentifier(zone: string): boolean {
+  return !/^([+-]|[A-IK-Z]$)/.test(zone);
+}
+
+/**
  * The `utc_offset` argument MRI's `Time.new` accepts: `"UTC"`, an offset —
  * `"+09"`, `"+0900"`, `"+09:00"`, `"+09:00:30"` or a number of seconds east of
  * UTC, which is the form Rails passes
@@ -70,16 +80,6 @@ export function resetLocalTimeZoneId(): void {
  * `86400`. A numeric offset needs no whole-second bound either: MRI takes a
  * `Float`/`Rational` and answers it back from `utc_offset`.
  */
-/**
- * Whether a string names a zone rather than spelling a `utc_offset`. MRI's
- * `Time#getlocal` takes only the offset spellings — a leading sign, or one of
- * the military letters — plus a zone OBJECT, which a zone identifier stands in
- * for here.
- */
-function isZoneIdentifier(zone: string): boolean {
-  return !/^([+-]|[A-IK-Z]$)/.test(zone);
-}
-
 function utcOffsetArgument(zone: string | number): "UTC" | number {
   if (typeof zone === "number") {
     if (!Number.isFinite(zone) || Math.abs(zone) >= 86400) {
@@ -842,26 +842,6 @@ export class Time {
   }
 
   /**
-   * Ruby `Time#getlocal(utc_offset = nil)` (`ruby/time.c` `time_getlocaltime`),
-   * the same instant seated in the local system zone — or, with an argument, at
-   * that offset. MRI's `localtime` mutates the receiver and `getlocal` answers a
-   * converted copy; trails' `Time` is immutable, so the copy is the answer here
-   * the way `getutc` already is.
-   *
-   * An offset spelling — `"+05:00"`, `"Z"`, a seconds Integer — is read the way
-   * the constructor's `utc_offset` is, so the answer carries the offset and no
-   * zone, and its `zone` is `nil` as MRI's is. MRI also takes a zone OBJECT
-   * here, the one thing a JS string cannot be; a zone identifier stands in for
-   * it, and seats the answer in that zone.
-   */
-  getlocal(utcOffset: string | number | null = null): Time {
-    if (typeof utcOffset === "string" && !isZoneIdentifier(utcOffset)) {
-      return Time.#atInstant(this.#instant, utcOffsetArgument(utcOffset));
-    }
-    return Time.#atInstant(this.#instant, utcOffset);
-  }
-
-  /**
    * Ruby `Time#getutc` (`ruby/time.c` `time_getutc`), the same instant in UTC.
    * `lib/time.rb`'s `httpdate` reaches it as `dup.utc`, an in-place conversion
    * of a copy; trails' `Time` is immutable, so the copy is the answer here.
@@ -885,8 +865,17 @@ export class Time {
    * given — `Time.utc(...).getlocal(0).utc_offset` is `0` and
    * `.getlocal("+05:00")` moves the wall clock five hours east. Like
    * {@link Time#getutc} it answers a copy, because trails' `Time` is immutable.
+   *
+   * An offset spelling — `"+05:00"`, `"Z"`, a seconds Integer — is read the way
+   * the constructor's `utc_offset` is, so the answer carries the offset and no
+   * zone, and its `zone` is `nil` as MRI's is. MRI also takes a zone OBJECT
+   * here, the one thing a JS string cannot be; a zone identifier stands in for
+   * it, and seats the answer in that zone.
    */
   getlocal(utcOffset: number | string | null = null): Time {
+    if (typeof utcOffset === "string" && !isZoneIdentifier(utcOffset)) {
+      return Time.#atInstant(this.#instant, utcOffsetArgument(utcOffset));
+    }
     return Time.#atInstant(this.#instant, utcOffset);
   }
 

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -70,6 +70,16 @@ export function resetLocalTimeZoneId(): void {
  * `86400`. A numeric offset needs no whole-second bound either: MRI takes a
  * `Float`/`Rational` and answers it back from `utc_offset`.
  */
+/**
+ * Whether a string names a zone rather than spelling a `utc_offset`. MRI's
+ * `Time#getlocal` takes only the offset spellings — a leading sign, or one of
+ * the military letters — plus a zone OBJECT, which a zone identifier stands in
+ * for here.
+ */
+function isZoneIdentifier(zone: string): boolean {
+  return !/^([+-]|[A-IK-Z]$)/.test(zone);
+}
+
 function utcOffsetArgument(zone: string | number): "UTC" | number {
   if (typeof zone === "number") {
     if (!Number.isFinite(zone) || Math.abs(zone) >= 86400) {
@@ -837,8 +847,17 @@ export class Time {
    * that offset. MRI's `localtime` mutates the receiver and `getlocal` answers a
    * converted copy; trails' `Time` is immutable, so the copy is the answer here
    * the way `getutc` already is.
+   *
+   * An offset spelling — `"+05:00"`, `"Z"`, a seconds Integer — is read the way
+   * the constructor's `utc_offset` is, so the answer carries the offset and no
+   * zone, and its `zone` is `nil` as MRI's is. MRI also takes a zone OBJECT
+   * here, the one thing a JS string cannot be; a zone identifier stands in for
+   * it, and seats the answer in that zone.
    */
   getlocal(utcOffset: string | number | null = null): Time {
+    if (typeof utcOffset === "string" && !isZoneIdentifier(utcOffset)) {
+      return Time.#atInstant(this.#instant, utcOffsetArgument(utcOffset));
+    }
     return Time.#atInstant(this.#instant, utcOffset);
   }
 

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -832,6 +832,17 @@ export class Time {
   }
 
   /**
+   * Ruby `Time#getlocal(utc_offset = nil)` (`ruby/time.c` `time_getlocaltime`),
+   * the same instant seated in the local system zone — or, with an argument, at
+   * that offset. MRI's `localtime` mutates the receiver and `getlocal` answers a
+   * converted copy; trails' `Time` is immutable, so the copy is the answer here
+   * the way `getutc` already is.
+   */
+  getlocal(utcOffset: string | number | null = null): Time {
+    return Time.#atInstant(this.#instant, utcOffset);
+  }
+
+  /**
    * Ruby `Time#getutc` (`ruby/time.c` `time_getutc`), the same instant in UTC.
    * `lib/time.rb`'s `httpdate` reaches it as `dup.utc`, an in-place conversion
    * of a copy; trails' `Time` is immutable, so the copy is the answer here.


### PR DESCRIPTION
Bundle of two stories.

## 1. includes/preload colon sweep — relation, preloader, test-helpers

Rails passes association names to `includes` / `preload` / `eager_load` /
`references` as Symbols (`relation/query_methods.rb:88-101`), and CLAUDE.md
spells a Ruby Symbol as a colon-prefixed string. This sweeps the
`packages/activerecord/src/relation`, `associations/preloader` and
`test-helpers` trees onto that spelling — keys and values, nested-hash and
multi-arg forms alike.

Raw strings naming a TABLE for `references` stay bare, as Rails passes those
as Strings (`references!`); `symbol-references-eager-load.trails.test.ts`
keeps its bare/colon comparison on the `references` side deliberately.

No new normalization site: the strip stays at `JoinDependency.walkTree` and
`Preloader::Branch#_normalizeAssociationName`.
`associations/preloader/through-association.ts` was already colon-spelled.

Three raw-value assertions move with the stored values, matching what Rails
asserts:
- `associations_test.rb:144` `assert_equal [:foo], ...references_values`
- `relations_test.rb:49` `Car.incl_engines.incl_tyres`
- `unscope-coverage.test.ts` preload/eagerLoad buckets

## 2. `travel_to`'s input arms build a `Time`

`time_helpers.rb:162-175` lands every input arm on a `Time` held in a single
`now` local, then normalizes with `change(usec: 0)` and `getlocal`. trails
split that into `instant` + `now`, floored the sub-second with
`Instant.fromEpochMilliseconds(Math.floor(ms / 1000) * 1000)`, and spelled
`getlocal` as `Time.at(new Rational(...))`.

Now each arm builds a `Time` and the two normalizations are the real calls.
Supporting convergences:

- `Time#getlocal(utc_offset = nil)` on `@blazetrails/date`'s `Time`
  (`ruby/time.c` `time_getlocaltime`) — the same instant in the local system
  zone, or at an explicit offset. An offset spelling (`"+05:00"`, `"Z"`, a
  seconds Integer) goes through the constructor's own `utc_offset` reader, so
  the answer carries the offset and no zone and its `zone` is `nil` as MRI's is.
  MRI also takes a zone OBJECT there, which a JS string cannot be; a zone
  identifier stands in for it, and is what `to_time`'s `:zone` arm passes.
- A `::Time` overload on `change` in `time-ext.ts`
  (`core_ext/time/calculations.rb:123-177`), reseating through the existing
  shared arm.
- `TimeWithZone#localtime` / `getlocal` answer a `::Time`
  (`time_with_zone.rb:83-86`), which is what `test_localtime`'s
  `assert_instance_of Time` asserts — the mirrored trails assertions move onto
  it.
- `TimeWithZone#to_time` is the three-arm `preserve_timezone` switch
  (`time_with_zone.rb:493-501`) rather than a bare UTC instant. The five
  `test_to_time_with_preserve_timezone_*` mirrors were asserting on `twz.utc()`
  — they now call `to_time` under each setting, as Rails does
  (`time_with_zone_test.rb:547-586`).

Two `call-mismatches-exclude` rows retire with those last two
(`time-with-zone.ts` `localtime`/`to_time` → `getlocal`); baseline row count
drops 6 → 4 for that source, deleted by hand rather than reseeded.

### Why `change` stays a free function

`change` lives in ActiveSupport's `core_ext/time/calculations.rb`, not in ruby
core, so its trails home is `packages/activesupport/src/time-ext.ts` — the
mirror of that file — and every method in it (`advance`, `midnight`,
`secondsSinceMidnight`, …) is spelled as a receiver-taking free function.
Moving `change` onto `packages/date`'s `Time` would put ActiveSupport code in
the ruby-core package and add a member to a file `parity:api` maps to core
`::Time`, which has no `change`. CLAUDE.md's mixin idiom — a `this`-typed
function assigned to the class in the class's own file — cannot bridge the two
either, because `packages/date` cannot import from `@blazetrails/activesupport`.
So `change(now, { usec: 0 })` is the settled trails spelling of Rails'
`now.change(usec: 0)`, and the call is made where Rails makes it.

`parity:api:calls` and `parity:api:calls:args` are green; `parity:api:extra`
gains nothing.

Closes-story: converge-includes-preload-colon-sweep-relation-and-preloader
Closes-story: travel-to-input-arms-build-a-time
