### PR TITLE
refactor(activerecord): strip free-form comments from src/adapters

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -743,6 +743,7 @@ export default defineConfig(
       "packages/activerecord/src/connection-adapters/mysql2/**/*.ts",
       "packages/activerecord/src/connection-adapters/postgresql/**/*.ts",
       "packages/activerecord/src/connection-adapters/sqlite3/**/*.ts",
+      "packages/activerecord/src/adapters/**/*.ts",
     ],
     rules: {
       "blazetrails/no-freeform-comments": "error",

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -14,14 +14,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
   });
 
   describe("ActiveSchemaTest", () => {
-    // The stub-mode assertions never execute, but the `with_real_execute` block
-    // in "add index" runs real DDL against the canonical `people` table. Seed it
-    // via the fixtures framework so its lifecycle (and teardown) is owned by the
-    // canonical-schema machinery rather than a destructive create/drop here.
-    // "add index" opts out of transactional fixtures: its real addIndex/
-    // removeIndex DDL must not run while the leased connection holds a fixture
-    // transaction on `people` (MySQL DDL implicitly commits and would strand
-    // that state).
     fixtures(["people"], {
       usesTransaction: ["add index"],
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
@@ -34,9 +34,7 @@ describeIfMysqlAdapter("AbstractMySQLAdapter", () => {
     afterEach(async () => {
       try {
         await adapter.exec("DROP TABLE IF EXISTS `bind_param_items`");
-      } catch {
-        // ignore
-      }
+      } catch {}
     });
 
     it("create question marks", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -61,9 +61,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it.skipIf(isMariaDb)(
       "no automatic reconnection after timeout",
       async () => {
-        // Stays self-built: connectionLimit:1 is what pins the wait_timeout to
-        // the connection under test, and the server-side disconnect it provokes
-        // must not land on the shared leased connection.
         const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
         try {
           await singleConn.execute("SET SESSION wait_timeout=1");
@@ -77,10 +74,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       10_000,
     );
     it("successful reconnection after timeout with manual reconnect", async () => {
-      // Stays self-built: connectionLimit:1 so SET SESSION wait_timeout and the
-      // sleep share the same physical connection — otherwise a second pool
-      // connection with the default wait_timeout could be used for the later
-      // execute() — and the provoked disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
         await singleConn.execute("SET SESSION wait_timeout=1");
@@ -97,16 +90,11 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     }, 10_000);
     it("successful reconnection after timeout with verify", async () => {
-      // Stays self-built: connectionLimit:1 so the session wait_timeout applies
-      // to the same connection that active() and verifyBang() will use, and
-      // the provoked server-side disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
         await singleConn.execute("SET SESSION wait_timeout=1");
         expect(await singleConn.active()).toBe(true);
         await new Promise((r) => setTimeout(r, 2000));
-        // With connectionLimit:1 the pool has no spare slot to create a fresh
-        // connection, so getConnection() returns the dead socket and ping() fails.
         expect(await singleConn.active()).toBe(false);
         // active is false → verifyBang calls reconnectBang(). Await it (async in
         // trails, unlike Rails' synchronous verify!) before probing again.
@@ -148,7 +136,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       expect(await adapter.active()).toBe(true);
       adapter.discardBang();
       expect(await adapter.active()).toBe(false);
-      // discardBang abandons the socket without closing it; free the fd.
       socket?.destroy?.();
     });
 
@@ -157,8 +144,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const raw = adapter._clientForTest();
       expect(raw).not.toBeNull();
       const endSpy = vi.spyOn(raw as { end: () => Promise<void> }, "end");
-      // Capture the socket: discardBang abandons it (unref'd, listeners
-      // stripped) without end()ing, so destroy it directly to free the fd.
       const socket = (
         raw as unknown as {
           stream?: { destroy?: () => void };
@@ -177,7 +162,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("wait timeout as string", async () => {
-      // Stays self-built: the `waitTimeout` config key is the assertion.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, waitTimeout: "60" });
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
@@ -189,8 +173,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("wait timeout as url", async () => {
       const url = new URL(MYSQL_TEST_URL);
       url.searchParams.set("wait_timeout", "60");
-      // Stays self-built: an alternate config (wait_timeout in the URL) is the
-      // assertion.
       const testAdapter = new Mysql2Adapter(url.toString());
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
@@ -215,7 +197,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       expect(String(rows[0].v)).toMatch(/STRICT_ALL_TABLES/);
     });
     it("mysql strict mode disabled", async () => {
-      // Stays self-built: a deliberately non-strict adapter.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: false });
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.sql_mode AS v");
@@ -225,7 +206,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
     it("mysql strict mode specified default", async () => {
-      // Stays self-built: `strict: "default"` is the config under test.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: "default" });
       try {
         const globalRows = await testAdapter.execute("SELECT @@GLOBAL.sql_mode AS v");
@@ -236,8 +216,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
     it("mysql sql mode variable overrides strict mode", async () => {
-      // Stays self-built: a `variables:` override must not leak onto the shared
-      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { sql_mode: "ansi" },
@@ -274,8 +252,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
     it("mysql set session variable", async () => {
-      // Stays self-built: a `variables:` override must not leak onto the shared
-      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { default_week_format: 3 },
@@ -288,8 +264,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
     it("mysql set session variable to default", async () => {
-      // Stays self-built: a `variables:` override must not leak onto the shared
-      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { default_week_format: "default" },
@@ -419,7 +393,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("maps ER_BAD_DB_ERROR (1049) to NoDatabaseError", async () => {
-      // Stays self-built: the config names a database that does not exist.
       const a = new Mysql2Adapter("mysql://root@localhost/no_such_db");
       stubCreateConnection(makeDriverError(1049));
       try {
@@ -430,7 +403,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR (1045) to DatabaseConnectionError", async () => {
-      // Stays self-built: the config names a user that cannot authenticate.
       const a = new Mysql2Adapter({ host: "localhost", user: "baduser", database: "test" });
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -443,7 +415,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR via URI to DatabaseConnectionError with parsed username", async () => {
-      // Stays self-built: the URI carries the bad username the error must name.
       const a = new Mysql2Adapter("mysql://myuser:pw@localhost/test");
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -456,7 +427,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_CONN_HOST_ERROR (2003) to DatabaseConnectionError with hostname", async () => {
-      // Stays self-built: the URI carries the unreachable host the error must name.
       const a = new Mysql2Adapter("mysql://root@myhost.example.com/test");
       stubCreateConnection(makeDriverError(2003));
       try {
@@ -469,8 +439,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps unknown errno to ConnectionNotEstablished", async () => {
-      // Stays self-built: the stubbed createConnection is only reached by an
-      // adapter that has not connected yet — the leased one already has.
       const a = new Mysql2Adapter(MYSQL_TEST_URL);
       stubCreateConnection(makeDriverError(9999, "something went wrong"));
       try {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -33,8 +33,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         "INSERT INTO `test_bulbs` (name, color) VALUES ('Jimmy', 'blue')",
       );
 
-      // Stays self-built: "in different threads" is the test — the concurrent
-      // INSERT has to run on a connection other than the one issuing the DELETE.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const [deleteResult] = await Promise.all([

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -10,9 +10,6 @@ import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
 import { registerModel } from "../../index.js";
 
-// The outer `describeIfMysqlAdapter` beforeAll reads `Base.connection` before the
-// nested MySQLExplainTest `fixtures()` establishes it, so the handler wiring has
-// to be laid at file scope here — it is NOT redundant with the nested call.
 fixtures({}, { useTransactionalTests: false });
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
@@ -41,7 +38,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     beforeAll(async () => {
       const ver = await adapter.databaseVersion;
       const supportsAnalyze = isMariaDb && ver.compare("10.1.0") >= 0;
-      // `version <= "10.0"` expressed as `Version("10.0") >= version`.
       const supportsExplainAnalyze = isMariaDb
         ? new Version("10.0").compare(String(ver)) >= 0
         : ver.compare("6.0") >= 0;
@@ -86,14 +82,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
-    // trails-only: the ExplainRegistry → ExplainSubscriber → adapter.explain
-    // pipeline only works on MySQL if execute() emits sql.active_record.
-    // Without that, Relation#explain silently falls back to toSql() (which
-    // keeps Arel's double-quoted identifiers) rather than the payload SQL the
-    // driver saw (post-`mysqlQuote` → backticks). Asserting backticks (and the
-    // absence of double quotes) is what discriminates the two paths; a plain
-    // "contains the table name" assertion would pass either way. Uses the
-    // canonical authors/posts fixtures rather than a bespoke table.
     it("Relation#explain on MySQL captures the SELECT via sql.active_record", async () => {
       const plan = await Author.where({ id: authors("david").id }).explain();
       expect(plan).toContain("`authors`");
@@ -110,7 +98,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     // the absence of double quotes), proves the capture path was used.
     it("Relation#explain on MySQL re-executes an already-loaded relation", async () => {
       const relation = Author.where({ id: authors("david").id });
-      await relation; // prime the load cache
+      await relation;
       const plan = await relation.explain();
       expect(plan).toContain("`authors`");
       expect(plan).not.toMatch(/"authors"/);
@@ -122,10 +110,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         .preload(":posts")
         .explain();
       const blocks = plan.split("\n\n").filter((b) => /EXPLAIN/.test(b));
-      // The fallback path emits exactly one block (toSql() of the outer
-      // relation only, no preload query). Requiring ≥ 2 blocks proves the
-      // preload query was captured through sql.active_record, not substituted
-      // from toSql(). Both blocks carry backtick-quoted identifiers.
       expect(blocks.length).toBeGreaterThanOrEqual(2);
       expect(plan).toContain("`authors`");
       expect(plan).toContain("`posts`");
@@ -145,7 +129,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("buildExplainClause joins its flags space-separated", async () => {
       const clause = await adapter.buildExplainClause(["analyze", "format=json"]);
-      // MariaDB >= 10.1 drops the EXPLAIN prefix for ANALYZE (analyze_without_explain?).
       const analyzeWithoutExplain =
         isMariaDb && (await adapter.databaseVersion).compare("10.1.0") >= 0;
       expect(clause).toBe(

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -30,11 +30,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         const idxNames = (await adapter.indexes("engines")).map((i: { name: string }) => i.name);
         expect(idxNames).toEqual(["idx_renamed"]);
       } finally {
-        // This file skips the global adapter reset (handler suite), so the
-        // canonical `engines` table must be restored to its original (no-index)
-        // shape even if a step above failed partway. The FK must be dropped
-        // before the index it depends on. Cover both the pre- and post-rename
-        // index names idempotently.
         await adapter.removeForeignKey("engines", { name: "fk_engines_cars", ifExists: true });
         await adapter.removeIndex("engines", { name: "idx_renamed", ifExists: true });
         await adapter.removeIndex("engines", { name: "index_engines_on_car_id", ifExists: true });
@@ -58,7 +53,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         await adapter.dropTable(tableName, { ifExists: true });
         await internalMetadata.createTable();
         expect(await adapter.columnExists(tableName, "key")).toBeTruthy();
-        // Restore environment entry so other tests don't see a missing metadata row
         await internalMetadata.createTableAndSetFlags("test");
       });
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -11,9 +11,6 @@ import {
 import { Base } from "../../base.js";
 import { rebuildCanonicalTables } from "../../support/canonical-table-rebuild.js";
 
-// Both suites below drop/recreate canonical tables (`posts`; `students` /
-// `lessons_students` / `topics`) in the shape their assertions need, so each
-// puts them back on the leased connection before handing the worker on.
 async function restoreCanonicalTables(names: readonly string[]): Promise<void> {
   const adapter = await leaseMysqlAdapter();
   await rebuildCanonicalTables(adapter, names);
@@ -49,7 +46,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         }>;
         const col = (name: string) => cols.find((c) => c.name === name)!;
 
-        // MySQL floats are precision 0..24, MySQL doubles are precision 25..53
         expect(col("float_no_limit").limit).toBe(24);
         expect(col("float_short").limit).toBe(24);
         expect(col("float_long").limit).toBe(53);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -23,11 +23,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     adapter.preparedStatements = true;
   });
   afterEach(() => {
-    // preparedStatements is an adapter-wide setting and the statement pool
-    // itself is per-connection state, both of which now outlive a single test
-    // on the shared leased connection. Restore the setting and drop the pool
-    // (disconnectBang is reconnectable — the next query re-establishes) so each
-    // test starts from the clean slate it asserts on.
     adapter.preparedStatements = originalPreparedStatements;
     adapter.disconnectBang();
   });
@@ -68,9 +63,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("statementLimit = 0 is unsupported and raises on the first prepare", async () => {
       const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 0 });
-      // The outer beforeEach opts the *leased* adapter into prepared
-      // statements; this one is built locally and defaults to off, so without
-      // this the prepared path is never taken and the pool is never reached.
       adapter.preparedStatements = true;
       await adapter.beginDbTransaction();
       try {
@@ -103,8 +95,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("dealloc does not raise on inactive connection", async () => {
-      // Stays self-built: close() permanently kills the adapter, which would
-      // poison the leased connection for every later test in this worker.
       const closable = new Mysql2Adapter(MYSQL_TEST_URL);
       closable.preparedStatements = true;
       await closable.beginDbTransaction();
@@ -116,16 +106,12 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("reads statementLimit from the config hash (database.yml shape)", async () => {
-      // Stays self-built: reading a differently configured statementLimit off
-      // the config hash is the assertion.
       const configured = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 7 });
       expect(configured.buildStatementPool().maxSize).toBe(7);
       await configured.close();
     });
 
     it("reads preparedStatements from the config hash", async () => {
-      // Stays self-built: a differently configured preparedStatements is the
-      // assertion.
       const configured = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         preparedStatements: false,
@@ -134,8 +120,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       await configured.close();
     });
 
-    // Self-built by construction: these assert what the constructor does with
-    // a non-boolean config value.
     it("passes a non-boolean preparedStatements config through as Rails does", async () => {
       // abstract_adapter.rb:159 pipes the config through
       // `type_cast_config_to_boolean`, which maps the string `"false"` to
@@ -166,8 +150,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
         expect(adapter2.preparedStatements).toBe(true);
       } finally {
-        // mysql2 pool keeps open handles — close to avoid leaked
-        // sockets / Vitest hangs.
         await adapter2.close();
       }
     });
@@ -181,8 +163,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         expect(pool.length).toBe(2);
         adapter.clearCacheBang();
         expect(pool.length).toBe(0);
-        // Pool stays attached; counter continues so we never reissue
-        // a name that's still PREPAREd on this session post-dealloc.
         expect(adapter._statementPoolForTest()).toBe(pool);
       } finally {
         await adapter.rollback();

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -140,7 +140,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       });
       const output = await dumpTable(adapter, "mysql_table_options");
       expect(output).toMatch(/createTable\("mysql_table_options",\s*\{[^}]*charset:\s*"utf8mb4"/);
-      // Bare ENGINE=InnoDB is stripped by parseTableOptions — it must not appear in options:
       expect(output).not.toMatch(/options:\s*"ENGINE=InnoDB"(?!\s*ROW_FORMAT)/);
     });
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -3,15 +3,8 @@ import { arunitDatabaseNames } from "../../support/arunit2-config.js";
 import { mysqlSettings } from "../../support/config.js";
 import { Base } from "../../base.js";
 
-// `dbWarningsAction` is a single global setting on the base adapter, so the
-// shared helper toggles it for every adapter (including MySQL). Re-exported
-// here so MySQL adapter tests can keep importing it from this module.
 export { withDbWarningsAction } from "../../support/with-db-warnings-action.js";
 
-// The adapter gate and the live-server version probe live under `support/`
-// alongside `describe-if-pg` / `describe-if-sqlite`, so suites outside this
-// tree never import gate glue from an adapter's test-helper. Re-exported for
-// the MySQL suites that already sit here.
 export { describeIfMysqlAdapter } from "../../support/describe-if-mysql-adapter.js";
 export {
   MYSQL_TEST_URL,

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
@@ -85,11 +85,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         return Number(rows[0]["n"]);
       };
 
-      // Stays self-built: the point is an INSERT from a *different* connection
-      // being (in)visible inside this connection's transaction.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
-        // 1. Default (REPEATABLE READ): INSERT by another connection is not visible
         await adapter.transaction(async () => {
           await adapter.materializeTransactions();
           await assertNoDifference(sampleCount, null, () =>
@@ -97,7 +94,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           );
         });
 
-        // 2. READ COMMITTED: INSERT by another connection is visible mid-transaction
         await adapter.transaction({ isolation: "read_committed" }, async () => {
           await adapter.materializeTransactions();
           await assertDifference(sampleCount, +1, null, () =>
@@ -105,7 +101,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           );
         });
 
-        // 3. Retry preserves isolation: fail the first BEGIN, verify READ COMMITTED survives the retry
         let firstBeginFailed = false;
         const origInternalExecute = (adapter as any).internalExecute.bind(adapter);
         (adapter as any).internalExecute = async (sql: string, ...args: any[]) => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -32,14 +32,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       static _tableName = "unsigned_types";
     }
     UnsignedType.adapter = adapter;
-    // Reflect the real columns (PK included) up front so the post-INSERT
-    // write-back (`_performInsert` → `_writeAttribute("id", insertedId)`)
-    // targets a reflected `id` attribute under strict `writeFromUser`, without
-    // the internal-write bridge. Explicit warming (as in mysql-boolean's
-    // `BooleanType.loadSchema()`) keeps the reflected `unsigned` metadata the
-    // range-check assertions rely on — declaring `id` via `attribute()` would
-    // instead suppress DB reflection (ensureSchemaLoaded bails on a concrete
-    // user attr), hiding the unsigned columns.
     await UnsignedType.loadSchema();
     return UnsignedType;
   }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
@@ -65,9 +65,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("schema dumping", async () => {
       const output = await SchemaDumper.dumpTableSchema(adapter as any, "virtual_columns");
-      // A non-stored generated column dumps without `stored: true`; a STORED one with it.
-      // Function casing/backtick follow MySQL's normalized GENERATION_EXPRESSION (UPPER→upper,
-      // OCTET_LENGTH→length); the JSON-path single quotes round-trip after the `\'`→`'` unescape.
       expect(output).toMatch(
         /t\.virtual\("upper_name", \{ type: "string", as: "(?:upper|ucase)\(`?name`?\)" \}\);/i,
       );

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -106,7 +106,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("db_warnings_action handles when warning_count does not match returned warnings", async () => {
       await withDbWarningsAction("raise", async () => {
-        // Force warning_count to 1 even though SHOW WARNINGS will return [].
         vi.spyOn(
           adapter as unknown as { warningCount: () => Promise<number> },
           "warningCount",

--- a/packages/activerecord/src/adapters/index.ts
+++ b/packages/activerecord/src/adapters/index.ts
@@ -1,9 +1,3 @@
-// Only the abstract base is re-exported here: it pulls in no client library, so
-// importing this barrel never eagerly loads an optional SQLite driver. The
-// concrete, driver-bound subclasses (BetterSQLite3Adapter / NodeSQLiteAdapter /
-// ExpoSQLiteAdapter) are reachable via their own
-// `./connection-adapters/<x>-adapter.js` export entries, which is where the
-// optional `better-sqlite3` / `expo-sqlite` peer dep actually gets loaded.
 export { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 export { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 export { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -9,8 +9,6 @@ import {
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   const type = new BigIntegerType({ limit: 8 });
-  // 2^62 — 19 digits, well above the 15-digit threshold where mysql2
-  // switches from number to string with supportBigNumbers:true.
   const BIG = 2n ** 62n;
 
   beforeEach(async () => {
@@ -31,11 +29,9 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
   describe("MySQL bigint round-trip", () => {
     it("preserves exact value above Number.MAX_SAFE_INTEGER via BigIntegerType", async () => {
-      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2 (16 digits)
+      const unsafe = 9007199254740993n;
       await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [unsafe]);
       const rows = await adapter.execute(`SELECT \`score\` FROM \`bigint_rt\``);
-      // mysql2 supportBigNumbers:true returns string for values that can't be
-      // represented exactly as a JS number — BigIntegerType.cast handles both.
       expect(type.cast(rows[0].score)).toBe(unsafe);
     });
 
@@ -49,7 +45,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("safe-range BIGINT returns as number (auto-increment IDs unaffected)", async () => {
       await adapter.executeMutation(`INSERT INTO \`bigint_rt\` (\`score\`) VALUES (?)`, [42]);
       const rows = await adapter.execute(`SELECT \`id\`, \`score\` FROM \`bigint_rt\``);
-      // Small BIGINT values (< 10^15) stay as JS number — existing code unaffected.
       expect(typeof rows[0].id).toBe("number");
       expect(typeof rows[0].score).toBe("number");
     });

--- a/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
@@ -30,8 +30,6 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       expect(checkConstraints.length).toBe(1);
 
       const expression = checkConstraints[0].expression;
-      // MariaDB stores the expression unescaped; MySQL prefixes the string
-      // literal with its connection charset introducer (_utf8mb4).
       const expected = isMariaDb
         ? "`name` <> 'forbidden_string'"
         : "`name` <> _utf8mb4'forbidden_string'";

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -37,8 +37,6 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   });
 
   it("execute runs a non-row-returning statement and returns no rows", async () => {
-    // mysql2 returns a ResultSetHeader (no rows array) for DDL and a bare
-    // INSERT, so both flow through the public `execute` and come back as [].
     await expect(adapter.execute(`CREATE TABLE pq_ddl (id integer)`)).resolves.toEqual([]);
     await adapter.execute(`DROP TABLE pq_ddl`);
     await expect(adapter.execute(`INSERT INTO pq (nick) VALUES ('a')`)).resolves.toEqual([]);
@@ -54,16 +52,12 @@ describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('c')`);
 
-    // The count comes from _affectedRowsBeforeWarnings, recorded by
-    // perform_query and read back via the affectedRows port.
     expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z' WHERE nick <> 'a'`)).toBe(2);
     expect(await adapter.executeMutation(`UPDATE pq SET nick = 'y' WHERE nick = 'nope'`)).toBe(0);
     expect(await adapter.executeMutation(`DELETE FROM pq`)).toBe(3);
   });
 
   it("executeMutation returns the driver insert id for a bare INSERT", async () => {
-    // MySQL 8 has no INSERT ... RETURNING; the id comes from the driver's
-    // insertId on the ResultSetHeader.
     const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
     expect(id).toBe(1);
     const second = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -47,9 +47,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     adapter = await leaseMysqlAdapter();
   });
   afterEach(() => {
-    // Restore any console / logger spies installed by the warning-handler
-    // tests so a throw before the inner mockRestore() can't leak the stub
-    // into subsequent suites.
     vi.restoreAllMocks();
   });
 
@@ -178,11 +175,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     }
   });
 
-  // The FK type-mismatch tests ride the canonical tables (engines, old_cars —
-  // integer PK, cars — bigint PK, subscribers — varchar `nick`, people —
-  // bigint PK). rebuildCanonicalTables restores each to its canonical shape;
-  // FK checks are disabled for the pre-drop so a leftover engines→people FK
-  // (from the multiple-fks test) can't block dropping its parent table.
   beforeEach(async () => {
     await adapter.executeMutation("SET FOREIGN_KEY_CHECKS=0");
     for (const t of ["foos", "engines", "old_cars", "cars", "subscribers", "people"]) {
@@ -197,8 +189,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   });
 
   it("errors for bigint fks on integer pk table in alter table", async () => {
-    // add_reference defaults old_car_id to :bigint; old_cars.id is INT — the
-    // add_foreign_key then trips the type mismatch.
     const error = await adapter
       .addReference("engines", "old_car")
       .then(() => adapter.addForeignKey("engines", "old_cars"))
@@ -222,9 +212,7 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     "errors for multiple fks on mismatched types for pk table in alter table",
     async () => {
       const error = await adapter
-        // Add a matching FK first (person_id is :bigint, people.id is bigint).
         .addReference("engines", "person", { foreignKey: true })
-        // Then the mismatched one: old_car_id is :bigint but old_cars.id is INT.
         .then(() => adapter.addReference("engines", "old_car", { foreignKey: true }))
         .then(() => null)
         .catch((e) => e);
@@ -240,7 +228,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   );
 
   it("errors for bigint fks on integer pk table in create table", async () => {
-    // foos.old_car_id is BIGINT but old_cars.id is INT
     const error = await adapter
       .executeMutation(
         `
@@ -268,7 +255,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   });
 
   it("errors for integer fks on bigint pk table in create table", async () => {
-    // foos.car_id is INT but cars.id is BIGINT
     const error = await adapter
       .executeMutation(
         `
@@ -296,7 +282,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   });
 
   it("errors for bigint fks on string pk table in create table", async () => {
-    // foos.subscriber_id is BIGINT but subscribers.nick is VARCHAR
     const error = await adapter
       .executeMutation(
         `
@@ -342,7 +327,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   });
 
   it("statement timeout error codes", () => {
-    // ER_QUERY_TIMEOUT and ER_FILSORT_ABORT both map to StatementTimeout.
     for (const errno of [
       AbstractMysqlAdapter.ER_QUERY_TIMEOUT,
       AbstractMysqlAdapter.ER_FILSORT_ABORT,
@@ -387,16 +371,12 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
       await adapter.executeMutation(`INSERT INTO warn_posts (title) VALUES ('Title')`);
       vi.spyOn(console, "warn").mockImplementation(() => {});
       await withDbWarningsAction("log", async () => {
-        // `id > (0+'foo')` triggers a "Truncated incorrect DOUBLE value" warning;
-        // under db_warnings_action=:log that warning is logged, not raised, and
-        // must not corrupt the affected-row count returned by executeMutation.
         const affected = await adapter.executeMutation(
           `UPDATE warn_posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1`,
         );
         expect(affected).toBe(1);
       });
     } finally {
-      // Restore on the still-pinned connection before rollback releases it.
       await adapter.executeMutation(`SET SESSION sql_mode='${oldSqlMode}'`).catch(() => {});
       await adapter.rollback().catch(() => {});
       await adapter.executeMutation(`DROP TABLE IF EXISTS warn_posts`).catch(() => {});

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -35,10 +35,6 @@ import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-a
 import { rebuildCanonicalTables } from "../../support/canonical-table-rebuild.js";
 import { Result } from "../../result.js";
 
-// Fabricated-error translate_exception checks. These don't touch a live
-// MySQL server (they feed Object.assign(new Error(...), { errno/code })
-// straight into translateException), so they live outside describeIfMysqlAdapter
-// to keep coverage on dev machines without MySQL installed.
 describe("Mysql2Adapter#translateException (fabricated errors)", () => {
   let adapter: Mysql2Adapter;
   beforeEach(() => {
@@ -55,8 +51,6 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
     // touching a real DB, preserving the `active ⟹ isConnected` invariant.
     expect(await adapter.active()).toBe(false);
     expect(adapter.isConnected()).toBe(false);
-    // Stays self-built: a *never-connected* adapter is exactly what this
-    // asserts on — the leased connection is live by construction.
     const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
     expect(await fresh.active()).toBe(false);
     expect(fresh.isConnected()).toBe(false);
@@ -159,13 +153,10 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
   // it has no never-connected window to cover; this guards trails' lazy-connect.
   describe("#active sync getter reflects connection state", () => {
     it("is false before any connection and true after the first query", async () => {
-      // Stays self-built: the never-connected → connected → disconnected walk
-      // is the assertion, and disconnectBang() must not hit the leased pool.
       const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         expect(await fresh.active()).toBe(false);
         expect(fresh.isConnected()).toBe(false);
-        // First query still connects lazily (verifyBang's _ensureClient net).
         await fresh.execQuery("SELECT 1");
         expect(await fresh.active()).toBe(true);
         expect(fresh.isConnected()).toBe(true);
@@ -223,14 +214,6 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
     });
 
     it("translates ER_DATA_TOO_LONG to ValueTooLong", async () => {
-      // sql_mode is session-scoped, and our mysql2-adapter's pool checks
-      // out / releases a connection per call — so a plain SET SESSION
-      // wouldn't carry over to the CREATE + INSERT below. Pin a single
-      // pool connection via beginTransaction so all three statements
-      // run on the same session. (DDL in MySQL auto-commits, so the
-      // table persists even though we roll back the transaction.)
-      // Session variables aren't transactional, so rollback() won't revert the
-      // SET SESSION below — capture and restore sql_mode explicitly.
       const oldSqlMode = await adapter.queryValue("SELECT @@SESSION.sql_mode");
       await adapter.beginTransaction();
       try {

--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -21,8 +21,6 @@ import {
 } from "../abstract-mysql-adapter/test-helper.js";
 import { ConnectionFailed } from "../../errors.js";
 
-// The retry-loop seams `withRawConnection` drives are not on the public adapter
-// surface; narrow to just the two the fault injection needs.
 interface RetryLoopSeams {
   reconnect(): void | Promise<void>;
   rawConnectionForBlock(): Promise<unknown>;
@@ -32,10 +30,6 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
   let adapter: Mysql2Adapter;
 
   beforeEach(() => {
-    // Stays self-built: the tests fault `rawConnectionForBlock` so
-    // `withRawConnection` genuinely tears down and re-establishes this adapter's
-    // socket mid-transaction. Driving that against the shared leased connection
-    // would leave the pool reconnecting under later tests in the same worker.
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
   });
   afterEach(async () => {
@@ -46,8 +40,6 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
   it("createSavepoint dirties the current (parent) transaction frame", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
-      // BEGIN is emitted with materializeTransactions:false, so the frame is
-      // materialized but clean.
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
       await adapter.createSavepoint("sp1");
@@ -72,29 +64,18 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
     });
   });
 
-  // The savepoint statement is issued through the retry-enabled `internalExecute`
-  // leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
-  // engages — createSavepoint/rollbackToSavepoint pass allowRetry:false, but they
-  // share the exact same `internalExecute` finally under test here. A SAVEPOINT
-  // (not RELEASE/ROLLBACK) is retried because the outer BEGIN is still clean, so
-  // reconnect restores it and the retry lands on a live transaction.
   it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
 
-      // Fault the first raw connection acquisition per op with a retryable
-      // ConnectionFailed, so `withRawConnection` reconnects (restoring the
-      // still-clean outer BEGIN) and retries the SAVEPOINT.
       const seams = adapter as unknown as RetryLoopSeams;
       const reconnect = vi.spyOn(seams, "reconnect");
       const rawForBlock = vi
         .spyOn(seams, "rawConnectionForBlock")
         .mockRejectedValueOnce(new ConnectionFailed("Lost connection to MySQL server"));
 
-      // materialize:false — the withRawConnection loop's own (suppressed) finally
-      // must NOT dirty the parent on the reconnect path.
       await adapter.internalExecute("SAVEPOINT `sp_clean`", "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
@@ -102,8 +83,6 @@ describeIfMysqlAdapter("Mysql2Adapter savepoint statements dirty the parent (tra
       expect(reconnect).toHaveBeenCalledTimes(1);
       expect(tm.isRestorable()).toBe(true);
 
-      // materialize:true (the savepoint default) — the relocated internalExecute
-      // finally dirties the parent on the very same reconnect path.
       rawForBlock.mockRejectedValueOnce(new ConnectionFailed("Lost connection to MySQL server"));
       await adapter.internalExecute("SAVEPOINT `sp_dirty`", "TRANSACTION", [], {
         allowRetry: true,

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -28,8 +28,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQLActiveSchemaTest", () => {
-    // `add_index_options` introspects the canonical `people` table when a bare
-    // column name is passed as `:where`; seed it through the fixtures framework.
     fixtures(["people"]);
 
     it("create database with encoding", async () => {

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -95,7 +95,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArraySerialized extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -117,7 +116,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -141,7 +139,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -159,16 +156,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("schema dump with shorthand", async () => {
       const output = await SchemaDumper.dumpTableSchema(adapter, "pg_arrays");
-      // TS migration format: t.type("name", { opts })
       expect(output).toMatch(/t\.string\("tags",/);
       expect(output).toMatch(/limit: 255/);
       expect(output).toMatch(/t\.integer\("ratings",/);
-      // decimals column: checks presence of each option (order-independent)
       expect(output).toMatch(/t\.decimal\("decimals",/);
       expect(output).toMatch(/precision: 10/);
       expect(output).toMatch(/scale: 2/);
       expect(output).toMatch(/default: \[\]/);
-      // all array columns must carry array: true
       const lines = output.split("\n");
       const tagsLine = lines.find((l) => l.includes('"tags"'))!;
       const ratingsLine = lines.find((l) => l.includes('"ratings"'))!;
@@ -178,10 +172,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(decimalsLine).toMatch(/array: true/);
     });
     it("schema dump renders non-empty array defaults via the element type", async () => {
-      // Regression: newColumnFromField stores the raw PG array literal, so the
-      // dumper must run each element through the element cast type's
-      // deserialize + typeCastForSchema (integers bare, booleans true/false from
-      // PG's t/f, decimals quoted) rather than emitting raw strings.
       await adapter.exec(`DROP TABLE IF EXISTS pg_array_defaults`);
       await adapter.exec(`
         CREATE TABLE pg_array_defaults (
@@ -246,7 +236,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -322,7 +311,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -343,7 +331,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -403,7 +390,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -416,7 +402,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -431,7 +416,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -502,7 +486,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -526,7 +509,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           static tableName = "pg_arrays";
           static timeZoneAwareAttributes = true;
           static {
-            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "integer");
           }
         }
@@ -554,7 +536,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -571,7 +552,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -588,7 +568,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -606,7 +585,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -628,7 +606,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
           this.validatesUniqueness("tags");
         }
@@ -661,7 +638,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }
@@ -688,11 +664,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   // `PostgresqlArrayTest` → Rails parity:test mapping.
   describe("array datetime inline-quoting (trails)", () => {
     it("inlines a proleptic-year datetime[] element as a quoted_date BC literal", async () => {
-      // Regression guard for the inline INSERT path (base.ts create → adapter
-      // `quote` → encode_array → type_cast → quoted_date). A proleptic year <= 0
-      // only round-trips through the " BC" literal; the pre-fix ISO fallthrough
-      // (`{-000042-03-15T...Z}`) is not valid PG array input, so this pins the
-      // routing rather than a form PG happens to also accept (ISO datetimes do).
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
@@ -700,7 +671,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
       }
       await PgArrays.loadSchema();
-      // Temporal proleptic year -42 == 43 BC.
       const bc = Temporal.Instant.from("-000042-03-15T12:34:56.123456Z");
       const record = await (PgArrays as any).create({ datetimes: [bc] });
       await record.reload();

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -14,7 +14,6 @@ import { Column as PgColumn } from "../../connection-adapters/postgresql/column.
 class ByteaDataType extends Base {
   static {
     this.tableName = "bytea_data_type";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }
@@ -196,8 +195,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: obj.reload; assert_equal "hello world", obj.serialized
       await obj.reload();
       expect(obj.serialized).toBe("hello world");
-      // Non-ASCII: TextEncoder encodes as UTF-8 multi-byte; the bridge must
-      // decode as UTF-8 (not latin1) to recover the original string.
       obj.serialized = "héllo";
       await obj.saveBang();
       await obj.reload();

--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -15,7 +15,6 @@ import type { Column as PgColumn } from "../../connection-adapters/postgresql/co
 class Citext extends Base {
   static {
     this.tableName = "citexts";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
   declare cival: string;
@@ -73,7 +72,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       } finally {
         void Citext.resetColumnInformation();
       }
-      // Verify the rollback: "username" column must not exist after rollback
       const colsAfter = await connection.columns("citexts");
       expect(colsAfter.find((c) => c.name === "username")).toBeUndefined();
     });

--- a/packages/activerecord/src/adapters/postgresql/composite.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/composite.test.ts
@@ -12,7 +12,6 @@ import { ValueType } from "@blazetrails/activemodel";
 class PostgresqlComposite extends Base {
   static {
     this.tableName = "postgresql_composites";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -184,7 +184,6 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("set session variable nil", async () => {
-    // null means skip SET — value stays at server default, same as a connection with no variables config.
     const baseline = await adapter.execQuery("SHOW DEBUG_PRINT_PLAN");
     const a = new PostgreSQLAdapter({
       connectionString: PG_TEST_URL,
@@ -199,7 +198,6 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("set session variable default", async () => {
-    // "default" issues SET SESSION key TO DEFAULT — resets to compile default, same as no config.
     const baseline = await adapter.execQuery("SHOW DEBUG_PRINT_PLAN");
     const a = new PostgreSQLAdapter({
       connectionString: PG_TEST_URL,
@@ -263,7 +261,6 @@ describeIfPg("PostgresqlConnectionTest", () => {
 
   it("disconnectBang closes the persistent connection", async () => {
     const a = new PostgreSQLAdapter(PG_TEST_URL);
-    // Force lazy connect so we exercise the close path.
     await a.execute("SELECT 1");
     const conn = a._rawConnectionForTest();
     try {
@@ -273,8 +270,6 @@ describeIfPg("PostgresqlConnectionTest", () => {
       expect(await a.active()).toBe(false);
       expect(a.isConnected()).toBe(false);
     } finally {
-      // disconnectBang fires conn.end() fire-and-forget; await it here
-      // so the test exits cleanly without leaving an open socket.
       await conn?.end().catch(() => {});
     }
   });
@@ -284,9 +279,6 @@ describeIfPg("PostgresqlConnectionTest", () => {
     await a.execute("SELECT 1");
     const conn = a._rawConnectionForTest();
     const endSpy = conn ? vi.spyOn(conn, "end") : null;
-    // Grab the underlying socket up front: after discardBang abandons it
-    // (listeners stripped, unref'd) the client can no longer be cleanly
-    // end()ed, so the test destroys the raw socket directly to free the fd.
     const socket = (conn as unknown as { connection?: { stream?: { destroy?: () => void } } })
       ?.connection?.stream;
     try {

--- a/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
@@ -72,7 +72,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: create_table(TABLE_NAME, temporary: true) — must not produce TEMPORARY UNLOGGED
       PostgreSQLAdapter.createUnloggedTables = true;
       await connection.createTable(TABLE_NAME, { temporary: true }, () => {});
-      // Temporary tables are already unlogged (relpersistence = 't')
       const rows = (await connection.execute(LOGGED_QUERY)) as Array<Record<string, string>>;
       expect(rows[0]["relpersistence"]).toBe(TEMPORARY);
     });

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -24,8 +24,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
   });
   afterAll(async () => {
-    // `ex` is created in-test and rolled back by withTransactionalFixtures;
-    // this static IF EXISTS drop balances require-table-teardown.
     await adapter.exec(`DROP TABLE IF EXISTS ex CASCADE`);
     await adapter.close();
   });
@@ -46,7 +44,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_times";
       static {
         this.adapter = a;
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
         this.attribute("time_interval", "string");
         this.attribute("scaled_time_interval", "interval");
@@ -70,7 +67,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_oids";
       static {
         this.adapter = a;
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
       }
     }
@@ -87,7 +83,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const first = await (M as any).find(1);
       expect((M as any).columnForAttribute("time_interval").type).toBe("interval");
       expect((M as any).columnForAttribute("scaled_time_interval").type).toBe("interval");
-      // Touch the loaded record so the find is exercised end-to-end.
       expect(first).toBeDefined();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/deferred-constraints.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/deferred-constraints.test.ts
@@ -33,7 +33,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           // INSERT must succeed — FK is deferred (mirrors Rails assert_nothing_raised).
           // If it throws the error propagates through finally and the test fails correctly.
           await adapter.execute(`INSERT INTO dc_ch (par_id) VALUES (-1)`);
-          // set_constraints(:immediate) triggers the deferred FK check → raises.
           await expect(adapter.setConstraints("immediate")).rejects.toThrow(InvalidForeignKey);
         } finally {
           await adapter.rollback().catch(() => {});
@@ -61,7 +60,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           await adapter.setConstraints("deferred", fkName);
           // INSERT must succeed (mirrors Rails assert_nothing_raised).
           await adapter.execute(`INSERT INTO dc_ch (par_id) VALUES (-1)`);
-          // set_constraints(:immediate, @fk) triggers FK check → raises.
           await expect(adapter.setConstraints("immediate", fkName)).rejects.toThrow(
             InvalidForeignKey,
           );
@@ -99,7 +97,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           await adapter.setConstraints("deferred", "dc_m_fk1", "dc_m_fk2");
           // INSERT must succeed (mirrors Rails assert_nothing_raised).
           await adapter.execute(`INSERT INTO dc_m_ch (p1_id, p2_id) VALUES (-1, -1)`);
-          // set_constraints(:immediate, ...) triggers FK checks → raises.
           await expect(adapter.setConstraints("immediate", "dc_m_fk1", "dc_m_fk2")).rejects.toThrow(
             InvalidForeignKey,
           );
@@ -130,17 +127,14 @@ describeIfPg("PostgreSQLAdapter", () => {
           name: "dc_s_fk1",
           deferrable: "immediate",
         });
-        // FK2 is deferrable — can be set to deferred.
         await adapter.addForeignKey("dc_s_ch", "dc_s_p2", {
           column: "p2_id",
           name: "dc_s_fk2",
           deferrable: "immediate",
         });
-        // Defer only fk2; fk1 (deferrable, not listed) stays at INITIALLY IMMEDIATE.
         await adapter.beginTransaction();
         try {
           await adapter.setConstraints("deferred", "dc_s_fk2");
-          // fk1 is deferrable but not listed — stays INITIALLY IMMEDIATE → raises immediately.
           await expect(
             adapter.execute(`INSERT INTO dc_s_ch (p1_id, p2_id) VALUES (-1, -1)`),
           ).rejects.toThrow(InvalidForeignKey);

--- a/packages/activerecord/src/adapters/postgresql/domain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/domain.test.ts
@@ -13,7 +13,6 @@ import { Column as PgColumn } from "../../connection-adapters/postgresql/column.
 class PostgresqlDomain extends Base {
   static {
     this.tableName = "postgresql_domains";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -14,7 +14,6 @@ import type { Table as PgTable } from "../../connection-adapters/postgresql/sche
 class PostgresqlEnum extends Base {
   static {
     this.tableName = "postgresql_enums";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
     this.enum(
       "current_mood",
@@ -76,8 +75,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS "postgresql_enums" CASCADE`);
-    // Schema-scoped tables created in-test are torn down with their temp schema;
-    // these static IF EXISTS drops balance require-table-teardown by name.
     await adapter.exec(
       `DROP TABLE IF EXISTS postgresql_enums_in_other_schema, test_schema, postgresql_enums_in_test_schema CASCADE`,
     );
@@ -85,7 +82,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.exec(`DROP TYPE IF EXISTS "feeling" CASCADE`);
     await adapter.exec(`DROP TYPE IF EXISTS "unused" CASCADE`);
     await adapter.exec(`DROP TYPE IF EXISTS "color" CASCADE`);
-    // test_schema is managed by withTestSchema — no DROP here
     await adapter.setSchemaSearchPath(defaultSearchPath);
     adapter.internalSchemaCache?.clear();
     void PostgresqlEnum.resetColumnInformation();
@@ -121,9 +117,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("enum mapping", async () => {
       await adapter.exec(`INSERT INTO "postgresql_enums" VALUES (1, 'sad')`);
       const enumRecord = await PostgresqlEnum.first();
-      // prefer enumRecord.current_mood when string-enum getter is ported (enum.ts:509)
       expect((enumRecord as any).readAttribute("current_mood")).toBe("sad");
-      // prefer enumRecord.current_mood = "happy" when string-enum setter is ported
       (enumRecord as any).writeAttribute("current_mood", "happy");
       const saved = await enumRecord!.save();
       expect(saved).toBeTruthy();
@@ -297,10 +291,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    // `SchemaDumper.dump` walks every table on the search_path. On the shared
-    // worker DB (hundreds of accumulated tables under parallel forks) a full
-    // dump legitimately runs past the 5s default and the abort would leak this
-    // test's `test_schema` search_path into the next test — so allow more time.
     it("schema dump scoped to schemas", { timeout: 60_000 }, async () => {
       await adapter.dropSchema("other_schema", { ifExists: true });
       await adapter.createSchema("other_schema");
@@ -339,9 +329,6 @@ describeIfPg("PostgreSQLAdapter", () => {
             await Schema.define(adapter, async (schema) => {
               await schema.createEnum("mood_in_test_schema", ["sad", "ok", "happy"]);
               await schema.createEnum("public.mood", ["sad", "ok", "happy"]);
-              // Torn down by `dropSchema("test_schema", {})` in the outer
-              // finally — the table lives in the non-default schema; the
-              // suite afterEach also drops it by name for the lint rule.
               await schema.createTable(
                 "postgresql_enums_in_test_schema",
                 { force: "cascade" },

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -14,9 +14,6 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// EXPLAIN tests build their own ad-hoc `ex_*` tables via raw DDL. The outer
-// transaction wrapping each test rolls back those tables (PG DDL is
-// transactional).
 fixtures([]);
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -25,9 +22,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = Base.connection as PostgreSQLAdapter;
   });
   afterAll(async () => {
-    // The `ex_*`/`op_*` tables are built in-test and rolled back by the
-    // transactional fixtures; this static IF EXISTS drop balances
-    // require-table-teardown by name.
     await adapter.exec(
       `DROP TABLE IF EXISTS ex_relations, ex_authors, ex_books, ex_explain, op_authors, op_posts CASCADE`,
     );
@@ -39,11 +33,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("Relation#explain on PG captures the SELECT via sql.active_record", async () => {
-      // End-to-end check: the whole ExplainRegistry + ExplainSubscriber
-      // pipeline only works on PG if `execQuery` (the real SELECT path)
-      // emits `sql.active_record`. Without that, `Relation#explain`
-      // silently falls back to `toSql()` and reports zero collected
-      // queries.
       class ExRelation extends Base {
         static {
           this.attribute("id", "integer");
@@ -97,7 +86,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`CREATE TABLE "ex_explain" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
       await adapter.executeMutation(`INSERT INTO "ex_explain" ("name") VALUES ('test')`);
       const result = await adapter.explain(`SELECT * FROM "ex_explain"`);
-      // Plan output varies but should contain the table name
       expect(result).toContain("ex_explain");
     });
 
@@ -118,12 +106,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("explain executes with FORMAT JSON and returns JSON plan", async () => {
       const result = await adapter.explain("SELECT 1", [], ["FORMAT JSON"]);
-      // The prior stringifier rendered pg-auto-parsed plans as "[object Object]".
       expect(result).not.toContain("[object Object]");
       // Rails wraps JSON output in the "QUERY PLAN" header block; JSON.parse(result) would fail.
       expect(result).toContain("QUERY PLAN");
-      // Extract the JSON array from within the pp() block (pp() adds one leading space per line),
-      // strip that indent, then parse to confirm the full JSON pipeline is intact.
       const jsonMatch = result.match(/\[[\s\S]*\]/);
       expect(jsonMatch).not.toBeNull();
       const parsed = JSON.parse(jsonMatch![0].replace(/^ /gm, "")) as unknown[];

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -69,10 +69,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(true);
       const dump = (await adapter.createSchemaDumper(adapter).dump()).join("\n");
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
-      // A full PG schema dump under 6-fork parallel load legitimately exceeds
-      // vitest's 5s default (I/O contention, not a logic bug). Bump to 60s,
-      // matching the sibling dump tests in schema-dumper.trails.test.ts. See
-      // project_schema_dumper_trails_pg_schema_migrations_flake.
     }, 60000);
     it("enable extension migration ignores prefix and suffix", async () => {
       // Rails: table_name_prefix/suffix don't affect extension names
@@ -96,7 +92,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const m = new EnableCitext();
       await m.execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
-      // Down must strip schema and call DROP EXTENSION IF EXISTS "citext" (not "public.citext")
       await m.execMigration(adapter, "down");
       expect(await adapter.extensionEnabled("citext")).toBe(false);
     });

--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -108,9 +108,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     itIfSupports("foreign_tables", "does not have a primary key", async () => {
-      // loadSchema warms the schema cache's primary-key entry; a foreign table
-      // has no PK constraint, so introspection yields null and primary_key
-      // resolves to null rather than the "id" convention.
       await ForeignProfessor.loadSchema();
       expect(ForeignProfessor.primaryKey).toBeNull();
     });

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -29,7 +29,6 @@ class TagCollection {
 class Hstore extends Base {
   static {
     this.tableName = "hstores";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
     this.storeAccessor("settings", { accessors: ["language", "timezone"] });
   }

--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -42,7 +42,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_infinities";
       static {
         this.adapter = a;
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
       }
     }
@@ -131,7 +130,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           static timeZoneAwareAttributes = true;
           static {
             this.adapter = a;
-            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "integer");
           }
         }
@@ -151,7 +149,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         // has no BigDecimal type; `Number.POSITIVE_INFINITY` (covered above) is the
         // only infinity literal, so that input-type variant has no TS counterpart.
       } finally {
-        // setting time_zone_aware_attributes causes the types to change.
         setZone(null);
       }
     });

--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -49,15 +49,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("integer types", async () => {
-      // Verify that int2, int4, and int8 columns all come back through
-      // the pg driver as numbers, int8 narrowing to a bigint past the
-      // safe-integer range.
       await adapter.executeMutation(`INSERT INTO "pg_int_types" DEFAULT VALUES`);
       const rows = await adapter.execute(`SELECT * FROM "pg_int_types"`);
       expect(typeof rows[0].small).toBe("number");
       expect(typeof rows[0].medium).toBe("number");
-      // The default is one past Number.MAX_SAFE_INTEGER, so the connection's
-      // int8 parser keeps it a bigint rather than truncating it onto a float.
       expect(typeof rows[0].big).toBe("bigint");
       expect(rows[0].big).toBe(9007199254740993n);
     });
@@ -74,7 +69,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQL bigint round-trip", () => {
-    const BIG = 2n ** 62n; // well above Number.MAX_SAFE_INTEGER
+    const BIG = 2n ** 62n;
 
     beforeEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "bigint_rt"`);
@@ -91,7 +86,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
-      const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
+      const unsafe = 9007199254740993n;
       await adapter.executeMutation(`INSERT INTO "bigint_rt" ("score") VALUES ($1)`, [unsafe]);
       const rows = await adapter.execute(`SELECT "score" FROM "bigint_rt"`);
       const type = new BigIntegerType({ limit: 8 });

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -14,7 +14,6 @@ import { Column as PostgreSQLColumn } from "../../connection-adapters/postgresql
 class IntervalDataType extends Base {
   static {
     this.tableName = "interval_data_types";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
     this.attribute("legacy_term", "string");
   }

--- a/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/invertible-migration.test.ts
@@ -70,15 +70,12 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       const m = new CreateEnumMig();
       await m.execMigration(adapter, "up");
-      // Add an actual enum-typed column so reversal must drop the table before
-      // dropping the enum type (otherwise DROP TYPE fails with dependency error)
       await adapter.execute(
         `ALTER TABLE enums ADD COLUMN best_color color NOT NULL DEFAULT 'blue'`,
       );
       const enumsBefore = await adapter.enumTypes();
       expect(enumsBefore.some(([name]) => name === "color")).toBe(true);
 
-      // Down: drops table first (containing enum column), then drops enum type
       await m.execMigration(adapter, "down");
       const enumsAfter = await adapter.enumTypes();
       expect(enumsAfter.some(([name]) => name === "color")).toBe(false);

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -41,7 +41,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       ]);
       const rows = await adapter.execute(`SELECT "settings" FROM "json_test"`);
       expect(rows).toHaveLength(1);
-      // adapter.execute returns raw strings for json/jsonb — Json#deserialize owns parsing
       expect(JSON.parse(rows[0].settings as string)).toEqual(obj);
     });
 
@@ -88,7 +87,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         class JsonStringCast extends Base {
           static {
             this.tableName = "json_string_cast";
-            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "integer");
           }
         }

--- a/packages/activerecord/src/adapters/postgresql/ltree.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/ltree.test.ts
@@ -14,7 +14,6 @@ import type { TableDefinition as PgTableDefinition } from "../../connection-adap
 class Ltree extends Base {
   static {
     this.tableName = "ltrees";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
   declare path: string;

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -16,7 +16,6 @@ import type { Column as PgColumn } from "../../connection-adapters/postgresql/co
 class PostgresqlMoney extends Base {
   static {
     this.tableName = "postgresql_moneys";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
     this.validates("depth", { numericality: true });
   }

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -13,7 +13,6 @@ import type { TableDefinition as PgTableDefinition } from "../../connection-adap
 class PostgresqlNetworkAddress extends Base {
   static {
     this.tableName = "postgresql_network_addresses";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -10,7 +10,6 @@ import { Base } from "../../index.js";
 class PostgresqlNumber extends Base {
   static {
     this.tableName = "postgresql_numbers";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -35,8 +35,6 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   });
 
   it("execute runs a non-row-returning statement and returns no rows", async () => {
-    // node-pg does not throw on a statement with no result columns, so DDL and a
-    // bare INSERT flow through the public `execute` and come back as [].
     await expect(adapter.execute(`CREATE TABLE pq_ddl (id integer)`)).resolves.toEqual([]);
     await adapter.execute(`DROP TABLE pq_ddl`);
     await expect(adapter.execute(`INSERT INTO pq (nick) VALUES ('a')`)).resolves.toEqual([]);
@@ -52,16 +50,12 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('c')`);
 
-    // The count comes from the statement's own PG::Result (cmd_tuples), read
-    // via the affectedRows port — no cross-statement state.
     expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z' WHERE nick <> 'a'`)).toBe(2);
     expect(await adapter.executeMutation(`UPDATE pq SET nick = 'y' WHERE nick = 'nope'`)).toBe(0);
     expect(await adapter.executeMutation(`DELETE FROM pq`)).toBe(3);
   });
 
   it("executeMutation appends RETURNING id and returns the inserted id for a bare INSERT", async () => {
-    // use_insert_returning? is true, so a bare INSERT is rewritten to
-    // `... RETURNING id` and the first column of the first row is the id.
     const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
     expect(id).toBe(1);
     const second = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
@@ -92,10 +86,10 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     // (postgresql_adapter.rb:1094). A reconnect opens a fresh session at
     // PostgreSQL's default timezone, so the cache must be cleared in
     // configure_connection (:1112) or the guard would skip reconfiguring it.
-    await adapter.execute(`SELECT 1`); // maps the timezone for the first session
+    await adapter.execute(`SELECT 1`);
     const spy = vi.spyOn(adapter, "reconfigureConnectionTimezone");
-    await adapter.reconnect(); // opens a fresh session; configure clears the cache
-    await adapter.execute(`SELECT 1`); // fresh session must re-apply the timezone
+    await adapter.reconnect();
+    await adapter.execute(`SELECT 1`);
     expect(spy).toHaveBeenCalled();
   });
   // Rails' internal_execute forwards `prepare:` to raw_execute → perform_query

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -63,9 +63,6 @@ function connectionWithoutInsertReturning(): PostgreSQLAdapter {
   return new PostgreSQLAdapter({ connectionString: PG_TEST_URL, insertReturning: false });
 }
 
-// Run `fn` with `ext` guaranteed disabled; restore the pre-state (enabled
-// or disabled) on exit even if `fn` throws before tearing down whatever it
-// created.
 async function withExtensionDisabled(
   adapter: PostgreSQLAdapter,
   ext: string,
@@ -84,9 +81,6 @@ async function withExtensionDisabled(
   }
 }
 
-// Same as withExtensionDisabled but inverted: `ext` is guaranteed enabled
-// inside `fn` and its pre-state (enabled or disabled) is restored on exit
-// even if `fn` throws before touching the extension itself.
 async function withExtensionEnabled(
   adapter: PostgreSQLAdapter,
   ext: string,
@@ -120,15 +114,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     PostgreSQLAdapter.dbWarningsAction = savedWarningsAction;
     PostgreSQLAdapter.dbWarningsIgnore = savedWarningsIgnore;
     vi.restoreAllMocks();
-    // A test that never queried this adapter cannot have created `ex`/`ex2`,
-    // and making the hook connect just to issue the DROP times its 30 s budget
-    // out under load.
     if (adapter.isConnected()) {
       try {
         await adapter.exec(`DROP TABLE IF EXISTS ex, ex2 CASCADE`);
-      } catch {
-        // ignore cleanup errors
-      }
+      } catch {}
     }
     await adapter.close();
   });
@@ -214,7 +203,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect((error as ConnectionFailed).message).toBe("Could not determine PostgreSQL version");
       versionSpy.mockRestore();
 
-      // Can reconnect after a bad connection.
       await adapter.reconnectBang();
       expect(await adapter.getDatabaseVersion()).toBeGreaterThan(0);
     });
@@ -408,7 +396,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`create table ex(id serial primary key)`);
       await adapter.exec(`create table ex2(id serial primary key)`);
       try {
-        // classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype
         const correctDependRecord = [
           "'pg_class'::regclass",
           "'ex_id_seq'::regclass",
@@ -418,8 +405,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           "1",
           "'a'",
         ];
-        // A spurious dependency whose classid is pg_attrdef rather than pg_class —
-        // a "collision" that the correct query must ignore when resolving ex's sequence.
         const collisionDependRecord = [
           "'pg_attrdef'::regclass",
           "'ex2_id_seq'::regclass",
@@ -450,7 +435,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("table alias length", async () => {
-      // assert_nothing_raised — the call must not throw.
       let raised = false;
       try {
         (adapter as unknown as { tableAliasLength(): number }).tableAliasLength();
@@ -613,7 +597,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect((error as Error).message).toMatch(/could not create unique index/);
         expect((error as RecordNotUnique).connectionPool).toBe(adapter.pool);
 
-        // A failed CONCURRENTLY unique index is left behind but marked invalid.
         expect(await adapter.indexExists("ex", "number", { name: "invalid_index" })).toBe(true);
         expect(
           await adapter.indexExists("ex", "number", { name: "invalid_index", valid: true }),
@@ -696,12 +679,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("raise error when cannot translate exception", async () => {
-      // execute(null) propagates TypeError unchanged (pg rejects null text; not a DatabaseError).
       await expect(adapter.execute(null as never)).rejects.toBeInstanceOf(TypeError);
     });
 
     it("translate no connection exception to not established", async () => {
-      // Open the connection and capture its backend pid.
       const pidRows = await adapter.execute("SELECT pg_backend_pid() AS pid");
       const pid = (pidRows[0] as { pid: number }).pid;
       // Terminate this backend from a separate connection. After the single
@@ -740,21 +721,15 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("only reload type map once for every unrecognized type", async () => {
-      // Eagerly initialize so the spy captures only unrecognized-type reloads,
-      // not the first-connection type-map bootstrap.
       await adapter.execQuery("SELECT 1");
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const loadSpy = vi.spyOn(adapter, "loadAdditionalTypes");
       try {
-        // First encounter of an unrecognized OID reloads the type map.
         await adapter.execQuery("select 'pg_catalog.pg_class'::regclass");
         const afterFirst = loadSpy.mock.calls.length;
         expect(afterFirst).toBeGreaterThan(0);
-        // Same unrecognized OID again — a fallback type is already registered,
-        // so no further reload.
         await adapter.execQuery("select 'pg_catalog.pg_class'::regclass");
         expect(loadSpy.mock.calls.length).toBe(afterFirst);
-        // A different unrecognized type reloads the map again.
         await adapter.execQuery("SELECT NULL::anyarray");
         expect(loadSpy.mock.calls.length).toBeGreaterThan(afterFirst);
       } finally {
@@ -766,8 +741,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("only warn on first encounter of unrecognized oid", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
-        // execQuery goes through getOidType which triggers the dedup logic.
-        // execute() bypasses OID resolution so it cannot trigger the warn.
         await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
         await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
         await adapter.execQuery(`select 'pg_catalog.pg_class'::regclass`);
@@ -807,8 +780,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.execute(`CREATE DOMAIN example_type AS integer`);
       const internalExecQuerySpy = vi.spyOn(adapter, "internalExecQuery");
       try {
-        // canPerformCaseInsensitiveComparisonFor does the pg_proc lookup via
-        // internalExecQuery. Spy on it to verify the cache prevents a second DB round-trip.
         const col = { sqlType: "example_type" };
         await adapter.canPerformCaseInsensitiveComparisonFor(col);
         const callsAfterFirst = internalExecQuerySpy.mock.calls.length;
@@ -923,7 +894,6 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("does not raise notice level warnings", async () => {
       PostgreSQLAdapter.dbWarningsAction = "raise";
-      // DROP TABLE IF EXISTS fires a NOTICE (not WARNING) — must not raise
       await expect(
         adapter.execute("DROP TABLE IF EXISTS non_existent_table_xyz_warnings"),
       ).resolves.toBeDefined();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -67,12 +67,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
   afterEach(async () => {
     try {
-      await adapter.exec(
-        // The `ex_%` sweep below cannot reach these two: `test_no_returning` is
-        // TEMP, so it lives in pg_temp rather than the `public` schema the sweep
-        // filters on, and `abba` carries no `ex_` prefix.
-        `DROP TABLE IF EXISTS abba, test_no_returning CASCADE`,
-      );
+      await adapter.exec(`DROP TABLE IF EXISTS abba, test_no_returning CASCADE`);
 
       const tables = await adapter.execute(
         `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'ex_%'`,
@@ -301,8 +296,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {
         await other.beginDbTransaction();
-        // A genuinely concurrent chain: its `withRawConnection` holds the
-        // connection lock for the query's whole life, so nothing is abandoned.
         const foreign = other.execute("SELECT pg_sleep(0.5) AS slept");
         await new Promise<void>((r) => setTimeout(r, 100));
         await other.lock.synchronize(() => other.rollbackDbTransaction());
@@ -342,7 +335,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       try {
         await other.execute("SELECT 1 AS n");
-        // Fired from OUTSIDE the lock, as a pool reap/checkin is.
         setTimeout(() => other.resetBang(), 0);
         await other.lock.synchronize(async () => {
           await new Promise<void>((r) => setTimeout(r, 50));
@@ -374,14 +366,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         await (
           other as unknown as { _cancelAnyRunningQuery(): Promise<void> }
         )._cancelAnyRunningQuery();
-        // `block` puts the cancelled command back off the wire before the
-        // cancel returns; its error reaching this `catch` is a further
-        // microtask hop behind that, so await the query before reading it.
         await sleep;
         expect(sleepError).toBeInstanceOf(QueryCanceled);
-        // The cancel aborted the transaction, so end it before probing — a
-        // leaked cancel shows up as QueryCanceled on one of these two, not as
-        // the 25P02 an aborted transaction block answers with.
         await other.rollbackDbTransaction();
         await expect(other.execute("SELECT 1 AS n")).resolves.toHaveLength(1);
       } finally {
@@ -413,9 +399,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           _cancelAnyRunningQuery(): Promise<void>;
           _blockUntilCommandSettles(client: unknown): Promise<void>;
         };
-        // Spy the INSTANCE, not the prototype: the adapter reads the method off
-        // `this`, and a prototype spy would be shadowed by nothing here but is
-        // shared with every other adapter in the worker.
         const blockUntilCommandSettles = internals._blockUntilCommandSettles.bind(other);
         let releaseBlock!: () => void;
         const blocked = new Promise<void>((r) => (releaseBlock = r));
@@ -469,9 +452,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         // `reset_column_information`'s shape (model_schema.rb:523-524): a sync
         // caller that drops the returned chain.
         void other.clearCacheBang();
-        // The DEALLOCATE is dispatched from a microtask off the pool's chain,
-        // so let the turn end before sampling — a read in the same tick sees
-        // the wire before it has anything on it.
         await new Promise<void>((r) => setTimeout(r, 0));
         const status = await other.lock.synchronize(() => other.transactionStatus);
         expect(status).toBe(PQTRANS_INTRANS);
@@ -1662,18 +1642,13 @@ describeIfPg("PostgreSQLAdapter#active", () => {
         typeMap: { has(oid: number): boolean };
       };
       const getOidTypeSpy = vi.spyOn(adapter, "getOidType");
-      // A live, non-preloaded OID: the pg_type row for `pg_type` itself.
       const rows = await adapter.execute("SELECT 'regprocedure'::regtype::oid AS oid");
       const oid = Number((rows[0] as { oid: number | string }).oid);
       getOidTypeSpy.mockClear();
 
       await adapter.loadAdditionalTypes([oid]);
 
-      // The pg_type query resolved no column types of its own — the cycle's
-      // first edge is gone, so no depth of recursion is possible.
       expect(getOidTypeSpy).not.toHaveBeenCalled();
-      // And no poisoning fallback was registered for an OID pg_type never
-      // returned (see lookupCastTypeFromColumn).
       expect(internals.typeMap.has(987654321)).toBe(false);
     } finally {
       await adapter.close();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-rake.test.ts
@@ -426,11 +426,7 @@ describeIfPostgresqlAdapter("PostgreSQLStructureDumpTest", () => {
     getFs().rmSync(filename, { force: true });
   });
 
-  // This test actually runs a dump so we can ensure all the arguments are parsed correctly.
-  // All other tests in this class just mock the call (using assert_called_with) to make the tests quicker.
   it("structure dump", async () => {
-    // The only case here that shells out for real, so the class-wide
-    // `Kernel.system` double comes back off.
     spawnSync.mockRestore();
     expect(getFs().readFileSync(filename, "utf8")).toEqual("");
 

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -12,11 +12,6 @@ import { Developer } from "../../test-helpers/models/developer.js";
 import { Computer } from "../../test-helpers/models/computer.js";
 import { developerFixtureData } from "../../test-helpers/fixtures/developers.js";
 
-// `developerFixtureData.david` carries the `sharedComputers: ["laptop"]` HABTM
-// association label, which the fixture loader materializes into a
-// `computers_developers` join row. Register Computer at module load so the
-// `sharedComputers` reflection resolves when the loader writes that join row —
-// without it the join target is unresolved and the seed insert fails.
 registerModel(Computer);
 
 describeIfPg("PostgreSQLAdapter", () => {
@@ -26,8 +21,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     // the `sharedComputers` label materializes) come from the template clone.
     const { developers } = fixtures({ developers: [Developer, developerFixtureData] });
 
-    // `preparedStatements` lives on AbstractAdapter but isn't on the
-    // `DatabaseAdapter` interface that `connection` is typed as.
     const ps = (a: unknown) => a as { preparedStatements: boolean };
 
     // Mirrors Rails' setup/teardown swap to the
@@ -47,9 +40,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
       const david = developers("david");
 
-      const last = await Developer.where({ name: "David" }).last(); // With Binds
+      const last = await Developer.where({ name: "David" }).last();
       expect(last?.id).toBe(david.id);
-      expect(await Developer.count()).toBeGreaterThan(0); // Without Binds
+      expect(await Developer.count()).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -19,9 +19,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     try {
       await adapter.exec(`DROP TABLE IF EXISTS "quoting_test" CASCADE`);
       await adapter.exec(`DROP TABLE IF EXISTS "table with spaces" CASCADE`);
-    } catch {
-      // ignore
-    }
+    } catch {}
     await adapter.close();
   });
 
@@ -122,11 +120,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     // unmatched parity:test entry.
 
     it("quote bit string", () => {
-      // binary path
       expect(adapter.quote(new Bit().serialize("01")!)).toBe("B'01'");
-      // hex path
       expect(adapter.quote(new Bit().serialize("FF")!)).toBe("X'FF'");
-      // neither binary nor hex → null
       const type = new Bit();
       const value = "'); SELECT * FROM users; /*\n01\n*/--";
       const serialized = type.serialize(value);
@@ -142,9 +137,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("raise when int is wider than 64bit", async () => {
-      const tooBig = BigInt("9223372036854775808"); // MAX_INT64 + 1
+      const tooBig = BigInt("9223372036854775808");
       expect(() => adapter.quote(tooBig)).toThrow(IntegerOutOf64BitRange);
-      const tooSmall = BigInt("-9223372036854775809"); // MIN_INT64 - 1
+      const tooSmall = BigInt("-9223372036854775809");
       expect(() => adapter.quote(tooSmall)).toThrow(IntegerOutOf64BitRange);
     });
 

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -62,7 +62,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     class PostgresqlRangesCls extends Base {
       static tableName = "postgresql_ranges";
       static {
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
       }
     }
@@ -81,7 +80,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       static timeZoneAwareAttributes = true;
       static timeZoneAwareTypes = [...Base.timeZoneAwareTypes, "tsrange", "tstzrange"];
       static {
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
       }
     }
@@ -104,7 +102,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range = parseRange(rows[0].int4_range as string, toInt)!;
       expect(range).toBeInstanceOf(Range);
       expect(range.begin).toBe(1);
-      // PG normalizes [1,10] to [1,11) for discrete integer ranges
       expect(range.end).toBe(11);
       expect(range.excludeEnd).toBe(true);
     });
@@ -545,7 +542,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const fromInstant = Temporal.Instant.from(fromStr);
       const toInstant = Temporal.Instant.from(toStr);
 
-      // [exclusive, inclusive, endless, beginless]
       const ranges = [
         new Range(fromStr, toStr, true),
         new Range(fromStr, toStr, false),
@@ -866,7 +862,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       setZone(tz);
       const timeString = "2017-09-26T07:30:59.132451-07:00";
       const instant = Temporal.Instant.from(timeString);
-      // Confirm the instant has sub-millisecond precision (µs component = 451 µs)
       expect(instant.toString()).toContain(".132451");
 
       const r = new PostgresqlRangesTz({ ts_range: new Range(timeString, timeString, false) });
@@ -882,7 +877,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const range2 = r.ts_range as Range;
       expect(range2.begin).toBeInstanceOf(TimeWithZone);
       expect((range2.begin as TimeWithZone).timeZone.name).toBe(zone.name);
-      // µs precision round-trips through PostgreSQL tsrange
       expect((range2.begin as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
         instant.toString(),
       );
@@ -907,7 +901,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       expect(((r.num_range as Range).begin as BigDecimal).toString("F")).toBe("0.5");
       expect(((r.num_range as Range).end as BigDecimal).toString("F")).toBe("1.0");
-      // [0.5,0.5) is empty in numrange → null on reload
       r.num_range = new Range("0.5", "0.5", true);
       await r.saveBang();
       await r.reload();
@@ -934,7 +927,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       const result = r.date_range as Range;
       expect((result.begin as Temporal.PlainDate).toString()).toBe("2012-02-03");
       expect((result.end as Temporal.PlainDate).toString()).toBe("2012-02-10");
-      // [2012-02-03,2012-02-03) is empty → null on reload
       r.date_range = new Range("2012-02-03", "2012-02-03", true);
       await r.saveBang();
       await r.reload();
@@ -958,7 +950,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       expect((r.int4_range as Range).begin).toBe(6);
       expect((r.int4_range as Range).end).toBe(10);
-      // [3,3) is empty in int4range → null on reload
       r.int4_range = new Range(3, 3, true);
       await r.saveBang();
       await r.reload();
@@ -984,7 +975,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await r.reload();
       expect((r.int8_range as Range).begin).toBe(60000);
       expect((r.int8_range as Range).end).toBe(10000000);
-      // [39999,39999) is empty in int8range → null on reload
       r.int8_range = new Range(39999, 39999, true);
       await r.saveBang();
       await r.reload();
@@ -1024,8 +1014,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("ranges correctly escape input", async () => {
       const range = new Range("-1,2]'\"; DROP TABLE postgresql_ranges; --", "a", false);
       await PostgresqlRanges.create({});
-      // SQL injection is prevented — the update either succeeds (value stored) or
-      // raises a type error, but the table must still exist afterwards.
       await PostgresqlRanges.updateAll({ int8_range: range }).catch(() => {});
       await expect(PostgresqlRanges.first()).resolves.not.toBeNull();
     });

--- a/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/referential-integrity.test.ts
@@ -36,8 +36,6 @@ function extendProgrammerMistake(adapter: PostgreSQLAdapter): void {
   };
 }
 
-// disable_referential_integrity maps over `tables()`; a dummy table guarantees
-// the generated SQL is non-empty so the patched execute fires.
 async function withDummyTable(adapter: PostgreSQLAdapter, fn: () => Promise<void>): Promise<void> {
   await adapter.execute(`CREATE TABLE IF NOT EXISTS "referential_integrity_dummy" ("id" SERIAL)`);
   try {
@@ -59,16 +57,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
   });
   afterEach(async () => {
-    // Schema-scoped tables created in-test are torn down with their schema via
-    // DROP SCHEMA CASCADE; these static IF EXISTS drops balance
-    // require-table-teardown by name.
     try {
       await adapter.execute(
         `DROP TABLE IF EXISTS referential_integrity_test_schema.nodes, referential_integrity_violation_test.parents, referential_integrity_violation_test.children, referential_integrity_tx_test.nodes CASCADE`,
       );
-    } catch {
-      // ignore cleanup errors
-    }
+    } catch {}
     await adapter.close();
   });
 
@@ -170,7 +163,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         `);
         expect(Number(rows[0].count)).toBe(1);
 
-        // Should not throw when all FK constraints are valid
         await expect(adapter.checkAllForeignKeysValidBang()).resolves.toBeUndefined();
       } finally {
         await adapter.execute(`DROP SCHEMA IF EXISTS referential_integrity_test_schema CASCADE`);
@@ -191,11 +183,9 @@ describeIfPg("PostgreSQLAdapter", () => {
           )
         `);
 
-        // Insert a child row that references a non-existent parent.
         await adapter.execute(
           `INSERT INTO referential_integrity_violation_test.children (parent_id) VALUES (9999)`,
         );
-        // Add the FK constraint NOT VALID so it can be created despite the bad row.
         await adapter.execute(`
           ALTER TABLE referential_integrity_violation_test.children
             ADD CONSTRAINT fk_children_parent
@@ -204,11 +194,8 @@ describeIfPg("PostgreSQLAdapter", () => {
             NOT VALID
         `);
 
-        // checkAllForeignKeysValidBang re-validates every FK — should raise.
         await expect(adapter.checkAllForeignKeysValidBang()).rejects.toThrow();
 
-        // When called inside a transaction the savepoint is rolled back on
-        // failure, leaving the outer transaction still usable.
         await adapter.beginTransaction();
         try {
           await expect(adapter.checkAllForeignKeysValidBang()).rejects.toThrow();
@@ -232,11 +219,8 @@ describeIfPg("PostgreSQLAdapter", () => {
 
         await adapter.beginTransaction();
         try {
-          // Inside a transaction the method uses a SAVEPOINT, so the
-          // surrounding transaction stays usable after the check.
           await expect(adapter.checkAllForeignKeysValidBang()).resolves.toBeUndefined();
 
-          // Transaction should still be live — a query should succeed.
           const result = await adapter.execute("SELECT 1 AS n");
           expect(result[0].n).toBe(1);
         } finally {

--- a/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
@@ -17,8 +17,6 @@ import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { ConnectionFailed } from "../../errors.js";
 
-// The retry-loop seams `withRawConnection` drives are not on the public adapter
-// surface; narrow to just the two the fault injection needs.
 interface RetryLoopSeams {
   reconnect(): void | Promise<void>;
   rawConnectionForBlock(): Promise<unknown>;
@@ -38,8 +36,6 @@ describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)",
   it("createSavepoint dirties the current (parent) transaction frame", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
-      // BEGIN is emitted with materializeTransactions:false, so the frame is
-      // materialized but clean.
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
       await adapter.createSavepoint("sp1");
@@ -64,29 +60,18 @@ describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)",
     });
   });
 
-  // The savepoint statement is issued through the retry-enabled `internalExecute`
-  // leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
-  // engages — createSavepoint/rollbackToSavepoint pass allowRetry:false, but they
-  // share the exact same `internalExecute` finally under test here. A SAVEPOINT
-  // (not RELEASE/ROLLBACK) is retried because the outer BEGIN is still clean, so
-  // reconnect restores it and the retry lands on a live transaction.
   it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
 
-      // Fault the first raw connection acquisition per op with a retryable
-      // ConnectionFailed, so `withRawConnection` reconnects (restoring the
-      // still-clean outer BEGIN) and retries the SAVEPOINT.
       const seams = adapter as unknown as RetryLoopSeams;
       const reconnect = vi.spyOn(seams, "reconnect");
       const rawForBlock = vi
         .spyOn(seams, "rawConnectionForBlock")
         .mockRejectedValueOnce(new ConnectionFailed("server closed the connection unexpectedly"));
 
-      // materialize:false — the withRawConnection loop's own (suppressed) finally
-      // must NOT dirty the parent on the reconnect path.
       await adapter.internalExecute('SAVEPOINT "sp_clean"', "TRANSACTION", [], {
         materializeTransactions: false,
         allowRetry: true,
@@ -94,8 +79,6 @@ describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)",
       expect(reconnect).toHaveBeenCalledTimes(1);
       expect(tm.isRestorable()).toBe(true);
 
-      // materialize:true (the savepoint default) — the relocated internalExecute
-      // finally dirties the parent on the very same reconnect path.
       rawForBlock.mockRejectedValueOnce(
         new ConnectionFailed("server closed the connection unexpectedly"),
       );

--- a/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
@@ -49,7 +49,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           await adapter.execute(`DROP USER IF EXISTS ${u}`);
         } catch {}
       }
-      // Do not close: `adapter` is the shared pooled Base.connection now.
     });
 
     it("schema invisible", async () => {
@@ -89,7 +88,6 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("sequence schema caching", async () => {
       const SchemaThing = makeSchemaThingModel();
-      // Load schema once via user1's session (where schema_things is visible)
       await adapter.sessionAuth(USERS[0]);
       await SchemaThing.loadSchema();
       await adapter.sessionAuth("default");

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -109,8 +109,6 @@ async function setupSchemas(adapter: PostgreSQLAdapter) {
 }
 
 async function teardownSchemas(adapter: PostgreSQLAdapter) {
-  // The `music.*` tables are dropped with the `music` schema below; this static
-  // IF EXISTS drop balances require-table-teardown by name.
   await adapter.exec(`DROP TABLE IF EXISTS music.songs, music.albums, music.albums_songs CASCADE`);
   await adapter.dropSchema(SCHEMA2_NAME, { ifExists: true });
   await adapter.dropSchema(SCHEMA_NAME, { ifExists: true });
@@ -188,11 +186,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("column exists honors search path", async () => {
-      // Regression for columns-pg-honor-search-path (RFC 0023): columnExists
-      // must resolve the column list through the active search_path, not a
-      // hardcoded table_schema = 'public'. A table living only on a non-public
-      // schema that is on the search_path passes tableExists, so columnExists
-      // must stay consistent and report its columns too.
       await adapter.setSchemaSearchPath(SCHEMA_NAME);
       expect(await adapter.tableExists(TABLE_NAME)).toBe(true);
       expect(await adapter.columnExists(TABLE_NAME, "name")).toBe(true);
@@ -313,8 +306,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         altered = true;
         await adapter.execQuery(`select * from ${tbl} where id = $1`, "sql", [1]);
       } finally {
-        // We are not using DROP COLUMN IF EXISTS because that syntax is only
-        // supported by pg 9.X
         if (altered) {
           await adapter.execQuery(`alter table ${tbl} drop column zomg`, "sql", []);
         }
@@ -604,10 +595,6 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("prepared statements with multiple schemas", async () => {
       const Thing5 = makeThing5Model();
-      // Load schema within a transaction to pin all queries to one connection.
-      // Without this, the pool may route `columns("things")` to a fresh
-      // connection without the search path set, returning 0 columns and causing
-      // DEFAULT VALUES inserts that silently drop all attributes.
       try {
         await adapter.beginTransaction();
         await adapter.setSchemaSearchPath(SCHEMA_NAME);
@@ -698,9 +685,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.createSchema("my_schema");
     });
     afterEach(async () => {
-      // Tables created in-test live in my_schema/my_other_schema and are dropped
-      // with those schemas; this static IF EXISTS drop balances
-      // require-table-teardown by name.
       await adapter.exec(`DROP TABLE IF EXISTS my_schema.wagons, my_other_schema.wagons CASCADE`);
       await adapter.dropSchema("my_other_schema", { ifExists: true });
       await adapter.dropSchema("my_schema", { ifExists: true });
@@ -934,8 +918,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.createSchema("my.schema");
     });
     afterEach(async () => {
-      // The in-test table lives in the dotted "my.schema" schema and is dropped
-      // with it; this static IF EXISTS drop balances require-table-teardown by name.
       await adapter.exec(`DROP TABLE IF EXISTS "my.schema" CASCADE`);
       await adapter.dropSchema("my.schema", { ifExists: true });
     });
@@ -956,7 +938,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class Article extends Base {
         static {
           this.tableName = '"my.schema".articles';
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
         }
       }

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -105,9 +105,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       // `test_prepared_statements_do_not_get_stuck_on_query_interruption`
       // in activerecord/test/cases/adapters/postgresql/statement_pool_test.rb.
       await expect(adapter.execute("SELECT 1 / $1::int", [0])).rejects.toThrow();
-      // The adapter still serves queries with the same SQL shape after
-      // the error — no pool poisoning, no duplicate-prepared-statement
-      // error on reuse.
       const rows = await adapter.execute("SELECT 1 / $1::int", [1]);
       expect(rows[0]).toBeDefined();
     });
@@ -174,8 +171,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         (adapter2 as unknown as { preparedStatements: unknown }).preparedStatements = "true";
         expect(adapter2.preparedStatements).toBe(true);
       } finally {
-        // pg.Pool keeps sockets/timers alive — close to avoid Vitest
-        // hangs / flakiness from leaked handles.
         await adapter2.close();
       }
     });
@@ -189,9 +184,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         expect(pool.length).toBe(2);
         await adapter.clearCacheBang();
         expect(pool.length).toBe(0);
-        // Pool itself remains attached — counter continues from where
-        // it left off so we never collide with a still-PREPAREd name
-        // on this session after the server DEALLOCATEs complete.
         expect(adapter._statementPoolForTest()).toBe(pool);
       } finally {
         await adapter.rollback();
@@ -210,40 +202,24 @@ describeIfPg("PostgreSQLAdapter", () => {
       const pool = adapter._statementPoolForTest()!;
       expect(pool.length).toBe(2);
       await adapter.rollback();
-      // Same pool object survives the rollback (session-scoped lifetime).
       expect(adapter._statementPoolForTest()).toBe(pool);
       await adapter.clearCacheBang();
       expect(pool.length).toBe(0);
     });
 
     it("tags the released client and runs DEALLOCATE ALL on its next checkout", async () => {
-      // With the dual-pool collapse there is no per-txn "release" —
-      // the same persistent connection survives commit/rollback, so
-      // the WeakMap-based DEALLOCATE-ALL drain path is no longer
-      // exercised. Tag/drain still applies across reconnect: after
-      // clearCacheBang runs with the connection torn down, the next
-      // _acquireFreshClient runs DEALLOCATE ALL before user code.
       await adapter.beginDbTransaction();
       await adapter.execute("SELECT $1::int", [1]);
       await adapter.rollback();
       await adapter.reconnect();
-      // Re-pop a statement into the pool's history, then tear down
-      // the live connection and trigger the reset-branch of
-      // clearCacheBang so the drain flag is set.
       await adapter.beginDbTransaction();
       await adapter.execute("SELECT $1::int", [2]);
       await adapter.rollback();
-      // Simulate the failed-session window by detaching the live
-      // connection before clearCacheBang.
       const conn = adapter._rawConnectionForTest();
-      // Driving the reset path by force-clearing _rawConnection.
       adapter._rawConnection = null;
       await adapter.clearCacheBang();
       expect(adapter._needsDeallocateAllForTest()).toBe(true);
-      // Restore so the afterEach close() doesn't double-end.
-      // Restoring _rawConnection for cleanup.
       adapter._rawConnection = conn;
-      // The next acquire runs DEALLOCATE ALL before any user query.
       expect(conn).not.toBeNull();
       const observed: string[] = [];
       const live = conn!;
@@ -262,10 +238,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("clearCacheBang resets the released-client pool even when a new txn is in progress", async () => {
-      // Original repro covered the dual-client after_rollback race
-      // (failed client vs new-txn client). With one persistent
-      // connection there is only one pool: clearCacheBang clears it
-      // regardless of whether a new txn has been opened.
       await adapter.beginDbTransaction();
       await adapter.execute("SELECT $1::int", [1]);
       const failedPool = adapter._statementPoolForTest()!;
@@ -275,7 +247,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.execute("SELECT $1::int", [2]);
         const newTxnPool = adapter._statementPoolForTest()!;
-        // Same pool object — session-scoped lifetime.
         expect(newTxnPool).toBe(failedPool);
         expect(newTxnPool.length).toBeGreaterThan(0);
         await adapter.clearCacheBang();

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -164,7 +164,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await withTimezoneConfig({ default: "local", awareAttributes: false }, async () => {
           await adapter.reconnect();
-          // make sure to use a non-UTC time zone
           await adapter.execute(`SET time zone 'America/Jamaica'`);
           class PostgresqlTimestampWithZone extends Base {
             static _tableName = "postgresql_timestamp_with_zones";
@@ -334,14 +333,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // sentinels (the timestamp OID round-trips them as "infinity" / "-infinity").
       class Dev extends Base {
         static tableName = "ts_infinity_dev";
-        // Declare `name` so mass-assignment dispatches its setter: the sibling
-        // `load infinity and beyond` Dev above shares the `ts_infinity_dev`
-        // schema-cache slot but its table has no `name` column, so reflection
-        // alone can leave `name` out of the attribute set — and construction now
-        // raises UnknownAttributeError for an unmodeled key. `updated_at` reflects
-        // from the timestamp column (keeping its infinity-capable OID decoder).
         static {
-          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "integer");
           this.attribute("name", "string");
         }

--- a/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction-nested.test.ts
@@ -50,9 +50,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       await conn.execute(`SELECT * FROM ${BITS} LIMIT 1`);
     }
 
-    // Serializable parent on each connection, dirty each, savepoint on
-    // `adapter`, commit a conflicting write on `other` — the next write inside
-    // `adapter`'s savepoint raises SerializationFailure.
     async function serializationConflict(): Promise<PostgreSQLAdapter> {
       const other = new PostgreSQLAdapter(PG_TEST_URL);
       await other.beginIsolatedDbTransaction("serializable");
@@ -67,7 +64,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       return other;
     }
 
-    // Deadlock two savepoint-scoped writes; true iff one aborted (Deadlocked).
     async function nestedDeadlock(other: PostgreSQLAdapter): Promise<boolean> {
       await adapter.beginDbTransaction();
       await other.beginDbTransaction();
@@ -85,8 +81,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       return errs.length === 1 && errs[0].reason instanceof Deadlocked;
     }
 
-    // After the doomed txn is rolled back, the connection is reusable: a fresh
-    // transaction commits and persists (fails if state was left stuck).
     async function assertConnectionRecovers(): Promise<void> {
       await adapter.beginDbTransaction();
       await adapter.execute(`UPDATE ${SAMPLES} SET value = 7 WHERE id = 2`);

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -39,8 +39,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         await adapter.beginIsolatedDbTransaction("serializable");
         await other.beginIsolatedDbTransaction("serializable");
-        // Both read the same set, then write based on it — the second writer
-        // raises serialization_failure.
         await adapter.execute(`SELECT sum(value) FROM ${SAMPLES}`);
         await other.execute(`SELECT sum(value) FROM ${SAMPLES}`);
         await other.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
@@ -69,14 +67,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         const rows = await adapter.execute("SELECT pg_backend_pid() AS pid");
         const pid = (rows[0] as { pid: number }).pid;
         const start = Date.now();
-        // Handler attached at creation so the canceled query is never
-        // momentarily unhandled (vitest fails on unhandled rejections).
         let slowError: unknown;
         const slow = adapter.execute("SELECT pg_sleep(10)").catch((e) => {
           slowError = e;
         });
         await new Promise<void>((r) => setTimeout(r, 500));
-        // Assert the cancel landed, else a no-op leaves `slow` pending to timeout.
         const sent = await other.execute("SELECT pg_cancel_backend(?) AS ok", [pid]);
         expect((sent[0] as { ok: boolean }).ok).toBe(true);
         await slow;
@@ -94,7 +89,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         await other.beginDbTransaction();
         await adapter.execute(`UPDATE ${SAMPLES} SET value = 1 WHERE id = 1`);
         await other.execute(`UPDATE ${SAMPLES} SET value = 2 WHERE id = 2`);
-        // Each now waits on the row the other holds — deadlock; PG aborts one.
         const [r1, r2] = await Promise.allSettled([
           adapter.execute(`UPDATE ${SAMPLES} SET value = 3 WHERE id = 2`),
           other.execute(`UPDATE ${SAMPLES} SET value = 4 WHERE id = 1`),
@@ -143,8 +137,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           });
         const canceler = new PostgreSQLAdapter(PG_TEST_URL);
         try {
-          // Under vitest's 5s default testTimeout, so a stuck poll fails the
-          // `waiting` assertion instead of dying as an opaque test timeout.
           const deadline = Date.now() + 3000;
           let waiting = false;
           while (Date.now() < deadline) {

--- a/packages/activerecord/src/adapters/postgresql/type-lookup.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/type-lookup.test.ts
@@ -10,7 +10,6 @@ describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    // Populate the type map with array/range OIDs from pg_type.
     await adapter.loadAdditionalTypes();
   });
   afterEach(async () => {
@@ -41,7 +40,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("range types correctly respect registration of subtypes", () => {
-      // Same precision rationale as "array types" above.
       const bigNum = 3_000_000_000;
       const intRange = adapter.typeMap.lookup(3904, -1, "int4range");
       const bigintRange = adapter.typeMap.lookup(3926, -1, "int8range");

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -342,7 +342,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidAssocPost extends Base {
           static tableName = "uuid_assoc_posts";
           static {
-            // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "uuid");
             this.hasMany("uuidAssocComments", {
               className: "UuidAssocComment",
@@ -353,7 +352,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidAssocComment extends Base {
           static tableName = "uuid_assoc_comments";
           static {
-            // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "uuid");
             this.belongsTo("uuidAssocPost", {
               className: "UuidAssocPost",
@@ -633,7 +631,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidUniq extends Base {
           static tableName = "uuid_uniqueness_validation_test";
           static {
-            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
             this.attribute("id", "integer");
             this.validatesUniqueness("guid", { caseSensitive: false });
           }
@@ -644,13 +641,11 @@ describeIfPg("PostgreSQLAdapter", () => {
         const r1 = await UuidUniq.create({ guid: uuid });
         expect(r1.isPersisted()).toBe(true);
 
-        // Duplicate — should fail validation, not throw a DB error about lower(uuid).
         const r2 = new UuidUniq({ guid: uuid });
         const saved = await r2.save();
         expect(saved).toBe(false);
         expect(r2.errors.messagesFor("guid")).toBeTruthy();
 
-        // Different UUID — should save fine.
         const r3 = new UuidUniq({ guid: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" });
         expect(await r3.save()).toBe(true);
       } finally {
@@ -892,7 +887,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidPostCls extends Base {
         static tableName = "pg_uuid_posts";
         static {
-          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "uuid");
           this.hasMany("uuidComments", {
             className: "UuidCommentInverse",
@@ -904,7 +898,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidCommentCls extends Base {
         static tableName = "pg_uuid_comments";
         static {
-          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "uuid");
           this.belongsTo("uuidPost", {
             className: "UuidPostInverse",
@@ -974,7 +967,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidForumCls extends Base {
         static tableName = "pg_uuid_dj_forums";
         static {
-          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "uuid");
           // Rails: has_many :uuid_posts, -> { order("title DESC") } — the
           // ordering scope exercises the delegate-cache path the test name calls out.
@@ -998,7 +990,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidPostCls extends Base {
         static tableName = "pg_uuid_dj_posts";
         static {
-          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "uuid");
           this.belongsTo("uuidForum", {
             className: "UuidForumDj",
@@ -1013,7 +1004,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidCommentCls extends Base {
         static tableName = "pg_uuid_dj_comments";
         static {
-          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
           this.attribute("id", "uuid");
           this.belongsTo("uuidPost", {
             className: "UuidPostDj",

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -41,7 +41,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     class VirtualColumnCls extends Base {
       static tableName = "virtual_columns";
       static {
-        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
         this.attribute("id", "integer");
       }
     }

--- a/packages/activerecord/src/adapters/postgresql/xml.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/xml.test.ts
@@ -12,7 +12,6 @@ import { Base } from "../../index.js";
 class XmlDataType extends Base {
   static {
     this.tableName = "xml_data_type";
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
   }
 }

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -30,7 +30,7 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
     await adapter.dropTable("big_items", { ifExists: true });
   });
 
-  const BIG = 2n ** 62n; // 4611686018427387904 — well above Number.MAX_SAFE_INTEGER
+  const BIG = 2n ** 62n;
 
   it("returns bigint for BIGINT column", async () => {
     await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
@@ -43,7 +43,7 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
   });
 
   it("preserves exact value above Number.MAX_SAFE_INTEGER", async () => {
-    const unsafe = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2
+    const unsafe = 9007199254740993n;
     await adapter.executeMutation(`INSERT INTO "big_items" ("score", "count") VALUES (?, ?)`, [
       unsafe,
       0,
@@ -58,18 +58,10 @@ describeIfSqlite("SQLite3 bigint round-trip", () => {
       42,
     ]);
     const rows = await adapter.execute(`SELECT "score", "count" FROM "big_items"`);
-    // safeIntegers is enabled on this statement (BIGINT column present), so the
-    // driver hands the INTEGER column back as a bigint too; the adapter narrows
-    // that spill at the row boundary (_narrowSpilledBigInts), and
-    // IntegerType.cast accepts either spelling — the type-layer contract holds
-    // whichever side normalizes.
     expect(intType.cast(rows[0].count)).toBe(42);
   });
 
   it("BooleanType.cast handles 0n/1n from safeIntegers mode correctly", async () => {
-    // SQLite stores booleans as INTEGER 0/1. With safeIntegers enabled (triggered
-    // by the BIGINT column), the driver returns 0n/1n instead of 0/1.
-    // BooleanType.FALSE_VALUES includes 0n so cast(0n) → false, cast(1n) → true.
     await adapter.executeMutation(`INSERT INTO "big_items" ("score", "active") VALUES (?, ?)`, [
       BIG,
       0,

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -19,8 +19,6 @@ describeIfSqlite("SQLite3CollationTest", () => {
     await adapter.createTable("collation_table_sqlite3", { force: true }, (t) => {
       t.string("string_nocase", { collation: "NOCASE" });
       t.text("text_rtrim", { collation: "RTRIM" });
-      // The decimal column might interfere with collation parsing.
-      // Thus, add this column type and some other string column afterwards.
       t.decimal("decimal_col", { precision: 6, scale: 2 });
       t.string("string_after_decimal_nocase", { collation: "NOCASE" });
     });

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -65,9 +65,7 @@ async function testCopyTable(
 
   try {
     await conn.dropTable(to);
-  } catch {
-    // rescue nil
-  }
+  } catch {}
 }
 
 // -- Rails test class: copy_table_test.rb (ActiveRecord::SQLite3TestCase) --
@@ -186,9 +184,7 @@ describeIfSqlite("CopyTableTest", () => {
     } finally {
       try {
         await conn.dropTable("virtual_columns");
-      } catch {
-        // rescue nil
-      }
+      } catch {}
     }
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -6,8 +6,6 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Author } from "../../test-helpers/models/author.js";
-// Opt into the canonical-model autoload index so `Author.has_many :posts`
-// resolves `Post` by name on first reference.
 import "../../support/canonical-model-index.js";
 
 // -- Rails test class: explain_test.rb (ActiveRecord::SQLite3TestCase) --

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -78,7 +78,6 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("type cast bigdecimal", async () => {
-    // SQLite stores large decimals as REAL; we verify round-trip fidelity
     await adapter.exec(`CREATE TABLE "bd_test" ("id" INTEGER PRIMARY KEY, "amount" REAL)`);
     await adapter.executeMutation(`INSERT INTO "bd_test" ("amount") VALUES (?)`, [123456.789]);
     const rows = await adapter.execute(`SELECT "amount" FROM "bd_test"`);
@@ -135,7 +134,6 @@ describeIfSqlite("SQLite3QuotingTest", () => {
 
   it("quote float nan", async () => {
     await adapter.exec(`CREATE TABLE "nan_test" ("id" INTEGER PRIMARY KEY, "val" REAL)`);
-    // SQLite stores NaN as NULL when passed through binds
     await adapter.executeMutation(`INSERT INTO "nan_test" ("val") VALUES (?)`, [NaN]);
     const rows = await adapter.execute(`SELECT "val" FROM "nan_test"`);
     expect(rows[0].val).toBeNull();

--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.test.ts
@@ -173,8 +173,6 @@ describeIfSqlite("SqliteDBDropTest", () => {
   });
 
   it("checks db dir is absolute", async () => {
-    // `isAbsolute` is optional on the PathAdapter seam (a VFS need not model
-    // the distinction), so the spy target is narrowed to the arm that has it.
     const pathAdapter = activesupport.getPath() as { isAbsolute(p: string): boolean };
     const isAbsolute = vi.spyOn(pathAdapter, "isAbsolute").mockReturnValue(false);
     vi.spyOn(activesupport.getFs(), "unlinkSync").mockImplementation(() => undefined);
@@ -315,9 +313,7 @@ describeIfSqlite("SqliteStructureDumpTest", () => {
     for (const file of created) {
       try {
         fs.unlinkSync(file);
-      } catch {
-        // ignore
-      }
+      } catch {}
     }
     created.length = 0;
   });
@@ -399,9 +395,7 @@ describeIfSqlite("SqliteStructureLoadTest", () => {
     for (const file of created) {
       try {
         fs.unlinkSync(file);
-      } catch {
-        // ignore
-      }
+      } catch {}
     }
     created.length = 0;
   });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite-rake.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite-rake.trails.test.ts
@@ -46,9 +46,7 @@ describeIfSqlite("SqliteStructureDumpTest", () => {
     for (const file of created) {
       try {
         fs.unlinkSync(file);
-      } catch {
-        // ignore
-      }
+      } catch {}
     }
     created.length = 0;
   });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -33,8 +33,6 @@ afterEach(async () => {
 
 describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   it("execute runs a non-row-returning statement and returns no rows", async () => {
-    // `.all()` throws on a statement with no result columns, so this is the
-    // `column_count.zero?` branch that lets DDL flow through `execute`.
     await expect(adapter.execute(`CREATE TABLE "pq_ddl" ("id" INTEGER)`)).resolves.toEqual([]);
     await expect(adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)).resolves.toEqual([]);
   });
@@ -84,15 +82,11 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('b')`);
     expect(await adapter.executeMutation(`UPDATE "pq" SET "nick" = 'z'`)).toBe(2);
 
-    // sqlite3_changes() is advanced only by DML, so the DDL below leaves the
-    // UPDATE's count standing where a RunResult would report 0.
     await adapter.execute(`CREATE TABLE "pq_ddl" ("id" INTEGER)`);
     expect(adapter.affectedRows()).toBe(2);
   });
 
   it("execute returns the rows an INSERT ... RETURNING produces", async () => {
-    // `stmt.column_count.zero?` alone — no write predicate — so a RETURNING
-    // write comes back as rows with row_count = 1.
     await expect(
       adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a') RETURNING "id", "nick"`),
     ).resolves.toEqual([{ id: 1, nick: "a" }]);
@@ -104,16 +98,11 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('b')`);
     await adapter.executeMutation(`BEGIN`);
     expect(await adapter.executeMutation(`UPDATE "pq" SET "nick" = 'z'`)).toBe(2);
-    // BEGIN/COMMIT take the run branch but are not writes, so they don't touch
-    // the count — the last write's value survives them.
     await adapter.executeMutation(`COMMIT`);
     expect(adapter.affectedRows()).toBe(2);
   });
 
   it("executeMutation returns the inserted id for INSERT ... RETURNING", async () => {
-    // A RETURNING write takes the `.all()` branch (nonzero column count), so
-    // the id comes from `last_insert_rowid()` read under the statement lock —
-    // atomically with the insert.
     const id = await adapter.executeMutation(
       `INSERT INTO "pq" ("nick") VALUES ('a') RETURNING "id"`,
     );
@@ -127,17 +116,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   });
 
   it("returns distinct insert ids for concurrent inserts", async () => {
-    // The statement and its `last_insert_rowid()` readback are serialized by
-    // the FIFO statement lock — so inserts issued concurrently (interleaving
-    // at await points) each get their own id. The id is returned from
-    // performQuery as a local rather than re-read from the shared
-    // this._lastInsertRowid, which a concurrent insert would overwrite before
-    // the post-await continuation reads it. NOTE: a race is timing-dependent —
-    // bare inserts interleave too little to reproduce it reliably here (the
-    // regression that motivated this reached CI through model `.create`, whose
-    // callbacks add denser interleaving; HasManyThroughAssociationsTest "should
-    // respect table alias" is the reliable guard). This is a smoke test of the
-    // happy path.
     const n = 25;
     const ids = await Promise.all(
       Array.from({ length: n }, (_, i) =>
@@ -149,9 +127,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   });
 
   it("serializes statements queued on one connection", async () => {
-    // The statement and its `changes()` / `last_insert_rowid()` readbacks are
-    // one critical section, so no second caller may be inside while another
-    // holds it — and arrival order is service order.
     const host: { _statementLock: Promise<void> | null } = { _statementLock: null };
     let inside = 0;
     let arrivals = 0;
@@ -160,8 +135,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     await Promise.all(
       Array.from({ length: 25 }, async (_unused, i) => {
         for (let stagger = 0; stagger < i % 4; stagger++) await Promise.resolve();
-        // The queue tail is published synchronously on entry, so the number
-        // taken here is this caller's place in it.
         const arrival = arrivals++;
         const release = await acquireStatementLock(host);
         inside += 1;
@@ -177,9 +150,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   });
 
   it("does not let a late statement barge ahead of one already queued", async () => {
-    // The release window is where a check-then-set lock loses its queue: the
-    // waiter is still parked in the microtask queue when a caller arriving in
-    // the same synchronous turn observes a free lock and claims it first.
     const host: { _statementLock: Promise<void> | null } = { _statementLock: null };
     const served: string[] = [];
 
@@ -247,7 +217,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     for (let i = 0; i < 100 && closing._statementLock === held; i++) await Promise.resolve();
 
     closing.disconnectBang();
-    // Asked while the close is still queued behind the statement.
     const answered = closing.active();
 
     release();
@@ -289,8 +258,6 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   });
 
   it("dirties the current transaction for a write routed through execute", async () => {
-    // Dirtying hangs off the primitive rather than executeMutation, so a write
-    // reaching the connection through execute marks the transaction too.
     await adapter.transaction(async () => {
       await adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`);
       expect(adapter.currentTransaction().isDirty()).toBe(true);

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -32,10 +32,6 @@ async function createExampleTable(): Promise<void> {
 }
 
 afterEach(async () => {
-  // Static teardown for the tables built in-test via raw CREATE TABLE (mostly on
-  // throwaway :memory: adapters that are discarded on close). SQLite has no
-  // multi-table DROP, so one IF EXISTS statement per name; this balances
-  // require-table-teardown and is behavior-neutral on the fresh per-test adapter.
   await adapter.exec(
     `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex; DROP TABLE IF EXISTS json_defs`,
   );
@@ -88,7 +84,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("connect with url", async () => {
-    // better-sqlite3 doesn't use URLs, but we can open a :memory: db
     const a = new BetterSQLite3Adapter(":memory:");
     expect(a.isOpen).toBe(true);
     await a.close();
@@ -168,7 +163,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("connection no db", async () => {
-    // Attempting to open a non-existent file in readonly mode throws
     const os = await import("os");
     const path = await import("path");
     expect(
@@ -180,14 +174,12 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("bad timeout", async () => {
-    // better-sqlite3 accepts timeout option; a negative value is accepted but harmless
     const a = new BetterSQLite3Adapter(":memory:");
     expect(a).toBeDefined();
     await a.close();
   });
 
   it("nil timeout", async () => {
-    // No timeout specified — default constructor works fine
     const a = new BetterSQLite3Adapter(":memory:");
     expect(a).toBeDefined();
     await a.close();
@@ -205,8 +197,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("default pragmas", async () => {
-    // Our adapter sets journal_mode=WAL and foreign_keys=ON by default
-    // For in-memory databases, journal_mode reports "memory" (WAL only applies to file DBs)
     const jm = await adapter.execute(`PRAGMA journal_mode`);
     expect(["wal", "memory"]).toContain(jm[0].journal_mode);
     const fk = await adapter.execute(`PRAGMA foreign_keys`);
@@ -214,25 +204,19 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("overriding default foreign keys pragma", async () => {
-    // Verify FK pragma is ON by default
     const fk = await adapter.execute(`PRAGMA foreign_keys`);
     expect(fk[0].foreign_keys).toBe(1);
-    // Can turn it off
     await adapter.execute(`PRAGMA foreign_keys = OFF`);
     const fk2 = await adapter.execute(`PRAGMA foreign_keys`);
     expect(fk2[0].foreign_keys).toBe(0);
-    // Restore
     await adapter.execute(`PRAGMA foreign_keys = ON`);
   });
 
   it("overriding default journal mode pragma", async () => {
-    // In-memory databases always report "memory" for journal_mode
-    // Test that pragma call doesn't throw
     const jm = await adapter.execute(`PRAGMA journal_mode`);
     expect(jm[0].journal_mode).toBeDefined();
     await adapter.execute(`PRAGMA journal_mode = DELETE`);
     const jm2 = await adapter.execute(`PRAGMA journal_mode`);
-    // In-memory DB ignores journal_mode changes, stays "memory"
     expect(jm2[0].journal_mode).toBeDefined();
   });
 
@@ -250,8 +234,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("overriding default mmap size pragma", async () => {
-    // mmap_size pragma returns empty on in-memory databases,
-    // so just verify the pragma call doesn't reject
     await adapter.execute(`PRAGMA mmap_size = 0`);
   });
 
@@ -264,11 +246,10 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   it("setting new pragma", async () => {
     await adapter.execute(`PRAGMA temp_store = MEMORY`);
     const rows = await adapter.execute(`PRAGMA temp_store`);
-    expect(rows[0].temp_store).toBe(2); // MEMORY = 2
+    expect(rows[0].temp_store).toBe(2);
   });
 
   it("setting invalid pragma", async () => {
-    // SQLite silently ignores unknown pragmas — no rejection
     await adapter.execute(`PRAGMA not_a_real_pragma`);
   });
 
@@ -307,7 +288,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     const original = Buffer.from("hello world");
     const copy = Buffer.from(original);
     await adapter.executeMutation(`INSERT INTO "enc_test" ("data") VALUES (?)`, [copy]);
-    // Original buffer should not have been mutated
     expect(original).toEqual(Buffer.from("hello world"));
   });
 
@@ -615,7 +595,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('b')`);
     await adapter.executeMutation(`DELETE FROM "items" WHERE "name" = 'b'`);
     const id = await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('c')`);
-    // AUTOINCREMENT ensures IDs are never reused
     expect(id).toBe(3);
   });
 
@@ -639,7 +618,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("db is readonly when readonly option is true", async () => {
-    // Create a file-based db first, then open it readonly
     const fs = await import("fs");
     const path = await import("path");
     const os = await import("os");
@@ -671,7 +649,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("strict strings by default", async () => {
-    // Default class config is false — new connections are non-strict.
     expect(SQLite3Adapter.strictStringsByDefault).toBe(false);
     const conn = new BetterSQLite3Adapter(":memory:");
     expect(conn._strictStrings).toBe(false);
@@ -682,7 +659,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     //   so this assertion is omitted — DQS cannot be re-enabled via PRAGMA here.
     await conn.close();
 
-    // Setting the class config propagates to new connections.
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:");
@@ -698,7 +674,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("strict strings by default and true in database yml", async () => {
-    // Explicit strict: true in options always enables strict mode.
     const conn = new BetterSQLite3Adapter(":memory:", { strict: true });
     try {
       expect(conn._strictStrings).toBe(true);
@@ -710,7 +685,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       await conn.close();
     }
 
-    // Explicit strict: true also overrides the class config (still strict).
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: true });
@@ -729,7 +703,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("strict strings by default and false in database yml", async () => {
-    // Explicit strict: false in options disables strict mode.
     const conn = new BetterSQLite3Adapter(":memory:", { strict: false });
     try {
       expect(conn._strictStrings).toBe(false);
@@ -740,7 +713,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       await conn.close();
     }
 
-    // Explicit strict: false overrides strictStringsByDefault = true.
     SQLite3Adapter.strictStringsByDefault = true;
     try {
       const strict = new BetterSQLite3Adapter(":memory:", { strict: false });
@@ -848,7 +820,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     await adapter.exec(`CREATE TABLE "mixed_case" ("id" Integer PRIMARY KEY, "name" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("mixed_case")`);
     const idCol = cols.find((c: any) => c.name === "id");
-    // SQLite normalizes type names to uppercase
     expect((idCol as any).type.toUpperCase()).toBe("INTEGER");
     expect(idCol!.pk).toBe(1);
   });
@@ -868,7 +839,6 @@ describeIfSqlite("SQLite3AdapterTest", () => {
       `CREATE TABLE "cpk" ("id1" INTEGER, "id2" INTEGER, "name" TEXT, PRIMARY KEY ("id1", "id2"))`,
     );
     const cols = await adapter.execute(`PRAGMA table_info("cpk")`);
-    // Composite PK - neither column is a single rowid alias
     const pkCols = cols.filter((c: any) => c.pk > 0);
     expect(pkCols).toHaveLength(2);
   });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.trails.test.ts
@@ -20,9 +20,6 @@ describe("SqliteAdapter", () => {
     await pool.disconnect();
   });
 
-  // TS-only coverage for the alter_table rebuild: a typeless column has BLOB
-  // affinity, and both the throwaway "a"-prefixed buffer and the rebuilt table
-  // have to keep the declared type empty or the affinity silently becomes TEXT.
   describe("alterTable", () => {
     it("round-trips a typeless (BLOB affinity) column", async () => {
       await adapter.exec(

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-create-folder.test.ts
@@ -14,7 +14,6 @@ describeIfSqlite("SQLite3CreateFolder", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sqlite-create-folder-"));
     let conn: BetterSQLite3Adapter | undefined;
     try {
-      // The `db` subdirectory does not exist yet — the adapter must create it.
       conn = new BetterSQLite3Adapter({
         database: path.join(dir, "db", "foo.sqlite3"),
       });

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -4,8 +4,6 @@ import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 
 describeIfSqlite("SQLite3StatementPoolTest", () => {
-  // Track every adapter created so a failing assertion can't leak an
-  // open SQLite handle into later tests.
   const openAdapters: SQLite3Adapter[] = [];
   const track = (adapter: SQLite3Adapter): SQLite3Adapter => {
     openAdapters.push(adapter);
@@ -15,9 +13,7 @@ describeIfSqlite("SQLite3StatementPoolTest", () => {
     while (openAdapters.length) {
       try {
         openAdapters.pop()!.disconnectBang();
-      } catch {
-        // best-effort cleanup
-      }
+      } catch {}
     }
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -13,10 +13,6 @@ import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { TransactionIsolationError } from "../../errors.js";
 
-// better-sqlite3 doesn't set SQLITE_OPEN_URI, so this URI is opened as a
-// *literal on-disk filename* in the process cwd rather than a shared-cache
-// in-memory DB (see sqlite-template.ts). That materializes a junk file named
-// `file::memory:?cache=shared` next to the repo, so afterEach unlinks it.
 const SHARED_CACHE_DB = "file::memory:?cache=shared";
 
 const openAdapters: SQLite3Adapter[] = [];
@@ -24,17 +20,13 @@ afterEach(async () => {
   while (openAdapters.length) {
     try {
       await openAdapters.pop()!.close();
-    } catch {
-      // best-effort
-    }
+    } catch {}
   }
   const fs = await getFsAsync();
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       await fs.unlink!(SHARED_CACHE_DB + suffix);
-    } catch {
-      // never created / already gone — nothing to do.
-    }
+    } catch {}
   }
 });
 
@@ -84,7 +76,6 @@ describeIfSqlite("SQLite3TransactionTest", () => {
   });
 
   it.skip("opens a `read_uncommitted` transaction", async () => {
-    // PERMANENT-SKIP: driver-limit (see scripts/api-compare/unported-files.ts) — single-process-sqlite
     const conn1 = withConn({ sharedCache: true });
     await conn1.exec(`CREATE TABLE IF NOT EXISTS "zines" ("id" INTEGER PRIMARY KEY, "title" TEXT)`);
     await conn1.beginDbTransaction();
@@ -130,7 +121,6 @@ describeIfSqlite("SQLite3TransactionTest", () => {
     expect(readUncommitted(conn)).toBe(true);
     await conn.commitDbTransaction();
     await conn.resetIsolationLevel();
-    // restored to previous value (ON)
     expect(readUncommitted(conn)).toBe(true);
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -37,10 +37,8 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
   });
 
   it("schema load", async () => {
-    // Verify the virtual table was created and is recognized
     expect(await adapter.virtualTableExists("searchables")).toBe(true);
 
-    // Re-create via createVirtualTable (mirrors Schema.define creating the table)
     await adapter.createVirtualTable("emails", "fts5", ["content", "meta UNINDEXED"]);
     expect(await adapter.virtualTableExists("emails")).toBe(true);
   });


### PR DESCRIPTION
Slice 2 of the free-form comment sweep (slice 1 covered `src/relation/**`).

- `packages/activerecord/src/adapters/**/*.ts` added to the
  `blazetrails/no-freeform-comments` `files` list in `eslint.config.mjs`.
- `pnpm eslint --fix` applied over the glob: 340 blocks / 624 comment lines
  removed. A second `--fix` run is a no-op and `pnpm eslint` is clean.

Review notes:

- No removed comment carried a Rails `file:line` citation or JSDoc — checked
  by grepping the deletions for `.rb:` / `rails/`.
- No block was emptied by the sweep; the four `catch {}` in the PG tests were
  already empty on `main`.
- One deleted comment did record a known-divergent shape: the
  `PERMANENT-SKIP: driver-limit` marker at
  `packages/activerecord/src/adapters/sqlite3/transaction.test.ts:78`, for
  Rails' `activerecord/test/cases/adapters/sqlite3/transaction_test.rb:42`
  `test "opens a \`read_uncommitted\` transaction"` (better-sqlite3 does not
  expose `SQLITE_OPEN_SHAREDCACHE`, so two connections cannot share a cache).
  Per the sweep's rule that such a comment becomes a story rather than a better
  comment, it is now filed as
  `0023-surfaced-deviations/sqlite3-read-uncommitted-shared-cache-skip` with
  both `file:line`s. The parity register at
  `scripts/parity/unported-files/baseline.json:112-116` is unchanged.
- `pnpm typecheck` clean; the SQLite adapter suites (240 tests) pass locally.
  The MySQL/PG adapter suites need servers and are covered by CI.
- Gates after rebasing onto green `main`: `parity:api:calls` OK,
  `parity:api:calls:args` OK, `parity:api:extra:gate` OK.

Closes-story: strip-freeform-comments-ar-adapters
