### PR TITLE
fix(activerecord): loadAsync sets loaded so the loaded? readers drain the future

### DIFF
--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -214,6 +214,32 @@ describe("Relation#load_async", () => {
     expect(relation.isLoaded).toBe(true);
   });
 
+  it("drains the scheduled query from the loaded? readers", async () => {
+    // relation.rb:1149 — `load_async` sets `@loaded` alongside `@future_result`,
+    // so `size` (relation.rb:353-359), `empty?` (:362-370), `one?` (:399-405)
+    // and `many?` all take their `loaded?` arm, reach `records` -> `load`, and
+    // drain the parked future through `!loaded? || scheduled?` (:1180) rather
+    // than issuing a COUNT/EXISTS of their own.
+    await Topic.create({ title: "sole async topic", author_name: "David" });
+
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    const relation = Topic.where({ title: "sole async topic" }).loadAsync();
+    expect(relation.isLoaded).toBe(true);
+    expect(relation.isScheduled).toBe(true);
+
+    expect(await relation.size()).toBe(1);
+    expect(await relation.isEmpty()).toBe(false);
+    expect(await relation.isOne()).toBe(true);
+    expect(await relation.isMany()).toBe(false);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(relation.isScheduled).toBe(false);
+  });
+
   it("runs the query in the foreground when no executor is configured", async () => {
     restoreExecutor?.();
     restoreExecutor = undefined;

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -584,7 +584,12 @@ export class Relation<T extends Base> {
     // AssociationRelation distinction (three distinct Rails classes) while
     // rendering each one's namespace-qualified Rails constant path.
     const className = (this.constructor as typeof Relation)._railsClassName;
-    if (this.isLoaded) {
+    // `scheduled?` is excluded from Rails' plain `loaded?` (relation.rb:1149
+    // leaves both true at once) because this reader is synchronous: the rows
+    // sit unresolved in `@future_result` and JS cannot block to drain them, so
+    // a scheduled relation renders through the elided arm below rather than
+    // claiming it loaded to zero records.
+    if (this.isLoaded && !this.isScheduled) {
       const max = takeLimit(this.limitValue);
       const entries = this._records.slice(0, max).map((record) => record.inspect());
       if (entries.length === 11) entries[10] = "...";
@@ -728,13 +733,11 @@ export class Relation<T extends Base> {
     // (relation.rb:1138-1154). Both of those reads need the connection that
     // will run the query, so trails makes them where it is in hand — in
     // `execMainQuery` — and marks the load async here.
-    if (!this.isLoaded && !this._futureResult) {
-      // Rails' `unless loaded?` (relation.rb:1141). trails also guards on the
-      // parked handle so a second `loadAsync()` joins the scheduled query
-      // rather than issuing another one; Rails cannot reach that state because
-      // its `load_async` sets `@loaded` in the same breath (relation.rb:1149),
-      // which trails leaves to `toArray`, whose own `loaded?` guard is what
-      // that assignment exists to satisfy.
+    if (!this.isLoaded) {
+      // Rails' `unless loaded?` (relation.rb:1141) — a second `loadAsync()`
+      // joins the scheduled query rather than issuing another one, because
+      // `@loaded` goes true in the same breath the handle is parked
+      // (relation.rb:1149).
       const result = this.execMainQuery(true);
       // relation.rb:1145-1146 `if result.is_a?(Array) then @records = result` —
       // the contradiction arm hands back rows rather than a handle
@@ -752,6 +755,13 @@ export class Relation<T extends Base> {
         if (result instanceof Promise) void result.catch(() => {});
         this._futureResult = result;
       }
+      // relation.rb:1149 `@loaded = true`. This is what makes the `loaded?`
+      // readers (`size`, `empty?`, `one?`, `many?`) reach `records` -> `load`,
+      // whose `!loaded? || scheduled?` guard (relation.rb:1180) drains the
+      // parked future instead of issuing a second query. The `Result` arm above
+      // already set it through `loadRecords`, as Rails' `@records = result` arm
+      // is followed by the same assignment.
+      this._loaded = true;
     }
     return this;
   }
@@ -995,12 +1005,11 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load
    */
   async load(): Promise<LoadedRelation<this>> {
-    // relation.rb:1180 `if !loaded? || scheduled?`. The `scheduled?` disjunct
-    // is unreachable here: Rails' `load_async` sets `@loaded` in the same
-    // breath it parks the handle (relation.rb:1149), which is what its `load`
-    // needs the disjunct to see past; trails leaves `_loaded` false so the
-    // first disjunct already carries a scheduled relation into `execQueries`.
-    if (!this.isLoaded) await this.toArray();
+    // relation.rb:1180 `if !loaded? || scheduled?` — `load_async` leaves the
+    // relation `loaded?` with its rows still parked in `@future_result`
+    // (relation.rb:1149), and the `scheduled?` disjunct is what carries it into
+    // `exec_queries` to drain them.
+    if (!this.isLoaded || this.isScheduled) await this.toArray();
     return stripThenable(this);
   }
 
@@ -1013,14 +1022,15 @@ export class Relation<T extends Base> {
     if (this.isNullRelation()) return [];
     // relation.rb:1180's `loaded?` guard reads the seam, not `@loaded`, so a
     // subclass that owns its loadedness (CollectionProxy,
-    // collection_proxy.rb:53) takes this arm correctly. Rails' second
-    // disjunct — `|| scheduled?` — needs no spelling here: `loadAsync` leaves
-    // `_loaded` false, so a scheduled relation already falls through.
+    // collection_proxy.rb:53) takes this arm correctly. The negation of Rails'
+    // second disjunct — `|| scheduled?` — is spelled here: a `load_async`
+    // relation is `loaded?` with its rows still parked, and must fall through
+    // to `exec_queries` to drain them.
     // relation.rb:337-339 `to_ary` is `records.dup`, so the loaded arm reads
     // the `records` seam a CollectionProxy overrides (collection_proxy.rb:
     // 1024-1026), not the ivar. `records` re-enters `load`, whose `loaded?`
     // guard is already satisfied, so it returns without re-entering here.
-    if (this.isLoaded) return [...(await this.records())];
+    if (this.isLoaded && !this.isScheduled) return [...(await this.records())];
     // Run the query inside `with_connection` so the pool releases the connection
     // afterwards instead of holding it permanently. The build / execute path
     // reads the threaded connection via `_conn()` (see {@link withConnection})

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -192,7 +192,11 @@ export class Batches {
     let generator: () => AsyncGenerator<LoadedRelation<Relation<T>>>;
     if (remaining === 0) {
       generator = async function* () {};
-    } else if (this.loaded) {
+    } else if (this.loaded && !this.isScheduled) {
+      // `batchOnLoadedRelation` reads the materialized `@records` array
+      // synchronously, so a `load_async` relation — `loaded?` with its rows
+      // still parked (relation.rb:1149) — takes the querying arm instead;
+      // there is no synchronous way to drain the future here.
       const loadedBatches = batchOnLoadedRelation({
         relation: this,
         start,

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -178,10 +178,10 @@ interface CalculationRelation {
   // --- read by pluck / pick / ids (calculations.rb:291-412) ---
   /** Mirrors `Relation#loaded?`. */
   loaded: boolean;
-  /** Mirrors `Relation#@records`; the `loaded?` arm of `ids` reads it directly. */
-  _records: Array<{ _readAttribute(name: string): unknown }>;
   /** Mirrors `Relation#records` (relation.rb:250). */
-  records(): Promise<any[]>;
+  records(): Promise<
+    Array<{ _readAttribute(name: string): unknown; get(attrName: string): unknown }>
+  >;
   /** Mirrors `Relation#table`. */
   table: Table;
   /** Mirrors `Relation#limit` (query_methods.rb:407). */
@@ -757,7 +757,7 @@ export async function ids(this: CalculationRelation): Promise<unknown[]> {
     // calculations.rb:373 `records.map` — the `records` seam, not `@records`,
     // so a `load_async` relation (loaded? with its rows still parked,
     // relation.rb:1149) drains the future here instead of mapping over nothing.
-    const result = (await this.records()).map((record: any) => {
+    const result = (await this.records()).map((record) => {
       if (primaryKeyArray.length === 1) {
         return record._readAttribute(primaryKeyArray[0]);
       }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -754,7 +754,10 @@ export async function ids(this: CalculationRelation): Promise<unknown[]> {
       : [primaryKey];
 
   if (this.loaded) {
-    const result = this._records.map((record) => {
+    // calculations.rb:373 `records.map` — the `records` seam, not `@records`,
+    // so a `load_async` relation (loaded? with its rows still parked,
+    // relation.rb:1149) drains the future here instead of mapping over nothing.
+    const result = (await this.records()).map((record: any) => {
       if (primaryKeyArray.length === 1) {
         return record._readAttribute(primaryKeyArray[0]);
       }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1967,7 +1967,11 @@ function excludingWithCallee(callee: "excluding" | "without") {
     // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
     const combined: unknown[] = [...records];
     for (const relation of relations) {
-      if (relation.isLoaded) combined.push(...relation._records);
+      // `scheduled?` is excluded from the `loaded?` read because `excluding`
+      // is synchronous and cannot drain a parked `@future_result`
+      // (relation.rb:1149): a scheduled relation defers to the marker arm,
+      // which re-queries its ids, rather than contributing zero.
+      if (relation.isLoaded && !relation.isScheduled) combined.push(...relation._records);
       else combined.push(relation);
     }
     return excludingBang.call(this.spawn(), combined);


### PR DESCRIPTION
Follow-up to #6750, which gave trails Rails' `@future_result` / `scheduled?`
dispatch but deliberately left out the other half of `load_async`'s shape.

Rails' `load_async` sets `@loaded = true` in the same breath it parks the
future (`relation.rb:1149`). That is what makes the `loaded?` readers
cooperate with a scheduled query: `size` (`:353-359`), `empty?` (`:362-370`),
`one?` (`:399-405`) and `many?` all take their `loaded?` arm, reach `records`
-> `load`, and drain `@future_result` through `!loaded? || scheduled?`
(`:1180`) instead of issuing a second `COUNT(*)` / `EXISTS`.

## Changes

- `loadAsync` sets `_loaded` alongside `_futureResult` (`relation.rb:1149`).
  The extra `&& !this._futureResult` guard goes away — `unless loaded?`
  (`relation.rb:1141`) now covers a repeat call on its own, as in Rails.
- `load` / `toArray` guard on Rails' `!loaded? || scheduled?`
  (`relation.rb:1180`).
- `Calculations#ids` converges onto the `records` seam (`calculations.rb:373`)
  instead of reading `@records`, so it drains like the rest.
- The synchronous `loaded?` readers that cannot await a drain — `inspect`,
  `in_batches`' `batch_on_loaded_relation` arm, and `excluding`'s `ids` fold —
  exclude `scheduled?` explicitly, each justified at the call site, so none of
  them answers as though the relation loaded to zero rows. `computeCacheVersion`
  and `prettyPrint` already read through `records()` and drain unchanged.

## Verification

New regression case in `relation-load-async.trails.test.ts` asserts that
`loadAsync()` followed by `size()` / `isEmpty()` / `isOne()` / `isMany()`
issues exactly one `selectAll`; it fails on the baseline (`isLoaded` is
`false`, and the readers re-query).

`parity:api:calls` / `:args` / `:extra:gate` all clean.

Closes-story: load-async-sets-loaded-so-loaded-readers-drain-the-future
