### PR TITLE
refactor(activesupport): XmlMini Symbols are colon-prefixed strings

### DIFF
--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -656,6 +656,7 @@ describe("HashToXmlTest", () => {
         age: 26,
         age_in_millis: 820497600000,
         moved_on: RubyDate.civil(2005, 11, 15),
+        resident: ":yes",
       },
       xmlOptions,
     );
@@ -665,6 +666,7 @@ describe("HashToXmlTest", () => {
     expect(xml).toContain('<age type="integer">26</age>');
     expect(xml).toContain('<age-in-millis type="integer">820497600000</age-in-millis>');
     expect(xml).toContain('<moved-on type="date">2005-11-15</moved-on>');
+    expect(xml).toContain('<resident type="symbol">yes</resident>');
   });
 
   it("one level with nils", () => {

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -256,7 +256,7 @@ describe("ToTagTest", () => {
   });
 
   it("#to_tag accepts symbol types", () => {
-    toTag("b", Symbol("name"), options);
+    toTag("b", ":name", options);
     assertXml('<b type="symbol">name</b>');
   });
 

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -82,7 +82,9 @@ const DEFAULT_ENCODINGS: Record<string, string> = {
  * `ActiveSupport::Duration`).
  */
 const FORMATTING: Record<string, (value: unknown) => string> = {
-  symbol: (value) => (typeof value === "symbol" ? (value.description ?? "") : String(value)),
+  // `symbol.to_s` (xml_mini.rb:47) — the Symbol's name. A Ruby Symbol is a
+  // colon-prefixed string in trails, so the leading colon comes off.
+  symbol: (value) => String(value).slice(1),
   date: (value) => (value instanceof Temporal.PlainDate ? value.toString() : String(value)),
   time: (value) => (value instanceof Temporal.PlainTime ? value.toString() : String(value)),
   dateTime: formatDateTime,
@@ -425,16 +427,17 @@ export interface ToTagOptions extends RenameKeyOptions {
 function inferTypeName(value: unknown): string | undefined {
   if (value == null) return undefined;
   switch (typeof value) {
-    case "symbol":
-      return "symbol";
     case "boolean":
       return "boolean";
     case "bigint":
       return "integer";
     case "number":
       return Number.isInteger(value) ? "integer" : "float";
+    // A Ruby Symbol is a colon-prefixed string in trails, so the
+    // `TYPE_NAMES["Symbol"] => "symbol"` arm (xml_mini.rb:29) reads it here;
+    // any other string is untyped, as `to_str`-responders are in Rails.
     case "string":
-      return undefined;
+      return value.startsWith(":") ? "symbol" : undefined;
   }
   if (value instanceof BigDecimal) return "decimal";
   // boundary: a JS Date maps to the XML `dateTime` type.

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -82,9 +82,14 @@ const DEFAULT_ENCODINGS: Record<string, string> = {
  * `ActiveSupport::Duration`).
  */
 const FORMATTING: Record<string, (value: unknown) => string> = {
-  // `symbol.to_s` (xml_mini.rb:47) — the Symbol's name. A Ruby Symbol is a
-  // colon-prefixed string in trails, so the leading colon comes off.
-  symbol: (value) => String(value).slice(1),
+  // `symbol.to_s` (xml_mini.rb:56). A Ruby Symbol is a colon-prefixed string
+  // in trails, so `to_s` drops the colon; a String reaching here through an
+  // explicit `type: "symbol"` option (xml_mini.rb:119) is already its own
+  // `to_s` and passes through unchanged.
+  symbol: (value) => {
+    const s = String(value);
+    return s.startsWith(":") ? s.slice(1) : s;
+  },
   date: (value) => (value instanceof Temporal.PlainDate ? value.toString() : String(value)),
   time: (value) => (value instanceof Temporal.PlainTime ? value.toString() : String(value)),
   dateTime: formatDateTime,


### PR DESCRIPTION
XmlMini modelled a Ruby Symbol as a JS `Symbol`, contradicting CLAUDE.md's ratified rule ("A Ruby Symbol is a JS string, never a JS `Symbol`"), which left the `TYPE_NAMES["Symbol"] => "symbol"` arm (`xml_mini.rb:29`) unreachable for trails' actual Symbol representation.

- `inferTypeName` now resolves `type="symbol"` from a colon-prefixed string; the `typeof value === "symbol"` arm is removed.
- `FORMATTING.symbol` emits the name via `.slice(1)` — Rails' `symbol.to_s` (`xml_mini.rb:47`).
- `one level with types` regains the `resident: :yes` term dropped in #6818 (`hash_ext_test.rb:509-515`), and `#to_tag accepts symbol types` passes `":name"`.
- `to_xml` -> `fromTrustedXml` round-trips a Symbol (`PARSING.symbol` already returned `":yes"`); plain `fromXml` still rejects it, since `symbol` is a DISALLOWED_TYPE in Rails.

`pnpm parity:api:calls` / `:args` green, no new baseline rows.

Closes-story: converge-xmlmini-symbol-representation-onto-colon-strings