### PR TITLE
refactor(activerecord,trailties,activerecord-cli): delete the registeredMigrations seam

### DIFF
--- a/packages/activerecord-cli/src/__e2e__/helpers.ts
+++ b/packages/activerecord-cli/src/__e2e__/helpers.ts
@@ -1,4 +1,4 @@
-import { DatabaseTasks } from "@blazetrails/activerecord";
+import { DatabaseTasks, Migrator } from "@blazetrails/activerecord";
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -50,7 +50,7 @@ export async function mkE2eTmpDir(prefix: string): Promise<string> {
 export async function teardownE2eFixture(tmpDir: string): Promise<void> {
   DatabaseTasks.databaseConfiguration = null;
   (DatabaseTasks as unknown as { _root: string | null })._root = null;
-  DatabaseTasks.registerMigrations([]);
+  Migrator.migrationsPaths = ["db/migrate"];
   DatabaseTasks.seedLoader = null;
   await rm(tmpDir, { recursive: true, force: true });
 }

--- a/packages/activerecord-cli/src/db-helpers.ts
+++ b/packages/activerecord-cli/src/db-helpers.ts
@@ -4,6 +4,7 @@ import {
   DatabaseTasks,
   DatabaseConfigurations,
   MigrationContext,
+  Migrator,
   NullSchemaMigration,
   NullInternalMetadata,
 } from "@blazetrails/activerecord";
@@ -33,6 +34,10 @@ export async function loadDatabaseConfig(cwd: string): Promise<DatabaseConfigura
   const configs = normalizeSqlitePaths(DatabaseConfigurations.fromEnv(raw), cwd);
   DatabaseTasks.databaseConfiguration = configs;
   DatabaseTasks.root = cwd;
+  // `db:load_config` (`railties/databases.rake:27`): the discovery paths every
+  // pool falls back to when its own `db_config.migrations_paths` is absent
+  // (`connection_pool.rb:299`). Absolute, as `Rails.application.paths` are.
+  Migrator.migrationsPaths = DatabaseTasks.migrationsPaths.map((p) => resolve(join(cwd, p)));
   await establishEnvironmentConnection(DatabaseConfigurations.currentEnv());
   return configs;
 }
@@ -51,11 +56,6 @@ export async function tryLoadModels(cwd: string): Promise<Record<string, unknown
  */
 export function loadMigrations(cwd: string): import("@blazetrails/activerecord").MigrationProxy[] {
   const paths = DatabaseTasks.migrationsPaths.map((p) => resolve(join(cwd, p)));
-  const migrations = new MigrationContext(
-    paths,
-    new NullSchemaMigration(),
-    new NullInternalMetadata(),
-  ).migrations;
-  DatabaseTasks.registerMigrations(migrations);
-  return migrations;
+  return new MigrationContext(paths, new NullSchemaMigration(), new NullInternalMetadata())
+    .migrations;
 }

--- a/packages/activerecord-cli/src/db-migrate.test.ts
+++ b/packages/activerecord-cli/src/db-migrate.test.ts
@@ -91,6 +91,11 @@ describe("DbMigrateTest", () => {
   });
 
   it("db:migrate calls MigrationContext#migrations before migrate", async () => {
+    // Discovery is `migration_connection_pool.migration_context`
+    // (`database_tasks.rb:270`), so the real `migrate` has to run for the
+    // getter to be reached.
+    vi.mocked(DatabaseTasks.migrate).mockRestore();
+    DatabaseConfigurations.defaultEnv = "development";
     const discoverSpy = vi
       .spyOn(MigrationContext.prototype, "migrations", "get")
       .mockReturnValue([]);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from "path";
 import { getEnv, getFsAsync, setEnv } from "@blazetrails/activesupport";
 import { DatabaseTasks, DatabaseConfigurations } from "@blazetrails/activerecord";
-import { loadDatabaseConfig, loadMigrations, tryLoadModels } from "./db-helpers.js";
+import { loadDatabaseConfig, tryLoadModels } from "./db-helpers.js";
 import { withEnvironmentConnection } from "./environment.js";
 
 async function runCreate(
@@ -105,7 +105,6 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
   await tryLoadModels(cwd);
-  loadMigrations(cwd);
 
   // Rails' `rake db:migrate` (railties/databases.rake:89) takes its target from
   // `ENV["VERSION"]`, which `migrate_all` reads back through `target_version`;
@@ -132,7 +131,6 @@ export async function dbRollback(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
   await tryLoadModels(cwd);
-  loadMigrations(cwd);
   const step = parseStep(args, 1);
 
   try {
@@ -299,7 +297,6 @@ export async function dbPrepare(cwd: string, _args: string[]): Promise<number> {
   }
 
   await tryLoadModels(cwd);
-  loadMigrations(cwd);
   installSeedLoader(cwd);
 
   try {
@@ -362,7 +359,6 @@ export async function dbMigrateStatus(cwd: string, args: string[]): Promise<numb
     return 1;
   }
   await tryLoadModels(cwd);
-  loadMigrations(cwd);
 
   const env = DatabaseConfigurations.currentEnv();
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -531,8 +531,6 @@ export class ConnectionPool implements ReapablePool {
 
   // --- Migration / Schema ---
 
-  private _schemaMigration?: SchemaMigration;
-  private _internalMetadata?: InternalMetadata;
   private _adapterProxy?: DatabaseAdapter;
 
   private _getAdapterProxy(): DatabaseAdapter {
@@ -594,30 +592,15 @@ export class ConnectionPool implements ReapablePool {
   }
 
   get schemaMigration(): SchemaMigration {
-    if (!this._schemaMigration) {
-      this._schemaMigration = new SchemaMigration(this);
-    }
-    return this._schemaMigration;
+    return new SchemaMigration(this);
   }
 
   get internalMetadata(): InternalMetadata {
-    if (!this._internalMetadata) {
-      this._internalMetadata = new InternalMetadata(this);
-    }
-    return this._internalMetadata;
+    return new InternalMetadata(this);
   }
 
-  private _migrationContext?: MigrationContext;
-
   get migrationContext(): MigrationContext {
-    if (!this._migrationContext) {
-      this._migrationContext = new MigrationContext(
-        this.migrationsPaths,
-        this.schemaMigration,
-        this.internalMetadata,
-      );
-    }
-    return this._migrationContext;
+    return new MigrationContext(this.migrationsPaths, this.schemaMigration, this.internalMetadata);
   }
 
   // --- Query cache (delegated to ConnectionPoolConfiguration) ---

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -31,7 +31,7 @@ import {
 import { executionContextId } from "./connection-pool/execution-context.js";
 import { SchemaMigration } from "../../schema-migration.js";
 import { InternalMetadata } from "../../internal-metadata.js";
-import { MigrationContext } from "../../migration.js";
+import { MigrationContext, Migrator } from "../../migration.js";
 
 /**
  * A connection that supports transaction management.
@@ -589,7 +589,7 @@ export class ConnectionPool implements ReapablePool {
     // `DatabaseConfig#migrationsPaths` answers a bare string for a single-path
     // config; Rails wraps in `Array(migrations_paths)` before globbing
     // (migration.rb:1369), and without that a string iterates per character.
-    const paths = (this.dbConfig as any).migrationsPaths ?? ["db/migrate"];
+    const paths = (this.dbConfig as any).migrationsPaths ?? Migrator.migrationsPaths;
     return Array.isArray(paths) ? paths : [paths];
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2422,8 +2422,8 @@ export class MigrationContext<
 }
 
 export class Migrator {
-  /** Mirrors: ActiveRecord::Migrator.migrations_paths (`migration.rb:1407`) */
-  static migrationsPaths: string[] = [];
+  /** Mirrors: ActiveRecord::Migrator.migrations_paths (`migration.rb:1407`, `:1419`) */
+  static migrationsPaths: string[] = ["db/migrate"];
 
   private _migrations: MigrationProxy[];
   private _schemaMigration: SchemaMigration;

--- a/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
@@ -5,14 +5,16 @@ import { join } from "path";
 import { DatabaseTasks } from "./database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
-import type { MigrationProxy } from "../migration.js";
-import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
+
+// Rails' `MIGRATIONS_ROOT` (`test/cases/migration_test.rb`); `10_urban` holds
+// one self-contained migration, so `migrate_all` has something to run without
+// depending on the canonical schema.
+const MIGRATIONS_ROOT = new URL("../test-helpers/migrations", import.meta.url).pathname;
 
 describe("DatabaseTasksMigrateAllMetadataTest", () => {
   const dirs: string[] = [];
 
   afterEach(async () => {
-    DatabaseTasks.registerMigrations([]);
     DatabaseTasks.databaseConfiguration = null;
     try {
       Base.removeConnection();
@@ -20,18 +22,6 @@ describe("DatabaseTasksMigrateAllMetadataTest", () => {
       void 0;
     }
     for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
-  });
-
-  const migration = (version: number, name: string): MigrationProxy => ({
-    version,
-    name,
-    migration: () =>
-      anonymousMigration(
-        name,
-        version,
-        async () => {},
-        async () => {},
-      ),
   });
 
   async function setupConfigs(): Promise<void> {
@@ -45,16 +35,17 @@ describe("DatabaseTasksMigrateAllMetadataTest", () => {
           database: join(dir, "primary.sqlite3"),
           pool: 1,
           useMetadataTable: false,
+          migrationsPaths: `${MIGRATIONS_ROOT}/10_urban`,
         },
         animals: {
           adapter: "sqlite3",
           database: join(dir, "animals.sqlite3"),
           pool: 1,
           useMetadataTable: false,
+          migrationsPaths: `${MIGRATIONS_ROOT}/10_urban`,
         },
       },
     });
-    DatabaseTasks.registerMigrations([migration(1, "CreateNothing")]);
     await Base.establishConnection({
       adapter: "sqlite3",
       database: join(dir, "primary.sqlite3"),

--- a/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
@@ -6,9 +6,7 @@ import { DatabaseTasks } from "./database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
 
-// Rails' `MIGRATIONS_ROOT` (`test/cases/migration_test.rb`); `10_urban` holds
-// one self-contained migration, so `migrate_all` has something to run without
-// depending on the canonical schema.
+// Rails' `MIGRATIONS_ROOT` (`test/cases/migration_test.rb`).
 const MIGRATIONS_ROOT = new URL("../test-helpers/migrations", import.meta.url).pathname;
 
 describe("DatabaseTasksMigrateAllMetadataTest", () => {

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -8,30 +8,26 @@ import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
 import { UnknownMigrationVersionError } from "../migration.js";
 
-/**
- * Discovery is `MigrationContext#migrations` (`migration.rb:1303-1315`) reading
- * the pool's own `db_config.migrations_paths` (`connection_pool.rb:294-299`),
- * so a migration these tests can watch has to be a file under such a path —
- * the shape Rails' own `DatabaseTasksMigrationTestCase` uses
- * (`test/cases/tasks/database_tasks_test.rb:1036-1039`). `reverted` is the
- * revert log the generated `down` bodies append to.
- */
-declare global {
-  var __trailsRollbackReverted: string[] | undefined;
-}
+// Discovery is `MigrationContext#migrations` (`migration.rb:1303-1315`) reading
+// the pool's own `db_config.migrations_paths` (`connection_pool.rb:294-299`),
+// so a migration these tests can watch has to be a file under such a path — the
+// shape Rails' `DatabaseTasksMigrationTestCase` uses
+// (`test/cases/tasks/database_tasks_test.rb:1036-1039`). A generated `down`
+// appends its name to the revert log the test then reads.
+const REVERT_LOG = "__trailsRollbackReverted";
 
-const reverted = (): string[] => (globalThis.__trailsRollbackReverted ??= []);
+const reverted = (): string[] =>
+  ((globalThis as Record<string, unknown>)[REVERT_LOG] as string[] | undefined) ?? [];
 
 async function writeMigration(dir: string, version: number, name: string): Promise<void> {
-  const className = name;
   const fileName = name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
   await writeFile(
     join(dir, `${version}_${fileName}.ts`),
     `import { Migration } from "${new URL("../migration.js", import.meta.url).pathname}";
-export class ${className} extends Migration {
+export class ${name} extends Migration {
   async up() {}
   async down() {
-    (globalThis.__trailsRollbackReverted ??= []).push("${name}");
+    (globalThis.${REVERT_LOG} ??= []).push("${name}");
   }
 }
 `,
@@ -42,7 +38,7 @@ describe("DatabaseTasksRollbackTest", () => {
   const dirs: string[] = [];
 
   afterEach(async () => {
-    globalThis.__trailsRollbackReverted = undefined;
+    delete (globalThis as Record<string, unknown>)[REVERT_LOG];
     DatabaseTasks.databaseConfiguration = null;
     try {
       Base.removeConnection();

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -1,52 +1,88 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import { DatabaseTasks } from "./database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
-import { UnknownMigrationVersionError, type MigrationProxy } from "../migration.js";
-import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
+import { UnknownMigrationVersionError } from "../migration.js";
+
+/**
+ * Discovery is `MigrationContext#migrations` (`migration.rb:1303-1315`) reading
+ * the pool's own `db_config.migrations_paths` (`connection_pool.rb:294-299`),
+ * so a migration these tests can watch has to be a file under such a path —
+ * the shape Rails' own `DatabaseTasksMigrationTestCase` uses
+ * (`test/cases/tasks/database_tasks_test.rb:1036-1039`). `reverted` is the
+ * revert log the generated `down` bodies append to.
+ */
+declare global {
+  var __trailsRollbackReverted: string[] | undefined;
+}
+
+const reverted = (): string[] => (globalThis.__trailsRollbackReverted ??= []);
+
+async function writeMigration(dir: string, version: number, name: string): Promise<void> {
+  const className = name;
+  const fileName = name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  await writeFile(
+    join(dir, `${version}_${fileName}.ts`),
+    `import { Migration } from "${new URL("../migration.js", import.meta.url).pathname}";
+export class ${className} extends Migration {
+  async up() {}
+  async down() {
+    (globalThis.__trailsRollbackReverted ??= []).push("${name}");
+  }
+}
+`,
+  );
+}
 
 describe("DatabaseTasksRollbackTest", () => {
-  afterEach(() => {
-    DatabaseTasks.registerMigrations([]);
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    globalThis.__trailsRollbackReverted = undefined;
     DatabaseTasks.databaseConfiguration = null;
     try {
       Base.removeConnection();
     } catch {
       void 0;
     }
+    for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true });
   });
 
+  async function migrationsPath(...migrations: Array<[number, string]>): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "trails-rollback-"));
+    dirs.push(dir);
+    await mkdir(dir, { recursive: true });
+    for (const [version, name] of migrations) await writeMigration(dir, version, name);
+    return dir;
+  }
+
   it("rolls back the migrations registered for the pool's database", async () => {
-    const reverted: string[] = [];
-    const migration = (version: number, name: string): MigrationProxy => ({
-      version,
-      name,
-      migration: () =>
-        anonymousMigration(
-          name,
-          version,
-          async () => {},
-          async () => {
-            reverted.push(name);
-          },
-        ),
-    });
+    const primaryPath = await migrationsPath([2, "PrimaryOnly"]);
+    const animalsPath = await migrationsPath([3, "AnimalsOnly"]);
 
     const env = DatabaseTasks.env;
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [env]: {
-        primary: { adapter: "sqlite3", database: ":memory:", pool: 1 },
-        animals: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+        primary: {
+          adapter: "sqlite3",
+          database: ":memory:",
+          pool: 1,
+          migrationsPaths: primaryPath,
+        },
+        animals: {
+          adapter: "sqlite3",
+          database: ":memory:",
+          pool: 1,
+          migrationsPaths: animalsPath,
+        },
       },
     });
     const configs = DatabaseTasks.configsFor({ envName: env });
     const primary = configs.find((c) => c.name === "primary")!;
-    const animals = configs.find((c) => c.name === "animals")!;
-
-    DatabaseTasks.registerMigrations([migration(1, "Fallback")]);
-    DatabaseTasks.registerMigrations([migration(2, "PrimaryOnly")], primary);
-    DatabaseTasks.registerMigrations([migration(3, "AnimalsOnly")], animals);
 
     await Base.establishConnection(primary);
     const schemaMigration = new SchemaMigration(Base.connectionPool());
@@ -55,34 +91,20 @@ describe("DatabaseTasksRollbackTest", () => {
 
     await DatabaseTasks.rollback();
 
-    expect(reverted).toEqual(["PrimaryOnly"]);
+    expect(reverted()).toEqual(["PrimaryOnly"]);
     expect(await schemaMigration.versions()).toEqual([]);
   });
 
   it("rollback goes through move, not Migrator's applied-version walk", async () => {
-    const reverted: string[] = [];
-    const migration = (version: number, name: string): MigrationProxy => ({
-      version,
-      name,
-      migration: () =>
-        anonymousMigration(
-          name,
-          version,
-          async () => {},
-          async () => {
-            reverted.push(name);
-          },
-        ),
-    });
-
-    DatabaseTasks.registerMigrations([
-      migration(1, "First"),
-      migration(2, "Second"),
-      migration(3, "Third"),
-    ]);
+    const path = await migrationsPath([1, "First"], [2, "Second"], [3, "Third"]);
 
     DatabaseTasks.databaseConfiguration = null;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({
+      adapter: "sqlite3",
+      database: ":memory:",
+      pool: 1,
+      migrationsPaths: path,
+    });
     const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("1");
@@ -90,27 +112,20 @@ describe("DatabaseTasksRollbackTest", () => {
 
     await DatabaseTasks.rollback(2);
 
-    expect(reverted).toEqual(["Third"]);
+    expect(reverted()).toEqual(["Third"]);
     expect(await schemaMigration.versions()).toEqual(["1"]);
   });
 
   it("rollback raises UnknownMigrationVersionError for an unknown current version", async () => {
-    DatabaseTasks.registerMigrations([
-      {
-        version: 1,
-        name: "Known",
-        migration: () =>
-          anonymousMigration(
-            "Known",
-            1,
-            async () => {},
-            async () => {},
-          ),
-      },
-    ]);
+    const path = await migrationsPath([1, "Known"]);
 
     DatabaseTasks.databaseConfiguration = null;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({
+      adapter: "sqlite3",
+      database: ":memory:",
+      pool: 1,
+      migrationsPaths: path,
+    });
     const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("999");
@@ -119,32 +134,22 @@ describe("DatabaseTasksRollbackTest", () => {
   });
 
   it("rolls back off the ambient pool when no configurations are loaded", async () => {
-    const reverted: string[] = [];
-    DatabaseTasks.registerMigrations([
-      {
-        version: 1,
-        name: "Ambient",
-        migration: () =>
-          anonymousMigration(
-            "Ambient",
-            1,
-            async () => {},
-            async () => {
-              reverted.push("Ambient");
-            },
-          ),
-      },
-    ]);
+    const path = await migrationsPath([1, "Ambient"]);
 
     DatabaseTasks.databaseConfiguration = null;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({
+      adapter: "sqlite3",
+      database: ":memory:",
+      pool: 1,
+      migrationsPaths: path,
+    });
     const schemaMigration = new SchemaMigration(Base.connectionPool());
     await schemaMigration.createTable();
     await schemaMigration.createVersion("1");
 
     await DatabaseTasks.rollback();
 
-    expect(reverted).toEqual(["Ambient"]);
+    expect(reverted()).toEqual(["Ambient"]);
     expect(await schemaMigration.versions()).toEqual([]);
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -23,7 +23,6 @@ import type { ConnectionPool } from "../connection-adapters/abstract/connection-
 import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
 import { fixtures } from "../test-fixtures.js";
-import { anonymousMigration } from "../test-helpers/anonymous-migration.js";
 
 // database_tasks_test.rb:476-485 — Rails saves and restores
 // `ActiveRecord::Base.configurations` around a stubbed set rather than clearing
@@ -893,9 +892,9 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
  *
  * `self.use_transactional_tests = false` needs no analogue: trails tests are
  * non-transactional unless they opt in via `useTransactionalTests()`. The
- * `folder_name` class attribute likewise has none — trails migrations are
- * registered programmatically with `DatabaseTasks.registerMigrations` rather
- * than read from `MIGRATIONS_ROOT/<folder_name>`.
+ * `folder_name` class attribute is the argument of
+ * {@link databaseTasksMigrationTestCase}, since a TS describe block has no
+ * class body to override it in.
  */
 const skipMigrationTestCase = adapterType !== "sqlite" || inMemoryDb();
 
@@ -959,7 +958,9 @@ async function backupIntoConnection(sourceFile: string): Promise<void> {
   }
 }
 
-function databaseTasksMigrationTestCase(): MigrationTestCase {
+const MIGRATIONS_ROOT = new URL("../test-helpers/migrations", import.meta.url).pathname;
+
+function databaseTasksMigrationTestCase(folderName = "valid"): MigrationTestCase {
   let stdoutChunks: string[] = [];
   let stdoutSpy: MockInstance | undefined;
 
@@ -972,14 +973,19 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
     });
     const ambient = ambientPoolConfiguration();
     const sourceFile = String(ambient.database);
-    await Base.establishConnection({ ...ambient, database: ":memory:", pool: 1 });
+    const migrationsPath = [MIGRATIONS_ROOT, folderName].join("/");
+    await Base.establishConnection({
+      ...ambient,
+      database: ":memory:",
+      pool: 1,
+      migrationsPaths: migrationsPath,
+    });
     await backupIntoConnection(sourceFile);
   });
 
   afterEach(async () => {
     stdoutSpy?.mockRestore();
     stdoutSpy = undefined;
-    DatabaseTasks.registerMigrations([]);
     DatabaseTasks.databaseConfiguration = originalConfigurations;
     DatabaseTasks.clearRegisteredTasks();
     try {
@@ -1003,13 +1009,17 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
 }
 
 describe("DatabaseTasksMigrateTest", () => {
+  let originalVerbose: string | undefined;
   let originalVersion: string | undefined;
-  databaseTasksMigrationTestCase();
+  const testCase = databaseTasksMigrationTestCase();
 
   beforeEach(() => {
+    originalVerbose = process.env.VERBOSE;
     originalVersion = process.env.VERSION;
   });
   afterEach(() => {
+    if (originalVerbose === undefined) delete process.env.VERBOSE;
+    else process.env.VERBOSE = originalVerbose;
     if (originalVersion === undefined) delete process.env.VERSION;
     else process.env.VERSION = originalVersion;
   });
@@ -1017,39 +1027,34 @@ describe("DatabaseTasksMigrateTest", () => {
   it.skipIf(skipMigrationTestCase)(
     "migrate set and unset empty values for verbose and version env vars",
     async () => {
-      DatabaseTasks.registerTask(
-        "sqlite",
-        class {
-          async create(): Promise<void> {}
-        },
-      );
-      let migrated = false;
-      DatabaseTasks.registerMigrations([
-        {
-          version: 1,
-          name: "M1",
-          migration: () =>
-            anonymousMigration(
-              "M1",
-              1,
-              async () => {
-                migrated = true;
-              },
-              async () => {},
-            ),
-        },
-      ]);
+      process.env.VERSION = "2";
+      process.env.VERBOSE = "false";
+
+      // run down migration because it was already run on copied db
+      expect(await testCase.captureMigrationOutput()).toBe("");
+
+      process.env.VERBOSE = "";
       process.env.VERSION = "";
-      await DatabaseTasks.migrate();
-      expect(migrated).toBe(true);
+
+      // re-run up migration
+      expect(await testCase.captureMigrationOutput()).toContain("migrating");
     },
   );
 
   it.skipIf(skipMigrationTestCase)(
     "migrate set and unset nonsense values for verbose and version env vars",
     async () => {
-      process.env.VERSION = "nonsense";
-      await expect(DatabaseTasks.migrate()).rejects.toThrow(/Invalid format/);
+      // run down migration because it was already run on copied db
+      process.env.VERSION = "2";
+      process.env.VERBOSE = "false";
+
+      expect(await testCase.captureMigrationOutput()).toBe("");
+
+      process.env.VERBOSE = "yes";
+      process.env.VERSION = "2";
+
+      // run no migration because 2 was already run
+      expect(await testCase.captureMigrationOutput()).toBe("");
     },
   );
 });
@@ -1058,26 +1063,14 @@ describe("DatabaseTasksMigrateScopeTest", () => {
   let originalVerbose: string | undefined;
   let originalVersion: string | undefined;
   let originalScope: string | undefined;
-  const testCase = databaseTasksMigrationTestCase();
+  // Rails: `self.folder_name = "scope"` (database_tasks_test.rb:1103).
+  const testCase = databaseTasksMigrationTestCase("scope");
 
   beforeEach(() => {
     if (skipMigrationTestCase) return;
     originalVerbose = process.env.VERBOSE;
     originalVersion = process.env.VERSION;
     originalScope = process.env.SCOPE;
-    DatabaseTasks.registerMigrations([
-      {
-        version: 1,
-        name: "Unscoped",
-        migration: () => anonymousMigration("Unscoped", 1),
-      },
-      {
-        version: 2,
-        name: "MysqlOnly",
-        scope: "mysql",
-        migration: () => anonymousMigration("MysqlOnly", 2),
-      },
-    ]);
   });
 
   afterEach(() => {
@@ -1135,23 +1128,6 @@ describe("DatabaseTasksMigrateStatusTest", () => {
     // Mirror Rails test setup: @schema_migration.create_table (database_tasks_test.rb:1169)
     const pool = Base.connectionPool();
     await new SchemaMigration(pool).createTable();
-    DatabaseTasks.registerMigrations([
-      {
-        version: 1,
-        name: "Valid people have last names",
-        migration: () => anonymousMigration("Valid people have last names", 1),
-      },
-      {
-        version: 2,
-        name: "We need reminders",
-        migration: () => anonymousMigration("We need reminders", 2),
-      },
-      {
-        version: 3,
-        name: "Innocent jointable",
-        migration: () => anonymousMigration("Innocent jointable", 3),
-      },
-    ]);
   });
 
   it.skipIf(skipMigrationTestCase)("migrate status table", async () => {
@@ -1200,7 +1176,6 @@ describe("DatabaseTasksMigrateErrorTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       [DatabaseTasks.env]: { adapter: "sqlite3", database: dbFile },
     });
-    DatabaseTasks.registerMigrations([]);
     const clearSpy = vi.spyOn(SchemaReflection.prototype, "clearBang");
     try {
       await DatabaseTasks.migrate();
@@ -1215,7 +1190,6 @@ describe("DatabaseTasksMigrateErrorTest", () => {
         /* no pool */
       }
       DatabaseTasks.databaseConfiguration = originalConfigurations;
-      DatabaseTasks.registerMigrations([]);
       DatabaseTasks.clearRegisteredTasks();
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -313,89 +313,6 @@ export class DatabaseTasks {
     }
   }
 
-  private static _migrations: Array<import("../migration.js").MigrationProxy> = [];
-
-  private static _migrationsByConfig = new Map<
-    string,
-    Array<import("../migration.js").MigrationProxy>
-  >();
-
-  /**
-   * Rails derives migrations per config from `db_config.migrations_paths`
-   * via the pool's `migration_context` (`connection_pool.rb:294-299`); there
-   * is no filesystem loader down here, so the caller pre-loads them and
-   * registers them against a config. Registering without one sets the
-   * fallback used by configs with no entry of their own, and resets the
-   * per-config registry so a fresh invocation never inherits stale
-   * migrations.
-   */
-  static registerMigrations(
-    migrations: Array<import("../migration.js").MigrationProxy>,
-    dbConfig?: DatabaseConfig,
-  ): void {
-    if (dbConfig === undefined) {
-      this._migrations = migrations;
-      this._migrationsByConfig.clear();
-    } else {
-      this._migrationsByConfig.set(this._migrationsKey(dbConfig), migrations);
-    }
-  }
-
-  // `configs_for(env_name:, name:)` is how Rails identifies one config, so
-  // env + name is the key — name alone collides across environments, which
-  // may carry different migrations_paths (`hash_config.rb:50-53`).
-  private static _migrationsKey(dbConfig: DatabaseConfig): string {
-    return `${dbConfig.envName}\u0000${dbConfig.name}`;
-  }
-
-  private static _migrationsFor(
-    dbConfig: DatabaseConfig,
-  ): Array<import("../migration.js").MigrationProxy> {
-    return this._migrationsByConfig.get(this._migrationsKey(dbConfig)) ?? this._migrations;
-  }
-
-  /**
-   * Rails reaches the run surface through `MigrationContext`
-   * (`migration.rb:1211`), whose `#migrations` reads `migrations_paths` off
-   * disk. trails registers migrations in memory per db_config, so the context
-   * answers that list instead — the same override Rails' own
-   * `migrator_class` test helper uses.
-   */
-  private static async _migrationContextFor(
-    adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
-    dbConfig: DatabaseConfig,
-  ): Promise<import("../migration.js").MigrationContext> {
-    const { MigrationContext } = await import("../migration.js");
-    const { SchemaMigration } = await import("../schema-migration.js");
-    const { InternalMetadata } = await import("../internal-metadata.js");
-    const migrations = this._migrationsFor(dbConfig);
-    const paths = dbConfig.migrationsPaths;
-    return new (class extends MigrationContext {
-      override get migrations(): import("../migration.js").MigrationProxy[] {
-        return migrations;
-      }
-    })(
-      paths == null ? [] : Array.isArray(paths) ? paths : [paths],
-      new SchemaMigration(adapter.pool),
-      new InternalMetadata(adapter.pool),
-    );
-  }
-
-  private static async _migratorFor(
-    adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
-    dbConfig: DatabaseConfig,
-  ): Promise<import("../migration.js").Migrator> {
-    const { Migrator } = await import("../migration.js");
-    const { SchemaMigration } = await import("../schema-migration.js");
-    const { InternalMetadata } = await import("../internal-metadata.js");
-    return new Migrator(
-      "up",
-      this._migrationsFor(dbConfig),
-      new SchemaMigration(adapter.pool),
-      new InternalMetadata(adapter.pool),
-    );
-  }
-
   /**
    * @param version Exact-version *filter* — only the migration with this
    *   version runs (`db:migrate:up` / `:down` semantics). Rails' `db:migrate`
@@ -429,14 +346,7 @@ export class DatabaseTasks {
     const verboseWas = Migration.verbose;
     Migration.verbose = isVerbose();
 
-    const runMigration = async (
-      adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
-      dbConfig: DatabaseConfig,
-    ) => {
-      // Rails builds the migrator from `migration_connection_pool.migration_context`
-      // (`connection_pool.rb:294-299`), i.e. from the pool's own
-      // `db_config.migrations_paths` — not from a process-global list.
-      const migrator = await this._migratorFor(adapter, dbConfig);
+    const runMigration = async (pool: ConnectionPool) => {
       // Rails block: `version.blank? ? (scope.blank? || scope == m.scope) : m.version == version`
       // `version` is the *method parameter* (explicit arg), NOT ENV["VERSION"].
       // The rake task always calls migrate() with no arg, so version is nil → scope filter only.
@@ -451,7 +361,10 @@ export class DatabaseTasks {
       } else if (scope !== undefined && scope.trim() !== "") {
         filter = (m) => m.scope === scope;
       }
-      const ran = await migrator.migrate(effectiveVersion ?? null, filter);
+      // Rails: `migration_connection_pool.migration_context.migrate(target_version) { |m| ... }`
+      // (`database_tasks.rb:270`) — the context reads the pool's own
+      // `db_config.migrations_paths` (`connection_pool.rb:294-299`).
+      const ran = await pool.migrationContext.migrate(effectiveVersion ?? null, filter);
       if (scope && scope.trim() !== "" && ran.length === 0 && Migration.verbose) {
         // Rails: `Migration.write("No migrations ran. ...")` — write puts to
         // $stdout (`migration.rb:1001`); `Migration.verbose` is the gate
@@ -462,13 +375,13 @@ export class DatabaseTasks {
       // reflected schema so post-migration introspection re-reads the
       // freshly-migrated tables. Optional-chained so an adapter without a
       // schema cache is a no-op rather than a crash.
-      adapter.schemaCache.clearBang();
+      (await pool.leaseConnection()).schemaCache.clearBang();
     };
 
     try {
       const pool = this.migrationConnectionPool();
       if (!skipInitialize) await initializeDatabase(pool.dbConfig);
-      await runMigration(await pool.leaseConnection(), pool.dbConfig);
+      await runMigration(pool);
     } finally {
       Migration.verbose = verboseWas;
     }
@@ -501,8 +414,7 @@ export class DatabaseTasks {
     this.checkTargetVersion(version);
     const pool = this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
-    const context = await this._migrationContextFor(adapter, pool.dbConfig);
-    await context.run(direction, version);
+    await pool.migrationContext.run(direction, version);
     adapter.schemaCache.clearBang();
   }
 
@@ -512,9 +424,7 @@ export class DatabaseTasks {
   ): Promise<void> {
     const pool = this.migrationConnectionPool();
     const adapter = await pool.leaseConnection();
-    const dbConfig = pool.dbConfig;
-    const context = await this._migrationContextFor(adapter, dbConfig);
-    await context[direction](steps);
+    await pool.migrationContext[direction](steps);
     adapter.schemaCache.clearBang();
   }
 
@@ -1153,12 +1063,11 @@ export class DatabaseTasks {
 
   static async migrateStatus(): Promise<void> {
     const pool = this.migrationConnectionPool();
-    const adapter = await pool.leaseConnection();
-    const migrator = await this._migratorFor(adapter, pool.dbConfig);
+    await pool.leaseConnection();
     if (!(await pool.schemaMigration.tableExists())) {
       throw new Error("Schema migrations table does not exist yet.");
     }
-    const rows = await migrator.migrationsStatus();
+    const rows = await pool.migrationContext.migrationsStatus();
     const dbName = pool.dbConfig.database ?? ":memory:";
     const center = (s: string, w: number) => {
       const pad = w - s.length;
@@ -1184,9 +1093,8 @@ export class DatabaseTasks {
    */
   static async currentVersion(): Promise<number> {
     const pool = this.migrationConnectionPool();
-    const adapter = await pool.leaseConnection();
-    const migrator = await this._migratorFor(adapter, pool.dbConfig);
-    return migrator.currentVersionReadOnly();
+    await pool.leaseConnection();
+    return (await pool.migrationContext.currentVersion()) ?? 0;
   }
 
   static async migrateAll(): Promise<void> {
@@ -1241,8 +1149,8 @@ export class DatabaseTasks {
         for (const dbConfig of dbConfigs) {
           if (!dumpDbConfigs.includes(dbConfig)) dumpDbConfigs.push(dbConfig);
           await this.withTemporaryPool(dbConfig, async (pool) => {
-            const migrator = await this._migratorFor(await pool.leaseConnection(), dbConfig);
-            await migrator.migrate(version ?? null);
+            await pool.leaseConnection();
+            await pool.migrationContext.migrate(version ?? null);
           });
         }
       }
@@ -1266,8 +1174,7 @@ export class DatabaseTasks {
     environment = this._normalizeEnv(environment);
     await this.withTemporaryPoolForEach({ env: environment }, async (pool) => {
       const dbConfig = pool.dbConfig;
-      const context = await this._migrationContextFor(await pool.leaseConnection(), dbConfig);
-      const versionsToRun = await context.pendingMigrationVersions();
+      const versionsToRun = await pool.migrationContext.pendingMigrationVersions();
       const targetVersion = this.targetVersion();
       for (const version of versionsToRun) {
         if (targetVersion !== null && targetVersion !== Number(version)) continue;

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -361,9 +361,6 @@ export class DatabaseTasks {
       } else if (scope !== undefined && scope.trim() !== "") {
         filter = (m) => m.scope === scope;
       }
-      // Rails: `migration_connection_pool.migration_context.migrate(target_version) { |m| ... }`
-      // (`database_tasks.rb:270`) — the context reads the pool's own
-      // `db_config.migrations_paths` (`connection_pool.rb:294-299`).
       const ran = await pool.migrationContext.migrate(effectiveVersion ?? null, filter);
       if (scope && scope.trim() !== "" && ran.length === 0 && Migration.verbose) {
         // Rails: `Migration.write("No migrations ran. ...")` — write puts to
@@ -1063,7 +1060,6 @@ export class DatabaseTasks {
 
   static async migrateStatus(): Promise<void> {
     const pool = this.migrationConnectionPool();
-    await pool.leaseConnection();
     if (!(await pool.schemaMigration.tableExists())) {
       throw new Error("Schema migrations table does not exist yet.");
     }
@@ -1093,7 +1089,6 @@ export class DatabaseTasks {
    */
   static async currentVersion(): Promise<number> {
     const pool = this.migrationConnectionPool();
-    await pool.leaseConnection();
     return (await pool.migrationContext.currentVersion()) ?? 0;
   }
 
@@ -1149,7 +1144,6 @@ export class DatabaseTasks {
         for (const dbConfig of dbConfigs) {
           if (!dumpDbConfigs.includes(dbConfig)) dumpDbConfigs.push(dbConfig);
           await this.withTemporaryPool(dbConfig, async (pool) => {
-            await pool.leaseConnection();
             await pool.migrationContext.migrate(version ?? null);
           });
         }

--- a/packages/activerecord/src/test-helpers/migrations/scope/1_unscoped.ts
+++ b/packages/activerecord/src/test-helpers/migrations/scope/1_unscoped.ts
@@ -1,0 +1,8 @@
+// vendor/rails/activerecord/test/migrations/scope/1_unscoped.rb
+import { Migration } from "../../../migration.js";
+
+export class Unscoped extends Migration {
+  async change(): Promise<void> {
+    await this.createTable("unscoped");
+  }
+}

--- a/packages/activerecord/src/test-helpers/migrations/scope/2_mysql_only.mysql.ts
+++ b/packages/activerecord/src/test-helpers/migrations/scope/2_mysql_only.mysql.ts
@@ -1,0 +1,8 @@
+// vendor/rails/activerecord/test/migrations/scope/2_mysql_only.mysql.rb
+import { Migration } from "../../../migration.js";
+
+export class MysqlOnly extends Migration {
+  async change(): Promise<void> {
+    await this.createTable("mysql_only");
+  }
+}

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -148,10 +148,21 @@ async function taskableDatabaseEntries(
 ): Promise<DatabaseEntry[]> {
   const dbName = validateDatabaseFlag(opts);
   const allConfigs = await loadAllDatabaseConfigs(envName);
-  const all = allConfigs.map(({ name, config: rawConfig }) => {
-    const raw = normalizeRawConfig(rawConfig);
-    return { name, raw, hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>) };
-  });
+  // Rails reads discovery paths off the configuration hash
+  // (`hash_config.rb:52`), and the pool's `migration_context` is built from
+  // them (`connection_pool.rb:294-299`) — so the resolved defaults belong in
+  // the hash the HashConfig is built from, not in a side registry.
+  const all = await Promise.all(
+    allConfigs.map(async ({ name, config: rawConfig }) => {
+      const raw = normalizeRawConfig(rawConfig);
+      raw.migrationsPaths = await migrationsDirsForConfig(name, raw);
+      return {
+        name,
+        raw,
+        hashConfig: new HashConfig(envName, name, raw as Record<string, unknown>),
+      };
+    }),
+  );
   const taskable = all.filter((c) => c.hashConfig.databaseTasks());
   const filtered = dbName ? taskable.filter((c) => c.name === dbName) : taskable;
   if (filtered.length === 0 && dbName) {
@@ -582,7 +593,6 @@ async function withMigrationTasksForDb(
     console.log(`${ctx.prefix}No migrations found.`);
     return;
   }
-  DatabaseTasks.registerMigrations(migrations, ctx.config);
   await withPrefixedStdout(ctx.prefix, async () => {
     await withRegisteredConfiguration(ctx.config, operation);
   });
@@ -629,10 +639,9 @@ async function runMigrateAll(): Promise<void> {
   const envName = resolveEnv();
   const entries = await taskableDatabaseEntries({}, envName);
   const migrationsFor = new Map<string, MigrationProxy[]>();
-  for (const { name, raw, hashConfig } of entries) {
+  for (const { name, raw } of entries) {
     const migrations = discoverMigrations(await migrationsDirsForConfig(name, raw));
     migrationsFor.set(name, migrations);
-    DatabaseTasks.registerMigrations(migrations, hashConfig);
   }
   if ([...migrationsFor.values()].every((m) => m.length === 0)) {
     console.log("No migrations found.");
@@ -964,22 +973,6 @@ export function dbCommand(): Command {
         entries.findIndex((entry) => entry.hashConfig.isPrimary()),
         0,
       );
-
-      // Per config, not per name: an env may point the same-named database at
-      // its own migrationsPaths.
-      const migrationSets = await Promise.all(
-        allEntries.map(async (entry) =>
-          discoverMigrations(await migrationsDirsForConfig(entry.name, entry.raw)),
-        ),
-      );
-      // Register the current env's primary set unregistered first: that clears
-      // any per-config registrations left by an earlier command and leaves a
-      // sensible fallback for a config with no directory of its own.
-      // `allEntries` leads with the current env, so `primaryIndex` lines up.
-      DatabaseTasks.registerMigrations(migrationSets[primaryIndex] ?? []);
-      allEntries.forEach((entry, i) => {
-        DatabaseTasks.registerMigrations(migrationSets[i] ?? [], entry.hashConfig);
-      });
 
       // Rails' load_seed runs against the established connection, which is
       // the primary's; Base has no connection here, so lend it one.


### PR DESCRIPTION
Finishes RFC 0051's migration-discovery unification: the second migration
source is gone, and `MigrationContext#migrations` is the only one.

## What went

- `DatabaseTasks.registerMigrations` / `_migrationsFor` / `_migrationsKey` /
  `_migrationsByConfig` / `_migrationsFor`'s fallback list, and the anonymous
  `MigrationContext` subclass in `_migrationContextFor` — Rails' test-only
  `migrator_class` override living in production code.
- `_migrationContextFor` and `_migratorFor` themselves.

## What replaced them

Every run surface reaches migrations the way Rails does, through the pool's own
`migration_context`:

- `migrate` → `migration_connection_pool.migration_context.migrate(target) { |m| … }`
  (`database_tasks.rb:270`), `migrateStatus` → `.migrations_status` (`:311`),
  `currentVersion` → `.current_version`, `rollback`/`forward`/`runMigration` →
  `.rollback` / `.forward` / `.run`, `dbConfigsWithVersions` →
  `.pending_migration_versions`.
- `ConnectionPool#migrationsPaths` falls back to `Migrator.migrationsPaths`
  rather than a hardcoded literal (`connection_pool.rb:299`), and
  `Migrator.migrationsPaths` defaults to `["db/migrate"]` (`migration.rb:1419`).
- trailties resolves its per-name `migrationsPaths` defaults into the
  configuration hash each `HashConfig` is built from, which is where Rails reads
  them (`hash_config.rb:52`).
- activerecord-cli's `loadDatabaseConfig` sets `Migrator.migrationsPaths`, the
  port of `db:load_config`'s `ActiveRecord::Migrator.migrations_paths =
  DatabaseTasks.migrations_paths` (`railties/databases.rake:27`);
  `loadMigrations` is discovery-only now and its four call sites in `db-tasks.ts`
  are gone.

## Tests

The AR migration tests move onto real migration directories, which is what
Rails' `DatabaseTasksMigrationTestCase` does — its setup establishes `:memory:`
with `migrations_paths: [MIGRATIONS_ROOT, folder_name]`
(`database_tasks_test.rb:1036-1039`). `folder_name` becomes the argument of
`databaseTasksMigrationTestCase`, since a TS `describe` has no class body to
override it in, and `MigrateScopeTest` passes `"scope"`. Along the way the
`DatabaseTasksMigrateTest` bodies converge on the Rails ones (VERSION=2/
VERBOSE=false down-run, then the re-run), which they had drifted from. New
fixture dir `test-helpers/migrations/scope/` mirrors
`vendor/rails/activerecord/test/migrations/scope/`.

`database-tasks-rollback.trails.test.ts` writes its migrations to a tmp
`migrationsPaths` dir per test — same names, same assertions.

Gates: `parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate`,
assertion ratchet all OK; `parity:api:extra` for activerecord drops
`registerMigrations` from `tasks/database-tasks.ts`'s novel surface.

Closes-story: unify-migration-discovery-delete-registered-migrations-seam
