### PR TITLE
fix(ci,activemodel,activerecord): run the date suite; converge secure_password ivars and the @primary_key seat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,7 @@ jobs:
           packages/arel
           packages/activemodel
           packages/activesupport
+          packages/date
           packages/i18n
           scripts/guides-typecheck
           scripts/tasks
@@ -733,6 +734,7 @@ jobs:
           packages/arel
           packages/activemodel
           packages/activesupport
+          packages/date
           packages/did-you-mean
           packages/globalid
           packages/i18n

--- a/packages/activemodel/src/secure-password.trails.test.ts
+++ b/packages/activemodel/src/secure-password.trails.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Model } from "./index.js";
+import { hasSecurePassword, SecurePassword } from "./secure-password.js";
+
+let savedMinCost: boolean;
+
+beforeEach(() => {
+  savedMinCost = SecurePassword.minCost;
+  SecurePassword.minCost = true;
+});
+
+afterEach(() => {
+  SecurePassword.minCost = savedMinCost;
+});
+
+describe("SecurePasswordTrailsTest", () => {
+  it("password= dispatches through the public password_digest writer", () => {
+    const seen: unknown[] = [];
+
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("password_digest", "string");
+      }
+    }
+    hasSecurePassword(User, "password", {});
+
+    // Rails writes the digest with `self.public_send("#{attribute}_digest=", ...)`
+    // (secure_password.rb:188,193), so a model that overrides the writer sees it.
+    class OverridingUser extends User {}
+    Object.defineProperty(OverridingUser.prototype, "password_digest", {
+      get(this: Model) {
+        return this._readAttribute("password_digest");
+      },
+      set(this: Model, value: unknown) {
+        seen.push(value);
+        this._writeAttribute("password_digest", value);
+      },
+      configurable: true,
+    });
+
+    const u = new OverridingUser({ name: "test" });
+    (u as any).password = "secret";
+
+    expect(seen.length).toBe(1);
+    expect(String(seen[0])).toMatch(/^\$2[aby]\$/);
+  });
+
+  it("password_confirmation is not an attribute", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("password_digest", "string");
+      }
+    }
+    hasSecurePassword(User, "password", {});
+
+    // secure_password.rb:197 is a plain `attr_accessor`, so the confirmation
+    // lives in an ivar and never reaches the attribute set.
+    expect(User._defaultAttributes().isKey("passwordConfirmation")).toBe(false);
+
+    const u = new User({ name: "test" });
+    (u as any).passwordConfirmation = "secret";
+    expect((u as any).passwordConfirmation).toBe("secret");
+    expect(Object.keys(u.attributes)).not.toContain("passwordConfirmation");
+  });
+});

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -44,11 +44,8 @@ export function hasSecurePassword(
     modelClass.attribute(digestAttr, "string");
   }
 
-  if (!modelClass._defaultAttributes().isKey(confirmationAttr)) {
-    modelClass.attribute(confirmationAttr, "string");
-  }
-
   const passwordCache = new WeakMap<object, string | null>();
+  const confirmationCache = new WeakMap<object, string | null>();
   const challengeCache = new WeakMap<object, string | null>();
 
   Object.defineProperty(modelClass.prototype, attribute, {
@@ -58,11 +55,14 @@ export function hasSecurePassword(
     set(this: Model, unencryptedPassword: unknown) {
       if (unencryptedPassword === null || unencryptedPassword === undefined) {
         passwordCache.set(this, null);
-        this._writeAttribute(digestAttr, null);
+        (this as unknown as Record<string, unknown>)[digestAttr] = null;
       } else if (String(unencryptedPassword) !== "") {
         passwordCache.set(this, String(unencryptedPassword));
         const cost = SecurePassword.minCost ? MIN_COST : DEFAULT_COST;
-        this._writeAttribute(digestAttr, bcrypt.hashSync(String(unencryptedPassword), cost));
+        (this as unknown as Record<string, unknown>)[digestAttr] = bcrypt.hashSync(
+          String(unencryptedPassword),
+          cost,
+        );
       }
     },
     configurable: true,
@@ -70,10 +70,10 @@ export function hasSecurePassword(
 
   Object.defineProperty(modelClass.prototype, confirmationAttr, {
     get(this: Model) {
-      return this._readAttribute(confirmationAttr);
+      return confirmationCache.get(this) ?? null;
     },
     set(this: Model, value: unknown) {
-      this._writeAttribute(confirmationAttr, value);
+      confirmationCache.set(this, value === null || value === undefined ? null : String(value));
     },
     configurable: true,
   });
@@ -92,7 +92,7 @@ export function hasSecurePassword(
   const saltMethodName = `${attribute}Salt`;
   Object.defineProperty(modelClass.prototype, saltMethodName, {
     get(this: Model) {
-      const digest = this._readAttribute(digestAttr) as string | null;
+      const digest = (this as unknown as Record<string, unknown>)[digestAttr] as string | null;
       if (!digest) return null;
       return bcrypt.getSalt(digest);
     },
@@ -105,7 +105,7 @@ export function hasSecurePassword(
   Object.defineProperty(modelClass.prototype, authMethodName, {
     value: function (this: Model, unencryptedPassword: unknown) {
       if (typeof unencryptedPassword !== "string" || !unencryptedPassword) return false;
-      const digest = this._readAttribute(digestAttr) as string | null;
+      const digest = (this as unknown as Record<string, unknown>)[digestAttr] as string | null;
       if (!digest) return false;
       return bcrypt.compareSync(unencryptedPassword, digest) ? this : false;
     },
@@ -116,7 +116,7 @@ export function hasSecurePassword(
   if (validations) {
     modelClass.validate((record: Model) => {
       const pwd = passwordCache.get(record);
-      const digest = record._readAttribute(digestAttr);
+      const digest = (record as unknown as Record<string, unknown>)[digestAttr];
 
       if (isBlank(digest) && (pwd === undefined || pwd === null)) {
         record.errors.add(attribute, ":blank");
@@ -141,8 +141,8 @@ export function hasSecurePassword(
         const humanAttr = modelClass.humanAttributeName
           ? modelClass.humanAttributeName(attribute)
           : humanize(attribute);
-        const confirmation = record._readAttribute(confirmationAttr);
-        if (confirmation !== undefined && confirmation !== null && pwd !== confirmation) {
+        const confirmation = (record as unknown as Record<string, unknown>)[confirmationAttr];
+        if (confirmation !== null && confirmation !== undefined && pwd !== confirmation) {
           record.errors.add(attribute, ":confirmation", { attribute: humanAttr });
         }
       }

--- a/packages/activemodel/src/secure-password.ts
+++ b/packages/activemodel/src/secure-password.ts
@@ -45,7 +45,7 @@ export function hasSecurePassword(
   }
 
   const passwordCache = new WeakMap<object, string | null>();
-  const confirmationCache = new WeakMap<object, string | null>();
+  const confirmationCache = new WeakMap<object, unknown>();
   const challengeCache = new WeakMap<object, string | null>();
 
   Object.defineProperty(modelClass.prototype, attribute, {
@@ -73,7 +73,7 @@ export function hasSecurePassword(
       return confirmationCache.get(this) ?? null;
     },
     set(this: Model, value: unknown) {
-      confirmationCache.set(this, value === null || value === undefined ? null : String(value));
+      confirmationCache.set(this, value);
     },
     configurable: true,
   });

--- a/packages/activerecord/src/attribute-methods/composite-primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/composite-primary-key.ts
@@ -14,13 +14,10 @@ import { PrimaryKey, type PrimaryKeyInstance, type PrimaryKeyRecord } from "./pr
  *
  * Ruby's `@primary_key`, the ivar seeded from the class at `init_internals`
  * (core.rb:846) — read off the record's own slot, in the order the class
- * declares. A record built before its schema reflected has no seat and reads
- * through to the class; see `primaryKeyOf` in primary-key.ts.
+ * declares.
  */
 function primaryKeyOf(record: object): string[] {
-  const seated = (record as { _primaryKey?: string[] })._primaryKey;
-  if (seated !== undefined) return seated;
-  return (record.constructor as any).primaryKey as string[];
+  return (record as { _primaryKey: string[] })._primaryKey;
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/primary-key-slot.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key-slot.trails.test.ts
@@ -2,10 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import { Base } from "../base.js";
 
 // Rails seats `@primary_key` once, at `init_internals` (core.rb:846), and every
-// instance-side reader reads that ivar (primary_key.rb:18-56). trails' schema
-// reflection is async, so the seat is taken only once the class can answer for
-// real; a record built in the cold window reads through to the class instead of
-// latching `get_primary_key`'s "id" convention forever.
+// instance-side reader reads that ivar (primary_key.rb:18-56) — so the record
+// keeps the key its class answered at construction, whatever the class says
+// later.
 describe("per-instance @primary_key slot", () => {
   it("seats the record's primary key from the class at init_internals", () => {
     class SeatedToy extends Base {
@@ -27,14 +26,14 @@ describe("per-instance @primary_key slot", () => {
     expect(spy).toHaveBeenCalledWith("toy_id");
   });
 
-  it("a record built before its schema loads still resolves the real primary key", () => {
+  it("keeps the seat the class answered at construction", () => {
     class ColdToy extends Base {
       static override tableName = "toys";
     }
 
     const record = new ColdToy();
 
-    expect((record as unknown as { _primaryKey?: string })._primaryKey).toBeUndefined();
+    expect((record as unknown as { _primaryKey?: string })._primaryKey).toBe("id");
 
     (ColdToy as unknown as { adapter: unknown }).adapter = {
       internalSchemaCache: { getCachedPrimaryKeys: () => "toy_id" },
@@ -45,6 +44,9 @@ describe("per-instance @primary_key slot", () => {
     );
     void record.id;
 
-    expect(spy).toHaveBeenCalledWith("toy_id");
+    expect(spy).toHaveBeenCalledWith("id");
+
+    const warm = new ColdToy();
+    expect((warm as unknown as { _primaryKey?: string })._primaryKey).toBe("toy_id");
   });
 });

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -151,17 +151,9 @@ export class PrimaryKey {
   }
 }
 
-/**
- * Ruby's readers read the record's `@primary_key` ivar, seeded from the class
- * at `init_internals` (core.rb:846). trails seats the same slot there, but only
- * once the class can answer for real: schema reflection is async here, so a
- * record built before its columns hash arrives has no seat and reads through to
- * the class, which resolves the real key as soon as it lands.
- */
+/** Ruby's `@primary_key`, seeded from the class at `init_internals` (core.rb:846). */
 function primaryKeyOf(record: object): string | string[] {
-  const seated = (record as { _primaryKey?: string | string[] })._primaryKey;
-  if (seated !== undefined) return seated;
-  return (record.constructor as any).primaryKey;
+  return (record as { _primaryKey: string | string[] })._primaryKey;
 }
 
 // ---------------------------------------------------------------------------
@@ -200,29 +192,6 @@ function cachedSchemaCacheFor(
   if (host._adapter?.internalSchemaCache) return host._adapter.internalSchemaCache;
   const pool = host.connectionPool?.();
   return pool?.activeConnection?.internalSchemaCache ?? pool?.poolConfig?.schemaCache ?? undefined;
-}
-
-/**
- * Whether the class can answer `primary_key` for real yet — an explicitly
- * configured key, or one the schema cache has already reflected.
- *
- * Ruby's `init_internals` seats `@primary_key` from the class unconditionally
- * (core.rb:846) because `get_primary_key` is synchronous there. trails reflects
- * the schema asynchronously, so `getPrimaryKey` answers the "id" convention
- * until the cache is warm; seating that would latch it for the record's
- * lifetime. `initInternals` guards Rails' assignment with this,
- * and `primaryKeyOf` reads through to the class while it is false.
- * @internal
- */
-export function isPrimaryKeySettled(this: PrimaryKeyHost): boolean {
-  if (this._primaryKey !== undefined) return true;
-  try {
-    const tableName = this.tableName;
-    if (tableName == null) return false;
-    return cachedSchemaCacheFor(this)?.getCachedPrimaryKeys?.(tableName) !== undefined;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -39,7 +39,6 @@ import type { PrettyPrinter } from "./pretty-print.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { buildPkWhereNode, columnsHash } from "./model-schema.js";
-import { isPrimaryKeySettled } from "./attribute-methods/primary-key.js";
 import { StatementCache } from "./statement-cache.js";
 import { withConnection } from "./connection-handling.js";
 import { RangeError as ActiveModelRangeError, runAllCallbacks } from "@blazetrails/activemodel";
@@ -856,14 +855,6 @@ export function arelTable(this: CoreHost): Table {
  * already assigned; the flag is raised here instead, at the first seat that
  * runs before the assignment and in Rails' own order.
  *
- * `@primary_key = klass.primary_key` (core.rb:846) is seated below, but behind
- * `isPrimaryKeySettled`: schema reflection is asynchronous, so a record
- * constructed before its schema loads would latch a placeholder key for its
- * whole life. While the slot is unseated, `primaryKeyOf`
- * (attribute-methods/primary-key.ts) reads through to the class. Dropping the
- * guard and seating unconditionally is tracked separately (RFC 0115
- * `drop-the-primary-key-seat-guard-once-schema-reflection-is-warm`).
- *
  * @internal
  */
 export function initInternals(
@@ -890,9 +881,7 @@ export function initInternals(
   this._destroyedByAssociation = null;
   this._startTransactionState = null;
   const klass = this.constructor as any;
-  // core.rb:846 — `@primary_key = klass.primary_key`, guarded because trails
-  // resolves the schema asynchronously; see `isPrimaryKeySettled`.
-  if (isPrimaryKeySettled.call(klass)) this._primaryKey = klass.primaryKey;
+  this._primaryKey = klass.primaryKey;
   this._strictLoading = klass.strictLoadingByDefault ?? false;
   this._strictLoadingMode = klass.strictLoadingMode;
 

--- a/packages/date/src/test-date-conv.test.ts
+++ b/packages/date/src/test-date-conv.test.ts
@@ -251,14 +251,20 @@ function nsec(t: Temporal.ZonedDateTime | Temporal.PlainDateTime): number {
   return t.millisecond * 1_000_000 + t.microsecond * 1_000 + t.nanosecond;
 }
 
-/** Ruby `DateTime#iso8601(n)`, off the Temporal value `toDatetime` answers. */
+/**
+ * Ruby `DateTime#iso8601(n)`, off the Temporal value `toDatetime` answers. A
+ * `PlainDateTime` is that mapping's spelling of an `of` of `0` — the same
+ * reading {@link offsetSeconds} takes below — and `DateTime#iso8601` prints
+ * that offset as `+00:00` (`date_core.c` `of2str`, `:1973-1980`), never bare
+ * and never `Z`.
+ */
 function iso8601(
   d: Temporal.ZonedDateTime | Temporal.PlainDateTime,
   fractionDigits: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9,
 ): string {
   return d instanceof Temporal.ZonedDateTime
     ? d.toString({ fractionalSecondDigits: fractionDigits, timeZoneName: "never" })
-    : d.toString({ fractionalSecondDigits: fractionDigits });
+    : `${d.toString({ fractionalSecondDigits: fractionDigits })}+00:00`;
 }
 
 /** Ruby `DateTime#offset`, in seconds rather than as a fraction of a day. */

--- a/packages/date/src/test-date.test.ts
+++ b/packages/date/src/test-date.test.ts
@@ -133,7 +133,11 @@ describe("TestDate", () => {
     expect(dt).toBeInstanceOf(DateTimeSub);
 
     expect(DateSub.today()).toBeInstanceOf(Temporal.PlainDate);
-    expect(DateTimeSub.now()).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect(DateTimeSub.now()).toBeInstanceOf(
+      Temporal.Now.zonedDateTimeISO().offsetNanoseconds === 0
+        ? Temporal.PlainDateTime
+        : Temporal.ZonedDateTime,
+    );
 
     expect(d.toS()).toEqual("-4712-01-01");
     expect(dt.toS()).toEqual("-4712-01-01T00:00:00+00:00");

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -496,6 +496,7 @@ let seatedTime: {
   zoned: Temporal.ZonedDateTime;
   instant: Temporal.Instant;
   timeZoneId: string | null;
+  tzmodeUtc: boolean;
 } | null = null;
 
 export class Time {
@@ -518,6 +519,14 @@ export class Time {
   #instant: Temporal.Instant;
   /** @internal The receiver's zone, or `null` when it was built from an offset. */
   #timeZoneId: string | null;
+  /**
+   * @internal MRI's `TZMODE_UTC` bit (`time.c`), which is set by `Time.utc` and
+   * by a zone argument naming UTC — and NOT by the local zone, even where that
+   * zone IS UTC: `TZ=UTC Time.now.utc?` is `false` and its `#to_s` prints
+   * `+0000` rather than `UTC`. The zone identifier alone cannot tell the two
+   * apart, so the mode is carried rather than re-derived from it.
+   */
+  #tzmodeUtc: boolean;
   /** @internal Seconds east of UTC — Ruby's `Time#utc_offset`. */
   #utcOffsetMemo: number | null;
 
@@ -627,11 +636,20 @@ export class Time {
    * disambiguation picks the earlier offset for the repeated hour after a DST
    * fall-back — so `Time.at(t)` could answer an instant an hour from `t`.
    */
-  static #atInstant(instant: Temporal.Instant, zone: string | number | null = null): Time {
+  static #atInstant(
+    instant: Temporal.Instant,
+    zone: string | number | null = null,
+    tzmodeUtc?: boolean,
+  ): Time {
     const timeZoneId =
       zone == null ? nowTimeZoneId() : typeof zone === "number" ? of2str(zone) : zone;
     const zoned = instant.toZonedDateTimeISO(timeZoneId);
-    seatedTime = { zoned, instant, timeZoneId: typeof zone === "number" ? null : timeZoneId };
+    seatedTime = {
+      zoned,
+      instant,
+      timeZoneId: typeof zone === "number" ? null : timeZoneId,
+      tzmodeUtc: tzmodeUtc ?? (zone != null && zoned.timeZoneId === "UTC"),
+    };
     return new Time(0);
   }
 
@@ -658,7 +676,11 @@ export class Time {
       if (microsecondsWithFrac !== 0) {
         throw new TypeError("can't convert Time into an exact number");
       }
-      return Time.#atInstant(seconds.#instant, seconds.#timeZoneId ?? seconds.#utcOffset);
+      return Time.#atInstant(
+        seconds.#instant,
+        seconds.#timeZoneId ?? seconds.#utcOffset,
+        seconds.#tzmodeUtc,
+      );
     }
     const timew = numExact(seconds)
       .mul(1_000_000_000)
@@ -768,7 +790,7 @@ export class Time {
   static #mktimeIsdst(time: Time, isdst: boolean | null): Time {
     if (isdst == null || time.#timeZoneId == null || time.isdst === isdst) return time;
     const earlier = time.#plain.toZonedDateTime(time.#timeZoneId, { disambiguation: "earlier" });
-    const candidate = Time.#atInstant(earlier.toInstant(), time.#timeZoneId);
+    const candidate = Time.#atInstant(earlier.toInstant(), time.#timeZoneId, time.#tzmodeUtc);
     return candidate.isdst === isdst ? candidate : time;
   }
 
@@ -836,6 +858,7 @@ export class Time {
       this.#zoned = seat.zoned;
       this.#instant = seat.instant;
       this.#timeZoneId = seat.timeZoneId;
+      this.#tzmodeUtc = seat.tzmodeUtc;
       return;
     }
     year = obj2vint(year);
@@ -873,6 +896,7 @@ export class Time {
       hour === 24 ? plain.add({ hours: 1 }) : wholeSec === 60 ? plain.add({ seconds: 1 }) : plain;
     const utcOffset = zone == null ? nowTimeZoneId() : utcOffsetArgument(zone);
     this.#timeZoneId = typeof utcOffset === "number" ? null : utcOffset;
+    this.#tzmodeUtc = zone != null && this.#timeZoneId === "UTC";
     // MRI's `find_time_t` (`time.c`) settles a wall clock a DST fall-back
     // repeats on the STANDARD-time occurrence when `isdst` is `nil`:
     // `TZ=America/New_York Time.local(2005, 10, 30, 1, 0, 0)` is `-0500`, where
@@ -1131,12 +1155,12 @@ export class Time {
   /**
    * Ruby `Time#utc?` (`ruby/time.c` `time_utc_p`, not vendored — the gem's
    * `lib/time.rb` and `date_core.c` both duck-type it), true for the times
-   * `Time.utc` builds. A time built from an offset is not a UTC time even when
-   * the offset is zero, which is the distinction `#to_s` and `#xmlschema`
-   * print.
+   * `Time.utc` builds. Neither a time built from an offset nor one built in the
+   * local zone is a UTC time even when that offset or zone is UTC, which is the
+   * distinction `#to_s` and `#xmlschema` print.
    */
   isUtc(): boolean {
-    return this.#timeZoneId === "UTC";
+    return this.#tzmodeUtc;
   }
 
   /**

--- a/scripts/ci-suite-coverage.test.ts
+++ b/scripts/ci-suite-coverage.test.ts
@@ -23,8 +23,8 @@ const execFileAsync = promisify(execFile);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const CI_YML = path.join(REPO_ROOT, ".github/workflows/ci.yml");
 
-// Roots holding non-package test files. packages/ is excluded: those suites
-// are covered by the per-package jobs, whose filters are whole directories.
+// Roots holding non-package test files. packages/ has its own walk below,
+// which checks a whole package directory rather than each file.
 const TOOLING_ROOTS = ["scripts", "eslint", "vendor"];
 
 // Suites that deliberately do not run in CI yet. Every entry needs a reason
@@ -115,6 +115,20 @@ function ciVitestFilters(yml: string): string[] {
     }
   }
   return filters;
+}
+
+/**
+ * Packages whose suite CI runs from inside the package, via
+ * `pnpm --filter <name> exec vitest run`. Those filters are package-relative,
+ * so {@link ciVitestFilters} skips them; the package is still covered.
+ */
+function ciPackageFilterDirs(yml: string): string[] {
+  const dirs: string[] = [];
+  for (const line of yml.split("\n")) {
+    const match = line.match(/--filter\s+(?:@[\w-]+\/)?([\w.-]+)\s+exec\s+vitest\s+run/);
+    if (match) dirs.push(`packages/${match[1]}`);
+  }
+  return dirs;
 }
 
 /** The `unit-tests:` job block, sliced out at the next job at the same indent. */
@@ -461,6 +475,28 @@ describe("CI runs every tooling test suite", () => {
       .map((f) => f.split(path.sep).join("/"))
       .filter((f) => !(f in KNOWN_UNRUN))
       .filter((f) => !filters.some((filter) => f.startsWith(filter)));
+    expect(uncovered).toEqual([]);
+  });
+
+  // The package half of the same defect: packages/date held 13 files and 362
+  // tests that no ci.yml job ran — the change filters named the package, so a
+  // date change woke the Unit Tests job, which then ran no date test.
+  it("covers each package test suite with a ci.yml vitest filter", async () => {
+    const yml = await readFile(CI_YML, "utf8");
+    const filters = [...ciVitestFilters(yml), ...ciPackageFilterDirs(yml)];
+
+    const packagesDir = path.join(REPO_ROOT, "packages");
+    const entries = await readdir(packagesDir, { withFileTypes: true });
+    const uncovered: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+      const files = await collectTestFiles(path.join(packagesDir, entry.name), []);
+      if (files.length === 0) continue;
+      const dir = `packages/${entry.name}`;
+      if (!filters.some((filter) => dir.startsWith(filter.replace(/\/$/, "")))) {
+        uncovered.push(dir);
+      }
+    }
     expect(uncovered).toEqual([]);
   });
 


### PR DESCRIPTION
Four bundled convergences.

CI — no job ran `packages/date`: the change filters named it (ci.yml:109-118)
so a date change woke the Unit Tests job, which then ran none of its 13 files
/ 362 tests. Add the package to the Unit Tests and coverage `vitest run`
lists, and widen scripts/ci-suite-coverage.test.ts so a package holding
`*.test.ts` with no ci.yml vitest filter fails the way a `scripts/` file
already does.

secure_password confirmation — secure_password.rb:197 is a plain
`attr_accessor :"#{attribute}_confirmation", :"#{attribute}_challenge"`, one
storage decision for both halves. trails backed the challenge with an ivar
slot but declared the confirmation as a real attribute, so it reached dirty
tracking, `attributes` and serialization where Rails' is invisible. Back it
with a `confirmationCache` slot beside `challengeCache` and drop the
`attribute()` declaration.

secure_password digest — Rails writes and reads the digest through the public
accessor (`public_send("#{attribute}_digest=", ...)`, secure_password.rb:188,
193, 189, 212), which dispatches to whatever the model defines. trails went
straight to `_writeAttribute` / `_readAttribute`, bypassing an override.
Dispatch by property at all four sites plus the validation's digest read.

@primary_key — core.rb:846 seats the ivar unconditionally. Drop the
`isPrimaryKeySettled` guard and both `primaryKeyOf` class fallbacks, so the
readers are the bare ivar read of primary_key.rb:18-56 and
composite_primary_key.rb:18-25.

Closes-story: date-suite-is-not-run-by-any-ci-job
Closes-story: converge-password-confirmation-onto-the-rails-ivar-pair
Closes-story: drop-the-primary-key-seat-guard-once-schema-reflection-is-warm
Closes-story: secure-password-digest-writes-bypass-the-public-setter