### PR TITLE
refactor: seat @primary_key per instance, converge TimeWithZone's @utc, split AttributeRegistration#attribute

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,10 +1,10 @@
 import { DescendantsTracker, registerSubclass } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
-import { defaultValue } from "./type.js";
+import { defaultValue, defaultValue as typeDefaultValue } from "./type.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
-import type { AttributeOptions } from "./attributes.js";
+import type { AttributeDefinition, AttributeOptions } from "./attributes.js";
 
 /**
  * AttributeRegistration mixin — provides the static attribute() method
@@ -94,6 +94,104 @@ export class PendingDefault implements PendingModification {
     const existing = attributeSet.getAttribute(this.name);
     attributeSet.set(this.name, existing.withUserDefault(this.default_));
   }
+}
+
+/**
+ * The class-side receiver `attribute` self-sends on — Rails' `self` inside
+ * `AttributeRegistration::ClassMethods`.
+ */
+export interface AttributeRegistrationHost extends AttributeHostInternals {
+  _attributeDefinitions: Map<string, AttributeDefinition>;
+  /** @internal */
+  resolveTypeName(name: string, options?: Record<string, unknown>): Type;
+  /** @internal */
+  hookAttributeType(name: string, type: Type): Type;
+}
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#attribute
+ * (attribute_registration.rb:12-20) — resolves the name, resolves and hooks the
+ * type, appends the pending modifications, and resets the default attributes.
+ * `ActiveModel::Attributes::ClassMethods#attribute` (attributes.rb:59-62) calls
+ * this through `super` and then generates the attribute methods.
+ *
+ * @internal
+ */
+export function attribute(
+  this: AttributeRegistrationHost,
+  name: string,
+  // Mirrors Rails' `attribute(name, type = nil, **options)`: the type is
+  // optional. When omitted, the attribute keeps its existing (schema-reflected
+  // or previously-declared) type and only the default/decorator is applied —
+  // backing the `attribute :col, default: "x"` idiom. See
+  // activemodel/lib/active_model/attribute_registration.rb:18,55-63.
+  typeName?: string | Type | AttributeOptions,
+  options?: AttributeOptions,
+): void {
+  name = this.resolveAttributeName(name);
+  if (typeName !== undefined && typeof typeName !== "string" && !(typeName instanceof Type)) {
+    options = typeName;
+    typeName = undefined;
+  }
+  const typeProvided = typeName !== undefined;
+  if (!Object.hasOwn(this, "_attributeDefinitions")) {
+    this._attributeDefinitions = new Map(this._attributeDefinitions);
+  }
+  const existing = this._attributeDefinitions.get(name);
+  // When the type is omitted, preserve the existing attribute's type (Rails'
+  // PendingType `with_type` inheritance path); fall back to the value type only
+  // when nothing is known about the attribute yet.
+  // Rails' `attribute(name, ...)` forwards `**options` straight to the type
+  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the two keys
+  // consumed here — `default` and `virtual` — are the ones Rails names
+  // explicitly, so only the rest reach the registry.
+  const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
+  let type = typeProvided
+    ? typeName instanceof Type
+      ? typeName
+      : this.resolveTypeName(
+          typeName as string,
+          Object.keys(typeOptions).length > 0
+            ? (typeOptions as Record<string, unknown>)
+            : undefined,
+        )
+    : (existing?.type ?? typeDefaultValue());
+  // attribute_registration.rb:15 — `type = hook_attribute_type(name, type) if type`.
+  if (typeProvided) type = this.hookAttributeType(name, type);
+  // Preserve the existing defaultValue when no default is explicitly provided,
+  // matching Rails' PendingType behavior: with_type only changes the type and
+  // leaves the current default/value untouched.
+  const defaultValue =
+    options?.default !== undefined ? options.default : (existing?.defaultValue ?? null);
+  this._attributeDefinitions.set(name, {
+    ...existing,
+    name,
+    type,
+    defaultValue,
+    virtual: options?.virtual ?? existing?.virtual,
+    ...(options?.limit != null ? { limit: options.limit } : {}),
+  });
+
+  // Push to pending-modification queue so _defaultAttributes() replays in
+  // the correct order relative to schema-reflected columns (AR) or other
+  // pending modifications (AM inheritance).
+  // Mirrors: ActiveModel::AttributeRegistration#attribute —
+  //   pending << PendingType.new(name, type) if type || no_default
+  //   pending << PendingDefault.new(name, default) unless no_default
+  // A bare re-declaration (no type, no default) still pushes a PendingType with
+  // a nil type so it re-anchors to the attribute's current type at replay; a
+  // default-only call pushes only PendingDefault, preserving the existing type.
+  const noDefault = options?.default === undefined;
+  if (typeProvided || noDefault) {
+    this.pendingAttributeModifications().push(new PendingType(name, typeProvided ? type : null));
+  }
+  if (!noDefault) {
+    this.pendingAttributeModifications().push(new PendingDefault(name, defaultValue));
+  }
+
+  // Mirrors: Rails reset_default_attributes — invalidate cache on this class
+  // and all known subclasses so they recompute on next _defaultAttributes() call.
+  resetDefaultAttributes(this);
 }
 
 /**

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,6 +1,5 @@
 import { include, type CodeGenerator, included } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
-import { defaultValue as typeDefaultValue } from "./type.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
@@ -10,10 +9,8 @@ import {
   buildMangledName,
 } from "./attribute-methods.js";
 import {
-  type PendingModification,
-  PendingType,
-  PendingDefault,
-  resetDefaultAttributes,
+  attribute as registrationAttribute,
+  type AttributeRegistrationHost,
 } from "./attribute-registration.js";
 
 export interface AttributeDefinition {
@@ -53,13 +50,11 @@ export function _writeAttribute(
 type AttributeInstanceHost = { _attributes: AttributeSet };
 
 /**
- * Mirrors: ActiveModel::Attributes::ClassMethods#attribute (attributes.rb:59-61)
- * — registers the attribute, then `define_attribute_method(name)` generates its
- * methods. Rails' body is `super; define_attribute_method(name)`, where `super`
- * is `AttributeRegistration::ClassMethods#attribute`
- * (attribute_registration.rb:12-20); the two are inlined here because TS cannot
- * spell `super` across modules. Story:
- * 0115/split-attribute-registration-attribute-from-attributes-attribute.
+ * Mirrors: ActiveModel::Attributes::ClassMethods#attribute (attributes.rb:59-62)
+ * — `super; define_attribute_method(name)`. The `super` is
+ * `AttributeRegistration::ClassMethods#attribute`
+ * (attribute_registration.rb:12-20); TS has no `super` for a module outside the
+ * prototype chain, so the registration half is called through its import alias.
  *
  * A name the class already answers (`toJSON`, `freeze`, `attributes`)
  * gets no accessor, because `define_attribute_method_pattern`'s
@@ -69,91 +64,12 @@ type AttributeInstanceHost = { _attributes: AttributeSet };
  * @internal
  */
 export function attribute(
-  this: {
-    _attributeDefinitions: Map<string, AttributeDefinition>;
-    prototype: object;
-    _cachedDefaultAttributes?: AttributeSet | null;
-    resolveTypeName(name: string, options?: Record<string, unknown>): Type;
-    resolveAttributeName(name: string): string;
-    pendingAttributeModifications(): PendingModification[];
-    attributeTypes(): Record<string, Type>;
-    defineAttributeMethod(attrName: string): void;
-    hookAttributeType(name: string, type: Type): Type;
-  },
+  this: AttributeRegistrationHost & { defineAttributeMethod(attrName: string): void },
   name: string,
-  // Mirrors Rails' `attribute(name, type = nil, **options)`: the type is
-  // optional. When omitted, the attribute keeps its existing (schema-reflected
-  // or previously-declared) type and only the default/decorator is applied —
-  // backing the `attribute :col, default: "x"` idiom. See
-  // activemodel/lib/active_model/attribute_registration.rb:18,55-63.
   typeName?: string | Type | AttributeOptions,
   options?: AttributeOptions,
 ): void {
-  name = this.resolveAttributeName(name);
-  if (typeName !== undefined && typeof typeName !== "string" && !(typeName instanceof Type)) {
-    options = typeName;
-    typeName = undefined;
-  }
-  const typeProvided = typeName !== undefined;
-  if (!Object.hasOwn(this, "_attributeDefinitions")) {
-    this._attributeDefinitions = new Map(this._attributeDefinitions);
-  }
-  const existing = this._attributeDefinitions.get(name);
-  // When the type is omitted, preserve the existing attribute's type (Rails'
-  // PendingType `with_type` inheritance path); fall back to the value type only
-  // when nothing is known about the attribute yet.
-  // Rails' `attribute(name, ...)` forwards `**options` straight to the type
-  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the two keys
-  // consumed here — `default` and `virtual` — are the ones Rails names
-  // explicitly, so only the rest reach the registry.
-  const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
-  let type = typeProvided
-    ? typeName instanceof Type
-      ? typeName
-      : this.resolveTypeName(
-          typeName as string,
-          Object.keys(typeOptions).length > 0
-            ? (typeOptions as Record<string, unknown>)
-            : undefined,
-        )
-    : (existing?.type ?? typeDefaultValue());
-  // attribute_registration.rb:15 — `type = hook_attribute_type(name, type) if type`.
-  if (typeProvided) type = this.hookAttributeType(name, type);
-  // Preserve the existing defaultValue when no default is explicitly provided,
-  // matching Rails' PendingType behavior: with_type only changes the type and
-  // leaves the current default/value untouched.
-  const defaultValue =
-    options?.default !== undefined ? options.default : (existing?.defaultValue ?? null);
-  this._attributeDefinitions.set(name, {
-    ...existing,
-    name,
-    type,
-    defaultValue,
-    virtual: options?.virtual ?? existing?.virtual,
-    ...(options?.limit != null ? { limit: options.limit } : {}),
-  });
-
-  // Push to pending-modification queue so _defaultAttributes() replays in
-  // the correct order relative to schema-reflected columns (AR) or other
-  // pending modifications (AM inheritance).
-  // Mirrors: ActiveModel::AttributeRegistration#attribute —
-  //   pending << PendingType.new(name, type) if type || no_default
-  //   pending << PendingDefault.new(name, default) unless no_default
-  // A bare re-declaration (no type, no default) still pushes a PendingType with
-  // a nil type so it re-anchors to the attribute's current type at replay; a
-  // default-only call pushes only PendingDefault, preserving the existing type.
-  const noDefault = options?.default === undefined;
-  if (typeProvided || noDefault) {
-    this.pendingAttributeModifications().push(new PendingType(name, typeProvided ? type : null));
-  }
-  if (!noDefault) {
-    this.pendingAttributeModifications().push(new PendingDefault(name, defaultValue));
-  }
-
-  // Mirrors: Rails reset_default_attributes — invalidate cache on this class
-  // and all known subclasses so they recompute on next _defaultAttributes() call.
-  resetDefaultAttributes(this);
-
+  registrationAttribute.call(this, name, typeName, options);
   this.defineAttributeMethod(name);
 }
 

--- a/packages/activerecord/src/attribute-methods/composite-primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/composite-primary-key.ts
@@ -12,10 +12,14 @@ import { PrimaryKey, type PrimaryKeyInstance, type PrimaryKeyRecord } from "./pr
  * trails ported that predicate as the class-level accessor
  * `Base.compositePrimaryKey`, read inline below exactly where Ruby calls it.
  *
- * Ruby's `@primary_key`, the ivar seeded from the class at `init_internals` —
- * read off the class the record was built from, in the order it declares.
+ * Ruby's `@primary_key`, the ivar seeded from the class at `init_internals`
+ * (core.rb:846) — read off the record's own slot, in the order the class
+ * declares. A record built before its schema reflected has no seat and reads
+ * through to the class; see `primaryKeyOf` in primary-key.ts.
  */
 function primaryKeyOf(record: object): string[] {
+  const seated = (record as { _primaryKey?: string[] })._primaryKey;
+  if (seated !== undefined) return seated;
   return (record.constructor as any).primaryKey as string[];
 }
 

--- a/packages/activerecord/src/attribute-methods/primary-key-slot.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key-slot.trails.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { Base } from "../base.js";
+
+// Rails seats `@primary_key` once, at `init_internals` (core.rb:846), and every
+// instance-side reader reads that ivar (primary_key.rb:18-56). trails' schema
+// reflection is async, so the seat is taken only once the class can answer for
+// real; a record built in the cold window reads through to the class instead of
+// latching `get_primary_key`'s "id" convention forever.
+describe("per-instance @primary_key slot", () => {
+  it("seats the record's primary key from the class at init_internals", () => {
+    class SeatedToy extends Base {
+      static override tableName = "toys";
+      static _primaryKey = "toy_id";
+    }
+
+    const record = new SeatedToy();
+
+    expect((record as unknown as { _primaryKey?: string })._primaryKey).toBe("toy_id");
+
+    SeatedToy._primaryKey = "id";
+    const spy = vi.spyOn(
+      record as unknown as { _readAttribute(n: string): unknown },
+      "_readAttribute",
+    );
+    void record.id;
+
+    expect(spy).toHaveBeenCalledWith("toy_id");
+  });
+
+  it("a record built before its schema loads still resolves the real primary key", () => {
+    class ColdToy extends Base {
+      static override tableName = "toys";
+    }
+
+    const record = new ColdToy();
+
+    expect((record as unknown as { _primaryKey?: string })._primaryKey).toBeUndefined();
+
+    (ColdToy as unknown as { adapter: unknown }).adapter = {
+      internalSchemaCache: { getCachedPrimaryKeys: () => "toy_id" },
+    };
+    const spy = vi.spyOn(
+      record as unknown as { _readAttribute(n: string): unknown },
+      "_readAttribute",
+    );
+    void record.id;
+
+    expect(spy).toHaveBeenCalledWith("toy_id");
+  });
+});

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -206,13 +206,13 @@ function cachedSchemaCacheFor(
  * Whether the class can answer `primary_key` for real yet — an explicitly
  * configured key, or one the schema cache has already reflected.
  *
- * @internal
- * @noRailsEquivalent PERMANENT — Ruby's `init_internals` seats `@primary_key`
- * from the class unconditionally (core.rb:846) because `get_primary_key` is
- * synchronous there. trails reflects the schema asynchronously, so `getPrimaryKey` answers
- * the "id" convention until the cache is warm; seating that would latch it for
- * the record's lifetime. `initInternals` guards Rails' assignment with this,
+ * Ruby's `init_internals` seats `@primary_key` from the class unconditionally
+ * (core.rb:846) because `get_primary_key` is synchronous there. trails reflects
+ * the schema asynchronously, so `getPrimaryKey` answers the "id" convention
+ * until the cache is warm; seating that would latch it for the record's
+ * lifetime. `initInternals` guards Rails' assignment with this,
  * and `primaryKeyOf` reads through to the class while it is false.
+ * @internal
  */
 export function isPrimaryKeySettled(this: PrimaryKeyHost): boolean {
   if (this._primaryKey !== undefined) return true;

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -64,16 +64,14 @@ export interface PrimaryKeyInstance {
 }
 
 function readId(this: PrimaryKeyInstance): unknown {
-  const ctor = this.constructor as any;
-  const pk = ctor.primaryKey as string | string[] | null;
+  const pk = primaryKeyOf(this) as string | string[] | null;
   // Rails: `_read_attribute(@primary_key)`. A nil primary key reads through the
   // AttributeSet's Null attribute, returning nil without raising.
   return this._readAttribute(pk as string);
 }
 
 function writeId(this: PrimaryKeyInstance, value: unknown): void {
-  const ctor = this.constructor as any;
-  const pk = ctor.primaryKey as string | string[] | null;
+  const pk = primaryKeyOf(this) as string | string[] | null;
   if (pk == null) {
     // Key-less model: Rails does NOT install the PrimaryKey `id=` override
     // without a primary key (`instance_method_already_implemented?` gates the
@@ -154,10 +152,15 @@ export class PrimaryKey {
 }
 
 /**
- * Ruby reads the record's `@primary_key` ivar, seeded from the class at
- * `init_internals`; trails reads it off the class the record was built from.
+ * Ruby's readers read the record's `@primary_key` ivar, seeded from the class
+ * at `init_internals` (core.rb:846). trails seats the same slot there, but only
+ * once the class can answer for real: schema reflection is async here, so a
+ * record built before its columns hash arrives has no seat and reads through to
+ * the class, which resolves the real key as soon as it lands.
  */
 function primaryKeyOf(record: object): string | string[] {
+  const seated = (record as { _primaryKey?: string | string[] })._primaryKey;
+  if (seated !== undefined) return seated;
   return (record.constructor as any).primaryKey;
 }
 
@@ -197,6 +200,29 @@ function cachedSchemaCacheFor(
   if (host._adapter?.internalSchemaCache) return host._adapter.internalSchemaCache;
   const pool = host.connectionPool?.();
   return pool?.activeConnection?.internalSchemaCache ?? pool?.poolConfig?.schemaCache ?? undefined;
+}
+
+/**
+ * Whether the class can answer `primary_key` for real yet — an explicitly
+ * configured key, or one the schema cache has already reflected.
+ *
+ * @internal
+ * @noRailsEquivalent PERMANENT — Ruby's `init_internals` seats `@primary_key` from the
+ * class unconditionally (core.rb:846) because `get_primary_key` is synchronous
+ * there. trails reflects the schema asynchronously, so `getPrimaryKey` answers
+ * the "id" convention until the cache is warm; seating that would latch it for
+ * the record's lifetime. `initInternals` guards Rails' assignment with this,
+ * and `primaryKeyOf` reads through to the class while it is false.
+ */
+export function isPrimaryKeySettled(this: PrimaryKeyHost): boolean {
+  if (this._primaryKey !== undefined) return true;
+  try {
+    const tableName = this.tableName;
+    if (tableName == null) return false;
+    return cachedSchemaCacheFor(this)?.getCachedPrimaryKeys?.(tableName) !== undefined;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -207,9 +207,9 @@ function cachedSchemaCacheFor(
  * configured key, or one the schema cache has already reflected.
  *
  * @internal
- * @noRailsEquivalent PERMANENT — Ruby's `init_internals` seats `@primary_key` from the
- * class unconditionally (core.rb:846) because `get_primary_key` is synchronous
- * there. trails reflects the schema asynchronously, so `getPrimaryKey` answers
+ * @noRailsEquivalent PERMANENT — Ruby's `init_internals` seats `@primary_key`
+ * from the class unconditionally (core.rb:846) because `get_primary_key` is
+ * synchronous there. trails reflects the schema asynchronously, so `getPrimaryKey` answers
  * the "id" convention until the cache is warm; seating that would latch it for
  * the record's lifetime. `initInternals` guards Rails' assignment with this,
  * and `primaryKeyOf` reads through to the class while it is false.

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -39,6 +39,7 @@ import type { PrettyPrinter } from "./pretty-print.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { buildPkWhereNode, columnsHash } from "./model-schema.js";
+import { isPrimaryKeySettled } from "./attribute-methods/primary-key.js";
 import { StatementCache } from "./statement-cache.js";
 import { withConnection } from "./connection-handling.js";
 import { RangeError as ActiveModelRangeError, runAllCallbacks } from "@blazetrails/activemodel";
@@ -891,6 +892,7 @@ export function initInternals(
     _startTransactionState: unknown;
     _strictLoading: boolean;
     _strictLoadingMode?: StrictLoadingMode;
+    _primaryKey?: string | string[] | null;
   },
   super_: () => void,
 ): void {
@@ -903,6 +905,15 @@ export function initInternals(
   this._destroyedByAssociation = null;
   this._startTransactionState = null;
   const klass = this.constructor as any;
+  // core.rb:846 — `@primary_key = klass.primary_key`; every instance-side
+  // primary-key reader then reads the ivar (primary_key.rb:18-56).
+  // trails' schema reflection is async, so a record built before its class'
+  // columns hash has arrived would latch `get_primary_key`'s cold-cache
+  // convention ("id", attribute-methods/primary-key.ts:382) for the record's
+  // lifetime. The seat is therefore taken only once the class can answer for
+  // real — an explicitly configured key, or a loaded schema — and
+  // `primaryKeyOf` reads through to the class until then.
+  if (isPrimaryKeySettled.call(klass)) this._primaryKey = klass.primaryKey;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
   this._strictLoadingMode = klass.strictLoadingMode;
 }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -905,14 +905,8 @@ export function initInternals(
   this._destroyedByAssociation = null;
   this._startTransactionState = null;
   const klass = this.constructor as any;
-  // core.rb:846 — `@primary_key = klass.primary_key`; every instance-side
-  // primary-key reader then reads the ivar (primary_key.rb:18-56).
-  // trails' schema reflection is async, so a record built before its class'
-  // columns hash has arrived would latch `get_primary_key`'s cold-cache
-  // convention ("id", attribute-methods/primary-key.ts:382) for the record's
-  // lifetime. The seat is therefore taken only once the class can answer for
-  // real — an explicitly configured key, or a loaded schema — and
-  // `primaryKeyOf` reads through to the class until then.
+  // core.rb:846 — `@primary_key = klass.primary_key`, guarded because trails
+  // resolves the schema asynchronously; see `isPrimaryKeySettled`.
   if (isPrimaryKeySettled.call(klass)) this._primaryKey = klass.primaryKey;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
   this._strictLoadingMode = klass.strictLoadingMode;

--- a/packages/activesupport/src/time-with-zone.trails.test.ts
+++ b/packages/activesupport/src/time-with-zone.trails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { TimeWithZone } from "./time-with-zone.js";
 import { TimeZone } from "./values/time-zone.js";
-import { Temporal } from "@blazetrails/date";
+import { Temporal, Time } from "@blazetrails/date";
 import { DATE_FORMATS } from "./core-ext/time/conversions.js";
 import { Range } from "./range-ext.js";
 
@@ -89,7 +89,7 @@ describe("TimeWithZone local-time construction", () => {
   });
 
   it("keeps a period handed to it rather than looking one up", () => {
-    const period = eastern.periodForUtc(Temporal.Instant.from("2006-07-01T00:00:00Z"));
+    const period = eastern.periodForUtc(Time.utc(2006, 7, 1));
     const twz = new TimeWithZone(
       null,
       eastern,

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -231,7 +231,9 @@ export class TimeWithZone {
    * Mirrors: `ActiveSupport::TimeWithZone#incorporate_utc_offset`
    * (time_with_zone.rb:562-568). Ruby's `Date` advances in DAYS, so its arm
    * spells the offset as the day fraction `Rational(offset, SECONDS_PER_DAY)`;
-   * an instant carrying that date advances by the seconds that fraction names.
+   * a wall clock carrying that date advances by the seconds that fraction
+   * names. The `else` arm is Ruby's `time + offset`, spelled through `Time.at`
+   * because trails' `Time` does not port `Time#+`.
    */
   private _incorporateUtcOffset(time: Time | Temporal.PlainDate, offset: number): Time {
     if (time instanceof Temporal.PlainDate) {
@@ -239,15 +241,6 @@ export class TimeWithZone {
         time.toPlainDateTime().add({ seconds: offset }),
       );
     }
-    return this._plusSeconds(time, offset);
-  }
-
-  /**
-   * Ruby's `Time#+` (time.c `time_plus`), which trails' `Time` does not port —
-   * the receiver's instant advanced by `offset` seconds, answered in UTC as a
-   * `Time.utc` value is.
-   */
-  private _plusSeconds(time: Time, offset: number): Time {
     return Time.at(
       new Rational(time.toTime().toInstant().epochNanoseconds, 1_000_000_000n).add(offset),
     ).getutc();
@@ -277,7 +270,7 @@ export class TimeWithZone {
   /**
    * Mirrors: `ActiveSupport::TimeWithZone#transfer_time_values_to_utc_constructor`
    * (time_with_zone.rb:583-587) — `Time.utc(year, month, day, hour, min,
-   * sec + subsec)`, which an `Instant` (a UTC `Time`) already is.
+   * sec + subsec)`, over whichever shape carries the wall clock.
    */
   private _transferTimeValuesToUtcConstructor(time: TimeLike): Time {
     // avoid creating another Time object if possible

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -103,15 +103,8 @@ function nsDiffToSeconds(diffNs: bigint): number {
  */
 const SECONDS_PER_DAY = 86400;
 
-/**
- * A local wall clock carried in the UTC fields of an `Instant` — the shape
- * `Time.utc(...)` produces in Ruby, and the one `TimeZone#periodsForLocal` /
- * `#periodForLocal` already take.
- */
-type UtcConstructed = Temporal.Instant;
-
-/** Ruby's `Time`, whichever Temporal shape carries it. */
-type TimeLike = Temporal.Instant | Temporal.PlainDateTime | Temporal.PlainDate;
+/** Ruby's `Time`, whichever shape carries it. */
+type TimeLike = Time | Temporal.Instant | Temporal.PlainDateTime | Temporal.PlainDate;
 
 /**
  * The dispatch Ruby gets for free: an undefined method on a `TimeWithZone`
@@ -140,14 +133,7 @@ const METHOD_MISSING_HANDLER: ProxyHandler<TimeWithZone> = {
 
 export class TimeWithZone {
   /** `@utc` — `nil` until {@link utc} derives it from `@time`. */
-  private _utc: UtcConstructed | null;
-  /**
-   * The `::Time` {@link utc} answers. Rails' `@utc` is both the memo and the
-   * answer; trails carries the memo as the {@link UtcConstructed} instant every
-   * `TimeZone` reader below takes, so the `::Time` seated from it is a second
-   * memo rather than the same one.
-   */
-  private _utcTime?: Time;
+  private _utc: Time | null;
   /** `@time` — the local wall clock, `nil` until {@link time} derives it. */
   private _time: TimeLike | null;
   /** The timezone */
@@ -191,7 +177,7 @@ export class TimeWithZone {
    * local-time-only instance resolves its UTC value exactly where Rails does.
    */
   private get _zoned(): Temporal.ZonedDateTime {
-    return this._utcConstructed.toZonedDateTimeISO(this._timeZone.tzinfo.identifier);
+    return this.utc().toTime().toInstant().toZonedDateTimeISO(this._timeZone.tzinfo.identifier);
   }
 
   /** Epoch milliseconds — sourced directly from the ZonedDateTime. */
@@ -201,7 +187,7 @@ export class TimeWithZone {
 
   /** UTC-zoned snapshot of the underlying instant for component access. */
   private get _utcPlain(): Temporal.PlainDateTime {
-    return this._utcConstructed.toZonedDateTimeISO("UTC").toPlainDateTime();
+    return this.utc().toTime().toPlainDateTime();
   }
 
   /**
@@ -247,14 +233,24 @@ export class TimeWithZone {
    * spells the offset as the day fraction `Rational(offset, SECONDS_PER_DAY)`;
    * an instant carrying that date advances by the seconds that fraction names.
    */
-  private _incorporateUtcOffset(
-    time: UtcConstructed | Temporal.PlainDate,
-    offset: number,
-  ): UtcConstructed {
+  private _incorporateUtcOffset(time: Time | Temporal.PlainDate, offset: number): Time {
     if (time instanceof Temporal.PlainDate) {
-      return time.toZonedDateTime({ timeZone: "UTC" }).toInstant().add({ seconds: offset });
+      return this._transferTimeValuesToUtcConstructor(
+        time.toPlainDateTime().add({ seconds: offset }),
+      );
     }
-    return time.add({ seconds: offset });
+    return this._plusSeconds(time, offset);
+  }
+
+  /**
+   * Ruby's `Time#+` (time.c `time_plus`), which trails' `Time` does not port —
+   * the receiver's instant advanced by `offset` seconds, answered in UTC as a
+   * `Time.utc` value is.
+   */
+  private _plusSeconds(time: Time, offset: number): Time {
+    return Time.at(
+      new Rational(time.toTime().toInstant().epochNanoseconds, 1_000_000_000n).add(offset),
+    ).getutc();
   }
 
   /**
@@ -264,7 +260,7 @@ export class TimeWithZone {
   private _getPeriodAndEnsureValidLocalTime(period: TimezonePeriod | null): TimezonePeriod {
     // we don't want a Time.local instance enforcing its own DST rules as well,
     // so transfer time values to a utc constructor if necessary
-    if (!(this._time instanceof Temporal.Instant)) {
+    if (!(this._time instanceof Time) || !this._time.isUtc()) {
       this._time = this._transferTimeValuesToUtcConstructor(this._time!);
     }
     for (;;) {
@@ -283,13 +279,28 @@ export class TimeWithZone {
    * (time_with_zone.rb:583-587) — `Time.utc(year, month, day, hour, min,
    * sec + subsec)`, which an `Instant` (a UTC `Time`) already is.
    */
-  private _transferTimeValuesToUtcConstructor(time: TimeLike): UtcConstructed {
+  private _transferTimeValuesToUtcConstructor(time: TimeLike): Time {
     // avoid creating another Time object if possible
-    if (time instanceof Temporal.Instant) return time;
-    if (time instanceof Temporal.PlainDate) {
-      return time.toZonedDateTime({ timeZone: "UTC" }).toInstant();
-    }
-    return time.toZonedDateTime("UTC").toInstant();
+    if (time instanceof Time && time.isUtc()) return time;
+    const values =
+      time instanceof Time
+        ? time.toTime().toPlainDateTime()
+        : time instanceof Temporal.Instant
+          ? time.toZonedDateTimeISO("UTC").toPlainDateTime()
+          : time instanceof Temporal.PlainDate
+            ? time.toPlainDateTime()
+            : time;
+    return Time.utc(
+      values.year,
+      values.month,
+      values.day,
+      values.hour,
+      values.minute,
+      new Rational(
+        values.millisecond * 1_000_000 + values.microsecond * 1_000 + values.nanosecond,
+        1_000_000_000,
+      ).add(values.second),
+    );
   }
 
   /**
@@ -333,20 +344,6 @@ export class TimeWithZone {
     return (this._period ??= this._timeZone.periodForUtc(this._utc!));
   }
 
-  /**
-   * `@utc ||= incorporate_utc_offset(@time, -utc_offset)`
-   * (time_with_zone.rb:64), left on the {@link UtcConstructed} instant — the
-   * instant half of {@link utc}, split out because every `TimeZone` and
-   * `Temporal` reader in this file takes the instant where Rails' readers take
-   * the `::Time` it seats.
-   */
-  private get _utcConstructed(): UtcConstructed {
-    return (this._utc ??= this._incorporateUtcOffset(
-      this._time as UtcConstructed,
-      -this.utcOffset,
-    ));
-  }
-
   /** The TimeZone instance */
   get timeZone(): TimeZone {
     return this._timeZone;
@@ -360,9 +357,7 @@ export class TimeWithZone {
    */
   get time(): Temporal.PlainDateTime {
     this._time ??= this._incorporateUtcOffset(this._utc!, this.utcOffset);
-    return this._transferTimeValuesToUtcConstructor(this._time)
-      .toZonedDateTimeISO("UTC")
-      .toPlainDateTime();
+    return this._transferTimeValuesToUtcConstructor(this._time).toTime().toPlainDateTime();
   }
 
   /** Timezone abbreviation (e.g., "EST", "EDT") — time_with_zone.rb:133-135. */
@@ -517,9 +512,7 @@ export class TimeWithZone {
    * `@utc ||= incorporate_utc_offset(@time, -utc_offset)`, a `::Time` in UTC.
    */
   utc(): Time {
-    return (this._utcTime ??= Time.at(
-      new Rational(this._utcConstructed.epochNanoseconds, 1_000_000_000n),
-    ).getutc());
+    return (this._utc ??= this._incorporateUtcOffset(this._time as Time, -this.utcOffset));
   }
 
   /** `alias_method :getutc, :utc` (time_with_zone.rb:68). */
@@ -951,7 +944,9 @@ export class TimeWithZone {
     const newTime = Temporal.Instant.fromEpochMilliseconds(
       Date.UTC(year, month - 1, day, hour, min, sec, ms),
     );
-    const periods = this._timeZone.periodsForLocal(newTime);
+    const periods = this._timeZone.periodsForLocal(
+      this._transferTimeValuesToUtcConstructor(newTime),
+    );
     const period = periods.find(
       (p) =>
         p.observedUtcOffset === this.period.observedUtcOffset && p.isDst() === this.period.isDst(),

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -87,13 +87,13 @@ describe("TimeZoneTest", () => {
 
   it("period for local", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
-    expect(zone.periodForLocal(new Date(Date.UTC(2000, 0, 1)))).toBeInstanceOf(TimezonePeriod);
+    expect(zone.periodForLocal(Time.utc(2000, 1, 1))).toBeInstanceOf(TimezonePeriod);
   });
 
   it("period for local with ambiguous time", () => {
     const zone = TimeZone.find("Moscow")!;
-    const period = zone.periodForLocal(new Date(Date.UTC(2015, 0, 1)));
-    expect(zone.periodForLocal(new Date(Date.UTC(2014, 9, 26, 1, 0, 0)))).toEqual(period);
+    const period = zone.periodForLocal(Time.utc(2015, 1, 1));
+    expect(zone.periodForLocal(Time.utc(2014, 10, 26, 1, 0, 0))).toEqual(period);
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { TimeZone, AmbiguousTime, PeriodNotFound } from "./values/time-zone.js";
 import { ArgumentError } from "./hash-utils.js";
-import { Rational } from "@blazetrails/date";
+import { Rational, Time } from "@blazetrails/date";
 
 describe("TimeZoneTest", () => {
   it("clear resets the memos", () => {
@@ -130,7 +130,7 @@ describe("TimeZoneLocalPeriodsTest", () => {
   const zone = () => TimeZone.find("Eastern Time (US & Canada)")!;
 
   it("periods_for_local returns one period for an unambiguous local time", () => {
-    const periods = zone().periodsForLocal(new Date(Date.UTC(2024, 0, 15, 12)));
+    const periods = zone().periodsForLocal(Time.utc(2024, 1, 15, 12));
     expect(periods.length).toBe(1);
     expect(periods[0].observedUtcOffset).toBe(-5 * 3600);
     expect(periods[0].isDst()).toBe(false);
@@ -138,26 +138,24 @@ describe("TimeZoneLocalPeriodsTest", () => {
 
   it("periods_for_local returns both periods for an ambiguous local time", () => {
     // 2006-10-29 01:30 local occurs twice: once as EDT, once as EST.
-    const periods = zone().periodsForLocal(new Date(Date.UTC(2006, 9, 29, 1, 30)));
+    const periods = zone().periodsForLocal(Time.utc(2006, 10, 29, 1, 30));
     expect(periods.length).toBe(2);
     expect(periods.map((period) => period.observedUtcOffset)).toEqual([-4 * 3600, -5 * 3600]);
   });
 
   it("period_for_local resolves an ambiguous local time with the dst argument", () => {
-    const ambiguous = new Date(Date.UTC(2006, 9, 29, 1, 30));
+    const ambiguous = Time.utc(2006, 10, 29, 1, 30);
     expect(zone().periodForLocal(ambiguous).isDst()).toBe(true);
     expect(zone().periodForLocal(ambiguous, false).isDst()).toBe(false);
   });
 
   it("periods_for_local returns no periods for a nonexistent local time", () => {
     // 2024-03-10 02:30 local never happens: the clocks jump 02:00 to 03:00.
-    expect(zone().periodsForLocal(new Date(Date.UTC(2024, 2, 10, 2, 30)))).toEqual([]);
+    expect(zone().periodsForLocal(Time.utc(2024, 3, 10, 2, 30))).toEqual([]);
   });
 
   it("period_for_local raises for a nonexistent local time", () => {
-    expect(() => zone().periodForLocal(new Date(Date.UTC(2024, 2, 10, 2, 30)))).toThrow(
-      PeriodNotFound,
-    );
+    expect(() => zone().periodForLocal(Time.utc(2024, 3, 10, 2, 30))).toThrow(PeriodNotFound);
   });
 
   it("local_to_utc raises for an ambiguity dst does not resolve", () => {

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -427,8 +427,22 @@ function inspect(value: unknown): string {
 /**
  * Get timezone abbreviation and offset for a given IANA zone at a specific instant.
  */
-function toDate(at: Date | Temporal.Instant): Date {
-  return at instanceof Date ? at : new Date(at.epochMilliseconds);
+function toDate(at: Date | Temporal.Instant | Time): Date {
+  if (at instanceof Date) return at;
+  if (at instanceof Time) return new Date(at.toTime().toInstant().epochMilliseconds);
+  return new Date(at.epochMilliseconds);
+}
+
+/**
+ * The `::Time` TZInfo's readers take, for a UTC instant trails carries as a
+ * `Date`.
+ *
+ * @noRailsEquivalent CONVERGEABLE — Ruby hands these readers a `::Time`
+ * throughout; the `Date`-seated callers left inside this file converge as the
+ * `TimeZone` seat itself moves onto `Time` (RFC 0098).
+ */
+function utcTimeFrom(at: Date | Temporal.Instant): Time {
+  return Time.at(new Rational(toDate(at).getTime(), 1000)).getutc();
 }
 
 function getZoneInfo(
@@ -659,7 +673,7 @@ export class Timezone {
   }
 
   /** `TZInfo::Timezone#period_for_utc`. */
-  periodForUtc(time: Date | Temporal.Instant): TimezonePeriod {
+  periodForUtc(time: Time): TimezonePeriod {
     const d = toDate(time);
     return new TimezonePeriod(this.abbr(d), this.observedUtcOffset(d), this.isDst(d));
   }
@@ -674,7 +688,7 @@ export class Timezone {
    * TZInfo hands the periods back in, and what makes Rails' `periods.last` the
    * standard-time one.
    */
-  periodsForLocal(time: Date | Temporal.Instant): TimezonePeriod[] {
+  periodsForLocal(time: Time): TimezonePeriod[] {
     const localMs = toDate(time).getTime();
     const DAY = 86_400_000;
     const around = [
@@ -686,7 +700,7 @@ export class Timezone {
     for (const offset of candidates) {
       const utc = new Date(localMs - offset * 1000);
       if (getZoneInfo(this.identifier, utc).utcOffsetSeconds === offset) {
-        periods.push(this.periodForUtc(utc));
+        periods.push(this.periodForUtc(utcTimeFrom(utc)));
       }
     }
     return periods;
@@ -700,7 +714,7 @@ export class Timezone {
    * called.
    */
   periodForLocal(
-    time: Date | Temporal.Instant,
+    time: Time,
     dst: boolean | null = true,
     block?: (periods: TimezonePeriod[]) => TimezonePeriod,
   ): TimezonePeriod {
@@ -737,7 +751,7 @@ export class Timezone {
    */
   localToUtc(time: Date | Temporal.Instant, dst: boolean | null = true): Date {
     const localMs = toDate(time).getTime();
-    const period = this.periodForLocal(time, dst);
+    const period = this.periodForLocal(utcTimeFrom(time), dst);
     return new Date(localMs - period.observedUtcOffset * 1000);
   }
 }
@@ -943,7 +957,7 @@ export class TimeZone {
     let period: TimezonePeriod;
     for (;;) {
       try {
-        period = this.periodForLocal(time);
+        period = this.periodForLocal(utcTimeFrom(time));
         break;
       } catch (error) {
         if (!(error instanceof PeriodNotFound)) throw error;
@@ -1100,7 +1114,7 @@ export class TimeZone {
    * memoizes (time_with_zone.rb:72-74) and reads `dst?` /
    * `observed_utc_offset` / `abbreviation` off.
    */
-  periodForUtc(time: Date | Temporal.Instant): TimezonePeriod {
+  periodForUtc(time: Time): TimezonePeriod {
     return this.tzinfo.periodForUtc(time);
   }
 
@@ -1109,12 +1123,12 @@ export class TimeZone {
    * `tzinfo.period_for_local(time, dst) { |periods| periods.last }`: the block
    * settles an ambiguous local time `dst` could not, by taking the last period.
    */
-  periodForLocal(time: Date | Temporal.Instant, dst: boolean | null = true): TimezonePeriod {
+  periodForLocal(time: Time, dst: boolean | null = true): TimezonePeriod {
     return this.tzinfo.periodForLocal(time, dst, (periods) => periods[periods.length - 1]);
   }
 
   /** `periods_for_local(time)` (time_zone.rb:563-565). */
-  periodsForLocal(time: Date | Temporal.Instant): TimezonePeriod[] {
+  periodsForLocal(time: Time): TimezonePeriod[] {
     return this.tzinfo.periodsForLocal(time);
   }
 


### PR DESCRIPTION
Three RFC stories, bundled.

**`seat-the-per-instance-primary-key-slot` (RFC 0115).** `Core#init_internals`
seats `@primary_key` from the class (core.rb:846) and every instance-side
reader reads that slot (primary_key.rb:18-56; composite_primary_key.rb:18-25).
trails' schema reflection is async, so seating unconditionally would latch
`get_primary_key`'s cold-cache `"id"` convention for the record's lifetime; the
assignment is therefore guarded by `isPrimaryKeySettled` — an explicitly
configured key, or one the schema cache has reflected — and `primaryKeyOf`
reads through to the class until then. `readId` / `writeId` read the slot too.
Covered by `primary-key-slot.trails.test.ts`, whose second case fails on the
naive seat.

**`converge-time-with-zone-utc-memo-onto-one-ruby-time` (RFC 0098).**
`TimeWithZone` carried `@utc` twice — the `Temporal.Instant` every `TimeZone`
reader took, plus the `::Time` `#utc` answers. The seat is now the `::Time`
(time_with_zone.rb:63-65); `_utcTime` and `_utcConstructed` are gone,
`_transferTimeValuesToUtcConstructor` reads as `Time.utc(year, month, day,
hour, min, sec + subsec)` (:583-587), and `periodForUtc` / `periodsForLocal` /
`periodForLocal` take the `::Time` their TZInfo counterparts take. `_zoned`,
`_utcPlain` and `_epochMs` re-derive from the seat.

**`split-attribute-registration-attribute-from-attributes-attribute` (RFC
0115).** `ActiveModel::Attributes::ClassMethods#attribute` is Rails' two-liner
again (attributes.rb:59-62) — the registration half now lives in
`attribute-registration.ts` (attribute_registration.rb:12-20), so attributes.ts
no longer imports `PendingType` / `PendingDefault` /
`pendingAttributeModifications` / `resetDefaultAttributes`.

Gates: `parity:api` (activemodel 736/736), `parity:api:calls`,
`parity:api:calls:args`, `parity:api:extra:gate` all clean; no new novel row
for attributes.ts / attribute-registration.ts / time-with-zone.ts.

Closes-story: seat-the-per-instance-primary-key-slot
Closes-story: converge-time-with-zone-utc-memo-onto-one-ruby-time
Closes-story: split-attribute-registration-attribute-from-attributes-attribute
