### PR TITLE
refactor(activerecord): WhereClause carries Rails' String predicate arms

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -284,7 +284,7 @@ describe("PredicateBuilderTest", () => {
     const table = castedTable("posts");
     const compile = (node: Nodes.Node) => new Visitors.ToSql(testConnection).compile(node);
     const buildInverted = (builder: PredicateBuilder, hash: Record<string, unknown>) =>
-      new WhereClause(builder.buildFromHash(hash)).invert().predicates;
+      new WhereClause(builder.buildFromHash(hash)).invert().predicates as Nodes.Node[];
 
     it("builds IS NOT NULL for null values", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
@@ -428,7 +428,7 @@ describe("PredicateBuilderTest", () => {
       const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = new WhereClause(builder.buildFromHash({ authors: { name: "Rails" } })).invert()
-        .predicates;
+        .predicates as Nodes.Node[];
       const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"authors"."name"');
       // Negation binds the RHS, so 'Rails' rides a QueryAttribute bind.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1064,14 +1064,6 @@ function leftOuterJoinsBang(this: QueryMethodsHost, ...args: AssociationSpec[]):
 
 /**
  * @internal
- *
- * @missingRailsCall order:constructor,buildFromHash — CONVERGEABLE: the sanitize_sql arm
- *   wraps the fragment in `new Nodes.SqlLiteral` where Rails stores the bare
- *   String (query_methods.rb:1627), so a constructor Rails does not make lands
- *   ahead of `build_from_hash`. trails' WhereClause types its predicates
- *   `Nodes.Node[]` and lacks Rails' String predicate arms
- *   (where_clause.rb:160,167,190,203), which the bare String needs. Tracked by
- *   story where-clause-string-predicate-arms (RFC 0106).
  */
 export function buildWhereClause(
   this: QueryMethodsHost,
@@ -1090,7 +1082,7 @@ export function buildWhereClause(
     return buildWhereClause.call(this, head, tail);
   }
 
-  let parts: Nodes.Node[];
+  let parts: (Nodes.Node | string)[];
   if (typeof opts === "string") {
     // Mirrors build_where_clause (query_methods.rb:1620-1628): a bare fragment is
     // wrapped verbatim as Arel.sql(opts); a fragment whose first rest arg is a
@@ -1104,9 +1096,7 @@ export function buildWhereClause(
     } else if (opts.includes("?")) {
       parts = [buildBoundSqlLiteral.call(this, opts, rest)];
     } else {
-      parts = [
-        new Nodes.SqlLiteral(this.model.sanitizeSql(rest.length === 0 ? opts : [opts, ...rest])!),
-      ];
+      parts = [this.model.sanitizeSql(rest.length === 0 ? opts : [opts, ...rest])!];
     }
   } else if (isPlainObject(opts)) {
     // Mirrors build_where_clause (query_methods.rb:1640): a hash condition

--- a/packages/activerecord/src/relation/where-clause-string-predicates.trails.test.ts
+++ b/packages/activerecord/src/relation/where-clause-string-predicates.trails.test.ts
@@ -1,0 +1,37 @@
+/**
+ * WhereClause's String predicate arms (where_clause.rb:160, 167, 190, 203).
+ *
+ * Rails stores a bare String predicate — `build_where_clause`'s sanitize_sql
+ * arm is `parts = [model.sanitize_sql(...)]` (query_methods.rb:1627) — and
+ * WhereClause handles the String downstream. Ruby gets these arms for free
+ * because SqlLiteral subclasses String; TypeScript needs them spelled out, so
+ * they are covered here rather than in the Rails-mirrored file.
+ */
+import { describe, it, expect } from "vitest";
+import { Table, Nodes } from "@blazetrails/arel";
+import { WhereClause } from "./where-clause.js";
+
+function table(): Table {
+  return new Table("table");
+}
+
+describe("WhereClause String predicates (trails)", () => {
+  it("wraps a String predicate in a Grouping around a SqlLiteral", () => {
+    const ast = new WhereClause(["id = 1"]).ast;
+    expect(ast).toBeInstanceOf(Nodes.Grouping);
+    expect((ast as Nodes.Grouping).expr).toBeInstanceOf(Nodes.SqlLiteral);
+  });
+
+  it("inverts a String predicate into NOT of its SqlLiteral", () => {
+    const inverted = new WhereClause(["id = 1"]).invert().predicates;
+    expect(inverted).toHaveLength(1);
+    const node = inverted[0] as Nodes.Not;
+    expect(node).toBeInstanceOf(Nodes.Not);
+    expect(node.expr).toBeInstanceOf(Nodes.SqlLiteral);
+  });
+
+  it("does not treat a String predicate as an equality node", () => {
+    const clause = new WhereClause([table().get("id").eq(1), "id = 1"]);
+    expect(Object.keys(clause.toH())).toEqual(["id"]);
+  });
+});

--- a/packages/activerecord/src/relation/where-clause-string-predicates.trails.test.ts
+++ b/packages/activerecord/src/relation/where-clause-string-predicates.trails.test.ts
@@ -30,6 +30,14 @@ describe("WhereClause String predicates (trails)", () => {
     expect(node.expr).toBeInstanceOf(Nodes.SqlLiteral);
   });
 
+  it("compares a String predicate equal to a SqlLiteral carrying the same SQL", () => {
+    const asString = new WhereClause(["id = 1"]);
+    const asLiteral = new WhereClause([new Nodes.SqlLiteral("id = 1")]);
+    expect(asString.equals(asLiteral)).toBe(true);
+    expect(asString.minus(asLiteral).isEmpty()).toBe(true);
+    expect(asString.union(asLiteral).predicates).toHaveLength(1);
+  });
+
   it("does not treat a String predicate as an equality node", () => {
     const clause = new WhereClause([table().get("id").eq(1), "id = 1"]);
     expect(Object.keys(clause.toH())).toEqual(["id"]);

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -190,10 +190,7 @@ describe("ActiveRecord::Relation", () => {
     it("ast removes any empty strings", () => {
       const t = table();
       const whereClause = new WhereClause([t.get("id").in([1, 2, 3])]);
-      const whereClauseWithEmpty = new WhereClause([
-        t.get("id").in([1, 2, 3]),
-        new Nodes.SqlLiteral(""),
-      ]);
+      const whereClauseWithEmpty = new WhereClause([t.get("id").in([1, 2, 3]), ""]);
       expect(whereClause.ast.eql(whereClauseWithEmpty.ast)).toBe(true);
     });
 

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -135,12 +135,7 @@ export class WhereClause {
     return (
       other instanceof WhereClause &&
       this.predicates.length === other.predicates.length &&
-      this.predicates.every((predicate, i) => {
-        const otherPredicate = other.predicates[i];
-        return typeof predicate === "string" || typeof otherPredicate === "string"
-          ? predicate === otherPredicate
-          : predicate.eql(otherPredicate);
-      })
+      this.predicates.every((predicate, i) => predicateEql(predicate, other.predicates[i]))
     );
   }
 
@@ -268,6 +263,25 @@ export class WhereClause {
   }
 }
 
+/**
+ * @internal
+ * @noRailsEquivalent PERMANENT: `Arel::Nodes::SqlLiteral < String`
+ *   (arel/nodes/sql_literal.rb:5), so a literal and a bare String carrying the
+ *   same SQL are `==` in Ruby and Rails' plain `predicates ==`, `predicates -`
+ *   and `predicates |` (where_clause.rb:18,22,75-79) dedup the pair. TypeScript
+ *   cannot subclass the string primitive, so that inherited equality is spelled
+ *   out here; `Node#eql` compares constructors and would never match across the
+ *   two spellings.
+ */
+function predicateEql(a: Nodes.Node | string, b: Nodes.Node | string): boolean {
+  const sqlText = (node: Nodes.Node | string): string | null =>
+    typeof node === "string" ? node : node instanceof Nodes.SqlLiteral ? node.value : null;
+  const aText = sqlText(a);
+  const bText = sqlText(b);
+  if (aText !== null || bText !== null) return aText === bText;
+  return (a as Nodes.Node).eql(b);
+}
+
 /** @internal */
 function invertPredicate(node: Nodes.Node | string | null | undefined): Nodes.Node {
   if (node == null) {
@@ -285,11 +299,7 @@ function subtractNodes(
 ): (Nodes.Node | string)[] {
   const result: (Nodes.Node | string)[] = [];
   for (const node of a) {
-    if (
-      !b.some((other) =>
-        typeof node === "string" || typeof other === "string" ? node === other : node.eql(other),
-      )
-    ) {
+    if (!b.some((other) => predicateEql(node, other))) {
       result.push(node);
     }
   }
@@ -349,13 +359,7 @@ function unionNodes(
 ): (Nodes.Node | string)[] {
   const result: (Nodes.Node | string)[] = [...a];
   for (const node of b) {
-    if (
-      !result.some((existing) =>
-        typeof existing === "string" || typeof node === "string"
-          ? existing === node
-          : existing.eql(node),
-      )
-    ) {
+    if (!result.some((existing) => predicateEql(existing, node))) {
       result.push(node);
     }
   }

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -1,9 +1,11 @@
 /**
  * WhereClause — manages WHERE predicates on a Relation.
  *
- * Stores a single array of Arel nodes, matching Rails' WhereClause which
- * holds a flat `predicates` array. All condition types (hash, raw SQL,
- * NOT, Arel nodes) are converted to nodes at insertion time.
+ * Stores a single array of predicates, matching Rails' WhereClause which
+ * holds a flat `predicates` array. A predicate is an Arel node or a raw
+ * String — `build_where_clause`'s sanitize_sql arm stores the bare String
+ * (query_methods.rb:1627) and this class handles it at where_clause.rb:160,
+ * 167, 190 and 203.
  *
  * Mirrors: ActiveRecord::Relation::WhereClause
  */
@@ -12,10 +14,6 @@ import { Nodes, fetchAttribute, sql } from "@blazetrails/arel";
 import { ArgumentError } from "@blazetrails/activemodel";
 
 export class WhereClause {
-  // Rails' predicates array holds raw Strings alongside Arel nodes —
-  // `build_where_clause`'s sanitize_sql arm stores the bare String
-  // (query_methods.rb:1627) and this class handles it at where_clause.rb:160,
-  // 167, 190 and 203.
   private _predicates: (Nodes.Node | string)[];
 
   /** @internal */
@@ -394,7 +392,6 @@ function extractAttribute(node: Nodes.Node | string): Nodes.Attribute | null {
 
 /** @internal */
 function isEqualityNode(node: Nodes.Node | string): boolean {
-  // Rails' `!node.is_a?(String) && node.equality?` (where_clause.rb:159-161).
   if (typeof node === "string") return false;
   if (node instanceof Nodes.Equality) return true;
   if (typeof (node as any).isEquality === "function") return (node as any).isEquality();

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -8,22 +8,27 @@
  * Mirrors: ActiveRecord::Relation::WhereClause
  */
 
-import { Nodes, fetchAttribute } from "@blazetrails/arel";
+import { Nodes, fetchAttribute, sql } from "@blazetrails/arel";
+import { ArgumentError } from "@blazetrails/activemodel";
 
 export class WhereClause {
-  private _predicates: Nodes.Node[];
+  // Rails' predicates array holds raw Strings alongside Arel nodes —
+  // `build_where_clause`'s sanitize_sql arm stores the bare String
+  // (query_methods.rb:1627) and this class handles it at where_clause.rb:160,
+  // 167, 190 and 203.
+  private _predicates: (Nodes.Node | string)[];
 
   /** @internal */
-  get predicates(): Nodes.Node[] {
+  get predicates(): (Nodes.Node | string)[] {
     return this._predicates;
   }
 
   /** @internal */
-  set predicates(value: Nodes.Node[]) {
+  set predicates(value: (Nodes.Node | string)[]) {
     this._predicates = value;
   }
 
-  constructor(predicates: Nodes.Node[] = []) {
+  constructor(predicates: (Nodes.Node | string)[] = []) {
     this._predicates = predicates;
   }
 
@@ -132,7 +137,12 @@ export class WhereClause {
     return (
       other instanceof WhereClause &&
       this.predicates.length === other.predicates.length &&
-      this.predicates.every((predicate, i) => predicate.eql(other.predicates[i]))
+      this.predicates.every((predicate, i) => {
+        const otherPredicate = other.predicates[i];
+        return typeof predicate === "string" || typeof otherPredicate === "string"
+          ? predicate === otherPredicate
+          : predicate.eql(otherPredicate);
+      })
     );
   }
 
@@ -174,7 +184,9 @@ export class WhereClause {
   }
 
   /** @internal */
-  private exceptPredicates(columns: (string | Nodes.Attribute | Nodes.Node)[]): Nodes.Node[] {
+  private exceptPredicates(
+    columns: (string | Nodes.Attribute | Nodes.Node)[],
+  ): (Nodes.Node | string)[] {
     // Rails: separate Attribute objects from string column names.
     // Attributes compared via eql() (table-qualified), strings by name only.
     const attrNodes: Nodes.Attribute[] = [];
@@ -211,18 +223,26 @@ export class WhereClause {
    *  manager paths build their WHERE list from it directly. */
   predicatesWithWrappedSqlLiterals(): Nodes.Node[] {
     return this.nonEmptyPredicates().map((node) => {
-      if (node instanceof Nodes.SqlLiteral) return wrapSqlLiteral(node);
+      if (node instanceof Nodes.SqlLiteral || typeof node === "string") return wrapSqlLiteral(node);
       return node;
     });
   }
 
-  /** @internal */
-  private nonEmptyPredicates(): Nodes.Node[] {
-    return this.predicates.filter((n) => !(n instanceof Nodes.SqlLiteral && n.value === ""));
+  /**
+   * @internal
+   * Rails' `predicates - ARRAY_WITH_EMPTY_STRING` (where_clause.rb:197-200)
+   * drops a SqlLiteral("") too, because SqlLiteral subclasses String in Ruby.
+   */
+  private nonEmptyPredicates(): (Nodes.Node | string)[] {
+    return this.predicates.filter(
+      (n) => n !== "" && !(n instanceof Nodes.SqlLiteral && n.value === ""),
+    );
   }
 
   /** @internal */
-  private eachAttributes(fn: (attr: Nodes.Attribute | Nodes.Node, node: Nodes.Node) => void): void {
+  private eachAttributes(
+    fn: (attr: Nodes.Attribute | Nodes.Node, node: Nodes.Node | string) => void,
+  ): void {
     for (const node of this.predicates) {
       let attr: Nodes.Attribute | Nodes.Node | null = extractAttribute(node);
       if (!attr && isEqualityNode(node)) {
@@ -237,8 +257,8 @@ export class WhereClause {
   }
 
   /** @internal */
-  protected referencedColumns(): Record<string, Nodes.Node> {
-    const hash: Record<string, Nodes.Node> = {};
+  protected referencedColumns(): Record<string, Nodes.Node | string> {
+    const hash: Record<string, Nodes.Node | string> = {};
     this.eachAttributes((attr, node) => {
       const key =
         attr instanceof Nodes.Attribute
@@ -251,14 +271,27 @@ export class WhereClause {
 }
 
 /** @internal */
-function invertPredicate(node: Nodes.Node): Nodes.Node {
+function invertPredicate(node: Nodes.Node | string | null | undefined): Nodes.Node {
+  if (node == null) {
+    throw new ArgumentError("Invalid argument for .where.not(), got nil.");
+  }
+  if (typeof node === "string") {
+    return new Nodes.Not(new Nodes.SqlLiteral(node));
+  }
   return node.invert();
 }
 
-function subtractNodes(a: Nodes.Node[], b: Nodes.Node[]): Nodes.Node[] {
-  const result: Nodes.Node[] = [];
+function subtractNodes(
+  a: (Nodes.Node | string)[],
+  b: (Nodes.Node | string)[],
+): (Nodes.Node | string)[] {
+  const result: (Nodes.Node | string)[] = [];
   for (const node of a) {
-    if (!b.some((other) => node.eql(other))) {
+    if (
+      !b.some((other) =>
+        typeof node === "string" || typeof other === "string" ? node === other : node.eql(other),
+      )
+    ) {
       result.push(node);
     }
   }
@@ -268,7 +301,7 @@ function subtractNodes(a: Nodes.Node[], b: Nodes.Node[]): Nodes.Node[] {
 // Mirrors Rails: `node.left if equality_node?(node) && node.left.is_a?(Arel::Predications)`.
 // Returns the left-hand expression of an equality predicate when it is a
 // non-Attribute Arel node (a NamedFunction, etc.), else null.
-function predicationLeft(node: Nodes.Node): Nodes.Node | null {
+function predicationLeft(node: Nodes.Node | string): Nodes.Node | null {
   const isEquality = typeof (node as any).isEquality === "function" && (node as any).isEquality();
   if (!isEquality) return null;
   const left = (node as any).left;
@@ -277,14 +310,12 @@ function predicationLeft(node: Nodes.Node): Nodes.Node | null {
 }
 
 /** @internal */
-function equalities(predicates: Nodes.Node[], equalityOnly: boolean): Nodes.Node[] {
+function equalities(predicates: (Nodes.Node | string)[], equalityOnly: boolean): Nodes.Node[] {
   const result: Nodes.Node[] = [];
   for (const node of predicates) {
-    const matches = equalityOnly
-      ? node instanceof Nodes.Equality
-      : typeof (node as any).isEquality === "function" && (node as any).isEquality();
+    const matches = equalityOnly ? node instanceof Nodes.Equality : isEqualityNode(node);
     if (matches) {
-      result.push(node);
+      result.push(node as Nodes.Node);
     } else if (node instanceof Nodes.And) {
       result.push(...equalities((node as any).children, equalityOnly));
     }
@@ -314,10 +345,19 @@ function extractNodeValue(node: unknown): unknown {
   return node;
 }
 
-function unionNodes(a: Nodes.Node[], b: Nodes.Node[]): Nodes.Node[] {
-  const result = [...a];
+function unionNodes(
+  a: (Nodes.Node | string)[],
+  b: (Nodes.Node | string)[],
+): (Nodes.Node | string)[] {
+  const result: (Nodes.Node | string)[] = [...a];
   for (const node of b) {
-    if (!result.some((existing) => existing.eql(node))) {
+    if (
+      !result.some((existing) =>
+        typeof existing === "string" || typeof node === "string"
+          ? existing === node
+          : existing.eql(node),
+      )
+    ) {
       result.push(node);
     }
   }
@@ -325,17 +365,20 @@ function unionNodes(a: Nodes.Node[], b: Nodes.Node[]): Nodes.Node[] {
 }
 
 /** @internal */
-function predicates(wc: WhereClause): Nodes.Node[] {
+function predicates(wc: WhereClause): (Nodes.Node | string)[] {
   return wc.predicates;
 }
 
 /** @internal */
-function wrapSqlLiteral(node: Nodes.SqlLiteral): Nodes.Node {
+function wrapSqlLiteral(node: Nodes.SqlLiteral | string): Nodes.Node {
+  if (typeof node === "string") {
+    node = sql(node);
+  }
   return new Nodes.Grouping(node);
 }
 
 /** @internal */
-function extractAttribute(node: Nodes.Node): Nodes.Attribute | null {
+function extractAttribute(node: Nodes.Node | string): Nodes.Attribute | null {
   let attrNode: Nodes.Attribute | null = null;
   fetchAttribute(node, (attr: Nodes.Node) => {
     if (!(attr instanceof Nodes.Attribute)) return true;
@@ -350,7 +393,9 @@ function extractAttribute(node: Nodes.Node): Nodes.Attribute | null {
 }
 
 /** @internal */
-function isEqualityNode(node: Nodes.Node): boolean {
+function isEqualityNode(node: Nodes.Node | string): boolean {
+  // Rails' `!node.is_a?(String) && node.equality?` (where_clause.rb:159-161).
+  if (typeof node === "string") return false;
   if (node instanceof Nodes.Equality) return true;
   if (typeof (node as any).isEquality === "function") return (node as any).isEquality();
   return false;


### PR DESCRIPTION
Splits the last unconverged row out of `query-methods-order-only-call-inversions` (RFC 0106).

`build_where_clause`'s sanitize_sql arm wrapped the sanitized fragment in `new Nodes.SqlLiteral(...)`; Rails stores the bare String (`query_methods.rb:1627`, `parts = [model.sanitize_sql(...)]`) and lets `Relation::WhereClause` handle the String arm downstream. The pre-wrap is what the call-set gate reported as `build_where_clause order:constructor,buildFromHash`.

## What changed

- `WhereClause`'s predicate type admits `string` alongside `Nodes.Node`, and the four Rails String arms are ported:
  - `equality_node?`'s `!node.is_a?(String)` guard — `where_clause.rb:159-161`
  - `invert_predicate`'s `NilClass` and `String` arms — `where_clause.rb:163-172`
  - `predicates_with_wrapped_sql_literals`' `::String` case — `where_clause.rb:187-195`
  - `wrap_sql_literal`'s `Arel.sql` coercion — `where_clause.rb:202-207`
  - `non_empty_predicates` drops a bare `""` as well as a `SqlLiteral("")`; Ruby gets both from `SqlLiteral < String` — `where_clause.rb:197-200`
- `build_where_clause`'s sanitize_sql arm is now `parts = [model.sanitizeSql(...)]`, no `SqlLiteral` wrap.
- The `buildWhereClause` / `order:constructor,buildFromHash` `@missingRailsCall` tag is deleted; `pnpm parity:api:calls` green.
- `where_clause_test.rb:176-181` ("ast removes any empty strings") now passes Rails' bare `""` rather than a `SqlLiteral("")`.
- New `where-clause-string-predicates.trails.test.ts` covers the arms Ruby gets for free from `SqlLiteral < String`.

## Verification

- `pnpm typecheck`, `pnpm lint` clean
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK, `pnpm parity:api:extra:gate` OK
- `where-clause`, `where`, `where-chain`, `or`, `and`, `merging`, `predicate-builder`, `where-raw-bind-defer` suites pass

Closes-story: where-clause-string-predicate-arms