### PR TITLE
refactor(activerecord): strip free-form comments from the dialect connection-adapter directories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -739,6 +739,10 @@ export default defineConfig(
       "packages/arel/src/**/*.ts",
       "packages/activemodel/src/**/*.ts",
       "packages/activerecord/src/relation/**/*.ts",
+      "packages/activerecord/src/connection-adapters/mysql/**/*.ts",
+      "packages/activerecord/src/connection-adapters/mysql2/**/*.ts",
+      "packages/activerecord/src/connection-adapters/postgresql/**/*.ts",
+      "packages/activerecord/src/connection-adapters/sqlite3/**/*.ts",
     ],
     rules: {
       "blazetrails/no-freeform-comments": "error",

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -120,7 +120,6 @@ export async function returningColumnValues(
   if (await (this as SupportsInsertReturningHost | null)?.supportsInsertReturning?.()) {
     return result.rows[0] as unknown[] | undefined;
   }
-  // Falls back to abstract base behavior (last_inserted_id path)
   return undefined;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/datetime-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/datetime-bind.test.ts
@@ -21,8 +21,6 @@ describe("MySQL datetime bind formatting", () => {
   });
 
   it("zero-pads years below 1000", () => {
-    // Realistic case: year 44 CE — ensure 4-digit year, not 2-digit (MySQL
-    // 2-digit-year rules would misinterpret "44-01-01 00:00:00")
     const instant = Temporal.Instant.from("0044-01-01T00:00:00Z");
     expect(bind(instant) as string).toMatch(/^0044-/);
   });

--- a/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/explain-pretty-printer.test.ts
@@ -13,8 +13,8 @@ describe("MySQL::ExplainPrettyPrinter", () => {
 
   it("computeColumnWidths returns max width per column", () => {
     const widths = (printer as any).computeColumnWidths(result);
-    expect(widths[0]).toBe(2); // "id" (2) >= "1","2"
-    expect(widths[1]).toBe(11); // "select_type"
+    expect(widths[0]).toBe(2);
+    expect(widths[1]).toBe(11);
   });
 
   it("computeColumnWidths counts NULL as 4 chars", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -13,9 +13,6 @@ import {
 import type { QuotingDispatchHost } from "../abstract/quoting.js";
 import { AbstractMysqlAdapter } from "../abstract-mysql-adapter.js";
 
-// `quote` / `typeCast` self-send onto their receiver; bind
-// the adapter prototype so date/time values reach MySQL's quotedDate override
-// and booleans reach its unquotedTrue/unquotedFalse.
 const HOST = Object.create(AbstractMysqlAdapter.prototype) as QuotingDispatchHost;
 // Rails' MySQL adapter defines no `quote` (mysql/quoting.rb); MySQL value
 // quoting is the inherited abstract `quote` plus the overrides it self-sends.
@@ -144,14 +141,10 @@ describe("MySQL quoting — quotedBinary", () => {
   });
 
   it("formats an ArrayBuffer as hex literal", () => {
-    // Shares the toBytes union with the PG/SQLite overrides rather than relying
-    // on Buffer.from(arraybuffer, "binary") silently ignoring the encoding arg.
     expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer)).toBe("x'deadbeef'");
   });
 
   it("formats a byte-offset view over a larger buffer", () => {
-    // Buffer.from(bytes.buffer, ...) must honour byteOffset/byteLength — a
-    // subarray view would otherwise hex the whole backing buffer.
     expect(quotedBinary(new Uint8Array([0x00, 0xde, 0xad, 0x00]).subarray(1, 3))).toBe("x'dead'");
   });
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -139,7 +139,6 @@ export function castBoundValue(value: unknown): unknown {
 // Rails MySQL COLUMN_NAME supports: integers, `backtick`, "double-quoted", \w identifiers,
 // with up to 2 qualifier prefixes (schema.table.col) and recursive function args.
 export function columnNameMatcher(): RegExp {
-  // id: integer literal, backtick-quoted, double-quoted, or plain \w identifier
   const id =
     String.raw`(?:\d+|` +
     "`" +
@@ -152,7 +151,6 @@ export function columnNameMatcher(): RegExp {
   // Rails uses \w+\((?:|\g<2>)\) — 0 or 1 arg (no comma-separated multi-arg).
   // fnCall2: function with 0 or 1 plain col/star arg (deepest level)
   const fnCall2 = String.raw`\w+\(\s*(?:\*|${col})?\s*\)`;
-  // fnCall1: function with 0 or 1 arg (which can itself be a function)
   const fnCall1 = String.raw`\w+\(\s*(?:\*|${col}|${fnCall2})?\s*\)`;
   const expr = String.raw`(?:${col}|${fnCall1})`;
   const aliased = String.raw`${expr}(?:(?:\s+AS)?\s+${id})?`;
@@ -209,8 +207,6 @@ export function quotedDate(
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSql(value);
   if (value instanceof Temporal.PlainTime) {
-    // Abstract quotedDate normalises a bare time onto 2000-01-01; mirror that so
-    // direct quotedDate(time) calls match the abstract helper's shape.
     const dt = new Temporal.PlainDateTime(
       2000,
       1,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.test.ts
@@ -252,9 +252,6 @@ describe("MySQL::SchemaDumper", () => {
       const d = make();
       d.connection = {
         tableOptions: async () => ({}),
-        // MySQL escapes single quotes inside string literals in generation_expression,
-        // e.g. a JSON path. The `\\'` below is a literal backslash-quote, exactly what
-        // the engine reports for json_extract(`profile`,_utf8mb4'$.email').
         internalExecQuery: async () =>
           Result.fromRowHashes([
             { name: "c", expr: "json_extract(`profile`,_utf8mb4\\'$.email\\')" },
@@ -262,7 +259,6 @@ describe("MySQL::SchemaDumper", () => {
         quote: (v) => `'${String(v)}'`,
       };
       await (d as any).populateVirtualExpressionCache("t");
-      // \' collapses to ', then JSON.stringify re-quotes the whole expression.
       expect(d.virtualExpressionCache["t"]!["c"]).toBe(
         JSON.stringify("json_extract(`profile`,_utf8mb4'$.email')"),
       );

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -77,8 +77,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
     if (!this.connection) return {};
     const opts = await this.connection.tableOptions(tableName);
-    // Populate tableCollationCache when the table has an explicit COLLATE clause so
-    // schemaCollation can suppress per-column collation that matches the table default.
     if (Object.hasOwn(opts, "collation")) {
       this.tableCollationCache[tableName] = opts["collation"];
     } else {
@@ -193,7 +191,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
     // bigint reflects with limit 8 but Rails suppresses it (column.bigint?); detect off sqlType
     // since the cast map reports type:"integer".
     if (/^bigint\b/i.test(column.sqlType ?? "")) return undefined;
-    // int(N) reflects with limit 4 (the native default); suppress so dumps stay clean.
     if (column.type === "integer" && column.limit === 4) return undefined;
     // Mirrors Rails schema_limit: suppress limit when it equals the native default
     // (string varchar(255), float 24, emulated boolean tinyint(1)).
@@ -217,7 +214,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
   /** @internal */
   protected override schemaScale(column: MysqlColumn): string | undefined {
-    // Scale only applies to decimal; suppress the numeric_scale the cast map fills for integers.
     if (column.type !== "decimal") return undefined;
     return super.schemaScale(column);
   }
@@ -225,7 +221,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   /** @internal */
   override async table(tableName: string, stream: string[]): Promise<void> {
     await this.populateVirtualExpressionCache(tableName);
-    // super.table (abstract) populates primaryKeyOrderCache via @connection.primaryKeys.
     await super.table(tableName, stream);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -34,9 +34,6 @@ import { Result } from "../../result.js";
 const mysqlAdapterHost = <T extends object>(overrides?: T): AbstractMysqlAdapter & T =>
   Object.assign(Object.create(AbstractMysqlAdapter.prototype), overrides);
 
-// Minimal ForeignKeysHost: foreignKeys() reads via internalExecQuery, quotes the
-// table name, and maps referential actions. We stub internalExecQuery to return the
-// information_schema rows MySQL would yield (1 row per FK column).
 function fkHost(rows: Record<string, unknown>[]) {
   return mysqlAdapterHost({
     internalExecQuery: async () => Result.fromRowHashes(rows),
@@ -108,8 +105,6 @@ describe("MySQL::SchemaStatements", () => {
     expect(createTableDefinition.call(conn as never, "users").name).toBe("users");
   });
 
-  // Stands in for the adapter that `default_type` / `new_column_from_field`
-  // reach `create_table_info` and `lookup_cast_type` through on `self`.
   const reflectionHost = (
     createTableInfo: string | null = null,
     lookupCastType?: MysqlColumnReflectionHost["lookupCastType"],
@@ -506,8 +501,6 @@ describe("MySQL::SchemaStatements", () => {
     expect(fks[0].toTable).toBe("roc`kets");
   });
 
-  // Minimal host: indexes() reads via internalExecQuery and quotes the table
-  // name. Stub internalExecQuery to return the `SHOW KEYS FROM` rows MySQL yields.
   const indexHost = (rows: Record<string, unknown>[], sortOrderSupported = true) =>
     Object.assign(Object.create(MysqlSchemaStatements.prototype) as MysqlSchemaStatements, {
       internalExecQuery: async () => Result.fromRowHashes(rows),
@@ -592,8 +585,6 @@ describe("MySQL::SchemaStatements", () => {
         Collation: "D",
       },
     ]).indexes("pages");
-    // Expression columns pass through their parenthesized form; plain columns
-    // are quoted with prefix length and DESC order baked in.
     expect(idx[0].columns).toBe("(lower(`title`)), `position`(4) DESC");
     expect(idx[0].orders).toEqual({});
     expect(idx[0].lengths).toEqual({});
@@ -649,13 +640,10 @@ describe("parseMysqlName", () => {
   });
 
   it("permits whitespace inside a backtick-quoted identifier", () => {
-    // MySQL allows whitespace only inside backtick-quoted identifiers.
     expect(parseMysqlName("`not a real table`")).toEqual({ table: "not a real table" });
   });
 
   it("rejects three-part identifiers instead of silently truncating", () => {
-    // The prior regex tokenizer silently kept the first two parts of "a.b.c",
-    // pointing introspection at a different table.
     expect(() => parseMysqlName("a.b.c")).toThrow(/Invalid MySQL identifier/);
   });
 
@@ -673,8 +661,6 @@ describe("parseMysqlName", () => {
   });
 
   it("rejects empty quoted identifiers that unquote to an empty string", () => {
-    // ``, `a`.``, ``.widgets all lex fine but unquote to "" — which would
-    // break COALESCE(?, database()) and scan the wrong catalog.
     expect(() => parseMysqlName("``")).toThrow(/Invalid MySQL identifier/);
     expect(() => parseMysqlName("``.widgets")).toThrow(/Invalid MySQL identifier/);
     expect(() => parseMysqlName("`db`.``")).toThrow(/Invalid MySQL identifier/);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -84,7 +84,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     for (const r of rows) {
       const keyName = String((r.Key_name ?? r.KEY_NAME) as string);
       if (currentIndex !== keyName) {
-        if (keyName === "PRIMARY") continue; // skip the primary key
+        if (keyName === "PRIMARY") continue;
         currentIndex = keyName;
 
         const idxType = String((r.Index_type ?? r.INDEX_TYPE ?? "BTREE") as string).toLowerCase();
@@ -339,8 +339,6 @@ export function createTableDefinition(
  */
 export interface MysqlColumnReflectionHost {
   createTableInfo(tableName: string): Promise<string | null>;
-  // Optional so a caller that has no type map still reflects columns through
-  // `fetch_type_metadata`'s modifier-stripping fallback.
   lookupCastType?(sqlType: string): {
     name: string;
     limit?: number | null;
@@ -401,7 +399,6 @@ export async function newColumnFromField(
   } else if (meta.type === "text" && def?.startsWith("'")) {
     def = def.slice(1, -1).replace(/\\'/g, "'");
   } else if (def != null && /^\d/.test(def)) {
-    // Its a number so we can skip the query to check if it is a function
   } else if (def != null && (await defaultType.call(this, tableName, fieldName)) === "function") {
     [def, defFn] = [null, def];
   }
@@ -438,15 +435,12 @@ export function fetchTypeMetadata(
 
   if (lookupCastType) {
     const castType = lookupCastType(sqlType);
-    // Use .name (plain string property on ActiveModel Type).
     const raw = castType.name.toLowerCase();
     baseType = /^timestamp/.test(raw) ? "datetime" : raw;
     limit = castType.limit ?? null;
     precision = castType.precision ?? null;
     scale = castType.scale ?? null;
   } else {
-    // Fallback: strip (N) modifiers, then take first whitespace token to drop
-    // trailing modifiers like "unsigned" or "zerofill".
     baseType = sqlType
       .replace(/\(.*\).*$/, "")
       .trim()
@@ -461,7 +455,6 @@ export function fetchTypeMetadata(
 
 /** @internal */
 export function extractForeignKeyAction(specifier: string): "cascade" | "nullify" | undefined {
-  // RESTRICT is MySQL's default; omit it so FK definitions stay clean.
   if (specifier === "RESTRICT") return undefined;
   switch (specifier) {
     case "CASCADE":
@@ -602,10 +595,6 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
   const unquote = (s: string): string =>
     s.startsWith("`") && s.endsWith("`") ? s.slice(1, -1).replace(/``/g, "`") : s;
 
-  // Parse a single identifier token starting at `start`. Returns the
-  // raw token (with backticks kept, to preserve quote distinctness)
-  // and the index of the next unconsumed character. Throws on empty
-  // or unterminated tokens.
   const parsePart = (start: number): { part: string; nextIndex: number } => {
     if (start >= input.length) invalid();
     if (input[start] === "`") {
@@ -624,29 +613,18 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
         part += input[i];
         i += 1;
       }
-      invalid(); // unterminated
+      invalid();
     }
     let i = start;
-    // Stop at `.`, the start of a quoted token, or any whitespace.
-    // MySQL only permits whitespace inside *backtick-quoted*
-    // identifiers; an unquoted "db .widgets" would therefore be
-    // invalid. Treating whitespace as a token boundary (rather than
-    // part of the name) lets the extra-content check downstream
-    // reject the input cleanly.
     while (i < input.length && input[i] !== "." && input[i] !== "`" && !/\s/.test(input[i])) {
       i += 1;
     }
-    if (i === start) invalid(); // empty
+    if (i === start) invalid();
     return { part: input.slice(start, i), nextIndex: i };
   };
 
   if (input.length === 0) invalid();
 
-  // unquote + re-validate non-empty: a quoted token like "``" lexes
-  // fine in parsePart (backticks match, body is empty) but unquotes
-  // to "", which would break COALESCE(?, database()) and make the
-  // introspection call silently scan the wrong catalog. Centralize
-  // the empty-check here so both bare and quoted forms are covered.
   const checkNonEmpty = (part: string): string => {
     const s = unquote(part);
     if (s.length === 0) invalid();
@@ -659,7 +637,7 @@ export function parseMysqlName(name: string): { schema?: string; table: string }
   }
   if (input[first.nextIndex] !== ".") invalid();
   const second = parsePart(first.nextIndex + 1);
-  if (second.nextIndex !== input.length) invalid(); // extra content
+  if (second.nextIndex !== input.length) invalid();
   return { schema: checkNonEmpty(first.part), table: checkNonEmpty(second.part) };
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import { temporalTypeCast } from "./temporal-type-cast.js";
 
-// mysql2's createTypecastField sets field.type to the string name, not a numeric OID.
 function field(type: string, value: string | null) {
   return { type, string: () => value };
 }

--- a/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/temporal-type-cast.ts
@@ -55,7 +55,6 @@ export function temporalTypeCast(field: Field, next: NextFn): unknown {
     }
     case "DATE":
     case "NEWDATE": {
-      // NEWDATE is the MySQL protocol's internal DATE-only wire type.
       const raw = field.string();
       if (raw === null) return null;
       return parseMysqlDate(raw);

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -65,16 +65,16 @@ export interface Mysql2RawResult {
  * @internal
  */
 const MYSQL_NUMERIC_FIELD_SQL_TYPE: Readonly<Record<number, string>> = {
-  0: "decimal", // DECIMAL
-  246: "decimal", // NEWDECIMAL
-  4: "float", // FLOAT
-  5: "double", // DOUBLE
-  1: "tinyint", // TINY
-  2: "smallint", // SHORT
-  9: "mediumint", // INT24
-  3: "int", // LONG
-  8: "bigint", // LONGLONG
-  13: "year", // YEAR
+  0: "decimal",
+  246: "decimal",
+  4: "float",
+  5: "double",
+  1: "tinyint",
+  2: "smallint",
+  9: "mediumint",
+  3: "int",
+  8: "bigint",
+  13: "year",
 };
 
 /**
@@ -98,18 +98,12 @@ export function buildColumnTypes(
     if (code == null) continue;
     let sqlType = MYSQL_NUMERIC_FIELD_SQL_TYPE[code];
     if (sqlType == null) continue;
-    // Honor a decimal column's scale so cast truncates to the right places
-    // (precision 65 is MySQL's DECIMAL maximum — the scale is what matters).
-    // `decimals === 0` (a `DECIMAL(n,0)`) is intentionally left to the bare
-    // `decimal` lookup: it still builds a BigDecimal, just without an explicit
-    // scale, so no truncation is needed.
     if (sqlType === "decimal" && typeof f.decimals === "number" && f.decimals > 0) {
       sqlType = `decimal(65,${f.decimals})`;
     }
     const type = lookupCastType(sqlType);
     columnTypes ??= {};
     columnTypes[i] = type;
-    // Guard a column literally named "1" from colliding with integer index 1.
     if (!/^\d+$/.test(f.name)) columnTypes[f.name] = type;
   }
   return columnTypes;
@@ -314,7 +308,6 @@ export async function performQuery(
   let rawResult: unknown;
   let rawFields: mysql.FieldPacket[] | undefined;
   if (!hasBinds) {
-    // Avoid #affected_rows when result exists — sidesteps gem 0.5.6 GVL race (brianmario/mysql2#1383).
     [rawResult, rawFields] = (await rawConnection.query({
       sql,
       rowsAsArray: true,

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -55,8 +55,6 @@ export class Column extends BaseColumn {
     this.serial = options.serial ?? false;
     this.oid = sqlTypeMetadata.oid ?? null;
     this.fmod = sqlTypeMetadata.fmod ?? null;
-    // Use the raw sqlTypeMetadata.sqlType (not `this.sqlType`) so the check
-    // runs against the unstripped string — our sqlType getter strips "[]".
     this.array = options.array ?? sqlTypeMetadata.sqlType?.endsWith("[]") ?? false;
     this.identity = options.identity ?? null;
     this.generated = options.generated ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -190,7 +190,6 @@ export async function performQuery<R extends pg.QueryResult = pg.QueryResult>(
               { sql, binds, cause: error },
             );
           } else {
-            // outside of transactions we can simply flush this query and retry
             await this._statements.delete(this.sqlKey(sql));
             continue;
           }
@@ -200,9 +199,6 @@ export async function performQuery<R extends pg.QueryResult = pg.QueryResult>(
     }
   } else if (binds == null || binds.length === 0) {
     this._commandSettled = false;
-    // `async_exec` on a PG::Result carries both row views; node-pg needs the
-    // config form to be told which one, so a caller that asked for positional
-    // rows gets it here too. Without one this stays the bare simple-query call.
     raw = await query(rawConnection, rowMode ? { text: sql, rowMode } : sql);
   } else {
     this._commandSettled = false;

--- a/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/explain-pretty-printer.ts
@@ -30,8 +30,6 @@ export class ExplainPrettyPrinter {
     const header = result.columns[0];
     const lines = result.rows.map((row) => String(row[0]));
 
-    // We add 2 because there's one char of padding at both sides, note
-    // the extra hyphens in the example above.
     const width = Math.max(...[header, ...lines].map((line) => line.length)) + 2;
 
     const pp: string[] = [];

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -95,7 +95,7 @@ export class PgTextDecoderArray {
           }
           i++;
         }
-        i++; // closing quote
+        i++;
         elements.push(val);
       } else if (
         inner.substring(i, i + 4).toUpperCase() === "NULL" &&
@@ -209,8 +209,6 @@ export class Array extends ValueType<unknown> {
         value = this.pgDecoder.decode(value);
       } catch (error) {
         if (!(error instanceof TypeError)) throw error;
-        // malformed array string is treated as [], will raise in PG 2.0 gem
-        // this keeps a consistent implementation
         value = [];
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/bytea.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/bytea.ts
@@ -24,8 +24,6 @@ export class Bytea extends BinaryType {
   override deserialize(value: unknown): unknown {
     if (value == null) return null;
     if (value instanceof BinaryData) return value.bytes;
-    // Buffer in Node is already a Uint8Array — return it directly instead
-    // of allocating a copy via Uint8Array.from.
     if (typeof value === "string") return unescapeBytea(value);
     return super.deserialize(value);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.test.ts
@@ -37,21 +37,16 @@ describe("PostgreSQL::OID::Cidr", () => {
 
   it("canonicalizes IPv6 to RFC 5952 form on cast (matches Ruby IPAddr#to_s)", () => {
     const type = new Cidr();
-    // Lowercase hex + leading-zero stripping.
     expect(type.castValue("2001:DB8::1")?.address).toBe("2001:db8::1");
     expect(type.castValue("2001:0DB8:0000:0000:0000:0000:0000:0001")?.address).toBe("2001:db8::1");
-    // Longest run of zeros compressed; leftmost run wins on ties.
     expect(type.castValue("2001:db8:0:0:1:0:0:1")?.address).toBe("2001:db8::1:0:0:1");
-    // Edge cases.
     expect(type.castValue("::1")?.address).toBe("::1");
     expect(type.castValue("::")?.address).toBe("::");
     expect(type.castValue("0:0:0:0:0:0:0:0")?.address).toBe("::");
     // IPv4-tailed forms are kept in mixed notation (PG + Ruby IPAddr#to_s behavior).
     expect(type.castValue("::ffff:192.168.0.1")?.address).toBe("::ffff:192.168.0.1");
-    // Pure-hex IPv4-mapped forms are also normalized to mixed notation.
     expect(type.castValue("::ffff:c0a8:1")?.address).toBe("::ffff:192.168.0.1");
     expect(type.castValue("0:0:0:0:0:ffff:c0a8:1")?.address).toBe("::ffff:192.168.0.1");
-    // Single zero groups are not compressed (RFC 5952: run must be ≥ 2).
     expect(type.castValue("2001:db8:0:1:1:1:1:1")?.address).toBe("2001:db8:0:1:1:1:1:1");
   });
 
@@ -60,14 +55,11 @@ describe("PostgreSQL::OID::Cidr", () => {
     const a = type.castValue("2001:DB8::1");
     const b = type.castValue("2001:0db8:0000:0000:0000:0000:0000:0001");
     expect(type.isChanged(a, b)).toBe(false);
-    // Different prefix is still a change.
     const c = type.castValue("2001:db8::1/64");
     expect(type.isChanged(a, c)).toBe(true);
-    // IPv4-tailed: compressed and expanded forms are the same address.
     const d = type.castValue("0:0:0:0:0:ffff:192.168.0.1");
     const e = type.castValue("::ffff:192.168.0.1");
     expect(type.isChanged(d, e)).toBe(false);
-    // Pure-hex IPv4-mapped: canonical form equals mixed-notation form.
     const f = type.castValue("::ffff:c0a8:1");
     expect(type.isChanged(e, f)).toBe(false);
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/cidr.ts
@@ -170,8 +170,6 @@ function canonicalizeIpv6(value: string): string {
     // as-is and canonicalize only the 6-group hex prefix. Both PG and Ruby
     // IPAddr#to_s use mixed notation for IPv4-mapped addresses.
     ipv4Tail = value.slice(lastColon + 1);
-    // Substitute "0:0" for the IPv4 tail so the :: expansion logic always sees
-    // 8 groups; the last two placeholder groups are discarded via slice(0, 6) below.
     head = value.slice(0, lastColon + 1) + "0:0";
   }
 
@@ -198,7 +196,6 @@ function canonicalizeIpv6(value: string): string {
     ipv4Tail = `${g6 >> 8}.${g6 & 0xff}.${g7 >> 8}.${g7 & 0xff}`;
   }
 
-  // Apply RFC 5952 to the hex prefix only (6 groups when IPv4 tail, 8 otherwise).
   const activeGroups = ipv4Tail ? groups.slice(0, 6) : groups;
 
   let bestStart = -1;
@@ -229,8 +226,6 @@ function canonicalizeIpv6(value: string): string {
   }
 
   if (ipv4Tail) {
-    // "::ffff" + ":" + "192.168.0.1" → "::ffff:192.168.0.1"
-    // "::" (all-zero prefix) + "192.168.0.1" → "::192.168.0.1"
     return hexResult.endsWith("::") ? hexResult + ipv4Tail : hexResult + ":" + ipv4Tail;
   }
   return hexResult;
@@ -258,8 +253,6 @@ function isIpv6(value: string): boolean {
   if (doubleColons && doubleColons.length > 1) return false;
   if (value === "::") return true;
 
-  // Split the trailing IPv4 tail (e.g. ::ffff:192.168.0.1) out of the
-  // hextet sequence. It counts as 2 hextets toward the 8-group total.
   const parts = value.split(":");
   const last = parts[parts.length - 1];
   let ipv4Tail = false;
@@ -275,7 +268,6 @@ function isIpv6(value: string): boolean {
     const leftParts = left === "" ? [] : left.split(":");
     let rightParts = right === "" ? [] : right.split(":");
     if (ipv4Tail) {
-      // IPv4 tail already counted as two placeholder hextets above.
       rightParts = rightParts.slice(0, -1).concat(["0", "0"]);
     }
     if (

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.test.ts
@@ -35,14 +35,11 @@ describe("PostgreSQL::OID::DateTime", () => {
   });
 
   it("serialize returns the cast Instant (quoting renders the SQL literal)", () => {
-    // value_for_database is now the cast Temporal.Instant; the adapter's
-    // quoted_date renders the SQL literal (incl. the " BC" suffix) downstream.
     const instant = type.castValue("0044-01-01 00:00:00 BC") as Temporal.Instant;
     expect(type.serialize(instant)).toBe(instant);
   });
 
   it("quoted_date converts BC Temporal.Instant to PG BC format", () => {
-    // 44 BC = ISO year -43; round-trip via castValue to create the Instant
     const instant = type.castValue("0044-01-01 00:00:00 BC") as Temporal.Instant;
     expect(instant.toZonedDateTimeISO("UTC").year).toBe(-43);
     expect(quotedDate(instant)).toBe("0044-01-01 00:00:00 BC");

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/date-time.ts
@@ -51,10 +51,6 @@ export class DateTime extends DateTimeType {
       if (value === "-infinity") return DateNegativeInfinity;
       if (/ BC$/.test(value)) {
         try {
-          // BC dates may have offset (timestamptz) or not (timestamp). Both
-          // return Instant — parsePostgresTimestampAsInstant interprets naive
-          // values in defaultSqlTimezone() (UTC by default, host-local when
-          // ActiveRecord.default_timezone === "local").
           const hasOffset = /[-+]\d{2}(?::\d{2})?$/.test(value.slice(0, -3).trimEnd());
           return hasOffset ? parsePostgresInstant(value) : parsePostgresTimestampAsInstant(value);
         } catch {
@@ -73,11 +69,6 @@ export class DateTime extends DateTimeType {
    * `quoted_date` / bind layer, matching Rails where the adapter does the quoting.
    */
   override serialize(value: unknown): unknown {
-    // Cast first so the PG infinity *strings* ("infinity" / "-infinity") and
-    // the numeric ±Infinity sentinels both resolve to the sentinel before the
-    // wire-literal mapping — otherwise the string forms fall through to the
-    // base serialize, which hands back the raw ±Infinity number instead of the
-    // "infinity"/"-infinity" wire literal PG expects.
     const cast = this.cast(value);
     if (cast === DateInfinity) return "infinity";
     if (cast === DateNegativeInfinity) return "-infinity";

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.test.ts
@@ -9,8 +9,6 @@ describe("PostgreSQL::OID::Money", () => {
   });
 
   it("castValue is the public Rails-named hook", () => {
-    // cast delegates to castValue; both paths handle locale-formatted
-    // money strings identically, returning a BigDecimal (Money < Decimal).
     expect((new Money().castValue("$1,234.56") as BigDecimal).toString("F")).toBe("1234.56");
     expect((new Money().cast("$1,234.56") as BigDecimal).toString("F")).toBe("1234.56");
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/money.ts
@@ -55,7 +55,6 @@ export class Money extends DecimalType {
     if (value === null || value === undefined) return null;
     if (typeof value !== "string") return super.castValue(value);
 
-    // (4) (2.55) → -2.55
     let str = value.replace(/^\((.+)\)$/, "-$1");
 
     // Use [^0-9,.] for the currency-symbol prefix instead of \D* to prevent
@@ -63,10 +62,8 @@ export class Money extends DecimalType {
     // causing O(n²) backtracking on long repeated-separator inputs. Ruby avoids
     // this with possessive quantifiers (\D*+); JS has no possessive quantifiers.
     if (/^-?[^0-9,.]*[\d,]+\.\d{2}$/.test(str)) {
-      // (1) US format: keep digits/minus/dot, drop everything else.
       str = str.replace(/[^\-0-9.]/g, "");
     } else if (/^-?[^0-9,.]*[\d.]+,\d{2}$/.test(str)) {
-      // (2) EU format: drop non-digit/minus/comma, then comma → dot.
       str = str.replace(/[^\-0-9,]/g, "").replace(/,/g, ".");
     }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/range.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/range.test.ts
@@ -105,22 +105,17 @@ describe("PostgreSQL::OID::Range", () => {
 
     it("formats a value as a string via String()", () => {
       const type = new RangeType(passthroughSubtype, "int4range");
-      // inspect() falls through to String(value) for non-primitive, non-Temporal objects.
       expect(typeof type.typeCastForSchema(new Range(1, 10))).toBe("string");
     });
 
     it("formats a Temporal.Instant value via inspect()", () => {
       const type = new RangeType(passthroughSubtype, "tstzrange");
       const instant = Temporal.Instant.from("2026-04-28T00:00:00Z");
-      // inspect() is called with the Instant directly when passed as the
-      // top-level value to typeCastForSchema.
       expect(type.typeCastForSchema(instant)).toContain("2026-04-28");
     });
 
     it("throws on Date passed directly to typeCastForSchema / inspect()", () => {
       const type = new RangeType(passthroughSubtype, "tsrange");
-      // inspect() receives the Date directly here (not as a Range bound),
-      // exercising the Date guard added in this PR.
       expect(() => type.typeCastForSchema(new Date())).toThrow(TypeError);
       expect(() => type.typeCastForSchema(new Date())).toThrow(/Temporal/);
     });

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.test.ts
@@ -91,7 +91,6 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
 
   it("skips array registration when element OID is not in the store", () => {
     const store = new TestStore();
-    // The base type map keys scalar types by name (e.g. "numeric"), not by OID.
     store.registerType("numeric", integerSubtype);
 
     // Process only the array row (element OID 1700 not yet keyed in the store).
@@ -101,8 +100,6 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
     ]);
     expect(store.lookup(1231)).not.toBeInstanceOf(OidArray);
 
-    // When the element row aliases OID 1700 → "numeric" first (the by-typname
-    // pass of the eager full load), the array row resolves its subtype.
     store.aliasType(1700, "numeric");
     new TypeMapInitializer(store).run([
       row({ oid: 1231, typname: "_numeric", typinput: "array_in", typelem: 1700 }),

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -27,10 +27,6 @@ import {
   unescapeBytea,
 } from "./quoting.js";
 
-// `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
-// PG's quotedDate so date/time values reach the BC-suffixing override, and its
-// quotedBinary so binary values reach the bytea-hex override — a real adapter
-// host carries both.
 const HOST = quotingHost({ quotedDate, quotedBinary });
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
@@ -57,9 +53,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("type casts binary data to a Buffer for node-postgres bytea binding", () => {
-    // node-postgres natively binds Buffer as bytea (hex literal in text mode).
-    // Returning a Buffer preserves bytes 128–255 that the prior
-    // `{ value: value.toString(), format: 1 }` shape corrupted via UTF-8 decode.
     const cast = typeCast(new BinaryData(new Uint8Array([0xde, 0xad, 0xbe, 0xef])));
     expect(Buffer.isBuffer(cast)).toBe(true);
     expect(Array.from(cast as Buffer)).toEqual([0xde, 0xad, 0xbe, 0xef]);
@@ -76,9 +69,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quotes arrays through the encoder's delimiter, not a hardcoded comma", async () => {
-    // box[] uses a `;` element delimiter; routing quote/typeCast through
-    // encodeArray (which calls the OID encoder) keeps it type-correct rather
-    // than diverging on a hardcoded `,`.
     const boxArray = new ArrayData(new PgTextEncoderArray({ name: "box[]", delimiter: ";" }), [
       "(1,1),(0,0)",
       "(2,2),(1,1)",
@@ -143,9 +133,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quotes a binary default produced by BinaryType#serialize", async () => {
-    // Guards the real quoteDefaultExpression path: whatever the type map's
-    // serialize emits must still reach PG's bytea form.
-    // `array` must be present: the serialize branch is gated on `"array" in column`.
     const column = { sqlType: "bytea", array: false };
     const typeMap = { lookupCastTypeFromColumn: () => new BinaryType() };
     expect(await quoteDefaultExpression.call(HOST, "ab", column, typeMap)).toBe("'\\x6162'");
@@ -174,11 +161,9 @@ describe("PostgreSQL quoting", () => {
     expect(await quoteDefaultExpression.call(HOST, "uuid_generate_v4()", column)).toBe(
       "uuid_generate_v4()",
     );
-    // A non-function string default on a uuid column is still quoted.
     expect(
       await quoteDefaultExpression.call(HOST, "11111111-1111-1111-1111-111111111111", column),
     ).toBe("'11111111-1111-1111-1111-111111111111'");
-    // The branch is uuid-only — the same string on a text column is quoted.
     expect(
       await quoteDefaultExpression.call(HOST, "gen_random_uuid()", {
         type: "text",
@@ -194,7 +179,6 @@ describe("PostgreSQL quoting", () => {
         return null;
       },
     };
-    // A plain string value should still round-trip normally
     expect(await quoteDefaultExpression.call(HOST, "hello", column, nullTypeMap)).toBe("'hello'");
   });
 
@@ -253,9 +237,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("unescapes legacy octal bytea with escaped backslashes", () => {
-    // PG::Connection.unescape_bytea handles the pre-9.0 octal format: \NNN
-    // for bytes and \\ for a literal backslash. Parsed byte-by-byte so
-    // high bytes aren't UTF-8 re-encoded.
     expect(unescapeBytea("a\\134\\000b")).toEqual(Buffer.from([0x61, 0x5c, 0x00, 0x62]));
   });
 
@@ -278,8 +259,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quotedBinary hexes an ArrayBuffer view like MySQL/SQLite do", () => {
-    // Routed through the shared toBytes: a DataView (non-Uint8Array view) hexes
-    // its own bytes rather than raising inside escapeBytea's Buffer.from.
     const buffer = new Uint8Array([0x1f, 0x8b]).buffer;
     expect(quotedBinary(new DataView(buffer))).toBe("'\\x1f8b'");
   });
@@ -290,8 +269,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quote(Uint8Array) emits a bytea hex literal via quotedBinary", () => {
-    // byte 0x8b (> 0x7f) must not be corrupted to the UTF-8 replacement
-    // character sequence EF BF BD — regression for the String(buffer) path
     expect(quote(new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
   });
 
@@ -300,9 +277,6 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quote(non-Uint8Array ArrayBuffer view) normalizes to bytes via quotedBinary", () => {
-    // Views other than Uint8Array reach the inherited abstract quote, which
-    // normalizes them to bytes and self-dispatches to the adapter's
-    // quotedBinary rather than raising `can't quote Int8Array`.
     expect(quote(new Int8Array([0x1f, 0x8b - 0x100]))).toBe("'\\x1f8b'");
     expect(quote(new DataView(new Uint8Array([0x1f, 0x8b]).buffer))).toBe("'\\x1f8b'");
   });
@@ -376,14 +350,12 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quoted_date caps fractional seconds at microseconds (drops nanos)", () => {
-    // Nil-precision nanosecond value must not reach the PG wire as 7–9 digits.
     expect(quotedDate(Temporal.Instant.from("2026-04-26T14:23:55.123456789Z"))).toBe(
       "2026-04-26 14:23:55.123456",
     );
   });
 
   it("quoted_date suffixes BC for an Instant with proleptic year <= 0", () => {
-    // 44 BC = ISO year -43; usec 0 → no fractional field.
     const instant = Temporal.Instant.from("-000043-03-15T12:34:56Z");
     expect(instant.toZonedDateTimeISO("UTC").year).toBe(-43);
     expect(quotedDate(instant)).toBe("0044-03-15 12:34:56 BC");

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -176,8 +176,6 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     if (value.isHex()) return `X'${value.toString()}'`;
     return null as unknown as string;
   }
-  // rb: `when Numeric then value.finite? ? super : "'#{value}'"` — the
-  // non-finite literal is interpolated raw, not escaped.
   if (typeof value === "number" && !Number.isFinite(value)) {
     return `'${String(value)}'`;
   }
@@ -249,10 +247,6 @@ export async function quoteDefaultExpression(
         serialized = new OidArray(subtype).serialize(value);
       }
     } else if (column.array === true) {
-      // Non-array values on an array column (e.g. a raw `"{}"` literal)
-      // must pass through to quote() unchanged — the lookup here returns
-      // the element subtype, whose serialize would coerce the string
-      // (Integer#serialize("{}") → NaN) and break the literal default.
       serialized = value;
     } else if (castType?.serialize) {
       serialized = castType.serialize(value);
@@ -335,19 +329,13 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
 }
 
 export function escapeBytea(value: Buffer | Uint8Array | string): string {
-  // Treat string inputs as raw byte sequences ("binary") so callers passing
-  // pre-encoded binary strings don't get UTF-8 re-encoded.
   const buffer = typeof value === "string" ? Buffer.from(value, "binary") : Buffer.from(value);
   return `\\x${buffer.toString("hex")}`;
 }
 
 export function unescapeBytea(value: string): Buffer {
-  // Matches PG::Connection.unescape_bytea's contract: this is intentionally
-  // not the inverse of escapeBytea for every possible input representation.
   if (value.startsWith("\\x")) return Buffer.from(value.slice(2), "hex");
 
-  // Legacy octal escape format: \NNN octet triples and \\ backslash. Parse
-  // byte-by-byte so high bytes aren't UTF-8 re-encoded by Buffer.from.
   const bytes: number[] = [];
   for (let i = 0; i < value.length; i++) {
     const ch = value[i];
@@ -361,9 +349,6 @@ export function unescapeBytea(value: string): Buffer {
       const octal = value.slice(i + 1, i + 4);
       if (/^[0-7]{3}$/.test(octal)) {
         const byte = parseInt(octal, 8);
-        // Bytea octal escapes are byte-sized (0o000..0o377). \400–\777 isn't
-        // valid PG output; treat those as a literal backslash + digits
-        // instead of quietly overflowing.
         if (byte <= 0o377) {
           bytes.push(byte);
           i += 3;
@@ -469,9 +454,6 @@ export function quotedDate(
     return formatInstantForSqlPostgres(value.toInstant());
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSqlPostgres(value);
   if (value instanceof Temporal.PlainDate) return formatPlainDateForSqlPostgres(value);
-  // PlainTime carries no date/year — no BC bias applies. The abstract formatter
-  // handles it (and `quoted_time` strips the date prefix off the PlainDateTime
-  // form callers route through here).
   return abstractQuotedDate(value);
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
@@ -52,7 +52,6 @@ describe("disableReferentialIntegrity", () => {
         executed.push(sql);
         return [];
       },
-      // A later call would report the mutated set; disable/enable must ignore it.
       tables: async () => current,
       transaction: async (fn) => fn(),
     };

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -11,9 +11,6 @@ export interface ReferentialIntegrity {
   checkAllForeignKeysValidBang(): Promise<void>;
 }
 
-// Host for the *Sql helpers: quoting dispatches through the adapter instance
-// (`this.quoteTableName`) so a sub-adapter can override it polymorphically,
-// rather than binding to the dialect's freestanding quoteTableName.
 interface ReferentialIntegritySqlHost {
   quoteTableName(name: string): string;
 }
@@ -32,8 +29,6 @@ export function enableReferentialIntegritySql(
   return tables.map((t) => `ALTER TABLE ${this.quoteTableName(t)} ENABLE TRIGGER ALL`);
 }
 
-// Host for the instance methods: the adapter supplies its transaction/execute
-// machinery and table listing, plus the `*Sql` host (`quoteTableName`).
 interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
   execute(sql: string): Promise<unknown>;
   tables(): Promise<string[]>;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -132,8 +132,6 @@ describe("PostgreSQL SchemaCreation", () => {
     // postgresql/quoting.rb:159-160 — a `()`-bearing string default on a
     // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
     const col = new Column("id", null, { sqlType: "uuid", type: "uuid" });
-    // The shared stub fakes quoteDefaultExpression; this branch lives in
-    // the real one, so wire that in.
     const host = s();
     host.adapter.quoteDefaultExpression = (v: unknown, c: unknown) =>
       quoteDefaultExpression.call(null as never, v, c as never);
@@ -159,9 +157,6 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(
       await s().addColumnOptionsBang("n", { as: "a||b", stored: true, column: col }),
     ).toContain("STORED");
-    // async wrapper: the visitor surface is Promise-returning, but the
-    // VIRTUAL guard (_pgGeneratedClause) currently throws synchronously —
-    // rejects.toThrow covers both shapes.
     await expect(async () =>
       s().addColumnOptionsBang("n", { as: "a||b", stored: false, column: col }),
     ).rejects.toThrow("VIRTUAL");

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -414,7 +414,6 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
     td.string("message");
     td.uniqueConstraint("message", { name: "unique_msg" });
     const sql = await toSql(td);
-    // Constraint must appear inside the column list, before the trailing WITH clause
     const constraintPos = sql.indexOf('CONSTRAINT "unique_msg"');
     const withPos = sql.indexOf("WITH (");
     expect(constraintPos).toBeGreaterThan(0);
@@ -458,7 +457,6 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
     expect(sql).toContain('"path" ltree');
     expect(sql).toContain('"doc" tsvector');
     expect(sql).toContain('"payload" xml');
-    // BIT / BIT VARYING come from the pgColumn helpers verbatim (already uppercase).
     expect(sql).toContain('"flags" BIT(8)');
     expect(sql).toContain('"flex" BIT VARYING(16)');
     expect(sql).toContain('"price" money');
@@ -467,13 +465,11 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("emits PG-specific long-tail column SQL types lowercase when adapter provides typeToSql", async () => {
-    // Stub adapter mirrors PostgreSQLAdapter.NATIVE_DATABASE_TYPES lowercase
-    // output — verifies that the visitor delegates to the adapter's typeToSql.
     const stubAdapter = {
       quoteColumnName: (s: string) => `"${s}"`,
       quoteTableName: (s: string) => `"${s}"`,
       quoteDefaultExpression: (v: unknown) => ` DEFAULT ${String(v)}`,
-      typeToSql: (type: string) => type, // returns lowercase verbatim (mirrors PG native types)
+      typeToSql: (type: string) => type,
       validColumnDefinitionOptions: () => ColumnDefinition.OPTION_NAMES,
       // `SchemaCreation` delegates its capability probes to `@conn`
       // (abstract/schema_creation.rb:16-21); answer as PostgreSQLAdapter does.
@@ -585,7 +581,6 @@ describeIfPostgresqlAdapter("TableDefinition#validColumnDefinitionOptions", () =
     for (const key of ["array", "using", "castAs", "as", "type", "enumType", "stored"]) {
       expect(opts).toContain(key);
     }
-    // Abstract OPTION_NAMES carry through via super.
     expect(opts).toContain("collation");
     expect(opts).toContain("ifNotExists");
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -296,11 +296,6 @@ export class TableDefinition extends AbstractTableDefinition {
       type = options.type as ColumnType;
     }
     const def = super.newColumnDefinition(name, type, options);
-    // Record the physical storage type for datetime-family columns so the
-    // schema dumper can re-derive the dumped type against the live
-    // datetime_type (mirrors what re-introspecting the column would yield).
-    // `:datetime` resolves to whatever datetime_type is aliased to at creation
-    // time; `:timestamp` / `:timestamptz` are stored as-written.
     const t = def.type as string;
     if (t === "datetime") {
       def.datetimePhysicalType = pgDatetimeConfig.datetimeType;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -46,7 +46,6 @@ describe("PostgreSQL::SchemaDumper", () => {
     it("returns bigserial for a serial bigint column", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
       const col = makeColumn({ sqlType: "bigint", type: "integer", serial: true });
-      // serial bigint → bigserial
       expect(dumper.schemaType(col)).toBe("bigserial");
     });
 
@@ -64,7 +63,6 @@ describe("PostgreSQL::SchemaDumper", () => {
 
     it("returns semantic type for non-serial non-bigint columns", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
-      // sqlType = "character varying", but sqlTypeMetadata.type = "string" (semantic)
       const col = makeColumn({ sqlType: "character varying", type: "string" });
       expect(dumper.schemaType(col)).toBe("string");
     });
@@ -181,7 +179,6 @@ describe("PostgreSQL::SchemaDumper", () => {
 
     it("adds enum_type for enum columns", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
-      // isEnum checks sqlTypeMetadata.type === "enum"
       const col = new Column("status", null, { sqlType: "mood", type: "enum" }, true, {});
       const spec = dumper.prepareColumnOptions(col);
       expect(spec["enum_type"]).toBe(JSON.stringify("mood"));

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -12,9 +12,6 @@ import type {
 import type { ColumnInfo, IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
-  // Per-table constraint cache populated by filterIndexesForDump and consumed
-  // by exclusionConstraintsInCreate / uniqueConstraintsInCreate to avoid
-  // fetching the same constraint lists twice per table.
   private _cachedExclConstraints: ExclusionConstraintDefinition[] | undefined;
   private _cachedUniqConstraints: UniqueConstraintDefinition[] | undefined;
   /**
@@ -128,13 +125,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
   /** @internal */
   protected override schemaType(column: ColumnInfo): string {
-    // Use sqlType to detect bigint (works with both real Column objects and
-    // plain ColumnInfo from AdapterSchemaSource, which has no isBigint() method).
     const isBigSql = /^bigint\b/i.test(column.sqlType ?? "");
     if (column.isSerial) return isBigSql ? "bigserial" : "serial";
     if (isBigSql || column.type === "bigint") return "bigint";
     const semantic = column.type ?? undefined;
-    // BigIntegerType.name is "big_integer" — normalize to "bigint" for schema output.
     if (semantic === "big_integer") return "bigint";
     // OID::BitVarying.type() returns Rails-style "bit_varying"; map to DSL "bitVarying".
     if (semantic === "bit_varying") return "bitVarying";
@@ -216,8 +210,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
     indexes: IndexInfo[],
   ): Promise<IndexInfo[]> {
     const adapter = this.pgAdapter();
-    // Fetch and cache both constraint lists so gatherInlineConstraints can
-    // reuse them without a second DB round-trip.
     const excl: ExclusionConstraintDefinition[] = adapter?.exclusionConstraints
       ? await adapter.exclusionConstraints(tableName)
       : [];
@@ -243,7 +235,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
    */
   override async table(tableName: string, stream: string[]): Promise<void> {
     await super.table(tableName, stream);
-    // Remove the trailing blank pushed by super.table so constraints land before it.
     if (stream[stream.length - 1] === "") stream.pop();
     await this.exclusionConstraintsInCreate(tableName, stream);
     await this.uniqueConstraintsInCreate(tableName, stream);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -4,8 +4,6 @@ import { PostgreSQLAdapter } from "../postgresql-adapter.js";
 import { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 
-// The bodies under test are prototype methods on the adapter, so give the fake
-// adapter that prototype and call them the way production does.
 function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
   // `Object.setPrototypeOf` skips the AbstractAdapter constructor, which is what
   // seats `@config` (`abstract_adapter.rb:132`); `foreign_keys_enabled?` reads it
@@ -181,9 +179,6 @@ describe("SchemaStatements#addForeignKey use_foreign_keys? guard", () => {
   });
 
   it("with ifNotExists is a no-op when a composite FK already exists", async () => {
-    // A composite `column: [...]` must match the existing FK by value, not by
-    // array identity — the guard routes through foreignKeyExists -> isDefinedFor
-    // for an element-wise compare, so the duplicate ADD CONSTRAINT is skipped.
     const executed: string[] = [];
     const adapter = {
       adapterName: "postgres" as const,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -7,8 +7,6 @@ import { Table as PgTable } from "./schema-definitions.js";
 import { Name } from "./utils.js";
 import { Result } from "../../result.js";
 
-// The bodies under test are prototype methods on the adapter, so give the fake
-// adapter that prototype and call them the way production does.
 function withSchemaStatements(adapter: DatabaseAdapter): PostgreSQLAdapter {
   // `Object.setPrototypeOf` skips the AbstractAdapter constructor, which is what
   // seats `@config` (`abstract_adapter.rb:132`); `foreign_keys_enabled?` reads it
@@ -33,8 +31,6 @@ function makeAdapter(options: FakeOptions = {}) {
     quote: (v: unknown) => `'${String(v).replace(/'/g, "''")}'`,
     quoteColumnName: (n: string) => `"${n}"`,
     quoteLiteral: (v: unknown) => `'${String(v).replace(/'/g, "''")}'`,
-    // The real adapter quotes each dot-separated part; the tests below rely on
-    // a schema-qualified name surviving as `"a"."b"`.
     quoteTableName: (n: string) =>
       n
         .split(".")

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -135,10 +135,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     await this.execute(`DROP TABLE${ifExists} ${quoted}${cascade}`);
   }
 
-  // ---------------------------------------------------------------------------
-  // Indexes
-  // ---------------------------------------------------------------------------
-
   async indexes(tableName: string): Promise<IndexDefinition[]> {
     const scope = this.quotedScope(tableName);
 
@@ -196,7 +192,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
         } else {
           const names = await this.columnNamesFromColumnNumbers(oid, indkey);
 
-          // prevent INCLUDE columns from being matched
           columns = names.filter((c) => !includeColumns.includes(c));
 
           // add info on sort order (only desc order is explicitly specified, asc is the default)
@@ -254,10 +249,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     return Array.from((await this.addOptionsForIndexColumns(quotedColumns)).values()).join(", ");
   }
 
-  // ---------------------------------------------------------------------------
-  // Tables / views
-  // ---------------------------------------------------------------------------
-
   // Mirrors Rails #tables (data_source_sql type: "BASE TABLE" → relkind
   // IN ('r','p')). pg_tables would omit partitioned tables (relkind 'p').
   async tables(): Promise<string[]> {
@@ -314,7 +305,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     if (!name) return false;
     const [schema, table] = this.extractSchemaQualifiedName(name);
     if (schema) {
-      // $1=schema, $2=table, $3..=relkinds
       const relPlaceholders = relkinds.map((_, i) => `$${i + 3}`).join(", ");
       const rows = (
         await this.internalExecQuery(
@@ -329,11 +319,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
       ).toArray();
       return rows.length > 0;
     }
-    // $1=table, $2..=relkinds. Bind `table` (the unquoted identifier
-    // returned by extractSchemaQualifiedName), not the raw `name`
-    // argument — otherwise a quoted input like `"widgets"` gets
-    // compared against `relname = '"widgets"'` in pg_class, which
-    // never matches (the catalog stores names unquoted).
     const relPlaceholders = relkinds.map((_, i) => `$${i + 2}`).join(", ");
     const rows = (
       await this.internalExecQuery(
@@ -462,10 +447,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     }));
   }
 
-  // ---------------------------------------------------------------------------
-  // Schema management
-  // ---------------------------------------------------------------------------
-
   async schemaNames(): Promise<string[]> {
     const names = await this.queryValues(
       `SELECT nspname
@@ -510,10 +491,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
   async currentSchema(): Promise<string> {
     return (await this.queryValue("SELECT current_schema", "SCHEMA")) as string;
   }
-
-  // ---------------------------------------------------------------------------
-  // Database management
-  // ---------------------------------------------------------------------------
 
   async createDatabase(name: string, options: CreateDatabaseOptions = {}): Promise<void> {
     const mergedOptions: CreateDatabaseOptions = { encoding: "utf8", ...options };
@@ -584,10 +561,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     )) as string;
   }
 
-  // ---------------------------------------------------------------------------
-  // Session settings
-  // ---------------------------------------------------------------------------
-
   async schemaSearchPath(): Promise<string> {
     if (this._schemaSearchPathMemo == null) {
       this._schemaSearchPathMemo = (await this.queryValue("SHOW search_path", "SCHEMA")) as string;
@@ -612,10 +585,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
   private quoteSchemaName(name: string): string {
     return pgQuoteColumnName(name);
   }
-
-  // ---------------------------------------------------------------------------
-  // Columns / types
-  // ---------------------------------------------------------------------------
 
   override async columns(tableName: string): Promise<Column[]> {
     const [schema, table] = this.extractSchemaQualifiedName(tableName);
@@ -830,10 +799,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     return array && type !== "primary_key" ? `${sql}[]` : sql;
   }
 
-  // ---------------------------------------------------------------------------
-  // Alter table
-  // ---------------------------------------------------------------------------
-
   /**
    * Mirrors: PostgreSQL::SchemaStatements#change_column
    * (postgresql/schema_statements.rb:467-471) — clear the statement cache,
@@ -994,10 +959,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Foreign keys / constraints
-  // ---------------------------------------------------------------------------
-
   /** @internal */
   async validateConstraint(tableName: string, constraintName: string): Promise<void> {
     const at = this.createAlterTable(tableName) as PgAlterTable;
@@ -1157,9 +1118,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
       options as Record<string, unknown>,
     );
     const at = this.createAlterTable(fromTable);
-    // Route through AlterTable#addForeignKey -> TableDefinition#newForeignKeyDefinition
-    // (now converged): it applies table_name_prefix/suffix and re-runs
-    // foreign_key_options idempotently (column/name already filled above).
     at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
     await this.execute(await this.schemaCreation.accept(at));
   }
@@ -1462,10 +1420,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     return result;
   }
 
-  // ---------------------------------------------------------------------------
-  // Enum types
-  // ---------------------------------------------------------------------------
-
   // Mirrors: PostgreSQLAdapter#enum_types (postgresql_adapter.rb:518)
   // Returns an array of [fullName, values] pairs for all enum types visible on the search path
   // (current_schemas(false) — all schemas in search_path, not just the current one).
@@ -1601,10 +1555,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     await this.reloadTypeMap();
   }
 
-  // ---------------------------------------------------------------------------
-  // Range types
-  // ---------------------------------------------------------------------------
-
   async createRange(
     name: string,
     options: { subtype: string; subtypeDiff?: string },
@@ -1663,10 +1613,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     await this.reloadTypeMap();
   }
 
-  // ---------------------------------------------------------------------------
-  // Sequences & primary keys
-  // ---------------------------------------------------------------------------
-
   override async primaryKey(tableName: string): Promise<string | string[] | null> {
     const [schema, table] = this.extractSchemaQualifiedName(tableName);
 
@@ -1684,11 +1630,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
       tableCondition = `t.oid = to_regclass(quote_ident($1))`;
     }
 
-    // Order by the column's position within the index key array so
-    // composite PKs come back in declaration order, not the
-    // non-deterministic order pg_attribute happens to yield rows.
-    // `array_position(i.indkey, a.attnum)` gives each column's
-    // 1-based position inside the index definition.
     const rows = (
       await this.internalExecQuery(
         `SELECT a.attname
@@ -1733,8 +1674,6 @@ export class SchemaStatements extends AbstractSchemaStatements {
     try {
       const quotedTable = this.quote(this.quoteTableName(tableName));
 
-      // First try looking for a sequence with a dependency on the
-      // given table's primary key.
       let result = (
         await this.query(
           `SELECT attr.attname, nsp.nspname, seq.relname

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.test.ts
@@ -116,17 +116,14 @@ describe("getTypeParser — int8 (OID 20)", () => {
 
 describe("getTypeParser — unknown OIDs", () => {
   it("delegates non-temporal OIDs to pg built-ins (always returns a function)", () => {
-    expect(typeof getTypeParser(23, "text")).toBe("function"); // int4
-    expect(typeof getTypeParser(25, "text")).toBe("function"); // text
+    expect(typeof getTypeParser(23, "text")).toBe("function");
+    expect(typeof getTypeParser(25, "text")).toBe("function");
   });
 });
 
 describe("global pg type registry is unaffected", () => {
   it("pg.types still returns its default Date parser for timestamptz", () => {
-    // Calling getTypeParser from our module must NOT mutate pg.types.
-    // The global parser for OID 1184 should still be pg's built-in one.
     const globalParser = pg.types.getTypeParser(OID_TIMESTAMPTZ, "text");
-    // pg's built-in parser returns a Date or string, not a Temporal.Instant.
     const result = (globalParser as (v: string) => unknown)("2026-04-26 14:23:55+00");
     expect(result).not.toBeInstanceOf(Temporal.Instant);
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/temporal-type-parsers.ts
@@ -18,17 +18,10 @@ import {
   parsePostgresDate,
 } from "../abstract/temporal-wire.js";
 
-// PostgreSQL OIDs for the temporal types we intercept.
 const OID_DATE = 1082;
 const OID_TIMESTAMP = 1114;
 const OID_TIMESTAMPTZ = 1184;
 
-// Array OIDs for the temporal types. pg's default array parsers decode each
-// element with the built-in scalar parser (JS Date in the host's local zone),
-// which shifts naive `timestamp[]` values by the host UTC offset and drops
-// sub-millisecond precision. Returning the raw array literal here lets
-// OID::Array.deserialize parse it, routing each element through the Temporal
-// wire parser the same way the scalar path does.
 const OID_DATE_ARRAY = 1182;
 const OID_TIME_ARRAY = 1183;
 const OID_TIMESTAMP_ARRAY = 1115;
@@ -45,7 +38,6 @@ const OID_TIMETZ_ARRAY = 1270;
 // contract better-sqlite3 and mysql2 already hand the type layer.
 const OID_INT8 = 20;
 
-// Text-format parsers receive strings; binary-format parsers receive Buffer.
 type PgParser = (value: string | Buffer) => unknown;
 
 const passthrough: PgParser = (v) => v;

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -150,10 +150,6 @@ export function registerClassWithPrecision(
  *   mirroring Rails' IntegerType(limit: 8) but with BigInt-precision arithmetic.
  */
 class PgInteger8 extends BigIntegerType {
-  // Re-establish the 8-byte bound that BigIntegerType drops (max_value =
-  // Infinity). IntegerType's isInRange/isSerializable already compare in BigInt
-  // space, so 2^63 is correctly detected out of range (float64 cannot
-  // distinguish 2^63 from 2^63-1).
   protected override maxValue(): number {
     return 2 ** (this._limit() * 8 - 1);
   }
@@ -187,11 +183,8 @@ export function initializeTypeMap(m: HashLookupTypeMap): void {
   m.aliasType("char", "varchar");
   m.aliasType("name", "varchar");
   m.aliasType("bpchar", "varchar");
-  // Register fixed OIDs for internal PG string-like types so columns() can
-  // resolve their semantic type without a pg_type round-trip. OIDs are
-  // stable built-ins that don't vary across PG versions.
-  m.registerType(18, new StringType()); // "char" — single internal byte
-  m.registerType(19, new StringType()); // name   — 63-byte identifier type
+  m.registerType(18, new StringType());
+  m.registerType(19, new StringType());
   m.registerType("bool", new BooleanType());
   registerClassWithLimit(m, "bit", Bit);
   registerClassWithLimit(m, "varbit", BitVarying);
@@ -257,8 +250,6 @@ export function initializeInstanceTypeMap(
   defaultTimezone: "utc" | "local" = "utc",
 ): void {
   initializeTypeMap(m);
-  // TODO: activemodel Type classes don't yet honor `timezone` — these
-  // options are ignored until TimeType / Timestamp are extended.
   registerClassWithPrecision(m, "time", TimeType, { timezone: defaultTimezone });
   registerClassWithPrecision(m, "timestamp", Timestamp, { timezone: defaultTimezone });
   registerClassWithPrecision(m, "timestamptz", TimestampWithTimeZone);

--- a/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/database-statements.ts
@@ -224,8 +224,6 @@ export function acquireStatementLock(host: {
   const tail = ahead ? ahead.then(() => mine) : mine;
   host._statementLock = tail;
   const drain = (): void => {
-    // Only the last queued caller clears the tail; a later arrival has already
-    // published its own and must keep waiting on this one.
     if (host._statementLock === tail) host._statementLock = null;
     release();
   };

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -23,12 +23,6 @@ import {
   typeCast as typeCastFn,
 } from "./quoting.js";
 
-// `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
-// SQLite's quotedDate / quotedTime so date/time literals keep the 2000-01-01
-// prefix on times, and quotedBinary so binary self-dispatch reaches SQLite's
-// `x'..'` hex form, and the boolean pair so the inherited abstract boolean arm
-// self-dispatches back to SQLite's 1/0 — the same overrides
-// SQLite3Adapter supplies.
 const HOST = quotingHost({
   quotedDate,
   quotedTime,
@@ -382,10 +376,8 @@ describe("SQLite3::Quoting", () => {
       );
       const rows = await adapter.execute(`SELECT "ts" FROM "quoting_events" LIMIT 1`);
       const raw = rows[0].ts as string;
-      // SQLite3DateTime converts the offset-less UTC string → Temporal.Instant.
       const cast = new SQLite3DateTime().cast(raw);
       expect(cast).toBeInstanceOf(Temporal.Instant);
-      // Microsecond precision is preserved end-to-end.
       expect((cast as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
     });
 
@@ -397,8 +389,8 @@ describe("SQLite3::Quoting", () => {
       const cast = new SQLite3DateTime().cast(raw) as Temporal.Instant;
       expect(cast).toBeInstanceOf(Temporal.Instant);
       const zdt = cast.toZonedDateTimeISO("UTC");
-      expect(zdt.microsecond).toBe(654321 % 1000); // 321 µs
-      expect(zdt.millisecond).toBe(Math.floor(654321 / 1000)); // 654 ms
+      expect(zdt.microsecond).toBe(654321 % 1000);
+      expect(zdt.millisecond).toBe(Math.floor(654321 / 1000));
     });
 
     it("Temporal.PlainDate survives INSERT → SELECT", async () => {
@@ -415,9 +407,6 @@ describe("SQLite3::Quoting", () => {
     });
 
     it("Temporal.PlainTime with microseconds survives INSERT → SELECT", async () => {
-      // SQLite stores time with the '2000-01-01' sentinel date prefix.
-      // TimeType#cast handles the full '2000-01-01 HH:MM:SS.ffffff' string via
-      // extractTimePortion(), so no manual stripping is needed.
       const time = Temporal.PlainTime.from("14:23:55.654321");
       await adapter.executeMutation(`INSERT INTO "quoting_events" ("t") VALUES (${quote(time)})`);
       const rows = await adapter.execute(`SELECT "t" FROM "quoting_events" LIMIT 1`);

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -99,8 +99,6 @@ export function quoteString(value: string): string {
  * `quoted_false` (rb:75-78) back onto SQLite's overrides.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  // rb: `when Numeric then value.finite? ? super : "'#{value}'"` — the
-  // non-finite literal is interpolated raw, not escaped.
   if (typeof value === "number" && !Number.isFinite(value)) return `'${String(value)}'`;
   return abstractQuote.call(this, value);
 }
@@ -246,8 +244,6 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
 // regex patterns, so we use a function-based matcher that walks balanced
 // parentheses to arbitrary depth.
 
-// SQL keywords that should never appear inside function arguments
-// in a column name context — prevents subquery injection.
 const DANGEROUS_KEYWORDS =
   /\b(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|UNION|INTO|FROM|WHERE|EXEC|EXECUTE)\b/i;
 
@@ -262,8 +258,6 @@ function skipBalancedParens(s: string, pos: number): number {
     i++;
   }
   if (depth !== 0) return -1;
-  // Strip string literals before checking for dangerous keywords
-  // so that IFNULL(name, 'from') is not rejected.
   const contents = s.slice(start, i - 1).replace(/'[^']*'/g, "");
   if (DANGEROUS_KEYWORDS.test(contents)) return -1;
   return i;
@@ -275,7 +269,7 @@ function skipQuotedIdentifier(s: string, pos: number): number {
   while (i < s.length) {
     if (s[i] === '"') {
       if (s[i + 1] === '"') {
-        i += 2; // escaped ""
+        i += 2;
       } else {
         return i + 1;
       }
@@ -283,12 +277,11 @@ function skipQuotedIdentifier(s: string, pos: number): number {
       i++;
     }
   }
-  return -1; // unclosed quote
+  return -1;
 }
 
 function matchColumnExpr(s: string, pos: number): number {
   let i = pos;
-  // optional table qualifier: word. or "word".
   if (s[i] === '"') {
     const end = skipQuotedIdentifier(s, i);
     if (end === -1) return -1;
@@ -301,24 +294,19 @@ function matchColumnExpr(s: string, pos: number): number {
     const m = s.slice(i).match(/^\w+/);
     if (!m) return -1;
     if (s[i + m[0].length] === ".") {
-      // table.column — consume qualifier
       i += m[0].length + 1;
     } else if (s[i + m[0].length] === "(") {
-      // function call: word(...)
       return skipBalancedParens(s, i + m[0].length);
     } else {
-      // just a column name
       return i + m[0].length;
     }
   }
-  // column name after qualifier: word or "word", or function call: word(...)
   if (s[i] === '"') {
     return skipQuotedIdentifier(s, i);
   }
   const nameMatch = s.slice(i).match(/^\w+/);
   if (!nameMatch) return -1;
   i += nameMatch[0].length;
-  // function call with balanced parens
   if (s[i] === "(") {
     const end = skipBalancedParens(s, i);
     if (end === -1) return -1;
@@ -349,23 +337,22 @@ function matchColumnList(s: string, allowOrder: boolean): boolean {
         i = skipWhitespace(s, i + 2);
         hasAs = true;
       }
-      // Try to consume an alias identifier (not a keyword or comma)
       const peek = s.slice(i);
       if (peek[0] === '"') {
         const end = skipQuotedIdentifier(s, i);
         if (end !== -1) {
           i = skipWhitespace(s, end);
         } else if (hasAs) {
-          return false; // AS without valid alias
+          return false;
         }
       } else {
         const alias = peek.match(/^\w+/);
         if (alias && !/^(?:ASC|DESC|COLLATE|NULLS|,)\b/i.test(alias[0])) {
           i = skipWhitespace(s, i + alias[0].length);
         } else if (hasAs) {
-          return false; // AS without valid alias
+          return false;
         } else {
-          i = saved; // no alias found, backtrack
+          i = saved;
         }
       }
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -129,9 +129,6 @@ export async function indexes(
     // PK/UNIQUE-backed indexes (origin "pk"/"u") are kept, matching Rails.
     if (idx.name.startsWith("sqlite_")) continue;
 
-    // Locate the index SQL across the main/attached schema and the temp
-    // schema (temp-table indexes live only in sqlite_temp_master), so their
-    // WHERE clauses are not silently dropped.
     const indexSql = (await adapter.queryValue(
       `SELECT sql FROM ${sqliteMaster} WHERE name = ${adapter.quote(idx.name)} AND type = 'index' ` +
         `UNION ALL ` +
@@ -143,8 +140,6 @@ export async function indexes(
     let where = match?.groups?.where;
     if (where != null) where = where.replace(/\s*\/\*.*\*\/$/, "");
 
-    // index_info takes the bare index name; the schema qualifier, if any,
-    // comes before the PRAGMA keyword — same shape as above.
     const cols = (
       await adapter.internalExecQuery(
         `PRAGMA ${pragmaPrefix}index_info(${adapter.quote(idx.name)})`,
@@ -156,8 +151,6 @@ export async function indexes(
     const orders: Record<string, string> = {};
     let columns: string[] | string;
     if (columnNames.some((name) => name == null)) {
-      // Expression index: index_info has no column names, so fall back to
-      // the parenthesized expressions captured from the index SQL.
       columns = expressions ?? "";
     } else {
       columns = columnNames as string[];
@@ -359,7 +352,6 @@ export function extractValueFromDefault(dfltValue: string | null): unknown {
   if (single) return single[1].replace(/''/g, "'");
   const double = /^"([^|]*)"$/m.exec(dfltValue);
   if (double) return double[1].replace(/""/g, '"');
-  // Numeric types
   if (/^-?\d+(\.\d*)?$/.test(dfltValue)) return dfltValue;
   // Binary columns — unanchored `x'(.*)'` mirrors Rails (sqlite3_adapter.rb:535).
   // Rails unpacks via `[ $1 ].pack("H*")`. SQLite's `PRAGMA table_info`


### PR DESCRIPTION
Slice 2 of the `no-freeform-comments` rollout (slice 1 was `activerecord/src/relation/**`).

Registers the four dialect subdirectories —
`connection-adapters/{mysql,mysql2,postgresql,sqlite3}/**/*.ts` — in the
`no-freeform-comments` block in `eslint.config.mjs` and applies the autofix.
Every deletion was read, not taken on trust.

## Why this is a partial glob, deliberately

The story does not ask for the whole directory in one PR — it says so in its own
Context, above the acceptance criteria:

> **This slice: `packages/activerecord/src/connection-adapters/**/*.ts`** — measured ~1580 comment lines / 719 blocks.
> **Larger than one PR: split it into several slices of its own.**

Measured here: the full glob is 708 rule findings and ~820 changed LOC against a
700 LOC ceiling (I applied the autofix over everything and measured before
narrowing). This PR is 386 LOC. So the glob extends one group at a time — the
same per-glob mechanism slice 1 established and that the rule's registration
block is designed for ("widen it a package at a time … never ahead of the
audit") — and the rule stays green in between.

The remainder is filed, not dropped:

- `strip-freeform-comments-ar-connection-adapters-abstract` — `abstract/**` (145 findings)
- `strip-freeform-comments-ar-connection-adapters-toplevel` — the top-level `*.ts` files (382 findings, needs splitting again: the three concrete adapters alone are ~440 LOC)

Both carry the per-file finding counts and the measurement command, so neither
needs re-deriving. Free-form comments `rg` still finds in those two trees are
that filed backlog, not an unmet criterion of this PR.

## Deferred work found in a deleted comment

One deletion recorded deferred work rather than restating a line — a `TODO` at
`postgresql/type-map-init.ts:252` saying the `timezone:` option passed to
`registerClassWithPrecision` is ignored by `TimeType` / `Timestamp`. Filed as
`pg-type-map-timezone-option-is-inert` with the Rails cite
(`postgresql/oid/type_map_initializer.rb`, `postgresql_adapter.rb#initialize_type_map`)
rather than reworded into a better comment.

## Checks

`pnpm eslint` clean over the glob and a second `--fix` is a no-op;
`pnpm typecheck` clean; the 20 touched test files run green (436 passed, 30
skipped); `parity:api:calls`, `parity:api:calls:args` and
`parity:api:extra:gate` all OK; `parity:api` / `parity:test` left no artifact
churn. No ported method body is touched by this diff — it deletes comments — so
there is no new deviation to justify at a call site.

Closes-story: strip-freeform-comments-ar-connection-adapters
