### PR TITLE
refactor(activerecord): replace opens the transaction; source_preloaders passes the built scope

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -787,11 +787,11 @@ export class CollectionAssociation extends Association {
    * (collection_association.rb:251), against the baseline captured before the
    * in-memory half of `replace` mutated `target`.
    *
+   * Rails inlines this as the transaction's block; it is a named private
+   * helper here only because the block is async while `replace` is not (a JS
+   * property setter cannot await, RFC 0068). It retires with that split.
+   *
    * @internal
-   * @noRailsEquivalent CONVERGEABLE — Rails inlines this as the transaction's
-   * block; it is a named private helper here only because the block is async
-   * while `replace` is not (a JS property setter cannot await, RFC 0068). It
-   * retires with that split.
    */
   protected async replaceRecordsInTransaction(pending: ReplacePlan): Promise<void> {
     // If the association wasn't loaded at assignment time, fetch the persisted

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -26,10 +26,13 @@ export interface ReplacePlan {
   originalTarget: Base[];
   wasLoaded: boolean;
   /**
-   * The new-owner arm's own DB work, when it had any. That arm is I/O-free —
-   * a new owner's `concat` never inserts and `remove_records` skips
-   * `delete_records` — except when the records being REMOVED are persisted,
-   * which Rails deletes in a transaction (`delete_or_destroy`, :393-397).
+   * The DB work `replace` has already started and cannot await: on the
+   * persisted arm the `transaction { replace_records(...) }` it opened
+   * (collection_association.rb:251), and on the new-owner arm that arm's own
+   * work when it had any — it is I/O-free (a new owner's `concat` never
+   * inserts and `remove_records` skips `delete_records`) except when the
+   * records being REMOVED are persisted, which Rails deletes in a transaction
+   * (`delete_or_destroy`, :393-397).
    */
   pending?: Promise<unknown>;
 }
@@ -141,7 +144,7 @@ export class CollectionAssociation extends Association {
    */
   async writer(records: Base[]): Promise<void> {
     const plan = this.replace(records);
-    if (plan) await this.persistReplacePlan(plan);
+    if (plan?.pending) await plan.pending;
   }
 
   /**
@@ -338,7 +341,7 @@ export class CollectionAssociation extends Association {
       // persisted-owner half to the plan the sync `replace` returns (the
       // awaitable `writer` does the same two steps).
       const plan = this.replace(records);
-      if (plan) await this.persistReplacePlan(plan);
+      if (plan?.pending) await plan.pending;
     }
   }
 
@@ -709,11 +712,13 @@ export class CollectionAssociation extends Association {
    * first `save()` autosaves the target.
    *
    * For a *persisted* owner Rails additionally runs the diffed deletes +
-   * inserts in a transaction; that DB work cannot happen here (this is
-   * synchronous, and reached from the property setter), so it is returned as a
-   * plan for the awaitable {@link writer} to execute via
-   * {@link persistReplacePlan}. Returns `null` when there is nothing to
-   * persist.
+   * inserts in a transaction (`transaction { replace_records(...) }`,
+   * collection_association.rb:251) — opened here, on Rails' arm and under
+   * Rails' `other_array != original_target` guard. The DB work inside it
+   * cannot be awaited here (this is synchronous, and reached from mass
+   * assignment), so the open transaction's promise rides out on the returned
+   * plan for the awaitable {@link writer} to await. Returns `null` when there
+   * is nothing to persist.
    */
   replace(otherArray: Base[]): ReplacePlan | null {
     // The writer path (`firm.clients = [...]`, `firm.client_ids = [...]`, mass
@@ -746,7 +751,7 @@ export class CollectionAssociation extends Association {
       }
     } else {
       // Persisted owner: `load_target` here is DB I/O this synchronous body
-      // cannot run, so the in-memory baseline stands in and `persistReplacePlan`
+      // cannot run, so the in-memory baseline stands in and `replaceRecordsInTransaction`
       // re-reads the real `original_target` before diffing. Rails also calls
       // replace_common_records_in_memory before diffing; for a new owner it
       // skips it (replace_records leaves common records untouched), so it lives
@@ -761,36 +766,34 @@ export class CollectionAssociation extends Association {
         for (const r of this.difference(otherArray, this.target)) {
           this.setOwnerAttributes(r);
           // `skipCallbacks` because this add is only the in-memory placeholder
-          // for the deferred `replace_records`: `persistReplacePlan` restores
+          // for the deferred `replace_records`: `replaceRecordsInTransaction` restores
           // `originalTarget` and re-runs the Rails body, whose `concat` fires
           // `before_add`/`after_add` for real. Firing them here too would
           // double them for every gained record.
           this.addToTarget(r, { skipCallbacks: true });
         }
         this.loadedBang();
-        return { newTarget: [...otherArray], originalTarget, wasLoaded };
+        const plan: ReplacePlan = { newTarget: [...otherArray], originalTarget, wasLoaded };
+        plan.pending = this.transaction(() => this.replaceRecordsInTransaction(plan));
+        return plan;
       }
     }
     return null;
   }
 
   /**
-   * Run the persisted-owner half of {@link replace}: the diffed deletes +
-   * inserts, in a transaction (Rails' `replace_records`,
-   * collection_association.rb:242). Awaited inline by {@link writer} — the
-   * in-memory `replace` above has already mutated `target`, so this restores
-   * the captured baseline for the duration of the diff.
+   * The body of the transaction {@link replace} opens on Rails' persisted-owner
+   * arm: `replace_records(other_array, original_target)`
+   * (collection_association.rb:251), against the baseline captured before the
+   * in-memory half of `replace` mutated `target`.
    *
-   * @noRailsEquivalent CONVERGEABLE — the awaitable half of `replace`
-   * (collection_association.rb:242), split off because a JS property setter
-   * cannot await (RFC 0068). Public rather than protected because
-   * `CollectionProxy#replace` (collection_proxy.rb:391-393) delegates here from
-   * outside the class, spelling the same two steps `writer`
-   * (collection_association.rb:46-48) does; it retires with the split.
+   * @internal
+   * @noRailsEquivalent CONVERGEABLE — Rails inlines this as the transaction's
+   * block; it is a named private helper here only because the block is async
+   * while `replace` is not (a JS property setter cannot await, RFC 0068). It
+   * retires with that split.
    */
-  async persistReplacePlan(pending: ReplacePlan): Promise<void> {
-    if (pending.pending) await pending.pending;
-    if (this.owner.isNewRecord()) return;
+  protected async replaceRecordsInTransaction(pending: ReplacePlan): Promise<void> {
     // If the association wasn't loaded at assignment time, fetch the persisted
     // baseline directly rather than via findTarget, to avoid the loadedBang short-circuit
     // and without mutating this.target (mirrors Rails' load_target in replace).
@@ -803,16 +806,14 @@ export class CollectionAssociation extends Association {
       pending.originalTarget = [...dbRecords];
     }
     const currentTarget = this.target;
-    await this.transaction(async () => {
-      // replaceRecords diffs against assoc.target; restore originalTarget so
-      // it sees the real DB state rather than the already-updated in-memory target
-      this._targetStore = [...pending.originalTarget];
-      try {
-        await replaceRecords(this, pending.newTarget, pending.originalTarget);
-      } finally {
-        this._targetStore = currentTarget;
-      }
-    });
+    // replaceRecords diffs against assoc.target; restore originalTarget so
+    // it sees the real DB state rather than the already-updated in-memory target
+    this._targetStore = [...pending.originalTarget];
+    try {
+      await replaceRecords(this, pending.newTarget, pending.originalTarget);
+    } finally {
+      this._targetStore = currentTarget;
+    }
   }
 
   /**
@@ -1596,7 +1597,7 @@ export function includesRecord(records: Base[], record: Base): boolean {
  * (collection_association.rb:414-424).
  *
  * `Promise<Base[]> | Base[]` because both arms of `replace` reach it: the
- * persisted one from the awaitable {@link CollectionAssociation.persistReplacePlan},
+ * persisted one from the awaitable {@link CollectionAssociation.replaceRecordsInTransaction},
  * the new-owner one from the synchronous `replace` body, where `delete` and
  * `concat` are I/O-free and this runs inline start to finish.
  *

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -892,7 +892,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async replace(otherArray: T[]): Promise<T[]> {
     const association = this._collectionAssociation();
     const plan = association.replace(otherArray);
-    if (plan) await association.persistReplacePlan(plan);
+    if (plan?.pending) await plan.pending;
     return this._target;
   }
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -186,6 +186,7 @@ export class ThroughAssociation extends Association {
     );
   }
 
+  /** Mirrors: `preloader/through_association.rb:70-72`. */
   private async sourcePreloaders(): Promise<Association[]> {
     if (this._sourcePreloaders !== undefined) return this._sourcePreloaders;
 
@@ -195,51 +196,10 @@ export class ThroughAssociation extends Association {
       return [];
     }
 
-    // Mirror Rails' `source_preloaders`, which spawns a fresh Preloader on
-    // `source_reflection.name` passing this preloader's built `scope`
-    // (through_association.rb:70-71). Rails passes the full built scope
-    // (reflection_scope merged, `preloader/association.rb:294-304`); trails empties
-    // the source where_clause ONLY when `throughScope` already resolved it
-    // by copying the FULL where_clause onto the through query and eager-loading the
-    // source there (the `!where_clause.empty?` branch, for every source kind). In
-    // that case the middle records arrive with their source association already
-    // loaded, so this stage issues no query and re-applying the where would
-    // reference the through / intermediate table this source query never joins
-    // (e.g. `no such column: memberships.favorite`). What the source query keeps is
-    // the non-where structure — `order`, `select`, `distinct` — so
-    // `orderedPostComments`' `order(id: :desc)` still orders the source query in
-    // the fallthrough where the reflection where_clause was empty (no eager-load).
-    //
-    // The `source_type` branch of `throughScope` (rb:115-116) applies ONLY
-    // the source_type filter and does NOT copy the reflection where_clause onto
-    // the through query, so the source is genuinely queried here and MUST keep the
-    // reflection scope's (source-table) predicates — otherwise a scoped
-    // polymorphic-through loses them. So empty the where only when NOT a
-    // source_type reflection.
-    //
-    // For a nested source (source is itself a through), carry nothing: the
-    // sub-chain re-derives its own scope (including order) at its own recursive
-    // preload stage, and carrying the flattened chain scope's joins/select here
-    // would duplicate the middle records.
-    let sourceScope = null;
-    const sourceIsNested = (sourceRefl as any).isThroughReflection?.() ?? false;
-    const hasSourceType = !!(this.reflection as any).options?.sourceType;
-    if (!sourceIsNested && !this.reflectionScope.isEmptyScope) {
-      sourceScope = this.reflectionScope.clone();
-      if (!hasSourceType) {
-        sourceScope.whereClause = new WhereClause([]);
-      }
-    }
-    if (sourceScope != null && this.preloadScope != null) {
-      sourceScope = sourceScope.merge(this.preloadScope);
-    } else if (sourceScope == null) {
-      sourceScope = this.preloadScope;
-    }
-
     const preloader = new Preloader({
       records: middleRecords,
       associations: [sourceRefl.name],
-      scope: sourceScope,
+      scope: this.scope,
       associateByDefault: false,
     });
     this._sourcePreloaders = await preloader.loaders();

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/collection-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "replace",
-    "call": "transaction",
-    "reason": "Rails wraps `replace_records` in `transaction` (collection_association.rb:251); the synchronous writer path returns a ReplacePlan and opens the transaction in `persistReplacePlan` (collection-association.ts:775-791)."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/preloader/through-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/through-association.ts",
-    "rubyName": "source_preloaders",
-    "call": "scope",
-    "reason": "Deliberate: the source Preloader is handed a scope derived from `reflectionScope`/`preloadScope` rather than `scope`, because `throughScope` may already have eager-loaded the source (see the block comment at the call site)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "source_records_by_owner",
     "call": "reduce",
     "kind": "args",


### PR DESCRIPTION
Two RFC 0112 convergences (one Rails method that had become N trails things), plus one bundled story that turned out to be already landed.

### `CollectionAssociation#replace` opens the transaction

`collection_association.rb:249-256` wraps `replace_records` in `transaction`, on the non-new-record arm, under `other_array != original_target`. trails opened it later, in `persistReplacePlan`. Now `replace` opens it at Rails' branch and guard; the async block it cannot await (a JS property setter cannot await, RFC 0068) rides out on the returned `ReplacePlan.pending` for `writer` / `assignIds` / `CollectionProxy#replace` to await. `persistReplacePlan` survives as the private `replaceRecordsInTransaction` — the transaction's block, tagged CONVERGEABLE.

The `replace` -> `transaction` baseline row is deleted; the shard is now empty and removed.

### `Preloader::ThroughAssociation#source_preloaders` passes the built scope

`through_association.rb:70-72` hands the source Preloader this preloader's built `scope`. trails derived a substitute from `reflectionScope`/`preloadScope` and emptied the source `whereClause` when `throughScope` had eager-loaded the source, with a ~30-line comment explaining a policy Rails does not have. It now passes `this.scope`.

No compensating filter is needed: when `throughScope` eager-loaded the source, the middle records arrive with the source association already loaded, and `LoaderRecords` only queries the keys whose owners are not loaded (`preloader/association.rb:76-88`) — so that where is never turned into SQL against a table this query does not join. That is why Rails can pass the full scope too.

The `source_preloaders` -> `scope` row is deleted; the two `kind: "args"` `reduce` rows stay (language shortcoming).

### Already landed

`top-level-function-missing-rails-call-tag-does-not-suppress` was fixed by #6898 (`compare.ts` credits a top-level function's tag with its owned pair's suppressions; `activesupport/inflector.json` deleted, regression cases in `compare.test.ts`). It is marked done against #6898 in the tasks repo and carries no closure trailer here — this PR closes only the two ActiveRecord convergence stories. (An earlier `/link` run re-stamped it to this PR; that has been corrected.)

Gates: `parity:api:calls` OK (474 baselined, 323 unreviewed, tight), `parity:api:calls:args` OK, typecheck and eslint clean. Ran the associations / preloader / eager / autosave suites locally.

Closes-story: collection-association-replace-does-not-open-the-transaction
Closes-story: source-preloaders-does-not-pass-the-built-scope
