### PR TITLE
fix(activerecord): compute_if_absent touches inline, shifts before yield, and loses the store race

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -80,18 +80,29 @@ export class Store {
     compute: () => Promise<Record<string, unknown>[]>,
   ): Promise<Record<string, unknown>[]> {
     this.checkVersion();
+
     if (!this.enabled) return compute();
 
-    const cached = this.get(key);
-    if (cached !== undefined) {
-      return Promise.resolve(cached.map((row) => ({ ...row })));
+    const entry = this._map.get(key);
+    if (entry) {
+      this._map.delete(key);
+      this._map.set(key, entry);
+      return Promise.resolve(entry.map((row) => ({ ...row })));
+    }
+
+    if (this._maxSize != null && this._map.size >= this._maxSize) {
+      // `@map.shift` (query_cache.rb:76) — evict the oldest entry, which for a
+      // JS `Map` is the first insertion-ordered key.
+      const oldestKey = this._map.keys().next().value;
+      if (oldestKey !== undefined) this._map.delete(oldestKey);
     }
 
     return compute().then((result) => {
-      if (this._maxSize != null && this._map.size >= this._maxSize) {
-        const firstKey = this._map.keys().next().value;
-        if (firstKey !== undefined) this._map.delete(firstKey);
-      }
+      // `@map[key] ||= yield` (query_cache.rb:79): the assignment loses to a
+      // value stored while this compute was in flight, so a second concurrent
+      // miss on the same key does not overwrite the first one's result.
+      const stored = this._map.get(key);
+      if (stored) return stored.map((row) => ({ ...row }));
       this._map.set(key, result);
       return result.map((row) => ({ ...row }));
     });

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -171,6 +171,37 @@ describe("Store max size eviction gate (trails)", () => {
     expect(store.get("b")).toEqual([{ key: "b" }]);
     expect(store.get("c")).toEqual([{ key: "c" }]);
   });
+
+  // `compute_if_absent` (query_cache.rb:66-80) touches the entry it finds —
+  // `@map.delete(key)` then `@map[key] = entry` — so a cache HIT makes that key
+  // the newest and the eviction shift takes some other key.
+  it("a hit refreshes the entry so the shift evicts a colder key", async () => {
+    const store = new Store(null, 2);
+    store.enabled = true;
+    await fill(store, ["a", "b"]);
+    await store.computeIfAbsent("a", () => Promise.reject(new Error("miss")));
+    await fill(store, ["c"]);
+    expect(store.get("a")).toEqual([{ key: "a" }]);
+    expect(store.get("b")).toBeUndefined();
+  });
+
+  // `@map[key] ||= yield` (query_cache.rb:79) only assigns when the key is
+  // still absent, so the loser of two concurrent misses on the same key does
+  // not clobber the value the winner stored.
+  it("a concurrent miss on the same key does not overwrite the stored value", async () => {
+    const store = new Store(null, null);
+    store.enabled = true;
+    let resolveSecond: (rows: Record<string, unknown>[]) => void = () => {};
+    const second = new Promise<Record<string, unknown>[]>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const first = store.computeIfAbsent("a", () => Promise.resolve([{ key: "first" }]));
+    const later = store.computeIfAbsent("a", () => second);
+    await first;
+    resolveSecond([{ key: "second" }]);
+    expect(await later).toEqual([{ key: "first" }]);
+    expect(store.get("a")).toEqual([{ key: "first" }]);
+  });
 });
 
 // Rails routes schema reflection through `internal_exec_query`, a method


### PR DESCRIPTION
RFC 0096 wave-5 residual `naming` rows were re-read against the vendored Ruby.
One of them was a real behaviour gap; this PR ports it.

## `QueryCache::Store#compute_if_absent`

`query_cache.rb:66-80`:

```ruby
def compute_if_absent(key)
  check_version
  return yield unless @enabled
  if entry = @map.delete(key)
    return @map[key] = entry
  end
  if @max_size && @map.size >= @max_size
    @map.shift # evict the oldest entry
  end
  @map[key] ||= yield
end
```

trails delegated the LRU touch to `get()`, evicted *after* the compute
resolved, and assigned unconditionally. The last of those is a real
behaviour difference: `@map[key] ||= yield` loses to a value stored while
the yield was in flight, so two concurrent misses on the same key agree on
the winner's rows. trails' unconditional `set` let the loser clobber it.
The new `a concurrent miss on the same key does not overwrite the stored
value` case fails on the pre-change body and passes after.

The body now mirrors the Ruby line for line, which also retires the
`compute_if_absent` / `delete` arg-shape row: the only `delete` in the TS
body was the eviction (`ref:firstKey`), and the inlined touch restores
Rails' `@map.delete(key)`.

`pnpm parity:api:calls:args` reports 431 → 430 call-arg mismatches; both
call gates stay green with no new `call-mismatches-exclude/` row.
`pnpm parity:api:extra:gate` OK; `parity:api` / `parity:test` unmoved
(body-only change).

## The remaining rows — dispositioned in the task system

Recorded row by row in the story body itself
(`rfcs/0096-naming-identifier-burndown/stories/wave-5-residual-arg-shape-findings.md`,
tasks `124ed80f6`), not only here. Each row is converged, re-filed as an
owned convergence story, or recorded PERMANENT with the specific
TypeScript language shortcoming that blocks it. None is closed by a
rename.

Re-filed as scheduled stories under RFC 0096:

| story | rows |
| --- | --- |
| `converge-belongs-to-polymorphic-foreign-type` | 3 — needs the reflection type unified first |
| `converge-create-schema-dumper-source-arity` | 3 — needs the wrapping at `schema-dumper.ts:573` moved to the dumper side |
| `converge-activesupport-temporal-receiver-chaining` | 5 — the `receiver()` rebuild plus `time-ext.ts#advance` |
| `converge-transactions-splat-and-transaction-receiver` | 4 — the a1 splat/receiver rows |

The rest are PERMANENT, e.g. `RegExp.prototype.match` does not exist
(`abstract_mysql_adapter.rb:986`), `PRAGMA table_info("aux"."t")` returns
zero rows for an ATTACHed database (`sqlite3_adapter.rb:790-796`), TS
cannot rebind a parameter across types
(`predicate_builder.rb:157-159`), and a JS module cannot bind both a local
and the imported helper it calls under one identifier.

Closes-story: wave-5-residual-arg-shape-findings
