### PR TITLE
refactor(activesupport,activerecord): RFC 0096 wave 5 naming burndown (5-story bundle)

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -384,14 +384,14 @@ export class Association {
     }
     // Branches 3 + 4.
     const associationScope = this.associationScope();
-    const globalScope = klass.globalCurrentScope();
+    const scope = klass.globalCurrentScope();
     const targetScope = this.targetScope();
     const base =
       targetScope != null && typeof targetScope.mergeBang === "function"
         ? targetScope.mergeBang(associationScope)
         : associationScope;
-    if (globalScope) {
-      return typeof base?.mergeBang === "function" ? base.mergeBang(globalScope) : base;
+    if (scope) {
+      return typeof base?.mergeBang === "function" ? base.mergeBang(scope) : base;
     }
     return base;
   }
@@ -1029,11 +1029,11 @@ export class Association {
   protected targetScope(): any {
     const klass = this.klass as typeof Base | undefined;
     if (!klass) return null;
-    const sfa = (klass as any).scopeForAssociation?.() ?? null;
+    const scopeForAssociation = (klass as any).scopeForAssociation?.() ?? null;
     const arFactory = getAssociationRelationFactory();
-    if (!arFactory) return sfa;
+    if (!arFactory) return scopeForAssociation;
     const ar = arFactory(klass, this);
-    return sfa ? (ar as any).mergeBang(sfa) : ar;
+    return scopeForAssociation ? (ar as any).mergeBang(scopeForAssociation) : ar;
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -211,18 +211,24 @@ export class BelongsToAssociation extends SingularAssociation {
    * target is an unsaved new record.
    */
   isTargetChanged(): boolean {
-    const changed = this.foreignKeyNames().some((fk) => this.owner.attributeChanged(fk));
+    const changed = this.foreignKeyNames().some((foreignKey) =>
+      this.owner.attributeChanged(foreignKey),
+    );
     return (
       changed || (!this.foreignKeyPresent() && this.target != null && this.target.isNewRecord())
     );
   }
 
   isTargetPreviouslyChanged(): boolean {
-    return this.foreignKeyNames().some((fk) => this.owner.attributePreviouslyChanged(fk));
+    return this.foreignKeyNames().some((foreignKey) =>
+      this.owner.attributePreviouslyChanged(foreignKey),
+    );
   }
 
   isSavedChangeToTarget(): boolean {
-    return this.foreignKeyNames().some((fk) => this.owner.isSavedChangeToAttribute(fk));
+    return this.foreignKeyNames().some((foreignKey) =>
+      this.owner.isSavedChangeToAttribute(foreignKey),
+    );
   }
 
   // --- Protected ---
@@ -470,10 +476,11 @@ export class BelongsToAssociation extends SingularAssociation {
         const touch = (this.reflection.options as any).touch;
         await target.incrementBang(counterCol, by, touch != null ? { touch } : {});
       } else {
-        const foreignKey = this.foreignKeyNames().map((fk) =>
-          (this.owner as any)._readAttribute?.(fk),
+        await this.updateCountersViaScope(
+          this.klass,
+          this.foreignKeyNames().map((fk) => (this.owner as any)._readAttribute?.(fk)),
+          by,
         );
-        await this.updateCountersViaScope(this.klass, foreignKey, by);
       }
     }
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -80,18 +80,18 @@ export class CollectionAssociation extends Association {
    * inversing: true)` and a `nil` is a no-op — it cannot be removed from the
    * inverse.
    */
-  override set target(records: Base | Base[] | null) {
+  override set target(record: Base | Base[] | null) {
     if (!this.reflection.klass?.hasManyInversing) {
-      super.target = records;
+      super.target = record;
       return;
     }
 
-    if (records === null) {
+    if (record === null) {
       // It's not possible to remove the record from the inverse association.
-    } else if (Array.isArray(records)) {
-      super.target = records;
+    } else if (Array.isArray(record)) {
+      super.target = record;
     } else {
-      void this.replaceOnTarget(records, true, { replace: true, inversing: true });
+      void this.replaceOnTarget(record, true, { replace: true, inversing: true });
     }
   }
 

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -384,8 +384,9 @@ export class HasManyAssociation extends CollectionAssociation {
     if (reflection.hasActiveCachedCounter()) {
       // has_active_cached_counter? guarantees a counter column, but guard
       // against a null column anyway — `nil.to_i == 0` in Rails.
-      const column = reflection.counterCacheColumn();
-      count = column == null ? 0 : toI((this.owner as any).readAttribute(column));
+      const counterCacheColumn = reflection.counterCacheColumn();
+      count =
+        counterCacheColumn == null ? 0 : toI((this.owner as any).readAttribute(counterCacheColumn));
     } else {
       count = await (this as unknown as CollectionAssociation).scope().count("all");
     }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -189,14 +189,14 @@ export class JoinDependency {
    * (join_dependency.rb:71) — `(base, table, associations, join_type)`.
    */
   constructor(
-    baseModel: typeof Base,
+    base: typeof Base,
     table: Table | Nodes.TableAlias | null,
     associations: AssociationSpec | AssociationSpec[] | null,
     joinType: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin | null,
   ) {
-    this._baseModel = baseModel;
-    const baseTable = table ?? (baseModel as any).arelTable;
-    this._baseAlias = baseTable.name ?? (baseModel as any).tableName;
+    this._baseModel = base;
+    table ??= (base as any).arelTable;
+    this._baseAlias = String(table!.name ?? (base as any).tableName);
     this._aliasTracker = new AliasTracker(
       this._baseTableAliasLength(),
       new Map([[this._baseAlias, 1]]),
@@ -205,7 +205,7 @@ export class JoinDependency {
     // to construct each node's provisional join, so it is set first.
     this._joinType = joinType ?? Nodes.OuterJoin;
     const tree = JoinDependency.makeTree(associations ?? []);
-    this._joinRoot = new JoinBase(baseModel, baseTable, this.build(tree, baseModel));
+    this._joinRoot = new JoinBase(base, table as Table, this.build(tree, base));
     this._assignPaths(this._joinRoot, null);
   }
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -196,7 +196,7 @@ export class JoinDependency {
   ) {
     this._baseModel = base;
     table ??= (base as any).arelTable;
-    this._baseAlias = String(table!.name ?? (base as any).tableName);
+    this._baseAlias = (table as any).name ?? (base as any).tableName;
     this._aliasTracker = new AliasTracker(
       this._baseTableAliasLength(),
       new Map([[this._baseAlias, 1]]),

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1112,14 +1112,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * @missingRailsCall first — PERMANENT: RFC 0106: Ruby Set#first on `insert.keys`
    *   (abstract_mysql_adapter.rb:640). JS Set has no `first`; the port
-   *   destructures the iterator (`const [firstKey] = insert.keys`), which emits
+   *   destructures the iterator (`const [first] = insert.keys`), which emits
    *   no callee. The sibling `quote_column_name` call converged in the same
    *   pass.
    */
   override async buildInsertSql(insert: InsertBuilder): Promise<string> {
     // Can use any column as it will be assigned to itself.
-    const [firstKey] = insert.keys;
-    const noOpColumn = firstKey !== undefined ? this.quoteColumnName(firstKey) : undefined;
+    const [first] = insert.keys;
+    const noOpColumn = first !== undefined ? this.quoteColumnName(first) : undefined;
 
     // MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
     // then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -410,7 +410,7 @@ export class ConnectionHandler {
   /** @internal */
   private resolvePoolConfig(
     config: DatabaseConfig | string | Record<string, unknown>,
-    ownerName: ConnectionDescriptor | ConnectionOwner,
+    connectionName: ConnectionDescriptor | ConnectionOwner,
     role: string,
     shard: string,
   ): PoolConfig {
@@ -419,6 +419,6 @@ export class ConnectionHandler {
     if (!dbConfig.adapter) {
       throw new AdapterNotSpecified("database configuration does not specify adapter");
     }
-    return new PoolConfig(ownerName, dbConfig, role, shard);
+    return new PoolConfig(connectionName, dbConfig, role, shard);
   }
 }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1734,8 +1734,8 @@ export class Table {
     return this._schema.indexExists(this.name, columnName, options);
   }
 
-  async renameIndex(oldName: string, newName: string): Promise<void> {
-    return this._schema.renameIndex(this.name, oldName, newName);
+  async renameIndex(indexName: string, newIndexName: string): Promise<void> {
+    return this._schema.renameIndex(this.name, indexName, newIndexName);
   }
 
   async change(columnName: string, type: ColumnType, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -257,24 +257,24 @@ export class TableDefinition extends AbstractTableDefinition {
     // postgresql/schema_definitions.rb:265-268 — this is where a constraint
     // declared inside `create_table` gets its generated name and its
     // `deferrable` validation, not just the `add_exclusion_constraint` path.
-    const opts = (this._adapter as unknown as PgConstraintOptionsConn).exclusionConstraintOptions(
+    options = (this._adapter as unknown as PgConstraintOptionsConn).exclusionConstraintOptions(
       this.name,
       expression,
       options as Record<string, unknown>,
     ) as ExclusionConstraintOptions;
-    return new ExclusionConstraintDefinition(this.name, expression, opts);
+    return new ExclusionConstraintDefinition(this.name, expression, options);
   }
 
   newUniqueConstraintDefinition(
     columnName: string | string[],
     options: UniqueConstraintOptions = {},
   ): UniqueConstraintDefinition {
-    const opts = (this._adapter as unknown as PgConstraintOptionsConn).uniqueConstraintOptions(
+    options = (this._adapter as unknown as PgConstraintOptionsConn).uniqueConstraintOptions(
       this.name,
       columnName,
       options as Record<string, unknown>,
     ) as UniqueConstraintOptions;
-    return new UniqueConstraintDefinition(this.name, columnName, opts);
+    return new UniqueConstraintDefinition(this.name, columnName, options);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -140,7 +140,7 @@ export function quotedTime(value: QuotedTimeValue): string {
   if (value instanceof TimeValue) {
     value = value.getobj().toZonedDateTimeISO(defaultSqlTimezone()).toPlainDateTime();
   }
-  const dt =
+  value =
     value instanceof Temporal.PlainTime
       ? new Temporal.PlainDateTime(
           2000,
@@ -154,7 +154,7 @@ export function quotedTime(value: QuotedTimeValue): string {
           value.nanosecond,
         )
       : value.with({ year: 2000, month: 1, day: 1 });
-  return quotedDate(dt).replace(/^\d{4}-\d{2}-\d{2} /, "2000-01-01 ");
+  return quotedDate(value).replace(/^\d{4}-\d{2}-\d{2} /, "2000-01-01 ");
 }
 
 export function quotedBinary(value: Uint8Array | ArrayBuffer | BinaryData): string {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -302,7 +302,7 @@ export class DatabaseConfigurations {
    */
   private buildConfigs(
     configs: RawConfigurations | DatabaseConfig[],
-    currentEnv: string = DatabaseConfigurations.defaultEnv,
+    defaultEnv: string = DatabaseConfigurations.defaultEnv,
   ): DatabaseConfig[] {
     if (Array.isArray(configs)) return configs;
 
@@ -317,15 +317,15 @@ export class DatabaseConfigurations {
     );
 
     // `unless db_configs.find(&:for_current_env?)` (database_configurations.rb:212).
-    // `currentEnv` stands in for Rails' `default_env` so `fromEnv` can build under
-    // the env the runtime selectors actually look configs up by.
-    if (!dbConfigs.some((c) => c.envName === currentEnv)) {
-      const urlConfig = this.environmentUrlConfig(currentEnv, "primary", {});
+    // Rails' `default_env` is supplied by the caller here so `fromEnv` can build
+    // under the env the runtime selectors actually look configs up by.
+    if (!dbConfigs.some((c) => c.envName === defaultEnv)) {
+      const urlConfig = this.environmentUrlConfig(defaultEnv, "primary", {});
       if (urlConfig) dbConfigs.push(urlConfig);
     }
 
     return this.mergeDbEnvironmentVariables(
-      currentEnv,
+      defaultEnv,
       dbConfigs.filter((c) => c != null),
     );
   }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -303,8 +303,11 @@ export class EnumType extends ValueType<string> {
   // maps to its stored value, anything else passes through the subtype's cast
   // (so e.g. the string "true" type-casts to boolean `true` for a query).
   serialize(value: unknown): number | string | boolean | null {
-    const mapped = this._mapping.fetch(value as string, value as EnumValue);
-    return this._subtypeType.serialize(mapped) as number | string | boolean | null;
+    return this._subtypeType.serialize(this._mapping.fetch(value as string, value as EnumValue)) as
+      | number
+      | string
+      | boolean
+      | null;
   }
 
   // The in-memory value is the label string; the database value is the mapped
@@ -318,8 +321,10 @@ export class EnumType extends ValueType<string> {
 
   // Mirrors Rails: `subtype.serializable?(mapping.fetch(value, value))`.
   isSerializable(value: unknown, block?: (castValue: unknown) => void): boolean {
-    const mapped = this._mapping.fetch(value as string, value as EnumValue);
-    return this._subtypeType.isSerializable(mapped, block);
+    return this._subtypeType.isSerializable(
+      this._mapping.fetch(value as string, value as EnumValue),
+      block,
+    );
   }
 
   assertValidValue(value: unknown): void {

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -421,8 +421,7 @@ export class InsertAll {
 
   /** @internal */
   private resolveAttributeAliases(): void {
-    const firstInsert = first(this.inserts);
-    if (!firstInsert || !this.hasAttributeAliases(firstInsert)) return;
+    if (!this.hasAttributeAliases(first(this.inserts) ?? {})) return;
     this.inserts = this.inserts.map((insert) => {
       const resolved: Record<string, unknown> = {};
       for (const [attribute, val] of Object.entries(insert)) {

--- a/packages/activerecord/src/integration.ts
+++ b/packages/activerecord/src/integration.ts
@@ -36,8 +36,8 @@ type TemporalTimestamp = Temporal.Instant;
 export function toParam(this: Identifiable): string | null {
   const pk = this.id;
   if (pk == null) return null;
-  const delimiter: string = (this.constructor as any).paramDelimiter ?? "_";
-  return Array.isArray(pk) ? pk.join(delimiter) : String(pk);
+  const paramDelimiter: string = (this.constructor as any).paramDelimiter ?? "_";
+  return Array.isArray(pk) ? pk.join(paramDelimiter) : String(pk);
 }
 
 /**
@@ -115,14 +115,14 @@ export function cacheVersion(this: Identifiable): string | null {
     // type-casting reader. Only user-assigned values fall through to the
     // alias-aware reader (so models aliasing updated_at to a real column
     // still resolve their cache version).
-    const raw = this.readAttributeBeforeTypeCast("updated_at");
-    if (canUseFastCacheVersion(this, raw)) {
-      return rawTimestampToCacheVersion(raw as string);
+    let timestamp = this.readAttributeBeforeTypeCast("updated_at");
+    if (canUseFastCacheVersion(this, timestamp)) {
+      return rawTimestampToCacheVersion(timestamp as string);
     }
-    const val = this.readAttribute("updated_at");
-    if (val instanceof Temporal.Instant) {
+    timestamp = this.readAttribute("updated_at");
+    if (timestamp instanceof Temporal.Instant) {
       const cacheTimestampFormat: string = klass.cacheTimestampFormat ?? "usec";
-      return toFs(val, cacheTimestampFormat);
+      return toFs(timestamp, cacheTimestampFormat);
     }
     return null;
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2170,11 +2170,12 @@ export class MigrationContext<
     const fileList = this.migrationFiles().map((file) => {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) throw new IllegalMigrationNameError(file);
-      const [rawVersion, name, scope] = parsed;
-      if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(rawVersion)) {
-        throw new InvalidMigrationTimestampError(rawVersion, name);
+      const [, name, scope] = parsed;
+      let version = parsed[0];
+      if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
+        throw new InvalidMigrationTimestampError(version, name);
       }
-      const version = SchemaMigration.normalizeMigrationNumber(rawVersion);
+      version = SchemaMigration.normalizeMigrationNumber(version);
       const status = dbList.delete(version) ? ("up" as const) : ("down" as const);
       return { status, version, name: humanize(name + scope) };
     });
@@ -2284,12 +2285,14 @@ export class MigrationContext<
     const migrations = this.migrationFiles().map((file) => {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) throw new IllegalMigrationNameError(file);
-      const [rawVersion, rawName, scope] = parsed;
-      if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(rawVersion)) {
-        throw new InvalidMigrationTimestampError(rawVersion, rawName);
+      const scope = parsed[2];
+      let version: string | number = parsed[0];
+      let name = parsed[1];
+      if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
+        throw new InvalidMigrationTimestampError(version, name);
       }
-      const version = toInteger(rawVersion);
-      const name = camelize(rawName);
+      version = toInteger(version);
+      name = camelize(name);
       let loaded: Promise<Migration> | undefined;
       return {
         version,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2170,8 +2170,9 @@ export class MigrationContext<
     const fileList = this.migrationFiles().map((file) => {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) throw new IllegalMigrationNameError(file);
-      const [, name, scope] = parsed;
       let version = parsed[0];
+      const name = parsed[1];
+      const scope = parsed[2];
       if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
         throw new InvalidMigrationTimestampError(version, name);
       }
@@ -2285,9 +2286,9 @@ export class MigrationContext<
     const migrations = this.migrationFiles().map((file) => {
       const parsed = this.parseMigrationFilename(file);
       if (!parsed) throw new IllegalMigrationNameError(file);
-      const scope = parsed[2];
       let version: string | number = parsed[0];
       let name = parsed[1];
+      const scope = parsed[2];
       if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
         throw new InvalidMigrationTimestampError(version, name);
       }

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -313,20 +313,19 @@ export class HashMerger {
   }
 
   merge(): any {
-    return new Merger(this.relation, this.buildOther()).merge();
+    return new Merger(this.relation, this.other()).merge();
   }
 
   // Rails `HashMerger#other`: build a fresh relation and apply each hash value
   // to it via `public_send("#{k}!", *v)` so where-value interpolation etc.
   // happens on the built relation rather than by directly merging raw values.
-  private buildOther(): any {
+  private other(): any {
     // `Relation.create(relation.model, table:, predicate_builder:)`
-    // (merger.rb:26-30) — trails' constructor takes the same three.
-    const other: any = new Relation(
-      this.relation.model,
-      this.relation.table,
-      this.relation.predicateBuilder,
-    );
+    // (merger.rb:26-30).
+    const other: any = Relation.create(this.relation.model, {
+      table: this.relation.table,
+      predicateBuilder: this.relation.predicateBuilder,
+    });
     for (const [key, value] of Object.entries(this.hash)) {
       // `select` dispatches to `_select!` (Rails renames `:select` → `:_select`
       // to avoid Enumerable#select!); trails mirrors this with `_selectBang`.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2806,25 +2806,25 @@ export function arelColumn(
   // default through as the literal it sums over, and `async_sum`'s nil one
   // (calculations.rb:182) as `""`, the empty `SUM()`.
   const isSymbol = isRubySymbol(field);
-  let fieldStr = isSymbol ? symbolToName(field) : field == null ? "" : String(field);
-  fieldStr = modelClass?.attributeAliases?.[fieldStr] ?? fieldStr;
+  field = isSymbol ? symbolToName(field as string) : field == null ? "" : String(field);
+  field = (modelClass?.attributeAliases?.[field] as string | undefined) ?? field;
 
   const fromClause = (this as any).fromClause;
   const from = fromClause?.name || fromClause?.value;
 
-  if (modelClass?.columnsHash?.()[fieldStr] && (!from || isTableNameMatches.call(this, from))) {
+  if (modelClass?.columnsHash?.()[field] && (!from || isTableNameMatches.call(this, from))) {
     const table: any = this.table;
-    return table.get(fieldStr);
+    return table.get(field);
   }
-  const dotMatch = fieldStr.match(/^(?<table>(?:\w+\.)?\w+)\.(?<column>\w+)$/);
+  const dotMatch = field.match(/^(?<table>(?:\w+\.)?\w+)\.(?<column>\w+)$/);
   if (dotMatch) {
     return arelColumnWithTable.call(this, dotMatch.groups!.table, dotMatch.groups!.column);
   }
-  if (fallback) return fallback(fieldStr);
+  if (fallback) return fallback(field);
   // Ruby `Arel.sql(is_symbol ? quote_table_name(field) : field)`
   // (query_methods.rb:2005): a Symbol names a column and is quoted; a String is
   // raw SQL and is not.
-  const quoted = isSymbol ? connectionFor(modelClass).quoteTableName(fieldStr) : fieldStr;
+  const quoted = isSymbol ? connectionFor(modelClass).quoteTableName(field) : field;
   return Arel.sql(quoted);
 }
 

--- a/packages/activerecord/src/statement-cache.ts
+++ b/packages/activerecord/src/statement-cache.ts
@@ -211,10 +211,12 @@ export class StatementCache {
     const relation = callable(new Params());
     const arel = typeof relation.arel === "function" ? relation.arel() : relation.arel;
 
-    const [queryBuilder, binds] = connection.cacheableQuery(StatementCache, arel) as [
+    const cacheableQuery = connection.cacheableQuery(StatementCache, arel) as [
       Query | PartialQuery,
       unknown[],
     ];
+    const queryBuilder = cacheableQuery[0];
+    let binds = cacheableQuery[1];
 
     // The prepared path (the Composite collector) already unwraps each collected
     // BindParam to its `.value`; the unprepared PartialQueryCollector path
@@ -222,8 +224,8 @@ export class StatementCache {
     // bound attributes/Substitutes directly — otherwise a concrete bind (e.g.
     // the LIMIT added by find/find_by) reaches the adapter's quote() as a raw
     // BindParam ("can't quote BindParam").
-    const normalizedBinds = binds.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
-    const bindMap = new BindMap(normalizedBinds);
+    binds = binds.map((b) => (b instanceof Nodes.BindParam ? b.value : b));
+    const bindMap = new BindMap(binds);
     return new StatementCache(queryBuilder, bindMap, relation.model);
   }
 

--- a/packages/activerecord/src/validations/absence.ts
+++ b/packages/activerecord/src/validations/absence.ts
@@ -9,10 +9,9 @@ import { AbsenceValidator as BaseAbsenceValidator } from "@blazetrails/activemod
 import { wrap } from "@blazetrails/activesupport";
 
 export class AbsenceValidator extends BaseAbsenceValidator {
-  validateEach(record: any, attribute: string, value: unknown): void {
-    let associationOrValue = value;
+  validateEach(record: any, attribute: string, associationOrValue: unknown): void {
     if (record.constructor._reflectOnAssociation?.(attribute)) {
-      associationOrValue = wrap(value).filter(
+      associationOrValue = wrap(associationOrValue).filter(
         (v: any) => !(typeof v?.markedForDestruction === "function" && v.markedForDestruction()),
       );
     }

--- a/packages/activerecord/src/validations/presence.ts
+++ b/packages/activerecord/src/validations/presence.ts
@@ -9,10 +9,9 @@ import { PresenceValidator as BasePresenceValidator } from "@blazetrails/activem
 import { wrap } from "@blazetrails/activesupport";
 
 export class PresenceValidator extends BasePresenceValidator {
-  validateEach(record: any, attribute: string, value: unknown): void {
-    let associationOrValue = value;
+  validateEach(record: any, attribute: string, associationOrValue: unknown): void {
     if (record.constructor._reflectOnAssociation?.(attribute)) {
-      associationOrValue = wrap(value).filter(
+      associationOrValue = wrap(associationOrValue).filter(
         (v: any) => !(typeof v?.markedForDestruction === "function" && v.markedForDestruction()),
       );
     }

--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -363,17 +363,15 @@ export class FileStore extends Store implements CacheStore {
     amount = Integer(amount);
 
     return this.lockFile(key, () => {
-      const entry = this.readEntry(key, options);
+      let entry = this.readEntry(key, options);
 
       if (!entry || entry.isExpired() || entry.isMismatched(version)) {
         this.write(name, amount, options);
         return amount;
       } else {
         const num = toI(entry.value) + amount;
-        this.writeEntry(
-          key,
-          new Entry(num, { expiresAt: entry.expiresAt, version: entry.version }),
-        );
+        entry = new Entry(num, { expiresAt: entry.expiresAt, version: entry.version });
+        this.writeEntry(key, entry);
         return num;
       }
     });

--- a/packages/activesupport/src/encrypted-file.ts
+++ b/packages/activesupport/src/encrypted-file.ts
@@ -121,8 +121,7 @@ export class EncryptedFile {
     const fs = await getFsAsync();
     const path = await this.resolveContentPath();
     if (key !== null && (await fs.exists(path))) {
-      const raw = (await fs.readFile!(path, "utf8")).trim();
-      return this.decrypt(raw);
+      return this.decrypt((await fs.readFile!(path, "utf8")).trim());
     }
     throw new MissingContentError(path);
   }

--- a/packages/activesupport/src/hash-with-indifferent-access.ts
+++ b/packages/activesupport/src/hash-with-indifferent-access.ts
@@ -343,12 +343,12 @@ export class HashWithIndifferentAccess<V = unknown> {
     if (otherHash instanceof HashWithIndifferentAccess) {
       this.regularUpdate(otherHash, block);
     } else {
-      for (const [key, value] of Object.entries(otherHash)) {
-        let v = value as V;
+      for (const [key, given] of Object.entries(otherHash) as [string, V][]) {
+        let value = given;
         if (block && this.key(key)) {
-          v = block(this.convertKey(key), this.get(key)!, v);
+          value = block(this.convertKey(key), this.get(key)!, value);
         }
-        this.regularWriter(this.convertKey(key), this.convertValue(v));
+        this.regularWriter(this.convertKey(key), this.convertValue(value));
       }
     }
   }

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -13,19 +13,19 @@ function applyInflections(
   rules: { rule: RegExp; replacement: string }[],
   locale = "en",
 ): string {
-  if (!word || word.length === 0) return word;
+  let result = word;
 
-  if (inflections(locale).uncountables.isUncountable(word)) {
-    return word;
-  }
-
-  for (const { rule, replacement } of rules) {
-    if (rule.test(word)) {
-      return word.replace(rule, replacement);
+  if (word.length === 0 || inflections(locale).uncountables.isUncountable(result)) {
+    return result;
+  } else {
+    for (const { rule, replacement } of rules) {
+      if (rule.test(result)) {
+        result = result.replace(rule, replacement);
+        break;
+      }
     }
+    return result;
   }
-
-  return word;
 }
 
 export function pluralize(word: string, locale = "en"): string {
@@ -171,9 +171,8 @@ export function tableize(className: string): string {
 }
 
 export function classify(tableName: string): string {
-  // Strip leading schema name: "schema.table" -> "table"
-  const stripped = tableName.replace(/.*\./, "");
-  return camelize(singularize(stripped));
+  // strip out any leading schema name
+  return camelize(singularize(tableName.replace(/.*\./, "")));
 }
 
 export function dasherize(underscoredWord: string): string {

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -172,7 +172,7 @@ export function tableize(className: string): string {
 
 export function classify(tableName: string): string {
   // strip out any leading schema name
-  return camelize(singularize(tableName.replace(/.*\./, "")));
+  return camelize(singularize(String(tableName).replace(/.*\./, "")));
 }
 
 export function dasherize(underscoredWord: string): string {

--- a/packages/activesupport/src/subscriber.ts
+++ b/packages/activesupport/src/subscriber.ts
@@ -154,14 +154,13 @@ export class Subscriber {
 
   private static _addEventSubscriber(event: string, state: ClassState): void {
     if (this._invalidEvent(event)) return;
-    const sub = state.subscriber!;
+    const subscriber = state.subscriber!;
     const notifier = state.notifier!;
     const pattern = `${event}.${state.namespace}`;
 
-    if (sub.patterns.has(pattern)) return;
+    if (subscriber.patterns.has(pattern)) return;
 
-    const handle = notifier.subscribe(pattern, sub);
-    sub.patterns.set(pattern, handle);
+    subscriber.patterns.set(pattern, notifier.subscribe(pattern, subscriber));
   }
 
   private static _removeEventSubscriber(event: string, state: ClassState): void {

--- a/packages/activesupport/src/time-zone-config.ts
+++ b/packages/activesupport/src/time-zone-config.ts
@@ -33,8 +33,8 @@ export function zone(): TimeZone | null {
  * Mirrors `IsolatedExecutionState[:time_zone] = find_zone!(time_zone)`
  * (zones.rb:41-43).
  */
-export function setZone(zone: TimeZone | string | number | Duration | null | false): void {
-  _zone = findZoneBang(zone);
+export function setZone(timeZone: TimeZone | string | number | Duration | null | false): void {
+  _zone = findZoneBang(timeZone);
 }
 
 /**
@@ -53,8 +53,8 @@ export function setZoneDefault(zone: TimeZone | null): void {
  * Matches Rails' Time.use_zone. Only supports synchronous callbacks — async
  * callbacks would observe the wrong zone after the first await.
  */
-export function useZone<T>(zone: string | TimeZone, fn: () => T): T {
-  const newZone = findZoneBang(zone);
+export function useZone<T>(timeZone: string | TimeZone, fn: () => T): T {
+  const newZone = findZoneBang(timeZone);
   const prev = _zone;
   _zone = newZone;
   try {
@@ -76,9 +76,9 @@ export function useZone<T>(zone: string | TimeZone, fn: () => T): T {
  * implementation, the bang form, with the ArgumentError swallowed
  * (core_ext/time/zones.rb:97-99).
  */
-export function findZone(zone: unknown): TimeZone | null | false {
+export function findZone(timeZone: unknown): TimeZone | null | false {
   try {
-    return findZoneBang(zone);
+    return findZoneBang(timeZone);
   } catch (e) {
     if (e instanceof ArgumentError) return null;
     throw e;
@@ -92,11 +92,11 @@ export function findZone(zone: unknown): TimeZone | null | false {
  * lookup, the Numeric/Duration offset scan, and the wrong-class raise
  * (time_zone.rb:249) — lives in `TimeZone.find`, the port of `[]`.
  */
-export function findZoneBang(zone: unknown): TimeZone | null | false {
-  if (zone === null || zone === undefined) return null;
-  if (zone === false) return false;
-  const found = TimeZone.find(zone);
-  if (found == null) throw new ArgumentError(`Invalid Timezone: ${String(zone)}`);
+export function findZoneBang(timeZone: unknown): TimeZone | null | false {
+  if (timeZone === null || timeZone === undefined) return null;
+  if (timeZone === false) return false;
+  const found = TimeZone.find(timeZone);
+  if (found == null) throw new ArgumentError(`Invalid Timezone: ${String(timeZone)}`);
   return found;
 }
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1100,8 +1100,8 @@ export class TimeZone {
    * memoizes (time_with_zone.rb:72-74) and reads `dst?` /
    * `observed_utc_offset` / `abbreviation` off.
    */
-  periodForUtc(date: Date | Temporal.Instant): TimezonePeriod {
-    return this.tzinfo.periodForUtc(date);
+  periodForUtc(time: Date | Temporal.Instant): TimezonePeriod {
+    return this.tzinfo.periodForUtc(time);
   }
 
   /**

--- a/scripts/api-compare/naming-taxonomy.ts
+++ b/scripts/api-compare/naming-taxonomy.ts
@@ -163,6 +163,7 @@ export const JS_RESERVED_WORDS = new Set(
 export const NO_JS_EQUIVALENT: Record<string, string[]> = {
   class: ["constructor"],
   compact: ["filter"],
+  detect: ["find"],
   first: ["at"],
   gsub: ["replaceAll", "replace"],
   httpdate: ["toUTCString"],
@@ -174,9 +175,11 @@ export const NO_JS_EQUIVALENT: Record<string, string[]> = {
   read: ["readFile"],
   size: ["length"],
   strip: ["trim"],
+  sub: ["replace"],
   to_f: ["parseFloat", "Number"],
   to_i: ["parseInt", "Number"],
   to_s: ["toString", "String"],
+  unicode_normalize: ["normalize"],
 };
 
 /**


### PR DESCRIPTION
> **This PR closes a five-story bundle, not just `wave-5-naming-activesupport`.**
> The five wave-5 slots were scheduled as one bundle to one worker, and their
> file sets are disjoint by construction — wave 5 split RFC 0096's remaining
> 107 convergeable rows into six non-overlapping file sets precisely so they
> could be worked without collision. The `activerecord/` files in this diff are
> the file sets of the other four stories, each named in its own
> `Closes-story:` trailer below:
>
> | Story | File set |
> |---|---|
> | `wave-5-naming-activesupport` | `activesupport/` only |
> | `wave-5-naming-ar-model-core` | `activerecord/` top level, `validations/`, `middleware/` |
> | `wave-5-naming-ar-adapters` | `activerecord/connection-adapters/**` |
> | `wave-5-naming-ar-associations` | `activerecord/associations/**` |
> | `wave-5-naming-ar-relation` | `activerecord/relation*`, `scoping/`, `statement-cache.ts` |
>
> Every file touched here falls in exactly one of those five sets. The one
> file outside all of them is `scripts/api-compare/naming-taxonomy.ts`, the
> gate's own classifier — see **Taxonomy** below.

RFC 0096 wave 5: renames body-local identifiers to the Rails ones across the
six wave-5 file sets, and inlines the expressions Rails inlines. The
call-argument `naming` population inside the AR require closure drops from
**267 convergeable rows to 226** (41 converged); no row is added to any
`call-mismatches-exclude/` shard.

Every change is locals and parameters only (plus two private-method renames to
the Rails name: `HashMerger#buildOther` -> `#other`). No public surface, method
name, field name, or behaviour change.

### Converged

- **activesupport** — `time-zone-config` `zone` -> `timeZone`
  (`core_ext/time/zones.rb:41,61,81,93`); `hash-with-indifferent-access` `v` ->
  `value` (`hash_with_indifferent_access.rb:424-434`); `inflector`
  `apply_inflections` rebuilt on Rails' `result` local and `classify` inlined
  onto `table_name.sub` (`inflector/methods.rb:218-221,270-279`); `subscriber`
  `sub` -> `subscriber`; `cache/file-store#modify_value` rebinds `entry`
  (`file_store.rb:226-244`); `encrypted-file#read` inlines the `strip`;
  `values/time-zone#period_for_utc` `date` -> `time` (`time_zone.rb:555`).
- **AR model core** — `migration` `rawVersion`/`rawName` -> Rails' rebound
  `version`/`name` (`migration.rb:1303-1313,1330-1343`); `integration`
  `delimiter` -> `paramDelimiter`, `raw` -> `timestamp`
  (`integration.rb:56-59,97-110`); `database-configurations` `currentEnv` ->
  `defaultEnv` (`database_configurations.rb:205-217`); `enum#serialize` /
  `#serializable?` inline the `mapping.fetch` (`enum.rb:264-270`);
  `insert-all` inlines `@inserts.first`; `validations/absence` + `/presence`
  `value` -> `associationOrValue`.
- **adapters** — `connection-handler` `ownerName` -> `connectionName`
  (`abstract/connection_handler.rb:275-280`); `abstract/schema-definitions#renameIndex`
  -> `indexName`/`newIndexName` (`:777-779`); `postgresql/schema-definitions`
  `opts` -> Rails' rebound `options` (`:265-273`); `sqlite3/quoting#quoted_time`
  rebinds `value`; `abstract-mysql-adapter` `firstKey` -> `first` (`:640`).
- **associations** — `belongs-to-association` `fk` -> `foreignKey` in the three
  target-changed predicates, plus the inlined `update_counters_via_scope` read
  (`belongs_to_association.rb:16-26,73-81`); `association` `globalScope` ->
  `scope`, `sfa` -> `scopeForAssociation` (`association.rb:107-117,312-314`);
  `collection-association#target=` `records` -> `record`;
  `has-many-association` `column` -> `counterCacheColumn`; `join-dependency`
  ctor `baseModel`/`baseTable` -> `base`/`table` (`join_dependency.rb:71-75`).
- **relation** — `query-methods#arel_column` rebinds `field`
  (`query_methods.rb:1990-2006`); `merger` `buildOther` -> `other`, now built
  through `Relation.create` as Rails does (`merger.rb:26-30`);
  `statement-cache#create` rebinds `binds`.

### Taxonomy

`naming-taxonomy.ts` gains three `NO_JS_EQUIVALENT` pairs whose TS spelling is
the JS builtin doing the same work, matching the existing `inject`/`reduce` and
`gsub`/`replace` entries: `detect`/`find` (Ruby's own alias for
`Enumerable#detect`), `sub`/`replace`, and `unicode_normalize`/`normalize`.

### Left standing and re-filed

Rows in these file sets that are really a1 (argument order) or a3 (invented
helper / conversion) findings are **not** renamed away, per the RFC's
`## Design`. They are re-filed as
`0096-naming-identifier-burndown/wave-5-residual-arg-shape-findings`, with the
Rails `file:line` for each. That story also records one behaviour gap the read
surfaced: `abstract/query-cache#compute_if_absent` is missing Rails' LRU touch
(`@map.delete(key)` then re-insert) and `@map.shift` eviction.

### One semantic change, and why

`HashMerger#buildOther` -> `#other` made the method match Rails by name, which
put it into the call-set population and immediately turned `parity:api:calls`
red: the body built its relation with `new Relation(...)` where `merger.rb:26-30`
calls `Relation.create`. Per CLAUDE.md the fix is to make the body call what
Rails calls, not to baseline the row, so it now goes through `Relation.create`
(which is also what resolves the per-model delegate class and the scope proxy,
as Rails' does). The whole `packages/activerecord/src/relation/` and
`.../associations/` suites are green on it.

### Verification

- `pnpm build`, `pnpm typecheck`, `pnpm lint` green.
- `pnpm parity:api:calls` OK (423 baselined, 323 unreviewed — unchanged).
- `pnpm parity:api:calls:args` OK (146 baselined shape rows — unchanged).
- `pnpm parity:api:extra:gate` OK (arel novel 0/0, total 63/63).
- `pnpm parity:api` totals unchanged (AR closure 9003/9006, files 517/521).
- Tests: `packages/activerecord/src/{relation,associations,validations,connection-adapters,migration}`,
  `statement-cache`, `enum`, `integration`, `insert-all`,
  `database-configurations`, `migration`, plus the touched activesupport files
  and `scripts/api-compare` + `scripts/parity` — all green locally.

Closes-story: wave-5-naming-activesupport
Closes-story: wave-5-naming-ar-model-core
Closes-story: wave-5-naming-ar-adapters
Closes-story: wave-5-naming-ar-associations
Closes-story: wave-5-naming-ar-relation

