### PR TITLE
refactor(activerecord): retire the attribute-definition registry from the _default_attributes seed

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -13,7 +13,6 @@ import {
   AttributeSet,
   type Type,
   applyPendingAttributeModifications,
-  defaultValue as typeDefaultValue,
   resetDefaultAttributes as amResetDefaultAttributes,
 } from "@blazetrails/activemodel";
 // The pending queue is private on ActiveModel (attribute_registration.rb:77);
@@ -21,14 +20,14 @@ import {
 // queue from ActiveRecord, so it imports the queue accessor and the pending
 // classes off the defining module rather than the package's public barrel.
 import {
-  PendingDefault,
-  PendingType,
+  type PendingModification,
   pendingAttributeModifications,
 } from "@blazetrails/activemodel/attribute-registration";
 import { registerSubclass } from "@blazetrails/activesupport";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup, adapterNameFrom, type AdapterNameSource } from "./type.js";
-import { cachedColumnsHash, isSchemaLoaded, pendingAttributeDeclarationQ } from "./model-schema.js";
+import { cachedColumnsHash, isSchemaLoaded } from "./model-schema.js";
+import { connectionPool, threadedConnectionFor } from "./connection-handling.js";
 
 type AnyClass = any;
 
@@ -39,22 +38,6 @@ interface AttributeDefinition {
   limit?: number | null;
   /** Declared via `attribute(name, type, { virtual: true })` — not DB-backed. */
   virtual?: boolean;
-  /**
-   * For `source:"schema"` defs, the `tableName` the columns were reflected
-   * against. A non-STI subclass that overrides `_tableName` and declares an
-   * `attribute()` before reflecting forks (clones) its ancestor's map, copying
-   * the ancestor's schema defs — which describe a *different* table. Recording
-   * the reflected table lets `ensureSchemaLoaded` distinguish those foreign
-   * defs from ones reflected against this class's own table.
-   */
-  reflectedTable?: string;
-  /**
-   * The bare `type_for_column` result for this column, before any decoration
-   * was baked into `type`. `_defaultAttributes` seeds from this so the
-   * pending-decorator replay is the ONLY thing that wraps — mirroring Rails,
-   * which seeds from `type_for_column` (attributes.rb:241-245).
-   */
-  reflectedColumnType?: Type;
 }
 
 /**
@@ -77,6 +60,41 @@ export interface Attributes {
 }
 
 const NO_DEFAULT = Symbol("NO_DEFAULT");
+
+const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
+
+/**
+ * `ActiveRecord::Attributes::ClassMethods#define_default_attribute`
+ * (attributes.rb:277-291), deferred onto the pending-modification queue.
+ *
+ * Rails runs that body eagerly against `_default_attributes` because nothing
+ * rebuilds the set behind it; trails rebuilds it from `columns_hash` plus the
+ * queue on every `reset_default_attributes`, so the same three arms have to
+ * replay with the rest of the queue rather than being written once.
+ */
+class PendingDefinedDefault implements PendingModification {
+  constructor(
+    readonly name: string,
+    readonly value: unknown,
+    readonly type: Type,
+    readonly fromUser: boolean,
+  ) {}
+
+  applyTo(attributeSet: AttributeSet): void {
+    let defaultAttribute: Attribute;
+    if (this.value === NO_DEFAULT_PROVIDED) {
+      defaultAttribute = attributeSet.getAttribute(this.name).withType(this.type);
+    } else if (this.fromUser) {
+      defaultAttribute = attributeSet
+        .getAttribute(this.name)
+        .withType(this.type)
+        .withUserDefault(this.value);
+    } else {
+      defaultAttribute = Attribute.fromDatabase(this.name, this.value, this.type);
+    }
+    attributeSet.set(this.name, defaultAttribute);
+  }
+}
 
 /**
  * Lower-level attribute registration that accepts a resolved type object
@@ -101,8 +119,7 @@ export function defineAttribute(
   const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
 
   this._attributeDefinitions.set(name, {
-    // Spread existing to preserve metadata fields (reflectedTable, virtual, etc.)
-    // that other code paths (resetColumnInformation, schema reflection) rely on.
+    // Spread existing to preserve the `virtual` flag a prior declaration set.
     ...existing,
     name,
     type: castType,
@@ -110,19 +127,21 @@ export function defineAttribute(
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
 
-  // Rails stores nothing for `user_provided_default:`; it forwards it to
-  // `define_default_attribute`'s `from_user:`, which picks the Attribute
-  // subclass (attributes.rb:229-238,277-291). Queueing the declaration only
-  // when it IS user-provided is that same fork: the replay applies
-  // `with_user_default` (cast), a `from_user: false` def stays a column seed.
-  if (userProvidedDefault) {
-    pendingAttributeModifications.call(this).push(new PendingType(name, castType));
-    if (defaultValue !== NO_DEFAULT) {
-      pendingAttributeModifications
-        .call(this)
-        .push(new PendingDefault(name, resolvedDefault ?? null));
-    }
-  }
+  // Rails' `define_attribute` writes `define_default_attribute`'s result
+  // straight into the already-materialized `_default_attributes`
+  // (attributes.rb:232-238). trails rebuilds that set from `columns_hash` plus
+  // the pending queue on every reset, so the same body is queued instead of
+  // written — see PendingDefinedDefault.
+  pendingAttributeModifications
+    .call(this)
+    .push(
+      new PendingDefinedDefault(
+        name,
+        defaultValue === NO_DEFAULT ? NO_DEFAULT_PROVIDED : (resolvedDefault ?? null),
+        castType,
+        userProvidedDefault,
+      ),
+    );
 
   amResetDefaultAttributes(this);
   // A newly declared attribute may be virtual (no DB column); force the next
@@ -150,34 +169,34 @@ export function defineAttribute(
  * Build the AttributeSet that seeds every new record's `_attributes`.
  *
  * Mirrors: ActiveRecord::Attributes::ClassMethods#_default_attributes
+ * (attributes.rb:241-252):
  *
- * Rails' column-seed-then-replay: seeds every real DB column via
- * `Attribute.fromDatabase(name, column.default, type)` (so the default flows
- * through `deserialize`), then replays the pending-modification queue —
- * user-declared `attribute()` PendingType/PendingDefault entries and
- * `decorate_attributes` PendingDecorators (e.g. enums) — on top. A user
- * type-override on a real column (an enum) therefore keeps the FromDatabase
- * attribute and its deserialized default. User-declared attributes that are NOT
- * DB columns seed from `_attributeDefinitions`: with a default via
- * `withUserDefault` (cast), without one via `fromDatabase(null, type)` — the
- * latter required for `LockingType`, whose `deserialize(null)` returns 0.
+ *   @default_attributes ||= begin
+ *     attributes_hash = with_connection do |connection|
+ *       columns_hash.transform_values do |column|
+ *         ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
+ *       end
+ *     end
+ *     attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
+ *     apply_pending_attribute_modifications(attribute_set)
+ *     attribute_set
+ *   end
+ *
+ * The seed is `columns_hash` alone; every user declaration arrives with the
+ * pending-modification replay, so a `attribute :col, :integer` on a real column
+ * keeps the column's position and its deserialized default while the replayed
+ * `PendingType` swaps the type.
  */
 export function _defaultAttributes(this: AnyClass): AttributeSet {
-  // Reflect the (always-warm, RFC 0031) schema cache into `_attributeDefinitions`
-  // before building, so real columns — notably the `id` PK — are seeded even
-  // when the model is first constructed without a query (e.g. `new Car({name})`,
-  // where no STI `type` key drives the usual reflect-on-`new` path). Without
-  // this the strict `writeFromUser` raises on the post-INSERT `id` write-back.
-  // `columnsHash` reads the warm cache directly (and reconciles the definitions),
-  // which the bare `loadSchema` cache-sync path does not reliably do for
-  // dynamically-defined / STI models. A genuinely tableless model reflects
-  // nothing and falls through to the attribute-synthesized view as before.
-  //
-  // Gated on `!_schemaLoaded`: once the schema has been reflected the real
-  // columns are already in `_attributeDefinitions`, so skipping avoids both the
-  // redundant work and — importantly — the `.connection` access inside
-  // `columnsHash`, which would otherwise permanently check out a connection on
-  // every construction under `permanent_connection_checkout` = disallowed.
+  // Reflect the (always-warm, RFC 0031) schema cache before building, so real
+  // columns — notably the `id` PK — are seeded even when the model is first
+  // constructed without a query (e.g. `new Car({name})`, where no STI `type` key
+  // drives the usual reflect-on-`new` path). Without this the strict
+  // `writeFromUser` raises on the post-INSERT `id` write-back. Gated on
+  // `!_schemaLoaded`: once reflected, `columnsHash` is settled, so skipping
+  // avoids the `.connection` access inside `columnsHash`, which would otherwise
+  // permanently check out a connection on every construction under
+  // `permanent_connection_checkout` = disallowed.
   if (!isSchemaLoaded.call(this) && !this.abstractClass && this.tableName) {
     try {
       this.columnsHash();
@@ -198,69 +217,44 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     // class-definition hook (CLAUDE.md, "Module mixins").
     registerSubclass(Object.getPrototypeOf(cacheHost), cacheHost);
 
-    // Phase 1: seed schema columns via `Attribute.fromDatabase`, mirroring Rails'
-    // `columns_hash.transform_values { Attribute.from_database(col.name, col.default, type) }`.
-    // A real DB column — even one carrying a user type-override (e.g. an enum) —
-    // seeds from_database with the column's raw default so the default flows
-    // through `deserialize`, not `cast`; the user override is layered back on in
-    // phase 2 (a bare `attribute(name)` PendingType keeps the FromDatabase
-    // wrapper, `decorate_attributes` swaps the type). User-declared attributes
-    // that are NOT DB columns seed from `_attributeDefinitions`: with a default
-    // via withUserDefault (cast), without one via fromDatabase(null) — the latter
-    // matters for LockingType, where deserialize(null) → 0.
-    // `undefined` = the schema cache has no entry for this table (not reflected
-    // yet); `{}` = reflected and genuinely columnless. The seed below must tell
-    // them apart, so keep the miss rather than folding it into an empty hash.
-    const cachedColumns = cachedColumnsHash(cacheHost);
-    const columns = cachedColumns ?? {};
-    const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
+    // Ruby's `with_connection` block. Both probes are connection-free reads (no
+    // `.connection`), so the hot `new Model()` path never forces a permanent
+    // checkout; a model with no leased connection reflects no columns and is
+    // built from the pending replay alone.
+    let connection: unknown;
+    try {
+      connection =
+        threadedConnectionFor(cacheHost) ??
+        cacheHost._adapter ??
+        connectionPool.call(cacheHost).activeConnection;
+    } catch {
+      connection = undefined;
+    }
+    // Rails reads `columns_hash` — the memo `load_schema!` settled
+    // (model_schema.rb:592-594) — so prefer this class's own memo and fall back
+    // to the warm schema cache only for a class that has not reflected yet.
+    const columns: Record<string, unknown> =
+      (Object.prototype.hasOwnProperty.call(cacheHost, "_columnsHash")
+        ? cacheHost._columnsHash
+        : undefined) ??
+      cachedColumnsHash(cacheHost) ??
+      {};
+    const ignored = new Set<string>(cacheHost.ignoredColumns ?? []);
     const attributesHash = new Map<string, Attribute>();
-    // Rails seeds phase 1 from `columns_hash` alone (attributes.rb:241-245) and
-    // the non-column declarations arrive with the phase-2 replay, so a column
-    // holds its schema position even under an `attribute` override.
-    const orderedDefNames = [
-      ...Object.keys(columns).filter((name) => defs.has(name)),
-      ...[...defs.keys()].filter((name) => columns[name] === undefined),
-    ];
-    for (const name of orderedDefNames) {
-      const def = defs.get(name)!;
-      const column = columns[name];
-      if (column !== undefined || !pendingAttributeDeclarationQ(cacheHost, name)) {
-        // Rails' `columns_hash.transform_values { Attribute.from_database(name,
-        // column.default, type_for_column(connection, column)) }`
-        // (attributes.rb:241-245) — a user type-override on a real column (an
-        // enum, `serialize`, `encrypts`) is layered back on in phase 2.
-        //
-        // Seed from the BARE reflected column type, not `def.type` — trails
-        // eagerly bakes decorations into `def.type` (a back-compat convenience
-        // Rails lacks), and phase 2 replays those same decorators, so seeding
-        // from `def.type` applies each one twice.
-        const seedType = def.reflectedColumnType ?? def.type;
-        const defaultValue = column !== undefined ? column.default : def.defaultValue;
-        attributesHash.set(name, Attribute.fromDatabase(name, defaultValue ?? null, seedType));
-      } else if (def.defaultValue != null) {
-        const base = Attribute.withCastValue(name, null, def.type);
-        attributesHash.set(name, base.withUserDefault(def.defaultValue));
-      } else if (def.type !== typeDefaultValue()) {
-        attributesHash.set(name, Attribute.fromDatabase(name, null, def.type));
-      } else if (cachedColumns === undefined) {
-        // Deviation: Rails resolves `columns_hash` synchronously before
-        // `_default_attributes` (attributes.rb:241-250), so a decorator branching
-        // on `subtype == Type.default_value` (enum.rb:240) never has to tell "no
-        // such column" from trails' "not reflected yet". A schema-cache MISS is
-        // that state — not an empty hash (a reflected columnless table must still
-        // raise) and not `!_schemaLoaded` (the warm-cache probe above stamps the
-        // flag even when the reflection yielded nothing, which is how PG got
-        // here). A non-singleton `value` stands in until the table reflects; once
-        // it has, an absent name is genuinely absent and stays out of the set, as
-        // Rails' columns-only seed leaves it.
-        attributesHash.set(name, Attribute.fromDatabase(name, null, typeLookup("value")));
-      }
+    for (const [name, column] of Object.entries(columns)) {
+      // `load_schema!` drops the ignored columns before `@columns_hash` is
+      // stashed (model_schema.rb:592-594), so they never reach the seed.
+      if (ignored.has(name)) continue;
+      attributesHash.set(
+        name,
+        Attribute.fromDatabase(
+          name,
+          (column as { default?: unknown }).default ?? null,
+          typeForColumn.call(cacheHost, connection, column),
+        ),
+      );
     }
 
-    // Phase 2: replay user-declared attribute() calls from the pending queue.
-    // These always win over schema columns, matching Rails' ordering guarantee.
-    // Mirrors: apply_pending_attribute_modifications(attribute_set)
     const attributeSet = new AttributeSet(attributesHash);
     applyPendingAttributeModifications(cacheHost, attributeSet);
 
@@ -270,38 +264,12 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
   return cacheHost._cachedDefaultAttributes;
 }
 
-const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
-
 /**
  * @internal
  * Mirrors: ActiveRecord::Attributes::ClassMethods#reload_schema_from_cache
  */
 function reloadSchemaFromCache(this: AnyClass): void {
   amResetDefaultAttributes(this);
-}
-
-/**
- * @internal
- * Mirrors: ActiveRecord::Attributes::ClassMethods#define_default_attribute
- */
-function defineDefaultAttribute(
-  this: AnyClass,
-  name: string,
-  value: unknown,
-  type: Type,
-  fromUser: boolean,
-): void {
-  const defaults = _defaultAttributes.call(this);
-  let defaultAttr: Attribute;
-  if (value === NO_DEFAULT_PROVIDED) {
-    defaultAttr = defaults.getAttribute(name).withType(type);
-  } else if (fromUser) {
-    const existing = defaults.getAttribute(name);
-    defaultAttr = existing.withType(type).withUserDefault(value);
-  } else {
-    defaultAttr = Attribute.fromDatabase(name, value, type);
-  }
-  defaults.set(name, defaultAttr);
 }
 
 /**
@@ -330,11 +298,28 @@ export function resolveTypeName(
 /**
  * @internal
  * Mirrors: ActiveRecord::Attributes::ClassMethods#type_for_column
+ * (attributes.rb:300-302) — `hook_attribute_type(column.name, super)`, whose
+ * `super` is ActiveRecord::ModelSchema::ClassMethods#type_for_column
+ * (model_schema.rb:622-629): the adapter's cast type for the column, run
+ * through the immutable-string conversion. TS cannot spell `super` across
+ * modules, so the two bodies are inlined in Rails order. Falls back to the
+ * `value` type when no connection is available to look the column up.
  */
-function typeForColumn(
-  this: AnyClass,
-  _connection: unknown,
-  column: { name: string; type: Type },
-): Type {
-  return column.type;
+function typeForColumn(this: AnyClass, connection: unknown, column: unknown): Type {
+  const lookupCastTypeFromColumn = (
+    connection as { lookupCastTypeFromColumn?: (c: unknown) => Type }
+  )?.lookupCastTypeFromColumn;
+  let type =
+    (typeof lookupCastTypeFromColumn === "function"
+      ? lookupCastTypeFromColumn.call(connection, column)
+      : null) ?? typeLookup("value");
+
+  // Only mutable StringType responds to toImmutableString, mirroring Ruby's
+  // `type.respond_to?(:to_immutable_string)` guard.
+  if (this.immutableStringsByDefault) {
+    const toImmutableString = (type as { toImmutableString?: () => Type }).toImmutableString;
+    if (typeof toImmutableString === "function") type = toImmutableString.call(type);
+  }
+
+  return this.hookAttributeType((column as { name: string }).name, type);
 }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -64,13 +64,14 @@ const NO_DEFAULT = Symbol("NO_DEFAULT");
 const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
 
 /**
- * `ActiveRecord::Attributes::ClassMethods#define_default_attribute`
- * (attributes.rb:277-291), deferred onto the pending-modification queue.
+ * `define_default_attribute`'s body (attributes.rb:277-291), carried on the
+ * pending-modification queue so it replays with the rest of it.
  *
- * Rails runs that body eagerly against `_default_attributes` because nothing
- * rebuilds the set behind it; trails rebuilds it from `columns_hash` plus the
- * queue on every `reset_default_attributes`, so the same three arms have to
- * replay with the rest of the queue rather than being written once.
+ * Rails writes the result straight into `_default_attributes` because nothing
+ * rebuilds that set behind it; trails rebuilds it from `columns_hash` plus the
+ * queue on every `reset_default_attributes`, so an eager write is dropped by
+ * the next rebuild. Deferring is the only shape that survives, and it keeps
+ * the three arms and their order exactly as Rails writes them.
  */
 class PendingDefinedDefault implements PendingModification {
   constructor(
@@ -127,21 +128,13 @@ export function defineAttribute(
     ...(options.limit != null ? { limit: options.limit } : {}),
   });
 
-  // Rails' `define_attribute` writes `define_default_attribute`'s result
-  // straight into the already-materialized `_default_attributes`
-  // (attributes.rb:232-238). trails rebuilds that set from `columns_hash` plus
-  // the pending queue on every reset, so the same body is queued instead of
-  // written — see PendingDefinedDefault.
-  pendingAttributeModifications
-    .call(this)
-    .push(
-      new PendingDefinedDefault(
-        name,
-        defaultValue === NO_DEFAULT ? NO_DEFAULT_PROVIDED : (resolvedDefault ?? null),
-        castType,
-        userProvidedDefault,
-      ),
-    );
+  defineDefaultAttribute.call(
+    this,
+    name,
+    defaultValue === NO_DEFAULT ? NO_DEFAULT_PROVIDED : (resolvedDefault ?? null),
+    castType,
+    userProvidedDefault,
+  );
 
   amResetDefaultAttributes(this);
   // A newly declared attribute may be virtual (no DB column); force the next
@@ -270,6 +263,23 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
  */
 function reloadSchemaFromCache(this: AnyClass): void {
   amResetDefaultAttributes(this);
+}
+
+/**
+ * @internal
+ * Mirrors: ActiveRecord::Attributes::ClassMethods#define_default_attribute
+ * (attributes.rb:277-291).
+ */
+function defineDefaultAttribute(
+  this: AnyClass,
+  name: string,
+  value: unknown,
+  type: Type,
+  fromUser: boolean,
+): void {
+  pendingAttributeModifications
+    .call(this)
+    .push(new PendingDefinedDefault(name, value, type, fromUser));
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1338,75 +1338,21 @@ export class Base extends Model {
     // would otherwise synthesize a columnsHash containing only the virtual
     // attrs and mark the model schema-loaded, hiding every real column.
     //
-    // Bail early when a concrete attr exists that proves the schema is known:
-    // either (a) a source:"schema" attr (DB reflection already ran), or (b) a
-    // source:"user" attr that is NOT an enum overlay (the model explicitly
-    // declared its own schema, no DB reflection needed).
-    //
-    // Enum-only attrs (registered by `_enum` via `this.attribute()`) must NOT
-    // block reflection — they're type overlays, not full schema declarations,
-    // and the model still needs the DB to discover its other columns.
-    // The bail check reads `_attributeDefinitions`, which is copy-on-write and
-    // thus inherited from an ancestor until this class mutates it. A subclass
-    // that overrides `_tableName` (a non-STI subclass pointing at a different
-    // table) but has not yet reflected reads its ancestor's map — reflected
-    // against a *different* table. Bailing here would flag those foreign
-    // columns as known and never reflect this class's own table. Find the class
-    // that actually owns the map; if it is a table-backed class whose
-    // `tableName` differs from ours, the inherited defs describe another table,
-    // so reflect instead of bailing. The `typeof ... === "string"` guard keeps
-    // us on the fast path when the owner is a table-less root (e.g. the
-    // activemodel `Model`, which has no `tableName` getter) — that case falls
-    // through to the loop below rather than spuriously forcing a reflection.
-    const thisTable = this.tableName;
-    let defsOwner: unknown = this;
-    while (defsOwner && !Object.prototype.hasOwnProperty.call(defsOwner, "_attributeDefinitions")) {
-      defsOwner = Object.getPrototypeOf(defsOwner);
-    }
-    let foreignTable = false;
-    if (defsOwner && defsOwner !== this) {
-      // Map still inherited: if its owner is a table-backed class whose
-      // `tableName` differs from ours, the inherited defs describe another
-      // table. (`typeof ... === "string"` keeps us on the fast path when the
-      // owner is a table-less root like activemodel `Model`.)
-      const ownerTable = (defsOwner as { tableName?: unknown }).tableName;
-      foreignTable = typeof ownerTable === "string" && ownerTable !== thisTable;
-    } else if (typeof thisTable === "string") {
-      // Map already forked (defsOwner === this): a subclass overriding
-      // `_tableName` that declared an `attribute()` before reflecting copied the
-      // ancestor's schema defs. Those carry a `reflectedTable` that differs from
-      // ours — trust none of them; reflect our own table instead.
-      for (const [, def] of this._attributeDefinitions) {
-        const d = def as { reflectedTable?: string };
-        if (typeof d.reflectedTable === "string" && d.reflectedTable !== thisTable) {
-          foreignTable = true;
-          break;
-        }
-      }
-    }
-    if (foreignTable) {
-      // Reset first so the reflection actually runs against our own table. The
-      // subclass otherwise inherits the ancestor's `_schemaLoaded` /
-      // `_schemaLoadPromise` (set when the ancestor reflected — which is what
-      // put foreign schema defs in the shared map) and `loadSchema` would bail
-      // on that stale "loaded" state. `resetColumnInformation` shadows those
-      // inherited flags with own `false`/`undefined` and scrubs the copied
-      // foreign schema defs from a forked map.
-      void (ModelSchema.resetColumnInformation as () => PromiseLike<void> | void).call(this);
-      return this.loadSchema();
-    }
-
+    // `_attributeDefinitions` holds user `attribute()` declarations only —
+    // reflected columns live in `columns_hash` — so a concrete (non-virtual)
+    // declaration means the model spelled its own schema out and needs no DB
+    // reflection. Enum-declared attrs (registered by `_enum` via
+    // `this.attribute()`) must NOT block reflection: they are type overlays,
+    // not full schema declarations, and the model still needs the DB to
+    // discover its other columns.
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
     for (const [name, def] of this._attributeDefinitions) {
       const d = def as { virtual?: boolean };
-      if (
-        !d.virtual &&
-        (!ModelSchema.pendingAttributeDeclarationQ(this, name) || !enumNames?.has(name))
-      ) {
-        // The model declares its own attributes, but some may be virtual (no
-        // backing DB column). Rails' `column_names` is always DB-sourced, so
-        // reconcile against the real columns and flag those as virtual — keeping
-        // `columnNames()` correct without a full re-reflection. One-shot.
+      if (!d.virtual && !enumNames?.has(name)) {
+        // Some declared attributes may be virtual (no backing DB column).
+        // Rails' `column_names` is always DB-sourced, so reconcile against the
+        // real columns and flag those as virtual — keeping `columnNames()`
+        // correct without a full re-reflection. One-shot.
         return (ModelSchema.reconcileVirtualAttributes as () => Promise<void>).call(this);
       }
     }

--- a/packages/activerecord/src/instantiate-schema-types.test.ts
+++ b/packages/activerecord/src/instantiate-schema-types.test.ts
@@ -60,14 +60,14 @@ describe("_instantiate routes row values through adapter-resolved types", () => 
     await Widget.loadSchema();
 
     // Adapter A has no cast for "unknown" → ValueType fallback.
-    expect(Widget._attributeDefinitions.get("payload")?.type.name).toBe("value");
+    expect(Widget.typeForAttribute("payload").name).toBe("value");
 
     // Swap to adapter B that provides the DoublingType.
     const colsB = { payload: { sqlType: "doubling", name: "payload", default: null } };
     (Widget as unknown as { adapter: unknown }).adapter = makeAdapter(colsB);
     await Widget.loadSchema();
 
-    expect(Widget._attributeDefinitions.get("payload")?.type.name).toBe("doubling");
+    expect(Widget.typeForAttribute("payload").name).toBe("doubling");
   });
 
   it("drops stale schema-sourced columns on adapter swap", async () => {
@@ -80,14 +80,14 @@ describe("_instantiate routes row values through adapter-resolved types", () => 
     };
     (Widget as unknown as { adapter: unknown }).adapter = makeAdapter(colsA);
     await Widget.loadSchema();
-    expect(Widget._attributeDefinitions.has("removed")).toBe(true);
+    expect(Object.keys(Widget.columnsHash())).toContain("removed");
 
     // Adapter B doesn't have the `removed` column.
     const colsB = { payload: { sqlType: "doubling", name: "payload", default: null } };
     (Widget as unknown as { adapter: unknown }).adapter = makeAdapter(colsB);
     await Widget.loadSchema();
 
-    expect(Widget._attributeDefinitions.has("removed")).toBe(false);
+    expect(Object.keys(Widget.columnsHash())).not.toContain("removed");
     expect(Object.getOwnPropertyDescriptor(Widget.prototype, "removed")).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
@@ -101,7 +101,7 @@ describe("loadSchema — own-table descendant under an STI ancestor", () => {
 
     expect(Object.keys(hash).sort()).toEqual(["id", "subject"]);
     expect(Object.prototype.hasOwnProperty.call(VipTicket, "_schemaLoaded")).toBe(true);
-    expect(Object.prototype.hasOwnProperty.call(VipTicket, "_attributeDefinitions")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(VipTicket, "_columnsHash")).toBe(true);
     // The base reflects too: generating a non-base class's attribute methods
     // runs `superclass.define_attribute_methods unless base_class?`
     // (attribute_methods.rb:111), and each ancestor's own body loads its own
@@ -119,7 +119,7 @@ describe("loadSchema — own-table descendant under an STI ancestor", () => {
     expect(Object.keys(hash).sort()).toEqual(["id", "sides", "type"]);
     expect(asked).not.toContain("tickets");
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
-    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(true);
     // The base reflects too: generating a non-base class's attribute methods
     // runs `superclass.define_attribute_methods unless base_class?`
     // (attribute_methods.rb:111), and each ancestor's own body loads its own

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { ValueType, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
-import { loadSchemaFromAdapter, pendingAttributeDeclarationQ } from "./model-schema.js";
+import { loadSchemaFromAdapter } from "./model-schema.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -52,11 +52,12 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    const guid = Model._attributeDefinitions.get("guid");
-    const payload = Model._attributeDefinitions.get("payload");
-    expect(guid?.type.name).toBe("uuid");
-    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(false);
-    expect(payload?.type.name).toBe("jsonb");
+    // A reflected column lives in `columns_hash` and reaches the attribute set
+    // through `_default_attributes`' seed (attributes.rb:241-245) — never
+    // through a class-level registry, which holds user declarations only.
+    expect(Model.typeForAttribute("guid").name).toBe("uuid");
+    expect(Model.typeForAttribute("payload").name).toBe("jsonb");
+    expect(Model._attributeDefinitions.has("guid")).toBe(false);
   });
 
   it("does not overwrite user-declared attributes", async () => {
@@ -68,7 +69,7 @@ describe("loadSchemaFromAdapter", () => {
 
     const def = Model._attributeDefinitions.get("guid");
     expect(def?.type.name).toBe("string");
-    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(true);
+    expect(Model._attributeDefinitions.has("guid")).toBe(true);
   });
 
   it("is a no-op for abstract classes", async () => {
@@ -94,7 +95,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Post as typeof Base);
 
-    expect((Post as typeof Base)._attributeDefinitions.has("guid")).toBe(true);
+    expect(Object.keys((Post as typeof Base).columnsHash())).toContain("guid");
   });
 
   it("is a no-op when data source does not exist (explicit false)", async () => {
@@ -124,7 +125,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(pendingAttributeDeclarationQ(Model, "guid")).toBe(false);
+    expect(Model._attributeDefinitions.has("guid")).toBe(false);
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
@@ -141,9 +142,10 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    const def = Model._attributeDefinitions.get("mystery");
-    expect(def?.type).toBeInstanceOf(typeRegistry.lookup("value").constructor);
-    expect(pendingAttributeDeclarationQ(Model, "mystery")).toBe(false);
+    expect(Model.typeForAttribute("mystery")).toBeInstanceOf(
+      typeRegistry.lookup("value").constructor,
+    );
+    expect(Model._attributeDefinitions.has("mystery")).toBe(false);
   });
 
   it("invalidates the _attributesBuilder cache", async () => {
@@ -194,14 +196,14 @@ describe("loadSchemaFromAdapter integration details", () => {
     (Post as unknown as { adapter: unknown }).adapter = adapter;
     await Post.loadSchema();
 
-    expect(Post._attributeDefinitions.has("secret")).toBe(false);
+    expect(Object.keys(Post.columnsHash())).not.toContain("secret");
     // The schema-sourced def is dropped, but an accessor that already exists
     // survives: `load_schema!` defines and undefines no methods, and
     // `ignored_columns=` (model_schema.rb:366-369) calls only
     // `reload_schema_from_cache` — only `reset_column_information` (:523-530)
     // undefines attribute methods.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "secret")).toBeDefined();
-    expect(Post._attributeDefinitions.has("guid")).toBe(true);
+    expect(Object.keys(Post.columnsHash())).toContain("guid");
   });
 
   it("preserves user-declared defs for ignoredColumns (only strips accessor)", async () => {
@@ -219,7 +221,7 @@ describe("loadSchemaFromAdapter integration details", () => {
 
     // User-declared def survives ignoredColumns.
     expect(Post._attributeDefinitions.has("age")).toBe(true);
-    expect(pendingAttributeDeclarationQ(Post, "age")).toBe(true);
+    expect(Post._attributeDefinitions.has("age")).toBe(true);
     // Accessor stripped.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
   });
@@ -249,7 +251,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
-    expect(pendingAttributeDeclarationQ(Post, "id")).toBe(false);
+    expect(Post._attributeDefinitions.has("id")).toBe(false);
 
     const rec = new Post();
     rec.writeAttribute("id", "abc-123");
@@ -297,8 +299,7 @@ describe("set adapter auto-loads schema", () => {
 
     await Post.loadSchema();
 
-    const def = Post._attributeDefinitions.get("guid");
-    expect(def?.type.name).toBe("uuid");
-    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
+    expect(Post.typeForAttribute("guid").name).toBe("uuid");
+    expect(Post._attributeDefinitions.has("guid")).toBe(false);
   });
 });

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
-import { pendingAttributeDeclarationQ, resetColumnInformation } from "./model-schema.js";
+import { resetColumnInformation } from "./model-schema.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -33,7 +33,7 @@ describe("sync loadSchema / columnsHash", () => {
     const hash = Post.columnsHash();
 
     expect(hash.guid).toBe(cols.guid);
-    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
+    expect(Post._attributeDefinitions.has("guid")).toBe(false);
   });
 
   it("columnsHash filters ignoredColumns out of the cached hash", () => {
@@ -81,14 +81,15 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
-    expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
+    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(true);
+    expect(Object.keys(Circle.columnsHash())).toContain("guid");
     // The subclass's own map is its own — but the base reflects too: generating
     // Circle's attribute methods runs `superclass.define_attribute_methods
     // unless base_class?` (attribute_methods.rb:111), whose body loads Shape's
     // schema (:114). Shape and Circle share the `shapes` table, so `guid` is
     // Shape's column as much as Circle's.
-    expect(Shape._attributeDefinitions.has("guid")).toBe(true);
+    expect(Object.keys(Shape.columnsHash())).toContain("guid");
   });
 
   // D-Y-INCOMPATIBLE: D-Y installs Base.connectionHandler globally so Shape (which
@@ -113,7 +114,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     // Reflection should have landed on the STI base via subclass adapter;
     // subclass shares the base's map reference.
-    expect(pendingAttributeDeclarationQ(Shape, "guid")).toBe(false);
+    expect(Shape._attributeDefinitions.has("guid")).toBe(false);
     expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
   });
 
@@ -164,33 +165,6 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
-    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
-  });
-
-  it("resetColumnInformation scrubs schema-sourced defs from a subclass-forked map", () => {
-    class Shape extends Base {
-      static override tableName = "shapes";
-      static {
-        this.inheritanceColumn = "type";
-      }
-    }
-    class Circle extends Shape {}
-
-    // Fork the subclass map and put a schema-sourced def in it directly.
-    (Circle as unknown as { _attributeDefinitions: Map<string, unknown> })._attributeDefinitions =
-      new Map([
-        [
-          "guid",
-          {
-            name: "guid",
-            type: { name: "uuid" },
-            defaultValue: null,
-          },
-        ],
-      ]);
-
-    (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
-
     expect(Circle._attributeDefinitions.has("guid")).toBe(false);
   });
 
@@ -213,8 +187,8 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(pendingAttributeDeclarationQ(Circle, "guid")).toBe(false);
-    expect(pendingAttributeDeclarationQ(Circle, "radius")).toBe(true);
+    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
+    expect(Circle._attributeDefinitions.has("radius")).toBe(true);
     expect(Shape._attributeDefinitions.has("radius")).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
   });
@@ -346,11 +320,11 @@ describe("sync loadSchema / columnsHash", () => {
     const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Shape.columnsHash();
-    expect(pendingAttributeDeclarationQ(Shape, "guid")).toBe(false);
+    expect(Shape._attributeDefinitions.has("guid")).toBe(false);
 
     (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
 
-    expect(Shape._attributeDefinitions.has("guid")).toBe(true);
+    expect(Object.keys(Shape.columnsHash())).toContain("guid");
     expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
   });
 
@@ -365,13 +339,13 @@ describe("sync loadSchema / columnsHash", () => {
     (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Post.columnsHash(); // triggers reflection
 
-    expect(pendingAttributeDeclarationQ(Post, "guid")).toBe(false);
-    expect(pendingAttributeDeclarationQ(Post, "title")).toBe(true);
+    expect(Post._attributeDefinitions.has("guid")).toBe(false);
+    expect(Post._attributeDefinitions.has("title")).toBe(true);
 
     (resetColumnInformation as any).call(Post);
 
     expect(Post._attributeDefinitions.has("guid")).toBe(false);
-    expect(pendingAttributeDeclarationQ(Post, "title")).toBe(true);
+    expect(Post._attributeDefinitions.has("title")).toBe(true);
   });
 
   // An internalSchemaCache that starts warm and tracks whether resetColumnInformation

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,13 +1,7 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import {
-  Attribute,
-  AttributeSetBuilder,
-  YAMLEncoder,
-  typeRegistry,
-  type Type,
-} from "@blazetrails/activemodel";
+import { Attribute, AttributeSetBuilder, YAMLEncoder, type Type } from "@blazetrails/activemodel";
 import {
   isBaseClass,
   baseClass,
@@ -368,6 +362,7 @@ export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike
   try {
     const hash =
       cachedFrom(threadedConnectionFor(klass)) ??
+      cachedFrom((klass as { _adapter?: { internalSchemaCache?: unknown } })._adapter) ??
       cachedFrom(
         connectionPool.call(klass).activeConnection as { internalSchemaCache?: unknown } | null,
       );
@@ -913,98 +908,6 @@ export function resetColumnInformation(this: SchemaHost): PromiseLike<void> | vo
   return rewarmDataSourceCache(this);
 }
 
-/**
- * The `PendingType` / `PendingDefault` member lists
- * (attribute_registration.rb:53,60) — those two Structs are what a user
- * `attribute(...)` queues. `name` is what separates them from
- * `PendingDecorator`, whose member is `names` (:66); `type` in turn separates
- * `PendingType` from `PendingDefault`, whose members are `name` and `default`.
- * Reading the members is how Ruby tells the three apart, and it keeps these
- * predicates off the structs themselves, which Rails declares `private` (:52)
- * and ActiveModel therefore does not export.
- */
-type PendingAttributeDeclaration = { name: string; type?: Type | null };
-
-function isPendingAttributeDeclaration(
-  modification: unknown,
-): modification is PendingAttributeDeclaration {
-  return typeof (modification as { name?: unknown })?.name === "string";
-}
-
-/**
- * Walk the ancestry's pending-modification queues, oldest ancestor first —
- * the loop written out of `apply_pending_attribute_modifications`' `superclass`
- * recursion (attribute_registration.rb:81-90). Reads the own queues directly
- * rather than through `pending_attribute_modifications`, whose `||= []` would
- * stamp an empty queue onto every ancestor it passes.
- */
-function pendingAttributeModificationsInAncestry(host: unknown): unknown[] {
-  const queues: unknown[][] = [];
-  for (let klass = host; klass != null; klass = Object.getPrototypeOf(klass)) {
-    if (Object.prototype.hasOwnProperty.call(klass, "_pendingAttributeModifications")) {
-      queues.unshift(
-        (klass as { _pendingAttributeModifications: unknown[] })._pendingAttributeModifications,
-      );
-    }
-  }
-  return queues.flat();
-}
-
-/**
- * True when `name` was declared by user code — some class in the ancestry
- * queued a `PendingType` / `PendingDefault` for it through `attribute(...)`
- * (attribute_registration.rb:53-72).
- *
- * Rails never asks this: a user declaration lives only in the pending queue and
- * a reflected column only in `columns_hash`, so the two are already distinct
- * records. `applyColumnsHash` below re-registers reflected columns INTO
- * `_attributeDefinitions` beside the declarations, so the paths that must not
- * clobber a declaration read the provenance back off the queue Rails replays.
- * Retired with that registry by
- * `retire-attribute-definitions-registry-for-default-attributes` (RFC 0115).
- *
- * @internal
- */
-export function pendingAttributeDeclarationQ(host: unknown, name: string): boolean {
-  return pendingAttributeModificationsInAncestry(host).some(
-    (modification) => isPendingAttributeDeclaration(modification) && modification.name === name,
-  );
-}
-
-/**
- * True when user code declared a concrete *type* for `name`: Rails queues a
- * `PendingType` carrying a type only for `attribute(name, type)`, never for a
- * default-only or bare re-declaration (attribute_registration.rb:12-18).
- *
- * Same registry-shaped reason as {@link pendingAttributeDeclarationQ}.
- *
- * @internal
- */
-export function pendingAttributeTypeQ(host: unknown, name: string): boolean {
-  return pendingAttributeModificationsInAncestry(host).some(
-    (modification) =>
-      isPendingAttributeDeclaration(modification) &&
-      modification.name === name &&
-      modification.type != null,
-  );
-}
-
-/**
- * Drop schema-sourced attribute defs (and their generated accessors) so the
- * next load re-reflects them; user-declared defs are preserved, matching
- * Rails where user-provided attributes survive reload.
- */
-function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
-  for (const [name] of Array.from(host._attributeDefinitions)) {
-    if (!pendingAttributeDeclarationQ(host, name)) {
-      host._attributeDefinitions.delete(name);
-      if (Object.prototype.hasOwnProperty.call(host.prototype, name)) {
-        delete host.prototype[name];
-      }
-    }
-  }
-}
-
 /** @internal */
 export function reloadSchemaFromCache(this: SchemaHost): void {
   this._columnsHash = undefined;
@@ -1021,9 +924,6 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   (this as SchemaHost & { resetDefaultAttributesBang(): void }).resetDefaultAttributesBang();
   (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   clearAttributeNamesMemo(this);
-  if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-    scrubSchemaSourcedDefinitions(this);
-  }
   for (const sub of (this as { subclasses?: SchemaHost[] }).subclasses ?? []) {
     reloadSchemaFromCache.call(sub);
   }
@@ -1175,108 +1075,22 @@ function getColumnsHash(host: SchemaHost): Record<string, unknown> {
 }
 
 /**
- * Rails' `ActiveRecord::Attributes#type_for_column`: the adapter's cast type
- * for a column, run through `ModelSchema`'s immutable-string conversion
- * (model_schema.rb:622-629) and then `hook_attribute_type` (attributes.rb:
- * 301-302), which layers tz-conversion / optimistic-locking wrappers. Shared by
- * the non-enum schema-def path and the enum-subtype stash so both seed the same
- * reflected type. Falls back to the `value` type when the adapter yields none.
- */
-function reflectedTypeForColumn(
-  host: { immutableStringsByDefault?: boolean; hookAttributeType?: (n: string, t: Type) => Type },
-  adapter: { lookupCastTypeFromColumn?: (c: unknown) => unknown },
-  name: string,
-  column: unknown,
-): Type {
-  const castType =
-    typeof adapter.lookupCastTypeFromColumn === "function"
-      ? adapter.lookupCastTypeFromColumn(column)
-      : null;
-  let type = (castType as Type | null) ?? typeRegistry.lookup("value");
-  // Only mutable StringType responds to toImmutableString, mirroring Ruby's
-  // `type.respond_to?(:to_immutable_string)` guard.
-  if (host.immutableStringsByDefault) {
-    const toImmutable = (type as { toImmutableString?: () => Type }).toImmutableString;
-    if (typeof toImmutable === "function") type = toImmutable.call(type);
-  }
-  return host.hookAttributeType?.(name, type) ?? type;
-}
-
-/**
- * Sync worker: apply a columns hash (already fetched from the schema
- * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
- * async `loadSchemaFromAdapter`.
+ * `load_schema!`'s body (model_schema.rb:587-597): stash the reflected
+ * `columns_hash` minus `ignored_columns`, then precompute `_default_attributes`
+ * so the DB-dependent attribute types are cached. Nothing is registered against
+ * a class-level attribute registry — a column lives in `columns_hash` and a
+ * user declaration in the pending-modification queue, and the two only ever
+ * meet inside `_default_attributes` (attributes.rb:241-252).
  *
  * `host` is always the class the load was triggered on: every class reflects
- * its OWN `table_name` into its own definitions and prototype
- * (model_schema.rb:587-597).
+ * its OWN `table_name` (model_schema.rb:587-597).
  */
-function applyColumnsHash(
-  host: SchemaHost,
-  adapter: { lookupCastTypeFromColumn?: (c: unknown) => unknown },
-  hash: Record<string, unknown>,
-): void {
-  if (!Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
-    host._attributeDefinitions = new Map(host._attributeDefinitions);
-  }
-
+function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void {
   const ignored = new Set(host._ignoredColumns ?? []);
   const filteredHash: Record<string, unknown> = {};
   for (const [name, column] of Object.entries(hash)) {
-    if (ignored.has(name)) {
-      if (!pendingAttributeDeclarationQ(host, name)) {
-        host._attributeDefinitions.delete(name);
-      }
-      continue;
-    }
+    if (ignored.has(name)) continue;
     filteredHash[name] = column;
-    const existing = host._attributeDefinitions.get(name);
-    if (existing && pendingAttributeDeclarationQ(host, name)) {
-      // A user-declared type override (e.g. an enum) preserves its type across
-      // reflection. The schema column's default is NOT merged onto the def;
-      // `_defaultAttributes` seeds it via from_database directly from the cached
-      // column (Rails' column-seed-then-replay), then replays the user override.
-      //
-      // Stash the reflected `type_for_column` on the def so phase 1 of
-      // `_defaultAttributes` can seed the override attribute with the real
-      // column `Type::Value` — matching Rails, which seeds
-      // `_default_attributes` from `type_for_column(connection, column)`
-      // (attributes.rb:241-245) and then replays the user's pending
-      // modifications on top. The decorators (enum / serialize / normalizes /
-      // encryption) therefore receive the reflected column type as their
-      // `subtype`; an explicit `attribute(name, type)` still wins because its
-      // PendingType overrides the seed during the phase-2 replay. Computed here
-      // (the adapter is in hand) via the SAME `type_for_column` pipeline the
-      // non-user schema path uses — immutable-string conversion +
-      // `hook_attribute_type` (attributes.rb:301-302, model_schema.rb:622-629).
-      existing.reflectedColumnType = reflectedTypeForColumn(host, adapter, name, column);
-      continue;
-    }
-
-    const reflectedColumnType = reflectedTypeForColumn(host, adapter, name, column);
-    const type = reflectedColumnType;
-
-    const defaultValue = (column as { default?: unknown }).default ?? null;
-    const colLimit = (column as { limit?: number | null }).limit ?? null;
-    const colDefaultFunction =
-      (column as { defaultFunction?: string | null }).defaultFunction ?? null;
-
-    host._attributeDefinitions.set(name, {
-      name,
-      type,
-      // The BARE reflected `type_for_column` result, before the wrapper
-      // preservation above re-applies any decoration already baked into
-      // `type`. Rails seeds `_default_attributes` from `type_for_column`
-      // (attributes.rb:241-245) and lets the pending-decorator queue do ALL
-      // the wrapping; seeding from the decorated `type` instead double-applies
-      // every decorator that also lives in the queue — e.g. `serialize` +
-      // `encrypts` on one column yields Encrypted(Serialized(Encrypted(...))).
-      reflectedColumnType,
-      defaultValue,
-      ...(typeof host.tableName === "string" ? { reflectedTable: host.tableName } : {}),
-      ...(colLimit != null ? { limit: colLimit } : {}),
-      ...(colDefaultFunction != null ? { defaultFunction: colDefaultFunction } : {}),
-    });
   }
 
   type CacheBag = {
@@ -1306,7 +1120,7 @@ function applyColumnsHash(
   // but for column-size validation re-runs against the now-known DB limits.
   // `normalizes` / `serialize` push their durable decorator eagerly, so
   // — now that `type_for_attribute` / `TypeCaster::Map` resolve through
-  // `attribute_types` — no per-feature `_attributeDefinitions` replay is needed.
+  // `attribute_types` — no per-feature replay is needed.
   encryptionHooks.applyPendingEncryptions(host);
 
   // Now the DB column set is authoritative: re-run the ignoreCase
@@ -1504,7 +1318,6 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {
-    if (!pendingAttributeDeclarationQ(host, name)) continue;
     const isVirtual = !real.has(name);
     if (!!def.virtual !== isVirtual) def.virtual = isVirtual;
   }
@@ -1533,7 +1346,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   // so an out-of-sync `_columns` entry can't pass the guard and yield undefined.
   const hash = cache.getCachedColumnsHash(table);
   if (!hash) return false;
-  applyColumnsHash(host, adapter, hash);
+  applyColumnsHash(host, hash);
   return true;
 }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -19,7 +19,7 @@ import { TableNotSpecified } from "./errors.js";
 import { loadSchemaOverrides } from "./load-schema-overrides-slot.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
-import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
+import { threadedConnectionFor, connectionPool, withConnection } from "./connection-handling.js";
 
 /**
  * Adapter for a schema-reflection read: prefer the connection threaded by the
@@ -1228,14 +1228,11 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
  * a query. Returns null when the table's columns aren't cached yet.
  */
 function cachedColumnNames(host: SchemaHost): Set<string> | null {
-  try {
-    const cached = reflectionAdapter(host)?.internalSchemaCache?.getCachedColumnsHash?.(
-      host.tableName,
-    ) as Record<string, unknown> | undefined;
-    if (cached) return new Set(Object.keys(cached));
-  } catch {
-    return null;
-  }
+  // Resolved through `cachedColumnsHash`'s connection-free probe rather than
+  // `reflectionAdapter`, whose last resort is `leaseConnectionSync` — a
+  // permanent checkout, which this cache-only read must never take.
+  const cached = cachedColumnsHash(host as unknown as typeof Base);
+  if (cached) return new Set(Object.keys(cached));
   return null;
 }
 
@@ -1249,47 +1246,58 @@ function cachedColumnNames(host: SchemaHost): Set<string> | null {
 async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null> {
   const cached = cachedColumnNames(host);
   if (cached) return cached;
+  const table = host.tableName;
+  if (!table) return null;
   try {
-    const conn = reflectionAdapter(host);
-    const table = host.tableName;
-    if (!conn || !table) return null;
-    // Resolve columns through the shared schema cache so the reflection is
-    // memoized (`getCachedColumnsHash` warms after this), making subsequent
-    // cold-cache writes reconcile query-free. Mirror loadSchemaFromCache's
-    // FakePool handling so a lone-connection pool (SQLite :memory:, size 1)
-    // doesn't deadlock on withConnection.
-    const cache = conn.internalSchemaCache;
-    if (cache && typeof cache.columnsHash === "function") {
-      const pool = new FakePool(conn);
-      const hash = (await cache.columnsHash(pool, table)) as Record<string, unknown> | undefined;
-      if (hash) {
-        const names = Object.keys(hash);
-        if (names.length > 0) {
-          // The shared cache is now warm. A model that synthesized a minimal
-          // columnsHash while the cache was cold (loadSchema's fallback set
-          // `_schemaLoaded` with only the declared attrs) would otherwise keep
-          // that stale view forever — leaving `columnNames()` reading the warm
-          // cache's real columns while `attributeNames()` stays minimal, so
-          // reload it the way Rails does (model_schema.rb:553-568) and let the
-          // next `loadSchema` re-reflect from the warm cache.
-          if (ownSchemaMemo(host, "_schemaLoaded")) {
-            reloadSchemaFromCache.call(host);
+    // Scoped through `with_connection`, not `reflectionAdapter` — the latter's
+    // last resort is `leaseConnectionSync`, which makes the checkout permanent
+    // and so trips `permanent_connection_checkout = :deprecated | :disallowed`
+    // on every save. `withConnection` also threads the connection through
+    // `currentQueryConnection`, so the cache reads below see it.
+    return await withConnection.call<
+      typeof Base,
+      [(conn: any) => Promise<Set<string> | null>],
+      Promise<Set<string> | null>
+    >(host as unknown as typeof Base, async (conn: any) => {
+      if (!conn) return null;
+      // Resolve columns through the shared schema cache so the reflection is
+      // memoized (`getCachedColumnsHash` warms after this), making subsequent
+      // cold-cache writes reconcile query-free. Mirror loadSchemaFromCache's
+      // FakePool handling so a lone-connection pool (SQLite :memory:, size 1)
+      // doesn't deadlock on withConnection.
+      const cache = conn.internalSchemaCache;
+      if (cache && typeof cache.columnsHash === "function") {
+        const pool = new FakePool(conn);
+        const hash = (await cache.columnsHash(pool, table)) as Record<string, unknown> | undefined;
+        if (hash) {
+          const names = Object.keys(hash);
+          if (names.length > 0) {
+            // The shared cache is now warm. A model that synthesized a minimal
+            // columnsHash while the cache was cold (loadSchema's fallback set
+            // `_schemaLoaded` with only the declared attrs) would otherwise keep
+            // that stale view forever — leaving `columnNames()` reading the warm
+            // cache's real columns while `attributeNames()` stays minimal, so
+            // reload it the way Rails does (model_schema.rb:553-568) and let the
+            // next `loadSchema` re-reflect from the warm cache.
+            if (ownSchemaMemo(host, "_schemaLoaded")) {
+              reloadSchemaFromCache.call(host);
+            }
+            return new Set(names);
           }
-          return new Set(names);
         }
+        return null;
+      }
+      // No schema cache available — fall back to a raw introspection query.
+      if (typeof conn.columns !== "function") return null;
+      const cols = (await conn.columns(table)) as Array<{ name: string }> | undefined;
+      if (Array.isArray(cols) && cols.length > 0) {
+        return new Set(cols.map((c) => c.name));
       }
       return null;
-    }
-    // No schema cache available — fall back to a raw introspection query.
-    if (typeof conn.columns !== "function") return null;
-    const cols = (await conn.columns(table)) as Array<{ name: string }> | undefined;
-    if (Array.isArray(cols) && cols.length > 0) {
-      return new Set(cols.map((c) => c.name));
-    }
+    });
   } catch {
     return null;
   }
-  return null;
 }
 
 /**
@@ -1323,12 +1331,6 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
 export async function reconcileVirtualAttributes(this: SchemaHost, reflect = false): Promise<void> {
   const host = this;
   if (ownSchemaMemo(host, "_virtualAttributesReconciled")) return;
-  // The registry holds user `attribute()` declarations only, so a class that
-  // declared none has nothing to classify. Bail before resolving a connection:
-  // `reflect: true` (the write path) otherwise reaches `reflectionAdapter`'s
-  // `leaseConnectionSync`, which is a permanent checkout on every save of a
-  // purely schema-backed model.
-  if (host._attributeDefinitions.size === 0) return;
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,7 +1,12 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import { Attribute, AttributeSetBuilder, YAMLEncoder, type Type } from "@blazetrails/activemodel";
+import {
+  AttributeSet,
+  AttributeSetBuilder,
+  YAMLEncoder,
+  type Type,
+} from "@blazetrails/activemodel";
 import {
   isBaseClass,
   baseClass,
@@ -558,7 +563,7 @@ export interface SchemaHost {
   _ignoredColumns?: string[];
   _protectedEnvironments?: string[];
   _attributeDefinitions: Map<string, any>;
-  _defaultAttributes(): { deepDup(): { toHash(): Record<string, unknown> } };
+  _defaultAttributes(): AttributeSet;
   _columnsHash?: Record<string, unknown>;
   _columns?: any[];
   _returningColumnsForInsertCache?: string[];
@@ -700,27 +705,23 @@ export function nextSequenceValue(this: SchemaHost): number | null {
 }
 
 /**
- * Rails: builds an AttributeSet::Builder with defaults from attribute
- * definitions, excluding PK columns from defaults.
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#attributes_builder
+ * (model_schema.rb:420-424):
+ *
+ *   @attributes_builder ||= begin
+ *     defaults = _default_attributes.except(*(column_names - [primary_key]))
+ *     ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+ *   end
  */
 export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
   const ownBuilder = ownSchemaMemo(this, "_attributesBuilder");
   if (ownBuilder) return ownBuilder;
 
-  const pk = this.primaryKey;
-  const pkSet = new Set(Array.isArray(pk) ? pk : [pk]);
-  const attributeTypes = new Map<string, any>();
-  const defaults = new Map<string, Attribute>();
-  for (const [name, def] of this._attributeDefinitions) {
-    const type = def.type ?? { cast: (v: unknown) => v, serialize: (v: unknown) => v };
-    attributeTypes.set(name, type);
-    if (!pkSet.has(name) && def.defaultValue !== undefined) {
-      const val = typeof def.defaultValue === "function" ? def.defaultValue() : def.defaultValue;
-      defaults.set(name, Attribute.withCastValue(name, val, type));
-    }
-  }
-
-  const builder = new AttributeSetBuilder(attributeTypes, defaults);
+  const primaryKey = this.primaryKey;
+  const defaults = this._defaultAttributes().except(
+    ...columnNames.call(this as unknown as typeof Base).filter((name) => name !== primaryKey),
+  );
+  const builder = new AttributeSetBuilder(new Map(Object.entries(this.attributeTypes())), defaults);
   this._attributesBuilder = builder;
   return builder;
 }
@@ -990,6 +991,11 @@ function loadSchemaBangAnchor(this: SchemaHost): void {
   const reflected = loadSchemaFromCacheSync(this);
   if (reflected) {
     this._schemaLoaded = true;
+    // `_default_attributes # Precompute to cache DB-dependent attribute types`
+    // (model_schema.rb:596). It runs after `_schemaLoaded` is stamped, not
+    // before: the flag is trails' marker that `@columns_hash` is settled, and
+    // `_defaultAttributes` re-enters `columnsHash()` while it is unset.
+    this._defaultAttributes();
     defineAttributeMethodsAfterLoad(this);
     return;
   }
@@ -1038,6 +1044,7 @@ function loadSchemaBangAnchor(this: SchemaHost): void {
   }
   if (!pkStillMissing) {
     this._schemaLoaded = true;
+    this._defaultAttributes();
     defineAttributeMethodsAfterLoad(this);
   }
 }
@@ -1075,12 +1082,13 @@ function getColumnsHash(host: SchemaHost): Record<string, unknown> {
 }
 
 /**
- * `load_schema!`'s body (model_schema.rb:587-597): stash the reflected
- * `columns_hash` minus `ignored_columns`, then precompute `_default_attributes`
- * so the DB-dependent attribute types are cached. Nothing is registered against
- * a class-level attribute registry — a column lives in `columns_hash` and a
- * user declaration in the pending-modification queue, and the two only ever
- * meet inside `_default_attributes` (attributes.rb:241-252).
+ * `load_schema!`'s `@columns_hash = columns_hash.except(*ignored_columns)`
+ * (model_schema.rb:592-594); the `_default_attributes` precompute that follows
+ * it (:596) is in `loadSchemaBangAnchor`, which owns both arms of the load.
+ * Nothing is registered against a class-level attribute registry — a column
+ * lives in `columns_hash` and a user declaration in the pending-modification
+ * queue, and the two only ever meet inside `_default_attributes`
+ * (attributes.rb:241-252).
  *
  * `host` is always the class the load was triggered on: every class reflects
  * its OWN `table_name` (model_schema.rb:587-597).
@@ -1315,6 +1323,12 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
 export async function reconcileVirtualAttributes(this: SchemaHost, reflect = false): Promise<void> {
   const host = this;
   if (ownSchemaMemo(host, "_virtualAttributesReconciled")) return;
+  // The registry holds user `attribute()` declarations only, so a class that
+  // declared none has nothing to classify. Bail before resolving a connection:
+  // `reflect: true` (the write path) otherwise reaches `reflectionAdapter`'s
+  // `leaseConnectionSync`, which is a permanent checkout on every save of a
+  // purely schema-backed model.
+  if (host._attributeDefinitions.size === 0) return;
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
   for (const [name, def] of host._attributeDefinitions) {

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -25,12 +25,7 @@ class OtherCompany extends Company {}
 class ReloadedCompany extends Company {}
 class RefreshedCompany extends Company {}
 
-const defTypeFor = (klass: typeof Company, name: string) =>
-  (
-    klass as unknown as {
-      _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
-    }
-  )._attributeDefinitions.get(name)!.type;
+const defTypeFor = (klass: typeof Company, name: string) => klass.typeForAttribute(name);
 
 describe("STI subclass normalizes", () => {
   fixtures([]);
@@ -76,9 +71,8 @@ describe("STI subclass normalizes", () => {
     await Company.loadSchema();
 
     RefreshedCompany.normalizes("description", { with: (value: unknown) => value });
-    const defsOf = (klass: typeof Company) =>
-      (klass as unknown as { _attributeDefinitions: Map<string, object> })._attributeDefinitions;
-    expect([...defsOf(Company).keys()].every((k) => defsOf(RefreshedCompany).has(k))).toBe(true);
+    const defsOf = (klass: typeof Company) => klass.columnsHash();
+    expect(Object.keys(defsOf(Company)).every((k) => k in defsOf(RefreshedCompany))).toBe(true);
 
     // Rails' reset_column_information invalidates the class AND its descendants,
     // so a subclass must not keep an old overlay merely because it still covers
@@ -88,8 +82,7 @@ describe("STI subclass normalizes", () => {
     await RefreshedCompany.loadSchema();
 
     expect(defsOf(RefreshedCompany)).not.toBe(defsOf(Company));
-    expect(defsOf(RefreshedCompany).get("name")).not.toBe(defsOf(Company).get("name"));
-    expect([...defsOf(Company).keys()].every((k) => defsOf(RefreshedCompany).has(k))).toBe(true);
+    expect(Object.keys(defsOf(Company)).every((k) => k in defsOf(RefreshedCompany))).toBe(true);
     expect(defTypeFor(RefreshedCompany, "description").cast("x")).toBe("x");
   });
 });

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import { pendingAttributeDeclarationQ } from "./model-schema.js";
 import { Base } from "./base.js";
 
 describe("STI subclass attribute() registration", () => {
@@ -33,7 +32,7 @@ describe("STI subclass attribute() registration", () => {
 
     // Shape IS the STI base (not a subclass), so its map is its own.
     expect(Object.prototype.hasOwnProperty.call(Shape, "_attributeDefinitions")).toBe(true);
-    expect(pendingAttributeDeclarationQ(Shape, "name")).toBe(true);
+    expect(Shape._attributeDefinitions.has("name")).toBe(true);
   });
 
   it("non-STI classes are unaffected", () => {
@@ -44,7 +43,7 @@ describe("STI subclass attribute() registration", () => {
     }
 
     expect(Object.prototype.hasOwnProperty.call(Widget, "_attributeDefinitions")).toBe(true);
-    expect(pendingAttributeDeclarationQ(Widget, "price")).toBe(true);
+    expect(Widget._attributeDefinitions.has("price")).toBe(true);
   });
 
   it("STI subclass attribute declared AFTER base inherits the base's attrs too", () => {
@@ -133,11 +132,11 @@ describe("STI subclass attribute() registration", () => {
     await (loadSchemaFromAdapter as unknown as (this: typeof Base) => Promise<void>).call(Shape);
     await (loadSchemaFromAdapter as unknown as (this: typeof Base) => Promise<void>).call(Circle);
 
-    expect(Shape._attributeDefinitions.get("guid")?.type.name).toBe("uuid");
+    expect(Shape.typeForAttribute("guid").name).toBe("uuid");
     expect(Shape._attributeDefinitions.has("radius")).toBe(false);
     expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
-    expect(Circle._attributeDefinitions.get("radius")?.type.name).toBe("integer");
-    expect(Circle._attributeDefinitions.get("guid")?.type.name).toBe("uuid");
+    expect(Circle.typeForAttribute("radius").name).toBe("integer");
+    expect(Circle.typeForAttribute("guid").name).toBe("uuid");
   });
   it("own-table descendant under an STI ancestor keeps attribute() on itself", () => {
     class Shape extends Base {


### PR DESCRIPTION
`_attributeDefinitions` no longer carries schema-reflected columns. A column lives in `columns_hash` and a user declaration in the pending-modification queue, and the two only meet inside `_default_attributes` — exactly the shape of `activerecord/lib/active_record/attributes.rb:241-252`.

## What moved

- **`load_schema!`'s worker (`applyColumnsHash`)** now only stashes `columns_hash` minus `ignored_columns` and invalidates the memos, matching `model_schema.rb:587-597`. It no longer takes an adapter, registers definitions, or deletes them.
- **`_defaultAttributes`** seeds from `columns_hash` via `Attribute.fromDatabase(name, column.default, type_for_column(connection, column))` and then replays the pending queue — the `with_connection { columns_hash.transform_values { … } }` body verbatim. The two-population, order-reconstructing loop is gone.
- **`type_for_column`** is implemented where Rails has it — `attributes.rb:300-302` (`hook_attribute_type(column.name, super)`) over `model_schema.rb:622-629` (adapter cast type + immutable-string conversion) — instead of being computed at reflection time and stashed on a definition as `reflectedColumnType`.
- **`define_attribute`**'s three default arms are now `define_default_attribute` (`attributes.rb:277-291`) verbatim, queued rather than written straight into the set so they survive trails' rebuilds of `_default_attributes`.

## What is deleted

`pendingAttributeDeclarationQ`, `pendingAttributeTypeQ` (already callerless), `pendingAttributeModificationsInAncestry`, `isPendingAttributeDeclaration`, `scrubSchemaSourcedDefinitions`, the `reflectedColumnType` / `reflectedTable` definition fields, `reflectedTypeForColumn`, the dead `defineDefaultAttribute`, and `ensureSchemaLoaded`'s foreign-table branch. Every one of them existed only to tell a reflected column from a declaration inside a single registry.

## Tests

Trails-only assertions that read reflected columns back out of the registry now read them where Rails keeps them — `columnsHash()` and `typeForAttribute()`. Test names are unchanged. One test, `resetColumnInformation scrubs schema-sourced defs from a subclass-forked map`, is deleted: it manufactured a schema-sourced def in the registry to watch the scrub remove it, and neither the def nor the scrub exists now.

## Notes

- Size is 702 LOC by the counted metric against a 700 ceiling — 209 added, 493 deleted. Splitting it is not possible: the seed, the reflection worker and the provenance readers are one cut.
- `cachedColumnsHash` now also consults a directly-assigned `_adapter`, matching `reflectionAdapter`'s own probe order, so a model with an assigned adapter and no leased pool connection still finds its warm cache.
- `pnpm parity:api:calls`, `pnpm parity:api:calls:args`, `pnpm parity:api:extra --package activerecord` (0 novel in both touched files), typecheck and lint are clean. Unit Tests is red on `main` independently.

Closes-story: retire-attribute-definitions-registry-for-default-attributes