### PR TITLE
perf(activerecord): load the fixtures schema-cache warm from a boot dump

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Column } from "./column.js";
+
+describe("PostgreSQL::Column JSON round-trip", () => {
+  it("preserves the subclass and its state through the schema-cache dump", () => {
+    const col = new Column(
+      "tags",
+      null,
+      { sqlType: "character varying[]", type: "string", oid: 1015, fmod: -1 },
+      true,
+      { serial: false, identity: "a", generated: "s" },
+    );
+
+    const back = Column.fromJSON(col.toJSON()) as Column;
+
+    expect(back).toBeInstanceOf(Column);
+    expect(back.isArray()).toBe(true);
+    expect(back.oid).toBe(1015);
+    expect(back.fmod).toBe(-1);
+    expect(back.isIdentity).toBe(true);
+    expect(back.isVirtual()).toBe(true);
+    expect(back).toEqual(col);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -5,6 +5,7 @@
  */
 
 import { Column as BaseColumn } from "../column.js";
+import type { ColumnJSON } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
@@ -126,4 +127,68 @@ export class Column extends BaseColumn {
       this.isSerial === other.isSerial
     );
   }
+
+  /**
+   * @noRailsEquivalent PERMANENT: the schema-cache dump. Rails dumps through
+   *   YAML/Marshal, which round-trips the adapter's Column subclass and its
+   *   state on its own (`schema_cache.rb:406`); trails' dump is JSON, so the
+   *   subclass has to spell out what it carries and tag itself for
+   *   `rehydrateColumn`. Mirrors MySQL::Column's pair.
+   */
+  override toJSON(): PostgresqlColumnJSON {
+    return {
+      ...super.toJSON(),
+      __postgresql: true,
+      serial: this.serial,
+      oid: this.oid,
+      fmod: this.fmod,
+      array: this.array,
+      identity: this.identity,
+      generated: this.generated,
+    };
+  }
+
+  static override fromJSON(data: ColumnJSON): BaseColumn {
+    const p = data as PostgresqlColumnJSON;
+    return new Column(
+      p.name,
+      p.default,
+      {
+        sqlType: p.sqlTypeMetadata?.sqlType,
+        type: p.sqlTypeMetadata?.type,
+        oid: p.oid ?? undefined,
+        fmod: p.fmod ?? undefined,
+        limit: p.sqlTypeMetadata?.limit ?? null,
+        precision: p.sqlTypeMetadata?.precision ?? null,
+        scale: p.sqlTypeMetadata?.scale ?? null,
+      },
+      p.null,
+      {
+        collation: p.collation,
+        defaultFunction: p.defaultFunction,
+        comment: p.comment,
+        primaryKey: p.primaryKey,
+        serial: p.serial,
+        array: p.array,
+        identity: p.identity,
+        generated: p.generated,
+      },
+    );
+  }
+}
+
+/**
+ * A dumped PostgreSQL::Column — the discriminator and subclass state a JSON
+ * dump has to carry where Rails' YAML/Marshal dump round-trips the class
+ * itself. Without it a loaded cache reports every column non-`array?`,
+ * non-`serial?` and OID-less (`schema_cache.rb:406`, `schema_cache.rb:228`).
+ */
+export interface PostgresqlColumnJSON extends ColumnJSON {
+  __postgresql: true;
+  serial: boolean;
+  oid: number | null;
+  fmod: number | null;
+  array: boolean;
+  identity: string | null;
+  generated: string | null;
 }

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -10,6 +10,8 @@ import { Gzip } from "@blazetrails/activesupport/gzip";
 import { Column } from "./column.js";
 import type { ColumnJSON } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
+import { Column as PostgresqlColumn } from "./postgresql/column.js";
+import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { IndexDefinition } from "./abstract/schema-definitions.js";
@@ -60,8 +62,14 @@ function serializeColumn(col: any): ColumnJSON {
 
 function rehydrateColumn(data: unknown): Column {
   if (data instanceof Column) return data;
-  const json = data as ColumnJSON & { __mysql?: boolean };
+  const json = data as ColumnJSON & {
+    __mysql?: boolean;
+    __postgresql?: boolean;
+    __sqlite3?: boolean;
+  };
   if (json && json.__mysql) return MysqlColumn.fromJSON(json);
+  if (json && json.__postgresql) return PostgresqlColumn.fromJSON(json);
+  if (json && json.__sqlite3) return Sqlite3Column.fromJSON(json);
   return Column.fromJSON(json);
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -40,3 +40,22 @@ describe("SQLite3::Column#hasDefault", () => {
     expect(col.hasDefault).toBe(false);
   });
 });
+
+describe("SQLite3::Column JSON round-trip", () => {
+  it("preserves the subclass and its state through the schema-cache dump", () => {
+    const col = new Column("id", null, { sqlType: "INTEGER", type: "integer" }, false, {
+      primaryKey: true,
+      autoIncrement: true,
+      rowid: true,
+      generatedType: "stored",
+    });
+
+    const back = Column.fromJSON(col.toJSON()) as Column;
+
+    expect(back).toBeInstanceOf(Column);
+    expect(back.autoIncrement).toBe(true);
+    expect(back.rowid).toBe(true);
+    expect(back.isVirtualStored()).toBe(true);
+    expect(back).toEqual(col);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -5,6 +5,7 @@
  */
 
 import { Column as BaseColumn } from "../column.js";
+import type { ColumnJSON } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
@@ -70,4 +71,59 @@ export class Column extends BaseColumn {
       other instanceof Column && super.equals(other) && this.autoIncrement === other.autoIncrement
     );
   }
+
+  /**
+   * @noRailsEquivalent PERMANENT: the schema-cache dump. Rails dumps through
+   *   YAML/Marshal, which round-trips the adapter's Column subclass and its
+   *   state on its own (`schema_cache.rb:406`); trails' dump is JSON, so the
+   *   subclass has to spell out what it carries and tag itself for
+   *   `rehydrateColumn`. Mirrors MySQL::Column's pair.
+   */
+  override toJSON(): Sqlite3ColumnJSON {
+    return {
+      ...super.toJSON(),
+      __sqlite3: true,
+      autoIncrement: this.autoIncrement,
+      rowid: this.rowid,
+      generatedType: this._generatedType,
+    };
+  }
+
+  static override fromJSON(data: ColumnJSON): BaseColumn {
+    const s = data as Sqlite3ColumnJSON;
+    return new Column(
+      s.name,
+      s.default,
+      {
+        sqlType: s.sqlTypeMetadata?.sqlType,
+        type: s.sqlTypeMetadata?.type,
+        limit: s.sqlTypeMetadata?.limit ?? null,
+        precision: s.sqlTypeMetadata?.precision ?? null,
+        scale: s.sqlTypeMetadata?.scale ?? null,
+      },
+      s.null,
+      {
+        collation: s.collation,
+        defaultFunction: s.defaultFunction,
+        primaryKey: s.primaryKey,
+        autoIncrement: s.autoIncrement,
+        rowid: s.rowid,
+        generatedType: s.generatedType,
+      },
+    );
+  }
+}
+
+/**
+ * A dumped SQLite3::Column. Rails' schema-cache dump is YAML/Marshal, which
+ * round-trips the adapter's Column subclass on its own; a JSON dump has to
+ * carry the discriminator and the subclass' own state explicitly, or a cache
+ * loaded from disk would answer `auto_increment?` and `virtual?` `false` for
+ * every column (`schema_cache.rb:406`, `schema_cache.rb:228`).
+ */
+export interface Sqlite3ColumnJSON extends ColumnJSON {
+  __sqlite3: true;
+  autoIncrement: boolean;
+  rowid: boolean;
+  generatedType: "stored" | "virtual" | null;
 }

--- a/packages/activerecord/src/support/drop-all-tables.ts
+++ b/packages/activerecord/src/support/drop-all-tables.ts
@@ -8,7 +8,7 @@ import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
  * schema: Rails' own migration bookkeeping, which migrator tests manage per-test
  * and rely on the reset clearing. Dropped like any non-boot-laid table.
  */
-const BOOKKEEPING_TABLE_NAMES: ReadonlySet<string> = new Set([
+export const BOOKKEEPING_TABLE_NAMES: ReadonlySet<string> = new Set([
   "schema_migrations",
   "ar_internal_metadata",
 ]);

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "../base.js";
 import { fixtures } from "../test-fixtures.js";
-import { templateSchemaCache } from "./schema-cache-dump.js";
+import {
+  dumpedTables,
+  fingerprintOf,
+  schemaShapes,
+  templateSchemaCache,
+  templateSchemaFingerprint,
+} from "./schema-cache-dump.js";
 
 describe("templateSchemaCache", () => {
   fixtures({});
@@ -20,5 +26,41 @@ describe("templateSchemaCache", () => {
     expect(Object.keys(live.getCachedColumnsHash("posts") ?? {})).toEqual(
       Object.keys(dumped.getCachedColumnsHash("posts") ?? {}),
     );
+  });
+
+  it("fingerprints the live schema as the boot dump's", async () => {
+    const shapes = await schemaShapes(Base.connection);
+    expect(fingerprintOf(shapes, dumpedTables(templateSchemaCache()!))).toBe(
+      templateSchemaFingerprint(),
+    );
+  });
+
+  it("stops matching once a canonical table is altered, so no file replays a stale dump", async () => {
+    const cached = dumpedTables(templateSchemaCache()!);
+    await Base.connection.addColumn("topics", "boot_dump_probe", "string");
+    try {
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(
+        templateSchemaFingerprint(),
+      );
+    } finally {
+      await Base.connection.removeColumn("topics", "boot_dump_probe");
+    }
+    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
+      templateSchemaFingerprint(),
+    );
+  });
+
+  it("still matches when a table the dump never described is added", async () => {
+    const cached = dumpedTables(templateSchemaCache()!);
+    await Base.connection.createTable("boot_dump_bespoke", {}, (t) => {
+      t.string("name");
+    });
+    try {
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
+        templateSchemaFingerprint(),
+      );
+    } finally {
+      await Base.connection.dropTable("boot_dump_bespoke");
+    }
   });
 });

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "../base.js";
+import { fixtures } from "../test-fixtures.js";
+import { templateSchemaCache } from "./schema-cache-dump.js";
+
+describe("templateSchemaCache", () => {
+  fixtures({});
+
+  it("carries the canonical schema globalSetup laid, so the per-file warm needs no reflection", () => {
+    const cache = templateSchemaCache();
+    expect(cache).not.toBeNull();
+    expect(cache!.size).not.toBe(0);
+    expect(cache!.getCachedColumnsHash("topics")).toHaveProperty("title");
+    expect(cache!.getCachedPrimaryKeys("topics")).toBe("id");
+  });
+
+  it("is what the warm left in the pool's cache", () => {
+    const live = Base.connection.internalSchemaCache;
+    const dumped = templateSchemaCache()!;
+    expect(Object.keys(live.getCachedColumnsHash("posts") ?? {})).toEqual(
+      Object.keys(dumped.getCachedColumnsHash("posts") ?? {}),
+    );
+  });
+});

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "../base.js";
+import { activeLane } from "./connection.js";
 import { fixtures } from "../test-fixtures.js";
 import {
   dumpedTables,
@@ -62,5 +63,47 @@ describe("templateSchemaCache", () => {
     } finally {
       await Base.connection.dropTable("boot_dump_bespoke");
     }
+  });
+
+  /**
+   * sqlite has no column comments — `supports_comments?` is false there
+   * (`abstract_adapter.rb:502` returns false and
+   * `sqlite3_adapter.rb` has no override) — so the
+   * comment arm of the fingerprint is only exercisable on PG and MySQL.
+   */
+  it.skipIf(activeLane() === "sqlite")(
+    "stops matching once a canonical column's comment changes",
+    async () => {
+      const cached = dumpedTables(templateSchemaCache()!);
+      await Base.connection.addColumn("topics", "boot_dump_probe", "string");
+      const before = fingerprintOf(await schemaShapes(Base.connection), cached);
+      try {
+        const commenting = Base.connection as unknown as {
+          changeColumnComment(table: string, column: string, comment: string): Promise<void>;
+        };
+        await commenting.changeColumnComment("topics", "boot_dump_probe", "changed");
+        expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(before);
+      } finally {
+        await Base.connection.removeColumn("topics", "boot_dump_probe");
+      }
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
+        templateSchemaFingerprint(),
+      );
+    },
+  );
+
+  it("stops matching once an index is added to a canonical table", async () => {
+    const cached = dumpedTables(templateSchemaCache()!);
+    await Base.connection.addIndex("topics", "title", { name: "boot_dump_probe_index" });
+    try {
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(
+        templateSchemaFingerprint(),
+      );
+    } finally {
+      await Base.connection.removeIndex("topics", { name: "boot_dump_probe_index" });
+    }
+    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
+      templateSchemaFingerprint(),
+    );
   });
 });

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -29,37 +29,43 @@ describe("templateSchemaCache", () => {
     );
   });
 
-  it("fingerprints the live schema as the boot dump's", async () => {
-    const shapes = await schemaShapes(Base.connection);
-    expect(fingerprintOf(shapes, dumpedTables(templateSchemaCache()!.marshalDump()))).toBe(
-      templateSchemaFingerprint(),
+  /**
+   * The boot fingerprint is the baseline the replay compares against, but it is
+   * not an invariant of a running worker: a file that alters a canonical table
+   * and leaves it altered is exactly the case the guard exists for, and the
+   * between-file reset restores rows, not shapes (`drop-all-tables.ts`
+   * `resetTestTables`). So these assert the property the guard actually needs —
+   * that the fingerprint moves for a change to a dumped table and does not move
+   * for anything else — against a baseline taken here, not against boot.
+   */
+  it("recorded a boot fingerprint, and fingerprints a database deterministically", async () => {
+    expect(templateSchemaFingerprint()).toEqual(expect.any(String));
+    const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
+      fingerprintOf(await schemaShapes(Base.connection), cached),
     );
   });
 
   it("stops matching once a canonical table is altered, so no file replays a stale dump", async () => {
     const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+    const before = fingerprintOf(await schemaShapes(Base.connection), cached);
     await Base.connection.addColumn("topics", "boot_dump_probe", "string");
     try {
-      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(
-        templateSchemaFingerprint(),
-      );
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(before);
     } finally {
       await Base.connection.removeColumn("topics", "boot_dump_probe");
     }
-    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
-      templateSchemaFingerprint(),
-    );
+    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(before);
   });
 
   it("still matches when a table the dump never described is added", async () => {
     const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+    const before = fingerprintOf(await schemaShapes(Base.connection), cached);
     await Base.connection.createTable("boot_dump_bespoke", {}, (t) => {
       t.string("name");
     });
     try {
-      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
-        templateSchemaFingerprint(),
-      );
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(before);
     } finally {
       await Base.connection.dropTable("boot_dump_bespoke");
     }
@@ -67,14 +73,15 @@ describe("templateSchemaCache", () => {
 
   /**
    * sqlite has no column comments — `supports_comments?` is false there
-   * (`abstract_adapter.rb:502` returns false and
-   * `sqlite3_adapter.rb` has no override) — so the
-   * comment arm of the fingerprint is only exercisable on PG and MySQL.
+   * (`abstract_adapter.rb:502` returns false and `sqlite3_adapter.rb` has no
+   * override) — so the comment arm of the fingerprint is only exercisable on PG
+   * and MySQL.
    */
   it.skipIf(activeLane() === "sqlite")(
     "stops matching once a canonical column's comment changes",
     async () => {
       const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+      const clean = fingerprintOf(await schemaShapes(Base.connection), cached);
       await Base.connection.addColumn("topics", "boot_dump_probe", "string");
       const before = fingerprintOf(await schemaShapes(Base.connection), cached);
       try {
@@ -86,24 +93,19 @@ describe("templateSchemaCache", () => {
       } finally {
         await Base.connection.removeColumn("topics", "boot_dump_probe");
       }
-      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
-        templateSchemaFingerprint(),
-      );
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(clean);
     },
   );
 
   it("stops matching once an index is added to a canonical table", async () => {
     const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+    const before = fingerprintOf(await schemaShapes(Base.connection), cached);
     await Base.connection.addIndex("topics", "title", { name: "boot_dump_probe_index" });
     try {
-      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(
-        templateSchemaFingerprint(),
-      );
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(before);
     } finally {
       await Base.connection.removeIndex("topics", { name: "boot_dump_probe_index" });
     }
-    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(
-      templateSchemaFingerprint(),
-    );
+    expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(before);
   });
 });

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -31,13 +31,13 @@ describe("templateSchemaCache", () => {
 
   it("fingerprints the live schema as the boot dump's", async () => {
     const shapes = await schemaShapes(Base.connection);
-    expect(fingerprintOf(shapes, dumpedTables(templateSchemaCache()!))).toBe(
+    expect(fingerprintOf(shapes, dumpedTables(templateSchemaCache()!.marshalDump()))).toBe(
       templateSchemaFingerprint(),
     );
   });
 
   it("stops matching once a canonical table is altered, so no file replays a stale dump", async () => {
-    const cached = dumpedTables(templateSchemaCache()!);
+    const cached = dumpedTables(templateSchemaCache()!.marshalDump());
     await Base.connection.addColumn("topics", "boot_dump_probe", "string");
     try {
       expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(
@@ -52,7 +52,7 @@ describe("templateSchemaCache", () => {
   });
 
   it("still matches when a table the dump never described is added", async () => {
-    const cached = dumpedTables(templateSchemaCache()!);
+    const cached = dumpedTables(templateSchemaCache()!.marshalDump());
     await Base.connection.createTable("boot_dump_bespoke", {}, (t) => {
       t.string("name");
     });
@@ -74,7 +74,7 @@ describe("templateSchemaCache", () => {
   it.skipIf(activeLane() === "sqlite")(
     "stops matching once a canonical column's comment changes",
     async () => {
-      const cached = dumpedTables(templateSchemaCache()!);
+      const cached = dumpedTables(templateSchemaCache()!.marshalDump());
       await Base.connection.addColumn("topics", "boot_dump_probe", "string");
       const before = fingerprintOf(await schemaShapes(Base.connection), cached);
       try {
@@ -93,7 +93,7 @@ describe("templateSchemaCache", () => {
   );
 
   it("stops matching once an index is added to a canonical table", async () => {
-    const cached = dumpedTables(templateSchemaCache()!);
+    const cached = dumpedTables(templateSchemaCache()!.marshalDump());
     await Base.connection.addIndex("topics", "title", { name: "boot_dump_probe_index" });
     try {
       expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -19,7 +19,7 @@
  *
  * @internal Boot/template setup and the fixtures warm only.
  */
-import { getEnv, getOsAsync } from "@blazetrails/activesupport";
+import { getEnv, getOsAsync, hexdigest } from "@blazetrails/activesupport";
 import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { SchemaCache } from "../connection-adapters/schema-cache.js";
@@ -27,6 +27,18 @@ import { TEMP_DB_PREFIX } from "./sqlite-template.js";
 
 /** Env var: absolute path of the boot-produced schema-cache dump. */
 export const SCHEMA_CACHE_DUMP_ENV = "AR_TEST_SCHEMA_CACHE_DUMP";
+
+/**
+ * Env var: {@link fingerprintOf} over the schema the dump describes, as it was
+ * when the dump was taken. A worker replays the dump only against a database
+ * that still fingerprints the same.
+ */
+export const SCHEMA_CACHE_FINGERPRINT_ENV = "AR_TEST_SCHEMA_CACHE_FINGERPRINT";
+
+/** The boot fingerprint, or `null` when this run produced no dump. */
+export function templateSchemaFingerprint(): string | null {
+  return getEnv(SCHEMA_CACHE_FINGERPRINT_ENV) ?? null;
+}
 
 /**
  * Path of this run's dump. Carries {@link TEMP_DB_PREFIX} and the run token so
@@ -46,14 +58,87 @@ export async function dumpTemplateSchemaCache(
   adapter: DatabaseAdapter,
   pool: unknown,
   runToken: string,
-): Promise<string | null> {
+): Promise<{ filename: string; fingerprint: string } | null> {
   const cache = adapter.internalSchemaCache;
   if (!cache) return null;
   await cache.addAll(pool);
   const filename = await schemaCacheDumpPathFor(runToken);
   cache.dumpTo(filename);
-  return filename;
+  return {
+    filename,
+    fingerprint: fingerprintOf(await schemaShapes(adapter), dumpedTables(cache)),
+  };
 }
+
+/** The table names a cache describes — its `@data_sources` (`schema_cache.rb:416`). */
+export function dumpedTables(cache: SchemaCache): ReadonlySet<string> {
+  const dataSources = cache.marshalDump()[4] as Record<string, boolean>;
+  return new Set(Object.keys(dataSources ?? {}));
+}
+
+/**
+ * Every table's shape, in one query per lane.
+ *
+ * The boot dump describes the schema as globalSetup laid it, and the between-file
+ * reset truncates the canonical tables rather than re-laying them
+ * (`drop-all-tables.ts` `resetTestTables`) — so a file that leaves an
+ * `addColumn` / `changeColumn` / `renameColumn` behind changes a canonical
+ * table's shape without changing the table *set*, and the next file must not be
+ * answered from the dump. Rails has no equivalent check because it never faces
+ * a stale dump: every DDL path invalidates the cache entry as it runs
+ * (`abstract/schema_statements.rb:306`, `:542`, and PostgreSQL's own clears at
+ * `postgresql/schema_statements.rb:460-467`, `:523-524`), which trails also
+ * does — but only within the process that ran the DDL, and the dump outlives it.
+ *
+ * One query, not one per table: reflecting each table to check it would cost
+ * exactly what the dump exists to avoid.
+ */
+export async function schemaShapes(adapter: DatabaseAdapter): Promise<Map<string, string>> {
+  const sql = SHAPE_QUERIES[adapter.adapterName];
+  if (sql === undefined) return new Map();
+  const shapes = new Map<string, string>();
+  for (const row of (await adapter.execute(sql)) as { name: string; col: string | null }[]) {
+    const name = String(row.name);
+    shapes.set(name, `${shapes.get(name) ?? ""}\n${row.col ?? ""}`);
+  }
+  return shapes;
+}
+
+/**
+ * Digest the shapes of `tables` alone, so tables the dump never described — a
+ * bespoke table a file laid in its own `beforeAll` — cannot make the dump look
+ * stale. `null` when a table the dump describes is no longer there.
+ */
+export function fingerprintOf(shapes: Map<string, string>, tables: ReadonlySet<string>): string {
+  const parts: string[] = [];
+  for (const table of [...tables].sort()) {
+    const shape = shapes.get(table);
+    if (shape === undefined) return MISSING_TABLE;
+    parts.push(`${table}\u0000${shape}`);
+  }
+  return hexdigest(parts.join("\u0001"));
+}
+
+/** The fingerprint of a schema that has lost a table the dump described. */
+const MISSING_TABLE = "missing-table";
+
+const SHAPE_QUERIES: Record<string, string> = {
+  sqlite: `SELECT name, sql AS col FROM sqlite_master
+           WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'`,
+  postgres: `SELECT table_name AS name,
+                    column_name || ' ' || data_type || ' ' ||
+                      coalesce(character_maximum_length::text, '') || ' ' ||
+                      is_nullable || ' ' || coalesce(column_default, '') AS col
+             FROM information_schema.columns
+             WHERE table_schema = ANY (current_schemas(false))
+             ORDER BY table_name, ordinal_position`,
+  mysql2: `SELECT TABLE_NAME AS name,
+                  CONCAT(COLUMN_NAME, ' ', COLUMN_TYPE, ' ', IS_NULLABLE, ' ',
+                         COALESCE(COLUMN_DEFAULT, '')) AS col
+           FROM information_schema.COLUMNS
+           WHERE TABLE_SCHEMA = DATABASE()
+           ORDER BY TABLE_NAME, ORDINAL_POSITION`,
+};
 
 /**
  * The boot dump, or `null` when this run produced none (no globalSetup, or a

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -90,16 +90,16 @@ export function dumpedTables(cache: SchemaCache): ReadonlySet<string> {
  * `postgresql/schema_statements.rb:460-467`, `:523-524`), which trails also
  * does — but only within the process that ran the DDL, and the dump outlives it.
  *
- * One query, not one per table: reflecting each table to check it would cost
- * exactly what the dump exists to avoid.
+ * Whole-database queries, not one per table: reflecting each table to check it
+ * would cost exactly what the dump exists to avoid.
  */
 export async function schemaShapes(adapter: DatabaseAdapter): Promise<Map<string, string>> {
-  const sql = SHAPE_QUERIES[adapter.adapterName];
-  if (sql === undefined) return new Map();
   const shapes = new Map<string, string>();
-  for (const row of (await adapter.execute(sql)) as { name: string; col: string | null }[]) {
-    const name = String(row.name);
-    shapes.set(name, `${shapes.get(name) ?? ""}\n${row.col ?? ""}`);
+  for (const sql of SHAPE_QUERIES[adapter.adapterName] ?? []) {
+    for (const row of (await adapter.execute(sql)) as { name: string; col: string | null }[]) {
+      const name = String(row.name);
+      shapes.set(name, `${shapes.get(name) ?? ""}\n${row.col ?? ""}`);
+    }
   }
   return shapes;
 }
@@ -107,7 +107,7 @@ export async function schemaShapes(adapter: DatabaseAdapter): Promise<Map<string
 /**
  * Digest the shapes of `tables` alone, so tables the dump never described — a
  * bespoke table a file laid in its own `beforeAll` — cannot make the dump look
- * stale. `null` when a table the dump describes is no longer there.
+ * stale. A table the dump describes that is no longer there can never match.
  */
 export function fingerprintOf(shapes: Map<string, string>, tables: ReadonlySet<string>): string {
   const parts: string[] = [];
@@ -122,22 +122,70 @@ export function fingerprintOf(shapes: Map<string, string>, tables: ReadonlySet<s
 /** The fingerprint of a schema that has lost a table the dump described. */
 const MISSING_TABLE = "missing-table";
 
-const SHAPE_QUERIES: Record<string, string> = {
-  sqlite: `SELECT name, sql AS col FROM sqlite_master
-           WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'`,
-  postgres: `SELECT table_name AS name,
-                    column_name || ' ' || data_type || ' ' ||
-                      coalesce(character_maximum_length::text, '') || ' ' ||
-                      is_nullable || ' ' || coalesce(column_default, '') AS col
-             FROM information_schema.columns
-             WHERE table_schema = ANY (current_schemas(false))
-             ORDER BY table_name, ordinal_position`,
-  mysql2: `SELECT TABLE_NAME AS name,
-                  CONCAT(COLUMN_NAME, ' ', COLUMN_TYPE, ' ', IS_NULLABLE, ' ',
-                         COALESCE(COLUMN_DEFAULT, '')) AS col
-           FROM information_schema.COLUMNS
-           WHERE TABLE_SCHEMA = DATABASE()
-           ORDER BY TABLE_NAME, ORDINAL_POSITION`,
+/**
+ * What a lane hashes, in whole-database form: the projection its own
+ * `columnDefinitions` reflects a Column from, plus its indexes — everything a
+ * cached entry holds and DDL can change, so no alteration to a dumped table can
+ * leave the fingerprint intact.
+ *
+ * sqlite needs one query for both: `sqlite_master.sql` is the `CREATE`
+ * statement itself, which carries collation and every column attribute, and its
+ * index rows carry `tbl_name`. PostgreSQL's column projection is
+ * `postgresql/schema-statements-class.ts:605-614` — type, default, notnull,
+ * oid, typmod, identity, generated, collation and comment, the fields
+ * `PostgreSQL::Column` stores. MySQL's is `SHOW FULL FIELDS`
+ * (`abstract-mysql-adapter.ts:1904`) read out of `information_schema`, whose
+ * `COLLATION_NAME` / `EXTRA` / `COLUMN_COMMENT` are its `Collation` / `Extra` /
+ * `Comment`.
+ */
+const SHAPE_QUERIES: Record<string, string[]> = {
+  sqlite: [
+    `SELECT tbl_name AS name, type || ' ' || coalesce(sql, '') AS col
+     FROM sqlite_master
+     WHERE name NOT LIKE 'sqlite_%'
+     ORDER BY type, name`,
+  ],
+  postgres: [
+    `SELECT t.relname AS name,
+            a.attname || ' ' ||
+              pg_catalog.format_type(a.atttypid, a.atttypmod) || ' ' ||
+              coalesce(pg_get_expr(d.adbin, d.adrelid), '') || ' ' ||
+              a.attnotnull::text || ' ' || a.atttypid::text || ' ' ||
+              a.atttypmod::text || ' ' || a.attidentity::text || ' ' ||
+              a.attgenerated::text || ' ' ||
+              coalesce(col.collname, '') || ' ' || coalesce(pgd.description, '') AS col
+     FROM pg_attribute a
+     JOIN pg_class t ON t.oid = a.attrelid
+     JOIN pg_namespace n ON n.oid = t.relnamespace
+     LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     LEFT JOIN pg_type pt ON a.atttypid = pt.oid
+     LEFT JOIN pg_collation col ON a.attcollation = col.oid AND a.attcollation <> pt.typcollation
+     LEFT JOIN pg_description pgd
+       ON pgd.objoid = a.attrelid AND pgd.classoid = 'pg_class'::regclass AND pgd.objsubid = a.attnum
+     WHERE n.nspname = ANY (current_schemas(false))
+       AND t.relkind IN ('r', 'v', 'm', 'p', 'f')
+       AND a.attnum > 0
+       AND NOT a.attisdropped
+     ORDER BY t.relname, a.attnum`,
+    `SELECT tablename AS name, indexdef AS col
+     FROM pg_indexes
+     WHERE schemaname = ANY (current_schemas(false))
+     ORDER BY tablename, indexname`,
+  ],
+  mysql2: [
+    `SELECT TABLE_NAME AS name,
+            CONCAT(COLUMN_NAME, ' ', COLUMN_TYPE, ' ', IS_NULLABLE, ' ',
+                   COALESCE(COLLATION_NAME, ''), ' ', COLUMN_KEY, ' ',
+                   COALESCE(COLUMN_DEFAULT, ''), ' ', EXTRA, ' ', COLUMN_COMMENT) AS col
+     FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE()
+     ORDER BY TABLE_NAME, ORDINAL_POSITION`,
+    `SELECT TABLE_NAME AS name,
+            CONCAT(INDEX_NAME, ' ', SEQ_IN_INDEX, ' ', COLUMN_NAME, ' ', NON_UNIQUE) AS col
+     FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+     ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`,
+  ],
 };
 
 /**

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -66,14 +66,16 @@ export async function dumpTemplateSchemaCache(
   cache.dumpTo(filename);
   return {
     filename,
-    fingerprint: fingerprintOf(await schemaShapes(adapter), dumpedTables(cache)),
+    fingerprint: fingerprintOf(await schemaShapes(adapter), dumpedTables(cache.marshalDump())),
   };
 }
 
-/** The table names a cache describes — its `@data_sources` (`schema_cache.rb:416`). */
-export function dumpedTables(cache: SchemaCache): ReadonlySet<string> {
-  const dataSources = cache.marshalDump()[4] as Record<string, boolean>;
-  return new Set(Object.keys(dataSources ?? {}));
+/**
+ * The table names a dump describes — `marshal_dump`'s fifth element, its
+ * `@data_sources` hash (`schema_cache.rb:416-418`).
+ */
+export function dumpedTables(marshalled: unknown[]): ReadonlySet<string> {
+  return new Set(Object.keys((marshalled[4] as Record<string, boolean>) ?? {}));
 }
 
 /**
@@ -136,7 +138,14 @@ const MISSING_TABLE = "missing-table";
  * `PostgreSQL::Column` stores. MySQL's is `SHOW FULL FIELDS`
  * (`abstract-mysql-adapter.ts:1904`) read out of `information_schema`, whose
  * `COLLATION_NAME` / `EXTRA` / `COLUMN_COMMENT` are its `Collation` / `Extra` /
- * `Comment`.
+ * `Comment`. Its index rows carry `STATISTICS.COLLATION` because that is where
+ * `IndexDefinition#orders` comes from — `"D"` is a descending column
+ * (`mysql/schema_statements.rb:43`, `:47`) — alongside `SUB_PART`
+ * (`lengths`) and `INDEX_TYPE` (`using`); MySQL 8's `EXPRESSION` is left out
+ * because MariaDB's `STATISTICS` has no such column, and the canonical schema
+ * has no functional index for it to describe. PostgreSQL and sqlite
+ * need no such spelling out: `pg_indexes.indexdef` and `sqlite_master.sql` are
+ * the index's own DDL, `DESC` and all.
  */
 const SHAPE_QUERIES: Record<string, string[]> = {
   sqlite: [
@@ -181,7 +190,9 @@ const SHAPE_QUERIES: Record<string, string[]> = {
      WHERE TABLE_SCHEMA = DATABASE()
      ORDER BY TABLE_NAME, ORDINAL_POSITION`,
     `SELECT TABLE_NAME AS name,
-            CONCAT(INDEX_NAME, ' ', SEQ_IN_INDEX, ' ', COLUMN_NAME, ' ', NON_UNIQUE) AS col
+            CONCAT(INDEX_NAME, ' ', SEQ_IN_INDEX, ' ', COLUMN_NAME, ' ', NON_UNIQUE, ' ',
+                   COALESCE(COLLATION, ''), ' ', COALESCE(SUB_PART, ''), ' ',
+                   INDEX_TYPE, ' ', COALESCE(INDEX_COMMENT, '')) AS col
      FROM information_schema.STATISTICS
      WHERE TABLE_SCHEMA = DATABASE()
      ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`,

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -1,0 +1,72 @@
+/**
+ * The boot-time schema-cache dump — Rails' `db:schema:cache:dump` for the test
+ * suite.
+ *
+ * Rails dumps the schema cache once (`SchemaCache#dump_to`,
+ * `schema_cache.rb:406`) and every process that boots afterwards loads it
+ * (`SchemaCache._load_from`, `schema_cache.rb:228`) rather than re-reflecting
+ * the database. trails' fixtures path used to re-reflect per test *file*:
+ * `SchemaCache#add` issues four introspection queries per table
+ * (`dataSourceExists` / `primaryKeys` / `columns` / `indexes`,
+ * `schema_cache.rb:292-300`), which over the ~200 canonical tables is ~800
+ * queries and ~0.3s on every file.
+ *
+ * The canonical schema is laid into the template database once at boot
+ * (`template-global-setup.ts`) and cloned into every worker slot, so one
+ * reflection of it describes every database the run will touch — exactly the
+ * precondition a dump needs. globalSetup takes it, and the per-file warm loads
+ * it.
+ *
+ * @internal Boot/template setup and the fixtures warm only.
+ */
+import { getEnv, getOsAsync } from "@blazetrails/activesupport";
+import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { SchemaCache } from "../connection-adapters/schema-cache.js";
+import { TEMP_DB_PREFIX } from "./sqlite-template.js";
+
+/** Env var: absolute path of the boot-produced schema-cache dump. */
+export const SCHEMA_CACHE_DUMP_ENV = "AR_TEST_SCHEMA_CACHE_DUMP";
+
+/**
+ * Path of this run's dump. Carries {@link TEMP_DB_PREFIX} and the run token so
+ * `sweepRunDbFiles` collects it with the run's databases.
+ */
+export async function schemaCacheDumpPathFor(runToken: string): Promise<string> {
+  const path = await getPathAsync();
+  const os = await getOsAsync();
+  return path.join(os.tmpdir(), `${TEMP_DB_PREFIX}schema-cache-${runToken}.json`);
+}
+
+/**
+ * Reflect the freshly-laid template schema and dump it. Returns the dump's
+ * path, or `null` when the adapter carries no schema cache to dump.
+ */
+export async function dumpTemplateSchemaCache(
+  adapter: DatabaseAdapter,
+  pool: unknown,
+  runToken: string,
+): Promise<string | null> {
+  const cache = adapter.internalSchemaCache;
+  if (!cache) return null;
+  await cache.addAll(pool);
+  const filename = await schemaCacheDumpPathFor(runToken);
+  cache.dumpTo(filename);
+  return filename;
+}
+
+/**
+ * The boot dump, or `null` when this run produced none (no globalSetup, or a
+ * lane that skipped the template build). Read once per module graph — vitest
+ * reloads the graph per test file, so this is one file read and parse per file
+ * in place of ~800 queries.
+ */
+export function templateSchemaCache(): SchemaCache | null {
+  if (loaded === undefined) {
+    const filename = getEnv(SCHEMA_CACHE_DUMP_ENV);
+    loaded = filename === undefined ? null : SchemaCache._loadFrom(filename);
+  }
+  return loaded;
+}
+
+let loaded: SchemaCache | null | undefined;

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -23,6 +23,7 @@ import { getEnv, getOsAsync, hexdigest } from "@blazetrails/activesupport";
 import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { SchemaCache } from "../connection-adapters/schema-cache.js";
+import { BOOKKEEPING_TABLE_NAMES } from "./drop-all-tables.js";
 import { TEMP_DB_PREFIX } from "./sqlite-template.js";
 
 /** Env var: absolute path of the boot-produced schema-cache dump. */
@@ -62,6 +63,15 @@ export async function dumpTemplateSchemaCache(
   const cache = adapter.internalSchemaCache;
   if (!cache) return null;
   await cache.addAll(pool);
+  // `resetTestTables` drops `schema_migrations` / `ar_internal_metadata`
+  // unconditionally between files and lets whoever needs them recreate them
+  // (`drop-all-tables.ts`), so a dump that described them would re-assert a
+  // dropped table as present — the stale `data_source_exists?` entry that
+  // reset's own `clearBang()` exists to prevent (`internal_metadata.rb:108-110`)
+  // — and would fingerprint-fail every file besides.
+  for (const table of BOOKKEEPING_TABLE_NAMES) {
+    cache.clearDataSourceCacheBang(adapter, table);
+  }
   const filename = await schemaCacheDumpPathFor(runToken);
   cache.dumpTo(filename);
   return {

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -23,6 +23,7 @@ import { PoolConfig } from "../connection-adapters/pool-config.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { loadSchema } from "./load-schema-helper.js";
 import { stampCanonicalSchema } from "./canonical-schema-stamp.js";
+import { SCHEMA_CACHE_DUMP_ENV, dumpTemplateSchemaCache } from "./schema-cache-dump.js";
 import {
   TEMPLATE_PATH_ENV,
   isSqliteRun,
@@ -78,16 +79,38 @@ async function pooledTemplateAdapter(
 
 async function buildTemplateSchema(
   adapter: DatabaseAdapter,
+  pool: ConnectionPool,
   runToken: string,
   close: () => Promise<void>,
 ): Promise<void> {
   try {
     await loadSchema(adapter);
     await stampCanonicalSchema(adapter, runToken);
+    await dumpSchemaCacheOnce(adapter, pool, runToken);
   } finally {
     await close();
   }
 }
+
+/**
+ * Take the run's one schema-cache dump off whichever template this adapter
+ * built. Every template of a run is laid from the same registry, so the first
+ * one to finish describes them all — MySQL builds a template per slot, and
+ * dumping each would only rewrite the same file N times.
+ */
+async function dumpSchemaCacheOnce(
+  adapter: DatabaseAdapter,
+  pool: ConnectionPool,
+  runToken: string,
+): Promise<void> {
+  _schemaCacheDump ??= dumpTemplateSchemaCache(adapter, pool, runToken).then((dump) => {
+    if (dump) process.env[SCHEMA_CACHE_DUMP_ENV] = dump;
+  });
+  await _schemaCacheDump;
+}
+
+/** The in-flight (or settled) dump — MySQL builds its templates concurrently. */
+let _schemaCacheDump: Promise<void> | null = null;
 
 /**
  * Per-adapter template-clone strategy. Each adapter checks whether it is
@@ -125,7 +148,7 @@ const sqliteAdapter: DbTemplateAdapter = {
       adapter: "sqlite3",
       database: templatePath,
     });
-    await buildTemplateSchema(adapter, runToken, async () => {
+    await buildTemplateSchema(adapter, pool, runToken, async () => {
       pool.releaseConnection();
       await pool.disconnectBang();
     });
@@ -186,6 +209,7 @@ const pgAdapter: DbTemplateAdapter = {
     try {
       await loadSchema(adapter);
       await stampCanonicalSchema(adapter, runToken);
+      await dumpSchemaCacheOnce(adapter, pool, runToken);
     } finally {
       try {
         pool.releaseConnection();
@@ -213,6 +237,7 @@ const pgAdapter: DbTemplateAdapter = {
         ownRunDatabases(base, runToken, await pgDatabaseNames(cleanup)),
       );
       await cleanup.end();
+      await sweepRunDbFiles(runToken);
     };
   },
 };
@@ -270,7 +295,7 @@ const mysqlAdapter: DbTemplateAdapter = {
           connectionLimit: 1,
           flags: ["FOUND_ROWS"],
         });
-        await buildTemplateSchema(adapter, runToken, async () => {
+        await buildTemplateSchema(adapter, pool, runToken, async () => {
           pool.releaseConnection();
           await pool.disconnectBang();
         });
@@ -287,6 +312,7 @@ const mysqlAdapter: DbTemplateAdapter = {
         ownRunDatabases(baseDb, runToken, await mysqlDatabaseNames(cleanup)),
       );
       await cleanup.end();
+      await sweepRunDbFiles(runToken);
     };
   },
 };

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -23,7 +23,11 @@ import { PoolConfig } from "../connection-adapters/pool-config.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { loadSchema } from "./load-schema-helper.js";
 import { stampCanonicalSchema } from "./canonical-schema-stamp.js";
-import { SCHEMA_CACHE_DUMP_ENV, dumpTemplateSchemaCache } from "./schema-cache-dump.js";
+import {
+  SCHEMA_CACHE_DUMP_ENV,
+  SCHEMA_CACHE_FINGERPRINT_ENV,
+  dumpTemplateSchemaCache,
+} from "./schema-cache-dump.js";
 import {
   TEMPLATE_PATH_ENV,
   isSqliteRun,
@@ -104,7 +108,9 @@ async function dumpSchemaCacheOnce(
   runToken: string,
 ): Promise<void> {
   _schemaCacheDump ??= dumpTemplateSchemaCache(adapter, pool, runToken).then((dump) => {
-    if (dump) process.env[SCHEMA_CACHE_DUMP_ENV] = dump;
+    if (!dump) return;
+    process.env[SCHEMA_CACHE_DUMP_ENV] = dump.filename;
+    process.env[SCHEMA_CACHE_FINGERPRINT_ENV] = dump.fingerprint;
   });
   await _schemaCacheDump;
 }

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -11,7 +11,13 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
 import type { SchemaCache } from "../connection-adapters/schema-cache.js";
-import { templateSchemaCache } from "../support/schema-cache-dump.js";
+import {
+  dumpedTables,
+  fingerprintOf,
+  schemaShapes,
+  templateSchemaCache,
+  templateSchemaFingerprint,
+} from "../support/schema-cache-dump.js";
 
 interface TxnHost {
   transactionManager: {
@@ -80,18 +86,20 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
 }
 
 /**
- * Load the boot dump into `sc` if the live database still agrees with it, and
- * report whether it was used.
+ * Load the boot dump into `sc` if the live database still matches the schema it
+ * describes, and report whether it was used.
  *
- * The dump describes the template as it was laid, and every worker database is
- * a clone of that template whose canonical tables are rebuilt to their laid
- * shape between files — but a file that drops a table must not make the next
- * file read a schema that is no longer there. So the dump is checked against
- * one `dataSources()` query (the call `add_all` makes first anyway, so it is
- * not an extra round trip): every dumped table must still exist, or the pool
- * reflects from scratch. Tables the live database has and the dump does not —
- * the bespoke table a previous file created — are reflected individually, a
- * handful of `add`s rather than ~200.
+ * The dump describes the template as globalSetup laid it, and every worker
+ * database is a clone of that template — but the between-file reset truncates
+ * the canonical tables rather than re-laying them, so a file that leaves an
+ * `addColumn` / `changeColumn` / `renameColumn` behind changes a canonical
+ * table's shape without changing the table *set*. The guard is therefore the
+ * boot fingerprint over the dumped tables' live shapes
+ * (`support/schema-cache-dump.ts`), which one query answers: any drop, add,
+ * rename or type change to a table the dump describes falls back to reflecting
+ * the database. Tables the live database has and the dump does not — the
+ * bespoke table a file lays in its own `beforeAll` — are reflected
+ * individually, a handful of `add`s rather than ~200.
  */
 async function replaySchemaCacheDump(
   adapter: TransactionalFixturesAdapter,
@@ -99,14 +107,11 @@ async function replaySchemaCacheDump(
   sc: NonNullable<TransactionalFixturesAdapter["internalSchemaCache"]>,
   dumped: SchemaCache,
 ): Promise<boolean> {
-  const marshalled = dumped.marshalDump();
-  const cached = new Set(Object.keys((marshalled[4] as Record<string, boolean>) ?? {}));
-  const live = new Set(await adapter.dataSources());
-  for (const table of cached) {
-    if (!live.has(table)) return false;
-  }
-  sc.marshalLoad(marshalled);
-  for (const table of live) {
+  const cached = dumpedTables(dumped);
+  const shapes = await schemaShapes(adapter);
+  if (fingerprintOf(shapes, cached) !== templateSchemaFingerprint()) return false;
+  sc.marshalLoad(dumped.marshalDump());
+  for (const table of shapes.keys()) {
     if (!cached.has(table)) await sc.add(pool, table);
   }
   return true;

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -94,12 +94,20 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
  * the canonical tables rather than re-laying them, so a file that leaves an
  * `addColumn` / `changeColumn` / `renameColumn` behind changes a canonical
  * table's shape without changing the table *set*. The guard is therefore the
- * boot fingerprint over the dumped tables' live shapes
- * (`support/schema-cache-dump.ts`), which one query answers: any drop, add,
- * rename or type change to a table the dump describes falls back to reflecting
- * the database. Tables the live database has and the dump does not — the
- * bespoke table a file lays in its own `beforeAll` — are reflected
- * individually, a handful of `add`s rather than ~200.
+ * boot fingerprint over the dumped tables' live shapes, which whole-database
+ * queries answer (`support/schema-cache-dump.ts`): any change to a table the
+ * dump describes falls back to reflecting the database. Tables the live
+ * database has and the dump does not — the bespoke table a file lays in its own
+ * `beforeAll` — are reflected individually, a handful of `add`s rather than
+ * ~200.
+ *
+ * Rails installs a loaded dump by replacing the cache object
+ * (`schema_cache.rb:139`, whose `load_cache` returns the new cache for
+ * `SchemaReflection` to hold). This loads into the cache the pool already
+ * handed out instead, because trails' adapter-side consumers hold
+ * `internalSchemaCache` by identity — the same reason `ConnectionPool` assigns
+ * a loaded cache back onto `poolConfig.schemaCache` rather than letting the two
+ * diverge (`connection-pool.ts` lazy-load).
  */
 async function replaySchemaCacheDump(
   adapter: TransactionalFixturesAdapter,
@@ -107,10 +115,11 @@ async function replaySchemaCacheDump(
   sc: NonNullable<TransactionalFixturesAdapter["internalSchemaCache"]>,
   dumped: SchemaCache,
 ): Promise<boolean> {
-  const cached = dumpedTables(dumped);
+  const marshalled = dumped.marshalDump();
+  const cached = dumpedTables(marshalled);
   const shapes = await schemaShapes(adapter);
   if (fingerprintOf(shapes, cached) !== templateSchemaFingerprint()) return false;
-  sc.marshalLoad(dumped.marshalDump());
+  sc.marshalLoad(marshalled);
   for (const table of shapes.keys()) {
     if (!cached.has(table)) await sc.add(pool, table);
   }

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -10,6 +10,8 @@ import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
+import type { SchemaCache } from "../connection-adapters/schema-cache.js";
+import { templateSchemaCache } from "../support/schema-cache-dump.js";
 
 interface TxnHost {
   transactionManager: {
@@ -52,6 +54,16 @@ function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"
  * adapters without a pool, and reflection failures are swallowed (the cache
  * simply stays cold for that table, falling back to the synthesized branch).
  *
+ * The introspection is **not** re-done per test file. `SchemaCache#add` issues
+ * four queries per table (`dataSourceExists` / `primaryKeys` / `columns` /
+ * `indexes`), which over the ~200 canonical tables is ~800 queries and ~0.3s of
+ * every file's runtime. globalSetup reflects the template database once and
+ * dumps it (`support/schema-cache-dump.ts`), and this loads the dump — Rails'
+ * `db:schema:cache:dump` plus `ActiveRecord.schema_cache_path`: dump once
+ * (`schema_cache.rb:406`), `SchemaCache._load_from` per process
+ * (`schema_cache.rb:228`). Only a run without a boot dump falls back to
+ * reflecting the database itself.
+ *
  * @internal
  */
 async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Promise<void> {
@@ -59,10 +71,45 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
   const pool = adapter.pool == null || adapter.pool instanceof NullPool ? null : adapter.pool;
   if (!sc || pool === null) return;
   try {
+    const dumped = templateSchemaCache();
+    if (dumped && (await replaySchemaCacheDump(adapter, pool, sc, dumped))) return;
     await sc.addAll(pool);
   } catch {
     // best-effort warm
   }
+}
+
+/**
+ * Load the boot dump into `sc` if the live database still agrees with it, and
+ * report whether it was used.
+ *
+ * The dump describes the template as it was laid, and every worker database is
+ * a clone of that template whose canonical tables are rebuilt to their laid
+ * shape between files — but a file that drops a table must not make the next
+ * file read a schema that is no longer there. So the dump is checked against
+ * one `dataSources()` query (the call `add_all` makes first anyway, so it is
+ * not an extra round trip): every dumped table must still exist, or the pool
+ * reflects from scratch. Tables the live database has and the dump does not —
+ * the bespoke table a previous file created — are reflected individually, a
+ * handful of `add`s rather than ~200.
+ */
+async function replaySchemaCacheDump(
+  adapter: TransactionalFixturesAdapter,
+  pool: ConnectionPool,
+  sc: NonNullable<TransactionalFixturesAdapter["internalSchemaCache"]>,
+  dumped: SchemaCache,
+): Promise<boolean> {
+  const marshalled = dumped.marshalDump();
+  const cached = new Set(Object.keys((marshalled[4] as Record<string, boolean>) ?? {}));
+  const live = new Set(await adapter.dataSources());
+  for (const table of cached) {
+    if (!live.has(table)) return false;
+  }
+  sc.marshalLoad(marshalled);
+  for (const table of live) {
+    if (!cached.has(table)) await sc.add(pool, table);
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## What

The fixtures schema-cache warm no longer reflects the database per test file.

`SchemaCache#add` issues four introspection queries per table
(`dataSourceExists` / `primaryKeys` / `columns` / `indexes`), so the eager
`add_all` PR #6936 extended to the non-transactional path cost ~800 queries and
~0.3s on **every** file — transactional files had always paid it.

Rails' answer is `db:schema:cache:dump` / `ActiveRecord.schema_cache_path`:
dump once (`schema_cache.rb:406`), `SchemaCache._load_from` per process
(`schema_cache.rb:228`). The canonical schema is laid into the template
database once at boot and cloned into every worker slot, so one dump describes
every database a run touches.

- `support/schema-cache-dump.ts` (new): globalSetup reflects the template it
  just laid and dumps it, once per run, to a `TEMP_DB_PREFIX`-named tmp file
  the existing run-token sweep collects. `templateSchemaCache()` loads it.
- `with-transactional-fixtures.ts`: the warm loads that dump instead of
  reflecting. A run with no boot dump still falls back to `addAll`.

An in-process memo was the cheaper-looking variant the story floated; measured,
it does not work — vitest's forked workers do **not** carry `globalThis` across
test files here (instrumented: `dumps.size` is 0 on every file), so the dump
has to be on disk.

### Stale-schema guard

The between-file reset truncates the canonical tables rather than re-laying them
(`drop-all-tables.ts` `resetTestTables`), so a file that leaves an
`addColumn` / `changeColumn` / `renameColumn` behind changes a canonical table's
shape without changing the table *set*. The replay is therefore gated on a
fingerprint of the dumped tables' live shapes, matched against the one
globalSetup recorded. Each lane hashes the projection its own
`columnDefinitions` reflects a `Column` from, plus its indexes: PostgreSQL's
`pg_attribute` query verbatim (`postgresql/schema-statements-class.ts:605-614`)
and `pg_indexes.indexdef`; MySQL's `SHOW FULL FIELDS` fields out of
`information_schema.COLUMNS` plus `STATISTICS` (`COLLATION` is where
`IndexDefinition#orders` comes from — `mysql/schema_statements.rb:43`, `:47`);
sqlite one query for both, since `sqlite_master.sql` is the `CREATE` statement
itself and its index rows carry `tbl_name`. Whole-database queries, never one
per table — that is what the dump exists to avoid.

Tables the dump never described are excluded from the fingerprint, so a bespoke
table a file lays in its own `beforeAll` costs one `add()` rather than a full
rewarm. Rails needs none of this: every DDL path invalidates the cache entry as
it runs (`abstract/schema_statements.rb:306`, `:542`;
`postgresql/schema_statements.rb:460-467`, `:523-524`), but only inside the
process that ran it, and the dump outlives that.

### Lossless dump

`SQLite3::Column` and `PostgreSQL::Column` gain the JSON round-trip
`MySQL::Column` already had. Rails' YAML/Marshal dump round-trips the adapter's
Column subclass on its own; trails' JSON dump silently dropped it, so a loaded
cache reported every column non-`array?`, non-`serial?` and not
auto-incremented. Caught by `base_test.rb`'s `test_clear_cache!`, which
compares reflected columns against cached ones.

## Numbers

sqlite, this host, 2 runs each, `origin/main` vs branch:

| file | before | after |
| --- | --- | --- |
| `cache-key.test.ts` (non-transactional) | 599 / 496 ms | 285 / 287 ms |
| `migration.test.ts` | 1488 / 1537 ms | 1307 / 1373 ms |
| `readonly.test.ts` (transactional) | 1665 / 1691 ms | 1446 / 1443 ms |

`cache-key.test.ts` is back below its pre-#6936 timing, and the transactional
file improves too.

Closes-story: warm-the-fixtures-schema-cache-from-a-boot-dump
