### PR TITLE
fix(activerecord): toSql renders the eager JOIN and per-column pk restriction for a composite-PK relation with LIMIT/OFFSET

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1984,7 +1984,23 @@ export class Relation<T extends Base> {
   ): Relation<T> {
     let rel = this.except("includes", "eagerLoad", "preload");
     QueryMethodBangs.joinsBang.call(rel as any, jd as any);
-    if (this.hasLimitOrOffset && !this._eagerJoinDependencyIsLimitable(jd)) {
+    if (
+      this.hasLimitOrOffset &&
+      !(
+        this.usingLimitableReflections(jd.reflections as never) &&
+        this.usingLimitableReflections(
+          QueryMethodBangs.constructJoinDependency.call(
+            this as any,
+            _qm.selectAssociationList
+              .call(this as any, this.joinsValues, null)
+              .concat(
+                _qm.selectAssociationList.call(this as any, this.leftOuterJoinsValues, null),
+              ) as AssociationSpec[],
+            null,
+          ).reflections as never,
+        )
+      )
+    ) {
       if (Array.isArray(basePk)) {
         // Rails `where!(**Array(primary_key).zip(limited_ids.transpose).to_h)`
         // (schema_statements.rb:1448) — a per-column `IN`, not a tuple `IN`.
@@ -2018,11 +2034,12 @@ export class Relation<T extends Base> {
    * forces the distinct-parent-id rewrite even when every eager reflection is
    * singular.
    *
-   * Rails spells this guard inline in `apply_join_dependency`, and so does
-   * {@link applyJoinDependency}. This copy serves only the SYNCHRONOUS eager
-   * paths that cannot route through it — `toSql` and the deferred distinct-PK
-   * predicate cluster — pending the sync/async collapse tracked by
-   * `converge-relation-subquery-distinct-pk-materialization`.
+   * Rails spells this guard inline in `apply_join_dependency`, and so do both
+   * trails mirrors of that method — {@link applyJoinDependency} and
+   * `_applyEagerJoinDependency`. This copy has one caller left, the trails-only
+   * deferred distinct-PK predicate cluster, which asks the question WITHOUT
+   * applying the join dependency; it retires with that cluster in the sync/async
+   * collapse tracked by `converge-sync-eager-builders-async-to-sql`.
    */
   private _eagerJoinDependencyIsLimitable(jd: JoinDependency): boolean {
     return (

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1988,11 +1988,16 @@ export class Relation<T extends Base> {
       if (Array.isArray(basePk)) {
         // Rails `where!(**Array(primary_key).zip(limited_ids.transpose).to_h)`
         // (schema_statements.rb:1448) — a per-column `IN`, not a tuple `IN`.
-        // Only the materialized form exists for a composite key: the inline
-        // subquery fallback has no single column to nest under.
-        const tuples = (limitedIds ?? []) as unknown[][];
+        // The synchronous fallback keeps that per-column shape too: each column
+        // gets its own single-column DISTINCT subquery, since a multi-column
+        // subquery is not a valid `IN` operand.
+        const tuples = limitedIds as unknown[][] | undefined;
         basePk.forEach((column, i) => {
-          rel = rel.where(this.table.get(column).in(tuples.map((tuple) => tuple[i]) as never));
+          const ids =
+            tuples !== undefined
+              ? tuples.map((tuple) => tuple[i])
+              : this._limitedDistinctRelation(jd, column).arel();
+          rel = rel.where(this.table.get(column).in(ids as never));
         });
       } else {
         const ids = limitedIds ?? this._limitedDistinctRelation(jd, basePk).arel();
@@ -2156,12 +2161,6 @@ export class Relation<T extends Base> {
    * OUTER JOINs), or null when this relation has no resolvable eager loading.
    * Shared by `toSql` (string path) and the set-operation operand
    * builder, which composes it into the compound's single collector.
-   *
-   * Also null for the one composite-PK case left after
-   * `distinct_relation_for_primary_key` took over the async path: this builder is
-   * synchronous, so it substitutes an inline `pk IN (SELECT DISTINCT …)` for the
-   * executed limited-ids query, and a composite key has no single column to nest
-   * that under. The plain arel is closer than a broken per-column `IN ()`.
    */
   private _buildEagerOperandManager(): SelectManager | null {
     const allEager = [...new Set([...this.eagerLoadValues, ...this.includesValues])];
@@ -2175,14 +2174,6 @@ export class Relation<T extends Base> {
       Nodes.OuterJoin,
     );
     if (jd.nodes.length === 0) return null;
-
-    if (
-      Array.isArray(basePk) &&
-      this.hasLimitOrOffset &&
-      !this._eagerJoinDependencyIsLimitable(jd)
-    ) {
-      return null;
-    }
 
     const eagerRelation = this._applyEagerJoinDependency(jd, basePk);
     jd.applyColumnAliases(eagerRelation);

--- a/packages/activerecord/src/relation/cpk-eager-limit-to-sql-renders-join.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-limit-to-sql-renders-join.trails.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `Relation#toSql` renders the eager JOIN and the primary-key restriction for a
+ * composite-PK relation with LIMIT/OFFSET over collection reflections.
+ *
+ * Rails' `to_sql` is
+ * `apply_join_dependency { |relation, jd| jd.apply_column_aliases(relation).to_sql }`
+ * (relation.rb:1210-1222), and `apply_join_dependency` runs
+ * `distinct_relation_for_primary_key` unconditionally — including for a
+ * composite key, where it rewrites the relation as
+ * `where!(**Array(primary_key).zip(limited_ids.transpose).to_h)`, a per-column
+ * `IN` (schema_statements.rb:1448).
+ *
+ * trails' `toSql` is synchronous, so it cannot execute the limited-ids query and
+ * nests the DISTINCT-pk query inline instead — per column, keeping Rails' shape.
+ * `_buildEagerOperandManager` used to answer `null` for this case, so `toSql`
+ * rendered the plain arel: no JOIN, no pk restriction at all — SQL that does not
+ * describe the query that would actually run.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-fixtures.js";
+import { CpkOrder, CpkBook } from "../test-helpers/models/cpk.js";
+import type { Base } from "../index.js";
+
+describe("Relation#to_sql composite-PK eager load with limit", () => {
+  fixtures(["cpkOrders", "cpkBooks"]);
+
+  beforeAll(() => {
+    [CpkOrder, CpkBook].forEach((m) => registerModel(m as unknown as typeof Base));
+  });
+
+  it("renders the eager JOIN and a per-column primary-key restriction", () => {
+    const sql = CpkOrder.eagerLoad(":books").limit(1).toSql();
+
+    expect(sql).toMatch(/LEFT OUTER JOIN/i);
+    expect(sql).toContain("cpk_books");
+    // One inline DISTINCT subquery per primary-key column — Rails' per-column
+    // `IN`, not a tuple `IN`. Identifier quoting differs per adapter, so assert
+    // on the unquoted column names and the subquery count.
+    expect((sql.match(/IN \(SELECT DISTINCT/gi) ?? []).length).toBe(2);
+    expect(sql).toContain("shop_id");
+    expect(sql).toMatch(/LIMIT/i);
+  });
+
+  it("renders the same restriction for offset without limit", () => {
+    const sql = CpkOrder.eagerLoad(":books").offset(2).toSql();
+
+    expect(sql).toMatch(/LEFT OUTER JOIN/i);
+    expect((sql.match(/IN \(SELECT DISTINCT/gi) ?? []).length).toBe(2);
+  });
+
+  it("loads the limited records through the materialized ids", async () => {
+    const orders = await CpkOrder.eagerLoad(":books").order("cpk_orders.id").limit(1);
+    expect(orders.length).toBe(1);
+  });
+});


### PR DESCRIPTION
`Relation#toSql` on a composite-PK relation that eager-loads a collection under
LIMIT/OFFSET rendered the plain arel: no eager JOIN and no primary-key
restriction at all — SQL that does not describe the query that would actually
run. `_buildEagerOperandManager` answered `null` for that case.

Rails has no such arm: `to_sql` is
`apply_join_dependency { |relation, jd| jd.apply_column_aliases(relation).to_sql }`
(`relation.rb:1210-1222`), and `apply_join_dependency` runs
`distinct_relation_for_primary_key` unconditionally, rewriting the relation as
`where!(**Array(relation.primary_key).zip(limited_ids.transpose).to_h)` —
a per-column `IN`, one per pk column (`schema_statements.rb:1448`).

- The composite-PK `null` arm in `_buildEagerOperandManager` is gone.
- `_applyEagerJoinDependency`'s composite arm now covers the synchronous case
  too: with no materialized `limitedIds`, each pk column gets its own
  single-column `_limitedDistinctRelation` subquery, keeping Rails' per-column
  `IN` shape (a multi-column subquery is not a valid `IN` operand). This is the
  same substitution the single-column path already makes for the sync seam —
  `toSql` cannot execute the limited-ids query — and it retires with that seam
  (`converge-sync-eager-builders-async-to-sql`).
- The async/execution path is untouched: it still passes materialized
  `limitedIds` and takes the literal-tuple branch.

`_eagerJoinDependencyIsLimitable` loses its `_buildEagerOperandManager` caller;
the two that remain (`_applyEagerJoinDependency`, `_isDeferredDistinctPkSubquery`)
are on the async-`toSql` seam's deletion list and cannot drop before it lands.

New trails test pins the rendered SQL and the load path; verified red on
baseline (both `toSql` cases render no `LEFT OUTER JOIN` before the change).
`parity:api:calls`, `parity:api:calls:args` and `parity:api:extra:gate` all OK.

Closes-story: sync-tosql-composite-pk-eager-limit-renders-no-join
