### PR TITLE
refactor(activerecord): attributes_for_create reads the composite-PK id reader

### DIFF
--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -10,14 +10,20 @@
 import { describe, it, expect, vi } from "vitest";
 import { Base, DangerousAttributeError, ReadonlyAttributeError, registerModel } from "./index.js";
 import { Model } from "@blazetrails/activemodel";
-import { GeneratedAttributeMethods, isMethodDefinedWithin } from "./attribute-methods.js";
+import {
+  attributesForCreate,
+  GeneratedAttributeMethods,
+  isMethodDefinedWithin,
+} from "./attribute-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
 import { registerSubclass } from "./inheritance.js";
 
 import { fixtures } from "./test-fixtures.js";
 import { Minivan } from "./test-helpers/models/minivan.js";
+import { CpkBook } from "./test-helpers/models/cpk.js";
 
 registerModel(Minivan);
+registerModel(CpkBook);
 
 /** Internal attribute-method generation surface exercised by these tests. */
 interface Generatable {
@@ -537,5 +543,29 @@ describe("ActiveRecord attribute read/write surface lives on Base, not Model", (
     expect(t.accessedFields()).toEqual([]);
     read(t);
     expect(t.accessedFields()).toEqual(["title"]);
+  });
+});
+
+// attribute_methods.rb:519-525 rejects a column when `pk_attribute?(name) &&
+// id.nil?`. For a composite key `id` returns an Array (composite_primary_key.rb
+// :8-14), which is never nil even when a member is, and `pk_attribute?` compares
+// against the Array `@primary_key` (attribute_methods.rb:543-545) — so on a
+// composite PK no column is ever dropped. trails used to test the per-column
+// attribute value instead and silently dropped each unset member.
+describe("attributesForCreate (trails)", () => {
+  fixtures([]);
+
+  it("keeps a nil composite primary key member", async () => {
+    await CpkBook.loadSchema();
+    const book = new CpkBook({ author_id: 1, title: "The Rails Way" });
+    expect(attributesForCreate.call(book as never, book.attributeNames())).toContain("id");
+  });
+
+  it("drops the primary key of a scalar-keyed record with no id", async () => {
+    await Minivan.loadSchema();
+    const minivan = new Minivan({ name: "cool.car" });
+    expect(attributesForCreate.call(minivan as never, minivan.attributeNames())).not.toContain(
+      "minivan_id",
+    );
   });
 });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -19,11 +19,13 @@ import { formatForInspect } from "./attribute-inspection.js";
 import { registerSubclass } from "./inheritance.js";
 
 import { fixtures } from "./test-fixtures.js";
+import { assertQueriesMatch } from "./testing/query-assertions.js";
 import { Minivan } from "./test-helpers/models/minivan.js";
-import { CpkBook } from "./test-helpers/models/cpk.js";
+import { CpkBook, CpkOrder } from "./test-helpers/models/cpk.js";
 
 registerModel(Minivan);
 registerModel(CpkBook);
+registerModel(CpkOrder);
 
 /** Internal attribute-method generation surface exercised by these tests. */
 interface Generatable {
@@ -559,6 +561,23 @@ describe("attributesForCreate (trails)", () => {
     await CpkBook.loadSchema();
     const book = new CpkBook({ author_id: 1, title: "The Rails Way" });
     expect(attributesForCreate.call(book as never, book.attributeNames())).toContain("id");
+  });
+
+  // With `partial_inserts` off, `attribute_names_for_partial_inserts`
+  // (dirty.rb:249-258) hands every non-auto-populated column to
+  // `attributes_for_create`, so the nil `shop_id` reaches the filter.
+  it("inserts a nil composite primary key member on create", async () => {
+    const oldPartialInserts = CpkOrder.partialInserts;
+    CpkOrder.partialInserts = false;
+    try {
+      let order: CpkOrder | undefined;
+      await assertQueriesMatch(/INSERT INTO[^(]+\([^)]*shop_id/i, 1, false, async () => {
+        order = await CpkOrder.create({ status: "paid" });
+      });
+      expect(order?.shop_id).toBeNull();
+    } finally {
+      CpkOrder.partialInserts = oldPartialInserts;
+    }
   });
 
   it("drops the primary key of a scalar-keyed record with no id", async () => {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -725,9 +725,8 @@ export function attributesForCreate(this: InstanceMethodHost, attributeNames: st
   // so this function stays the generic, locking-agnostic filter Rails ships.
   return attributeNames.filter((name) => {
     if (!colNames.has(name)) return false;
-    // Rails: pk_attribute?(name) && id.nil? — check per-column PK value so
-    // composite PKs work correctly (this.id would be an array, not null).
-    if (pkAttribute.call(this, name) && this._attributes?.get?.(name) == null) return false;
+    // Rails: pk_attribute?(name) && id.nil?
+    if (pkAttribute.call(this, name) && this.id == null) return false;
     // Rails: column_for_attribute(name).virtual?
     const col = mc.columnForAttribute?.(name);
     if (col?.virtual || col?.isVirtual?.()) return false;
@@ -743,7 +742,7 @@ export function formatForInspect(this: InstanceMethodHost, attr: string, value: 
 /** @internal */
 export function pkAttribute(this: InstanceMethodHost, name: string): boolean {
   const pk = (this.constructor as any)?.primaryKey ?? this._primaryKey;
-  return Array.isArray(pk) ? pk.includes(name) : name === pk;
+  return name === pk;
 }
 
 interface AttributeNamesHost {

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attributes_for_create",
-    "call": "id",
-    "reason": "Deviation (RFC 0106): Rails' `id.nil?` reads the composite-PK reader, which returns an Array for a composite key and so is never nil even when one member is. trails checks the per-column attribute value instead so a composite PK drops each unset member individually. Converging depends on the composite `id` reader story."
-  }
-]


### PR DESCRIPTION
`attributes_for_create` (`activerecord/lib/active_record/attribute_methods.rb:519-525`)
rejects a column when `pk_attribute?(name) && id.nil?`. trails checked the
per-column attribute value instead, so a composite PK dropped each unset member
individually — where Rails keeps them all: `id` returns an Array for a composite
key (`attribute_methods/composite_primary_key.rb:8-14`) and so is never nil, and
`pk_attribute?` compares the name against the Array `@primary_key`
(`attribute_methods.rb:543-545`).

- `attributesForCreate` reads `this.id` at the Rails call site.
- `pkAttribute` drops its invented `Array.includes` arm for Rails' `name == @primary_key`.
- Regression test (fails on baseline: `expected [ 'author_id', 'title', … ] to include 'id'`).
- `scripts/api-compare/call-mismatches-exclude/activerecord/attribute-methods.json`
  deleted — the shard held only this row.

`pnpm parity:api:calls`, `parity:api:calls:args` and `parity:api:extra:gate` green.

Closes-story: attributes-for-create-reads-the-composite-pk-id-reader
