### PR TITLE
refactor(activerecord,parity): AssociationRelation/DJAR converge onto exec_queries/load; stale-tag key carries the declaring class

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -3,7 +3,6 @@ import { Relation } from "./relation.js";
 import type { CollectionProxy } from "./associations/collection-proxy.js";
 import type { Association } from "./associations/association.js";
 import { setAssociationRelationFactory } from "./associations/_scope-slots.js";
-import { _cacheSingularTarget } from "./associations.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
 import { associationRelationClassFor, wrapWithScopeProxy } from "./relation/delegation.js";
 import { rebaseNewOwnerSeed } from "./associations/new-owner-seed-rebase.js";
@@ -290,95 +289,61 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Override the load path to propagate inverse_of / per-record
-   * strict-loading onto the fetched
-   * records — mirrors Rails' `AssociationRelation#exec_queries`, which
+   * Mirrors: ActiveRecord::AssociationRelation#exec_queries
+   * (association_relation.rb:43-49) — propagate inverse_of / per-record
+   * strict-loading onto the fetched records. Rails' body
    * calls `set_inverse_instance_from_queries` and `set_strict_loading`,
    * propagating the owner's strict-loading mode onto each record.
    * Without the inverse wiring, a record loaded via
    * `blog.posts.where(...)` wouldn't cache `post.blog = blog` on the
    * way back, so accessing the inverse would re-query.
    */
-  async toArray(): Promise<T[]> {
-    // The stale new-owner seed rebase runs in `super.toArray()` via the shared
-    // `isNullRelation()` chokepoint, before the query is built.
-    const owner = this._association.owner;
-    const reflection = this._association.reflection;
-    // Resolve the inverse association name via the registered Reflection,
-    // so automatic inverse_of (no explicit option) wires the parent onto
-    // each loaded child — mirrors `set_inverse_instance_from_queries`.
-    const ownerCtor = owner.constructor as typeof import("./base.js").Base;
-    const resolvedRefl = ownerCtor._reflectOnAssociation?.(reflection.name);
-    const inverseName: string | null =
-      resolvedRefl?.inverseName?.() ??
-      (reflection.options.inverseOf && !reflection.options.polymorphic
-        ? reflection.options.inverseOf
-        : null);
-
-    // Inverse wiring: mirrors Association#inversable? — only wire when the
-    // child's FK actually points at the owner. Chained queries that widen the
-    // scope (`.or(other.collection)`, `.unscope(:where)`) can return rows that
-    // belong to a *different* owner; wiring those would alias the wrong parent
-    // onto the child. The FK→PK comparison lives in
-    // `Association#matchesForeignKey` (Rails `matches_foreign_key?`).
-    const ownerRec = owner as unknown as { isPersisted?: () => boolean };
-    const ownerPersisted = ownerRec.isPersisted?.() ?? true;
-
-    // Rails' `AssociationRelation#exec_queries` yields a single per-record block
-    // that runs `set_inverse_instance_from_queries` AND `set_strict_loading`,
-    // both BEFORE `preload_associations` (association_relation.rb:43-49,
-    // relation.rb:1413-1414). We mirror that single block here. Wiring the
-    // inverse after the load (the old behavior) would overwrite a nested
-    // preload: e.g. `author.posts.includes(author: :first_posts)` preloads
-    // `first_posts` onto a freshly-loaded author, then a post-load inverse pass
-    // would replace `post.author` with the bare owner, losing the preloaded
-    // `first_posts`. Wiring first makes the preloader see `post.author` already
-    // loaded (the owner) and populate `first_posts` on that same record.
+  protected override async execQueries(): Promise<T[]> {
+    // Rails' body yields a single per-record block that runs
+    // `set_inverse_instance_from_queries` AND `set_strict_loading`, both BEFORE
+    // `preload_associations` (association_relation.rb:43-49,
+    // relation.rb:1413-1414). We mirror that single block here — trails'
+    // per-record seam is `_instantiateBlock`. Wiring the inverse after the load
+    // would overwrite a nested preload: e.g.
+    // `author.posts.includes(author: :first_posts)` preloads `first_posts` onto
+    // a freshly-loaded author, then a post-load inverse pass would replace
+    // `post.author` with the bare owner, losing the preloaded `first_posts`.
     //
     // Resolve the OO association off the owner (NOT `this._association`, which
     // is the JS-Proxy-wrapped CollectionProxy whose unknown-property trap raises
-    // a strict-loading violation) so the n+1-only-vs-mode logic stays in one
-    // place. `set_strict_loading` runs for EVERY record unconditionally — it
-    // propagates the owner's mode (which may be "off") onto each child.
-    const ownerAssoc = (
-      owner as unknown as {
+    // a strict-loading violation), so both calls land on the same `@association`
+    // Rails names.
+    const association = (
+      this._association.owner as unknown as {
         association?: (name: string) => {
+          setInverseInstanceFromQueries?: (record: unknown) => unknown;
           setStrictLoading?: (record: unknown) => unknown;
-          matchesForeignKey?: (record: unknown) => boolean;
         };
       }
-    ).association?.(reflection.name);
-    const strictLoad =
-      ownerAssoc && typeof ownerAssoc.setStrictLoading === "function"
-        ? ownerAssoc.setStrictLoading.bind(ownerAssoc)
+    ).association?.(this._association.reflection.name);
+    const setInverseInstanceFromQueries =
+      typeof association?.setInverseInstanceFromQueries === "function"
+        ? association.setInverseInstanceFromQueries.bind(association)
+        : null;
+    const setStrictLoading =
+      typeof association?.setStrictLoading === "function"
+        ? association.setStrictLoading.bind(association)
         : null;
 
     // Restore the prior block after the load rather than leaving the wrapper in
-    // place: a later `reload()` / repeated `toArray()` on the same relation must
+    // place: a later `reload()` / repeated load on the same relation must
     // not re-wrap and re-run the wiring N times.
     const prevBlock = this._instantiateBlock;
-    if (inverseName || strictLoad) {
+    if (setInverseInstanceFromQueries || setStrictLoading) {
       this._instantiateBlock = (record: T): void => {
         if (prevBlock) prevBlock(record);
-        if (inverseName) {
-          const childRec = record as unknown as { isPersisted?: () => boolean };
-          const childPersisted = childRec.isPersisted?.() ?? true;
-          // Mirrors `Association#inversable?`: wire when either side is unsaved,
-          // else fall to the (now base-resident) `matches_foreign_key?` check.
-          // The FK-match logic lives in `Association#matchesForeignKey`; the AR
-          // wiring stays separate only to route the cache through
-          // `_cacheSingularTarget` (which flags `_explicitTarget`, unlike the
-          // base `inversedFromQueries` path).
-          const inversable =
-            !ownerPersisted || !childPersisted || (ownerAssoc?.matchesForeignKey?.(record) ?? true);
-          if (inversable) _cacheSingularTarget(record as Base, inverseName, owner);
-        }
-        if (strictLoad) strictLoad(record);
+        if (setInverseInstanceFromQueries) setInverseInstanceFromQueries(record);
+        if (setStrictLoading) setStrictLoading(record);
       };
     }
 
     try {
-      return await super.toArray();
+      return await super.execQueries();
     } finally {
       this._instantiateBlock = prevBlock;
     }

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -292,9 +292,10 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * Mirrors: ActiveRecord::AssociationRelation#exec_queries
    * (association_relation.rb:43-49) — `super` with a per-record block that runs
    * `set_inverse_instance_from_queries` and `set_strict_loading`, both before
-   * `preload_associations` (relation.rb:1413-1414). trails' per-record seam is
-   * `_instantiateBlock`; the previous block is restored afterwards so a later
-   * `reload()` does not re-wrap it.
+   * `preload_associations` (relation.rb:1413-1414) and only then `yield`s to the
+   * caller's block (association_relation.rb:47). trails' per-record seam is
+   * `_instantiateBlock`, so the block already there is that `yield` and runs
+   * last; it is restored afterwards so a later `reload()` does not re-wrap it.
    *
    * `@association` is reached through the owner rather than off
    * `this._association`, which is the JS-Proxy-wrapped CollectionProxy whose
@@ -304,9 +305,9 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
     const association = this._association.owner.association(this._association.reflection.name);
     const prevBlock = this._instantiateBlock;
     this._instantiateBlock = (record: T): void => {
-      if (prevBlock) prevBlock(record);
       association.setInverseInstanceFromQueries(record);
       association.setStrictLoading(record);
+      if (prevBlock) prevBlock(record);
     };
 
     try {

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -290,57 +290,24 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
 
   /**
    * Mirrors: ActiveRecord::AssociationRelation#exec_queries
-   * (association_relation.rb:43-49) — propagate inverse_of / per-record
-   * strict-loading onto the fetched records. Rails' body
-   * calls `set_inverse_instance_from_queries` and `set_strict_loading`,
-   * propagating the owner's strict-loading mode onto each record.
-   * Without the inverse wiring, a record loaded via
-   * `blog.posts.where(...)` wouldn't cache `post.blog = blog` on the
-   * way back, so accessing the inverse would re-query.
+   * (association_relation.rb:43-49) — `super` with a per-record block that runs
+   * `set_inverse_instance_from_queries` and `set_strict_loading`, both before
+   * `preload_associations` (relation.rb:1413-1414). trails' per-record seam is
+   * `_instantiateBlock`; the previous block is restored afterwards so a later
+   * `reload()` does not re-wrap it.
+   *
+   * `@association` is reached through the owner rather than off
+   * `this._association`, which is the JS-Proxy-wrapped CollectionProxy whose
+   * unknown-property trap raises a strict-loading violation.
    */
   protected override async execQueries(): Promise<T[]> {
-    // Rails' body yields a single per-record block that runs
-    // `set_inverse_instance_from_queries` AND `set_strict_loading`, both BEFORE
-    // `preload_associations` (association_relation.rb:43-49,
-    // relation.rb:1413-1414). We mirror that single block here — trails'
-    // per-record seam is `_instantiateBlock`. Wiring the inverse after the load
-    // would overwrite a nested preload: e.g.
-    // `author.posts.includes(author: :first_posts)` preloads `first_posts` onto
-    // a freshly-loaded author, then a post-load inverse pass would replace
-    // `post.author` with the bare owner, losing the preloaded `first_posts`.
-    //
-    // Resolve the OO association off the owner (NOT `this._association`, which
-    // is the JS-Proxy-wrapped CollectionProxy whose unknown-property trap raises
-    // a strict-loading violation), so both calls land on the same `@association`
-    // Rails names.
-    const association = (
-      this._association.owner as unknown as {
-        association?: (name: string) => {
-          setInverseInstanceFromQueries?: (record: unknown) => unknown;
-          setStrictLoading?: (record: unknown) => unknown;
-        };
-      }
-    ).association?.(this._association.reflection.name);
-    const setInverseInstanceFromQueries =
-      typeof association?.setInverseInstanceFromQueries === "function"
-        ? association.setInverseInstanceFromQueries.bind(association)
-        : null;
-    const setStrictLoading =
-      typeof association?.setStrictLoading === "function"
-        ? association.setStrictLoading.bind(association)
-        : null;
-
-    // Restore the prior block after the load rather than leaving the wrapper in
-    // place: a later `reload()` / repeated load on the same relation must
-    // not re-wrap and re-run the wiring N times.
+    const association = this._association.owner.association(this._association.reflection.name);
     const prevBlock = this._instantiateBlock;
-    if (setInverseInstanceFromQueries || setStrictLoading) {
-      this._instantiateBlock = (record: T): void => {
-        if (prevBlock) prevBlock(record);
-        if (setInverseInstanceFromQueries) setInverseInstanceFromQueries(record);
-        if (setStrictLoading) setStrictLoading(record);
-      };
-    }
+    this._instantiateBlock = (record: T): void => {
+      if (prevBlock) prevBlock(record);
+      association.setInverseInstanceFromQueries(record);
+      association.setStrictLoading(record);
+    };
 
     try {
       return await super.execQueries();

--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -116,4 +116,22 @@ describe("AssociationRelation", () => {
     const [part] = await scope;
     expect((part as any)._associationCache("ship")?.target).toBe(ship);
   });
+
+  it("sets inverse_of through records() and load() as well as toArray()", async () => {
+    const ship = await freshShip();
+    const proxy = association<ShipPart>(ship, "parts");
+    await proxy.create({ name: "P1" });
+    const seed = () => proxy.where({}) as unknown as AssociationRelation<ShipPart>;
+
+    const [viaToArray] = await seed();
+    expect((viaToArray as any)._associationCache("ship")?.target).toBe(ship);
+
+    const [viaRecords] = await seed().records();
+    expect((viaRecords as any)._associationCache("ship")?.target).toBe(ship);
+
+    const loaded = seed();
+    await loaded.load();
+    const [viaLoad] = await loaded.records();
+    expect((viaLoad as any)._associationCache("ship")?.target).toBe(ship);
+  });
 });

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -474,14 +474,19 @@ export class Association {
     return record;
   }
 
+  /**
+   * Mirrors: Association#set_inverse_instance_from_queries
+   * (association.rb:139-144).
+   *
+   * `_explicitTarget` has no Rails analog — see {@link setInverseInstance}. It
+   * is raised here for the same reason, and only where `inversedFromQueries`
+   * actually took the write: an inverse it declined (`inversable?` false) must
+   * keep reading back as unset.
+   */
   setInverseInstanceFromQueries(record: Base): Base {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFromQueries(this.owner);
-      // `_explicitTarget` has no Rails analog — see `setInverseInstance`. It is
-      // raised here for the same reason, and only where `inversedFromQueries`
-      // actually took the write: an inverse it declined (`inversable?` false)
-      // must keep reading back as unset.
       if (!inverse.isCollection() && inverse.target === this.owner) {
         inverse._explicitTarget = true;
       }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -478,6 +478,13 @@ export class Association {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFromQueries(this.owner);
+      // `_explicitTarget` has no Rails analog — see `setInverseInstance`. It is
+      // raised here for the same reason, and only where `inversedFromQueries`
+      // actually took the write: an inverse it declined (`inversable?` false)
+      // must keep reading back as unset.
+      if (!inverse.isCollection() && inverse.target === this.owner) {
+        inverse._explicitTarget = true;
+      }
     }
     return record;
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -307,8 +307,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Self-referential alias so AssociationRelation#toArray can be called
-   * with `this` = CollectionProxy via `.call(this)`. AR#toArray reads
+   * Self-referential alias so AssociationRelation#execQueries can be called
+   * with `this` = CollectionProxy via `.call(this)`. AR#execQueries reads
    * `this._association.owner` and `this._association.reflection`; both are
    * already exposed as getters on CollectionProxy, so returning `this`
    * satisfies the contract without extra indirection.

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -208,4 +208,29 @@ describe("DisableJoinsAssociationScope", () => {
     const loaded = await djar;
     expect(loaded.map((p: any) => p.title)).toEqual(["p2", "p1"]);
   });
+
+  it("the id-order regroup is visible through records() and load()", async () => {
+    const post1 = await DjsPost.create({ djs_author_id: 2, title: "p1" });
+    const post2 = await DjsPost.create({ djs_author_id: 2, title: "p2" });
+    const seed = () => {
+      const djar = new DisableJoinsAssociationRelation(DjsPost, "id", [post2.id, post1.id]);
+      (djar as any).whereClause.predicates.push(
+        ...(DjsPost as any).where({ id: [post1.id, post2.id] }).whereClause.predicates,
+      );
+      return djar;
+    };
+
+    const viaRecords = seed();
+    expect((await viaRecords.records()).map((p: any) => p.title)).toEqual(["p2", "p1"]);
+    expect(viaRecords.isLoaded).toBe(true);
+
+    const viaLoad = seed();
+    await viaLoad.load();
+    expect(viaLoad.isLoaded).toBe(true);
+    expect((await viaLoad.records()).map((p: any) => p.title)).toEqual(["p2", "p1"]);
+
+    const viaToArray = seed();
+    expect((await viaToArray).map((p: any) => p.title)).toEqual(["p2", "p1"]);
+    expect(viaToArray.isLoaded).toBe(true);
+  });
 });

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -552,35 +552,35 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
 
   /**
    * Deferred-chain mode is a trails-only arm: the chain walk replaces the
-   * single SELECT Rails' `DisableJoinsAssociationScope` has already
-   * finished by the time it builds the relation, so it stands in for
-   * `exec_queries`' query. Routes through `_walkOnce()` so the walk
-   * (including intermediate plucks) is shared with any earlier `ids()`
-   * call. The chained query state on `this` (wheres / orders / limit /
-   * etc.) composes via `_composeChainedState` so chains like
-   * `DJAS.scope(...).where({title: 'foo'})` actually filter the walker's
-   * result.
+   * single SELECT Rails' `DisableJoinsAssociationScope` has already finished
+   * by the time it builds the relation, so it stands in for `exec_queries`'
+   * query. It routes through `_walkOnce()` so the walk (including intermediate
+   * plucks) is shared with any earlier `ids()` call, and the chained query
+   * state on `this` (wheres / orders / limit / etc.) composes via
+   * `_composeChainedState` so `DJAS.scope(...).where({title: 'foo'})` filters
+   * the walker's result.
+   *
+   * A limit/offset composed onto a walked scope that is ITSELF a loaded-chain
+   * DJAR is applied in memory, after the id-order regroup, because that is
+   * where Rails' `limit` / `first` overrides apply it
+   * (disable_joins_association_relation.rb:13-24); as SQL it would slice the
+   * wrong rows before the regroup. `merged` is a fresh spawn, so clearing the
+   * values on it is local to this load.
    */
   protected override async execQueries(): Promise<T[]> {
     if (this._chainWalker) {
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
-      // A limit/offset chained onto the deferred DJAR composes onto the walked
-      // scope; when that scope is itself a loaded-chain DJAR, Rails applies it
-      // through the `limit` / `first` overrides — in memory, AFTER the id-order
-      // regroup (disable_joins_association_relation.rb:13-24) — not as a SQL
-      // LIMIT that would slice the wrong rows before it. `merged` is a fresh
-      // spawn, so clearing the values on it is local to this load.
       if (merged instanceof DisableJoinsAssociationRelation && !merged._chainWalker) {
-        const window = merged as unknown as {
+        const bounds = merged as unknown as {
           limitValue?: number | null;
           offsetValue?: number | null;
         };
-        const limitVal = window.limitValue ?? null;
-        const offsetVal = window.offsetValue ?? null;
+        const limitVal = bounds.limitValue ?? null;
+        const offsetVal = bounds.offsetValue ?? null;
         if (limitVal !== null || offsetVal !== null) {
-          window.limitValue = null;
-          window.offsetValue = null;
+          bounds.limitValue = null;
+          bounds.offsetValue = null;
           const ordered = (await Relation.prototype.toArray.call(merged)) as T[];
           const start = offsetVal ?? 0;
           return ordered.slice(start, limitVal == null ? undefined : start + limitVal);
@@ -596,11 +596,12 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * (disable_joins_association_relation.rb:26-38) — load, then group the
    * records by `key` and re-emit them in `ids` order, because SQL
    * `IN(...)` does not preserve the id list's order.
+   *
+   * Deferred-chain mode carries no id list of its own — the ordering comes from
+   * the walked scope — so the regroup has nothing to do there.
    */
   override async load(): Promise<LoadedRelation<this>> {
     await super.load();
-    // Deferred-chain mode carries no id list of its own — the ordering
-    // comes from the walked scope — so the regroup has nothing to do.
     if (this._chainWalker) return stripThenable(this);
     const records = this._records;
 
@@ -623,9 +624,8 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       // computed once at construction, so the reorder avoids re-running
       // JSON.stringify per tuple on every load.
       for (const k of this._storedKeyStrings!) {
+        // A missing bucket is `records.compact!` (:36) — an id with no loaded row.
         const bucket = recordsById.get(k);
-        // `records.compact!` (disable_joins_association_relation.rb:36) —
-        // an id with no loaded row contributes nothing.
         if (bucket) ordered.push(...bucket);
       }
     } else {

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -1,4 +1,4 @@
-import { Relation } from "./relation.js";
+import { Relation, type LoadedRelation } from "./relation.js";
 import { argumentError } from "./relation/query-methods.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
 import {
@@ -6,6 +6,7 @@ import {
   wrapWithScopeProxy,
 } from "./relation/delegation.js";
 import { normalizeAssociationKey } from "./associations/key-normalization.js";
+import { stripThenable } from "./relation/thenable.js";
 import type { Base } from "./base.js";
 import type { Nodes } from "@blazetrails/arel";
 
@@ -33,14 +34,14 @@ interface TrustedClonePayload<T extends Base> {
  *   1. **Loaded-chain mode** (Rails' `DisableJoinsAssociationRelation`,
  *      `activerecord/lib/active_record/disable_joins_association_relation.rb`):
  *      constructed with `(klass, key, ids)` after the chain walk is
- *      complete. `toArray()` loads via Relation, then groups by `key`
+ *      complete. `load()` loads via Relation, then groups by `key`
  *      and re-emits in `ids` order so callers see join-table ordering
  *      (SQL `IN(...)` doesn't preserve list order). `limit` / `first`
  *      slice the loaded array in-memory rather than appending SQL
  *      LIMIT (matches Rails' deliberate deviation).
  *
  *   2. **Deferred-chain mode**: constructed with a `chainWalker`
- *      callback that performs the async chain walk on first `toArray()`
+ *      callback that performs the async chain walk on first load
  *      and returns the final scope (which itself may be a loaded-chain
  *      DJAR for the ordered-upstream wrap case). Lets `DJAS.scope()`
  *      return a `Relation` synchronously instead of `Promise<{ relation }>` —
@@ -549,65 +550,82 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     return wrapWithScopeProxy(rel);
   }
 
-  override async toArray(): Promise<T[]> {
+  /**
+   * Deferred-chain mode is a trails-only arm: the chain walk replaces the
+   * single SELECT Rails' `DisableJoinsAssociationScope` has already
+   * finished by the time it builds the relation, so it stands in for
+   * `exec_queries`' query. Routes through `_walkOnce()` so the walk
+   * (including intermediate plucks) is shared with any earlier `ids()`
+   * call. The chained query state on `this` (wheres / orders / limit /
+   * etc.) composes via `_composeChainedState` so chains like
+   * `DJAS.scope(...).where({title: 'foo'})` actually filter the walker's
+   * result.
+   */
+  protected override async execQueries(): Promise<T[]> {
     if (this._chainWalker) {
-      // Routes through `_walkOnce()` so the chain walk (including
-      // intermediate plucks) is shared with any earlier `ids()` call.
-      // The chained query state on `this` (wheres / orders / limit /
-      // etc.) composes via `_composeChainedState` so chains like
-      // `DJAS.scope(...).where({title: 'foo'})` actually filter the
-      // walker's result.
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
+      // A limit/offset chained onto the deferred DJAR composes onto the walked
+      // scope; when that scope is itself a loaded-chain DJAR, Rails applies it
+      // through the `limit` / `first` overrides — in memory, AFTER the id-order
+      // regroup (disable_joins_association_relation.rb:13-24) — not as a SQL
+      // LIMIT that would slice the wrong rows before it. `merged` is a fresh
+      // spawn, so clearing the values on it is local to this load.
+      if (merged instanceof DisableJoinsAssociationRelation && !merged._chainWalker) {
+        const window = merged as unknown as {
+          limitValue?: number | null;
+          offsetValue?: number | null;
+        };
+        const limitVal = window.limitValue ?? null;
+        const offsetVal = window.offsetValue ?? null;
+        if (limitVal !== null || offsetVal !== null) {
+          window.limitValue = null;
+          window.offsetValue = null;
+          const ordered = (await Relation.prototype.toArray.call(merged)) as T[];
+          const start = offsetVal ?? 0;
+          return ordered.slice(start, limitVal == null ? undefined : start + limitVal);
+        }
+      }
       return merged.toArray();
     }
-    // Loaded-chain mode: load via Relation, then group by `key` and
-    // re-emit in `ids` order so the caller sees join-table ordering
-    // (Rails' `load` override).
-    //
-    // Build a clone with `limitValue` / `offsetValue` cleared and
-    // load through that — never mutate `this`. Reason: deferred-mode
-    // composition (via `_composeChainedState`'s `merge`) can copy a
-    // chained `.limit(n)` / offset onto this loaded-chain DJAR.
-    // Letting the SQL path apply LIMIT before the IN-list reorder
-    // would slice the WRONG rows. Rails matches by overriding
-    // `limit`/`first` to load + take in memory; we do the same.
-    // Cloning (rather than mutating `this` across the await) keeps
-    // concurrent `toSql()` / `ids()` / second `toArray()` calls
-    // observing the original configured state.
-    type LimitOffset = { limitValue?: number | null; offsetValue?: number | null };
-    const self = this as unknown as LimitOffset & {
-      clone: () => DisableJoinsAssociationRelation<T>;
-    };
-    const limitVal = self.limitValue ?? null;
-    const offsetVal = self.offsetValue ?? null;
-    const loadClone = self.clone() as unknown as LimitOffset;
-    loadClone.limitValue = null;
-    loadClone.offsetValue = null;
-    // Call Relation's toArray directly on the clone — going through
-    // DJAR.toArray would re-enter the deferred/loaded branching and
-    // recurse forever for the loaded-chain mode.
-    const records = (await Relation.prototype.toArray.call(loadClone)) as T[];
-    const byKey = new Map<unknown, T[]>();
+    return super.execQueries();
+  }
+
+  /**
+   * Mirrors: ActiveRecord::DisableJoinsAssociationRelation#load
+   * (disable_joins_association_relation.rb:26-38) — load, then group the
+   * records by `key` and re-emit them in `ids` order, because SQL
+   * `IN(...)` does not preserve the id list's order.
+   */
+  override async load(): Promise<LoadedRelation<this>> {
+    await super.load();
+    // Deferred-chain mode carries no id list of its own — the ordering
+    // comes from the walked scope — so the regroup has nothing to do.
+    if (this._chainWalker) return stripThenable(this);
+    const records = this._records;
+
+    const recordsById = new Map<unknown, T[]>();
     const keyCols = Array.isArray(this.key) ? this.key : [this.key];
     const composite = this._composite;
-    for (const r of records) {
+    for (const record of records) {
       const raw = composite
-        ? keyCols.map((c) => r._readAttribute(c))
-        : r._readAttribute(keyCols[0]);
+        ? keyCols.map((c) => record._readAttribute(c))
+        : record._readAttribute(keyCols[0]);
       const k = serializeKey(raw, composite);
-      const bucket = byKey.get(k);
-      if (bucket) bucket.push(r);
-      else byKey.set(k, [r]);
+      const bucket = recordsById.get(k);
+      if (bucket) bucket.push(record);
+      else recordsById.set(k, [record]);
     }
+
     const ordered: T[] = [];
     if (composite) {
       // Walk `_storedKeyStrings` directly — the serialized forms were
       // computed once at construction, so the reorder avoids re-running
-      // JSON.stringify per tuple on every `toArray()` call.
-      const keyStrings = this._storedKeyStrings!;
-      for (const k of keyStrings) {
-        const bucket = byKey.get(k);
+      // JSON.stringify per tuple on every load.
+      for (const k of this._storedKeyStrings!) {
+        const bucket = recordsById.get(k);
+        // `records.compact!` (disable_joins_association_relation.rb:36) —
+        // an id with no loaded row contributes nothing.
         if (bucket) ordered.push(...bucket);
       }
     } else {
@@ -615,13 +633,13 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
         // Normalize the looked-up id the same way `serializeKey` normalized the
         // record-side key, so a number FK from the upstream pluck matches a
         // BigInt PK on the loaded record (and vice versa).
-        const bucket = byKey.get(normalizeAssociationKey(id));
+        const bucket = recordsById.get(normalizeAssociationKey(id));
         if (bucket) ordered.push(...bucket);
       }
     }
-    const start = offsetVal ?? 0;
-    const end = limitVal == null ? undefined : start + limitVal;
-    return start === 0 && end === undefined ? ordered : ordered.slice(start, end);
+
+    this._records = ordered;
+    return stripThenable(this);
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1046,7 +1046,7 @@ export class Relation<T extends Base> {
   /**
    * Mirrors: ActiveRecord::Relation#exec_queries (relation.rb:1403-1421).
    */
-  private async execQueries(): Promise<T[]> {
+  protected async execQueries(): Promise<T[]> {
     return this.skipQueryCacheIfNecessary(async () => {
       // Lazily reflect the schema before issuing the query so consumers
       // don't have to call loadSchema explicitly. Idempotent and cheap.

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -352,7 +352,7 @@ describe("reconcileFileText", () => {
       new Map(),
       () => "PERMANENT: x",
       undefined,
-      new Set([staleTagKey("bar", "logger")]),
+      new Set([staleTagKey("Foo", "bar", "logger")]),
     );
     expect(r.text!).not.toContain("@missingRailsCall logger");
     expect(r.text!).toContain("@missingRailsCall with_raw_connection — PERMANENT: escapes inline.");
@@ -360,6 +360,37 @@ describe("reconcileFileText", () => {
     expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([
       ["quoteString", "with_raw_connection"],
     ]);
+  });
+
+  it("does not retire a same-named sibling declaration's tag", () => {
+    // Two declarations of one name reachable from a single row-file: the
+    // stale key must name the OWNING class, or retiring `Store#bar` deletes
+    // the top-level `bar`'s reviewed receipt (RFC 0106).
+    const src = [
+      "export class Store {",
+      "  /**",
+      "   * @missingRailsCall logger — PERMANENT: no logger yet.",
+      "   */",
+      "  bar(): void {}",
+      "}",
+      "",
+      "/**",
+      " * @missingRailsCall logger — PERMANENT: reviewed elsewhere.",
+      " */",
+      "export function bar(): void {}",
+    ].join("\n");
+    const r = reconcileFileText(
+      "foo.ts",
+      src,
+      new Map(),
+      () => "PERMANENT: x",
+      undefined,
+      new Set([staleTagKey("Store", "bar", "logger")]),
+    );
+    expect(r.text!).toContain("@missingRailsCall logger — PERMANENT: reviewed elsewhere.");
+    expect(r.text!).not.toContain("@missingRailsCall logger — PERMANENT: no logger yet.");
+    expect(r.harvested.map((h) => [h.tsName, h.entry.call])).toEqual([["bar", "logger"]]);
+    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([["bar", "logger"]]);
   });
 
   it("is idempotent: a second run produces zero edits", () => {

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -674,6 +674,16 @@ describe("buildExpectations / groupByDeclFile for a class split into a subdirect
   it("always groups the row's own file, so a stale-tag-only run still opens it", () => {
     expect([...groupByDeclFile("cache.ts", new Map()).keys()]).toEqual(["cache.ts"]);
   });
+
+  it("groups a declaring file named only by a stale tag, so its file is opened too", () => {
+    // A stale-only run over a split declaration: no expectation reaches
+    // `cache/store.ts`, so without the extra group the tag's own file is never
+    // read and the stale tag survives.
+    expect([...groupByDeclFile("cache.ts", new Map(), ["cache/store.ts"]).keys()].sort()).toEqual([
+      "cache.ts",
+      "cache/store.ts",
+    ]);
+  });
 });
 
 describe("reconcileFileText with two Ruby names on one TS method", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -124,6 +124,12 @@ export interface SuppressedCall {
 export interface StaleTag {
   package: string;
   tsFile: string;
+  /** The declaring class (`""` for a top-level function) — see
+   *  compare.ts `StaleCallTag.tsClass`. Absent on an artifact written before
+   *  RFC 0106 keyed staleness by owner. */
+  tsClass?: string;
+  /** See `ArtifactMismatch.tsDeclFile`. */
+  tsDeclFile?: string;
   tsName: string;
   call: string;
 }
@@ -404,11 +410,14 @@ export function collectDeclarations(sf: ts.SourceFile): TaggableDecl[] {
 
 /** Reconcile every named function/method in one source file's text. Returns
  *  the new text (or null if unchanged) plus harvested non-placeholder drops. */
-/** Key for one stale-tag row within a file: the tag sits on a (tsName, call)
- *  site, NOT on the class-qualified expectation key `buildExpectations` builds
- *  — `staleCallTags` records no class. */
-export function staleTagKey(tsName: string, call: string): string {
-  return `${tsName}\u0000${call}`;
+/** Key for one stale-tag row within a declaring file: the class-qualified
+ *  (tsClass, tsName, call) site compare.ts reported it for. The class is what
+ *  keeps two declarations of one name reachable from a single row-file — a
+ *  top-level `foo` beside a `Store#foo` split into a subdirectory module, or
+ *  two classes in one file — from sharing a retirement key and deleting each
+ *  other's reviewed receipts (RFC 0106). */
+export function staleTagKey(tsClass: string, tsName: string, call: string): string {
+  return `${tsClass}\u0000${tsName}\u0000${call}`;
 }
 
 export function reconcileFileText(
@@ -499,7 +508,9 @@ export function reconcileFileText(
       const expected =
         exp?.calls ??
         new Set<string>(
-          entries.filter((e) => !staleTags?.has(staleTagKey(name, e.call))).map((e) => e.call),
+          entries
+            .filter((e) => !staleTags?.has(staleTagKey(owner, name, e.call)))
+            .map((e) => e.call),
         );
       const r = reconcile(
         entries,
@@ -510,7 +521,7 @@ export function reconcileFileText(
       if (!exp) {
         preserved.push(
           ...entries
-            .filter((entry) => !staleTags?.has(staleTagKey(name, entry.call)))
+            .filter((entry) => !staleTags?.has(staleTagKey(owner, name, entry.call)))
             .map((entry) => ({ tsName: name, entry })),
         );
       }
@@ -687,12 +698,18 @@ async function main(argv: string[]): Promise<number> {
   }
 
   const byFile = buildExpectations(artifact, pkg, onlyFile);
-  const staleByFile = new Map<string, Set<string>>();
+  // Grouped by DECLARING file, not by the row's `tsFile`: one row-file can
+  // group several declaring files, and handing each of them the row-file's
+  // whole stale set would retire a tag in a file compare.ts never reported it
+  // for.
+  const staleByDeclFile = new Map<string, Set<string>>();
   for (const t of artifact.staleTags ?? []) {
     if (t.package !== pkg) continue;
     if (onlyFile && t.tsFile !== onlyFile) continue;
-    const set = staleByFile.get(t.tsFile) ?? staleByFile.set(t.tsFile, new Set()).get(t.tsFile)!;
-    set.add(staleTagKey(t.tsName, t.call));
+    const declFile = t.tsDeclFile ?? t.tsFile;
+    const set =
+      staleByDeclFile.get(declFile) ?? staleByDeclFile.set(declFile, new Set()).get(declFile)!;
+    set.add(staleTagKey(t.tsClass ?? "", t.tsName, t.call));
     // A file whose only business this run is a stale tag has no expectation to
     // put it in `byFile`, and would otherwise never be opened.
     if (!byFile.has(t.tsFile)) byFile.set(t.tsFile, new Map());
@@ -729,7 +746,7 @@ async function main(argv: string[]): Promise<number> {
           (rubyName, call) =>
             reasons.get(keyOf({ package: pkg, tsFile, rubyName, call })) ?? DEFAULT_TAG_REASON,
           onlyCall.size > 0 ? onlyCall : undefined,
-          staleByFile.get(tsFile),
+          staleByDeclFile.get(declFile),
         );
       } catch (err) {
         console.error(`parity:api:build: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -613,13 +613,19 @@ export function buildExpectations(
  * baseline reason lives; the declaration can sit elsewhere when trails split a
  * Rails class into a subdirectory module (see `ArtifactMismatch.tsDeclFile`).
  * The row's own file is always a group, so a run whose only business there is a
- * stale tag still opens it.
+ * stale tag still opens it. `extraDeclFiles` groups the declaring files a
+ * stale-tag row names but no expectation reaches — a stale-only tag on a split
+ * declaration would otherwise never have its file opened.
  */
 export function groupByDeclFile(
   tsFile: string,
   expectations: ReadonlyMap<string, MethodExpectation>,
+  extraDeclFiles: Iterable<string> = [],
 ): Map<string, Map<string, MethodExpectation>> {
   const byDecl = new Map<string, Map<string, MethodExpectation>>([[tsFile, new Map()]]);
+  for (const file of extraDeclFiles) {
+    if (!byDecl.has(file)) byDecl.set(file, new Map());
+  }
   for (const [key, exp] of expectations) {
     const file = exp.declFile ?? tsFile;
     const group = byDecl.get(file) ?? byDecl.set(file, new Map()).get(file)!;
@@ -703,6 +709,7 @@ async function main(argv: string[]): Promise<number> {
   // whole stale set would retire a tag in a file compare.ts never reported it
   // for.
   const staleByDeclFile = new Map<string, Set<string>>();
+  const staleDeclFilesByFile = new Map<string, Set<string>>();
   for (const t of artifact.staleTags ?? []) {
     if (t.package !== pkg) continue;
     if (onlyFile && t.tsFile !== onlyFile) continue;
@@ -711,8 +718,13 @@ async function main(argv: string[]): Promise<number> {
       staleByDeclFile.get(declFile) ?? staleByDeclFile.set(declFile, new Set()).get(declFile)!;
     set.add(staleTagKey(t.tsClass ?? "", t.tsName, t.call));
     // A file whose only business this run is a stale tag has no expectation to
-    // put it in `byFile`, and would otherwise never be opened.
+    // put it in `byFile` (nor its declaring file in `groupByDeclFile`), and
+    // would otherwise never be opened.
     if (!byFile.has(t.tsFile)) byFile.set(t.tsFile, new Map());
+    const files =
+      staleDeclFilesByFile.get(t.tsFile) ??
+      staleDeclFilesByFile.set(t.tsFile, new Set()).get(t.tsFile)!;
+    files.add(declFile);
   }
 
   let skipped = 0;
@@ -724,7 +736,9 @@ async function main(argv: string[]): Promise<number> {
   const texts = new Map<string, string>();
   const rewritten = new Set<string>();
   for (const [tsFile, expectations] of [...byFile.entries()].sort()) {
-    for (const [declFile, group] of [...groupByDeclFile(tsFile, expectations).entries()].sort()) {
+    for (const [declFile, group] of [
+      ...groupByDeclFile(tsFile, expectations, staleDeclFilesByFile.get(tsFile) ?? []).entries(),
+    ].sort()) {
       const abs = path.join(srcDir, declFile);
       let text = texts.get(abs);
       if (text === undefined) {

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -1911,7 +1911,13 @@ describe("staleCallTags", () => {
       [callTagKey("relation.ts", "Relation", "load"), new Set(["synchronize"])],
     ]);
     expect(staleCallTags(tags, used)).toEqual([
-      { tsFile: "relation.ts", tsName: "load", call: "reload" },
+      {
+        tsFile: "relation.ts",
+        tsClass: "Relation",
+        tsDeclFile: undefined,
+        tsName: "load",
+        call: "reload",
+      },
     ]);
   });
 
@@ -1943,7 +1949,37 @@ describe("staleCallTags", () => {
     ]);
     const used = new Map([[callTagKey("core.ts", "Core", "load"), new Set<string>()]]);
     expect(staleCallTags(twoFiles, used)).toEqual([
-      { tsFile: "core.ts", tsName: "load", call: "synchronize" },
+      {
+        tsFile: "core.ts",
+        tsClass: "Core",
+        tsDeclFile: undefined,
+        tsName: "load",
+        call: "synchronize",
+      },
+    ]);
+  });
+
+  it("carries the declaring file when the class was split into a subdirectory", () => {
+    const declFiles = new Map([
+      ["cache.ts", new Map([["read", new Map([["Store", "cache/store.ts"]])]])],
+    ]);
+    const split = new Map([
+      [
+        "cache.ts",
+        new Map([
+          ["read", new Map([["Store", new Map([["instrument", "PERMANENT — receipt."]])]])],
+        ]),
+      ],
+    ]);
+    const used = new Map([[callTagKey("cache.ts", "Store", "read"), new Set<string>()]]);
+    expect(staleCallTags(split, used, declFiles)).toEqual([
+      {
+        tsFile: "cache.ts",
+        tsClass: "Store",
+        tsDeclFile: "cache/store.ts",
+        tsName: "read",
+        call: "instrument",
+      },
     ]);
   });
 
@@ -2011,7 +2047,13 @@ describe("staleCallTags", () => {
       [callTagKey("inflector.ts", "Inflector", "safeConstantize"), new Set(["match?"])],
     ]);
     expect(staleCallTags(topLevel, used)).toEqual([
-      { tsFile: "inflector.ts", tsName: "safeConstantize", call: "const_regexp" },
+      {
+        tsFile: "inflector.ts",
+        tsClass: "",
+        tsDeclFile: undefined,
+        tsName: "safeConstantize",
+        call: "const_regexp",
+      },
     ]);
   });
 });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1484,6 +1484,10 @@ export function usedForAnyOwner(
 export function staleCallTags(
   tagsByFileName: Map<string, Map<string, Map<string, Map<string, string>>>>,
   used: Map<string, Set<string>>,
+  declFileByFileNameOwner: ReadonlyMap<
+    string,
+    ReadonlyMap<string, ReadonlyMap<string, string>>
+  > = new Map(),
 ): StaleCallTag[] {
   const out: StaleCallTag[] = [];
   for (const [tsFile, byName] of tagsByFileName) {
@@ -1495,14 +1499,18 @@ export function staleCallTags(
           used.get(callTagKey(tsFile, tsClass, tsName)) ??
           used.get(callTagKey(tsFile, "*", tsName));
         if (hit === undefined) continue;
+        const tsDeclFile = declFileFor(declFileByFileNameOwner, tsFile, tsName, tsClass);
         for (const call of calls.keys()) {
-          if (!hit.has(call)) out.push({ tsFile, tsName, call });
+          if (!hit.has(call)) out.push({ tsFile, tsClass, tsDeclFile, tsName, call });
         }
       }
     }
   }
   return out.sort((a, b) =>
-    `${a.tsFile} ${a.tsName} ${a.call}` < `${b.tsFile} ${b.tsName} ${b.call}` ? -1 : 1,
+    `${a.tsFile} ${a.tsClass} ${a.tsName} ${a.call}` <
+    `${b.tsFile} ${b.tsClass} ${b.tsName} ${b.call}`
+      ? -1
+      : 1,
   );
 }
 
@@ -1513,6 +1521,16 @@ export function staleCallTags(
  *  "no longer flagged" would be unknowable rather than true. */
 export interface StaleCallTag {
   tsFile: string;
+  /** The class that declares the tagged member (`""` for a top-level
+   *  function) — the `callTagKey` identity the suppression side is keyed by.
+   *  Without it two declarations of one name reachable from `tsFile` share a
+   *  retirement key, so retiring a stale tag on one deletes the reviewed
+   *  receipt on the other (RFC 0106). */
+  tsClass: string;
+  /** The file the declaration actually lives in, when trails split the Rails
+   *  class into a subdirectory module and it differs from `tsFile`. See
+   *  `CallMismatch.tsDeclFile`. */
+  tsDeclFile?: string;
   tsName: string;
   call: string;
 }
@@ -4097,7 +4115,11 @@ export function main() {
         compared: callsCompared,
         mismatched: callMismatches.length,
         mismatches: callMismatches,
-        staleTags: staleCallTags(tsMissingCallTagsByFileName, callTagsUsed),
+        staleTags: staleCallTags(
+          tsMissingCallTagsByFileName,
+          callTagsUsed,
+          tsDeclFileByFileNameOwner,
+        ),
         suppressed: suppressedCalls,
         skeletons: callSkeletons,
       },
@@ -4106,7 +4128,11 @@ export function main() {
         mismatched: callArgMismatches.length,
         skipped: callArgsSkipped,
         mismatches: callArgMismatches,
-        staleTags: staleCallTags(tsMissingArgTagsByFileName, argTagsUsed),
+        staleTags: staleCallTags(
+          tsMissingArgTagsByFileName,
+          argTagsUsed,
+          tsDeclFileByFileNameOwner,
+        ),
         suppressed: suppressedArgCalls,
       },
       bodyHashes: bodyHashRecords,


### PR DESCRIPTION
Bundle of three stories: two RFC 0107 relation-decomposition convergences plus one RFC 0106 tooling fix.

## `AssociationRelation` overrides `exec_queries` (RFC 0107)

Rails wires the inverse instance and strict-loading mode from `exec_queries`
(`association_relation.rb:43-49`); trails hung it off `toArray`, which only worked
because trails' `load()` calls `toArray()` — the opposite of Rails' `to_ary → records → load`
chain, which PR #6905 could not invert for exactly this reason.

The override moves to `execQueries` (now `protected` on `Relation`, mirroring Ruby's
private-with-subclass-override), and the inline `inversable?` / `matches_foreign_key?`
reimplementation collapses onto the two calls Rails' block makes:
`@association.set_inverse_instance_from_queries(record)` and `set_strict_loading(record)`.
`Association#setInverseInstanceFromQueries` now raises RFC 0022's `_explicitTarget` when
its write lands, the way `setInverseInstance` already does, so the seeded target still
reads back as set rather than re-querying.

## `DisableJoinsAssociationRelation` overrides `load` (RFC 0107)

Rails overrides `load`, calls `super`, and rewrites `@records` **on self**
(`disable_joins_association_relation.rb:26-38`), so every later read sees the id order.
trails overrode `toArray` and regrouped a **clone**, so `records()` / `load()` never saw
the reorder and `isLoaded` stayed false.

`load` now carries Rails' body (group by `key`, flat-map over `ids`, compact, assign back).
The trails-only deferred chain walk moves to `execQueries`, where it stands in for the
query Rails' `DisableJoinsAssociationScope` has already finished; the clone's limit/offset
handling lands with Rails' own in-memory `limit` / `first` overrides.

## `staleTagKey` carries the declaring class (RFC 0106)

`staleCallTags` recorded only `{ tsFile, tsName, call }`, so two declarations of one name
reachable from a single row-file — a top-level `foo` beside a `Store#foo` split into a
subdirectory module, or two classes in one file — shared a retirement key, and retiring one
stale `@missingRailsCall` tag could delete the other's reviewed receipt. Rows now carry
`tsClass` (plus `tsDeclFile` where it differs), `staleTagKey` is keyed on the owner, and
`build.ts` groups the stale set per declaring file instead of handing the row-file's whole
set to each. Covered by a `build.test.ts` case that fails on the old key.

## Verification

- `pnpm parity:api:calls` OK (the `exec_queries` rename put the method into the compared
  population; it converged rather than adding a baseline row), `parity:api:calls:args` OK,
  `parity:api:extra:gate` OK, `parity:test` 69.1% unchanged.
- All 116 `packages/activerecord/src/associations` test files (2192 tests) green; the 68
  `relation*` files (1218 tests) green; `scripts/api-compare` compare/build tests green.

Closes-story: converge-association-relation-inverse-wiring-onto-exec-queries
Closes-story: converge-disable-joins-association-relation-onto-load
Closes-story: stale-tag-retirement-key-ignores-the-declaring-class
