### PR TITLE
refactor(activerecord): PG executeBatch issues one rawExecute over combined statements

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -7,10 +7,10 @@
 import type pg from "pg";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
-import type { ExplainOption } from "../abstract/database-statements.js";
 import { ActiveSupport } from "@blazetrails/activesupport";
 import { PreparedStatementCacheExpired, type SQLWarning } from "../../errors.js";
 import { Result } from "../../result.js";
+import { combineMultiStatements, type ExplainOption } from "../abstract/database-statements.js";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
@@ -260,35 +260,50 @@ export function affectedRows(result: pg.QueryResult): number {
 
 /** @internal */
 interface ExecuteBatchHost {
-  execute(sql: string, binds?: unknown[], name?: string | null): Promise<unknown>;
+  rawExecute(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    prepare?: boolean,
+    async?: boolean,
+    allowRetry?: boolean,
+    materializeTransactions?: boolean,
+    batch?: boolean,
+  ): Promise<unknown>;
 }
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute_batch
  *
- * Rails joins statements and calls execute once; we iterate because node-postgres returns
- * an array of results for multi-statement queries and our execute() expects a single result.
+ * Rails: `raw_execute(combine_multi_statements(statements), name, batch: true, **kwargs)`
+ * (postgresql/database_statements.rb:195-197). PG accepts the joined string in one
+ * simple-query message, so this is a single `rawExecute`; the positional arguments
+ * below are `raw_execute`'s own defaults (abstract/database_statements.rb:552) with
+ * the `**kwargs` PG forwards travelling on this call. Going through `raw_execute`
+ * rather than `internal_execute` is also what leaves batch statements uncommented —
+ * `preprocess_query`, which runs the query_transformers, is `internal_execute`'s
+ * step (`:589-591`).
  * @internal
  */
 export async function executeBatch(
   this: ExecuteBatchHost,
   statements: string[],
   name: string | null = null,
+  {
+    allowRetry = false,
+    materializeTransactions = true,
+  }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
-  // Match Rails' execute_batch → raw_execute, which skips the query_transformers
-  // pass: batch statements carry no QueryLogs comment. Flag each statement so
-  // preprocessQuery skips the transformer pass (write-checks still run); the flag
-  // is consumed synchronously there before any await, so it never spans the await,
-  // and the finally clears it if execute throws before consuming it.
-  const host = this as ExecuteBatchHost & { _inQueryTransformers?: boolean };
-  for (const statement of statements) {
-    host._inQueryTransformers = true;
-    try {
-      await this.execute(statement, [], name ?? undefined);
-    } finally {
-      host._inQueryTransformers = false;
-    }
-  }
+  await this.rawExecute(
+    combineMultiStatements(statements),
+    name,
+    [],
+    false,
+    false,
+    allowRetry,
+    materializeTransactions,
+    true,
+  );
 }
 
 /** @internal */

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -2,20 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
-    "rubyName": "execute_batch",
-    "call": "combine_multi_statements",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/database_statements.rb's `execute_batch` joins the statements with `combine_multi_statements`; trails' PG executeBatch hands the statement ARRAY to the adapter, which drives libpq's simple-query protocol per statement — there is no combined string to build. The abstract `combineMultiStatements` remains the shared helper for the MySQL path."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/database-statements.ts",
-    "rubyName": "execute_batch",
-    "call": "raw_execute",
-    "reason": "Per-site verified (RFC 0106 wave 4b): same site — the batch is executed through `internalExecute` so the `materializeTransactions`/`allowRetry` kwargs and the query-transformer guard travel with it, rather than through a bare `rawExecute`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "last_insert_id_result",
     "call": "internal_exec_query",
     "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/database_statements.rb's `last_insert_id_result` is `internal_exec_query(\"SELECT currval(...)\")`; trails reads the sequence value through the same adapter entry point spelled `queryValue`, which is `internal_exec_query` plus `.rows.first.first` — the row extraction is folded in."


### PR DESCRIPTION
`postgresql/database_statements.rb:195-197` is:

```ruby
def execute_batch(statements, name = nil, **kwargs)
  raw_execute(combine_multi_statements(statements), name, batch: true, **kwargs)
end
```

trails looped the statements and called `this.execute(...)` per statement,
setting `_inQueryTransformers` around each so `preprocessQuery` skipped the
transformer pass. PG accepts a joined multi-statement string in one simple-query
message — which is exactly what `combine_multi_statements` exists for — so the
loop was a real divergence, not a language shortcoming.

`executeBatch` now joins through `combineMultiStatements` and issues ONE
`rawExecute(sql, name, [], false, false, allowRetry, materializeTransactions, true)`
(positional defaults are `raw_execute`'s own,
abstract/database_statements.rb:552), matching the shape sqlite3's already-converged
`executeBatch` uses. The `_inQueryTransformers` flag is gone with it: going through
`raw_execute` rather than `internal_execute` is itself what leaves batch statements
uncommented, since `preprocess_query` is `internal_execute`'s step.

Both `execute_batch` baseline rows (`combine_multi_statements`, `raw_execute`) are
deleted from
`scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json`.

`pnpm parity:api:calls` and `:args` green. Verified against a local postgres:17:
`fixtures.test.ts`, `naked-fixtures.test.ts`, `database-tasks-truncate-tables.trails.test.ts`,
`adapters/postgresql/adapter.test.ts` all pass (fixtures load and truncate are the
two `executeBatch` callers).

Closes-story: pg-execute-batch-combines-statements-into-one-raw-execute