### PR TITLE
refactor(activemodel): fan out validates_with to validations/with.ts

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1,4 +1,4 @@
-import { Errors, StrictValidationFailed } from "./errors.js";
+import { Errors } from "./errors.js";
 import {
   ValidationContext,
   ValidationsContextHost,
@@ -96,6 +96,10 @@ import { ConfirmationValidator } from "./validations/confirmation.js";
 import { ComparisonValidator } from "./validations/comparison.js";
 import * as Validates from "./validations/validates.js";
 import {
+  ClassMethods as WithClassMethods,
+  validatesWith as withValidatesWith,
+} from "./validations/with.js";
+import {
   type AttributeDefinition,
   Attributes,
   attribute,
@@ -137,6 +141,12 @@ type ValidatorLike = ValidatorBase | EachValidator | { validate(record: Validata
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
 export interface Model {
+  /**
+   * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
+   * mixed on by the `include(Model, …)` at the bottom of this file.
+   */
+  validatesWith: typeof withValidatesWith;
+
   /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
   toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
 
@@ -408,120 +418,11 @@ export class Model {
    * Validates using a custom validator class instance.
    * The validator must implement validate(record).
    *
-   * Mirrors: ActiveModel::Validations.validates_with (with.rb:88-105), whose
-   * per-class `validate(validator, options)` (with.rb:103) is what applies the
-   * `on:` / `except_on:` merge.
+   * Mirrors: ActiveModel::Validations::ClassMethods#validates_with
+   * (validations/with.rb:88-105), mixed on by the `extend(Model, …)` at the
+   * bottom of this file.
    */
-  static validatesWith(
-    ...args: Array<
-      | {
-          new (
-            options: Record<string, unknown>,
-          ): ValidatorBase | { validate(record: ValidatableRecord): void };
-        }
-      | (ConditionalOptions & { strict?: boolean; [key: string]: unknown })
-    >
-  ): void {
-    const last = args[args.length - 1];
-    const options: ConditionalOptions & { strict?: boolean; [key: string]: unknown } =
-      typeof last === "function"
-        ? {}
-        : ((args.pop() as ConditionalOptions & { strict?: boolean; [key: string]: unknown }) ?? {});
-
-    const {
-      if: ifOpt,
-      unless: unlessOpt,
-      on: onOpt,
-      exceptOn: exceptOnOpt,
-      strict: isStrict,
-      ...rest
-    } = options;
-    const rawExplicit = (rest as { attributes?: unknown }).attributes;
-    const explicitAttributes: string[] | null = Array.isArray(rawExplicit)
-      ? rawExplicit.map(String)
-      : typeof rawExplicit === "string"
-        ? [rawExplicit]
-        : null;
-
-    type ValidatorCheckable = { checkValidityBang?(): void };
-    for (const klass of args as Array<{
-      new (
-        options: Record<string, unknown>,
-      ): ValidatorBase | { validate(record: ValidatableRecord): void };
-    }>) {
-      // Rails `validates_with` sets `options[:class] = self` before calling
-      // `klass.new(options.dup)` (with.rb:88-94), passing the FULL options hash —
-      // condition keys (`if`/`unless`/`on`), `strict`, and custom keys — plus
-      // `:class`; only `Validator#initialize` strips `:class` from its frozen
-      // `options` (validator.rb:107-110; our Validator base does the same),
-      // leaving every standard key visible in `validator.options`.
-      // `with_validation_test.rb:80` pins this: `validates_with(v, if: :cond,
-      // foo: :bar)` calls `new` with `{ foo: :bar, if: :cond, class: Topic }`.
-      // The extracted `ifOpt`/`unlessOpt`/`onOpt`/`isStrict` are used only to
-      // wire the callback (conditions + strict wrapper), NOT withheld from the
-      // validator. Passing `strict` through does not double-raise: a validator
-      // that forwards its options to `errors.add` raises there first
-      // (filteredErrorOptions keeps `strict`; errors.ts:249), matching Rails;
-      // the `isStrict` wrapper below only fires for validators that add errors
-      // without forwarding `strict`, so exactly one raise happens either way.
-      // `options[:class]` lets Acceptance / Confirmation call `setupBang` (Rails
-      // `setup!`), materializing their virtual accessors on the prototype so the
-      // constructor's setter-dispatch mass-assignment (RFC 0046) honors them.
-      const validator = new klass({ ...options, class: this });
-      if (!(validator instanceof EachValidator)) {
-        if (typeof (validator as ValidatorCheckable).checkValidityBang === "function") {
-          (validator as ValidatorCheckable).checkValidityBang!();
-        }
-      }
-      this._registerValidator(validator, explicitAttributes);
-
-      let callbackFn: CallbackFn;
-      if (isStrict) {
-        callbackFn = (record: object) => {
-          const r = record as ValidatableRecord & { errors: Errors };
-          const origErrors = r.errors;
-          const tempErrors = new Errors(r);
-          r.errors = tempErrors;
-          const settle = (): void => {
-            r.errors = origErrors;
-            if (tempErrors.any) {
-              throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
-            }
-          };
-          let validateResult: unknown;
-          try {
-            validateResult = validator.validate(r);
-          } catch (e) {
-            r.errors = origErrors;
-            throw e;
-          }
-          if (
-            validateResult != null &&
-            typeof (validateResult as PromiseLike<void>).then === "function"
-          ) {
-            return Promise.resolve(validateResult as PromiseLike<void>).then(
-              () => settle(),
-              (e) => {
-                r.errors = origErrors;
-                throw e;
-              },
-            );
-          }
-          settle();
-          return validateResult as void;
-        };
-      } else {
-        callbackFn = (record: object) => validator.validate(record as ValidatableRecord);
-      }
-
-      this.validate(callbackFn as (record: ValidatableRecord) => unknown, {
-        if: ifOpt,
-        unless: unlessOpt,
-        on: onOpt,
-        exceptOn: exceptOnOpt,
-      });
-    }
-  }
+  declare static validatesWith: Extended<typeof WithClassMethods>["validatesWith"];
 
   /**
    * Return all validators registered on this model.
@@ -688,7 +589,7 @@ export class Model {
   declare static skipCallback: Extended<typeof ASCallbacks.ClassMethods>["skipCallback"];
   declare static resetCallbacks: Extended<typeof ASCallbacks.ClassMethods>["resetCallbacks"];
 
-  private static _ensureOwnValidators(): void {
+  static _ensureOwnValidators(): void {
     // Copy-on-first-write dup. Rails' `inherited(base)` hook
     // (activemodel/lib/active_model/validations.rb:287-291) does this
     // eagerly at class-definition time; JS has no such hook, so we defer
@@ -705,39 +606,16 @@ export class Model {
 
   /**
    * Register `validator` under each of its declared attributes (or under
-   * the `null` key when none are declared — Rails matches this in
-   * `validates_with` via `_validators[nil] << validator`).
-   *
-   * `explicitAttributes` wins when the caller already parsed attributes
-   * from options (e.g. `validates_with MyValidator, attributes: [...]`
-   * with a validator class that doesn't store them on the instance).
-   * Otherwise fall back to `validator.attributes` (set by `EachValidator`)
-   * or `validator.options.attributes` (set by plain `Validator`
-   * subclasses). This three-tier lookup covers all three validator
-   * shapes `validates_with` accepts:
-   *   - `EachValidator` subclass (attributes on instance),
-   *   - `Validator` subclass (attributes in `options`),
-   *   - arbitrary class that just implements `validate()` (neither —
-   *     caller must pass attributes explicitly).
+   * the `null` key when none are declared) — the `_validators[...] <<
+   * validator` half of Rails `validates_with` (validations/with.rb:95-101),
+   * reached here from `validates_each`, whose Rails body registers by routing
+   * through `validates_with` itself (validations.rb:190-192).
    */
-  private static _registerValidator(
-    validator: ValidatorLike,
-    explicitAttributes?: readonly string[] | null,
-  ): void {
+  private static _registerValidator(validator: ValidatorLike): void {
     this._ensureOwnValidators();
-    const fromInstance = (validator as { attributes?: unknown }).attributes;
-    const fromOptions = (validator as { options?: { attributes?: unknown } }).options?.attributes;
-    const rawAttrs =
-      explicitAttributes && explicitAttributes.length > 0
-        ? explicitAttributes
-        : Array.isArray(fromInstance) && fromInstance.length > 0
-          ? fromInstance
-          : Array.isArray(fromOptions) && fromOptions.length > 0
-            ? fromOptions
-            : typeof fromOptions === "string"
-              ? [fromOptions]
-              : null;
-    const keys: Array<string | null> = rawAttrs ? rawAttrs.map(String) : [null];
+    const attributes = (validator as { attributes?: readonly string[] }).attributes;
+    const keys: Array<string | null> =
+      Array.isArray(attributes) && attributes.length > 0 ? attributes.map(String) : [null];
     for (const key of keys) {
       let bucket = this._validators.get(key);
       if (!bucket) {
@@ -1104,46 +982,6 @@ export class Model {
    */
   async isInvalid(context?: string | string[] | ValidationContext | null): Promise<boolean> {
     return !(await this.isValid(context));
-  }
-
-  /**
-   * Passes the record off to the class or classes specified and allows them
-   * to add errors based on more complex conditions, so a `validate :foo` body
-   * can run a validator on the spot:
-   *
-   *   validate :instanceValidations
-   *   instanceValidations() { this.validatesWith(MyValidator); }
-   *
-   * Mirrors: ActiveModel::Validations#validates_with
-   * (activemodel/lib/active_model/validations/with.rb:143-151). Unlike the
-   * class method it registers nothing — each klass is built and run
-   * immediately against `this`. Rails' loop is synchronous; a trails validator
-   * may return a promise (RFC 0063 made validation async), so each run is
-   * awaited in turn, which preserves Rails' one-validator-at-a-time order.
-   */
-  async validatesWith(
-    ...args: Array<
-      | {
-          new (
-            options: Record<string, unknown>,
-          ): ValidatorBase | { validate(record: ValidatableRecord): unknown };
-        }
-      | Record<string, unknown>
-    >
-  ): Promise<void> {
-    const last = args[args.length - 1];
-    const options: Record<string, unknown> =
-      typeof last === "function" ? {} : ((args.pop() as Record<string, unknown>) ?? {});
-    options.class = this.constructor;
-
-    for (const klass of args as Array<{
-      new (
-        options: Record<string, unknown>,
-      ): ValidatorBase | { validate(record: ValidatableRecord): unknown };
-    }>) {
-      const validator = new klass({ ...options });
-      await validator.validate(this as unknown as ValidatableRecord);
-    }
   }
 
   /**
@@ -1712,6 +1550,9 @@ classAttribute.call(Model, "attributeMethodPatterns", {
 
 // Ruby `include ActiveModel::Validations` brings ClassMethods#validates and
 // friends (validations/validates.rb:111-178) onto the class.
+extend(Model, WithClassMethods);
+include(Model, { validatesWith: withValidatesWith });
+
 extend(Model, {
   validates: Validates.validates,
   validatesBang: Validates.validatesBang,

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -723,43 +723,6 @@ describe("ValidationsTest (trails)", () => {
       expect(Person.validatorsOn("name")).toEqual([]);
     });
 
-    it("routes arbitrary { validate() } class into the right bucket via explicit attributes", () => {
-      // Rails `validates_with` also accepts any class that just implements
-      // `validate(record)`. Such a class won't expose `attributes` on the
-      // instance or in `options`, so `validatesWith` must route the explicit
-      // `attributes:` option through to the bucket lookup.
-      class PojoValidator {
-        validate(_record: unknown): void {}
-      }
-      class Person extends Model {
-        static {
-          this.attribute("name", "string");
-          this.validatesWith(PojoValidator, { attributes: ["name"] });
-        }
-      }
-      expect(Person.validatorsOn("name")).toHaveLength(1);
-      expect(Person.validatorsOn("name")[0]).toBeInstanceOf(PojoValidator);
-    });
-
-    it("routes plain Validator with attributes: option into the right bucket", async () => {
-      // Rails `validates_with MyValidator, attributes: [:name]` — the
-      // validator is a plain `Validator` (not EachValidator); attributes
-      // live in `options` rather than directly on the instance.
-      // _registerValidator must check both.
-      const { Validator: ValidatorBase } = await import("./validator.js");
-      class StaticValidator extends ValidatorBase {
-        override validate(): void {}
-      }
-      class Person extends Model {
-        static {
-          this.attribute("name", "string");
-          this.validatesWith(StaticValidator, { attributes: ["name"] });
-        }
-      }
-      expect(Person.validatorsOn("name")).toHaveLength(1);
-      expect(Person.validatorsOn("name")[0]).toBeInstanceOf(StaticValidator);
-    });
-
     it("validatorsOn returns a fresh array (no state-mutating reads)", () => {
       class Person extends Model {
         static {

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -49,11 +49,6 @@ export interface ValidatesWithClassHost {
   validate(fn: (record: ValidatableRecord) => unknown, options?: Record<string, unknown>): void;
 }
 
-/** The instance-level surface `Validations#validates_with` self-sends. */
-export interface ValidatesWithHost {
-  constructor: unknown;
-}
-
 /**
  * Passes the record off to the class or classes specified and allows them
  * to add errors based on more complex conditions, so a `validate :foo` body
@@ -64,13 +59,13 @@ export interface ValidatesWithHost {
  * validation async), so each run is awaited in turn, which preserves Rails'
  * one-validator-at-a-time order.
  */
-export async function validatesWith(this: ValidatesWithHost, ...args: unknown[]): Promise<void> {
+export async function validatesWith(this: ValidatableRecord, ...args: unknown[]): Promise<void> {
   const [klasses, options] = extractOptionsBang(args);
   options.class = this.constructor;
 
   for (const klass of klasses as ValidatorClass[]) {
     const validator = new klass({ ...options });
-    await validator.validate(this as unknown as ValidatableRecord);
+    await validator.validate(this);
   }
 }
 
@@ -116,6 +111,9 @@ export const ClassMethods = {
  * Ruby's `_validators` is a `Hash.new { |h, k| h[k] = [] }`
  * (validations.rb:50), so `_validators[key] << validator` vivifies the bucket.
  * A JS `Map` has no default proc; this is that one expression.
+ *
+ * @noRailsEquivalent PERMANENT — Ruby's default-proc vivification, which a JS
+ * `Map` cannot express in the subscript itself.
  */
 function _pushValidator(
   validators: Map<string | null, ValidatorLike[]>,

--- a/packages/activemodel/src/validations/with.ts
+++ b/packages/activemodel/src/validations/with.ts
@@ -1,3 +1,5 @@
+import { extractOptionsBang } from "@blazetrails/activesupport";
+
 import { EachValidator } from "../validator.js";
 import type { ValidatableRecord } from "../validator.js";
 import { ArgumentError, NameError } from "../attribute-assignment.js";
@@ -30,4 +32,100 @@ export class WithValidator extends EachValidator {
       throw new ArgumentError("WithValidator requires the :with option to be a non-blank string");
     }
   }
+}
+
+/**
+ * Anything `validates_with` accepts: a full `Validator`/`EachValidator`
+ * subclass, or any class that just implements `validate(record)`.
+ */
+type ValidatorLike = { validate(record: ValidatableRecord): unknown };
+
+type ValidatorClass = new (options: Record<string, unknown>) => ValidatorLike;
+
+/** The class-level surface `ClassMethods#validates_with` self-sends. */
+export interface ValidatesWithClassHost {
+  _validators: Map<string | null, ValidatorLike[]>;
+  _ensureOwnValidators(): void;
+  validate(fn: (record: ValidatableRecord) => unknown, options?: Record<string, unknown>): void;
+}
+
+/** The instance-level surface `Validations#validates_with` self-sends. */
+export interface ValidatesWithHost {
+  constructor: unknown;
+}
+
+/**
+ * Passes the record off to the class or classes specified and allows them
+ * to add errors based on more complex conditions, so a `validate :foo` body
+ * can run a validator on the spot.
+ *
+ * Mirrors: ActiveModel::Validations#validates_with (with.rb:144-151). Rails'
+ * loop is synchronous; a trails validator may return a promise (RFC 0063 made
+ * validation async), so each run is awaited in turn, which preserves Rails'
+ * one-validator-at-a-time order.
+ */
+export async function validatesWith(this: ValidatesWithHost, ...args: unknown[]): Promise<void> {
+  const [klasses, options] = extractOptionsBang(args);
+  options.class = this.constructor;
+
+  for (const klass of klasses as ValidatorClass[]) {
+    const validator = new klass({ ...options });
+    await validator.validate(this as unknown as ValidatableRecord);
+  }
+}
+
+export const ClassMethods = {
+  /**
+   * Passes the record off to the class or classes specified and allows them
+   * to add errors based on more complex conditions.
+   *
+   * Mirrors: ActiveModel::Validations::ClassMethods#validates_with
+   * (activemodel/lib/active_model/validations/with.rb:88-105).
+   */
+  validatesWith(this: ValidatesWithClassHost, ...args: unknown[]): void {
+    const [klasses, options] = extractOptionsBang(args);
+    options.class = this;
+
+    for (const klass of klasses as ValidatorClass[]) {
+      // Ruby `klass.new(options.dup, &block)` (with.rb:92) hands the FULL
+      // options hash — condition keys, `strict`, custom keys — plus `:class`
+      // to the validator; only `Validator#initialize` strips `:class`
+      // (validator.rb:107-110), leaving every standard key visible in
+      // `validator.options`.
+      const validator = new klass({ ...options });
+
+      this._ensureOwnValidators();
+      const attributes = (validator as { attributes?: readonly string[] }).attributes;
+      if (Array.isArray(attributes) && attributes.length > 0) {
+        for (const attribute of attributes) {
+          _pushValidator(this._validators, String(attribute), validator);
+        }
+      } else {
+        _pushValidator(this._validators, null, validator);
+      }
+
+      // Ruby passes the validator object itself as the callback filter
+      // (with.rb:103); a trails callback filter is a function, so the send is
+      // spelled out.
+      this.validate((record) => validator.validate(record), options);
+    }
+  },
+};
+
+/**
+ * Ruby's `_validators` is a `Hash.new { |h, k| h[k] = [] }`
+ * (validations.rb:50), so `_validators[key] << validator` vivifies the bucket.
+ * A JS `Map` has no default proc; this is that one expression.
+ */
+function _pushValidator(
+  validators: Map<string | null, ValidatorLike[]>,
+  key: string | null,
+  validator: ValidatorLike,
+): void {
+  let bucket = validators.get(key);
+  if (!bucket) {
+    bucket = [];
+    validators.set(key, bucket);
+  }
+  bucket.push(validator);
 }


### PR DESCRIPTION
Fans `validates_with` out of `model.ts` into `packages/activemodel/src/validations/with.ts`, the file `parity:api` maps to `validations/with.rb`, and converges both bodies onto the Ruby.

## What moved

- **`ClassMethods.validatesWith`** (with.rb:88-105) — `extract_options!`, `options[:class] = self`, then per-klass: `klass.new(options.dup)`, the `respond_to?(:attributes) && !attributes.empty?` registration branch inlined exactly as Rails writes it, then `validate(validator, options)`. 91 code lines → 22. Reaches `Model` via `extend(Model, WithClassMethods)`.
- **`validatesWith`** (instance, with.rb:144-151) — build each klass, run it against the receiver. Reaches `Model` via `include(Model, { validatesWith })`. Still `async` (RFC 0063 made validation async), awaiting one validator at a time, which is Rails' order.

## Three trails-only additions dropped

Each was checked against vendor/rails before removal, and the whole activemodel + activerecord-validations suites are green without them:

1. **`checkValidityBang()` re-invocation.** Rails calls `check_validity!` only from `EachValidator#initialize` (validator.rb:144); `validates_with` never does. Our `EachValidator` ctor already calls it (validator.ts:53).
2. **The `strict:` wrapper** (~35 lines swapping in a temp `Errors` and raising `StrictValidationFailed`). Rails raises from `errors.add`, which keeps `:strict` in the forwarded options — and trails' `Errors#add` already does the same (errors.ts). The AR `strict: true raises StrictValidationFailed on a uniqueness collision` test passes unchanged.
3. **`attributes:`-from-options bucket routing.** Rails' guard is `validator.respond_to?(:attributes)`, so a plain `Validator` or a bare `{ validate() }` class with `attributes: [...]` in its options lands in `_validators[nil]`, not in the per-attribute bucket. Two `validations.trails.test.ts` cases pinned that deviation ("routes arbitrary { validate() } class into the right bucket via explicit attributes", "routes plain Validator with attributes: option into the right bucket"); both are deleted rather than ratified.

## `_registerValidator`

Not carried into `with.ts`. `validatesEach` is its only remaining caller — Rails' `validates_each` registers by routing through `validates_with` itself (validations.rb:190-192), which needs `validates_with` to accept a block, so the convergence belongs with the validation-runner fan-out story rather than here. Its signature is narrowed to the one tier that caller uses and its doc now cites with.rb:95-101.

## `parity:api:extra` note

`validations/with.ts` reads `0 novel, 3 moved`, up from `0 novel, 1 moved`, and `--verbose` credits the new `validatesWith` row to `activemodel validations/with.rb ActiveModel::Validations#validates_with` — the same file it now sits in. That is a tool artifact, not drift: `extra-surface.ts:1515-1524` builds the per-file allow-set from each entity's *primary* declaration site, and `ActiveModel::Validations` / `…::ClassMethods` are first declared in `validations.rb`, so `with.rb`'s allow-set holds only `WithValidator`. Measured both shapes (exported object and bare top-level function) — both score `moved`, so the row is unavoidable without a tool change. Filed as `0115-activemodel-fidelity-convergence/extra-surface-allow-reopened-module-method-files`.

## Verification

- `pnpm vitest run packages/activemodel/src` — 1908 passed, 1 skipped
- `pnpm vitest run packages/activerecord/src/validations packages/activerecord/src/validations.test.ts` — 137 passed
- `pnpm parity:api` overall unchanged (13532/15423); `parity:api:calls` OK, `parity:api:calls:args` OK, `parity:api:extra:gate` OK, `pnpm lint` clean

Closes-story: fan-out-model-validates-with-to-validations-with
