### PR TITLE
fix(scripts): parity:api:build --dry-run names the args-kind rows it cannot migrate

### DIFF
--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -15,6 +15,8 @@ import {
   fileModuleName,
   groupByDeclFile,
   lowerMarksForDropped,
+  migrationSummary,
+  scopedRows,
   staleTagKey,
 } from "./build.js";
 import { serializeBaseline } from "./baseline-json.js";
@@ -782,5 +784,48 @@ describe("fileModuleName", () => {
     expect(fileModuleName("aggregations.ts")).toBe("Aggregations");
     expect(fileModuleName("secure-password.ts")).toBe("SecurePassword");
     expect(fileModuleName("connection-adapters/sqlite3/quoting.ts")).toBe("Quoting");
+  });
+});
+
+describe("migrationSummary", () => {
+  const row = (kind: "calls" | "args", call: string) => ({
+    package: "activesupport",
+    tsFile: "encrypted-file.ts",
+    rubyName: "encryptor",
+    call,
+    reason: DEFAULT_TAG_REASON,
+    ...(kind === "args" ? { kind: "args" as const, rubyArgs: ["a"] } : {}),
+  });
+
+  it("names the args-kind rows a call-SET dry run leaves behind", () => {
+    const lines = migrationSummary([row("args", "new"), row("args", "chomp")], 0, true);
+    expect(lines[0]).toContain("0 of 2 baseline entr(ies) in scope would migrate");
+    expect(lines[1]).toContain('2 of those row(s) are kind: "args"');
+    expect(lines[1]).toContain("LIVE rows, not stale ones");
+    expect(lines[1]).toContain("pnpm parity:api:calls:args");
+  });
+
+  it("says nothing extra when every row in scope is call-set kind", () => {
+    expect(migrationSummary([row("calls", "new")], 1, false)).toHaveLength(1);
+  });
+});
+
+describe("scopedRows", () => {
+  const row = (pkg: string, tsFile: string) => ({
+    package: pkg,
+    tsFile,
+    rubyName: "encryptor",
+    call: "new",
+    reason: DEFAULT_TAG_REASON,
+  });
+
+  it("keeps only the rows of the package and, when given, the file under build", () => {
+    const baseline = [
+      row("activesupport", "encrypted-file.ts"),
+      row("activesupport", "message-encryptor.ts"),
+      row("activerecord", "encrypted-file.ts"),
+    ];
+    expect(scopedRows(baseline, "activesupport")).toHaveLength(2);
+    expect(scopedRows(baseline, "activesupport", "encrypted-file.ts")).toEqual([baseline[0]]);
   });
 });

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -811,11 +811,11 @@ describe("migrationSummary", () => {
 });
 
 describe("scopedRows", () => {
-  const row = (pkg: string, tsFile: string) => ({
+  const row = (pkg: string, tsFile: string, call = "new") => ({
     package: pkg,
     tsFile,
     rubyName: "encryptor",
-    call: "new",
+    call,
     reason: DEFAULT_TAG_REASON,
   });
 
@@ -827,5 +827,15 @@ describe("scopedRows", () => {
     ];
     expect(scopedRows(baseline, "activesupport")).toHaveLength(2);
     expect(scopedRows(baseline, "activesupport", "encrypted-file.ts")).toEqual([baseline[0]]);
+  });
+
+  it("narrows to the requested --call cluster so the summary counts only what ran", () => {
+    const baseline = [
+      row("activesupport", "encrypted-file.ts", "new"),
+      row("activesupport", "encrypted-file.ts", "chomp"),
+    ];
+    expect(scopedRows(baseline, "activesupport", "encrypted-file.ts", new Set(["new"]))).toEqual([
+      baseline[0],
+    ]);
   });
 });

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -687,7 +687,7 @@ export async function lowerMarksForDropped(
 }
 
 /**
- * The baseline rows in this run's scope, both dimensions, so the run can say
+ * The baseline rows in this run's scope, BOTH dimensions, so the run can say
  * how many of them it did not migrate.
  *
  * `call-mismatches-exclude/` shards hold both dimensions (RFC 0095): a
@@ -719,7 +719,7 @@ export function scopedRows(
  * was excluding.
  */
 export function migrationSummary(
-  inScope: readonly ExcludeEntry[],
+  inScope: ExcludeEntry[],
   dropped: number,
   dryRun: boolean,
 ): string[] {
@@ -729,7 +729,7 @@ export function migrationSummary(
       `${dryRun ? "would be" : "were"} dropped from ` +
       `${path.relative(ROOT_DIR, BASELINE_DIR)}/.`,
   ];
-  const argsRows = rowsOfKind([...inScope], "args");
+  const argsRows = rowsOfKind(inScope, "args");
   if (argsRows.length > 0) {
     lines.push(
       `parity:api:build: ${argsRows.length} of those row(s) are kind: "args" and ` +
@@ -764,9 +764,6 @@ async function main(argv: string[]): Promise<number> {
   }
 
   const baseline = await loadSplitBaseline(BASELINE_DIR);
-  // Call-SET rows only: `keyOf` does not carry `kind`, so an args-kind row
-  // sharing a key would otherwise donate its reason to a `@missingRailsCall`
-  // receipt and then be dropped from the shard by the migration below.
   const callRows = rowsOfKind(baseline, "calls");
   const reasons = new Map<string, string>();
   for (const e of callRows) {
@@ -889,11 +886,7 @@ async function main(argv: string[]): Promise<number> {
     );
     for (const rel of moved) console.log(`  - ${rel}`);
   }
-  for (const line of migrationSummary(
-    scopedRows(baseline, pkg, onlyFile),
-    dropped,
-    dryRun,
-  )) {
+  for (const line of migrationSummary(scopedRows(baseline, pkg, onlyFile), dropped, dryRun)) {
     console.log(line);
   }
   console.log(

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -690,6 +690,10 @@ export async function lowerMarksForDropped(
  * The baseline rows in this run's scope, BOTH dimensions, so the run can say
  * how many of them it did not migrate.
  *
+ * The scope is exactly what the run acted on: `--package`, `--file`, and the
+ * repeatable `--call` cluster. Counting a row `--call` excluded would restate
+ * the misreading this summary exists to prevent, one narrowing down.
+ *
  * `call-mismatches-exclude/` shards hold both dimensions (RFC 0095): a
  * `kind: "args"` row is the call-ARGUMENT gate's, and this migrator only ever
  * mints `@missingRailsCall` receipts. Reporting a bare `0 rows would migrate`
@@ -702,9 +706,13 @@ export function scopedRows(
   baseline: readonly ExcludeEntry[],
   pkg: string,
   onlyFile?: string,
+  onlyCall?: ReadonlySet<string>,
 ): ExcludeEntry[] {
   return baseline.filter(
-    (e) => e.package === pkg && (onlyFile === undefined || e.tsFile === onlyFile),
+    (e) =>
+      e.package === pkg &&
+      (onlyFile === undefined || e.tsFile === onlyFile) &&
+      (onlyCall === undefined || onlyCall.has(e.call)),
   );
 }
 
@@ -886,7 +894,11 @@ async function main(argv: string[]): Promise<number> {
     );
     for (const rel of moved) console.log(`  - ${rel}`);
   }
-  for (const line of migrationSummary(scopedRows(baseline, pkg, onlyFile), dropped, dryRun)) {
+  for (const line of migrationSummary(
+    scopedRows(baseline, pkg, onlyFile, onlyCall.size > 0 ? onlyCall : undefined),
+    dropped,
+    dryRun,
+  )) {
     console.log(line);
   }
   console.log(

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -32,6 +32,11 @@
  * Usage:
  *   pnpm parity:api:build --package <pkg> [--file <tsFile>] [--call <ruby_call>] [--dry-run]
  *
+ * `--dry-run` reports what would move WITHOUT touching a file, and names the
+ * `kind: "args"` rows in scope it will never move — those belong to the
+ * call-ARGUMENT dimension (`pnpm parity:api:calls:args`), and a bare `0` for a
+ * shard full of them reads as "stale rows, delete the shard" (RFC 0106).
+ *
  * `--call` (repeatable) migrates one cluster of Ruby calls and leaves every
  * other flagged call baselined, so a source file whose curated rows mix a
  * permanent cluster with unrelated tracked debt migrates the cluster alone.
@@ -45,7 +50,13 @@ import * as path from "path";
 import * as ts from "typescript";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, ROOT_DIR, packageSrcDir } from "./config.js";
-import { type ExcludeEntry, callOf, keyOf, missingScope } from "./call-mismatch-baseline.js";
+import {
+  type ExcludeEntry,
+  callOf,
+  keyOf,
+  missingScope,
+  rowsOfKind,
+} from "./call-mismatch-baseline.js";
 import {
   MARK_DIR,
   loadSplitBaseline,
@@ -675,6 +686,61 @@ export async function lowerMarksForDropped(
   return { marks: next, moved: moved.sort() };
 }
 
+/**
+ * The baseline rows in this run's scope, both dimensions, so the run can say
+ * how many of them it did not migrate.
+ *
+ * `call-mismatches-exclude/` shards hold both dimensions (RFC 0095): a
+ * `kind: "args"` row is the call-ARGUMENT gate's, and this migrator only ever
+ * mints `@missingRailsCall` receipts. Reporting a bare `0 rows would migrate`
+ * for a shard whose remaining rows are all args-kind reads as "these rows are
+ * stale and exclude nothing" — a misreading that cost a full story cycle
+ * (RFC 0106; the rows deleted on that evidence were live, and their deletion
+ * red `parity:api:calls:args` with two NEW rows).
+ */
+export function scopedRows(
+  baseline: readonly ExcludeEntry[],
+  pkg: string,
+  onlyFile?: string,
+): ExcludeEntry[] {
+  return baseline.filter(
+    (e) => e.package === pkg && (onlyFile === undefined || e.tsFile === onlyFile),
+  );
+}
+
+/**
+ * What this run did to the baseline rows in its scope.
+ *
+ * The second line is the RFC 0106 fix: this migrator mints `@missingRailsCall`
+ * receipts, so it never migrates a `kind: "args"` row, and a shard whose
+ * remaining rows are all args-kind used to report a bare `0 rows would migrate`
+ * — indistinguishable from "these rows are stale and exclude nothing". Deleting
+ * such a shard on that reading reds `parity:api:calls:args` with the rows it
+ * was excluding.
+ */
+export function migrationSummary(
+  inScope: readonly ExcludeEntry[],
+  dropped: number,
+  dryRun: boolean,
+): string[] {
+  const lines = [
+    `parity:api:build: ${dropped} of ${inScope.length} baseline entr(ies) in scope ` +
+      `${dryRun ? "would migrate" : "migrated"} to @missingRailsCall tags and ` +
+      `${dryRun ? "would be" : "were"} dropped from ` +
+      `${path.relative(ROOT_DIR, BASELINE_DIR)}/.`,
+  ];
+  const argsRows = rowsOfKind([...inScope], "args");
+  if (argsRows.length > 0) {
+    lines.push(
+      `parity:api:build: ${argsRows.length} of those row(s) are kind: "args" and ` +
+        `${dryRun ? "would" : "did"} NOT migrate — this is the call-SET migrator. They are ` +
+        "LIVE rows, not stale ones: the call-ARGUMENT dimension converges with " +
+        "`@missingRailsArgs` receipts (see `pnpm parity:api:calls:args`).",
+    );
+  }
+  return lines;
+}
+
 async function main(argv: string[]): Promise<number> {
   const pkgIdx = argv.indexOf("--package");
   const pkg = pkgIdx !== -1 ? argv[pkgIdx + 1] : undefined;
@@ -698,8 +764,12 @@ async function main(argv: string[]): Promise<number> {
   }
 
   const baseline = await loadSplitBaseline(BASELINE_DIR);
+  // Call-SET rows only: `keyOf` does not carry `kind`, so an args-kind row
+  // sharing a key would otherwise donate its reason to a `@missingRailsCall`
+  // receipt and then be dropped from the shard by the migration below.
+  const callRows = rowsOfKind(baseline, "calls");
   const reasons = new Map<string, string>();
-  for (const e of baseline) {
+  for (const e of callRows) {
     reasons.set(keyOf(e), e.reason);
   }
 
@@ -804,8 +874,10 @@ async function main(argv: string[]): Promise<number> {
     if (dryRun) console.log(`would update ${path.relative(ROOT_DIR, abs)}`);
     else await fs.writeFile(abs, texts.get(abs)!);
   }
-  const remaining = baseline.filter((e) => !migrated.has(keyOf(e)));
-  const droppedEntries = baseline.filter((e) => migrated.has(keyOf(e)));
+  const remaining = baseline.filter(
+    (e) => (e.kind ?? "calls") !== "calls" || !migrated.has(keyOf(e)),
+  );
+  const droppedEntries = callRows.filter((e) => migrated.has(keyOf(e)));
   const dropped = droppedEntries.length;
   if (dropped > 0 && !dryRun) {
     await writeSplitBaseline(remaining, BASELINE_DIR);
@@ -817,11 +889,13 @@ async function main(argv: string[]): Promise<number> {
     );
     for (const rel of moved) console.log(`  - ${rel}`);
   }
-  console.log(
-    `parity:api:build: ${dropped} baseline entr(ies) ${dryRun ? "would migrate" : "migrated"} to ` +
-      `@missingRailsCall tags and ${dryRun ? "would be" : "were"} dropped from ` +
-      `${path.relative(ROOT_DIR, BASELINE_DIR)}/.`,
-  );
+  for (const line of migrationSummary(
+    scopedRows(baseline, pkg, onlyFile),
+    dropped,
+    dryRun,
+  )) {
+    console.log(line);
+  }
   console.log(
     `parity:api:build: ${changed} file(s) ${dryRun ? "would change" : "updated"} (${pkg}).`,
   );


### PR DESCRIPTION
The call-SET migrator mints `@missingRailsCall` receipts only, so it never moves a `kind: "args"` row. A shard whose remaining rows are all args-kind reported a bare `0 rows would migrate` — indistinguishable from "these rows are stale and exclude nothing". That misreading produced a story asserting both remaining rows in `call-mismatches-exclude/activesupport/encrypted-file.json` were dead; they were live args rows, and deleting the shard reds `pnpm parity:api:calls:args` with two NEW rows.

## Changes

- The summary now reads `0 of 2 baseline entr(ies) in scope would migrate` and, when the scope holds args-kind rows, adds a second line naming them as LIVE rows belonging to the call-ARGUMENT dimension, pointing at `pnpm parity:api:calls:args`.
- `migrationSummary` / `scopedRows` are exported and unit-tested; the args-only-shard case fails on the previous behaviour (which emitted a single bare line).
- Scopes the reason map and the dropped set to call-set rows: `keyOf` does not carry `kind`, so an args row sharing a key could donate its reason to a `@missingRailsCall` receipt and then be dropped from the shard by the migration.

The migrator stays call-set-only — the story allows either that or extending it, provided the unhandled kind is explicit.

## Verification

- `npx vitest run scripts/api-compare/build.test.ts` — 54 passed
- `lint-call-mismatches`, `lint-call-args`, `call-args-baseline`, `call-mismatch-baseline` tests — 85 passed
- eslint clean. No ported method bodies touched, so the parity call gates are unaffected (they could not be regenerated locally: this worktree has no `dist`).

Closes-story: call-set-migrator-dry-run-reports-zero-for-args-kind-rows