### PR TITLE
fix(scripts): query-parity fixtures pass association joins as Ruby Symbols

### DIFF
--- a/scripts/parity/pipeline/fixtures/ar-01/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-01/query.ts
@@ -6,4 +6,4 @@ import { Book } from "./models.js";
 // only the former is pinned by the runner's frozen clock.
 const oneWeekAgo = weeks(1).ago(Temporal.Instant.fromEpochMilliseconds(Date.now()));
 
-export default Book.joins("reviews").where("reviews.created_at > ?", oneWeekAgo);
+export default Book.joins(":reviews").where("reviews.created_at > ?", oneWeekAgo);

--- a/scripts/parity/pipeline/fixtures/ar-104/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-104/query.ts
@@ -1,5 +1,5 @@
 import { Author } from "./models.js";
 
-export default Author.joins("books")
+export default Author.joins(":books")
   .select("authors.*, COUNT(books.id) AS books_count")
   .group("authors.id");

--- a/scripts/parity/pipeline/fixtures/ar-110/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-110/query.ts
@@ -1,5 +1,5 @@
 import { Book } from "./models.js";
 
-export default Book.joins("reviews")
+export default Book.joins(":reviews")
   .where({ reviews: { rating: 5 } })
   .select("books.*, reviews.rating");

--- a/scripts/parity/pipeline/fixtures/ar-115/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-115/query.ts
@@ -1,3 +1,3 @@
 import { Author } from "./models.js";
 
-export default Author.joins("books").group("authors.id").having("COUNT(books.id) >= 2");
+export default Author.joins(":books").group("authors.id").having("COUNT(books.id) >= 2");

--- a/scripts/parity/pipeline/fixtures/ar-120/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-120/query.ts
@@ -1,3 +1,3 @@
 import { Book, Review } from "./models.js";
 
-export default Book.joins("reviews").where(Review.arelTable.get("rating").gteq(4));
+export default Book.joins(":reviews").where(Review.arelTable.get("rating").gteq(4));

--- a/scripts/parity/pipeline/fixtures/ar-127/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-127/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.joins("author").joins("reviews").where("reviews.rating > 3");
+export default Book.joins(":author").joins(":reviews").where("reviews.rating > 3");

--- a/scripts/parity/pipeline/fixtures/ar-130/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-130/query.ts
@@ -1,7 +1,7 @@
 import { sql } from "@blazetrails/arel";
 import { Author } from "./models.js";
 
-export default Author.joins("books")
+export default Author.joins(":books")
   .joins("INNER JOIN reviews ON reviews.book_id = books.id")
   .where("reviews.rating >= 4")
   .group("authors.id, authors.name")

--- a/scripts/parity/pipeline/fixtures/ar-139/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-139/query.ts
@@ -1,5 +1,5 @@
 import { Book } from "./models.js";
 
-export default Book.joins("author")
+export default Book.joins(":author")
   .where({ author: { name: "Alice" } })
   .order("authors.id");

--- a/scripts/parity/pipeline/fixtures/ar-152/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-152/query.ts
@@ -1,5 +1,5 @@
 import { Author } from "./models.js";
-export default Author.joins("publishedBooks")
+export default Author.joins(":publishedBooks")
   .where("published_books.title LIKE ?", "%Rails%")
   .select("authors.*, COUNT(published_books.id) AS book_count")
   .group("authors.id");

--- a/scripts/parity/pipeline/fixtures/ar-44/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-44/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.leftOuterJoins("author");
+export default Book.leftOuterJoins(":author");

--- a/scripts/parity/pipeline/fixtures/ar-55/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-55/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.joins("author").where({ authors: { name: "Rails" } });
+export default Book.joins(":author").where({ authors: { name: "Rails" } });

--- a/scripts/parity/pipeline/fixtures/ar-66/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-66/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.joins("author").group("authors.name").select("authors.name, COUNT(*) AS c");
+export default Book.joins(":author").group("authors.name").select("authors.name, COUNT(*) AS c");

--- a/scripts/parity/pipeline/fixtures/ar-71/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-71/query.ts
@@ -1,7 +1,3 @@
 import { Book } from "./models.js";
 
-// Rails: joins(:author, :reviews) — variadic single call.
-// trails Relation#joins(assocName, on?) accepts only one association per call;
-// passing a second string is treated as a raw ON clause, not a second assoc.
-// Chaining is the correct workaround until joins() is made variadic.
-export default Book.joins("author").joins("reviews");
+export default Book.joins(":author", ":reviews");

--- a/scripts/parity/pipeline/fixtures/ar-96/query.ts
+++ b/scripts/parity/pipeline/fixtures/ar-96/query.ts
@@ -1,3 +1,3 @@
 import { Book } from "./models.js";
 
-export default Book.leftOuterJoins("reviews");
+export default Book.leftOuterJoins(":reviews");


### PR DESCRIPTION
`Query Parity (diff)` has been red on `main` (scheduled run 32700161952) with 13 failing fixtures. Every one of them passes an association name to `joins` / `leftOuterJoins` as a bare string.

Rails discriminates on the Symbol type: `select_association_list` (`activerecord/lib/active_record/relation/query_methods.rb:1810-1823`) keeps `when Hash, Symbol, Array` as association specs and drops a raw SQL **String** through the `else`. trails spells a Ruby Symbol as a leading-colon string (CLAUDE.md, "A Ruby Symbol is a JS string, never a JS `Symbol`"), which `isRubySymbol` in `packages/activerecord/src/relation/query-methods.ts:2439` implements.

So the fixtures were writing raw SQL where Rails writes an association:

- `Author.joins("books")` → `SELECT ... FROM "authors" books GROUP BY ...` instead of `FROM "authors" INNER JOIN "books" ON "books"."author_id" = "authors"."id"`.
- `Book.leftOuterJoins("author")` raised `only Hash, Symbol and Array are allowed` from `build_join_buckets` (`query_methods.rb:1830-1836`), so the dump failed and the case counted as `trails-missing`.

Fix: colon-prefix the association arguments in the affected fixtures — the fixture side was wrong, not the port.

- 13 failing fixtures: ar-104, ar-110, ar-115, ar-120, ar-127, ar-130, ar-139, ar-152, ar-44, ar-55, ar-66, ar-71, ar-96.
- ar-01 too: it carries a known-gap row for a *datetime-precision* diff, and its `joins("reviews")` was silently broken behind that row. Its gap reason is accurate again now.
- ar-71 drops a stale comment claiming `joins()` takes only one association, and becomes the variadic single call Rails makes — `joins(:author, :reviews)`. `joins` is variadic (`query_methods.rb:868-871`, `query-methods.ts:1011`).

No `packages/**` changes.

## Verification

Full pipeline, locally, both sides, `PARITY_FROZEN_AT=2026-08-24T07:00:00.377Z`:

```
before: 183/204 passed, 6 known gap(s), 13 failure(s)
after:  196/204 passed, 8 known gap(s)
```

(ar-01/ar-52/ar-65 report `UNEXPECTED-PASS` only when the frozen-at lands on a whole second — the documented flake in their own known-gap reasons — so the run above uses a sub-second instant, as CI's `date -u +%3N` does.)

Closes-story: red-f8be16b9
