### PR TITLE
fix(scripts,activerecord): line-anchor JSDoc tags; Rails-only _default_attributes resets; seed GeneratedAttributeMethods

### DIFF
--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -37,7 +37,7 @@ const generatable = (cls: unknown): Generatable => cls as Generatable;
 describe("AttributeMethodsTest (trails)", () => {
   fixtures([]);
 
-  it("initializeGeneratedModules replaces a module ActiveModel built first", async () => {
+  it("a class-body attribute and aliasAttribute leave one GeneratedAttributeMethods", async () => {
     class Legacy extends Base {
       static {
         this.attribute("title", "string");
@@ -48,6 +48,29 @@ describe("AttributeMethodsTest (trails)", () => {
 
     expect(Legacy._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
     expect(new Legacy({ title: "t" }).heading).toBe("t");
+  });
+
+  // Rails' `inherited` hook (attribute_methods.rb:265-272) seats a
+  // GeneratedAttributeMethods for every class from the moment it exists. JS has
+  // no such hook, so an empty subclass reached only through
+  // `isInstanceMethodAlreadyImplemented` used to keep the bare `Module`
+  // ActiveModel's lazy `generated_attribute_methods` seats
+  // (activemodel/attribute_methods.rb:400-402) for its whole life.
+  it("a class reached only through isInstanceMethodAlreadyImplemented holds a GeneratedAttributeMethods", () => {
+    class Middle extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    class Leaf extends Middle {}
+
+    (
+      Leaf as unknown as { isInstanceMethodAlreadyImplemented(name: string): boolean }
+    ).isInstanceMethodAlreadyImplemented("title");
+
+    expect(Object.prototype.hasOwnProperty.call(Leaf, "_generatedAttributeMethods")).toBe(true);
+    expect(Leaf._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
+    expect(Leaf._generatedAttributeMethods!.inspect()).toBe("Leaf::GeneratedAttributeMethods");
   });
 
   it("defineAttributeMethods cascades to the superclass", async () => {

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -50,12 +50,6 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(new Legacy({ title: "t" }).heading).toBe("t");
   });
 
-  // Rails' `inherited` hook (attribute_methods.rb:265-272) seats a
-  // GeneratedAttributeMethods for every class from the moment it exists. JS has
-  // no such hook, so an empty subclass reached only through
-  // `isInstanceMethodAlreadyImplemented` used to keep the bare `Module`
-  // ActiveModel's lazy `generated_attribute_methods` seats
-  // (activemodel/attribute_methods.rb:400-402) for its whole life.
   it("a class reached only through isInstanceMethodAlreadyImplemented holds a GeneratedAttributeMethods", () => {
     class Middle extends Base {
       static {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -612,11 +612,23 @@ function instanceMethodOwner(klass: any, name: string): unknown {
  *
  * `Base` is found by the `_isActiveRecordBase` own-property sentinel rather
  * than imported, which would close a module-init cycle.
+ *
+ * Seeds the generated-methods module for the same reason {@link aliasAttribute}
+ * does, and closes the last hole in that seeding: both arms below reach
+ * ActiveModel's lazy `generated_attribute_methods`
+ * (activemodel/attribute_methods.rb:400-402), which would seat a bare `Module`
+ * for a class that declares nothing of its own — an empty
+ * `class Leaf extends Middle {}`. Rails cannot get there: its `inherited` hook
+ * (attribute_methods.rb:265-272) has already seated a `GeneratedAttributeMethods`
+ * for every class from the moment it exists.
  */
 export function isInstanceMethodAlreadyImplemented(
   this: AttributeMethodsHost,
   methodName: string,
 ): boolean {
+  if (!Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")) {
+    initializeGeneratedModules.call(this);
+  }
   if (isDangerousAttributeMethod.call(this, methodName)) {
     throw new DangerousAttributeError(
       `${methodName} is defined by Active Record. Check to make sure that you don't have an attribute or method with the same name.`,

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -733,27 +733,6 @@ describe("DefineAttributeSTITest", () => {
   });
 });
 
-describe("DefineAttributeBeforeSchemaLoadTest", () => {
-  fixtures([]);
-
-  it("define_attribute before the first schema load survives the load", async () => {
-    const intType = typeRegistry.lookup("integer");
-    class Post extends Base {
-      static {
-        this.tableName = "posts";
-      }
-    }
-    Post.defineAttribute("legacy_score", intType, { default: 7 });
-
-    await loadSchemaFromAdapter.call(Post as any);
-
-    const defaults = (Post as any)._defaultAttributes();
-    expect(defaults.keys()).toContain("legacy_score");
-    expect(defaults.getAttribute("legacy_score").value).toBe(7);
-    expect(defaults.keys()).toContain("title");
-  });
-});
-
 describe("ResetDefaultAttributesCascadeTest", () => {
   it("adding an attribute to a superclass invalidates an AR subclass _defaultAttributes cache", () => {
     class Post extends Base {

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -733,6 +733,32 @@ describe("DefineAttributeSTITest", () => {
   });
 });
 
+describe("DefineAttributeBeforeSchemaLoadTest", () => {
+  fixtures([]);
+
+  // Rails drops `@default_attributes` only in `reload_schema_from_cache`
+  // (attributes.rb:267-270), which `reset_column_information` calls — never an
+  // ordinary `load_schema!` (model_schema.rb:587-597). So an eager
+  // `define_attribute` write outlives the model's first reflection, and is
+  // dropped by `reset_column_information`.
+  it("define_attribute before the first schema load survives the load", async () => {
+    const intType = typeRegistry.lookup("integer");
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+      }
+    }
+    Post.defineAttribute("legacy_score", intType, { default: 7 });
+
+    await loadSchemaFromAdapter.call(Post as any);
+
+    const defaults = (Post as any)._defaultAttributes();
+    expect(defaults.keys()).toContain("legacy_score");
+    expect(defaults.getAttribute("legacy_score").value).toBe(7);
+    expect(defaults.keys()).toContain("title");
+  });
+});
+
 describe("ResetDefaultAttributesCascadeTest", () => {
   it("adding an attribute to a superclass invalidates an AR subclass _defaultAttributes cache", () => {
     class Post extends Base {

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -736,11 +736,6 @@ describe("DefineAttributeSTITest", () => {
 describe("DefineAttributeBeforeSchemaLoadTest", () => {
   fixtures([]);
 
-  // Rails drops `@default_attributes` only in `reload_schema_from_cache`
-  // (attributes.rb:267-270), which `reset_column_information` calls — never an
-  // ordinary `load_schema!` (model_schema.rb:587-597). So an eager
-  // `define_attribute` write outlives the model's first reflection, and is
-  // dropped by `reset_column_information`.
   it("define_attribute before the first schema load survives the load", async () => {
     const intType = typeRegistry.lookup("integer");
     class Post extends Base {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1101,19 +1101,22 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
     filteredHash[name] = column;
   }
 
+  // Rails' `load_schema!` settles `@columns_hash` and nothing else
+  // (model_schema.rb:587-597); `@default_attributes` / `@attribute_types` are
+  // dropped ONLY by `reload_schema_from_cache` (attributes.rb:267-270,
+  // activemodel/attribute_registration.rb:88-95) — i.e. by
+  // `reset_column_information`, never by an ordinary load. So an eager
+  // `define_default_attribute` write (attributes.rb:277-291) survives the
+  // model's first reflection here, exactly as it does in Ruby.
   type CacheBag = {
     _attributesBuilder?: unknown;
     _yamlEncoder?: unknown;
-    _cachedDefaultAttributes?: unknown;
-    _cachedAttributeTypes?: unknown;
     _columnsHash?: unknown;
     _columns?: unknown;
   };
   const bag = host as CacheBag;
   bag._attributesBuilder = undefined;
   bag._yamlEncoder = undefined;
-  bag._cachedDefaultAttributes = null;
-  bag._cachedAttributeTypes = null;
   bag._columns = undefined;
   host._columnsHash = filteredHash;
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1092,6 +1092,13 @@ function getColumnsHash(host: SchemaHost): Record<string, unknown> {
  *
  * `host` is always the class the load was triggered on: every class reflects
  * its OWN `table_name` (model_schema.rb:587-597).
+ *
+ * `load_schema!` settles `@columns_hash` and nothing else, so this drops no
+ * `@default_attributes` / `@attribute_types` memo: those are Rails-dropped only
+ * by `reload_schema_from_cache` (attributes.rb:267-270,
+ * activemodel/attribute_registration.rb:88-95), i.e. by
+ * `reset_column_information`. An eager `define_default_attribute` write
+ * (attributes.rb:277-291) therefore survives the model's first reflection.
  */
 function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void {
   const ignored = new Set(host._ignoredColumns ?? []);
@@ -1101,13 +1108,6 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
     filteredHash[name] = column;
   }
 
-  // Rails' `load_schema!` settles `@columns_hash` and nothing else
-  // (model_schema.rb:587-597); `@default_attributes` / `@attribute_types` are
-  // dropped ONLY by `reload_schema_from_cache` (attributes.rb:267-270,
-  // activemodel/attribute_registration.rb:88-95) — i.e. by
-  // `reset_column_information`, never by an ordinary load. So an eager
-  // `define_default_attribute` write (attributes.rb:277-291) survives the
-  // model's first reflection here, exactly as it does in Ruby.
   type CacheBag = {
     _attributesBuilder?: unknown;
     _yamlEncoder?: unknown;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1093,12 +1093,20 @@ function getColumnsHash(host: SchemaHost): Record<string, unknown> {
  * `host` is always the class the load was triggered on: every class reflects
  * its OWN `table_name` (model_schema.rb:587-597).
  *
- * `load_schema!` settles `@columns_hash` and nothing else, so this drops no
- * `@default_attributes` / `@attribute_types` memo: those are Rails-dropped only
- * by `reload_schema_from_cache` (attributes.rb:267-270,
- * activemodel/attribute_registration.rb:88-95), i.e. by
- * `reset_column_information`. An eager `define_default_attribute` write
- * (attributes.rb:277-291) therefore survives the model's first reflection.
+ * Rails drops `@default_attributes` / `@attribute_types` only in
+ * `reload_schema_from_cache` (attributes.rb:267-270,
+ * activemodel/attribute_registration.rb:88-95) — never in `load_schema!` — and
+ * gets away with it because `_default_attributes` (attributes.rb:241-252) reads
+ * `columns_hash` through the SYNCHRONOUS `load_schema` (model_schema.rb:530-546),
+ * which re-raises after resetting when the load fails. A Ruby memo is therefore
+ * built from the loaded columns by construction.
+ *
+ * trails' load is `async` (`loadSchemaFromAdapter` below), so a caller can force
+ * `_defaultAttributes` before the columns land and latch a memo built without
+ * them, which no later load would replace. The two memos are dropped here for
+ * that reason alone. Removing this reset is what CI caught: Topic's cold memo
+ * survived its load and every attribute read raised
+ * `UnknownAttributeError: unknown attribute 'title'`.
  */
 function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void {
   const ignored = new Set(host._ignoredColumns ?? []);
@@ -1111,12 +1119,16 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
   type CacheBag = {
     _attributesBuilder?: unknown;
     _yamlEncoder?: unknown;
+    _cachedDefaultAttributes?: unknown;
+    _cachedAttributeTypes?: unknown;
     _columnsHash?: unknown;
     _columns?: unknown;
   };
   const bag = host as CacheBag;
   bag._attributesBuilder = undefined;
   bag._yamlEncoder = undefined;
+  bag._cachedDefaultAttributes = null;
+  bag._cachedAttributeTypes = null;
   bag._columns = undefined;
   host._columnsHash = filteredHash;
 

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2161,6 +2161,21 @@ describe("mid-line tag mentions in reason prose", () => {
     expect(method.internal).toBeUndefined();
   });
 
+  it("mints no tag from a hang-indented continuation line, as ANY_TAG_LINE reads it", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * @missingRailsCall has_attribute? — PERMANENT: the readers are generated
+         *   at schema load, tagged
+         *   @noRailsEquivalent against CLAUDE.md's ratified rule.
+         */
+        aliasAttributeMethodDefinition(): void {}
+      }
+    `);
+    const method = info.instanceMethods.find((m) => m.name === "aliasAttributeMethodDefinition")!;
+    expect(method.noRailsEquivalent).toBeUndefined();
+  });
+
   it("mints no @missingRailsArgs from a mention inside a @missingRailsCall reason", () => {
     const info = extractFromSource(`
       class Foo {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -2131,6 +2131,51 @@ describe("extractFromProgram — file-level @noRailsEquivalent JSDoc", () => {
   });
 });
 
+describe("mid-line tag mentions in reason prose", () => {
+  it("mints no @noRailsEquivalent from a mention inside a @missingRailsCall reason", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * @missingRailsCall has_attribute? — PERMANENT: trails generates the readers at the
+         *   end of every schema load (tagged @noRailsEquivalent against CLAUDE.md's
+         *   "Generated attribute readers are properties").
+         */
+        aliasAttributeMethodDefinition(): void {}
+      }
+    `);
+    const method = info.instanceMethods.find((m) => m.name === "aliasAttributeMethodDefinition")!;
+    expect(method.noRailsEquivalent).toBeUndefined();
+  });
+
+  it("mints no @internal from a mention inside a @missingRailsCall reason", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * @missingRailsCall attribute_types — PERMANENT: the seam this replaces is
+         *   the wiring one, which is why it carries @internal rather than a name.
+         */
+        registerModel(): void {}
+      }
+    `);
+    const method = info.instanceMethods.find((m) => m.name === "registerModel")!;
+    expect(method.internal).toBeUndefined();
+  });
+
+  it("mints no @missingRailsArgs from a mention inside a @missingRailsCall reason", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * @missingRailsCall type_for_attribute — PERMANENT: the shape differs, but a
+         *   tag of the @missingRailsArgs family would be the wrong one here.
+         */
+        typeForAttribute(): void {}
+      }
+    `);
+    const method = info.instanceMethods.find((m) => m.name === "typeForAttribute")!;
+    expect(method.missingRailsArgs).toBeUndefined();
+  });
+});
+
 describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
   it("records the reason on a tagged class member and leaves its sibling bare", () => {
     const info = extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -69,6 +69,7 @@ import { extractorSchemaToken } from "./extractor-schema.js";
 import { staleBuilds, staleBuildMessage } from "./build-freshness.js";
 import { FOREIGN_READ_PREFIX, NEGATED_CALL_PREFIX } from "./enumerable-idioms.js";
 import {
+  ANY_TAG_LINE,
   TAG as MISSING_RAILS_CALL_TAG,
   suppressedCallReasonsIn,
   suppressedCallsIn,
@@ -1836,10 +1837,9 @@ function proseTagAfter(tag: ts.JSDocTag): { name: string; lineLeading: boolean }
 }
 
 /**
- * True when a JSDoc tag OPENS its line — the same rule `ANY_TAG_LINE`
- * (`missing-rails-call-tags.ts`) applies to the raw comment text, expressed
- * over TypeScript's parse instead of a regex. It is the single anchor every
- * tag reader here shares.
+ * True when a JSDoc tag OPENS its line, by the shared `ANY_TAG_LINE`
+ * (`missing-rails-call-tags.ts`) — the single anchor every tag reader here
+ * shares with the raw-text parser.
  *
  * TypeScript parses `@word` as a real tag wherever it appears, including
  * mid-sentence inside another tag's reason prose. A curated
@@ -1856,12 +1856,17 @@ export function isLineLeadingJsDocTag(tag: ts.JSDocTag): boolean {
 }
 
 /**
- * True when only comment-frame padding precedes `pos` on its line — the `/**`
- * opener of a one-line comment, the `*` of a continuation line, spaces and tabs.
+ * True when a tag at `pos` opens its line, by `ANY_TAG_LINE` — the rule
+ * `missing-rails-call-tags.ts` already applies to the raw comment text, shared
+ * rather than re-derived, so `*   @foo` is a continuation to both readers.
+ *
+ * The one normalization is the `/**` opener of a one-line comment, rewritten to
+ * the `*` frame `ANY_TAG_LINE` expects: `splitCommentLines` lifts a one-line
+ * comment's tags the same way before the parser walks them.
  */
 function isLineLeading(text: string, pos: number): boolean {
   const lineStart = text.lastIndexOf("\n", pos - 1) + 1;
-  return /^[ \t]*(?:\/\*)?\**[ \t]*$/.test(text.slice(lineStart, pos));
+  return ANY_TAG_LINE.test(text.slice(lineStart, pos + 2).replace(/^(\s*)\/\*\*/, "$1*"));
 }
 
 /**

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1724,7 +1724,9 @@ function taggedCommentOf<T>(
  * the tag is its only marker; consumers filter on `internal: true`.
  */
 export function hasInternalJsDocTag(node: ts.Node): boolean {
-  return ts.getJSDocTags(node).some((tag) => tag.tagName.text === "internal");
+  return ts
+    .getJSDocTags(node)
+    .some((tag) => tag.tagName.text === "internal" && isLineLeadingJsDocTag(tag));
 }
 
 /**
@@ -1746,7 +1748,7 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
  */
 export function noRailsEquivalentReason(node: ts.Node): string | undefined {
   for (const tag of ts.getJSDocTags(node)) {
-    if (tag.tagName.text !== "noRailsEquivalent") continue;
+    if (tag.tagName.text !== "noRailsEquivalent" || !isLineLeadingJsDocTag(tag)) continue;
     const reason = (ts.getTextOfJSDocComment(tag.comment) ?? "").replace(/\s+/g, " ").trim();
     if (reason === "") {
       const sf = node.getSourceFile();
@@ -1833,13 +1835,33 @@ function proseTagAfter(tag: ts.JSDocTag): { name: string; lineLeading: boolean }
   return undefined;
 }
 
-/** True when only comment-frame padding (`*`, spaces, tabs) precedes `pos` on its line. */
+/**
+ * True when a JSDoc tag OPENS its line — the same rule `ANY_TAG_LINE`
+ * (`missing-rails-call-tags.ts`) applies to the raw comment text, expressed
+ * over TypeScript's parse instead of a regex. It is the single anchor every
+ * tag reader here shares.
+ *
+ * TypeScript parses `@word` as a real tag wherever it appears, including
+ * mid-sentence inside another tag's reason prose. A curated
+ * `@missingRailsCall` reason naming another tag family — the reasons arguing a
+ * language shortcoming routinely name `@noRailsEquivalent` — therefore minted a
+ * PHANTOM tag on the enclosing declaration, with whatever prose followed it as
+ * its "reason" (hit for real in trails#6898). `missing-rails-call-tags.ts`
+ * already ends a reason only at a LINE-leading tag, so without this the two
+ * halves of one tag family disagreed about what counts as a tag; a mid-line
+ * mention is prose to both of them now.
+ */
+export function isLineLeadingJsDocTag(tag: ts.JSDocTag): boolean {
+  return isLineLeading(tag.getSourceFile().text, tag.getStart());
+}
+
+/**
+ * True when only comment-frame padding precedes `pos` on its line — the `/**`
+ * opener of a one-line comment, the `*` of a continuation line, spaces and tabs.
+ */
 function isLineLeading(text: string, pos: number): boolean {
-  for (let i = pos - 1; i >= 0 && text[i] !== "\n"; i--) {
-    const ch = text[i];
-    if (ch !== " " && ch !== "\t" && ch !== "*") return false;
-  }
-  return true;
+  const lineStart = text.lastIndexOf("\n", pos - 1) + 1;
+  return /^[ \t]*(?:\/\*)?\**[ \t]*$/.test(text.slice(lineStart, pos));
 }
 
 /**

--- a/scripts/api-compare/lint-detached-jsdoc-tags.ts
+++ b/scripts/api-compare/lint-detached-jsdoc-tags.ts
@@ -56,6 +56,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import * as ts from "typescript";
 import { ROOT_DIR } from "./config.js";
+import { isLineLeadingJsDocTag } from "./extract-ts-api.js";
 import { listSourceFiles } from "./lint-missing-rails-call-reasons.js";
 import { COMMITTED_TS_FILES, walkTsFiles } from "./ts-file-walk.js";
 
@@ -86,6 +87,7 @@ export interface Detachment {
 
 function significantTags(block: ts.JSDoc): string[] {
   return (block.tags ?? [])
+    .filter((tag) => isLineLeadingJsDocTag(tag))
     .map((tag) => tag.tagName.text)
     .filter((name) => SIGNIFICANT_TAGS.has(name));
 }

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -76,7 +76,7 @@ const tagLineStart = (tag: string): RegExp => new RegExp(`^\\s*\\*?\\s*${tag}\\b
 // hang indent (`*   `) can place one at line start — deeper-indented `@`
 // lines are continuations, not tag boundaries (found by the activerecord-wide
 // run: core.ts initInternals).
-const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
+export const ANY_TAG_LINE = /^\s*\*?\s?@\S/;
 const ONE_LINE_COMMENT = /^(\s*)\/\*\*(.*)\*\/\s*$/;
 
 /** One line of a comment as the parser sees it, carrying the line of the


### PR DESCRIPTION
Three related fidelity/tooling fixes.

### 1. Anchor JSDoc tag recognition to line start

`parity:api:build` migrates a baseline `reason` verbatim into a `@missingRailsCall`
block. TypeScript parses `@word` as a real tag wherever it appears, so a reason
naming another tag family mid-sentence minted a **phantom** tag on the enclosing
declaration (hit in #6898, which reddened `Rails API/Test Comparison` twice).
`missing-rails-call-tags.ts` already ends a reason only at a LINE-leading tag
(`ANY_TAG_LINE`), so the two halves of one family disagreed about what a tag is.

Tag recognition in the TS manifest extractor is now line-anchored through one
shared predicate, `isLineLeadingJsDocTag`, used by `hasInternalJsDocTag`,
`noRailsEquivalentReason` and `lint-detached-jsdoc-tags`. `isLineLeading` also
now accepts the `/**` opener of a one-line comment, which the old character walk
rejected. Guard tests cover the mid-line case for each family; two of the three
fail on the pre-fix extractor (the `@missingRailsArgs` one already went through
the text parser).

### 2. `_default_attributes` reset points — BLOCKED, not converged

Attempted and reverted. Rails drops `@default_attributes` only in
`reload_schema_from_cache` (`attributes.rb:267-270`), never in `load_schema!`,
and gets away with it because `_default_attributes` (`attributes.rb:241-252`)
reads `columns_hash` through the **synchronous** `load_schema`
(`model_schema.rb:530-546`), which re-raises after resetting when the load fails
— so a Ruby memo is built from the loaded columns by construction.

trails' load is `async` (`loadSchemaFromAdapter`), so a caller can force
`_defaultAttributes` before the columns land and latch a memo built without
them. Removing the trails-only reset reddened SQLite, PostgreSQL and MariaDB:
`Topic`'s cold memo survived its load and every read raised
`UnknownAttributeError: unknown attribute 'title'`. Withholding the memo until
`isSchemaLoaded` instead drops eager `defineAttribute` writes
(`DefineAttributeSTITest` red).

What ships is the story's alternative acceptance path: the reset stays and is
now **justified at the call site** with the Rails cites and the async-load
reason. The story is `tasks block`ed with that blocker; converging needs a
synchronous schema load or a recorded replay of the eager writes, and its
`Closes-story` trailer is dropped from this PR.

### 3. Seed `GeneratedAttributeMethods` for the lazy fallback reader

#6959 seeded the module at the AR-owned entry points a class body passes through,
but `isInstanceMethodAlreadyImplemented` still reached ActiveModel's lazy
`generated_attribute_methods` (`activemodel/attribute_methods.rb:400-402`) first
for an empty `class Leaf extends Middle {}`, seating a bare `Module` it then kept
for life. Rails' `inherited` hook (`attribute_methods.rb:265-272`) makes that
impossible. Seeded there too, and the misnamed
`initializeGeneratedModules replaces a module ActiveModel built first` test is
renamed to what it actually asserts.

`parity:api:calls`, `parity:api:calls:args`, `parity:api:extra`,
`parity:api:extra:gate`, `parity:api:detached` all green; zero new baseline rows.

Closes-story: anchor-jsdoc-tag-recognition-to-line-start
Closes-story: seed-generated-attribute-methods-for-lazy-fallback-readers
