### PR TITLE
refactor(activerecord): materialize excluding's loaded relation args eagerly

### DIFF
--- a/packages/activerecord/src/excluding.trails.test.ts
+++ b/packages/activerecord/src/excluding.trails.test.ts
@@ -5,6 +5,11 @@
  * primary-key attribute off the predicate builder's own table — Rails'
  * `predicate_builder[primary_key, records]` (predicate_builder.rb:53-55) — not
  * off the model's default arel table.
+ *
+ * A relation argument that is already `loaded?` needs no query for its ids —
+ * `Relation#ids` maps its rows (calculations.rb:373-380) — so `excluding`
+ * materializes that arm eagerly, where Rails materializes, and no marker is
+ * recorded at all. Rails has no test for it because it has no other arm.
  */
 import { describe, it, expect } from "vitest";
 import "./index.js";
@@ -12,6 +17,7 @@ import { Nodes } from "@blazetrails/arel";
 import { fixtures } from "./test-fixtures.js";
 import { registerModel } from "./associations.js";
 import { Relation } from "./relation.js";
+import { DeferredIdsNotIn } from "./relation/predicate-builder/deferred-distinct-pk-in.js";
 import { Post } from "./test-helpers/models/post.js";
 
 registerModel(Post);
@@ -27,6 +33,16 @@ describe("excluding deferred arm (trails)", () => {
     const attribute = predicate.left as Nodes.Attribute;
     expect(attribute.relation).toBeInstanceOf(Nodes.TableAlias);
     expect((attribute.relation as Nodes.TableAlias).name).toBe("p");
+  });
+
+  it("materializes a loaded relation argument to literal ids", async () => {
+    const loaded = await Post.where({ title: "Welcome to the weblog" }).load();
+    const sql = Post.excluding(loaded).toSql();
+
+    const predicate = Post.excluding(loaded).whereClause.predicates.at(-1);
+    expect(predicate).not.toBeInstanceOf(DeferredIdsNotIn);
+    expect(sql).not.toMatch(/IN \(SELECT/i);
+    expect(sql).toContain(String((await loaded.records())[0].id));
   });
 
   // `spawn.excluding!(...)` (query_methods.rb:1580) has no empty-argument

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
@@ -67,10 +67,13 @@ export class DeferredDistinctPkNotIn extends Nodes.NotIn {
  * `records + relations.flat_map(&:ids)` array:
  * `predicate_builder[primary_key, records].invert`. `relations.flat_map(&:ids)`
  * runs a separate `SELECT <pk>` query per relation, producing a literal id
- * array. trails' query builder is synchronous and cannot run `Relation#ids` at
- * `.excluding()`-build time, so we record one marker carrying both the already-
- * known `literalIds` (scalar/loaded record ids) and the still-unloaded
- * `innerRelations`. The load pipeline (`_materializeDeferredDistinctPkPredicates`)
+ * array — except for a `loaded?` relation, whose `ids` runs no query
+ * (calculations.rb:373-380) and which `excluding` therefore flattens eagerly,
+ * where Rails flattens. trails' query builder is synchronous and cannot run the
+ * id-select at `.excluding()`-build time, so the relations that DO need one — an
+ * un-loaded relation, or a `scheduled?` one whose parked rows must be drained —
+ * are recorded in one marker carrying both the already-known `literalIds`
+ * (scalar/loaded record ids) and those `innerRelations`. The load pipeline (`_materializeDeferredDistinctPkPredicates`)
  * awaits every `innerRelations[i].ids()`, concatenates them after `literalIds`,
  * and substitutes a single literal `attribute.notIn([...ids])` before compile —
  * preserving Rails' one-predicate shape, not an `AND` of separate `NOT IN`s.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1973,13 +1973,18 @@ function excludingWithCallee(callee: "excluding" | "without") {
     const flatMappedIds: unknown[] = [];
     const deferredRelations: any[] = [];
     for (const relation of relations) {
-      const primaryKey = relation.model.primaryKey;
-      if (relation.isLoaded && !relation.isScheduled && !Array.isArray(primaryKey)) {
-        for (const record of relation._records) {
-          flatMappedIds.push(record._readAttribute(primaryKey));
-        }
-      } else {
+      if (!relation.isLoaded || relation.isScheduled) {
         deferredRelations.push(relation);
+        continue;
+      }
+      const primaryKey = relation.model.primaryKey;
+      const primaryKeyArray: string[] = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      for (const record of relation._records) {
+        flatMappedIds.push(
+          primaryKeyArray.length === 1
+            ? record._readAttribute(primaryKeyArray[0])
+            : primaryKeyArray.map((column: string) => record._readAttribute(column)),
+        );
       }
     }
     const combined: unknown[] = [...records, ...flatMappedIds, ...deferredRelations];

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1959,11 +1959,30 @@ function excludingWithCallee(callee: "excluding" | "without") {
 
     // Rails `records + relations.flat_map(&:ids)` (query_methods.rb:1583-1586).
     // `Relation#ids` is the seam that decides per relation whether a query runs
-    // (calculations.rb:373), draining a parked `@future_result` on the `loaded?`
-    // arm. trails cannot run that select synchronously, so every relation
-    // argument is deferred uniformly and the load pipeline materializes it
-    // through `Relation#ids` rather than second-guessing the decision here.
-    const combined: unknown[] = [...records, ...relations];
+    // (calculations.rb:373): a relation that is already `loaded?` maps its rows
+    // with `record._read_attribute(primary_key)` and runs NO query, so that arm
+    // materializes HERE, where Rails materializes, and its literal ids reach
+    // `excluding!` in the same argument position Rails puts them in.
+    //
+    // The two arms trails cannot take eagerly stay deferred: a `scheduled?`
+    // relation (relation.rb:1170) is `loaded?` with its rows still parked in
+    // `@future_result`, and draining them is asynchronous; an un-loaded one
+    // needs the `SELECT <pk>` select, which the synchronous builder cannot run.
+    // Both go to `excluding!` as relations, and the load pipeline materializes
+    // them through `Relation#ids`.
+    const flatMappedIds: unknown[] = [];
+    const deferredRelations: any[] = [];
+    for (const relation of relations) {
+      const primaryKey = relation.model.primaryKey;
+      if (relation.isLoaded && !relation.isScheduled && !Array.isArray(primaryKey)) {
+        for (const record of relation._records) {
+          flatMappedIds.push(record._readAttribute(primaryKey));
+        }
+      } else {
+        deferredRelations.push(relation);
+      }
+    }
+    const combined: unknown[] = [...records, ...flatMappedIds, ...deferredRelations];
     return excludingBang.call(this.spawn(), combined);
   };
 }
@@ -1985,7 +2004,9 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // every relation arg's eagerly-materialized ids — built into ONE predicate.
   // Ruby materializes those ids before this call (synchronous query execution);
   // trails' builder is synchronous-and-lazy, so `excluding`/`without` leave
-  // every relation argument in `records` for us to defer here.
+  // the relation arguments whose ids it could NOT map without a query — an
+  // un-loaded or `scheduled?` one — in `records` for us to defer here; a
+  // `loaded?` one was already flattened to its literal ids there.
   const deferredRelations = records.filter((r) => isRelationLike(r));
   const literalRecords = records.filter((r) => !isRelationLike(r));
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1964,12 +1964,16 @@ function excludingWithCallee(callee: "excluding" | "without") {
     // materializes HERE, where Rails materializes, and its literal ids reach
     // `excluding!` in the same argument position Rails puts them in.
     //
-    // The two arms trails cannot take eagerly stay deferred: a `scheduled?`
-    // relation (relation.rb:1170) is `loaded?` with its rows still parked in
-    // `@future_result`, and draining them is asynchronous; an un-loaded one
-    // needs the `SELECT <pk>` select, which the synchronous builder cannot run.
-    // Both go to `excluding!` as relations, and the load pipeline materializes
-    // them through `Relation#ids`.
+    // The two arms trails cannot take eagerly stay deferred, and the reason is a
+    // language shortcoming, not a preference: an un-loaded relation's `ids`
+    // RUNS the `SELECT <pk>` (calculations.rb:390-404) and a `scheduled?` one
+    // (relation.rb:1170) must drain its parked `@future_result` — both
+    // asynchronous, while `excluding` is a synchronous chainable and every
+    // trails adapter's `select_all` is `Promise`-returning
+    // (connection-adapters/abstract/database-statements.ts), so there is no
+    // synchronous query to run here. Both go to `excluding!` as relations, and
+    // the load pipeline materializes them through `Relation#ids` at the first
+    // terminal.
     const flatMappedIds: unknown[] = [];
     const deferredRelations: any[] = [];
     for (const relation of relations) {
@@ -2061,13 +2065,20 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
  * already claimed by the caller.
  *
  * Mirrors: ActiveRecord::QueryMethods#arel (query_methods.rb:1594-1596)
- * @missingRailsCall with_connection — PERMANENT: `with_connection`
- * (query_methods.rb:1595) is the connection acquisition around `build_arel`.
- * trails' `Relation#withConnection` is a `Promise`-returning checkout and this
- * reader is synchronous — every caller reads `relation.arel()` inline while
- * building a query — so the acquisition is the direct `_conn()` lease, which
- * hands `build_arel` the same connection and raises the same
- * `ConnectionNotEstablished` when no pool is established.
+ * @missingRailsCall with_connection — PERMANENT: Rails is
+ * `@arel ||= with_connection { |c| build_arel(c, aliases) }`
+ * (query_methods.rb:1594-1595). The memo and the connection argument are ported
+ * verbatim; only the acquisition SHAPE differs, and a synchronous
+ * `with_connection` seam cannot exist. `ConnectionPool#withConnection`
+ * (connection-adapters/abstract/connection-pool.ts) is `async` for exactly one
+ * reason — `checkout()` awaits an available connection — so a synchronous seam
+ * could only ever serve an ALREADY-leased connection, which is precisely what
+ * `_conn()` returns (the `with_connection` block parameter threaded by the
+ * enclosing wrap, else the model's pool). This reader is read inline by ~30
+ * synchronous callers (`toSql`, `updateAll`, `deleteAll`, `selectAll`,
+ * `buildFrom`, the predicate builder), so it cannot become async either. The
+ * lease raises the same `ConnectionNotEstablished` Rails' `with_connection`
+ * raises when no pool is established.
  * @internal
  */
 export function arel(this: QueryMethodsHost, aliases?: AliasTracker): any {


### PR DESCRIPTION
## What

`QueryMethods#excluding` is
`spawn.excluding!(records + relations.flat_map(&:ids))`
(`query_methods.rb:1583`), and `Relation#ids` runs **no query** for a relation
that is already `loaded?` — it maps its rows with
`record._read_attribute(primary_key)` (`calculations.rb:373-380`).

trails deferred *every* relation argument through a `DeferredIdsNotIn` marker.
This takes the `loaded?` arm eagerly, where Rails takes it: those ids are
flattened into the `excluding!` argument array in the same position Rails puts
them, so no marker is recorded and `toSql()` renders literal ids rather than the
marker's `IN (SELECT ...)` display fallback.

The two arms trails cannot take synchronously stay deferred and unchanged:

- a `scheduled?` relation (`relation.rb:1170`) is `loaded?` with its rows still
  parked in `@future_result`, and draining them is asynchronous — so it keeps
  going through `Relation#ids` in the load pipeline, preserving the drain
  semantics #6922 landed;
- an un-loaded relation needs the `SELECT <pk>` select, which the synchronous
  builder cannot run.

## Story status — neither story is closed by this PR

**converge-excluding-deferred-ids-marker-to-eager-materialization** — this PR
ships the story's option 2 ("a relation argument that is already `loaded?`
needs no await and could build the literal predicate immediately — take that arm
eagerly and defer only the un-loaded ones"). Its first acceptance criterion —
an **un-loaded** relation rendering literal ids from `toSql()` — requires
running `SELECT <pk>` synchronously inside a synchronous `toSql()`. No trails
adapter offers a synchronous query and `toSql(): string` is read inline by
dozens of call sites, so that arm cannot converge without a synchronous query
seam. Story left open/blocked on that, not ratified.

**port-with-connection-acquisition-seam-for-the-arel-reader** — no code here.
Its achievable half already landed on main: #6755 removed the `{ sanitizeLimit }`
stand-ins and made the acquisition a real `_conn()` lease, and #6865 folded
`toArel` into the `arel` reader with the `@arel ||=` memo
(`relation/query-methods.ts`, `_arel` reset in `relation.ts#reset`). The one
remaining criterion — a **synchronous** `with_connection` seam — runs into the
same wall: `ConnectionPool#withConnection` is only async because `checkout()`
is, and a synchronous seam could only ever serve an already-leased connection,
which is exactly what `_conn()` already does.

## Review responses

**`query-methods.ts:1976` — the un-loaded arm still defers.** Correct, and it
cannot do otherwise here. Rails evaluates `relations.flat_map(&:ids)` before
`excluding!` (`query_methods.rb:1583`) and the un-loaded `ids` RUNS the select
(`calculations.rb:390-404`). `excluding` is a synchronous chainable and every
trails adapter's `select_all` is `Promise`-returning
(`connection-adapters/abstract/database-statements.ts:1293`, `:1375` — the
interface itself, so all three drivers), so there is no synchronous query to run
at this call site. The same wall stops `toSql()`: it is `toSql(): string`, read
inline by 26 non-test call sites, so it cannot await the materialization either.
This PR therefore ships the story's own option 2 verbatim ("a relation argument
that is already `loaded?` needs no await and could build the literal predicate
immediately — take that arm eagerly and defer only the un-loaded ones") and the
story stays open on the un-loaded arm rather than being closed. The blocker is
now cited at the call site with those Rails lines.

**`query-methods.ts:2073` — no synchronous `withConnection` seam.** Also
correct, and the same class of blocker. `ConnectionPool#withConnection` is
`async` for exactly one reason: `checkout()` awaits an available connection. A
synchronous seam could therefore only ever serve an **already-leased**
connection — which is precisely what `_conn()` returns (the `with_connection`
block parameter threaded by the enclosing wrap, else the model's pool). Adding a
`withConnectionSync` would be a rename of `_conn()` with a Rails-shaped
signature it cannot honour, i.e. exactly the "better justification for the
deviation" CLAUDE.md forbids. `arel()` ports the rest of
`query_methods.rb:1594-1595` verbatim, memo included. The `@missingRailsCall`
tag now carries that reasoning and those cites. That story is likewise left
open, not closed.

## Verification

- `excluding.test.ts`, `excluding.trails.test.ts`,
  `deferred-distinct-pk-in.trails.test.ts`, `relation-load-async.trails.test.ts`
  green; the new trails-only case fails on baseline (marker recorded, subquery
  rendered).
- `pnpm parity:api:calls` OK (423 baselined, unchanged), `pnpm parity:api:calls:args` OK.
- `pnpm typecheck` clean.
