### PR TITLE
refactor(activesupport,date): TimeWithZone#utc answers a ::Time; Time#change's zoned arm rebuilds through Time.local

### DIFF
--- a/packages/activemodel/src/type/helpers/time-value.test.ts
+++ b/packages/activemodel/src/type/helpers/time-value.test.ts
@@ -171,7 +171,7 @@ describe("userInputInTimeZone", () => {
   it("keeps sub-millisecond precision through the zone parse", () => {
     useZone("Eastern Time (US & Canada)", () => {
       const result = userInputInTimeZone("2024-06-15 14:30:00.123456789") as TimeWithZone;
-      expect(result.utc().epochNanoseconds % 1_000_000_000n).toBe(123456789n);
+      expect(result.utc().toTime().epochNanoseconds % 1_000_000_000n).toBe(123456789n);
     });
   });
 

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -537,14 +537,14 @@ describeIfPg("PostgreSQLAdapter", () => {
         const record = new PgArrays({ datetimes: [timeString] } as any);
         const before = (record as any).datetimes as TimeWithZone[];
         expect(before[0]).toBeInstanceOf(TimeWithZone);
-        expect(before[0].utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+        expect(before[0].utc().toTime().epochMilliseconds).toBe(instant.epochMilliseconds);
         expect(before[0].timeZone.name).toBe(zone.name);
 
         await (record as any).save();
         await (record as any).reload();
         const after = (record as any).datetimes as TimeWithZone[];
         expect(after[0]).toBeInstanceOf(TimeWithZone);
-        expect(after[0].utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+        expect(after[0].utc().toTime().epochMilliseconds).toBe(instant.epochMilliseconds);
         expect(after[0].timeZone.name).toBe(zone.name);
       } finally {
         setZone(null);

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -469,7 +469,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const r = new PostgresqlRangesTz({ tstz_range: new Range(timeString, timeString, false) });
       const range1 = r.tstz_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
-      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range1.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -478,7 +478,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       const range2 = r.tstz_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
-      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range2.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -493,7 +493,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const r = new PostgresqlRangesTz({ tstz_range: new Range(timeString, null, true) });
       const range1 = r.tstz_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
-      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range1.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -503,7 +503,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       const range2 = r.tstz_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
-      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range2.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -520,7 +520,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range1 = r.tstz_range as Range;
       expect(range1.begin).toBeNull();
       expect(range1.end).toBeInstanceOf(TimeWithZone);
-      expect((range1.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range1.end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
       expect((range1.end as TimeWithZone).timeZone.name).toBe(zone.name);
 
       await r.saveBang();
@@ -528,7 +530,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range2 = r.tstz_range as Range;
       expect(range2.begin).toBeNull();
       expect(range2.end).toBeInstanceOf(TimeWithZone);
-      expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range2.end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
       expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
     it("timezone array awareness tzrange", async () => {
@@ -552,7 +556,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const pre = r.tstz_ranges as Range[];
       expect(pre[0].begin).toBeInstanceOf(TimeWithZone);
       expect((pre[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((pre[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((pre[0].begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         fromInstant.epochMilliseconds,
       );
 
@@ -562,10 +566,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(post).toHaveLength(4);
       expect(post[0].begin).toBeInstanceOf(TimeWithZone);
       expect((post[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((post[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((post[0].begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         fromInstant.epochMilliseconds,
       );
-      expect((post[0].end as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((post[0].end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         toInstant.epochMilliseconds,
       );
       expect(post[2].begin).toBeInstanceOf(TimeWithZone);
@@ -700,7 +704,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, timeString, false) });
       const range1 = r.ts_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
-      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range1.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -709,7 +713,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       const range2 = r.ts_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
-      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range2.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -724,7 +728,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, null, true) });
       const range1 = r.ts_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
-      expect((range1.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range1.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -734,7 +738,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       const range2 = r.ts_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
-      expect((range2.begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((range2.begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         instant.epochMilliseconds,
       );
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
@@ -751,7 +755,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range1 = r.ts_range as Range;
       expect(range1.begin).toBeNull();
       expect(range1.end).toBeInstanceOf(TimeWithZone);
-      expect((range1.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range1.end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
       expect((range1.end as TimeWithZone).timeZone.name).toBe(zone.name);
 
       await r.saveBang();
@@ -759,7 +765,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range2 = r.ts_range as Range;
       expect(range2.begin).toBeNull();
       expect(range2.end).toBeInstanceOf(TimeWithZone);
-      expect((range2.end as TimeWithZone).utc().epochMilliseconds).toBe(instant.epochMilliseconds);
+      expect((range2.end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
+        instant.epochMilliseconds,
+      );
       expect((range2.end as TimeWithZone).timeZone.name).toBe(zone.name);
     });
     it("timezone array awareness tsrange", async () => {
@@ -782,7 +790,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const pre = r.ts_ranges as Range[];
       expect(pre[0].begin).toBeInstanceOf(TimeWithZone);
       expect((pre[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((pre[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((pre[0].begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         fromInstant.epochMilliseconds,
       );
 
@@ -792,10 +800,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(post).toHaveLength(4);
       expect(post[0].begin).toBeInstanceOf(TimeWithZone);
       expect((post[0].begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((post[0].begin as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((post[0].begin as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         fromInstant.epochMilliseconds,
       );
-      expect((post[0].end as TimeWithZone).utc().epochMilliseconds).toBe(
+      expect((post[0].end as TimeWithZone).utc().toTime().epochMilliseconds).toBe(
         toInstant.epochMilliseconds,
       );
       expect(post[2].begin).toBeInstanceOf(TimeWithZone);
@@ -865,7 +873,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range1 = r.ts_range as Range;
       expect(range1.begin).toBeInstanceOf(TimeWithZone);
       expect((range1.begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      expect((range1.begin as TimeWithZone).utc().toString()).toBe(instant.toString());
+      expect((range1.begin as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
+        instant.toString(),
+      );
 
       await r.saveBang();
       await r.reload();
@@ -873,7 +883,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
       // µs precision round-trips through PostgreSQL tsrange
-      expect((range2.begin as TimeWithZone).utc().toString()).toBe(instant.toString());
+      expect((range2.begin as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
+        instant.toString(),
+      );
     });
     it("create numrange", async () => {
       // Rails: assert_equal_round_trip(@new_range, :num_range, BigDecimal("0.5")...BigDecimal("1"))

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -210,7 +210,7 @@ describeIfPg("PostgreSQLAdapter", () => {
             // aware_types includes :timestamptz + a zone is set, so the timestamptz
             // column is wrapped in TimeWithZone (Rails: instance_of ActiveSupport::TimeWithZone).
             expect(record.time).toBeInstanceOf(TimeWithZone);
-            expect(record.time.utc().epochNanoseconds).toBe(
+            expect(record.time.utc().toTime().epochNanoseconds).toBe(
               Temporal.Instant.from("2010-01-01T11:00:00Z").epochNanoseconds,
             );
           },
@@ -281,7 +281,7 @@ describeIfPg("PostgreSQLAdapter", () => {
                 time: TimeWithZone;
               };
               expect(record.time).toBeInstanceOf(TimeWithZone);
-              expect(record.time.utc().epochNanoseconds).toBe(
+              expect(record.time.utc().toTime().epochNanoseconds).toBe(
                 Temporal.Instant.from("2010-01-01T11:00:00Z").epochNanoseconds,
               );
             },

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -941,7 +941,7 @@ describe("AttributeMethodsTest", () => {
       record.writeAttribute("written_on", utcTime);
       const wo = record.written_on;
       // record.written_on is equal to (i.e. simultaneous with) utc_time …
-      expect(wo.utc().epochNanoseconds).toBe(utcTime.epochNanoseconds);
+      expect(wo.utc().toTime().epochNanoseconds).toBe(utcTime.epochNanoseconds);
       // … but is a TimeWithZone …
       expect(wo).toBeInstanceOf(TimeWithZone);
       // … and is in the current Time.zone …
@@ -966,7 +966,7 @@ describe("AttributeMethodsTest", () => {
       const record = Topic.new({}) as unknown as { written_on: TimeWithZone };
       record.written_on = cstTime;
       const wo = record.written_on;
-      expect(wo.utc().epochNanoseconds).toBe(utcTime.epochNanoseconds);
+      expect(wo.utc().toTime().epochNanoseconds).toBe(utcTime.epochNanoseconds);
       expect(wo.timeZone.name).toBe("Pacific Time (US & Canada)");
       const t = wo.time;
       expect([t.year, t.month, t.day, t.hour, t.minute, t.second]).toEqual([

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -141,13 +141,13 @@ export class TimeZoneConverter extends ValueType<unknown> {
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     const oldInstant =
       oldValue instanceof TimeWithZone
-        ? oldValue.utc()
+        ? oldValue.utc().toTime().toInstant()
         : oldValue instanceof Temporal.Instant
           ? oldValue
           : null;
     const newInstant =
       newValue instanceof TimeWithZone
-        ? newValue.utc()
+        ? newValue.utc().toTime().toInstant()
         : newValue instanceof Temporal.Instant
           ? newValue
           : null;
@@ -177,7 +177,8 @@ export class TimeZoneConverter extends ValueType<unknown> {
   // subtype's serialize (which doesn't understand TimeWithZone) receives plain
   // Instants or timestamps.
   private _resolveForSerialize(value: unknown): unknown {
-    const extractUtc = (v: unknown): unknown => (v instanceof TimeWithZone ? v.utc() : v);
+    const extractUtc = (v: unknown): unknown =>
+      v instanceof TimeWithZone ? v.utc().toTime().toInstant() : v;
     if (Array.isArray(value)) {
       return value.map((v) => (isRangeLike(v) ? mapRange(v, extractUtc) : extractUtc(v)));
     }
@@ -271,7 +272,7 @@ function setTimeZoneWithoutConversion(value: unknown, subtypeIsUtc?: boolean): u
     const subMs = zoned.microsecond * 1000 + zoned.nanosecond;
     if (subMs === 0) return base;
     return new TimeWithZone(
-      Temporal.Instant.fromEpochNanoseconds(base.utc().epochNanoseconds + BigInt(subMs)),
+      Temporal.Instant.fromEpochNanoseconds(base.utc().toTime().epochNanoseconds + BigInt(subMs)),
       zone,
     );
   }

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -82,7 +82,7 @@ describe("TimeZoneConverterTest", () => {
     expect(twz.min).toBe(30);
     expect(twz.timeZone.name).toBe("Eastern Time (US & Canada)");
     // UTC instant should be 14:30 (10:30 EDT = UTC-4, so UTC = 10:30 + 4h)
-    expect(twz.utc().epochMilliseconds).toBe(
+    expect(twz.utc().toTime().epochMilliseconds).toBe(
       Temporal.Instant.from("2024-06-15T14:30:00Z").epochMilliseconds,
     );
   });
@@ -168,7 +168,9 @@ describe("TimeZoneConverterTest", () => {
       const converter = new TimeZoneConverter(new ZonelessDateTime());
       const result = converter.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 0 });
       expect(result).toBeInstanceOf(TimeWithZone);
-      expect((result as TimeWithZone).utc().toString()).toBe("2024-06-15T10:00:00Z");
+      expect((result as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
+        "2024-06-15T10:00:00Z",
+      );
     } finally {
       ActiveRecord.defaultTimezone = previous;
     }

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -842,9 +842,9 @@ describe("BasicsTest", () => {
       const topic = await Topic.create({ written_on: utcMidnight });
       const saved = await Topic.find(topic.id);
       const savedTime = saved.readAttribute("written_on") as TimeWithZone;
-      expect(savedTime.utc().epochNanoseconds).toBe(utcMidnight.epochNanoseconds);
+      expect(savedTime.utc().toTime().epochNanoseconds).toBe(utcMidnight.epochNanoseconds);
       // Rails: saved_time.to_a == [0, 0, 19, 31, 12, 1999, 5, 365, false, "EST"]
-      const local1 = savedTime.utc().toZonedDateTimeISO("America/New_York");
+      const local1 = savedTime.utc().toTime().withTimeZone("America/New_York");
       expect(local1.year).toBe(1999);
       expect(local1.month).toBe(12);
       expect(local1.day).toBe(31);
@@ -867,9 +867,9 @@ describe("BasicsTest", () => {
       const topic = await Topic.create({ written_on: cstMidnight });
       const saved = await Topic.find(topic.id);
       const savedTime = saved.readAttribute("written_on") as TimeWithZone;
-      expect(savedTime.utc().epochNanoseconds).toBe(cstMidnight.epochNanoseconds);
+      expect(savedTime.utc().toTime().epochNanoseconds).toBe(cstMidnight.epochNanoseconds);
       // Rails: saved_time.to_a == [0, 0, 1, 1, 1, 2000, 6, 1, false, "EST"]
-      const local2 = savedTime.utc().toZonedDateTimeISO("America/New_York");
+      const local2 = savedTime.utc().toTime().withTimeZone("America/New_York");
       expect(local2.year).toBe(2000);
       expect(local2.month).toBe(1);
       expect(local2.day).toBe(1);

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -205,9 +205,9 @@ describe("DirtyTest", () => {
       pirate.created_on = new TimeWithZone(Temporal.Now.instant().subtract({ hours: 24 }), zone);
       expect(pirate.attributeChanged("created_on")).toBe(true);
       expect(pirate.attributeWas("created_on")).toBeInstanceOf(TimeWithZone);
-      expect((pirate.attributeWas("created_on") as TimeWithZone).utc().epochMilliseconds).toBe(
-        oldCreatedOn.utc().epochMilliseconds,
-      );
+      expect(
+        (pirate.attributeWas("created_on") as TimeWithZone).utc().toTime().epochMilliseconds,
+      ).toBe(oldCreatedOn.utc().toTime().epochMilliseconds);
       pirate.created_on = oldCreatedOn;
       expect(pirate.attributeChanged("created_on")).toBe(false);
     });
@@ -838,7 +838,7 @@ describe("DirtyTest", () => {
 
       const topic = (await Target.create({ written_on: writtenOn })) as Rec;
       topic.written_on = new TimeWithZone(
-        (topic.written_on as TimeWithZone).utc().add({ milliseconds: 300 }),
+        (topic.written_on as TimeWithZone).utc().toTime().toInstant().add({ milliseconds: 300 }),
         zone,
       );
 

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -284,7 +284,7 @@ describe("MultiParameterAttributeTest", () => {
           // awareAttributes wraps as TimeWithZone at runtime; declared type is Instant|PlainDateTime
           const twz = (topic as any).written_on as TimeWithZone;
           expect(twz).toBeInstanceOf(TimeWithZone);
-          expect(twz.utc().toZonedDateTimeISO("UTC").hour).toBe(23); // PDT: local 16:24 → UTC 23:24
+          expect(twz.utc().toTime().hour).toBe(23); // PDT: local 16:24 → UTC 23:24
           expect(twz.hour).toBe(16); // wall-clock in zone
         },
       );

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -86,7 +86,7 @@ function compare(dateOrTime: Comparable, other: Comparable): number {
 function toInstant(dateOrTime: Comparable): Temporal.Instant {
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   if (dateOrTime instanceof Date) return instantFrom(dateOrTime);
-  if (dateOrTime instanceof TimeWithZone) return dateOrTime.utc();
+  if (dateOrTime instanceof TimeWithZone) return dateOrTime.utc().toTime().toInstant();
   if (dateOrTime instanceof Temporal.Instant) return dateOrTime;
   return dateOrTime.toZonedDateTime("UTC").toInstant();
 }

--- a/packages/activesupport/src/core-ext/date/calculations.ts
+++ b/packages/activesupport/src/core-ext/date/calculations.ts
@@ -239,7 +239,7 @@ export function compareWithCoercion(
       other instanceof Temporal.Instant
         ? other
         : other instanceof TimeWithZone
-          ? other.utc()
+          ? other.utc().toTime().toInstant()
           : Temporal.Instant.fromEpochMilliseconds(other.getTime());
     return Temporal.Instant.compare(
       (toDatetime instanceof Temporal.ZonedDateTime

--- a/packages/activesupport/src/core-ext/time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/time-ext.test.ts
@@ -345,14 +345,39 @@ describe("TimeExtCalculationsTest", () => {
     ).toThrow(ArgumentError);
   });
 
-  // Rails' `Time.local` receiver lands on `change`'s `elsif zone` arm
-  // (time/calculations.rb:173-174), which re-runs `Time.local` with the
-  // receiver's `isdst`. trails' JS-`Date` arm calls `local(...)` with no isdst
-  // equivalent, so a nominal time that occurs twice always resolves to the
-  // first occurrence and the second-occurrence assertions below cannot hold.
-  // Unskips with the `elsif zone` / `isdst` port
-  // (story `time-change-local-and-utc-offset-arms-conflated`).
-  it.skip("change preserves offset for local times around end of dst");
+  it("change preserves offset for local times around end of dst", () => {
+    withEnvTz("US/Eastern", () => {
+      // DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+      // were rolled back 1 hour.
+      const midnight = RubyTime.local(2005, 10, 30, 0, 0, 0); // 2005-10-30 00:00:00 -0400
+      // Rails reaches the first occurrence as `Time.local(..., 0, 59, 59) + 1`;
+      // trails' `Time` has no `#+`, so the same instant is named by the `isdst`
+      // argument `change`'s own `elsif zone` arm passes.
+      const oneAm1 = RubyTime.local(0, 0, 1, 30, 10, 2005, null, null, true, null); // -0400
+      const oneAm2 = RubyTime.local(2005, 10, 30, 1, 0, 0); // 2005-10-30 01:00:00 -0500
+      const twoAm = RubyTime.local(2005, 10, 30, 2, 0, 0); // 2005-10-30 02:00:00 -0500
+      expect(oneAm1.toTime().epochNanoseconds).toBeLessThan(oneAm2.toTime().epochNanoseconds);
+
+      const at = (time: RubyTime): bigint => time.toTime().epochNanoseconds;
+      const second = 1_000_000_000n;
+
+      expect(at(change(midnight, { hour: 1 }))).toBe(at(oneAm1));
+      expect(at(change(midnight, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(oneAm1, { hour: 0 }))).toBe(at(midnight));
+      expect(at(change(oneAm1, { hour: 1 }))).toBe(at(oneAm1));
+      expect(at(change(oneAm1, { sec: 1 }))).toBe(at(oneAm1) + second);
+      expect(at(change(oneAm1, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(oneAm2, { hour: 0 }))).toBe(at(midnight));
+      expect(at(change(oneAm2, { hour: 1 }))).toBe(at(oneAm2));
+      expect(at(change(oneAm2, { sec: 1 }))).toBe(at(oneAm2) + second);
+      expect(at(change(oneAm2, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(twoAm, { hour: 1 }))).toBe(at(oneAm2));
+      expect(at(change(twoAm, { hour: 0 }))).toBe(at(midnight));
+    });
+  });
 
   it("change preserves offset for zoned times around end of dst", () => {
     // DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
@@ -393,9 +418,36 @@ describe("TimeExtCalculationsTest", () => {
     expect([time2.year, time2.month, time2.day]).toEqual([2005, 1, 30]);
   });
 
-  // Same `elsif zone` / `isdst` gap as the US/Eastern local-times test above
-  // (story `time-change-local-and-utc-offset-arms-conflated`).
-  it.skip("change preserves fractional hour offset for local times around end of dst");
+  it("change preserves fractional hour offset for local times around end of dst", () => {
+    withEnvTz("Australia/Lord_Howe", () => {
+      // DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and
+      // clocks were rolled back 30 minutes.
+      const oneAm = RubyTime.local(2005, 3, 27, 1, 0, 0); // 2005-03-27 01:00:00 +1100
+      const one30Am1 = RubyTime.local(0, 30, 1, 27, 3, 2005, null, null, true, null); // +1100
+      const one30Am2 = RubyTime.local(2005, 3, 27, 1, 30, 0); // 2005-03-27 01:30:00 +1030
+      const twoAm = RubyTime.local(2005, 3, 27, 2, 0, 0); // 2005-03-27 02:00:00 +1030
+      expect(one30Am1.toTime().epochNanoseconds).toBeLessThan(one30Am2.toTime().epochNanoseconds);
+
+      const at = (time: RubyTime): bigint => time.toTime().epochNanoseconds;
+      const second = 1_000_000_000n;
+
+      expect(at(change(oneAm, { min: 30 }))).toBe(at(one30Am1));
+      expect(at(change(oneAm, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(one30Am1, { min: 0 }))).toBe(at(oneAm));
+      expect(at(change(one30Am1, { min: 30 }))).toBe(at(one30Am1));
+      expect(at(change(one30Am1, { min: 30, sec: 1 }))).toBe(at(one30Am1) + second);
+      expect(at(change(one30Am1, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(one30Am2, { min: 0 }))).toBe(at(oneAm));
+      expect(at(change(one30Am2, { min: 30 }))).toBe(at(one30Am2));
+      expect(at(change(one30Am2, { min: 30, sec: 1 }))).toBe(at(one30Am2) + second);
+      expect(at(change(one30Am2, { hour: 2 }))).toBe(at(twoAm));
+
+      expect(at(change(twoAm, { hour: 1, min: 30 }))).toBe(at(one30Am2));
+      expect(at(change(twoAm, { hour: 1 }))).toBe(at(oneAm));
+    });
+  });
 
   it("change preserves fractional hour offset for zoned times around end of dst", () => {
     // DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and

--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -40,8 +40,8 @@ describe("TimeWithZoneTest", () => {
 
   it("utc", () => {
     const twz = maketwz();
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
-    expect(twz.utc()).toBeInstanceOf(Temporal.Instant);
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc()).toBeInstanceOf(RubyTime);
   });
 
   it("time", () => {
@@ -61,7 +61,7 @@ describe("TimeWithZoneTest", () => {
       const twz = maketwz();
       const result = twz.inTimeZone();
       expect(result.timeZone.name).toBe("Alaska");
-      expect(result.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+      expect(result.utc().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
     });
   });
 
@@ -70,7 +70,7 @@ describe("TimeWithZoneTest", () => {
     const alaska = TimeZone.find("Alaska")!;
     const result = twz.inTimeZone("Alaska");
     expect(result.timeZone.name).toBe(alaska.name);
-    expect(result.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(result.utc().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
   });
 
   it("in time zone with new zone equal to old zone does not create new object", () => {
@@ -87,7 +87,7 @@ describe("TimeWithZoneTest", () => {
     // 2014-10-26 01:00:00 Moscow time was ambiguous due to DST change
     const moscow = TimeZone.find("Moscow")!;
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   it("localtime", () => {
@@ -612,7 +612,7 @@ describe("TimeWithZoneTest", () => {
 
   it("local to utc conversion with far future datetime", () => {
     const twz = eastern.local(2049, 12, 31, 19, 0, 0);
-    const utcMs = twz.utc().epochMilliseconds;
+    const utcMs = twz.utc().toTime().epochMilliseconds;
     expect(utcMs).toBe(Date.UTC(2050, 0, 1, 0, 0, 0));
   });
 
@@ -944,7 +944,7 @@ describe("TimeWithZoneTest", () => {
   it("marshal dump and load", () => {
     const twz = maketwz();
     const json = JSON.stringify({
-      utc: twz.utc().toString(),
+      utc: twz.utc().toTime().toInstant().toString(),
       timeZone: twz.timeZone.name,
     });
     const parsed = JSON.parse(json);
@@ -952,7 +952,7 @@ describe("TimeWithZoneTest", () => {
       instantFromDate(new Date(parsed.utc)),
       TimeZone.find(parsed.timeZone)!,
     );
-    expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(restored.utc().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
     expect(restored.timeZone.name).toBe(twz.timeZone.name);
     expect(restored.inspect()).toBe(twz.inspect());
   });
@@ -960,7 +960,7 @@ describe("TimeWithZoneTest", () => {
   it("marshal dump and load with tzinfo identifier", () => {
     const twz = new TimeWithZone(instantFromDate(new Date(Date.UTC(2000, 0, 1, 0))), eastern);
     const json = JSON.stringify({
-      utc: twz.utc().toString(),
+      utc: twz.utc().toTime().toInstant().toString(),
       timeZone: twz.timeZone.tzinfo.identifier,
     });
     const parsed = JSON.parse(json);
@@ -968,7 +968,7 @@ describe("TimeWithZoneTest", () => {
       instantFromDate(new Date(parsed.utc)),
       TimeZone.find(parsed.timeZone)!,
     );
-    expect(restored.utc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(restored.utc().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
     expect(restored.inspect()).toBe(twz.inspect());
   });
 
@@ -1044,7 +1044,7 @@ describe("TimeWithZoneTest", () => {
 
   it("instance created with local time returns correct utc time", () => {
     const twz = eastern.local(1999, 12, 31, 19);
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
   });
 
   it("instance created with local time enforces spring dst rules", () => {
@@ -1364,7 +1364,7 @@ describe("TimeWithZoneMethodsForTimeAndDateTimeTest", () => {
       instantFromDate(time),
       TimeZone.find("Eastern Time (US & Canada)")!,
     );
-    expect(twz.utc().epochMilliseconds).toBe(time.getTime());
+    expect(twz.utc().toTime().epochMilliseconds).toBe(time.getTime());
     // Original Date should not be modified
     expect(time.getTime()).toBe(Date.UTC(2000, 6, 1));
   });
@@ -1455,6 +1455,6 @@ describe("TimeWithZoneMethodsForString", () => {
     const moscow = TimeZone.find("Moscow")!;
     const twz = moscow.local(2014, 10, 26, 1, 0, 0);
     // Should resolve to the UTC equivalent
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 });

--- a/packages/activesupport/src/core-ext/time/conversions.ts
+++ b/packages/activesupport/src/core-ext/time/conversions.ts
@@ -110,22 +110,30 @@ export const DATE_FORMATS: Record<string, string | ((time: DateFormatsReceiver) 
  * the same way, so `:usec`/`:nsec` still read the microseconds a `Date` cannot
  * carry.
  */
-export function toFs(date: Date | Temporal.Instant, format: string = "default"): string {
-  const utc =
-    // boundary: the JS `Date` a caller still holds is the instant this bridges
-    // onto the ruby/date `Time` the Rails body formats.
-    date instanceof Date
-      ? Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO("UTC")
-      : date.toZonedDateTimeISO("UTC");
-  const time = RubyTime.utc(
-    utc.year,
-    utc.month,
-    utc.day,
-    utc.hour,
-    utc.minute,
-    utc.second,
-    utc.millisecond * 1_000 + utc.microsecond + utc.nanosecond / 1_000,
-  );
+export function toFs(date: Date | Temporal.Instant | RubyTime, format: string = "default"): string {
+  // A `::Time` receiver is already the one the Rails body formats — the value
+  // `TimeWithZone#to_fs` hands over as `utc.to_fs(format)`
+  // (time_with_zone.rb:220).
+  let time: RubyTime;
+  if (date instanceof RubyTime) {
+    time = date;
+  } else {
+    const utc =
+      // boundary: the JS `Date` a caller still holds is the instant this bridges
+      // onto the ruby/date `Time` the Rails body formats.
+      date instanceof Date
+        ? Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO("UTC")
+        : date.toZonedDateTimeISO("UTC");
+    time = RubyTime.utc(
+      utc.year,
+      utc.month,
+      utc.day,
+      utc.hour,
+      utc.minute,
+      utc.second,
+      utc.millisecond * 1_000 + utc.microsecond + utc.nanosecond / 1_000,
+    );
+  }
   const formatter = DATE_FORMATS[format];
   if (formatter != null) {
     return typeof formatter === "function" ? String(formatter(time)) : time.strftime(formatter);

--- a/packages/activesupport/src/message-pack/extensions.ts
+++ b/packages/activesupport/src/message-pack/extensions.ts
@@ -309,7 +309,7 @@ export const Extensions = {
   },
 
   writeTimeWithZone(twz: TimeWithZone, packer: Packer): void {
-    Extensions.writeTime(twz.utc(), packer);
+    Extensions.writeTime(twz.utc().toTime().toInstant(), packer);
     Extensions.writeTimeZone(twz.timeZone, packer);
   },
 

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -429,16 +429,10 @@ export function change(date: Date, options: ChangeOptions): Temporal.Instant;
 /**
  * A `::Time` receiver answers a `::Time`, as `change` does in Ruby, and takes
  * the same four terminal arms the Ruby body does — `:offset`, `utc?`, `zone`
- * and the trailing `utc_offset` one.
- *
- * The third arm, `elsif zone.respond_to?(:utc_to_local)`
- * (time/calculations.rb:148-171), is unreachable here: it selects a receiver
- * whose `zone` is a `TZInfo` zone OBJECT, and `@blazetrails/date`'s `Time#zone`
- * answers the tzdata abbreviation String and nothing else
- * (`packages/date/src/time.ts`, `Time#zone`), so `respond_to?(:utc_to_local)`
- * is false for every trails `::Time`. Its second-occurrence correction is not
- * lost with it — `::Time.local`'s own `isdst` argument makes the same choice on
- * the `elsif zone` arm below.
+ * and the trailing `utc_offset` one. The `zone.respond_to?(:utc_to_local)` arm
+ * (time/calculations.rb:148-171) selects a receiver whose `zone` is a `TZInfo`
+ * zone OBJECT, which no trails `::Time` is; its second-occurrence correction is
+ * not lost with it, because `::Time.local`'s `isdst` makes the same choice.
  */
 export function change(date: RubyTime, options: ChangeOptions): RubyTime;
 export function change(
@@ -515,10 +509,8 @@ export function change(
     1_000_000_000n,
   );
 
-  // `utc?` (time/calculations.rb:147) — a `::Time` carries Ruby's own flag, set
-  // by `Time.utc`; a `Temporal.ZonedDateTime` answers it by its zone; a JS
-  // `Date` carries no such flag and reads back in the system zone, so it stays
-  // off that arm even under `TZ=UTC`.
+  // `utc?` (time/calculations.rb:147) — a `::Time` carries Ruby's own flag; a
+  // JS `Date` carries none and is never `utc?`, even under `TZ=UTC`.
   const isUtc =
     date instanceof RubyTime
       ? date.isUtc()
@@ -526,10 +518,8 @@ export function change(
         ? false
         : date.timeZoneId === "UTC";
 
-  // `zone` (time/calculations.rb:149, :172) — a `::Time`'s tzdata abbreviation,
-  // `nil` when it was built from an offset. A JS `Date` carries only the
-  // system's local zone; a `Temporal.ZonedDateTime` is the receiver Rails reads
-  // through `utc_to_local`, the arm between the two.
+  // `zone` (time/calculations.rb:172) — a `::Time`'s tzdata abbreviation, `nil`
+  // when it was built from an offset; a JS `Date`'s is the system's.
   const zone =
     date instanceof RubyTime ? date.zone : date instanceof Date ? Temporal.Now.timeZoneId() : null;
 
@@ -556,10 +546,8 @@ export function change(
     return Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
   }
 
-  // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:148-171).
-  // Only a `Temporal.ZonedDateTime` reaches it: `@blazetrails/date`'s
-  // `Time#zone` answers the tzdata abbreviation String and nothing else, so
-  // `respond_to?(:utc_to_local)` is false for every trails `::Time`.
+  // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:148-171) —
+  // only a `Temporal.ZonedDateTime` carries a zone object to reach it.
   if (date instanceof Temporal.ZonedDateTime) {
     let newTime = Temporal.ZonedDateTime.from(
       { timeZone: date.timeZoneId, ...newComponents },
@@ -599,10 +587,8 @@ export function change(
 
   if (zone !== null) {
     // `elsif zone` (time/calculations.rb:172-175) — `::Time.local` in Ruby's
-    // reversed component order, with the receiver's `isdst` picking the
-    // occurrence of a wall clock a DST fall-back repeats. A JS `Date` has no
-    // `isdst` flag of its own to hand over, and carries milliseconds and
-    // nothing finer, so the answer is read back at its own resolution.
+    // reversed component order, `isdst` picking the occurrence of a wall clock a
+    // DST fall-back repeats. A JS `Date` has no `isdst` and only milliseconds.
     const newTime = RubyTime.local(
       newSecRational,
       newMin,

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -515,6 +515,24 @@ export function change(
     1_000_000_000n,
   );
 
+  // `utc?` (time/calculations.rb:147) — a `::Time` carries Ruby's own flag, set
+  // by `Time.utc`; a `Temporal.ZonedDateTime` answers it by its zone; a JS
+  // `Date` carries no such flag and reads back in the system zone, so it stays
+  // off that arm even under `TZ=UTC`.
+  const isUtc =
+    date instanceof RubyTime
+      ? date.isUtc()
+      : date instanceof Date
+        ? false
+        : date.timeZoneId === "UTC";
+
+  // `zone` (time/calculations.rb:149, :172) — a `::Time`'s tzdata abbreviation,
+  // `nil` when it was built from an offset. A JS `Date` carries only the
+  // system's local zone; a `Temporal.ZonedDateTime` is the receiver Rails reads
+  // through `utc_to_local`, the arm between the two.
+  const zone =
+    date instanceof RubyTime ? date.zone : date instanceof Date ? Temporal.Now.timeZoneId() : null;
+
   if (newOffset !== null) {
     // `if new_offset` (time/calculations.rb:145-146). Ruby's `::Time.new` takes
     // the offset as a `"+HH:MM"` String or a seconds Integer; Temporal spells
@@ -530,100 +548,89 @@ export function change(
     return date instanceof Date ? newTime.toInstant() : newTime;
   }
 
-  if (date instanceof RubyTime && date.isUtc()) {
+  if (isUtc) {
     // `elsif utc?` (time/calculations.rb:147-148).
-    return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSecRational);
-  }
-
-  if (date instanceof RubyTime) {
-    if (date.zone !== null) {
-      // `elsif zone` (time/calculations.rb:172-175) — Ruby's reversed component
-      // order, with the receiver's `isdst` picking the occurrence of a wall
-      // clock a DST fall-back repeats.
-      return RubyTime.local(
-        newSecRational,
-        newMin,
-        newHour,
-        newDay,
-        newMonth,
-        newYear,
-        null,
-        null,
-        date.isdst,
-        null,
-      );
+    if (date instanceof RubyTime) {
+      return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSecRational);
     }
-    // `else ::Time.new(..., utc_offset)` (time/calculations.rb:176-177) — a
-    // receiver built from an offset has no zone to answer.
-    return new RubyTime(newYear, newMonth, newDay, newHour, newMin, newSecRational, date.utcOffset);
-  }
-
-  if (!(date instanceof Date) && self.timeZoneId === "UTC") {
-    // `elsif utc?` (time/calculations.rb:147-148). Ruby's `utc?` is an explicit
-    // flag set by `Time.utc`, never true for a `Time.local` receiver whatever
-    // the host zone is; a JS `Date` carries no such flag and reads back in the
-    // system zone, so it stays off this arm even under `TZ=UTC`.
     return Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
   }
 
-  if (date instanceof Date) {
-    // `elsif zone` (time/calculations.rb:172-175): a JS `Date` carries no zone
-    // object, only the system's local zone, so it lands here rather than on the
-    // `utc_to_local` arm below or the trailing `utc_offset` one, and it has no
-    // `isdst` flag of its own to hand over.
-    // boundary: a JS `Date` carries milliseconds and nothing finer, so the
-    // answer is read back at the receiver's own resolution.
-    return Temporal.Instant.fromEpochMilliseconds(
-      RubyTime.local(
-        newSecRational,
-        newMin,
-        newHour,
-        newDay,
-        newMonth,
-        newYear,
-        null,
-        null,
-        null,
-        null,
-      ).toTime().epochMilliseconds,
+  // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:148-171).
+  // Only a `Temporal.ZonedDateTime` reaches it: `@blazetrails/date`'s
+  // `Time#zone` answers the tzdata abbreviation String and nothing else, so
+  // `respond_to?(:utc_to_local)` is false for every trails `::Time`.
+  if (date instanceof Temporal.ZonedDateTime) {
+    let newTime = Temporal.ZonedDateTime.from(
+      { timeZone: date.timeZoneId, ...newComponents },
+      // Ruby's `Time.new` with a zone object picks the first chronological
+      // occurrence of an ambiguous nominal time; `"compatible"` is the same choice.
+      { disambiguation: "compatible" },
     );
+
+    // Some versions of Ruby have a bug where Time.new with a zone object and
+    // fractional seconds will end up with a broken utc_offset.
+    // This is fixed in Ruby 3.3.1 and 3.2.4
+    if (!Number.isInteger(newTime.offsetNanoseconds)) {
+      newTime = newTime.add({ nanoseconds: 0 });
+    }
+
+    // When there are two occurrences of a nominal time due to DST ending,
+    // `Time.new` chooses the first chronological occurrence (the one with a
+    // larger UTC offset). However, for `change`, we want to choose the
+    // occurrence that matches this time's UTC offset.
+    //
+    // If the new time's UTC offset is larger than this time's UTC offset, the
+    // new time might be a first chronological occurrence. So we add the offset
+    // difference to fast-forward the new time, and check if the result has the
+    // desired UTC offset (i.e. is the second chronological occurrence).
+    const offsetDifference = newTime.offsetNanoseconds - date.offsetNanoseconds;
+    let newTime2: Temporal.ZonedDateTime;
+    if (
+      offsetDifference > 0 &&
+      (newTime2 = newTime.add({ nanoseconds: offsetDifference })).offsetNanoseconds ===
+        date.offsetNanoseconds
+    ) {
+      return newTime2;
+    } else {
+      return newTime;
+    }
   }
 
-  // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:150-172).
-  let newTime = Temporal.ZonedDateTime.from(
-    { timeZone: date.timeZoneId, ...newComponents },
-    // Ruby's `Time.new` with a zone object picks the first chronological
-    // occurrence of an ambiguous nominal time; `"compatible"` is the same choice.
-    { disambiguation: "compatible" },
+  if (zone !== null) {
+    // `elsif zone` (time/calculations.rb:172-175) — `::Time.local` in Ruby's
+    // reversed component order, with the receiver's `isdst` picking the
+    // occurrence of a wall clock a DST fall-back repeats. A JS `Date` has no
+    // `isdst` flag of its own to hand over, and carries milliseconds and
+    // nothing finer, so the answer is read back at its own resolution.
+    const newTime = RubyTime.local(
+      newSecRational,
+      newMin,
+      newHour,
+      newDay,
+      newMonth,
+      newYear,
+      null,
+      null,
+      date instanceof RubyTime ? date.isdst : null,
+      null,
+    );
+    return date instanceof Date
+      ? Temporal.Instant.fromEpochMilliseconds(newTime.toTime().epochMilliseconds)
+      : newTime;
+  }
+
+  // `else ::Time.new(..., utc_offset)` (time/calculations.rb:176-177) — a
+  // `::Time` built from an offset has no zone to answer.
+  return new RubyTime(
+    newYear,
+    newMonth,
+    newDay,
+    newHour,
+    newMin,
+    newSecRational,
+    (date as RubyTime).utcOffset,
   );
-
-  // Some versions of Ruby have a bug where Time.new with a zone object and
-  // fractional seconds will end up with a broken utc_offset.
-  // This is fixed in Ruby 3.3.1 and 3.2.4
-  if (!Number.isInteger(newTime.offsetNanoseconds)) {
-    newTime = newTime.add({ nanoseconds: 0 });
-  }
-
-  // When there are two occurrences of a nominal time due to DST ending,
-  // `Time.new` chooses the first chronological occurrence (the one with a
-  // larger UTC offset). However, for `change`, we want to choose the
-  // occurrence that matches this time's UTC offset.
-  //
-  // If the new time's UTC offset is larger than this time's UTC offset, the
-  // new time might be a first chronological occurrence. So we add the offset
-  // difference to fast-forward the new time, and check if the result has the
-  // desired UTC offset (i.e. is the second chronological occurrence).
-  const offsetDifference = newTime.offsetNanoseconds - date.offsetNanoseconds;
-  let newTime2: Temporal.ZonedDateTime;
-  if (
-    offsetDifference > 0 &&
-    (newTime2 = newTime.add({ nanoseconds: offsetDifference })).offsetNanoseconds ===
-      date.offsetNanoseconds
-  ) {
-    return newTime2;
-  } else {
-    return newTime;
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -421,67 +421,40 @@ interface ChangeOptions {
   offset?: string | number;
 }
 
-/**
- * `::Time.local` (time/calculations.rb:174) — builds a time in the system's
- * local zone, taking Ruby's reversed component order.
- * @internal
- */
-function local(
-  sec: number,
-  min: number,
-  hour: number,
-  day: number,
-  month: number,
-  year: number,
-): Date {
-  const secFloor = Math.floor(sec);
-  const nsec = Math.round((sec - secFloor) * 1_000_000_000);
-  return new Date(year, month - 1, day, hour, min, secFloor, Math.floor(nsec / 1_000_000));
-}
-
 export function change(
   date: Temporal.ZonedDateTime,
   options: ChangeOptions,
 ): Temporal.ZonedDateTime;
 export function change(date: Date, options: ChangeOptions): Temporal.Instant;
 /**
- * A `::Time` receiver answers a `::Time`, as `change` does in Ruby. The
- * components it reads are the ones its `to_time` carries, so the change runs
- * through the shared `ZonedDateTime` arm and is reseated. `Time`'s constructor
- * takes an offset rather than a zone id, so a zoned receiver comes back
- * carrying its offset — Rails' own `elsif zone` arm rebuilds through
- * `::Time.local`, which reseats in the system zone rather than the receiver's,
- * so neither keeps a foreign zone's abbreviation.
+ * A `::Time` receiver answers a `::Time`, as `change` does in Ruby, and takes
+ * the same four terminal arms the Ruby body does — `:offset`, `utc?`, `zone`
+ * and the trailing `utc_offset` one.
+ *
+ * The third arm, `elsif zone.respond_to?(:utc_to_local)`
+ * (time/calculations.rb:148-171), is unreachable here: it selects a receiver
+ * whose `zone` is a `TZInfo` zone OBJECT, and `@blazetrails/date`'s `Time#zone`
+ * answers the tzdata abbreviation String and nothing else
+ * (`packages/date/src/time.ts`, `Time#zone`), so `respond_to?(:utc_to_local)`
+ * is false for every trails `::Time`. Its second-occurrence correction is not
+ * lost with it — `::Time.local`'s own `isdst` argument makes the same choice on
+ * the `elsif zone` arm below.
  */
 export function change(date: RubyTime, options: ChangeOptions): RubyTime;
 export function change(
   date: Date | RubyTime | Temporal.ZonedDateTime,
   options: ChangeOptions,
 ): Temporal.Instant | RubyTime | Temporal.ZonedDateTime {
-  if (date instanceof RubyTime) {
-    const changed = change(date.toTime(), options);
-    return new RubyTime(
-      changed.year,
-      changed.month,
-      changed.day,
-      changed.hour,
-      changed.minute,
-      new Rational(
-        BigInt(changed.second) * 1_000_000_000n +
-          BigInt(
-            changed.millisecond * 1_000_000 + changed.microsecond * 1_000 + changed.nanosecond,
-          ),
-        1_000_000_000n,
-      ),
-      date.isUtc() ? "UTC" : changed.offset,
-    );
-  }
-
   // Ruby reads the components off the receiver; a JS `Date` spells those readers
-  // differently, and reads them in the system's local zone, so widen it to the
-  // one shape both arms below share.
+  // differently, and reads them in the system's local zone, and a `::Time`
+  // spells them on its own zone, so widen both to the one shape the arms below
+  // share.
   const self =
-    date instanceof Date ? instantFrom(date).toZonedDateTimeISO(Temporal.Now.timeZoneId()) : date;
+    date instanceof Date
+      ? instantFrom(date).toZonedDateTimeISO(Temporal.Now.timeZoneId())
+      : date instanceof RubyTime
+        ? date.toTime()
+        : date;
   const nsec = self.millisecond * 1_000_000 + self.microsecond * 1_000 + self.nanosecond;
 
   const newYear = options.year ?? self.year;
@@ -532,16 +505,57 @@ export function change(
     nanosecond: newNsecOfSec % 1_000,
   };
 
+  const newSecRational = new Rational(
+    BigInt(newComponents.second) * 1_000_000_000n +
+      BigInt(
+        newComponents.millisecond * 1_000_000 +
+          newComponents.microsecond * 1_000 +
+          newComponents.nanosecond,
+      ),
+    1_000_000_000n,
+  );
+
   if (newOffset !== null) {
     // `if new_offset` (time/calculations.rb:145-146). Ruby's `::Time.new` takes
     // the offset as a `"+HH:MM"` String or a seconds Integer; Temporal spells
     // the same fixed-offset zone with the String form only.
+    if (date instanceof RubyTime) {
+      return new RubyTime(newYear, newMonth, newDay, newHour, newMin, newSecRational, newOffset);
+    }
     const timeZone =
       typeof newOffset === "number"
         ? `${newOffset < 0 ? "-" : "+"}${String(Math.floor(Math.abs(newOffset) / 3600)).padStart(2, "0")}:${String(Math.floor((Math.abs(newOffset) % 3600) / 60)).padStart(2, "0")}`
         : newOffset;
     const newTime = Temporal.ZonedDateTime.from({ timeZone, ...newComponents });
     return date instanceof Date ? newTime.toInstant() : newTime;
+  }
+
+  if (date instanceof RubyTime && date.isUtc()) {
+    // `elsif utc?` (time/calculations.rb:147-148).
+    return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSecRational);
+  }
+
+  if (date instanceof RubyTime) {
+    if (date.zone !== null) {
+      // `elsif zone` (time/calculations.rb:172-175) — Ruby's reversed component
+      // order, with the receiver's `isdst` picking the occurrence of a wall
+      // clock a DST fall-back repeats.
+      return RubyTime.local(
+        newSecRational,
+        newMin,
+        newHour,
+        newDay,
+        newMonth,
+        newYear,
+        null,
+        null,
+        date.isdst,
+        null,
+      );
+    }
+    // `else ::Time.new(..., utc_offset)` (time/calculations.rb:176-177) — a
+    // receiver built from an offset has no zone to answer.
+    return new RubyTime(newYear, newMonth, newDay, newHour, newMin, newSecRational, date.utcOffset);
   }
 
   if (!(date instanceof Date) && self.timeZoneId === "UTC") {
@@ -553,10 +567,26 @@ export function change(
   }
 
   if (date instanceof Date) {
-    // `elsif zone` (time/calculations.rb:173-174): a JS `Date` carries no zone
+    // `elsif zone` (time/calculations.rb:172-175): a JS `Date` carries no zone
     // object, only the system's local zone, so it lands here rather than on the
-    // `utc_to_local` arm below or the trailing `utc_offset` one.
-    return instantFrom(local(newSec, newMin, newHour, newDay, newMonth, newYear));
+    // `utc_to_local` arm below or the trailing `utc_offset` one, and it has no
+    // `isdst` flag of its own to hand over.
+    // boundary: a JS `Date` carries milliseconds and nothing finer, so the
+    // answer is read back at the receiver's own resolution.
+    return Temporal.Instant.fromEpochMilliseconds(
+      RubyTime.local(
+        newSecRational,
+        newMin,
+        newHour,
+        newDay,
+        newMonth,
+        newYear,
+        null,
+        null,
+        null,
+        null,
+      ).toTime().epochMilliseconds,
+    );
   }
 
   // `elsif zone.respond_to?(:utc_to_local)` (time/calculations.rb:150-172).

--- a/packages/activesupport/src/time-with-zone.test.ts
+++ b/packages/activesupport/src/time-with-zone.test.ts
@@ -3,6 +3,7 @@ import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
 import { Duration } from "./duration.js";
 import { instantFromDate } from "./testing/temporal-helpers.js";
+import { Time } from "@blazetrails/date";
 import { Temporal } from "@blazetrails/date";
 import { inTimeZone } from "./core-ext/string/zones.js";
 import { setZone, zone as timeZone } from "./time-zone-config.js";
@@ -123,17 +124,17 @@ describe("TimeWithZoneTest", () => {
   it("utc() returns a Date in UTC", () => {
     const twz = eastern.local(2024, 1, 15, 10, 30, 0);
     const utc = twz.utc();
-    expect(utc).toBeInstanceOf(Temporal.Instant);
-    const z = utc.toZonedDateTimeISO("UTC");
+    expect(utc).toBeInstanceOf(Time);
+    const z = utc.toTime();
     expect(z.hour).toBe(15); // 10 EST + 5 = 15 UTC
     expect(z.minute).toBe(30);
   });
 
   it("getutc() and getgm() are aliases", () => {
     const twz = eastern.local(2024, 1, 15, 10, 0, 0);
-    expect(twz.getutc().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
-    expect(twz.getgm().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
-    expect(twz.gmtime().epochMilliseconds).toBe(twz.utc().epochMilliseconds);
+    expect(twz.getutc().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
+    expect(twz.getgm().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
+    expect(twz.gmtime().toTime().epochMilliseconds).toBe(twz.utc().toTime().epochMilliseconds);
   });
 
   it("toI() returns unix timestamp", () => {
@@ -167,7 +168,7 @@ describe("TimeWithZoneTest", () => {
 
     // Same moment, different local time
     expect(pstTime.hour).toBe(9); // 12 EST = 9 PST
-    expect(pstTime.utc().epochMilliseconds).toBe(estTime.utc().epochMilliseconds);
+    expect(pstTime.utc().toTime().epochMilliseconds).toBe(estTime.utc().toTime().epochMilliseconds);
   });
 
   it("inTimeZone() accepts a TimeZone object", () => {
@@ -419,7 +420,7 @@ describe("TimeWithZoneTest", () => {
 
   it("minus() with a Date returns seconds", () => {
     const twz = eastern.local(2024, 1, 15, 12, 0, 0);
-    const date = twz.utc();
+    const date = twz.utc().toTime().toInstant();
     expect(twz.minus(date)).toBe(0);
   });
 
@@ -561,7 +562,7 @@ describe("TimeWithZoneTest", () => {
 
   it("equals() works with Date", () => {
     const twz = eastern.local(2024, 1, 15, 12, 0, 0);
-    const date = twz.utc();
+    const date = twz.utc().toTime().toInstant();
     expect(twz.equals(date)).toBe(true);
   });
 
@@ -626,7 +627,7 @@ describe("TimeWithZoneTest", () => {
   it("handles year boundary crossing", () => {
     // Dec 31 23:00 EST = Jan 1 04:00 UTC
     const twz = eastern.local(2024, 12, 31, 23, 0, 0);
-    const z = twz.utc().toZonedDateTimeISO("UTC");
+    const z = twz.utc().toTime();
     expect(z.year).toBe(2025);
     expect(z.month).toBe(1);
     expect(z.day).toBe(1);
@@ -880,7 +881,7 @@ describe("TimeWithZoneTest", () => {
     expect(twz.dst()).toBe(false); // Hawaii doesn't observe DST
 
     // UTC should be 10 hours ahead
-    expect(twz.utc().toZonedDateTimeISO("UTC").hour).toBe(10);
+    expect(twz.utc().toTime().hour).toBe(10);
   });
 
   it("Alaska timezone basic operations", () => {
@@ -901,10 +902,10 @@ describe("TimeWithZoneTest", () => {
     const back_to_eastern = hawaii_twz.inTimeZone(eastern);
 
     // All should represent the same UTC instant
-    expect(eastern_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
-    expect(pacific_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
-    expect(hawaii_twz.utc().epochMilliseconds).toBe(utcTime.getTime());
-    expect(back_to_eastern.utc().epochMilliseconds).toBe(utcTime.getTime());
+    expect(eastern_twz.utc().toTime().epochMilliseconds).toBe(utcTime.getTime());
+    expect(pacific_twz.utc().toTime().epochMilliseconds).toBe(utcTime.getTime());
+    expect(hawaii_twz.utc().toTime().epochMilliseconds).toBe(utcTime.getTime());
+    expect(back_to_eastern.utc().toTime().epochMilliseconds).toBe(utcTime.getTime());
 
     // Local hours should differ
     expect(eastern_twz.hour).toBe(8); // EDT
@@ -998,9 +999,9 @@ describe("TimeWithZoneMethodsForString", () => {
     const previousZone = timeZone();
     setZone("Moscow");
     try {
-      expect((inTimeZone("2014-10-26 01:00:00") as TimeWithZone).utc().epochMilliseconds).toEqual(
-        Temporal.Instant.from("2014-10-25T22:00:00Z").epochMilliseconds,
-      );
+      expect(
+        (inTimeZone("2014-10-26 01:00:00") as TimeWithZone).utc().toTime().epochMilliseconds,
+      ).toEqual(Temporal.Instant.from("2014-10-25T22:00:00Z").epochMilliseconds);
     } finally {
       setZone(previousZone);
     }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -141,6 +141,13 @@ const METHOD_MISSING_HANDLER: ProxyHandler<TimeWithZone> = {
 export class TimeWithZone {
   /** `@utc` — `nil` until {@link utc} derives it from `@time`. */
   private _utc: UtcConstructed | null;
+  /**
+   * The `::Time` {@link utc} answers. Rails' `@utc` is both the memo and the
+   * answer; trails carries the memo as the {@link UtcConstructed} instant every
+   * `TimeZone` reader below takes, so the `::Time` seated from it is a second
+   * memo rather than the same one.
+   */
+  private _utcTime?: Time;
   /** `@time` — the local wall clock, `nil` until {@link time} derives it. */
   private _time: TimeLike | null;
   /** The timezone */
@@ -178,7 +185,7 @@ export class TimeWithZone {
    * local-time-only instance resolves its UTC value exactly where Rails does.
    */
   private get _zoned(): Temporal.ZonedDateTime {
-    return this.utc().toZonedDateTimeISO(this._timeZone.tzinfo.identifier);
+    return this._utcConstructed.toZonedDateTimeISO(this._timeZone.tzinfo.identifier);
   }
 
   /** Epoch milliseconds — sourced directly from the ZonedDateTime. */
@@ -188,7 +195,7 @@ export class TimeWithZone {
 
   /** UTC-zoned snapshot of the underlying instant for component access. */
   private get _utcPlain(): Temporal.PlainDateTime {
-    return this.utc().toZonedDateTimeISO("UTC").toPlainDateTime();
+    return this._utcConstructed.toZonedDateTimeISO("UTC").toPlainDateTime();
   }
 
   /**
@@ -318,6 +325,20 @@ export class TimeWithZone {
    */
   get period(): TimezonePeriod {
     return (this._period ??= this._timeZone.periodForUtc(this._utc!));
+  }
+
+  /**
+   * `@utc ||= incorporate_utc_offset(@time, -utc_offset)`
+   * (time_with_zone.rb:64), left on the {@link UtcConstructed} instant — the
+   * instant half of {@link utc}, split out because every `TimeZone` and
+   * `Temporal` reader in this file takes the instant where Rails' readers take
+   * the `::Time` it seats.
+   */
+  private get _utcConstructed(): UtcConstructed {
+    return (this._utc ??= this._incorporateUtcOffset(
+      this._time as UtcConstructed,
+      -this.utcOffset,
+    ));
   }
 
   /** The TimeZone instance */
@@ -487,27 +508,26 @@ export class TimeWithZone {
 
   /**
    * Mirrors: `ActiveSupport::TimeWithZone#utc` (time_with_zone.rb:63-65) —
-   * `@utc ||= incorporate_utc_offset(@time, -utc_offset)`.
+   * `@utc ||= incorporate_utc_offset(@time, -utc_offset)`, a `::Time` in UTC.
    */
-  utc(): Temporal.Instant {
-    return (this._utc ??= this._incorporateUtcOffset(
-      this._time as UtcConstructed,
-      -this.utcOffset,
-    ));
+  utc(): Time {
+    return (this._utcTime ??= Time.at(
+      new Rational(this._utcConstructed.epochNanoseconds, 1_000_000_000n),
+    ).getutc());
   }
 
-  /** Alias for utc() */
-  getutc(): Temporal.Instant {
+  /** `alias_method :getutc, :utc` (time_with_zone.rb:67). */
+  getutc(): Time {
     return this.utc();
   }
 
-  /** Alias for utc() */
-  getgm(): Temporal.Instant {
+  /** `alias_method :getgm, :utc` (time_with_zone.rb:66). */
+  getgm(): Time {
     return this.utc();
   }
 
-  /** Alias for utc() */
-  gmtime(): Temporal.Instant {
+  /** `alias_method :gmtime, :utc` (time_with_zone.rb:68). */
+  gmtime(): Time {
     return this.utc();
   }
 
@@ -515,19 +535,17 @@ export class TimeWithZone {
    * `alias_method :comparable_time, :utc` (time_with_zone.rb:66) — the value
    * `<=>` and `between?` compare on.
    */
-  comparableTime(): Temporal.Instant {
+  comparableTime(): Time {
     return this.utc();
   }
 
   /**
    * Mirrors: `ActiveSupport::TimeWithZone#localtime(utc_offset = nil)`
    * (time_with_zone.rb:83-85) — `utc.getlocal(utc_offset)`, a `::Time` at the
-   * given offset or zone, or in the system zone when none is given. trails'
-   * `utc` answers the instant rather than the `::Time` Rails' does, so the
-   * `::Time` `getlocal` is called on is seated from that instant here.
+   * given offset or zone, or in the system zone when none is given.
    */
   localtime(utcOffset: string | number | null = null): Time {
-    return Time.at(new Rational(this.utc().epochNanoseconds, 1_000_000_000n)).getlocal(utcOffset);
+    return this.utc().getlocal(utcOffset);
   }
 
   /** `alias_method :getlocal, :localtime` (time_with_zone.rb:86). */
@@ -1016,6 +1034,11 @@ export class TimeWithZone {
     }
     if (other instanceof Temporal.Instant) {
       return this._zoned.epochNanoseconds === other.epochNanoseconds;
+    }
+    // `other.eql?(utc)` (time_with_zone.rb:275) — `utc` is a `::Time`, so a
+    // `::Time` argument is the one Rails compares against it directly.
+    if (other instanceof Time) {
+      return this._zoned.epochNanoseconds === other.toTime().epochNanoseconds;
     }
     return false;
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -516,7 +516,7 @@ export class TimeWithZone {
     ).getutc());
   }
 
-  /** `alias_method :getutc, :utc` (time_with_zone.rb:67). */
+  /** `alias_method :getutc, :utc` (time_with_zone.rb:68). */
   getutc(): Time {
     return this.utc();
   }
@@ -526,7 +526,7 @@ export class TimeWithZone {
     return this.utc();
   }
 
-  /** `alias_method :gmtime, :utc` (time_with_zone.rb:68). */
+  /** `alias_method :gmtime, :utc` (time_with_zone.rb:69). */
   gmtime(): Time {
     return this.utc();
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -521,7 +521,7 @@ export class TimeWithZone {
     return this.utc();
   }
 
-  /** `alias_method :getgm, :utc` (time_with_zone.rb:66). */
+  /** `alias_method :getgm, :utc` (time_with_zone.rb:67). */
   getgm(): Time {
     return this.utc();
   }

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -273,7 +273,7 @@ describe("TimeZoneTest", () => {
     expect(twz.day).toBe(31);
     expect(twz.month).toBe(12);
     expect(twz.year).toBe(1999);
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(twz.timeZone).toBe(zone);
     expect(twz.toF()).toBe(secs);
   });
@@ -315,7 +315,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 with zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("1999-12-31T14:00:00-10:00");
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -347,7 +347,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.iso8601("2050-01-01T00:00:00-05:00");
-    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
+    expect(twz.utc().toTime().year).toBe(2050);
   });
 
   it("iso8601 should not black out system timezone dst jump", () => {
@@ -388,7 +388,7 @@ describe("TimeZoneTest", () => {
   it("iso8601 with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
     const twz = zone.iso8601("2014-10-26T01:00:00");
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
   it("iso8601 with ordinal date value", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
@@ -415,14 +415,14 @@ describe("TimeZoneTest", () => {
     expect(twz.day).toBe(31);
     expect(twz.month).toBe(12);
     expect(twz.year).toBe(1999);
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(twz.timeZone).toBe(zone);
   });
 
   it("parse string with timezone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2024-01-15T12:00:00Z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2024, 0, 15, 12, 0, 0));
     expect(twz.hour).toBe(7);
   });
 
@@ -435,7 +435,7 @@ describe("TimeZoneTest", () => {
   it("parse far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.parse("2050-01-01T00:00:00-05:00")!;
-    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
+    expect(twz.utc().toTime().year).toBe(2050);
   });
 
   it("parse returns nil when string without date information is passed in", () => {
@@ -512,7 +512,7 @@ describe("TimeZoneTest", () => {
   it("parse with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
     const twz = zone.parse("2014-10-26 01:00:00")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   // ---------------------------------------------------------------------------
@@ -521,7 +521,7 @@ describe("TimeZoneTest", () => {
   it("rfc3339", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("1999-12-31T14:00:00-10:00");
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1, 0, 0, 0));
     expect(twz.timeZone).toBe(zone);
   });
 
@@ -555,7 +555,7 @@ describe("TimeZoneTest", () => {
   it("rfc3339 far future date with time zone offset in string", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.rfc3339("2050-01-01T00:00:00-05:00");
-    expect(twz.utc().toZonedDateTimeISO("UTC").year).toBe(2050);
+    expect(twz.utc().toTime().year).toBe(2050);
   });
 
   it("rfc3339 should not black out system timezone dst jump", () => {
@@ -590,7 +590,7 @@ describe("TimeZoneTest", () => {
   it("strptime", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -598,7 +598,7 @@ describe("TimeZoneTest", () => {
   it("strptime with nondefault time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00", "%Y-%m-%d %H:%M:%S")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -606,7 +606,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as abbrev", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 PST", "%Y-%m-%d %H:%M:%S %Z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -614,7 +614,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as h offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08", "%Y-%m-%d %H:%M:%S %:::z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -622,7 +622,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as hm offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00", "%Y-%m-%d %H:%M:%S %:z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -630,7 +630,7 @@ describe("TimeZoneTest", () => {
   it("strptime with explicit time zone as hms offset", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 -08:00:00", "%Y-%m-%d %H:%M:%S %::z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 20));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 15));
     expect(twz.timeZone).toBe(zone);
   });
@@ -638,7 +638,7 @@ describe("TimeZoneTest", () => {
   it("strptime with almost explicit time zone", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = zone.strptime("1999-12-31 12:00:00 %Z", "%Y-%m-%d %H:%M:%S %%Z")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 17));
     expect(twz.time.toZonedDateTime("UTC").epochMilliseconds).toBe(Date.UTC(1999, 11, 31, 12));
     expect(twz.timeZone).toBe(zone);
   });
@@ -675,7 +675,7 @@ describe("TimeZoneTest", () => {
   it("strptime with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
     const twz = zone.strptime("2014-10-26 01:00:00", "%Y-%m-%d %H:%M:%S")!;
-    expect(twz.utc().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
+    expect(twz.utc().toTime().epochMilliseconds).toBe(Date.UTC(2014, 9, 25, 22, 0, 0));
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -556,62 +556,44 @@ export class Time {
    * the `Time.local` alias, which builds in the LOCAL zone. As with
    * {@link Time.utc}, the seventh positional is the microsecond, and passing it
    * truncates `sec` to a whole second.
+   *
+   * MRI's ten-argument form (`time.c` `time_arg`: `if (argc == 10)`) is the
+   * second overload — the `Time#to_a` splat, `[sec, min, hour, day, month,
+   * year, wday, yday, isdst, zone]`, the components in reverse. `wday`, `yday`
+   * and `zone` are read as `Qnil` whatever they hold, and `isdst` picks the
+   * occurrence of a wall clock a DST fall-back repeats: under
+   * `TZ=America/New_York`, `Time.local(0, 30, 1, 2, 11, 2008, nil, nil, true,
+   * nil)` is `-0400` and the same call with `false` is `-0500`.
    */
   static mktime(
-    year: number | string,
-    month?: number | string | null,
-    day?: number | string | null,
-    hour?: number | string | null,
-    min?: number | string | null,
-    sec?: number | string | Rational | null,
-    usec?: number,
-  ): Time;
-  /**
-   * MRI's ten-argument form (`time.c` `time_arg`: `if (argc == 10)`), which is
-   * the `Time#to_a` splat — `[sec, min, hour, day, month, year, wday, yday,
-   * isdst, zone]`, the components in reverse. `wday`, `yday` and `zone` are
-   * read as `Qnil` whatever they hold, and `isdst` picks the occurrence of a
-   * wall clock a DST fall-back repeats: under `TZ=America/New_York`,
-   * `Time.local(0, 30, 1, 2, 11, 2008, nil, nil, true, nil)` is `-0400` and the
-   * same call with `false` is `-0500`.
-   */
-  static mktime(
-    sec: number | string | Rational | null,
-    min: number | string | null,
-    hour: number | string | null,
-    day: number | string | null,
-    month: number | string | null,
-    year: number | string,
-    wday: null,
-    yday: null,
-    isdst: boolean | null,
-    zone: null,
-  ): Time;
-  static mktime(...args: unknown[]): Time {
+    ...args:
+      | [
+          year: number | string,
+          month?: number | string | null,
+          day?: number | string | null,
+          hour?: number | string | null,
+          min?: number | string | null,
+          sec?: number | string | Rational | null,
+          usec?: number,
+        ]
+      | [
+          sec: number | string | Rational | null,
+          min: number | string | null,
+          hour: number | string | null,
+          day: number | string | null,
+          month: number | string | null,
+          year: number | string,
+          wday: null,
+          yday: null,
+          isdst: boolean | null,
+          zone: null,
+        ]
+  ): Time {
     if (args.length === 10) {
-      const [sec, min, hour, day, month, year, , , isdst] = args as [
-        number | string | Rational | null,
-        number | string | null,
-        number | string | null,
-        number | string | null,
-        number | string | null,
-        number | string,
-        null,
-        null,
-        boolean | null,
-        null,
-      ];
+      const [sec, min, hour, day, month, year, , , isdst] = args;
       return Time.#mktimeIsdst(Time.mktime(year, month, day, hour, min, sec), isdst);
     }
-    const [year, month, day, hour, min, sec, usec] = args as [
-      number | string,
-      (number | string | null)?,
-      (number | string | null)?,
-      (number | string | null)?,
-      (number | string | null)?,
-      (number | string | Rational | null)?,
-      number?,
-    ];
+    const [year, month, day, hour, min, sec, usec] = args;
     return new Time(
       year,
       month ?? 1,
@@ -645,29 +627,8 @@ export class Time {
    * (`time.c`: both names bind `time_s_mktime`), so it takes the same
    * positionals — both forms — and builds in the LOCAL zone too.
    */
-  static local(
-    year: number | string,
-    month?: number | string | null,
-    day?: number | string | null,
-    hour?: number | string | null,
-    min?: number | string | null,
-    sec?: number | string | Rational | null,
-    usec?: number,
-  ): Time;
-  static local(
-    sec: number | string | Rational | null,
-    min: number | string | null,
-    hour: number | string | null,
-    day: number | string | null,
-    month: number | string | null,
-    year: number | string,
-    wday: null,
-    yday: null,
-    isdst: boolean | null,
-    zone: null,
-  ): Time;
-  static local(...args: unknown[]): Time {
-    return (Time.mktime as (...args: unknown[]) => Time)(...args);
+  static local(...args: Parameters<typeof Time.mktime>): Time {
+    return Time.mktime(...args);
   }
 
   /**

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -601,7 +601,7 @@ export class Time {
         boolean | null,
         null,
       ];
-      return Time.#mktimeIsdst(Time.#mktime(year, month, day, hour, min, sec, undefined), isdst);
+      return Time.#mktimeIsdst(Time.mktime(year, month, day, hour, min, sec), isdst);
     }
     const [year, month, day, hour, min, sec, usec] = args as [
       number | string,
@@ -612,26 +612,14 @@ export class Time {
       (number | string | Rational | null)?,
       number?,
     ];
-    return Time.#mktime(year, month ?? 1, day ?? 1, hour ?? 0, min ?? 0, sec ?? 0, usec);
-  }
-
-  static #mktime(
-    year: number | string,
-    month: number | string | null,
-    day: number | string | null,
-    hour: number | string | null,
-    min: number | string | null,
-    sec: number | string | Rational | null,
-    usec: number | undefined,
-  ): Time {
     return new Time(
       year,
-      month,
-      day,
-      hour,
-      min,
+      month ?? 1,
+      day ?? 1,
+      hour ?? 0,
+      min ?? 0,
       usec === undefined
-        ? sec
+        ? (sec ?? 0)
         : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
             new Rational(Math.round(usec * 1_000), 1_000_000_000),
           ),

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -559,12 +559,70 @@ export class Time {
    */
   static mktime(
     year: number | string,
-    month: number | string | null = 1,
-    day: number | string | null = 1,
-    hour: number | string | null = 0,
-    min: number | string | null = 0,
-    sec: number | string | Rational | null = 0,
+    month?: number | string | null,
+    day?: number | string | null,
+    hour?: number | string | null,
+    min?: number | string | null,
+    sec?: number | string | Rational | null,
     usec?: number,
+  ): Time;
+  /**
+   * MRI's ten-argument form (`time.c` `time_arg`: `if (argc == 10)`), which is
+   * the `Time#to_a` splat — `[sec, min, hour, day, month, year, wday, yday,
+   * isdst, zone]`, the components in reverse. `wday`, `yday` and `zone` are
+   * read as `Qnil` whatever they hold, and `isdst` picks the occurrence of a
+   * wall clock a DST fall-back repeats: under `TZ=America/New_York`,
+   * `Time.local(0, 30, 1, 2, 11, 2008, nil, nil, true, nil)` is `-0400` and the
+   * same call with `false` is `-0500`.
+   */
+  static mktime(
+    sec: number | string | Rational | null,
+    min: number | string | null,
+    hour: number | string | null,
+    day: number | string | null,
+    month: number | string | null,
+    year: number | string,
+    wday: null,
+    yday: null,
+    isdst: boolean | null,
+    zone: null,
+  ): Time;
+  static mktime(...args: unknown[]): Time {
+    if (args.length === 10) {
+      const [sec, min, hour, day, month, year, , , isdst] = args as [
+        number | string | Rational | null,
+        number | string | null,
+        number | string | null,
+        number | string | null,
+        number | string | null,
+        number | string,
+        null,
+        null,
+        boolean | null,
+        null,
+      ];
+      return Time.#mktimeIsdst(Time.#mktime(year, month, day, hour, min, sec, undefined), isdst);
+    }
+    const [year, month, day, hour, min, sec, usec] = args as [
+      number | string,
+      (number | string | null)?,
+      (number | string | null)?,
+      (number | string | null)?,
+      (number | string | null)?,
+      (number | string | Rational | null)?,
+      number?,
+    ];
+    return Time.#mktime(year, month ?? 1, day ?? 1, hour ?? 0, min ?? 0, sec ?? 0, usec);
+  }
+
+  static #mktime(
+    year: number | string,
+    month: number | string | null,
+    day: number | string | null,
+    hour: number | string | null,
+    min: number | string | null,
+    sec: number | string | Rational | null,
+    usec: number | undefined,
   ): Time {
     return new Time(
       year,
@@ -581,20 +639,47 @@ export class Time {
   }
 
   /**
+   * MRI's `isdst` argument (`time.c` `time_arg`, then `find_time_t`'s
+   * `!NIL_P(vtm->isdst)` search): a wall clock a DST fall-back repeats names
+   * two instants, and `isdst` picks the one whose flag matches. The
+   * constructor already seated the later — the `nil` `isdst` reading — so only
+   * the earlier occurrence has to be tried.
+   */
+  static #mktimeIsdst(time: Time, isdst: boolean | null): Time {
+    if (isdst == null || time.#timeZoneId == null || time.isdst === isdst) return time;
+    const earlier = time.#plain.toZonedDateTime(time.#timeZoneId, { disambiguation: "earlier" });
+    const candidate = Time.#atInstant(earlier.toInstant(), time.#timeZoneId);
+    return candidate.isdst === isdst ? candidate : time;
+  }
+
+  /**
    * Ruby `Time.local`, the singleton `Time.mktime` is aliased to
    * (`time.c`: both names bind `time_s_mktime`), so it takes the same
-   * positionals and builds in the LOCAL zone too.
+   * positionals — both forms — and builds in the LOCAL zone too.
    */
   static local(
     year: number | string,
-    month: number | string | null = 1,
-    day: number | string | null = 1,
-    hour: number | string | null = 0,
-    min: number | string | null = 0,
-    sec: number | string | Rational | null = 0,
+    month?: number | string | null,
+    day?: number | string | null,
+    hour?: number | string | null,
+    min?: number | string | null,
+    sec?: number | string | Rational | null,
     usec?: number,
-  ): Time {
-    return Time.mktime(year, month, day, hour, min, sec, usec);
+  ): Time;
+  static local(
+    sec: number | string | Rational | null,
+    min: number | string | null,
+    hour: number | string | null,
+    day: number | string | null,
+    month: number | string | null,
+    year: number | string,
+    wday: null,
+    yday: null,
+    isdst: boolean | null,
+    zone: null,
+  ): Time;
+  static local(...args: unknown[]): Time {
+    return (Time.mktime as (...args: unknown[]) => Time)(...args);
   }
 
   /**
@@ -689,12 +774,21 @@ export class Time {
       hour === 24 ? plain.add({ hours: 1 }) : wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? nowTimeZoneId() : utcOffsetArgument(zone);
     this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
+    // A wall clock a DST fall-back repeats names two instants, and MRI's
+    // `find_time_t` (`time.c`) settles on the STANDARD-time one when `isdst` is
+    // `nil`: under `TZ=America/New_York`, `Time.local(2005, 10, 30, 1, 0, 0)` is
+    // `-0500` and its `isdst` is false. `Temporal`'s default `"compatible"`
+    // picks the earlier occurrence instead, so the later one is asked for by
+    // name. For the "spring forward" gap the two agree — MRI rolls
+    // `2005-04-03 02:30` forward to `03:30 -0400`, and so does `"later"`.
+    const disambiguation = { disambiguation: "later" } as const;
     this.#utcOffsetMemo =
       typeof utcOffset === "number"
         ? utcOffset
-        : Number(this.#plain.toZonedDateTime(utcOffset).offsetNanoseconds) / 1_000_000_000;
+        : Number(this.#plain.toZonedDateTime(utcOffset, disambiguation).offsetNanoseconds) /
+          1_000_000_000;
     this.#instant = this.#plain
-      .toZonedDateTime(this.#timeZoneId ?? of2str(this.#utcOffset))
+      .toZonedDateTime(this.#timeZoneId ?? of2str(this.#utcOffset), disambiguation)
       .toInstant();
   }
 
@@ -780,6 +874,28 @@ export class Time {
   /** Ruby `Time#gmt_offset`, the `utc_offset` alias. */
   get gmtOffset(): number {
     return this.#utcOffset;
+  }
+
+  /**
+   * Ruby `Time#isdst` (`ruby/time.c` `time_isdst`), true when the receiver's
+   * zone is observing daylight saving. A time built from an offset rather than
+   * a zone has no zone to ask, and MRI answers `false` — `Time.new(2008, 7, 1,
+   * 0, 0, 0, "-04:00").isdst` is false where the same instant in
+   * `America/New_York` is true. The standard offset is the smaller of the
+   * zone's January and July offsets, the same reading {@link zone} takes for
+   * its abbreviation, so a negative-DST zone falls out the same way.
+   */
+  get isdst(): boolean {
+    if (this.#timeZoneId == null || this.#timeZoneId === "UTC") return false;
+    const zoned = this.#instant.toZonedDateTimeISO(this.#timeZoneId);
+    const january = Number(zoned.with({ month: 1, day: 1 }).offsetNanoseconds);
+    const july = Number(zoned.with({ month: 7, day: 1 }).offsetNanoseconds);
+    return Number(zoned.offsetNanoseconds) > Math.min(january, july);
+  }
+
+  /** Ruby `Time#dst?`, the `isdst` alias (`ruby/time.c` `time_isdst`). */
+  isDst(): boolean {
+    return this.isdst;
   }
 
   /**

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -723,13 +723,11 @@ export class Time {
       hour === 24 ? plain.add({ hours: 1 }) : wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? nowTimeZoneId() : utcOffsetArgument(zone);
     this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
-    // A wall clock a DST fall-back repeats names two instants, and MRI's
-    // `find_time_t` (`time.c`) settles on the STANDARD-time one when `isdst` is
-    // `nil`: under `TZ=America/New_York`, `Time.local(2005, 10, 30, 1, 0, 0)` is
-    // `-0500` and its `isdst` is false. `Temporal`'s default `"compatible"`
-    // picks the earlier occurrence instead, so the later one is asked for by
-    // name. For the "spring forward" gap the two agree — MRI rolls
-    // `2005-04-03 02:30` forward to `03:30 -0400`, and so does `"later"`.
+    // MRI's `find_time_t` (`time.c`) settles a wall clock a DST fall-back
+    // repeats on the STANDARD-time occurrence when `isdst` is `nil`:
+    // `TZ=America/New_York Time.local(2005, 10, 30, 1, 0, 0)` is `-0500`, where
+    // `Temporal`'s default `"compatible"` picks the earlier one. For the
+    // "spring forward" gap the two agree.
     const disambiguation = { disambiguation: "later" } as const;
     this.#utcOffsetMemo =
       typeof utcOffset === "number"
@@ -827,12 +825,10 @@ export class Time {
 
   /**
    * Ruby `Time#isdst` (`ruby/time.c` `time_isdst`), true when the receiver's
-   * zone is observing daylight saving. A time built from an offset rather than
-   * a zone has no zone to ask, and MRI answers `false` — `Time.new(2008, 7, 1,
-   * 0, 0, 0, "-04:00").isdst` is false where the same instant in
-   * `America/New_York` is true. The standard offset is the smaller of the
-   * zone's January and July offsets, the same reading {@link zone} takes for
-   * its abbreviation, so a negative-DST zone falls out the same way.
+   * zone is observing daylight saving. A time built from an offset has no zone
+   * to ask and MRI answers `false`. The standard offset is the smaller of the
+   * zone's January and July offsets, the reading {@link zone} takes for its
+   * abbreviation, so a negative-DST zone falls out the same way.
    */
   get isdst(): boolean {
     if (this.#timeZoneId == null || this.#timeZoneId === "UTC") return false;


### PR DESCRIPTION
Two RFC 0098 convergence stories, bundled because the second needs the first's `::Time` seat.

## `TimeWithZone#utc` answers a `::Time`

`ActiveSupport::TimeWithZone#utc` answers a `::Time`
(`activesupport/lib/active_support/time_with_zone.rb:63-65`), and `getgm`,
`gmtime`, `getutc` and `comparable_time` are its aliases (`:66-68`). trails
answered a `Temporal.Instant`, which is what forced PR #6895's seating hop:
`localtime` is Rails' one-liner `utc.getlocal(utc_offset)` (`:83-85`), but an
`Instant` has no `getlocal`.

`utc()` now answers `@blazetrails/date`'s `Time`, the four aliases follow it, and
`localtime` is the Rails one-liner with no reseating. The `UtcConstructed`
instant every `TimeZone` / `Temporal` reader in the file takes stays behind a
private `_utcConstructed`. `Time#toFs` grows a `::Time` arm rather than bridging
back through an instant, and `TimeWithZone#eql` grows the `::Time` arm Rails'
`other.eql?(utc)` (`:274-276`) implies.

Mirrored assertions follow Rails' `assert_instance_of Time` (`test_utc`,
time_with_zone_test.rb:18-22). No test name touched.

## `Time#change`'s zoned arm rebuilds through `Time.local`

Rails' `elsif zone` arm is
`::Time.local(new_sec, new_min, new_hour, new_day, new_month, new_year, nil, nil, isdst, nil)`
(`core_ext/time/calculations.rb:172-175`) — Ruby's reversed component order with
the receiver's `isdst`. trails' overload took the offset path instead, so a
receiver carrying a NAMED zone came back with `zone == null` and a repeated wall
clock always resolved to the first occurrence.

- `Time.local` / `Time.mktime` grow MRI's ten-argument form (`time.c`
  `time_arg`: `if (argc == 10)`), and `Time#isdst` / `Time#dst?` (`time_isdst`)
  supply the argument.
- `change` over a `::Time` now takes all four terminal arms — `:offset`, `utc?`,
  `zone`, and the trailing `utc_offset` — in Rails' order.
- The third arm, `elsif zone.respond_to?(:utc_to_local)` (`:148-171`), is
  recorded as unreachable at the call site: `@blazetrails/date`'s `Time#zone`
  answers the tzdata abbreviation String and nothing else, so
  `respond_to?(:utc_to_local)` is false for every trails `::Time`. Its
  second-occurrence correction is not lost — `Time.local`'s `isdst` makes the
  same choice on the `elsif zone` arm.
- The `Time` constructor's local path also settles an ambiguous wall clock on
  the STANDARD-time occurrence, as MRI's `find_time_t` does with a `nil` isdst:
  `TZ=America/New_York ruby -e 'p Time.local(2005, 10, 30, 1, 0, 0)'` is
  `-0500`, where Temporal's default `"compatible"` picked `-0400`.

Every behavioural claim above was checked against MRI directly.

## Tests

Unskips `change preserves offset for local times around end of dst` and
`change preserves fractional hour offset for local times around end of dst`,
which were parked on exactly this gap.

`parity:api:calls` and `parity:api:calls:args` both clean; `parity:test` delta
non-negative.

Closes-story: converge-time-with-zone-utc-onto-a-ruby-time
Closes-story: converge-time-change-zoned-arm-onto-time-local