### PR TITLE
refactor(activemodel,activerecord,arel,globalid): converge wave-5 naming tail to the Rails identifiers

### DIFF
--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -119,6 +119,13 @@ export abstract class Attribute {
     return this.typeCast(this.valueBeforeTypeCast);
   }
 
+  /**
+   * @missingRailsArgs changed_in_place? — PERMANENT: Rails passes the ivar
+   *   `@value_for_database` (attribute.rb:56), whose trails spelling is
+   *   `_valueForDatabase` — already taken by the port of the `_value_for_database`
+   *   method (attribute.rb:207). A TS class cannot carry a field and a method of
+   *   the same name, so the memo field keeps the `_cached` prefix.
+   */
   get valueForDatabase(): unknown {
     if (
       !this._hasValueForDatabase ||

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -282,11 +282,11 @@ export function serializableAttributes(
     .readAttributeForSerialization;
   const read =
     typeof instanceRead === "function"
-      ? (key: string) => instanceRead.call(record, key)
-      : (key: string) => readAttributeForSerialization(record, key);
+      ? (n: string) => instanceRead.call(record, n)
+      : (n: string) => readAttributeForSerialization(record, n);
   const result: Record<string, unknown> = {};
-  for (const key of attributeNames) {
-    safeSet(result, key, read(key));
+  for (const n of attributeNames) {
+    safeSet(result, n, read(n));
   }
   return result;
 }

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -223,6 +223,11 @@ export function optionAsNumber(
  * keeps a 17-digit integer out of the 15-significant-digit `parse_float`.
  *
  * @internal Rails-private helper.
+ *
+ * @missingRailsArgs parse_float — PERMANENT: Rails passes `Kernel.Float(raw_value)`
+ *   (numericality.rb:82), whose trails spelling is the `kernelFloat` helper —
+ *   `Kernel` is a Ruby module, not a JS object, so the call can never present the
+ *   `Float` identifier the Ruby side names.
  */
 export function parseAsNumber(
   rawValue: unknown,

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -70,19 +70,27 @@ export class Aes256Gcm {
    *   `generate_iv` can ask that object for `random_iv`; Node's `createCipheriv`
    *   takes the IV as a constructor argument, so the IV must be produced first
    *   and the two calls necessarily swap order.
+   *
+   * @missingRailsArgs generate_iv — PERMANENT: Rails' first argument is the live
+   *   `OpenSSL::Cipher` (aes256_gcm.rb:42), passed only so `generate_iv` can call
+   *   `cipher.random_iv` on it. Node's `createCipheriv` takes the IV as a
+   *   constructor argument, so no cipher object exists at that point and the slot
+   *   carries `@deterministic` — the value Rails reads off the receiver instead.
    */
   encrypt(clearText: string | Buffer): Message {
     this._validateKeyLength(this.secret);
     const keyBuf = Buffer.from(this.secret, "base64").subarray(0, KEY_LENGTH);
-    const inputBuf = Buffer.isBuffer(clearText) ? clearText : Buffer.from(clearText, "utf-8");
-    const iv = this.generateIv(this.deterministic, inputBuf);
+    // Ruby's `clear_text` is a byte String; the JS pair of that is a Buffer, so a
+    // string argument is decoded once here and `clearText` is bytes from here on.
+    if (typeof clearText === "string") clearText = Buffer.from(clearText, "utf-8");
+    const iv = this.generateIv(this.deterministic, clearText);
     const cipher = getCrypto().createCipheriv(Aes256Gcm.CIPHER_TYPE, keyBuf, iv, {
       authTagLength: AUTH_TAG_LENGTH,
     });
     // Rails' `clear_text.empty? ? clear_text.dup : cipher.update(clear_text)`
     // (aes256_gcm.rb:46) — an empty input never reaches `update`.
     let encryptedData =
-      inputBuf.length === 0 ? Buffer.from(inputBuf) : Buffer.from(cipher.update(inputBuf));
+      clearText.length === 0 ? Buffer.from(clearText) : Buffer.from(cipher.update(clearText));
     encryptedData = Buffer.concat([encryptedData, Buffer.from(cipher.final())]);
     if (!cipher.getAuthTag) {
       throw new Configuration("Crypto adapter does not support GCM auth tags (getAuthTag)");

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -76,12 +76,13 @@ export class Aes256Gcm {
    *   `cipher.random_iv` on it. Node's `createCipheriv` takes the IV as a
    *   constructor argument, so no cipher object exists at that point and the slot
    *   carries `@deterministic` — the value Rails reads off the receiver instead.
+   *
+   * Ruby's `clear_text` is a byte String, whose JS pair is a Buffer, so a string
+   * argument is decoded once on entry and `clearText` is bytes from there on.
    */
   encrypt(clearText: string | Buffer): Message {
     this._validateKeyLength(this.secret);
     const keyBuf = Buffer.from(this.secret, "base64").subarray(0, KEY_LENGTH);
-    // Ruby's `clear_text` is a byte String; the JS pair of that is a Buffer, so a
-    // string argument is decoded once here and `clearText` is bytes from here on.
     if (typeof clearText === "string") clearText = Buffer.from(clearText, "utf-8");
     const iv = this.generateIv(this.deterministic, clearText);
     const cipher = getCrypto().createCipheriv(Aes256Gcm.CIPHER_TYPE, keyBuf, iv, {

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -130,7 +130,7 @@ export class Encryptor {
       throw new Configuration("key and keyProvider can't be used simultaneously");
     }
     this.validatePayloadType(clearText);
-    const text = options?.deterministic ? this.forceEncodingIfNeeded(clearText) : clearText;
+    if (options?.deterministic) clearText = this.forceEncodingIfNeeded(clearText);
     // Resolve key provider: explicit keyProvider > raw key shortcut > default.
     // Raw key is wrapped in a minimal inline provider so buildEncryptedMessage
     // has a uniform interface (mirrors Rails' key_provider keyword arg).
@@ -143,7 +143,9 @@ export class Encryptor {
         : this.defaultKeyProvider());
     if (!keyProvider) throw new Configuration("No encryption key provided");
     const cipherOptions = { deterministic: options?.deterministic };
-    return this.serializeMessage(this.buildEncryptedMessage(text, { keyProvider, cipherOptions }));
+    return this.serializeMessage(
+      this.buildEncryptedMessage(clearText, { keyProvider, cipherOptions }),
+    );
   }
 
   decrypt(

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -34,9 +34,8 @@ export class KeyGenerator {
   }
 
   deriveKeyFrom(password: string, { length = this.keyLength() }: { length?: number } = {}): string {
-    const salt = this.keyDerivationSalt();
     const generator = new AsKeyGenerator(password, { hashDigestClass: this.hashDigestClass });
-    return generator.generateKey(salt, length).toString("base64");
+    return generator.generateKey(this.keyDerivationSalt(), length).toString("base64");
   }
 
   /** @internal */

--- a/packages/activerecord/src/support/schema-dumping-helper.ts
+++ b/packages/activerecord/src/support/schema-dumping-helper.ts
@@ -28,24 +28,24 @@ import { SchemaDumper } from "../connection-adapters/abstract/schema-dumper.js";
 export const FULL_DUMP_TIMEOUT_MS = 30_000;
 
 /**
- * Dump only the named `tables` from `source`, as a schema-DSL string.
+ * Dump only the named `tables` from `pool`, as a schema-DSL string.
  *
  * Mirrors `SchemaDumpingHelper#dump_table_schema(*tables)`: ignore every data
- * source except the requested ones, then run a full dump. The `source` doubles
- * as Rails' connection (it enumerates the data sources) and as the dump target.
+ * source except the requested ones, then run a full dump. Rails reads its
+ * `pool` off `ActiveRecord::Base.connection_pool`; trails takes it as the
+ * leading argument, and it doubles as Rails' `connection` (it enumerates the
+ * data sources) and as the dump target.
  */
-export async function dumpTableSchema(source: SchemaSource, ...tables: string[]): Promise<string> {
+export async function dumpTableSchema(pool: SchemaSource, ...tables: string[]): Promise<string> {
   const oldIgnoreTables = BaseSchemaDumper.ignoreTables;
   // Rails: `connection.data_sources - tables` (tables + views). Prefer the
   // adapter's `dataSources()` so views are also ignored; fall back to `tables()`
   // for a bare `SchemaSource` that only enumerates base tables.
-  const enumerated = source as { dataSources?: () => Promise<string[]> };
-  const dataSources = enumerated.dataSources
-    ? await enumerated.dataSources()
-    : await source.tables();
+  const enumerated = pool as { dataSources?: () => Promise<string[]> };
+  const dataSources = enumerated.dataSources ? await enumerated.dataSources() : await pool.tables();
   BaseSchemaDumper.ignoreTables = dataSources.filter((name) => !tables.includes(name));
   try {
-    return (await SchemaDumper.dump(source)).join("\n");
+    return (await SchemaDumper.dump(pool)).join("\n");
   } finally {
     BaseSchemaDumper.ignoreTables = oldIgnoreTables;
   }
@@ -57,13 +57,13 @@ export async function dumpTableSchema(source: SchemaSource, ...tables: string[])
  * Mirrors `SchemaDumpingHelper#dump_all_table_schema(ignore_tables = [])`.
  */
 export async function dumpAllTableSchema(
-  source: SchemaSource,
+  pool: SchemaSource,
   ignoreTables: (string | RegExp)[] = [],
 ): Promise<string> {
   const oldIgnoreTables = BaseSchemaDumper.ignoreTables;
   BaseSchemaDumper.ignoreTables = ignoreTables;
   try {
-    return (await SchemaDumper.dump(source)).join("\n");
+    return (await SchemaDumper.dump(pool)).join("\n");
   } finally {
     BaseSchemaDumper.ignoreTables = oldIgnoreTables;
   }

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -18,15 +18,15 @@ export class Function extends NodeExpression {
     this._alias = typeof value === "string" ? new SqlLiteral(value) : value;
   }
 
-  constructor(expressions: Node[], aliasNode: Node | string | null = null) {
+  constructor(expr: Node[], aliaz: Node | string | null = null) {
     super();
-    this.expressions = expressions;
-    this._alias = typeof aliasNode === "string" ? new SqlLiteral(aliasNode) : aliasNode;
+    this.expressions = expr;
+    this._alias = typeof aliaz === "string" ? new SqlLiteral(aliaz) : aliaz;
     this.distinct = false;
   }
 
-  as(aliasName: string): this {
-    this.alias = aliasName;
+  as(aliaz: string): this {
+    this.alias = aliaz;
     return this;
   }
 }

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -133,7 +133,7 @@ export class BaseLocator {
 
   /** @internal Mirrors: BaseLocator#find_records — batch find or where(pk: ids). */
   protected async findRecords(
-    klass: LocatorModel,
+    modelClass: LocatorModel,
     ids: unknown[],
     options: LocateOptions,
   ): Promise<unknown[]> {
@@ -141,12 +141,12 @@ export class BaseLocator {
     // form not yet supported by our AR layer. CPK + ignoreMissing falls
     // through to find(ids) (raises on missing) as a known limitation.
     //
-    // Use this.primaryKey(klass) as the single source of truth for the PK
+    // Use this.primaryKey(modelClass) as the single source of truth for the PK
     // shape — a subclass overriding primaryKey() must affect both the
     // composite-key gate AND the where() key consistently.
-    const pk = this.primaryKey(klass);
-    if (options.ignoreMissing && klass.where && !Array.isArray(pk)) {
-      const rel = klass.where({ [pk]: ids });
+    const pk = this.primaryKey(modelClass);
+    if (options.ignoreMissing && modelClass.where && !Array.isArray(pk)) {
+      const rel = modelClass.where({ [pk]: ids });
       if (!rel.toArray) {
         throw new Error(
           "LocatorModel.where() returned a relation without .toArray() — required for ignoreMissing.",
@@ -155,7 +155,7 @@ export class BaseLocator {
       const records = await rel.toArray();
       return Array.isArray(records) ? records : [];
     }
-    const result = await klass.find(ids);
+    const result = await modelClass.find(ids);
     return Array.isArray(result) ? result : [result];
   }
 
@@ -179,25 +179,25 @@ export class BaseLocator {
  */
 export class UnscopedLocator extends BaseLocator {
   async locate(gid: GlobalID, options: LocateOptions = {}): Promise<unknown | null> {
-    const klass = safeConstantize(gid.modelName) as LocatorModel | undefined;
-    return this.unscoped(klass, () => super.locate(gid, options));
+    const modelClass = safeConstantize(gid.modelName) as LocatorModel | undefined;
+    return this.unscoped(modelClass, () => super.locate(gid, options));
   }
 
   /** @internal */
   protected async findRecords(
-    klass: LocatorModel,
+    modelClass: LocatorModel,
     ids: unknown[],
     options: LocateOptions,
   ): Promise<unknown[]> {
-    return this.unscoped(klass, () => super.findRecords(klass, ids, options));
+    return this.unscoped(modelClass, () => super.findRecords(modelClass, ids, options));
   }
 
   /** @internal Mirrors: UnscopedLocator#unscoped. */
   protected unscoped<R>(
-    klass: LocatorModel | undefined,
+    modelClass: LocatorModel | undefined,
     block: () => R | Promise<R>,
   ): R | Promise<R> {
-    return klass?.unscoped ? klass.unscoped(block) : block();
+    return modelClass?.unscoped ? modelClass.unscoped(block) : block();
   }
 }
 


### PR DESCRIPTION
RFC 0096 wave 5, the `activerecord/encryption/**`, `activemodel/`, `arel/`,
`globalid/`, `activerecord-test-support/` slot. Every convergeable `naming`
call-argument row in that file set is now closed, and **no row was added to any
`call-mismatches-exclude/` shard**.

## Converged by rename (7 rows)

| file | Rails |
| --- | --- |
| `arel/nodes/function.ts` | `Function#initialize(expr, aliaz)` / `as(aliaz)` — `arel/nodes/function.rb:10,17` |
| `encryption/cipher/aes256-gcm.ts` | `encrypt` decodes into `clearText` itself instead of a separate `inputBuf` — `aes256_gcm.rb:34-46` |
| `encryption/encryptor.ts` | `encrypt` reassigns `clear_text` where Rails does — `encryptor.rb:49` |
| `encryption/key-generator.ts` | `derive_key_from` inlines `key_derivation_salt` into `generate_key` — `key_generator.rb:40` |
| `support/schema-dumping-helper.ts` (×2) | the leading argument is `pool`, the name `SchemaDumper.dump(pool)` uses — `test/support/schema_dumping_helper.rb:5,12` |
| `activemodel/serialization.ts` | `serializable_attributes` iterates `n` — `serialization.rb:175` |
| `globalid/locator.ts` | `find_records` / `unscoped` take `modelClass` — `global_id/locator.rb:192,217,221` |

## Closed with a `@missingRailsArgs` receipt (3 rows)

Genuine TypeScript shortcomings, each tagged at the call site with a `PERMANENT`
reason rather than baselined:

- `Attribute#valueForDatabase` — Rails passes the ivar `@value_for_database`
  (`attribute.rb:56`), whose trails spelling `_valueForDatabase` is already taken
  by the port of the `_value_for_database` method (`attribute.rb:207`). A TS class
  cannot carry a field and a method of the same name.
- `parse_as_number` — Rails passes `Kernel.Float(raw_value)`
  (`numericality.rb:82`); `Kernel` is a Ruby module, not a JS object, so the call
  can never present the `Float` identifier.
- `Aes256Gcm#encrypt` — Rails' first `generate_iv` argument is the live
  `OpenSSL::Cipher` (`aes256_gcm.rb:42`), passed only so it can call
  `cipher.random_iv`. Node's `createCipheriv` takes the IV as a constructor
  argument, so no cipher object exists yet and the slot carries `@deterministic`.
  The method's JSDoc already explained this; it now carries the matching receipt.

## Re-filed as a3 findings, not renamed away (2 rows)

Per the RFC's `## Design`, a row that is really an invented-helper/conversion
finding is filed rather than renamed. Both rows stand in the artifact until their
stories land:

- `0023-surfaced-deviations/attribute-set-deep-dup-invented-clone-helper` —
  `AttributeSet#deepDup` invents `cloneAttribute` + an identity cache and never
  ports `Attribute#deep_dup` (`attribute_set.rb:73-75`).
- `0023-surfaced-deviations/message-pack-serializer-load-buffer-conversion` —
  `MessagePackMessageSerializer#load` converts to `Buffer` at the call site; closing
  it means changing `ActiveSupport::MessagePack.load`'s signature, which this
  wave's "no public surface change" rule forbids.

## Filed alongside, not taken here

`Encryptor#encrypt` runs Rails' first two statements in the opposite order —
Rails forces the encoding then validates (`encryptor.rb:49-52`), trails validates
then forces. This wave forbids behaviour and control-flow changes, so the swap is
filed as
`0023-surfaced-deviations/encryptor-encrypt-validates-before-forcing-encoding`
rather than taken in a rename PR.

## Gates

- `pnpm parity:api:calls` — OK (423 baselined, 323 unreviewed, marks tight)
- `pnpm parity:api:calls:args` — OK (146 baselined shape rows)
- `pnpm parity:api:extra:gate` — OK (arel novel 0/0, total 63/63)
- Convergeable rows in this file set: 12 → 0 (population 255 → 247 burndown)
- `pnpm build`, `pnpm lint`, and the touched suites (activemodel serialization /
  attribute / numericality, arel function, globalid locator, all of
  `activerecord/src/encryption/` and `src/support/`, schema-dumper) are green.

## The other bundled story

`resolve-serialization-thenable-hash-async-return` is **not** in this PR — it is
now `blocked`, with its blocker filed as
`0023-surfaced-deviations/serializable-hash-async-return-boundary`.

Removing `thenableHash` / `asJsonThenable` means `serializableHash` and `asJson`
return `Promise` unconditionally, which is a cross-package async-boundary
decision (activemodel, activerecord, activesupport, actionview) that also has to
answer `JSON.stringify`'s synchronous `toJSON` contract. Per CLAUDE.md the story
cannot close by ratifying the deviation, and the alternative is bigger than a
bloat-burndown story — it needs its own decision the way RFC 0063 got one for
`isValid()`. The new story records the sync call sites so that work starts from
the reading already done here.

Closes-story: wave-5-naming-tail
