### PR TITLE
refactor(activerecord): strip freeform comments from associations implementation files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -745,6 +745,18 @@ export default defineConfig(
     },
   },
 
+  // ── no-freeform-comments, activerecord/associations: swept a slice at a
+  //    time. The implementation files are done; the test files under the same
+  //    tree are still outstanding, so they are ignored here rather than
+  //    holding the rule off the whole tree until they land. ──
+  {
+    files: ["packages/activerecord/src/associations/**/*.ts"],
+    ignores: ["packages/activerecord/src/associations/**/*.test.ts"],
+    rules: {
+      "blazetrails/no-freeform-comments": "error",
+    },
+  },
+
   // ── no conditionals in tests (all packages except activerecord) ──
   {
     files: [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -747,8 +747,9 @@ export default defineConfig(
 
   // ── no-freeform-comments, activerecord/associations: swept a slice at a
   //    time. The implementation files are done; the test files under the same
-  //    tree are still outstanding, so they are ignored here rather than
-  //    holding the rule off the whole tree until they land. ──
+  //    tree are still outstanding (story
+  //    strip-freeform-comments-ar-associations-tests), so they are ignored here
+  //    rather than holding the rule off the whole tree until they land. ──
   {
     files: ["packages/activerecord/src/associations/**/*.ts"],
     ignores: ["packages/activerecord/src/associations/**/*.test.ts"],

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -7,8 +7,6 @@ import { Table, Nodes } from "@blazetrails/arel";
 import { maxIdentifierLength } from "../connection-adapters/abstract/database-limits.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting.js";
 
-// DatabaseLimits' table_alias_length defaults to max_identifier_length; use the
-// abstract default directly (the free tableAliasLength now dispatches via `this`).
 const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
 
 /**
@@ -166,16 +164,13 @@ export class AliasTracker {
     tableName = (tableName ?? arelTable.name ?? String(arelTable)) as string;
 
     if (this._getCount(tableName) === 0) {
-      // If it's zero, we can have our table_name
       this.aliases.set(tableName, 1);
       if (arelTable.name !== tableName && typeof arelTable.alias === "function") {
         arelTable = arelTable.alias(tableName);
       }
     } else {
-      // Otherwise, we need to use an alias
       let aliasedName = this.tableAliasFor(block());
 
-      // Update the count
       const count = this._getCount(aliasedName) + 1;
       this.aliases.set(aliasedName, count);
 

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -83,10 +83,6 @@ type ScopeBuilder = {
 };
 
 export class ReflectionProxy {
-  // AbstractReflection rather than AssociationReflection because chain
-  // entries can be ThroughReflection / PolymorphicReflection wrappers;
-  // ReflectionProxy only reads structural fields (joinPrimaryKey/Fk,
-  // type, klass, name, scope, scopeFor) that all chain entries provide.
   readonly reflection: AbstractReflection;
   readonly aliasedTable: unknown;
 
@@ -104,12 +100,6 @@ export class ReflectionProxy {
     return null;
   }
 
-  // SimpleDelegator-style forwarding of the attributes AssociationScope
-  // reads. Kept explicit instead of a runtime Proxy so TypeScript sees
-  // the shape. The `_r` getter centralizes the cast — these fields are
-  // present on every chain entry shape (AssociationReflection,
-  // ThroughReflection, PolymorphicReflection) but not declared on the
-  // AbstractReflection base.
   private get _r(): {
     joinPrimaryKey(klass?: typeof Base): string | string[];
     joinForeignKey: string | string[];
@@ -436,7 +426,6 @@ export class AssociationScope {
       // Route through the reflection's canonical checkValidityBang (Rails'
       // single raise site) so the error carries the Rails-faithful message.
       routeThroughCheckValidity(owner.constructor as typeof Base, name);
-      // No reflection resolvable — minimal trails-only fallback guard.
       throw new CompositePrimaryKeyMismatchError({
         activeRecord: ownerName,
         name,
@@ -508,8 +497,6 @@ export class AssociationScope {
           return typeof fn === "function" ? fn.call(refl, name) : klass.tableName;
         });
       } else {
-        // Fallback for the legacy single-call path where no tracker
-        // is provided — bare table name, same behavior as before.
         aliasedTable = klass?.tableName ?? "";
       }
       chain.push(new ReflectionProxy(refl, aliasedTable));
@@ -547,9 +534,6 @@ export class AssociationScope {
     const joinPks = Array.isArray(rJoinPk) ? rJoinPk : [rJoinPk];
     const joinFks = Array.isArray(r.joinForeignKey) ? r.joinForeignKey : [r.joinForeignKey];
     if (joinPks.length !== joinFks.length) {
-      // Unwrap ReflectionProxy so activeRecord/name come from the
-      // underlying reflection rather than reading "<unknown>" off the
-      // proxy (which doesn't forward activeRecord).
       const base =
         (reflection as { reflection?: { name?: string; activeRecord?: { name?: string } } })
           .reflection ?? (reflection as { name?: string; activeRecord?: { name?: string } });
@@ -559,7 +543,6 @@ export class AssociationScope {
       // single raise site) so the error carries the Rails-faithful message.
       const ownerClass = base.activeRecord as unknown as typeof Base | undefined;
       if (ownerClass) routeThroughCheckValidity(ownerClass, name);
-      // No reflection resolvable — minimal trails-only fallback guard.
       throw new CompositePrimaryKeyMismatchError({
         activeRecord: ownerName,
         name,
@@ -587,8 +570,6 @@ export class AssociationScope {
         tableName = "";
       }
     }
-    // nextReflection may be a ReflectionProxy (with aliasedTable) or a
-    // raw reflection; resolve its table name the same way.
     const aliased = nr.aliasedTable;
     const foreignTableName =
       typeof aliased === "string"
@@ -702,15 +683,6 @@ export class AssociationScope {
     const chainHead = chain[0];
     for (let i = chain.length - 1; i >= 0; i--) {
       const reflection = chain[i];
-      // Iterate `reflection.constraints()` rather than special-casing
-      // PolymorphicReflection via instanceof. For ordinary
-      // AssociationReflection / ReflectionProxy entries `constraints()`
-      // returns `chain.flatMap(scopes)` — for non-through chain entries that's
-      // just `[self.scope].compact`. For PolymorphicReflection (sourceType
-      // wrapper) `constraints()` ALSO returns the `source_type_scope` lambda
-      // (`where(foreign_type: source_type)`). Iterating handles both cases
-      // without an instanceof check, avoiding a value-import cycle
-      // (reflection → associations → association-scope → reflection).
       const constraints =
         (
           reflection as { constraints?: () => Array<(...args: unknown[]) => unknown> }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -358,7 +358,6 @@ export class Association {
   scope(): any {
     const klass = this.klass as typeof Base | undefined;
     if (!klass) return undefined;
-    // Branch 1: disable_joins — delegate to DisableJoinsAssociationScope.
     if (this.disableJoins) {
       const djas = getDjasScopeBuilder();
       if (!djas)
@@ -375,14 +374,10 @@ export class Association {
       const reflection = ctor._reflectOnAssociation?.(this.reflection.name) ?? this.reflection;
       return djas({ owner: this.owner, reflection, klass } as never);
     }
-    // Branch 2: klass.current_scope.proxy_association == self.
-    // Fires when CollectionProxy.scoping sets an AssociationRelation as
-    // klass.currentScope; not yet implemented, so this is unreachable.
     const currentScope = (klass as any).currentScope();
     if (currentScope && currentScope.proxyAssociation === this) {
       return typeof currentScope.spawn === "function" ? currentScope.spawn() : currentScope;
     }
-    // Branches 3 + 4.
     const associationScope = this.associationScope();
     const scope = klass.globalCurrentScope();
     const targetScope = this.targetScope();
@@ -409,10 +404,6 @@ export class Association {
   associationScope(): any {
     const klass = this.klass as typeof Base | undefined;
     if (!klass) return undefined;
-    // Same relaxed staleness rule as `loadTarget` — reset the cached scope
-    // when the target went stale, including the nil-target-then-FK-set case
-    // (`_staleState == null && target == null`), so the reload re-derives the
-    // scope from the now-populated foreign key.
     if (this.isStaleTarget() && (this._staleState != null || this.target == null)) {
       this.resetScope();
     }
@@ -654,9 +645,6 @@ export class Association {
       // execute block — only freshly loaded records, never cached ones.
       if (result !== null) this.setStrictLoading(result as Base);
       if (this.loaded && this.staleState() !== staleStateBeforeLoad) return;
-      // Deliberately the bare ivar write, not `setTarget`: this is the loader
-      // storing what it just fetched, not a caller replacing the target, so it
-      // must not trip `setTarget`'s in-flight guard.
       this._writeTargetStore(result);
     }
   }
@@ -669,8 +657,6 @@ export class Association {
   async asyncLoadTarget(): Promise<Base | Base[] | null> {
     const result = await this.loadTarget();
     this._loadedViaAsync = true;
-    // Share the loaded target with the dotted collection proxy if it already
-    // exists (e.g. firm.clients was accessed before the async load completed).
     const name = this.reflection.name;
     const proxy = this.owner._collectionProxies.get(name) as
       | { loaded?: boolean; proxyAssociation?: Association }
@@ -750,8 +736,6 @@ export class Association {
   get reader(): Base | Base[] | null | Promise<Base | Base[] | null> {
     return this.target;
   }
-
-  // --- Protected / hook methods for subclasses ---
 
   protected staleState(): unknown {
     return undefined;
@@ -869,9 +853,6 @@ export class Association {
       if (!inverseName) return null;
       const recordAny = record as any;
       if (typeof recordAny.association !== "function") return null;
-      // `invertible_for?` establishes the inverse exists on the OWNER's side,
-      // which for a polymorphic belongs_to is a different class than the
-      // record's — so `record.association` can still raise here.
       try {
         return recordAny.association(inverseName);
       } catch {

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -88,14 +88,6 @@ export class BelongsToAssociation extends SingularAssociation {
    * to point to the new record.
    */
   override inversedFrom(record: Base | null): void {
-    // Make the assigned record available to `foreignKeyNames()` before
-    // `replaceKeys` derives the FK columns: its composite-PK branch reads the
-    // PK off the in-hand target instance (see `foreignKeyNames`), and without
-    // a set target it falls back to `this.klass`, forcing a registry resolve of
-    // the target class during pure inverse wiring (the has_many `<<`/push and
-    // readonly-collection paths route here via `_cacheSingularTarget`, where
-    // the class need not be registered). `super.inversedFrom` re-assigns the
-    // target and snapshots stale state; assigning early is otherwise inert.
     if (record) this.target = record;
     this.replaceKeys(record);
     super.inversedFrom(record);
@@ -231,8 +223,6 @@ export class BelongsToAssociation extends SingularAssociation {
     );
   }
 
-  // --- Protected ---
-
   protected override replace(record: Base | null): void {
     if (record) {
       this.raiseOnTypeMismatchBang(record);
@@ -257,8 +247,7 @@ export class BelongsToAssociation extends SingularAssociation {
     const fks = this.foreignKeyNames();
     if (fks.length !== 1) return null;
     return typeof (this.owner as any)._readAttribute === "function"
-      ? // Rails passes `{ |n| owner.send(:missing_attribute, n, caller) }` — a
-        // known-but-unselected FK column raises MissingAttributeError.
+      ? // Rails: `owner.send(:missing_attribute, n, caller)` (belongs_to_association.rb:165).
         (this.owner as any)._readAttribute(fks[0], (n: string) => {
           throw new MissingAttributeError(
             `missing attribute '${n}' for ${(this.owner.constructor as { name?: string }).name ?? "unknown"}`,
@@ -342,8 +331,6 @@ export class BelongsToAssociation extends SingularAssociation {
       return value != null;
     });
   }
-
-  // --- Private helpers ---
 
   private foreignKeyName(): string {
     const fk = this.reflection.foreignKey ?? `${underscore(this.reflection.name)}_id`;

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -76,19 +76,6 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     record: Base | null,
     { force = false }: { force?: boolean } = {},
   ): void {
-    // Write the polymorphic type column FIRST so that the dynamic
-    // `this.klass` resolves via the _type column before
-    // `super.replaceKeys` derives composite foreign-key names via
-    // `foreignKeyNames() → associationPrimaryKeys(null)`.
-    //
-    // Note: `replaceKeys` is called from both `replace(record)` (writer
-    // path) and `inversedFrom(record)` (inverse-wiring path). On the
-    // writer path, `setInverseInstance` runs in `replace()` before
-    // `replaceKeys`, so a missing-inverse raise leaves owner state
-    // untouched. On the `inversedFrom` path no inverse validation runs
-    // at all — the caller has already resolved the inverse pair — so
-    // the ordering inside `replaceKeys` is independent of that
-    // atomicity guarantee.
     const typeCol = this.foreignTypeName();
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
     // name (including "::" for namespaced classes). JS class names can't
@@ -136,10 +123,6 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
       const recordPk = (klass as any).primaryKey;
       if (recordPk) return inferCompositePrimaryKey(recordPk);
     }
-    // Polymorphic belongs_to: this.klass is dynamic — resolved at runtime
-    // from the _type column. Preserve the base class's klass-fallback for
-    // scope() / counter-cache paths that hit `associationPrimaryKeys(null)`
-    // once the _type column is set.
     const pk = (this.klass as any)?.primaryKey;
     if (pk) return inferCompositePrimaryKey(pk);
     const targetPk = (this.target as any)?.constructor?.primaryKey;
@@ -197,22 +180,10 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
       name: string;
       _registryKeys?: string[];
     };
-    // Cannot delegate to the static `polymorphicName(ctor)`: that derives the
-    // full name from `moduleName`/`_demodulizedName`, but some polymorphic
-    // targets are registered only under a `::`-qualified registry key with no
-    // matching `moduleName` (JS flattens `Access::NoticeMessage` to the bare
-    // `AccessNoticeMessage` class name). The registry key is the authoritative
-    // full name here; the static would return the un-namespaced JS name.
     const matching = (ctor._registryKeys ?? []).filter((k) => modelRegistry.get(k) === ctor);
     let name: string;
     if (matching.length > 0) {
       const existing = this.readForeignType();
-      // Delegated-type round-trip: a *_type already stored that matches one of
-      // this class's registry keys is a caller-configured type string — return
-      // it verbatim, which is correct regardless of `storeFullClassName` (it is
-      // the exact key the model is registered under, full `::` or bare). Fresh
-      // writes (the case the store-full-sti-class tests exercise) have
-      // `existing === null` and fall through to the demodulize path below.
       if (existing && matching.includes(existing)) return existing;
       name = matching.reduce((best, k) =>
         (k.match(/::/g) ?? []).length > (best.match(/::/g) ?? []).length ? k : best,

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -229,13 +229,9 @@ export class Association {
     });
   }
 
-  static defineValidations(_model: any, _reflection: any): void {
-    // noop in base — BelongsTo and HasOne override
-  }
+  static defineValidations(_model: any, _reflection: any): void {}
 
-  static defineChangeTrackingMethods(_model: any, _reflection: any): void {
-    // noop in base — BelongsTo overrides
-  }
+  static defineChangeTrackingMethods(_model: any, _reflection: any): void {}
 
   static validDependentOptions(): string[] {
     throw new Error("NotImplementedError");

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -145,8 +145,6 @@ export class BelongsTo extends SingularAssociation {
   ): Promise<void> {
     const fkColumns = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
 
-    // Fill missing old FK parts from current attributes for composite keys —
-    // unchanged columns have the same old/new value.
     const oldFkValues = fkColumns.map((col) => {
       const change = changes[col] as [unknown, unknown] | undefined;
       if (change) return change[0];

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -69,8 +69,6 @@ export class CollectionAssociation extends Association {
     // Rails: `return if callback_values.empty? && !method_defined`
     if (callbackValues.length === 0) {
       if (!isMethodDefined) return;
-      // Inherited but redefining without callbacks — shadow with own [] so the
-      // subclass doesn't inherit the parent's callback list.
       if (!Object.prototype.hasOwnProperty.call(model, fullCallbackName)) {
         model[fullCallbackName] = [];
       }
@@ -102,9 +100,6 @@ export class CollectionAssociation extends Association {
     const prior = Array.isArray(existing) ? existing : [];
     model[fullCallbackName] = [...prior, ...normalized];
 
-    // Also store normalized callbacks in the association options so
-    // `CollectionAssociation#callback`'s `callbacksFor` fallback (which reads
-    // options.beforeAdd etc.) finds them
     const assocs: any[] = model._associations ?? [];
     const assocDef = assocs.find((a: any) => a.name === name);
     if (assocDef) {
@@ -140,8 +135,6 @@ export class CollectionAssociation extends Association {
       });
     }
 
-    // `<singularized>Ids` reader stays as before (not a collection of
-    // records — just the FK list).
     const idsName = `${singularize(name)}Ids`;
     if (!(idsName in mixin)) {
       Object.defineProperty(mixin, idsName, {

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -60,8 +60,6 @@ export class HasAndBelongsToMany {
 
       /** @internal */
       static get tableName(): string {
-        // Table name needs to be resolved lazily
-        // because RHS class might not have been loaded
         return (tableName ??= this.tableNameResolver());
       }
 

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -72,10 +72,6 @@ export class HasOne extends SingularAssociation {
           // owns the removal and returns the promise to `await`.
           return assoc.loadTargetForBuild().then(() => assoc.build(...args));
         }
-        // An already-loaded target still gets `remove_target!` (FK nullified /
-        // destroyed per `:dependent`), so `build` returns a Promise for that
-        // case only — a new-record / no-target build keeps its synchronous
-        // return, the shape the STI-build tests assert.
         return assoc.build(...args);
       },
       writable: true,

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -87,7 +87,6 @@ export class CollectionAssociation extends Association {
     }
 
     if (record === null) {
-      // It's not possible to remove the record from the inverse association.
     } else if (Array.isArray(record)) {
       super.target = record;
     } else {
@@ -172,7 +171,6 @@ export class CollectionAssociation extends Association {
     ) {
       throw new CollectionPersistedAssignmentError(this.reflection.name);
     }
-    // The guard above refuses every arm that owes I/O, so nothing is pending.
     this.replace(records) as Base[];
   }
 
@@ -548,10 +546,7 @@ export class CollectionAssociation extends Association {
         ? "deleteAll"
         : dependent
           ? dependent
-          : // Rails' `options[:dependent] == :destroy` arm. Canonical trails
-            // models spell `:delete_all` as `"delete"`, which is the same delete
-            // strategy, so it collapses here too rather than falling through to
-            // nullify.
+          : // Rails: `options[:dependent] == :destroy` (collection_association.rb:157).
             optionDep === "destroy" || optionDep === "delete"
             ? "deleteAll"
             : optionDep;
@@ -692,11 +687,6 @@ export class CollectionAssociation extends Association {
    * rest of it continues off that promise where there is one.
    */
   replace(otherArray: Base[]): Promise<Base[] | undefined> | Base[] {
-    // The writer path (`firm.clients = [...]`, `firm.client_ids = [...]`, mass
-    // assignment) mutates `target` directly rather than going through
-    // `setTarget`, so it needs the in-flight guard applied here too —
-    // otherwise the ordinary user-facing assignment stays silently clobberable
-    // while only the raw `association(name).setTarget(...)` call is protected.
     this.raiseIfLoadInFlight();
     for (const val of otherArray) (this as any).raiseOnTypeMismatchBang(val);
     const replaceAgainst = (originalTarget: Base[]): Promise<Base[] | undefined> | Base[] => {
@@ -782,8 +772,6 @@ export class CollectionAssociation extends Association {
       return this.target;
     };
     if (this.findTargetNeeded()) {
-      // Every collection subclass overrides `findTarget` to return `Base[]`;
-      // the cast only narrows the singular-shaped base signature.
       return Promise.resolve(this.findTarget()).then((findTarget) => {
         this._targetStore = this.mergeTargetLists(findTarget as Base[], this.target);
         return loaded();
@@ -953,8 +941,6 @@ export class CollectionAssociation extends Association {
     }
   }
 
-  // --- Protected helpers ---
-
   /**
    * Mirrors `ForeignAssociation#set_owner_attributes` (foreign_association.rb:22),
    * which zips `Array(reflection.join_primary_key)` — the child FK columns —
@@ -1003,8 +989,6 @@ export class CollectionAssociation extends Association {
       }
     }
   }
-
-  // --- Private helpers ---
 
   private foreignKeyColumns(): string[] {
     return ownerForeignKeyColumns(
@@ -1087,8 +1071,6 @@ export class CollectionAssociation extends Association {
   ): Promise<Base[]> | Base[] {
     const isId = (r: Base | number | string | bigint): r is number | string | bigint =>
       typeof r === "number" || typeof r === "string" || typeof r === "bigint";
-    // Records passed as records need no lookup at all, so this stays inline —
-    // the arm `delete_or_destroy` takes for a new owner.
     if (!records.some(isId)) return records as Base[];
     const ids = records.map((r) => (isId(r) ? r : (r as any).id));
     if (this.reflection.options.through) {
@@ -1186,13 +1168,11 @@ export class CollectionAssociation extends Association {
   protected async nullifyAllRecords(): Promise<number> {
     const nullAttrs = this.computeNullifiedOwnerAttributes();
 
-    // Prefer scope-based bulk update (hits DB even if target isn't loaded)
     const rel = this.scope();
     if (rel && typeof rel.updateAll === "function") {
       return rel.updateAll(nullAttrs);
     }
 
-    // Fallback: load and update individually
     await this.loadTarget();
     for (const record of this.target) {
       for (const [attr, val] of Object.entries(nullAttrs)) {
@@ -1223,10 +1203,6 @@ export class CollectionAssociation extends Association {
         : (record as any)[key],
     );
     if (values.some((v) => v == null)) return record;
-    // BigInt PKs (int8 default under PG bigserial) can't go through
-    // JSON.stringify ("Do not know how to serialize a BigInt"); fold to their
-    // decimal string. Both merged lists read PKs from the same source, so the
-    // identity key stays deterministic.
     const ids = values.map((v) => (typeof v === "bigint" ? v.toString() : v));
     return JSON.stringify(ids.length === 1 ? ids[0] : ids);
   }
@@ -1266,10 +1242,6 @@ export class CollectionAssociation extends Association {
   mergeTargetLists(persisted: Base[], memory: Base[]): Base[] {
     if (memory.length === 0) return persisted;
 
-    // `memory.delete(record)` is Array#delete over AR `==` — id equality for a
-    // persisted record, object identity for a new one. `recordIdentity`
-    // returns exactly that: the id key, or the record itself when the PK is
-    // nil. Insertion order is the memory order the `reject` tail below reads.
     const memoryByIdentity = new Map<string | Base, Base>();
     for (const record of memory) memoryByIdentity.set(this.recordIdentity(record), record);
 
@@ -1388,9 +1360,6 @@ export class CollectionAssociation extends Association {
       this._wasLoaded = true;
       if (block) {
         const yield_ = block();
-        // Only a block that actually owes I/O defers the rest; a synchronous
-        // yield (a new-record owner's `concat_records`, whose `insert_record`
-        // never runs) finishes inline, under the sync `ensure` below.
         if (isThenable(yield_)) {
           yielded = true;
           return yield_.then(afterYield).finally(() => {
@@ -1444,9 +1413,6 @@ export function concatRecordsLoop(
     // but the insert inside `addRecord` is gated on the current `result` to match
     // Ruby's `result &&= insert_record(...)` short-circuit.
     const inserted = addRecord(records[i], result);
-    // The first record whose add owes I/O turns the whole loop asynchronous;
-    // everything before it has already run inline (a new-record owner never
-    // reaches `insert_record`, so the loop stays synchronous end to end).
     if (isThenable(inserted)) {
       const rest = records.slice(i + 1);
       return inserted.then(async (first) => {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -31,11 +31,6 @@ import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
 // via load(), so T[] is the correct contract for await semantics.
 // @ts-expect-error declaration-merge load() divergence — permanent, see class override
 export interface CollectionProxy<T extends Base = Base> {
-  // Thenable — makes CollectionProxy awaitable. Delegates to `load()`,
-  // which both returns the loaded records AND hydrates `_target`, so
-  // subsequent sync ops (`proxy.target.length`, `proxy[0]`, iteration)
-  // work after a single `await proxy`. Wired at the bottom of the file
-  // via `applyThenable(CollectionProxy.prototype, "load")`.
   then<TResult1 = T[], TResult2 = never>(
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
@@ -84,13 +79,6 @@ export type AssociationProxy<
 > = CollectionProxy<T> &
   DelegatedRelationMethods<T> &
   TExtensions & {
-    // Numeric indexing — `proxy[0]` reads the loaded target via the
-    // `wrapCollectionProxy` `get` trap. Lives on AssociationProxy (not
-    // raw CollectionProxy) because the runtime support comes from the
-    // JS Proxy wrapper. A bare `new CollectionProxy(...)` does NOT
-    // support indexing — you'd get `undefined` at runtime.
-    // Out-of-range / unloaded indices return `undefined`, matching
-    // `Array<T>[i]` semantics under TS's standard lib.
     readonly [index: number]: T | undefined;
   };
 
@@ -199,9 +187,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private set _replacedOrAddedTargets(value: Set<T>) {
     this._targetAssociation._replacedOrAddedTargets = value as Set<Base>;
   }
-  // The JS Proxy wrapper returned by association() — methods that return
-  // `self` (push / concat / append) hand this back so callers get the same
-  // object they hold, since `this` is the raw target, not the wrapper.
   private _proxySelf?: this;
 
   /**
@@ -386,7 +371,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   constructor(record: Base, assocName: string, assocDef: AssociationDefinition) {
-    // Prefer the rich reflection's klass so namespace-relative resolution applies.
     const targetModel = CollectionProxy._targetModelFor(record, assocName, assocDef);
     super(targetModel, targetModel.arelTable);
     this._record = record;
@@ -404,8 +388,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `scope.extending! reflection.extensions` (association_scope.rb:28).
     const extensions = this._targetAssociation.extensions;
     if (extensions.length > 0) {
-      // `self` in an extension body answers a named scope through
-      // `method_missing` on the extended proxy; the scope proxy is that lookup.
       const wrapped = wrapWithScopeProxy(this as unknown as Relation<T>);
       for (const mod of extensions) {
         if (typeof mod === "function") {
@@ -533,9 +515,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // (collection_association.rb:274).
     this._target = this._collectionAssociation().mergeTargetLists(results, this._target) as T[];
     this._targetLoaded = true;
-    // Snapshot the owner's `@stale_state` NOW (while owner FKs still reflect
-    // the load time). Letting it happen later — after a FK change — would
-    // capture the wrong state and mask the staleness.
     this._staleWrapper()?.loadedBang?.();
     return this._target;
   }
@@ -697,7 +676,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * callbacks all land on this proxy too.
    */
   async push(...records: T[]): Promise<Omit<this, "then"> | false> {
-    // Through association (including HABTM): create join records
     if (this._assocDef.options.through) {
       await this._pushThrough(records);
       return stripThenable(this._proxySelf ?? this);
@@ -972,11 +950,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   override reset(): this {
-    // Call Relation.reset() so inherited query state (_records,
-    // _loaded, _loadToken, _futureResult) is cleared alongside the
-    // association-specific target cache. Without super, callers using
-    // Relation#load() / Relation#loadAsync() patterns on the proxy
-    // would see stale results after reset.
     super.reset();
     this._targetLoaded = false;
     this._target = [];
@@ -1355,17 +1328,8 @@ for (const name of delegateMethods) {
   });
 }
 
-// Route `await proxy` through `load()` (not `toArray`) so the thenable
-// also hydrates `_target` — matches the documented contract that
-// `await proxy; proxy[0]` / `proxy.target.length` work after a single await.
-// `toArray()` stays available for callers who want a fresh array
-// without hydrating this proxy's `_target` / `_loaded` (it still goes
-// through `findTarget`, which syncs into the record's association
-// instance cache — only this proxy's local cache is left untouched).
 applyThenable(CollectionProxy.prototype, "load");
 
-// Register the constructor so associations.ts can late-bind (it can't
-// value-import CP at module init without re-entering the cycle).
 _setCollectionProxyCtor(
   CollectionProxy as unknown as Parameters<typeof _setCollectionProxyCtor>[0],
 );

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -178,10 +178,6 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     }
     const firstFk = (firstItem as { joinForeignKey: string | string[] }).joinForeignKey;
     const firstFkCols = keyColumns(firstFk, "joinForeignKey");
-    // Single-column shape stays `[v1, v2, ...]` (one value per join
-    // candidate). Composite shape becomes `[[v1a, v1b], ...]` (one
-    // tuple per join candidate). The owner contributes exactly one
-    // tuple as the chain seed.
     const seedTuple = readTuple(owner, firstFkCols);
     const initialIds: JoinIds = firstFkCols.length === 1 ? [seedTuple[0]] : [seedTuple];
     let acc: [ChainEntry, boolean, JoinIds] = [firstItem, false, initialIds];
@@ -204,8 +200,6 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         "joinPrimaryKey",
       );
       const records = this._addConstraintsDj(reflection, keyCols, joinIds, owner, ordered);
-      // Pluck single column → `[v, v, ...]`; pluck multiple →
-      // `[[v1a, v1b], ...]`. Forward as-is into the next iteration.
       const recordIds = (await (
         records as { pluck: (...cols: string[]) => Promise<unknown[]> }
       ).pluck(...foreignKeyCols)) as JoinIds;
@@ -262,17 +256,6 @@ export class DisableJoinsAssociationScope extends AssociationScope {
         [keyCols[0]]: joinIds,
       });
     } else {
-      // Composite key: route through `Relation#where(cols, tuples)`,
-      // which delegates to `PredicateBuilder.buildComposite`. That
-      // helper handles null-component filtering (SQL tuple-equality
-      // semantics), arity validation, single-column degeneracy → IN,
-      // and bind-param emission via QueryAttribute. Empty/all-filtered
-      // tuples become `Relation#none()`. No DJAS-local scaffolding.
-      // Defense in depth: the chain walk constructs `joinIds` from
-      // `pluck(...cols)` with `cols.length > 1`, which yields an
-      // array of tuples. A bug upstream that hands us a flat list
-      // (or mismatched arity) would otherwise surface deep inside
-      // PredicateBuilder with a less actionable trace.
       const arity = keyCols.length;
       const tuples = joinIds.map((t, i) => {
         if (!Array.isArray(t)) {
@@ -346,21 +329,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     const finalOrd = scope as { orderValues?: unknown[] };
     const finalOrders = (finalOrd.orderValues?.length ?? 0) > 0 ? [1] : [];
     if (finalOrders.length === 0 && ordered) {
-      // If PredicateBuilder.buildComposite short-circuited to
-      // `Relation#none()` (empty tuples / all-null components), the
-      // scope is already a never-match. Skip the wrap: the fresh DJAR
-      // would only copy `whereClause.predicates` and lose `_isNone`,
-      // causing a full-table SELECT instead of an empty result.
       if ((scope as { _isNone: boolean })._isNone) return scope;
-      // Loaded-chain wrap: DJAR loads via SQL, then re-groups by the
-      // join key and re-emits in `ids` order so callers see the
-      // through-table ordering (SQL `IN(...)` / composite OR-of-AND
-      // don't preserve list order). Both single-column and composite
-      // keys are supported — DJAR serializes tuples for Map identity
-      // so `[1, 100]` buckets collide as expected.
-      // Branch over key arity so we hit DJAR's correlated overloads.
-      // At this point `joinIds` is already shape-matched to `keyCols`
-      // by the single-vs-composite branches in `_addConstraintsDj`.
       const Ctor = disableJoinsAssociationRelationClassFor(klass);
       const split =
         keyCols.length === 1

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -532,9 +532,6 @@ export class CollectionIdsAssignmentError extends ActiveRecordError {
   readonly association: string;
 
   constructor(association: string) {
-    // The key that raised, derived here rather than passed in so the message
-    // can never name a key that differs from the one mass assignment matched
-    // (attribute-assignment.ts singularizes the same way).
     const idsName = `${singularize(association)}Ids`;
     super(
       `Cannot assign collection association \`${association}\` ids by mass assignment: ` +

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -236,10 +236,6 @@ export class HasManyAssociation extends CollectionAssociation {
    * `_buildAssociationInstance`.
    */
   protected override async findTarget(): Promise<Base[]> {
-    // Every caller assigns the returned records into this holder itself, so the
-    // loader's tail writeback into the same holder is redundant — and, because
-    // it lands mid-await, clobbers any reassignment made while the query was in
-    // flight. See `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
       const records = await findTarget(
@@ -391,9 +387,6 @@ export class HasManyAssociation extends CollectionAssociation {
       count = await (this as unknown as CollectionAssociation).scope().count("all");
     }
 
-    // If there's nothing in the database, @target should only contain new
-    // records or be an empty array. This is a documented side-effect of
-    // the method that may avoid an extra SELECT.
     if (count === 0) {
       selectBang((this as unknown as CollectionAssociation).target, (record) =>
         record.isNewRecord(),
@@ -505,10 +498,6 @@ function intersection(_assoc: HasManyAssociation, a: Base[], b: Base[]): Base[] 
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasManyAssociation): Record<string, null> {
-  // Resolve the rich reflection so foreignKey expansion (composite PKs,
-  // primaryKey overrides, polymorphic foreignType) matches what the
-  // association itself uses. Fall back to the CollectionAssociation's
-  // own FK column derivation, then to the simple options-based shape.
   const ctor = assoc.owner.constructor as {
     name: string;
     _reflectOnAssociation?: (n: string) => {
@@ -584,16 +573,7 @@ async function findTarget(
   if (options.through) {
     validateThroughReflection(record.constructor as typeof Base, assocName);
   }
-  // Check cached (inverse_of) first, then preloaded — skip when a scope
-  // override is provided (the scope has been mutated; the cache would return
-  // stale/incorrect data for the diverged query).
   if (!queryExecutor) {
-    // Honor an instance-cache hit (a directly-seeded or inverse-seeded
-    // collection target), but ignore the association's *own* seat — its
-    // collection proxy or the association object the proxy reads through:
-    // its in-memory built/pushed records are not a complete collection and must
-    // still be merged with a DB query (this loader runs inside that proxy's
-    // load path, where `proxy.loaded` is false by construction).
     const cache = record._associationCache(assocName);
     if (
       cache &&
@@ -620,24 +600,11 @@ async function findTarget(
     strictLoadingViolationBang({ owner: ctor, reflection });
   }
 
-  // Scope-override path: CollectionProxy passes this when its Relation state
-  // has been mutated (whereBang / orderBang / ...). The executor runs the
-  // mutated scope directly; cache lookup and scope rebuild are bypassed.
   if (queryExecutor) return queryExecutor();
 
-  // Handle through associations. Routes through AssociationScope's
-  // JOIN-based path for the simple shape (see
-  // _canRouteThroughViaAssociationScope); everything else stays on the
-  // 2-step loadHasManyThrough.
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflThrough = ctorEarly._reflectOnAssociation?.(assocName);
-    // Nested-through shapes flatten their whole `reflection.chain` into the
-    // JOIN-based AssociationScope path below, sharing its inverse-wiring and
-    // null-FK short-circuit. An unsaved owner resolves its through step from
-    // the in-memory association target (e.g. `post.author = mary` before save),
-    // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
-    // those on the 2-step loader.
     if (!_routeThroughViaAssociationScope(record, reflThrough, options)) {
       const { _buildAssociationInstance } = await import("./instance-methods.js");
       const through = _buildAssociationInstance.call(record, {
@@ -648,7 +615,6 @@ async function findTarget(
       }) as unknown as { loadHasManyThrough(): Promise<Base[]> };
       return through.loadHasManyThrough();
     }
-    // Fall through into the AssociationScope path below.
   }
 
   const ctor = record.constructor as typeof Base;
@@ -755,10 +721,6 @@ export function scope(
       });
     }
   }
-  // Null-FK short-circuit: read the SAME columns the eventual query
-  // reads. For non-through, reflection.joinForeignKey is the owner-
-  // side activeRecordPrimaryKey for hasMany. For through reflections the
-  // owner-side column is on `_ownerChainReflection` (chain.last).
   const reflForOwnerFk = _ownerChainReflection(reflection);
   const fkCheckPks = reflForOwnerFk
     ? Array.isArray(reflForOwnerFk.joinForeignKey)
@@ -789,7 +751,6 @@ export function scope(
     rel = baseRelation.merge(built);
     rel = applyAssociationScope(rel, assocDef.scope, record, reflection.scope);
   } else {
-    // Inline fallback: no reflection (lower-level test helpers).
     if (Array.isArray(foreignKey)) {
       const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
       const pkCols = Array.isArray(ownerKey) ? ownerKey : [ownerKey];
@@ -797,7 +758,6 @@ export function scope(
         // Route through the reflection's canonical checkValidityBang (Rails'
         // single raise site) so the error carries the Rails-faithful message.
         routeThroughCheckValidity(ctor, assocName);
-        // No reflection registered (lower-level test helper) — minimal guard.
         throw new CompositePrimaryKeyMismatchError({
           activeRecord: ctor.name,
           name: assocName,

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -564,10 +564,6 @@ function buildThroughRecord(this: HasManyThroughAssociation, record: Base): Base
   const proxy = throughProxy(this);
   if (!proxy || typeof proxy.build !== "function" || !sourceRefl?.name) return null;
 
-  // When the through is a singular (has_one/belongs_to) association that's already
-  // loaded, reuse the existing through record. For singular throughs there is only
-  // one possible join row, so the loaded target is always the right one — building
-  // a fresh record would wire FK on the new target to null instead of the real PK.
   const existingTarget = proxy.loaded ? proxy.target : undefined;
   if (existingTarget && !Array.isArray(existingTarget)) {
     cache.set(record, existingTarget);
@@ -588,14 +584,11 @@ function buildThroughRecord(this: HasManyThroughAssociation, record: Base): Base
 
 /** @internal */
 function throughScope(this: HasManyThroughAssociation): unknown {
-  // through_scope is set externally by the association's concat/insert path.
-  // Return the memoized scope if it was set; otherwise null.
   return (this as any)._throughScope ?? null;
 }
 
 /** @internal */
 function throughScopeAttributes(this: HasManyThroughAssociation): Record<string, unknown> {
-  // Extract WHERE conditions from the through scope for the through model's table.
   const throughName = this.reflection.options.through;
   if (!throughName) return {};
   const throughAssoc = (this.owner as any).association?.(throughName);
@@ -616,7 +609,6 @@ function throughScopeAttributes(this: HasManyThroughAssociation): Record<string,
   if (!scope || typeof scope.whereValuesHash !== "function") return {};
   const throughTable = throughAssoc.klass?.tableName ?? "";
   const attrs = scope.whereValuesHash(throughTable) as Record<string, unknown>;
-  // Exclude the FK columns and the STI inheritance column.
   const throughFk = throughAssoc.reflection?.options?.foreignKey ?? "";
   const inheritanceCol = throughAssoc.klass?.inheritanceColumn ?? "type";
   for (const key of [String(throughFk), inheritanceCol]) {
@@ -848,11 +840,6 @@ function throughProxy(assoc: HasManyThroughAssociation): ThroughTargetStore | nu
   } | null;
   if (!tr?.name) return null;
   const isCollection = tr.isCollection?.() ?? tr.macro === "hasMany";
-  // A collection through (has_many) keeps its canonical in-memory target on the
-  // user-facing CollectionProxy (RFC 0022); build / include / delete must use
-  // it. A singular through (has_many :posts through: a belongs_to/has_one
-  // :author) has no collection proxy — read the OO holder, exposing the same
-  // `build`/`loaded`/`target` surface so the singular-reuse branch still fires.
   if (isCollection) {
     return collectionProxyFor(assoc.owner, tr.name) as unknown as ThroughTargetStore;
   }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -337,7 +337,6 @@ export class HasOneAssociation extends SingularAssociation {
         // leave the association unloaded: `load_target` calls `loaded!`
         // unconditionally (association.rb:192), as does the `loadTarget()`.
         if (!this.target && !record) return;
-        // `hasChangesToSave` is a getter, read (not called) per #4900.
         const assigningAnotherRecord = !sameRecord(this.target, record);
         if (assigningAnotherRecord || record?.hasChangesToSave === true) {
           // Rails: `save &&= owner.persisted?` (:66).
@@ -564,10 +563,6 @@ export class HasOneAssociation extends SingularAssociation {
   private setOwnerAttributes(record: Base): void {
     if (this.reflection.options.through) return;
 
-    // `join_primary_key` / `join_foreign_key` / `type` live on the rich
-    // reflection, which the Association is not constructed with — it is
-    // resolved off the owner's class, the lookup the `type` read below has
-    // always used.
     const ctor = (this.owner as any).constructor;
     const richReflection = ctor._reflectOnAssociation?.(this.reflection.name) as {
       joinPrimaryKey?: (klass?: typeof Base) => string | string[];
@@ -747,8 +742,6 @@ async function preloadDestroyInverseBelongsTo(
       continue;
     }
     if (JSON.stringify(Array.isArray(fk) ? fk : [fk]) !== ownFk) continue;
-    // The owner must actually be an instance of the belongs_to's target class,
-    // so we don't query an unrelated association that happens to share the FK.
     if (klass && !(owner instanceof (klass as any))) continue;
     try {
       await (target as any).association(ref.name).loadTarget();
@@ -784,10 +777,6 @@ function transactionIf(
  * @internal
  */
 function nullifiedOwnerAttributes(assoc: HasOneAssociation): Record<string, null> {
-  // Resolve the rich reflection so foreignKey expansion (composite PKs,
-  // primaryKey overrides, polymorphic foreignType) matches what the
-  // association itself uses. Fall back to the HasOneAssociation's own
-  // foreignKeyColumns() derivation, then to options-based defaults.
   const ctor = assoc.owner.constructor as {
     name: string;
     _reflectOnAssociation?: (n: string) => {

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -131,9 +131,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    *
    * @internal
    */
-  protected override async detachDisplacedTarget(): Promise<void> {
-    // no-op — see JSDoc
-  }
+  protected override async detachDisplacedTarget(): Promise<void> {}
 
   /**
    * Runs the DB half of Rails' `create_through_record`
@@ -409,18 +407,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
         } else {
           this._pendingReplace = { record, previousTarget: null };
         }
-        // The just-built in-memory join record masks any UNLOADED pre-existing
-        // DB row, so `persistReplace` must reset the proxy and re-read from the
-        // DB. Only this branch needs that — the already-loaded reconcile keeps
-        // the proxy's memoized target intact.
         this._pendingUnloadedThroughReconcile = true;
-        // Suppress the general has_one autosave from independently persisting the
-        // just-built join row (which would double-write against the existing DB
-        // row): a truthy `_pendingReplace` marker on the through proxy makes
-        // `autosaveHasOne` skip it. The through proxy is a plain has_one with no
-        // `persistReplace`, so `flushPendingReplaces` never invokes the marker —
-        // our `persistReplace` is the sole persister, regardless of the order
-        // `flushPendingReplaces` visits associations.
         const tp = throughProxy as {
           _pendingReplace?: { record: Base | null; previousTarget: Base | null } | null;
         };
@@ -460,11 +447,6 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    */
   async persistReplace(save = true): Promise<void> {
     const pending = this._pendingReplace;
-    // Clear before the first `await` — mirrors HasOneAssociation#persistReplace.
-    // The new awaitable `writer` (inherited from HasOneAssociation) makes this
-    // path reachable concurrently (`await writer(a); await writer(b)`); without
-    // the early clear a second `replace` would mutate the shared `_pendingReplace`
-    // object still captured by reference in this call's `pending`.
     this._pendingReplace = null;
     // Only when we built a fresh in-memory join record over an UNLOADED
     // pre-existing row (else-branch reconcile): reset the through proxy so
@@ -526,8 +508,6 @@ async function createThroughRecord(
   }
 
   if (record) {
-    // Mutability is enforced inside constructJoinAttributes — keep the
-    // precondition in one place.
     const attrs = this.constructJoinAttributes(record);
 
     if (throughRecord) {

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -32,7 +32,6 @@ import {
  */
 export function _buildAssociationInstance(this: Base, assocDef: AssocDef): AssociationInstance {
   const opts = (assocDef.options ?? {}) as Record<string, unknown>;
-  // A reflection's `type` is the polymorphic `*_type` column, not the macro.
   switch (assocDef.macro ?? assocDef.type) {
     case "belongsTo":
       if (opts.polymorphic) return new BelongsToPolymorphicAssociation(this, assocDef as any);
@@ -51,42 +50,20 @@ export function _buildAssociationInstance(this: Base, assocDef: AssocDef): Assoc
 }
 
 function syncAssociationInstance(this: Base, name: string, instance: AssociationInstance): void {
-  // Optional call: `_associationInstances` also holds minimal ad-hoc holders
-  // for undeclared inverses (`associations.ts`'s literal, seed-association-cache)
-  // that implement only `target` / `isLoaded` / `setTarget`. Those are singular
-  // by construction, so falling through is right.
   if ((instance as { isCollection?(): boolean }).isCollection?.()) {
-    // One seat since RFC 0022's fold: the proxy writes `@loaded` on this very
-    // instance, so read it here rather than back off the proxy (which resolves
-    // its seat through this function).
     if (instance.loaded === true && !instance._staleStateIsSnapshotted) instance.loadedBang();
     return;
   }
-  // Reads the loaded target through the association cache
-  // (`Base#_associationCache`): a loaded collection proxy's canonical target
-  // array or a loaded singular holder's target. A cached "nil association"
-  // surfaces as `null` (not `undefined`), so the `!== undefined` guard still
-  // marks the instance loaded — matching `Association#doFindTarget`. When the
-  // cache *is* this very instance (a loaded singular holder caches itself),
-  // there is nothing to copy.
   const cached = this._associationCache(name);
   if (cached === instance) return;
   if (cached !== undefined) {
     if (instance.isLoaded()) {
-      // The stale state was captured at actual load time; re-snapshotting via
-      // loadedBang (inside setTarget) after a FK change would reset the
-      // detector and mask stale-target detection. Update the target directly
-      // without re-marking loaded.
       instance._writeTargetStore((cached.target as Base | Base[] | null) ?? null);
     } else {
       instance._setTargetFromLoader((cached.target as Base | Base[] | null) ?? null);
     }
     return;
   }
-  // Route through the real holder (`_preloadedHolderTarget`) so an
-  // eagerly-preloaded "nil association" (or empty collection) still marks the
-  // instance loaded — the boxed `{ value }` distinguishes a preloaded-nil from
-  // a miss, matching `Association#doFindTarget`'s cache semantics.
   const preloaded = _preloadedHolderTarget(this, name);
   if (preloaded) {
     instance._setTargetFromLoader(preloaded.value as any);
@@ -121,8 +98,6 @@ function assertSingularAssociation(
   return assocDef;
 }
 
-// Explicit `loadBelongsTo` / `loadHasOne` calls are legitimate lazy loads —
-// the caller asked for them — so they skip the strict-loading throw.
 async function bypassStrictLoading<T>(this: Base, fn: () => Promise<T>): Promise<T> {
   this._strictLoadingBypassCount += 1;
   try {
@@ -147,9 +122,6 @@ export function association(this: Base, name: string): AssociationInstance {
   }
 
   const ctor = this.constructor as typeof Base;
-  // A subclass that overrides an inherited association appends its own
-  // definition after the cloned parent entry, so the most-derived override
-  // is the *last* match — mirroring `_reflections` (keyed, override-wins).
   const assocDef = ctor._associations
     ?.slice()
     .reverse()

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -65,9 +65,6 @@ export interface AliasMap {
 }
 
 function getModelColumns(modelClass: any): string[] {
-  // columnsHash() triggers loadSchema() which populates _attributeDefinitions
-  // from the schema cache before columnNames() reads them. Guard with try/catch
-  // in case the model is abstract or has no adapter configured yet.
   let ch: Record<string, unknown> | undefined;
   if (typeof modelClass.columnsHash === "function") {
     try {
@@ -76,11 +73,7 @@ function getModelColumns(modelClass: any): string[] {
       ch = undefined;
     }
   }
-  // No columnNames() fallback: it would throw exactly like the caught
-  // columnsHash() above (abstract / no table).
   const cols: string[] = ch ? Object.keys(ch) : [];
-  // A falsy primaryKey ("" / null) marks a no-primary-key model — there is no
-  // PK column to fold into the SELECT list, so leave the columns as-is.
   const pk = modelClass.primaryKey;
   if (Array.isArray(pk)) {
     for (const k of pk) {
@@ -682,8 +675,6 @@ export class JoinDependency {
       // (join_dependency.rb:55-56): a Symbol and the equivalent String key the
       // same node, so a Symbol — spelled `":comments"` — drops its colon here.
       const name = associations.startsWith(":") ? associations.slice(1) : associations;
-      // Dotted strings ("comments.author") are a trails affordance: split them
-      // into nested levels so the builder joins each segment in turn.
       let cur = hash;
       for (const part of name.split(".")) {
         cur = cur[part] ??= Object.create(null);
@@ -743,8 +734,6 @@ export class JoinDependency {
     const aliases = this.aliases();
     const basePk = (this._baseModel as any).primaryKey ?? "id";
     const basePkCols: string[] = Array.isArray(basePk) ? basePk : [basePk];
-    // The base table's aliased (column, alias) pairs — all columns normally, or
-    // just the primary key under an explicit select (`applyColumnAliases`).
     const baseAliasCols = aliases.columnsForNode(joinRoot);
 
     const seen = new Map<any, Map<JoinPart, Map<unknown, any>>>();
@@ -763,9 +752,6 @@ export class JoinDependency {
         if (!/^t\d+_r\d+$/.test(key)) parentAttrs[key] = row[key];
       }
 
-      // The base key is read out of the aliased row exactly as the child keys are
-      // in `construct` (raw `row[aliases.columnAlias(node, col)]`), reusing the
-      // values already pulled into parentAttrs — one accessor, never the cast value.
       const parentKey = this._keyFor(basePkCols.map((c) => parentAttrs[c]));
       let parent = parents.get(parentKey);
       if (!parent) {
@@ -780,11 +766,6 @@ export class JoinDependency {
     }
 
     const parentList = [...parents.values()];
-    // Reverse index: each parent record → the RAW aliased dedup key it was
-    // stored under (the same `_keyFor` key `_collectAssociations` uses). The
-    // eager inverse-cache loop must look `associations` up by this raw key, not
-    // by re-reading the instantiated record's (deserialized) PK, which can
-    // diverge from the raw row value on adapters that deserialize PK columns.
     const parentKeys = new Map<any, unknown>();
     for (const [key, parent] of parents) parentKeys.set(parent, key);
     return {

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -128,8 +128,6 @@ export abstract class JoinPart {
   extractRecord(row: Record<string, unknown>, aliases: string): Record<string, unknown> {
     const record: Record<string, unknown> = {};
 
-    // Check for JoinDependency-style aliases (t{n}_r{n}) first, since
-    // the prefix `t1_` would falsely match generic prefix matching
     const indexMatch = aliases.match(/^t(\d+)$/);
     if (indexMatch) {
       const pattern = new RegExp(`^t${indexMatch[1]}_r(\\d+)$`);
@@ -149,7 +147,6 @@ export abstract class JoinPart {
       if (matched) return record;
     }
 
-    // Generic prefix matching: keys in the form `${aliases}_<attr>`
     const prefix = `${aliases}_`;
     for (const [key, value] of Object.entries(row)) {
       if (key.startsWith(prefix)) {

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -58,8 +58,6 @@ export class NestedError extends ActiveModelNestedError {
       innerError,
     });
     const name = association.reflection.name;
-    // isCollection: check the Association method if available, otherwise infer
-    // from whether target is an array (CollectionProxy always has array target).
     const isCollection =
       typeof association.isCollection === "function"
         ? association.isCollection()

--- a/packages/activerecord/src/associations/new-owner-seed-rebase.ts
+++ b/packages/activerecord/src/associations/new-owner-seed-rebase.ts
@@ -30,18 +30,10 @@ export function rebaseNewOwnerSeed(
   freshScope: unknown,
   seedPredicates: readonly unknown[],
 ): void {
-  // Drop the stale seed predicates (the `1=0`), keeping only the mutations
-  // layered on top, and clear the NullRelation flag so the merge is live.
-  // Assigned through the writer, not mutated through the reader: an unset
-  // `:where` key returns a fresh `WhereClause.empty()` per getter call, so the
-  // read-filter-write shape would silently drop the result.
   target.whereClause = new WhereClause(
     target.whereClause.predicates.filter((p) => !seedPredicates.includes(p)),
   );
   target._isNone = false;
-  // Merge the surviving mutations onto the freshly resolved scope, then adopt
-  // the merged state — the scope contributes the resolved FK + join, the
-  // mutations contribute the accumulated where/order/limit/etc.
   const merged = new Merger(freshScope, target).merge();
   target.initializeCopy(merged);
 }

--- a/packages/activerecord/src/associations/preloader.ts
+++ b/packages/activerecord/src/associations/preloader.ts
@@ -56,8 +56,6 @@ export class Preloader {
       associateByDefault: this.associateByDefault,
       scope: this.scope,
     });
-    // An array is the final record set; a Relation is materialized lazily by
-    // `materialize()`, driven from the `isEmpty()` check in `Batch`.
     this._materialized = !isRelation(this.records);
     if (this._materialized) {
       this._tree.setPreloadedRecords(this.records as Base[]);

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -161,9 +161,7 @@ export class Association {
       try {
         const association = (owners[0] as any).association(this.reflection.name);
         association.setInverseInstance(record);
-      } catch {
-        // Ignore if association doesn't exist
-      }
+      } catch {}
     }
   }
 
@@ -212,16 +210,12 @@ export class Association {
         const owner = owners[i];
         try {
           const association = (owner as any).association(this.reflection.name);
-          // Loader writeback, not an assignment — must not trip the
-          // in-flight guard (see Association#_setTargetFromLoader).
           association._setTargetFromLoader(record);
           association._loadedFromPreload = true;
           if (i === 0) {
             association.setInverseInstance(record);
           }
-        } catch {
-          // Ignore
-        }
+        } catch {}
       }
     }
   }
@@ -551,10 +545,6 @@ export class LoaderRecords {
       keysToLoad.delete(key);
     }
 
-    // Shared query across loaders: resolve each record's owning loader inside
-    // the instantiation block so the inverse is wired before find/initialize
-    // callbacks. setInverse is a no-op for a loader whose ownersByKey lacks the
-    // record's key, so wiring every loader leaves only the matching one active.
     const loaded = await this.loaderQuery.loadRecordsForKeys([...keysToLoad], (record) => {
       for (const loader of this.loaders) {
         loader.setInverse(record);

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -92,28 +92,13 @@ export class Batch {
 
     for (const record of await branch.sourceRecords()) {
       if (coveredRecords.has(record)) continue;
-      // Record a preloaded-nil default on the real holder so readers gating on
-      // `holder.isLoaded() && _loadedFromPreload` see it (RFC 0022).
-      //
-      // `association(branch.association)` throws only for a record whose class
-      // does not declare `branch.association` — exactly the
-      // `polymorphicParent && !reflection` records that `Branch#groupedRecords`
-      // skips (and so leaves uncovered) without ever resolving a holder. Those
-      // records have no reader for the association at all, so a holder-resident
-      // nil-default would be unreadable anyway; the old shadow-map entry was
-      // equally dead for them. Hence the catch is purely defensive — no reader
-      // asymmetry results from skipping the holder write here.
       try {
         const association = (record as any).association(branch.association);
         if (!association.isLoaded()) {
-          // Loader writeback (preload miss) — must not trip the in-flight
-          // guard. See Association#_setTargetFromLoader.
           association._setTargetFromLoader(null);
           association._loadedFromPreload = true;
         }
-      } catch {
-        // Association not declared on this record's class (see above).
-      }
+      } catch {}
     }
   }
 

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -160,14 +160,10 @@ export class ThroughAssociation extends Association {
           if (!(chainRefl as any).isPolymorphic?.()) {
             try {
               sourceClasses.push(chainRefl.klass);
-            } catch {
-              /* polymorphic */
-            }
+            } catch {}
           }
         }
-      } catch {
-        /* chain resolution may fail */
-      }
+      } catch {}
     }
 
     const seen = new Set<typeof Base>();
@@ -304,15 +300,11 @@ export class ThroughAssociation extends Association {
 
     const whereClause = reflScope?.whereClause;
     if (options.sourceType) {
-      // scope.where!(reflection.foreign_type => source_type) (rb:115-116)
       const foreignType = (this.reflection as any).foreignType;
       if (foreignType) {
         scope = scope.where({ [foreignType]: options.sourceType });
       }
     } else if (reflScope != null && whereClause != null && !whereClause.isEmpty()) {
-      // elsif !reflection_scope.where_clause.empty? (rb:117-143): copy the FULL
-      // where_clause onto the through query and JOIN the source reflection so
-      // every referenced column resolves in this single query.
       const sourceRefl = this.sourceReflection;
       if (sourceRefl) {
         // Mirror Rails' `through_scope` eager-load branch exactly for EVERY
@@ -376,14 +368,11 @@ export class ThroughAssociation extends Association {
           scope = scope.joins({ [sourceName]: nestedJoins });
         }
 
-        // left_outer_joins!(source_reflection.name => left_outer_joins) (rb:136-137).
         const nestedLeftOuter: any[] = reflScope?.leftOuterJoinsValues ?? [];
         if (nestedLeftOuter.length > 0) {
           scope = scope.leftOuterJoins({ [sourceName]: nestedLeftOuter });
         }
 
-        // scope.eager_loading? && order (rb:139-141): true here since we always
-        // includes! the source above.
         const orderClauses: any[] = reflScope?.orderValues ?? [];
         if (orderClauses.length > 0) {
           scope.orderValues = [...scope.orderValues, ...orderClauses];
@@ -391,8 +380,6 @@ export class ThroughAssociation extends Association {
       }
     }
 
-    // cascade_strict_loading: a strict-loading preload scope propagates to the
-    // through query so intermediate records inherit the constraint (rb:145).
     return this.cascadeStrictLoading(scope);
   }
 
@@ -429,9 +416,7 @@ export class ThroughAssociation extends Association {
       let throughKlass: typeof Base | null = null;
       try {
         throughKlass = throughRefl.klass;
-      } catch {
-        // klass resolution may fail for polymorphic reflections
-      }
+      } catch {}
       if (throughKlass) {
         for (const sourceName of sourceNames) {
           if (!sourceName) continue;

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -80,10 +80,6 @@ export class SingularAssociation extends Association {
     // the new target, so a passed block can mutate persisted attributes
     // (e.g. `build_bulb { |b| b.color = ... }`).
     const record = this.buildRecord(attributes, block);
-    // `set_new_record` → `replace(record, false)` runs `load_target` on EVERY
-    // build, so a persisted owner whose target has never been loaded still
-    // discovers (and displaces) the row in the DB. The load has to precede
-    // `setNewRecord`, which overwrites the target and marks it loaded.
     const setNewRecord = (): Base | null | Promise<Base | null> => {
       // Rails removes before promoting: `remove_target!`
       // (has_one_association.rb:69), then `self.target = record` (:84). That
@@ -188,28 +184,17 @@ export class SingularAssociation extends Association {
       return this.target;
     }
 
-    // An in-memory target (set via build / internal assignment paths
-    // like Preloader::Association#associate_records_from_unscoped,
-    // which can bind `association.target` without calling
-    // `loadedBang()`) is already resolved — no DB load would run, so
-    // strict loading should not fire. Mark it loaded to short-circuit
-    // future reads.
     if (this.target != null) {
       this.loadedBang();
       return this.target;
     }
 
-    // Sync resolution via preloaded / cached associations. `doFindTarget`
-    // returns `undefined` if nothing is cached, or the (possibly null)
-    // preloaded value if it is. A null from a preloaded key is a
-    // legitimate "nil association" — no query needed, no throw.
     const cached = this.doFindTarget();
     if (cached !== undefined) {
       this.target = cached as Base | null;
       return this.target;
     }
 
-    // A DB load would be required to answer.
     if (this.findTargetNeeded()) {
       if (this.isViolatesStrictLoading()) {
         const ctor = this.owner.constructor as typeof Base;
@@ -330,7 +315,6 @@ export class SingularAssociation extends Association {
             this as unknown as { loadHasOneThrough(): Promise<Base | null> }
           ).loadHasOneThrough();
         }
-        // Otherwise fall through to the scope path below.
       }
 
       let targetModel: typeof Base;
@@ -354,11 +338,6 @@ export class SingularAssociation extends Association {
         _validateHasOnePolymorphicKeys(owner, assocName, options);
       }
 
-      // Null-key short-circuit: read the SAME columns the eventual query reads, or
-      // a mismatch silently returns null where a real query would have found the
-      // row. That is `joinForeignKey` on the owner-side chain reflection for both
-      // macros — the owner's FK for belongs_to, its activeRecordPrimaryKey for
-      // has_one.
       const ownerSideReflection = _ownerChainReflection(reflection) ?? reflection;
       const keyColsForCheck = Array.isArray(ownerSideReflection.joinForeignKey)
         ? ownerSideReflection.joinForeignKey

--- a/packages/activerecord/src/associations/through-association.ts
+++ b/packages/activerecord/src/associations/through-association.ts
@@ -78,9 +78,6 @@ export function sourceReflection(assoc: { owner: Base; reflection: { name: strin
  * @internal
  */
 export function throughReflection(this: ThroughAssociationHost): unknown {
-  // Resolve the rich reflection first — this.reflection is the
-  // AssociationDefinition (no throughReflection getter), so we need
-  // ThroughReflection#throughReflection from the registry.
   type Refl = {
     throughReflection?: Refl | null;
     isThroughReflection?: () => boolean;

--- a/packages/activerecord/src/associations/validate-through-reflection.ts
+++ b/packages/activerecord/src/associations/validate-through-reflection.ts
@@ -41,8 +41,6 @@ export function validateThroughReflection(modelClass: typeof Base, assocName: st
     | null
     | undefined;
   if (!refl) return;
-  // Re-throw a previously-cached validation error so a caller that
-  // catches it can't sneak past validation on a retry.
   if (refl[CHECKED_ERROR] !== undefined) throw refl[CHECKED_ERROR];
   if (refl[CHECKED_OK]) return;
   // `AbstractReflection#checkValidityBang` (reflection.ts:743) only
@@ -54,10 +52,6 @@ export function validateThroughReflection(modelClass: typeof Base, assocName: st
   const isThrough = typeof refl.isThroughReflection === "function" && refl.isThroughReflection();
   if (!isThrough || typeof refl.checkValidityBang !== "function") return;
 
-  // Delegate to `ThroughReflection#checkValidityBang`. Cache the
-  // outcome on the reflection: success short-circuits future calls;
-  // failure stashes the error and re-throws on every call so a
-  // misconfiguration always surfaces, even after a catch.
   try {
     refl.checkValidityBang();
     refl[CHECKED_OK] = true;


### PR DESCRIPTION
Slice 2 of the `blazetrails/no-freeform-comments` rollout (slice 1 was
`packages/activerecord/src/relation/**`). This one sweeps the **implementation**
files under `packages/activerecord/src/associations/**`.

### Why the `ignores` for `**/*.test.ts`

The story itself specifies the split: *"measured ~1512 comment lines / 657
blocks. Larger than one PR: split it into several slices of its own."* The
measurement on this branch is 653 flagged blocks across 98 files; the 31
implementation files account for ~137 of them (444 deleted lines here), and the
test files account for the remaining ~500 — `has-many-associations.test.ts`
alone is 110. Sweeping both in one PR is several times the LOC ceiling, and
CLAUDE.md forbids fanning out into sibling PRs, so the remainder is registered
as its own story rather than shipped here:
`0023-surfaced-deviations/strip-freeform-comments-ar-associations-tests`, whose
first acceptance criterion is deleting the `ignores` entry this PR adds.

The `ignores` line is the mechanism the story's own framing calls for — the rule
is registered per glob so it "extends one directory at a time and stays green in
between". Leaving the rule off the whole associations tree until the test
backlog lands would let new freeform comments into the implementation files in
the meantime; the ignore keeps enforcement on everything already swept.

### The sweep

- `pnpm eslint --fix` over the glob; deletions reviewed hunk by hunk.
- Two comments the autofix truncated mid-sentence (a dangling clause left inside
  a ternary in `belongs-to-association.ts` and `collection-association.ts`) were
  rewritten as self-contained Rails citations pointing at
  `belongs_to_association.rb:165` and `collection_association.rb:157`.
- Blocks emptied by the deletions stay empty in code (`catch {}`, the
  `record.nil?` no-op arm Rails itself leaves empty at
  `collection_association.rb:75`) — no comment restored to fill them.
- `pnpm eslint` clean over the glob, second `--fix` run a no-op,
  `pnpm typecheck` clean, touched association test files green (1100 tests).
- Gates clean: `parity:api:calls`, `parity:api:calls:args`,
  `parity:api:extra --package activerecord`, `parity:api:extra:gate`.

Deferred work found in a deleted comment is filed rather than reworded:
`0023-surfaced-deviations/collection-proxy-scoping-current-scope` (Rails'
`Association#scope` `proxy_association == self` branch, association.rb:110, is
unreachable because `CollectionProxy#scoping` is not ported).

Closes-story: strip-freeform-comments-ar-associations
