### PR TITLE
refactor(activerecord): strip freeform comments from src/support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -739,6 +739,7 @@ export default defineConfig(
       "packages/arel/src/**/*.ts",
       "packages/activemodel/src/**/*.ts",
       "packages/activerecord/src/relation/**/*.ts",
+      "packages/activerecord/src/support/**/*.ts",
       "packages/activerecord/src/connection-adapters/mysql/**/*.ts",
       "packages/activerecord/src/connection-adapters/mysql2/**/*.ts",
       "packages/activerecord/src/connection-adapters/postgresql/**/*.ts",

--- a/packages/activerecord/src/support/ar-db-forks-parity.trails.test.ts
+++ b/packages/activerecord/src/support/ar-db-forks-parity.trails.test.ts
@@ -17,8 +17,6 @@ async function readSource(path: string): Promise<string> {
 }
 
 function stripComments(source: string): string {
-  // Line-based on purpose: a `/* ... */` sweep would swallow the config's
-  // glob strings ("packages/*/dx-tests/**") along with the code between them.
   return source
     .split("\n")
     .filter((line) => !/^\s*(\/\/|\/\*|\*)/.test(line))

--- a/packages/activerecord/src/support/ar-db-slots.trails.test.ts
+++ b/packages/activerecord/src/support/ar-db-slots.trails.test.ts
@@ -2,10 +2,6 @@ import { osAdapterConfig, registerOsAdapter } from "@blazetrails/activesupport";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 
-// workerForkCount() clamps to the host's cores - 1, so every expectation below
-// would otherwise depend on the machine running it (a 4-vCPU CI runner clamps
-// where a dev box does not). Pin the core count through the OS adapter instead
-// and vary it explicitly in the clamp tests.
 let cores = 64;
 const HOST_CORES = 64;
 
@@ -38,8 +34,6 @@ describe("ar-db-slots", () => {
     }
   });
 
-  // TRAILS_TEST_FORKS outranks AR_DB_FORKS, so it has to be cleared for every
-  // case that exercises the latter — a dev box may well have it exported.
   function setEnv(forks?: string, slots?: string): void {
     delete process.env.TRAILS_TEST_FORKS;
     if (forks === undefined) delete process.env.AR_DB_FORKS;
@@ -148,7 +142,6 @@ describe("ar-db-slots", () => {
       for (const forks of [1, 2, 4, 8]) {
         setEnv(String(forks));
         expect(slotPoolSize()).toBeGreaterThan(workerForkCount());
-        // ...even when an undersized override is supplied.
         setEnv(String(forks), "1");
         expect(slotPoolSize()).toBeGreaterThan(workerForkCount());
       }

--- a/packages/activerecord/src/support/ar-db-slots.ts
+++ b/packages/activerecord/src/support/ar-db-slots.ts
@@ -31,8 +31,6 @@
 import { getOs } from "@blazetrails/activesupport";
 import { DEFAULT_FORKS, resolveForkCount } from "./ar-db-forks-default.js";
 
-// Spare slots beyond the worker count. One is enough to cover a single
-// recycle overlap; two leaves margin for back-to-back recycles.
 const SLOT_HEADROOM = 2;
 
 export { DEFAULT_FORKS };

--- a/packages/activerecord/src/support/canonical-model-index-encryption-setup.ts
+++ b/packages/activerecord/src/support/canonical-model-index-encryption-setup.ts
@@ -1,9 +1,3 @@
-// Side-effect module: register the encryption namespace and install the
-// standard test key config. Imported for its side effect *before* the canonical
-// models barrel so encrypted models (which derive key material at module-eval
-// time) are loadable. Kept separate because ESM hoists all `import`s ahead of
-// top-level statements — the config must run in a module evaluated before the
-// barrel, not as a statement wedged between imports in the same file.
 import "../encryption.js";
 import { configureEncryption } from "../encryption/test-helpers.js";
 

--- a/packages/activerecord/src/support/canonical-model-index.trails.test.ts
+++ b/packages/activerecord/src/support/canonical-model-index.trails.test.ts
@@ -16,8 +16,6 @@ import { MyAppBusinessCompany } from "../test-helpers/models/company-in-module.j
 
 describe("canonical model autoload index (Zeitwerk analog)", () => {
   it("indexes canonical models by their class name", () => {
-    // Association-target-only models (no fixture set of their own) are present
-    // so they resolve on first reference without a manual `registerModel`.
     expect(canonicalModelIndex.get("Comment")).toBe(Comment);
     expect(canonicalModelIndex.get("Owner")).toBe(Owner);
   });
@@ -31,17 +29,11 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
   });
 
   it("resolveModel autoloads an indexed model on a registry miss", () => {
-    // Whether or not another test already registered it, the two-step returns
-    // the canonical class — the fallback covers the un-registered case.
     expect(resolve("Comment")).toBe(Comment);
     expect(resolve("Owner")).toBe(Owner);
   });
 
   it("autoloads an association-target model through reflection's computeClass", () => {
-    // `Pet belongsTo owner` names `Owner` only as a target — no fixture set, no
-    // manual `registerModel`. Resolving the reflection's `.klass` must autoload
-    // it via the fallback (reflection.ts computeClass), the empirical anchor for
-    // this part (HasManyReflection/BelongsToReflection._klass).
     const refl = (
       Pet as unknown as { _reflectOnAssociation(name: string): { klass: unknown } }
     )._reflectOnAssociation("owner");
@@ -57,16 +49,9 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
   });
 
   it("faults in a model that is constantize-able but absent from the registry", () => {
-    // registerSubclass (inheritance.ts:416) and the adapter setter
-    // (base.ts:1358) write the constant table WITHOUT registerModel, so an STI
-    // subclass can resolve through constantize while missing from
-    // modelRegistry — which the join planner reads directly
-    // (join-dependency.ts:344,371). autoloadModel must therefore gate on the
-    // registry, not on safeConstantize, or the fault-in is skipped and the join
-    // silently builds no node.
     const had = modelRegistry.get("Reply");
-    modelRegistry.delete("Reply"); // write-through drops the constant too
-    registerConstant("Reply", Reply); // re-create registerSubclass's half alone
+    modelRegistry.delete("Reply");
+    registerConstant("Reply", Reply);
     try {
       expect(safeConstantize("Reply")).toBe(Reply);
       expect(modelRegistry.has("Reply")).toBe(false);
@@ -78,8 +63,6 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
   });
 
   it("throws a constant-not-found error for a genuine miss", () => {
-    // A name in neither the registry nor the index must still throw, so the
-    // fallback can never silently mask a missing or misnamed model.
     expect(() => resolve("NoSuchCanonicalModel")).toThrow(
       /uninitialized constant NoSuchCanonicalModel/,
     );

--- a/packages/activerecord/src/support/canonical-model-index.ts
+++ b/packages/activerecord/src/support/canonical-model-index.ts
@@ -1,13 +1,6 @@
 import { Base } from "../base.js";
 import { _setCanonicalModelAutoloadIndex } from "../associations.js";
 import { qualifiedName } from "../inheritance.js";
-// The canonical models barrel eagerly evaluates encrypted models
-// (`EncryptedTrafficLight.encrypts(...)`, `EncryptedPost`'s eager key provider,
-// etc.) at module load, which requires the encryption namespace to be
-// registered AND a key config present. This side-effect import registers +
-// configures the standard test keys, and MUST precede the barrel import — it
-// lives in its own module because ESM hoists sibling `import`s ahead of any
-// top-level statement, so an inline config call would run too late.
 import "./canonical-model-index-encryption-setup.js";
 import * as canonicalModels from "../test-helpers/models/index.js";
 

--- a/packages/activerecord/src/support/canonical-schema.trails.test.ts
+++ b/packages/activerecord/src/support/canonical-schema.trails.test.ts
@@ -4,16 +4,6 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
 
-// Runs on SQLite regardless of the ambient ARCONN adapter (it constructs its own
-// in-memory adapters), which is where any faithful-transcription slip surfaces:
-// column names, types, defaults, nullability, PKs, and indexes all appear in the
-// dumped DDL.
-
-// `selectAll` returns a `Result` whose rows are positional arrays; `toArray()`
-// maps them to hash rows via the column index, so `r.type`/`r.name`/`r.sql`
-// resolve to real values. Reading the raw `{ columns, rows }` array rows
-// directly instead silently collapses every dump line to
-// "undefined undefined: undefined".
 async function dumpSchema(adapter: AbstractAdapter): Promise<string> {
   const res = await adapter.selectAll(
     "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name, type, sql",
@@ -31,11 +21,7 @@ describe("loadCanonicalSchema", () => {
       await loadCanonicalSchema(adapter);
       const dump = await dumpSchema(adapter);
 
-      // Sanity floor: the canonical schema is hundreds of tables + indexes, so a
-      // silently-empty dump can't pass this test.
       expect(dump.split("\n").length).toBeGreaterThan(300);
-      // Content floor: the dump must carry real DDL, not placeholder rows — a
-      // shape mismatch collapses every line to "undefined undefined: undefined".
       expect(dump).not.toContain("undefined undefined: undefined");
       expect(dump).toMatch(/table topics: CREATE TABLE "?topics"?/);
     } finally {

--- a/packages/activerecord/src/support/canonical-schema.ts
+++ b/packages/activerecord/src/support/canonical-schema.ts
@@ -89,8 +89,6 @@ class TableBuilder {
   ) {}
 
   private col(name: string, primitive: string, o: ColOpts = {}): void {
-    // The single-column integer PK is emitted inline at its declared offset,
-    // preserving the declared INTEGER width across adapters (see serialIdType).
     if (name === this.serialPk) {
       this.t.column(name, serialIdType(primitive as ColumnSpec, this.adapterName), {
         primaryKey: true,
@@ -2313,8 +2311,6 @@ export async function canonicalRegistrySchema(): Promise<Schema> {
       assertSerialPkIsPlainIntegral(def.name, def.meta.serialPk, columns[def.meta.serialPk]);
     }
     if (def.meta.primaryKey !== undefined && def.meta.serialPk === undefined) {
-      // `col` leaves these as declared, so nothing to reconcile; declaredSpec
-      // still raises when `primaryKey:` names a column the block never declared.
       for (const column of def.meta.primaryKey) declaredSpec(def.name, column, columns[column]);
     }
     const indexes: IndexSpec[] = builder.indexes.map(({ columns: c, opts }) => ({

--- a/packages/activerecord/src/support/canonical-table-rebuild-bulk-inbound-fk.trails.test.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild-bulk-inbound-fk.trails.test.ts
@@ -28,14 +28,6 @@ beforeAll(() => {
 
 describe.skipIf(lane === "sqlite")("bulkInboundFkHost (live catalog)", () => {
   it("drops a foreign key reaching in from a table it is not rebuilding", async () => {
-    // `lessons_students` is outside the rebuild set and `authors` declares no FK
-    // of its own, so nothing about the rebuilt set hints the constraint exists:
-    // only the bulk reverse lookup can find it, and PG/MySQL refuse the DROP
-    // while it is live.
-    // Canonical `lessons_students` declares no foreign key, so anything live on
-    // it is debris from an attempt that died before its own cleanup — clear it
-    // up front too, or `addForeignKey` throws on the duplicate constraint name
-    // and wedges this worker's DB for good.
     await clearLessonsStudentsForeignKeys();
     try {
       await adapter.addForeignKey("lessons_students", "authors", { column: "lesson_id" });
@@ -49,12 +41,6 @@ describe.skipIf(lane === "sqlite")("bulkInboundFkHost (live catalog)", () => {
   });
 
   it("leaves a same-named table outside the resolution scope alone", async () => {
-    // The regression this guards: matching the referenced table by *name*
-    // (`relname IN (...)`, or an unscoped information_schema lookup) reports a
-    // constraint on some other `authors` as a blocker, and the rebuild then
-    // drops a live foreign key that has nothing to do with the canonical DB.
-    // PG schemas are database-local, but every MySQL worker shares one server —
-    // so the decoy database is named after this worker's own database.
     const decoy = pg ? "decoy" : `${await currentDatabase()}_decoy`;
     const id = pg ? "id bigserial PRIMARY KEY" : "id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY";
     const dropDecoy = pg
@@ -65,26 +51,16 @@ describe.skipIf(lane === "sqlite")("bulkInboundFkHost (live catalog)", () => {
     await adapter.executeMutation(dropDecoy);
     await adapter.executeMutation(`${pg ? "CREATE SCHEMA" : "CREATE DATABASE"} ${decoy}`);
     try {
-      // Both decoy tables carry canonical names on purpose: `fkSafeDropPlan`
-      // drops a reported blocker whose referencing table is not live, so a decoy
-      // named anything else would be filtered out before the removal and a
-      // name-based catalog query would still look correct here.
       await adapter.executeMutation(`CREATE TABLE ${decoy}.authors (${id})`);
       await adapter.executeMutation(
         `CREATE TABLE ${decoy}.author_favorites (${id}, author_id bigint,
            CONSTRAINT fk_decoy_author FOREIGN KEY (author_id) REFERENCES ${decoy}.authors (id))`,
       );
-      // On PG the decoy has to be *on the search path* to be a candidate at all;
-      // the real path stays in front so plain `authors` still resolves to the
-      // canonical table. MySQL has no search path — another database is scope
-      // enough.
       if (pg) await adapter.executeMutation(`SET search_path = ${searchPath}, ${decoy}`);
 
       await rebuildCanonicalTables(adapter, ["authors"]);
 
       expect(await decoyForeignKeyNames(decoy)).toEqual(["fk_decoy_author"]);
-      // The rebuild itself has to have gone through, or the assertion above
-      // would pass on a helper that did nothing at all.
       expect(await adapter.columns("authors")).not.toHaveLength(0);
     } finally {
       if (pg) await adapter.executeMutation(`SET search_path = ${searchPath}`);

--- a/packages/activerecord/src/support/canonical-table-rebuild.trails.test.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.trails.test.ts
@@ -13,12 +13,6 @@ import {
   rebuildCanonicalTables,
 } from "./canonical-table-rebuild.js";
 
-// Runs on SQLite regardless of the ambient ARCONN adapter (it constructs its own
-// in-memory adapters).
-
-// `selectAll` returns a `Result` whose rows are positional arrays; `toArray()`
-// maps them to hash rows via the column index, so `r.type`/`r.name`/`r.sql`
-// resolve to real values.
 async function dumpSchema(adapter: AbstractAdapter): Promise<string> {
   const res = await adapter.selectAll(
     "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name, type, sql",
@@ -37,8 +31,6 @@ describe("rebuildCanonicalTables", () => {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
 
-      // Simulate a sibling file drifting `topics` to a reduced shape on the
-      // shared DB, then rebuild it back to canonical.
       await adapter.executeMutation("DROP TABLE topics");
       await adapter.executeMutation("CREATE TABLE topics (id integer PRIMARY KEY, title varchar)");
       expect(await dumpSchema(adapter)).not.toBe(canonical);
@@ -57,8 +49,6 @@ describe("rebuildCanonicalTables", () => {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
 
-      // Naming only the FK target must still restore the child: MySQL refuses to
-      // drop a table a live foreign key points at.
       await rebuildCanonicalTables(adapter, ["fk_test_has_pk"]);
       const dump = await dumpSchema(adapter);
       expect(dump).toBe(canonical);
@@ -76,10 +66,6 @@ describe("rebuildCanonicalTables", () => {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
 
-      // A test-added FK from a table outside the rebuild set: no drop order can
-      // work around it, so the rebuild has to drop the constraint itself.
-      // `authors` declares no FK of its own, so nothing about the rebuilt set
-      // hints that an inbound FK might exist — the rebuild has to go looking.
       await sqlite.addForeignKey("lessons_students", "authors", { column: "lesson_id" });
       expect(await sqlite.foreignKeys("lessons_students")).toHaveLength(1);
 
@@ -106,8 +92,6 @@ describe("rebuildCanonicalTables", () => {
 });
 
 describe("fkSafeDropPlan", () => {
-  // Stands in for the live database: `fks` maps a table to the tables it
-  // references, as `foreignKeys` would report them.
   function host(tables: string[], fks: Record<string, string[]> = {}): FkSafeDropPlanHost {
     return {
       tables: async () => tables,
@@ -117,8 +101,6 @@ describe("fkSafeDropPlan", () => {
   }
 
   test("drops a referencing table before its target", async () => {
-    // Registry order: lessons_students (referencer) is registered *before*
-    // students (target), so reversing registry order would drop students first.
     const { order } = await fkSafeDropPlan(
       host(["lessons_students", "students"], { lessons_students: ["students"] }),
       ["lessons_students", "students"],
@@ -166,8 +148,6 @@ describe("fkSafeDropPlan", () => {
   });
 
   test("reports a foreign key reaching in from outside the dropped set", async () => {
-    // `outside` is not being dropped, so no order among a/b can help: PG and
-    // MySQL refuse to drop `a` while its constraint is live.
     const plan = await fkSafeDropPlan(host(["a", "b", "outside"], { outside: ["a"], b: ["a"] }), [
       "a",
       "b",
@@ -219,8 +199,6 @@ describe("fkSafeDropPlan", () => {
       ["a", "b"],
       { scanInbound: true },
     );
-    // Only the dropped set is introspected per-table; `outside` is never
-    // touched individually — that is the whole point of the bulk lookup.
     expect(calls).toEqual(["a", "b"]);
     expect(bulk).toEqual([["a", "b"]]);
     expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
@@ -246,8 +224,6 @@ describe("fkSafeDropPlan", () => {
 });
 
 describe("bulkInboundFkHost", () => {
-  // Stands in for a live adapter: records the SQL it is handed and replays
-  // `rows` as the catalog result.
   function fakeAdapter(adapterName: string, rows: Record<string, unknown>[] = []) {
     const queries: string[] = [];
     const adapter = {
@@ -273,8 +249,6 @@ describe("bulkInboundFkHost", () => {
     await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors", "topics"]);
     expect(queries).toHaveLength(1);
     expect(queries[0]).toContain("pg_constraint");
-    // Matched by resolved OID, not by name: `relname IN (...)` would also match
-    // a same-named table in another search-path schema.
     expect(queries[0]).toContain("c.confrelid IN (to_regclass('authors'), to_regclass('topics'))");
   });
 
@@ -284,7 +258,6 @@ describe("bulkInboundFkHost", () => {
       to_table: "authors",
       name: "fk_rails_13f362e4f5",
     };
-    // MySQL's key_column_usage reports one row per constrained column.
     const { adapter } = fakeAdapter("mysql2", [row, { ...row }]);
     const blockers = await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors"]);
     expect(blockers).toEqual([
@@ -299,7 +272,6 @@ describe("bulkInboundFkHost", () => {
   });
 });
 
-// Read the live table-name set from sqlite_master.
 async function tableNames(adapter: AbstractAdapter): Promise<Set<string>> {
   const res = await adapter.selectAll("SELECT name FROM sqlite_master WHERE type = 'table'");
   return new Set(res.pluck("name").map((name) => String(name)));
@@ -313,8 +285,6 @@ describe("ensureCanonicalTables", () => {
       await loadCanonicalSchema(adapter);
       const canonical = await dumpSchema(adapter);
 
-      // Drop one table; ensure recreates just it (drop-free for the survivors)
-      // and restores it to its full canonical shape.
       await adapter.executeMutation("DROP TABLE topics");
       expect(await tableNames(adapter)).not.toContain("topics");
 
@@ -331,8 +301,6 @@ describe("ensureCanonicalTables", () => {
     const adapter = (await pool.checkout()) as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
-      // A drifted `topics` must survive: ensure creates nothing (all present)
-      // and — unlike rebuildCanonicalTables — never drops to restore shape.
       await adapter.executeMutation("DROP TABLE topics");
       await adapter.executeMutation("CREATE TABLE topics (id integer PRIMARY KEY, title varchar)");
       const drifted = await dumpSchema(adapter);

--- a/packages/activerecord/src/support/canonical-table-rebuild.ts
+++ b/packages/activerecord/src/support/canonical-table-rebuild.ts
@@ -152,8 +152,6 @@ export async function fkSafeDropPlan(
     if (emitted.has(name)) return;
     onPath.add(name);
     for (const edge of edges.get(name) ?? []) {
-      // A target still on the current path closes a cycle: no drop order can
-      // satisfy this edge, so report the constraint and ignore the edge.
       if (onPath.has(edge.toTable)) {
         blockers.push({ fromTable: name, toTable: edge.toTable, name: edge.name });
         continue;
@@ -164,8 +162,6 @@ export async function fkSafeDropPlan(
     emitted.add(name);
     ordered.push(name);
   };
-  // Referencers are emitted after their targets, so walk in input order and
-  // reverse: the result drops referencers first.
   for (const name of names) visit(name);
   return { order: ordered.reverse(), blockers };
 }
@@ -202,29 +198,14 @@ export function bulkInboundFkHost(
     const list = toTables.map((t) => adapter.quote(t)).join(", ");
     const sql =
       name === "postgres"
-        ? // The referenced table is matched by OID via `to_regclass`, not by
-          // name: `relname IN (...)` scoped to the search path would match a
-          // same-named table in *any* schema on it and report a false-positive
-          // blocker (a real `decoy.authors` did, when this filtered on
-          // `nspname = ANY (current_schemas(false))`). `to_regclass` applies
-          // exactly PostgreSQL's own name resolution — first match on the search
-          // path, NULL when nothing resolves, which simply matches no row — so a
-          // drop-set name resolves to the one relation the DDL will drop, the
-          // same relation the per-table `foreignKeys` would have introspected.
-          `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
+        ? `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
              FROM pg_constraint c
              JOIN pg_class t1 ON c.conrelid = t1.oid
              JOIN pg_class t2 ON c.confrelid = t2.oid
              WHERE c.contype = 'f'
                AND c.confrelid IN (${toTables.map((t) => `to_regclass(${adapter.quote(t)})`).join(", ")})
              ORDER BY c.conname`
-        : // `referenced_column_name IS NOT NULL` and the schema scoping mirror
-          // the per-table `foreignKeys` (mysql/schema-statements.ts): the null
-          // check keeps non-FK key usage out, and scoping *both* ends to
-          // DATABASE() keeps a same-named table in another database from
-          // reporting a false-positive blocker (MySQL has no search path, so
-          // there is no resolution step beyond this).
-          `SELECT kcu.table_name AS from_table,
+        : `SELECT kcu.table_name AS from_table,
                   kcu.referenced_table_name AS to_table,
                   kcu.constraint_name AS name
              FROM information_schema.key_column_usage kcu
@@ -234,9 +215,6 @@ export function bulkInboundFkHost(
                AND kcu.referenced_table_name IN (${list})
              ORDER BY kcu.constraint_name`;
     const rows = (await adapter.internalExecQuery(sql, "SCHEMA")).toArray();
-    // `key_column_usage` reports a composite foreign key as one row per column
-    // (the PG query joins no attribute rows, so it is already per-constraint);
-    // the plan wants one blocker per constraint either way.
     const seen = new Set<string>();
     const blockers: FkDropBlocker[] = [];
     for (const row of rows) {
@@ -281,9 +259,6 @@ export async function rebuildCanonicalTables(
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(`rebuildCanonicalTables: unknown canonical table(s): ${unknown.join(", ")}`);
   }
-  // A table nobody asked for still has to be rebuilt when it holds a foreign key
-  // into one that was: MySQL refuses to drop a table a live FK points at, and PG
-  // would cascade the constraint away silently.
   const dependents = await canonicalForeignKeyDependents();
   const queue = [...wanted];
   for (const name of queue) {
@@ -296,22 +271,11 @@ export async function rebuildCanonicalTables(
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;
   const { ss, typeMap } = await prepareSchema(adapter);
-  // `scanInbound` is not optional here: this helper exists as the shield against
-  // a sibling test that left a stray foreign key pointing at a canonical table,
-  // which is exactly the shape fkSafeDropPlan's default heuristic cannot see —
-  // the dropped table holds no FK of its own, so nothing would trigger the scan.
-  // The scan costs one FK introspection per live table not being rebuilt, which
-  // is why the host is wrapped: on PG/MySQL bulkInboundFkHost collapses that
-  // into a single catalog query (see its note on the deviation).
   const plan = await fkSafeDropPlan(
     bulkInboundFkHost(adapter, ss),
     defs.map((d) => d.name),
     { scanInbound: true },
   );
-  // An FK reaching in from a table nobody asked for (or one closing a cycle)
-  // has no drop order that works; drop the constraint itself first. The
-  // referencing table keeps its shape — only the constraint is lost, and a
-  // canonical table's own FKs come back with the recreate below.
   for (const blocker of plan.blockers) {
     await ss.removeForeignKey(blocker.fromTable, {
       name: blocker.name,

--- a/packages/activerecord/src/support/config.trails.test.ts
+++ b/packages/activerecord/src/support/config.trails.test.ts
@@ -37,8 +37,6 @@ describe("config", () => {
   });
 
   it("never selects a backend from a connection sub-setting", () => {
-    // The regression this whole module exists to prevent: connection details
-    // present in the environment must not switch the lane on their own.
     expect(activeLane(reader({ PGHOST: "db.example", MYSQL_HOST: "mysql.example" }))).toBe(
       "sqlite",
     );
@@ -78,7 +76,6 @@ describe("config", () => {
     ).toEqual({
       host: "db",
       port: 3307,
-      // config.example.yml:4,24 hard-code `username: rails` with no password.
       user: "rails",
       database: "activerecord_unittest",
       socket: "/tmp/mysql.sock",
@@ -120,8 +117,6 @@ describe("config", () => {
   });
 
   it("turns prepared statements on when MYSQL_PREPARED_STATEMENTS is present", () => {
-    // config.example.yml:7-11,27-31 tests the var with a bare `if`, so any
-    // value at all — including "" and "0" — turns prepared statements on.
     expect(mysqlPreparedStatements(reader({}))).toBe(false);
     expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "1" }))).toBe(true);
     expect(mysqlPreparedStatements(reader({ MYSQL_PREPARED_STATEMENTS: "0" }))).toBe(true);
@@ -129,8 +124,6 @@ describe("config", () => {
   });
 
   it("suffixes the database with the worker isolation slot above slot 1", () => {
-    // No run token: globalSetup provisioned nothing, so the historical
-    // shared-base-plus-`_N` naming stands.
     expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("activerecord_unittest");
     expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("activerecord_unittest_4");
     expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("activerecord_unittest_2");
@@ -152,9 +145,6 @@ describe("config", () => {
   });
 
   it("stamps the run token into the database name, slot 1 included", () => {
-    // With a run token stamped, slot 1 stops aliasing the bare base database:
-    // that alias is what made two concurrent runs collide on the un-suffixed
-    // name, leaving globalSetup free to DROP a live run's database.
     const stamped = (slot: string) =>
       postgresSettings(reader({ AR_DB_SLOT: slot, AR_TEST_RUN_TOKEN: "aaax1" })).database;
     expect(stamped("1")).toBe("activerecord_unittest_aaax1_1");
@@ -165,9 +155,6 @@ describe("config", () => {
   });
 
   it("treats an empty sub-setting as unset rather than as an empty value", () => {
-    // CI routinely sets a var to "" to mean "no value". Taking that literally
-    // yields host: "" / user: "" and the server answers `Access denied for
-    // user ''`.
     const settings = mysqlSettings(reader({ MYSQL_HOST: "", MYSQL_SOCK: "" }));
     expect(settings.host).toBe("localhost");
     expect(settings.socket).toBeUndefined();
@@ -175,9 +162,6 @@ describe("config", () => {
   });
 
   it("raises on a malformed slot rather than sharing the base database", () => {
-    // Silently falling back to the base DB is the cross-worker collision the
-    // slot mechanism exists to prevent, and would surface as an unrelated
-    // DDL failure much later.
     expect(() => postgresSettings(reader({ AR_DB_SLOT: "abc" }))).toThrow(/must be an integer/);
     expect(() => postgresSettings(reader({ AR_DB_SLOT: "0" }))).toThrow(/must be >= 1/);
   });
@@ -215,7 +199,6 @@ describe("config", () => {
   });
 
   it("raises for a socket field on the postgres scheme", () => {
-    // Postgres has no socket sub-setting; PGHOST carries it (see above).
     expect(() =>
       settingsUrl("postgres", { ...postgresSettings(reader({})), socket: "/tmp/pg.sock" }),
     ).toThrow(/PGHOST=/);
@@ -226,8 +209,6 @@ describe("config", () => {
     expect(postgresUrl(reader({ PGUSER: "u", PGPASSWORD: "p@ss word" }))).toBe(
       "postgres://u:p%40ss%20word@localhost:5432/activerecord_unittest",
     );
-    // No PGUSER means no userinfo at all, so pg resolves libpq's default user
-    // rather than seeing an empty username.
     expect(postgresUrl(reader({}))).toBe("postgres://localhost:5432/activerecord_unittest");
   });
 
@@ -247,7 +228,6 @@ describe("config", () => {
   });
 
   it("driverConfig omits password and socket entirely when unset", () => {
-    // `undefined` is not the same as absent to mysql2.
     const config = driverConfig(mysqlSettings(reader({})));
     expect(config).not.toHaveProperty("password");
     expect(config).not.toHaveProperty("socket");

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -144,9 +144,6 @@ export interface ServerSettings {
  */
 export const SLOT_ENV = "AR_DB_SLOT";
 
-// A malformed slot must never silently degrade to the shared base database —
-// that is precisely the cross-worker collision slots exist to prevent, and it
-// would surface later as an unrelated DDL or fixture failure.
 function slotNumber(read: EnvReader): number {
   const slot = intSetting(read, SLOT_ENV, 1);
   if (slot < 1) {
@@ -159,9 +156,6 @@ function slotNumber(read: EnvReader): number {
 function applySlot(database: string, read: EnvReader): string {
   const slot = slotNumber(read);
   const runToken = present(read, RUN_TOKEN_ENV);
-  // No run token means `globalSetup` provisioned nothing — a bare adapter
-  // script or a harness-less connection. There is no per-run database to point
-  // at, so the historical shared-base-plus-`_N` naming stands.
   if (runToken === undefined) return slot > 1 ? `${database}_${slot}` : database;
   return slotDatabaseName(database, runToken, slot);
 }
@@ -373,7 +367,6 @@ export function settingsUrl(scheme: "postgres" | "mysql", settings: ServerSettin
   const auth = credentials(settings);
 
   if (scheme === "postgres") {
-    // libpq treats a leading "/" in PGHOST as a socket directory, not a host.
     if (host.startsWith("/")) {
       const params = new URLSearchParams({ host, port: String(port) });
       return `postgres://${auth}/${database}?${params.toString()}`;

--- a/packages/activerecord/src/support/connection.trails.test.ts
+++ b/packages/activerecord/src/support/connection.trails.test.ts
@@ -62,13 +62,10 @@ describe("connect", () => {
     vi.stubEnv("ARCONN", "mysql2");
     const [arunit, arunit2, withoutPrepared] = (await testConfigurationHashes())
       .configurationHashes;
-    // config.example.yml:5,25 — the two entries differ in collation, and only
-    // arunit carries the time_zone variable.
     expect(arunit.configurationHash.collation).toBe("utf8mb4_unicode_ci");
     expect(arunit2.configurationHash.collation).toBe("utf8mb4_general_ci");
     expect(arunit.configurationHash.variables).toEqual({ time_zone: "+00:00" });
     expect(arunit2.configurationHash.variables).toBeUndefined();
-    // mysql2 omits the third entry, so expand_config synthesizes it.
     expect(withoutPrepared.configurationHash.collation).toBeUndefined();
     expect(withoutPrepared.adapter).toBe("mysql2");
   });
@@ -161,9 +158,6 @@ describe("connect", () => {
     ]);
   });
 
-  // `config.example.yml:85` names one fixed file, reused across runs; nothing
-  // about the running process (a run token, a worker slot, a tmpdir) may enter
-  // the name.
   it("names the same configured database on every call", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -155,11 +155,6 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3_mem: {
     adapter: "sqlite3",
     lane: "sqlite",
-    // `config.example.yml:93-99` — both entries are their own `:memory:` database,
-    // carrying `adapter` and `database` and nothing else.
-    // Exercised by ci.yml's `sqlite-mem-tests` job — the only lane where
-    // `inMemoryDb()` is true, and so the only thing keeping the
-    // `skipIf(inMemoryDb())` guards from rotting.
     build: async () => ({
       arunit: { adapter: "sqlite3", database: ":memory:" },
       arunit2: { adapter: "sqlite3", database: ":memory:" },
@@ -168,8 +163,6 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   postgresql: {
     adapter: "postgresql",
     lane: "postgres",
-    // `config.example.yml:74-81` — all three entries carry `min_messages`, and
-    // only `arunit_without_prepared_statements` turns prepared statements off.
     build: async () => {
       const shared = serverHash("postgresql", postgresSettings());
       return {

--- a/packages/activerecord/src/support/ddl-profile.trails.test.ts
+++ b/packages/activerecord/src/support/ddl-profile.trails.test.ts
@@ -33,7 +33,6 @@ describe("classifyDdl", () => {
       op: "DROP_INDEX",
       table: "people",
     });
-    // PG/SQLite DROP INDEX has no ON clause — fall back to the index name.
     expect(classifyDdl('DROP INDEX "idx_people_on_name"')).toEqual({
       op: "DROP_INDEX",
       table: "idx_people_on_name",
@@ -53,7 +52,6 @@ describe("classifyDdl", () => {
       op: "REFERENTIAL_INTEGRITY",
       table: "people",
     });
-    // Combined multi-table statement (PG disableReferentialIntegrity).
     const combined =
       'ALTER TABLE "ar_internal_metadata" ENABLE TRIGGER ALL;ALTER TABLE "people" ENABLE TRIGGER ALL';
     expect(classifyDdl(combined)).toEqual({
@@ -88,7 +86,6 @@ describe("classifyStatements", () => {
   });
 
   it("splits a ;-joined combined string into per-statement ops", () => {
-    // MariaDB combineMultiStatements / PG combined FK-toggle form.
     const combined = 'TRUNCATE TABLE "people";TRUNCATE TABLE "posts";TRUNCATE TABLE "books"';
     expect(classifyStatements(combined)).toEqual([
       { op: "TRUNCATE", table: "people" },

--- a/packages/activerecord/src/support/ddl-profile.ts
+++ b/packages/activerecord/src/support/ddl-profile.ts
@@ -34,9 +34,6 @@ export type DdlOp =
   | "DROP_INDEX"
   | "ALTER_TABLE"
   | "TRUNCATE"
-  // PG `disableReferentialIntegrity` wrapper around fixture loads / truncation:
-  // a combined `ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL` over every table.
-  // Tracked separately so it does not masquerade as schema-changing ALTERs.
   | "REFERENTIAL_INTEGRITY"
   | "OTHER_DDL";
 
@@ -58,12 +55,6 @@ interface OpAgg {
   count: number;
   ms: number;
 }
-// Live, bounded aggregates updated on each op. We deliberately do NOT retain a
-// per-op record array: a full-suite worker issues tens of thousands of DDL ops
-// and flush() runs after every test file, so keeping + re-serializing the whole
-// array each flush would be O(files × ops) with multi-MB writes. The aggregate
-// maps are bounded by distinct ops/tables/files, so flush stays cheap. A small
-// capped sample of statements is kept purely for classification spot-checking.
 const agg = {
   totalCount: 0,
   totalMs: 0,
@@ -80,11 +71,6 @@ function bump(bucket: Record<string, OpAgg>, key: string, ms: number): void {
   a.ms += ms;
 }
 
-// In a full-suite run one worker executes many files, so a fixed env var can't
-// attribute records. vitest's `expect.getState().testPath` is set throughout a
-// file's lifecycle — including beforeAll (where the heavy defineSchema DDL
-// runs) — so reading it lazily at record time attributes correctly. The setter
-// + env var remain as fallbacks for contexts where expect state is unset.
 let activeFile: string | null = null;
 let getTestPath: (() => string | undefined) | null = null;
 export function setTestPathResolver(fn: () => string | undefined): void {
@@ -112,9 +98,6 @@ function currentFile(): string {
  */
 export function classifyDdl(sqlRaw: string): { op: DdlOp; table: string | null } | null {
   const sql = sqlRaw.trimStart();
-  // Cheap prefix gate: this runs on EVERY query (reads included), so avoid
-  // uppercasing/scanning the whole string up front — only the leading keyword
-  // can decide DDL-ness. Wider scans happen lazily inside the matched branch.
   const head = sql.slice(0, 16).toUpperCase();
 
   const unquote = (s: string | undefined): string | null =>
@@ -134,9 +117,6 @@ export function classifyDdl(sqlRaw: string): { op: DdlOp; table: string | null }
     return { op: "ADD_INDEX", table: unquote(m?.[1]) };
   }
   if (head.startsWith("DROP INDEX")) {
-    // MySQL: `DROP INDEX name ON table` (has ON). PG/SQLite:
-    // `DROP INDEX [CONCURRENTLY] [IF EXISTS] name` (no ON) — fall back to the
-    // index name so PG/SQLite rows aren't all null.
     m = sql.match(/\bON\s+([^\s(;]+)/i);
     if (m) return { op: "DROP_INDEX", table: unquote(m[1]) };
     m = sql.match(/DROP\s+INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?([^\s(;,]+)/i);
@@ -145,16 +125,12 @@ export function classifyDdl(sqlRaw: string): { op: DdlOp; table: string | null }
   if (head.startsWith("ALTER TABLE")) {
     m = sql.match(/ALTER\s+TABLE\s+([^\s(]+)/i);
     const table = unquote(m?.[1]);
-    // PG's disableReferentialIntegrity wraps fixture loads/truncation in a
-    // combined `ALTER TABLE ... DISABLE/ENABLE TRIGGER ALL` over every table.
-    // Tracked separately so it doesn't masquerade as a schema-changing ALTER.
     if (/\b(?:DISABLE|ENABLE)\s+TRIGGER\b/i.test(sql)) {
       return { op: "REFERENTIAL_INTEGRITY", table };
     }
     return { op: "ALTER_TABLE", table };
   }
   if (head.startsWith("TRUNCATE")) {
-    // Stop at comma too: TRUNCATE may list multiple tables; record the first.
     m = sql.match(/TRUNCATE\s+(?:TABLE\s+)?([^\s(;,]+)/i);
     return { op: "TRUNCATE", table: unquote(m?.[1]) };
   }
@@ -201,8 +177,6 @@ function wrap(proto: Record<string, unknown>, method: string, sqlArgIndex: numbe
   if (typeof orig !== "function") return;
   proto[method] = async function patched(this: unknown, ...args: unknown[]) {
     const arg = args[sqlArgIndex];
-    // Fast reject: head-classify the whole string; non-DDL (SELECT/INSERT/…)
-    // bails before any split work. Only DDL strings pay the multi-statement split.
     if (typeof arg !== "string" || classifyDdl(arg) === null) {
       return orig.apply(this, args);
     }
@@ -216,8 +190,6 @@ function wrap(proto: Record<string, unknown>, method: string, sqlArgIndex: numbe
     try {
       return await orig.apply(this, args);
     } finally {
-      // One round-trip's elapsed ms split evenly across its statements, so the
-      // total ms is preserved while per-statement counts stay accurate.
       const per = (performance.now() - t0) / classified.length;
       for (const c of classified) {
         recordDdl({
@@ -249,11 +221,6 @@ export async function install(): Promise<void> {
     import("../connection-adapters/sqlite3-adapter.js"),
   ]);
 
-  // Patch only the two leaf primitives. Every `executeBatch` implementation
-  // re-dispatches each statement through `execute` (PG) or `executeMutation`
-  // (abstract/mysql/sqlite), so wrapping it too would double-count batched
-  // truncate/fixture DDL — and the leaf calls give better per-statement
-  // attribution (real table names, real per-statement timing).
   for (const klass of [PostgreSQLAdapter, Mysql2Adapter, SQLite3Adapter]) {
     const proto = klass.prototype as unknown as Record<string, unknown>;
     wrap(proto, "execute", 0);
@@ -263,9 +230,6 @@ export async function install(): Promise<void> {
   if (process.env.DDL_PROFILE_DEBUG === "1") {
     console.error(`[DDL_PROFILE] installed patches in pid ${process.pid}`);
   }
-  // vitest forks kill the worker rather than exiting cleanly, so process
-  // "exit"/"beforeExit" handlers do not fire. Flush from an afterAll instead
-  // (the setup file registers it) and keep the exit hooks as a backstop.
   process.on("exit", dumpSummary);
   process.on("beforeExit", dumpSummary);
 }
@@ -280,9 +244,6 @@ function dumpSummary(): void {
     console.error(`[DDL_PROFILE] dumpSummary pid ${process.pid}, ${agg.totalCount} ops`);
   }
   if (agg.totalCount === 0) return;
-  // One file per worker. A full-suite worker runs many test files and calls
-  // flush() in afterAll after each, so we overwrite cumulatively — the final
-  // write holds the worker's complete aggregates. Filename is unique per worker.
   const dir = process.env.DDL_PROFILE_OUT_DIR;
   const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
   const out =
@@ -309,7 +270,5 @@ function dumpSummary(): void {
         `[DDL_PROFILE] ${agg.totalCount} DDL ops, ${agg.totalMs.toFixed(1)}ms → ${out}`,
       );
     }
-  } catch {
-    // best-effort; never break a test run on dump failure
-  }
+  } catch {}
 }

--- a/packages/activerecord/src/support/describe-if-pg.ts
+++ b/packages/activerecord/src/support/describe-if-pg.ts
@@ -2,10 +2,6 @@ import { describe } from "vitest";
 import pg from "pg";
 import { postgresUrl } from "./config.js";
 
-// A *serialization* of the PG sub-settings (PGHOST/PGPORT/PGUSER/PGPASSWORD/
-// PGDATABASE), not an env var of its own: these suites probe the server
-// directly via describeIfPg regardless of ARCONN, so they need a URL to hand
-// the driver, but they no longer source one from the environment.
 export const PG_TEST_URL = postgresUrl();
 
 async function checkPg(): Promise<{

--- a/packages/activerecord/src/support/drop-all-tables.trails.test.ts
+++ b/packages/activerecord/src/support/drop-all-tables.trails.test.ts
@@ -51,7 +51,6 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
       execute: vi.fn(async () => {
         executeCallCount++;
         if (executeCallCount === 1) throw connErr;
-        // Second call (retry): return empty table list so no DROPs run.
         return [];
       }),
       executeMutation: vi.fn(async () => {}),
@@ -59,8 +58,6 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     } as unknown as DatabaseAdapter;
 
     await expect(dropAllTables(fakeAdapter)).resolves.toBeUndefined();
-    // First attempt: 1 execute call throws. Retry: 3 execute calls (matviews,
-    // views, tables) all return []. Total = 4.
     expect(executeCallCount).toBe(4);
   });
 
@@ -88,7 +85,6 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     const fakeAdapter = {
       adapterName: "postgres" as const,
       execute: vi.fn(async (sql: string) => {
-        // Return one matview on first pass; empty on retry.
         if (sql.includes("matviewname")) {
           return mutationCallCount === 0 ? [{ schemaname: "public", name: "mv1" }] : [];
         }
@@ -102,9 +98,6 @@ describe("dropAllTables (PG connection-error retry, fake adapter)", () => {
     } as unknown as DatabaseAdapter;
 
     await expect(dropAllTables(fakeAdapter)).resolves.toBeUndefined();
-    // First pass: 1 execute (matviews→mv1) + 1 executeMutation (throws).
-    // Retry: 3 execute calls (matviews/views/tables → all empty) + 0 mutations.
-    // Total execute calls = 4 proves the retry path ran.
     expect(fakeAdapter.execute).toHaveBeenCalledTimes(4);
     expect(mutationCallCount).toBe(1);
   });
@@ -119,9 +112,7 @@ describe("resetTestTables", () => {
 
     await resetTestTables(adapter);
 
-    // Canonical table survives (not dropped)...
     expect(await listTables(adapter)).toContain("articles");
-    // ...but its rows are cleared.
     expect(((await adapter.execute(`SELECT id FROM articles`)) as unknown[]).length).toBe(0);
   });
 
@@ -132,15 +123,10 @@ describe("resetTestTables", () => {
     await resetTestTables(adapter);
 
     expect(await listTables(adapter)).not.toContain("bespoke_reset_t");
-    // Canonical tables are still present after the bespoke drop.
     expect(await listTables(adapter)).toContain("articles");
   });
 
   it("drops bookkeeping tables (schema_migrations / ar_internal_metadata) like the old drop-all", async () => {
-    // These are non-canonical, so the reset drops them — matching the previous
-    // unconditional dropAllTables. Migrator tests (non-transactional) rely on a
-    // clean schema_migrations per test; preserving it would leak migration
-    // state and break them.
     await adapter.executeMutation(
       `CREATE TABLE IF NOT EXISTS schema_migrations (version VARCHAR(255) PRIMARY KEY)`,
     );
@@ -221,8 +207,6 @@ describe("purge-only pre-snapshot path", () => {
     schemaCache: { clearBang() {} },
   } as unknown as DatabaseAdapter;
 
-  // The sqlite arm lays its one table through createTable and nothing else, so
-  // stubbing that member runs the arm without touching a database.
   const armOnlyAdapter = {
     adapterName: "sqlite",
     createTable: async () => {},
@@ -273,8 +257,6 @@ describe("purge-only pre-snapshot path", () => {
     expect(await listTables(adapter)).toContain("defaults");
   });
 
-  // Kept last: this one runs a real purge, which drops the adapter-specific
-  // tables until the next test file's boot re-lays them.
   it("clears the rows of a canonical table, so the boot needs no truncate ahead of it", async () => {
     const { dropAllTablesModule } = await freshModules();
     await adapter.executeMutation(`INSERT INTO articles (id) VALUES (4243)`);

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -204,10 +204,6 @@ async function truncateNonEmpty(adapter: DatabaseAdapter, candidates: string[]):
       .join(" UNION ALL ");
     const rows = (await adapter.execute(probe)) as Array<{ t?: string; T?: string }>;
     toTruncate = rows.map((r) => r.t ?? r.T).filter((t): t is string => Boolean(t));
-    // A table nobody probed as non-empty still has to ride along when it holds a
-    // foreign key into one that did: PostgreSQL refuses to truncate a table an FK
-    // points at unless the referencing table is in the same statement, and it
-    // refuses whether or not that table holds rows.
     const dependents = await canonicalForeignKeyDependents();
     const wanted = new Set(toTruncate);
     for (const name of toTruncate) {
@@ -244,10 +240,6 @@ async function resetPgTables(
   try {
     await _resetPgTablesOnce(adapter, mode, bootLaid);
   } catch (e) {
-    // exec() routes through withRawConnection, whose retry loop calls
-    // reconnectBang → the PG reconnect() override on a connection error, so
-    // _rawConnection is now null and the next _acquireFreshClient() will open a
-    // fresh pg.Client. Retry exactly once.
     if (_isPgConnectionError(e)) {
       await _resetPgTablesOnce(adapter, mode, bootLaid);
     } else {
@@ -262,7 +254,6 @@ async function _resetPgTablesOnce(
   bootLaid: ReadonlySet<string>,
 ): Promise<void> {
   const schema = `ANY(current_schemas(false))`;
-  // Views/matviews are never canonical — always drop them.
   for (const { schemaname: s, name: n } of (await adapter.execute(
     `SELECT schemaname, matviewname AS name FROM pg_matviews WHERE schemaname = ${schema}`,
   )) as { schemaname: string; name: string }[]) {
@@ -287,9 +278,6 @@ async function _resetPgTablesOnce(
     `SELECT schemaname, tablename FROM pg_tables WHERE schemaname = ${schema}`,
   )) as { schemaname: string; tablename: string }[];
   for (const { schemaname: s, tablename: t } of tableRows) {
-    // A table living outside the default (public) schema — e.g. schema.test.ts's
-    // test_schema/test_schema2 — can never be a boot-laid canonical table; drop
-    // it regardless of mode so it can't bleed state into the next file.
     if (mode === "reset" && s === "public" && bootLaid.has(t)) {
       toTruncate.push(t);
       continue;

--- a/packages/activerecord/src/support/handler-resolved-adapter.trails.test.ts
+++ b/packages/activerecord/src/support/handler-resolved-adapter.trails.test.ts
@@ -14,8 +14,6 @@ import { useTransactionalTests } from "../test-fixtures/use-transactional-tests.
 
 class HandlerResolvedPost extends Base {
   static {
-    // Declare attribute types explicitly so the getter/setter is installed
-    // without schema reflection (which would re-enter the pool).
     this.attribute("title", "string");
   }
 
@@ -41,8 +39,6 @@ describe("handler-resolved adapter (Phase D-0)", () => {
   beforeAll(async () => {
     const adapter = Base.connection;
     await adapter.createTable("handler_resolved_comments", (t) => t.string("body"));
-    // D-0a: load schema for the bare model (no explicit attribute declarations).
-    // This deadlocked before the fix; now routes through the checked-out adapter.
     await HandlerResolvedComment.loadSchema();
   });
 
@@ -55,8 +51,6 @@ describe("handler-resolved adapter (Phase D-0)", () => {
   });
 
   it("bare class extends Base loads schema via lazy reflection without deadlock", async () => {
-    // D-0a: no explicit this.attribute() — schema comes from loadSchemaFromAdapter.
-    // On SQLite :memory: + pool size 1 this deadlocked before the fix.
     const comment = await HandlerResolvedComment.create({ body: "world" });
     expect(comment.body).toBe("world");
     expect(comment.isPersisted()).toBe(true);
@@ -64,7 +58,6 @@ describe("handler-resolved adapter (Phase D-0)", () => {
 
   it("model resolves adapter via handler — no static { this.adapter = X } needed", async () => {
     expect(Object.prototype.hasOwnProperty.call(HandlerResolvedPost, "_adapter")).toBe(false);
-    // The adapter is still accessible (via handler → pool → Base._adapter cache)
     expect(() => HandlerResolvedPost.connection).not.toThrow();
   });
 });

--- a/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-arm-guard.trails.test.ts
@@ -54,10 +54,6 @@ describe("load_schema arm-probe guard", () => {
     });
   });
 
-  // `createTable` is not the only interception that lays nothing: `runTable`
-  // reaches the database through the adapter's mixed-in SchemaStatements
-  // bodies, so a cover that stubs the members *they* go through is just as
-  // unsafe, and just as invisible outside the PG lane.
   for (const method of ["dropTable", "addIndex", "execute", "schemaCreation"]) {
     it(`rejects an adapter whose ${method} a proxy intercepts`, async () => {
       await withAdapter(async (adapter) => {
@@ -75,9 +71,6 @@ describe("load_schema arm-probe guard", () => {
     });
   }
 
-  // `schemaCreation` is an accessor, not a method, so the guard compares what
-  // the real one yields rather than its identity — PostgreSQLAdapter's builds a
-  // fresh visitor per read.
   it("rejects an adapter whose schemaCreation a proxy intercepts", async () => {
     await withAdapter(async (adapter) => {
       const probe = new Proxy(adapter, {
@@ -103,12 +96,6 @@ describe("load_schema arm-probe guard", () => {
     });
   });
 
-  // The gap this guard cannot close, pinned so it is not mistaken for a bug:
-  // a class-body override is found by the walk as that class's own member and
-  // matches what the lookup returned, exactly as PostgreSQLAdapter's override
-  // of AbstractAdapter's does. `assertNotStubbed`'s docstring carries the
-  // reasoning; `blazetrails/no-load-schema-with-stubbed-ddl` catches the shape
-  // lexically instead, which is what makes this acceptable.
   it("does not see a subclass that overrides createTable on its own prototype", async () => {
     class Probe extends BetterSQLite3Adapter {
       override async createTable(): Promise<void> {}
@@ -124,9 +111,6 @@ describe("load_schema arm-probe guard", () => {
     }
   });
 
-  // The counterpart direction: a proxy that only observes must still load, or
-  // the guard would break the pooling/logging wrappers that hand `loadSchema` a
-  // wrapped connection.
   it("passes an adapter behind a transparent proxy", async () => {
     await withAdapter(async (adapter) => {
       const passthrough = new Proxy(adapter, {

--- a/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper-uuid-default.trails.test.ts
@@ -71,9 +71,6 @@ describeIfPg("load_schema_helper: uuid_default without pgcrypto", () => {
         },
       });
 
-      // Must call the arm directly, not loadSchema: this cover stubs
-      // createTable, so the canonical half loadSchema runs first would query
-      // tables that were never really laid (#5676 regressed exactly that).
       await expect(
         loadAdapterSpecificSchema(probe as unknown as AbstractAdapter),
       ).rejects.toBeInstanceOf(StopLoad);

--- a/packages/activerecord/src/support/load-schema-helper.trails.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.trails.test.ts
@@ -17,8 +17,6 @@ describe("boot-laid table snapshot", () => {
   it("survives the reset for every table the adapter-specific arm lays", async () => {
     const adapter = Base.connection;
 
-    // The canonical half is already on this worker's DB, so only the
-    // adapter-specific arm is replayed here.
     await loadAdapterSpecificSchema(adapter);
     const bookkeeping = new Set(["schema_migrations", "ar_internal_metadata"]);
     const laid = (await adapter.tables()).filter((name) => !bookkeeping.has(name));
@@ -34,10 +32,6 @@ describe("boot-laid table snapshot", () => {
     const adapter = Base.connection;
     await adapter.executeMutation(`CREATE TABLE leftover_boot_t (id INTEGER PRIMARY KEY)`);
 
-    // `test-setup-dy.ts`'s boot order, replayed: the database is emptied of
-    // everything that is not canonical, then the schema is laid — here only its
-    // adapter-specific arm, the canonical half already being on this worker's
-    // DB — then the snapshot.
     await resetTestTables(adapter);
     await loadAdapterSpecificSchema(adapter);
     await recordBootLaidTables(adapter);

--- a/packages/activerecord/src/support/mysql-server-version.ts
+++ b/packages/activerecord/src/support/mysql-server-version.ts
@@ -2,10 +2,6 @@ import mysql from "mysql2/promise";
 import { Version } from "../connection-adapters/abstract-adapter.js";
 import { mysqlUrl } from "./config.js";
 
-// A *serialization* of the MySQL sub-settings, not an env var of its own. Only
-// for tests that build a *second*, differently configured adapter, where the
-// config is itself under test and must not leak onto the shared leased
-// connection. Everything else rides leaseMysqlAdapter (MySQL test-helper).
 export const MYSQL_TEST_URL = mysqlUrl();
 
 let mariaDb = false;
@@ -37,8 +33,6 @@ export const isMariaDb = mariaDb;
 /** Raw VERSION() string from the connected MySQL/MariaDB server (empty when unavailable). */
 export const mysqlVersion = mysqlVersionStr;
 
-// Parse the dotted version out of the raw VERSION() string the same way
-// AbstractMysqlAdapter#version_string does (strips the MariaDB 5.5.5- prefix).
 function parseMysqlVersion(full: string): Version | null {
   const m = full.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/);
   return m ? new Version(m[1], full) : null;

--- a/packages/activerecord/src/support/pg-template.trails.test.ts
+++ b/packages/activerecord/src/support/pg-template.trails.test.ts
@@ -31,10 +31,6 @@ describe.skipIf(!pgActive)("PG template-clone (Phase 1 probe)", () => {
   });
 
   it("the template DB is stamped with the canonical schema SHA1", async () => {
-    // The stamp workers derive from this run's token must equal the value
-    // globalSetup wrote into the template — that match is exactly what
-    // `canonicalSchemaUpToDate` checks, so every slot cloned from this template
-    // skips the boot DDL and only TRUNCATEs.
     const expectedSha1 = canonicalSchemaStamp(process.env[RUN_TOKEN_ENV]!);
 
     const templateDb = process.env[PG_TEMPLATE_ENV]!;

--- a/packages/activerecord/src/support/quote-database-name.trails.test.ts
+++ b/packages/activerecord/src/support/quote-database-name.trails.test.ts
@@ -19,10 +19,6 @@ describe("quoting a database name for harness DDL", () => {
   });
 
   it("keeps a sweepable leftover sweepable when its suffix carries a quote", () => {
-    // The regression: `runTokenOfDatabase` matches on the run-token *prefix*,
-    // so everything after it is unconstrained. Interpolating such a name raw
-    // made `DROP DATABASE` a syntax error, and globalSetup then failed on every
-    // subsequent run instead of reclaiming the leftover.
     const leftover = `${slotDatabaseName(BASE, "rabc000001", 1)}"; SELECT 1; --`;
     expect(runTokenOfDatabase(BASE, leftover)).toBe("rabc000001");
 
@@ -30,7 +26,6 @@ describe("quoting a database name for harness DDL", () => {
     expect(sql).toBe(
       `DROP DATABASE IF EXISTS "activerecord_unittest_rabc000001_1""; SELECT 1; --"`,
     );
-    // One identifier, so nothing after it can be read as a second statement.
     expect(sql.split('"').length - 1).toBe(4);
   });
 });

--- a/packages/activerecord/src/support/run-token.trails.test.ts
+++ b/packages/activerecord/src/support/run-token.trails.test.ts
@@ -16,10 +16,6 @@ const BASE = "activerecord_unittest";
 
 describe("run token", () => {
   it("carries the run start time so a name alone can be aged out", () => {
-    // Regression: an earlier spelling split the two halves on a literal "x",
-    // which `Date.now().toString(36)` itself contains for most of any given
-    // day — the parsed start time was then garbage, and the stale sweep would
-    // happily drop a concurrent run's live databases.
     const before = Date.now();
     const startedAt = runTokenStartedAt(newRunToken());
     expect(startedAt).not.toBeNull();
@@ -58,9 +54,6 @@ describe("slot database names", () => {
 });
 
 describe("drop targets", () => {
-  // The regression this whole story exists to prevent: globalSetup used to
-  // DROP `activerecord_unittest_2..N` unconditionally, so a second run wiped
-  // the first run's databases out from under its live workers.
   it("never targets a database belonging to a different run token", () => {
     const mine = "raaa000001";
     const theirs = "rbbb000002";
@@ -83,11 +76,6 @@ describe("drop targets", () => {
     ]);
   });
 
-  // The arunit2 sibling carries the run's token like every other database the
-  // run mints, but with a `2` on the base. An earlier spelling put the `2` on
-  // the token instead (`<base>_<token>2_<slot>`), so the sibling read as
-  // belonging to token `<token>2`: invisible to its own run's teardown, and
-  // droppable by a concurrent run's stale sweep once `<token>2` aged out.
   it("keeps the arunit2 sibling of a slot database under its own run token", () => {
     const mine = newRunToken();
     const theirs = newRunToken();

--- a/packages/activerecord/src/support/run-token.ts
+++ b/packages/activerecord/src/support/run-token.ts
@@ -40,15 +40,6 @@ export const RUN_TOKEN_ENV = "AR_TEST_RUN_TOKEN";
  */
 export const STALE_DB_AGE_MS = 6 * 60 * 60 * 1000;
 
-// `r<base36 millis><base36 random>`, the random half fixed-width so the two
-// halves split without a separator — every character base36 produces is itself
-// a legal separator candidate, so there is no safe one to pick.
-//
-// The leading millis is not decoration: a database name is all the stale sweep
-// has to go on — unlike a temp file, a PostgreSQL database carries no mtime to
-// compare against the cutoff. The `r` prefix is what keeps a legacy unstamped
-// leftover like `activerecord_unittest_2_arunit2` from parsing as a run token
-// whose "start time" is the epoch, which would make the sweep drop it.
 const RANDOM_LENGTH = 6;
 const TOKEN_PATTERN = "r[0-9a-z]+";
 

--- a/packages/activerecord/src/support/schema-dumping-helper.trails.test.ts
+++ b/packages/activerecord/src/support/schema-dumping-helper.trails.test.ts
@@ -15,13 +15,6 @@ beforeAll(() => {
   adapter = Base.adapter;
 });
 
-// Track the bespoke `sdh_*` tables each test creates so afterEach can drop
-// exactly those. Nothing clears these between tests — one
-// test reuses `sdh_kept` and would hit "table already exists" if left. Dropping
-// only the created tables (RFC 0060) replaces the old afterAll/afterEach
-// dropAllTables' ~330-table canonical DROP fan-out. Deriving the drop set
-// from `createSdhTable` (rather than a hand-maintained list) keeps it correct
-// as tests are added or renamed.
 const createdTables = new Set<string>();
 async function createSdhTable(name: string, columns = "id INTEGER PRIMARY KEY"): Promise<void> {
   createdTables.add(name);

--- a/packages/activerecord/src/support/schema-file-generator.trails.test.ts
+++ b/packages/activerecord/src/support/schema-file-generator.trails.test.ts
@@ -37,7 +37,6 @@ const MINI_SCHEMA: Schema = {
     columns: { gadget_id: "integer", name: "string" },
     primaryKey: ["gadget_id"],
   },
-  // Single-column STRING custom PK → stays the array form (not serial).
   registries: {
     columns: { code: "string", label: "string" },
     primaryKey: ["code"],
@@ -58,9 +57,7 @@ describe("generateSchemaFile", () => {
     const fs = await getFsAsync();
     try {
       fs.unlinkSync(filePath);
-    } catch {
-      /* already gone */
-    }
+    } catch {}
   });
 
   it("writes file to os.tmpdir keyed by VITEST_POOL_ID", async () => {
@@ -108,13 +105,11 @@ describe("generateSchemaFile", () => {
     // so its reflected position matches Rails (mirrors schema-types.ts).
     expect(content).toContain('"gadgets", { id: false }');
     expect(content).toContain('"gadget_id", "integer", { primaryKey: true }');
-    // The non-PK column is still emitted.
     expect(content).toContain('"name", "string"');
   });
 
   it("keeps a single-column string custom PK as the array (non-serial) form", () => {
     expect(content).toContain('primaryKey: ["code"]');
-    // The string PK column is still emitted as a column.
     expect(content).toContain('"code", "string"');
   });
 });
@@ -145,17 +140,10 @@ describe("generateSchemaFile (MySQL adapter)", () => {
     const fs = await getFsAsync();
     try {
       fs.unlinkSync(filePath);
-    } catch {
-      /* already gone */
-    }
+    } catch {}
   });
 
   it("emits native date, time, json column types (matching define-schema.ts)", () => {
-    // schema-types.ts COLUMN_TYPE_MAP_MYSQL maps date/time/json to their
-    // native MySQL types (PR #4141) so DATE/TIME/JSON columns round-trip as
-    // PlainDate/PlainTime/parsed-JSON instead of raw strings. The generator
-    // must agree, or the boot-laid canonical schema lays these as VARCHAR and
-    // schema loading never registers them for casting.
     expect(content).toContain('"occurred_on", "date"');
     expect(content).toContain('"scheduled_time", "time"');
     expect(content).toContain('"metadata", "json"');
@@ -208,9 +196,7 @@ describe("generateSchemaFile foreign keys", () => {
     for (const filePath of written) {
       try {
         fs.unlinkSync(filePath);
-      } catch {
-        /* already gone */
-      }
+      } catch {}
     }
   });
 
@@ -282,19 +268,7 @@ describe("generateSchemaFile single-column big_integer PK id type per adapter", 
   });
 });
 
-// PARITY GUARD — schema-file-generator.ts's per-adapter type mapping is a
-// parallel re-implementation of schema-types.ts's COLUMN_TYPE_MAP_* /
-// serialIdType. A one-sided edit reintroduces silent drift: PR #4461 fixed a
-// MariaDB regression where the generator's stale SCHEMA_TO_AR_MYSQL still
-// remapped date/time/json → string, even though schema-types.ts's map had
-// been converged to native MySQL types by PR #4141 — so boot-laid canonical
-// `topics.last_read` was created as varchar(255) instead of date. This guard
-// drives the generator for a schema covering every PrimitiveColumnSpec on each
-// adapter and asserts the emitted `t.column(name, "type", …)` matches the
-// authoritative COLUMN_TYPE_MAP_* the fixtures path (schema-types.ts) uses.
 describe("generateSchemaFile / define-schema.ts type-map parity", () => {
-  // Generate a schema file, read it back, and delete it — the generator's only
-  // observable output is the emitted module text.
   async function readGenerated(schema: Schema, adapter: string): Promise<string> {
     const filePath = await generateSchemaFile(schema, adapter);
     const fs = await getFsAsync();
@@ -303,8 +277,6 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
     return content;
   }
 
-  // Extract the emitted AR type for each column from a generated schema file:
-  // matches `t.column("colName", "arType", …)`.
   function emittedTypes(content: string): Record<string, string> {
     const out: Record<string, string> = {};
     const re = /t\.column\("([^"]+)", "([^"]+)"/g;
@@ -313,16 +285,12 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
     return out;
   }
 
-  // One column per key, named after the primitive so we can look it up.
   function schemaFor(types: readonly AnyPrimitiveColumnSpec[]): Schema {
     const columns: Record<string, ColumnSpec> = {};
     for (const t of types) columns[`c_${t}`] = t;
     return { parity_probe: columns };
   }
 
-  // `Record<PrimitiveColumnSpec, string>` forces each map to carry every
-  // primitive, so iterating its keys covers the full type surface — a primitive
-  // added to schema-types.ts is automatically exercised here.
   const CASES: ReadonlyArray<{
     adapter: string;
     map: Record<string, string>;
@@ -344,8 +312,6 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
     });
   }
 
-  // The exact #4461 regression, pinned: the generator's stale map remapped
-  // date/time/json → string on MySQL, so these must stay native, not VARCHAR.
   it("emits native date/time/json (not string) on MySQL — the PR #4461 regression", async () => {
     const emitted = emittedTypes(
       await readGenerated(schemaFor(["date", "time", "json"]), "mysql2"),
@@ -405,10 +371,6 @@ describe("generateSchemaFile / define-schema.ts type-map parity", () => {
 //     below, since the generator has no DB version.
 type RecordedIndex = { columns: string | string[]; options: Record<string, unknown> };
 
-// A recording context capturing every `addIndex` with the exact options object
-// the emitter passed. `createTable` runs the column callback against a no-op
-// table builder (columns aren't under test here); `dropTable` is the only other
-// surface the generated module touches.
 function makeIndexRecorder(): { recorded: RecordedIndex[]; ctx: Record<string, unknown> } {
   const recorded: RecordedIndex[] = [];
   const noopTable = { column: () => {} };
@@ -428,9 +390,6 @@ function makeIndexRecorder(): { recorded: RecordedIndex[]; ctx: Record<string, u
   return { recorded, ctx };
 }
 
-// Strip `undefined` values (canonical-schema.ts passes every option key,
-// undefined where absent; the generator omits absent keys) so the two normalize
-// equal.
 function normalizeIndexOptions(options: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(options)) if (v !== undefined) out[k] = v;
@@ -443,9 +402,6 @@ function normalizeRecorded(recorded: RecordedIndex[]): string {
   );
 }
 
-// Drive the GENERATOR: emit the schema file, dynamic-import it (the real
-// loadSchema path — DatabaseTasks.loadSchema imports the same file:// URL), and
-// run its default export against the recorder.
 async function generatorIndexes(
   schema: Schema,
   adapter: string,
@@ -462,11 +418,6 @@ async function generatorIndexes(
   return recorded;
 }
 
-// Drive the CANONICAL loader's shared `emitTableIndexes` (the real code
-// canonical-schema.ts's boot path runs) against the recorder and a fake
-// pool-less adapter. `supportsExpressionIndex` mimics the live DB capability the
-// runtime check reads (MySQL ≥ 8.0.13 / SQLite ≥ 3.9 true, MariaDB false);
-// `getDatabaseVersion` is awaited first by the real gate.
 async function canonicalIndexes(
   indexes: Parameters<typeof emitTableIndexes>[3],
   adapter: string,
@@ -485,12 +436,6 @@ async function canonicalIndexes(
   return recorded;
 }
 
-// One table's indexes exercising every option plus an expression index, in
-// canonical-schema.ts's `{ columns, opts }` shape. Boolean flags are only ever
-// set truthy (never explicit `false`) so the generator's truthy
-// `if (index.unique)` omission and the loader's always-passed `unique: opts.unique`
-// normalize identically. `GENERATOR_SCHEMA` flattens the same specs into the
-// generator's `IndexSpec` input.
 const PARITY_INDEXES: Parameters<typeof emitTableIndexes>[3] = [
   { columns: "title", opts: { unique: true, name: "idx_probe_title", where: "rating > 0" } },
   { columns: ["title", "rating"], opts: { order: { rating: "desc" }, length: { title: 10 } } },
@@ -521,40 +466,24 @@ const GENERATOR_SCHEMA: Schema = {
 };
 
 describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
-  // On PG/SQLite the generator keeps expression indexes (its coarse skip is
-  // MySQL-only) and the loader keeps them when the adapter supports them — so
-  // drive `emitTableIndexes` with `supportsExpressionIndex: true` to match.
   for (const adapter of ["postgres", "sqlite"] as const) {
     it(`emits the same addIndex calls as canonical-schema.ts on ${adapter}`, async () => {
       const [gen, canon] = await Promise.all([
         generatorIndexes(GENERATOR_SCHEMA, adapter),
         canonicalIndexes(PARITY_INDEXES, adapter, true),
       ]);
-      // Everything but the MySQL-only adapters-gated index survives on
-      // PG/SQLite (expression kept). Pin the count so the equality below can't
-      // pass vacuously if the schema wrapper stops being recognized and both
-      // sides silently record zero indexes.
       expect(gen).toHaveLength(PARITY_INDEXES.length - 1);
       expect(normalizeRecorded(gen)).toBe(normalizeRecorded(canon));
     });
   }
 
-  // On MySQL the generator drops every expression index unconditionally; the
-  // MariaDB reality (no expression-index support) makes the loader drop it too,
-  // so the deterministic surface — length gating + pass-through options — stays
-  // in lockstep. (The MySQL-8 divergence is the tracked residual below.)
   it("emits the same addIndex calls as canonical-schema.ts on mysql (MariaDB, no expression index)", async () => {
     const [gen, canon] = await Promise.all([
       generatorIndexes(GENERATOR_SCHEMA, "mysql2"),
       canonicalIndexes(PARITY_INDEXES, "mysql2", false),
     ]);
-    // Only the expression index is dropped (the adapters-gated MySQL-only
-    // index survives here), so the rest come through — pin the count so the
-    // equality can't pass vacuously.
     expect(gen).toHaveLength(PARITY_INDEXES.length - 1);
     expect(normalizeRecorded(gen)).toBe(normalizeRecorded(canon));
-    // Length survives on MySQL (both keep it) and the expression index is
-    // dropped by both — pin those two gates explicitly.
     expect(gen.some((r) => r.options.length !== undefined)).toBe(true);
     expect(gen.some((r) => r.columns === PARITY_EXPRESSION_INDEX)).toBe(false);
   });
@@ -574,21 +503,11 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
     }
   });
 
-  // Expression-index gating parity on MySQL 8. The generator now threads the
-  // caller-resolved `supportsExpressionIndex` capability (MySQL >= 8.0.13,
-  // SQLite >= 3.9, never MariaDB) instead of the coarse `adapterName === "mysql2"`
-  // skip, so on a live MySQL 8 (supportsExpressionIndex true) it keeps the
-  // expression index — matching canonical-schema.ts's `emitTableIndexes`, which
-  // uses the same runtime check. (Previously the PR #4471 tracked residual: the
-  // two diverged because the generator had no DB version. Closed by threading
-  // the capability flag from the caller into `generateSchemaFile`.)
   it("emits the same addIndex calls as canonical-schema.ts on mysql 8 (expression index kept)", async () => {
     const [gen, canonMysql8] = await Promise.all([
       generatorIndexes(GENERATOR_SCHEMA, "mysql2", true),
       canonicalIndexes(PARITY_INDEXES, "mysql2", true),
     ]);
-    // All four indexes survive on MySQL 8 (expression kept). Pin the count so
-    // the equality below can't pass vacuously.
     expect(gen).toHaveLength(PARITY_INDEXES.length);
     expect(gen.some((r) => r.columns === PARITY_EXPRESSION_INDEX)).toBe(true);
     expect(normalizeRecorded(gen)).toBe(normalizeRecorded(canonMysql8));

--- a/packages/activerecord/src/support/schema-file-generator.ts
+++ b/packages/activerecord/src/support/schema-file-generator.ts
@@ -52,18 +52,12 @@ function foreignKeysOf(t: TableSchema): ForeignKeySpec[] {
   return isWrapped(t) ? ((t as { foreignKeys?: ForeignKeySpec[] }).foreignKeys ?? []) : [];
 }
 
-// `integer` and `big_integer` both map to an auto-increment serial/identity PK
-// when declared `primaryKey: ["col"]`. Keep in sync with schema-types.ts's
-// isIntegerSpec / serialIdType.
 function isIntegerSpec(spec: ColumnSpec | undefined): boolean {
   if (spec === undefined) return false;
   const type = typeof spec === "string" ? spec : spec.type;
   return type === "integer" || type === "big_integer";
 }
 
-// The `id: { type }` value preserving the declared INTEGER width per adapter:
-// PG `serial`/`bigserial`, MySQL `integer`/`bigint`, SQLite always `integer`
-// (only `INTEGER PRIMARY KEY` aliases the rowid).
 function serialIdType(spec: ColumnSpec | undefined, adapterName?: string): string {
   const type = typeof spec === "string" ? spec : spec?.type;
   const isBig = type === "big_integer";
@@ -117,15 +111,8 @@ function generateCode(
     `export default async function defineSchema(ctx: DatabaseAdapter): Promise<void> {`,
   ];
 
-  // PG/MySQL: loadSchema runs on a shared database that other workers may already
-  // have connected to, so we can't DROP DATABASE. Use force:"cascade" per-table
-  // drop+recreate instead — safe for concurrent workers on a shared DB.
   const needsForce = adapterName === "postgres" || adapterName === "mysql2";
 
-  // A referencing table must go before the table it points at: PG/MySQL below
-  // drop+recreate each table in declaration order, and a live child FK blocks
-  // (MySQL) or cascades away (PG) the parent's drop. Dropping every FK-carrying
-  // table up front keeps the per-table `force: "cascade"` recreate safe.
   if (needsForce) {
     for (const [tableName, tableSpec] of Object.entries(schema)) {
       if (foreignKeysOf(tableSpec).length === 0) continue;
@@ -176,10 +163,6 @@ function generateCode(
     } else {
       lines.push(`  await ctx.createTable(${JSON.stringify(tableName)}, ${tOpts}, (t) => {`);
       for (const [colName, colSpec] of colEntries) {
-        // Emit the single-column integer PK inline at its declared offset.
-        // Preserve the declared INTEGER width per adapter (serialIdType); the
-        // default `primary_key` type widens to BIGINT on MySQL and breaks
-        // integer FK references. Keep in sync with schema-types.ts.
         if (colName === serialPkName) {
           lines.push(
             `    t.column(${JSON.stringify(colName)}, ${JSON.stringify(serialIdType(colSpec, adapterName))}, { primaryKey: true });`,
@@ -201,14 +184,6 @@ function generateCode(
     // characters, e.g. "(lower(external_id))") is gated below.
     for (const index of indexesOf(tableSpec)) {
       const isExpression = typeof index.columns === "string" && /\W/.test(index.columns);
-      // Expression-index gate. The generator has no live adapter, so the caller
-      // threads in `supportsExpressionIndex` (resolved from the DB version) to
-      // match `emitTableIndexes`' runtime `supportsExpressionIndex(adapter)`
-      // check (MySQL >= 8.0.13, SQLite >= 3.9, never MariaDB). When the flag is
-      // omitted, fall back to the coarse `adapterName === "mysql2"` skip — a
-      // last resort for a caller with no live connection. Live callers
-      // (test-setup-dy.ts, template-global-setup.ts) must thread the flag, or
-      // a MySQL-8 worker rebuild strips the canonical expression indexes.
       const dropExpression =
         supportsExpressionIndex !== undefined ? !supportsExpressionIndex : adapterName === "mysql2";
       if (isExpression && dropExpression) continue;

--- a/packages/activerecord/src/support/schema-types.ts
+++ b/packages/activerecord/src/support/schema-types.ts
@@ -1,10 +1,3 @@
-// Residual schema-type vocabulary left after RFC 0059 phase 4 deleted the
-// `defineSchema` DSL (PR #4587). This file no longer defines or emits any
-// schema — it holds only the `ColumnSpec` / `Schema` / `IndexSpec` type family
-// and the small pure helpers (`COLUMN_TYPE_MAP_*`, `serialIdType`, `columnsOf`,
-// `supportsExpressionIndex`, `isWrappedSchema`) that `canonical-schema.ts` and
-// the `TEST_SCHEMA` importers still consume.
-
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 export type PrimitiveColumnSpec =
@@ -147,21 +140,6 @@ const WRAPPER_KEYS = new Set(["columns", "primaryKey", "indexes", "foreignKeys"]
 
 /** @internal */
 export function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
-  // The wrapper and the legacy `Record<colName, ColumnSpec>` shape both
-  // permit a key called `columns`, so discrimination needs an unambiguous
-  // signal. We use the presence of `primaryKey` — the wrapper's sole
-  // purpose is to set a table-level PK, so making it required also
-  // collapses the only ambiguity: a legacy single-column table
-  // `{ columns: { type: "string" } }` is structurally identical to a
-  // wrapper with one column named `type`, but it cannot have `primaryKey`,
-  // so it stays unambiguously legacy.
-  //
-  // Rule:
-  //   1. `columns` is present and an object map.
-  //   2. At least one of `primaryKey` / `indexes` / `foreignKeys` is present
-  //      (the disambiguator from the legacy shape).
-  //   3. Any present `primaryKey` / `indexes` / `foreignKeys` is wrapper-shaped.
-  //   4. No other top-level keys.
   if (!table || typeof table !== "object") return false;
   const candidate = (table as { columns?: unknown }).columns;
   if (!candidate || typeof candidate !== "object") return false;
@@ -171,8 +149,6 @@ export function isWrappedSchema(table: TableSchema): table is WrappedTableSchema
   if (!hasPk && !hasIndexes && !hasForeignKeys) return false;
   if (hasPk) {
     const pk = (table as { primaryKey?: unknown }).primaryKey;
-    // Validate primaryKey is the wrapper-shaped value; otherwise this is a
-    // legacy table that happens to have a column called `primaryKey`.
     if (pk !== false && !Array.isArray(pk)) return false;
     if (Array.isArray(pk) && !pk.every((v) => typeof v === "string")) return false;
   }
@@ -242,8 +218,6 @@ export const COLUMN_TYPE_MAP_PG: Record<AnyPrimitiveColumnSpec, string> = {
   time: "time",
   binary: "binary",
   json: "json",
-  // PG-only types — passed straight through to PostgreSQLAdapter#typeToSql,
-  // which routes them via NATIVE_DATABASE_TYPES.
   citext: "citext",
   hstore: "hstore",
   uuid: "uuid",
@@ -251,20 +225,6 @@ export const COLUMN_TYPE_MAP_PG: Record<AnyPrimitiveColumnSpec, string> = {
   oid: "oid",
 };
 
-// MySQL/MariaDB accepts native DATETIME/DATE/TIME/JSON columns. AR serializes
-// Temporal.PlainTime values for TIME columns, so time attributes round-trip
-// with the correct type. Without native TIME, an introspected TIME-as-VARCHAR
-// resolves to StringType and multiparameter time assignment yields a raw string
-// (same problem that "date: string" caused before PR #4141 fixed it for DATE).
-// json maps to the native MySQL JSON column: mysql2 emits `json` via
-// MysqlSchemaCreation#typeToSql and registers `json` -> JsonType in its type
-// map (abstract-mysql-adapter.ts), so introspected canonical json columns
-// (e.g. admin_users.json_options) resolve to JsonType and round-trip on
-// mysql:8 — the same StringType deviation that afflicted DATE/TIME. `binary`
-// routes through the native BLOB mapping so encrypted binary attributes
-// round-trip (BinaryData-wrapped ciphertext needs a binary column). PG-only
-// types are deliberately absent — this map is keyed by `PrimitiveColumnSpec`,
-// which excludes them.
 /** @internal */
 export const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
   string: "string",
@@ -281,12 +241,6 @@ export const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
   json: "json",
 };
 
-// SQLite has type affinity rules but accepts native datetime/date/time/json
-// type names — they store as TEXT/BLOB under the hood while preserving the
-// declared type for schema reflection (so the type registry resolves to
-// SQLite3DateTime/DateType/TimeType/JsonType on load). datetime/date/time/
-// json all now inherit the native names from COLUMN_TYPE_MAP_MYSQL; `binary`
-// inherits the BLOB mapping likewise.
 /** @internal */
 export const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_MYSQL,

--- a/packages/activerecord/src/support/seed-association-cache.ts
+++ b/packages/activerecord/src/support/seed-association-cache.ts
@@ -12,10 +12,6 @@ import type { Base } from "../base.js";
  * does not require a real reflection — matching `@association_cache`.
  */
 export function seedAssociationCache(record: Base, name: string, target: unknown): void {
-  // A declared association has a real holder — set its target so the genuine
-  // reader / strict-loading logic runs off it. Mark `_explicitTarget` so the
-  // inner-loader short-circuit treats it as an explicit set (matching the old
-  // `_cachedAssociations.set` poke this replaces).
   try {
     const assoc = (
       record as unknown as {
@@ -28,10 +24,7 @@ export function seedAssociationCache(record: Base, name: string, target: unknown
     assoc._setTargetFromLoader(target);
     assoc._explicitTarget = true;
     return;
-  } catch {
-    // Undeclared name (FakeTopic/FakeReply fixtures): fall through to a minimal
-    // loaded holder, the way `@association_cache` tolerates ad-hoc inverses.
-  }
+  } catch {}
   (record as unknown as { _associationInstances: Map<string, unknown> })._associationInstances.set(
     name,
     {

--- a/packages/activerecord/src/support/setup-adapter-suite.trails.test.ts
+++ b/packages/activerecord/src/support/setup-adapter-suite.trails.test.ts
@@ -20,8 +20,6 @@ describe("setupAdapterSuite — schema + transactional rollback", () => {
 
   const a = (): RawAdapter => suite.adapter as unknown as RawAdapter;
 
-  // Sibling tests prove transactional rollback: if the first test's INSERT
-  // weren't rolled back, the second would see two rows after its own INSERT.
   it("first insert is rolled back between tests", async () => {
     await a().exec(`INSERT INTO widgets (id, name) VALUES (1, 'alpha')`);
     const rows = await a().execute(`SELECT * FROM widgets`);
@@ -41,9 +39,6 @@ describe("setupAdapterSuite — schema + transactional rollback", () => {
 });
 
 describe("setupAdapterSuite — close() and teardown semantics", () => {
-  // Shared observability across two sibling describes so we can assert the
-  // helper's afterAll ran (vitest runs afterAll in LIFO order, so a parent
-  // describe's afterAll fires after every child's).
   const defaultCloseSpy = vi.fn(async () => {});
   const defaultTeardown = vi.fn(async () => {});
   const optOutCloseSpy = vi.fn(async () => {});
@@ -88,7 +83,6 @@ describe("setupAdapterSuite — close() and teardown semantics", () => {
     });
   });
 
-  // Runs AFTER both inner describes' afterAlls (vitest LIFO).
   afterAll(async () => {
     expect(defaultTeardown).toHaveBeenCalledTimes(1);
     expect(defaultCloseSpy).toHaveBeenCalledTimes(1);

--- a/packages/activerecord/src/support/sqlite-template.trails.test.ts
+++ b/packages/activerecord/src/support/sqlite-template.trails.test.ts
@@ -148,7 +148,6 @@ describe.skipIf(!isSqliteRun())("sqlite template-clone (Phase 0 probe)", () => {
     const slot = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
     expect(workerDb).toContain(`-${slot}.sqlite`);
 
-    // Also distinct from the shared template — workers write to their own clone.
     expect(workerDb).not.toBe(process.env[TEMPLATE_PATH_ENV]);
   });
 

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -56,9 +56,7 @@ export function unlinkDbFiles(fs: FsAdapter, base: string): void {
   for (const suffix of DB_FILE_SUFFIXES) {
     try {
       fs.unlinkSync(base + suffix);
-    } catch {
-      // already gone / never created — nothing to do.
-    }
+    } catch {}
   }
 }
 
@@ -80,10 +78,6 @@ const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<st
 export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
   const registered = (cleanupG.__arDbCleanupPaths ??= new Set<string>());
   if (registered.has(base)) return;
-  // Claimed before the await so concurrent callers can't both get past the
-  // check, but released again if attaching fails — otherwise a rejected
-  // `getFsAsync()` would mark the path registered with no listener behind it,
-  // silently forfeiting cleanup for the rest of the process.
   registered.add(base);
   try {
     const fs = await getFsAsync();
@@ -113,9 +107,7 @@ async function tempDbEntries(fs: FsAdapter): Promise<string[]> {
 async function unlinkQuietly(fs: FsAdapter, target: string): Promise<void> {
   try {
     await fs.unlink?.(target);
-  } catch {
-    // best-effort
-  }
+  } catch {}
 }
 
 /**
@@ -186,9 +178,6 @@ export async function templatePathFor(runToken: string): Promise<string> {
   return path.join(await tmpRoot(), `ar-test-template-${runToken}.sqlite`);
 }
 
-// Shared across re-evaluations of the worker setupFile within one worker
-// process (isolate:true reloads the module graph per file, but globalThis
-// persists). Lets the restore happen once per worker, not once per file.
 const g = globalThis as typeof globalThis & { __arWorkerDbPath?: string };
 
 /**

--- a/packages/activerecord/src/support/stubbed-ddl-methods.trails.test.ts
+++ b/packages/activerecord/src/support/stubbed-ddl-methods.trails.test.ts
@@ -165,12 +165,9 @@ describe("STUBBED_DDL_METHODS", () => {
   test("covers every adapter member the canonical lay path touches", async () => {
     const touched = await recordLayPath();
 
-    // Floor: a proxy that recorded almost nothing would pass the subset check
-    // vacuously.
     expect(touched.has("execute")).toBe(true);
     expect(touched.has("createTable")).toBe(true);
     expect(touched.has("addIndex")).toBe(true);
-    // Floor: these come back only through the renderer boundary.
     expect(touched.has("quoteTableName")).toBe(true);
     expect(touched.has("nativeDatabaseTypes")).toBe(true);
 

--- a/packages/activerecord/src/support/supports.trails.test.ts
+++ b/packages/activerecord/src/support/supports.trails.test.ts
@@ -2,15 +2,11 @@ import { describe, expect, it } from "vitest";
 import { adapterType } from "../test-adapter.js";
 import { adapterSupports, describeIfSupports, itIfSupports } from "./supports.js";
 
-// Same lane-gated probe supports.ts itself uses — avoids a MySQL connection
-// attempt on the pg/sqlite lanes.
 const mysqlProbe =
   adapterType === "mysql"
     ? await import("./mysql-server-version.js")
     : { supportsExpressionIndex: false, supportsJson: false };
 
-// Assertions are computed from `adapterType` so they hold on every CI lane
-// (sqlite / postgres / mysql:8), not just the default sqlite run.
 describe("adapterSupports", () => {
   it("is true for capabilities available on every backend", () => {
     expect(adapterSupports("savepoints")).toBe(true);
@@ -20,16 +16,11 @@ describe("adapterSupports", () => {
   it("reflects the active adapter for backend-specific capabilities", () => {
     expect(adapterSupports("comments")).toBe(adapterType !== "sqlite");
     expect(adapterSupports("insert_conflict_target")).toBe(adapterType !== "mysql");
-    // json: `!mariadb? && >= 5.7.8` — true off the mysql lane, live-probed on it.
     expect(adapterSupports("json")).toBe(adapterType !== "mysql" || mysqlProbe.supportsJson);
-    // expression_index: PG + SQLite always; the MySQL family follows the live
-    // server (MySQL ≥ 8.0.13 true, MariaDB false) via the mysql test-helper probe.
     expect(adapterSupports("expression_index")).toBe(
       adapterType !== "mysql" || mysqlProbe.supportsExpressionIndex,
     );
-    // advisory_locks: PG + MySQL, not SQLite (mirrors the old skipIf(=== sqlite)).
     expect(adapterSupports("advisory_locks")).toBe(adapterType !== "sqlite");
-    // exclusion/unique constraints: PG only (mirrors skipIf(!== postgres)).
     expect(adapterSupports("exclusion_constraints")).toBe(adapterType === "postgres");
     expect(adapterSupports("unique_constraints")).toBe(adapterType === "postgres");
   });
@@ -39,12 +30,9 @@ describe("adapterSupports", () => {
   });
 
   it("treats a comma-joined key as a conjunction (all features must hold)", () => {
-    // insert_on_duplicate_update is supported everywhere; insert_conflict_target
-    // is the binding constraint (not on mysql), so the conjunction tracks it.
     expect(adapterSupports("insert_conflict_target,insert_on_duplicate_update")).toBe(
       adapterType !== "mysql",
     );
-    // exclusion_constraints is postgres-only → conjunction false off postgres.
     expect(adapterSupports("json,exclusion_constraints")).toBe(adapterType === "postgres");
   });
 
@@ -53,9 +41,6 @@ describe("adapterSupports", () => {
   });
 });
 
-// Smoke: the gate wrappers register without throwing and skip when unsupported.
-// `comments` is unsupported on the sqlite lane (suite skipped there); on
-// PG/MySQL these execute as real assertions.
 describeIfSupports("comments", "comments-gated suite", () => {
   it("runs only where comments are supported", () => {
     expect(adapterSupports("comments")).toBe(true);

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -53,12 +53,6 @@ import { inMemoryDb } from "./adapter-helper.js";
 const ALL = ["postgres", "mysql", "sqlite"] as const;
 type Backend = (typeof ALL)[number];
 
-// The MySQL-family `supports_*?` predicates that branch on `mariadb?` /
-// `database_version` have no static answer: the mysql lane runs MySQL 8 locally
-// but a MariaDB stand-in in CI, and the two disagree. Probe the server once, on
-// the mysql lane only — the dynamic import keeps the probe's connection attempt
-// off the pg/sqlite lanes, where the literals below stand in for a lane that
-// never asks.
 const mysql =
   adapterType === "mysql"
     ? await import("./mysql-server-version.js")
@@ -79,7 +73,6 @@ function withMysql(base: readonly Backend[], supported: boolean): readonly Backe
 }
 
 const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
-  // Available on every backend we test (pg17 / mysql:8 / recent sqlite).
   savepoints: ALL,
   foreign_keys: ALL,
   // `supports_check_constraints?`: MySQL ≥ 8.0.16; MariaDB ≥ 10.3.10 or
@@ -88,14 +81,11 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // `supports_json?`: `!mariadb? && database_version >= "5.7.8"`
   // (mysql2_adapter.rb:70).
   json: withMysql(["postgres", "sqlite"], mysql.supportsJson),
-  // SQL-standard COMMENT ON / inline column comments — not SQLite.
   comments: ["postgres", "mysql"],
   // `supports_concurrent_connections?`: `!@memory_database` on SQLite
   // (sqlite3_adapter.rb:198), true elsewhere — so it is config-derived, not
   // adapter-keyed: only the `sqlite3_mem` lane is `:memory:`.
   concurrent_connections: inMemoryDb() ? ["postgres", "mysql"] : ALL,
-  // `ON CONFLICT (target)` — Postgres/SQLite only; MySQL has no conflict
-  // target. Matches `adapterType !== "mysql"` in insert-all.test.ts.
   insert_conflict_target: ["postgres", "sqlite"],
   // Rails `supports_advisory_locks?`: PostgreSQL + MySQL true, SQLite false
   // (abstract default). (postgresql_adapter.rb:420, abstract_mysql_adapter.rb:161)
@@ -220,9 +210,6 @@ export const SUPPORTS_FEATURES: readonly string[] = Object.keys(SUPPORTS);
  */
 export function adapterSupports(feature: string): boolean {
   if (feature.includes(",")) {
-    // Resolve every member before folding: `.every()` short-circuits on the
-    // first false, which would let an unknown key downstream of an unsupported
-    // one pass silently on exactly the lanes where the typo matters.
     const answers = feature.split(",").map((f) => adapterSupports(f.trim()));
     return answers.every(Boolean);
   }

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -49,14 +49,6 @@ import {
 } from "./config.js";
 import { activeLane } from "./connection.js";
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-// Provision one slot DB per advisory-lock slot. The pool is sized with headroom
-// over the worker count (see ar-db-slots.ts), so workers recycling between files
-// always find a free slot. Single-worker runs don't slot, so they need only the
-// base DB.
 function slotCount(): number {
   return workerForkCount() <= 1 ? 1 : slotPoolSize();
 }
@@ -84,11 +76,6 @@ async function pooledTemplateAdapter(
   return { adapter: await pool.leaseConnection(), pool };
 }
 
-// Lay the canonical schema and stamp it, so the worker that claims this
-// database reports `canonicalSchemaUpToDate` and boots on the TRUNCATE fast
-// path instead of purging and re-laying what globalSetup just laid. The run
-// token is passed explicitly because `RUN_TOKEN_ENV` is only published to the
-// environment after provisioning finishes.
 async function buildTemplateSchema(
   adapter: DatabaseAdapter,
   runToken: string,
@@ -101,10 +88,6 @@ async function buildTemplateSchema(
     await close();
   }
 }
-
-// ---------------------------------------------------------------------------
-// Adapter interface
-// ---------------------------------------------------------------------------
 
 /**
  * Per-adapter template-clone strategy. Each adapter checks whether it is
@@ -120,10 +103,6 @@ interface DbTemplateAdapter {
    */
   provision(): Promise<(() => Promise<void>) | undefined>;
 }
-
-// ---------------------------------------------------------------------------
-// SQLite adapter
-// ---------------------------------------------------------------------------
 
 let _sqliteBuilds = 0;
 
@@ -160,12 +139,6 @@ const sqliteAdapter: DbTemplateAdapter = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// PostgreSQL adapter
-// ---------------------------------------------------------------------------
-
-// Set to the template DB name once globalSetup has built and stamped it; unset
-// means the PG template path did not run (sqlite/MySQL run, or globalSetup off).
 export const PG_TEMPLATE_ENV = "AR_TEST_PG_TEMPLATE";
 
 async function pgTerminateConnections(admin: pg.Client, dbName: string): Promise<void> {
@@ -182,8 +155,6 @@ async function pgDatabaseNames(admin: pg.Client): Promise<string[]> {
 }
 
 async function pgDropDatabases(admin: pg.Client, names: string[]): Promise<void> {
-  // Sequential: DROP DATABASE takes an exclusive lock on the server's shared
-  // catalogs, so concurrent drops serialize anyway and only add deadlock risk.
   for (const name of names) {
     await pgTerminateConnections(admin, name);
     await admin.query(`DROP DATABASE IF EXISTS ${quotePgDatabaseName(name)}`);
@@ -195,22 +166,13 @@ const pgAdapter: DbTemplateAdapter = {
 
   async provision() {
     const settings = postgresSettings();
-    // Unstamped, because nothing has stamped `RUN_TOKEN_ENV` yet: `applySlot`
-    // falls through to the bare `activerecord_unittest` in the main process.
-    // That bare name is the *base* every per-run name is built from — it is
-    // never itself provisioned or dropped.
     const base = settings.database;
     const runToken = newRunToken();
     const templateDb = `${runDatabasePrefix(base, runToken)}template`;
 
-    // Derive both connections from the settings rather than rewriting the URL
-    // string: a socket-directory PGHOST does not survive `new URL()` surgery.
     const admin = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
     await admin.connect();
 
-    // Reclaim what killed runs left behind, before anything of this run exists
-    // — the PG analogue of `sweepStaleDbFiles`. Only foreign tokens older than
-    // the cutoff, so a concurrent run's live databases are out of reach.
     await pgDropDatabases(admin, staleRunDatabases(base, runToken, await pgDatabaseNames(admin)));
 
     await admin.query(`CREATE DATABASE ${quotePgDatabaseName(templateDb)}`);
@@ -223,28 +185,15 @@ const pgAdapter: DbTemplateAdapter = {
     });
     try {
       await loadSchema(adapter);
-      // Stamp ar_internal_metadata so every slot cloned from this template
-      // reports `canonicalSchemaUpToDate` → the worker that claims it only
-      // TRUNCATEs (no DDL) instead of paying a full purge+reload. The run token
-      // is passed explicitly: it is published to the environment further down,
-      // after the slot DBs exist.
       await stampCanonicalSchema(adapter, runToken);
     } finally {
-      // Teardown must not mask a build/stamp failure: if the loader threw,
-      // a disconnect/terminate that also throws would replace the original
-      // error. Swallow teardown errors so the meaningful one always surfaces.
       try {
         pool.releaseConnection();
         await pool.disconnectBang();
         await pgTerminateConnections(admin, templateDb);
-      } catch {
-        // best-effort cleanup; the template DB is dropped at teardown anyway
-      }
+      } catch {}
     }
 
-    // No DROP in front of the CREATE: the names carry this run's token, so
-    // nothing can be occupying them — and a DROP here could only ever hit
-    // another run's live database.
     for (let slot = 1; slot <= slotCount(); slot++) {
       const slotDb = slotDatabaseName(base, runToken, slot);
       await admin.query(
@@ -259,9 +208,6 @@ const pgAdapter: DbTemplateAdapter = {
     return async () => {
       const cleanup = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
       await cleanup.connect();
-      // Every database this run created — the template, the slot DBs, and the
-      // `_arunit2` siblings suites create off a slot name — shares the run's
-      // prefix, so one filtered sweep reclaims the lot.
       await pgDropDatabases(
         cleanup,
         ownRunDatabases(base, runToken, await pgDatabaseNames(cleanup)),
@@ -271,21 +217,9 @@ const pgAdapter: DbTemplateAdapter = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// MySQL/MariaDB adapter
-// ---------------------------------------------------------------------------
-//
-// MySQL has no CREATE DATABASE … TEMPLATE primitive, so we can't clone. We
-// instead run defineSchema(TEST_SCHEMA) directly against each slot DB in
-// globalSetup. Same DDL cost as the current per-file preload, but moved to
-// before any worker forks — test-setup-dy.ts can then seed signatures and
-// make every subsequent per-file defineSchema(TEST_SCHEMA) a cache-hit.
-
 export const MYSQL_TEMPLATE_ENV = "AR_TEST_MYSQL_TEMPLATE";
 
 async function mysqlDatabaseNames(admin: mysql.Connection): Promise<string[]> {
-  // Aliased: MySQL and MariaDB disagree on the case of `SCHEMA_NAME` in the
-  // result set, and `SHOW DATABASES` names its column `Database`.
   const [rows] = await admin.query<mysql.RowDataPacket[]>(
     "SELECT schema_name AS name FROM information_schema.schemata",
   );
@@ -304,26 +238,17 @@ const mysqlAdapter: DbTemplateAdapter = {
   async provision() {
     const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
     const settings = mysqlSettings();
-    // Unstamped in the main process, exactly as on the PG path above.
     const baseDb = settings.database;
     const runToken = newRunToken();
     const n = slotCount();
 
-    // Built from the config hash rather than a URL so a socket-configured run
-    // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
-    // This connection is opened against the `mysql2` driver directly rather than
-    // through Mysql2Adapter, so it does not get the adapter's `username` → `user`
-    // or `socket` → `socketPath` mappings — spell the driver-native keys here.
     const { database: _adminDb, username, socket, ...adminOpts } = driverConfig(settings);
     const adminOptions = {
       ...adminOpts,
       user: username,
       ...(socket === undefined ? {} : { socketPath: socket }),
     } as mysql.ConnectionOptions;
-    // CREATE DATABASE for all slots first (sequential — DDL against the same
-    // server, CREATE must not race with itself).
     const admin = await mysql.createConnection(adminOptions);
-    // Stale sweep, as on the PG path above.
     await mysqlDropDatabases(
       admin,
       staleRunDatabases(baseDb, runToken, await mysqlDatabaseNames(admin)),
@@ -336,10 +261,6 @@ const mysqlAdapter: DbTemplateAdapter = {
     }
     await admin.end();
 
-    // Run defineSchema against each slot DB in parallel — each slot is an
-    // independent DB so there are no cross-slot conflicts. This mirrors how
-    // the old per-worker preload ran DDL in parallel across forks, keeping
-    // wall-clock cost at ~1× rather than N× sequential.
     await Promise.all(
       Array.from({ length: n }, (_, i) => i + 1).map(async (slot) => {
         const slotSettings = withDatabase(settings, slotDatabaseName(baseDb, runToken, slot));
@@ -369,10 +290,6 @@ const mysqlAdapter: DbTemplateAdapter = {
     };
   },
 };
-
-// ---------------------------------------------------------------------------
-// Dispatch
-// ---------------------------------------------------------------------------
 
 const ADAPTERS: DbTemplateAdapter[] = [sqliteAdapter, pgAdapter, mysqlAdapter];
 

--- a/packages/activerecord/src/support/template-stamp.trails.test.ts
+++ b/packages/activerecord/src/support/template-stamp.trails.test.ts
@@ -51,16 +51,8 @@ describe.skipIf(!sqliteActive)("sqlite template stamp", () => {
 
 describe.skipIf(!runToken)("boot fast path stamp", () => {
   it("leaves the database stamped for the next worker recycled onto it", async () => {
-    // Replays `test-setup-dy.ts`'s fast-path arm verbatim. `resetTestTables`
-    // drops `ar_internal_metadata` along with the other bookkeeping tables, so
-    // without the re-stamp that arm ends with, the stamp is single-use per
-    // database and every recycled worker pays the full purge+reload. Running
-    // the arm here is safe: it is the same reset the suite runs at worker boot,
-    // and it re-lays the adapter-specific tables it drops.
     const connection = await Base.leaseConnection();
     await resetTestTables(connection);
-    // The hazard the re-stamp answers, asserted rather than assumed: the reset
-    // takes the stamp with it, so the arm is not self-sustaining without it.
     expect(await canonicalSchemaUpToDate(connection)).toBe(false);
 
     await loadAdapterSpecificSchema(connection);
@@ -71,10 +63,6 @@ describe.skipIf(!runToken)("boot fast path stamp", () => {
 
 describe.skipIf(!runToken)("adapter-specific tables snapshot", () => {
   it("records the carried-forward set, not what the live database happens to hold", async () => {
-    // The fast path skips the adapter-specific arm when the snapshot is intact,
-    // so the snapshot must not shrink to whatever a test file left behind. A
-    // re-stamp that took a fresh snapshot here would drop `defaults` from the
-    // recorded set for every later file, with nothing left to re-lay it.
     const connection = await Base.leaseConnection();
     const before = await adapterSpecificTables(connection);
     expect(before, "boot must have recorded a snapshot").not.toBeNull();
@@ -112,8 +100,6 @@ describe.skipIf(!runToken)("snapshot value width", () => {
   });
 
   it("a shrinking snapshot does not read back the chunks it no longer uses", async () => {
-    // The chunk rows a wider snapshot wrote survive the narrower one that
-    // replaces it, so the count row — written last — is what bounds the read.
     const connection = await Base.leaseConnection();
     const before = await adapterSpecificTables(connection);
     try {


### PR DESCRIPTION
Slice of the `no-freeform-comments` sweep covering
`packages/activerecord/src/support/**/*.ts` (follow-on to
`strip-freeform-comments-activerecord`, which swept `src/relation/**`).

- Adds the glob to the `blazetrails/no-freeform-comments` block in
  `eslint.config.mjs`.
- Applies the autofix: 211 free-form comment blocks removed across 42 files.
  Deletions reviewed rather than taken on trust — no comment carrying a Rails
  `.rb:LINE` citation, a JSDoc tag, or a tool directive was removed, and no
  deleted comment recorded outstanding deferred work (the two that mention a
  divergence describe already-tracked residuals covered by tests in the same
  files), so no follow-up story was needed.
- Blocks emptied by a deletion are expressed in code as `catch {}` — the shape
  `drop-all-tables.ts` already used — rather than by restoring the comment.

`pnpm eslint` is clean over the glob and a second `--fix` run is a no-op;
`pnpm typecheck` is clean; `pnpm vitest run packages/activerecord/src/support`
is green (259 passed, 6 skipped).

Closes-story: strip-freeform-comments-ar-support
