### PR TITLE
docs(activerecord): retarget the init_internals primary-key note at the live story

### DIFF
--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -856,12 +856,13 @@ export function arelTable(this: CoreHost): Table {
  * already assigned; the flag is raised here instead, at the first seat that
  * runs before the assignment and in Rails' own order.
  *
- * `@primary_key = klass.primary_key` (core.rb:846) has no seat here: trails
- * resolves the primary key off the class at read time
- * (`primaryKeyOf`, attribute-methods/primary-key.ts), because schema reflection
- * is asynchronous and a record constructed before its schema loads would latch
- * a placeholder key for its whole life. Converging that slot is tracked
- * separately (RFC 0115 `seat-the-per-instance-primary-key-slot`).
+ * `@primary_key = klass.primary_key` (core.rb:846) is seated below, but behind
+ * `isPrimaryKeySettled`: schema reflection is asynchronous, so a record
+ * constructed before its schema loads would latch a placeholder key for its
+ * whole life. While the slot is unseated, `primaryKeyOf`
+ * (attribute-methods/primary-key.ts) reads through to the class. Dropping the
+ * guard and seating unconditionally is tracked separately (RFC 0115
+ * `drop-the-primary-key-seat-guard-once-schema-reflection-is-warm`).
  *
  * @internal
  */


### PR DESCRIPTION
`scripts/stale-story-references.test.ts` is red on main @e9d24042:

```
packages/activerecord/src/core.ts:839 seat-the-per-instance-primary-key-slot
```

PR #6934 landed that story — it seated `@primary_key` in `initInternals`,
guarded by `isPrimaryKeySettled` — but left the doc block above still saying
the slot "has no seat here" and citing the now-done story. Both halves are
fixed: the note describes the guard that is actually in the body, and points at
the live follow-up, `drop-the-primary-key-seat-guard-once-schema-reflection-is-warm`
(RFC 0115, in progress as #6956), which removes it.

Comment-only; `pnpm vitest run scripts/stale-story-references.test.ts` passes.

Closes-story: red-e9d24042