### PR TITLE
feat(activesupport): port Date value type for TimeZone#today/tomorrow/yesterday

### DIFF
--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -68,10 +68,7 @@ export function tomorrow(): Temporal.PlainDate {
 /** Mirrors: `Date.current` (`date/calculations.rb:48-50`) */
 export function current(): Temporal.PlainDate {
   const zone = timeZone();
-  if (zone) {
-    const today = zone.today();
-    return new Temporal.PlainDate(today.year, today.month, today.day);
-  }
+  if (zone) return zone.today();
   return Temporal.Now.plainDateISO();
 }
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -725,8 +725,9 @@ export class Timezone {
    * `TZInfo::Timezone#now` (`tzinfo/timezone.rb`) — `utc_to_local(Time.now.utc)`,
    * which `TimeZone#today` (time_zone.rb:521-523) calls `to_date` on. As of
    * tzinfo 2 the result is a local time carrying the observed UTC offset rather
-   * than a zone, so the offset is what the `zone` argument gets. `Time.now`
-   * reaches the same {@link currentTime} `TimeZone#timeNow` does, so a time
+   * than a zone (the note at time_zone.rb:540-541), so the offset is what the
+   * `zone` argument gets, and the sub-second is carried as the `Rational` MRI's
+   * `Time` holds it as. `Time.now` reaches the same {@link currentTime} `TimeZone#timeNow` does, so a time
    * travelled to moves the date here as MRI's stubbed `Time.now` moves it there.
    */
   now(): Time {
@@ -737,7 +738,13 @@ export class Timezone {
       local.day,
       local.hour,
       local.minute,
-      local.second,
+      new Rational(
+        BigInt(local.second) * 1_000_000_000n +
+          BigInt(local.nanosecond) +
+          BigInt(local.microsecond) * 1_000n +
+          BigInt(local.millisecond) * 1_000_000n,
+        1_000_000_000n,
+      ),
       Number(local.offsetNanoseconds) / 1_000_000_000,
     );
   }

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -926,6 +926,21 @@ export class TimeZone {
     return new TimeWithZone(instantFrom(this.timeNow()), this);
   }
 
+  /** `today` (time_zone.rb:520-523) — `tzinfo.now.to_date`. */
+  today(): Temporal.PlainDate {
+    return this.tzinfo.now().toDate();
+  }
+
+  /** `tomorrow` (time_zone.rb:525-528) — `today + 1`. */
+  tomorrow(): Temporal.PlainDate {
+    return this.today().add({ days: 1 });
+  }
+
+  /** `yesterday` (time_zone.rb:530-533) — `today - 1`. */
+  yesterday(): Temporal.PlainDate {
+    return this.today().subtract({ days: 1 });
+  }
+
   /**
    * `local(*args)` (time_zone.rb:363-366): build the wall clock with
    * `Time.utc(*args)` and hand it to `TimeWithZone.new(nil, self, time)`, which
@@ -1127,21 +1142,6 @@ export class TimeZone {
   /** `dst?(time)` (time_zone.rb:571-573) — `tzinfo.dst?(time)`. */
   isDst(time: Date | Temporal.Instant): boolean {
     return this.tzinfo.isDst(time);
-  }
-
-  /** `today` (time_zone.rb:520-523) — `tzinfo.now.to_date`. */
-  today(): Temporal.PlainDate {
-    return this.tzinfo.now().toDate();
-  }
-
-  /** `tomorrow` (time_zone.rb:525-528) — `today + 1`. */
-  tomorrow(): Temporal.PlainDate {
-    return this.today().add({ days: 1 });
-  }
-
-  /** `yesterday` (time_zone.rb:530-533) — `today - 1`. */
-  yesterday(): Temporal.PlainDate {
-    return this.today().subtract({ days: 1 });
   }
 
   /**

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -722,6 +722,27 @@ export class Timezone {
   }
 
   /**
+   * `TZInfo::Timezone#now` (`tzinfo/timezone.rb`) — `utc_to_local(Time.now.utc)`,
+   * which `TimeZone#today` (time_zone.rb:521-523) calls `to_date` on. As of
+   * tzinfo 2 the result is a local time carrying the observed UTC offset rather
+   * than a zone, so the offset is what the `zone` argument gets. `Time.now`
+   * reaches the same {@link currentTime} `TimeZone#timeNow` does, so a time
+   * travelled to moves the date here as MRI's stubbed `Time.now` moves it there.
+   */
+  now(): Time {
+    const local = this.utcToLocal(currentTime());
+    return new Time(
+      local.year,
+      local.month,
+      local.day,
+      local.hour,
+      local.minute,
+      local.second,
+      Number(local.offsetNanoseconds) / 1_000_000_000,
+    );
+  }
+
+  /**
    * `TZInfo::Timezone#utc_to_local`: as of tzinfo 2 this is the local time
    * carrying a non-zero UTC offset, which a `Temporal.ZonedDateTime` is.
    */
@@ -1101,30 +1122,19 @@ export class TimeZone {
     return this.tzinfo.isDst(time);
   }
 
-  /**
-   * Today's date in this timezone.
-   */
-  today(): { year: number; month: number; day: number } {
-    const n = this.now();
-    return { year: n.year, month: n.month, day: n.day };
+  /** `today` (time_zone.rb:520-523) — `tzinfo.now.to_date`. */
+  today(): Temporal.PlainDate {
+    return this.tzinfo.now().toDate();
   }
 
-  /**
-   * Tomorrow's date in this timezone.
-   */
-  tomorrow(): { year: number; month: number; day: number } {
-    const t = this.today();
-    const d = new Date(Date.UTC(t.year, t.month - 1, t.day + 1));
-    return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+  /** `tomorrow` (time_zone.rb:525-528) — `today + 1`. */
+  tomorrow(): Temporal.PlainDate {
+    return this.today().add({ days: 1 });
   }
 
-  /**
-   * Yesterday's date in this timezone.
-   */
-  yesterday(): { year: number; month: number; day: number } {
-    const t = this.today();
-    const d = new Date(Date.UTC(t.year, t.month - 1, t.day - 1));
-    return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+  /** `yesterday` (time_zone.rb:530-533) — `today - 1`. */
+  yesterday(): Temporal.PlainDate {
+    return this.today().subtract({ days: 1 });
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
+++ b/scripts/api-compare/call-mismatches-exclude/activesupport/values/time-zone.json
@@ -23,13 +23,6 @@
   {
     "package": "activesupport",
     "tsFile": "values/time-zone.ts",
-    "rubyName": "today",
-    "call": "to_date",
-    "reason": "`tzinfo.now.to_date` (time_zone.rb:521-523) answers a `::Date`; trails has no `Date` value type on this seam and `today()` returns the `{ year, month, day }` triple its callers (`tomorrow`, `yesterday`) consume, read off `now()`. Converging is the `Date` port, not the missing call."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "values/time-zone.ts",
     "rubyName": "utc_to_local",
     "call": "utc",
     "reason": "`Time.utc(t.year, ..., t.sec_fraction * 1_000_000)` (time_zone.rb:542-547). trails' non-offset arm rebuilds the same components as a JS `Date` through `Date.UTC`, the seat this method's callers read. Pre-existing: surfaced only once `DateTime#utc` (date_time/calculations.rb:184) was ported and `utc` entered the population."


### PR DESCRIPTION
Converges the `today` / `to_date` call-set baseline row.

`TimeZone#today` (`activesupport/lib/active_support/values/time_zone.rb:521-523`)
is `tzinfo.now.to_date`. trails had no `Date` value type on this seam, so
`today()` answered an ad-hoc `{ year, month, day }` triple read off `now()` and
never called `to_date`; `tomorrow` / `yesterday` did JS-`Date` arithmetic over
that triple.

- `Timezone#now` (the TZInfo stand-in) is `utc_to_local(Time.now.utc)`,
  answering a `Time` carrying the observed UTC offset — the shape tzinfo 2
  returns, per the note at `time_zone.rb:535-538`. It reads the clock through
  the same `currentTime()` `TimeZone#timeNow` uses, so time travel moves the
  date as MRI's stubbed `Time.now` moves it.
- `today()` is `this.tzinfo.now().toDate()` — `Time#to_date` from
  `@blazetrails/date` — answering `Temporal.PlainDate`.
- `tomorrow()` / `yesterday()` are `today + 1` / `today - 1` over that date.
- `Date.current` (`core_ext/date/calculations.rb:48-50`) returns
  `Time.zone.today` directly instead of rebuilding a `PlainDate` from the triple.

Gates: `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green; the
`values/time-zone.json` call-set shard is deleted (it held only this row).

Closes-story: port-activesupport-date-value-type-for-time-zone-today