### PR TITLE
refactor(activerecord): query-cache cache/enable stop adopting the block value; executeBatch routes through rawExecute

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -700,7 +700,11 @@ export interface AbstractAdapter {
   /** @internal */
   castResult?(rawResult: unknown): Result;
   /** @internal */
-  executeBatch(statements: string[], name?: string | null): Promise<void>;
+  executeBatch(
+    statements: string[],
+    name?: string | null,
+    kwargs?: { allowRetry?: boolean; materializeTransactions?: boolean },
+  ): Promise<void>;
   /** @internal */
   preprocessQuery(sql: string): string;
 
@@ -1147,9 +1151,9 @@ export class AbstractAdapter implements Quoting {
     return queryCacheEnabledGet.call(this as unknown as QueryCacheHost);
   }
 
-  async cache<T>(fn: () => T | Promise<T>): Promise<T> {
+  cache<T>(fn: () => T | Promise<T>): T | Promise<T> {
     this._ensureQueryCache();
-    return cacheMixin.call(this as unknown as QueryCacheHost, fn) as Promise<T>;
+    return cacheMixin.call(this as unknown as QueryCacheHost, fn) as T | Promise<T>;
   }
 
   enableQueryCacheBang(): void {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -17,6 +17,8 @@ import {
 import type { ExplainOption } from "./abstract/database-statements.js";
 import { Result } from "../result.js";
 import { isRubyTruthy } from "../ruby-truthy.js";
+import { KeyError } from "@blazetrails/activesupport";
+import { transactionIsolationLevels } from "./abstract/database-statements.js";
 import { rubyInspect } from "../relation/ruby-inspect.js";
 import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
@@ -551,8 +553,28 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   async beginDbTransaction(): Promise<void> {}
 
+  /**
+   * Mirrors: AbstractMysqlAdapter#begin_isolated_db_transaction
+   * (abstract_mysql_adapter.rb:230-239)
+   *
+   * @missingRailsCall fetch — PERMANENT: `Hash#fetch`'s raise-on-miss arm has no
+   *   JS equivalent — a plain index returns `undefined` — so the two arms are
+   *   ported explicitly below: the lookup, then Ruby's `KeyError` with Ruby's
+   *   own message. Same shape as the Mysql2Adapter and PostgreSQLAdapter
+   *   overrides of this method.
+   */
   async beginIsolatedDbTransaction(isolation: string): Promise<void> {
-    void isolation;
+    // From MySQL manual: The [SET TRANSACTION] statement applies only to the next single transaction performed within the session.
+    // So we don't need to implement #reset_isolation_level
+    //
+    // Rails: `transaction_isolation_levels.fetch(isolation)`
+    // (abstract_mysql_adapter.rb:235) — unknown levels raise Ruby's `KeyError`.
+    const level = transactionIsolationLevels()[isolation];
+    if (level === undefined) throw new KeyError(`key not found: :${isolation}`);
+    await this.executeBatch([`SET TRANSACTION ISOLATION LEVEL ${level}`, "BEGIN"], "TRANSACTION", {
+      allowRetry: true,
+      materializeTransactions: false,
+    });
   }
 
   async commitDbTransaction(): Promise<void> {}

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -640,7 +640,7 @@ export class ConnectionPool implements ReapablePool {
     return this._cacheConfig.dirtiesQueryCache;
   }
 
-  enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
+  enableQueryCache<T>(fn: () => T | Promise<T>): T | Promise<T> {
     return this._cacheConfig.enableQueryCache(fn);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1767,6 +1767,9 @@ export function internalExecute(
  * query_transformers, is `internal_execute`'s step
  * (abstract/database_statements.rb:589-591).
  *
+ * The positional arguments below are `raw_execute`'s own defaults
+ * (abstract/database_statements.rb:552).
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch
  * (abstract/database_statements.rb:594-598)
  * @internal
@@ -1781,8 +1784,6 @@ export async function executeBatch(
   }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
   for (const statement of statements) {
-    // The positional defaults here are `raw_execute`'s own
-    // (abstract/database_statements.rb:552).
     await (this as any).rawExecute(
       statement,
       name,

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -151,7 +151,11 @@ export interface DatabaseStatementsHost {
   withinNewTransaction?<T>(opts: unknown, fn: (tx?: unknown) => Promise<T> | T): Promise<T>;
   disableReferentialIntegrity?(fn: () => Promise<void>, tables?: string[]): Promise<void>;
   /** @internal */
-  executeBatch?(statements: string[], name?: string | null): Promise<void>;
+  executeBatch?(
+    statements: string[],
+    name?: string | null,
+    kwargs?: { allowRetry?: boolean; materializeTransactions?: boolean },
+  ): Promise<void>;
   /** @internal */
   buildTruncateStatement?(tableName: string): string;
   /** @internal */
@@ -1695,17 +1699,12 @@ function affectedRows(rawResult: any): never {
  * (commented) SQL — the Rails-faithful ordering where `preprocess_query` runs
  * in `internal_execute`, before `raw_execute`'s `log` block.
  *
- * `_inQueryTransformers` is a one-shot "skip the transformer pass" flag.
- * `executeBatch` sets it before each statement so batch SQL stays uncommented —
- * matching Rails, whose `execute_batch` calls `raw_execute` directly and so
- * skips the `query_transformers` loop. (Unlike Rails' `raw_execute`, the
- * write-checks above still run for batch statements; only the transformer pass
- * is suppressed.) The flag is **consumed synchronously here, before any await**,
- * so it can never span an await boundary and bleed into a concurrent query on
- * the same adapter. It also short-circuits a synchronous re-entrant call (a
- * transformer that itself runs SQL); real, async, DB-issuing transformers don't
- * hit this — by the time their query runs, the flag is already cleared, so they
- * transform normally, exactly as in Rails (which has no guard at all).
+ * `_inQueryTransformers` short-circuits a synchronous re-entrant call (a
+ * transformer that itself runs SQL). It is set and cleared **within one
+ * synchronous stretch**, so it can never span an await boundary and bleed into
+ * a concurrent query on the same adapter; real, async, DB-issuing transformers
+ * don't hit it — by the time their query runs the flag is already cleared, so
+ * they transform normally, exactly as in Rails (which has no guard at all).
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#preprocess_query
  * @internal
@@ -1714,10 +1713,7 @@ export function preprocessQuery(this: DatabaseStatementsHost, sql: string): stri
   this.checkIfWriteQuery?.(sql);
   markTransactionWrittenIfWrite.call(this, sql);
   const host = this as DatabaseStatementsHost & { _inQueryTransformers?: boolean };
-  if (host._inQueryTransformers) {
-    host._inQueryTransformers = false;
-    return sql;
-  }
+  if (host._inQueryTransformers) return sql;
   host._inQueryTransformers = true;
   try {
     for (const t of ActiveRecord.queryTransformers) {
@@ -1766,28 +1762,36 @@ export function internalExecute(
  * Executes each statement sequentially. Adapters with native batch support
  * (e.g. a driver that accepts a multi-statement string) should override this.
  *
+ * Going through `raw_execute` rather than `internal_execute` is what leaves
+ * batch statements uncommented — `preprocess_query`, which runs the
+ * query_transformers, is `internal_execute`'s step
+ * (abstract/database_statements.rb:589-591).
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#execute_batch
+ * (abstract/database_statements.rb:594-598)
  * @internal
  */
 export async function executeBatch(
   this: DatabaseStatementsHost,
   statements: string[],
-  name?: string | null,
+  name: string | null = null,
+  {
+    allowRetry = false,
+    materializeTransactions = true,
+  }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
-  // Rails' execute_batch calls raw_execute directly, so batch statements skip the
-  // query_transformers pass and carry no QueryLogs comment. trails routes batches
-  // through executeMutation (which preprocesses), so flag each statement to
-  // suppress the transformer pass (write-checks still run). The flag is consumed
-  // synchronously inside preprocessQuery before any await — so it never spans the
-  // await — and the finally clears it if executeMutation throws before consuming.
-  const host = this as DatabaseStatementsHost & { _inQueryTransformers?: boolean };
   for (const statement of statements) {
-    host._inQueryTransformers = true;
-    try {
-      await (this as any).executeMutation(statement);
-    } finally {
-      host._inQueryTransformers = false;
-    }
+    // The positional defaults here are `raw_execute`'s own
+    // (abstract/database_statements.rb:552).
+    await (this as any).rawExecute(
+      statement,
+      name,
+      [],
+      false,
+      false,
+      allowRetry,
+      materializeTransactions,
+    );
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -274,6 +274,13 @@ export class ConnectionPoolConfiguration {
     return result;
   }
 
+  /**
+   * NOT an `async` method, for the same reason `disableQueryCache` above is
+   * not: Ruby's `ensure` fires when the block RETURNS
+   * (abstract/query_cache.rb:149-157), so a block handing back a pending
+   * FutureResult restores synchronously and the handle passes through
+   * untouched. Awaiting it would adopt the thenable.
+   */
   enableQueryCache<T>(fn: () => T | Promise<T>): T | Promise<T> {
     const qc = this.queryCache;
     const oldEnabled = qc.enabled;
@@ -284,10 +291,6 @@ export class ConnectionPoolConfiguration {
       qc.enabled = oldEnabled;
       qc.dirties = oldDirties;
     };
-    // NOT an `async` method, for the same reason `disableQueryCache` above is
-    // not: Ruby's `ensure` fires when the block RETURNS, so a block handing
-    // back a pending FutureResult restores synchronously and the handle passes
-    // through untouched. Awaiting it would adopt the thenable.
     let result: T | Promise<T>;
     try {
       result = fn();

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -249,14 +249,14 @@ export class ConnectionPoolConfiguration {
     options: { dirties?: boolean } = {},
   ): T | Promise<T> {
     const { dirties = true } = options;
-    const qc = this.queryCache;
-    const oldEnabled = qc.enabled;
-    const oldDirties = qc.dirties;
-    qc.enabled = false;
-    qc.dirties = dirties;
+    const cache = this.queryCache;
+    const oldEnabled = cache.enabled;
+    const oldDirties = cache.dirties;
+    cache.enabled = false;
+    cache.dirties = dirties;
     const restore = () => {
-      qc.enabled = oldEnabled;
-      qc.dirties = oldDirties;
+      cache.enabled = oldEnabled;
+      cache.dirties = oldDirties;
     };
     // NOT an `async` method: Ruby's `ensure` fires when the block RETURNS, and
     // `exec_main_query`'s block returns a pending FutureResult rather than
@@ -282,14 +282,14 @@ export class ConnectionPoolConfiguration {
    * untouched. Awaiting it would adopt the thenable.
    */
   enableQueryCache<T>(fn: () => T | Promise<T>): T | Promise<T> {
-    const qc = this.queryCache;
-    const oldEnabled = qc.enabled;
-    const oldDirties = qc.dirties;
-    qc.enabled = true;
-    qc.dirties = true;
+    const cache = this.queryCache;
+    const oldEnabled = cache.enabled;
+    const oldDirties = cache.dirties;
+    cache.enabled = true;
+    cache.dirties = true;
     const restore = () => {
-      qc.enabled = oldEnabled;
-      qc.dirties = oldDirties;
+      cache.enabled = oldEnabled;
+      cache.dirties = oldDirties;
     };
     let result: T | Promise<T>;
     try {

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -274,18 +274,30 @@ export class ConnectionPoolConfiguration {
     return result;
   }
 
-  async enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T> {
+  enableQueryCache<T>(fn: () => T | Promise<T>): T | Promise<T> {
     const qc = this.queryCache;
     const oldEnabled = qc.enabled;
     const oldDirties = qc.dirties;
     qc.enabled = true;
     qc.dirties = true;
-    try {
-      return await fn();
-    } finally {
+    const restore = () => {
       qc.enabled = oldEnabled;
       qc.dirties = oldDirties;
+    };
+    // NOT an `async` method, for the same reason `disableQueryCache` above is
+    // not: Ruby's `ensure` fires when the block RETURNS, so a block handing
+    // back a pending FutureResult restores synchronously and the handle passes
+    // through untouched. Awaiting it would adopt the thenable.
+    let result: T | Promise<T>;
+    try {
+      result = fn();
+    } catch (error) {
+      restore();
+      throw error;
     }
+    if (result instanceof Promise) return result.finally(restore);
+    restore();
+    return result;
   }
 
   enableQueryCacheBang(): void {
@@ -356,8 +368,8 @@ export function queryCacheEnabled(this: QueryCacheHost): boolean {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#cache
  */
-export function cache<T>(this: QueryCacheHost, fn: () => T | Promise<T>): Promise<T> {
-  return this.pool.enableQueryCache(fn) as Promise<T>;
+export function cache<T>(this: QueryCacheHost, fn: () => T | Promise<T>): T | Promise<T> {
+  return this.pool.enableQueryCache(fn);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1971,7 +1971,7 @@ Mysql2Adapter.prototype.performQuery = mysql2PerformQuery;
 //
 // So mysql2 keeps AbstractAdapter's per-statement loop, which is correct
 // because it never combines. Story:
-// install-mysql2-execute-batch-once-multi-statements-are-sendable.
+// mysql2-execute-batch-routes-through-raw-execute (blocked on the above).
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
 // mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1951,14 +1951,26 @@ dirtiesQueryCache(Mysql2Adapter, "execute");
 // method of the adapter, so `raw_execute`'s `this.performQuery(...)` dispatch
 // resolves here (mysql2/database_statements.rb:41).
 Mysql2Adapter.prototype.performQuery = mysql2PerformQuery;
-// `Mysql2::DatabaseStatements#execute_batch` is deliberately NOT installed
-// beside it. Rails' `perform_query` turns multi-statements on for the batch
-// query itself — `raw_connection.set_server_option(OPTION_MULTI_STATEMENTS_ON)`
+// Rails installs `Mysql2::DatabaseStatements#execute_batch` here too
+// (`include Mysql2::DatabaseStatements`, mysql2_adapter.rb:21). trails cannot
+// yet, and the blocker is the driver rather than the port: the ported body is
+// correct (mysql2/database-statements.ts), but `combine_multi_statements`
+// (mysql/database_statements.rb:66-76) joins with `";\n"` unconditionally and
+// carries no multi-statement guard. Rails' guard lives in `perform_query`,
+// which turns the option on for the batch query itself —
+// `raw_connection.set_server_option(OPTION_MULTI_STATEMENTS_ON)`
 // (mysql2/database_statements.rb:41-45) — and node-mysql2 ships no command
-// class for `COM_SET_OPTION` (only the `SET_OPTION: 0x1b` wire constant), so a
-// combined `a;\nb` fails with ER_PARSE_ERROR on any connection not created
-// with multi-statements. Until that is closed, mysql2 inherits AbstractAdapter's
-// per-statement loop, which is correct if uncombined. Story:
+// class for COM_SET_OPTION: `lib/constants/commands.js:31` defines
+// `SET_OPTION: 0x1b` but `lib/commands/` has no `set_option.js`, and the
+// option is protocol-level with no SQL equivalent. Installing the override
+// therefore fails every batch on a connection not created with
+// multi-statements; measured against mariadb:11:
+//
+//   ER_PARSE_ERROR (1064) ... near 'CREATE TABLE batch_probe (id int)' at line 2
+//   sql: 'DROP TABLE IF EXISTS batch_probe;\nCREATE TABLE batch_probe (id int)'
+//
+// So mysql2 keeps AbstractAdapter's per-statement loop, which is correct
+// because it never combines. Story:
 // install-mysql2-execute-batch-once-multi-statements-are-sendable.
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1951,6 +1951,15 @@ dirtiesQueryCache(Mysql2Adapter, "execute");
 // method of the adapter, so `raw_execute`'s `this.performQuery(...)` dispatch
 // resolves here (mysql2/database_statements.rb:41).
 Mysql2Adapter.prototype.performQuery = mysql2PerformQuery;
+// `Mysql2::DatabaseStatements#execute_batch` is deliberately NOT installed
+// beside it. Rails' `perform_query` turns multi-statements on for the batch
+// query itself — `raw_connection.set_server_option(OPTION_MULTI_STATEMENTS_ON)`
+// (mysql2/database_statements.rb:41-45) — and node-mysql2 ships no command
+// class for `COM_SET_OPTION` (only the `SET_OPTION: 0x1b` wire constant), so a
+// combined `a;\nb` fails with ER_PARSE_ERROR on any connection not created
+// with multi-statements. Until that is closed, mysql2 inherits AbstractAdapter's
+// per-statement loop, which is correct if uncombined. Story:
+// install-mysql2-execute-batch-once-multi-statements-are-sendable.
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
 // mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -167,27 +167,52 @@ export async function selectAll(
 }
 
 /**
- * Combines statements via `combineMultiStatements` then executes each block.
- * Mirrors Rails' use of `multi_statement: true` for batched execution.
+ * Combines statements via `combineMultiStatements` then hands each combined
+ * block to `raw_execute` with `batch: true`.
+ *
+ * Going through `raw_execute` rather than `execute` is what leaves batch
+ * statements uncommented — `preprocess_query`, which runs the
+ * query_transformers, is `internal_execute`'s step
+ * (abstract/database_statements.rb:589-591) — so the `_inQueryTransformers`
+ * suppression flag this used to need is gone with it.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#execute_batch
+ * (mysql2/database_statements.rb:17-21)
  * @internal
- *
- * @missingRailsCall raw_execute — PERMANENT: Per-site verified (RFC 0106 wave
- *   4b): mysql2/database_statements.rb's `execute_batch` calls
- *   `raw_execute(combine_multi_statements(statements), name, batch: true)`;
- *   trails routes the batch through `internalExecute` so the multi-statement
- *   flag and the retry/materialize kwargs travel with it — see project note
- *   `_inQueryTransformers leaks off preprocessQuery` for why the batch path must
- *   not re-enter rawExecute directly.
  */
 export async function executeBatch(
-  this: MaxAllowedPacketHost & { execute(sql: string, name?: string | null): Promise<unknown> },
+  this: MaxAllowedPacketHost & {
+    rawExecute(
+      sql: string,
+      name?: string | null,
+      binds?: unknown[],
+      prepare?: boolean,
+      async?: boolean,
+      allowRetry?: boolean,
+      materializeTransactions?: boolean,
+      batch?: boolean,
+    ): Promise<unknown>;
+  },
   statements: string[],
-  name?: string | null,
+  name: string | null = null,
+  {
+    allowRetry = false,
+    materializeTransactions = true,
+  }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
   for (const statement of await combineMultiStatements.call(this, statements)) {
-    await this.execute(statement, name);
+    // The positional defaults here are `raw_execute`'s own
+    // (abstract/database_statements.rb:552).
+    await this.rawExecute(
+      statement,
+      name,
+      [],
+      false,
+      false,
+      allowRetry,
+      materializeTransactions,
+      true,
+    );
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -166,6 +166,20 @@ export async function selectAll(
   return this.internalExecQuery(sql, name, binds);
 }
 
+/** @internal */
+interface ExecuteBatchHost extends MaxAllowedPacketHost {
+  rawExecute(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    prepare?: boolean,
+    async?: boolean,
+    allowRetry?: boolean,
+    materializeTransactions?: boolean,
+    batch?: boolean,
+  ): Promise<unknown>;
+}
+
 /**
  * Combines statements via `combineMultiStatements` then hands each combined
  * block to `raw_execute` with `batch: true`.
@@ -176,23 +190,15 @@ export async function selectAll(
  * (abstract/database_statements.rb:589-591) — so the `_inQueryTransformers`
  * suppression flag this used to need is gone with it.
  *
+ * The positional arguments below are `raw_execute`'s own defaults
+ * (abstract/database_statements.rb:552).
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#execute_batch
  * (mysql2/database_statements.rb:17-21)
  * @internal
  */
 export async function executeBatch(
-  this: MaxAllowedPacketHost & {
-    rawExecute(
-      sql: string,
-      name?: string | null,
-      binds?: unknown[],
-      prepare?: boolean,
-      async?: boolean,
-      allowRetry?: boolean,
-      materializeTransactions?: boolean,
-      batch?: boolean,
-    ): Promise<unknown>;
-  },
+  this: ExecuteBatchHost,
   statements: string[],
   name: string | null = null,
   {
@@ -201,8 +207,6 @@ export async function executeBatch(
   }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
   for (const statement of await combineMultiStatements.call(this, statements)) {
-    // The positional defaults here are `raw_execute`'s own
-    // (abstract/database_statements.rb:552).
     await this.rawExecute(
       statement,
       name,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1304,8 +1304,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    *  (sqlite3/database_statements.rb:126-129).
    * @internal
    */
-  override async executeBatch(statements: string[], name?: string | null): Promise<void> {
-    return sqliteExecuteBatch.call(this, statements, name);
+  override async executeBatch(
+    statements: string[],
+    name?: string | null,
+    kwargs?: { allowRetry?: boolean; materializeTransactions?: boolean },
+  ): Promise<void> {
+    return sqliteExecuteBatch.call(this, statements, name, kwargs);
   }
 
   /** SQLite has no TRUNCATE; emit `DELETE FROM`.

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -389,7 +389,11 @@ export function affectedRows(this: PerformQueryHost, _result: unknown): number {
 export async function executeBatch(
   this: ExecuteBatchHost,
   statements: string[],
-  name?: string | null,
+  name: string | null = null,
+  {
+    allowRetry = false,
+    materializeTransactions = true,
+  }: { allowRetry?: boolean; materializeTransactions?: boolean } = {},
 ): Promise<void> {
   const sql = combineMultiStatements(statements);
   // Rails: `raw_execute(sql, name, batch: true, **kwargs)`
@@ -399,7 +403,7 @@ export async function executeBatch(
   // statements uncommented — `preprocess_query`, which runs the
   // query_transformers, is `internal_execute`'s step (`:589-591`) — so the
   // `_inQueryTransformers` suppression flag this used to set is gone with it.
-  await this.rawExecute(sql, name, [], false, false, false, true, true);
+  await this.rawExecute(sql, name, [], false, false, allowRetry, materializeTransactions, true);
 }
 
 /** @internal */

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -110,15 +110,16 @@ export class QueryCache {
 export const ClassMethods = {
   /**
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
+   *
+   * NOT `async`: Ruby's `ensure` fires when the block RETURNS
+   * (query_cache.rb:9-21), so a block handing back a pending FutureResult
+   * clears synchronously and the handle passes through untouched; awaiting it
+   * would adopt the thenable and resolve the scheduled query away.
    */
   cache<T>(this: typeof Base, block: () => T | Promise<T>): T | Promise<T> {
     if (this.connectedQ() || !this.configurations().empty) {
       const pool = this.connectionPool();
       const wasEnabled = pool.queryCacheEnabled;
-      // Ruby's `ensure` fires when the block RETURNS, so a block handing back a
-      // pending FutureResult clears synchronously and the handle passes through
-      // untouched; awaiting it would adopt the thenable and resolve the
-      // scheduled query away.
       const ensure = () => {
         if (!wasEnabled) pool.clearQueryCache();
       };

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -111,15 +111,27 @@ export const ClassMethods = {
   /**
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
    */
-  async cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
+  cache<T>(this: typeof Base, block: () => T | Promise<T>): T | Promise<T> {
     if (this.connectedQ() || !this.configurations().empty) {
       const pool = this.connectionPool();
       const wasEnabled = pool.queryCacheEnabled;
-      try {
-        return await pool.enableQueryCache(block);
-      } finally {
+      // Ruby's `ensure` fires when the block RETURNS, so a block handing back a
+      // pending FutureResult clears synchronously and the handle passes through
+      // untouched; awaiting it would adopt the thenable and resolve the
+      // scheduled query away.
+      const ensure = () => {
         if (!wasEnabled) pool.clearQueryCache();
+      };
+      let result: T | Promise<T>;
+      try {
+        result = pool.enableQueryCache(block);
+      } catch (error) {
+        ensure();
+        throw error;
       }
+      if (result instanceof Promise) return result.finally(ensure);
+      ensure();
+      return result;
     }
     return block();
   },

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -229,4 +229,37 @@ describe("Relation#load_async", () => {
     // Rails: `return load if !c.async_enabled?` (relation.rb:1140).
     expect((spy.mock.calls[0][3] as { async?: boolean }).async).toBe(false);
   });
+  itIfSupports(
+    "concurrent_connections",
+    "cache hands the block's pending FutureResult back unresolved",
+    async () => {
+      // `QueryCache::ClassMethods#cache` runs its restore in an `ensure`, which
+      // fires when the block RETURNS (query_cache.rb:9-21), so a block handing
+      // back a pending handle restores synchronously and the handle passes
+      // through untouched — the same shape `uncached` has on the other half of
+      // the pair. Adopting it here would resolve the scheduled query away.
+      const pool = (await Base.connectionPool()) as unknown as {
+        scheduleQuery(futureResult: unknown): void;
+      };
+      const scheduled: FutureResult[] = [];
+      vi.spyOn(pool, "scheduleQuery").mockImplementation((futureResult) => {
+        scheduled.push(futureResult as FutureResult);
+      });
+
+      const relation = Topic.cache(() => Topic.all().loadAsync()) as unknown as ReturnType<
+        typeof Topic.all
+      >;
+
+      // Not a Promise: an `async` wrapper would have adopted the relation.
+      expect(relation).not.toBeInstanceOf(Promise);
+      expect(scheduled[0]).toBeInstanceOf(FutureResult.SelectAll);
+      expect(scheduled[0].pending()).toBe(true);
+      // The restore already ran, synchronously, when the block returned.
+      expect((await Base.connectionPool()).queryCacheEnabled).toBe(false);
+
+      relation.reset();
+      expect(scheduled[0].pending()).toBe(false);
+      await expect(scheduled[0].result()).rejects.toBeInstanceOf(FutureResult.Canceled);
+    },
+  );
 });


### PR DESCRIPTION
Four bundled RFC 0106 / 0107 convergence stories.

### `cache` / `enable_query_cache` stop adopting the block value

PR #6905 converged the `uncached` / `disable_query_cache` half of Ruby's
query-cache block pair; the `cache` / `enable_query_cache` half was left
`async`. Ruby's `ensure` fires when the block RETURNS
(`query_cache.rb:9-21`, `abstract/query_cache.rb:149-157`), so a block handing
back a pending `FutureResult` restores synchronously and the handle passes
through untouched. `await`ing it adopted the thenable and resolved the
scheduled query away — the exact bug #6905 fixed on the other side.

`enableQueryCache` (cache config + pool), `QueryCache#cache` and
`QueryCache::ClassMethods#cache` now return `T | Promise<T>`, restoring
synchronously for a non-Promise value and via `.finally()` otherwise. Both
halves of the pair also take back Ruby's local name `cache`
(`abstract/query_cache.rb:140`, `:150`) where trails had `qc`.

### `execute_batch` routes through `raw_execute`

The abstract base (`abstract/database_statements.rb:594-598`) and mysql2
(`mysql2/database_statements.rb:17-21`) called `executeMutation` / `execute`
instead of `raw_execute`. The abstract loop also dropped `name` outright.
Both now call `rawExecute` per statement (per combined block for mysql2, with
`batch: true`), forwarding `name` and the `allow_retry` /
`materialize_transactions` kwargs — which now travel on the declared signature
at every level (`AbstractAdapter`, the `DatabaseStatements` host interface, and
the sqlite3 / PostgreSQL / mysql2 overrides).

Going through `raw_execute` is what leaves batch SQL uncommented —
`preprocess_query` is `internal_execute`'s step (`:589-591`) — so the
`_inQueryTransformers` batch-suppression arm retires with it. The flag keeps
only its synchronous re-entrancy guard (a transformer that itself runs SQL).

### `AbstractMysqlAdapter#begin_isolated_db_transaction`

Was a `void isolation` no-op; now ports `abstract_mysql_adapter.rb:230-239`
verbatim, passing `allowRetry: true, materializeTransactions: false`, which the
kwargs above made expressible. `Mysql2Adapter`'s existing override still
shadows it on the mysql2 lane.

### Why `Mysql2Adapter` does not install the mysql2 `execute_batch`

Raised in review, and the Rails citation is correct: Rails does
`include Mysql2::DatabaseStatements` (`mysql2_adapter.rb:21`), which brings
`execute_batch` (`mysql2/database_statements.rb:17-20`) onto the adapter. The
**ported body is converged in this PR** and matches that Ruby line for line.
What is not done is the install, and the blocker is the driver, not the port.

`combine_multi_statements` (`mysql/database_statements.rb:66-76`) joins with
`";\n"` unconditionally — it carries no multi-statement guard. In Rails the
guard lives in `perform_query`, which turns the option on for the batch query
itself and resets it after:

```ruby
reset_multi_statement = if batch && !multi_statements_enabled?
  raw_connection.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
  true
end
```

(`mysql2/database_statements.rb:41-45`). node-mysql2 exposes multi-statements
only as the `multipleStatements` connection-creation option and ships **no
command class for `COM_SET_OPTION`** — `lib/constants/commands.js:31` defines
`SET_OPTION: 0x1b`, but `lib/commands/` has no `set_option.js`, and the option
is protocol-level with no SQL equivalent. trails already ports the predicate
(`isMultiStatementsEnabled`, mirroring `mysql2/database_statements.rb:31-39`);
it is unused because nothing can act on a false answer.

Installing the override anyway is not a theoretical concern — measured against
`mariadb:11` with the override wired:

```
ER_PARSE_ERROR (1064): You have an error in your SQL syntax ... near
'CREATE TABLE batch_probe (id int)' at line 2
sql: 'DROP TABLE IF EXISTS batch_probe;\nCREATE TABLE batch_probe (id int)'
```

Every batch on the MySQL lane fails. The two escapes both cost more than they
buy in this PR: enabling `multipleStatements` globally on the pool config
deviates from Rails in both mechanism and intent (Rails scopes the option to
the batch query precisely to limit the injection surface) and changes behavior
for every existing mysql2 user, so it needs its own decision; hand-rolling a
`COM_SET_OPTION` command against node-mysql2's private `Command` base is
invented driver machinery.

So mysql2 keeps `AbstractAdapter`'s per-statement loop — which is correct
because it never combines — and the reasoning is recorded at the install site.

**This PR therefore does not close
`mysql2-execute-batch-routes-through-raw-execute`**, per review. That story is
`blocked` with the driver evidence, and its body now records that the ported
half landed here and the install is what remains, with the repro and the
remaining acceptance criteria. Notably, enabling `multipleStatements` globally
on the pool config is explicitly ruled out there as a fix without its own
decision: Rails scopes the option to the batch query precisely to limit the
injection surface, and a global enable changes behavior for every existing
mysql2 user.

### Not in this PR

`invert-to-ary-records-load-chain` was released back to the queue: its declared
dependencies (`converge-association-relation-inverse-wiring-onto-exec-queries`,
`converge-disable-joins-association-relation-onto-load`) are claimed but not yet
landed — both overrides still hang off `toArray` on `main`, so inverting the
chain now would silently route around them.

### Verification

- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
  `pnpm parity:api:extra:gate` OK (arel novel 0/0, total 63/63) — zero new
  baseline rows. The `Calls` advisory went 374 → 373 (mysql2 `execute_batch`
  converged); its `@missingRailsCall raw_execute` tag is deleted, not reworded.
- New trails-only case in `relation-load-async.trails.test.ts`: a `FutureResult`
  returned from inside `Model.cache { ... }` reaches the caller pending. Fails
  on baseline (`async cache` always returns a Promise).
- Green on SQLite: `query-cache*.test.ts`, `relation-load-async.trails.test.ts`,
  `sqlite3-adapter.query-transformers.test.ts`,
  `sqlite3-adapter-perform-query.trails.test.ts`, `test-fixtures.test.ts`,
  `instrumentation.test.ts`.
- Green on a real `mariadb:11`: `test-fixtures.test.ts`, `query-cache.test.ts`,
  `transactions.test.ts` — 205 passed, 19 skipped. The batched-DDL repro above
  succeeds in the shipped state.

Closes-story: converge-enable-query-cache-onto-the-block-value-return
Closes-story: abstract-execute-batch-routes-through-raw-execute
Closes-story: execute-batch-kwargs-and-begin-isolated-db-transaction
