### PR TITLE
fix(activerecord): Migration#migrate checks out a connection via pool.withConnection

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1321,21 +1321,24 @@ export class Migration {
   /**
    * Run the migration in a given direction.
    *
-   * Mirrors: ActiveRecord::Migration#migrate
-   *
-   * @missingRailsCall with_connection — CONVERGEABLE:
-   *   `DatabaseTasks.migration_connection.pool.with_connection` (migration.rb:973)
-   *   checks a connection out for the duration of `exec_migration`; trails runs
-   *   the migration body against the already-seated `this.connection`.
-   *   Convergence is RFC 0051 story
-   *   `migration-migrate-drops-pool-with-connection`, which lands on RFC 0073's
-   *   permanent-checkout flip.
+   * Mirrors: ActiveRecord::Migration#migrate (migration.rb:964-983). The body
+   * runs inside `DatabaseTasks.migration_connection.pool.with_connection`
+   * (`:973`) so the connection `exec_migration` is handed is one checked out
+   * for the duration of the migration. `DatabaseTasks` is reached through the
+   * call-time config source rather than an import for the same reason
+   * `#connection` does — naming `tasks/database-tasks.js` here would be a
+   * load-time edge back into a module that already imports this one.
    */
   async migrate(direction: "up" | "down"): Promise<void> {
     this.announce(direction === "up" ? "migrating" : "reverting");
-    const start = Date.now();
-    await this.execMigration(this.connection, direction);
-    const elapsed = ((Date.now() - start) / 1000).toFixed(4);
+    let timeElapsed = 0;
+    const pool = migrationArConfig()!.databaseTasks().migrationConnection().pool as ConnectionPool;
+    await pool.withConnection(async (conn) => {
+      const start = Date.now();
+      await this.execMigration(conn, direction);
+      timeElapsed = (Date.now() - start) / 1000;
+    });
+    const elapsed = timeElapsed.toFixed(4);
     this.announce(`${direction === "up" ? "migrated" : "reverted"} (${elapsed}s)`);
     this.write();
   }


### PR DESCRIPTION
`ActiveRecord::Migration#migrate` (`migration.rb:964-983`) wraps its `exec_migration` call in `ActiveRecord::Tasks::DatabaseTasks.migration_connection.pool.with_connection` (`:973`). trails ran `execMigration(this.connection, direction)` against the already-seated instance connection instead, so it never reached `DatabaseTasks.migrationConnection`, its pool, or `withConnection`.

`migrate` now seats `conn` from `migrationConnection().pool.withConnection(...)` and passes it to `execMigration`, and the `@missingRailsCall with_connection` tag is deleted. `DatabaseTasks` is reached through the call-time config source, matching `Migration#connection` — an import would be a load-time edge back into a module that already imports this one.

`pnpm parity:api:calls` and `pnpm parity:api:calls:args` green; migration/migrator/invertible-migration suites pass locally.

Closes-story: migration-migrate-drops-pool-with-connection