### PR TITLE
fix(scripts,activesupport): per-tag JSDoc slots; utc_to_local on ::Time; TimeWithZone#advance via Time#advance

### DIFF
--- a/packages/activesupport/src/core-ext/date-and-time/zones.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/zones.ts
@@ -12,7 +12,7 @@
  * stays line-for-line with the Ruby.
  */
 
-import { Temporal } from "@blazetrails/date";
+import { Temporal, Time as RubyTime } from "@blazetrails/date";
 import { TimeWithZone } from "../../time-with-zone.js";
 import { TimeZone } from "../../values/time-zone.js";
 import { findZoneBang, zone as currentZone } from "../../time-zone-config.js";
@@ -21,7 +21,7 @@ import { toTime } from "../date/conversions.js";
 import { Object } from "../object/acts-like.js";
 
 /** A receiver of the mixin: the `Date` arm or the `Time` arm. */
-export type DateOrTime = Temporal.PlainDate | Date | Temporal.Instant;
+export type DateOrTime = Temporal.PlainDate | Date | Temporal.Instant | RubyTime;
 
 /**
  * Returns the simultaneous time in `Time.zone` if a zone is given or if
@@ -55,12 +55,15 @@ export function inTimeZone(
   dateOrTime: Date | Temporal.Instant,
   zone?: unknown,
 ): TimeWithZone | Temporal.Instant;
+export function inTimeZone(dateOrTime: RubyTime, zone?: unknown): TimeWithZone | RubyTime;
 export function inTimeZone(
   dateOrTime: DateOrTime,
   zone: unknown = currentZone(),
-): TimeWithZone | Temporal.Instant {
+): TimeWithZone | Temporal.Instant | RubyTime {
   const timeZone = findZoneBang(zone);
-  const time = Object.actsLike(dateOrTime, "time") ? (dateOrTime as Date | Temporal.Instant) : null;
+  const time = Object.actsLike(dateOrTime, "time")
+    ? (dateOrTime as Date | Temporal.Instant | RubyTime)
+    : null;
 
   if (timeZone) {
     return timeWithZone(dateOrTime, time, timeZone);
@@ -80,7 +83,7 @@ export function inTimeZone(
  */
 function timeWithZone(
   dateOrTime: DateOrTime,
-  time: Date | Temporal.Instant | null,
+  time: Date | Temporal.Instant | RubyTime | null,
   zone: TimeZone,
 ): TimeWithZone {
   if (time !== null) {
@@ -97,6 +100,9 @@ function timeWithZone(
  * Ruby's `time.utc? ? time : time.getutc` (zones.rb:34) — the receiver read as
  * its UTC instant, which a `Temporal.Instant` already is.
  */
-function asInstant(time: Date | Temporal.Instant): Temporal.Instant {
+function asInstant(time: Date | Temporal.Instant | RubyTime): Temporal.Instant {
+  if (time instanceof RubyTime) {
+    return (time.isUtc() ? time : time.getutc()).toTime().toInstant();
+  }
   return time instanceof Temporal.Instant ? time : instantFrom(time);
 }

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -292,6 +292,16 @@ export function prevOccurring(date: Date, day: string): Temporal.Instant {
 // advance
 // ---------------------------------------------------------------------------
 
+interface AdvanceOptions {
+  years?: number;
+  months?: number;
+  weeks?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}
+
 /**
  * Rails' `Time#advance` (time/calculations.rb:194-217) writes the normalised
  * `:weeks` / `:days` back into the caller's hash, but `Date#advance`
@@ -300,18 +310,19 @@ export function prevOccurring(date: Date, day: string): Temporal.Instant {
  * date_ext_test.rb:367-371). One TS function stands in for both reopenings, so
  * it takes the non-mutating arm and normalises into a copy.
  */
+export function advance(date: Date, options: AdvanceOptions): Temporal.Instant;
+/**
+ * A `::Time` receiver answers a `::Time`, as it does in Ruby — the receiver
+ * `TimeWithZone#advance`'s variable-length arm hands `time.advance(options)`
+ * (time_with_zone.rb:433-434). A JS `Date` reads its components in the SYSTEM
+ * zone, so that arm cannot go through the `Date` one without moving the wall
+ * clock it is advancing.
+ */
+export function advance(date: RubyTime, options: AdvanceOptions): RubyTime;
 export function advance(
-  date: Date,
-  options: {
-    years?: number;
-    months?: number;
-    weeks?: number;
-    days?: number;
-    hours?: number;
-    minutes?: number;
-    seconds?: number;
-  },
-): Temporal.Instant {
+  date: Date | RubyTime,
+  options: AdvanceOptions,
+): Temporal.Instant | RubyTime {
   options = { ...options };
 
   if (options.weeks != null) {
@@ -326,18 +337,23 @@ export function advance(
     options.hours = (options.hours ?? 0) + 24 * partialDays;
   }
 
-  let d = toDate(date);
+  let d = date instanceof RubyTime ? date.toTime().toPlainDate() : toDate(date);
   if (options.years) d = d.add({ months: options.years * 12 });
   if (options.months) d = d.add({ months: options.months });
   if (options.weeks) d = d.add({ days: options.weeks * 7 });
   if (options.days) d = d.add({ days: options.days });
 
-  const timeAdvancedByDate = change(date, { year: d.year, month: d.month, day: d.day });
+  const timeAdvancedByDate =
+    date instanceof RubyTime
+      ? change(date, { year: d.year, month: d.month, day: d.day })
+      : change(date, { year: d.year, month: d.month, day: d.day });
   const secondsToAdvance =
     (options.seconds ?? 0) + (options.minutes ?? 0) * 60 + (options.hours ?? 0) * 3600;
 
   if (secondsToAdvance === 0) {
     return timeAdvancedByDate;
+  } else if (timeAdvancedByDate instanceof RubyTime) {
+    return timeAdvancedByDate.plus(secondsToAdvance);
   } else {
     return since(new Date(timeAdvancedByDate.epochMilliseconds), secondsToAdvance);
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -17,6 +17,7 @@ import { Rational, Time } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 import { DATE_FORMATS, toFs } from "./core-ext/time/conversions.js";
 import { advance as timeAdvance } from "./time-ext.js";
+import { inTimeZone } from "./core-ext/date-and-time/zones.js";
 import {
   preserveTimezone,
   utcToLocalReturnsUtcOffsetTimes,
@@ -831,21 +832,18 @@ export class TimeWithZone {
    * zone, exactly as `method_missing` (:553-557) does. Everything else advances
    * from `#utc`, for accuracy when moving across DST boundaries.
    *
-   * @missingRailsCall in_time_zone — CONVERGEABLE (RFC 0023): `in_time_zone`
-   *   (zones.ts) takes a `Date` or a `Temporal.Instant`, not the `::Time` that
-   *   `Time#advance` answers; its `time_with_zone` arm for a named zone is the
-   *   constructor call made here (zones.rb:32-38). Converging needs the
-   *   `::Time` receiver arm on `inTimeZone` itself.
+   * @missingRailsArgs in_time_zone — PERMANENT: Ruby's `in_time_zone` is a
+   * method ON the receiver; TypeScript cannot reopen `Time`, so
+   * `core-ext/date-and-time/zones.ts` is the receiver-form reopening of
+   * `DateAndTime::Zones` and takes the receiver as its first argument.
    */
   advance(options: AdvanceOptions): TimeWithZone {
-    // If we're advancing a value of variable length (i.e., years, weeks, months, days), advance from #time,
-    // otherwise advance from #utc, for accuracy when moving across DST boundaries
     if ([options.years, options.weeks, options.months, options.days].some((v) => v != null)) {
       return this._wrapWithTimeZone(
         timeAdvance(this._transferTimeValuesToUtcConstructor(this.time), options),
       ) as TimeWithZone;
     } else {
-      return new TimeWithZone(timeAdvance(this.utc(), options), this.timeZone);
+      return inTimeZone(timeAdvance(this.utc(), options), this.timeZone) as TimeWithZone;
     }
   }
 

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -16,6 +16,7 @@ import { instantFrom } from "./temporal.js";
 import { Rational, Time } from "@blazetrails/date";
 import { Encoding } from "./json/encoding.js";
 import { DATE_FORMATS, toFs } from "./core-ext/time/conversions.js";
+import { advance as timeAdvance } from "./time-ext.js";
 import {
   preserveTimezone,
   utcToLocalReturnsUtcOffsetTimes,
@@ -823,80 +824,29 @@ export class TimeWithZone {
   // ---------------------------------------------------------------------------
 
   /**
-   * Advance by calendar amounts. Variable parts (years, months, weeks, days)
-   * are applied in local time; fixed parts (hours, minutes, seconds) from UTC.
+   * Mirrors: `ActiveSupport::TimeWithZone#advance` (time_with_zone.rb:430-438).
+   * Variable-length parts advance from `#time` — the local wall clock, whose
+   * calendar arithmetic is `Time#advance`'s (time/calculations.rb:194-217) and
+   * through it `Date#advance`'s — and the result is wrapped back into this
+   * zone, exactly as `method_missing` (:553-557) does. Everything else advances
+   * from `#utc`, for accuracy when moving across DST boundaries.
    *
-   * @missingRailsCall any? — CONVERGEABLE (story
-   *   time-with-zone-advance-change-delegations, RFC 0023): Rails' advance (time_with_zone.rb:430-437) picks
-   *   the variable-length arm with `options.values_at(:years, :weeks, :months,
-   *   :days).any?` and hands it to `method_missing(:advance, options)`; trails
-   *   has no `method_missing` arm to hand it to and computes both arms inline,
-   *   so the guard is a plain `if (options.years)`-style test per key rather
-   *   than an `any?` over a values_at slice. Converging needs the `Time#advance`
-   *   core-ext port that the delegation targets.
-   * @missingRailsCall in_time_zone — CONVERGEABLE (story
-   *   time-with-zone-advance-change-delegations, RFC 0023): The fixed-length arm is
-   *   `utc.advance(options).in_time_zone(time_zone)` (time_with_zone.rb:436);
-   *   trails has no `Time#advance` core-ext for a `Temporal.Instant` to delegate
-   *   to, so the seconds offset is applied inline and there is no cross-zone
-   *   round trip to close with `in_time_zone`. Blocked on porting
-   *   `DateAndTime::Calculations#advance` for the `Time` receiver.
+   * @missingRailsCall in_time_zone — CONVERGEABLE (RFC 0023): `in_time_zone`
+   *   (zones.ts) takes a `Date` or a `Temporal.Instant`, not the `::Time` that
+   *   `Time#advance` answers; its `time_with_zone` arm for a named zone is the
+   *   constructor call made here (zones.rb:32-38). Converging needs the
+   *   `::Time` receiver arm on `inTimeZone` itself.
    */
   advance(options: AdvanceOptions): TimeWithZone {
-    const l = this._local();
-    let { year, month, day } = l;
-
-    // Apply variable parts in local time
-    if (options.years) year += options.years;
-    if (options.months) {
-      month += options.months;
-      // Normalize month overflow
-      while (month > 12) {
-        month -= 12;
-        year++;
-      }
-      while (month < 1) {
-        month += 12;
-        year--;
-      }
+    // If we're advancing a value of variable length (i.e., years, weeks, months, days), advance from #time,
+    // otherwise advance from #utc, for accuracy when moving across DST boundaries
+    if ([options.years, options.weeks, options.months, options.days].some((v) => v != null)) {
+      return this._wrapWithTimeZone(
+        timeAdvance(this._transferTimeValuesToUtcConstructor(this.time), options),
+      ) as TimeWithZone;
+    } else {
+      return new TimeWithZone(timeAdvance(this.utc(), options), this.timeZone);
     }
-    // Clamp day to valid range for the new month
-    const maxDay = daysInMonth(year, month);
-    if (day > maxDay) day = maxDay;
-
-    if (options.weeks) day += options.weeks * 7;
-    if (options.days) day += options.days;
-
-    // `TimeZone#local` builds its wall clock with `Time.utc`, which raises on a
-    // day outside the month rather than rolling over the way `Date.UTC` does —
-    // so carry the accumulated days into the calendar here.
-    const rolled = Temporal.PlainDate.from({ year, month, day: 1 }).add({ days: day - 1 });
-
-    // Reconstruct the local time, then convert to UTC
-    const newLocal = this._timeZone.local(
-      rolled.year,
-      rolled.month,
-      rolled.day,
-      l.hour,
-      l.minute,
-      l.second,
-      l.millisecond,
-    );
-
-    // Now apply fixed parts as seconds on UTC
-    let ms = 0;
-    if (options.hours) ms += options.hours * 3600000;
-    if (options.minutes) ms += options.minutes * 60000;
-    if (options.seconds) ms += options.seconds * 1000;
-
-    if (ms !== 0) {
-      return new TimeWithZone(
-        Temporal.Instant.fromEpochMilliseconds(Math.trunc(newLocal._epochMs + ms)),
-        this._timeZone,
-      );
-    }
-
-    return newLocal;
   }
 
   /**

--- a/packages/activesupport/src/time-zone.test.ts
+++ b/packages/activesupport/src/time-zone.test.ts
@@ -30,23 +30,23 @@ describe("TimeZoneTest", () => {
 
     withUtcToLocalReturnsUtcOffsetTimes(false, () => {
       // standard offset -0500
-      expect(zone.utcToLocal(new Date(Date.UTC(2000, 0, 1)))).toEqual(
-        new Date(Date.UTC(1999, 11, 31, 19)),
+      expect((zone.utcToLocal(Time.utc(2000, 1)) as Time).toS()).toBe(
+        Time.utc(1999, 12, 31, 19).toS(),
       );
       // dst offset -0400
-      expect(zone.utcToLocal(new Date(Date.UTC(2000, 6, 1)))).toEqual(
-        new Date(Date.UTC(2000, 5, 30, 20)),
+      expect((zone.utcToLocal(Time.utc(2000, 7)) as Time).toS()).toBe(
+        Time.utc(2000, 6, 30, 20).toS(),
       );
     });
 
     withUtcToLocalReturnsUtcOffsetTimes(true, () => {
-      const standard = zone.utcToLocal(new Date(Date.UTC(2000, 0, 1))) as Temporal.ZonedDateTime;
+      const standard = zone.utcToLocal(Time.utc(2000, 1)) as Temporal.ZonedDateTime;
       expect([standard.year, standard.month, standard.day, standard.hour]).toEqual([
         1999, 12, 31, 19,
       ]);
       expect(standard.offsetNanoseconds / 1_000_000_000).toBe(-18000);
 
-      const dst = zone.utcToLocal(new Date(Date.UTC(2000, 6, 1))) as Temporal.ZonedDateTime;
+      const dst = zone.utcToLocal(Time.utc(2000, 7)) as Temporal.ZonedDateTime;
       expect([dst.year, dst.month, dst.day, dst.hour]).toEqual([2000, 6, 30, 20]);
       expect(dst.offsetNanoseconds / 1_000_000_000).toBe(-14400);
     });
@@ -56,17 +56,18 @@ describe("TimeZoneTest", () => {
     const zone = TimeZone.find("Eastern Time (US & Canada)")!;
 
     withUtcToLocalReturnsUtcOffsetTimes(false, () => {
-      expect(zone.utcToLocal(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 1)))).toEqual(
-        new Date(Date.UTC(1999, 11, 31, 19, 0, 0, 1)),
+      expect((zone.utcToLocal(Time.utc(2000, 1, 1, 0, 0, 0, 1000)) as Time).toS()).toBe(
+        Time.utc(1999, 12, 31, 19, 0, 0, 1000).toS(),
       );
-      expect(zone.utcToLocal(new Date(Date.UTC(2000, 6, 1, 0, 0, 0, 1)))).toEqual(
-        new Date(Date.UTC(2000, 5, 30, 20, 0, 0, 1)),
+      expect((zone.utcToLocal(Time.utc(2000, 1, 1, 0, 0, 0, 1000)) as Time).nsec).toBe(1_000_000);
+      expect((zone.utcToLocal(Time.utc(2000, 7, 1, 0, 0, 0, 1000)) as Time).toS()).toBe(
+        Time.utc(2000, 6, 30, 20, 0, 0, 1000).toS(),
       );
     });
 
     withUtcToLocalReturnsUtcOffsetTimes(true, () => {
       const standard = zone.utcToLocal(
-        new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 1)),
+        Time.utc(2000, 1, 1, 0, 0, 0, 1000),
       ) as Temporal.ZonedDateTime;
       expect(standard.millisecond).toBe(1);
       expect(standard.offsetNanoseconds / 1_000_000_000).toBe(-18000);

--- a/packages/activesupport/src/time-zone.trails.test.ts
+++ b/packages/activesupport/src/time-zone.trails.test.ts
@@ -187,6 +187,13 @@ describe("TimeZoneLocalPeriodsTest", () => {
     expect(twz.nsec).toBe(456000000);
   });
 
+  it("utc_to_local keeps digits below the microsecond on the legacy arm", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    const utc = Time.utc(2000, 1, 1, 0, 0, 0, 123456.789);
+    expect(utc.nsec).toBe(123456789);
+    expect((eastern.utcToLocal(utc) as Time).nsec).toBe(123456789);
+  });
+
   it("at keeps digits below the millisecond", () => {
     const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     expect(eastern.at(946684800, 123456.789).nsec).toBe(123456789);

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -1060,7 +1060,8 @@ export class TimeZone {
    * as is; the legacy arm rebuilds it with `Time.utc(t.year, t.month, t.day,
    * t.hour, t.min, t.sec, t.sec_fraction * 1_000_000)` (time_zone.rb:545) —
    * `sec_fraction` in microseconds being the Temporal value's sub-second
-   * components, which carry no Rational.
+   * components folded into one microsecond count, the nanosecond remainder
+   * riding as its fraction so the full sub-microsecond precision survives.
    */
   utcToLocal(time: Time): Temporal.ZonedDateTime | Time {
     const t = this.tzinfo.utcToLocal(time);
@@ -1073,7 +1074,7 @@ export class TimeZone {
           t.hour,
           t.minute,
           t.second,
-          t.millisecond * 1_000 + t.microsecond,
+          t.millisecond * 1_000 + t.microsecond + t.nanosecond / 1_000,
         );
   }
 

--- a/packages/activesupport/src/values/time-zone.ts
+++ b/packages/activesupport/src/values/time-zone.ts
@@ -720,8 +720,8 @@ export class Timezone {
    * `TZInfo::Timezone#utc_to_local`: as of tzinfo 2 this is the local time
    * carrying a non-zero UTC offset, which a `Temporal.ZonedDateTime` is.
    */
-  utcToLocal(time: Date | Temporal.Instant): Temporal.ZonedDateTime {
-    return instantFrom(toDate(time)).toZonedDateTimeISO(this.identifier);
+  utcToLocal(time: Time): Temporal.ZonedDateTime {
+    return time.toTime().toInstant().toZonedDateTimeISO(this.identifier);
   }
 
   /**
@@ -1057,21 +1057,24 @@ export class TimeZone {
    * `tzinfo.utc_to_local` returns a time carrying a non-zero UTC offset — a
    * `Temporal.ZonedDateTime` here. The
    * `ActiveSupport.utc_to_local_returns_utc_offset_times` arm hands that back
-   * as is; the legacy arm rebuilds `Time.utc(...)` from its parts, which is a
-   * `Date` whose UTC fields carry the local wall clock.
-   *
-   * @missingRailsCall utc — PERMANENT. `Time.utc(t.year, ..., t.sec_fraction * 1_000_000)`
-   *   (time_zone.rb:542-547). trails' non-offset arm rebuilds the same
-   *   components as a JS `Date` through `Date.UTC`, the seat this method's
-   *   callers read. Pre-existing: surfaced only once `DateTime#utc`
-   *   (date_time/calculations.rb:184) was ported and `utc` entered the
-   *   population.
+   * as is; the legacy arm rebuilds it with `Time.utc(t.year, t.month, t.day,
+   * t.hour, t.min, t.sec, t.sec_fraction * 1_000_000)` (time_zone.rb:545) —
+   * `sec_fraction` in microseconds being the Temporal value's sub-second
+   * components, which carry no Rational.
    */
-  utcToLocal(time: Date | Temporal.Instant): Temporal.ZonedDateTime | Date {
+  utcToLocal(time: Time): Temporal.ZonedDateTime | Time {
     const t = this.tzinfo.utcToLocal(time);
     return utcToLocalReturnsUtcOffsetTimes()
       ? t
-      : new Date(Date.UTC(t.year, t.month - 1, t.day, t.hour, t.minute, t.second, t.millisecond));
+      : Time.utc(
+          t.year,
+          t.month,
+          t.day,
+          t.hour,
+          t.minute,
+          t.second,
+          t.millisecond * 1_000 + t.microsecond,
+        );
   }
 
   /**

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -261,6 +261,31 @@ describe("reconcileFileText", () => {
     ).toBeNull();
   });
 
+  it("leaves a same-family comment split by prose alone in either kind", () => {
+    // The single `slot` #6958 added is taken at the FIRST tag of the family, so
+    // a second receipt further down was hoisted up next to it — 0 rows
+    // migrated, 1 file rewritten (RFC 0106).
+    const src = [
+      "export class Foo {",
+      "  /**",
+      "   * @missingRailsCall alpha — PERMANENT: the first receipt.",
+      "   *",
+      "   * Prose sitting between two receipts of the SAME family.",
+      "   *",
+      "   * @missingRailsCall beta — PERMANENT: the second receipt.",
+      "   */",
+      "  bar(): void {}",
+      "}",
+    ].join("\n");
+    const calls = new Map([anyClass("bar", ["bar"], new Set(["alpha", "beta"]))]);
+    const reason = () => "PERMANENT: x";
+    expect(reconcileFileText("foo.ts", src, calls, reason).text).toBeNull();
+    const args = src.replace(/@missingRailsCall/g, "@missingRailsArgs");
+    expect(
+      reconcileFileText("foo.ts", args, calls, reason, undefined, undefined, ARGS_TAG).text,
+    ).toBeNull();
+  });
+
   it("lets a class of the file-module's name keep its own key", () => {
     // `relation.ts` declares `class Relation`, whose name IS the synthesized
     // file-module name: a top-level function of the same name must not claim

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -308,10 +308,27 @@ export function renderJsdoc(
     while (head.length > 1 && head.at(-1)!.trim() === "*") head.pop();
     return [...head, ...tail].join("\n");
   }
-  const tagLines = ordered.flatMap((e) => renderEntry(e, indent, tag));
   if (at !== undefined) {
-    return [...head.slice(0, at), ...tagLines, ...head.slice(at), ...tail].join("\n");
+    // One insertion point per tag, taken from the source in ascending order and
+    // paired with the sorted entries: same-family tags separated by prose go
+    // back to the lines they came from rather than all collapsing onto the
+    // first one, so a pass that migrates nothing rewrites nothing (RFC 0106).
+    // A mint (or a drop) leaves the counts unequal; the extras ride at the last
+    // known slot, which is today's sorted-append behaviour within a run of tags.
+    const slots = ordered
+      .map((e) => e.slot)
+      .filter((s): s is number => s !== undefined)
+      .sort((a, b) => a - b)
+      .map((s) => Math.min(s, head.length));
+    const out = head.slice();
+    const positions = ordered.map((_, i) => slots[Math.min(i, slots.length - 1)] ?? at);
+    // Descending, so an earlier insertion cannot shift a later one's index.
+    for (let i = ordered.length - 1; i >= 0; i--) {
+      out.splice(positions[i], 0, ...renderEntry(ordered[i], indent, tag));
+    }
+    return [...out, ...tail].join("\n");
   }
+  const tagLines = ordered.flatMap((e) => renderEntry(e, indent, tag));
   const sep = hasProse ? [`${indent} *`] : [];
   return [...head, ...sep, ...tagLines, ...tail].join("\n");
 }

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -50,6 +50,10 @@ export interface TagEntry {
   call: string;
   reason: string;
   rawLines: string[];
+  /** Index in `parseJsdoc`'s `rest` this tag was lifted from, so `renderJsdoc`
+   *  can put it back where it stood even when prose separates it from its
+   *  same-family neighbours (RFC 0106). Absent on a newly minted entry. */
+  slot?: number;
 }
 
 /** Where a JSDoc comment starts, so an empty-reason error can name a
@@ -173,7 +177,12 @@ export function parseJsdoc(
       // reason and slide past the empty-reason gate below. `rawLines` keeps
       // the line verbatim, so idempotency is unaffected.
       slot ??= rest.length;
-      open = { call: m[1], reason: (m[2] ?? "").trim(), rawLines: synthetic ? [] : [line] };
+      open = {
+        call: m[1],
+        reason: (m[2] ?? "").trim(),
+        rawLines: synthetic ? [] : [line],
+        slot: rest.length,
+      };
       entries.push(open);
       tagLineOf.set(open, sourceIndex);
       if (synthetic) open = null;


### PR DESCRIPTION
Three related fidelity fixes.

### `parity:api:build` reflowed same-family receipts split by prose

trails#6958 gave `parseJsdoc`/`renderJsdoc` a `slot` so a reconciled tag goes
back where it stood instead of being appended after the other family's tag
lines (which land in `rest` as prose). That slot is taken once, at the FIRST
tag of the family, so a comment with prose BETWEEN two same-family receipts
still re-flowed while migrating nothing — the second tag hoisted next to the
first, the blank `*` left dangling before `*/`.

Each `TagEntry` now records the `rest` index it was lifted from; `renderJsdoc`
pairs those indices (ascending) with the sorted entries and inserts each at its
own. A mint or a drop leaves the counts unequal and the extras ride at the last
known slot — today's sorted-append behaviour within a run of tags. The existing
sort normalization is unchanged.

### `TimeZone#utc_to_local` seats on the `::Time` it takes

`Timezone#utcToLocal` and `TimeZone#utcToLocal` now take the `::Time`
`utc_to_local` takes (`values/time_zone.rb:542-547`), and the non-offset arm
rebuilds with `Time.utc(t.year, ..., t.sec_fraction * 1_000_000)` (`:545`)
rather than `new Date(Date.UTC(...))` — retiring the `@missingRailsCall utc`,
as trails#6959 did for `TimeZone#local`.  `sec_fraction` is a Rational, so the fold
into the microsecond positional carries the nanosecond remainder as its
fraction — truncating to millisecond + microsecond would drop it.

### `TimeWithZone#advance` advances through `Time#advance`

`advance` picks its arm as `time_with_zone.rb:433-437` does and hands the
variable-length one to the `Time#advance` core-ext
(`time/calculations.rb:194-215`), which routes the calendar arithmetic through
`Date#advance` and grows the `::Time` receiver arm Ruby's has (a JS `Date`
reads its components in the SYSTEM zone, so that arm cannot go through the
`Date` one without moving the wall clock). The hand-rolled month carry,
`daysInMonth` clamp and `Temporal.PlainDate` day carry are gone.

`@missingRailsCall any?` and `method_missing` are retired; `in_time_zone`
carries a narrowed CONVERGEABLE receipt (its port takes a `Date`/`Instant`, not
the `::Time` `Time#advance` answers).

### Verification

- `pnpm parity:api:calls` and `pnpm parity:api:calls:args` green, no new
  baseline rows.
- `scripts/api-compare/**` (1339 tests), `packages/activesupport/src/core-ext/**`
  (1169), `time-ext.test.ts`, `time-zone.test.ts`, `time-zone.trails.test.ts`,
  `time-with-zone.test.ts`, `time-with-zone.trails.test.ts` — all green, no
  test renamed.
- New cycle `time-with-zone.ts` ↔ `time-ext.ts` verified TDZ-free by importing
  the built `dist/**.js` modules as entry modules.

Closes-story: api-build-reflows-same-family-tags-split-by-prose
Closes-story: move-utc-to-local-onto-ruby-time
Closes-story: time-with-zone-advance-delegates-to-time-advance
