### PR TITLE
refactor(activerecord): RFC 0107 — relation readers take the loaded?/records seams; reset cancels the parked FutureResult

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -162,6 +162,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._targetAssociation._targetStore = records;
   }
 
+  /**
+   * Rails' `CollectionProxy#records` IS `load_target` (collection_proxy.rb:
+   * 1024-1026), so every inherited `Relation` reader that takes its `loaded?`
+   * arm reads the association target rather than `Relation`'s own `@records`.
+   * The async readers reach that through the overridden `records()`; the
+   * synchronous `inspect` (relation.rb:1290-1297) cannot await, so it reads the
+   * `@records` ivar and this override is what points that ivar at the target.
+   */
+  protected override get _records(): T[] {
+    return this._target;
+  }
+
+  protected override set _records(records: T[]) {
+    this._target = records;
+  }
+
   private get _targetLoaded(): boolean {
     return this._targetAssociation._loadedStore;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -644,7 +644,10 @@ export class ConnectionPool implements ReapablePool {
     return this._cacheConfig.enableQueryCache(fn);
   }
 
-  disableQueryCache<T>(fn: () => T | Promise<T>, options: { dirties?: boolean } = {}): Promise<T> {
+  disableQueryCache<T>(
+    fn: () => T | Promise<T>,
+    options: { dirties?: boolean } = {},
+  ): T | Promise<T> {
     return this._cacheConfig.disableQueryCache(fn, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -244,22 +244,34 @@ export class ConnectionPoolConfiguration {
     return connection;
   }
 
-  async disableQueryCache<T>(
+  disableQueryCache<T>(
     fn: () => T | Promise<T>,
     options: { dirties?: boolean } = {},
-  ): Promise<T> {
+  ): T | Promise<T> {
     const { dirties = true } = options;
     const qc = this.queryCache;
     const oldEnabled = qc.enabled;
     const oldDirties = qc.dirties;
     qc.enabled = false;
     qc.dirties = dirties;
-    try {
-      return await fn();
-    } finally {
+    const restore = () => {
       qc.enabled = oldEnabled;
       qc.dirties = oldDirties;
+    };
+    // NOT an `async` method: Ruby's `ensure` fires when the block RETURNS, and
+    // `exec_main_query`'s block returns a pending FutureResult rather than
+    // rows, so the restore is synchronous there too. Awaiting the block would
+    // adopt that thenable and resolve the handle away.
+    let result: T | Promise<T>;
+    try {
+      result = fn();
+    } catch (error) {
+      restore();
+      throw error;
     }
+    if (result instanceof Promise) return result.finally(restore);
+    restore();
+    return result;
   }
 
   async enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
@@ -364,9 +376,9 @@ export function uncached<T>(
   this: QueryCacheHost,
   fn: () => T | Promise<T>,
   options: { dirties?: boolean } = {},
-): Promise<T> {
+): T | Promise<T> {
   const { dirties = true } = options;
-  return this.pool.disableQueryCache(fn, { dirties }) as Promise<T>;
+  return this.pool.disableQueryCache(fn, { dirties });
 }
 
 /**

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -134,10 +134,13 @@ export const ClassMethods = {
     this: typeof Base,
     block: () => T | Promise<T>,
     options: { dirties?: boolean } = {},
-  ): Promise<T> {
+  ): T | Promise<T> {
     if (this.connectedQ() || !this.configurations().empty) {
       return this.connectionPool().disableQueryCache(block, options);
     }
-    return Promise.resolve(block());
+    // Ruby returns the block's value; resolving it here would adopt a pending
+    // FutureResult, which `skip_query_cache_if_necessary` (relation.rb:
+    // 1466-1471) hands back untouched.
+    return block();
   },
 };

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -135,6 +135,57 @@ describe("Relation#load_async", () => {
     await expect(scheduled[0].result()).rejects.toBeInstanceOf(FutureResult.Canceled);
   });
 
+  itIfSupports(
+    "concurrent_connections",
+    "reset cancels the scheduled query of a skip_query_cache! relation",
+    async () => {
+      // `skip_query_cache_if_necessary` yields and hands the block's value
+      // back untouched (relation.rb:1466-1471), so the `uncached` arm parks the
+      // same pending handle the plain arm does.
+      const pool = (await Base.connectionPool()) as unknown as {
+        scheduleQuery(futureResult: unknown): void;
+      };
+      const scheduled: FutureResult[] = [];
+      vi.spyOn(pool, "scheduleQuery").mockImplementation((futureResult) => {
+        scheduled.push(futureResult as FutureResult);
+      });
+
+      const relation = Topic.all().skipQueryCacheBang().loadAsync();
+      expect(scheduled[0]).toBeInstanceOf(FutureResult.SelectAll);
+
+      relation.reset();
+
+      expect(scheduled[0].pending()).toBe(false);
+      await expect(scheduled[0].result()).rejects.toBeInstanceOf(FutureResult.Canceled);
+    },
+  );
+
+  itIfSupports(
+    "concurrent_connections",
+    "reset cancels an eager-loaded relation's scheduled query",
+    async () => {
+      // `apply_join_dependency` yields and hands the block's value back
+      // (finder_methods.rb:457-481), so the eager arm's
+      // `select_all(relation.arel, "SQL", async: async)` (relation.rb:1436)
+      // parks a pending handle too.
+      const pool = (await Base.connectionPool()) as unknown as {
+        scheduleQuery(futureResult: unknown): void;
+      };
+      const scheduled: FutureResult[] = [];
+      vi.spyOn(pool, "scheduleQuery").mockImplementation((futureResult) => {
+        scheduled.push(futureResult as FutureResult);
+      });
+
+      const relation = Topic.eagerLoad(":replies").loadAsync();
+      expect(scheduled[0]).toBeInstanceOf(FutureResult.SelectAll);
+
+      relation.reset();
+
+      expect(scheduled[0].pending()).toBe(false);
+      await expect(scheduled[0].result()).rejects.toBeInstanceOf(FutureResult.Canceled);
+    },
+  );
+
   it("issues an eager-loaded relation's join query with async on", async () => {
     // Rails' exec_main_query forwards `async:` to its eager_loading? arm too —
     // `c.select_all(relation.arel, "SQL", async: async)` (relation.rb:1436).

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -108,6 +108,33 @@ describe("Relation#load_async", () => {
     },
   );
 
+  itIfSupports("concurrent_connections", "reset cancels the scheduled query", async () => {
+    // Mirrors relation.rb:1195-1196 — `@future_result&.cancel` — which is
+    // reachable only because `exec_main_query` hands the pending FutureResult
+    // back unresolved (relation.rb:1148). Hold the scheduled query off the
+    // executor so `reset` lands while it is still pending, exactly as Rails'
+    // thread pool leaves it until a worker picks it up.
+    const pool = (await Base.connectionPool()) as unknown as {
+      scheduleQuery(futureResult: unknown): void;
+    };
+    const scheduled: FutureResult[] = [];
+    vi.spyOn(pool, "scheduleQuery").mockImplementation((futureResult) => {
+      scheduled.push(futureResult as FutureResult);
+    });
+
+    const relation = Topic.all().loadAsync();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].pending()).toBe(true);
+
+    relation.reset();
+
+    expect(scheduled[0].pending()).toBe(false);
+    // `executeOrSkip` is the worker's entry point (future_result.rb:100-108);
+    // a canceled handle is no longer pending, so it skips the query outright.
+    scheduled[0].executeOrSkip();
+    await expect(scheduled[0].result()).rejects.toBeInstanceOf(FutureResult.Canceled);
+  });
+
   it("issues an eager-loaded relation's join query with async on", async () => {
     // Rails' exec_main_query forwards `async:` to its eager_loading? arm too —
     // `c.select_all(relation.arel, "SQL", async: async)` (relation.rb:1436).

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -42,6 +42,7 @@ import {
 } from "./relation/uncacheable-methods-slot.js";
 import { InsertAll, type InsertAllOptions } from "./insert-all.js";
 import { Result } from "./result.js";
+import { FutureResult, Complete } from "./future-result.js";
 import { ScopeRegistry } from "./scoping.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
 import { include, type Included } from "@blazetrails/activesupport";
@@ -501,7 +502,21 @@ export class Relation<T extends Base> {
   // runs via `_exec_scope`, which is what makes `already_in_scope?` (and hence
   // `spawn`'s `model.all` branch) reachable at all.
   private _delegateToModel = false;
-  private _records: T[] = [];
+  private _recordsStore: T[] = [];
+  /**
+   * Rails' `@records` ivar. `protected` rather than `private` so
+   * `CollectionProxy` can point it at the association target the way it already
+   * points `isLoaded` at `@association.loaded?` (collection_proxy.rb:53) — the
+   * TS spelling of Rails' `records` seam (collection_proxy.rb:1024-1026) for
+   * the ONE reader that cannot go through it, the synchronous `inspect`.
+   */
+  protected get _records(): T[] {
+    return this._recordsStore;
+  }
+
+  protected set _records(records: T[]) {
+    this._recordsStore = records;
+  }
   // Rails `@take` / `@offsets` (finder_methods.rb:586, 599-600).
   protected _take?: T | null;
   protected _offsets?: Map<number, T | null>;
@@ -520,16 +535,21 @@ export class Relation<T extends Base> {
    * `loadAsync` parks so the foreground `execQueries` pass drains the ROWS
    * (relation.rb:1405-1409) instead of issuing the query itself.
    *
-   * Rails holds a `Concurrent`-backed `FutureResult`; trails holds the promise
-   * `execMainQuery` returns. `FutureResult` is a thenable, so an `async` method
-   * that returns one already resolves it — that promise IS trails' handle to
-   * the same scheduled query, and it is what `isScheduled` reads. Same
-   * decision, same reason, as the `@noRailsEquivalent PERMANENT` tag on
-   * `ar-config.ts:55` — spelled as prose here because `parity:api:extra` never
-   * scores a `_`-prefixed private member, so a real tag on one reads back as
-   * stale.
+   * Holds what `relation.rb:1148` holds: the unresolved handle
+   * `exec_main_query` hands back — a `FutureResult` on the scheduled arm, a
+   * `Complete` on the `@none` arm (`FutureResult.wrap([])`, relation.rb:1426).
+   * `exec_main_query` is deliberately NOT an `async` method for that reason: a
+   * JS `async` function awaits any thenable it returns, and `FutureResult`
+   * defines `then`, so an `async` boundary would resolve the handle into rows
+   * and leave nothing to `cancel`.
+   *
+   * The two remaining `Promise<Result>` arms are trails' own async residue —
+   * the eager-loading arm goes through the async `applyJoinDependency`, and
+   * `skipQueryCacheIfNecessary`'s `uncached` arm returns a promise where Ruby's
+   * `disable_query_cache` returns the block's value — so `reset` narrows before
+   * cancelling.
    */
-  private _futureResult?: Promise<Result>;
+  private _futureResult?: FutureResult | Complete | Result | Promise<Result>;
   /**
    * Monotonic token bumped on reset()/reload() so an in-flight toArray()
    * that started before the reset can detect it lost the race and skip
@@ -588,7 +608,7 @@ export class Relation<T extends Base> {
     // AssociationRelation distinction (three distinct Rails classes) while
     // rendering each one's namespace-qualified Rails constant path.
     const className = (this.constructor as typeof Relation)._railsClassName;
-    if (this._loaded) {
+    if (this.isLoaded) {
       const max = takeLimit(this.limitValue);
       const entries = this._records.slice(0, max).map((record) => record.inspect());
       if (entries.length === 11) entries[10] = "...";
@@ -617,7 +637,9 @@ export class Relation<T extends Base> {
    */
   async prettyPrint(pp: PrettyPrinter): Promise<void> {
     const max = takeLimit(this.limitValue);
-    const subject = this._loaded ? this._records : await this.annotate("loading for pp").limit(max);
+    const subject = this.isLoaded
+      ? await this.records()
+      : await this.annotate("loading for pp").limit(max);
     const entries = subject.slice(0, max) as (T | string)[];
     if (entries.length === 11) entries[10] = "...";
     await pp.pp(entries);
@@ -683,12 +705,15 @@ export class Relation<T extends Base> {
     this._shouldEagerLoad = undefined;
     this._cacheKeys = undefined;
     this._cacheVersions = undefined;
-    // Mirrors relation.rb:1195-1196 (`@future_result&.cancel; @future_result =
-    // nil`). A JS promise has no `cancel`, so the load token stands in: an
-    // already-running toArray() checks it after its await and skips committing
-    // if it lost the race, so a stale background load can't re-populate
-    // records after a reset.
+    // The load token has no Rails equivalent: it covers the trails-only race
+    // where a reset lands mid-await, which Rails cannot have because
+    // `exec_queries` (relation.rb:1416-1421) is synchronous.
     this._loadToken += 1;
+    // Mirrors relation.rb:1195-1196 (`@future_result&.cancel; @future_result =
+    // nil`). Ruby's `&.` guards nil only — the other shapes trails can park
+    // (a `Complete`, a plain promise) have no `cancel`, exactly as Ruby's
+    // `FutureResult::Complete` has none (future_result.rb:5-23).
+    if (this._futureResult instanceof FutureResult) this._futureResult.cancel();
     this._futureResult = undefined;
     return this;
   }
@@ -727,20 +752,20 @@ export class Relation<T extends Base> {
     // (relation.rb:1138-1154). Both of those reads need the connection that
     // will run the query, so trails makes them where it is in hand — in
     // `execMainQuery` — and marks the load async here.
-    if (!this._loaded && !this._futureResult) {
+    if (!this.isLoaded && !this._futureResult) {
       // Rails' `unless loaded?` (relation.rb:1141). trails also guards on the
       // parked handle so a second `loadAsync()` joins the scheduled query
       // rather than issuing another one; Rails cannot reach that state because
       // its `load_async` sets `@loaded` in the same breath (relation.rb:1149),
-      // which trails leaves to `toArray` — its `_loaded` fast paths, and
-      // `size`/`isEmpty`'s, read `_records` directly rather than routing
-      // through `load` the way Rails' do.
+      // which trails leaves to `toArray`, whose own `loaded?` guard is what
+      // that assignment exists to satisfy.
       const futureResult = this.execMainQuery(true);
-      // Attach a no-op rejection handler so a failure here isn't treated as an
-      // unhandled rejection if nothing else awaits the relation. The stored
-      // promise still carries the rejection to `execQueries` through a separate
-      // chain.
-      void futureResult.catch(() => {});
+      // A FutureResult keeps its failure in `@error` and re-raises it from
+      // `result` (future_result.rb:120-125), so only the promise arms need a
+      // no-op rejection handler to keep an unawaited relation from surfacing an
+      // unhandled rejection. The stored value still carries the failure to
+      // `execQueries` through a separate chain.
+      if (futureResult instanceof Promise) void futureResult.catch(() => {});
       this._futureResult = futureResult;
     }
     return this;
@@ -838,7 +863,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#size
    */
   async size(): Promise<number> {
-    if (this._loaded) return this._records.length;
+    if (this.isLoaded) return (await this.records()).length;
     return this.count("all") as Promise<number>;
   }
 
@@ -996,7 +1021,12 @@ export class Relation<T extends Base> {
    */
   async toArray(): Promise<T[]> {
     if (this.isNullRelation()) return [];
-    if (this._loaded) return [...this._records];
+    // relation.rb:1180's `loaded?` guard reads the seam, not `@loaded`, so a
+    // subclass that owns its loadedness (CollectionProxy,
+    // collection_proxy.rb:53) takes this arm correctly. Rails' second
+    // disjunct — `|| scheduled?` — needs no spelling here: `loadAsync` leaves
+    // `_loaded` false, so a scheduled relation already falls through.
+    if (this.isLoaded) return [...this._records];
     // Run the query inside `with_connection` so the pool releases the connection
     // afterwards instead of holding it permanently. The build / execute path
     // reads the threaded connection via `_conn()` (see {@link withConnection})
@@ -1047,7 +1077,10 @@ export class Relation<T extends Base> {
       if (this.isScheduled) {
         const future = this._futureResult!;
         this._futureResult = undefined;
-        rows = await future;
+        // relation.rb:1408 `future.result`. `Complete#result` is an attribute
+        // and the promise arms are already promises, so only the FutureResult
+        // spells the call; the rest settle through `await` to the same rows.
+        rows = await (future instanceof FutureResult ? future.result() : future);
       } else {
         rows = await this.execMainQuery();
       }
@@ -1085,14 +1118,11 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#exec_main_query (relation.rb:1423-1452).
    * Returns rows; `instantiateRecords` turns them into records.
    *
-   * @missingRailsCall wrap — CONVERGEABLE (story port-load-async-future-result-for-select-async-arm): Verified per-site (RFC 0106): relation.rb:1426 is
-   *   `FutureResult.wrap([])`, the async arm of the `@none` short-circuit.
-   *   trails has no FutureResult — `loadAsync` memoizes the load PROMISE itself
-   *   (relation.ts:753-765) because instantiation/eager-loading/preloading are
-   *   all awaited inside `execQueries` — so the async arm returns the same
-   *   `Result.empty()` the sync arm does.
+   * NOT an `async` method: `FutureResult` implements the JS thenable protocol,
+   * so an `async` boundary would adopt the scheduled handle and resolve it into
+   * rows, leaving `reset` (relation.rb:1195) nothing to cancel.
    */
-  private async execMainQuery(async = false): Promise<Result> {
+  private execMainQuery(async = false): Result | Promise<Result> | FutureResult | Complete {
     // Rails' load_async bails to a plain `load` unless `c.async_enabled?` and
     // passes `async: !c.current_transaction.joinable?` into `exec_main_query`
     // (relation.rb:1140-1142), which forwards it to BOTH of its query arms —
@@ -1101,7 +1131,13 @@ export class Relation<T extends Base> {
     // querying.rb:67-68).
     // Mirrors relation.rb:1424-1429: the `@none` arm short-circuits before the
     // query cache block and before any SQL is issued.
-    if (this._isNone) return Result.empty();
+    if (this._isNone) {
+      if (async) {
+        return FutureResult.wrap(Result.empty());
+      } else {
+        return Result.empty();
+      }
+    }
 
     const c = this._conn();
     // Rails computes `async: !c.current_transaction.joinable?` in `load_async`,
@@ -1113,7 +1149,7 @@ export class Relation<T extends Base> {
 
     // Mirrors relation.rb:1431-1451: ONE `skip_query_cache_if_necessary` over
     // the contradiction / eager_loading? / plain arms, not one per arm.
-    return this.skipQueryCacheIfNecessary(async () => {
+    return this.skipQueryCacheIfNecessary(() => {
       // relation.rb:1432-1433: a contradictory where-clause (e.g. `where(id: [])`,
       // which compiles to an empty `IN`) returns `[].freeze` before any SELECT.
       if (this.whereClause.isContradiction()) return Result.empty();
@@ -1130,9 +1166,9 @@ export class Relation<T extends Base> {
         });
       }
 
-      // Mirrors relation.rb:1449 (`_query_by_sql` → querying.rb:67-68). A
-      // scheduled FutureResult is a thenable, so the promise this returns
-      // settles to the same rows `future.result` yields in `execQueries`.
+      // Mirrors relation.rb:1449 (`_query_by_sql` → querying.rb:67-68). On the
+      // async arm `select_all` hands back the pending FutureResult itself
+      // (database_statements.rb:74), which is what `loadAsync` parks.
       return c.selectAll(this.arel(), `${this.model.name} Load`, [], { async });
     });
   }
@@ -2821,13 +2857,14 @@ export class Relation<T extends Base> {
     let size: unknown = 0;
     let timestamp: unknown = null;
 
-    if (this._loaded) {
-      size = this._records.length;
+    if (this.isLoaded) {
+      const records = await this.records();
+      size = records.length;
       if ((size as number) > 0) {
         // Ruby's `Array#max`, which orders through `<=>`; a cast datetime
         // attribute sits on a `Temporal.Instant`, which has no relational
         // operators of its own.
-        timestamp = this._records
+        timestamp = records
           .map((record) =>
             (record as unknown as { readAttribute(name: string): unknown }).readAttribute(
               timestampColumn,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -543,13 +543,13 @@ export class Relation<T extends Base> {
    * defines `then`, so an `async` boundary would resolve the handle into rows
    * and leave nothing to `cancel`.
    *
-   * The two remaining `Promise<Result>` arms are trails' own async residue —
-   * the eager-loading arm goes through the async `applyJoinDependency`, and
-   * `skipQueryCacheIfNecessary`'s `uncached` arm returns a promise where Ruby's
-   * `disable_query_cache` returns the block's value — so `reset` narrows before
-   * cancelling.
+   * The one `Promise<Result>` arm left is `apply_join_dependency`'s
+   * `distinct_relation_for_primary_key` rewrite (finder_methods.rb:465-475),
+   * which ISSUES a query before yielding. Ruby blocks on it and still yields
+   * the handle; JS cannot block, so that arm — and only that arm — settles
+   * through a promise, and `reset` narrows before cancelling.
    */
-  private _futureResult?: FutureResult | Complete | Result | Promise<Result>;
+  private _futureResult?: FutureResult | Complete | Promise<Result>;
   /**
    * Monotonic token bumped on reset()/reload() so an in-flight toArray()
    * that started before the reset can detect it lost the race and skip
@@ -759,14 +759,23 @@ export class Relation<T extends Base> {
       // its `load_async` sets `@loaded` in the same breath (relation.rb:1149),
       // which trails leaves to `toArray`, whose own `loaded?` guard is what
       // that assignment exists to satisfy.
-      const futureResult = this.execMainQuery(true);
-      // A FutureResult keeps its failure in `@error` and re-raises it from
-      // `result` (future_result.rb:120-125), so only the promise arms need a
-      // no-op rejection handler to keep an unawaited relation from surfacing an
-      // unhandled rejection. The stored value still carries the failure to
-      // `execQueries` through a separate chain.
-      if (futureResult instanceof Promise) void futureResult.catch(() => {});
-      this._futureResult = futureResult;
+      const result = this.execMainQuery(true);
+      // relation.rb:1145-1146 `if result.is_a?(Array) then @records = result` —
+      // the contradiction arm hands back rows rather than a handle
+      // (relation.rb:1433), and Rails parks only the handle. trails' rows are a
+      // `Result`, so they go through `instantiateRecords` first; Rails can
+      // assign them straight across because that arm is only ever `[].freeze`.
+      if (result instanceof Result) {
+        this.loadRecords(this.instantiateRecords(result));
+      } else {
+        // A FutureResult keeps its failure in `@error` and re-raises it from
+        // `result` (future_result.rb:120-125); only the promise arm needs a
+        // no-op rejection handler to keep an unawaited relation from surfacing
+        // an unhandled rejection. It still carries the failure to `execQueries`
+        // through a separate chain.
+        if (result instanceof Promise) void result.catch(() => {});
+        this._futureResult = result;
+      }
     }
     return this;
   }
@@ -1010,7 +1019,12 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load
    */
   async load(): Promise<LoadedRelation<this>> {
-    await this.toArray();
+    // relation.rb:1180 `if !loaded? || scheduled?`. The `scheduled?` disjunct
+    // is unreachable here: Rails' `load_async` sets `@loaded` in the same
+    // breath it parks the handle (relation.rb:1149), which is what its `load`
+    // needs the disjunct to see past; trails leaves `_loaded` false so the
+    // first disjunct already carries a scheduled relation into `execQueries`.
+    if (!this.isLoaded) await this.toArray();
     return stripThenable(this);
   }
 
@@ -1026,7 +1040,11 @@ export class Relation<T extends Base> {
     // collection_proxy.rb:53) takes this arm correctly. Rails' second
     // disjunct — `|| scheduled?` — needs no spelling here: `loadAsync` leaves
     // `_loaded` false, so a scheduled relation already falls through.
-    if (this.isLoaded) return [...this._records];
+    // relation.rb:337-339 `to_ary` is `records.dup`, so the loaded arm reads
+    // the `records` seam a CollectionProxy overrides (collection_proxy.rb:
+    // 1024-1026), not the ivar. `records` re-enters `load`, whose `loaded?`
+    // guard is already satisfied, so it returns without re-entering here.
+    if (this.isLoaded) return [...(await this.records())];
     // Run the query inside `with_connection` so the pool releases the connection
     // afterwards instead of holding it permanently. The build / execute path
     // reads the threaded connection via `_conn()` (see {@link withConnection})
@@ -1044,7 +1062,9 @@ export class Relation<T extends Base> {
     // without clobbering the fresh state.
     if (token !== this._loadToken) return records;
     this.loadRecords(records);
-    return [...this._records];
+    // relation.rb:339 `records.dup` — `loadRecords` has satisfied the `loaded?`
+    // guard, so this is the seam read, not a re-entry.
+    return [...(await this.records())];
   }
 
   /**
@@ -1158,7 +1178,10 @@ export class Relation<T extends Base> {
       // (relation.rb:1434) exactly as `exec_queries` does for its preload list.
       if (this.isEagerLoading) {
         // Mirrors: relation.rb:1435-1446.
-        return this.applyJoinDependency({}, async (relation, joinDependency) => {
+        // The block is deliberately not `async` either: it returns
+        // `select_all(..., async: async)`'s pending handle (relation.rb:1436),
+        // which an `async` arrow would adopt and resolve into rows.
+        return this.applyJoinDependency({}, (relation, joinDependency) => {
           if (relation.isNullRelation()) return Result.empty();
           joinDependency.applyColumnAliases(relation);
           this._joinDependency = joinDependency;
@@ -1703,17 +1726,20 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::FinderMethods#apply_join_dependency
    * (finder_methods.rb:457-481).
    *
-   * Only the block form Rails also offers is provided: `distinct_relation_for_primary_key`
-   * EXECUTES a query, so this method is async, and a trails `Relation` is
-   * thenable — returning one out of a `Promise` would run it and resolve to its
-   * records. Callers that want Rails' `relation = apply_join_dependency` shape
-   * capture the yielded relation from the block.
+   * Only the block form Rails also offers is provided: a trails `Relation` is
+   * thenable, so returning one out of a `Promise` would run it and resolve to
+   * its records. Callers that want Rails' `relation = apply_join_dependency`
+   * shape capture the yielded relation from the block.
+   *
+   * NOT an `async` method: Ruby yields to the block and hands its value back
+   * untouched, and `exec_main_query`'s eager arm yields a pending FutureResult
+   * (relation.rb:1436) that an `async` boundary would adopt and resolve.
    * @internal
    */
-  async applyJoinDependency<R>(
+  applyJoinDependency<R>(
     { eagerLoading = this.groupValues.length === 0 }: { eagerLoading?: boolean },
     block: (relation: Relation<T>, joinDependency: JoinDependency) => R | Promise<R>,
-  ): Promise<R> {
+  ): R | Promise<R> {
     const joinDependency = QueryMethodBangs.constructJoinDependency.call(
       this as any,
       [...new Set([...this.eagerLoadValues, ...this.includesValues])] as any,
@@ -1746,15 +1772,22 @@ export class Relation<T extends Base> {
       // `distinct_relation_for_primary_key` performs is an in-place mutation of
       // the relation it is handed, and a thenable `Relation` cannot be returned
       // through a `Promise`, so it mutates `relation` and returns nothing here.
-      await this.skipQueryCacheIfNecessary(() =>
-        this.model.withConnection((c: DatabaseAdapter) =>
-          (
-            c as unknown as {
-              distinctRelationForPrimaryKey(rel: unknown): Promise<void>;
-            }
-          ).distinctRelationForPrimaryKey(relation),
+      // The ONE arm that cannot hand the block's value straight back: Ruby
+      // blocks on this query (finder_methods.rb:465-475) and still yields
+      // afterwards, so a JS caller has to await it first. A FutureResult
+      // yielded past this point is therefore adopted — the residual promise
+      // arm `_futureResult` documents.
+      return Promise.resolve(
+        this.skipQueryCacheIfNecessary(() =>
+          this.model.withConnection((c: DatabaseAdapter) =>
+            (
+              c as unknown as {
+                distinctRelationForPrimaryKey(rel: unknown): Promise<void>;
+              }
+            ).distinctRelationForPrimaryKey(relation),
+          ),
         ),
-      );
+      ).then(() => block(relation, joinDependency));
     }
 
     return block(relation, joinDependency);
@@ -3156,6 +3189,11 @@ export class Relation<T extends Base> {
     return value < 0 ? new Nodes.Subtraction(expr, bind) : new Nodes.Addition(expr, bind);
   }
 
+  /**
+   * Mirrors: ActiveRecord::Relation#skip_query_cache_if_necessary
+   * (relation.rb:1466-1471) — `uncached(&block)` or a bare `yield`, each
+   * handing the block's value back untouched.
+   */
   private skipQueryCacheIfNecessary<R>(block: () => R | Promise<R>): R | Promise<R> {
     if (this.skipQueryCacheValue) {
       return this.model.uncached(block);


### PR DESCRIPTION
Converges two RFC 0107 stories in `relation.ts`.

## Relation readers branch on `_loaded` / `_records` instead of the seams

Rails' `Relation` readers take their loaded arm through the `loaded?` and
`records` seams, never through the `@loaded` / `@records` ivars — `records`
(relation.rb:342), `size` (:349), `load` (:1180), `pretty_print` (:1265),
`inspect` (:1291), `compute_cache_version` (:475-478).

That indirection is load-bearing: `CollectionProxy` overrides exactly those two
members (`loaded?` is `@association.loaded?`, collection_proxy.rb:53; `records`
is `load_target`, :1024-1026), which is how the inherited `Relation` bodies read
an association's target with no override of their own. PR #6758 converged
`isEmpty` / `isMany` / `isOne` for that reason; the rest of the file still read
the ivars, each one correct on a plain `Relation` and wrong on a proxy.

`size`, `toArray`, `prettyPrint`, `computeCacheVersion`, `loadAsync` and
`inspect` now go through `this.isLoaded` / `await this.records()`. The
writer-side assignments in `reset` and the load path stay as they are — Rails
assigns the ivars there too.

`inspect` is the one reader that cannot use the async `records()` seam (Rails
blocks on DB I/O there; a synchronous JS method returning a string cannot). So
`_records` becomes a `protected` accessor pair that `CollectionProxy` points at
the association target — the same shape it already uses for `isLoaded`, and the
TS spelling of the `records` seam for a caller that can't await.

## `reset` must cancel the parked future result, not just drop it

Rails' `reset` does two things to the handle (relation.rb:1195-1196):

```ruby
@future_result&.cancel
@future_result = nil
```

trails only did the second, with a `_loadToken` bump standing in. That covers
the *staleness* hazard but not the *work* hazard: the query still ran to
completion against the pool after the relation was reset.

The cancel was unreachable because `execMainQuery` was an `async` method and
`FutureResult` is a thenable, so the handle was resolved into rows at the
`return` boundary and `loadAsync` could only park a `Promise<Result>`.

`execMainQuery` is no longer `async`. Every layer beneath it already hands the
pending handle back unresolved — `DatabaseStatements.selectAll`
(database_statements.rb:74) and the query-cache wrapper are both deliberately
non-`async` for this exact reason — so:

- `_futureResult` holds what relation.rb:1148 holds.
- `reset()` cancels it before clearing.
- `execQueries`' scheduled arm drains it via `result()` (relation.rb:1408).
- the `@none` async arm spells `FutureResult.wrap` (relation.rb:1426), retiring
  its `@missingRailsCall` tag.

The `_loadToken` guard stays: it covers the separate trails-only race where a
reset lands mid-await, which Rails cannot have because `exec_queries`
(relation.rb:1416-1421) is synchronous.

Two arms still hand back a plain promise — the eager-loading arm goes through
the async `applyJoinDependency`, and `skipQueryCacheIfNecessary`'s `uncached`
arm returns a promise where Ruby's `disable_query_cache` returns the block's
value — so `reset` narrows before cancelling, exactly as Ruby's `&.` does
nothing useful for a `Complete` (which has no `cancel`, future_result.rb:5-23).

## Verification

- New `relation-load-async.trails.test.ts` case: `loadAsync()` + `reset()`
  leaves the scheduled `FutureResult` non-pending, `executeOrSkip()` issues no
  query, and `result()` rejects with `Canceled`. Fails on baseline
  (`expected true to be false` — the handle stays pending).
- `parity:api` relation.rb -> relation.ts stays 401/401.
- `parity:api:calls`, `:args`, `parity:api:extra:gate` all OK, zero new rows.
- Green locally: relations, relation, relation.trails, relation-load-async,
  relation/load-async, relation-exec-main-query, null-relation, cache-key,
  collection-cache-key, nested-attributes, query-cache, asynchronous-queries,
  future-result.trails, and all 121 files under `src/associations`.

Closes-story: converge-relation-loaded-arm-readers-onto-seams
Closes-story: reset-cancels-the-parked-future-result
