### PR TITLE
fix(activerecord,trailties): pendingMigrations mirrors Rails; collection inverse write via inversedFrom

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -571,13 +571,16 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
     (assoc as unknown as { _explicitTarget: boolean })._explicitTarget = true;
     return;
   }
+  // A collection inverse takes the same single Rails inverse write as the
+  // singular arm — `set_inverse_instance` → `inversed_from`
+  // (association.rb:132-137, 153-155), whose `self.target = record` lands on
+  // `CollectionAssociation#target=` (collection_association.rb:284-295).
+  // `_explicitTarget` is deliberately NOT raised here: `setInverseInstance`
+  // skips it for a collection too, and only `_loadedSingularTarget` reads it.
   const existing = record._associationInstances.get(assocName) as
-    | { _setTargetFromLoader(t: unknown): void; _explicitTarget?: boolean }
+    | { inversedFrom(record: Base | null): void }
     | undefined;
-  if (existing) {
-    existing._setTargetFromLoader(target);
-    existing._explicitTarget = true;
-  }
+  existing?.inversedFrom(target);
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -540,10 +540,10 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
 }
 
 /**
- * Write a singular (belongs_to / has_one) target onto the record's
- * `SingularAssociation` holder, reached via `record.association(name)` and
- * stored there as `target` — the trails analog of Rails' `@target` living on
- * the association object (`@association_cache[name]`). Every write is Rails'
+ * Write an inverse target onto the record's holder for `assocName`, reached
+ * via `record.association(name)` and stored there as `target` — the trails
+ * analog of Rails' `@target` living on the association object
+ * (`@association_cache[name]`). Every write is Rails'
  * one inverse write, `set_inverse_instance` -> `inversed_from`
  * (`association.rb:132-137, 153-155`); a collection name reaches
  * `CollectionAssociation#target=` (`collection_association.rb:284-295`)

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -543,8 +543,12 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
  * Write a singular (belongs_to / has_one) target onto the record's
  * `SingularAssociation` holder, reached via `record.association(name)` and
  * stored there as `target` — the trails analog of Rails' `@target` living on
- * the association object (`@association_cache[name]`). Only singular inverses
- * get the holder write; a collection inverse name is left to its proxy.
+ * the association object (`@association_cache[name]`). Every write is Rails'
+ * one inverse write, `set_inverse_instance` -> `inversed_from`
+ * (`association.rb:132-137, 153-155`); a collection name reaches
+ * `CollectionAssociation#target=` (`collection_association.rb:284-295`)
+ * through it, and does not raise `_explicitTarget`, which `setInverseInstance`
+ * likewise skips for a collection and only `_loadedSingularTarget` reads.
  *
  * RFC 0022: writers and inverse-of seeders route through the holder, which is
  * the single source of truth — surfaced to readers via `Base#_associationCache`.
@@ -571,16 +575,7 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
     (assoc as unknown as { _explicitTarget: boolean })._explicitTarget = true;
     return;
   }
-  // A collection inverse takes the same single Rails inverse write as the
-  // singular arm — `set_inverse_instance` → `inversed_from`
-  // (association.rb:132-137, 153-155), whose `self.target = record` lands on
-  // `CollectionAssociation#target=` (collection_association.rb:284-295).
-  // `_explicitTarget` is deliberately NOT raised here: `setInverseInstance`
-  // skips it for a collection too, and only `_loadedSingularTarget` reads it.
-  const existing = record._associationInstances.get(assocName) as
-    | { inversedFrom(record: Base | null): void }
-    | undefined;
-  existing?.inversedFrom(target);
+  record._associationInstances.get(assocName)?.inversedFrom(target);
 }
 
 /**

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2811,31 +2811,13 @@ export class Migrator {
   }
 
   /**
-   * Read-only variant of {@link pendingMigrations}: does not create the
-   * schema_migrations / ar_internal_metadata tables. Treats a missing
-   * schema_migrations as "no applied versions", so every known migration
-   * is considered pending.
-   *
-   * Matches Rails' `pending_migration_versions` (built from
-   * `get_all_versions`, which checks `table_exists?` and returns [] on
-   * miss).
-   */
-  async pendingMigrationsReadOnly(): Promise<MigrationProxy[]> {
-    const applied = (await this._schemaMigration.tableExists())
-      ? await this._appliedVersions()
-      : new Set<number>();
-    return this.migrations.filter((m) => !applied.has(m.version));
-  }
-
-  /**
    * Get pending (unapplied) migrations.
    *
    * Mirrors: ActiveRecord::Migrator#pending_migrations
    */
   async pendingMigrations(): Promise<MigrationProxy[]> {
-    await this._ensureSchemaTable();
-    const applied = await this.migrated();
-    return this.migrations.filter((m) => !applied.has(m.version));
+    const alreadyMigrated = await this.migrated();
+    return this.migrations.filter((m) => !alreadyMigrated.has(m.version));
   }
 
   /**

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -201,9 +201,6 @@ describe("Migrator trails extensions", () => {
 
     const pending = await migrator.pendingMigrations();
     expect(pending.map((m) => m.version)).toEqual([3, 1]);
-
-    const pendingReadOnly = await migrator.pendingMigrationsReadOnly();
-    expect(pendingReadOnly.map((m) => m.version)).toEqual([3, 1]);
   });
 
   it("migrate returns [] when both the current and target version are 0", async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -830,10 +830,7 @@ export function dbCommand(): Command {
         const migrations = discoverMigrations(mDirs);
         if (migrations.length === 0) return;
         const migrator = createMigrator(adapter, migrations);
-        // Use the read-only pending check so running this in a
-        // production-health-check context (e.g. before deploying) doesn't
-        // silently create schema_migrations / ar_internal_metadata.
-        const pending = await migrator.pendingMigrationsReadOnly();
+        const pending = await migrator.pendingMigrations();
         if (pending.length > 0) {
           // Match Rails' output format (from activerecord/lib/active_record/
           // railties/databases.rake), with the command name swapped for


### PR DESCRIPTION
Two RFC stories, one PR.

## `Migrator#pendingMigrations` (RFC 0051)

`pending_migrations` (`migration.rb:1475-1478`) is two lines and calls nothing
else:

```ruby
def pending_migrations
  already_migrated = migrated
  migrations.reject { |m| already_migrated.include?(m.version) }
end
```

Ours opened with `await this._ensureSchemaTable()`. That call is gone; the body
now mirrors the Ruby line for line.

One correction to the story's premise, worth stating plainly: this does **not**
stop the reader from creating `schema_migrations`, and it should not. Rails'
`Migrator#initialize` calls `@schema_migration.create_table` /
`@internal_metadata.create_table` as its last act (`migration.rb:1429-1430`), so
`pool.migration_context.open.pending_migrations` — the `databases.rake:330-336`
reader behind `db:abort_if_pending_migrations` — creates both tables in Rails
too. `_ensureSchemaTable` is trails' memoized stand-in for that constructor step
(a constructor cannot await), reached from `loadMigrated`. So behaviour is
unchanged and the method body is now the Rails one.

`pendingMigrationsReadOnly` — the trails-only second spelling of the same Rails
method, which existed only to skip that write — is deleted. Both callers
(`activerecord-cli/src/pending-migrations.ts`,
`trailties/src/commands/db.ts` `abort_if_pending_migrations`) are the
`databases.rake` site, so they move onto `pendingMigrations()`, the reader Rails
uses there.

### Review response: criterion 3 is met; the story's premise is not Rails

Re `migration.ts:2810` still reaching `_ensureSchemaTable()` through
`migrated()` -> `loadMigrated()` — that is deliberate, and removing it would
create a divergence rather than close one. `Migrator#initialize` creates both
tables as its last act, for every Migrator, unconditionally:

```ruby
# activerecord/lib/active_record/migration.rb:1421-1432
def initialize(direction, migrations, schema_migration, internal_metadata, target_version = nil)
  ...
  validate(@migrations)

  @schema_migration.create_table
  @internal_metadata.create_table
end
```

`MigrationContext#open` (`migration.rb:1413-1415`) builds precisely that
Migrator, so `databases.rake:333`'s
`pool.migration_context.open.pending_migrations` — the reader behind
`db:abort_if_pending_migrations` — creates `schema_migrations` and
`ar_internal_metadata` **in Rails**, on a fresh database, today. There is no
`table_exists?` guard anywhere on that path; the only guard is inside
`SchemaMigration#create_table` itself (`schema_migration.rb:53-61`), which makes
the create idempotent, not conditional on the caller.

So the story's headline — "reading which migrations are pending must not create
the schema table" — describes behavior Rails does not have. Its acceptance
criterion 3 is the part that is actually about fidelity, and this PR satisfies
it as written: the `ensure` now sits at *Rails' own level* (the constructor
stand-in reached from `loadMigrated`) instead of inside the reader body, and
`pendingMigrations` is `migrated` + `reject`, nothing else.

Making the pending path skip the create would mean either a `table_exists?`
guard Rails does not have on `load_migrated`, or resurrecting
`pendingMigrationsReadOnly` under a new name — which is the trails-only second
spelling of a Rails method that criterion 2 exists to delete. Per CLAUDE.md only
a genuine TypeScript shortcoming justifies deviating, and there is none here:
the constructor-stand-in memoization is purely because a constructor cannot
`await`, and it lands the write exactly where Ruby lands it.

I have not found a shape that removes the write and stays faithful, because
Rails' write is upstream of every Migrator path. If the maintainers want the
no-write behavior regardless — a deliberate, documented trails-over-Rails call
for production health checks — that is a decision above this PR, and I would
take it as a follow-up story rather than smuggle it in under a fidelity story.

## `_cacheSingularTarget`'s collection arm (RFC 0112)

The arm after the `belongsTo`/`hasOne` early return wrote
`existing._setTargetFromLoader(target); existing._explicitTarget = true` —
neither of which exists on Rails' `Association`. Rails has exactly one inverse
write: `set_inverse_instance` → `inversed_from`
(`association.rb:132-137, 153-155`), whose `self.target = record` lands on
`CollectionAssociation#target=` (`collection_association.rb:284-295`). The arm
now calls `inversedFrom`, which reaches the same setter, so the write is
identical minus the bespoke spelling.

`_explicitTarget` is deliberately not raised there: `setInverseInstance` skips it
for a collection (`association.ts:463`), and its only reader,
`_loadedSingularTarget`, is singular-only — so the flag was dead on this path.

Retiring the `_explicitTarget` / `_loadedFromPreload` fields themselves is the
story's alternative clause and does not fit here — it touches ~8 files across
the preloader, join-dependency and strict-loading readers. Filed as
`0112-one-rails-thing-n-trails-things/retire-explicit-target-and-loaded-from-preload-fields`
with the call sites already enumerated.

## Verification

- `pnpm typecheck` clean.
- `migrator.trails.test.ts`, `migrator.test.ts`, `pending-migrations.test.ts`
  (85 tests), plus `associations.test.ts`, `association-cache.trails.test.ts`,
  `nested-attributes.test.ts`, `autosave-association.test.ts`,
  `inverse-associations.test.ts`, `eager-load-nested-include.test.ts`,
  `trailties db.test.ts` (718 tests) — all green.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
  `pnpm parity:api:extra:gate` OK. No baseline row added or widened.

Closes-story: migrator-pending-migrations-must-not-create-schema-table
Closes-story: cache-singular-target-inverse-write-bypasses-inversed-from
