### PR TITLE
refactor(activerecord): call defineAttributeMethods from Core#initInternals

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -14,6 +14,7 @@ export {
   AttrNames,
   buildMangledName,
   defineAttributeMethods,
+  undefineAttributeMethods,
   isInstanceMethodAlreadyImplemented,
 } from "./attribute-methods.js";
 export type { InstanceHost } from "./attribute-methods.js";

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -484,6 +484,12 @@ describe("AttributeMethodsTest", () => {
     }
     const topic = new TopicClass({ title: "New topic" }) as any;
     TopicClass.undefineAttributeMethods();
+    // Ruby brings the undefined methods back on the next read, through
+    // `method_missing` (attribute_methods.rb:487-499). A JS property cannot
+    // trap a read (CLAUDE.md, "Generated attribute readers are properties"), so
+    // trails' generation point is `Core#init_internals` (core.rb:849) — the
+    // next construction is what defines them again, for `topic` too.
+    expect((new TopicClass({ title: "New topic" }) as any).title).toBe("New topic");
     expect(topic.title).toBe("New topic");
   });
   it("#method_missing define methods on the fly in a thread safe way, even when decorated", async () => {

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -484,11 +484,9 @@ describe("AttributeMethodsTest", () => {
     }
     const topic = new TopicClass({ title: "New topic" }) as any;
     TopicClass.undefineAttributeMethods();
-    // Ruby brings the undefined methods back on the next read, through
-    // `method_missing` (attribute_methods.rb:487-499). A JS property cannot
-    // trap a read (CLAUDE.md, "Generated attribute readers are properties"), so
-    // trails' generation point is `Core#init_internals` (core.rb:849) — the
-    // next construction is what defines them again, for `topic` too.
+    // Ruby brings the methods back on the next read, through `method_missing`.
+    // A JS property cannot trap a read (CLAUDE.md, "Generated attribute readers
+    // are properties"), so trails' trigger is `init_internals` (core.rb:849).
     expect((new TopicClass({ title: "New topic" }) as any).title).toBe("New topic");
     expect(topic.title).toBe("New topic");
   });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -393,10 +393,8 @@ describe("AttributeMethodsTest (trails)", () => {
 
     (Employee as unknown as { undefineAttributeMethods(): void }).undefineAttributeMethods();
 
-    // Read through the existing record: Rails asserts `method_defined?` goes
-    // false (attribute_methods_test.rb:1098-1117), and constructing again would
-    // regenerate — `init_internals` calls `define_attribute_methods`
-    // (core.rb:849).
+    // Read through the existing record: constructing again would regenerate,
+    // since `init_internals` calls `define_attribute_methods` (core.rb:849).
     expect(employee.nameChanged).toBeUndefined();
   });
 
@@ -406,10 +404,9 @@ describe("AttributeMethodsTest (trails)", () => {
         this.attribute("name", "string");
       }
     }
-    // `initInternals` generates at construction (core.rb:849), over the bare
-    // module ActiveModel's lazy `generated_attribute_methods` seated for the
-    // class-body `attribute` call — one carrier must answer `nameChanged`, or
-    // `undefineAttributeMethods` clears only one of them.
+    // Construction generates (core.rb:849) over the bare module ActiveModel
+    // seated for the class-body `attribute` call; two carriers would leave
+    // `undefineAttributeMethods` clearing only one of them.
     new Employee({});
 
     let carriers = 0;

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -388,13 +388,39 @@ describe("AttributeMethodsTest (trails)", () => {
         this.attribute("name", "string");
       }
     }
-    expect(typeof (new Employee({}) as unknown as { nameChanged: unknown }).nameChanged).toBe(
-      "function",
-    );
+    const employee = new Employee({}) as unknown as { nameChanged: unknown };
+    expect(typeof employee.nameChanged).toBe("function");
 
     (Employee as unknown as { undefineAttributeMethods(): void }).undefineAttributeMethods();
 
-    expect((new Employee({}) as unknown as { nameChanged: unknown }).nameChanged).toBeUndefined();
+    // Read through the existing record: Rails asserts `method_defined?` goes
+    // false (attribute_methods_test.rb:1098-1117), and constructing again would
+    // regenerate — `init_internals` calls `define_attribute_methods`
+    // (core.rb:849).
+    expect(employee.nameChanged).toBeUndefined();
+  });
+
+  it("seats one generated-methods carrier when construction generates first", () => {
+    class Employee extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    // `initInternals` generates at construction (core.rb:849), over the bare
+    // module ActiveModel's lazy `generated_attribute_methods` seated for the
+    // class-body `attribute` call — one carrier must answer `nameChanged`, or
+    // `undefineAttributeMethods` clears only one of them.
+    new Employee({});
+
+    let carriers = 0;
+    for (
+      let link: object | null = Employee.prototype;
+      link;
+      link = Object.getPrototypeOf(link) as object | null
+    ) {
+      if (Object.prototype.hasOwnProperty.call(link, "nameChanged")) carriers += 1;
+    }
+    expect(carriers).toBe(1);
   });
 
   it("generates once when the schema load drives generation first", () => {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::AttributeMethods
  */
-import { CodeGenerator, include, Module } from "@blazetrails/activesupport";
+import { CodeGenerator, include, uninclude, Module } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import {
   aliasesByAttributeName,
@@ -11,6 +11,7 @@ import {
   type AttributeMethodPattern,
   isInstanceMethodAlreadyImplemented as _amInstanceMethodAlreadyImplemented,
   defineAttributeMethods as amDefineAttributeMethods,
+  undefineAttributeMethods as amUndefineAttributeMethods,
   type InstanceHost as AttributeMethodsInstanceHost,
   type DirtyOptions,
 } from "@blazetrails/activemodel";
@@ -312,8 +313,28 @@ export function dangerousAttributeMethods(): Set<string> {
  * ancestry does.
  */
 export function initializeGeneratedModules(this: AttributeMethodsHost): void {
+  // Rails runs this from `inherited`, so the ivar is always empty here and the
+  // `include` below is the class's only generated-methods entry. In trails a
+  // class body can reach ActiveModel's lazy `generated_attribute_methods`
+  // (attribute_methods.rb:400-402) first, which seats a bare `Module` and
+  // includes it; replacing it means taking its carrier back out of the
+  // prototype chain — `include()` splices a fresh one per call, so leaving it
+  // there would keep answering every method it defines after an
+  // `undef_method` on the replacement. Its methods carry over, as they would
+  // in Ruby where there is only ever the one module.
+  const previous = Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")
+    ? this._generatedAttributeMethods
+    : undefined;
   this._generatedAttributeMethods = new GeneratedAttributeMethods();
   this._generatedAttributeMethods.ownerName = this.name;
+  if (previous instanceof Module) {
+    this._generatedAttributeMethods.moduleEval((mod) => {
+      for (const name of previous.instanceMethods()) {
+        Object.defineProperty(mod, name, previous.instanceMethod(name)!);
+      }
+    });
+    uninclude(this as unknown as new (...args: unknown[]) => unknown, previous);
+  }
   this._attributeMethodsGenerated = false;
   this._aliasAttributesMassGenerated = false;
   include(this as unknown as new (...args: unknown[]) => unknown, this._generatedAttributeMethods);
@@ -520,9 +541,23 @@ export function generateAliasAttributes(this: AttributeMethodsHost): void {
   this._aliasAttributesMassGenerated = true;
 }
 
+/**
+ * Mirrors: ActiveRecord::AttributeMethods::ClassMethods#undefine_attribute_methods
+ * (attribute_methods.rb:143-149). `GeneratedAttributeMethods::LOCK.synchronize`
+ * has no seat — JS is single-threaded — but the `super if
+ * @attribute_methods_generated` guard does: without generated methods there is
+ * nothing to undefine, and ActiveModel's `super` would otherwise clear a
+ * module this class never generated into. Both ivars are per-class, so only an
+ * *own* truthy flag counts as generated (an inherited `true` belongs to the
+ * parent).
+ */
 export function undefineAttributeMethods(this: AttributeMethodsHost): void {
-  const amFn = Object.getPrototypeOf(this)?.undefineAttributeMethods;
-  if (typeof amFn === "function") amFn.call(this);
+  if (
+    Object.prototype.hasOwnProperty.call(this, "_attributeMethodsGenerated") &&
+    this._attributeMethodsGenerated
+  ) {
+    amUndefineAttributeMethods.call(this as never);
+  }
   this._attributeMethodsGenerated = false;
   this._aliasAttributesMassGenerated = false;
 }

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -311,17 +311,17 @@ export function dangerousAttributeMethods(): Set<string> {
  * wires this attribute-methods entry point as the single static (see base.ts),
  * so the super call reaches `generatedAssociationMethods` just as Rails' method
  * ancestry does.
+ *
+ * Rails runs this from `inherited`, so the ivar is always empty and the
+ * `include` is the class's only generated-methods entry. In trails a class body
+ * can reach ActiveModel's lazy `generated_attribute_methods`
+ * (attribute_methods.rb:400-402) first, which seats a bare `Module` and
+ * includes it. Replacing that one means taking its carrier back out of the
+ * prototype chain: `include()` splices a fresh carrier per call, so the stale
+ * one would keep answering every method it defines after an `undef_method` on
+ * the replacement. Its methods carry over, leaving the single module Ruby has.
  */
 export function initializeGeneratedModules(this: AttributeMethodsHost): void {
-  // Rails runs this from `inherited`, so the ivar is always empty here and the
-  // `include` below is the class's only generated-methods entry. In trails a
-  // class body can reach ActiveModel's lazy `generated_attribute_methods`
-  // (attribute_methods.rb:400-402) first, which seats a bare `Module` and
-  // includes it; replacing it means taking its carrier back out of the
-  // prototype chain — `include()` splices a fresh one per call, so leaving it
-  // there would keep answering every method it defines after an
-  // `undef_method` on the replacement. Its methods carry over, as they would
-  // in Ruby where there is only ever the one module.
   const previous = Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")
     ? this._generatedAttributeMethods
     : undefined;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -196,6 +196,7 @@ import {
   ClassMethods as AttributeMethodsClassMethods,
   isAttributeMethod as _isAttributeMethod,
   defineAttributeMethods as _defineAttributeMethods,
+  undefineAttributeMethods as _undefineAttributeMethods,
   initializeGeneratedModules as _initializeGeneratedModules,
   GeneratedAttributeMethods,
   generateAliasAttributes as _generateAliasAttributes,
@@ -1510,6 +1511,7 @@ export class Base extends Model {
   // (attribute_methods.rb:139-159): no attr-name splat, and it answers whether
   // the class's methods were generated.
   declare static defineAttributeMethods: typeof _defineAttributeMethods;
+  declare static undefineAttributeMethods: typeof _undefineAttributeMethods;
   declare static generateAliasAttributes: typeof _generateAliasAttributes;
   declare static _defaultAttributes: typeof _arDefaultAttributes;
   /** @internal */
@@ -4720,6 +4722,7 @@ extend(Base, ModelSchema.ClassMethods);
 extend(Base, {
   defineAttribute: _defineAttribute,
   defineAttributeMethods: _defineAttributeMethods,
+  undefineAttributeMethods: _undefineAttributeMethods,
   initializeGeneratedModules: _initializeGeneratedModules,
   generateAliasAttributes: _generateAliasAttributes,
   eagerlyGenerateAliasAttributeMethods: _eagerlyGenerateAliasAttributeMethods,

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -862,22 +862,6 @@ export function arelTable(this: CoreHost): Table {
  * a placeholder key for its whole life. Converging that slot is tracked
  * separately (RFC 0115 `seat-the-per-instance-primary-key-slot`).
  *
- * `klass.define_attribute_methods` (core.rb:849) has no seat here either, and
- * is CONVERGEABLE rather than permanent. It carries no `@missingRailsCall`
- * because the tag cannot apply to it: the extractor records the Ruby side as
- * `ref:define_attribute_methods`, and `ref:` identifiers are report-only, so
- * `parity:api:calls` never flags this omission and reads any tag on it as a
- * STALE justification (gate exit 1). The reason therefore lives here in prose
- * until the call itself lands. Porting it was tried and reverted: a
- * construction-time generation pass runs before the async schema load, and the
- * post-load pass (`applyColumnsHash`, model-schema.ts:1301-1302, which clears
- * `_attributeMethodsGenerated` so the next demand regenerates) then seats a
- * SECOND generated-module carrier. `undefineAttributeMethods` clears one of the
- * two, so the accessor survives an undefine that Rails' own
- * `attribute_methods_test.rb:1098-1117` requires to clear it. The duplicate
- * carrier is the blocker, not the call; RFC 0115
- * `call-define-attribute-methods-from-init-internals` carries the finding.
- *
  * @internal
  */
 export function initInternals(
@@ -905,6 +889,8 @@ export function initInternals(
   const klass = this.constructor as any;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
   this._strictLoadingMode = klass.strictLoadingMode;
+
+  klass.defineAttributeMethods();
 }
 
 /**

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -197,6 +197,31 @@ function featureHook(mod: unknown, name: string): ((base: unknown) => void) | un
   return typeof hook === "function" ? (hook as (base: unknown) => void).bind(mod) : undefined;
 }
 
+/**
+ * Take a `Module` back out of a class's prototype chain, dropping the carrier
+ * `include()` spliced in for it.
+ *
+ * @noRailsEquivalent PERMANENT: Ruby's ancestry is a list of module entries and
+ * `include`ing a module already in it is a no-op, so a Ruby class that seats a
+ * second module over the same ivar leaves no duplicate entry behind and never
+ * needs to take one out. trails' `include()` splices a fresh carrier on every
+ * call, so replacing an already-included module — ActiveRecord's
+ * `initialize_generated_modules` seating its `GeneratedAttributeMethods` over
+ * the bare `Module` ActiveModel's lazy `generated_attribute_methods` built
+ * first — would otherwise strand the old carrier in the chain, still answering
+ * every method it defines after an `undef_method` on the new one.
+ */
+export function uninclude(klass: AnyClass, mod: Module): void {
+  const carrier = carriers.get(mod);
+  if (!carrier) return;
+  for (let link = klass.prototype as object; link; link = Object.getPrototypeOf(link)) {
+    if (Object.getPrototypeOf(link) === carrier) {
+      Object.setPrototypeOf(link, Object.getPrototypeOf(carrier));
+      return;
+    }
+  }
+}
+
 export function include(klass: AnyClass, mod: ModuleObject | AnyClass | Module): void {
   const appendFeatures = featureHook(mod, "appendFeatures");
   if (appendFeatures) return appendFeatures(klass);

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -611,7 +611,7 @@ export {
 } from "./callbacks.js";
 export type { ClassMethods } from "./callbacks.js";
 export { Concern, MultipleIncludedBlocks, MultiplePrependBlocks } from "./concern.js";
-export { include, extend, included, extended, Module } from "./include.js";
+export { include, uninclude, extend, included, extended, Module } from "./include.js";
 export type { Included, Extended } from "./include.js";
 export { CodeGenerator, MethodSet } from "./code-generator.js";
 export type { MethodSource } from "./code-generator.js";


### PR DESCRIPTION
Rails' last line of `init_internals` is `klass.define_attribute_methods`
(`activerecord/lib/active_record/core.rb:849`). trails omitted it and generated
at the end of every schema load instead. A first port attempt was reverted
because the call seated a **second** generated-module carrier per class, so
`undefine_attribute_methods` cleared only one of the two.

## The duplicate carrier

Probed: a class-body `attribute("name", "string")` reaches ActiveModel's lazy
`generated_attribute_methods` (`activemodel/attribute_methods.rb:400-402`),
which seats a bare `Module` and includes it. `initializeGeneratedModules` then
replaces that field with a `GeneratedAttributeMethods`
(`activerecord/attribute_methods.rb:41-47`) and calls `include()` again —
which splices a *fresh* carrier per call, leaving the stale one in the
prototype chain still answering every method it defined.

Rails never hits this: its `inherited` hook seeds the module before any class
body runs, so there is only ever one. The replacement now carries the old
module's methods over and takes its carrier back out of the chain, via a new
`uninclude()` in activesupport (tagged `@noRailsEquivalent PERMANENT` — Ruby's
ancestry never grows a duplicate entry, so Ruby has nothing to undo).

## `undefine_attribute_methods` was unreachable

ActiveRecord's override (`attribute_methods.rb:143-149`) existed in
`attribute-methods.ts` but was never wired onto `Base`, so `Base` inherited
ActiveModel's: neither `@attribute_methods_generated` nor
`@alias_attributes_mass_generated` was cleared and nothing regenerated
afterwards. It is wired now, with its `super if @attribute_methods_generated`
guard ported.

## Tests

- New: `seats one generated-methods carrier when construction generates first`
  — fails on this branch without the carrier fix (2 carriers).
- `#method_missing define methods on the fly in a thread safe way`: Ruby
  regenerates on the next read through `method_missing`; a JS property cannot
  trap a read (CLAUDE.md, "Generated attribute readers are properties"), so the
  trails trigger is the next construction. Assertion kept, name unchanged.
- `undefineAttributeMethods clears the generated dirty accessors` now reads
  through the existing record rather than constructing a new one, since
  constructing regenerates — which is the point of this PR.

Green on SQLite locally: `attribute-methods.test.ts`,
`attribute-methods.trails.test.ts`, `base.test.ts`, `attributes.test.ts`,
`inheritance.test.ts`, `attribute-methods/**`, activemodel
`attribute-methods.test.ts`. `parity:api:calls`, `parity:api:calls:args`,
`parity:api:extra:gate` all OK with no new baseline rows.

Closes-story: call-define-attribute-methods-from-init-internals