### PR TITLE
fix(activerecord,trailties): expression-aware MySQL index fingerprint; rake-only migration methods to callers; db/migrate default

### DIFF
--- a/packages/activerecord-cli/src/db-migrate.test.ts
+++ b/packages/activerecord-cli/src/db-migrate.test.ts
@@ -57,7 +57,7 @@ describe("DbMigrateTest", () => {
     loadSchemaCurrentSpy = vi.fn().mockResolvedValue(undefined);
     loadSeedSpy = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(DatabaseTasks, "migrate").mockImplementation(migrateSpy);
-    vi.spyOn(DatabaseTasks, "rollback").mockImplementation(rollbackSpy);
+    vi.spyOn(MigrationContext.prototype, "rollback").mockImplementation(rollbackSpy);
     vi.spyOn(DatabaseTasks, "loadSchemaCurrent").mockImplementation(loadSchemaCurrentSpy);
     vi.spyOn(DatabaseTasks, "loadSeed").mockImplementation(loadSeedSpy);
     vi.spyOn(MigrationContext.prototype, "migrations", "get").mockReturnValue([]);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -135,8 +135,6 @@ export async function dbRollback(cwd: string, args: string[]): Promise<number> {
 
   try {
     await withEnvironmentConnection(
-      // Rails: `migration_connection_pool.migration_context.rollback(step)`
-      // (`railties/databases.rake:269`).
       () => DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step),
       DatabaseTasks.env,
     );
@@ -343,8 +341,6 @@ export async function dbVersion(cwd: string, args: string[]): Promise<number> {
     const dbName = config.database ?? config.envName ?? "(unknown)";
     try {
       await DatabaseTasks.withTemporaryPool(config, async () => {
-        // Rails: `puts "Current version: #{pool.migration_context.current_version}"`
-        // (`railties/databases.rake:311`).
         const version =
           (await DatabaseTasks.migrationConnectionPool().migrationContext.currentVersion()) ?? 0;
         if (all) console.log(`${dbName}: Current version: ${version}`);

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -134,7 +134,12 @@ export async function dbRollback(cwd: string, args: string[]): Promise<number> {
   const step = parseStep(args, 1);
 
   try {
-    await withEnvironmentConnection(() => DatabaseTasks.rollback(step), DatabaseTasks.env);
+    await withEnvironmentConnection(
+      // Rails: `migration_connection_pool.migration_context.rollback(step)`
+      // (`railties/databases.rake:269`).
+      () => DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step),
+      DatabaseTasks.env,
+    );
     return 0;
   } catch (err) {
     console.error(`ar: db:rollback failed — ${String(err)}`);
@@ -338,7 +343,10 @@ export async function dbVersion(cwd: string, args: string[]): Promise<number> {
     const dbName = config.database ?? config.envName ?? "(unknown)";
     try {
       await DatabaseTasks.withTemporaryPool(config, async () => {
-        const version = await DatabaseTasks.currentVersion();
+        // Rails: `puts "Current version: #{pool.migration_context.current_version}"`
+        // (`railties/databases.rake:311`).
+        const version =
+          (await DatabaseTasks.migrationConnectionPool().migrationContext.currentVersion()) ?? 0;
         if (all) console.log(`${dbName}: Current version: ${version}`);
         else console.log(`Current version: ${version}`);
       });

--- a/packages/activerecord-cli/src/db-version.test.ts
+++ b/packages/activerecord-cli/src/db-version.test.ts
@@ -36,7 +36,7 @@ describe("DbVersionTest", () => {
     vi.spyOn(console, "log").mockImplementation((m) => void out.push(String(m)));
     vi.spyOn(console, "error").mockImplementation((m) => void err.push(String(m)));
     currentVersionSpy = vi.fn().mockResolvedValue(20260101000001);
-    vi.spyOn(DatabaseTasks, "currentVersion").mockImplementation(currentVersionSpy);
+    vi.spyOn(MigrationContext.prototype, "currentVersion").mockImplementation(currentVersionSpy);
     withTemporaryPoolFn = vi
       .fn()
       .mockImplementation(async (_config: unknown, fn: () => unknown) => fn());

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Base } from "../base.js";
 import { activeLane } from "./connection.js";
 import { fixtures } from "../test-fixtures.js";
+import { itIfSupports } from "./supports.js";
 import {
   dumpedTables,
   fingerprintOf,
@@ -108,4 +109,35 @@ describe("templateSchemaCache", () => {
     }
     expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(before);
   });
+
+  /**
+   * A functional index reports no column at all on MySQL —
+   * `information_schema.STATISTICS.COLUMN_NAME` is NULL and the expression sits
+   * in `EXPRESSION`, which is what `SHOW KEYS`' `Expression` feeds
+   * `IndexDefinition#columns` from (`mysql/schema_statements.rb:36-52`). So an
+   * expression that changed with the column set unchanged is the one index
+   * edit that could leave the fingerprint intact. MariaDB has no such column
+   * and no functional indexes at all, hence the capability gate.
+   */
+  itIfSupports(
+    "expression_index",
+    "stops matching once a canonical functional index's expression changes",
+    async () => {
+      const cached = dumpedTables(templateSchemaCache()!.marshalDump());
+      const clean = fingerprintOf(await schemaShapes(Base.connection), cached);
+      await Base.connection.addIndex("topics", "(lower(title))", { name: "boot_dump_probe_index" });
+      try {
+        const before = fingerprintOf(await schemaShapes(Base.connection), cached);
+        expect(before).not.toBe(clean);
+        await Base.connection.removeIndex("topics", { name: "boot_dump_probe_index" });
+        await Base.connection.addIndex("topics", "(upper(title))", {
+          name: "boot_dump_probe_index",
+        });
+        expect(fingerprintOf(await schemaShapes(Base.connection), cached)).not.toBe(before);
+      } finally {
+        await Base.connection.removeIndex("topics", { name: "boot_dump_probe_index" });
+      }
+      expect(fingerprintOf(await schemaShapes(Base.connection), cached)).toBe(clean);
+    },
+  );
 });

--- a/packages/activerecord/src/support/schema-cache-dump.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.ts
@@ -24,6 +24,7 @@ import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { SchemaCache } from "../connection-adapters/schema-cache.js";
 import { BOOKKEEPING_TABLE_NAMES } from "./drop-all-tables.js";
+import { supportsExpressionIndex } from "./schema-types.js";
 import { TEMP_DB_PREFIX } from "./sqlite-template.js";
 
 /** Env var: absolute path of the boot-produced schema-cache dump. */
@@ -107,7 +108,7 @@ export function dumpedTables(marshalled: unknown[]): ReadonlySet<string> {
  */
 export async function schemaShapes(adapter: DatabaseAdapter): Promise<Map<string, string>> {
   const shapes = new Map<string, string>();
-  for (const sql of SHAPE_QUERIES[adapter.adapterName] ?? []) {
+  for (const sql of await shapeQueriesFor(adapter)) {
     for (const row of (await adapter.execute(sql)) as { name: string; col: string | null }[]) {
       const name = String(row.name);
       shapes.set(name, `${shapes.get(name) ?? ""}\n${row.col ?? ""}`);
@@ -151,9 +152,14 @@ const MISSING_TABLE = "missing-table";
  * `Comment`. Its index rows carry `STATISTICS.COLLATION` because that is where
  * `IndexDefinition#orders` comes from — `"D"` is a descending column
  * (`mysql/schema_statements.rb:43`, `:47`) — alongside `SUB_PART`
- * (`lengths`) and `INDEX_TYPE` (`using`); MySQL 8's `EXPRESSION` is left out
- * because MariaDB's `STATISTICS` has no such column, and the canonical schema
- * has no functional index for it to describe. PostgreSQL and sqlite
+ * (`lengths`) and `INDEX_TYPE` (`using`), and `EXPRESSION`, which is where a
+ * functional index's `IndexDefinition#columns` comes from (`SHOW KEYS`'
+ * `Expression`, `mysql/schema_statements.rb:36-52`) and whose row carries a
+ * NULL `COLUMN_NAME`. MariaDB's `STATISTICS` has no `EXPRESSION` column at all
+ * — selecting it is `ER_BAD_FIELD_ERROR` — so the projection is keyed off
+ * `supportsExpressionIndex`, which is Rails' own
+ * `!mariadb? && database_version >= "8.0.13"`
+ * (`mysql/schema_statements.rb` / `abstract_mysql_adapter.rb`). PostgreSQL and sqlite
  * need no such spelling out: `pg_indexes.indexdef` and `sqlite_master.sql` are
  * the index's own DDL, `DESC` and all.
  */
@@ -200,14 +206,27 @@ const SHAPE_QUERIES: Record<string, string[]> = {
      WHERE TABLE_SCHEMA = DATABASE()
      ORDER BY TABLE_NAME, ORDINAL_POSITION`,
     `SELECT TABLE_NAME AS name,
-            CONCAT(INDEX_NAME, ' ', SEQ_IN_INDEX, ' ', COLUMN_NAME, ' ', NON_UNIQUE, ' ',
+            CONCAT(INDEX_NAME, ' ', SEQ_IN_INDEX, ' ', COALESCE(COLUMN_NAME, ''), ' ', NON_UNIQUE, ' ',
                    COALESCE(COLLATION, ''), ' ', COALESCE(SUB_PART, ''), ' ',
-                   INDEX_TYPE, ' ', COALESCE(INDEX_COMMENT, '')) AS col
+                   INDEX_TYPE, ' ', COALESCE(INDEX_COMMENT, ''), ' ', /*EXPRESSION*/'') AS col
      FROM information_schema.STATISTICS
      WHERE TABLE_SCHEMA = DATABASE()
      ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`,
   ],
 };
+
+/**
+ * `SHAPE_QUERIES` for this adapter, with the MySQL index projection's
+ * `EXPRESSION` slot filled in only where the server has that column. A
+ * functional index reports `COLUMN_NAME` NULL, so without it two different
+ * expressions over the same (empty) column set fingerprint identically.
+ */
+async function shapeQueriesFor(adapter: DatabaseAdapter): Promise<string[]> {
+  const queries = SHAPE_QUERIES[adapter.adapterName] ?? [];
+  if (adapter.adapterName !== "mysql2") return queries;
+  const expression = (await supportsExpressionIndex(adapter)) ? "COALESCE(EXPRESSION, '')" : "''";
+  return queries.map((sql) => sql.replace("/*EXPRESSION*/''", expression));
+}
 
 /**
  * The boot dump, or `null` when this run produced none (no globalSetup, or a

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -8,6 +8,10 @@ import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
 import { UnknownMigrationVersionError } from "../migration.js";
 
+// `rake db:rollback` inlines
+// `DatabaseTasks.migration_connection_pool.migration_context.rollback(step)`
+// (`railties/databases.rake:269`), which is what these exercise.
+//
 // Discovery is `MigrationContext#migrations` (`migration.rb:1303-1315`) reading
 // the pool's own `db_config.migrations_paths` (`connection_pool.rb:294-299`),
 // so a migration these tests can watch has to be a file under such a path — the
@@ -85,7 +89,7 @@ describe("DatabaseTasksRollbackTest", () => {
     await schemaMigration.createTable();
     await schemaMigration.createVersion("2");
 
-    await DatabaseTasks.rollback();
+    await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(1);
 
     expect(reverted()).toEqual(["PrimaryOnly"]);
     expect(await schemaMigration.versions()).toEqual([]);
@@ -106,7 +110,7 @@ describe("DatabaseTasksRollbackTest", () => {
     await schemaMigration.createVersion("1");
     await schemaMigration.createVersion("3");
 
-    await DatabaseTasks.rollback(2);
+    await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(2);
 
     expect(reverted()).toEqual(["Third"]);
     expect(await schemaMigration.versions()).toEqual(["1"]);
@@ -126,7 +130,9 @@ describe("DatabaseTasksRollbackTest", () => {
     await schemaMigration.createTable();
     await schemaMigration.createVersion("999");
 
-    await expect(DatabaseTasks.rollback()).rejects.toThrow(UnknownMigrationVersionError);
+    await expect(
+      DatabaseTasks.migrationConnectionPool().migrationContext.rollback(1),
+    ).rejects.toThrow(UnknownMigrationVersionError);
   });
 
   it("rolls back off the ambient pool when no configurations are loaded", async () => {
@@ -143,7 +149,7 @@ describe("DatabaseTasksRollbackTest", () => {
     await schemaMigration.createTable();
     await schemaMigration.createVersion("1");
 
-    await DatabaseTasks.rollback();
+    await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(1);
 
     expect(reverted()).toEqual(["Ambient"]);
     expect(await schemaMigration.versions()).toEqual([]);

--- a/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-rollback.trails.test.ts
@@ -8,10 +8,6 @@ import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
 import { UnknownMigrationVersionError } from "../migration.js";
 
-// `rake db:rollback` inlines
-// `DatabaseTasks.migration_connection_pool.migration_context.rollback(step)`
-// (`railties/databases.rake:269`), which is what these exercise.
-//
 // Discovery is `MigrationContext#migrations` (`migration.rb:1303-1315`) reading
 // the pool's own `db_config.migrations_paths` (`connection_pool.rb:294-299`),
 // so a migration these tests can watch has to be a file under such a path — the

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -384,47 +384,6 @@ export class DatabaseTasks {
     }
   }
 
-  /**
-   * @internal Rails has no `DatabaseTasks.rollback`; `rake db:rollback`
-   * (`railties/databases.rake:269`) inlines
-   * `DatabaseTasks.migration_connection_pool.migration_context.rollback(step)`.
-   * The body lives here rather than in the CLI because the pool handle is
-   * here — otherwise this is the rake task: the pool it is handed, no
-   * `configurations` lookup and no early return.
-   */
-  static async rollback(steps: number = 1): Promise<void> {
-    await this._stepMigrations("rollback", steps);
-  }
-
-  /** @internal Same deviation as {@link rollback}, for `db:forward` (`databases.rake:279`). */
-  static async forward(steps: number = 1): Promise<void> {
-    await this._stepMigrations("forward", steps);
-  }
-
-  /**
-   * @internal Same deviation as {@link rollback}: `db:migrate:up` /
-   * `db:migrate:down` (`railties/databases.rake:174-177`, `:205-208`) inline
-   * `migration_connection_pool.migration_context.run(direction, target_version)`.
-   * The body lives here because the CLI has no pool handle of its own.
-   */
-  static async runMigration(direction: "up" | "down", version: number | string): Promise<void> {
-    this.checkTargetVersion(version);
-    const pool = this.migrationConnectionPool();
-    const adapter = await pool.leaseConnection();
-    await pool.migrationContext.run(direction, version);
-    adapter.schemaCache.clearBang();
-  }
-
-  private static async _stepMigrations(
-    direction: "rollback" | "forward",
-    steps: number,
-  ): Promise<void> {
-    const pool = this.migrationConnectionPool();
-    const adapter = await pool.leaseConnection();
-    await pool.migrationContext[direction](steps);
-    adapter.schemaCache.clearBang();
-  }
-
   private static async _migrationAdapter(): Promise<
     import("../connection-adapters/abstract-adapter.js").AbstractAdapter
   > {
@@ -1078,18 +1037,6 @@ export class DatabaseTasks {
       puts(`${center(row.status, 8)}  ${row.version.padEnd(14)}  ${row.name}`);
     }
     puts();
-  }
-
-  /**
-   * Return the highest applied migration version, or 0 if no migrations
-   * have been run (or the schema_migrations table does not yet exist).
-   *
-   * Mirrors: `ActiveRecord::Base.connection_pool.migration_context.current_version`
-   * (called by `rails db:version`).
-   */
-  static async currentVersion(): Promise<number> {
-    const pool = this.migrationConnectionPool();
-    return (await pool.migrationContext.currentVersion()) ?? 0;
   }
 
   static async migrateAll(): Promise<void> {

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -1032,7 +1032,7 @@ describe("db subcommand CLI actions", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-db-cli-"));
     originalCwd = process.cwd();
     fs.mkdirSync(path.join(tmpDir, "config"), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate"), { recursive: true });
     fs.writeFileSync(
       path.join(tmpDir, "config", "database.ts"),
       `export default {
@@ -1096,7 +1096,7 @@ describe("db subcommand CLI actions", () => {
 
   it("db abort_if_pending_migrations exits 1 and prints each pending", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1116,7 +1116,7 @@ export class CreatePosts extends Migration {
 
   it("db version reports the highest applied version after migrate", async () => {
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1150,7 +1150,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1202,7 +1202,7 @@ export class CreatePosts extends Migration {
       ["20260101000002", "authors", "CreateAuthors"],
     ]) {
       fs.writeFileSync(
-        path.join(tmpDir, "db", "migrations", `${version}_create_${table}.ts`),
+        path.join(tmpDir, "db", "migrate", `${version}_create_${table}.ts`),
         `import { Migration } from "@blazetrails/activerecord";
 export class ${cls} extends Migration {
   async up() { await this.createTable(${JSON.stringify(table)}, (t) => { t.string("title"); }); }
@@ -1237,7 +1237,7 @@ export class ${cls} extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -1692,7 +1692,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_widgets.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_widgets.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateWidgets extends Migration {
   async up() { await this.createTable("widgets", (t) => { t.string("name"); }); }
@@ -1736,17 +1736,17 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, "ran");`,
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(testPrimaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(testAnimalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(testAnimalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1754,7 +1754,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -1833,7 +1833,7 @@ export class CreateDogs extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1885,17 +1885,17 @@ export class CreateFixtures extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb + ".test")} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb + ".test")} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb + ".test")}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -1903,7 +1903,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2077,18 +2077,18 @@ fs.writeFileSync(${JSON.stringify(seedMarker)}, String(prev + 1));`,
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    // Primary migrations in db/migrations; animals in db/migrations_animals.
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    // Primary migrations in db/migrations; animals in db/migrate_animals.
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2096,7 +2096,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2161,17 +2161,17 @@ export class CreateDogs extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2179,7 +2179,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2209,17 +2209,17 @@ export class CreateDogs extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2227,7 +2227,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2263,15 +2263,15 @@ export class CreateDogs extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     const migration = (cls: string, table: string) =>
       `import { Migration } from "@blazetrails/activerecord";
 export class ${cls} extends Migration {
@@ -2279,19 +2279,19 @@ export class ${cls} extends Migration {
   async down() { await this.dropTable(${JSON.stringify(table)}); }
 }`;
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000001_one_migration.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000001_one_migration.ts"),
       migration("OneMigration", "ones"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000002_two_migration.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000002_two_migration.ts"),
       migration("TwoMigration", "twos"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000003_three_migration.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000003_three_migration.ts"),
       migration("ThreeMigration", "threes"),
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000004_four_migration.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000004_four_migration.ts"),
       migration("FourMigration", "fours"),
     );
 
@@ -2335,17 +2335,17 @@ export class ${cls} extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
-    fs.mkdirSync(path.join(tmpDir, "db", "migrations_animals"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "db", "migrate_animals"), { recursive: true });
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2353,7 +2353,7 @@ export class CreateUsers extends Migration {
 }`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations_animals", "20260101000001_create_dogs.ts"),
+      path.join(tmpDir, "db", "migrate_animals", "20260101000001_create_dogs.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateDogs extends Migration {
   async up() { await this.createTable("dogs", (t) => { t.string("breed"); }); }
@@ -2389,7 +2389,7 @@ export class CreateDogs extends Migration {
 
   it("db migrate respects migrationsPaths config override", async () => {
     // A named DB can set migrationsPaths to override the default
-    // db/migrations_<name> convention. Verify the CLI discovers
+    // an explicit migrationsPaths convention. Verify the CLI discovers
     // migrations from the configured path instead.
     const primaryDb = path.join(tmpDir, "mp-primary.sqlite3");
     const animalsDb = path.join(tmpDir, "mp-animals.sqlite3");
@@ -2409,7 +2409,7 @@ export class CreateDogs extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_users.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_users.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateUsers extends Migration {
   async up() { await this.createTable("users", (t) => { t.string("name"); }); }
@@ -2453,11 +2453,11 @@ export class CreateCats extends Migration {
       `export default {
   development: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
   test: {
     primary: { adapter: "sqlite3", database: ${JSON.stringify(primaryDb)} },
-    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)} },
+    animals: { adapter: "sqlite3", database: ${JSON.stringify(animalsDb)}, migrationsPaths: "db/migrate_animals" },
   },
 };`,
     );
@@ -2609,7 +2609,7 @@ export class CreateCats extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_things.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_things.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateThings extends Migration {
   async up() { await this.createTable("things", (t) => { t.string("name"); }); }
@@ -2639,7 +2639,7 @@ export class CreateThings extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_posts.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_posts.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreatePosts extends Migration {
   async up() { await this.createTable("posts", (t) => { t.string("title"); }); }
@@ -2696,7 +2696,7 @@ export class CreatePosts extends Migration {
 };`,
     );
     fs.writeFileSync(
-      path.join(tmpDir, "db", "migrations", "20260101000000_create_things.ts"),
+      path.join(tmpDir, "db", "migrate", "20260101000000_create_things.ts"),
       `import { Migration } from "@blazetrails/activerecord";
 export class CreateThings extends Migration {
   async up() { await this.createTable("things", (t) => { t.string("name"); }); }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -71,11 +71,6 @@ function normalizeRawConfig(raw: RawConfig): RawConfig {
   return normalized as RawConfig;
 }
 
-async function migrationsDir(): Promise<string> {
-  const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
-  return path.resolve(fs.cwd(), Migrator.migrationsPaths[0]);
-}
-
 /**
  * Resolve the migrations directories for a named database config.
  * Mirrors Rails' per-DB migrations_paths: the user can set `migrationsPaths`

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -73,18 +73,21 @@ function normalizeRawConfig(raw: RawConfig): RawConfig {
 
 async function migrationsDir(): Promise<string> {
   const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
-  return path.join(fs.cwd(), "db", "migrations");
+  return path.resolve(fs.cwd(), Migrator.migrationsPaths[0]);
 }
 
 /**
  * Resolve the migrations directories for a named database config.
- * Mirrors Rails' per-DB migrations_paths: the user can set
- * `migrationsPaths` (string or string[]) in config/database.ts;
- * otherwise primary defaults to `db/migrations` and named DBs
- * default to `db/migrations_<name>`. Returns an array because
- * Rails supports multiple directories per config.
+ * Mirrors Rails' per-DB migrations_paths: the user can set `migrationsPaths`
+ * (string or string[]) in config/database.ts (`HashConfig#migrations_paths`,
+ * `database_configurations/hash_config.rb:50-53`); otherwise every config,
+ * primary or named, falls back to `Migrator.migrations_paths` — `db/migrate`
+ * (`migration.rb:1419`) — which is the fallback a pool applies when its config
+ * names none (`connection_adapters/abstract/connection_pool.rb:299`). Rails has
+ * no per-name default. Returns an array because Rails supports multiple
+ * directories per config.
  */
-async function migrationsDirsForConfig(name: string, config: RawConfig): Promise<string[]> {
+async function migrationsDirsForConfig(config: RawConfig): Promise<string[]> {
   const [fs, path] = await Promise.all([getFsAsync(), getPathAsync()]);
   const cwd = fs.cwd();
   const raw = (config as { migrationsPaths?: string | string[] }).migrationsPaths;
@@ -93,8 +96,7 @@ async function migrationsDirsForConfig(name: string, config: RawConfig): Promise
     const dirs = [...new Set(raw.filter((p) => p.length > 0).map((p) => path.resolve(cwd, p)))];
     if (dirs.length > 0) return dirs;
   }
-  if (name === "primary") return [path.join(cwd, "db", "migrations")];
-  return [path.join(cwd, "db", `migrations_${name}`)];
+  return Migrator.migrationsPaths.map((p) => path.resolve(cwd, p));
 }
 
 /**
@@ -155,7 +157,7 @@ async function taskableDatabaseEntries(
   const all = await Promise.all(
     allConfigs.map(async ({ name, config: rawConfig }) => {
       const raw = normalizeRawConfig(rawConfig);
-      raw.migrationsPaths = await migrationsDirsForConfig(name, raw);
+      raw.migrationsPaths = await migrationsDirsForConfig(raw);
       return {
         name,
         raw,
@@ -587,7 +589,7 @@ async function withMigrationTasksForDb(
   operation: () => Promise<void>,
   opts?: { afterPending?: (pending: number) => void; runWhenEmpty?: boolean },
 ): Promise<void> {
-  const mDirs = await migrationsDirsForConfig(ctx.name, ctx.raw);
+  const mDirs = await migrationsDirsForConfig(ctx.raw);
   const migrations = discoverMigrations(mDirs);
   if (migrations.length === 0 && !opts?.runWhenEmpty) {
     console.log(`${ctx.prefix}No migrations found.`);
@@ -640,7 +642,7 @@ async function runMigrateAll(): Promise<void> {
   const entries = await taskableDatabaseEntries({}, envName);
   const migrationsFor = new Map<string, MigrationProxy[]>();
   for (const { name, raw } of entries) {
-    const migrations = discoverMigrations(await migrationsDirsForConfig(name, raw));
+    const migrations = discoverMigrations(await migrationsDirsForConfig(raw));
     migrationsFor.set(name, migrations);
   }
   if ([...migrationsFor.values()].every((m) => m.length === 0)) {
@@ -766,7 +768,11 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.rollback(step));
+        await withMigrationTasksForDb(ctx, async () => {
+          // Rails: `migration_connection_pool.migration_context.rollback(step)`
+          // (`railties/databases.rake:269`).
+          await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step);
+        });
       });
     });
 
@@ -783,7 +789,11 @@ export function dbCommand(): Command {
         return;
       }
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.forward(step));
+        await withMigrationTasksForDb(ctx, async () => {
+          // Rails: `migration_connection_pool.migration_context.forward(step)`
+          // (`railties/databases.rake:279`).
+          await DatabaseTasks.migrationConnectionPool().migrationContext.forward(step);
+        });
       });
     });
 
@@ -845,7 +855,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
-        const mDirs = await migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(raw);
         const migrations = discoverMigrations(mDirs);
         if (migrations.length === 0) return;
         const migrator = createMigrator(adapter, migrations);
@@ -883,9 +893,17 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("up", opts.version), {
-          runWhenEmpty: true,
-        });
+        await withMigrationTasksForDb(
+          ctx,
+          async () => {
+            // Rails: `check_target_version` then
+            // `migration_connection_pool.migration_context.run(:up, target_version)`
+            // (`railties/databases.rake:172-177`).
+            DatabaseTasks.checkTargetVersion(opts.version);
+            await DatabaseTasks.migrationConnectionPool().migrationContext.run("up", opts.version);
+          },
+          { runWhenEmpty: true },
+        );
       });
     });
 
@@ -896,9 +914,20 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
-        await withMigrationTasksForDb(ctx, () => DatabaseTasks.runMigration("down", opts.version), {
-          runWhenEmpty: true,
-        });
+        await withMigrationTasksForDb(
+          ctx,
+          async () => {
+            // Rails: `check_target_version` then
+            // `migration_connection_pool.migration_context.run(:down, target_version)`
+            // (`railties/databases.rake:203-208`).
+            DatabaseTasks.checkTargetVersion(opts.version);
+            await DatabaseTasks.migrationConnectionPool().migrationContext.run(
+              "down",
+              opts.version,
+            );
+          },
+          { runWhenEmpty: true },
+        );
       });
     });
 
@@ -1035,7 +1064,7 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
-        const mDirs = await migrationsDirsForConfig(name, raw);
+        const mDirs = await migrationsDirsForConfig(raw);
         const migrations = discoverMigrations(mDirs);
         if (migrations.length === 0) {
           console.log(`${prefix}No migrations found.`);
@@ -1072,7 +1101,10 @@ export function dbCommand(): Command {
         await withMigrationTasksForDb(
           ctx,
           async () => {
-            await DatabaseTasks.rollback(step);
+            // Rails `db:migrate:redo` invokes `db:rollback` then `db:migrate`
+            // (`railties/databases.rake:216-227`), i.e. the same inline
+            // `migration_context.rollback(step)` as `db:rollback` (`:269`).
+            await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step);
             await DatabaseTasks.migrate();
           },
           {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -396,7 +396,7 @@ async function runMigrate(
   targetVersion?: string,
   options: RunOptions = {},
 ): Promise<void> {
-  const migrations = discoverMigrations([await migrationsDir()]);
+  const migrations = discoverMigrations(await migrationsDirsForConfig(raw));
   if (migrations.length === 0) {
     console.log("No migrations found.");
     return;
@@ -769,8 +769,6 @@ export function dbCommand(): Command {
       }
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          // Rails: `migration_connection_pool.migration_context.rollback(step)`
-          // (`railties/databases.rake:269`).
           await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step);
         });
       });
@@ -790,8 +788,6 @@ export function dbCommand(): Command {
       }
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          // Rails: `migration_connection_pool.migration_context.forward(step)`
-          // (`railties/databases.rake:279`).
           await DatabaseTasks.migrationConnectionPool().migrationContext.forward(step);
         });
       });
@@ -896,9 +892,6 @@ export function dbCommand(): Command {
         await withMigrationTasksForDb(
           ctx,
           async () => {
-            // Rails: `check_target_version` then
-            // `migration_connection_pool.migration_context.run(:up, target_version)`
-            // (`railties/databases.rake:172-177`).
             DatabaseTasks.checkTargetVersion(opts.version);
             await DatabaseTasks.migrationConnectionPool().migrationContext.run("up", opts.version);
           },
@@ -917,9 +910,6 @@ export function dbCommand(): Command {
         await withMigrationTasksForDb(
           ctx,
           async () => {
-            // Rails: `check_target_version` then
-            // `migration_connection_pool.migration_context.run(:down, target_version)`
-            // (`railties/databases.rake:203-208`).
             DatabaseTasks.checkTargetVersion(opts.version);
             await DatabaseTasks.migrationConnectionPool().migrationContext.run(
               "down",
@@ -1101,9 +1091,6 @@ export function dbCommand(): Command {
         await withMigrationTasksForDb(
           ctx,
           async () => {
-            // Rails `db:migrate:redo` invokes `db:rollback` then `db:migrate`
-            // (`railties/databases.rake:216-227`), i.e. the same inline
-            // `migration_context.rollback(step)` as `db:rollback` (`:269`).
             await DatabaseTasks.migrationConnectionPool().migrationContext.rollback(step);
             await DatabaseTasks.migrate();
           },

--- a/packages/trailties/src/commands/destroy.test.ts
+++ b/packages/trailties/src/commands/destroy.test.ts
@@ -49,7 +49,7 @@ describe("DestroyCommand", () => {
   });
 
   it("destroy migration anchors the filename match", async () => {
-    const migrationsDir = path.join(tmpDir, "db", "migrations");
+    const migrationsDir = path.join(tmpDir, "db", "migrate");
     fs.mkdirSync(migrationsDir, { recursive: true });
     const target = path.join(migrationsDir, "20260101000000_create_posts.ts");
     const decoy = path.join(migrationsDir, "20260202000000_add_create_posts_flag.ts");

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -24,7 +24,7 @@ export function destroyCommand(): Command {
       removeFile(cwd, `test/models/${fileName}.test.ts`);
 
       // Find and remove migration
-      const migrationsDir = path.join(cwd, "db", "migrations");
+      const migrationsDir = path.join(cwd, "db", "migrate");
       if (fs.existsSync(migrationsDir)) {
         // Escape the user-derived tableName so regex metacharacters can't
         // widen the match.
@@ -35,7 +35,7 @@ export function destroyCommand(): Command {
         const pattern = new RegExp(`^\\d+_create_${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
-            removeFile(cwd, `db/migrations/${f}`);
+            removeFile(cwd, `db/migrate/${f}`);
           }
         }
       }
@@ -58,7 +58,7 @@ export function destroyCommand(): Command {
     .argument("<name>", "Migration name")
     .action((name: string) => {
       const cwd = getCwd();
-      const migrationsDir = path.join(cwd, "db", "migrations");
+      const migrationsDir = path.join(cwd, "db", "migrate");
       if (!fs.existsSync(migrationsDir)) return;
 
       // Anchor on `^<timestamp>_<name>\.(ts|js)$` so a name like
@@ -70,7 +70,7 @@ export function destroyCommand(): Command {
       const pattern = new RegExp(`^\\d+_${underscored}\\.(ts|js)$`);
       for (const f of fs.readdirSync(migrationsDir)) {
         if (pattern.test(f)) {
-          removeFile(cwd, `db/migrations/${f}`);
+          removeFile(cwd, `db/migrate/${f}`);
         }
       }
     });
@@ -94,13 +94,13 @@ export function destroyCommand(): Command {
       removeFile(cwd, `test/controllers/${tableName}-controller.test.ts`);
 
       // Migration
-      const migrationsDir = path.join(cwd, "db", "migrations");
+      const migrationsDir = path.join(cwd, "db", "migrate");
       if (fs.existsSync(migrationsDir)) {
         const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const pattern = new RegExp(`^\\d+_create_${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
-            removeFile(cwd, `db/migrations/${f}`);
+            removeFile(cwd, `db/migrate/${f}`);
           }
         }
       }

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -84,7 +84,7 @@ describe("AppGenerator", () => {
     expect(exists("src/app/assets/images/.gitkeep")).toBe(true);
     expect(exists("vite.config.ts")).toBe(true);
 
-    expect(exists("db/migrations/.gitkeep")).toBe(true);
+    expect(exists("db/migrate/.gitkeep")).toBe(true);
     expect(exists("db/seeds.ts")).toBe(true);
     expect(exists("db/schema.ts")).toBe(true);
 

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -717,7 +717,7 @@ export const filterParameters = [
   }
 
   private createDbFiles(): void {
-    this.createFile("db/migrations/.gitkeep", "");
+    this.createFile("db/migrate/.gitkeep", "");
 
     this.createFile(
       "db/seeds.ts",

--- a/packages/trailties/src/generators/migration-generator.test.ts
+++ b/packages/trailties/src/generators/migration-generator.test.ts
@@ -30,7 +30,7 @@ describe("MigrationGeneratorTest", () => {
     const gen = makeGen();
     const files = gen.run("change_title_body_from_posts", []);
     expect(files.length).toBe(1);
-    expect(files[0]).toMatch(/^db\/migrations\/\d{14}_change_title_body_from_posts\.ts$/);
+    expect(files[0]).toMatch(/^db\/migrate\/\d{14}_change_title_body_from_posts\.ts$/);
     const content = readMigration(files);
     expect(content).toContain("class ChangeTitleBodyFromPosts extends Migration");
   });

--- a/packages/trailties/src/generators/migration-generator.ts
+++ b/packages/trailties/src/generators/migration-generator.ts
@@ -224,7 +224,7 @@ export class MigrationGenerator extends GeneratorBase {
     }
     lastTimestamp = timestamp;
     const ext = this.ext();
-    const filename = `db/migrations/${timestamp}_${underscore(name)}${ext}`;
+    const filename = `db/migrate/${timestamp}_${underscore(name)}${ext}`;
     const ts = this.isTypeScript();
     const returnType = ts ? ": Promise<void>" : "";
 

--- a/packages/trailties/src/generators/model-generator.test.ts
+++ b/packages/trailties/src/generators/model-generator.test.ts
@@ -26,7 +26,7 @@ function readModel(name: string): string {
 }
 
 function findMigration(files: string[]): string {
-  const migFile = files.find((f) => f.startsWith("db/migrations/"));
+  const migFile = files.find((f) => f.startsWith("db/migrate/"));
   expect(migFile).toBeDefined();
   return fs.readFileSync(path.join(tmpDir, migFile!), "utf-8");
 }
@@ -61,7 +61,7 @@ describe("ModelGeneratorTest", () => {
     const files = gen.run("Account", [], { parent: "Admin::Account" });
     const content = readModel("account");
     expect(content).toContain("class Account extends AdminAccount");
-    expect(files.find((f) => f.startsWith("db/migrations/"))).toBeUndefined();
+    expect(files.find((f) => f.startsWith("db/migrate/"))).toBeUndefined();
   });
 
   it.skip("model with database option", () => {
@@ -80,7 +80,7 @@ describe("ModelGeneratorTest", () => {
     const gen = makeGen();
     const files = gen.run("Account", ["name:string"], { migration: false });
     expect(files).toContain("src/app/models/account.ts");
-    expect(files.find((f) => f.startsWith("db/migrations/"))).toBeUndefined();
+    expect(files.find((f) => f.startsWith("db/migrate/"))).toBeUndefined();
   });
 
   it.skip("model with parent option database option and no migration option", () => {
@@ -114,7 +114,7 @@ describe("ModelGeneratorTest", () => {
   it("migration", () => {
     const gen = makeGen();
     const files = gen.run("Account", ["name:string", "age:integer"]);
-    const migFile = files.find((f) => f.startsWith("db/migrations/"));
+    const migFile = files.find((f) => f.startsWith("db/migrate/"));
     expect(migFile).toBeDefined();
     const content = fs.readFileSync(path.join(tmpDir, migFile!), "utf-8");
     expect(content).toContain("class CreateAccounts extends Migration");
@@ -143,7 +143,7 @@ describe("ModelGeneratorTest", () => {
   it("migration is skipped", () => {
     const gen = makeGen();
     const files = gen.run("Account", ["name:string"], { migration: false });
-    expect(files.find((f) => f.startsWith("db/migrations/"))).toBeUndefined();
+    expect(files.find((f) => f.startsWith("db/migrate/"))).toBeUndefined();
   });
 
   it("migration with attributes", () => {
@@ -448,7 +448,7 @@ describe("ModelGenerator (JavaScript project)", () => {
   it("generates .js migration file", () => {
     const gen = makeJsGen();
     const files = gen.run("User", ["name:string"]);
-    const migFile = files.find((f) => f.startsWith("db/migrations/"));
+    const migFile = files.find((f) => f.startsWith("db/migrate/"));
     expect(migFile).toMatch(/\.js$/);
   });
 

--- a/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
@@ -19,7 +19,7 @@ describe("MigrationGeneratorTest", () => {
       output: () => {},
       name: "add_title_to_posts",
     }).run();
-    expect(files[0]).toMatch(/^db\/migrations\/\d+_add_title_to_posts\.ts$/);
+    expect(files[0]).toMatch(/^db\/migrate\/\d+_add_title_to_posts\.ts$/);
     const content = fs.readFileSync(path.join(tmpDir, files[0]), "utf-8");
     expect(content).toContain("class AddTitleToPosts extends Migration");
     expect(content).toContain("async change(): Promise<void>");

--- a/packages/trailties/src/generators/rails/migration/migration-generator.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.ts
@@ -55,7 +55,7 @@ export class MigrationGenerator extends NamedBase {
       timestamp = (parseInt(lastTimestamp, 10) + 1).toString();
     }
     lastTimestamp = timestamp;
-    const filename = `db/migrations/${timestamp}_${this.fileName}${this.ext()}`;
+    const filename = `db/migrate/${timestamp}_${this.fileName}${this.ext()}`;
     this.createFile(filename, emitMigrationSource(classify(this.fileName), timestamp));
     return this.getCreatedFiles();
   }

--- a/packages/trailties/src/generators/rails/scaffold/scaffold-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold/scaffold-generator.test.ts
@@ -47,7 +47,7 @@ describe("ScaffoldGeneratorTest", () => {
 
     expect(files.some((f) => f.includes("test/models/product-line.test.ts"))).toBe(true);
 
-    const migration = files.find((f) => f.startsWith("db/migrations/"))!;
+    const migration = files.find((f) => f.startsWith("db/migrate/"))!;
     const migContent = readFile(migration);
     expect(migContent).toContain('t.references("product"');
     expect(migContent).toContain('t.boolean("approved")');
@@ -130,7 +130,7 @@ describe("ScaffoldGeneratorTest", () => {
     expect(model).toContain('this.belongsTo("product")');
     expect(model).toContain('this.belongsTo("cart")');
 
-    const migration = files.find((f) => f.startsWith("db/migrations/"))!;
+    const migration = files.find((f) => f.startsWith("db/migrate/"))!;
     const migContent = readFile(migration);
     expect(migContent).toContain('t.references("product"');
     expect(migContent).toContain('t.references("cart"');
@@ -209,7 +209,7 @@ describe("ScaffoldGeneratorTest (JavaScript project)", () => {
     const files = gen.run("Post", ["title:string"]);
     expect(files).toContain("src/app/controllers/posts-controller.js");
     expect(files).toContain("src/app/models/post.js");
-    const migFile = files.find((f) => f.startsWith("db/migrations/"));
+    const migFile = files.find((f) => f.startsWith("db/migrate/"));
     expect(migFile).toMatch(/\.js$/);
   });
 


### PR DESCRIPTION
Bundle of three stories.

### 1. Boot-dump fingerprint misses a MySQL functional index's expression

`SHAPE_QUERIES`' MySQL index projection now carries `EXPRESSION` — the column
`SHOW KEYS`' `Expression` feeds `IndexDefinition#columns` from
(`mysql/schema_statements.rb:36-52`) — gated on Rails'
`supports_expression_index?` (`!mariadb? && database_version >= "8.0.13"`,
`abstract_mysql_adapter.rb:104`), since MariaDB's `information_schema.STATISTICS`
has no such column and selecting it is `ER_BAD_FIELD_ERROR`.

The story called this "harmless today because the canonical schema has no
functional index" — that premise is stale: `test-schema.ts:214` declares
`{ columns: "(lower(external_id))", unique: true }`, emitted wherever
`supportsExpressionIndex` holds. And the miss was worse than the story
describes: a functional index reports `COLUMN_NAME` NULL, so the whole
`CONCAT(...)` evaluated to NULL and `row.col ?? ""` dropped the index row from
the fingerprint entirely — not just its expression. `COLUMN_NAME` is now
`COALESCE`d.

New test uses `itIfSupports("expression_index", ...)`, the settled capability
gate; it asserts the fingerprint moves both for adding a functional index and
for changing its expression with the column set unchanged.

### 2. DatabaseTasks' rake-only migration methods move to callers

Deleted `rollback`, `forward`, `_stepMigrations`, `runMigration`,
`currentVersion`. Each caller now inlines what its rake task inlines:

- `databases.rake:269` — `migration_context.rollback(step)` (trailties
  `db rollback`, `db migrate:redo`; activerecord-cli `dbRollback`)
- `databases.rake:279` — `migration_context.forward(step)`
- `databases.rake:172-177` / `:203-208` — `check_target_version` then
  `migration_context.run(:up|:down, target_version)`
- `databases.rake:311` — `pool.migration_context.current_version` for `db:version`

The trails-added `schemaCache.clearBang()` after each of these is gone with
them: Rails clears the schema cache only in `DatabaseTasks.migrate`
(`database_tasks.rb:280`), not in these rake tasks.

**One acceptance criterion is not implemented, deliberately.** The story lists
`migrateStatus` for deletion on the premise that Rails has no counterpart. It
does — `ActiveRecord::Tasks::DatabaseTasks#migrate_status`,
`tasks/database_tasks.rb:302-315`, table printing and all; `databases.rake:230-232`
calls it rather than inlining it, and `dbMigrateStatus` already mirrors that
exactly. Removing it would have been a divergence, so it stays.

`parity:api:extra --package activerecord` for `tasks/database-tasks.ts` goes
5 moved → 4 (`currentVersion` retired); novel is unchanged at 4 — the story
predicted the drop in the novel column, but `currentVersion` was counted under
moved.

`runMigrate` was the only caller of a `migrationsDir()` helper that hardcoded
one directory and ignored the config it was already handed; it now goes through
`migrationsDirsForConfig(raw)` like every other discovery site, so an explicit
`migrationsPaths` is honored on `db migrate` too. The helper is gone.

### 3. trailties migration paths default to db/migrate

`migrationsDirsForConfig` keeps only the explicit `migrationsPaths` arm and
falls back to `Migrator.migrationsPaths` — `["db/migrate"]`
(`migration.rb:1419`), the fallback a pool applies when its config names none
(`connection_pool.rb:299`) — for every config, primary or named. The
`db/migrations_<name>` per-name synthesis is gone; Rails has no per-name
default, a named database gets its paths from `migrations_paths` in
`database.yml` (`hash_config.rb:50-53`). The `name` parameter went with it.

Scaffolding (`trails generate migration`, model/scaffold/resource generators,
`app-generator`'s `.gitkeep`) and `trails destroy` now write and scan
`db/migrate`. The multi-DB `db.test.ts` cases that leaned on the `_<name>`
convention now set `migrationsPaths: "db/migrate_animals"` explicitly, which
is the Rails shape. All 107 `db.test.ts` cases and the whole trailties suite
(786 tests) pass; test names unchanged.

The website's Frontiers sandbox is a second, independent implementation of the
same CLI over a VFS — it imports none of these generators and still writes
`db/migrations/`. Out of scope here; filed as
`0051-migration-schema-statements-fidelity/website-frontiers-sandbox-still-scaffolds-db-migrations`.

Per-caller `databases.rake` citations live in this description rather than as
inline comments in the diff.

Closes-story: boot-dump-fingerprint-misses-mysql-functional-index
Closes-story: database-tasks-rake-only-migration-methods-move-to-callers
Closes-story: trailties-migrations-paths-default-is-not-db-migrate
