### PR TITLE
docs(website): idioms static-block example uses ActiveRecord Base

### DIFF
--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -211,15 +211,15 @@ Rails puts class-level configuration in the class body directly.
 Trails puts the equivalent in a `static {}` initializer block.
 
 ```ts
-import { Model } from "@blazetrails/activemodel";
+import { Base } from "@blazetrails/activerecord";
 
-class Post extends Model {
+class Post extends Base {
   declare title: string;
 
   static {
     Post.attribute("title", "string");
     Post.validates("title", { presence: true });
-    Post.beforeSave((record: Post) => {
+    Post.beforeSave((record) => {
       record.title = record.title.trim();
     });
   }


### PR DESCRIPTION
## What

The `Guides Code Type Check` job is red on main @7b6e6719:

```
packages/website/docs/guides/idioms.md:222:10: error TS2339: Property 'beforeSave' does not exist on type 'typeof Post'.
```

## Why

`before_save` is one of the twelve macros generated by ActiveRecord::Callbacks' `define_model_callbacks :save, :create, :update, :destroy` (`activerecord/lib/active_record/callbacks.rb:416`) via `activemodel/lib/active_model/callbacks.rb:130`. `ActiveModel::Model` has no `before_save`. #6916 removed the hand-written ActiveModel statics, so the guide snippet — which extended `@blazetrails/activemodel`'s `Model` — no longer type-checks.

## How

The snippet now extends `Base` from `@blazetrails/activerecord`, like every other code block in the guide. `pnpm guides:typecheck`: all 17 blocks clean.

Closes-story: red-7b6e6719