### PR TITLE
refactor(activesupport): memoize TimeWithZone#to_time's arms; Time#change carries one new_sec Rational

### DIFF
--- a/packages/activesupport/src/core-ext/time-with-zone.test.ts
+++ b/packages/activesupport/src/core-ext/time-with-zone.test.ts
@@ -889,6 +889,7 @@ describe("TimeWithZoneTest", () => {
     const twz = maketwz();
     const time = twz.toTime();
     expect(time).toBeInstanceOf(RubyTime);
+    expect(twz.toTime()).toBe(time);
     expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(time.utcOffset).toBe(-18000);
     expect(time.zone).toBe("EST");
@@ -899,6 +900,7 @@ describe("TimeWithZoneTest", () => {
     const twz = maketwz();
     const time = twz.toTime();
     expect(time).toBeInstanceOf(RubyTime);
+    expect(twz.toTime()).toBe(time);
     expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(time.utcOffset).toBe(-18000);
     expect(time.zone).toBeNull();
@@ -909,6 +911,7 @@ describe("TimeWithZoneTest", () => {
     const twz = maketwz();
     const time = twz.toTime();
     expect(time).toBeInstanceOf(RubyTime);
+    expect(twz.toTime()).toBe(time);
     expect(time.toTime().epochMilliseconds).toBe(Date.UTC(2000, 0, 1));
     expect(time.utcOffset).toBe(-18000);
     expect(time.zone).toBeNull();

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -55,8 +55,15 @@ export function middleOfDay(date: Date): Temporal.Instant {
   return change(date, { hour: 12 });
 }
 
+/**
+ * @missingRailsArgs change — PERMANENT: time/calculations.rb:256-263 passes
+ * `usec: Rational(999999999, 1000)`, and trails passes the same Rational; Ruby's
+ * `Rational()` is a Kernel function where TS spells the construction
+ * `new Rational(...)`, which the extractor records as `ref:constructor` rather
+ * than `ref:Rational`.
+ */
 export function endOfDay(date: Date): Temporal.Instant {
-  return change(date, { hour: 23, min: 59, sec: 59, usec: 999999999 / 1000 });
+  return change(date, { hour: 23, min: 59, sec: 59, usec: new Rational(999999999, 1000) });
 }
 
 // Rails' `alias`es on the day boundaries — time/calculations.rb:241-243,
@@ -80,8 +87,15 @@ export function beginningOfHour(date: Date): Temporal.Instant {
   return change(date, { min: 0 });
 }
 
+/**
+ * @missingRailsArgs change — PERMANENT: time/calculations.rb:273-279 passes
+ * `usec: Rational(999999999, 1000)`, and trails passes the same Rational; Ruby's
+ * `Rational()` is a Kernel function where TS spells the construction
+ * `new Rational(...)`, which the extractor records as `ref:constructor` rather
+ * than `ref:Rational`.
+ */
 export function endOfHour(date: Date): Temporal.Instant {
-  return change(date, { min: 59, sec: 59, usec: 999999999 / 1000 });
+  return change(date, { min: 59, sec: 59, usec: new Rational(999999999, 1000) });
 }
 
 // time/calculations.rb:270, 281.
@@ -96,8 +110,15 @@ export function beginningOfMinute(date: Date): Temporal.Instant {
   return change(date, { sec: 0 });
 }
 
+/**
+ * @missingRailsArgs change — PERMANENT: time/calculations.rb:289-294 passes
+ * `usec: Rational(999999999, 1000)`, and trails passes the same Rational; Ruby's
+ * `Rational()` is a Kernel function where TS spells the construction
+ * `new Rational(...)`, which the extractor records as `ref:constructor` rather
+ * than `ref:Rational`.
+ */
 export function endOfMinute(date: Date): Temporal.Instant {
-  return change(date, { sec: 59, usec: 999999999 / 1000 });
+  return change(date, { sec: 59, usec: new Rational(999999999, 1000) });
 }
 
 // time/calculations.rb:286, 295.
@@ -415,7 +436,8 @@ interface ChangeOptions {
   hour?: number;
   min?: number;
   sec?: number;
-  usec?: number;
+  /** Ruby passes a `Rational` here (`Rational(999999999, 1000)`), as well as an Integer. */
+  usec?: number | Rational;
   nsec?: number;
   /** Ruby's `:offset` takes either a `"+HH:MM"` String or a seconds Integer. */
   offset?: string | number;
@@ -456,11 +478,17 @@ export function change(
   const newDay = options.day ?? self.day;
   const newHour = options.hour ?? self.hour;
   const newMin = options.min ?? (options.hour !== undefined ? 0 : self.minute);
-  let newSec =
-    options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.second);
+  // Ruby's `new_sec` is a Rational from the moment the microseconds fold in
+  // (`new_sec += Rational(new_usec, 1000000)`, time/calculations.rb:141), and
+  // every terminal arm passes that one local; seeding it as a Rational here is
+  // the same value at every step.
+  let newSec = new Rational(
+    options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.second),
+    1,
+  );
   const newOffset = options.offset ?? null;
 
-  let newUsec: number;
+  let newUsec: Rational;
   const newNsec = options.nsec;
   if (newNsec !== undefined) {
     if (options.usec !== undefined) {
@@ -472,21 +500,30 @@ export function change(
           .join(", ")}}`,
       );
     }
-    newUsec = newNsec / 1000;
+    newUsec = new Rational(newNsec, 1000);
   } else {
+    const usec = options.usec;
     newUsec =
-      options.usec ??
-      (options.hour !== undefined || options.min !== undefined || options.sec !== undefined
-        ? 0
-        : nsec / 1000);
+      usec !== undefined
+        ? usec instanceof Rational
+          ? usec
+          : new Rational(usec, 1)
+        : options.hour !== undefined || options.min !== undefined || options.sec !== undefined
+          ? new Rational(0, 1)
+          : new Rational(nsec, 1000);
   }
 
-  if (newUsec >= 1000000) throw new ArgumentError("argument out of range");
+  if (newUsec.cmp(1000000) >= 0) throw new ArgumentError("argument out of range");
 
-  newSec += newUsec / 1_000_000;
+  // `new_sec += Rational(new_usec, 1000000)` (time/calculations.rb:141) —
+  // `Rational()` of a Rational over an Integer is that Rational divided by it,
+  // which `quo` spells.
+  newSec = newSec.add(newUsec.quo(1_000_000));
 
-  const secFloor = Math.floor(newSec);
-  const newNsecOfSec = Math.round((newSec - secFloor) * 1_000_000_000);
+  // The `Temporal` arms below take the wall clock as components rather than as
+  // a seconds Rational, so they read `new_sec`'s whole and fractional halves.
+  const secFloor = newSec.div(1);
+  const newNsecOfSec = newSec.add(-secFloor).mul(1_000_000_000).toI();
   const newComponents = {
     year: newYear,
     month: newMonth,
@@ -498,16 +535,6 @@ export function change(
     microsecond: Math.floor(newNsecOfSec / 1_000) % 1_000,
     nanosecond: newNsecOfSec % 1_000,
   };
-
-  const newSecRational = new Rational(
-    BigInt(newComponents.second) * 1_000_000_000n +
-      BigInt(
-        newComponents.millisecond * 1_000_000 +
-          newComponents.microsecond * 1_000 +
-          newComponents.nanosecond,
-      ),
-    1_000_000_000n,
-  );
 
   // `utc?` (time/calculations.rb:147) — a `::Time` carries Ruby's own flag; a
   // JS `Date` carries none and is never `utc?`, even under `TZ=UTC`.
@@ -528,7 +555,7 @@ export function change(
     // the offset as a `"+HH:MM"` String or a seconds Integer; Temporal spells
     // the same fixed-offset zone with the String form only.
     if (date instanceof RubyTime) {
-      return new RubyTime(newYear, newMonth, newDay, newHour, newMin, newSecRational, newOffset);
+      return new RubyTime(newYear, newMonth, newDay, newHour, newMin, newSec, newOffset);
     }
     const timeZone =
       typeof newOffset === "number"
@@ -541,7 +568,7 @@ export function change(
   if (isUtc) {
     // `elsif utc?` (time/calculations.rb:147-148).
     if (date instanceof RubyTime) {
-      return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSecRational);
+      return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSec);
     }
     return Temporal.ZonedDateTime.from({ timeZone: "UTC", ...newComponents });
   }
@@ -590,7 +617,7 @@ export function change(
     // reversed component order, `isdst` picking the occurrence of a wall clock a
     // DST fall-back repeats. A JS `Date` has no `isdst` and only milliseconds.
     const newTime = RubyTime.local(
-      newSecRational,
+      newSec,
       newMin,
       newHour,
       newDay,
@@ -614,7 +641,7 @@ export function change(
     newDay,
     newHour,
     newMin,
-    newSecRational,
+    newSec,
     (date as RubyTime).utcOffset,
   );
 }

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -478,10 +478,6 @@ export function change(
   const newDay = options.day ?? self.day;
   const newHour = options.hour ?? self.hour;
   const newMin = options.min ?? (options.hour !== undefined ? 0 : self.minute);
-  // Ruby's `new_sec` is a Rational from the moment the microseconds fold in
-  // (`new_sec += Rational(new_usec, 1000000)`, time/calculations.rb:141), and
-  // every terminal arm passes that one local; seeding it as a Rational here is
-  // the same value at every step.
   let newSec = new Rational(
     options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : self.second),
     1,
@@ -515,13 +511,10 @@ export function change(
 
   if (newUsec.cmp(1000000) >= 0) throw new ArgumentError("argument out of range");
 
-  // `new_sec += Rational(new_usec, 1000000)` (time/calculations.rb:141) —
-  // `Rational()` of a Rational over an Integer is that Rational divided by it,
-  // which `quo` spells.
+  // `Rational(new_usec, 1000000)` (time/calculations.rb:141) — `Rational()` of a
+  // Rational over an Integer is that Rational divided by it, which `quo` spells.
   newSec = newSec.add(newUsec.quo(1_000_000));
 
-  // The `Temporal` arms below take the wall clock as components rather than as
-  // a seconds Rational, so they read `new_sec`'s whole and fractional halves.
   const secFloor = newSec.div(1);
   const newNsecOfSec = newSec.add(-secFloor).mul(1_000_000_000).toI();
   const newComponents = {

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -154,6 +154,12 @@ export class TimeWithZone {
   private readonly _timeZone: TimeZone;
   /** `@period` — memoized by {@link period}. */
   private _period?: TimezonePeriod;
+  /** `@to_time_with_timezone` — memoized by {@link toTime}'s `:zone` arm. */
+  private _toTimeWithTimezone?: Time;
+  /** `@to_time_with_instance_offset` — memoized by {@link toTime}'s offset arm. */
+  private _toTimeWithInstanceOffset?: Time;
+  /** `@to_time_with_system_offset` — memoized by {@link toTime}'s system arm. */
+  private _toTimeWithSystemOffset?: Time;
 
   /**
    * Mirrors: `ActiveSupport::TimeWithZone#initialize`
@@ -563,16 +569,15 @@ export class TimeWithZone {
    * Rails hands `getlocal` the `TimeZone` object itself for the `:zone` arm,
    * which `::Time` reads through `utc_to_local`; `@blazetrails/date`'s `Time`
    * seats a zone by its IANA identifier, which is the same zone spelled the way
-   * that constructor takes it. The three `@to_time_with_*` memos Rails keeps are
-   * not carried — the value is recomputed rather than cached.
+   * that constructor takes it.
    */
   toTime(): Time {
     if (this.preserveTimezone() === ":zone") {
-      return this.getlocal(this.timeZone.tzinfo.identifier);
+      return (this._toTimeWithTimezone ??= this.getlocal(this.timeZone.tzinfo.identifier));
     } else if (this.preserveTimezone()) {
-      return this.getlocal(this.utcOffset);
+      return (this._toTimeWithInstanceOffset ??= this.getlocal(this.utcOffset));
     } else {
-      return this.getlocal();
+      return (this._toTimeWithSystemOffset ??= this.getlocal());
     }
   }
 


### PR DESCRIPTION
Two of the three bundled stories; the third is blocked with measurements (below).

## `TimeWithZone#to_time` memoizes each `preserve_timezone` arm

`time_with_zone.rb:493-501` memoizes each arm in its own ivar. #6895 ported the
three-arm switch without the memos, so the value was rebuilt on every call.
Carried as `_toTimeWithTimezone` / `_toTimeWithInstanceOffset` /
`_toTimeWithSystemOffset`, which is what makes the `freeze` preload
(`time_with_zone.rb:1177`) meaningful.

The three mirrored tests regain the `assert_equal time.object_id,
@twz.to_time.object_id` line Rails' bodies carry
(`time_with_zone_test.rb:553`, `:566`, `:580`) as a `toBe` identity check. No
test name touched.

## `Time#change` carries one `new_sec`, a `Rational`

Rails' `new_sec` is a Rational from `new_sec += Rational(new_usec, 1000000)`
(`time/calculations.rb:141`) onward, and all five terminal arms (`:145`, `:147`,
`:150`, `:174`, `:176`) pass that one local. trails carried it twice — a JS
number floored into the `Temporal` components, plus a `newSecRational` rebuilt
back out of those components for the `::Time` arms.

Now: `newSec` is seeded as a `Rational`, `newUsec` is a `Rational` (the
`>= 1000000` guard reads against it), the `Temporal` components are derived
from `newSec` rather than the other way round, and `newSecRational` is gone.
`end_of_day` / `end_of_hour` / `end_of_minute` pass
`Rational(999999999, 1000)` as Rails does (`:261`, `:277`, `:292`) instead of
the float `999999999 / 1000`.

Those three call sites carry a `@missingRailsArgs change — PERMANENT` tag:
Ruby's `Rational()` is a Kernel function, TS spells the same construction
`new Rational(...)`, and the extractor records that as `ref:constructor` rather
than `ref:Rational`. Same value, different spelling; no baseline row added.

`core-ext/time-ext.test.ts` and `core-ext/date-ext.test.ts` are untouched and
green, including `advance with nsec` and `all day`.

## `Time#isdst` — blocked, not shipped

The third story asked `Time#isdst` to read the zone's real DST flag instead of
comparing the instant's offset to January/July. Measured against MRI first —
3,714 samples (418 `Intl.supportedValuesOf("timeZone")` zones x 9 dates,
`TZ=<zone> ruby -e 'p Time.local(...).isdst'`) — and both proposed
replacements are **worse** than what is there:

| reading | mismatches vs MRI |
| --- | --- |
| current January/July sampling | 121 |
| story option 2, `getTimeZoneTransition` segments (3/6/7/9/12/18-month windows) | 778 / 719 / 621 / 748 / 709 / 680 |
| best offset-only variant found (min over 24 monthly samples) | 113 |

Option 2 reads every **permanent** standard-offset shift as DST —
`America/Cancun` 2015, `Europe/Istanbul` 2016, `Asia/Amman` 2022,
`Africa/Juba` 2020 are all `false` in MRI and `true` under it. Option 1 (CLDR
names) does not carry the flag either: `America/New_York` 1943 formats as
`GMT-4` with no daylight wording (MRI `true`), and `Europe/Dublin` in summer
formats as `Irish Standard Time` (MRI `true`).

No runtime API exposes tzdata's `tm_isdst` bit, so only option 3 — vendoring a
generated tzdata isdst table into `@blazetrails/date` — can actually converge
this, and that is a data-table story of its own rather than a rewrite of this
getter. `pnpm tasks block`ed with those numbers so it can be re-scoped.
`tzdataAbbreviation`'s sibling heuristic is therefore left as it is, matching.

Closes-story: carry-time-with-zone-to-time-arm-memos
Closes-story: converge-time-change-new-sec-onto-one-rational
