### PR TITLE
refactor(activerecord): retire callbacks.ts's duplicate beforeValidation/afterValidation free functions

### DIFF
--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -1,7 +1,6 @@
 import { underscore, pluralize, isBlank, safeConstantize } from "@blazetrails/activesupport";
 import type { AssociationInstanceHost } from "./association.js";
 import { SingularAssociation } from "./singular-association.js";
-import { beforeValidation } from "../../callbacks.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 import { pendingCounterCacheColumns } from "../../counter-cache-state.js";
 import { ActiveRecord } from "../../ar-config.js";
@@ -294,7 +293,7 @@ export class BelongsTo extends SingularAssociation {
     // `_belongsToDefaultsApplied`, so we skip here to keep the block at Rails'
     // exactly-once (belongs_to_association.rb:46-48) — re-running would invoke a
     // block that returned nil a second time.
-    beforeValidation(model, (record: any) => {
+    model.beforeValidation((record: any) => {
       if (record._belongsToDefaultsApplied) return;
       if (typeof record.association !== "function") return;
       const assoc = record.association(reflection.name);

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -11,7 +11,6 @@
 import type { Base } from "./base.js";
 import { included } from "@blazetrails/activesupport";
 import {
-  _registerCallbackOnProto,
   runAllCallbacks,
   snapshotCallbacksOnProto,
   restoreCallbacksOnProto,
@@ -29,51 +28,6 @@ import {
 } from "./attribute-methods/dirty.js";
 
 type ModelCtor = typeof Base;
-
-export type CallbackOptions<TRecord = Base> = {
-  if?: (record: TRecord) => boolean;
-  unless?: (record: TRecord) => boolean;
-  prepend?: boolean;
-};
-
-/**
- * A callback filter: a block, or — as Rails' macros take a Symbol — the NAME
- * of a method on the record, resolved against it at invocation time
- * (ActiveSupport::Callbacks::CallTemplate::MethodCall).
- */
-export type CallbackFilter<TRecord, TReturn = void | Promise<void>> =
-  | ((record: TRecord) => TReturn)
-  | string;
-
-export type ValidationCallbackOptions<TRecord = Base> = CallbackOptions<TRecord> & {
-  on?: "create" | "update" | Array<"create" | "update">;
-};
-
-/**
- * Register a before_validation callback.
- *
- * Mirrors: ActiveRecord::Callbacks.before_validation
- */
-export function beforeValidation<T extends ModelCtor>(
-  modelClass: T,
-  fn: CallbackFilter<InstanceType<T>>,
-  options?: ValidationCallbackOptions<InstanceType<T>>,
-): void {
-  registerCallback(modelClass, "before", "validation", fn, options);
-}
-
-/**
- * Register an after_validation callback.
- *
- * Mirrors: ActiveRecord::Callbacks.after_validation
- */
-export function afterValidation<T extends ModelCtor>(
-  modelClass: T,
-  fn: CallbackFilter<InstanceType<T>>,
-  options?: ValidationCallbackOptions<InstanceType<T>>,
-): void {
-  registerCallback(modelClass, "after", "validation", fn, options);
-}
 
 /**
  * Mirrors: ActiveRecord::Callbacks' `included do ... end` (callbacks.rb:412-417).
@@ -117,31 +71,6 @@ export async function resetCallbacks(
       restoreCallbacksOnProto((klass as { prototype: object }).prototype, event, snapshot);
     }
   }
-}
-
-type AnyCallbackOptions = CallbackOptions<never> | ValidationCallbackOptions<never>;
-
-function registerCallback(
-  modelClass: ModelCtor,
-  timing: "before" | "after",
-  event: string,
-  fn: ((...args: any[]) => unknown) | string,
-  options?: AnyCallbackOptions,
-): void {
-  const conditions: Record<string, unknown> = {};
-  if (options?.if) conditions.if = options.if;
-  if (options?.unless) conditions.unless = options.unless;
-  if (options?.prepend) conditions.prepend = options.prepend;
-  if (event === "validation" && "on" in (options ?? {})) {
-    conditions.on = (options as ValidationCallbackOptions<never>).on;
-  }
-  _registerCallbackOnProto(
-    (modelClass as unknown as { prototype: object }).prototype,
-    timing,
-    event,
-    fn,
-    conditions,
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`ActiveRecord::Callbacks`'s `included do` block (`activerecord/lib/active_record/callbacks.rb:413`) does `include ActiveModel::Validations::Callbacks`, whose `ClassMethods` (`activemodel/lib/active_model/validations/callbacks.rb:32-110`) is where `before_validation` / `after_validation` live — and, since #6923, where the trails port lives too, reached on `Base` through `Model`'s `extend(Model, ValidationsCallbacksClassMethods)`.

So `packages/activerecord/src/callbacks.ts`'s `beforeValidation` / `afterValidation` free functions were a second, divergent spelling of a macro that already exists at the Rails name in the Rails module — the last survivors of the group #6916 and #6923 retired. Their options shape diverged too: `registerCallback` forwarded `on:` only for `event === "validation"` and typed it `"create" | "update"`, where Rails puts no such restriction and converts through `set_options_for_callback` (`validations/callbacks.rb:99-109`).

Deleted: `beforeValidation`, `afterValidation`, `registerCallback`, and the now-orphaned `CallbackOptions` / `CallbackFilter` / `ValidationCallbackOptions` types. The one caller, `Builder::BelongsTo`'s default-block registration, now spells `model.beforeValidation(...)` — the Rails macro, as `builder/belongs_to.rb` spells it.

- `pnpm parity:api:extra --package activerecord` — `callbacks.ts` drops to 0 novel.
- `pnpm parity:api:calls` / `:args` clean, no baseline or mark changes.
- `callbacks.test.ts` (21) and `belongs-to-associations.test.ts` (154) pass.

Closes-story: retire-ar-callbacks-validation-free-functions