### PR TITLE
refactor(activerecord): strip freeform comments from src/a*.ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -740,6 +740,9 @@ export default defineConfig(
       "packages/activemodel/src/**/*.ts",
       "packages/activerecord/src/relation/**/*.ts",
       "packages/activerecord/src/support/**/*.ts",
+      // activerecord/src root files, swept alphabetically one slice per PR
+      // (story strip-freeform-comments-ar-root-b onward for the rest).
+      "packages/activerecord/src/a*.ts",
       "packages/activerecord/src/connection-adapters/mysql/**/*.ts",
       "packages/activerecord/src/connection-adapters/mysql2/**/*.ts",
       "packages/activerecord/src/connection-adapters/postgresql/**/*.ts",

--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -22,7 +22,6 @@ afterAll(() => {
 });
 
 describe("ActiveRecordSchemaTest", () => {
-  // Ride the primary schema-loaded pool via `Base.connection`.
   fixtures({}, { useTransactionalTests: false });
 
   let adapter: DatabaseAdapter;
@@ -64,13 +63,11 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("schema without version is the current version schema", () => {
-    // Schema class exists and can be instantiated
     const s = new Schema(adapter);
     expect(s).toBeInstanceOf(Schema);
   });
 
   it("schema version accessor", () => {
-    // Migration instances have a version property
     class V1 extends Migration {
       async change() {}
     }
@@ -85,7 +82,6 @@ describe("ActiveRecordSchemaTest", () => {
         t.integer("count");
       });
     });
-    // Verify table exists
     await adapter.executeMutation(
       `INSERT INTO "schema_test" ("title", "count") VALUES ('hello', 1)`,
     );
@@ -120,13 +116,11 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("schema raises an error for invalid column type", () => {
-    // TableDefinition doesn't have a method for an invalid type; calling a nonexistent method should throw
     const td = new TableDefinition("test_invalid", { adapter });
     expect(() => (td as any).unknownType("col")).toThrow();
   });
 
   it("schema subclass", () => {
-    // Schema can be extended
     class MySchema extends Schema {}
     const s = new MySchema(adapter);
     expect(s).toBeInstanceOf(Schema);
@@ -148,14 +142,12 @@ describe("ActiveRecordSchemaTest", () => {
         t.index(["email"], { name: "idx_email_2", unique: true });
       });
     });
-    // Verify table and indexes created without error
     await adapter.executeMutation(`INSERT INTO "multi_idx" ("email") VALUES ('test@test.com')`);
     const rows = await adapter.execute(`SELECT * FROM "multi_idx"`);
     expect(rows.length).toBe(1);
   });
 
   it.skipIf(adapterType !== "postgres")("timestamps with and without zones", async () => {
-    // TableDefinition timestamps creates created_at and updated_at as datetime
     const td = new TableDefinition("tz_test", { adapter });
     td.timestamps();
     const colNames = td.columns.map((c) => c.name);
@@ -169,7 +161,6 @@ describe("ActiveRecordSchemaTest", () => {
     const td = new TableDefinition("ts_default", { adapter });
     td.timestamps();
     const createdAt = td.columns.find((c) => c.name === "created_at");
-    // timestamps sets null: false by default
     expect(createdAt!.options.null).toBe(false);
   });
 
@@ -199,7 +190,6 @@ describe("ActiveRecordSchemaTest", () => {
     const m = new TsMig();
     m.connection = adapter;
     await m.up();
-    // Verify timestamps were added
     await adapter.executeMutation(
       `INSERT INTO "ts_change" ("name", "created_at", "updated_at") VALUES ('test', '2023-01-01', '2023-01-01')`,
     );
@@ -262,7 +252,6 @@ describe("ActiveRecordSchemaTest", () => {
     const m = new TsOptMig();
     m.connection = adapter;
     await m.up();
-    // null: true means we can insert without providing timestamp values
     await adapter.executeMutation(`INSERT INTO "ts_opts" ("name") VALUES ('test')`);
     const rows = await adapter.execute(`SELECT * FROM "ts_opts"`);
     expect(rows.length).toBe(1);
@@ -285,7 +274,6 @@ describe("ActiveRecordSchemaTest", () => {
     const m = new AddTsMig();
     m.connection = adapter;
     await m.up();
-    // Verify timestamps were added
     await adapter.executeMutation(
       `INSERT INTO "ts_add" ("name", "created_at", "updated_at") VALUES ('test', '2023-01-01', '2023-01-01')`,
     );

--- a/packages/activerecord/src/adapter-connection.trails.test.ts
+++ b/packages/activerecord/src/adapter-connection.trails.test.ts
@@ -54,7 +54,6 @@ class LifecycleTestAdapter extends AbstractAdapter {
   }
 }
 
-// Adapter that intercepts selectAll to capture allowRetry and simulate reconnects.
 class QueryTestAdapter extends LifecycleTestAdapter {
   capturedAllowRetry: boolean | undefined;
   failOnce = false;
@@ -89,7 +88,6 @@ class QueryTestAdapter extends LifecycleTestAdapter {
   }
 }
 
-// Minimal Post model for retryable-classification tests.
 class PostForRetryTest extends Base {
   static {
     this.attribute("title", "string");
@@ -103,13 +101,10 @@ describe("AdapterConnection retryable classification (trails-only)", () => {
     adapter.simulateConnect();
     PostForRetryTest.adapter = adapter as unknown as DatabaseAdapter;
 
-    // The raw-SQL WHERE makes the SELECT non-retryable, and the retryable
-    // from() node must not raise it back (regression: collector reset).
     const fromNode = new Nodes.SqlLiteral("posts", { retryable: true });
     await PostForRetryTest.where("1 = 1").from(fromNode).limit(1);
     expect(adapter.capturedAllowRetry).toBe(false);
 
-    // A fully retryable query with a from(Arel node) stays retryable.
     await PostForRetryTest.where({ id: 1 }).from(fromNode).limit(1);
     expect(adapter.capturedAllowRetry).toBe(true);
 
@@ -120,8 +115,6 @@ describe("AdapterConnection retryable classification (trails-only)", () => {
     await PostForRetryTest.where({ id: 1 }).from(rawFromNode).limit(1);
     expect(adapter.capturedAllowRetry).toBe(false);
 
-    // from(Relation) compiles its subquery separately too — a non-retryable
-    // fragment inside the subquery must lower the outer classification.
     const rawSubquery = PostForRetryTest.where("1 = 1");
     await PostForRetryTest.where({ id: 1 }).from(rawSubquery, "sub").limit(1);
     expect(adapter.capturedAllowRetry).toBe(false);
@@ -164,9 +157,7 @@ class ReconnectLifecycleAdapter extends AbstractAdapter {
   disconnectCalls = 0;
   failConfigure = false;
   reconnectCalls = 0;
-  // Number of leading reconnect() calls that should throw before succeeding.
   reconnectFailures = 0;
-  // Error thrown by the failing reconnect() attempts.
   reconnectError: () => Error = () => new ConnectionFailed("connection reset");
 
   override reconnect(): void {
@@ -261,7 +252,6 @@ describe("AbstractAdapter reconnect/verify lifecycle", () => {
     a.reconnectFailures = 99;
 
     await expect(a.reconnectBang()).rejects.toBeInstanceOf(ConnectionFailed);
-    // Initial attempt plus connectionRetries (2) retries.
     expect(a.reconnectCalls).toBe(3);
     expect((a as unknown as { _verified: boolean })._verified).toBe(false);
     expect((a as unknown as { _lastActivity: number })._lastActivity).toBe(0);

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -24,8 +24,6 @@ import { adapterType } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import { itIfSupports } from "./support/supports.js";
 import { runWithoutConnection } from "./support/connection-helper.js";
-// Opt into the canonical-model autoload index so association targets resolve by
-// name on first reference — no manual `registerModel`.
 import "./support/canonical-model-index.js";
 import { Book } from "./test-helpers/models/book.js";
 import { Post } from "./test-helpers/models/post.js";
@@ -89,11 +87,6 @@ async function roundTripBinds(conn: DatabaseAdapter, binds: unknown[]): Promise<
 // adapter's lazy-transaction bookkeeping).
 async function rawTransactionOpen(conn: DatabaseAdapter): Promise<boolean> {
   if (adapterType === "postgres") {
-    // ruby-pg reads `raw_connection.transaction_status == PG::PQTRANS_INTRANS`.
-    // node-postgres' pg.Client exposes no transaction_status, but the PG
-    // adapter flips `_inTransaction` in the very code path that issues
-    // BEGIN/COMMIT/ROLLBACK on the raw client, so it faithfully tracks whether
-    // a transaction is live on the raw connection.
     return Boolean((conn as unknown as { _inTransaction?: boolean })._inTransaction);
   }
   if (adapterType === "mysql") {
@@ -216,7 +209,6 @@ async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
       return false;
     }
   }
-  // SQLite (not reached: remote-disconnect cases are gated on remoteSupported).
   return conn.active();
 }
 
@@ -226,10 +218,6 @@ async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
 describe("AdapterTest", () => {
   fixtures(["accounts", "authors", "tasks", "topics", "subscribers", "posts", "books"], {
     usesTransaction: [
-      // Raise a DB error mid-statement (aborts an open PG transaction, poisoning
-      // transactional teardown) — run un-wrapped; they persist nothing. The
-      // index tests' add_index/remove_index commit (DDL auto-commits on MySQL),
-      // so they too run outside the shared transaction (cleanup in a finally).
       "value limit violations are translated to specific exception",
       "numeric value out of ranges are translated to specific exception",
       "uniqueness violations are translated to specific exception",
@@ -238,7 +226,6 @@ describe("AdapterTest", () => {
       "indexes",
       "remove index when name and wrong column name specified",
       "remove index when name and wrong column name specified positional argument",
-      // Re-establishes `Base`, swapping the pool out from under the fixture pin.
       "disable prepared statements",
     ],
   });
@@ -264,7 +251,6 @@ describe("AdapterTest", () => {
   it("create record with pk as zero", async () => {
     await Book.create({ id: 0 });
     expect((await Book.find(0)).id).toBe(0);
-    // assert_nothing_raised: a throw here fails the test.
     await Book.destroy(0);
   });
 
@@ -364,10 +350,6 @@ describe("AdapterTest", () => {
     }
   });
 
-  // current database (gated by respond_to?(:current_database)) lives in the
-  // MySQL-gated AdapterTest block below (MySQL) and adapters/postgresql/
-  // adapter.test.ts (PG).
-
   it("#exec_query queries with no result set return an empty ActiveRecord::Result", async () => {
     const result = await Base.connection.execQuery("INSERT INTO subscribers(nick) VALUES('me')");
     expect(result).toBeInstanceOf(Result);
@@ -381,9 +363,6 @@ describe("AdapterTest", () => {
     expect(result.rows).toEqual([]);
     expect(result.columns.length).toBeGreaterThan(0);
   });
-
-  // charset / collation / show-variable / cross-database-selects (MySQL-only)
-  // live in the MySQL-gated AdapterTest block below.
 
   // Rails gates this `unless in_memory_db?` (adapter_test.rb:176): a
   // re-established `:memory:` connection is a fresh, empty database.
@@ -588,11 +567,8 @@ describe("AdapterForeignKeyTest", () => {
 
   it("disable referential integrity", async () => {
     const conn = Base.connection;
-    // assert_nothing_raised: a throw inside the block fails the test.
     await conn.disableReferentialIntegrity(async () => {
       await insertIntoFkTestHasFk();
-      // delete created record as otherwise disableReferentialIntegrity will
-      // try to enable constraints after the block and fail.
       await conn.executeMutation("DELETE FROM fk_test_has_fk");
     });
   });
@@ -619,7 +595,6 @@ describe("AdapterTestWithoutTransaction", () => {
     const conn = Base.connection;
     conn.enableQueryCacheBang();
     try {
-      // posts fixtures are loaded (e.g. "welcome"), so the count is fixture-backed.
       expect(posts("welcome").id).toBeGreaterThan(0);
       const count = (await Post.count()) as number;
 
@@ -759,7 +734,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     usesTransaction: nonTransactional,
   });
 
-  // remote_disconnect / kill_connection_from_server are MySQL/PG-only.
   const remoteSupported = adapterType !== "sqlite";
 
   // Cases blocked on genuine trails PG/MySQL adapter divergences that the faithful
@@ -890,18 +864,13 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     async () => {
       await remoteDisconnect(connection);
 
-      connection.cleanBang(); // this simulates a fresh checkout from the pool
+      connection.cleanBang();
 
-      // Backdate last activity to simulate a connection we haven't used in a while
       (connection as unknown as { _lastActivity: number })._lastActivity =
         Date.now() - 5 * 60 * 1000;
 
-      // Clean did not verify / fix the connection
       expect(await activePredicate(connection)).toBe(false);
 
-      // Because the connection hasn't been verified since checkout, and the
-      // query cannot safely be retried, the connection is verified before
-      // querying.
       await Post.deleteAll();
 
       expect(await connection.active()).toBe(true);
@@ -913,14 +882,10 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     async () => {
       await remoteDisconnect(connection);
 
-      connection.cleanBang(); // this simulates a fresh checkout from the pool
+      connection.cleanBang();
 
-      // Clean did not verify / fix the connection
       expect(await activePredicate(connection)).toBe(false);
 
-      // Because the query cannot be retried, and we (mistakenly) believe the
-      // connection is still good, the query fails — the alternative would be
-      // excessive reverification.
       await expect(Post.deleteAll()).rejects.toBeInstanceOf(AdapterError);
     },
   );
@@ -930,14 +895,13 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     async () => {
       await remoteDisconnect(connection);
 
-      connection.cleanBang(); // this simulates a fresh checkout from the pool
+      connection.cleanBang();
 
       (connection as unknown as { _lastActivity: number })._lastActivity =
         Date.now() - 5 * 60 * 1000;
 
       expect(await activePredicate(connection)).toBe(false);
 
-      // Quote string will not verify a broken connection.
       connection.quoteString("");
 
       await Post.deleteAll();
@@ -949,7 +913,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
   it.skipIf(!remoteSupported)(
     "querying after a failed non-retryable query restores and succeeds",
     async () => {
-      await Post.first(); // Connection verified (and prepared statement pool populated)
+      await Post.first();
 
       await remoteDisconnect(connection);
 
@@ -957,7 +921,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
         connection.execute("INSERT INTO posts(title, body) VALUES ('foo', 'bar')"),
       ).rejects.toBeInstanceOf(ConnectionFailed);
 
-      expect(await Post.first()).toBeTruthy(); // Verifying causes a reconnect and the query succeeds
+      expect(await Post.first()).toBeTruthy();
       expect(await connection.active()).toBe(true);
     },
   );
@@ -1046,12 +1010,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     expect(await connection.active()).toBe(true);
   });
 
-  // Runs on every remote-capable adapter (PG + MySQL/MariaDB). #4935 closed the
-  // two MySQL divergences that used to gate this to PG: (1) Mysql2Adapter now
-  // overrides `verifyBang` to probe with a real `active?`-style ping
-  // (`active()`) so it detects the server-side kill and reconnects, and
-  // (2) `isMysql2ConnectionError` now maps the mysql2 driver's "Can't add new
-  // command when connection is in closed state" to `ConnectionFailed`.
   it.skipIf(!remoteSupported)(
     "active transaction is restored after remote disconnection",
     async () => {
@@ -1060,8 +1018,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
         await connection.materializeTransactions();
         await remoteDisconnect(connection);
 
-        // Regular queries are not retryable, so the only abstract operation we
-        // can perform here is a direct verify.
         await connection.verifyBang();
 
         await Post.deleteAll();
@@ -1070,8 +1026,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
         throw new Rollback();
       });
 
-      // The deletion occurred within the outer (rolled-back) transaction, not
-      // directly on the freshly-reestablished connection, so the posts remain:
       expect((await Post.count()) as number).toBeGreaterThan(0);
     },
   );
@@ -1089,10 +1043,8 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
         }),
       ).rejects.toBeInstanceOf(ConnectionFailed);
 
-      expect(invocations).toBe(1); // the whole transaction block is not retried
+      expect(invocations).toBe(1);
 
-      // After the (outermost) transaction block failed, the connection is ready
-      // to reconnect on next use, but hasn't done so yet.
       expect(await activePredicate(connection)).toBe(false);
       expect((await Post.count()) as number).toBeGreaterThan(0);
     },
@@ -1151,9 +1103,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     const pool = (connection as unknown as { pool: { newConnection(): DatabaseAdapter } }).pool;
     const fresh = pool.newConnection();
     try {
-      // The pool may hand back an already-connected adapter (sync drivers open
-      // eagerly), which would have run configure_connection before our override
-      // is installed. Disconnect so the first query reconnects and re-runs it.
       fresh.disconnectBang();
       // Rails relies on the default connection_retries (1); trails' getter
       // defaults to 1 too (abstract-adapter.ts:1581), so no explicit set needed.
@@ -1223,8 +1172,6 @@ describe("InvalidateTransactionTest", () => {
         }
       });
 
-      // asserting outside of the transaction to make sure we actually reach the
-      // end of the test and perform the assertion
       expect(invalidated).toBe(true);
     },
   );

--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -303,9 +303,6 @@ describe("lazy composed_of inclusion", () => {
     class Plain extends Base {}
     expect(own(Plain, "reload")).toBe(false);
     expect(own(Plain, "initializeDup")).toBe(false);
-    // Its reload is the inherited AutosaveAssociation#reload wrapper (which
-    // delegates to Persistence#reload), not an aggregation-cache wrapper. The
-    // aggregation wrapper is only mixed in by composed_of.
     expect(Plain.prototype.reload).toBe(Base.prototype.reload);
     expect(Plain.prototype.reload).not.toBe(persistenceReload);
   });
@@ -338,10 +335,8 @@ describe("lazy composed_of inclusion", () => {
         composedOf(this, "credit", { className: Money, mapping: [["credit", "amount"]] });
       }
     }
-    // `self < Aggregations` is already true via inheritance, so no own override.
     expect(own(SubPriced, "reload")).toBe(false);
     expect(own(SubPriced, "initializeDup")).toBe(false);
-    // But it still inherits the composed_of overrides from Priced.
     expect(SubPriced.prototype.reload).toBe(Priced.prototype.reload);
     expect(SubPriced.prototype.reload).not.toBe(persistenceReload);
   });

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -8,10 +8,6 @@ import { assertValidKeys, camelize, constantize, prepend } from "@blazetrails/ac
  * Mirrors: ActiveRecord::Aggregations
  */
 
-// ---------------------------------------------------------------------------
-// Cache accessors
-// ---------------------------------------------------------------------------
-
 export function getAggregationCache(record: Base): Map<string, unknown> {
   const self = record as any;
   if (!self._aggregationCache) self._aggregationCache = new Map<string, unknown>();
@@ -25,10 +21,6 @@ export function clearAggregationCache(record: Base): void {
     (self._aggregationCache as Map<string, unknown>).clear();
   }
 }
-
-// ---------------------------------------------------------------------------
-// ClassMethods
-// ---------------------------------------------------------------------------
 
 interface ComposedOfOptions {
   /**
@@ -246,10 +238,6 @@ function writerMethod(
     configurable: true,
   });
 }
-
-// ---------------------------------------------------------------------------
-// Instance methods
-// ---------------------------------------------------------------------------
 
 /**
  * Give the dup an independent shallow copy of the source's aggregation cache.

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -25,9 +25,6 @@ describe("AnnotateTest", () => {
   });
 
   it("annotate is sanitized", async () => {
-    // Each annotation is routed through `sanitize_as_sql_comment`, so embedded
-    // `*/` / `/*` are spaced apart and can never break out of the wrapping
-    // comment.
     await assertQueriesMatch(
       /SELECT .* FROM .* \/\* \* \/foo\/ \* \*\//i,
       undefined,

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -21,8 +21,6 @@ type AnyClass = abstract new (...args: never[]) => object;
 export function isSchemaCacheIgnoredTable(tableName: string): boolean {
   for (const entry of ActiveRecord.schemaCacheIgnoredTables) {
     if (entry instanceof RegExp) {
-      // Reset lastIndex so /g and /y patterns don't alternate between
-      // matches across calls (same precaution SchemaDumper#isIgnored takes).
       entry.lastIndex = 0;
       if (entry.test(tableName)) return true;
     } else if (entry === tableName) {

--- a/packages/activerecord/src/association-cache.test.ts
+++ b/packages/activerecord/src/association-cache.test.ts
@@ -7,7 +7,6 @@ describe("association cache fold", () => {
     cache.instances.set("posts", { kind: "instance" });
     cache.proxies.set("posts", { kind: "proxy" });
 
-    // One backing slot per name.
     expect(cache.store.size).toBe(1);
     expect(cache.instances.get("posts")).toEqual({ kind: "instance" });
     expect(cache.proxies.get("posts")).toEqual({ kind: "proxy" });
@@ -28,7 +27,6 @@ describe("association cache fold", () => {
     expect(cache.instances.delete("a")).toBe(true);
     expect(cache.instances.has("a")).toBe(false);
     expect(cache.instances.delete("a")).toBe(false);
-    // Slot dropped once empty.
     expect(cache.store.size).toBe(0);
   });
 

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -78,12 +78,9 @@ describe("AssociationsTest", () => {
     // in-memory target before the reload — exercises the CPK reconciliation path.
     const order = await CpkOrder.create({ shop_id: 1, status: "paid" });
     const book = await (order as any).books.create({ id: [3, 4], title: "Book" });
-    // Update the book in DB behind the in-memory instance so persisted/in-memory diverge
     const dbBook = await CpkBook.where({ author_id: 3, id: 4 }).first();
     await dbBook!.updateColumns({ title: "A different title" });
-    // Reload the association — must reconcile the existing in-memory book by CPK
     await (order as any).books.load();
-    // CPK identity of the in-memory book is preserved after reload
     expect(book.id).toEqual([3, 4]);
   });
 });
@@ -228,9 +225,6 @@ describe("AssociationProxyTest", () => {
     expect(await member.favoriteMemberships.isEmpty()).toBe(true);
     const membership = await member.favoriteMemberships.createBang({});
     await membership.updateBang({ favorite: false });
-    // CollectionAssociation#size has different behavior when loaded vs. non-loaded:
-    // the first call marks the association as loaded and the second call takes a
-    // different code path, so it's important to keep both assertions.
     expect(await member.favoriteMemberships.size()).toBe(0);
     expect(await member.favoriteMemberships.size()).toBe(0);
   });
@@ -261,7 +255,6 @@ describe("AssociationProxyTest", () => {
   it("save on parent does not load target", async () => {
     const david = developers("david") as any;
     expect(david.projects.loaded).toBe(false);
-    // update_columns on parent should not trigger association loading.
     await david.updateColumns({ salary: 80_000 });
     expect(david.projects.loaded).toBe(false);
   });
@@ -378,9 +371,7 @@ describe("AssociationProxyTest", () => {
     const david = authors("david") as any;
     const post = await Post.create({ title: "original", body: "b" });
     await david.posts.push(post);
-    // Mutate the in-memory instance.
     post.title = "mutated";
-    // load() should preserve the in-memory instance, not replace with a fresh DB copy.
     const loaded = await david.posts.load();
     const found = loaded.find((r: any) => r.readAttribute("id") === post.id);
     expect(found).toBe(post);
@@ -953,10 +944,6 @@ describe("PreloaderTest", () => {
     otherDogComment.origin_type = otherDog.constructor.name;
     otherDogComment.origin_id = otherDog.id;
 
-    // Both Dog and OtherDog are backed by a table named `dogs`, however they are
-    // stored in different databases and should therefore result in two separate
-    // queries rather than be batched together — `LoaderQuery#hashKey`
-    // distinguishes loaders by connection identity.
     const spy = vi.spyOn(LoaderQuery.prototype, "loadRecordsInBatch");
     await new Preloader({
       records: [dogComment, otherDogComment],
@@ -1341,8 +1328,6 @@ describe("PreloaderTest", () => {
 });
 
 describe("OverridingAssociationsTest", () => {
-  // Tests are synchronous reflection checks — no DB queries; fixtures([])
-  // wires the canonical schema without declaring any fixture set.
   fixtures([]);
 
   // Mirrors Rails' nested DifferentPerson / PeopleList / DifferentPeopleList classes.
@@ -1843,7 +1828,6 @@ describe("AssociationsTest", () => {
   it("force reload", async () => {
     const firm = new Firm({ name: "A New Firm, Inc" });
     await firm.save();
-    // forcing to load all clients
     for (const _ of await firm.clients) {
       void _;
     }
@@ -1853,7 +1837,6 @@ describe("AssociationsTest", () => {
     const client = new Client({ name: "TheClient.com", firm_id: firm.id });
     await client.save();
 
-    // New firm should have cached no client objects / zero count.
     expect(await firm.clients.isEmpty()).toBe(true);
     expect(await firm.clients.size()).toBe(0);
 
@@ -2038,11 +2021,6 @@ describe("AssociationsTest", () => {
     });
     await tag.save();
 
-    // Noise join row that collides on blog_post_id but not blog_id: a tag on a
-    // different blog wired to this post's id via a deliberately cross-blog join
-    // row. The composite through scope keys on [blog_id, blog_post_id], so it
-    // must AND both columns — a regression to single-column (blog_post_id-only)
-    // filtering would leak this row into `blogPost.tags`.
     const otherBlogId = (shardedBlogs("sharded_blog_two") as any).id;
     const noiseTag = await ShardedTag.create({ name: "Other Blog Tag", blog_id: otherBlogId });
     await ShardedBlogPostTag.create({
@@ -2071,10 +2049,6 @@ describe("AssociationsTest", () => {
       name: "Ruby on Rails",
       blog_id: (blogPost as any).blog_id,
     });
-    // The autosave variant exists to prove `<<` saves the unsaved target before
-    // building the join row (matching the canonical `append composite foreign key
-    // has many association with autosave` above); assert that transition so the
-    // test can't pass with a pre-persisted tag.
     expect(tag.isNewRecord()).toBe(true);
 
     await association(blogPost, "tags").push(tag);
@@ -2194,7 +2168,6 @@ describe("AssociationsTest", () => {
     (childPost.association("parent") as any).writer(parentPost);
     await childPost.save();
 
-    // reload to forget the parent association
     const reloaded = await ShardedBlogPost.find((childPost as any).id);
     const loaded = await (reloaded as any).loadBelongsTo("parent");
     expect(loaded.id).toBe((parentPost as any).id);
@@ -2354,12 +2327,6 @@ describe("AssociationsTest", () => {
     ).toBe(false);
   });
 
-  // Exercises loadHasMany's inline (no-reflection) fallback against a
-  // query_constraints owner: invoked with a composite FK and an unregistered
-  // association name, the fallback must derive the owner key from the owner's
-  // query_constraints (`[blog_id, id]`, mirroring
-  // `reflection.activeRecordPrimaryKey`) rather than zipping the scalar `id`
-  // against the 2-column FK (which would raise CompositePrimaryKeyMismatchError).
   it("has many loads via inline fallback resolving composite owner key from query constraints", async () => {
     const post = await ShardedBlogPost.create({ blog_id: 1, title: "Post" });
     await ShardedComment.create({ blog_id: 1, blog_post_id: (post as any).id, body: "A" });
@@ -2433,9 +2400,6 @@ describe("AssociationsTest", () => {
   });
 
   it("delete single composite has many through join row", async () => {
-    // Covers the composite-aware delete on a has_many :through: the join lookup
-    // must AND across both [blog_id, blog_post_id] columns so only the owning
-    // join row is removed.
     const blogPost = shardedBlogPosts("great_post_blog_one");
     const tag = await ShardedTag.create({ name: "shared", blog_id: (blogPost as any).blog_id });
     await ShardedBlogPostTag.create({
@@ -2444,8 +2408,6 @@ describe("AssociationsTest", () => {
       tag_id: (tag as any).id,
     });
 
-    // Noise join row colliding on blog_post_id + tag_id but a different blog_id;
-    // a regression to single-column (blog_post_id-only) deletion would remove it.
     const otherBlogId = (shardedBlogs("sharded_blog_two") as any).id;
     await ShardedBlogPostTag.create({
       blog_id: otherBlogId,
@@ -2455,7 +2417,6 @@ describe("AssociationsTest", () => {
 
     await association(blogPost, "tags").delete(tag);
 
-    // Only the owning composite join row is removed; the cross-blog noise row stays.
     expect(
       await ShardedBlogPostTag.where({
         blog_id: (blogPost as any).blog_id,
@@ -2470,7 +2431,6 @@ describe("AssociationsTest", () => {
         tag_id: (tag as any).id,
       }),
     ).toHaveLength(1);
-    // Target tag itself is untouched.
     expect(await ShardedTag.where({ id: (tag as any).id })).not.toHaveLength(0);
   });
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -18,8 +18,6 @@ import {
 } from "./relation/delegation.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
 import { qualifiedName } from "./inheritance.js";
-// Re-export the slot's setter so the package entry and other internal
-// callers don't need to import the slot module directly.
 export { _setCollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -236,20 +234,12 @@ export interface ReflectionLike {
  * @internal
  */
 class ModelRegistry extends Map<string, typeof Base> {
-  // Write-through runs here, not at each caller, so a direct
-  // `modelRegistry.set` (the HABTM join model) or `.delete` (the PG schema
-  // helper) cannot leave the registry and the constant table disagreeing.
-  // `registerModelConstant` is the single path that binds a model class to a
-  // name; this must not write the constant table itself.
   override set(name: string, model: typeof Base): this {
     registerModelConstant(name, model);
     return super.set(name, model);
   }
 
   override delete(name: string): boolean {
-    // The constant table is wider than the registry, so the name may since have
-    // been rebound (e.g. by registerSubclass) to a class this registry entry
-    // knows nothing about — only drop the constant when it is still ours.
     const model = super.get(name);
     const deleted = super.delete(name);
     if (deleted) unregisterConstant(name, model);
@@ -377,12 +367,6 @@ export function registerModel(
   if (Array.isArray(nameOrModel)) {
     for (const m of nameOrModel) {
       registerModel(m);
-      // STI subclass: its direct prototype is another AR model, not the
-      // framework `Base` (a base model's prototype is `Base` directly). We
-      // locate `Base` by walking the chain for the class that *owns*
-      // `_isActiveRecordBase` — `Base` declares it; every subclass inherits it —
-      // rather than importing the `Base` value (that would create an
-      // associations.ts ⇄ base.ts module-init cycle).
       const proto = Object.getPrototypeOf(m) as typeof Base;
       if (proto && proto !== Function.prototype && proto !== frameworkBase(m)) {
         registerSubclass(m);
@@ -394,8 +378,6 @@ export function registerModel(
     if (!model) throw new Error("registerModel(name, model) requires a model class");
     assertActiveRecordBase(model);
     modelRegistry.set(nameOrModel, model);
-    // Attach registry key so callers that resolve a class back to the names it
-    // was registered under (reflection's `computeClass`) can match it.
     const keys: string[] = model._registryKeys ?? [];
     if (!keys.includes(nameOrModel)) keys.push(nameOrModel);
     model._registryKeys = keys;
@@ -452,11 +434,6 @@ export function autoloadModel(name: string): void {
   // keyed unprefixed, so strip here too or `compute_class("::#{class_name}")`
   // (reflection.rb:427) can never fault one in.
   const bare = name.replace(/^::/, "");
-  // Gate on the *registry*, not the constant table. `registerSubclass`
-  // (inheritance.ts) and the adapter setter write constants without going
-  // through `registerModel`, so an STI subclass can be constantize-able while
-  // still absent from `modelRegistry` — which the join planner reads directly.
-  // Gating on `safeConstantize` would skip the fault-in and leave it absent.
   if (modelRegistry.has(bare)) return;
   const autoloaded = canonicalModelAutoloadIndex?.get(bare);
   if (autoloaded) registerModel(autoloaded);
@@ -483,8 +460,6 @@ export function resolveAssocClass(
     ) => { klass?: typeof Base; isPolymorphic?: () => boolean } | null;
   };
   const refl = ctor._reflectOnAssociation?.(assocName);
-  // Skip .klass for polymorphic associations — it throws by design.
-  // All other errors (e.g. not-an-AR-subclass) must propagate.
   if (refl && !refl.isPolymorphic?.()) {
     const richKlass = refl.klass;
     if (richKlass) return richKlass;
@@ -527,8 +502,6 @@ export function _resolveInverseName(
   options: AssociationOptions,
 ): string | null {
   if (options.inverseOf === false) return null;
-  // Explicit inverseOf wins everywhere, including polymorphic belongs_to
-  // (where automatic detection can't pick a target).
   if (typeof options.inverseOf === "string") return options.inverseOf;
   if (options.polymorphic) return null;
   const refl = ownerCtor._reflectOnAssociation?.(assocName);
@@ -590,15 +563,9 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
     // For has_one the FK lives on the target, so `inversedFrom` is equivalent
     // to `setTarget` (assign + loadedBang) with no owner FK write.
     assoc.inversedFrom(target);
-    // Flag as an explicit assignment so the inner loaders' short-circuit
-    // (`_loadedSingularTarget`) distinguishes it from a memoized query load.
     (assoc as unknown as { _explicitTarget: boolean })._explicitTarget = true;
     return;
   }
-  // Undeclared inverse name (an inverse reached via automatic-inverse wiring
-  // whose reflection isn't a declared singular association): cache the value on
-  // a minimal loaded holder keyed by the name for ad-hoc inverses. Surfaced
-  // through `Base#_associationCache`.
   const existing = record._associationInstances.get(assocName) as
     | { _setTargetFromLoader(t: unknown): void; _explicitTarget?: boolean }
     | undefined;
@@ -640,9 +607,6 @@ export function _loadedSingularTarget(
   const instance = record._associationInstances.get(assocName) as
     | { isLoaded(): boolean; _explicitTarget?: boolean; target?: Base | null }
     | undefined;
-  // Only an *explicit* set/seed short-circuits — a prior query load on the
-  // holder must re-query (matches the old `_cachedAssociations` write-shadow,
-  // which never recorded query loads).
   if (instance?.isLoaded() && instance._explicitTarget) {
     return { value: instance.target ?? null };
   }
@@ -871,10 +835,7 @@ export class Associations {
           writable: false,
         })[HABTM_WRAPPED_NAMES];
     const prevDestroyAssociations = self.prototype.destroyAssociations;
-    if (ownWrappedNames.has(name)) {
-      // Skip wrapper layering on redeclaration — the existing chain already
-      // handles this association.
-    } else {
+    if (!ownWrappedNames.has(name)) {
       ownWrappedNames.add(name);
       self.prototype.destroyAssociations = async function (this: {
         association(n: string): { handleDependency(): Promise<void>; reset?(): void };
@@ -951,12 +912,6 @@ export function _canRouteThroughViaAssociationScope(
 ): boolean {
   if (!reflection) return false;
   if (options.disableJoins) return false;
-  // Only ThroughReflection has a real distinct sourceReflection.
-  // AssociationReflection.sourceReflection returns `this` (line 793 in
-  // reflection.ts), which means HABTM and other non-through reflections
-  // would falsely match. Gate explicitly on isThroughReflection so HABTM's
-  // anonymous-join-model machinery (with its own load path) keeps using
-  // the existing 2-step loaders.
   if (typeof reflection.isThroughReflection !== "function" || !reflection.isThroughReflection()) {
     return false;
   }
@@ -971,10 +926,6 @@ export function _canRouteThroughViaAssociationScope(
   // per-step poly guards below target the chain-length-2 direct-source
   // shape and don't apply to the flattened multi-step walk.
   if (typeof reflection.isNested === "function" && reflection.isNested()) return true;
-  // Polymorphic has_many / has_one source (rare): the chain walker
-  // would need inversion machinery not present in PR 3c. Polymorphic
-  // belongsTo source WITH sourceType is routed — the chain head resolves
-  // its own runtime klass, so the sourceType class's PK drives the JOIN.
   if (
     typeof src.isPolymorphic === "function" &&
     src.isPolymorphic() &&
@@ -982,10 +933,6 @@ export function _canRouteThroughViaAssociationScope(
   ) {
     return false;
   }
-  // Polymorphic belongsTo source requires sourceType to resolve the
-  // target class. Without sourceType the JOIN can't pick a single
-  // target table — fall back to the 2-step loader which handles that
-  // by grouping through records by type.
   if (typeof src.isPolymorphic === "function" && src.isPolymorphic() && !options.sourceType) {
     return false;
   }
@@ -1136,11 +1083,6 @@ export function _builtAssociationScope(
     try {
       instance = assocFn.call(record, assocName) as typeof instance;
     } catch (e) {
-      // Only swallow the "association not registered" case (low-level
-      // test fixtures that bypass `Associations.hasMany.call`). Real
-      // bugs in instance construction must surface — otherwise the
-      // fresh-build fallback would silently mask them and callers
-      // would see mysterious behavior changes.
       if (e instanceof AssociationNotFoundError) {
         instance = undefined;
       } else {
@@ -1185,9 +1127,6 @@ export function _skipSingularStatementCache(
   targetModel: typeof Base,
   options: AssociationOptions,
 ): boolean {
-  // `reflection.has_scope?` — a caller-supplied `scope:` lambda (or the
-  // reflection's own macro-time scope) is instance-dependent (it receives the
-  // owner), so the compiled SQL can't be shared.
   if (reflection.scope) return true;
   const refl = reflection as {
     hasScope?(): boolean;
@@ -1211,7 +1150,6 @@ export function _skipSingularStatementCache(
   ) {
     return true;
   }
-  // `source_reflection.active_record.default_scopes.any?` (through chains).
   if ((refl.sourceReflection?.activeRecord?.defaultScopes?.length ?? 0) > 0) return true;
   return false;
 }
@@ -1236,11 +1174,6 @@ export async function _loadSingularViaStatementCache(
   reflection: ReflectionLike,
   targetModel: typeof Base,
 ): Promise<Base | null> {
-  // Materialize the Association instance (as `_builtAssociationScope` does on
-  // the take() path) for its `targetScope()` — see `baseScope` below, which
-  // needs it to carry a through association's join-model STI condition. Only
-  // the "not registered" case is swallowed; real construction bugs must
-  // surface.
   let instance: { targetScope?: () => unknown } | undefined;
   const assocFn = (record as { association?: (n: string) => unknown }).association;
   if (typeof assocFn === "function") {
@@ -1349,7 +1282,6 @@ export function _findTargetReachable(
   options: AssociationOptions,
   kind: "belongsTo" | "foreign",
 ): boolean {
-  // belongs_to requires foreign_key_present? regardless of new/persisted state.
   if (kind === "belongsTo") {
     return _associationForeignKeyPresent(record, assocName, options, kind);
   }
@@ -1449,12 +1381,6 @@ export function _inlinePolymorphicKeys(
     (options.queryConstraints || hasQueryConstraints.call(ctor as any))
   ) {
     const qc = options.queryConstraints ?? queryConstraintsList.call(ctor as any);
-    // Mirror deriveFkQueryConstraints (reflection.ts) faithfully — including its
-    // ArgumentError raises for the underivable query_constraints shapes: a list
-    // with >2 attributes, a list missing the owner's scalar primary key (or a
-    // composite owner PK), and a list whose keys can't be interpreted against
-    // the owner PK. The inline (no-reflection) path is no excuse to silently
-    // scalar-collapse those configs.
     if (qc) {
       const ownerPk = ctor.primaryKey;
 
@@ -1496,11 +1422,6 @@ export function _inlinePolymorphicKeys(
       );
     }
   }
-  // Scalar path — identical to the pre-fix inline behavior
-  // (`Array.isArray(primaryKey) ? "id" : primaryKey`): a scalar polymorphic FK
-  // pairs with a single owner key. `_inlineOwnerKey` can return the
-  // query_constraints array, which a scalar FK can't zip against, so collapse
-  // here rather than delegating.
   const scalarOwnerKey = Array.isArray(primaryKey) ? "id" : primaryKey;
   return { fkCols: [scalarFk], ownerKeyCols: [scalarOwnerKey] };
 }
@@ -1531,7 +1452,6 @@ export function association<T extends Base = Base>(
 ): AssociationProxy<T> {
   const existing = record._collectionProxies.get(assocName) as AssociationProxy<T> | undefined;
   if (existing) {
-    // Hydrate from preloaded data if proxy was cached before preloading ran
     if (!existing.loaded) {
       const preloaded = _preloadedHolderTarget(record, assocName)?.value;
       if (preloaded != null) {
@@ -1548,10 +1468,6 @@ export function association<T extends Base = Base>(
 
   const ctor = record.constructor as typeof Base;
   const associations: AssociationDefinition[] = ctor._associations ?? [];
-  // Most-derived override wins (subclass appends after the cloned parent
-  // entry), aligning with `_reflections`' keyed override semantics. Covered by
-  // has-one-associations.test.ts "nullification on association change" (a
-  // DependentFirm whose `account` override must beat the inherited Company one).
   const assocDef = associations
     .slice()
     .reverse()
@@ -1561,15 +1477,6 @@ export function association<T extends Base = Base>(
   }
   validateThroughReflection(ctor, assocName);
   if (!_CollectionProxyCtor) {
-    // Deliberate constraint: `associations.ts`, `relation.ts`,
-    // `collection-proxy.ts`, and `base.ts` form a mandatory mutual
-    // dependency — CP `extends Relation`, Relation/Base call back
-    // into the association wiring, and attempting to value-import CP
-    // at this module's top would observe a partial module during
-    // init. The package entry (`@blazetrails/activerecord`) loads CP
-    // explicitly and triggers self-registration; deep-importing
-    // `associations.js` bypasses that. See the collection-proxy-slot
-    // module for the load-order details.
     throw new Error(
       "CollectionProxy not registered. Either import '@blazetrails/activerecord' " +
         "once (the package entry loads CollectionProxy eagerly), or, if you are " +
@@ -1579,8 +1486,6 @@ export function association<T extends Base = Base>(
         "`association()` call.",
     );
   }
-  // Route through the CollectionProxy per-model subclass carrier (its `_create`
-  // factory) so generated relation methods resolve as real methods on the proxy.
   const proxy = (
     _CollectionProxyCtor as unknown as {
       _create: (r: Base, n: string, d: AssociationDefinition) => CollectionProxy<T>;
@@ -1594,9 +1499,6 @@ export function association<T extends Base = Base>(
   }
 
   const wrapped = wrapCollectionProxy<T>(proxy);
-  // Record the JS Proxy wrapper on the underlying instance so methods that
-  // return `self` (push / concat / append) hand back the same object callers
-  // hold — `this` inside a method is the raw target, not the wrapper.
   (proxy as any)._proxySelf = wrapped;
   record._collectionProxies.set(assocName, wrapped);
   return wrapped;
@@ -1630,11 +1532,6 @@ function wrapCollectionProxy<T extends Base = Base>(
       if (Reflect.has(target, prop) && !preferSyncRecordDelegate) return value;
       if (value !== undefined && !preferSyncRecordDelegate) return value;
 
-      // Numeric indexing — `proxy[0]`, `proxy[1]` read the loaded target
-      // via the public `target` accessor. Matches array semantics; same
-      // constraint as the other array-likeness on CollectionProxy: reads
-      // whatever's loaded. `await proxy` (or `await proxy.load()`) hydrates
-      // `_target` first if you need a fresh load.
       if (typeof prop === "string" && NUMERIC_INDEX_PATTERN.test(prop)) {
         return target.target[Number(prop)];
       }
@@ -1808,17 +1705,10 @@ export function associationInstanceGet(this: Base, name: string): unknown {
       | { isLoaded?(): boolean; target?: unknown; _writeTargetStore?(t: unknown): void }
       | undefined;
     if (inst?.isLoaded?.()) return inst;
-    // In-memory built records (no preload, no DB load). Surface them on the
-    // Association instance's `target` by the bare ivar write (not `target=`,
-    // which flips `loadedBang`) so the Association stays unloaded — matching
-    // the `@_was_loaded` ephemeral flag semantics above.
     if (proxyHasBuiltRecords && inst && Array.isArray(inst.target)) {
       inst._writeTargetStore?.(proxy.target);
       return inst;
     }
-    // Association-side build (`record.association(name).build(...)`) populates
-    // `existing.target` directly while `loaded` stays false. Treat that as
-    // cached too.
     if (existingHasBuiltRecords && inst && inst === existing) {
       return inst;
     }

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -64,7 +64,6 @@ describe("AttributeMethodsTest", () => {
       }
     }
     const p = Post.new({ published: false }) as any;
-    // false is a valid value, not "blank"
     expect(p.published).toBe(false);
   });
 
@@ -250,9 +249,6 @@ describe("AttributeMethodsTest", () => {
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        // canonical `posts.body` is NOT NULL; default it so the many
-        // `create({ title })` sites below satisfy the constraint. `score` is a
-        // synthetic non-column attribute exercised purely in memory.
         this.attribute("body", "string", { default: "" });
         this.attribute("score", "integer");
       }
@@ -457,9 +453,6 @@ describe("AttributeMethodsTest", () => {
   });
   it("bulk updates respect access control", async () => {
     const { Post } = makeModel();
-    // `legacy_comments_count` is a real canonical `posts` column (an integer
-    // counter), so the bulk UPDATE has a column to write; the synthetic
-    // `score` attribute isn't persisted (excluded by `attributesForCreate`).
     await Post.create({ title: "bulk" });
     await Post.where({ title: "bulk" }).updateAll({ legacy_comments_count: 5 });
     const updated = await Post.findBy({ title: "bulk" });
@@ -696,7 +689,6 @@ describe("AttributeMethodsTest", () => {
     const { Post } = makeModel();
     const p = new Post({});
     expect(p.id).toBeNull();
-    // Accessing id again should still return null (not throw)
     expect(p.id).toBeNull();
   });
   it("respond_to?", () => {
@@ -816,7 +808,6 @@ describe("AttributeMethodsTest", () => {
     const Topic = makeTopic();
     const t = new Topic({ written_on: "2023-01-15" });
     const raw = t.readAttributeBeforeTypeCast("written_on");
-    // Raw value is the string before casting
     expect(raw).toBeDefined();
   });
 
@@ -910,11 +901,9 @@ describe("AttributeMethodsTest", () => {
   it("non-attribute read and write", async () => {
     const Topic = makeTopic();
     const t = new Topic({});
-    // Writing to a non-attribute should throw or be ignored
     try {
       t.nonexistent = "value";
     } catch (e) {
-      // Expected: MissingAttributeError or similar
       expect(e).toBeDefined();
     }
   });
@@ -944,13 +933,9 @@ describe("AttributeMethodsTest", () => {
       };
       record.writeAttribute("written_on", utcTime);
       const wo = record.written_on;
-      // record.written_on is equal to (i.e. simultaneous with) utc_time …
       expect(wo.utc().toTime().epochNanoseconds).toBe(utcTime.epochNanoseconds);
-      // … but is a TimeWithZone …
       expect(wo).toBeInstanceOf(TimeWithZone);
-      // … and is in the current Time.zone …
       expect(wo.timeZone.name).toBe("Pacific Time (US & Canada)");
-      // … and represents time values adjusted accordingly (Time.utc(2007,12,31,16)).
       const t = wo.time;
       expect([t.year, t.month, t.day, t.hour, t.minute, t.second]).toEqual([
         2007, 12, 31, 16, 0, 0,
@@ -1035,7 +1020,6 @@ describe("AttributeMethodsTest", () => {
     t.readAttribute = (attrName: string, block?: (name: string) => unknown) =>
       String(superReadAttribute(attrName, block)).toUpperCase();
 
-    // `[]` dispatches read_attribute, so the override reaches bracket reads too.
     expect(t.readAttribute("title")).toBe("STOP CHANGING THE TOPIC");
     expect(t.get("title")).toBe("STOP CHANGING THE TOPIC");
 
@@ -1348,7 +1332,6 @@ describe("AttributeMethodsTest", () => {
     // warm, so the real columns are known and an unknown name is detectable.
     await Topic.create({ title: "orig" });
     const t = (await Topic.first()) as any;
-    // known attributes can be written
     t.writeAttribute("title", "known");
     expect(t.readAttribute("title")).toBe("known");
     // Mirrors: topic[:no_column_exists] = "Hello!" → assert_raises MissingAttributeError
@@ -1406,9 +1389,6 @@ describe("initialize_generated_modules", () => {
         this.attribute("title", "string");
       }
     }
-    // Declaring the attribute routes through defineAttributeMethods, which
-    // must seed the generated module — no explicit initializeGeneratedModules
-    // call in the test.
     (Topic as any).defineAttributeMethods();
     expect(Topic._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
   });
@@ -1419,7 +1399,6 @@ describe("initialize_generated_modules", () => {
         this.attribute("title", "string");
       }
     }
-    // Simulate already-generated state, then prove the reset fires.
     (Topic as any)._attributeMethodsGenerated = true;
     (Topic as any)._aliasAttributesMassGenerated = true;
     Topic.initializeGeneratedModules();
@@ -1434,7 +1413,6 @@ describe("initialize_generated_modules", () => {
       }
     }
     Topic.initializeGeneratedModules();
-    // Core's version initializes the generated-association-methods set.
     expect((Topic as any)._generatedAssociationMethods).toBeInstanceOf(Set);
   });
 });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -61,8 +61,6 @@ describe("AttributeMethodsTest (trails)", () => {
         this.attribute("breed", "string");
       }
     }
-    // Generating the subclass drives the parent's generation first, so the
-    // parent's own flag is set even though it was never generated directly.
     generatable(Dog).defineAttributeMethods();
     expect(Object.prototype.hasOwnProperty.call(Animal, "_attributeMethodsGenerated")).toBe(true);
     expect(generatable(Animal)._attributeMethodsGenerated).toBe(true);
@@ -222,8 +220,6 @@ describe("AttributeMethodsTest (trails)", () => {
     await Topic.loadSchema();
     const first = Topic.attributeNames();
     (Topic as unknown as { resetColumnInformation(): void }).resetColumnInformation();
-    // The reset drops the shared cache's per-table entry; re-reflect so the
-    // suite's warm-cache invariant is restored for later tests.
     await Topic.loadSchema();
     const second = Topic.attributeNames();
     expect(second).not.toBe(first);

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -23,16 +23,12 @@ import {
   initializeGeneratedModules as _coreInitializeGeneratedModules,
 } from "./core.js";
 import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js";
-// toKey/id: inline to avoid a circular dependency (primary-key.ts imports
-// dangerousAttributeMethods from this file)
 import { reload as _reload } from "./persistence.js";
 import { cachedTableExists, loadSchema } from "./model-schema.js";
 import {
   serializableHash as _serializableHash,
   attributeNamesForSerialization as _attrNamesForSerialization,
 } from "./serialization.js";
-// defineAttributeMethods is implemented here since AM doesn't expose it as a
-// static on Model.
 
 /**
  * The AttributeMethods module interface.
@@ -628,8 +624,6 @@ export function isInstanceMethodAlreadyImplemented(
   if (Object.prototype.hasOwnProperty.call(superclass ?? {}, "_isActiveRecordBase")) {
     return _amInstanceMethodAlreadyImplemented.call(this as any, methodName);
   } else {
-    // If ThisClass < ... < SomeSuperClass < ... < Base and SomeSuperClass
-    // defines its own attribute method, then we don't want to override that.
     const base = frameworkBase(this);
     const defined =
       base != null &&
@@ -963,9 +957,6 @@ import {
   attributeCameFromUser as _attributeCameFromUser,
 } from "./attribute-methods/before-type-cast.js";
 import { queryCastAttribute as _queryCastAttribute } from "./attribute-methods/query.js";
-// primary-key.ts imports dangerousAttributeMethods from this file, so we cannot
-// import from it here (cycle). These 5 delegates are inlined the same way
-// toKey/id are inlined above (see comment near line 12).
 import {
   isSavedChangeToAttribute as _isSavedChangeToAttribute,
   savedChangeToAttribute as _savedChangeToAttribute,

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -134,7 +134,6 @@ describe("CustomPropertiesTest", () => {
       }
     }
 
-    // Limit retention asserted on the reflected column (see RFC 0043 note above).
     expect(
       (UnoverloadedType.columnsHash() as Record<string, { limit?: number }>)
         .overloaded_string_with_limit.limit,
@@ -312,7 +311,6 @@ describe("CustomPropertiesTest", () => {
 
     expect((new Klass() as any).counter).toBe(1);
 
-    // column_defaults will increment the counter since the proc is called
     void Klass.columnDefaults;
 
     expect((new Klass() as any).counter).toBe(3);
@@ -382,7 +380,7 @@ describe("CustomPropertiesTest", () => {
     }
 
     class Child extends Parent {}
-    new Child(); // force a schema load
+    new Child();
 
     Parent.attribute("foo", typeRegistry.lookup("value"));
 
@@ -655,13 +653,10 @@ describe("DefaultAttributesTest", () => {
   it("attribute() overriding only type preserves the schema default", () => {
     const intType = typeRegistry.lookup("integer");
     class Post extends Base {}
-    // Schema reflection gives score a default of 5
     Post.defineAttribute("score", intType, { default: 5, userProvidedDefault: false });
-    // User overrides type to string without specifying a default
     Post.attribute("score", "string");
 
     const defaults = Post._defaultAttributes();
-    // Type changed to string, but schema default (5) is preserved
     expect(defaults.getAttribute("score").type.name).toBe("string");
     expect(defaults.getAttribute("score").value).toBe("5");
   });
@@ -707,7 +702,6 @@ describe("DefineAttributeSTITest", () => {
       }
     }
     Post.defineAttribute("id", strType);
-    // Base.prototype.id (the CPK-aware getter) must still be used, not a plain accessor
     const ownDesc = Object.getOwnPropertyDescriptor(Post.prototype, "id");
     expect(ownDesc).toBeUndefined();
   });
@@ -722,15 +716,12 @@ describe("ResetDefaultAttributesCascadeTest", () => {
     }
     class SpecialPost extends (Post as any) {}
 
-    // Prime the subclass cache via AR's _defaultAttributes path
     const before = (SpecialPost as any)._defaultAttributes();
     expect(before.keys()).toContain("title");
     expect(before.keys()).not.toContain("score");
 
-    // Add attribute to superclass at runtime
     Post.attribute("score", "integer", { default: 0 });
 
-    // Subclass cache must be invalidated and rebuilt with the new attribute
     const after = (SpecialPost as any)._defaultAttributes();
     expect(after.keys()).toContain("score");
     expect(after.getAttribute("score").value).toBe(0);

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -120,7 +120,6 @@ export function defineAttribute(
   const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
 
   this._attributeDefinitions.set(name, {
-    // Spread existing to preserve the `virtual` flag a prior declaration set.
     ...existing,
     name,
     type: castType,
@@ -137,9 +136,6 @@ export function defineAttribute(
   );
 
   amResetDefaultAttributes(this);
-  // A newly declared attribute may be virtual (no DB column); force the next
-  // ensureSchemaLoaded to re-run the virtual reconciliation (model-schema.ts
-  // reconcileVirtualAttributes) so it isn't skipped by the one-shot guard.
   this._virtualAttributesReconciled = false;
   encryptionHooks.applyPendingEncryptions(this);
 
@@ -181,21 +177,10 @@ export function defineAttribute(
  * `PendingType` swaps the type.
  */
 export function _defaultAttributes(this: AnyClass): AttributeSet {
-  // Reflect the (always-warm, RFC 0031) schema cache before building, so real
-  // columns — notably the `id` PK — are seeded even when the model is first
-  // constructed without a query (e.g. `new Car({name})`, where no STI `type` key
-  // drives the usual reflect-on-`new` path). Without this the strict
-  // `writeFromUser` raises on the post-INSERT `id` write-back. Gated on
-  // `!_schemaLoaded`: once reflected, `columnsHash` is settled, so skipping
-  // avoids the `.connection` access inside `columnsHash`, which would otherwise
-  // permanently check out a connection on every construction under
-  // `permanent_connection_checkout` = disallowed.
   if (!isSchemaLoaded.call(this) && !this.abstractClass && this.tableName) {
     try {
       this.columnsHash();
-    } catch {
-      // TableNotSpecified / no cache entry — keep the synthesized view.
-    }
+    } catch {}
   }
 
   const cacheHost = this;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -150,7 +150,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     ship.name = "Pearl Changed";
     cacheAssoc(pirate, "ship", ship);
     await expect(pirate.save()).rejects.toThrow("Oh noes!");
-    // Destruction should be rolled back — ship still exists
     const reloaded = await Ship.find(ship.id);
     expect(reloaded).toBeTruthy();
   });
@@ -234,7 +233,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     pirate.catchphrase = "Changed Catchphrase";
     cacheAssoc(ship, "pirate", pirate);
     await expect(ship.save()).rejects.toThrow("Oh noes!");
-    // Destruction should be rolled back — pirate still exists
     const reloaded = await Pirate.find(pirate.id);
     expect(reloaded).toBeTruthy();
   });
@@ -315,7 +313,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const b2 = await Bird.create({ name: "birds_1", pirate_id: pirate.id });
     b1.markForDestruction();
     b2.markForDestruction();
-    // Override the second bird's destroy to raise after super
     const origDestroy = b2.destroy.bind(b2);
     (b2 as any).destroy = async () => {
       await origDestroy();
@@ -323,7 +320,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     };
     cacheAssoc(pirate, "birds", [b1, b2]);
     await expect(pirate.save()).rejects.toThrow("Oh noes!");
-    // Both destructions should be rolled back
     const remaining = await Bird.where({ pirate_id: pirate.id });
     expect(remaining.length).toBe(2);
   });
@@ -457,8 +453,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const parrot = await Parrot.create({ name: "Polly" });
     const proxy = association(pirate, "parrots");
     await proxy.push(parrot);
-    // Parrot is persisted and unchanged; autosave validation should only consider
-    // associated records that have actually been changed
     cacheAssoc(pirate, "parrots", [parrot]);
     expect(await pirate.isValid()).toBe(true);
   });
@@ -471,7 +465,6 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     for (const p of await proxy) p.markForDestruction();
     expect(await pirate.save()).toBe(true);
 
-    // The join record is already gone — saving again issues no queries.
     await assertNoQueries(false, async () => {
       expect(await pirate.save()).toBe(true);
     });
@@ -880,7 +873,6 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     }
     registerModel("CpkOrderPk", CpkOrderPk);
     registerModel("CpkBookFk", CpkBookFk);
-    // has_one with single-column FK on CPK parent (like OrderWithPrimaryKeyAssociatedBook)
     const order = new CpkOrderPk({ id: [5, 7], status: "open" });
     const book = new CpkBookFk({ signature: "My Book" });
     cacheAssoc(order, "cpkBookFk", book);
@@ -888,7 +880,6 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     expect(saved).toBe(true);
     expect(order.isNewRecord()).toBe(false);
     expect(book.isNewRecord()).toBe(false);
-    // autosave propagates the "id" component of the composite PK into book.order_id
     expect(book.order_id).toBe(7);
   });
   it("assign ids for through a belongs to", async () => {
@@ -1015,7 +1006,6 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   }
 
   it("should save parent but not invalid child", async () => {
-    // Without autosave: invalid has_one child does not block parent save
     class PFirm extends Base {
       declare name: string | null;
       declare pAccount: PAccount | null;
@@ -1413,7 +1403,6 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    // No changes — save should succeed without infinite loop
     cacheAssoc(pirate, "ship", ship);
     const saved = await pirate.save();
     expect(saved).toBe(true);
@@ -1444,7 +1433,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   it("should automatically validate the associated model", async () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
-    const ship = new Ship({ name: "" }); // invalid
+    const ship = new Ship({ name: "" });
     cacheAssoc(pirate, "ship", ship);
     const saved = await pirate.save();
     expect(saved).toBe(false);
@@ -1553,9 +1542,6 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
         this.validates("catchphrase", { presence: true });
-        // The FK derived from the association name would be `deep_pirate_id`;
-        // the real `ships` column is `pirate_id`. The bridge used to swallow
-        // the phantom write; strict _writeAttribute surfaces it.
         this.hasOne("deepShip", { autosave: true, foreignKey: "pirate_id" });
       }
     }
@@ -1577,13 +1563,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
     const saved = await pirate.save({ validate: false });
     expect(saved).toBe(true);
-    // Reload and verify all empty strings were persisted (validations bypassed at every depth)
     const reloadedPirate = await DeepPirate.find(pirate.id as number);
     expect(reloadedPirate.catchphrase).toBe("");
     const reloadedShip = await DeepShip.find(ship.id as number);
     expect(reloadedShip.name).toBe("");
-    // Parts must also be saved with blank names — a regression where has_many autosave
-    // doesn't propagate validate:false would leave them with their original names.
     const reloadedPart1 = await DeepPart.find(part1.id as number);
     const reloadedPart2 = await DeepPart.find(part2.id as number);
     expect(reloadedPart1.name).toBe("");
@@ -1592,7 +1575,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   it("should still raise an ActiveRecordRecord Invalid exception if we want that", async () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
-    const ship = new Ship({ name: "" }); // invalid — presence required
+    const ship = new Ship({ name: "" });
     cacheAssoc(pirate, "ship", ship);
     await expect(pirate.saveBang()).rejects.toThrow(RecordInvalid);
   });
@@ -1617,12 +1600,11 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   it("should rollback any changes if an exception occurred while saving", async () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
-    const ship = new Ship({ name: "" }); // invalid — presence required
+    const ship = new Ship({ name: "" });
     pirate.catchphrase = "Changed";
     cacheAssoc(pirate, "ship", ship);
     const saved = await pirate.save();
     expect(saved).toBe(false);
-    // Parent's update should be rolled back
     const reloaded = await Pirate.find(pirate.id);
     expect(reloaded.catchphrase).toBe("Yarr");
   });
@@ -1635,10 +1617,6 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   });
 
   it("mark for destruction is ignored without autosave true", async () => {
-    // `ShipWithoutNestedAttributes has_many :parts` is declared without
-    // autosave, so `mark_for_destruction` is ignored: the part is still
-    // validated as an ordinary new child and its blank name invalidates the
-    // ship. Only an autosave association skips validating a marked child.
     const ship = new ShipWithoutNestedAttributes({ name: "The Black Flag" });
     const part = ship.parts.build();
     part.markForDestruction();
@@ -1708,8 +1686,6 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     expect(chef._readAttribute("employable_type")).toBe("SwapCakeDesigner");
     expect(chef._readAttribute("employable_id")).toBe(cake.id);
 
-    // Reassign chef to drink — polymorphic type column flips even when
-    // employable_id may collide. autosave on drink should re-persist the chef.
     chef._writeAttribute("employable_type", "SwapDrinkDesigner");
     cacheAssoc(drink, "chef", chef);
     await drink.save();
@@ -1768,7 +1744,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
   it("should save parent but not invalid child", async () => {
     const { Author, Post } = makeModels();
-    const author = new Author({ name: "" }); // invalid
+    const author = new Author({ name: "" });
     const post = new Post({ name: "Hello" });
     cacheAssoc(post, "author", author);
     const saved = await post.save();
@@ -1949,7 +1925,6 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     const { Author, Post } = makeModels();
     const author = await Author.create({ name: "Valid" });
     const post = await Post.create({ name: "Test", author_id: author.id });
-    // Author is persisted and not cached — should not be validated
     const saved = await post.save();
     expect(saved).toBe(true);
   });
@@ -2011,7 +1986,6 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     expect(saved).toBe(true);
     expect(order.isNewRecord()).toBe(false);
     expect(book.isNewRecord()).toBe(false);
-    // autosave should have propagated composite FK from order PK to book
     expect(book.shop_id).toBe(1);
     expect(book.order_id).toBe(2);
   });
@@ -2071,7 +2045,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
 
   it("should automatically validate the associated model", async () => {
     const { Pirate, Ship } = makeModels();
-    const pirate = new Pirate({ catchphrase: "" }); // invalid
+    const pirate = new Pirate({ catchphrase: "" });
     const ship = new Ship({ name: "Pearl" });
     cacheAssoc(ship, "pirate", pirate);
     const saved = await ship.save();
@@ -2125,7 +2099,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    pirate.catchphrase = ""; // invalid — presence required
+    pirate.catchphrase = "";
     cacheAssoc(ship, "pirate", pirate);
     await expect(ship.saveBang()).rejects.toThrow(RecordInvalid);
   });
@@ -2153,7 +2127,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     const { Pirate, Ship } = makeModels();
     const pirate = await Pirate.create({ catchphrase: "Yarr" });
     const ship = await Ship.create({ name: "Pearl", pirate_id: pirate.id });
-    pirate.catchphrase = ""; // invalid — presence required
+    pirate.catchphrase = "";
     ship.name = "Changed";
     cacheAssoc(ship, "pirate", pirate);
     const saved = await ship.save();
@@ -2499,7 +2473,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       static {
         this._tableName = "people";
         this.attribute("first_name", "string");
-        // :create-only validation — should not fire when context is :update
         this.validate(
           function (record: any) {
             if (record.first_name !== "cool") {
@@ -2529,13 +2502,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     registerModel("ContextReference", ContextReference);
 
     const person = await ContextPerson.create({ first_name: "cool" });
-    // Change to "nah" — still valid because on:create validator doesn't run in :update context
     person.first_name = "nah";
     expect(await person.isValid()).toBe(true);
 
-    // autosave through reference should also be valid —
-    // autosave uses the owner's _validationContext (nil → not custom) so person is validated
-    // in its default :update context, where the :create-only validator is skipped.
     const ref = new ContextReference({ person });
     cacheAssoc(ref, "person", person);
     const valid = await ref.isValid();
@@ -2699,7 +2668,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     }
     registerModel("Profile", Profile);
     registerModel("DuplicateCallbackProfileUser", DuplicateCallbackProfileUser);
-    // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
     const reflection = (DuplicateCallbackProfileUser as any)._reflectOnAssociation("profile");
     addAutosaveAssociationCallbacks.call(DuplicateCallbackProfileUser, reflection);
 
@@ -2825,17 +2793,15 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     }
     registerModel("DupCbParrot", DupCbParrot);
     registerModel("DupCbPirate", DupCbPirate);
-    // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
     const reflection = (DupCbPirate as any)._reflectOnAssociation("parrots");
     expect(reflection).toBeDefined();
     addAutosaveAssociationCallbacks.call(DupCbPirate, reflection);
 
     const pirate = await DupCbPirate.create({ catchphrase: "Arrr" });
     const parrot = await DupCbParrot.create({ name: "Polly" });
-    saveCount = 0; // reset after create (create triggers beforeSave)
+    saveCount = 0;
     const proxy = association(pirate, "parrots");
     await proxy.push(parrot);
-    // Make parrot dirty so autosave saves it
     parrot.name = "Polly Updated";
     pirate.catchphrase = "trigger";
     await pirate.save();
@@ -2843,9 +2809,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   });
 
   it("cyclic autosaves do not add multiple validations", async () => {
-    // ShipWithoutNestedAttributes: has_many :prisoners (no autosave), two presence validators.
-    // Prisoner: belongs_to :ship (autosave: true). Cyclic: prisoner.valid? calls ship.valid? again.
-    // _ensureNoDuplicateErrors (after_validation) deduplicates to exactly 1 error for :name.
     class ShipCyclic extends Base {
       declare name: string | null;
       declare prisoners: AssociationProxy<PrisonerCyclic>;
@@ -2882,7 +2845,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
 
     const ship = new ShipCyclic({ name: "" });
     const prisoner = new PrisonerCyclic({});
-    // Wire cached associations so _loadedAssociation finds them without a DB hit.
     cacheAssoc(ship, "prisoners", [prisoner]);
     cacheAssoc(prisoner, "ship", ship);
 
@@ -3010,10 +2972,6 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
     cacheAssoc(ship, "parts", [part]);
     await pirate.save();
     part.name = "changed";
-    // Extra records in the DB that are absent from the already-loaded
-    // collections. `valid?` calls `nested_records_changed_for_autosave?`,
-    // which must consult the loaded target only — never reload — so these
-    // extras are not pulled in.
     await Ship.create({ name: "Black Rock", pirate_id: pirate.id });
     await Part.create({ name: "Stern", ship_id: ship.id });
     await assertNoQueries(false, async () => {
@@ -3314,9 +3272,6 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
     cacheAssoc(ship, "part", part);
     await pirate.save();
     part.name = "changed";
-    // Extra record in the DB absent from the already-loaded singular
-    // associations. `valid?` must consult the loaded target only — never
-    // reload — so this extra is not pulled in.
     await Part.create({ name: "Stern", ship_id: ship.id });
     await assertNoQueries(false, async () => {
       await pirate.isValid();
@@ -3515,9 +3470,6 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
 describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
   fixtures([]);
 
-  // Dynamic import so esbuild doesn't rename the bespoke same-named classes
-  // declared inside the describe.skip blocks above (Author/Book) — see the
-  // canonical-import esbuild class-rename gotcha.
   let AuthorM: typeof Base;
   let BookM: typeof Base;
   let PublishedBookM: typeof Base;
@@ -3700,7 +3652,6 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
     const org = await HotOrg.create({ name: "Org" });
     const member = await HotMember.create({ name: "M" });
     await HotDetail.create({ company_id: org.id, developer_id: member.id });
-    // Cache the through target — even cached, has_one_through should not autosave
     cacheAssoc(member, "hotOrg", org);
     org.name = "Modified";
     const saved = await member.save();
@@ -4446,7 +4397,7 @@ describe("should update children when autosave is true and parent is new but chi
     registerModel(RIArticle);
     const article = await RIArticle.create({ name: "test" });
     const tag = await RITag.create({ name: "valid", author_id: article.id });
-    tag.name = ""; // invalid — presence required
+    tag.name = "";
     cacheAssoc(article, "riTags", [tag]);
     await expect(article.saveBang()).rejects.toThrow(RecordInvalid);
   });
@@ -4553,7 +4504,6 @@ describe("ChangedForAutosaveTest", () => {
     a.association("b").setTarget(b as any);
     b.association("a").setTarget(a as any);
 
-    // Should not stack overflow
     expect(a.changedForAutosave()).toBe(false);
     expect(b.changedForAutosave()).toBe(false);
   });
@@ -4561,10 +4511,6 @@ describe("ChangedForAutosaveTest", () => {
 
 describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
   fixtures([]);
-  // When a class has queryConstraints and the has_one uses an explicit composite FK,
-  // assoc.options.foreignKey is the composite array. The reflection normalizes it
-  // into options.queryConstraints internally. computePrimaryKey(reflection) therefore
-  // hits branch 2 and returns queryConstraintsList — pairing with the composite FK.
   it("pairs queryConstraintsList PK with explicit composite FK on QC owner", async () => {
     class QcOwner extends Base {
       declare tree_id: number | null;
@@ -4600,30 +4546,17 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
     }
     registerModel("QcOwner", QcOwner);
     registerModel("QcChild", QcChild);
-    // Explicit composite FK — assoc.options.foreignKey = ["tree_id","parent_id"].
-    // The old scalar-guard skipped computePrimaryKey → used ctor.primaryKey = "id" → mismatch.
-    // The fixed code calls computePrimaryKey(reflection) which, via branch 2 (reflection
-    // normalizes array FK into queryConstraints), returns queryConstraintsList = ["tree_id","id"].
     const owner = new QcOwner({ tree_id: 5, id: 11, name: "Corp" });
     const child = new QcChild({ name: "Doc" });
     owner.association("qcChild").setTarget(child as any);
     const saved = await owner.save();
     expect(saved).toBe(true);
     expect(child.isNewRecord()).toBe(false);
-    // PK ["tree_id","id"] zipped with FK ["tree_id","parent_id"]:
-    // child.tree_id ← owner.tree_id = 5, child.parent_id ← owner.id = 11
     expect(child.tree_id).toBe(5);
     expect(child.parent_id).toBe(11);
   });
 
   it("does not collapse QC-derived PK array via the 'id' rule for scalar FK", async () => {
-    // Guard against the bug where the composite_primary_key? collapse was applied to QC
-    // arrays. If QC list is ["tree_id","id"] and FK is scalar "tree_id", the old code
-    // would collapse to "id" and assign owner.id into child.tree_id — wrong.
-    // With the fix (gate on Array.isArray(ctor.primaryKey)), QC arrays are not collapsed;
-    // instead the composite/scalar mismatch path is reached. In a properly configured
-    // association both FK and PK would be composite, so no-mismatch is the happy path.
-    // This test confirms the collapse does NOT fire for QC-derived PK arrays.
     class QcNoCollapse extends Base {
       declare tree_id: number | null;
       declare name: string | null;
@@ -4635,7 +4568,6 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
         this.attribute("tree_id", "integer");
         this.attribute("id", "integer");
         this.attribute("name", "string");
-        // QC list — ctor.primaryKey remains scalar "id"
         (this as any)._queryConstraintsList = ["tree_id", "id"];
         (this as any)._hasQueryConstraints = true;
         this.hasOne("qcNoCollapseChild", {
@@ -4659,23 +4591,16 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
     }
     registerModel("QcNoCollapse", QcNoCollapse);
     registerModel("QcNoCollapseChild", QcNoCollapseChild);
-    // Explicit composite FK — reflection normalizes array FK to queryConstraints.
-    // computePrimaryKey branch 2 returns QC list ["tree_id","id"].
-    // Array PK + array FK → composite pairing (no "id" collapse).
     const owner = new QcNoCollapse({ tree_id: 9, id: 77, name: "v" });
     const child = new QcNoCollapseChild({ name: "l" });
     owner.association("qcNoCollapseChild").setTarget(child as any);
     const saved = await owner.save();
     expect(saved).toBe(true);
     expect(child.isNewRecord()).toBe(false);
-    // PK ["tree_id","id"] paired with FK ["tree_id","parent_id"]:
-    // child.tree_id ← owner.tree_id = 9, child.parent_id ← owner.id = 77
     expect(child.tree_id).toBe(9);
     expect(child.parent_id).toBe(77);
   });
 
-  // When a class has queryConstraints and the has_one uses a scalar FK,
-  // computePrimaryKey collapses the QC list to a scalar PK via the "id" rule.
   it("uses queryConstraintsList as PK when class has_query_constraints? and scalar FK", async () => {
     class QcTenant extends Base {
       declare tree_id: number | null;
@@ -4688,7 +4613,6 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
         this.attribute("tree_id", "integer");
         this.attribute("id", "integer");
         this.attribute("name", "string");
-        // Simulate a model with query_constraints [:tree_id, :id]
         (this as any)._queryConstraintsList = ["tree_id", "id"];
         (this as any)._hasQueryConstraints = true;
         this.hasOne("qcTenantRecord", {
@@ -4712,15 +4636,12 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
     }
     registerModel("QcTenant", QcTenant);
     registerModel("QcTenantRecord", QcTenantRecord);
-    // Scalar FK "parent_id". computePrimaryKey (scalar-FK branch) returns QC list ["tree_id","id"].
-    // The scalar-FK collapse applies: includes("id") → "id" → rec.parent_id = tenant.id = 42.
     const tenant = new QcTenant({ tree_id: 7, id: 42, name: "Acme" });
     const rec = new QcTenantRecord({ name: "hello" });
     tenant.association("qcTenantRecord").setTarget(rec as any);
     const saved = await tenant.save();
     expect(saved).toBe(true);
     expect(rec.isNewRecord()).toBe(false);
-    // computePrimaryKey → QC list ["tree_id","id"] → scalar collapse "id" → rec.parent_id = 42
     expect(rec.parent_id).toBe(42);
   });
 });

--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -157,16 +157,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     registerModel("WidgetOwner", WidgetOwner);
 
     const owner = await WidgetOwner.create({ name: "Alice" });
-    // Create a persisted, unchanged widget with a blank status
     const widget = await Widget.create({ name: "", author_id: owner.id });
     cacheAssoc(owner, "widgets", [widget]);
 
-    // Default context: widget is unchanged → skipped → owner is valid
     const defaultValid = await owner.isValid();
     expect(defaultValid).toBe(true);
 
-    // Custom context "publish": unchanged widget must be validated too, and its
-    // presence validator fires → owner is invalid
     const publishValid = await owner.isValid("publish" as any);
     expect(publishValid).toBe(false);
   });
@@ -196,7 +192,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     }
     registerModel("DefaultBelongsToAuthor", Author);
     registerModel("DefaultBelongsToPost", Post);
-    // No `autosave:` option — exercises the default-on registration path.
     Associations.belongsTo.call(Post, "author", {
       foreignKey: "author_id",
       className: "DefaultBelongsToAuthor",
@@ -237,8 +232,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     }
     registerModel("ZipParent", Parent);
     registerModel("ZipChild", Child);
-    // PK ["id"] (scalar) zipped against FK ["parent_id", "group"] →
-    // pairs [("id", "parent_id")]; the trailing "group" FK is dropped.
     Associations.belongsTo.call(Child, "parent", {
       primaryKey: "id",
       foreignKey: ["parent_id", "group"],
@@ -256,8 +249,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
     expect(child.parent_id).toBe(parent.id);
-    // Trailing FK "group" was dropped from the zip; the existing
-    // owner value must survive untouched (no overwrite to undefined/null).
     expect(child.group).toBe("us-west");
   });
 
@@ -294,16 +285,13 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       className: "DefaultAutosaveAuthor",
     });
 
-    const author = new Author({}); // name missing — validation fails
+    const author = new Author({});
     const post = new Post({ name: "ok" });
     cacheAssoc(post, "author", author);
     const saved = await post.save();
-    // Owner save succeeds — default branch swallows child failure.
     expect(saved).toBe(true);
     expect(post.isNewRecord()).toBe(false);
-    // Child remained unsaved because record.save(validate: true) failed.
     expect(author.isNewRecord()).toBe(true);
-    // Owner.errors stays clean — propagateErrors is gated on autosave.
     expect(post.errors.size).toBe(0);
   });
 
@@ -332,8 +320,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     }
     registerModel("LongPkParent", Parent);
     registerModel("LongPkChild", Child);
-    // Explicit composite PK ["id", "name"] zipped against scalar FK
-    // ["author_id"] → only ("id", "author_id") pairs; ("name", nil) drops.
     Associations.belongsTo.call(Child, "parent", {
       primaryKey: ["id", "name"],
       foreignKey: "author_id",
@@ -347,8 +333,6 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
     expect(child.author_id).toBe(parent.id);
-    // The dropped ("name", nil) pair didn't attempt to write — no throw,
-    // no spurious column write.
   });
 });
 
@@ -422,8 +406,6 @@ describe("TestAutosaveAssociationsInGeneral association_valid?", () => {
     registerModel("AssociationValidDoomedBird", DoomedBird);
 
     const pirate = await CanonicalPirate.create({ catchphrase: "Yarr" });
-    // `name` is `validates presence` on Bird, so this child is invalid — and
-    // `birds` is autosave through `accepts_nested_attributes_for`.
     const doomed = new DoomedBird({ name: "" });
     pirate.association("birds").setTarget([doomed] as any);
 

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -22,10 +22,6 @@ function _guardKey(association: unknown): string {
   return String(association);
 }
 
-// ---------------------------------------------------------------------------
-// Host interface — what `this` must provide for all this-typed functions
-// ---------------------------------------------------------------------------
-
 interface AutosaveAssociationHost {
   [key: symbol]: unknown;
   _markedForDestruction: boolean;
@@ -44,10 +40,6 @@ interface AutosaveAssociationHost {
   };
   constructor: { primaryKey?: string | string[]; name: string };
 }
-
-// ---------------------------------------------------------------------------
-// Module object — included into Base via include(Base, AutosaveAssociation)
-// ---------------------------------------------------------------------------
 
 type ReloadOptions = { lock?: boolean | string; unscoped?: boolean };
 type ReloadFn<T extends Base> = (this: T, options?: ReloadOptions) => Promise<T>;
@@ -117,10 +109,6 @@ export const AutosaveAssociation = {
   saveBelongsToAssociation,
 };
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 function _setValidatingBelongsToFor(record: any, association: unknown, value: boolean): void {
   let map = record[VALIDATING_BELONGS_TO_FOR] as Map<string, boolean> | undefined;
   if (!map) {
@@ -152,10 +140,6 @@ function _setAutosavingBelongsToFor(record: any, association: unknown, value: bo
     if (map.size === 0) delete record[AUTOSAVING_BELONGS_TO_FOR];
   }
 }
-
-// ---------------------------------------------------------------------------
-// Standalone exports (used by other modules, called via dynamic import)
-// ---------------------------------------------------------------------------
 
 export function isDestroyable(record: Base): boolean {
   return !record.isNewRecord() && record.markedForDestruction();
@@ -215,10 +199,6 @@ export async function flushPendingReplaces(record: Base): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Validate & autosave (called from Base.isValid and Base.save)
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Save callbacks, registered per association by
 // `addAutosaveAssociationCallbacks` (autosave_association.rb:171-206).
 // HABTM reflections route into `saveCollectionAssociation` as a hasMany-typed
@@ -249,11 +229,8 @@ export async function saveCollectionAssociation(
   }
   const autosave = reflection.options?.autosave;
 
-  // By saving the instance variable in a local variable,
-  // we make the whole callback re-entrant.
   const newRecordBeforeSave = !!(this as any)._newRecordBeforeSave;
 
-  // reconstruct the scope now that we know the owner's id
   association.resetScope();
 
   let records: Base[] | null = associatedRecordsToValidateOrSave.call(
@@ -327,18 +304,6 @@ export async function saveHasOneAssociation(
     await association.persistReplace();
   }
 
-  // A has_one *through* suppresses its through-proxy's independent autosave by
-  // planting a sentinel `_pendingReplace` on the (plain has_one) proxy: over an
-  // UNLOADED pre-existing join row the through builds a fresh join record in
-  // memory so `owner.through` reads present it synchronously, but that record
-  // must NOT be inserted here — the through's own `persistReplace` reconciles
-  // the existing DB row via `load_target` + `update`, and persisting it here
-  // would duplicate that row. A plain `HasOneAssociation` never sets
-  // `_pendingReplace` itself (its displacement removal runs inline, via
-  // `detachDisplacedTarget`), and the through association itself clears its marker
-  // in the `persistReplace` above, so a truthy marker on a non-through
-  // association is unambiguously that suppression sentinel. Skip
-  // the end-record persistence; the through owns the join row.
   if (association?._pendingReplace && !isThrough) {
     return true;
   }
@@ -888,7 +853,6 @@ export function defineNonCyclicMethod(this: any, name: string, fn: (this: any) =
         clear();
         throw e;
       }
-      // Keep the guard set until async work settles to prevent re-entrant autosave cycles.
       if (result != null && typeof result.then === "function") {
         return result.then(
           (v: any) => {


### PR DESCRIPTION
First alphabetical slice of the `packages/activerecord/src/*.ts` root sweep.

`blazetrails/no-freeform-comments` is registered per glob, so the root
directory is swept one slice per PR and the rule stays green in between. This
adds `packages/activerecord/src/a*.ts` to the block's `files` list
(`eslint.config.mjs`) and applies the autofix over it — 219 violations, 469
deleted lines across 18 files.

The deletions were reviewed rather than taken on trust:

- No `TODO`/`FIXME`/deferred-work comment was among them, so nothing needed
  filing as a story.
- One autofix emptied an `if` arm — `associations.ts` had
  `if (ownWrappedNames.has(name)) { /* skip wrapper layering */ } else {`.
  That is re-expressed in code as `if (!ownWrappedNames.has(name)) {` rather
  than by restoring the comment.
- `prettier --write` over the glob collapses the blank-line runs the deletions
  leave behind.

`pnpm eslint` is clean over the glob and a second `--fix` run is a no-op;
`pnpm typecheck` is clean; `associations.test.ts` and
`habtm-destroy-order.test.ts` (the tests covering the one code change) pass.

The remaining ~1510 violations across the rest of the root directory are filed
as `strip-freeform-comments-ar-root-b` (`b*.ts` next, with the per-letter
measurements recorded in its context).

Closes-story: strip-freeform-comments-ar-root