### PR TITLE
fix(date,activerecord,activesupport): Time.new's string form; converge finder_needs_type_condition?, benchmark dispatch, encryption-schemes fixtures

### DIFF
--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,12 +1,5 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "_unsignedDecimal",
-      "_unsignedFloat",
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
-    "packages/activerecord/src/connection-handling.ts": ["_connection", "connection"],
-    "packages/activesupport/src/core-ext/benchmark.ts": ["_ms", "ms"]
+    "packages/activerecord/src/connection-handling.ts": ["connection"]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,5 +1,12 @@
 {
   "files": {
-    "packages/activerecord/src/connection-handling.ts": ["connection"]
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "_unsignedDecimal",
+      "_unsignedFloat",
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
+    "packages/activerecord/src/connection-handling.ts": ["_connection", "connection"],
+    "packages/activesupport/src/core-ext/benchmark.ts": ["_ms", "ms"]
   }
 }

--- a/packages/actionpack/src/abstract-controller/logger.test.ts
+++ b/packages/actionpack/src/abstract-controller/logger.test.ts
@@ -16,7 +16,15 @@ describe("benchmark()", () => {
 
   it("awaits a promise-returning block and logs exactly once after resolution", async () => {
     const lines: string[] = [];
-    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    const logger: LoggerLike = {
+      debug: () => {},
+      info: (m) => {
+        lines.push(m);
+      },
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    };
     const result = await benchmark.call({ logger }, "fetch", async () => {
       await new Promise((r) => setTimeout(r, 5));
       return 42;
@@ -26,17 +34,17 @@ describe("benchmark()", () => {
     expect(lines[0]).toMatch(/^fetch \(\d+\.\d+ms\)$/);
   });
 
-  it("tolerates a logger whose `info` is not a function", () => {
-    let ran = false;
-    benchmark.call({ logger: { info: "not a function" } as unknown as LoggerLike }, "work", () => {
-      ran = true;
-    });
-    expect(ran).toBe(true);
-  });
-
   it("logs an info line with elapsed ms when a logger is attached", () => {
     const lines: string[] = [];
-    const logger: LoggerLike = { info: (m) => lines.push(m) };
+    const logger: LoggerLike = {
+      debug: () => {},
+      info: (m) => {
+        lines.push(m);
+      },
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    };
     benchmark.call({ logger }, "render template", () => 1 + 1);
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/^render template \(\d+\.\d+ms\)$/);

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1942,13 +1942,11 @@ describe("BasicsTest", () => {
     }
     const log: string[] = [];
     const savedLogger = Base.logger;
-    // Logger stub has no debug/info handlers — benchmark should no-op for those levels
-    Base.logger = {
-      debug: undefined,
-      info: undefined,
-      warn: (msg: string) => log.push(msg),
-      error: (msg: string) => log.push(msg),
-    };
+    // Rails: `ActiveSupport::Logger.new(log)` with `level = Logger::WARN`, so
+    // the debug line is filtered by level rather than by a missing method.
+    const logger = new Logger({ write: (s: string) => log.push(s) });
+    logger.level = Logger.WARN;
+    Base.logger = logger as any;
     try {
       await Base.benchmark("Debug Topic Count", { level: "debug" }, () => Topic.count());
       await Base.benchmark("Warn Topic Count", { level: "warn" }, () => Topic.count());

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1942,11 +1942,10 @@ describe("BasicsTest", () => {
     }
     const log: string[] = [];
     const savedLogger = Base.logger;
-    // Rails: `ActiveSupport::Logger.new(log)` with `level = Logger::WARN`, so
-    // the debug line is filtered by level rather than by a missing method.
+    // Rails filters the debug line by level, not by a missing method.
     const logger = new Logger({ write: (s: string) => log.push(s) });
     logger.level = Logger.WARN;
-    Base.logger = logger as any;
+    Base.logger = logger;
     try {
       await Base.benchmark("Debug Topic Count", { level: "debug" }, () => Topic.count());
       await Base.benchmark("Warn Topic Count", { level: "warn" }, () => Topic.count());

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -177,6 +177,7 @@ import {
   extend,
   classAttribute,
   benchmark as benchmarkable,
+  type BenchmarkLogger,
   runLoadHooks,
   isBlank as _isBlankValue,
   type PrependMethod,
@@ -1640,35 +1641,18 @@ export class Base extends Model {
   }
 
   // -- Logger --
-  static _logger: {
-    debug?: (...args: any[]) => void;
-    info?: (...args: any[]) => void;
-    warn?: (...args: any[]) => void;
-    error?: (...args: any[]) => void;
-  } | null = null;
+  static _logger: BenchmarkLogger | null = null;
 
   /**
    * Set or get the logger for SQL and lifecycle events.
    *
    * Mirrors: ActiveRecord::Base.logger
    */
-  static get logger(): {
-    debug?: (...args: any[]) => void;
-    info?: (...args: any[]) => void;
-    warn?: (...args: any[]) => void;
-    error?: (...args: any[]) => void;
-  } | null {
+  static get logger(): BenchmarkLogger | null {
     return this._logger;
   }
 
-  static set logger(
-    log: {
-      debug?: (...args: any[]) => void;
-      info?: (...args: any[]) => void;
-      warn?: (...args: any[]) => void;
-      error?: (...args: any[]) => void;
-    } | null,
-  ) {
+  static set logger(log: BenchmarkLogger | null) {
     this._logger = log;
   }
 

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -126,11 +126,18 @@ describe("EachTest", () => {
 
   it("warn if order scope is set", async () => {
     const previousLogger = Base.logger;
-    Base.logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+    Base.logger = logger;
     try {
       for await (const _post of Post.order("title").findEach({})) {
       }
-      expect(Base.logger.warn).toHaveBeenCalledWith(Batches.ORDER_IGNORE_MESSAGE);
+      expect(logger.warn).toHaveBeenCalledWith(Batches.ORDER_IGNORE_MESSAGE);
     } finally {
       Base.logger = previousLogger;
     }

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -24,8 +24,6 @@ import {
 } from "./test-helpers.js";
 import { fixtures } from "../test-fixtures.js";
 
-// Rails' counterpart is an `ActiveRecord::EncryptionTestCase`, so it inherits
-// `use_transactional_tests` — each case starts from an empty table.
 fixtures([]);
 
 class TestEncryptor implements EncryptorLike {
@@ -67,8 +65,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   let savedSupportUnencryptedData: boolean;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
 
-  // Lay the canonical tables once: DDL inside the per-test transaction would
-  // auto-commit on MariaDB and break the wrap.
+  // Laid once: DDL inside the per-test transaction auto-commits on MariaDB.
   beforeAll(async () => {
     await freshAdapter();
   });

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
@@ -22,6 +22,11 @@ import {
   makeKeyProvider,
   withoutEncryption,
 } from "./test-helpers.js";
+import { fixtures } from "../test-fixtures.js";
+
+// Rails' counterpart is an `ActiveRecord::EncryptionTestCase`, so it inherits
+// `use_transactional_tests` — each case starts from an empty table.
+fixtures([]);
 
 class TestEncryptor implements EncryptorLike {
   constructor(private readonly map: Record<string, string>) {}
@@ -61,6 +66,12 @@ function makeType(
 describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   let savedSupportUnencryptedData: boolean;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  // Lay the canonical tables once: DDL inside the per-test transaction would
+  // auto-commit on MariaDB and break the wrap.
+  beforeAll(async () => {
+    await freshAdapter();
+  });
 
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
@@ -426,11 +437,6 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
         }
       } as any;
       new encryptedAuthorClass();
-      // No transactional fixtures in this file: an earlier case in the suite
-      // leaves a row with the same deterministic ciphertext behind, which would
-      // make the find_by hit ambiguous.
-      await encryptedAuthorClass.deleteAll();
-
       const author = await encryptedAuthorClass.create({ name: "STEPHEN KING" });
       const found = await encryptedAuthorClass.findBy({ name: "STEPHEN KING" });
       expect(found).not.toBeNull();

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -138,16 +138,13 @@ export function descendants(modelClass: typeof Base): (typeof Base)[] {
  */
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
-  // Rails: `if self == Base` → false. Detected via the `_isActiveRecordBase`
-  // own-property sentinel on Base.
+  // `self == Base` is read off the `_isActiveRecordBase` own-property sentinel.
   if (Object.prototype.hasOwnProperty.call(modelClass, "_isActiveRecordBase")) return false;
   const superclass = Object.getPrototypeOf(modelClass) as typeof Base | null;
-  // Above Base there is no superclass to ask; Ruby never reaches here.
+  // Above Base there is no `superclass` to ask; Ruby never reaches here.
   if (!superclass || superclass === Function.prototype || typeof superclass.name !== "string")
     return true;
-  // Rails: `elsif superclass.abstract_class?` → recurse.
   if (superclass.abstractClass) return isDescendsFromActiveRecord.call(superclass);
-  // Rails: `else superclass == Base || !columns_hash.include?(inheritance_column)`.
   if (Object.prototype.hasOwnProperty.call(superclass, "_isActiveRecordBase")) return true;
   // Ruby `columns_hash.include?(inheritance_column)` is false for the nil
   // `inheritance_column` of an STI-disabled model, so no separate arm.
@@ -671,7 +668,6 @@ export function defineDynamicSelectReaders(record: Base): void {
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#finder_needs_type_condition?
  */
 export function isFinderNeedsTypeCondition(modelClass: typeof Base): boolean {
-  // Rails: `:true == (@finder_needs_type_condition ||= descends_from_active_record? ? :false : :true)`.
   if (!Object.prototype.hasOwnProperty.call(modelClass, "_finderNeedsTypeCondition")) {
     (modelClass as any)._finderNeedsTypeCondition = !modelClass.isDescendsFromActiveRecord();
   }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -121,30 +121,6 @@ export function descendants(modelClass: typeof Base): (typeof Base)[] {
 }
 
 /**
- * Hierarchical half of Rails' `descends_from_active_record?`: the `self == Base`
- * / abstract-superclass recursion / `superclass == Base` structure, with the
- * inheritance-column-presence test left to the caller. Splitting it out lets
- * {@link isFinderNeedsTypeCondition} memoize the stable structural answer without
- * caching a transient cold-schema column miss.
- *
- * Independent of the explicit `inheritanceColumn` sentinel that
- * {@link isStiSubclass} keys off — that sentinel still gates the
- * registry-resolved row-dispatch paths.
- *
- * @internal
- */
-function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
-  // Rails: `self == Base` → false.
-  if (Object.prototype.hasOwnProperty.call(modelClass, "_isActiveRecordBase")) return false;
-  const parent = Object.getPrototypeOf(modelClass) as typeof Base | null;
-  if (!parent || parent === Function.prototype || typeof parent.name !== "string") return true;
-  // Rails: `elsif superclass.abstract_class?` → recurse through the abstract chain.
-  if (parent.abstractClass) return descendsFromActiveRecordByHierarchy(parent);
-  // Rails else branch begins with `superclass == Base`.
-  return Object.prototype.hasOwnProperty.call(parent, "_isActiveRecordBase");
-}
-
-/**
  * Check if a model descends directly from ActiveRecord::Base — i.e. it is a
  * hierarchy root rather than a concrete STI subclass.
  *
@@ -162,15 +138,20 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  */
 export function isDescendsFromActiveRecord(this: typeof Base): boolean {
   const modelClass = this;
-  // Rails' first arm, `if self == Base` → false, returns before the column
-  // test — Base has no table, so asking it for `columns_hash` raises.
+  // Rails: `if self == Base` → false. Detected via the `_isActiveRecordBase`
+  // own-property sentinel on Base.
   if (Object.prototype.hasOwnProperty.call(modelClass, "_isActiveRecordBase")) return false;
-  if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  const columnsHash = modelClass.columnsHash();
-  const inheritCol = modelClass.inheritanceColumn;
+  const superclass = Object.getPrototypeOf(modelClass) as typeof Base | null;
+  // Above Base there is no superclass to ask; Ruby never reaches here.
+  if (!superclass || superclass === Function.prototype || typeof superclass.name !== "string")
+    return true;
+  // Rails: `elsif superclass.abstract_class?` → recurse.
+  if (superclass.abstractClass) return isDescendsFromActiveRecord.call(superclass);
+  // Rails: `else superclass == Base || !columns_hash.include?(inheritance_column)`.
+  if (Object.prototype.hasOwnProperty.call(superclass, "_isActiveRecordBase")) return true;
   // Ruby `columns_hash.include?(inheritance_column)` is false for the nil
   // `inheritance_column` of an STI-disabled model, so no separate arm.
-  return !Object.keys(columnsHash).includes(inheritCol as string);
+  return !Object.keys(modelClass.columnsHash()).includes(modelClass.inheritanceColumn as string);
 }
 
 /**
@@ -690,21 +671,11 @@ export function defineDynamicSelectReaders(record: Base): void {
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#finder_needs_type_condition?
  */
 export function isFinderNeedsTypeCondition(modelClass: typeof Base): boolean {
-  if (Object.prototype.hasOwnProperty.call(modelClass, "_finderNeedsTypeCondition")) {
-    return (modelClass as any)._finderNeedsTypeCondition === true;
+  // Rails: `:true == (@finder_needs_type_condition ||= descends_from_active_record? ? :false : :true)`.
+  if (!Object.prototype.hasOwnProperty.call(modelClass, "_finderNeedsTypeCondition")) {
+    (modelClass as any)._finderNeedsTypeCondition = !modelClass.isDescendsFromActiveRecord();
   }
-  // Rails: `descends_from_active_record? ? :false : :true`, memoized.
-  if (!modelClass.isDescendsFromActiveRecord()) {
-    (modelClass as any)._finderNeedsTypeCondition = true;
-    return true;
-  }
-  // `descends` is true. Memoize only the stable reasons (a hierarchy root, or STI
-  // explicitly disabled); a non-root model that descends only because its `type`
-  // column hasn't reflected yet must recompute once schema warms.
-  if (descendsFromActiveRecordByHierarchy(modelClass) || modelClass.inheritanceColumn === null) {
-    (modelClass as any)._finderNeedsTypeCondition = false;
-  }
-  return false;
+  return (modelClass as any)._finderNeedsTypeCondition === true;
 }
 
 // The primary abstract class is stored in the canonical `ar-config.ts` module

--- a/packages/activesupport/src/benchmarkable.ts
+++ b/packages/activesupport/src/benchmarkable.ts
@@ -8,11 +8,11 @@
 import { assertValidKeys } from "./hash-utils.js";
 
 export interface BenchmarkLogger {
-  debug?(message: string): void;
-  info?(message: string): void;
-  warn?(message: string): void;
-  error?(message: string): void;
-  fatal?(message: string): void;
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  fatal(message: string): void;
   silence?(tempLevel?: number, fn?: () => void): void;
 }
 
@@ -71,10 +71,7 @@ export function benchmark<T>(
     const start = monotonicNow();
     const finish = (): T | Promise<Awaited<T>> => {
       const ms = monotonicNow() - start;
-      const write = (logger as Record<string, unknown>)[options.level!];
-      if (typeof write === "function") {
-        (write as (msg: string) => void).call(logger, `${message} (${ms.toFixed(1)}ms)`);
-      }
+      logger[options.level!](`${message} (${ms.toFixed(1)}ms)`);
       return result as Awaited<T>;
     };
 

--- a/packages/activesupport/src/time-travel.test.ts
+++ b/packages/activesupport/src/time-travel.test.ts
@@ -9,6 +9,11 @@ import {
   setTimeOffsetNs,
 } from "./time-travel.js";
 
+/** The instant `assert_equal`'s `Time#==` compares two Times on. */
+function instantOf(time: Time): bigint {
+  return time.toTime().epochNanoseconds;
+}
+
 describe("TimeTravelTest", () => {
   afterEach(() => {
     travelBack();
@@ -27,8 +32,16 @@ describe("TimeTravelTest", () => {
     let inside: Date | null = null;
     travel(1000, {}, () => {
       inside = currentTime();
+      // `precision:` acts only on the STRING form, so this arm answers the same
+      // instant travelled or not (`time_travel_test.rb:55`).
+      expect(instantOf(Time.new("2000-12-31 23:59:59.56789", { precision: 3 }))).toBe(
+        instantOf(Time.new("2000-12-31 23:59:59.567")),
+      );
     });
     expect(inside).not.toBeNull();
+    expect(instantOf(Time.new("2000-12-31 23:59:59.56789", { precision: 3 }))).toBe(
+      instantOf(Time.new("2000-12-31 23:59:59.567")),
+    );
   });
 
   it("time helper travel to", () => {

--- a/packages/activesupport/src/time-travel.test.ts
+++ b/packages/activesupport/src/time-travel.test.ts
@@ -32,8 +32,6 @@ describe("TimeTravelTest", () => {
     let inside: Date | null = null;
     travel(1000, {}, () => {
       inside = currentTime();
-      // `precision:` acts only on the STRING form, so this arm answers the same
-      // instant travelled or not (`time_travel_test.rb:55`).
       expect(instantOf(Time.new("2000-12-31 23:59:59.56789", { precision: 3 }))).toBe(
         instantOf(Time.new("2000-12-31 23:59:59.567")),
       );

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -383,6 +383,8 @@ describe("Time", () => {
         Time.new("2000-12-31 23:59:59.567").nsec,
       );
       expect(Time.new("2000-12-31 23:59:59.56789", { precision: 20 }).nsec).toBe(567890000);
+      // A negative `precision` truncates nothing, as `nil` does.
+      expect(Time.new("2000-12-31 23:59:59.56789", { precision: -1 }).nsec).toBe(567890000);
       // `precision:` acts on nothing but the string form.
       expect(Time.new(2020, 1, 1, 0, 0, 0.56789, null, { precision: 3 }).nsec).toBe(567890000);
     });

--- a/packages/date/src/time.trails.test.ts
+++ b/packages/date/src/time.trails.test.ts
@@ -365,4 +365,64 @@ describe("Time", () => {
       expect(eastern.zone).toBe("EST");
     });
   });
+  describe("Time.new given a String", () => {
+    it("parses MRI's `time_init_parse` grammar", () => {
+      const t = Time.new("2000-12-31 23:59:59.56789");
+      expect(t.strftime("%Y-%m-%d %H:%M:%S")).toBe("2000-12-31 23:59:59");
+      expect(t.nsec).toBe(567890000);
+      expect(Time.new("2020-01-01T01:02:03Z").isUtc()).toBe(true);
+      expect(Time.new("2020-01-01 01:02:03 +05:00").utcOffset).toBe(18000);
+      expect(Time.new("2020-01-01 01:02:03+0530").utcOffset).toBe(19800);
+      expect(Time.new("2020-01-01 01:02:03A").utcOffset).toBe(3600);
+      expect(Time.new("2020").strftime("%Y-%m-%d %H:%M:%S")).toBe("2020-01-01 00:00:00");
+      expect(Time.new("-05000-01-01 01:02:03").year).toBe(-5000);
+    });
+
+    it("truncates the sub-second to `precision:` digits", () => {
+      expect(Time.new("2000-12-31 23:59:59.56789", { precision: 3 }).nsec).toBe(
+        Time.new("2000-12-31 23:59:59.567").nsec,
+      );
+      expect(Time.new("2000-12-31 23:59:59.56789", { precision: 20 }).nsec).toBe(567890000);
+      // `precision:` acts on nothing but the string form.
+      expect(Time.new(2020, 1, 1, 0, 0, 0.56789, null, { precision: 3 }).nsec).toBe(567890000);
+    });
+
+    it("takes `in:` for a string that spells no zone of its own", () => {
+      expect(Time.new("2020-01-01 00:00:00", { in: "+05:00" }).utcOffset).toBe(18000);
+      // MRI does NOT collide the two: the zone the string spells wins.
+      expect(Time.new("2020-01-01 00:00:00+01:00", { in: "+05:00" }).utcOffset).toBe(3600);
+    });
+
+    it("raises MRI's own message at the step that stopped the parse", () => {
+      expect(() => Time.new("garbage")).toThrow(new ArgumentError('can\'t parse: "garbage"'));
+      expect(() => Time.new("202-01-01T01:02:03")).toThrow(
+        new ArgumentError("year must be 4 or more digits: 202"),
+      );
+      expect(() => Time.new("2020-1-01 01:02:03")).toThrow(
+        new ArgumentError("two digits mon is expected after `-': -1-01 01:02"),
+      );
+      expect(() => Time.new("2020-01-0")).toThrow(
+        new ArgumentError("two digits mday is expected after `-': -0"),
+      );
+      expect(() => Time.new("2020-01-01")).toThrow(new ArgumentError("no time information"));
+      expect(() => Time.new("2020-01-01 1:02:03")).toThrow(
+        new ArgumentError("two digits hour is expected:  1:02:03"),
+      );
+      expect(() => Time.new("2020-01-01T01")).toThrow(new ArgumentError("missing min part: 01"));
+      expect(() => Time.new("2020-01-01T01:02")).toThrow(
+        new ArgumentError("missing sec part: 01:02"),
+      );
+      expect(() => Time.new("2020-01-01T01:02:")).toThrow(
+        new ArgumentError("two digits sec is expected after `:': :"),
+      );
+      expect(() => Time.new("2000-12-31 23:59:59.5", { precision: 0 })).toThrow(
+        new ArgumentError("subsecond expected after dot: 23:59:59.5"),
+      );
+      expect(() => Time.new("2020-01-01T01:02:03+05:0")).toThrow(
+        new ArgumentError(
+          '"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: +05:0',
+        ),
+      );
+    });
+  });
 });

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -349,10 +349,11 @@ function parseFixedDigits(str: string, ptr: number, n: number): number | null {
  * more, fixed two-digit month/day/hour/min/sec fields, and every one of MRI's
  * own messages at the step that raises it.
  *
- * `precision` is the sub-second digits kept: it truncates the parsed fraction
- * before it is carried, and a fraction it truncates away entirely is MRI's
- * `subsecond expected after dot:` — `Time.new("2000-12-31 23:59:59.5",
- * precision: 0)` raises rather than answering a whole second.
+ * `precision` is the sub-second digits kept: a non-negative one truncates the
+ * parsed fraction before it is carried, and a fraction it truncates away
+ * entirely is MRI's `subsecond expected after dot:` — `Time.new("2000-12-31
+ * 23:59:59.5", precision: 0)` raises rather than answering a whole second. A
+ * negative `precision` keeps the whole fraction, the answer `nil` gets.
  *
  * The zone is handed back as the substring the string spells, so
  * {@link utcOffsetArgument} — the same reader the seventh positional goes
@@ -442,7 +443,10 @@ function timeInitParse(
         ptr++;
         let fracDigits = 0;
         while (isDigit(str[ptr + fracDigits])) fracDigits++;
-        const frac = str.slice(ptr, ptr + fracDigits).slice(0, Math.max(precision, 0));
+        const parsedFrac = str.slice(ptr, ptr + fracDigits);
+        // MRI truncates only for a non-negative `precision`; a negative one
+        // keeps the whole fraction, as `nil` does.
+        const frac = precision < 0 ? parsedFrac : parsedFrac.slice(0, precision);
         ptr += fracDigits;
         if (frac.length === 0) {
           throw new ArgumentError(

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -106,7 +106,9 @@ function utcOffsetArgument(zone: string | number): "UTC" | number {
     const hours = code <= 73 ? code - 64 : code <= 77 ? code - 65 : 77 - code;
     return hours * 3600;
   }
-  throw new ArgumentError('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset');
+  throw new ArgumentError(
+    `"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: ${zone}`,
+  );
 }
 
 /**
@@ -314,8 +316,148 @@ function isTimeNewOptions(arg: unknown): arg is TimeNewOptions {
 }
 
 /** The defaults `Time.new`'s positionals fall back to once a keyword hash is
- *  lifted out of the slot one of them would have bound. */
-const TIME_NEW_DEFAULTS = [undefined, 1, 1, 0, 0, 0, null];
+ *  lifted out of the slot one of them would have bound. The `mon` slot falls
+ *  back to `undefined` rather than to `1`, because an absent `mon` is what
+ *  MRI's `nil.equal?(mon) && String === year` reads to take the STRING form. */
+const TIME_NEW_DEFAULTS = [undefined, undefined, 1, 0, 0, 0, null];
+
+/**
+ * The tail MRI's `time_init_parse` prints in a parse error — the separator it
+ * stopped at plus ten characters, its `%.*s` width.
+ */
+function rest(str: string, ptr: number): string {
+  return str.slice(ptr, ptr + 11);
+}
+
+function isDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= "0" && ch <= "9";
+}
+
+/**
+ * The fixed-width integer field MRI's `time_init_parse` reads with its
+ * `parse_int(..., width, ...)`: exactly `n` digits, or nothing.
+ */
+function parseFixedDigits(str: string, ptr: number, n: number): number | null {
+  for (let i = 0; i < n; i++) if (!isDigit(str[ptr + i])) return null;
+  return Number(str.slice(ptr, ptr + n));
+}
+
+/**
+ * MRI's `time_init_parse` (`time.c`), the parser behind the STRING form of
+ * `Time.new` — `Time.new("2000-12-31 23:59:59.56789")`. The grammar is
+ * `[+-]YYYY[-MM[-DD]][ T]hh:mm:ss[.frac][ zone]`, with a year of four digits or
+ * more, fixed two-digit month/day/hour/min/sec fields, and every one of MRI's
+ * own messages at the step that raises it.
+ *
+ * `precision` is the sub-second digits kept: it truncates the parsed fraction
+ * before it is carried, and a fraction it truncates away entirely is MRI's
+ * `subsecond expected after dot:` — `Time.new("2000-12-31 23:59:59.5",
+ * precision: 0)` raises rather than answering a whole second.
+ *
+ * The zone is handed back as the substring the string spells, so
+ * {@link utcOffsetArgument} — the same reader the seventh positional goes
+ * through — takes it and raises the same message on a malformed one.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby core `::Time`; see the class comment.
+ */
+function timeInitParse(
+  str: string,
+  precision: number,
+): [number, number, number, number, number, number | Rational, string | null] {
+  const end = str.length;
+  let ptr = 0;
+  const sign = str[ptr] === "-" || str[ptr] === "+" ? str[ptr++] : "";
+  let digits = 0;
+  while (isDigit(str[ptr + digits])) digits++;
+  if (digits === 0) throw new ArgumentError(`can't parse: ${JSON.stringify(str)}`);
+  if (digits < 4) {
+    throw new ArgumentError(`year must be 4 or more digits: ${str.slice(ptr, ptr + digits)}`);
+  }
+  const year = Number(`${sign}${str.slice(ptr, ptr + digits)}`);
+  ptr += digits;
+  let mon = 1;
+  let mday = 1;
+  let hour = 0;
+  let min = 0;
+  let sec: number | Rational = 0;
+  let dated = false;
+  if (str[ptr] === "-") {
+    const dash = ptr++;
+    const parsed = parseFixedDigits(str, ptr, 2);
+    if (parsed === null) {
+      throw new ArgumentError(`two digits mon is expected after \`-': ${rest(str, dash)}`);
+    }
+    mon = parsed;
+    ptr += 2;
+    dated = true;
+    if (str[ptr] === "-") {
+      const mdayDash = ptr++;
+      const parsedMday = parseFixedDigits(str, ptr, 2);
+      if (parsedMday === null) {
+        throw new ArgumentError(`two digits mday is expected after \`-': ${rest(str, mdayDash)}`);
+      }
+      mday = parsedMday;
+      ptr += 2;
+    }
+  }
+  let zone: string | null = null;
+  if (ptr === end) {
+    // A date with no time part at all is MRI's `no time information`; a bare
+    // year is not — it lands on the 1st of January.
+    if (dated) throw new ArgumentError("no time information");
+  } else {
+    const sep = ptr;
+    if (str[ptr] === "T") ptr++;
+    else while (str[ptr] === " ") ptr++;
+    if (ptr === end) {
+      if (str[sep] !== "T") throw new ArgumentError(`can't parse: ${JSON.stringify(str)}`);
+    } else if (isDigit(str[ptr])) {
+      const timeStart = ptr;
+      const parsedHour = parseFixedDigits(str, ptr, 2);
+      if (parsedHour === null) {
+        throw new ArgumentError(`two digits hour is expected: ${rest(str, sep)}`);
+      }
+      hour = parsedHour;
+      ptr += 2;
+      if (str[ptr] !== ":") {
+        throw new ArgumentError(`missing min part: ${str.slice(timeStart, timeStart + 10)}`);
+      }
+      let colon = ptr++;
+      const parsedMin = parseFixedDigits(str, ptr, 2);
+      if (parsedMin === null) {
+        throw new ArgumentError(`two digits min is expected after \`:': ${rest(str, colon)}`);
+      }
+      min = parsedMin;
+      ptr += 2;
+      if (str[ptr] !== ":") {
+        throw new ArgumentError(`missing sec part: ${str.slice(timeStart, timeStart + 10)}`);
+      }
+      colon = ptr++;
+      const parsedSec = parseFixedDigits(str, ptr, 2);
+      if (parsedSec === null) {
+        throw new ArgumentError(`two digits sec is expected after \`:': ${rest(str, colon)}`);
+      }
+      sec = parsedSec;
+      ptr += 2;
+      if (str[ptr] === ".") {
+        ptr++;
+        let fracDigits = 0;
+        while (isDigit(str[ptr + fracDigits])) fracDigits++;
+        const frac = str.slice(ptr, ptr + fracDigits).slice(0, Math.max(precision, 0));
+        ptr += fracDigits;
+        if (frac.length === 0) {
+          throw new ArgumentError(
+            `subsecond expected after dot: ${str.slice(timeStart, Math.min(ptr, timeStart + 10))}`,
+          );
+        }
+        sec = new Rational(parsedSec, 1).add(new Rational(Number(frac), 10 ** frac.length));
+      }
+      while (str[ptr] === " ") ptr++;
+    }
+    if (ptr < end) zone = str.slice(ptr);
+  }
+  return [year, mon, mday, hour, min, sec, zone];
+}
 
 /**
  * The keywords MRI's `Time.new` takes beside its positionals (`time.c`
@@ -411,12 +553,12 @@ export class Time {
    * `Time.new("2000-12-31 23:59:59.56789", precision: 3)` is
    * `Time.new("2000-12-31 23:59:59.567")` — and MRI applies it to nothing else:
    * `Time.new(2020, 1, 1, 0, 0, 0.56789, precision: 3).nsec` is `567890000`,
-   * the untrimmed value. trails does not port the string form yet, so the
-   * keyword is taken and, as in MRI without a string, changes nothing. Taking
-   * it is what `travel_to`'s `Time.new` stub reads: it forwards to the original
-   * method whenever it is handed anything at all (`time_helpers.rb:180-187`),
-   * so `Time.new(precision: 3)` answers the real current time, not the
-   * travelled one.
+   * the untrimmed value. The string is parsed by {@link timeInitParse}, and a
+   * zone the string itself spells wins over `in:` rather than colliding with
+   * it. Taking the keyword at all is also what `travel_to`'s `Time.new` stub
+   * reads: it forwards to the original method whenever it is handed anything
+   * at all (`time_helpers.rb:180-187`), so `Time.new(precision: 3)` answers the
+   * real current time, not the travelled one.
    *
    * The keywords are spelled as a trailing object and, as in MRI, may follow
    * any number of positionals — `Time.new({ precision: 3 })`,
@@ -430,7 +572,7 @@ export class Time {
    */
   static new(
     year?: number | string | TimeNewOptions,
-    month: number | string | TimeNewOptions | null = 1,
+    month: number | string | TimeNewOptions | null | undefined = undefined,
     day: number | string | TimeNewOptions | null = 1,
     hour: number | string | TimeNewOptions | null = 0,
     min: number | string | TimeNewOptions | null = 0,
@@ -458,6 +600,13 @@ export class Time {
       throw new ArgumentError("timezone argument given as positional and keyword arguments");
     }
     if (year === undefined) return Time.#atInstant(Temporal.Now.instant(), inZone);
+    // MRI: `if nil.equal?(mon) and String === year` — the STRING form, and the
+    // only place `precision:` acts (`timev.rb` `Time#initialize`). A zone the
+    // string itself spells wins over `in:`, as it does in MRI.
+    if (typeof year === "string" && month === undefined) {
+      const [y, mon, mday, hour, min, sec, zoneStr] = timeInitParse(year, options.precision ?? 9);
+      return new Time(y, mon, mday, hour, min, sec, zoneStr ?? inZone);
+    }
     return new Time(
       year as number | string,
       month as number | string | null,

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -358,7 +358,10 @@ function parseFixedDigits(str: string, ptr: number, n: number): number | null {
  * {@link utcOffsetArgument} — the same reader the seventh positional goes
  * through — takes it and raises the same message on a malformed one.
  *
- * @noRailsEquivalent PERMANENT — Ruby core `::Time`; see the class comment.
+ * A `mon` the string does not spell leaves the field at MRI's own `-1`
+ * sentinel, which is what separates a bare year — `Time.new("2020")`, the 1st
+ * of January — from a date whose time part is missing altogether, MRI's
+ * `no time information`.
  */
 function timeInitParse(
   str: string,
@@ -375,12 +378,11 @@ function timeInitParse(
   }
   const year = Number(`${sign}${str.slice(ptr, ptr + digits)}`);
   ptr += digits;
-  let mon = 1;
-  let mday = 1;
+  let mon = -1;
+  let mday = -1;
   let hour = 0;
   let min = 0;
   let sec: number | Rational = 0;
-  let dated = false;
   if (str[ptr] === "-") {
     const dash = ptr++;
     const parsed = parseFixedDigits(str, ptr, 2);
@@ -389,7 +391,6 @@ function timeInitParse(
     }
     mon = parsed;
     ptr += 2;
-    dated = true;
     if (str[ptr] === "-") {
       const mdayDash = ptr++;
       const parsedMday = parseFixedDigits(str, ptr, 2);
@@ -402,9 +403,7 @@ function timeInitParse(
   }
   let zone: string | null = null;
   if (ptr === end) {
-    // A date with no time part at all is MRI's `no time information`; a bare
-    // year is not — it lands on the 1st of January.
-    if (dated) throw new ArgumentError("no time information");
+    if (mon !== -1) throw new ArgumentError("no time information");
   } else {
     const sep = ptr;
     if (str[ptr] === "T") ptr++;
@@ -456,7 +455,7 @@ function timeInitParse(
     }
     if (ptr < end) zone = str.slice(ptr);
   }
-  return [year, mon, mday, hour, min, sec, zone];
+  return [year, mon === -1 ? 1 : mon, mday === -1 ? 1 : mday, hour, min, sec, zone];
 }
 
 /**
@@ -553,9 +552,11 @@ export class Time {
    * `Time.new("2000-12-31 23:59:59.56789", precision: 3)` is
    * `Time.new("2000-12-31 23:59:59.567")` — and MRI applies it to nothing else:
    * `Time.new(2020, 1, 1, 0, 0, 0.56789, precision: 3).nsec` is `567890000`,
-   * the untrimmed value. The string is parsed by {@link timeInitParse}, and a
-   * zone the string itself spells wins over `in:` rather than colliding with
-   * it. Taking the keyword at all is also what `travel_to`'s `Time.new` stub
+   * the untrimmed value. MRI takes the string form on
+   * `nil.equal?(mon) && String === year` — no second positional — and parses it
+   * with {@link timeInitParse}; a zone the string itself spells wins over `in:`
+   * rather than colliding with it. The keyword defaults to 9 digits, the whole
+   * sub-second. Taking the keyword at all is also what `travel_to`'s `Time.new` stub
    * reads: it forwards to the original method whenever it is handed anything
    * at all (`time_helpers.rb:180-187`), so `Time.new(precision: 3)` answers the
    * real current time, not the travelled one.
@@ -600,9 +601,6 @@ export class Time {
       throw new ArgumentError("timezone argument given as positional and keyword arguments");
     }
     if (year === undefined) return Time.#atInstant(Temporal.Now.instant(), inZone);
-    // MRI: `if nil.equal?(mon) and String === year` — the STRING form, and the
-    // only place `precision:` acts (`timev.rb` `Time#initialize`). A zone the
-    // string itself spells wins over `in:`, as it does in MRI.
     if (typeof year === "string" && month === undefined) {
       const [y, mon, mday, hour, min, sec, zoneStr] = timeInitParse(year, options.precision ?? 9);
       return new Time(y, mon, mday, hour, min, sec, zoneStr ?? inZone);

--- a/scripts/non-transactional-row-writes.json
+++ b/scripts/non-transactional-row-writes.json
@@ -2,7 +2,6 @@
   "packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts",
   "packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts",
   "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
-  "packages/activerecord/src/encryption/encryption-schemes.test.ts",
   "packages/activerecord/src/invertible-migration.test.ts",
   "packages/activerecord/src/migration/columns.test.ts",
   "packages/activerecord/src/migration/rename-table.test.ts",


### PR DESCRIPTION
Four bundled stories.

**`time-new-parses-a-string-argument`** — `Time.new` now takes a String first
argument and parses it as MRI's `time_init_parse` (`time.c`) does: the
`[+-]YYYY[-MM[-DD]][ T]hh:mm:ss[.frac][ zone]` grammar, fixed-width fields, and
MRI's own message at each step (verified against `ruby 3.3.11`, including the
`%.*s` truncation of the printed tail). `precision:` truncates the parsed
sub-second before it is carried and still acts on nothing else. The zone the
string spells is handed to `utcOffsetArgument`, the same reader the seventh
positional goes through, and — as in MRI — wins over `in:` rather than
colliding with it. That reader's message now carries the offending zone, as
MRI's does. Restores the two `assert_equal Time.new("2000-12-31 23:59:59.567"),
Time.new("2000-12-31 23:59:59.56789", precision: 3)` arms of
`time_travel_test.rb:55,61`.

**`finder-needs-type-condition-memoizes-conditionally`** —
`isFinderNeedsTypeCondition` is the unconditional memo of
`inheritance.rb:92-95`, `isDescendsFromActiveRecord` carries Rails' own three
arms (`:82-88`), and `descendsFromActiveRecordByHierarchy` — extra surface that
existed only to serve the conditional memo, obsolete since #6926 — is deleted.

**`converge-benchmark-level-dispatch-onto-public-send`** — `benchmark`
dispatches the level method directly, the `public_send` of
`benchmarkable.rb:47`, and `BenchmarkLogger`'s five levels are required.
`ActiveRecord::Base.logger` is typed as that logger rather than a parallel
all-optional shape. The trails-only test asserting the old silence goes with the
guard, and `BasicsTest > benchmark with log level` converges onto Rails'
`ActiveSupport::Logger.new(log)` with `level = Logger::WARN` — the debug line is
filtered by level, as in `base_test.rb:1462-1475`, not by a missing method.

**`encryption-schemes-test-lacks-transactional-fixtures`** —
`encryption-schemes.test.ts` runs under `fixtures([])`, matching the
`use_transactional_tests` its `ActiveRecord::EncryptionTestCase` counterpart
inherits, so the trails-only `deleteAll()` and its comment are gone. The
canonical tables are laid once in `beforeAll` — DDL inside the per-test
transaction would auto-commit on MariaDB.

Green locally: `packages/activerecord/src/encryption`, `inheritance*`,
`sti-attribute-routing`, `base.test.ts`, `batches.test.ts`, all of
`packages/activesupport/src` and `packages/date/src`, `parity:api:calls`,
`:args`, `parity:api:extra:gate`, `parity:test:assertions`, `lint`, `typecheck`.

Closes-story: encryption-schemes-test-lacks-transactional-fixtures
Closes-story: finder-needs-type-condition-memoizes-conditionally
Closes-story: time-new-parses-a-string-argument
Closes-story: converge-benchmark-level-dispatch-onto-public-send

---

**Review follow-up — the story criterion, not the code, was wrong.** The
acceptance criterion "a zone in the string plus `in:` raises MRI's
ArgumentError" does not describe MRI: on `ruby 3.3.11`,
`Time.new("2020-01-01 00:00:00+01:00", in: "+05:00").utc_offset` is `3600` —
the string's own zone wins and the keyword is dropped. The
`timezone argument given as positional and keyword arguments` guard stays over
the seventh positional only, which is where MRI raises it. Corrected in the
story (blazetrailsdev/tasks@9b3d17be4), along with a second stale line: the
vendored `time_travel_test.rb` carries the restored `assert_equal` pair at
`:55,61`, both inside `test_time_helper_travel_with_block`, not four arms
across the with-usec test.
