### PR TITLE
fix(activerecord): descends_from_active_record? reads columns_hash in the cold window

### DIFF
--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -58,3 +58,23 @@ describe("ensure_proper_type on an unreflected subclass", () => {
     expect(new ColdClient({}).type).toBe("ColdClient");
   });
 });
+
+describe("descends_from_active_record? on a cold model", () => {
+  // No `fixtures` here on purpose: the cold window is the one where nothing has
+  // leased a connection yet, so there is no warm `columns_hash` to read.
+
+  // The cold twin of "a virtual type attribute is not an inheritance column":
+  // Rails' `columns_hash.include?(inheritance_column)` (inheritance.rb:82-88)
+  // loads the schema when the columns are not reflected yet, rather than
+  // answering from `attribute_types` — which counts the virtual `type` and
+  // misreads the model as an STI subclass.
+  it("a virtual type attribute on an unreflected model is not an inheritance column", () => {
+    class ColdVirtualTypeAuthor extends Author {
+      static {
+        this.attribute("type", "string", { virtual: true } as never);
+      }
+    }
+
+    expect(ColdVirtualTypeAuthor.isDescendsFromActiveRecord()).toBe(true);
+  });
+});

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -60,14 +60,11 @@ describe("ensure_proper_type on an unreflected subclass", () => {
 });
 
 describe("descends_from_active_record? on a cold model", () => {
-  // No `fixtures` here on purpose: the cold window is the one where nothing has
-  // leased a connection yet, so there is no warm `columns_hash` to read.
-
-  // The cold twin of "a virtual type attribute is not an inheritance column":
-  // Rails' `columns_hash.include?(inheritance_column)` (inheritance.rb:82-88)
-  // loads the schema when the columns are not reflected yet, rather than
-  // answering from `attribute_types` — which counts the virtual `type` and
-  // misreads the model as an STI subclass.
+  // No `fixtures` on purpose: the cold window is the one where nothing has
+  // leased a connection, so there is no warm `columns_hash` to read and Rails'
+  // `columns_hash.include?(inheritance_column)` (inheritance.rb:82-88) has to
+  // load the schema rather than answer from `attribute_types`, which counts the
+  // virtual `type` and misreads the model as an STI subclass.
   it("a virtual type attribute on an unreflected model is not an inheritance column", () => {
     class ColdVirtualTypeAuthor extends Author {
       static {

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -162,6 +162,9 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  */
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
+  // Rails' first arm, `if self == Base` → false, returns before the column
+  // test — Base has no table, so asking it for `columns_hash` raises.
+  if (Object.prototype.hasOwnProperty.call(modelClass, "_isActiveRecordBase")) return false;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
   const columnsHash = modelClass.columnsHash();
   const inheritCol = modelClass.inheritanceColumn;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -7,7 +7,6 @@
 import type { Base } from "./base.js";
 import { modelRegistry, registerModelConstant } from "./associations.js";
 import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
-import { cachedColumnsHash } from "./model-schema.js";
 import {
   camelize,
   constantize,
@@ -160,28 +159,12 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * paths.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#descends_from_active_record?
- *
- * @missingRailsCall columns_hash — PERMANENT: Language shortcoming: Ruby's `columns_hash`
- * loads the schema on first touch, and this predicate is reachable from inside
- * that load (the relation `define_attribute_methods` builds asks it), so
- * calling `columnsHash()` re-enters `load_schema` — which memoizes only on the
- * way out (`model_schema.rb:534-545`) and so recurses without bound. The
- * already-reflected columns are read out of the schema cache instead, which is
- * the same `@columns_hash` Rails would have answered from.
  */
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  // Story: descends-from-active-record-cold-window-reads-attribute-types (RFC
-  // 0078) — an unreflected model, and every abstract class (trails reflects
-  // none), still answers from `attribute_types`, which counts a virtual `type`
-  // where `columns_hash` would not. Closing that window means removing the
-  // re-entry named above, not changing the reader.
-  const columnsHash = cachedColumnsHash(modelClass);
+  const columnsHash = modelClass.columnsHash();
   const inheritCol = modelClass.inheritanceColumn;
-  if (columnsHash === undefined) {
-    return inheritCol === null || !Object.keys(modelClass.attributeTypes()).includes(inheritCol);
-  }
   // Ruby `columns_hash.include?(inheritance_column)` is false for the nil
   // `inheritance_column` of an STI-disabled model, so no separate arm.
   return !Object.keys(columnsHash).includes(inheritCol as string);

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -244,22 +244,6 @@ describe("PersistenceTest (trails)", () => {
 });
 
 describe("PersistenceTest (trails)", () => {
-  fixtures(["companies"]);
-
-  // Rails' becomes allocates with `klass.allocate` (persistence.rb:487), which
-  // never enters Inheritance::ClassMethods#new — so the abstract-class / Base
-  // guard `new` enforces (inheritance.rb:57) must not fire for becomes().
-  it("becomes bypasses the Base abstract-instantiation guard", async () => {
-    const { Base } = await import("./index.js");
-    const { Company } = await import("./test-helpers/models/company.js");
-    const company = await Company.first();
-    const asBase = company!.becomes(Base as never);
-    expect(asBase).toBeInstanceOf(Base);
-    expect((asBase as unknown as { id: unknown }).id).toBe(company!.id);
-  });
-});
-
-describe("PersistenceTest (trails)", () => {
   fixtures(["posts"]);
 
   // persistence.rb:243-246 — the prefetch arm re-casts the sequence value

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -19,6 +19,7 @@ import { ClothingItem } from "./test-helpers/models/clothing-item.js";
 import { Minimalistic } from "./test-helpers/models/minimalistic.js";
 import { Aircraft } from "./test-helpers/models/aircraft.js";
 import { Post as CanonicalPost } from "./test-helpers/models/post.js";
+import { Company } from "./test-helpers/models/company.js";
 import { captureSql } from "./testing/sql-capture.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
@@ -240,6 +241,29 @@ describe("PersistenceTest (trails)", () => {
     expect(MinimalisticAircraft.columnNames()).not.toContain("expires_at");
     expect(MinimalisticAircraft.columnNames()).toContain("name");
     expect(aircraft.wingspan).toBeNull();
+  });
+});
+
+describe("PersistenceTest (trails)", () => {
+  fixtures(["companies"]);
+
+  // Rails' becomes allocates with `klass.allocate` (persistence.rb:487), which
+  // never enters Inheritance::ClassMethods#new — so the abstract-class guard
+  // `new` raises NotImplementedError from (inheritance.rb:56-59) must not fire
+  // for becomes(). The guard's other half, `self == Base`, is not reachable
+  // through becomes in Rails either: `allocate.send(:initialize)` seeds
+  // `@attributes` from `_default_attributes`, which loads the schema and
+  // raises TableNotSpecified for table-less Base.
+  it("becomes bypasses the abstract-instantiation guard", async () => {
+    class AbstractFirm extends Company {
+      static {
+        this.abstractClass = true;
+      }
+    }
+    const company = await Company.first();
+    const asAbstract = company!.becomes(AbstractFirm as never);
+    expect(asAbstract).toBeInstanceOf(AbstractFirm);
+    expect((asAbstract as unknown as { id: unknown }).id).toBe(company!.id);
   });
 });
 


### PR DESCRIPTION
`descends_from_active_record?` must answer Rails' `!columns_hash.include?(inheritance_column)` (`activerecord/lib/active_record/inheritance.rb:82-88`) — real column metadata, so a concrete model carrying only a *virtual* declared `type` attribute is not classified as an STI subclass.

trails#6805 converged the warm half (read the reflected columns out of the schema cache) but left a cold fallback to `attribute_types`, which counts the virtual `type`. The fallback existed because calling `columnsHash()` used to re-enter `load_schema` through a relation built during attribute-method generation.

That re-entry is gone on main: `defineAttributeMethods` (`attribute-methods.ts`) builds no relation, mirroring `activemodel/lib/active_model/attribute_methods.rb:104-125`. Verified by running the two suites that overflowed the stack in run 32446311544 (`validations/uniqueness-validation`, `core.trails`) with the direct call in place — both green.

So `isDescendsFromActiveRecord` now calls `columnsHash()` unconditionally, and the `@missingRailsCall columns_hash` tag is deleted.

Regression test: `inheritance.trails.test.ts` → "a virtual type attribute on an unreflected model is not an inheritance column" — the cold twin of the reflected case shipped in #6805. It deliberately omits `fixtures`, since the cold window is the one where nothing has leased a connection and there is no warm `columns_hash` to read. It fails on the baseline (`expected false to be true`) and passes here.

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra --package activerecord` clean, `pnpm typecheck` clean.

Closes-story: descends-from-active-record-cold-window-reads-attribute-types