### PR TITLE
refactor(activerecord,activemodel,activesupport): drain scheduled relations in excluding/in_batches; converge defineModelCallbacks and XmlMini keys

### DIFF
--- a/packages/activemodel/src/callbacks.trails.test.ts
+++ b/packages/activemodel/src/callbacks.trails.test.ts
@@ -1,0 +1,23 @@
+/**
+ * trails-only: `define_model_callbacks` dispatches its generators with
+ * `send("_define_#{type}_model_callback", self, callback)` (callbacks.rb:124-126),
+ * so an `only:` entry with no matching generated method raises `NoMethodError`.
+ * TypeScript has no `send`, and the failure mode of the map that stands in for
+ * it has to be pinned rather than assumed.
+ */
+import { describe, it, expect } from "vitest";
+import { Model } from "./index.js";
+import { NoMethodError } from "./attribute-assignment.js";
+
+describe("defineModelCallbacks", () => {
+  it("raises NoMethodError for an only: entry with no generator", () => {
+    class Topic extends Model {}
+
+    expect(() =>
+      (Topic as unknown as { defineModelCallbacks(...a: unknown[]): void }).defineModelCallbacks(
+        "create",
+        { only: ["bogus"] },
+      ),
+    ).toThrow(NoMethodError);
+  });
+});

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -5,7 +5,7 @@
  * (activemodel/lib/active_model/callbacks.rb)
  */
 
-import { ArgumentError } from "./attribute-assignment.js";
+import { ArgumentError, NoMethodError } from "./attribute-assignment.js";
 import {
   Callback,
   Value,
@@ -66,7 +66,16 @@ export function defineModelCallbacks(this: object, ...args: unknown[]): void {
     if (klass.prototype) asDefineCallbacks(klass.prototype, callback, options);
 
     for (const type of types) {
-      _defineModelCallbackByType[type](this, callback);
+      const methodName = `_define_${String(type)}_model_callback`;
+      const generator = _defineModelCallbackByType[methodName];
+      // Ruby's `send` on an unknown name raises NoMethodError; a bare call of
+      // the missing entry would surface a TypeError instead.
+      if (!generator) {
+        throw new NoMethodError(
+          `undefined method '${methodName}' for class ${(this as { name?: string }).name}`,
+        );
+      }
+      generator(this, callback);
     }
   }
 }
@@ -74,13 +83,15 @@ export function defineModelCallbacks(this: object, ...args: unknown[]): void {
 /**
  * @noRailsEquivalent PERMANENT: stands in for `send("_define_#{type}_model_callback", ...)`
  *   (callbacks.rb:125) — TS has no `send`, and the three targets are
- *   module-private functions, not members of `this`. Not exported.
+ *   module-private functions, not members of `this`. Keyed by the interpolated
+ *   Ruby method name so an unknown `only:` entry misses exactly as `send` does.
+ *   Not exported.
  */
 const _defineModelCallbackByType: Record<string, (klass: CallbackHost, callback: string) => void> =
   {
-    before: _defineBeforeModelCallback,
-    after: _defineAfterModelCallback,
-    around: _defineAroundModelCallback,
+    _define_before_model_callback: _defineBeforeModelCallback,
+    _define_after_model_callback: _defineAfterModelCallback,
+    _define_around_model_callback: _defineAroundModelCallback,
   };
 
 /** Minimum shape required of a record object threaded through a callback chain. */

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -32,7 +32,9 @@ type AnyCallback = BeforeCallback | AfterCallback | AroundCallback;
  * Creates beforeX(), afterX(), and/or aroundX() class methods for each event
  * name. Pass `{ only: ["before"] }` as the last argument to limit which
  * timing types are created (defaults to all three); every other option is
- * forwarded to `defineCallbacks`, as Rails does.
+ * forwarded to `defineCallbacks`, as Rails does — including the default
+ * `scope: [:kind, :name]` (callbacks.rb:113), which makes an object callback
+ * registered by `beforeSave` dispatch to `beforeSave` rather than `before`.
  *
  * Mirrors: ActiveModel::Callbacks.define_model_callbacks
  * (activemodel/lib/active_model/callbacks.rb:109-127)
@@ -44,46 +46,35 @@ export function defineModelCallbacks(
   ...rest: [...string[], DefineModelCallbacksOptions]
 ): void;
 export function defineModelCallbacks(this: object, ...args: unknown[]): void {
-  // `options = callbacks.extract_options!` (callbacks.rb:110).
   const [callbacks, extracted] = extractOptionsBang(args);
-  // `{ skip_after_callbacks_if_terminated: true, scope: [:kind, :name],
-  //    only: [:before, :around, :after] }.merge!(options)` (callbacks.rb:111-115).
-  // `scope` is the chain's dispatch scope, so an object callback registered by
-  // `before_save` calls `beforeSave` rather than a bare `before`
-  // (activesupport/lib/active_support/callbacks.rb, `current_scopes`).
-  const options: DefineModelCallbacksOptions = {
+  let options = extracted as DefineModelCallbacksOptions;
+  options = {
     skipAfterCallbacksIfTerminated: true,
     scope: ["kind", "name"],
     only: ["before", "around", "after"],
-    ...(extracted as DefineModelCallbacksOptions),
+    ...options,
   };
 
-  // `types = Array(options.delete(:only))` (callbacks.rb:117).
   const types = kernelArray(options.only);
   delete options.only;
 
   const klass = this as { prototype?: object };
 
   for (const callback of callbacks as string[]) {
-    // `define_callbacks(callback, options)` (callbacks.rb:120) — the chain
-    // lives on the prototype, which is where trails' instances resolve it.
+    // `define_callbacks` registers on the prototype, where trails' instances
+    // resolve the chain; Ruby's `self` here is the class itself.
     if (klass.prototype) asDefineCallbacks(klass.prototype, callback, options);
 
-    // `send("_define_#{type}_model_callback", self, callback)`
-    // (callbacks.rb:122-126) — driven by `types`, in the caller's order.
     for (const type of types) {
-      _defineModelCallbackByType[type]?.(this, callback);
+      _defineModelCallbackByType[type](this, callback);
     }
   }
 }
 
 /**
- * The `send("_define_#{type}_model_callback", ...)` dispatch table
- * (callbacks.rb:125). TypeScript has no `send`, and the three targets are
- * module-private functions rather than members of `this`, so the interpolated
- * method name resolves through this map.
- * @noRailsEquivalent PERMANENT: stands in for Ruby's `send` on an interpolated
- *   private method name; no new surface (it is not exported).
+ * @noRailsEquivalent PERMANENT: stands in for `send("_define_#{type}_model_callback", ...)`
+ *   (callbacks.rb:125) — TS has no `send`, and the three targets are
+ *   module-private functions, not members of `this`. Not exported.
  */
 const _defineModelCallbackByType: Record<string, (klass: CallbackHost, callback: string) => void> =
   {

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -18,6 +18,8 @@ import {
   type CallbackObject as ASCallbackObject,
   type RunCallbacksOptions as ASRunCallbacksOptions,
   assertValidKeys,
+  extractOptionsBang,
+  type DefineCallbacksOptions,
   defineCallbacks as asDefineCallbacks,
   skipCallback as asSkipCallback,
   getCallbackChains as asGetCallbackChains,
@@ -27,12 +29,13 @@ import {
 type AnyCallback = BeforeCallback | AfterCallback | AroundCallback;
 
 /**
- * Core implementation of define_model_callbacks.
  * Creates beforeX(), afterX(), and/or aroundX() class methods for each event
  * name. Pass `{ only: ["before"] }` as the last argument to limit which
- * timing types are created (defaults to all three).
+ * timing types are created (defaults to all three); every other option is
+ * forwarded to `defineCallbacks`, as Rails does.
  *
  * Mirrors: ActiveModel::Callbacks.define_model_callbacks
+ * (activemodel/lib/active_model/callbacks.rb:109-127)
  */
 export function defineModelCallbacks(this: object, event: string, ...rest: string[]): void;
 export function defineModelCallbacks(
@@ -41,65 +44,59 @@ export function defineModelCallbacks(
   ...rest: [...string[], DefineModelCallbacksOptions]
 ): void;
 export function defineModelCallbacks(this: object, ...args: unknown[]): void {
-  let options: DefineModelCallbacksOptions = {};
-  const eventNames: string[] = [];
+  // `options = callbacks.extract_options!` (callbacks.rb:110).
+  const [callbacks, extracted] = extractOptionsBang(args);
+  // `{ skip_after_callbacks_if_terminated: true, scope: [:kind, :name],
+  //    only: [:before, :around, :after] }.merge!(options)` (callbacks.rb:111-115).
+  // `scope` is the chain's dispatch scope, so an object callback registered by
+  // `before_save` calls `beforeSave` rather than a bare `before`
+  // (activesupport/lib/active_support/callbacks.rb, `current_scopes`).
+  const options: DefineModelCallbacksOptions = {
+    skipAfterCallbacksIfTerminated: true,
+    scope: ["kind", "name"],
+    only: ["before", "around", "after"],
+    ...(extracted as DefineModelCallbacksOptions),
+  };
 
-  const validTimings: CallbackTiming[] = ["before", "after", "around"];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (typeof arg === "string") {
-      eventNames.push(arg);
-    } else if (
-      i === args.length - 1 &&
-      arg !== undefined &&
-      arg !== null &&
-      typeof arg === "object" &&
-      !Array.isArray(arg)
-    ) {
-      options = arg as DefineModelCallbacksOptions;
-      const knownKeys = new Set(["only"]);
-      for (const key of Object.keys(options)) {
-        if (!knownKeys.has(key)) throw new ArgumentError(`Unknown option: ${key}`);
-      }
-      if (options.only) {
-        for (const t of options.only) {
-          if (!validTimings.includes(t)) {
-            throw new ArgumentError(
-              `Invalid callback type: ${t}. Must be one of: ${validTimings.join(", ")}`,
-            );
-          }
-        }
-      }
-    } else if (typeof arg !== "string") {
-      throw new ArgumentError(`Expected event name (string), got ${typeof arg}`);
+  // `types = Array(options.delete(:only))` (callbacks.rb:117).
+  const types = kernelArray(options.only);
+  delete options.only;
+
+  const klass = this as { prototype?: object };
+
+  for (const callback of callbacks as string[]) {
+    // `define_callbacks(callback, options)` (callbacks.rb:120) — the chain
+    // lives on the prototype, which is where trails' instances resolve it.
+    if (klass.prototype) asDefineCallbacks(klass.prototype, callback, options);
+
+    // `send("_define_#{type}_model_callback", self, callback)`
+    // (callbacks.rb:122-126) — driven by `types`, in the caller's order.
+    for (const type of types) {
+      _defineModelCallbackByType[type]?.(this, callback);
     }
   }
-
-  if (eventNames.length === 0) {
-    throw new ArgumentError("At least one event name must be provided to defineModelCallbacks");
-  }
-
-  const timings: CallbackTiming[] = options.only ?? ["before", "after", "around"];
-  const klass = this as { prototype?: object } & Record<string, unknown>;
-
-  for (const event of eventNames) {
-    // Register the chain on the prototype with the same config used by
-    // _registerCallbackOnProto so skipAfterCallbacksIfTerminated is consistent
-    // regardless of which call runs first.
-    // Mirrors: ActiveModel::Callbacks → define_callbacks (activesupport)
-    if (klass.prototype)
-      asDefineCallbacks(klass.prototype, event, { skipAfterCallbacksIfTerminated: true });
-    if (timings.includes("before")) _defineBeforeModelCallback(this, event);
-    if (timings.includes("after")) _defineAfterModelCallback(this, event);
-    if (timings.includes("around")) _defineAroundModelCallback(this, event);
-  }
 }
+
+/**
+ * The `send("_define_#{type}_model_callback", ...)` dispatch table
+ * (callbacks.rb:125). TypeScript has no `send`, and the three targets are
+ * module-private functions rather than members of `this`, so the interpolated
+ * method name resolves through this map.
+ * @noRailsEquivalent PERMANENT: stands in for Ruby's `send` on an interpolated
+ *   private method name; no new surface (it is not exported).
+ */
+const _defineModelCallbackByType: Record<string, (klass: CallbackHost, callback: string) => void> =
+  {
+    before: _defineBeforeModelCallback,
+    after: _defineAfterModelCallback,
+    around: _defineAroundModelCallback,
+  };
 
 /** Minimum shape required of a record object threaded through a callback chain. */
 export type CallbackRecord = object;
 
-export interface DefineModelCallbacksOptions {
-  only?: CallbackTiming[];
+export interface DefineModelCallbacksOptions extends DefineCallbacksOptions {
+  only?: CallbackTiming | CallbackTiming[];
 }
 
 export interface CallbacksClassMethods {

--- a/packages/activerecord/src/relation-load-async.trails.test.ts
+++ b/packages/activerecord/src/relation-load-async.trails.test.ts
@@ -240,6 +240,49 @@ describe("Relation#load_async", () => {
     expect(relation.isScheduled).toBe(false);
   });
 
+  it("drains a scheduled relation argument to #excluding instead of re-querying its ids", async () => {
+    // `excluding` folds relation arguments with `relations.flat_map(&:ids)`
+    // (query_methods.rb:1583-1586), and `Calculations#ids` takes its `loaded?`
+    // arm through the `records` seam (calculations.rb:373), which drains a
+    // parked future — so a `load_async` relation costs no id-select of its own.
+    const excluded = await Topic.create({ title: "excluded async topic", author_name: "David" });
+    await Topic.create({ title: "kept async topic", author_name: "David" });
+
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    const scheduled = Topic.where({ title: "excluded async topic" }).loadAsync();
+    const titles = await Topic.excluding(scheduled).pluck("title");
+
+    expect(titles).toEqual(["kept async topic"]);
+    expect((excluded as { id: unknown }).id).not.toBe(null);
+    // The scheduled SELECT plus the pluck — no third query for the ids.
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("batches a scheduled relation in memory instead of re-querying", async () => {
+    // `in_batches`' `if loaded?` arm batches `records` in memory
+    // (batches.rb), and that read drains the parked future (relation.rb:1149).
+    await Topic.create({ title: "batched async topic", author_name: "David" });
+    await Topic.create({ title: "other batched async topic", author_name: "David" });
+
+    const connection = Base.connection as unknown as {
+      selectAll: (...args: unknown[]) => unknown;
+    };
+    const spy = vi.spyOn(connection, "selectAll");
+
+    const relation = Topic.all().loadAsync();
+    const seen: string[] = [];
+    for await (const topic of relation.findEach({ batchSize: 1 })) {
+      seen.push((topic as { title: string }).title);
+    }
+
+    expect(seen.length).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it("runs the query in the foreground when no executor is configured", async () => {
     restoreExecutor?.();
     restoreExecutor = undefined;

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -192,21 +192,22 @@ export class Batches {
     let generator: () => AsyncGenerator<LoadedRelation<Relation<T>>>;
     if (remaining === 0) {
       generator = async function* () {};
-    } else if (this.loaded && !this.isScheduled) {
-      // `batchOnLoadedRelation` reads the materialized `@records` array
-      // synchronously, so a `load_async` relation — `loaded?` with its rows
-      // still parked (relation.rb:1149) — takes the querying arm instead;
-      // there is no synchronous way to drain the future here.
-      const loadedBatches = batchOnLoadedRelation({
-        relation: this,
-        start,
-        finish,
-        cursor,
-        order: (order ?? "asc") as any,
-        batchLimit,
-      });
+    } else if (this.loaded) {
       generator = async function* () {
         await ensureValidOptions();
+        // Rails' `if loaded?` arm of `in_batches` batches the relation's own
+        // `records` in memory. That read goes through the `records` seam, which
+        // drains a parked `@future_result` (relation.rb:1149), so a
+        // `load_async` relation batches its scheduled rows rather than
+        // re-querying — hence the await, and hence `loaded?` alone as the guard.
+        const loadedBatches = await batchOnLoadedRelation({
+          relation: self,
+          start,
+          finish,
+          cursor,
+          order: (order ?? "asc") as any,
+          batchLimit,
+        });
         for (const batchRows of loadedBatches) {
           const batchRel = self.clone();
           batchRel.orderValues = batchOrders.map(([col, dir]) =>
@@ -433,16 +434,17 @@ export function buildBatchOrders(
 }
 
 /** @internal */
-export function batchOnLoadedRelation(opts: {
+export async function batchOnLoadedRelation(opts: {
   relation: any;
   start: unknown;
   finish: unknown;
   cursor: string[];
   order: "asc" | "desc" | ("asc" | "desc")[];
   batchLimit: number;
-}): any[] {
+}): Promise<any[]> {
   const { relation, cursor, batchLimit } = opts;
-  let records: any[] = globalThis.Array.isArray(relation._records) ? relation._records : [];
+  const loaded = await relation.records();
+  let records: any[] = globalThis.Array.isArray(loaded) ? loaded : [];
   const order = buildBatchOrders(cursor, opts.order as any).map(([, second]) => second);
 
   if (opts.start != null || opts.finish != null) {

--- a/packages/activerecord/src/relation/batches.ts
+++ b/packages/activerecord/src/relation/batches.ts
@@ -195,11 +195,9 @@ export class Batches {
     } else if (this.loaded) {
       generator = async function* () {
         await ensureValidOptions();
-        // Rails' `if loaded?` arm of `in_batches` batches the relation's own
-        // `records` in memory. That read goes through the `records` seam, which
-        // drains a parked `@future_result` (relation.rb:1149), so a
-        // `load_async` relation batches its scheduled rows rather than
-        // re-querying — hence the await, and hence `loaded?` alone as the guard.
+        // Rails' `if loaded?` arm batches the relation's own `records` in
+        // memory; that read drains a parked `@future_result` (relation.rb:1149),
+        // which is why the branch is taken inside the async generator.
         const loadedBatches = await batchOnLoadedRelation({
           relation: self,
           start,

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1957,23 +1957,16 @@ function excludingWithCallee(callee: "excluding" | "without") {
       );
     }
 
-    // Rails `records + relations.flat_map(&:ids)`. `Relation#ids` returns the
-    // cached `records.map(&:id)` when the relation is loaded (calculations.rb:371)
-    // and re-queries otherwise. A loaded relation's records are already in
-    // memory, so spread them into the literal `records` collection to match
-    // Rails exactly (no extra query). An unloaded relation is deferred:
-    // `excludingBang` records a marker that the load pipeline materializes into a
-    // literal `id NOT IN (1, 2, 3)` via `Relation#ids` (a separate id-select),
-    // matching Rails' eager `flat_map(&:ids)` rather than emitting a subquery.
-    const combined: unknown[] = [...records];
-    for (const relation of relations) {
-      // `scheduled?` is excluded from the `loaded?` read because `excluding`
-      // is synchronous and cannot drain a parked `@future_result`
-      // (relation.rb:1149): a scheduled relation defers to the marker arm,
-      // which re-queries its ids, rather than contributing zero.
-      if (relation.isLoaded && !relation.isScheduled) combined.push(...relation._records);
-      else combined.push(relation);
-    }
+    // Rails `records + relations.flat_map(&:ids)` (query_methods.rb:1583-1586).
+    // `Relation#ids` is the seam that decides per relation whether a query runs:
+    // it returns the already-materialized `records.map(&:id)` when the relation
+    // is `loaded?` — including a `load_async` relation, whose parked
+    // `@future_result` it drains (relation.rb:1149, calculations.rb:373) — and
+    // selects the ids otherwise. trails cannot run that select synchronously, so
+    // EVERY relation argument is deferred uniformly: `excludingBang` records a
+    // marker that the load pipeline materializes through `Relation#ids`,
+    // preserving Rails' per-relation decision instead of second-guessing it here.
+    const combined: unknown[] = [...records, ...relations];
     return excludingBang.call(this.spawn(), combined);
   };
 }
@@ -1994,15 +1987,15 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // `records` is `records + relations.flat_map(&:ids)` — scalar AR records plus
   // every relation arg's eagerly-materialized ids — built into ONE predicate.
   // Ruby materializes those ids before this call (synchronous query execution);
-  // trails' builder is synchronous-and-lazy, so `excluding`/`without` leave any
-  // UNLOADED relation in `records` for us to defer here.
-  const unloadedRelations = records.filter((r) => isRelationLike(r));
+  // trails' builder is synchronous-and-lazy, so `excluding`/`without` leave
+  // every relation argument in `records` for us to defer here.
+  const deferredRelations = records.filter((r) => isRelationLike(r));
   const literalRecords = records.filter((r) => !isRelationLike(r));
 
-  // No unloaded relations: every value's id is known now, so build the literal
+  // No relation arguments: every value's id is known now, so build the literal
   // predicate exactly as Rails does (array handler dereferences AR records to
   // their ids).
-  if (unloadedRelations.length === 0) {
+  if (deferredRelations.length === 0) {
     // Rails `predicate_builder[primary_key, records].invert` — `#[]` reads the
     // attribute straight off the builder's arel table (predicate_builder.rb:53-55).
     this.whereClause = this.whereClause.plus(
@@ -2029,11 +2022,11 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   const literalIds = literalRecords.map((r) => (isBaseInstance(r) ? (r as any).id : r));
   // Build the positive `IN (subquery)` (Rails builds positively and inverts);
   // only its subquery `right` is needed for the marker's display fallback.
-  const inlineSubquery = (this.predicateBuilder.build(attribute, unloadedRelations[0]) as Nodes.In)
+  const inlineSubquery = (this.predicateBuilder.build(attribute, deferredRelations[0]) as Nodes.In)
     .right as Nodes.Node;
   this.whereClause = this.whereClause.plus(
     new WhereClause([
-      new DeferredIdsNotIn(attribute, inlineSubquery, literalIds, unloadedRelations),
+      new DeferredIdsNotIn(attribute, inlineSubquery, literalIds, deferredRelations),
     ]),
   );
   return this;

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1958,14 +1958,11 @@ function excludingWithCallee(callee: "excluding" | "without") {
     }
 
     // Rails `records + relations.flat_map(&:ids)` (query_methods.rb:1583-1586).
-    // `Relation#ids` is the seam that decides per relation whether a query runs:
-    // it returns the already-materialized `records.map(&:id)` when the relation
-    // is `loaded?` — including a `load_async` relation, whose parked
-    // `@future_result` it drains (relation.rb:1149, calculations.rb:373) — and
-    // selects the ids otherwise. trails cannot run that select synchronously, so
-    // EVERY relation argument is deferred uniformly: `excludingBang` records a
-    // marker that the load pipeline materializes through `Relation#ids`,
-    // preserving Rails' per-relation decision instead of second-guessing it here.
+    // `Relation#ids` is the seam that decides per relation whether a query runs
+    // (calculations.rb:373), draining a parked `@future_result` on the `loaded?`
+    // arm. trails cannot run that select synchronously, so every relation
+    // argument is deferred uniformly and the load pipeline materializes it
+    // through `Relation#ids` rather than second-guessing the decision here.
     const combined: unknown[] = [...records, ...relations];
     return excludingBang.call(this.spawn(), combined);
   };

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -333,7 +333,10 @@ describe("ToTagTest", () => {
   });
 
   it("#to_tag should dasherize the space when passed a symbol with spaces as a key", () => {
-    toTag(Symbol("New   York"), 33, options);
+    // Rails passes the Symbol `:"New   York"` (xml_mini_test.rb:172); a Ruby
+    // Symbol is a JS string in trails, and a Symbol KEY renders as its bare
+    // name (`key.to_s`, xml_mini.rb:118) — no leading colon.
+    toTag("New   York", 33, options);
     assertXml('<New---York type="integer">33</New---York>');
   });
 

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -463,11 +463,6 @@ function inferTypeName(value: unknown): string | undefined {
   return (value as { constructor?: { name?: string } }).constructor?.name;
 }
 
-/** `key.to_s`: a symbol key renders as its name, everything else via `String`. */
-function keyToString(key: unknown): string {
-  return typeof key === "symbol" ? (key.description ?? "") : String(key);
-}
-
 /**
  * The stringified key, underscored first when `underscoreKeys` is set
  * (ActiveModel's camelCase keys) so a later `dasherize` has `_`/space
@@ -476,7 +471,7 @@ function keyToString(key: unknown): string {
  * `Hash#to_xml`/`Array#to_xml`, which each call `rename_key`).
  */
 function tagKey(key: unknown, options: ToTagOptions): string {
-  const name = keyToString(key);
+  const name = String(key);
   return options.underscoreKeys ? underscore(name) : name;
 }
 
@@ -522,7 +517,7 @@ export interface ToXmlOptions extends Omit<ToTagOptions, "builder"> {
  *   Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms
  *   (immutable `{ ...options }` spread instead of merge, destructured
  *   `options.type` instead of delete, direct function invocation, and
- *   String()/keyToString()) — no behavioral omission.
+ *   String()) — no behavioral omission.
  */
 export function toTag(key: unknown, value: unknown, options: ToTagOptions): void {
   const { builder } = options;
@@ -533,7 +528,7 @@ export function toTag(key: unknown, value: unknown, options: ToTagOptions): void
     // A callable receives the merged options (with the builder); arity 1 gets
     // just the options, otherwise it also gets the singularized tag name.
     if (value.length === 1) value(merged);
-    else value(merged, singularize(keyToString(key)));
+    else value(merged, singularize(String(key)));
     return;
   }
   if (value != null && typeof (value as { toXml?: unknown }).toXml === "function") {


### PR DESCRIPTION
Four convergences: two `loaded?`-guard fixes left behind by #6918, plus the
`defineModelCallbacks` and `XmlMini` key-stringification stories.

## `excluding` drains a scheduled relation (query_methods.rb:1583-1586)

`excluding` read `relation._records` behind `isLoaded && !isScheduled`. Rails
folds relation arguments with `relations.flat_map(&:ids)`, and `Calculations#ids`
takes its `loaded?` arm through the `records` seam (calculations.rb:373) — which
drains a parked `@future_result`. So relation arguments now go through the
deferred-ids marker **uniformly**, and the load pipeline materialises them via
`Relation#ids`, preserving Rails' per-relation decision instead of second-guessing
it at build time. No `_records` read survives in `query-methods.ts`.

Note: the added regression test also passes on the baseline — #6918's `ids`
convergence already drained the future through the marker path, so the extra
id-select the story context predicted does not actually fire. The remaining
divergence was representational (`_records`, and the `!isScheduled` conjunct),
and that is what this converges; the test pins the query count.

## `in_batches` drains a scheduled relation (batches.rb, the `if loaded?` arm)

The `loaded?` branch was taken synchronously at call time, and
`batchOnLoadedRelation` read `_records` synchronously — so `load_async`
relations fell to the querying arm. The branch does not have to be synchronous:
`batchOnLoadedRelation` is now `async` and reads the `records` seam, and the call
moved inside the async generator. Guard is `this.loaded` alone.

Regression test **fails on baseline**: `findEach` over a `loadAsync()` relation
issued 4 `selectAll` calls, now 1.

## `defineModelCallbacks` (callbacks.rb:109-127)

Replaced the ~50-line hand-rolled argument walk with the nine Ruby lines:
`extractOptionsBang` for `extract_options!`, the Rails defaults object merged
under the caller's options, `Array(options.delete(:only))` for `types`, the whole
merged `options` forwarded to `defineCallbacks` (previously a fresh
`{ skipAfterCallbacksIfTerminated: true }` literal), and generator dispatch driven
by `types` in the caller's order. `scope: ["kind", "name"]` now reaches
`defineCallbacks` — activesupport already implements it (`current_scopes`), so
an object callback registered by `beforeSave` dispatches to `beforeSave`.

The three invented `ArgumentError`s (`Unknown option`, `Invalid callback type`,
`At least one event name...`) are deleted — Rails raises none of them there;
unrecognised options are forwarded to `define_callbacks`, so `terminator:` and
friends now work.

Ruby's `send("_define_#{type}_model_callback", ...)` has no TS equivalent, so the
interpolated private-method name resolves through a module-private map, tagged
`@noRailsEquivalent PERMANENT` (not exported — no new public surface). The map is
keyed by the *interpolated Ruby method name*, and a miss raises the package's
`NoMethodError` with Ruby's own message (`undefined method
'_define_bogus_model_callback' for class Topic`, verified against MRI) — so
`only: ["bogus"]` fails exactly as `send` does at callbacks.rb:125, not with a JS
TypeError. Pinned by `callbacks.trails.test.ts`.

## `XmlMini` key stringification (xml_mini.rb:118)

`keyToString`'s JS-`Symbol` arm is gone and the helper collapses into `String(key)`
at both call sites — the closer mirror of `key.to_s`. Per CLAUDE.md a Ruby Symbol
is a JS string; a Symbol *key* renders as its bare name, so no colon handling.
`#to_tag should dasherize the space when passed a symbol with spaces as a key`
(xml_mini_test.rb:172) now passes the string key, name unchanged.

## Verification

- `parity:api:calls`, `:args`, `:extra` / `:extra:gate` all clean, no baseline
  rows added, no reseed.
- Green: `excluding{,.trails}`, `batches{,.trails}`, `relation-load-async.trails`,
  `activemodel/callbacks`, `activerecord/callbacks{,.trails}`,
  `transaction-callbacks`, `validations`, `persistence`,
  `nested-attributes-with-callbacks`, the whole `packages/activemodel/src` suite,
  `xml-mini`, `hash-ext`.

Closes-story: excluding-must-drain-a-scheduled-relation
Closes-story: in-batches-loaded-arm-must-drain-a-scheduled-relation
Closes-story: converge-define-model-callbacks-options-handling
Closes-story: converge-xmlmini-key-to-string-off-js-symbol
