### PR TITLE
refactor(activerecord,trailties): Rails-shaped schema-cache install; Column encode_with/init_with; zero-arity check_target_version; migrate_status

### DIFF
--- a/docs/infrastructure/browser-compat-plan.md
+++ b/docs/infrastructure/browser-compat-plan.md
@@ -87,9 +87,20 @@ Files to migrate:
 | `schema.ts:114`                      | 1     | `process.env.NODE_ENV`                           | `getEnv("TRAILS_ENV", "development")`                     |
 | `database-configurations.ts:254,269` | 2     | `NODE_ENV`, `DATABASE_URL`                       | `TRAILS_ENV`; `DATABASE_URL` stays                        |
 | `migration.ts:1461,1931`             | 2     | `NODE_ENV`, `DISABLE_DATABASE_ENVIRONMENT_CHECK` | `TRAILS_ENV`, `TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK` |
-| `tasks/database-tasks.ts:350,358`    | 2     | `VERSION`                                        | `TRAILS_MIGRATION_VERSION`                                |
+| `tasks/database-tasks.ts:350,358`    | 2     | `VERSION`                                        | `VERSION` — reverted, see below                           |
 
 `DATABASE_URL` is an industry standard and stays unchanged.
+
+**`VERSION` is an exception, reverted in #6980.** BC-2 renamed it to
+`TRAILS_MIGRATION_VERSION`, but `DatabaseTasks.target_version` /
+`check_target_version` are a single-source pair over `ENV["VERSION"]`
+(`database_tasks.rb:317-325`) that the `db:migrate:up` / `:down` rake tasks
+read and require directly (`databases.rake:170`), and RFC 0051 converges that
+pair on Rails' shape. The prefixed name lost to Rails fidelity here; `VERSION`
+is the only key `targetVersion()` reads, and it is what `trails db migrate:up`
+/ `:down` and `ar db:migrate --version` publish. This is a per-variable
+exception, not a reversal of the `TRAILS_` policy — `TRAILS_ENV` and
+`TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK` are unaffected.
 
 **Implementation note (shipped in #1251):** The original spec called for the full
 `EnvAdapter` / `registerEnvAdapter` / `getEnvAdapter` pattern mirroring `getFs`.

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -110,8 +110,8 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
   // `ENV["VERSION"]`, which `migrate_all` reads back through `target_version`;
   // `--version` is the CLI spelling of that env var, not an extra argument.
   const version = flagValue(args, "--version");
-  const previousVersion = getEnv("TRAILS_MIGRATION_VERSION");
-  if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", version);
+  const previousVersion = getEnv("VERSION");
+  if (version !== undefined) setEnv("VERSION", version);
   try {
     await withEnvironmentConnection(() => DatabaseTasks.migrateAll(), DatabaseTasks.env);
     return 0;
@@ -119,7 +119,7 @@ export async function dbMigrate(cwd: string, args: string[]): Promise<number> {
     console.error(`ar: db:migrate failed — ${String(err)}`);
     return 1;
   } finally {
-    if (version !== undefined) setEnv("TRAILS_MIGRATION_VERSION", previousVersion);
+    if (version !== undefined) setEnv("VERSION", previousVersion);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -477,12 +477,24 @@ export class ConnectionPool implements ReapablePool {
     return this.poolConfig.schemaReflection;
   }
 
+  /**
+   * Mirrors: `ActiveRecord::ConnectionAdapters::ConnectionPool#schema_reflection=`
+   * (`connection_pool.rb:289-292`) — swap the underlying reflection and bust the
+   * cached `BoundSchemaReflection` so the next `schemaCache` access wraps the new
+   * reflection, not the stale one. Assigning a reflection constructed *with* a
+   * cache (`SchemaReflection.new(path, cache)`, `schema_cache.rb:16-19`) is how
+   * Rails installs an already-loaded dump; a caller holding an adapter reaches it
+   * through `adapter.pool`.
+   *
+   * The lazy-load guards reset too, so the new reflection's on-disk cache path
+   * gets loaded on the next first-connection event where the old reflection had
+   * already tripped them. The raw cache needs no reset: `poolConfig.schemaCache`
+   * reads through to the reflection's own slot, so a reflection arriving without
+   * a cache already reads null — and nulling it blindly would discard a
+   * preloaded one.
+   */
   set schemaReflection(value: SchemaReflection) {
     this.poolConfig.schemaReflection = value;
-    // Matches Rails' `schema_reflection=`: swap the underlying
-    // reflection AND bust the cached BoundSchemaReflection so the
-    // next schemaCache access wraps the new reflection, not the
-    // stale one.
     this._boundSchemaCache = undefined;
     this._lazyLoadTriggered = false;
     this._lazyLoadPromise = null;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -488,7 +488,6 @@ export class ConnectionPool implements ReapablePool {
     this._lazyLoadPromise = null;
     this._eagerWarmTriggered = false;
     this._eagerWarmPromise = null;
-    this.poolConfig.schemaCache = null;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1060,9 +1060,7 @@ export class SchemaStatements {
         ).toArray();
         return rows.map((row: any) => {
           const meta = deduplicate(new SqlTypeMetadata({ sqlType: row.type, type: row.type }));
-          return new Column(row.name, row.dflt_value, meta, row.notnull === 0, {
-            primaryKey: row.pk > 0,
-          });
+          return new Column(row.name, row.dflt_value, meta, row.notnull === 0);
         });
       }
       case "postgres": {
@@ -1120,9 +1118,7 @@ export class SchemaStatements {
               scale: row.numeric_scale ?? null,
             }),
           );
-          return new Column(row.column_name, row.column_default, meta, row.is_nullable === "YES", {
-            primaryKey: row.is_primary_key === true,
-          });
+          return new Column(row.column_name, row.column_default, meta, row.is_nullable === "YES");
         });
       }
       case "mysql2": {
@@ -1162,9 +1158,6 @@ export class SchemaStatements {
             row.COLUMN_DEFAULT ?? row.column_default,
             meta,
             (row.IS_NULLABLE ?? row.is_nullable) === "YES",
-            {
-              primaryKey: (row.COLUMN_KEY ?? row.column_key) === "PRI",
-            },
           );
         });
       }

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -29,12 +29,6 @@ describe("ColumnEqualityTrails", () => {
     ).toBe(false);
   });
 
-  it("ignores primaryKey, which Rails' Column does not carry", () => {
-    const a = new Column("id", null, meta(), false, { primaryKey: true });
-    const b = new Column("id", null, meta(), false, { primaryKey: false });
-    expect(a.equals(b)).toBe(true);
-  });
-
   it("is not equal to a non-Column", () => {
     const column = new Column("title", null, meta());
     expect(column.equals(null)).toBe(false);

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -16,7 +16,6 @@ export class Column {
   defaultFunction: string | null;
   collation: string | null;
   comment: string | null;
-  primaryKey: boolean;
 
   constructor(
     name: string,
@@ -27,7 +26,6 @@ export class Column {
       defaultFunction?: string | null;
       collation?: string | null;
       comment?: string | null;
-      primaryKey?: boolean;
     } = {},
   ) {
     this.name = name;
@@ -37,7 +35,6 @@ export class Column {
     this.defaultFunction = options.defaultFunction ?? null;
     this.collation = options.collation ?? null;
     this.comment = options.comment ?? null;
-    this.primaryKey = options.primaryKey ?? false;
   }
 
   get sqlType(): string | null {
@@ -137,26 +134,9 @@ export class Column {
    * that does the allocating is `rehydrateColumn` (`schema-cache.ts`). Because
    * these are Ruby ivars re-assigned here, the fields above cannot be `readonly`.
    *
-   * `primary_key` is the one key beyond Rails' seven, and it is a deviation, not
-   * an oversight — Rails' Column has no `@primary_key` ivar, because primary-key
-   * membership lives in the cache's own `@primary_keys` slot
-   * (`schema_cache.rb:416`).
-   *
-   * It cannot be dropped while trails' Column carries the flag at all, because
-   * the flag is **adapter-dependent**: sqlite3's `columns()` reflects
-   * `primaryKey: true` for a real primary key, while postgresql's and mysql's
-   * reflect `false` and resolve the key solely from `@primary_keys`. So the
-   * dump has to reproduce whichever answer the reflecting adapter gave —
-   * deriving it from `@primary_keys` instead makes a dump-loaded cache report
-   * `true` on every lane and reds `base_test.rb`'s `test_clear_cache!` on
-   * postgresql and mysql (it compares a dump-loaded cache against a reflected
-   * one, where Rails only ever compares reflected-vs-reflected); omitting it
-   * entirely reports `false` on every lane and reds the same test plus the
-   * schema dumper on sqlite3. Both were measured on CI for this PR.
-   *
-   * Converging this means making the flag authoritative on the reflect path too
-   * (or removing it), which is RFC 0078
-   * `make-column-primary-key-flag-authoritative-or-remove-it`, filed from here.
+   * The key set is Rails' exactly. trails' Column carries no primary-key flag
+   * either, for the same reason Rails' does not: the key is the schema cache's,
+   * held in its own `@primary_keys` slot (`schema_cache.rb:416`).
    */
   initWith(coder: ColumnCoder): void {
     this.name = coder["name"] as string;
@@ -168,7 +148,6 @@ export class Column {
     this.defaultFunction = (coder["default_function"] as string | null) ?? null;
     this.collation = (coder["collation"] as string | null) ?? null;
     this.comment = (coder["comment"] as string | null) ?? null;
-    this.primaryKey = (coder["primary_key"] as boolean) ?? false;
   }
 
   /**
@@ -176,8 +155,7 @@ export class Column {
    * (`column.rb:55-63`), the seam `SchemaCache#dump_to` serializes through
    * (`schema_cache.rb:406`).
    *
-   * The seven keys are Rails' exactly, in Rails' order; `primaryKey` stays out
-   * (see {@link initWith}).
+   * The seven keys are Rails' exactly, in Rails' order.
    *
    * `class` is the JSON stand-in for YAML's `!ruby/object:` tag. Rails restores
    * the adapter's Column subclass from that tag and lets `init_with` fill only
@@ -202,7 +180,6 @@ export class Column {
     coder["default_function"] = this.defaultFunction;
     coder["collation"] = this.collation;
     coder["comment"] = this.comment;
-    coder["primary_key"] = this.primaryKey;
   }
 
   deduplicate(): this {

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -9,8 +9,6 @@ import type { SqlTypeMetadataJSON } from "./sql-type-metadata.js";
 import { humanize } from "@blazetrails/activesupport";
 
 export class Column {
-  // Ruby ivars, assigned by the constructor and re-assigned by `initWith`
-  // (`column.rb:46-53`), so they cannot be `readonly`.
   name: string;
   sqlTypeMetadata: SqlTypeMetadata | null;
   null: boolean;
@@ -136,7 +134,12 @@ export class Column {
    * Mirrors: ActiveRecord::ConnectionAdapters::Column#init_with
    * (`column.rb:46-53`). Rails' YAML/Marshal protocol allocates the class named
    * by the document's tag and then fills its ivars from the coder; the caller
-   * that does the allocating is `rehydrateColumn` (`schema-cache.ts`).
+   * that does the allocating is `rehydrateColumn` (`schema-cache.ts`). Because
+   * these are Ruby ivars re-assigned here, the fields above cannot be `readonly`.
+   *
+   * `primary_key` has no Rails counterpart in this pair: Rails' Column carries
+   * no `@primary_key` ivar at all — the primary key lives on the schema cache's
+   * own map — while trails' Column does.
    */
   initWith(coder: ColumnCoder): void {
     this.name = coder["name"] as string;
@@ -148,9 +151,6 @@ export class Column {
     this.defaultFunction = (coder["default_function"] as string | null) ?? null;
     this.collation = (coder["collation"] as string | null) ?? null;
     this.comment = (coder["comment"] as string | null) ?? null;
-    // `primary_key` has no Rails counterpart in this pair: Rails' Column has no
-    // `@primary_key` ivar at all (it lives on the schema cache's primary-key
-    // map), while trails' Column carries one.
     this.primaryKey = (coder["primary_key"] as boolean) ?? false;
   }
 

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -137,9 +137,10 @@ export class Column {
    * that does the allocating is `rehydrateColumn` (`schema-cache.ts`). Because
    * these are Ruby ivars re-assigned here, the fields above cannot be `readonly`.
    *
-   * `primary_key` has no Rails counterpart in this pair: Rails' Column carries
-   * no `@primary_key` ivar at all — the primary key lives on the schema cache's
-   * own map — while trails' Column does.
+   * The key set is Rails' exactly — `primaryKey` is deliberately absent, because
+   * Rails' Column carries no `@primary_key` ivar: primary-key membership lives
+   * in the schema cache's own `@primary_keys` slot (`schema_cache.rb:416`), and
+   * `SchemaCache` derives the trails-only flag back from there on load.
    */
   initWith(coder: ColumnCoder): void {
     this.name = coder["name"] as string;
@@ -151,13 +152,15 @@ export class Column {
     this.defaultFunction = (coder["default_function"] as string | null) ?? null;
     this.collation = (coder["collation"] as string | null) ?? null;
     this.comment = (coder["comment"] as string | null) ?? null;
-    this.primaryKey = (coder["primary_key"] as boolean) ?? false;
   }
 
   /**
    * Mirrors: ActiveRecord::ConnectionAdapters::Column#encode_with
    * (`column.rb:55-63`), the seam `SchemaCache#dump_to` serializes through
    * (`schema_cache.rb:406`).
+   *
+   * The seven keys are Rails' exactly, in Rails' order; `primaryKey` stays out
+   * (see {@link initWith}).
    *
    * `class` is the JSON stand-in for YAML's `!ruby/object:` tag. Rails restores
    * the adapter's Column subclass from that tag and lets `init_with` fill only
@@ -182,7 +185,6 @@ export class Column {
     coder["default_function"] = this.defaultFunction;
     coder["collation"] = this.collation;
     coder["comment"] = this.comment;
-    coder["primary_key"] = this.primaryKey;
   }
 
   deduplicate(): this {

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -137,10 +137,26 @@ export class Column {
    * that does the allocating is `rehydrateColumn` (`schema-cache.ts`). Because
    * these are Ruby ivars re-assigned here, the fields above cannot be `readonly`.
    *
-   * The key set is Rails' exactly — `primaryKey` is deliberately absent, because
-   * Rails' Column carries no `@primary_key` ivar: primary-key membership lives
-   * in the schema cache's own `@primary_keys` slot (`schema_cache.rb:416`), and
-   * `SchemaCache` derives the trails-only flag back from there on load.
+   * `primary_key` is the one key beyond Rails' seven, and it is a deviation, not
+   * an oversight — Rails' Column has no `@primary_key` ivar, because primary-key
+   * membership lives in the cache's own `@primary_keys` slot
+   * (`schema_cache.rb:416`).
+   *
+   * It cannot be dropped while trails' Column carries the flag at all, because
+   * the flag is **adapter-dependent**: sqlite3's `columns()` reflects
+   * `primaryKey: true` for a real primary key, while postgresql's and mysql's
+   * reflect `false` and resolve the key solely from `@primary_keys`. So the
+   * dump has to reproduce whichever answer the reflecting adapter gave —
+   * deriving it from `@primary_keys` instead makes a dump-loaded cache report
+   * `true` on every lane and reds `base_test.rb`'s `test_clear_cache!` on
+   * postgresql and mysql (it compares a dump-loaded cache against a reflected
+   * one, where Rails only ever compares reflected-vs-reflected); omitting it
+   * entirely reports `false` on every lane and reds the same test plus the
+   * schema dumper on sqlite3. Both were measured on CI for this PR.
+   *
+   * Converging this means making the flag authoritative on the reflect path too
+   * (or removing it), which is RFC 0078
+   * `make-column-primary-key-flag-authoritative-or-remove-it`, filed from here.
    */
   initWith(coder: ColumnCoder): void {
     this.name = coder["name"] as string;
@@ -152,6 +168,7 @@ export class Column {
     this.defaultFunction = (coder["default_function"] as string | null) ?? null;
     this.collation = (coder["collation"] as string | null) ?? null;
     this.comment = (coder["comment"] as string | null) ?? null;
+    this.primaryKey = (coder["primary_key"] as boolean) ?? false;
   }
 
   /**
@@ -185,6 +202,7 @@ export class Column {
     coder["default_function"] = this.defaultFunction;
     coder["collation"] = this.collation;
     coder["comment"] = this.comment;
+    coder["primary_key"] = this.primaryKey;
   }
 
   deduplicate(): this {

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -9,14 +9,16 @@ import type { SqlTypeMetadataJSON } from "./sql-type-metadata.js";
 import { humanize } from "@blazetrails/activesupport";
 
 export class Column {
-  readonly name: string;
-  readonly sqlTypeMetadata: SqlTypeMetadata | null;
-  readonly null: boolean;
-  readonly default: unknown;
-  readonly defaultFunction: string | null;
-  readonly collation: string | null;
-  readonly comment: string | null;
-  readonly primaryKey: boolean;
+  // Ruby ivars, assigned by the constructor and re-assigned by `initWith`
+  // (`column.rb:46-53`), so they cannot be `readonly`.
+  name: string;
+  sqlTypeMetadata: SqlTypeMetadata | null;
+  null: boolean;
+  default: unknown;
+  defaultFunction: string | null;
+  collation: string | null;
+  comment: string | null;
+  primaryKey: boolean;
 
   constructor(
     name: string,
@@ -130,32 +132,57 @@ export class Column {
     return false;
   }
 
-  toJSON(): ColumnJSON {
-    return {
-      name: this.name,
-      default: this.default,
-      sqlTypeMetadata: this.sqlTypeMetadata?.toJSON() ?? null,
-      null: this.null,
-      defaultFunction: this.defaultFunction,
-      collation: this.collation,
-      comment: this.comment,
-      primaryKey: this.primaryKey,
-    };
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::Column#init_with
+   * (`column.rb:46-53`). Rails' YAML/Marshal protocol allocates the class named
+   * by the document's tag and then fills its ivars from the coder; the caller
+   * that does the allocating is `rehydrateColumn` (`schema-cache.ts`).
+   */
+  initWith(coder: ColumnCoder): void {
+    this.name = coder["name"] as string;
+    this.sqlTypeMetadata = coder["sql_type_metadata"]
+      ? SqlTypeMetadata.fromJSON(coder["sql_type_metadata"] as SqlTypeMetadataJSON)
+      : null;
+    this.null = coder["null"] as boolean;
+    this.default = coder["default"];
+    this.defaultFunction = (coder["default_function"] as string | null) ?? null;
+    this.collation = (coder["collation"] as string | null) ?? null;
+    this.comment = (coder["comment"] as string | null) ?? null;
+    // `primary_key` has no Rails counterpart in this pair: Rails' Column has no
+    // `@primary_key` ivar at all (it lives on the schema cache's primary-key
+    // map), while trails' Column carries one.
+    this.primaryKey = (coder["primary_key"] as boolean) ?? false;
   }
 
-  static fromJSON(data: ColumnJSON): Column {
-    return new Column(
-      data.name,
-      data.default,
-      data.sqlTypeMetadata ? SqlTypeMetadata.fromJSON(data.sqlTypeMetadata) : null,
-      data.null,
-      {
-        defaultFunction: data.defaultFunction,
-        collation: data.collation,
-        comment: data.comment,
-        primaryKey: data.primaryKey,
-      },
-    );
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::Column#encode_with
+   * (`column.rb:55-63`), the seam `SchemaCache#dump_to` serializes through
+   * (`schema_cache.rb:406`).
+   *
+   * `class` is the JSON stand-in for YAML's `!ruby/object:` tag. Rails restores
+   * the adapter's Column subclass from that tag and lets `init_with` fill only
+   * the seven base ivars, leaving the subclass' own ivars nil; a JSON document
+   * carries no tag, so the tag is written as a key and `rehydrateColumn`
+   * dispatches on it.
+   *
+   * The subclass overrides below then go one step further than Rails and encode
+   * their own state too. That is a deliberate deviation, not an oversight:
+   * Rails' data loss is invisible because Rails only ever compares a reflected
+   * cache against another reflected one, while trails' fixtures warm compares a
+   * dump-loaded cache against a reflected one — dropping `array` / `serial` /
+   * `rowid` & co. reds `base_test.rb`'s `test_clear_cache!`. Tracked by RFC
+   * 0096 `converge-column-encode-with-init-with`.
+   */
+  encodeWith(coder: ColumnCoder): void {
+    coder["class"] = "Column";
+    coder["name"] = this.name;
+    coder["sql_type_metadata"] = this.sqlTypeMetadata?.toJSON() ?? null;
+    coder["null"] = this.null;
+    coder["default"] = this.default;
+    coder["default_function"] = this.defaultFunction;
+    coder["collation"] = this.collation;
+    coder["comment"] = this.comment;
+    coder["primary_key"] = this.primaryKey;
   }
 
   deduplicate(): this {
@@ -181,16 +208,12 @@ function metadataEquals(a: SqlTypeMetadata | null, b: SqlTypeMetadata | null): b
   return a.equals(b);
 }
 
-export interface ColumnJSON {
-  name: string;
-  default: unknown;
-  sqlTypeMetadata: SqlTypeMetadataJSON | null;
-  null: boolean;
-  defaultFunction: string | null;
-  collation: string | null;
-  comment: string | null;
-  primaryKey: boolean;
-}
+/**
+ * Psych's `coder` — the untyped key/value bag `encode_with` writes and
+ * `init_with` reads (`column.rb:46-63`). Same shape `SchemaCache#encodeWith`
+ * takes (`schema-cache.ts`).
+ */
+export type ColumnCoder = Record<string, unknown>;
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullColumn

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Column as MysqlColumn } from "./column.js";
 
 describe("MysqlColumn", () => {
-  it("round-trips autoIncrement / unsigned / virtual through toJSON/fromJSON", () => {
+  it("round-trips autoIncrement / unsigned / virtual through encodeWith/initWith", () => {
     const original = new MysqlColumn(
       "id",
       null,
@@ -10,8 +10,12 @@ describe("MysqlColumn", () => {
       false,
       { primaryKey: true, autoIncrement: true, unsigned: true, virtual: false },
     );
-    const json = JSON.parse(JSON.stringify(original.toJSON()));
-    const restored = MysqlColumn.fromJSON(json);
+    const coder: Record<string, unknown> = {};
+    original.encodeWith(coder);
+    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
+    // fill its ivars from the coder.
+    const restored = Object.create(MysqlColumn.prototype) as MysqlColumn;
+    restored.initWith(JSON.parse(JSON.stringify(coder)));
     expect(restored.autoIncrement).toBe(true);
     expect(restored.unsigned).toBe(true);
     expect(restored.virtual).toBe(false);

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -17,7 +17,7 @@ describe("MysqlColumn", () => {
     expect(restored.autoIncrement).toBe(true);
     expect(restored.unsigned).toBe(true);
     expect(restored.virtual).toBe(false);
-    expect(restored.primaryKey).toBe(true);
+    expect(coder).not.toHaveProperty("primary_key");
     expect(restored.sqlType).toBe("bigint(20) unsigned");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -12,8 +12,6 @@ describe("MysqlColumn", () => {
     );
     const coder: Record<string, unknown> = {};
     original.encodeWith(coder);
-    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
-    // fill its ivars from the coder.
     const restored = Object.create(MysqlColumn.prototype) as MysqlColumn;
     restored.initWith(JSON.parse(JSON.stringify(coder)));
     expect(restored.autoIncrement).toBe(true);

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -8,7 +8,7 @@ describe("MysqlColumn", () => {
       null,
       { sqlType: "bigint(20) unsigned", type: "integer", limit: 8 },
       false,
-      { primaryKey: true, autoIncrement: true, unsigned: true, virtual: false },
+      { autoIncrement: true, unsigned: true, virtual: false },
     );
     const coder: Record<string, unknown> = {};
     original.encodeWith(coder);
@@ -17,7 +17,6 @@ describe("MysqlColumn", () => {
     expect(restored.autoIncrement).toBe(true);
     expect(restored.unsigned).toBe(true);
     expect(restored.virtual).toBe(false);
-    expect(restored.primaryKey).toBe(true);
     expect(restored.sqlType).toBe("bigint(20) unsigned");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -17,7 +17,7 @@ describe("MysqlColumn", () => {
     expect(restored.autoIncrement).toBe(true);
     expect(restored.unsigned).toBe(true);
     expect(restored.virtual).toBe(false);
-    expect(coder).not.toHaveProperty("primary_key");
+    expect(restored.primaryKey).toBe(true);
     expect(restored.sqlType).toBe("bigint(20) unsigned");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -33,7 +33,6 @@ export class Column extends BaseColumn {
       collation?: string | null;
       comment?: string | null;
       defaultFunction?: string | null;
-      primaryKey?: boolean;
       unsigned?: boolean;
       autoIncrement?: boolean;
       virtual?: boolean;
@@ -51,7 +50,6 @@ export class Column extends BaseColumn {
       collation: options.collation,
       comment: options.comment,
       defaultFunction: options.defaultFunction,
-      primaryKey: options.primaryKey,
     });
     this.unsigned = options.unsigned ?? false;
     this.autoIncrement = options.autoIncrement ?? false;

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -5,18 +5,18 @@
  */
 
 import { Column as BaseColumn } from "../column.js";
-import type { ColumnJSON } from "../column.js";
+import type { ColumnCoder } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
-  readonly unsigned: boolean;
-  readonly autoIncrement: boolean;
-  readonly virtual: boolean;
+  unsigned: boolean;
+  autoIncrement: boolean;
+  virtual: boolean;
   /** Raw MySQL `Extra` string (e.g. "VIRTUAL GENERATED", "STORED GENERATED",
    *  "auto_increment"). Mirrors Rails' `MySQL::Column#extra` (delegated from
    *  sql_type_metadata); the schema dumper reads it to distinguish stored from
    *  virtual generated columns. */
-  readonly extra: string;
+  extra: string;
 
   constructor(
     name: string,
@@ -93,48 +93,21 @@ export class Column extends BaseColumn {
     return this.virtual;
   }
 
-  override toJSON(): MysqlColumnJSON {
-    return {
-      ...super.toJSON(),
-      __mysql: true,
-      unsigned: this.unsigned,
-      autoIncrement: this.autoIncrement,
-      virtual: this.virtual,
-      extra: this.extra,
-    };
+  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
+  override initWith(coder: ColumnCoder): void {
+    super.initWith(coder);
+    this.unsigned = (coder["unsigned"] as boolean) ?? false;
+    this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
+    this.virtual = (coder["virtual"] as boolean) ?? false;
+    this.extra = (coder["extra"] as string) ?? "";
   }
 
-  static override fromJSON(data: ColumnJSON): Column {
-    const m = data as MysqlColumnJSON;
-    return new Column(
-      m.name,
-      m.default,
-      {
-        sqlType: m.sqlTypeMetadata?.sqlType,
-        type: m.sqlTypeMetadata?.type,
-        limit: m.sqlTypeMetadata?.limit ?? null,
-        precision: m.sqlTypeMetadata?.precision ?? null,
-        scale: m.sqlTypeMetadata?.scale ?? null,
-      },
-      m.null,
-      {
-        collation: m.collation,
-        comment: m.comment,
-        defaultFunction: m.defaultFunction,
-        primaryKey: m.primaryKey,
-        unsigned: m.unsigned,
-        autoIncrement: m.autoIncrement,
-        virtual: m.virtual,
-        extra: m.extra ?? "",
-      },
-    );
+  override encodeWith(coder: ColumnCoder): void {
+    super.encodeWith(coder);
+    coder["class"] = "MySQL::Column";
+    coder["unsigned"] = this.unsigned;
+    coder["auto_increment"] = this.autoIncrement;
+    coder["virtual"] = this.virtual;
+    coder["extra"] = this.extra;
   }
-}
-
-export interface MysqlColumnJSON extends ColumnJSON {
-  __mysql: true;
-  unsigned: boolean;
-  autoIncrement: boolean;
-  virtual: boolean;
-  extra?: string;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -11,7 +11,12 @@ describe("PostgreSQL::Column JSON round-trip", () => {
       { serial: false, identity: "a", generated: "s" },
     );
 
-    const back = Column.fromJSON(col.toJSON()) as Column;
+    const coder: Record<string, unknown> = {};
+    col.encodeWith(coder);
+    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
+    // fill its ivars from the coder.
+    const back = Object.create(Column.prototype) as Column;
+    back.initWith(JSON.parse(JSON.stringify(coder)));
 
     expect(back).toBeInstanceOf(Column);
     expect(back.isArray()).toBe(true);

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -13,8 +13,6 @@ describe("PostgreSQL::Column JSON round-trip", () => {
 
     const coder: Record<string, unknown> = {};
     col.encodeWith(coder);
-    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
-    // fill its ivars from the coder.
     const back = Object.create(Column.prototype) as Column;
     back.initWith(JSON.parse(JSON.stringify(coder)));
 

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -22,9 +22,6 @@ describe("PostgreSQL::Column JSON round-trip", () => {
     expect(back.fmod).toBe(-1);
     expect(back.isIdentity).toBe(true);
     expect(back.isVirtual()).toBe(true);
-    // Rails' `encode_with` writes no `@primary_key` (`column.rb:55-63`); the
-    // flag is the schema cache's, derived from its own `primary_keys` slot.
-    expect(coder).not.toHaveProperty("primary_key");
-    expect({ ...back, primaryKey: col.primaryKey }).toEqual({ ...col });
+    expect(back).toEqual(col);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -22,6 +22,9 @@ describe("PostgreSQL::Column JSON round-trip", () => {
     expect(back.fmod).toBe(-1);
     expect(back.isIdentity).toBe(true);
     expect(back.isVirtual()).toBe(true);
-    expect(back).toEqual(col);
+    // Rails' `encode_with` writes no `@primary_key` (`column.rb:55-63`); the
+    // flag is the schema cache's, derived from its own `primary_keys` slot.
+    expect(coder).not.toHaveProperty("primary_key");
+    expect({ ...back, primaryKey: col.primaryKey }).toEqual({ ...col });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -5,16 +5,16 @@
  */
 
 import { Column as BaseColumn } from "../column.js";
-import type { ColumnJSON } from "../column.js";
+import type { ColumnCoder } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
-  readonly serial: boolean;
-  readonly oid: number | null;
-  readonly fmod: number | null;
-  readonly array: boolean;
-  readonly identity: string | null;
-  readonly generated: string | null;
+  serial: boolean;
+  oid: number | null;
+  fmod: number | null;
+  array: boolean;
+  identity: string | null;
+  generated: string | null;
 
   constructor(
     name: string,
@@ -128,67 +128,25 @@ export class Column extends BaseColumn {
     );
   }
 
-  /**
-   * @noRailsEquivalent PERMANENT: the schema-cache dump. Rails dumps through
-   *   YAML/Marshal, which round-trips the adapter's Column subclass and its
-   *   state on its own (`schema_cache.rb:406`); trails' dump is JSON, so the
-   *   subclass has to spell out what it carries and tag itself for
-   *   `rehydrateColumn`. Mirrors MySQL::Column's pair.
-   */
-  override toJSON(): PostgresqlColumnJSON {
-    return {
-      ...super.toJSON(),
-      __postgresql: true,
-      serial: this.serial,
-      oid: this.oid,
-      fmod: this.fmod,
-      array: this.array,
-      identity: this.identity,
-      generated: this.generated,
-    };
+  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
+  override initWith(coder: ColumnCoder): void {
+    super.initWith(coder);
+    this.serial = (coder["serial"] as boolean) ?? false;
+    this.oid = (coder["oid"] as number | null) ?? null;
+    this.fmod = (coder["fmod"] as number | null) ?? null;
+    this.array = (coder["array"] as boolean) ?? false;
+    this.identity = (coder["identity"] as string | null) ?? null;
+    this.generated = (coder["generated"] as string | null) ?? null;
   }
 
-  static override fromJSON(data: ColumnJSON): BaseColumn {
-    const p = data as PostgresqlColumnJSON;
-    return new Column(
-      p.name,
-      p.default,
-      {
-        sqlType: p.sqlTypeMetadata?.sqlType,
-        type: p.sqlTypeMetadata?.type,
-        oid: p.oid ?? undefined,
-        fmod: p.fmod ?? undefined,
-        limit: p.sqlTypeMetadata?.limit ?? null,
-        precision: p.sqlTypeMetadata?.precision ?? null,
-        scale: p.sqlTypeMetadata?.scale ?? null,
-      },
-      p.null,
-      {
-        collation: p.collation,
-        defaultFunction: p.defaultFunction,
-        comment: p.comment,
-        primaryKey: p.primaryKey,
-        serial: p.serial,
-        array: p.array,
-        identity: p.identity,
-        generated: p.generated,
-      },
-    );
+  override encodeWith(coder: ColumnCoder): void {
+    super.encodeWith(coder);
+    coder["class"] = "PostgreSQL::Column";
+    coder["serial"] = this.serial;
+    coder["oid"] = this.oid;
+    coder["fmod"] = this.fmod;
+    coder["array"] = this.array;
+    coder["identity"] = this.identity;
+    coder["generated"] = this.generated;
   }
-}
-
-/**
- * A dumped PostgreSQL::Column — the discriminator and subclass state a JSON
- * dump has to carry where Rails' YAML/Marshal dump round-trips the class
- * itself. Without it a loaded cache reports every column non-`array?`,
- * non-`serial?` and OID-less (`schema_cache.rb:406`, `schema_cache.rb:228`).
- */
-export interface PostgresqlColumnJSON extends ColumnJSON {
-  __postgresql: true;
-  serial: boolean;
-  oid: number | null;
-  fmod: number | null;
-  array: boolean;
-  identity: string | null;
-  generated: string | null;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -33,7 +33,6 @@ export class Column extends BaseColumn {
       collation?: string | null;
       defaultFunction?: string | null;
       comment?: string | null;
-      primaryKey?: boolean;
       serial?: boolean;
       array?: boolean;
       identity?: string | null;
@@ -51,7 +50,6 @@ export class Column extends BaseColumn {
       collation: options.collation,
       defaultFunction: options.defaultFunction,
       comment: options.comment,
-      primaryKey: options.primaryKey,
     });
     this.serial = options.serial ?? false;
     this.oid = sqlTypeMetadata.oid ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -365,12 +365,11 @@ describe("SchemaStatements#columns delegates to newColumnFromField", () => {
       for (const oid of oids ?? []) ss.typeMap.registerType(oid, new ValueType());
     });
 
-    const [id] = await ss.columns("things");
+    await ss.columns("things");
 
     const definitions = sql.find((text) => text.includes("pg_attribute"))!;
     expect(definitions).not.toContain("indisprimary");
     expect(definitions).not.toContain("pg_index");
-    expect(id.primaryKey).toBe(false);
   });
 
   it("carries the serial and comment flags through the ported body", async () => {

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -19,14 +19,13 @@ import * as os from "os";
 function makeColumn(
   name: string,
   sqlType: string,
-  opts: { default?: unknown; null?: boolean; primaryKey?: boolean } = {},
+  opts: { default?: unknown; null?: boolean } = {},
 ): Column {
   return new Column(
     name,
     opts.default ?? null,
     new SqlTypeMetadata({ sqlType, type: sqlType.replace(/\(.*/, "") }),
     opts.null ?? true,
-    { primaryKey: opts.primaryKey ?? false },
   );
 }
 
@@ -78,7 +77,7 @@ describe("SchemaCacheTest", () => {
   it("yaml dump and load", async () => {
     const cache = new SchemaCache();
     const cols = [
-      makeColumn("id", "integer", { primaryKey: true, null: false }),
+      makeColumn("id", "integer", { null: false }),
       makeColumn("name", "varchar(255)"),
       makeColumn("created_at", "timestamp"),
     ];
@@ -96,7 +95,6 @@ describe("SchemaCacheTest", () => {
     expect(loadedCols).toBeDefined();
     expect(loadedCols!["id"]).toBeInstanceOf(Column);
     expect(loadedCols!["id"].sqlType).toBe("integer");
-    expect(loadedCols!["id"].primaryKey).toBe(true);
     expect(loadedCols!["id"].null).toBe(false);
     expect(loadedCols!["name"].sqlType).toBe("varchar(255)");
     expect(loadedCols!["name"].humanName()).toBe("Name");
@@ -123,7 +121,7 @@ describe("SchemaCacheTest", () => {
     // JSON; _loadFrom auto-detects the .gz extension and gunzips first.
     const cache = new SchemaCache();
     await warm(cache, "courses", "id", [
-      makeColumn("id", "integer", { primaryKey: true, null: false }),
+      makeColumn("id", "integer", { null: false }),
       makeColumn("name", "varchar(255)"),
       makeColumn("created_at", "timestamp"),
     ]);
@@ -161,34 +159,6 @@ describe("SchemaCacheTest", () => {
     expect(pk).toBeNull();
   });
 
-  it("getCachedPrimaryKeys derives custom primary key from warm columns", () => {
-    const cache = new SchemaCache();
-    // id: false table with a custom string PK — only the columns are warmed
-    // (loadSchema warms the columns hash, not the dedicated primary-keys map).
-    cache.setColumns("countries", [
-      makeColumn("country_id", "string", { primaryKey: true, null: false }),
-      makeColumn("name", "string"),
-    ]);
-    expect(cache.getCachedPrimaryKeys("countries")).toBe("country_id");
-  });
-
-  it("getCachedPrimaryKeys derives composite primary key from warm columns", () => {
-    const cache = new SchemaCache();
-    cache.setColumns("countries_treaties", [
-      makeColumn("country_id", "string", { primaryKey: true, null: false }),
-      makeColumn("treaty_id", "string", { primaryKey: true, null: false }),
-    ]);
-    expect(cache.getCachedPrimaryKeys("countries_treaties")).toEqual(["country_id", "treaty_id"]);
-  });
-
-  it("getCachedPrimaryKeys falls through (undefined) for a warm key-less table", () => {
-    // No flagged PK column: defer to the convention/async query rather than
-    // resolving `null` here, so a table that resolved "id" before still does.
-    const cache = new SchemaCache();
-    cache.setColumns("postgresql_arrays", [makeColumn("commission", "string")]);
-    expect(cache.getCachedPrimaryKeys("postgresql_arrays")).toBeUndefined();
-  });
-
   it("getCachedPrimaryKeys is undefined for an unwarmed table", () => {
     const cache = new SchemaCache();
     expect(cache.getCachedPrimaryKeys("missing")).toBeUndefined();
@@ -196,58 +166,8 @@ describe("SchemaCacheTest", () => {
 
   it("getCachedPrimaryKeys prefers the explicit primary-keys map over columns", async () => {
     const cache = new SchemaCache();
-    await warm(cache, "users", null, [makeColumn("id", "integer", { primaryKey: true })]);
+    await warm(cache, "users", null, [makeColumn("id", "integer")]);
     expect(cache.getCachedPrimaryKeys("users")).toBeNull();
-  });
-
-  it("setColumns clears a promoted-unique primaryKey flag the authoritative key excludes", async () => {
-    // MySQL/MariaDB report column_key = 'PRI' for a UNIQUE-NOT-NULL column when
-    // the table has no PRIMARY KEY, so the adapter reflects a bogus primary
-    // flag. add() warms _primaryKeys (authoritative, null here) before columns,
-    // so setColumns reconciles the flag away — matching Rails' MySQL::Column,
-    // which carries no per-column primary flag.
-    const cache = new SchemaCache();
-    const nick = makeColumn("nick", "varchar(100)", { primaryKey: true, null: false });
-    await warm(cache, "subscribers", null, [nick, makeColumn("name", "varchar(100)")]);
-    expect(nick.primaryKey).toBe(false);
-    expect(cache.getCachedColumnsHash("subscribers")!["nick"].primaryKey).toBe(false);
-  });
-
-  it("setColumns keeps a genuine primaryKey flag the authoritative key includes", async () => {
-    const cache = new SchemaCache();
-    const id = makeColumn("id", "integer", { primaryKey: true, null: false });
-    await warm(cache, "users", "id", [id, makeColumn("name", "text")]);
-    expect(id.primaryKey).toBe(true);
-  });
-
-  it("setColumns leaves flags untouched when the authoritative key is not warm", () => {
-    const cache = new SchemaCache();
-    const id = makeColumn("id", "integer", { primaryKey: true, null: false });
-    cache.setColumns("countries", [id]);
-    expect(id.primaryKey).toBe(true);
-  });
-
-  it("initWith reconciles a stale dump's promoted-unique primaryKey flag", () => {
-    // A schema cache dumped before this convergence can carry MySQL's bogus
-    // promoted-unique `primaryKey: true` alongside `primary_keys: { table: null }`.
-    // Deriving the columns hash on load must not resurface the flag.
-    const cache = new SchemaCache();
-    cache.initWith({
-      columns: {
-        subscribers: [
-          new Column(
-            "nick",
-            null,
-            new SqlTypeMetadata({ sqlType: "varchar(100)", type: "varchar" }),
-            false,
-            { primaryKey: true },
-          ),
-        ],
-      },
-      primary_keys: { subscribers: null },
-    });
-    expect(cache.getCachedColumnsHash("subscribers")!["nick"].primaryKey).toBe(false);
-    expect(cache.getCachedPrimaryKeys("subscribers")).toBeNull();
   });
 
   it("columns for existent table", async () => {
@@ -321,7 +241,7 @@ describe("SchemaCacheTest", () => {
   it("marshal dump and load", async () => {
     const cache = new SchemaCache();
     await warm(cache, "users", "id", [
-      makeColumn("id", "integer", { primaryKey: true }),
+      makeColumn("id", "integer"),
       makeColumn("email", "varchar(255)"),
     ]);
 
@@ -361,7 +281,7 @@ describe("SchemaCacheTest", () => {
         columns: async (t: string) =>
           t === "courses"
             ? [
-                makeColumn("id", "integer", { primaryKey: true }),
+                makeColumn("id", "integer"),
                 makeColumn("name", "varchar(255)"),
                 makeColumn("created_at", "timestamp"),
               ]
@@ -404,7 +324,7 @@ describe("SchemaCacheTest", () => {
     // JSON payload and `_loadFrom` auto-detects the `.gz` suffix.
     const cache = new SchemaCache();
     await warm(cache, "courses", "id", [
-      makeColumn("id", "integer", { primaryKey: true }),
+      makeColumn("id", "integer"),
       makeColumn("name", "varchar(255)"),
       makeColumn("created_at", "timestamp"),
     ]);
@@ -414,14 +334,14 @@ describe("SchemaCacheTest", () => {
     const loaded = SchemaCache._loadFrom(filename);
     expect(loaded).not.toBeNull();
     expect(loaded!.isCached("courses")).toBe(true);
-    expect(loaded!.getCachedColumnsHash("courses")!["id"].primaryKey).toBe(true);
+    expect(await loaded!.primaryKeys(null, "courses")).toBe("id");
   });
   it("gzip dumps identical", async () => {
     // Rails: two .gz dumps of the same cache (with a 1s sleep between) must
     // be byte-identical, since the gzip header carries no mtime. Node's
     // zlib.gzipSync writes mtime=0 / OS=0xff, so the same property holds.
     const cache = new SchemaCache();
-    await warm(cache, "posts", "id", [makeColumn("id", "integer", { primaryKey: true })]);
+    await warm(cache, "posts", "id", [makeColumn("id", "integer")]);
 
     const a = path.join(tmpDir, "schema_cache_a.json.gz");
     const b = path.join(tmpDir, "schema_cache_b.json.gz");
@@ -503,7 +423,7 @@ describe("SchemaCacheTest", () => {
     // here we cover the SchemaReflection-level contract that backs it.
     const cachePath = path.join(tmpDir, "schema_cache.json");
     const cache = new SchemaCache();
-    await warm(cache, "gadgets", "id", [makeColumn("id", "integer", { primaryKey: true })]);
+    await warm(cache, "gadgets", "id", [makeColumn("id", "integer")]);
     cache.dumpTo(cachePath);
 
     const prevCheck = SchemaReflection.checkSchemaCacheDumpVersion;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -412,12 +412,7 @@ export class SchemaCache {
    * connection-checkout flip).
    */
   getCachedPrimaryKeys(tableName: string): string | string[] | null | undefined {
-    if (this._primaryKeys.has(tableName)) return this._primaryKeys.get(tableName);
-    const cols = this._columns.get(tableName);
-    if (!cols) return undefined;
-    const pkCols = cols.filter((c) => c.primaryKey).map((c) => c.name);
-    if (pkCols.length === 0) return undefined;
-    return pkCols.length === 1 ? pkCols[0] : pkCols;
+    return this._primaryKeys.get(tableName);
   }
 
   async indexes(pool: unknown, tableName: string): Promise<IndexDefinition[]> {
@@ -494,7 +489,6 @@ export class SchemaCache {
    * connection-checkout flip).
    */
   setColumns(tableName: string, cols: Column[]): void {
-    this.reconcilePrimaryKeyFlags(tableName, cols);
     this._columns.set(tableName, cols);
     const hash: Record<string, Column> = {};
     for (const col of cols) {
@@ -502,40 +496,6 @@ export class SchemaCache {
     }
     this._columnsHash.set(tableName, hash);
     this._dataSourceExists.set(tableName, true);
-  }
-
-  /**
-   * Clear per-column `primaryKey` flags that the authoritative `_primaryKeys`
-   * cache contradicts. This is a general safety net for any adapter whose
-   * `columns()` could over-report a primary flag, reconciled query-free against
-   * `_primaryKeys` (which `add()` warms via the authoritative
-   * `SHOW KEYS ... 'PRIMARY'` / key_column_usage query before `columns()`, so
-   * by the time `setColumns` runs the key is already authoritative).
-   *
-   * Historically this cleared MySQL/MariaDB's "promoted unique" false positive:
-   * they report `column_key = 'PRI'` for a UNIQUE-NOT-NULL index when a table has
-   * no PRIMARY KEY, so `columns()` used to reflect a bogus flag on that column.
-   * `columns()` now carries no per-column primary flag at all for MySQL/MariaDB —
-   * matching Rails' `MySQL::Column`, which has none and resolves the key solely
-   * from the `PRIMARY` constraint — so this reconcile is a no-op for MySQL
-   * (nothing is ever set `true`, so there is nothing to clear). It stays as a
-   * harmless guard for any adapter that could theoretically over-report.
-   *
-   * Clear-only: a flag is dropped when the authoritative key set excludes the
-   * column, never added. Real primary keys (whose flag the adapter already set
-   * and whose name the query returns) are untouched, and adapters that reflect
-   * the flag correctly (sqlite/postgres) agree with the query so nothing changes.
-   * When `_primaryKeys` is not yet warm the flags are left as reflected.
-   */
-  private reconcilePrimaryKeyFlags(tableName: string, cols: Column[]): void {
-    if (!this._primaryKeys.has(tableName)) return;
-    const pk = this._primaryKeys.get(tableName);
-    const pkNames = new Set(pk == null ? [] : Array.isArray(pk) ? pk : [pk]);
-    for (const col of cols) {
-      if (col.primaryKey && !pkNames.has(col.name)) {
-        (col as { primaryKey: boolean }).primaryKey = false;
-      }
-    }
   }
 
   async addAll(pool: unknown): Promise<void> {
@@ -608,14 +568,6 @@ export class SchemaCache {
    * Rebuild `_columnsHash` from `_columns`, the tail of both load paths
    * (`initWith` and `marshalLoad`).
    *
-   * Both `_columns` and the authoritative `_primaryKeys` are already loaded, so
-   * reconcile the per-column `primaryKey` flags against the key cache before
-   * exposing the hash — a schema cache dumped before this convergence can carry
-   * MySQL's promoted-unique `primaryKey: true` alongside
-   * `primary_keys: { table: null }`, and the derive step must not resurface the
-   * bogus flag. Mirrors Rails treating `@primary_keys` as authoritative while
-   * deriving `columns_hash` (schema_cache.rb).
-   *
    * @missingRailsCall deep_deduplicate — PERMANENT: Per-site verified (RFC 0106 wave 4b):
    *   schema_cache.rb:441-445 calls `deep_deduplicate` to intern strings with
    *   Ruby's `-@`; JS has no string-interning primitive and identical string
@@ -625,7 +577,6 @@ export class SchemaCache {
   private deriveColumnsHashAndDeduplicateValues(): void {
     this._columnsHash.clear();
     for (const [table, cols] of this._columns) {
-      this.reconcilePrimaryKeyFlags(table, cols);
       const hash: Record<string, Column> = {};
       for (const col of cols) {
         hash[col.name] = col;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -527,14 +527,6 @@ export class SchemaCache {
    * the flag correctly (sqlite/postgres) agree with the query so nothing changes.
    * When `_primaryKeys` is not yet warm the flags are left as reflected.
    */
-  private derivePrimaryKeyFlags(tableName: string, cols: Column[]): void {
-    const pk = this._primaryKeys.get(tableName);
-    const pkNames = new Set(pk == null ? [] : Array.isArray(pk) ? pk : [pk]);
-    for (const col of cols) {
-      col.primaryKey = pkNames.has(col.name);
-    }
-  }
-
   private reconcilePrimaryKeyFlags(tableName: string, cols: Column[]): void {
     if (!this._primaryKeys.has(tableName)) return;
     const pk = this._primaryKeys.get(tableName);
@@ -616,17 +608,13 @@ export class SchemaCache {
    * Rebuild `_columnsHash` from `_columns`, the tail of both load paths
    * (`initWith` and `marshalLoad`).
    *
-   * Rails' `Column#encode_with` writes seven keys and no `@primary_key`
-   * (`column.rb:55-63`) — a column's primary-key membership is not column state
-   * in Rails at all, it lives in the cache's own `@primary_keys` slot, which
-   * `marshal_dump` carries separately (`schema_cache.rb:416`). trails' Column
-   * does carry the flag, so rather than widening the column coder past Rails'
-   * key set, the flag is derived here from that authoritative slot once both
-   * halves are loaded. This is a derive, not
-   * {@link reconcilePrimaryKeyFlags}' clear-only reconcile: on the load path
-   * there is no adapter-reported flag to preserve or contradict, so
-   * `_primaryKeys` is the only source — which also drops MySQL's
-   * promoted-unique false positive out of any older dump for free.
+   * Both `_columns` and the authoritative `_primaryKeys` are already loaded, so
+   * reconcile the per-column `primaryKey` flags against the key cache before
+   * exposing the hash — a schema cache dumped before this convergence can carry
+   * MySQL's promoted-unique `primaryKey: true` alongside
+   * `primary_keys: { table: null }`, and the derive step must not resurface the
+   * bogus flag. Mirrors Rails treating `@primary_keys` as authoritative while
+   * deriving `columns_hash` (schema_cache.rb).
    *
    * @missingRailsCall deep_deduplicate — PERMANENT: Per-site verified (RFC 0106 wave 4b):
    *   schema_cache.rb:441-445 calls `deep_deduplicate` to intern strings with
@@ -637,7 +625,7 @@ export class SchemaCache {
   private deriveColumnsHashAndDeduplicateValues(): void {
     this._columnsHash.clear();
     for (const [table, cols] of this._columns) {
-      this.derivePrimaryKeyFlags(table, cols);
+      this.reconcilePrimaryKeyFlags(table, cols);
       const hash: Record<string, Column> = {};
       for (const col of cols) {
         hash[col.name] = col;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -527,6 +527,14 @@ export class SchemaCache {
    * the flag correctly (sqlite/postgres) agree with the query so nothing changes.
    * When `_primaryKeys` is not yet warm the flags are left as reflected.
    */
+  private derivePrimaryKeyFlags(tableName: string, cols: Column[]): void {
+    const pk = this._primaryKeys.get(tableName);
+    const pkNames = new Set(pk == null ? [] : Array.isArray(pk) ? pk : [pk]);
+    for (const col of cols) {
+      col.primaryKey = pkNames.has(col.name);
+    }
+  }
+
   private reconcilePrimaryKeyFlags(tableName: string, cols: Column[]): void {
     if (!this._primaryKeys.has(tableName)) return;
     const pk = this._primaryKeys.get(tableName);
@@ -605,13 +613,20 @@ export class SchemaCache {
   }
 
   /**
-   * Rebuild `_columnsHash` from `_columns`. Both `_columns` and the
-   * authoritative `_primaryKeys` are already loaded, so reconcile the per-column
-   * `primaryKey` flags against the key cache before exposing the hash — a schema
-   * cache dumped before this convergence can carry MySQL's promoted-unique
-   * `primaryKey: true` alongside `primary_keys: { table: null }`, and the derive
-   * step must not resurface the bogus flag. Mirrors Rails treating `@primary_keys`
-   * as authoritative while deriving `columns_hash` (schema_cache.rb).
+   * Rebuild `_columnsHash` from `_columns`, the tail of both load paths
+   * (`initWith` and `marshalLoad`).
+   *
+   * Rails' `Column#encode_with` writes seven keys and no `@primary_key`
+   * (`column.rb:55-63`) — a column's primary-key membership is not column state
+   * in Rails at all, it lives in the cache's own `@primary_keys` slot, which
+   * `marshal_dump` carries separately (`schema_cache.rb:416`). trails' Column
+   * does carry the flag, so rather than widening the column coder past Rails'
+   * key set, the flag is derived here from that authoritative slot once both
+   * halves are loaded. This is a derive, not
+   * {@link reconcilePrimaryKeyFlags}' clear-only reconcile: on the load path
+   * there is no adapter-reported flag to preserve or contradict, so
+   * `_primaryKeys` is the only source — which also drops MySQL's
+   * promoted-unique false positive out of any older dump for free.
    *
    * @missingRailsCall deep_deduplicate — PERMANENT: Per-site verified (RFC 0106 wave 4b):
    *   schema_cache.rb:441-445 calls `deep_deduplicate` to intern strings with
@@ -622,7 +637,7 @@ export class SchemaCache {
   private deriveColumnsHashAndDeduplicateValues(): void {
     this._columnsHash.clear();
     for (const [table, cols] of this._columns) {
-      this.reconcilePrimaryKeyFlags(table, cols);
+      this.derivePrimaryKeyFlags(table, cols);
       const hash: Record<string, Column> = {};
       for (const col of cols) {
         hash[col.name] = col;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -8,7 +8,7 @@
 import { getFs, getPath } from "@blazetrails/activesupport";
 import { Gzip } from "@blazetrails/activesupport/gzip";
 import { Column } from "./column.js";
-import type { ColumnJSON } from "./column.js";
+import type { ColumnCoder } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
 import { Column as PostgresqlColumn } from "./postgresql/column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
@@ -26,41 +26,36 @@ async function withConnection<T>(
   return callback(pool);
 }
 
-function serializeColumn(col: any): ColumnJSON {
-  if (typeof col.toJSON === "function") return col.toJSON();
-  return {
-    name: col.name,
-    default: col.default,
-    sqlTypeMetadata:
-      col.sqlTypeMetadata?.toJSON?.() ??
-      (col.sqlType != null
-        ? {
-            sqlType: col.sqlType,
-            type: col.type ?? col.sqlType,
-            limit: col.limit ?? null,
-            precision: col.precision ?? null,
-            scale: col.scale ?? null,
-          }
-        : null),
-    null: col.null ?? true,
-    defaultFunction: col.defaultFunction ?? null,
-    collation: col.collation ?? null,
-    comment: col.comment ?? null,
-    primaryKey: col.primaryKey ?? false,
-  };
+function serializeColumn(col: Column): ColumnCoder {
+  const coder: ColumnCoder = {};
+  col.encodeWith(coder);
+  return coder;
 }
 
+/**
+ * The Column subclasses a dump can name, keyed by the `class` tag
+ * `Column#encodeWith` writes — JSON's stand-in for YAML's `!ruby/object:` tag.
+ */
+const COLUMN_CLASSES: Record<string, { prototype: Column }> = {
+  Column,
+  "MySQL::Column": MysqlColumn,
+  "PostgreSQL::Column": PostgresqlColumn,
+  "SQLite3::Column": Sqlite3Column,
+};
+
+/**
+ * Psych's restore step: allocate the tagged class, then `init_with` the coder
+ * (`psych/visitors/to_ruby.rb`; `column.rb:46-53`). `Object.create` is the JS
+ * `allocate` — it must not run a constructor, because the coder is the only
+ * source of state.
+ */
 function rehydrateColumn(data: unknown): Column {
   if (data instanceof Column) return data;
-  const json = data as ColumnJSON & {
-    __mysql?: boolean;
-    __postgresql?: boolean;
-    __sqlite3?: boolean;
-  };
-  if (json && json.__mysql) return MysqlColumn.fromJSON(json);
-  if (json && json.__postgresql) return PostgresqlColumn.fromJSON(json);
-  if (json && json.__sqlite3) return Sqlite3Column.fromJSON(json);
-  return Column.fromJSON(json);
+  const coder = data as ColumnCoder;
+  const klass = COLUMN_CLASSES[coder["class"] as string] ?? Column;
+  const column = Object.create(klass.prototype) as Column;
+  column.initWith(coder);
+  return column;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
@@ -59,8 +59,6 @@ describe("SQLite3Adapter schema introspection", () => {
     const name = cols.find((c) => c.name === "name");
     expect(name?.null).toBe(false);
     expect(name?.sqlType).toBe("TEXT");
-    const id = cols.find((c) => c.name === "id");
-    expect(id?.primaryKey).toBe(true);
   });
 
   it("columns reflects a STORED generated column's expression as default_function", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -52,8 +52,6 @@ describe("SQLite3::Column JSON round-trip", () => {
 
     const coder: Record<string, unknown> = {};
     col.encodeWith(coder);
-    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
-    // fill its ivars from the coder.
     const back = Object.create(Column.prototype) as Column;
     back.initWith(JSON.parse(JSON.stringify(coder)));
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -59,9 +59,6 @@ describe("SQLite3::Column JSON round-trip", () => {
     expect(back.autoIncrement).toBe(true);
     expect(back.rowid).toBe(true);
     expect(back.isVirtualStored()).toBe(true);
-    // Rails' `encode_with` writes no `@primary_key` (`column.rb:55-63`); the
-    // flag is the schema cache's, derived from its own `primary_keys` slot.
-    expect(coder).not.toHaveProperty("primary_key");
-    expect({ ...back, primaryKey: col.primaryKey }).toEqual({ ...col });
+    expect(back).toEqual(col);
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -44,7 +44,6 @@ describe("SQLite3::Column#hasDefault", () => {
 describe("SQLite3::Column JSON round-trip", () => {
   it("preserves the subclass and its state through the schema-cache dump", () => {
     const col = new Column("id", null, { sqlType: "INTEGER", type: "integer" }, false, {
-      primaryKey: true,
       autoIncrement: true,
       rowid: true,
       generatedType: "stored",

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -50,7 +50,12 @@ describe("SQLite3::Column JSON round-trip", () => {
       generatedType: "stored",
     });
 
-    const back = Column.fromJSON(col.toJSON()) as Column;
+    const coder: Record<string, unknown> = {};
+    col.encodeWith(coder);
+    // Psych's restore step (`column.rb:46-53`): allocate the tagged class, then
+    // fill its ivars from the coder.
+    const back = Object.create(Column.prototype) as Column;
+    back.initWith(JSON.parse(JSON.stringify(coder)));
 
     expect(back).toBeInstanceOf(Column);
     expect(back.autoIncrement).toBe(true);

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -59,6 +59,9 @@ describe("SQLite3::Column JSON round-trip", () => {
     expect(back.autoIncrement).toBe(true);
     expect(back.rowid).toBe(true);
     expect(back.isVirtualStored()).toBe(true);
-    expect(back).toEqual(col);
+    // Rails' `encode_with` writes no `@primary_key` (`column.rb:55-63`); the
+    // flag is the schema cache's, derived from its own `primary_keys` slot.
+    expect(coder).not.toHaveProperty("primary_key");
+    expect({ ...back, primaryKey: col.primaryKey }).toEqual({ ...col });
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -27,7 +27,6 @@ export class Column extends BaseColumn {
     options: {
       collation?: string | null;
       defaultFunction?: string | null;
-      primaryKey?: boolean;
       autoIncrement?: boolean;
       rowid?: boolean;
       generatedType?: "stored" | "virtual" | null;
@@ -43,7 +42,6 @@ export class Column extends BaseColumn {
     super(name, defaultValue, meta, null_, {
       collation: options.collation,
       defaultFunction: options.defaultFunction,
-      primaryKey: options.primaryKey,
     });
     this.autoIncrement = options.autoIncrement ?? false;
     this.rowid = options.rowid ?? false;

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -5,12 +5,12 @@
  */
 
 import { Column as BaseColumn } from "../column.js";
-import type { ColumnJSON } from "../column.js";
+import type { ColumnCoder } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
-  readonly autoIncrement: boolean;
-  readonly rowid: boolean;
+  autoIncrement: boolean;
+  rowid: boolean;
   private _generatedType: "stored" | "virtual" | null;
 
   constructor(
@@ -72,58 +72,19 @@ export class Column extends BaseColumn {
     );
   }
 
-  /**
-   * @noRailsEquivalent PERMANENT: the schema-cache dump. Rails dumps through
-   *   YAML/Marshal, which round-trips the adapter's Column subclass and its
-   *   state on its own (`schema_cache.rb:406`); trails' dump is JSON, so the
-   *   subclass has to spell out what it carries and tag itself for
-   *   `rehydrateColumn`. Mirrors MySQL::Column's pair.
-   */
-  override toJSON(): Sqlite3ColumnJSON {
-    return {
-      ...super.toJSON(),
-      __sqlite3: true,
-      autoIncrement: this.autoIncrement,
-      rowid: this.rowid,
-      generatedType: this._generatedType,
-    };
+  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
+  override initWith(coder: ColumnCoder): void {
+    super.initWith(coder);
+    this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
+    this.rowid = (coder["rowid"] as boolean) ?? false;
+    this._generatedType = (coder["generated_type"] as "stored" | "virtual" | null) ?? null;
   }
 
-  static override fromJSON(data: ColumnJSON): BaseColumn {
-    const s = data as Sqlite3ColumnJSON;
-    return new Column(
-      s.name,
-      s.default,
-      {
-        sqlType: s.sqlTypeMetadata?.sqlType,
-        type: s.sqlTypeMetadata?.type,
-        limit: s.sqlTypeMetadata?.limit ?? null,
-        precision: s.sqlTypeMetadata?.precision ?? null,
-        scale: s.sqlTypeMetadata?.scale ?? null,
-      },
-      s.null,
-      {
-        collation: s.collation,
-        defaultFunction: s.defaultFunction,
-        primaryKey: s.primaryKey,
-        autoIncrement: s.autoIncrement,
-        rowid: s.rowid,
-        generatedType: s.generatedType,
-      },
-    );
+  override encodeWith(coder: ColumnCoder): void {
+    super.encodeWith(coder);
+    coder["class"] = "SQLite3::Column";
+    coder["auto_increment"] = this.autoIncrement;
+    coder["rowid"] = this.rowid;
+    coder["generated_type"] = this._generatedType;
   }
-}
-
-/**
- * A dumped SQLite3::Column. Rails' schema-cache dump is YAML/Marshal, which
- * round-trips the adapter's Column subclass on its own; a JSON dump has to
- * carry the discriminator and the subclass' own state explicitly, or a cache
- * loaded from disk would answer `auto_increment?` and `virtual?` `false` for
- * every column (`schema_cache.rb:406`, `schema_cache.rb:228`).
- */
-export interface Sqlite3ColumnJSON extends ColumnJSON {
-  __sqlite3: true;
-  autoIncrement: boolean;
-  rowid: boolean;
-  generatedType: "stored" | "virtual" | null;
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -253,7 +253,6 @@ export function newColumnFromField(
       // trails-only: Rails' new_column_from_field passes no primary_key (PKs are
       // derived separately via primary_keys). trails' Column carries the flag and
       // `columns()` reflection consumers expect it set, so seed it from PRAGMA pk.
-      primaryKey: Number(field["pk"]) > 0,
       autoIncrement: Boolean(field["auto_increment"]),
       rowid,
       generatedType,

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -152,7 +152,15 @@ function conciseOptions<T>(
 export interface SchemaSource {
   /** @internal */
   tables(): string[] | Promise<string[]>;
-  columns(tableName: string): ColumnInfo[] | Promise<ColumnInfo[]>;
+  /**
+   * `pkNames` is the authoritative primary key for `tableName`, which the
+   * dumper has already fetched (`@connection.primary_key(table)`). Columns
+   * carry no primary-key flag of their own — Rails' Column classes have none —
+   * so a source that builds `ColumnInfo` from real columns uses this rather
+   * than issuing the key query a second time. Optional: mock sources that
+   * hand back `ColumnInfo` directly set `primaryKey` themselves.
+   */
+  columns(tableName: string, pkNames?: readonly string[]): ColumnInfo[] | Promise<ColumnInfo[]>;
   /** @internal */
   indexes(tableName: string): IndexInfo[] | Promise<IndexInfo[]>;
   /**
@@ -285,8 +293,23 @@ class AdapterSchemaSource implements SchemaSource {
     );
   }
 
-  async columns(tableName: string): Promise<ColumnInfo[]> {
+  /** @internal The authoritative primary key for `tableName`, as column names. */
+  private async _primaryKeyNames(tableName: string): Promise<string[]> {
+    const adapter = this._adapter as {
+      primaryKeys?: (t: string) => Promise<string[] | null | undefined>;
+    };
+    if (typeof adapter.primaryKeys !== "function") return [];
+    try {
+      return (await adapter.primaryKeys(tableName)) ?? [];
+    } catch {
+      // Live introspection is best-effort, as it is in SchemaDumper#table.
+      return [];
+    }
+  }
+
+  async columns(tableName: string, pkNames?: readonly string[]): Promise<ColumnInfo[]> {
     const cols = await this._adapter.columns(tableName);
+    const pk = new Set(pkNames ?? (await this._primaryKeyNames(tableName)));
     return cols.map((col) => {
       // Generated/virtual columns: carry the flag through so the dialect dumper's
       // schemaTypeWithVirtual / prepareColumnOptions emit `t.virtual` with
@@ -313,7 +336,7 @@ class AdapterSchemaSource implements SchemaSource {
         sqlType: col.sqlType ?? undefined,
         oid: (col as any).oid ?? undefined,
         fmod: (col as any).fmod ?? undefined,
-        primaryKey: col.primaryKey,
+        primaryKey: pk.has(col.name),
         null: col.null,
         // A virtual column has no user-visible default (Rails Column#has_default?
         // is false); clear it so schemaDefault doesn't emit a `default:` alongside
@@ -842,7 +865,7 @@ export abstract class SchemaDumper {
     }
     this.tableName = table;
     try {
-      const columns = await this._source.columns(table);
+      const columns = await this._source.columns(table, this.primaryKeyOrderCache[table]);
       const rawIndexes = await this._source.indexes(table);
       const indexes = await this.filterIndexesForDump(table, rawIndexes);
       const adapterTableOpts = await this.fetchTableOptions(table);

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -31,6 +31,26 @@ describe("templateSchemaCache", () => {
   });
 
   /**
+   * The warm installs the dump by *replacing* the pool's cache object, as
+   * Rails' `load_cache` does (`schema_cache.rb:116-139`). Every adapter-side
+   * consumer has to see it through that swap — `AbstractAdapter#schemaCache`
+   * and `#internalSchemaCache`, and `TypeCaster::Connection` via
+   * `poolConfig.schemaCache` — which is only true because each reads the
+   * reflection's slot live rather than holding a cache by identity.
+   */
+  it("is one object, reached by every adapter-side consumer after the swap", () => {
+    const conn = Base.connection;
+    const installed = conn.pool.schemaReflection.loadedCache;
+    expect(installed).not.toBeNull();
+    expect(conn.internalSchemaCache).toBe(installed);
+    expect(Base.connectionPool().poolConfig.schemaCache).toBe(installed);
+    // Not the shared module-scoped dump: each pool installs its own dup, as
+    // Rails gets for free from `_load_from` running per reflection
+    // (`schema_cache.rb:116-121`).
+    expect(installed).not.toBe(templateSchemaCache());
+  });
+
+  /**
    * The boot fingerprint is the baseline the replay compares against, but it is
    * not an invariant of a running worker: a file that alters a canonical table
    * and leaves it altered is exactly the case the guard exists for, and the

--- a/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
+++ b/packages/activerecord/src/support/schema-cache-dump.trails.test.ts
@@ -36,7 +36,10 @@ describe("templateSchemaCache", () => {
    * consumer has to see it through that swap — `AbstractAdapter#schemaCache`
    * and `#internalSchemaCache`, and `TypeCaster::Connection` via
    * `poolConfig.schemaCache` — which is only true because each reads the
-   * reflection's slot live rather than holding a cache by identity.
+   * reflection's slot live rather than holding a cache by identity. The
+   * installed cache is not the shared module-scoped dump either: each pool gets
+   * its own dup, as Rails gets for free from `_load_from` running per reflection
+   * (`schema_cache.rb:116-121`).
    */
   it("is one object, reached by every adapter-side consumer after the swap", () => {
     const conn = Base.connection;
@@ -44,9 +47,6 @@ describe("templateSchemaCache", () => {
     expect(installed).not.toBeNull();
     expect(conn.internalSchemaCache).toBe(installed);
     expect(Base.connectionPool().poolConfig.schemaCache).toBe(installed);
-    // Not the shared module-scoped dump: each pool installs its own dup, as
-    // Rails gets for free from `_load_from` running per reflection
-    // (`schema_cache.rb:116-121`).
     expect(installed).not.toBe(templateSchemaCache());
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1447,26 +1447,27 @@ describe("DatabaseTaskCheckTargetVersionTest", () => {
   });
 
   it("check target version does not raise error on empty version", () => {
-    expect(() => DatabaseTasks.checkTargetVersion("")).not.toThrow();
+    process.env.VERSION = "";
+    expect(() => DatabaseTasks.checkTargetVersion()).not.toThrow();
   });
 
   it("check target version does not raise error if version is not set", () => {
     delete process.env.VERSION;
-    expect(() => DatabaseTasks.checkTargetVersion(undefined)).not.toThrow();
+    expect(() => DatabaseTasks.checkTargetVersion()).not.toThrow();
   });
 
   it("check target version raises error on invalid version format", () => {
     for (const version of ["unknown", "0.1.11", "1.1.11", "0 ", "1.", "1_", "1_name"]) {
-      expect(() => DatabaseTasks.checkTargetVersion(version)).toThrow(
-        /Invalid format of target version/,
-      );
+      process.env.VERSION = version;
+      expect(() => DatabaseTasks.checkTargetVersion()).toThrow(/Invalid format of target version/);
     }
   });
 
   it("check target version does not raise error on valid version format", () => {
     // Rails' last case is `001_name.rb`; trails' migrations are `.ts`/`.js`.
     for (const version of ["0", "1", "001", "1_001", "001_name.ts", "20230101120000"]) {
-      expect(() => DatabaseTasks.checkTargetVersion(version)).not.toThrow();
+      process.env.VERSION = version;
+      expect(() => DatabaseTasks.checkTargetVersion()).not.toThrow();
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1141,11 +1141,11 @@ describe("DatabaseTasksMigrateStatusTest", () => {
 
 describe("DatabaseTasksMigrateErrorTest", () => {
   it("migrate raise error on invalid version format", async () => {
-    setEnv("TRAILS_MIGRATION_VERSION", "abc");
+    setEnv("VERSION", "abc");
     try {
       await expect(DatabaseTasks.migrate()).rejects.toThrow(/Invalid format/);
     } finally {
-      setEnv("TRAILS_MIGRATION_VERSION", undefined);
+      setEnv("VERSION", undefined);
     }
   });
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -496,8 +496,19 @@ export class DatabaseTasks {
    *   arguments since it gained Rails' `async:` kwarg (result.rb:94-100) —
    *   nothing in the TS body was dropped.
    *
-   * `TRAILS_MIGRATION_VERSION` is canonical; `VERSION` is the legacy fallback
-   * (one-release window). The `to_i` is Rails'
+   * The env key is `TRAILS_MIGRATION_VERSION`, not Rails' bare `VERSION`, with
+   * `VERSION` kept as a legacy fallback (one-release window). That is a
+   * deliberate repo-wide deviation, not a local choice: BC-2 renamed AR's
+   * process env vars under a `TRAILS_` prefix — `NODE_ENV` → `TRAILS_ENV`,
+   * `VERSION` → `TRAILS_MIGRATION_VERSION`
+   * (`docs/infrastructure/browser-compat-plan.md`, shipped in #1251) — and the
+   * trails-prefixed name outranks the unprefixed one wherever both are read.
+   * {@link checkTargetVersion} reads this method rather than the env directly,
+   * so the pair stays single-source over that one key exactly as Rails'
+   * `check_target_version` / `target_version` are single-source over
+   * `ENV["VERSION"]` (`database_tasks.rb:317-325`).
+   *
+   * The `to_i` is Rails'
    * (`ENV["VERSION"].to_i`, database_tasks.rb:323-325) and never fails —
    * `"unknown"` is `0`, which is truthy in Ruby and is exactly what lets
    * {@link checkTargetVersion} reach its format check for a malformed VERSION.

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -495,14 +495,15 @@ export class DatabaseTasks {
    *   `empty?` maps onto the unrelated `ActiveRecord::Result.empty`, which takes
    *   arguments since it gained Rails' `async:` kwarg (result.rb:94-100) —
    *   nothing in the TS body was dropped.
+   *
+   * `TRAILS_MIGRATION_VERSION` is canonical; `VERSION` is the legacy fallback
+   * (one-release window). The `to_i` is Rails'
+   * (`ENV["VERSION"].to_i`, database_tasks.rb:323-325) and never fails —
+   * `"unknown"` is `0`, which is truthy in Ruby and is exactly what lets
+   * {@link checkTargetVersion} reach its format check for a malformed VERSION.
    */
   static targetVersion(): number | null {
-    // TRAILS_MIGRATION_VERSION is canonical; VERSION is the legacy fallback (one-release window).
     const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
-    // Rails: `ENV["VERSION"].to_i if ENV["VERSION"] && !ENV["VERSION"].empty?`
-    // (database_tasks.rb:323-325). `to_i` never fails — "unknown" is 0, and 0 is
-    // truthy in Ruby, which is what lets `check_target_version` below reach its
-    // format check for a malformed VERSION.
     if (version === undefined || version === "") return null;
     const match = version.match(/^\s*(-?\d+)/);
     return match ? Number(match[1]) : 0;
@@ -1018,12 +1019,18 @@ export class DatabaseTasks {
     await this.seedLoader.loadSeed();
   }
 
+  /**
+   * Mirrors: `ActiveRecord::Tasks::DatabaseTasks#migrate_status`
+   * (`database_tasks.rb:302-315`), which `databases.rake:230-232` calls rather
+   * than inlining.
+   *
+   * The missing-table arm is Rails' `Kernel.abort` (`:304`) as a throw:
+   * `Kernel.abort` exits the process, which a library method has no business
+   * doing here, so the CLI's own error-to-exit-code path carries it. Same shape
+   * {@link checkSchemaFile} already takes for the same Ruby call.
+   */
   static async migrateStatus(): Promise<void> {
     if (!(await this.migrationConnectionPool().schemaMigration.tableExists())) {
-      // Rails: Kernel.abort "Schema migrations table does not exist yet."
-      // (database_tasks.rb:303-305). Same shape as checkSchemaFile above:
-      // Kernel.abort exits the process, which a library method has no business
-      // doing in trails, so the CLI's own error-to-exit-code path carries it.
       throw new Error("Schema migrations table does not exist yet.");
     }
     const rows = await this.migrationConnectionPool().migrationContext.migrationsStatus();

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -499,18 +499,19 @@ export class DatabaseTasks {
   static targetVersion(): number | null {
     // TRAILS_MIGRATION_VERSION is canonical; VERSION is the legacy fallback (one-release window).
     const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
-    if (!version) return null;
-    const str = version.trim();
-    if (str === "" || !/^\d+$/.test(str)) return null;
-    return parseInt(str, 10);
+    // Rails: `ENV["VERSION"].to_i if ENV["VERSION"] && !ENV["VERSION"].empty?`
+    // (database_tasks.rb:323-325). `to_i` never fails — "unknown" is 0, and 0 is
+    // truthy in Ruby, which is what lets `check_target_version` below reach its
+    // format check for a malformed VERSION.
+    if (version === undefined || version === "") return null;
+    const match = version.match(/^\s*(-?\d+)/);
+    return match ? Number(match[1]) : 0;
   }
 
-  static checkTargetVersion(version?: number | string): void {
-    const v = version ?? getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
-    if (v === undefined || v === null || String(v) === "") return;
-    const str = String(v);
-    if (!Migration.isValidVersionFormat(str)) {
-      throw new Error(`Invalid format of target version: \`VERSION=${str}\``);
+  static checkTargetVersion(): void {
+    const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
+    if (this.targetVersion() !== null && !Migration.isValidVersionFormat(version ?? "")) {
+      throw new Error(`Invalid format of target version: \`VERSION=${version}\``);
     }
   }
 
@@ -1018,19 +1019,21 @@ export class DatabaseTasks {
   }
 
   static async migrateStatus(): Promise<void> {
-    const pool = this.migrationConnectionPool();
-    if (!(await pool.schemaMigration.tableExists())) {
+    if (!(await this.migrationConnectionPool().schemaMigration.tableExists())) {
+      // Rails: Kernel.abort "Schema migrations table does not exist yet."
+      // (database_tasks.rb:303-305). Same shape as checkSchemaFile above:
+      // Kernel.abort exits the process, which a library method has no business
+      // doing in trails, so the CLI's own error-to-exit-code path carries it.
       throw new Error("Schema migrations table does not exist yet.");
     }
-    const rows = await pool.migrationContext.migrationsStatus();
-    const dbName = pool.dbConfig.database ?? ":memory:";
+    const rows = await this.migrationConnectionPool().migrationContext.migrationsStatus();
     const center = (s: string, w: number) => {
       const pad = w - s.length;
       const left = Math.floor(pad / 2);
       return " ".repeat(left) + s + " ".repeat(pad - left);
     };
     const puts = (s = "") => stdout.write(s + "\n");
-    puts(`\ndatabase: ${dbName}\n`);
+    puts(`\ndatabase: ${this.migrationConnectionPool().dbConfig.database}\n`);
     puts(`${center("Status", 8)}  ${"Migration ID".padEnd(14)}  Migration Name`);
     puts("-".repeat(50));
     for (const row of rows) {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -317,8 +317,8 @@ export class DatabaseTasks {
    * @param version Exact-version *filter* — only the migration with this
    *   version runs (`db:migrate:up` / `:down` semantics). Rails' `db:migrate`
    *   rake task never passes it. "Migrate up to here" is
-   *   `ENV["TRAILS_MIGRATION_VERSION"]`, read through {@link targetVersion},
-   *   exactly as Rails reads `ENV["VERSION"]` (`database_tasks.rb:268-269`).
+   *   `ENV["VERSION"]`, read through {@link targetVersion}, exactly as Rails
+   *   reads it (`database_tasks.rb:268-269`).
    */
   static async migrate(options?: { skipInitialize?: boolean }): Promise<void>;
   static async migrate(
@@ -496,17 +496,9 @@ export class DatabaseTasks {
    *   arguments since it gained Rails' `async:` kwarg (result.rb:94-100) —
    *   nothing in the TS body was dropped.
    *
-   * The env key is `TRAILS_MIGRATION_VERSION`, not Rails' bare `VERSION`, with
-   * `VERSION` kept as a legacy fallback (one-release window). That is a
-   * deliberate repo-wide deviation, not a local choice: BC-2 renamed AR's
-   * process env vars under a `TRAILS_` prefix — `NODE_ENV` → `TRAILS_ENV`,
-   * `VERSION` → `TRAILS_MIGRATION_VERSION`
-   * (`docs/infrastructure/browser-compat-plan.md`, shipped in #1251) — and the
-   * trails-prefixed name outranks the unprefixed one wherever both are read.
    * {@link checkTargetVersion} reads this method rather than the env directly,
-   * so the pair stays single-source over that one key exactly as Rails'
-   * `check_target_version` / `target_version` are single-source over
-   * `ENV["VERSION"]` (`database_tasks.rb:317-325`).
+   * so the pair is single-source over `ENV["VERSION"]` exactly as Rails'
+   * `check_target_version` / `target_version` are (`database_tasks.rb:317-325`).
    *
    * The `to_i` is Rails'
    * (`ENV["VERSION"].to_i`, database_tasks.rb:323-325) and never fails —
@@ -514,14 +506,14 @@ export class DatabaseTasks {
    * {@link checkTargetVersion} reach its format check for a malformed VERSION.
    */
   static targetVersion(): number | null {
-    const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
+    const version = getEnv("VERSION");
     if (version === undefined || version === "") return null;
     const match = version.match(/^\s*(-?\d+)/);
     return match ? Number(match[1]) : 0;
   }
 
   static checkTargetVersion(): void {
-    const version = getEnv("TRAILS_MIGRATION_VERSION") ?? getEnv("VERSION");
+    const version = getEnv("VERSION");
     if (this.targetVersion() !== null && !Migration.isValidVersionFormat(version ?? "")) {
       throw new Error(`Invalid format of target version: \`VERSION=${version}\``);
     }

--- a/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-fixtures/with-transactional-fixtures.ts
@@ -10,7 +10,7 @@ import { Base } from "../base.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { NullPool } from "../connection-adapters/abstract/connection-pool.js";
-import type { SchemaCache } from "../connection-adapters/schema-cache.js";
+import { SchemaReflection, type SchemaCache } from "../connection-adapters/schema-cache.js";
 import {
   dumpedTables,
   fingerprintOf,
@@ -78,7 +78,7 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
   if (!sc || pool === null) return;
   try {
     const dumped = templateSchemaCache();
-    if (dumped && (await replaySchemaCacheDump(adapter, pool, sc, dumped))) return;
+    if (dumped && (await replaySchemaCacheDump(adapter, pool, dumped))) return;
     await sc.addAll(pool);
   } catch {
     // best-effort warm
@@ -101,25 +101,28 @@ async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Prom
  * `beforeAll` — are reflected individually, a handful of `add`s rather than
  * ~200.
  *
- * Rails installs a loaded dump by replacing the cache object
- * (`schema_cache.rb:139`, whose `load_cache` returns the new cache for
- * `SchemaReflection` to hold). This loads into the cache the pool already
- * handed out instead, because trails' adapter-side consumers hold
- * `internalSchemaCache` by identity — the same reason `ConnectionPool` assigns
- * a loaded cache back onto `poolConfig.schemaCache` rather than letting the two
- * diverge (`connection-pool.ts` lazy-load).
+ * The install is Rails': `load_cache` returns a freshly built `SchemaCache` and
+ * the `SchemaReflection` holds it (`schema_cache.rb:116-139`, `:16-19`) — the
+ * cache object is *replaced*, never loaded into. `ConnectionPool#schemaReflection=`
+ * (`connection_pool.rb:289-292`) is that replacement reached from a caller that
+ * holds an adapter, and every adapter-side consumer — `AbstractAdapter#schemaCache`,
+ * `#internalSchemaCache`, `TypeCaster::Connection` via `poolConfig.schemaCache` —
+ * reads the reflection's slot live on each access, so they all see the new cache.
+ *
+ * The dump is module-scoped and shared by every pool this file warms, so each
+ * pool installs its own dup: Rails gets that for free from `_load_from` running
+ * per reflection.
  */
 async function replaySchemaCacheDump(
   adapter: TransactionalFixturesAdapter,
   pool: ConnectionPool,
-  sc: NonNullable<TransactionalFixturesAdapter["internalSchemaCache"]>,
   dumped: SchemaCache,
 ): Promise<boolean> {
-  const marshalled = dumped.marshalDump();
-  const cached = dumpedTables(marshalled);
+  const cached = dumpedTables(dumped.marshalDump());
   const shapes = await schemaShapes(adapter);
   if (fingerprintOf(shapes, cached) !== templateSchemaFingerprint()) return false;
-  sc.marshalLoad(marshalled);
+  pool.schemaReflection = new SchemaReflection(null, dumped.initializeDup());
+  const sc = adapter.internalSchemaCache;
   for (const table of shapes.keys()) {
     if (!cached.has(table)) await sc.add(pool, table);
   }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -571,21 +571,20 @@ async function withMigrationTasksForDb(
 }
 
 /**
- * Runs `fn` with `TRAILS_MIGRATION_VERSION` set to `targetVersion`, so
- * `DatabaseTasks.target_version` sees it exactly as it sees Rails'
- * `ENV["VERSION"]` (`tasks/database_tasks.rb:268`).
+ * Runs `fn` with `VERSION` set to `targetVersion`, the env var
+ * `DatabaseTasks.targetVersion` reads (`tasks/database_tasks.rb:268`, `:323`).
  */
 async function withTargetVersionEnv(
   targetVersion: string | null,
   fn: () => Promise<void>,
 ): Promise<void> {
   if (targetVersion === null) return fn();
-  const was = env.TRAILS_MIGRATION_VERSION;
-  setEnv("TRAILS_MIGRATION_VERSION", targetVersion);
+  const was = env.VERSION;
+  setEnv("VERSION", targetVersion);
   try {
     await fn();
   } finally {
-    setEnv("TRAILS_MIGRATION_VERSION", was);
+    setEnv("VERSION", was);
   }
 }
 
@@ -834,9 +833,7 @@ export function dbCommand(): Command {
    * themselves (`database_tasks.rb:317-325`), so the `--version` flag is
    * published as the env var rather than threaded through the predicate, and
    * `migration_context.run` is handed `target_version` read back off it — one
-   * source, as in the rake task. The key published is trails'
-   * `TRAILS_MIGRATION_VERSION` rather than Rails' bare `VERSION`; see
-   * `DatabaseTasks.targetVersion` for why that rename is repo-wide.
+   * source, as in the rake task.
    *
    * Commander's `requiredOption` is the CLI form of the rake task's
    * `raise "VERSION is required"` guard (`databases.rake:169`, `:198`).

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -827,6 +827,13 @@ export function dbCommand(): Command {
       });
     });
 
+  /**
+   * `db:migrate:up` / `db:migrate:down` — `check_target_version` then
+   * `migration_context.run(:up | :down, target_version)`
+   * (`railties/databases.rake:165-208`). Both of those read `ENV["VERSION"]`
+   * themselves (`database_tasks.rb:317-325`), so the `--version` flag is
+   * published as the env var rather than threaded through the predicate.
+   */
   cmd
     .command("migrate:up")
     .description("Run a specific migration up (by version)")
@@ -835,11 +842,6 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          // Rails' rake task sets nothing: `check_target_version` and
-          // `target_version` both read ENV["VERSION"] themselves
-          // (`databases.rake:171-177`, `database_tasks.rb:317-325`), so the
-          // --version flag is published as the env var rather than threaded
-          // through the predicate.
           await withTargetVersionEnv(opts.version, async () => {
             DatabaseTasks.checkTargetVersion();
             await DatabaseTasks.migrationConnectionPool().migrationContext.run(
@@ -859,8 +861,6 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          // Same env-var contract as migrate:up above
-          // (`databases.rake:195-207`).
           await withTargetVersionEnv(opts.version, async () => {
             DatabaseTasks.checkTargetVersion();
             await DatabaseTasks.migrationConnectionPool().migrationContext.run(

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -832,7 +832,14 @@ export function dbCommand(): Command {
    * `migration_context.run(:up | :down, target_version)`
    * (`railties/databases.rake:165-208`). Both of those read `ENV["VERSION"]`
    * themselves (`database_tasks.rb:317-325`), so the `--version` flag is
-   * published as the env var rather than threaded through the predicate.
+   * published as the env var rather than threaded through the predicate, and
+   * `migration_context.run` is handed `target_version` read back off it — one
+   * source, as in the rake task. The key published is trails'
+   * `TRAILS_MIGRATION_VERSION` rather than Rails' bare `VERSION`; see
+   * `DatabaseTasks.targetVersion` for why that rename is repo-wide.
+   *
+   * Commander's `requiredOption` is the CLI form of the rake task's
+   * `raise "VERSION is required"` guard (`databases.rake:169`, `:198`).
    */
   cmd
     .command("migrate:up")

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -835,8 +835,18 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          DatabaseTasks.checkTargetVersion(opts.version);
-          await DatabaseTasks.migrationConnectionPool().migrationContext.run("up", opts.version);
+          // Rails' rake task sets nothing: `check_target_version` and
+          // `target_version` both read ENV["VERSION"] themselves
+          // (`databases.rake:171-177`, `database_tasks.rb:317-325`), so the
+          // --version flag is published as the env var rather than threaded
+          // through the predicate.
+          await withTargetVersionEnv(opts.version, async () => {
+            DatabaseTasks.checkTargetVersion();
+            await DatabaseTasks.migrationConnectionPool().migrationContext.run(
+              "up",
+              DatabaseTasks.targetVersion()!,
+            );
+          });
         });
       });
     });
@@ -849,8 +859,15 @@ export function dbCommand(): Command {
     .action(async (opts) => {
       await forEachDatabase(opts, async (ctx) => {
         await withMigrationTasksForDb(ctx, async () => {
-          DatabaseTasks.checkTargetVersion(opts.version);
-          await DatabaseTasks.migrationConnectionPool().migrationContext.run("down", opts.version);
+          // Same env-var contract as migrate:up above
+          // (`databases.rake:195-207`).
+          await withTargetVersionEnv(opts.version, async () => {
+            DatabaseTasks.checkTargetVersion();
+            await DatabaseTasks.migrationConnectionPool().migrationContext.run(
+              "down",
+              DatabaseTasks.targetVersion()!,
+            );
+          });
         });
       });
     });

--- a/scripts/parity/pipeline/schema/node/dump.ts
+++ b/scripts/parity/pipeline/schema/node/dump.ts
@@ -95,12 +95,16 @@ async function main(): Promise<void> {
 
     for (const tableName of tables) {
       const cols = await adapter.columns(tableName);
+      // Columns carry no primary-key flag (Rails' do not either); the key is
+      // the adapter's own `primary_key(table)`.
+      const tablePk = await adapter.primaryKey(tableName);
+      const pkNames = new Set(tablePk == null ? [] : Array.isArray(tablePk) ? tablePk : [tablePk]);
       const idxDefs = (await adapter.indexes(tableName)) as IntrospectedIndex[];
 
       const columns: NativeColumn[] = cols.map((col) => ({
         name: col.name,
         sqlType: col.sqlType ?? col.type ?? "",
-        primaryKey: col.primaryKey,
+        primaryKey: pkNames.has(col.name),
         null: col.null,
         default: col.default !== null && col.default !== undefined ? String(col.default) : null,
         limit: col.limit,


### PR DESCRIPTION
Converges four RFC-tracked deviations.

**Schema-cache dump installation** (RFC 0078). Rails installs a loaded dump by
*replacing* the cache object — `load_cache` builds a fresh `SchemaCache` and the
`SchemaReflection` holds it (`schema_cache.rb:116-139`, `:16-19`). The fixtures
warm was doing the opposite, `marshalLoad`ing a dump into the cache the pool had
already handed out, on the premise that adapter-side consumers hold
`internalSchemaCache` by identity. They do not: `AbstractAdapter#internalSchemaCache`,
`#schemaCache` and `poolConfig.schemaCache` all read the reflection's slot live,
so `pool.schemaReflection = new SchemaReflection(null, dump.dup)` —
`ConnectionPool#schema_reflection=` (`connection_pool.rb:289-292`) — is a
sufficient install, and the marshal round-trip is gone. `ConnectionPool`'s
setter no longer nulls `poolConfig.schemaCache` afterwards, which read through
to the new reflection and threw the just-installed cache away.

**`Column#encodeWith` / `#initWith`** (RFC 0096) replace the bespoke
`toJSON` / `static fromJSON` pair on the base class and all three adapter
subclasses, at Rails' names and coder argument (`column.rb:46-63`). The
`__mysql` / `__postgresql` / `__sqlite3` discriminator booleans collapse into
one `class` key — the JSON stand-in for YAML's `!ruby/object:` tag — and
`rehydrateColumn` restores through Psych's shape: allocate the tagged class,
then `initWith` the coder. The three `@noRailsEquivalent PERMANENT` tags go with
the methods; the one surviving deviation, subclass state in the dump where
Rails' `encode_with` writes seven keys and drops it, is documented at
`Column#encodeWith` with the `test_clear_cache!` constraint that forces it.

**`DatabaseTasks.checkTargetVersion`** (RFC 0051) is zero-arity and reads
`ENV["VERSION"]` through `targetVersion()`, as Rails does
(`database_tasks.rb:317-321`). `targetVersion` gains Rails' `to_i` semantics so
a malformed VERSION still reaches the format check; trails' digits-only regex
returned null and skipped it. trailties' `migrate:up` / `migrate:down` publish
`--version` as the env var, which is what the rake task's caller does
(`databases.rake:165-208`).

**`DatabaseTasks.migrateStatus`** (RFC 0051) drops the invented `":memory:"`
fallback and prints `db_config.database` bare (`database_tasks.rb:308`), and
re-reads `migration_connection_pool` at each of Rails' three use sites. The
`Kernel.abort` arm stays a throw, cited at the call site as language-forced —
the same shape `checkSchemaFile` already takes.

Closes-story: converge-schema-cache-install-onto-cache-replacement
Closes-story: check-target-version-takes-a-version-argument-rails-takes-none
Closes-story: migrate-status-aborts-as-error-and-invents-a-memory-database-fallback
Closes-story: converge-column-encode-with-init-with

---

## Review round 1

**`primary_key` in the column coder — fixed.** The reviewer is right: Rails'
`Column#encode_with` writes seven keys and no `@primary_key`
(`column.rb:55-63`), because primary-key membership is not column state in
Rails — it lives in the cache's own `@primary_keys` slot, which `marshal_dump`
carries separately (`schema_cache.rb:416`). `primary_key` is out of the coder,
which now matches Rails' key set and order exactly.

It was load-bearing, though — dropping it outright reds 3 tests
(`schema-dumper.ts:316,973` reads `col.primaryKey`), because trails' Column does
carry the flag. So it is now *derived* from the authoritative slot on the load
path: `SchemaCache#deriveColumnsHashAndDeduplicateValues` — the tail of both
`initWith` and `marshalLoad` — sets each column's flag from `_primaryKeys` once
both halves are loaded. That is a derive, distinct from the existing clear-only
`reconcilePrimaryKeyFlags` used on the reflect path: on the load path there is
no adapter-reported flag to preserve or contradict, so the slot is the only
source. Free side effect — MySQL's promoted-unique false positive is now dropped
out of any older dump too.

**`TRAILS_MIGRATION_VERSION` — fixed.** Converged to `ENV["VERSION"]`, per the
maintainer's call on the escalation below.

Digging turned up that the previous form, `TRAILS_MIGRATION_VERSION ?? VERSION`,
was wrong under *both* governing registers: Rails reads only `ENV["VERSION"]`
(`database_tasks.rb:317-325`), and BC-2's own read-back policy is "read the
`TRAILS_` name only — no fallback, direct replacement". So the compatibility arm
had no defender either way; the only live question was which single key remains.
That was a collision between the story's acceptance criterion and a shipped
repo-wide rename that names this exact file and variable, so it went to the
maintainer rather than being decided in review. **Answer: Rails fidelity wins for
this variable.**

`VERSION` is now the only key `targetVersion()` reads, and the only key
published by `trails db migrate:up` / `:down` (`withTargetVersionEnv`) and
`ar db:migrate --version` (`activerecord-cli/src/db-tasks.ts:113-122`); the test
that pinned the prefixed name moves with them. Recorded as a per-variable
exception in `docs/infrastructure/browser-compat-plan.md` so the next reader
doesn't re-derive the rename — `TRAILS_ENV` and
`TRAILS_DISABLE_DATABASE_ENVIRONMENT_CHECK` are unaffected. The follow-up story
I had filed for the fallback is closed as obsolete.

Also corrected: an earlier revision of this description claimed the pair read
`ENV["VERSION"]` when it did not. It does now.


---

## Review rounds 3–4 — `primary_key` converged by deleting the field

Round 2 dropped `primary_key` from the coder and derived it from the cache's
slot; CI red it on PG + MariaDB. Round 3 restored the key with a documented
deviation; the reviewer correctly held that this leaves the story's key-set
acceptance unmet. Round 4 converges it properly: **`Column#primaryKey` is gone.**

The unblocking fact: **no Rails Column class carries a primary-key concept at
all** — `grep -n primary` over `column.rb` and every adapter subclass returns
nothing. So the field was trails-only, and its value was adapter-dependent
(sqlite3 reflected `true`, postgresql and mysql `false`), which is exactly why
the dump had to carry it verbatim and why each earlier attempt red a different
lane. Removing the field removes the disagreement at the source:

- the three adapter `columns()` paths no longer set it
- `SchemaCache#reconcilePrimaryKeyFlags` goes with it, as does
  `getCachedPrimaryKeys`' column-flag fallback — `_primaryKeys` is the only
  source now
- the schema dumper fills `ColumnInfo.primaryKey` from the authoritative key
  `SchemaDumper#table` has **already** fetched, threaded through
  `SchemaSource#columns(tableName, pkNames)`

That last point matters: populating it with a fresh `primaryKeys()` call per
table cost ~5% on the dump and pushed `schema dump include migration version`
against its budget. Threading the already-fetched key issues **no extra query**
— that test measures 5.09s on PG against a 6.06s baseline, i.e. faster than
before this PR.

`ColumnInfo.primaryKey` stays: it is the dumper's own DTO and mock sources set
it directly. `Column#encodeWith` / `initWith` now carry exactly Rails' seven
keys, in Rails' order, with no deviation note.

Tests for the removed machinery are removed with it (all trails-only, no Rails
counterpart). One assertion converges rather than disappears: `marshal dump and
load with gzip` now asserts `cache.primaryKeys(null, "courses") === "id"`,
mirroring Rails' `assert_equal "id", cache.primary_keys("courses")`
(`schema_cache_test.rb:225`), where it had asserted a column flag.

The RFC 0078 follow-up story I had filed for this is closed — the work is here.

Verified on all three lanes before pushing, after the rebase: sqlite3 (548
tests), postgres:17 (375), mariadb:11 (319). Call-mismatch baseline drops
417 → 416.
