### PR TITLE
fix(activesupport,activerecord): withEnvTz drops the local-zone memo, as tzset does

### DIFF
--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -34,8 +34,6 @@ const FIXED_LOCAL = "2026-07-25 19:25:21.123";
 describe("InternalMetadata#currentTime", () => {
   beforeAll(() => {
     vi.stubEnv("TZ", "America/New_York");
-    // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
-    // to drop it, exactly as `tzset` does.
     resetLocalTimeZoneId();
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_INSTANT));

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -7,6 +7,7 @@ import { fixtures } from "./test-fixtures.js";
 import { NullPool } from "./connection-adapters/abstract/connection-pool.js";
 import { toSqlAndBinds } from "./connection-adapters/abstract/database-statements.js";
 import { Nodes } from "@blazetrails/arel";
+import { resetLocalTimeZoneId } from "@blazetrails/date";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
 function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
@@ -33,6 +34,9 @@ const FIXED_LOCAL = "2026-07-25 19:25:21.123";
 describe("InternalMetadata#currentTime", () => {
   beforeAll(() => {
     vi.stubEnv("TZ", "America/New_York");
+    // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
+    // to drop it, exactly as `tzset` does.
+    resetLocalTimeZoneId();
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_INSTANT));
   });
@@ -40,6 +44,7 @@ describe("InternalMetadata#currentTime", () => {
   afterAll(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    resetLocalTimeZoneId();
   });
 
   it("formats as YYYY-MM-DD HH:mm:ss.SSS with no zone designator", () => {

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { DateTime, Rational, Temporal, Time } from "@blazetrails/date";
+import { DateTime, Rational, Temporal, Time, resetLocalTimeZoneId } from "@blazetrails/date";
 import { Object as ObjectExt } from "./object/acts-like.js";
 import {
   advance,
@@ -69,10 +69,14 @@ function asDate(instant: Temporal.Instant): Date {
 
 function withEnvTz<T>(tz: string, fn: () => T): T {
   vi.stubEnv("TZ", tz);
+  // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
+  // to drop it, exactly as `tzset` does.
+  resetLocalTimeZoneId();
   try {
     return fn();
   } finally {
     vi.unstubAllEnvs();
+    resetLocalTimeZoneId();
   }
 }
 

--- a/packages/activesupport/src/core-ext/date-time-ext.test.ts
+++ b/packages/activesupport/src/core-ext/date-time-ext.test.ts
@@ -69,8 +69,6 @@ function asDate(instant: Temporal.Instant): Date {
 
 function withEnvTz<T>(tz: string, fn: () => T): T {
   vi.stubEnv("TZ", tz);
-  // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
-  // to drop it, exactly as `tzset` does.
   resetLocalTimeZoneId();
   try {
     return fn();


### PR DESCRIPTION
`date-time-ext.test.ts`'s `withEnvTz` stubbed `TZ` without dropping `Time`'s `localTimeZoneId` memo (`packages/date/src/time.ts:34-49`, MRI's `tzset` cache). The `localtime` / `getlocal` cases warmed the memo with `US/Eastern`, and every later `Time#change` then read its components in the real zone and rebuilt them through `RubyTime.local` in the stale Eastern one.

Under `TZ=UTC` (CI) that reds five `DateAndTime::Calculations` predicates — `today?`, `yesterday?` (x2), `tomorrow?` (x2). On a host already on Eastern the stub is a no-op, so the file passes locally, which is why it only failed on CI.

`time-ext.test.ts:66-92` and `string-ext.test.ts:111-120` already call `resetLocalTimeZoneId()` on both sides of the stub; this makes the two remaining TZ-stubbing tests match.

Verified: `TZ=UTC pnpm vitest run packages/activesupport/src/core-ext/date-time-ext.test.ts` fails on the baseline (5 failed) and passes with the fix.

Closes-story: red-7221c93b