### PR TITLE
fix(nokogiri,activesupport): XmlMini_Nokogiri#parse raises Nokogiri::XML::SyntaxError

### DIFF
--- a/packages/activesupport/src/core-ext/hash-ext.test.ts
+++ b/packages/activesupport/src/core-ext/hash-ext.test.ts
@@ -295,7 +295,9 @@ describe("HashExtTest", () => {
  * `XMLMiniEngineTest.run_with_gem` (`xml_mini_engine_test.rb:8-13`), which
  * gates the Nokogiri legs of Rails' backend matrix. Ruby's `rescue LoadError`
  * catches only the package being absent; `import()` signals that as
- * `ERR_MODULE_NOT_FOUND` naming the specifier.
+ * `ERR_MODULE_NOT_FOUND` naming the specifier. Ruby's block then reads
+ * `Nokogiri::XML::SyntaxError` off the constant the `require` installed; ESM
+ * has no such ambient constant, so the imported module is yielded to it.
  */
 async function runWithGem(
   gemName: string,
@@ -316,11 +318,10 @@ async function runWithGem(
     }
     return;
   }
-  // Ruby reads `Nokogiri::XML::SyntaxError` off the constant the `require`
-  // installed; ESM has no such ambient constant, so the module is yielded.
   block(gem);
 }
 
+/** `Nokogiri::XML::SyntaxError`, once `runWithGem` has imported the gem. */
 let nokogiriSyntaxError: (new (...args: any[]) => Error) | undefined;
 
 function hashToXmlTests(engine: string): void {

--- a/packages/activesupport/src/core-ext/hash-ext.test.ts
+++ b/packages/activesupport/src/core-ext/hash-ext.test.ts
@@ -297,9 +297,13 @@ describe("HashExtTest", () => {
  * catches only the package being absent; `import()` signals that as
  * `ERR_MODULE_NOT_FOUND` naming the specifier.
  */
-async function runWithGem(gemName: string, block: () => void): Promise<void> {
+async function runWithGem(
+  gemName: string,
+  block: (gem: Record<string, any>) => void,
+): Promise<void> {
+  let gem: Record<string, any>;
   try {
-    await import(/* @vite-ignore */ gemName);
+    gem = await import(/* @vite-ignore */ gemName);
   } catch (e) {
     if (
       !(
@@ -312,8 +316,12 @@ async function runWithGem(gemName: string, block: () => void): Promise<void> {
     }
     return;
   }
-  block();
+  // Ruby reads `Nokogiri::XML::SyntaxError` off the constant the `require`
+  // installed; ESM has no such ambient constant, so the module is yielded.
+  block(gem);
 }
+
+let nokogiriSyntaxError: (new (...args: any[]) => Error) | undefined;
 
 function hashToXmlTests(engine: string): void {
   describe("HashToXmlTest", () => {
@@ -414,17 +422,13 @@ function hashToXmlTests(engine: string): void {
 
     it("expansion count is limited", async () => {
       // hash_ext_test.rb:1023-1032 switches on `XmlMini.backend.name`; a trails
-      // backend is the module namespace object, not a named constant. The
-      // Nokogiri arm is `Error`, not Ruby's `Nokogiri::XML::SyntaxError`,
-      // because `@blazetrails/nokogiri` carries no counterpart for
-      // `raise doc.errors.first` (nokogiri.rb:27) to raise — tracked by
-      // `nokogiri-backend-raises-syntax-error`.
+      // backend is the module namespace object, not a named constant.
       const backend = XmlMini.backend();
       const expected =
         backend === XmlMini_REXML
           ? RuntimeError
           : backend === XmlMini_Nokogiri
-            ? Error
+            ? nokogiriSyntaxError
             : backend === XmlMini_NokogiriSAX
               ? RuntimeError
               : undefined;
@@ -457,7 +461,8 @@ function hashToXmlTests(engine: string): void {
 
 hashToXmlTests("REXML");
 
-await runWithGem("@blazetrails/nokogiri", () => {
+await runWithGem("@blazetrails/nokogiri", (Nokogiri) => {
+  nokogiriSyntaxError = Nokogiri.XML.SyntaxError;
   hashToXmlTests("Nokogiri");
   hashToXmlTests("NokogiriSAX");
 });

--- a/packages/activesupport/src/xml-mini/nokogiri.ts
+++ b/packages/activesupport/src/xml-mini/nokogiri.ts
@@ -31,7 +31,7 @@ interface XmlNode {
 }
 
 interface XmlDocument {
-  readonly errors: ReadonlyArray<{ message: string }>;
+  readonly errors: ReadonlyArray<Error>;
   readonly root: XmlNode;
   dispose(): void;
 }
@@ -131,7 +131,7 @@ export function parse(data: string | StringIO | null | undefined): XmlHash {
     const doc = nokogiri!.parseXml(data);
     try {
       if (doc.errors.length > 0) {
-        throw new Error(doc.errors[0].message);
+        throw doc.errors[0];
       }
       return { [doc.root.name]: nodeToHash(doc.root) };
     } finally {

--- a/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
@@ -12,10 +12,8 @@
  * `Nokogiri::XML::SyntaxError`; and `NokogiriSAXEngineTest`, whose is
  * `RuntimeError`. `nokogirisax.ts` raises Ruby's `RuntimeError` for its bare
  * `raise error_message` (`nokogirisax.rb:37-39`); the DOM backend re-raises the
- * parser's own first error as a plain `Error` (`nokogiri.ts:131`) because
- * `@blazetrails/nokogiri` carries no `Nokogiri::XML::SyntaxError` counterpart
- * for Ruby's `raise doc.errors.first` (`nokogiri.rb:27`) to raise — tracked by
- * `nokogiri-backend-raises-syntax-error`.
+ * parser's own first error (`raise doc.errors.first`, `nokogiri.rb:27`), a
+ * `Nokogiri::XML::SyntaxError`.
  * The three calls live in this one file, rather than in a file per Ruby file,
  * because `parity:test` credits a Rails test file against its convention TS
  * file and every one of these names is defined in `xml_mini_engine_test.rb`.
@@ -49,14 +47,20 @@ function isLoadError(e: unknown, gemName: string): boolean {
  * `XMLMiniEngineTest.run_with_gem` (`xml_mini_engine_test.rb:8-13`): require
  * the gem, yield, and skip the suite on `LoadError`.
  */
-async function runWithGem(gemName: string, block: () => void): Promise<void> {
+async function runWithGem(
+  gemName: string,
+  block: (gem: Record<string, any>) => void,
+): Promise<void> {
+  let gem: Record<string, any>;
   try {
-    await import(/* @vite-ignore */ gemName);
+    gem = await import(/* @vite-ignore */ gemName);
   } catch (e) {
     if (!isLoadError(e, gemName)) throw e;
     return;
   }
-  block();
+  // Ruby reads `Nokogiri::XML::SyntaxError` off the constant the `require`
+  // installed; ESM has no such ambient constant, so the module is yielded.
+  block(gem);
 }
 
 interface EngineTestsOptions {
@@ -307,11 +311,11 @@ engineTests({
   expansionAttackError: RuntimeError,
 });
 
-await runWithGem("@blazetrails/nokogiri", () => {
+await runWithGem("@blazetrails/nokogiri", (Nokogiri) => {
   engineTests({
     engine: "Nokogiri",
     backendModule: XmlMini_Nokogiri,
-    expansionAttackError: Error,
+    expansionAttackError: Nokogiri.XML.SyntaxError,
   });
 
   engineTests({

--- a/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
+++ b/packages/activesupport/src/xml-mini/xml-mini-engine.test.ts
@@ -45,7 +45,9 @@ function isLoadError(e: unknown, gemName: string): boolean {
 
 /**
  * `XMLMiniEngineTest.run_with_gem` (`xml_mini_engine_test.rb:8-13`): require
- * the gem, yield, and skip the suite on `LoadError`.
+ * the gem, yield, and skip the suite on `LoadError`. Ruby's block then reads
+ * `Nokogiri::XML::SyntaxError` off the constant the `require` installed; ESM
+ * has no such ambient constant, so the imported module is yielded to it.
  */
 async function runWithGem(
   gemName: string,
@@ -58,8 +60,6 @@ async function runWithGem(
     if (!isLoadError(e, gemName)) throw e;
     return;
   }
-  // Ruby reads `Nokogiri::XML::SyntaxError` off the constant the `require`
-  // installed; ESM has no such ambient constant, so the module is yielded.
   block(gem);
 }
 

--- a/packages/nokogiri/src/index.ts
+++ b/packages/nokogiri/src/index.ts
@@ -1,13 +1,14 @@
 import { XmlDocument } from "./xml/document.js";
 import { XmlNode } from "./xml/node.js";
 import { parseXml } from "./xml/parse.js";
+import { SyntaxError } from "./xml/syntax-error.js";
 import { SaxDocument } from "./sax/document.js";
 import { SaxParser } from "./sax/parser.js";
 
-export const XML = { Document: XmlDocument, Node: XmlNode };
+export const XML = { Document: XmlDocument, Node: XmlNode, SyntaxError };
 export const SAX = { Document: SaxDocument, Parser: SaxParser };
 export { parseXml, SaxDocument, SaxParser };
 export type { XmlNode, XmlDocument };
 export type { AttrNode } from "./xml/node.js";
-export type { XmlError } from "./xml/document.js";
+export { SyntaxError };
 export type { Readable } from "./readable.js";

--- a/packages/nokogiri/src/index.ts
+++ b/packages/nokogiri/src/index.ts
@@ -10,5 +10,5 @@ export const SAX = { Document: SaxDocument, Parser: SaxParser };
 export { parseXml, SaxDocument, SaxParser };
 export type { XmlNode, XmlDocument };
 export type { AttrNode } from "./xml/node.js";
-export { SyntaxError };
+export type { SyntaxError };
 export type { Readable } from "./readable.js";

--- a/packages/nokogiri/src/xml/document.ts
+++ b/packages/nokogiri/src/xml/document.ts
@@ -1,34 +1,28 @@
 import { XmlDocument as LibXmlDocument, XmlParseError } from "libxml2-wasm";
 import { XmlNode } from "./node.js";
 import { type Readable, readSource } from "../readable.js";
-
-export interface XmlError {
-  level: "warning" | "error" | "fatal";
-  message: string;
-  line?: number;
-  column?: number;
-}
+import { SyntaxError } from "./syntax-error.js";
 
 export class XmlDocument {
-  readonly errors: ReadonlyArray<XmlError>;
+  readonly errors: ReadonlyArray<SyntaxError>;
   private _doc: LibXmlDocument | null;
   private _root: XmlNode | null;
 
-  private constructor(doc: LibXmlDocument | null, errors: XmlError[]) {
+  private constructor(doc: LibXmlDocument | null, errors: SyntaxError[]) {
     this._doc = doc;
     this.errors = errors;
     this._root = doc !== null ? new XmlNode(doc.root) : null;
   }
 
   static parse(data: string | Readable): XmlDocument {
-    const errors: XmlError[] = [];
+    const errors: SyntaxError[] = [];
     try {
       const doc = LibXmlDocument.fromString(readSource(data));
       return new XmlDocument(doc, errors);
     } catch (e) {
       if (e instanceof XmlParseError) {
         for (const detail of e.details) {
-          errors.push({ level: "fatal", message: detail.message });
+          errors.push(new SyntaxError(detail.message, "fatal", detail.line, detail.col));
         }
         return new XmlDocument(null, errors);
       }

--- a/packages/nokogiri/src/xml/syntax-error.ts
+++ b/packages/nokogiri/src/xml/syntax-error.ts
@@ -1,0 +1,23 @@
+/**
+ * Mirrors: `Nokogiri::XML::SyntaxError` (nokogiri
+ * `lib/nokogiri/xml/syntax_error.rb`) — the exception the parser collects into
+ * `Nokogiri::XML::Document#errors` and that `raise doc.errors.first` raises.
+ */
+export class SyntaxError extends Error {
+  readonly level: "warning" | "error" | "fatal";
+  readonly line?: number;
+  readonly column?: number;
+
+  constructor(
+    message: string,
+    level: "warning" | "error" | "fatal",
+    line?: number,
+    column?: number,
+  ) {
+    super(message);
+    this.name = "SyntaxError";
+    this.level = level;
+    this.line = line;
+    this.column = column;
+  }
+}

--- a/packages/nokogiri/src/xml/syntax-error.ts
+++ b/packages/nokogiri/src/xml/syntax-error.ts
@@ -15,7 +15,7 @@ export class SyntaxError extends Error {
     column?: number,
   ) {
     super(message);
-    this.name = "SyntaxError";
+    this.name = "Nokogiri::XML::SyntaxError";
     this.level = level;
     this.line = line;
     this.column = column;


### PR DESCRIPTION
`XmlMini_Nokogiri#parse` mirrors `raise doc.errors.first`
(`activesupport/lib/active_support/xml_mini/nokogiri.rb:27`), whose first
element is a `Nokogiri::XML::SyntaxError` instance — the class both
`nokogiri_engine_test.rb:12` and `hash_ext_test.rb:1026` name. trails raised
`new Error(doc.errors[0].message)` because `@blazetrails/nokogiri` had no
`SyntaxError` counterpart.

- `@blazetrails/nokogiri` exports `SyntaxError` (`XML.SyntaxError`), replacing
  the plain `XmlError` record; `XmlDocument.parse` collects libxml2 error
  details as instances of it, carrying `level`, `line`, `column`.
- `xml-mini/nokogiri.ts` raises `doc.errors[0]` directly.
- `xml-mini-engine.test.ts` and `hash-ext.test.ts` name the Rails class and
  drop their deviation comments. Ruby reads the class off the constant
  `require "nokogiri"` installed; ESM has no ambient constant, so `runWithGem`
  yields the imported module.

Closes-story: nokogiri-backend-raises-syntax-error