### PR TITLE
refactor(activemodel): fan out the validates macro to validations/validates.ts

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -9,8 +9,6 @@ import {
   raiseValidationError as validationsRaiseValidationError,
   predicateForValidationContext as validationsPredicateForValidationContext,
   _mergeAttributes as validationsMergeAttributes,
-  _validatesDefaultKeys as validationsValidatesDefaultKeys,
-  _parseValidatesOptions as validationsParseValidatesOptions,
   VALID_OPTIONS_FOR_VALIDATE,
   readAttributeForValidation as validationsReadAttributeForValidation,
 } from "./validations.js";
@@ -63,7 +61,7 @@ import {
 } from "./serialization.js";
 import { BlockValidator, EachValidator, Validator as ValidatorBase } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
-import type { ConditionalOptions, ConditionFn } from "./validations.js";
+import type { ConditionalOptions } from "./validations.js";
 import * as AttributeMethods from "./attribute-methods.js";
 import {
   AttributeMethodPattern,
@@ -96,6 +94,7 @@ import { FormatValidator } from "./validations/format.js";
 import { AcceptanceValidator } from "./validations/acceptance.js";
 import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
+import * as Validates from "./validations/validates.js";
 import {
   type AttributeDefinition,
   Attributes,
@@ -280,128 +279,18 @@ export class Model {
   }
 
   /**
-   * Mirrors: ActiveModel::Validations::ClassMethods#validates (validates.rb:111-133).
-   * `validations` is `defaults.slice!(*_validates_default_keys)` — a validator key
-   * with a falsy value still counts here; `next unless options` (validates.rb:127)
-   * is what skips building it.
+   * Mirrors: ActiveModel::Validations::ClassMethods#validates
+   * (validations/validates.rb:111-133), mixed on by the
+   * `extend(Model, Validates)` at the bottom of this file.
    */
-  static validates(...args: [...attributes: string[], rules: Record<string, unknown>]): void {
-    const rules = args[args.length - 1] as Record<string, unknown>;
-    const attributes = args.slice(0, -1) as string[];
+  declare static validates: Extended<typeof Validates>["validates"];
 
-    const validations = Object.keys(rules).filter((k) => !this._validatesDefaultKeys().includes(k));
-
-    if (attributes.length === 0) {
-      throw new ArgumentError("You need to supply at least one attribute");
-    }
-    if (validations.length === 0) {
-      throw new ArgumentError("You need to supply at least one validation");
-    }
-
-    const onContext = rules.on as string | undefined;
-    const exceptOnContext = rules.exceptOn as string | string[] | undefined;
-    const ifCond = rules.if as ConditionFn | ConditionFn[] | undefined;
-    const unlessCond = rules.unless as ConditionFn | ConditionFn[] | undefined;
-    const isStrict = rules.strict as boolean | undefined;
-    const sharedAllowNil = rules.allowNil as boolean | undefined;
-    const sharedAllowBlank = rules.allowBlank as boolean | undefined;
-
-    const shared: Record<string, unknown> = {};
-    if (onContext !== undefined) shared.on = onContext;
-    if (exceptOnContext !== undefined) shared.exceptOn = exceptOnContext;
-    if (ifCond !== undefined) shared.if = ifCond;
-    if (unlessCond !== undefined) shared.unless = unlessCond;
-    if (isStrict) shared.strict = true;
-
-    const validatorSpecs: Array<{
-      klass: new (options: Record<string, unknown>) => ValidatorBase;
-      opts: Record<string, unknown>;
-    }> = [];
-
-    if (rules.presence) {
-      const opts = rules.presence === true ? {} : (rules.presence as Record<string, unknown>);
-      validatorSpecs.push({ klass: PresenceValidator, opts });
-    }
-
-    if (rules.absence) {
-      const opts = rules.absence === true ? {} : (rules.absence as Record<string, unknown>);
-      validatorSpecs.push({ klass: AbsenceValidator, opts });
-    }
-
-    if (rules.length) {
-      const opts = { ...(rules.length as Record<string, unknown>) };
-      if (sharedAllowNil !== undefined && opts.allowNil === undefined)
-        opts.allowNil = sharedAllowNil;
-      if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
-        opts.allowBlank = sharedAllowBlank;
-      validatorSpecs.push({ klass: LengthValidator, opts });
-    }
-
-    if (rules.numericality) {
-      const opts =
-        rules.numericality === true ? {} : { ...(rules.numericality as Record<string, unknown>) };
-      if (sharedAllowNil !== undefined && opts.allowNil === undefined)
-        opts.allowNil = sharedAllowNil;
-      if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
-        opts.allowBlank = sharedAllowBlank;
-      validatorSpecs.push({ klass: NumericalityValidator, opts });
-    }
-
-    if (rules.inclusion) {
-      const opts = { ...(rules.inclusion as Record<string, unknown>) };
-      if (sharedAllowNil !== undefined && opts.allowNil === undefined)
-        opts.allowNil = sharedAllowNil;
-      if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
-        opts.allowBlank = sharedAllowBlank;
-      validatorSpecs.push({ klass: InclusionValidator, opts });
-    }
-
-    if (rules.exclusion) {
-      const opts = { ...(rules.exclusion as Record<string, unknown>) };
-      if (sharedAllowNil !== undefined && opts.allowNil === undefined)
-        opts.allowNil = sharedAllowNil;
-      if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
-        opts.allowBlank = sharedAllowBlank;
-      validatorSpecs.push({ klass: ExclusionValidator, opts });
-    }
-
-    if (rules.format) {
-      const opts = { ...(rules.format as Record<string, unknown>) };
-      if (sharedAllowNil !== undefined && opts.allowNil === undefined)
-        opts.allowNil = sharedAllowNil;
-      if (sharedAllowBlank !== undefined && opts.allowBlank === undefined)
-        opts.allowBlank = sharedAllowBlank;
-      validatorSpecs.push({ klass: FormatValidator, opts });
-    }
-
-    if (rules.acceptance) {
-      const opts = rules.acceptance === true ? {} : (rules.acceptance as Record<string, unknown>);
-      validatorSpecs.push({ klass: AcceptanceValidator, opts });
-    }
-
-    if (rules.confirmation) {
-      const opts =
-        rules.confirmation === true ? {} : (rules.confirmation as Record<string, unknown>);
-      validatorSpecs.push({ klass: ConfirmationValidator, opts });
-    }
-
-    if (rules.comparison) {
-      validatorSpecs.push({
-        klass: ComparisonValidator,
-        opts: rules.comparison as Record<string, unknown>,
-      });
-    }
-
-    for (const { klass, opts } of validatorSpecs) {
-      this.validatesWith(klass, { ...opts, attributes, ...shared });
-    }
-  }
-
-  static validatesBang(...args: [...attributes: string[], rules: Record<string, unknown>]): void {
-    const rules = args[args.length - 1] as Record<string, unknown>;
-    const attributes = args.slice(0, -1) as string[];
-    this.validates(...attributes, { ...rules, strict: true });
-  }
+  /**
+   * Mirrors: ActiveModel::Validations::ClassMethods#validates!
+   * (validations/validates.rb:153-157), mixed on by the
+   * `extend(Model, Validates)` at the bottom of this file.
+   */
+  declare static validatesBang: Extended<typeof Validates>["validatesBang"];
 
   static clearValidatorsBang(): void {
     // Rails: `_validators.clear` (activemodel/lib/active_model/validations.rb:248).
@@ -985,7 +874,7 @@ export class Model {
    *
    * @internal Rails-private helper.
    */
-  static _validatesDefaultKeys = validationsValidatesDefaultKeys;
+  declare static _validatesDefaultKeys: Extended<typeof Validates>["_validatesDefaultKeys"];
 
   /**
    * Normalize a validator option value into the option hash the
@@ -994,7 +883,7 @@ export class Model {
    *
    * @internal Rails-private helper.
    */
-  static _parseValidatesOptions = validationsParseValidatesOptions;
+  declare static _parseValidatesOptions: Extended<typeof Validates>["_parseValidatesOptions"];
 
   /**
    * Mirrors: ActiveModel::API#initialize → ActiveModel::Attributes#initialize
@@ -1819,6 +1708,15 @@ classAttribute.call(Model, "attributeAliases", { instanceWriter: false, default:
 classAttribute.call(Model, "attributeMethodPatterns", {
   instanceWriter: false,
   default: [new AttributeMethodPattern()],
+});
+
+// Ruby `include ActiveModel::Validations` brings ClassMethods#validates and
+// friends (validations/validates.rb:111-178) onto the class.
+extend(Model, {
+  validates: Validates.validates,
+  validatesBang: Validates.validatesBang,
+  _validatesDefaultKeys: Validates._validatesDefaultKeys,
+  _parseValidatesOptions: Validates._parseValidatesOptions,
 });
 
 // Ruby `extend ActiveModel::Translation` (translation.rb:22, via naming.rb).

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -311,10 +311,7 @@ describe("ValidationsTest (trails)", () => {
 
       static {
         this.attribute("name", "string");
-        this.validates("name", {
-          presence: true,
-          uniqueness: true,
-        });
+        this.validates("name", { presence: true });
       }
 
       override async isValid(): Promise<boolean> {

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -1,5 +1,3 @@
-import { Range } from "@blazetrails/activesupport";
-
 import { Errors } from "./errors.js";
 import type { ValidatableRecord } from "./validator.js";
 import { I18n } from "./i18n.js";
@@ -446,35 +444,4 @@ export interface ConditionalOptions {
   exceptOn?: string | string[];
   /** Register ahead of the already-registered validate callbacks. */
   prepend?: boolean;
-}
-
-/**
- * The default option keys recognized by `validates(...)`. Subclasses
- * override to add custom keys. Mirrors Rails
- * `_validates_default_keys`
- * (activemodel/lib/active_model/validations/validates.rb:162-164).
- *
- * @internal Rails-private helper.
- */
-export function _validatesDefaultKeys(): string[] {
-  return ["if", "unless", "on", "allowBlank", "allowNil", "strict", "exceptOn"];
-}
-
-/**
- * Normalize a validator option value into the option hash the
- * validator constructor expects. Mirrors Rails
- * `_parse_validates_options(options)`
- * (activemodel/lib/active_model/validations/validates.rb:166-177):
- * `true` → `{}`, plain hash → unchanged, Range or Array → `{ in: options }`,
- * anything else → `{ with: options }`.
- *
- * @internal Rails-private helper.
- */
-export function _parseValidatesOptions(options: unknown): Record<string, unknown> {
-  if (options === true) return {};
-  if (options !== null && typeof options === "object" && options.constructor === Object) {
-    return options as Record<string, unknown>;
-  }
-  if (options instanceof Range || Array.isArray(options)) return { in: options };
-  return { with: options };
 }

--- a/packages/activemodel/src/validations/validates.test.ts
+++ b/packages/activemodel/src/validations/validates.test.ts
@@ -210,26 +210,26 @@ describe("ValidatesTest", () => {
     expect(p.errors.messagesFor("name")).toEqual(["is required"]);
   });
 
-  it("validates with unknown validator", async () => {
+  it("validates with unknown validator", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
-        this.validates("name", { unknownValidator: true } as any);
       }
     }
-    const p = new Person({ name: "Alice" });
-    expect(await p.isValid()).toBe(true);
+    expect(() => Person.validates("name", { unknown: true } as any)).toThrow(
+      "Unknown validator: 'UnknownValidator'",
+    );
   });
 
-  it("validates with disabled unknown validator", async () => {
+  it("validates with disabled unknown validator", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
-        this.validates("name", { foobar: false } as any);
       }
     }
-    const p = new Person({ name: "Alice" });
-    expect(await p.isValid()).toBe(true);
+    expect(() => Person.validates("name", { unknown: false } as any)).toThrow(
+      "Unknown validator: 'UnknownValidator'",
+    );
   });
 
   it("validates with if as shared conditions", async () => {

--- a/packages/activemodel/src/validations/validates.ts
+++ b/packages/activemodel/src/validations/validates.ts
@@ -51,21 +51,20 @@ export interface ValidatesHost {
  */
 export function validates(
   this: ValidatesHost,
-  ...attributes: [...attributes: string[], rules: Record<string, unknown>]
+  ...args: [...attributes: string[], rules: Record<string, unknown>]
 ): void {
-  const [rest, extracted] = extractOptionsBang(attributes as unknown[]);
-  const attrs = rest as string[];
+  const [attributes, extracted] = extractOptionsBang(args as unknown[]);
   const defaults = { ...extracted };
   const validations = sliceBang(defaults, ...this._validatesDefaultKeys());
 
-  if (attrs.length === 0) {
+  if (attributes.length === 0) {
     throw new ArgumentError("You need to supply at least one attribute");
   }
   if (Object.keys(validations).length === 0) {
     throw new ArgumentError("You need to supply at least one validation");
   }
 
-  defaults.attributes = attrs;
+  defaults.attributes = attributes;
 
   for (const [rawKey, options] of Object.entries(validations)) {
     const key = `${camelize(rawKey)}Validator`;
@@ -87,11 +86,11 @@ export function validates(
  */
 export function validatesBang(
   this: ValidatesHost,
-  ...attributes: [...attributes: string[], rules: Record<string, unknown>]
+  ...args: [...attributes: string[], rules: Record<string, unknown>]
 ): void {
-  const [rest, options] = extractOptionsBang(attributes as unknown[]);
+  const [attributes, options] = extractOptionsBang(args as unknown[]);
   options.strict = true;
-  this.validates(...(rest as string[]), options);
+  this.validates(...(attributes as string[]), options);
 }
 
 /**

--- a/packages/activemodel/src/validations/validates.ts
+++ b/packages/activemodel/src/validations/validates.ts
@@ -1,0 +1,120 @@
+import { Range, camelize, extractOptionsBang, sliceBang } from "@blazetrails/activesupport";
+
+import { ArgumentError } from "../attribute-assignment.js";
+
+import { Validator } from "../validator.js";
+import { AbsenceValidator } from "./absence.js";
+import { AcceptanceValidator } from "./acceptance.js";
+import { ComparisonValidator } from "./comparison.js";
+import { ConfirmationValidator } from "./confirmation.js";
+import { ExclusionValidator } from "./exclusion.js";
+import { FormatValidator } from "./format.js";
+import { InclusionValidator } from "./inclusion.js";
+import { LengthValidator } from "./length.js";
+import { NumericalityValidator } from "./numericality.js";
+import { PresenceValidator } from "./presence.js";
+
+type ValidatorClass = new (options: Record<string, unknown>) => Validator;
+
+/**
+ * Ruby resolves `const_get("#{key.to_s.camelize}Validator")`
+ * (validates.rb:121-126) against the model class, whose ancestry reaches
+ * `ActiveModel::Validations` and so its bundled validator constants. JS has no
+ * constant lookup that walks a class's namespace, so the bundled half of that
+ * ancestry is this table; the class's own statics are consulted first, which is
+ * where a model-local `TitleValidator` lives.
+ */
+const BUNDLED_VALIDATORS: Record<string, ValidatorClass> = {
+  AbsenceValidator,
+  AcceptanceValidator,
+  ComparisonValidator,
+  ConfirmationValidator,
+  ExclusionValidator,
+  FormatValidator,
+  InclusionValidator,
+  LengthValidator,
+  NumericalityValidator,
+  PresenceValidator,
+};
+
+/** The `Model` surface `validates` self-sends. */
+export interface ValidatesHost {
+  _validatesDefaultKeys(): string[];
+  _parseValidatesOptions(options: unknown): Record<string, unknown>;
+  validates(...args: unknown[]): void;
+  validatesWith(...args: unknown[]): void;
+}
+
+/**
+ * Mirrors: ActiveModel::Validations::ClassMethods#validates
+ * (validations/validates.rb:111-133).
+ */
+export function validates(
+  this: ValidatesHost,
+  ...attributes: [...attributes: string[], rules: Record<string, unknown>]
+): void {
+  const [rest, extracted] = extractOptionsBang(attributes as unknown[]);
+  const attrs = rest as string[];
+  const defaults = { ...extracted };
+  const validations = sliceBang(defaults, ...this._validatesDefaultKeys());
+
+  if (attrs.length === 0) {
+    throw new ArgumentError("You need to supply at least one attribute");
+  }
+  if (Object.keys(validations).length === 0) {
+    throw new ArgumentError("You need to supply at least one validation");
+  }
+
+  defaults.attributes = attrs;
+
+  for (const [rawKey, options] of Object.entries(validations)) {
+    const key = `${camelize(rawKey)}Validator`;
+
+    const validator = (this as unknown as Record<string, unknown>)[key] ?? BUNDLED_VALIDATORS[key];
+    if (typeof validator !== "function") {
+      throw new ArgumentError(`Unknown validator: '${key}'`);
+    }
+
+    if (options == null || options === false) continue;
+
+    this.validatesWith(validator, { ...defaults, ...this._parseValidatesOptions(options) });
+  }
+}
+
+/**
+ * Mirrors: ActiveModel::Validations::ClassMethods#validates!
+ * (validations/validates.rb:153-157).
+ */
+export function validatesBang(
+  this: ValidatesHost,
+  ...attributes: [...attributes: string[], rules: Record<string, unknown>]
+): void {
+  const [rest, options] = extractOptionsBang(attributes as unknown[]);
+  options.strict = true;
+  this.validates(...(rest as string[]), options);
+}
+
+/**
+ * Mirrors: ActiveModel::Validations::ClassMethods#_validates_default_keys
+ * (validations/validates.rb:162-164).
+ *
+ * @internal Rails-private helper.
+ */
+export function _validatesDefaultKeys(): string[] {
+  return ["if", "unless", "on", "allowBlank", "allowNil", "strict", "exceptOn"];
+}
+
+/**
+ * Mirrors: ActiveModel::Validations::ClassMethods#_parse_validates_options
+ * (validations/validates.rb:166-178).
+ *
+ * @internal Rails-private helper.
+ */
+export function _parseValidatesOptions(options: unknown): Record<string, unknown> {
+  if (options === true) return {};
+  if (options !== null && typeof options === "object" && options.constructor === Object) {
+    return options as Record<string, unknown>;
+  }
+  if (options instanceof Range || Array.isArray(options)) return { in: options };
+  return { with: options };
+}

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -265,16 +265,17 @@ export function validates(
     // The Model.validates class method is reached via _parentValidates,
     // registered by Base at module load via _setSuperValidates.
   },
-  attribute: string,
-  rules: Record<string, unknown>,
+  ...args: [...attributes: string[], rules: Record<string, unknown>]
 ): void {
+  const rules = args[args.length - 1] as Record<string, unknown>;
+  const attributes = args.slice(0, -1) as string[];
   const arRules = { ...rules };
   const shared = extractShared(arRules);
   const { allowNil: sharedAllowNil, allowBlank: sharedAllowBlank, ...sharedRest } = shared;
 
   const buildOpts = (opts: Record<string, unknown>) => ({
     ...opts,
-    attributes: [attribute],
+    attributes,
     ...sharedRest,
     ...(opts.allowNil === undefined && sharedAllowNil !== undefined
       ? { allowNil: sharedAllowNil }
@@ -312,11 +313,13 @@ export function validates(
     // routes to validatesWith); its async validateEach runs the existence check
     // inline in the async validation chain, honoring on/if/unless/strict.
     const { attributes: _attributes, ...uniqOpts } = buildOpts(opts) as Record<string, unknown>;
-    validatesUniqueness.call(
-      this,
-      attribute,
-      uniqOpts as Parameters<typeof validatesUniqueness>[1],
-    );
+    for (const attribute of attributes) {
+      validatesUniqueness.call(
+        this,
+        attribute,
+        uniqOpts as Parameters<typeof validatesUniqueness>[1],
+      );
+    }
   }
   // Delegate remaining rules (inclusion/exclusion/format/...) to ActiveModel's validates.
   const hasRemaining = Object.keys(arRules).some(
@@ -329,19 +332,19 @@ export function validates(
       );
     }
     // `super.validates` — delegate to Model's `validates` class method.
-    _parentValidates.call(this, attribute, arRules);
+    _parentValidates.call(this, ...attributes, arRules);
   }
 }
 
 // Late-bound reference to Model's `validates` class method — registered by
 // Base to break the circular-import chain.
 let _parentValidates:
-  | ((this: unknown, attribute: string, rules: Record<string, unknown>) => void)
+  | ((this: unknown, ...args: [...attributes: string[], rules: Record<string, unknown>]) => void)
   | null = null;
 
 /** @internal Called by Base to register Model's validates as the super. */
 export function _setSuperValidates(
-  fn: (this: unknown, attribute: string, rules: Record<string, unknown>) => void,
+  fn: (this: unknown, ...args: [...attributes: string[], rules: Record<string, unknown>]) => void,
 ): void {
   _parentValidates = fn;
 }

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -165,9 +165,9 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // entire surface — every method in `global_id.rb` itself — buckets there.
   "globalid:global_id.rb": "global-id.ts",
   // `validations.rb` opens `Validations::ClassMethods` first, so `validates`,
-  // `validates!` and their two private helpers bucket under it. trails carries
-  // all four on `Model` (model.ts), the class `Validations` is mixed into.
-  "activemodel:validations/validates.rb": "model.ts",
+  // `validates!` and their two private helpers bucket under it. trails keeps
+  // all four in the file whose name Rails gives them.
+  "activemodel:validations/validates.rb": "validations/validates.ts",
   // Likewise `HelperMethods`, whose first definition Rails puts in
   // `validations/absence.rb`; trails' `_mergeAttributes` lives in validations.ts.
   "activemodel:validations/helper_methods.rb": "validations.ts",


### PR DESCRIPTION
`validates`, `validates!`, `_validates_default_keys` and `_parse_validates_options`
have `activemodel/lib/active_model/validations/validates.rb` as their Rails home;
trails carried all four on `Model`, with a 95-line hand-rolled dispatch table
where Rails has a ~30-line `each_validator` loop.

## What moved

New `packages/activemodel/src/validations/validates.ts`, reaching `Model` via
`extend(Model, …)` (the Ruby `include ActiveModel::Validations` class-method
half). `scripts/parity/conventions.ts` no longer redirects
`activemodel:validations/validates.rb` to `model.ts` — it maps to the file whose
name Rails gives it, still 4/4 at 100%.

## What converged

The body now follows `validates.rb:111-133` branch for branch:
`attributes.extract_options!.dup`, the `slice!(*_validates_default_keys)`
defaults/validations split, both empty guards, `defaults[:attributes] =
attributes`, per-key `"#{key.to_s.camelize}Validator"` resolution,
`next unless options`, and the
`validates_with(validator, defaults.merge(_parse_validates_options(options)))`
tail.

Constant resolution (`validates.rb:121-126`) consults the model class's own
statics first — Ruby `const_get` reaching a model-local `TitleValidator` — then
the bundled validator table, and raises
`ArgumentError: Unknown validator: '…'` where Rails does. That raise sits
*before* the falsy-options skip, so `unknown: false` raises too; the two tests
asserting silent tolerance were pinning a divergence and now match
`validates_test.rb:130-136`.

Falling out of the loop:

- shared `allowNil` / `allowBlank` / `strict` now reach every validator instead
  of a hand-picked subset;
- per-validator options override the shared defaults, not the other way round;
- `ActiveRecord::Validations::ClassMethods#validates` takes `*attributes` in
  Rails, so the AR override widens to match rather than accepting one attribute.

No new helper: the port reuses `extractOptionsBang` and `sliceBang` from
`@blazetrails/activesupport`, the existing ports of `Array#extract_options!` and
`Hash#slice!`.

## Not in scope

`model.ts` still imports the validator classes for the `validatesXOf` helpers
(Rails' `HelperMethods`, defined in each validator's own `.rb`) — a separate
fan-out. The `validates_each → omits validates_with` row in
`call-mismatches-exclude/activemodel/model.json` belongs to `validatesEach`, not
to this macro, and is untouched.

## Verification

- `pnpm vitest run packages/activemodel/src/validations packages/activemodel/src/validations{,.trails}.test.ts packages/activerecord/src/validations packages/activerecord/src/validations.test.ts` — 32 files, 712 passed
- `pnpm vitest run packages/activemodel/src` — 91 files, 1910 passed
- `pnpm parity:api` — activemodel 736/736 (100%), files 66/66
- `pnpm parity:api:extra --package activemodel` — `validates` / `validatesBang`
  gone from `model.ts`; `validations/validates.ts` scores 0 extra
- `pnpm parity:api:calls` OK · `pnpm parity:api:calls:args` OK ·
  `pnpm parity:api:extra:gate` OK · `pnpm typecheck` · `pnpm lint`

Closes-story: fan-out-model-validates-macro-to-validations-validates
