### PR TITLE
refactor(activerecord): converge define_attribute onto define_default_attribute + Attribute::UserProvidedDefault

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -29,10 +29,10 @@ export class AttributeSet {
    *
    * Mirrors: `delegate :fetch, to: :attributes`.
    */
-  fetch(name: string, defaultOrBlock?: Attribute | ((name: string) => Attribute)): Attribute {
+  fetch<T = Attribute>(name: string, defaultOrBlock?: T | ((name: string) => T)): Attribute | T {
     const attr = this.attributes().get(name);
     if (attr !== undefined) return attr;
-    if (typeof defaultOrBlock === "function") return defaultOrBlock(name);
+    if (typeof defaultOrBlock === "function") return (defaultOrBlock as (name: string) => T)(name);
     if (defaultOrBlock !== undefined) return defaultOrBlock;
     const err = new Error(`key not found: ${JSON.stringify(name)}`);
     err.name = "KeyError";

--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -6,9 +6,6 @@
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],
-      "@blazetrails/activemodel/attribute-registration": [
-        "../../activemodel/src/attribute-registration.ts"
-      ],
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
       "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -9,7 +9,12 @@
  */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base } from "./index.js";
-import { typeRegistry, StringType, IntegerType } from "@blazetrails/activemodel";
+import {
+  typeRegistry,
+  StringType,
+  IntegerType,
+  UserProvidedDefault,
+} from "@blazetrails/activemodel";
 import { Array as OidArray } from "./connection-adapters/postgresql/oid/array.js";
 import { RangeType } from "./connection-adapters/postgresql/oid/range.js";
 import { BigDecimal } from "@blazetrails/activesupport";
@@ -515,6 +520,9 @@ describe("CustomPropertiesTest", () => {
 });
 
 describe("DefineAttributeTest", () => {
+  // `define_attribute` writes the type and the default attribute only
+  // (attributes.rb:231-239); it generates no reader, so these read through
+  // `read_attribute` the way Rails does before `define_attribute_methods` runs.
   it("define_attribute registers a type object directly", () => {
     const intType = typeRegistry.lookup("integer");
     class Post extends Base {
@@ -523,7 +531,7 @@ describe("DefineAttributeTest", () => {
       }
     }
     const p = new Post({ score: "42" });
-    expect(p.score).toBe(42);
+    expect(p.readAttribute("score")).toBe(42);
   });
 
   it("define_attribute with default value", () => {
@@ -534,7 +542,7 @@ describe("DefineAttributeTest", () => {
       }
     }
     const p = new Post({});
-    expect(p.rating).toBe(5);
+    expect(p.readAttribute("rating")).toBe(5);
   });
 
   it("define_attribute preserves existing default when no default given", () => {
@@ -547,7 +555,7 @@ describe("DefineAttributeTest", () => {
       }
     }
     const p = new Post({});
-    expect(p.score).toBe(10);
+    expect(p.readAttribute("score")).toBe(10);
   });
 
   it("define_attribute with userProvidedDefault false uses database cast", () => {
@@ -558,10 +566,22 @@ describe("DefineAttributeTest", () => {
       }
     }
     const p = new Post({});
-    expect(p.views).toBe(0);
+    expect(p.readAttribute("views")).toBe(0);
   });
 
-  it("define_attribute invalidates _defaultAttributes cache", () => {
+  it("define_attribute builds a UserProvidedDefault when the default is user-provided", () => {
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.defineAttribute("score", intType, { default: "5" });
+      }
+    }
+    expect(Post._defaultAttributes().getAttribute("score")).toBeInstanceOf(UserProvidedDefault);
+    // Ruby `_default_attributes.fetch(name.to_s) { nil }` — no prior attribute.
+    expect((Post._defaultAttributes().getAttribute("score") as any).originalAttribute).toBeNull();
+  });
+
+  it("define_attribute writes into the memoized _defaultAttributes", () => {
     const strType = typeRegistry.lookup("string");
     const intType = typeRegistry.lookup("integer");
     class Post extends Base {
@@ -571,8 +591,11 @@ describe("DefineAttributeTest", () => {
     }
     const before = Post._defaultAttributes();
     Post.defineAttribute("score", intType);
-    const after = Post._defaultAttributes();
-    expect(before).not.toBe(after);
+    // attributes.rb:290 assigns into `_default_attributes` itself, so the set
+    // is mutated in place rather than invalidated.
+    expect(Post._defaultAttributes()).toBe(before);
+    expect(before.getAttribute("score").type.name).toBe("integer");
+    expect(Post.typeForAttribute("score").name).toBe("integer");
   });
 });
 
@@ -630,9 +653,8 @@ describe("DefaultAttributesTest", () => {
   });
 
   it("_defaultAttributes seeds schema columns via fromDatabase then replays user pending queue", () => {
-    const intType = typeRegistry.lookup("integer");
     class Post extends Base {}
-    Post.defineAttribute("views", intType, { default: 0, userProvidedDefault: false });
+    (Post as any)._columnsHash = { views: { name: "views", default: 0 } };
     Post.attribute("title", "string", { default: "untitled" });
 
     const defaults = Post._defaultAttributes();
@@ -641,9 +663,8 @@ describe("DefaultAttributesTest", () => {
   });
 
   it("user attribute() declaration overrides schema column type via pending queue", () => {
-    const intType = typeRegistry.lookup("integer");
     class Post extends Base {}
-    Post.defineAttribute("score", intType, { default: 0, userProvidedDefault: false });
+    (Post as any)._columnsHash = { score: { name: "score", default: 0 } };
     Post.attribute("score", "string");
 
     const defaults = Post._defaultAttributes();
@@ -651,9 +672,8 @@ describe("DefaultAttributesTest", () => {
   });
 
   it("attribute() overriding only type preserves the schema default", () => {
-    const intType = typeRegistry.lookup("integer");
     class Post extends Base {}
-    Post.defineAttribute("score", intType, { default: 5, userProvidedDefault: false });
+    (Post as any)._columnsHash = { score: { name: "score", default: 5 } };
     Post.attribute("score", "string");
 
     const defaults = Post._defaultAttributes();
@@ -674,10 +694,10 @@ describe("DefineAttributeSTITest", () => {
     }
     class Dog extends (Animal as any) {}
     (Dog as any).defineAttribute("legs", intType, { default: 4 });
-    expect((Dog as any)._attributeDefinitions.has("legs")).toBe(true);
-    expect((Animal as any)._attributeDefinitions.has("legs")).toBe(false);
+    expect((Dog as any)._defaultAttributes().isKey("legs")).toBe(true);
+    expect((Animal as any)._defaultAttributes().isKey("legs")).toBe(false);
     const d = new (Dog as any)({});
-    expect(d.legs).toBe(4);
+    expect(d.readAttribute("legs")).toBe(4);
   });
 
   it("_defaultAttributes is memoized per class, not shared with the STI base", () => {

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -578,7 +578,7 @@ describe("DefineAttributeTest", () => {
     }
     expect(Post._defaultAttributes().getAttribute("score")).toBeInstanceOf(UserProvidedDefault);
     // Ruby `_default_attributes.fetch(name.to_s) { nil }` — no prior attribute.
-    expect((Post._defaultAttributes().getAttribute("score") as any).originalAttribute).toBeNull();
+    expect(Post._defaultAttributes().getAttribute("score").getOriginalAttribute()).toBeNull();
   });
 
   it("define_attribute writes into the memoized _defaultAttributes", () => {

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -654,7 +654,9 @@ describe("DefaultAttributesTest", () => {
 
   it("_defaultAttributes seeds schema columns via fromDatabase then replays user pending queue", () => {
     class Post extends Base {}
-    (Post as any)._columnsHash = { views: { name: "views", default: 0 } };
+    (Post as unknown as { _columnsHash?: Record<string, unknown> })._columnsHash = {
+      views: { name: "views", default: 0 },
+    };
     Post.attribute("title", "string", { default: "untitled" });
 
     const defaults = Post._defaultAttributes();
@@ -664,7 +666,9 @@ describe("DefaultAttributesTest", () => {
 
   it("user attribute() declaration overrides schema column type via pending queue", () => {
     class Post extends Base {}
-    (Post as any)._columnsHash = { score: { name: "score", default: 0 } };
+    (Post as unknown as { _columnsHash?: Record<string, unknown> })._columnsHash = {
+      score: { name: "score", default: 0 },
+    };
     Post.attribute("score", "string");
 
     const defaults = Post._defaultAttributes();
@@ -673,7 +677,9 @@ describe("DefaultAttributesTest", () => {
 
   it("attribute() overriding only type preserves the schema default", () => {
     class Post extends Base {}
-    (Post as any)._columnsHash = { score: { name: "score", default: 5 } };
+    (Post as unknown as { _columnsHash?: Record<string, unknown> })._columnsHash = {
+      score: { name: "score", default: 5 },
+    };
     Post.attribute("score", "string");
 
     const defaults = Post._defaultAttributes();

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -11,34 +11,17 @@
 import {
   Attribute,
   AttributeSet,
+  UserProvidedDefault,
   type Type,
   applyPendingAttributeModifications,
   resetDefaultAttributes as amResetDefaultAttributes,
 } from "@blazetrails/activemodel";
-// The pending queue is private on ActiveModel (attribute_registration.rb:77);
-// only `attribute` (:17) pushes onto it. `define_attribute` reaches the same
-// queue from ActiveRecord, so it imports the queue accessor and the pending
-// classes off the defining module rather than the package's public barrel.
-import {
-  type PendingModification,
-  pendingAttributeModifications,
-} from "@blazetrails/activemodel/attribute-registration";
 import { registerSubclass } from "@blazetrails/activesupport";
-import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup, adapterNameFrom, type AdapterNameSource } from "./type.js";
 import { cachedColumnsHash, isSchemaLoaded } from "./model-schema.js";
 import { connectionPool, threadedConnectionFor } from "./connection-handling.js";
 
 type AnyClass = any;
-
-interface AttributeDefinition {
-  name: string;
-  type: Type;
-  defaultValue?: unknown;
-  limit?: number | null;
-  /** Declared via `attribute(name, type, { virtual: true })` — not DB-backed. */
-  virtual?: boolean;
-}
 
 /**
  * Static interface for the Attributes module.
@@ -54,104 +37,35 @@ export interface Attributes {
   defineAttribute(
     name: string,
     castType: Type,
-    options?: { default?: unknown; userProvidedDefault?: boolean; limit?: number | null },
+    options?: { default?: unknown; userProvidedDefault?: boolean },
   ): void;
   _defaultAttributes(): AttributeSet;
 }
 
-const NO_DEFAULT = Symbol("NO_DEFAULT");
-
-const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
-
-/**
- * `define_default_attribute`'s body (attributes.rb:277-291), carried on the
- * pending-modification queue so it replays with the rest of it.
- *
- * Rails writes the result straight into `_default_attributes` because nothing
- * rebuilds that set behind it; trails rebuilds it from `columns_hash` plus the
- * queue on every `reset_default_attributes`, so an eager write is dropped by
- * the next rebuild. Deferring is the only shape that survives, and it keeps
- * the three arms and their order exactly as Rails writes them.
- */
-class PendingDefinedDefault implements PendingModification {
-  constructor(
-    readonly name: string,
-    readonly value: unknown,
-    readonly type: Type,
-    readonly fromUser: boolean,
-  ) {}
-
-  applyTo(attributeSet: AttributeSet): void {
-    let defaultAttribute: Attribute;
-    if (this.value === NO_DEFAULT_PROVIDED) {
-      defaultAttribute = attributeSet.getAttribute(this.name).withType(this.type);
-    } else if (this.fromUser) {
-      defaultAttribute = attributeSet
-        .getAttribute(this.name)
-        .withType(this.type)
-        .withUserDefault(this.value);
-    } else {
-      defaultAttribute = Attribute.fromDatabase(this.name, this.value, this.type);
-    }
-    attributeSet.set(this.name, defaultAttribute);
-  }
-}
-
 /**
  * Lower-level attribute registration that accepts a resolved type object
- * directly, bypassing string-based type lookup. Used by adapters after
- * `lookupCastTypeFromColumn` and by code that already has a type in hand.
+ * directly, bypassing string-based type lookup.
  *
  * Mirrors: ActiveRecord::Attributes::ClassMethods#define_attribute
+ * (attributes.rb:231-239):
+ *
+ *   def define_attribute(name, cast_type, default: NO_DEFAULT_PROVIDED, user_provided_default: true)
+ *     attribute_types[name] = cast_type
+ *     define_default_attribute(name, default, cast_type, from_user: user_provided_default)
+ *   end
  */
 export function defineAttribute(
   this: AnyClass,
   name: string,
   castType: Type,
-  options: { default?: unknown; userProvidedDefault?: boolean; limit?: number | null } = {},
+  options: { default?: unknown; userProvidedDefault?: boolean } = {},
 ): void {
-  const { default: defaultValue = NO_DEFAULT, userProvidedDefault = true } = options;
+  const { default: default_ = NO_DEFAULT_PROVIDED, userProvidedDefault = true } = options;
 
-  if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-    this._attributeDefinitions = new Map(this._attributeDefinitions);
-  }
-
-  const existing: AttributeDefinition | undefined = this._attributeDefinitions.get(name);
-  const resolvedDefault = defaultValue === NO_DEFAULT ? existing?.defaultValue : defaultValue;
-
-  this._attributeDefinitions.set(name, {
-    ...existing,
-    name,
-    type: castType,
-    defaultValue: resolvedDefault ?? null,
-    ...(options.limit != null ? { limit: options.limit } : {}),
+  this.attributeTypes()[name] = castType;
+  defineDefaultAttribute.call(this, name, default_, castType, {
+    fromUser: userProvidedDefault,
   });
-
-  defineDefaultAttribute.call(
-    this,
-    name,
-    defaultValue === NO_DEFAULT ? NO_DEFAULT_PROVIDED : (resolvedDefault ?? null),
-    castType,
-    userProvidedDefault,
-  );
-
-  amResetDefaultAttributes(this);
-  this._virtualAttributesReconciled = false;
-  encryptionHooks.applyPendingEncryptions(this);
-
-  // Route prototype-accessor generation through defineAttributeMethods rather
-  // than installing inline here. Rails generates attribute methods lazily via
-  // `define_attribute_methods`; we mirror that single generation path by
-  // invalidating the generated-methods flag and regenerating, so the accessor
-  // for the just-declared attribute (and the `id`-skip) is handled in one place.
-  if (this.prototype) {
-    const klass = this as unknown as {
-      _attributeMethodsGenerated?: boolean;
-      defineAttributeMethods?: () => boolean;
-    };
-    klass._attributeMethodsGenerated = false;
-    klass.defineAttributeMethods?.();
-  }
 }
 
 /**
@@ -250,6 +164,10 @@ function reloadSchemaFromCache(this: AnyClass): void {
   amResetDefaultAttributes(this);
 }
 
+// attributes.rb:274-275 — `NO_DEFAULT_PROVIDED = Object.new`, a private
+// constant read only by `define_default_attribute`.
+const NO_DEFAULT_PROVIDED = Symbol("NO_DEFAULT_PROVIDED");
+
 /**
  * @internal
  * Mirrors: ActiveRecord::Attributes::ClassMethods#define_default_attribute
@@ -260,11 +178,24 @@ function defineDefaultAttribute(
   name: string,
   value: unknown,
   type: Type,
-  fromUser: boolean,
+  { fromUser }: { fromUser: boolean },
 ): void {
-  pendingAttributeModifications
-    .call(this)
-    .push(new PendingDefinedDefault(name, value, type, fromUser));
+  let defaultAttribute: Attribute;
+  if (value === NO_DEFAULT_PROVIDED) {
+    defaultAttribute = this._defaultAttributes().getAttribute(name).withType(type);
+  } else if (fromUser) {
+    defaultAttribute = new UserProvidedDefault(
+      name,
+      value,
+      type,
+      // Ruby `_default_attributes.fetch(name.to_s) { nil }` — the block runs
+      // only when the key is absent, so a stored attribute is passed through.
+      this._defaultAttributes().isKey(name) ? this._defaultAttributes().getAttribute(name) : null,
+    );
+  } else {
+    defaultAttribute = Attribute.fromDatabase(name, value, type);
+  }
+  this._defaultAttributes().set(name, defaultAttribute);
 }
 
 /**

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -188,9 +188,7 @@ function defineDefaultAttribute(
       name,
       value,
       type,
-      // Ruby `_default_attributes.fetch(name.to_s) { nil }` — the block runs
-      // only when the key is absent, so a stored attribute is passed through.
-      this._defaultAttributes().isKey(name) ? this._defaultAttributes().getAttribute(name) : null,
+      this._defaultAttributes().fetch(name, () => null),
     );
   } else {
     defaultAttribute = Attribute.fromDatabase(name, value, type);

--- a/packages/activerecord/virtualized-dx-tests/tsconfig.json
+++ b/packages/activerecord/virtualized-dx-tests/tsconfig.json
@@ -6,9 +6,6 @@
     "baseUrl": ".",
     "paths": {
       "@blazetrails/activerecord": ["../src/index.ts"],
-      "@blazetrails/activemodel/attribute-registration": [
-        "../../activemodel/src/attribute-registration.ts"
-      ],
       "@blazetrails/activemodel": ["../../activemodel/src/index.ts"],
       "@blazetrails/arel": ["../../arel/src/index.ts"],
       "@blazetrails/activesupport": ["../../activesupport/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -175,10 +175,6 @@ const alias = {
   "@blazetrails/activesupport": path.resolve(__dirname, "packages/activesupport/src/index.ts"),
   "@blazetrails/arel/src": path.resolve(__dirname, "packages/arel/src"),
   "@blazetrails/arel": path.resolve(__dirname, "packages/arel/src/index.ts"),
-  "@blazetrails/activemodel/attribute-registration": path.resolve(
-    __dirname,
-    "packages/activemodel/src/attribute-registration.ts",
-  ),
   "@blazetrails/activemodel/yaml": path.resolve(
     __dirname,
     "packages/activemodel/src/attribute-set/codecs/yaml.ts",


### PR DESCRIPTION
Converges `ActiveRecord::Attributes::ClassMethods#define_attribute` onto its Rails body.

Rails (`activerecord/lib/active_record/attributes.rb:231-239`) is two statements:

```ruby
attribute_types[name] = cast_type
define_default_attribute(name, default, cast_type, from_user: user_provided_default)
```

and `define_default_attribute` (`attributes.rb:277-291`) holds the `from_user:` fork —
`ActiveModel::Attribute::UserProvidedDefault` when true, `Attribute.from_database` when
false, and a bare `with_type` re-anchor under `NO_DEFAULT_PROVIDED` (`attributes.rb:274-275`).

trails expressed the same split through an `_attributeDefinitions` row plus a
`PendingDefinedDefault` pushed onto ActiveModel's private pending-modification queue.
Both are gone:

- `defineAttribute` is now the two Rails statements; `defineDefaultAttribute` mirrors
  attributes.rb:277-291 line for line, including `_default_attributes.fetch(name) { nil }`
  as the `originalAttribute` handed to `UserProvidedDefault`, which is now constructed on
  this path.
- `NO_DEFAULT` (read by the caller) becomes `NO_DEFAULT_PROVIDED`, read only by
  `defineDefaultAttribute`.
- The `@blazetrails/activemodel/attribute-registration` deep import is gone, with its
  `vitest.config.ts` alias and both dx-test tsconfig `paths` entries (no importer remains).
- The non-Rails tail (`_virtualAttributesReconciled` reset, `applyPendingEncryptions`,
  forced attribute-method regeneration, the `limit` option) goes with it — Rails'
  `define_attribute` does none of it and there is no in-tree caller.

Test fallout, all in trails-invented describes with no Rails counterpart: `define_attribute`
generates no reader (Rails defers that to `define_attribute_methods`), so the four
`DefineAttributeTest` cases read through `readAttribute`; the "invalidates the cache" case
becomes "writes into the memoized `_defaultAttributes`", since attributes.rb:290 assigns
into the set rather than dropping it; and two `DefaultAttributesTest` cases that used
`defineAttribute` as a stand-in for schema reflection now seed `_columnsHash` directly,
which is the path they meant to exercise. One case added for the `UserProvidedDefault`
construction.

`pnpm parity:api:calls` and `:args` both OK with zero new rows.

Closes-story: converge-ar-define-attribute-onto-define-default-attribute
