### PR TITLE
refactor(activerecord,trailties,activerecord-cli,website): Migrator keeps only its migration.rb:1404 surface

### DIFF
--- a/docs/frontiers/README.md
+++ b/docs/frontiers/README.md
@@ -144,8 +144,8 @@ Replace the text-input CLI (`TasksPanel.svelte`) with a real terminal emulator.
 
 - Check Ghostty WASM availability (https://github.com/ghostty-org/ghostty)
 - Fallback: xterm.js + xterm-addon-fit (established, used by VS Code web)
-- Integration: render in splitpane, dispatch to `trail-cli.ts` `exec()`, ANSI colors
-- Add ANSI escape codes to `trail-cli.ts` output (backwards-compatible)
+- Integration: render in splitpane, dispatch to `trails-cli.ts` `exec()`, ANSI colors
+- Add ANSI escape codes to `trails-cli.ts` output (backwards-compatible)
 
 ## Followups
 

--- a/docs/frontiers/WS1_FOUNDATION_DOCS.md
+++ b/docs/frontiers/WS1_FOUNDATION_DOCS.md
@@ -494,7 +494,7 @@ src/lib/frontiers/components/
 src/lib/frontiers/components/
   Terminal.svelte
 src/lib/frontiers/
-  trail-cli.ts              — Add ANSI color codes (backwards-compatible)
+  trails-cli.ts             — Add ANSI color codes (backwards-compatible)
 ```
 
 ---

--- a/docs/frontiers/WS2_MUSIC.md
+++ b/docs/frontiers/WS2_MUSIC.md
@@ -7,7 +7,7 @@
 
 ## Approach
 
-TDD. Content is validated by automated replay tests that boot a runtime, execute every action, and assert every checkpoint. Tests run in CI — a change to `trail-cli.ts` or `activerecord` that breaks the Music tutorial fails the build.
+TDD. Content is validated by automated replay tests that boot a runtime, execute every action, and assert every checkpoint. Tests run in CI — a change to `trails-cli.ts` or `activerecord` that breaks the Music tutorial fails the build.
 
 ---
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -203,7 +203,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await expect(
@@ -212,7 +213,8 @@ describe("MigrationTest", () => {
         [migrateProxy(101, (m) => m.addColumn("people", "last_name", "string"))],
         new SchemaMigration(adapter.pool),
         new InternalMetadata(adapter.pool),
-      ).migrate(101),
+        101,
+      ).migrate(),
     ).rejects.toThrow();
   });
 
@@ -350,7 +352,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     // if_not_exists: true must not raise even though the column already exists.
@@ -363,7 +366,8 @@ describe("MigrationTest", () => {
       ],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(101);
+      101,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -610,7 +614,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
@@ -618,7 +623,8 @@ describe("MigrationTest", () => {
       [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(101);
+      101,
+    ).migrate();
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
     // Removing a missing column with if_not_exists unset: SQLite removes
@@ -630,8 +636,9 @@ describe("MigrationTest", () => {
       [migrateProxy(102, (m) => m.removeColumn("people", "last_name"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
+      102,
     )
-      .migrate(102)
+      .migrate()
       .catch((e: unknown) => e);
     expect((error as Error | undefined)?.message ?? "").toMatch(
       adapterType === "sqlite"
@@ -762,9 +769,10 @@ describe("MigrationTest", () => {
       migrations,
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
+      "20131219224947",
     );
     expect(await migrator.currentVersion()).toBe(0);
-    await migrator.migrate("20131219224947");
+    await migrator.migrate();
     expect(await migrator.currentVersion()).toBe(20131219224947);
   });
 
@@ -840,7 +848,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
@@ -848,7 +857,8 @@ describe("MigrationTest", () => {
       [migrateProxy(101, (m) => m.removeColumn("people", "last_name"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(101);
+      101,
+    ).migrate();
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
     // if_exists: true must not raise even though the column is already gone.
@@ -857,7 +867,8 @@ describe("MigrationTest", () => {
       [migrateProxy(102, (m) => m.removeColumn("people", "last_name", { ifExists: true }))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(102);
+      102,
+    ).migrate();
     expect(await personColumnNames(adapter)).not.toContain("last_name");
   });
 
@@ -874,7 +885,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", type))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
@@ -882,7 +894,8 @@ describe("MigrationTest", () => {
       [migrateProxy(101, (m) => m.addColumn("people", "last_name", type, { ifNotExists: true }))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(101);
+      101,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -896,7 +909,8 @@ describe("MigrationTest", () => {
       [migrateProxy(100, (m) => m.addColumn("people", "last_name", "string"))],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(100);
+      100,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
 
     await new Migrator(
@@ -908,7 +922,8 @@ describe("MigrationTest", () => {
       ],
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
-    ).migrate(101);
+      101,
+    ).migrate();
     expect(await personColumnNames(adapter)).toContain("last_name");
   });
 
@@ -974,7 +989,7 @@ describe("MigrationTest", () => {
     );
     await expect(migrator.migrate()).rejects.toThrow("Something broke");
     // Migration should not be recorded as applied
-    const versions = await migrator.getAllVersions();
+    const versions = [...(await migrator.migrated())];
     expect(versions).not.toContain(100);
   });
 
@@ -1005,7 +1020,7 @@ describe("MigrationTest", () => {
         new InternalMetadata(adapter.pool),
       );
       await expect(migrator.migrate()).rejects.toThrow("Something broke");
-      const versions = await migrator.getAllVersions();
+      const versions = [...(await migrator.migrated())];
       expect(versions).not.toContain(100);
     },
   );
@@ -1082,7 +1097,7 @@ describe("MigrationTest", () => {
     // which re-runs the failed load and raises out of the rescue itself, so the
     // "all later migrations canceled" wrapper never gets built.
     expect(err).toBe(loadError);
-    const versions = await migrator.getAllVersions();
+    const versions = [...(await migrator.migrated())];
     expect(versions).not.toContain(102);
   });
 
@@ -1519,8 +1534,9 @@ describe("MigrationTest", () => {
         [proxy],
         new SchemaMigration(adapter.pool),
         new InternalMetadata(adapter.pool),
+        100,
       );
-      await expect(migrator.run("up", 100)).rejects.toThrow(ConcurrentMigrationError);
+      await expect(migrator.run()).rejects.toThrow(ConcurrentMigrationError);
     } finally {
       getSpy.mockRestore();
     }
@@ -1556,7 +1572,7 @@ describe("MigrationTest", () => {
         await migrator.migrate();
         expect(getSpy).toHaveBeenCalledTimes(1);
         expect(releaseSpy).toHaveBeenCalledWith(getSpy.mock.calls[0][0]);
-        expect(await migrator.getAllVersions()).toContain(200);
+        expect([...(await migrator.migrated())]).toContain(200);
       } finally {
         getSpy.mockRestore();
         releaseSpy.mockRestore();

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2081,15 +2081,13 @@ export class MigrationContext<
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
     const selectedMigrations = block ? this.migrations.filter(block) : this.migrations;
-    return this._migrateWithMigrator(
-      new Migrator(
-        "up",
-        selectedMigrations,
-        this.schemaMigration,
-        this.internalMetadata,
-        targetVersion,
-      ),
-    );
+    return new Migrator(
+      "up",
+      selectedMigrations,
+      this.schemaMigration,
+      this.internalMetadata,
+      targetVersion,
+    ).migrate();
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#down (`migration.rb:1258-1266`) */
@@ -2099,28 +2097,13 @@ export class MigrationContext<
     block?: (m: MigrationProxy) => boolean,
   ): Promise<MigrationProxy[]> {
     const selectedMigrations = block ? this.migrations.filter(block) : this.migrations;
-    return this._migrateWithMigrator(
-      new Migrator(
-        "down",
-        selectedMigrations,
-        this.schemaMigration,
-        this.internalMetadata,
-        targetVersion,
-      ),
-    );
-  }
-
-  /**
-   * @internal `Migrator#migrate` is `use_advisory_lock? ? with_advisory_lock
-   * { migrate_without_lock } : migrate_without_lock` (`migration.rb:1452-1458`).
-   * It is spelled out here because trails' `Migrator#migrate` still carries the
-   * MigrationContext-shaped `(targetVersion, block)` signature its remaining
-   * callers pass; `migrator-run-surface-caller-migration` collapses it.
-   */
-  private async _migrateWithMigrator(migrator: Migrator): Promise<MigrationProxy[]> {
-    return migrator.isUseAdvisoryLock()
-      ? migrator.withAdvisoryLock(() => migrator.migrateWithoutLock())
-      : migrator.migrateWithoutLock();
+    return new Migrator(
+      "down",
+      selectedMigrations,
+      this.schemaMigration,
+      this.internalMetadata,
+      targetVersion,
+    ).migrate();
   }
 
   /**
@@ -2151,16 +2134,13 @@ export class MigrationContext<
     direction: "up" | "down",
     targetVersion: number | string,
   ): Promise<number | undefined> {
-    const migrator = new Migrator(
+    return new Migrator(
       direction,
       this.migrations,
       this.schemaMigration,
       this.internalMetadata,
       targetVersion,
-    );
-    return migrator.isUseAdvisoryLock()
-      ? migrator.withAdvisoryLock(() => migrator.runWithoutLock())
-      : migrator.runWithoutLock();
+    ).run();
   }
 
   /**
@@ -2334,8 +2314,12 @@ export class MigrationContext<
    * one way a single migration can be present twice, as a `.ts` source beside
    * the `.js` its build emitted. Rails has no such twin, so it loads once:
    * `.ts` beats `.js`, source over compiled output.
+   *
+   * `protected`, not `private`: Ruby's `private` still lets a subclass override
+   * the method, which is how a context over a non-filesystem source (the
+   * browser CLI's virtual FS) names its own files.
    */
-  private migrationFiles(): string[] {
+  protected migrationFiles(): string[] {
     const { readdirSync, existsSync } = getFs();
     const { join } = getPath();
     const files: string[] = [];
@@ -2375,7 +2359,7 @@ export class MigrationContext<
    *   result (migration.rb:1375) is a method; JS reads the first match off the
    *   `String#match` result by index, which records no callee.
    */
-  private parseMigrationFilename(filename: string): [string, string, string] | null {
+  protected parseMigrationFilename(filename: string): [string, string, string] | null {
     const base = filename.replace(/.*[/\\]/, "");
     const m = base.match(/^([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.(?:ts|js)$/);
     if (!m) return null;
@@ -2527,64 +2511,16 @@ export class Migrator {
   }
 
   /**
-   * Run all pending migrations up, or migrate to a specific version.
-   *
-   * Mirrors: ActiveRecord::Migrator#migrate (`migration.rb:1452-1458`) — the
-   * advisory-lock gate. A target equal to the current version runs `up`, so an
-   * unapplied migration below an already-applied target still runs. The target
-   * is rejected up front because Ruby compares it against `current_version`
-   * directly, while it may reach us as a string.
-   *
-   * Rails' `#migrate` takes no arguments; the `(targetVersion, block)`
-   * signature its callers still pass is what
-   * `migrator-run-surface-caller-migration` collapses. Until then the direction
-   * choice `MigrationContext#migrate` (`migration.rb:1228-1238`) makes is made
-   * here, on a per-run `Migrator` built the way Rails builds one.
+   * @internal Mirrors: ActiveRecord::Migrator#migrate (`migration.rb:1452-1458`)
+   * — the advisory-lock gate over `migrate_without_lock`. The direction and
+   * target version are the ones this Migrator was constructed with; the
+   * `target_version.nil? / == 0 / >` dispatch belongs to
+   * {@link MigrationContext.migrate} (`migration.rb:1228-1238`).
    */
-  async migrate(
-    targetVersion?: number | string | null,
-    block?: (m: MigrationProxy) => boolean,
-  ): Promise<MigrationProxy[]> {
-    // With no target this is Rails' `Migrator#migrate`, which runs the
-    // direction this Migrator was built with; with one it is
-    // `MigrationContext#migrate`'s dispatch (`migration.rb:1228-1238`).
-    let direction: "up" | "down" = this._direction;
-    if (targetVersion != null) {
-      direction = "up";
-      if (this._invalidTarget(targetVersion)) {
-        throw new UnknownMigrationVersionError(targetVersion);
-      }
-      const target = BigInt(targetVersion);
-      const current = BigInt(await this.currentVersion());
-      if (current === BigInt(0) && target === BigInt(0)) return [];
-      if (current > target) direction = "down";
-    }
-
-    const migrator = new Migrator(
-      direction,
-      block ? this._migrations.filter(block) : this._migrations,
-      this._schemaMigration,
-      this._internalMetadata,
-      targetVersion ?? null,
-    );
-    try {
-      return migrator.isUseAdvisoryLock()
-        ? await migrator.withAdvisoryLock(() => migrator.migrateWithoutLock())
-        : await migrator.migrateWithoutLock();
-    } finally {
-      this._invalidateMigrated();
-    }
-  }
-
-  /**
-   * Rails builds a fresh `Migrator` for every `up` / `down` / `run`, so the
-   * caller's own `@migrated_versions` memo can never go stale. Our `Migrator`
-   * doubles as `MigrationContext` and is read again after delegating, so the
-   * memo has to be dropped once a per-run migrator has changed
-   * schema_migrations underneath it.
-   */
-  private _invalidateMigrated(): void {
-    this._migratedVersions = undefined;
+  async migrate(): Promise<MigrationProxy[]> {
+    return this.isUseAdvisoryLock()
+      ? this.withAdvisoryLock(() => this.migrateWithoutLock())
+      : this.migrateWithoutLock();
   }
 
   /**
@@ -2655,10 +2591,9 @@ export class Migrator {
     return applied.has(proxy.version);
   }
 
-  /** @internal Mirrors: ActiveRecord::Migrator#invalid_target? */
+  /** @internal Mirrors: ActiveRecord::Migrator#invalid_target? (`migration.rb:1523-1525`) */
   isInvalidTarget(): boolean {
-    if (this._targetVersion === null) return false;
-    return this._invalidTarget(this._targetVersion);
+    return this._targetVersion !== null && this._targetVersion !== 0 && !this.target();
   }
 
   /**
@@ -2757,112 +2692,10 @@ export class Migrator {
     return BigInt(Migrator._MIGRATOR_SALT) * BigInt(dbNameHash);
   }
 
-  /**
-   * Get the current schema version.
-   *
-   * Mirrors: ActiveRecord::Migrator.current_version
-   */
+  /** @internal Mirrors: ActiveRecord::Migrator#current_version (`migration.rb:1435-1437`) */
   async currentVersion(): Promise<number> {
-    const versions = await this.getAllVersions();
-    return versions.length > 0 ? Math.max(...versions) : 0;
-  }
-
-  /**
-   * Get all applied migration versions.
-   *
-   * Mirrors: ActiveRecord::Migrator.get_all_versions
-   */
-  async getAllVersions(): Promise<number[]> {
-    await this._ensureSchemaTable();
-    const applied = await this._appliedVersions();
-    return [...applied].sort((a, b) => a - b);
-  }
-
-  /**
-   * Read-only check for whether `schema_migrations` already exists.
-   * Used by `db prepare` to decide whether the DB is fresh (should run
-   * seeds) vs. already-initialized (just run pending migrations).
-   *
-   * Mirrors Rails' `initialize_database` which checks
-   * `schema_migration.table_exists?` for the same purpose.
-   */
-  async schemaMigrationTableExists(): Promise<boolean> {
-    return this._schemaMigration.tableExists();
-  }
-
-  /**
-   * Read-only variant of {@link currentVersion}: returns 0 when the
-   * schema_migrations table doesn't yet exist, without creating it.
-   *
-   * Matches Rails' `current_version` exactly (it calls `get_all_versions`
-   * which checks `schema_migration.table_exists?` and returns [] on miss).
-   * The regular {@link currentVersion} keeps the legacy auto-create path
-   * to stay compatible with internal callers that rely on it.
-   */
-  async currentVersionReadOnly(): Promise<number> {
-    if (!(await this._schemaMigration.tableExists())) return 0;
-    const applied = await this._appliedVersions();
-    let max = BigInt(0);
-    for (const v of applied) {
-      const bv = BigInt(v);
-      if (bv > max) max = bv;
-    }
-    return Number(max);
-  }
-
-  /**
-   * Get pending (unapplied) migrations.
-   *
-   * Mirrors: ActiveRecord::Migrator#pending_migrations
-   */
-  async pendingMigrations(): Promise<MigrationProxy[]> {
-    const alreadyMigrated = await this.migrated();
-    return this.migrations.filter((m) => !alreadyMigrated.has(m.version));
-  }
-
-  /**
-   * Get status of all migrations.
-   *
-   * Mirrors: ActiveRecord::Migrator#migrations_status
-   */
-  async migrationsStatus(): Promise<
-    Array<{ status: "up" | "down"; version: string; name: string }>
-  > {
-    await this._ensureSchemaTable();
-    // Mirrors Rails: db_list uses schema_migration.normalized_versions and file
-    // versions go through schema_migration.normalize_migration_number before
-    // matching (migration.rb:1319-1328 / schema_migration.rb:69-70).
-    const applied = new Set(await this._schemaMigration.normalizedVersions());
-
-    const fileList = this._migrations.map((m) => {
-      const normV = SchemaMigration.normalizeMigrationNumber(String(m.version));
-      const isUp = applied.delete(normV);
-      return {
-        status: (isUp ? "up" : "down") as "up" | "down", // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
-        version: normV,
-        // Mirrors Rails: `(name + scope).humanize` — the snake-case filename
-        // part concatenated with the scope suffix, humanized (migration.rb:1330).
-        // Our proxy carries the camelized class name, so underscore it back
-        // before appending the (already snake-case) scope and humanizing.
-        name: humanize(underscore(m.name) + (m.scope ?? "")),
-      };
-    });
-
-    // Mirrors Rails Migrator#migrations_status: applied versions with no
-    // matching file get a placeholder name. Combined list sorts numerically.
-    const dbList = [...applied].map((version) => ({
-      status: "up" as const,
-      version,
-      name: "********** NO FILE **********",
-    }));
-
-    // Rails sorts by `version.to_i` — non-numeric rows coerce to 0 rather
-    // than raising.
-    return [...dbList, ...fileList].sort((a, b) => {
-      const va = toInteger(a.version);
-      const vb = toInteger(b.version);
-      return va < vb ? -1 : va > vb ? 1 : 0;
-    });
+    const migrated = await this.migrated();
+    return migrated.size > 0 ? Math.max(...migrated) : 0;
   }
 
   private _sortMigrations(migrations: MigrationProxy[]): MigrationProxy[] {
@@ -2910,39 +2743,11 @@ export class Migrator {
     return new Set(await this._schemaMigration.integerVersions());
   }
 
-  /**
-   * Mirrors Rails' `Migrator#invalid_target?`: a target version is invalid when
-   * it is given, is not 0, and does not correspond to any known migration.
-   */
-  private _invalidTarget(targetVersion: number | string): boolean {
-    const key = toInteger(String(targetVersion));
-    if (key === 0) return false;
-    return !this._migrations.some((m) => m.version === key);
-  }
-
-  /**
-   * Run exactly one migration (identified by `targetVersion`) in the given
-   * direction. Used by the `db:migrate:up` / `db:migrate:down` CLI paths
-   * where the user supplies a specific VERSION.
-   *
-   * Mirrors: ActiveRecord::MigrationContext#run (which builds a Migrator
-   * scoped to `target_version` and calls `#run`).
-   */
-  async run(direction: "up" | "down", targetVersion: number | string): Promise<number | undefined> {
-    const migrator = new Migrator(
-      direction,
-      this._migrations,
-      this._schemaMigration,
-      this._internalMetadata,
-      targetVersion,
-    );
-    try {
-      return migrator.isUseAdvisoryLock()
-        ? await migrator.withAdvisoryLock(() => migrator.runWithoutLock())
-        : await migrator.runWithoutLock();
-    } finally {
-      this._invalidateMigrated();
-    }
+  /** @internal Mirrors: ActiveRecord::Migrator#run (`migration.rb:1444-1450`) */
+  async run(): Promise<number | undefined> {
+    return this.isUseAdvisoryLock()
+      ? this.withAdvisoryLock(() => this.runWithoutLock())
+      : this.runWithoutLock();
   }
 
   /**
@@ -3014,6 +2819,13 @@ export class Migrator {
     return kept;
   }
 
+  /** @internal Mirrors: ActiveRecord::Migrator#pending_migrations (`migration.rb:1475-1478`) */
+  async pendingMigrations(): Promise<MigrationProxy[]> {
+    const alreadyMigrated = await this.migrated();
+    return this.migrations.filter((m) => !alreadyMigrated.has(m.version));
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#migrated (`migration.rb:1480-1482`) */
   async migrated(): Promise<Set<number>> {
     return this._migratedVersions ?? this.loadMigrated();
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2358,6 +2358,8 @@ export class MigrationContext<
    * @missingRailsCall first — PERMANENT: Ruby `Array#first` on the `scan`
    *   result (migration.rb:1375) is a method; JS reads the first match off the
    *   `String#match` result by index, which records no callee.
+   *
+   * `protected` for the same reason {@link migrationFiles} is.
    */
   protected parseMigrationFilename(filename: string): [string, string, string] | null {
     const base = filename.replace(/.*[/\\]/, "");
@@ -2508,6 +2510,13 @@ export class Migrator {
       throw new ConcurrentMigrationError(ConcurrentMigrationError.RELEASE_LOCK_FAILED_MESSAGE);
     }
     return fnResult as T;
+  }
+
+  /** @internal Mirrors: ActiveRecord::Migrator#run (`migration.rb:1444-1450`) */
+  async run(): Promise<number | undefined> {
+    return this.isUseAdvisoryLock()
+      ? this.withAdvisoryLock(() => this.runWithoutLock())
+      : this.runWithoutLock();
   }
 
   /**
@@ -2741,13 +2750,6 @@ export class Migrator {
 
   private async _appliedVersions(): Promise<Set<number>> {
     return new Set(await this._schemaMigration.integerVersions());
-  }
-
-  /** @internal Mirrors: ActiveRecord::Migrator#run (`migration.rb:1444-1450`) */
-  async run(): Promise<number | undefined> {
-    return this.isUseAdvisoryLock()
-      ? this.withAdvisoryLock(() => this.runWithoutLock())
-      : this.runWithoutLock();
   }
 
   /**

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -73,11 +73,6 @@ describe("MigratorTest", () => {
   // Rails' migrator_class(count) builds a MigrationContext subclass whose
   // #migrations returns the sensor list; in trails a Migrator carries its own
   // migrations, so this just wraps `sensors`.
-  function migratorClass(count: number): { calls: Array<[string, number]>; migrator: Migrator } {
-    const { calls, migrations } = sensors(count);
-    return { calls, migrator: new Migrator("up", migrations, schemaMigration, internalMetadata) };
-  }
-
   // Rails' migrator_class(count) subclasses MigrationContext and overrides
   // #migrations to return the sensor list, which is why its `.new("valid", ...)`
   // path argument is never read. Same shape here.
@@ -137,19 +132,19 @@ describe("MigratorTest", () => {
     const list = (): MigrationProxy[] => [migration("Foo", 1), migration("Bar", 2)];
 
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", 3),
+      new Migrator("up", list(), schemaMigration, internalMetadata, 3).run(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", -1),
+      new Migrator("up", list(), schemaMigration, internalMetadata, -1).run(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).run("up", 0),
+      new Migrator("up", list(), schemaMigration, internalMetadata, 0).run(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).migrate(3),
+      new Migrator("up", list(), schemaMigration, internalMetadata, 3).migrate(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).migrate(-1),
+      new Migrator("up", list(), schemaMigration, internalMetadata, -1).migrate(),
     ).rejects.toThrow(UnknownMigrationVersionError);
   });
 
@@ -252,9 +247,8 @@ describe("MigratorTest", () => {
     const path = `${MIGRATIONS_ROOT}/valid`;
     await seedVersions(2, 10);
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      [path],
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -270,9 +264,8 @@ describe("MigratorTest", () => {
     const path = `${MIGRATIONS_ROOT}/old_and_new_versions`;
     await seedVersions(230, 231, 20210716122844, 20210716123013);
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      [path],
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -290,9 +283,8 @@ describe("MigratorTest", () => {
     // migration application which should not affect ordering in status.
     await seedVersions(230, 231, 20210716123013);
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      [path],
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -308,9 +300,8 @@ describe("MigratorTest", () => {
     const path = `${MIGRATIONS_ROOT}/valid_with_subdirectories`;
     await seedVersions(2, 10);
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      [path],
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -328,9 +319,8 @@ describe("MigratorTest", () => {
     // as applied.
     await seedVersions(1, 2, 3);
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext([path], schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      [path],
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -348,9 +338,8 @@ describe("MigratorTest", () => {
     ];
     await seedVersions("20100101010101", "20160528010101");
 
-    const status = await new Migrator(
-      "up",
-      new MigrationContext(paths, schemaMigration, internalMetadata).migrations,
+    const status = await new MigrationContext(
+      paths,
       schemaMigration,
       internalMetadata,
     ).migrationsStatus();
@@ -460,11 +449,11 @@ describe("MigratorTest", () => {
   it("migrator one up", async () => {
     const { calls, migrations } = sensors(3);
 
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 1).migrate();
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 2).migrate();
     expect(calls).toEqual([["up", 2]]);
   });
 
@@ -479,7 +468,7 @@ describe("MigratorTest", () => {
     ]);
     calls.length = 0;
 
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
+    await new Migrator("down", migrations, schemaMigration, internalMetadata, 1).migrate();
     expect(calls).toEqual([
       ["down", 3],
       ["down", 2],
@@ -489,42 +478,43 @@ describe("MigratorTest", () => {
   it("migrator one up one down", async () => {
     const { calls, migrations } = sensors(3);
 
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 1).migrate();
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
+    await new Migrator("down", migrations, schemaMigration, internalMetadata, 0).migrate();
     expect(calls).toEqual([["down", 1]]);
   });
 
   it("migrator double up", async () => {
     const { calls, migrations } = sensors(3);
-    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
+    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 1);
     expect(await migrator.currentVersion()).toBe(0);
 
-    await migrator.migrate(1);
+    await migrator.migrate();
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await migrator.migrate(1);
+    await migrator.migrate();
     expect(calls).toEqual([]);
   });
 
   it("migrator double down", async () => {
     const { calls, migrations } = sensors(3);
-    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
+    let migrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 1);
 
     expect(await migrator.currentVersion()).toBe(0);
 
-    await migrator.run("up", 1);
+    await migrator.run();
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
-    await migrator.run("down", 1);
+    migrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 1);
+    await migrator.run();
     expect(calls).toEqual([["down", 1]]);
     calls.length = 0;
 
-    await migrator.run("down", 1);
+    await migrator.run();
     expect(calls).toEqual([]);
 
     expect(await migrator.currentVersion()).toBe(0);
@@ -543,14 +533,14 @@ describe("MigratorTest", () => {
       const { migrations } = sensors(3);
 
       Migration.verbose = true;
-      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
-      await upMigrator.migrate(1);
+      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 1);
+      await upMigrator.migrate();
       expect(lines.length).not.toBe(0);
 
       lines.length = 0;
 
-      const downMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
-      await downMigrator.migrate(0);
+      const downMigrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 0);
+      await downMigrator.migrate();
       expect(lines.length).not.toBe(0);
     } finally {
       spy.mockRestore();
@@ -567,12 +557,12 @@ describe("MigratorTest", () => {
       const { migrations } = sensors(3);
 
       Migration.verbose = false;
-      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
-      await upMigrator.migrate(1);
+      const upMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 1);
+      await upMigrator.migrate();
       expect(lines.length).toBe(0);
 
-      const downMigrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
-      await downMigrator.migrate(0);
+      const downMigrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 0);
+      await downMigrator.migrate();
       expect(lines.length).toBe(0);
     } finally {
       spy.mockRestore();
@@ -583,24 +573,24 @@ describe("MigratorTest", () => {
     const { calls, migrations } = sensors(3);
 
     // migrate up to 1
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 1).migrate();
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
     // migrate down to 0
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
+    await new Migrator("down", migrations, schemaMigration, internalMetadata, 0).migrate();
     expect(calls).toEqual([["down", 1]]);
     calls.length = 0;
 
     // migrate down to 0 again
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(0);
+    await new Migrator("down", migrations, schemaMigration, internalMetadata, 0).migrate();
     expect(calls).toEqual([]);
   });
 
   it("migrator going down due to version target", async () => {
-    const { calls, migrator } = migratorClass(3);
+    const { calls, context: migrator } = migrationContextClass(3);
 
-    await migrator.migrate(1);
+    await migrator.up(1);
     expect(calls).toEqual([["up", 1]]);
     calls.length = 0;
 
@@ -631,7 +621,7 @@ describe("MigratorTest", () => {
   });
 
   it("migrator output when running single migration", async () => {
-    const { migrator } = migratorClass(1);
+    const { context: migrator } = migrationContextClass(1);
 
     const result = await migrator.run("up", 1);
 
@@ -658,7 +648,7 @@ describe("MigratorTest", () => {
   });
 
   it("migrator db has no schema migrations table", async () => {
-    const { migrator } = migratorClass(3);
+    const { context: migrator } = migrationContextClass(3);
 
     await schemaMigration.dropTable();
     expect(await schemaMigration.tableExists()).toBe(false);
@@ -682,7 +672,7 @@ describe("MigratorTest", () => {
     // migrate up to 1
     await seedVersions("1");
 
-    const { calls, migrator } = migratorClass(3);
+    const { calls, context: migrator } = migrationContextClass(3);
     await migrator.migrate();
 
     expect(calls).toEqual([

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -13,6 +13,7 @@ import {
 } from "vitest";
 import { stdout } from "@blazetrails/activesupport";
 import {
+  MigrationContext,
   Migrator,
   CheckPending,
   PendingMigrationError,
@@ -45,6 +46,19 @@ function withMigrationConnection(adapter: DatabaseAdapter): void {
 /** The env name `record_environment` stamps: `connection.pool.db_config.env_name`. */
 function envName(adapter: DatabaseAdapter): string {
   return (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName;
+}
+
+/**
+ * Rails' `migrator_class` (`migrator_test.rb:229-238`): a `MigrationContext`
+ * subclass whose `#migrations` answers an in-memory list, so the path argument
+ * is never read.
+ */
+function migrationContext(migrations: MigrationProxy[]): MigrationContext {
+  return new (class extends MigrationContext {
+    override get migrations(): MigrationProxy[] {
+      return migrations;
+    }
+  })(["db/migrate"], schemaMigration, internalMetadata);
 }
 
 function makeMigration(
@@ -160,13 +174,13 @@ describe("Migrator trails extensions", () => {
     // (migration.rb:1503-1505); target 0 stays valid.
     const list = (): MigrationProxy[] => [makeMigration(1, "M1"), makeMigration(2, "M2")];
     await expect(
-      new Migrator("up", list(), schemaMigration, internalMetadata).migrate(3),
+      new Migrator("up", list(), schemaMigration, internalMetadata, 3).migrate(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("down", list(), schemaMigration, internalMetadata).migrate(3),
+      new Migrator("down", list(), schemaMigration, internalMetadata, 3).migrate(),
     ).rejects.toThrow(UnknownMigrationVersionError);
     await expect(
-      new Migrator("down", list(), schemaMigration, internalMetadata).migrate(0),
+      new Migrator("down", list(), schemaMigration, internalMetadata, 0).migrate(),
     ).resolves.toEqual([]);
   });
 
@@ -185,7 +199,7 @@ describe("Migrator trails extensions", () => {
     expect(ran).toEqual(["2"]);
 
     ran.length = 0;
-    await new Migrator("up", [m1(), m2()], schemaMigration, internalMetadata).migrate(2);
+    await migrationContext([m1(), m2()]).migrate(2);
     expect(ran).toEqual(["1"]);
   });
 
@@ -205,36 +219,26 @@ describe("Migrator trails extensions", () => {
 
   it("migrate returns [] when both the current and target version are 0", async () => {
     const ran: string[] = [];
-    const migrator = new Migrator(
-      "up",
-      [
-        makeMigration(0, "M0", async () => {
-          ran.push("0");
-        }),
-      ],
-      schemaMigration,
-      internalMetadata,
-    );
-    await expect(migrator.migrate(0)).resolves.toEqual([]);
+    const migrationContextForTest = migrationContext([
+      makeMigration(0, "M0", async () => {
+        ran.push("0");
+      }),
+    ]);
+    await expect(migrationContextForTest.migrate(0)).resolves.toEqual([]);
     expect(ran).toEqual([]);
   });
 
   it("migrate applies its block by selecting the migrations handed to the per-run Migrator", async () => {
     const ran: string[] = [];
-    const migrator = new Migrator(
-      "up",
-      [
-        makeMigration(1, "M1", async () => {
-          ran.push("1");
-        }),
-        makeMigration(2, "M2", async () => {
-          ran.push("2");
-        }),
-      ],
-      schemaMigration,
-      internalMetadata,
-    );
-    await migrator.migrate(null, (m) => m.version === 2);
+    const migrationContextForTest = migrationContext([
+      makeMigration(1, "M1", async () => {
+        ran.push("1");
+      }),
+      makeMigration(2, "M2", async () => {
+        ran.push("2");
+      }),
+    ]);
+    await migrationContextForTest.migrate(null, (m) => m.version === 2);
     expect(ran).toEqual(["2"]);
   });
 
@@ -251,10 +255,7 @@ describe("Migrator trails extensions", () => {
     ];
 
     await new Migrator("up", migrations(), schemaMigration, internalMetadata).migrate();
-    await new Migrator("up", migrations(), schemaMigration, internalMetadata).migrate(
-      1,
-      (m) => m.version !== 3,
-    );
+    await migrationContext(migrations()).migrate(1, (m) => m.version !== 3);
     expect(reverted).toEqual(["2"]);
   });
 
@@ -419,8 +420,9 @@ describe("Migrator advisory lock wrapping", () => {
       [makeMigration(1, "M1")],
       schemaMigration,
       internalMetadata,
+      1,
     );
-    await migrator.run("up", 1);
+    await migrator.run();
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
 
@@ -466,7 +468,13 @@ describe("Migrator advisory lock wrapping", () => {
     );
     await migrator.migrate();
     lockLog.length = 0;
-    await migrator.migrate(0);
+    await new Migrator(
+      "down",
+      [makeMigration(1, "M1")],
+      schemaMigration,
+      internalMetadata,
+      0,
+    ).migrate();
     expect(lockLog).toEqual(["lock", "unlock"]);
   });
 
@@ -754,7 +762,7 @@ describe("Migrator runnable direction awareness", () => {
 
   it("runnable going up returns only unapplied migrations", async () => {
     const migrations = three();
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 2).migrate();
 
     const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([3]);
@@ -762,7 +770,7 @@ describe("Migrator runnable direction awareness", () => {
 
   it("runnable going up stops at the target version", async () => {
     const migrations = three();
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(1);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 1).migrate();
 
     const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata, 2);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([2]);
@@ -786,7 +794,7 @@ describe("Migrator runnable direction awareness", () => {
 
   it("runnable going down ignores migrations that never ran", async () => {
     const migrations = three();
-    await new Migrator("up", migrations, schemaMigration, internalMetadata).migrate(2);
+    await new Migrator("up", migrations, schemaMigration, internalMetadata, 2).migrate();
 
     const migrator = new Migrator("down", migrations, schemaMigration, internalMetadata, 0);
     expect((await migrator.runnable()).map((m) => m.version)).toEqual([2, 1]);

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -53,7 +53,7 @@ function envName(adapter: DatabaseAdapter): string {
  * subclass whose `#migrations` answers an in-memory list, so the path argument
  * is never read.
  */
-function migrationContext(migrations: MigrationProxy[]): MigrationContext {
+function migrationContextClass(migrations: MigrationProxy[]): MigrationContext {
   return new (class extends MigrationContext {
     override get migrations(): MigrationProxy[] {
       return migrations;
@@ -199,7 +199,7 @@ describe("Migrator trails extensions", () => {
     expect(ran).toEqual(["2"]);
 
     ran.length = 0;
-    await migrationContext([m1(), m2()]).migrate(2);
+    await migrationContextClass([m1(), m2()]).migrate(2);
     expect(ran).toEqual(["1"]);
   });
 
@@ -219,18 +219,18 @@ describe("Migrator trails extensions", () => {
 
   it("migrate returns [] when both the current and target version are 0", async () => {
     const ran: string[] = [];
-    const migrationContextForTest = migrationContext([
+    const migrationContext = migrationContextClass([
       makeMigration(0, "M0", async () => {
         ran.push("0");
       }),
     ]);
-    await expect(migrationContextForTest.migrate(0)).resolves.toEqual([]);
+    await expect(migrationContext.migrate(0)).resolves.toEqual([]);
     expect(ran).toEqual([]);
   });
 
   it("migrate applies its block by selecting the migrations handed to the per-run Migrator", async () => {
     const ran: string[] = [];
-    const migrationContextForTest = migrationContext([
+    const migrationContext = migrationContextClass([
       makeMigration(1, "M1", async () => {
         ran.push("1");
       }),
@@ -238,7 +238,7 @@ describe("Migrator trails extensions", () => {
         ran.push("2");
       }),
     ]);
-    await migrationContextForTest.migrate(null, (m) => m.version === 2);
+    await migrationContext.migrate(null, (m) => m.version === 2);
     expect(ran).toEqual(["2"]);
   });
 
@@ -255,7 +255,7 @@ describe("Migrator trails extensions", () => {
     ];
 
     await new Migrator("up", migrations(), schemaMigration, internalMetadata).migrate();
-    await migrationContext(migrations()).migrate(1, (m) => m.version !== 3);
+    await migrationContextClass(migrations()).migrate(1, (m) => m.version !== 3);
     expect(reverted).toEqual(["2"]);
   });
 

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -13,6 +13,11 @@ import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 import { Base } from "./base.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 
+// Rails' `@path_a` / `@path_b` (multi_db_migrator_test.rb:33-34).
+const MIGRATIONS_ROOT = new URL("./test-helpers/migrations", import.meta.url).pathname;
+const PATH_A = [`${MIGRATIONS_ROOT}/valid`];
+const PATH_B = [`${MIGRATIONS_ROOT}/to_copy`];
+
 function sensor(
   version: number,
   name: string,
@@ -145,8 +150,11 @@ describe("MultiDbMigratorTest", () => {
     await schemaMigrationA.createVersion("2");
     await schemaMigrationA.createVersion("10");
 
-    const migratorA = new Migrator("up", migrationsA, schemaMigrationA, internalMetadataA);
-    const statusA = await migratorA.migrationsStatus();
+    const statusA = await new MigrationContext(
+      PATH_A,
+      schemaMigrationA,
+      internalMetadataA,
+    ).migrationsStatus();
     expect(statusA).toEqual([
       { status: "down", version: "001", name: "Valid people have last names" },
       { status: "up", version: "002", name: "We need reminders" },
@@ -155,8 +163,11 @@ describe("MultiDbMigratorTest", () => {
     ]);
 
     await schemaMigrationB.createVersion("4");
-    const migratorB = new Migrator("up", migrationsB, schemaMigrationB, internalMetadataB);
-    const statusB = await migratorB.migrationsStatus();
+    const statusB = await new MigrationContext(
+      PATH_B,
+      schemaMigrationB,
+      internalMetadataB,
+    ).migrationsStatus();
     expect(statusB).toEqual([
       { status: "down", version: "001", name: "People have hobbies" },
       { status: "down", version: "002", name: "People have descriptions" },

--- a/packages/activerecord/src/multi-db-migrator.trails.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.trails.test.ts
@@ -58,7 +58,7 @@ describe("MultiDbMigratorTest (trails)", () => {
 
     await migratorA.migrate();
 
-    expect(await migratorA.getAllVersions()).toEqual([1, 2, 3]);
-    expect(await migratorB.getAllVersions()).toEqual([]);
+    expect(await schemaMigrationA.integerVersions()).toEqual([1, 2, 3]);
+    expect(await schemaMigrationB.integerVersions()).toEqual([]);
   });
 });

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -1,13 +1,9 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
-import { createAndMigrate, eachDatabase, createAndLoadSchema } from "./test-databases.js";
-import type { MigrationProxy } from "./migration.js";
+import { eachDatabase, createAndLoadSchema } from "./test-databases.js";
 import { Base } from "./index.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import { fixtures } from "./test-fixtures.js";
-import { SchemaMigration } from "./schema-migration.js";
-import { InternalMetadata } from "./internal-metadata.js";
-import { anonymousMigration } from "./test-helpers/anonymous-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
 // supplied stubbed configs. They also go through the array constructor arm so
@@ -243,73 +239,6 @@ describe("TestDatabasesTest", () => {
         process.env.VERBOSE = originalVerbose;
       }
     }
-  });
-
-  it("createAndMigrate runs migrations on all adapters", async () => {
-    const adapter = Base.connection;
-    const log: string[] = [];
-    const migrations: MigrationProxy[] = [
-      {
-        version: 1,
-        name: "M1",
-        migration: () =>
-          anonymousMigration(
-            "M1",
-            1,
-            async () => {
-              log.push("up");
-            },
-            async () => {},
-          ),
-      },
-    ];
-
-    // This runs against the shared worker DB (Base.connection). Many other
-    // test files apply a version-"1" migration too, so version 1 may already be
-    // recorded in schema_migrations — in which case migrator.up() correctly
-    // no-ops and the log stays empty. Clear this version first so the migration
-    // actually runs, mirroring how Rails' migrator tests isolate
-    // schema_migrations state. createTable is CREATE TABLE IF NOT EXISTS, so
-    // ensuring the table exists before the delete keeps both statements from
-    // erroring inside the fixtures transaction (a failed DELETE would poison
-    // the PG transaction with 25P02).
-    const schemaMigration = new SchemaMigration(adapter.pool);
-    await schemaMigration.createTable();
-    await schemaMigration.deleteVersion("1");
-
-    await createAndMigrate([adapter], migrations);
-    expect(log).toEqual(["up"]);
-  });
-
-  it("createAndMigrate stamps the environment from the adapter's pool", async () => {
-    // migration.rb:1512-1516 — `record_environment` writes
-    // `connection.pool.db_config.env_name`, so the stamp follows the pool the
-    // adapter is checked out of, not any TRAILS_ENV/NODE_ENV reading.
-    const adapter = Base.connection;
-    const schemaMigration = new SchemaMigration(adapter.pool);
-    await schemaMigration.createTable();
-    await schemaMigration.deleteVersion("1");
-    const internalMetadata = new InternalMetadata(adapter.pool);
-    await internalMetadata.createTable();
-    await internalMetadata.deleteAllEntries();
-
-    await createAndMigrate([adapter], [
-      {
-        version: 1,
-        name: "M1",
-        migration: () =>
-          anonymousMigration(
-            "M1",
-            1,
-            async () => {},
-            async () => {},
-          ),
-      },
-    ] as MigrationProxy[]);
-
-    expect(await internalMetadata.get("environment")).toBe(
-      (adapter.pool as { dbConfig: { envName: string } }).dbConfig.envName,
-    );
   });
 
   it("eachDatabase iterates all adapters", async () => {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -5,34 +5,8 @@
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
-import type { MigrationProxy } from "./migration.js";
-import { Migrator } from "./migration.js";
-import { SchemaMigration } from "./schema-migration.js";
-import { InternalMetadata } from "./internal-metadata.js";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
-
-/**
- * Run migrations on each test database adapter.
- *
- * Mirrors: ActiveRecord::TestDatabases.create_and_migrate
- */
-export async function createAndMigrate(
-  adapters: DatabaseAdapter[],
-  migrations: MigrationProxy[],
-): Promise<void> {
-  for (const adapter of adapters) {
-    // Rails' TestDatabases defines no `create_and_migrate`; the Migrator it
-    // builds is the Rails one (`migration.rb:1421-1433`).
-    const migrator = new Migrator(
-      "up",
-      migrations,
-      new SchemaMigration(adapter.pool),
-      new InternalMetadata(adapter.pool),
-    );
-    await migrator.migrate();
-  }
-}
 
 /**
  * Iterate over test database adapters, calling the callback for each.

--- a/packages/activerecord/src/test-helpers/migrations/to_copy/1_people_have_hobbies.ts
+++ b/packages/activerecord/src/test-helpers/migrations/to_copy/1_people_have_hobbies.ts
@@ -1,0 +1,12 @@
+// vendor/rails/activerecord/test/migrations/to_copy/1_people_have_hobbies.rb
+import { Migration } from "../../../migration.js";
+
+export class PeopleHaveHobbies extends Migration {
+  async up(): Promise<void> {
+    await this.addColumn("people", "hobbies", "text");
+  }
+
+  async down(): Promise<void> {
+    await this.removeColumn("people", "hobbies");
+  }
+}

--- a/packages/activerecord/src/test-helpers/migrations/to_copy/2_people_have_descriptions.ts
+++ b/packages/activerecord/src/test-helpers/migrations/to_copy/2_people_have_descriptions.ts
@@ -1,0 +1,12 @@
+// vendor/rails/activerecord/test/migrations/to_copy/2_people_have_descriptions.rb
+import { Migration } from "../../../migration.js";
+
+export class PeopleHaveDescriptions extends Migration {
+  async up(): Promise<void> {
+    await this.addColumn("people", "description", "text");
+  }
+
+  async down(): Promise<void> {
+    await this.removeColumn("people", "description");
+  }
+}

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -769,21 +769,22 @@ export class CreatePosts extends Migration {
     const migrations = discoverMigrations(tmpDir);
     const schemaMigration = new SchemaMigration(adapter.pool);
     const internalMetadata = new InternalMetadata(adapter.pool);
-    const migrator = new Migrator("up", migrations, schemaMigration, internalMetadata);
-    // `rollback` lives on MigrationContext (`migration.rb:1240-1242`); it reads
-    // the same bookkeeping tables, over the same discovered migration list.
     const context = migrationContextFor(tmpDir, schemaMigration, internalMetadata);
+    // Rails' `Migrator#initialize` creates the bookkeeping tables
+    // (`migration.rb:1429-1430`) before anything reads them; `migrations_status`
+    // reads `schema_migration.normalized_versions` directly.
+    await schemaMigration.createTable();
 
     // Status before migrate
-    const beforeStatus = await migrator.migrationsStatus();
+    const beforeStatus = await context.migrationsStatus();
     expect(beforeStatus).toHaveLength(1);
     expect(beforeStatus[0].status).toBe("down");
 
     // Migrate up
-    await migrator.migrate();
+    await context.migrate();
 
     // Status after migrate
-    const afterStatus = await migrator.migrationsStatus();
+    const afterStatus = await context.migrationsStatus();
     expect(afterStatus[0].status).toBe("up");
 
     // Verify table exists
@@ -796,7 +797,7 @@ export class CreatePosts extends Migration {
     await context.rollback(1);
 
     // Status after rollback
-    const rollbackStatus = await migrator.migrationsStatus();
+    const rollbackStatus = await context.migrationsStatus();
     expect(rollbackStatus[0].status).toBe("down");
 
     // Verify table is gone
@@ -902,20 +903,18 @@ export class CreateWidgets extends Migration {
 }`,
     );
 
-    const migrations = discoverMigrations(tmpDir);
-    const migrator = new Migrator(
-      "up",
-      migrations,
+    const context = migrationContextFor(
+      tmpDir,
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
     );
 
-    await migrator.run("up", "20260101000000");
+    await context.run("up", "20260101000000");
     expect(
       await adapter.execute(`SELECT name FROM sqlite_master WHERE type='table' AND name='widgets'`),
     ).toHaveLength(1);
 
-    await migrator.run("down", "20260101000000");
+    await context.run("down", "20260101000000");
     expect(
       await adapter.execute(`SELECT name FROM sqlite_master WHERE type='table' AND name='widgets'`),
     ).toHaveLength(0);
@@ -928,13 +927,12 @@ export class CreateWidgets extends Migration {
     adapter = new BetterSQLite3Adapter(":memory:");
     await establishMigrationConnection(adapter);
 
-    const migrator = new Migrator(
-      "up",
-      [],
+    const context = migrationContextFor(
+      "/nonexistent",
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
     );
-    await expect(migrator.run("up", "99999999999999")).rejects.toBeInstanceOf(
+    await expect(context.run("up", "99999999999999")).rejects.toBeInstanceOf(
       UnknownMigrationVersionError,
     );
   });
@@ -954,17 +952,15 @@ export class CreatePosts extends Migration {
 }`,
     );
 
-    const migrations = discoverMigrations(tmpDir);
-    const migrator = new Migrator(
-      "up",
-      migrations,
+    const context = migrationContextFor(
+      tmpDir,
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
     );
 
-    expect((await migrator.pendingMigrations()).length).toBe(1);
-    await migrator.migrate();
-    expect((await migrator.pendingMigrations()).length).toBe(0);
+    expect((await context.open().pendingMigrations()).length).toBe(1);
+    await context.migrate();
+    expect((await context.open().pendingMigrations()).length).toBe(0);
   });
 });
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -803,7 +803,6 @@ export function dbCommand(): Command {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
         const mDirs = await migrationsDirsForConfig(raw);
         const migrationContext = migrationContextFor(adapter, mDirs);
-        if (migrationContext.migrations.length === 0) return;
         const pending = await migrationContext.open().pendingMigrations();
         if (pending.length > 0) {
           // Match Rails' output format (from activerecord/lib/active_record/

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -993,9 +993,11 @@ export function dbCommand(): Command {
 
         // `DatabaseTasks.migrate_status` aborts before reading
         // schema_migrations when the table is not there yet
-        // (`tasks/database_tasks.rb:303-305`).
+        // (`tasks/database_tasks.rb:303-305`) — `Kernel.abort` writes the
+        // message to stderr and exits non-zero.
         if (!(await migrationContext.schemaMigration.tableExists())) {
-          console.log(`${prefix}Schema migrations table does not exist yet.`);
+          console.error(`${prefix}Schema migrations table does not exist yet.`);
+          setExitCode(1);
           return;
         }
 

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -748,8 +748,9 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, prefix }) => {
-        const migrationContext = migrationContextFor(adapter, []);
-        const version = (await migrationContext.currentVersion()) ?? 0;
+        // `pool.migration_context.current_version` (`databases.rake:311`),
+        // whose nil — a NoDatabaseError — interpolates to nothing.
+        const version = (await migrationContextFor(adapter, []).currentVersion()) ?? "";
         console.log(`${prefix}Current version: ${version}`);
       });
     });
@@ -803,8 +804,6 @@ export function dbCommand(): Command {
         const mDirs = await migrationsDirsForConfig(raw);
         const migrationContext = migrationContextFor(adapter, mDirs);
         if (migrationContext.migrations.length === 0) return;
-        // `pool.migration_context.open.pending_migrations`
-        // (`railties/databases.rake:333`).
         const pending = await migrationContext.open().pendingMigrations();
         if (pending.length > 0) {
           // Match Rails' output format (from activerecord/lib/active_record/

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -22,12 +22,10 @@ import {
   InternalMetadata,
   MigrationContext,
   Migrator,
-  NullInternalMetadata,
-  NullSchemaMigration,
   SchemaMigration,
   eachCurrentEnvironment,
 } from "@blazetrails/activerecord";
-import type { DatabaseAdapter, MigrationProxy } from "@blazetrails/activerecord";
+import type { DatabaseAdapter } from "@blazetrails/activerecord";
 
 async function closeAdapter(adapter: DatabaseAdapter): Promise<void> {
   const maybeClose = (adapter as unknown as { close?: () => Promise<void> }).close;
@@ -92,21 +90,6 @@ async function migrationsDirsForConfig(config: RawConfig): Promise<string[]> {
     if (dirs.length > 0) return dirs;
   }
   return Migrator.migrationsPaths.map((p) => path.resolve(cwd, p));
-}
-
-/**
- * Discover migrations across `dirs`, through the one discovery path there is:
- * `MigrationContext#migrations` (`migration.rb:1303-1315`), which scans every
- * one of its `migrations_paths`. Duplicate-version validation is handled by
- * Migrator (which throws DuplicateMigrationVersionError) so conflicting
- * migrations are surfaced as errors instead of being silently skipped.
- *
- * The context is built with the null collaborators `Migration.copy` uses
- * (`migration.rb:1065-1066`): discovery never reaches the connected half.
- */
-function discoverMigrations(dirs: string[]): MigrationProxy[] {
-  return new MigrationContext(dirs, new NullSchemaMigration(), new NullInternalMetadata())
-    .migrations;
 }
 
 interface DatabaseOpts {
@@ -370,16 +353,15 @@ interface RunOptions {
 }
 
 /**
- * Centralized Migrator construction so every CLI command stamps
- * ar_internal_metadata.environment with the resolved TRAILS_ENV and
- * respects useMetadataTable. Without this, `db migrate:up`,
- * `db migrate:status`, etc. would default to NODE_ENV and potentially
- * stamp a different env than `db migrate`.
+ * The `pool.migration_context` every `databases.rake` task reaches through
+ * (`connection_adapters/abstract/connection_pool.rb:298-300`): a
+ * `MigrationContext` over this config's migration directories, seated with the
+ * pool's own `schema_migration` / `internal_metadata` so each CLI command
+ * stamps ar_internal_metadata.environment with the resolved TRAILS_ENV.
  */
-function createMigrator(adapter: DatabaseAdapter, migrations: MigrationProxy[]): Migrator {
-  return new Migrator(
-    "up",
-    migrations,
+function migrationContextFor(adapter: DatabaseAdapter, dirs: string[]): MigrationContext {
+  return new MigrationContext(
+    dirs,
     new SchemaMigration(adapter.pool),
     new InternalMetadata(adapter.pool),
   );
@@ -391,11 +373,10 @@ async function runMigrate(
   targetVersion?: string,
   options: RunOptions = {},
 ): Promise<void> {
-  const migrations = discoverMigrations(await migrationsDirsForConfig(raw));
-  const migrator = createMigrator(adapter, migrations);
-  await migrator.migrate(targetVersion ?? null);
+  const migrationContext = migrationContextFor(adapter, await migrationsDirsForConfig(raw));
+  await migrationContext.migrate(targetVersion ?? null);
 
-  const pending = await migrator.pendingMigrations();
+  const pending = await migrationContext.open().pendingMigrations();
   if (pending.length === 0) console.log("All migrations are up to date.");
 
   if (!options.skipDump) await dumpSchemaAfterMigrate(raw);
@@ -619,10 +600,9 @@ async function withTargetVersionEnv(
 async function runMigrateAll(): Promise<void> {
   const envName = resolveEnv();
   const entries = await taskableDatabaseEntries({}, envName);
-  const migrationsFor = new Map<string, MigrationProxy[]>();
+  const migrationsDirsFor = new Map<string, string[]>();
   for (const { name, raw } of entries) {
-    const migrations = discoverMigrations(await migrationsDirsForConfig(raw));
-    migrationsFor.set(name, migrations);
+    migrationsDirsFor.set(name, await migrationsDirsForConfig(raw));
   }
 
   // Rails' `load_config` leaves the primary connection established, which is
@@ -652,15 +632,9 @@ async function runMigrateAll(): Promise<void> {
       for (const { name, raw, hashConfig } of entries) {
         const prefix = multiDb ? `[${name}] ` : "";
         await DatabaseTasks.withTemporaryPool(hashConfig, async (pool) => {
-          const migrations = migrationsFor.get(name) ?? [];
           const adapter = await pool.leaseConnection();
-          const migrator = new Migrator(
-            "up",
-            migrations,
-            new SchemaMigration(adapter.pool),
-            new InternalMetadata(adapter.pool),
-          );
-          const pending = await migrator.pendingMigrations();
+          const migrationContext = migrationContextFor(adapter, migrationsDirsFor.get(name) ?? []);
+          const pending = await migrationContext.open().pendingMigrations();
           if (pending.length === 0) console.log(`${prefix}All migrations are up to date.`);
           await dumpSchemaAfterMigrate(raw, hashConfig);
         });
@@ -774,8 +748,8 @@ export function dbCommand(): Command {
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, prefix }) => {
-        const migrator = createMigrator(adapter, []);
-        const version = await migrator.currentVersionReadOnly();
+        const migrationContext = migrationContextFor(adapter, []);
+        const version = (await migrationContext.currentVersion()) ?? 0;
         console.log(`${prefix}Current version: ${version}`);
       });
     });
@@ -827,10 +801,11 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
         const mDirs = await migrationsDirsForConfig(raw);
-        const migrations = discoverMigrations(mDirs);
-        if (migrations.length === 0) return;
-        const migrator = createMigrator(adapter, migrations);
-        const pending = await migrator.pendingMigrations();
+        const migrationContext = migrationContextFor(adapter, mDirs);
+        if (migrationContext.migrations.length === 0) return;
+        // `pool.migration_context.open.pending_migrations`
+        // (`railties/databases.rake:333`).
+        const pending = await migrationContext.open().pendingMigrations();
         if (pending.length > 0) {
           // Match Rails' output format (from activerecord/lib/active_record/
           // railties/databases.rake), with the command name swapped for
@@ -1016,9 +991,17 @@ export function dbCommand(): Command {
     .action(async (opts: DatabaseOpts) => {
       await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
         const mDirs = await migrationsDirsForConfig(raw);
-        const migrations = discoverMigrations(mDirs);
-        const migrator = createMigrator(adapter, migrations);
-        const statuses = await migrator.migrationsStatus();
+        const migrationContext = migrationContextFor(adapter, mDirs);
+
+        // `DatabaseTasks.migrate_status` aborts before reading
+        // schema_migrations when the table is not there yet
+        // (`tasks/database_tasks.rb:303-305`).
+        if (!(await migrationContext.schemaMigration.tableExists())) {
+          console.log(`${prefix}Schema migrations table does not exist yet.`);
+          return;
+        }
+
+        const statuses = await migrationContext.migrationsStatus();
 
         console.log("");
         console.log(`${prefix}Status   Migration ID    Migration Name`);

--- a/packages/website/src/lib/frontiers/components/tutorial/ActionCard.svelte
+++ b/packages/website/src/lib/frontiers/components/tutorial/ActionCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { FileDiff } from "../../tutorials/types.js";
-  import type { CliResult } from "../../trail-cli.js";
+  import type { CliResult } from "../../trails-cli.js";
   import type { VirtualFS } from "../../virtual-fs.js";
   import CliAction from "./CliAction.svelte";
   import DiffViewer from "./DiffViewer.svelte";

--- a/packages/website/src/lib/frontiers/components/tutorial/ActionCard.test.ts
+++ b/packages/website/src/lib/frontiers/components/tutorial/ActionCard.test.ts
@@ -4,7 +4,7 @@ import ActionCard from "./ActionCard.svelte";
 import initSqlJs, { type SqlJsStatic } from "sql.js";
 import { SqlJsAdapter } from "../../sql-js-adapter.js";
 import { VirtualFS } from "../../virtual-fs.js";
-import type { CliResult } from "../../trail-cli.js";
+import type { CliResult } from "../../trails-cli.js";
 
 let SQL: SqlJsStatic;
 let vfs: VirtualFS;

--- a/packages/website/src/lib/frontiers/components/tutorial/CliAction.svelte
+++ b/packages/website/src/lib/frontiers/components/tutorial/CliAction.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CliResult } from "../../trail-cli.js";
+  import type { CliResult } from "../../trails-cli.js";
 
   interface Props {
     command: string;

--- a/packages/website/src/lib/frontiers/components/tutorial/CliAction.test.ts
+++ b/packages/website/src/lib/frontiers/components/tutorial/CliAction.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
 import CliAction from "./CliAction.svelte";
-import type { CliResult } from "../../trail-cli.js";
+import type { CliResult } from "../../trails-cli.js";
 
 function mockExec(result: Partial<CliResult> = {}): (cmd: string) => Promise<CliResult> {
   return vi.fn().mockResolvedValue({

--- a/packages/website/src/lib/frontiers/components/tutorial/StepContent.svelte
+++ b/packages/website/src/lib/frontiers/components/tutorial/StepContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TutorialStep } from "../../tutorials/types.js";
-  import type { CliResult } from "../../trail-cli.js";
+  import type { CliResult } from "../../trails-cli.js";
   import type { VirtualFS } from "../../virtual-fs.js";
   import type { SqlJsAdapter } from "../../sql-js-adapter.js";
   import ActionCard from "./ActionCard.svelte";

--- a/packages/website/src/lib/frontiers/components/tutorial/StepContent.test.ts
+++ b/packages/website/src/lib/frontiers/components/tutorial/StepContent.test.ts
@@ -9,7 +9,7 @@ import initSqlJs, { type SqlJsStatic } from "sql.js";
 import { SqlJsAdapter } from "../../sql-js-adapter.js";
 import { VirtualFS } from "../../virtual-fs.js";
 import type { TutorialStep } from "../../tutorials/types.js";
-import type { CliResult } from "../../trail-cli.js";
+import type { CliResult } from "../../trails-cli.js";
 
 let SQL: SqlJsStatic;
 let adapter: SqlJsAdapter;

--- a/packages/website/src/lib/frontiers/runtime.ts
+++ b/packages/website/src/lib/frontiers/runtime.ts
@@ -1,11 +1,11 @@
 import type { SqlJsStatic } from "sql.js";
 import { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VirtualFS } from "./virtual-fs.js";
-import { createTrailCLI, dropUserTables, type CliResult } from "./trail-cli.js";
+import { createTrailsCLI, dropUserTables, type CliResult } from "./trails-cli.js";
 import type { MigrationProxy } from "@blazetrails/activerecord/migration";
 
 export type { VirtualFS, VfsFile } from "./virtual-fs.js";
-export type { CliResult } from "./trail-cli.js";
+export type { CliResult } from "./trails-cli.js";
 
 export interface Runtime {
   adapter: SqlJsAdapter;
@@ -61,7 +61,7 @@ export async function createRuntime(SQL: SqlJsStatic): Promise<Runtime> {
   }
 
   function buildCli() {
-    return createTrailCLI({
+    return createTrailsCLI({
       vfs,
       adapter,
       executeCode,

--- a/packages/website/src/lib/frontiers/sandbox-sw.test.ts
+++ b/packages/website/src/lib/frontiers/sandbox-sw.test.ts
@@ -178,9 +178,9 @@ describe("sandbox-sw message handling", () => {
 
   describe("CLI execution", () => {
     it("trail-cli accepts generate model command", async () => {
-      const { createTrailCLI } = await import("./trail-cli.js");
+      const { createTrailsCLI } = await import("./trails-cli.js");
       const migrations: any[] = [];
-      const cli = createTrailCLI({
+      const cli = createTrailsCLI({
         vfs,
         adapter,
         executeCode: async () => {},

--- a/packages/website/src/lib/frontiers/sandbox-sw.ts
+++ b/packages/website/src/lib/frontiers/sandbox-sw.ts
@@ -13,7 +13,7 @@ import { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VirtualFS } from "./virtual-fs.js";
 import { CompiledCache } from "./compiled-cache.js";
 import { stripTypes } from "./transpiler.js";
-import { createTrailCLI, type CliResult } from "./trail-cli.js";
+import { createTrailsCLI, type CliResult } from "./trails-cli.js";
 import { createAppServer, type AppServer } from "./app-server.js";
 import { requestToRackEnvWithBody, rackResponseToFetchResponse } from "./rack-bridge.js";
 import { resolveVfsPath } from "./vfs-resolve.js";
@@ -38,7 +38,7 @@ let adapter: SqlJsAdapter;
 let vfs: VirtualFS;
 let compiled: CompiledCache;
 let migrations: MigrationProxy[] = [];
-let cli: ReturnType<typeof createTrailCLI>;
+let cli: ReturnType<typeof createTrailsCLI>;
 let appServer: AppServer;
 let initialized = false;
 
@@ -94,7 +94,7 @@ async function init(): Promise<void> {
   vfs = new VirtualFS(adapter);
   compiled = new CompiledCache(adapter);
 
-  cli = createTrailCLI({
+  cli = createTrailsCLI({
     vfs,
     adapter,
     executeCode,
@@ -121,7 +121,7 @@ function replaceDatabase(data: Uint8Array): void {
   vfs = new VirtualFS(adapter);
   compiled = new CompiledCache(adapter);
   migrations = [];
-  cli = createTrailCLI({
+  cli = createTrailsCLI({
     vfs,
     adapter,
     executeCode,

--- a/packages/website/src/lib/frontiers/sw-protocol.ts
+++ b/packages/website/src/lib/frontiers/sw-protocol.ts
@@ -4,7 +4,7 @@
  */
 
 import type { VfsFile } from "./virtual-fs.js";
-import type { CliResult } from "./trail-cli.js";
+import type { CliResult } from "./trails-cli.js";
 
 // ── Request → Response mapping ──────────────────────────────────────────
 // Each request type maps to exactly one response shape. SwClient.send()

--- a/packages/website/src/lib/frontiers/sw-runtime-proxy.ts
+++ b/packages/website/src/lib/frontiers/sw-runtime-proxy.ts
@@ -3,7 +3,7 @@
  * Separated from SwAdapterProxy which handles DB introspection only.
  */
 
-import type { CliResult } from "./trail-cli.js";
+import type { CliResult } from "./trails-cli.js";
 import type { SwClient } from "./sw-client.js";
 
 export class SwRuntimeProxy {

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -89,19 +89,21 @@ class VfsMigrationContext extends MigrationContext {
     return this.migrationFiles().flatMap((path) => {
       const parsed = this.parseMigrationFilename(path);
       if (!parsed) return [];
-      const [version, name] = parsed;
+      const [rawVersion, name] = parsed;
       return [
         {
-          version,
+          version: Number(rawVersion),
           name: camelize(name),
           filename: path,
           migration: async (): Promise<Migration> => {
             const content = this.vfs.read(path)?.content;
             if (!content) throw new Error(`File not found: ${path}`);
             await this.executeCode(content);
-            const reg = this.getMigrations().find((r) => r.version === version);
+            const reg = this.getMigrations().find((r) => r.version === rawVersion);
             if (!reg) {
-              throw new Error(`Migration ${version} from ${path} did not register after execution`);
+              throw new Error(
+                `Migration ${rawVersion} from ${path} did not register after execution`,
+              );
             }
             return reg.migration();
           },

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -86,7 +86,7 @@ class VfsMigrationContext extends MigrationContext {
   }
 
   override get migrations(): MigrationProxy[] {
-    return this.migrationFiles().flatMap((path) => {
+    const migrations = this.migrationFiles().flatMap((path) => {
       const parsed = this.parseMigrationFilename(path);
       if (!parsed) return [];
       const [rawVersion, name] = parsed;
@@ -110,6 +110,10 @@ class VfsMigrationContext extends MigrationContext {
         },
       ];
     });
+
+    // `migrations.sort_by(&:version)` (`migration.rb:1315`) — lexicographic
+    // path order puts `10_` before `2_`.
+    return migrations.sort((a, b) => Number(a.version) - Number(b.version));
   }
 }
 

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -2,7 +2,7 @@ import type { VirtualFS } from "./virtual-fs.js";
 import type { SqlJsAdapter } from "./sql-js-adapter.js";
 import { VfsModelGenerator, VfsMigrationGenerator, VfsAppGenerator } from "./vfs-generator.js";
 import type { Migration, MigrationProxy } from "@blazetrails/activerecord/migration";
-import { Migrator } from "@blazetrails/activerecord/migration";
+import { MigrationContext } from "@blazetrails/activerecord/migration";
 import { InternalMetadata, SchemaMigration } from "@blazetrails/activerecord";
 import {
   camelize,
@@ -51,38 +51,64 @@ const MIGRATION_FILE_PATTERN = /^(\d+)[-_](.+)\.(?:ts|js)$/;
 // (a) evaluate the file in a sandbox that exposes registerMigration, or
 // (b) be changed to return the migration class directly so we can build the
 //     proxy without the registry lookup.
-function discoverMigrations(
-  vfs: VirtualFS,
-  executeCode: (code: string) => Promise<unknown>,
-  getMigrations: () => MigrationProxy[],
-): MigrationProxy[] {
-  return vfs
-    .list()
-    .filter((f) => f.path.startsWith("db/migrate/"))
-    .flatMap((file) => {
-      const basename = file.path.split("/").pop() ?? "";
-      const match = basename.match(MIGRATION_FILE_PATTERN);
-      if (!match) return [];
+/**
+ * The `MigrationContext` every `db:*` command runs through, over the browser's
+ * virtual FS instead of a directory: Rails' `migration_files` /
+ * `parse_migration_filename` (`migration.rb:1369-1376`) are private, and a Ruby
+ * private method is still overridable by a subclass, so discovery is repointed
+ * there and the run surface (`migrate` / `rollback` / `open` /
+ * `migrations_status`) is inherited unchanged.
+ */
+class VfsMigrationContext extends MigrationContext {
+  constructor(
+    private readonly vfs: VirtualFS,
+    private readonly executeCode: (code: string) => Promise<unknown>,
+    private readonly getMigrations: () => MigrationProxy[],
+    schemaMigration: SchemaMigration,
+    internalMetadata: InternalMetadata,
+  ) {
+    super(["db/migrate"], schemaMigration, internalMetadata);
+  }
+
+  protected override migrationFiles(): string[] {
+    return this.vfs
+      .list()
+      .map((f) => f.path)
+      .filter((path) => path.startsWith("db/migrate/") && this.parseMigrationFilename(path))
+      .sort();
+  }
+
+  protected override parseMigrationFilename(filename: string): [string, string, string] | null {
+    const basename = filename.split("/").pop() ?? "";
+    const match = basename.match(MIGRATION_FILE_PATTERN);
+    if (!match) return null;
+    return [match[1], match[2].replace(/-/g, "_"), ""];
+  }
+
+  override get migrations(): MigrationProxy[] {
+    return this.migrationFiles().flatMap((path) => {
+      const parsed = this.parseMigrationFilename(path);
+      if (!parsed) return [];
+      const [version, name] = parsed;
       return [
         {
-          version: match[1],
-          name: camelize(match[2].replace(/-/g, "_")),
-          filename: file.path,
+          version,
+          name: camelize(name),
+          filename: path,
           migration: async (): Promise<Migration> => {
-            const content = vfs.read(file.path)?.content;
-            if (!content) throw new Error(`File not found: ${file.path}`);
-            await executeCode(content);
-            const reg = getMigrations().find((r) => r.version === match[1]);
+            const content = this.vfs.read(path)?.content;
+            if (!content) throw new Error(`File not found: ${path}`);
+            await this.executeCode(content);
+            const reg = this.getMigrations().find((r) => r.version === version);
             if (!reg) {
-              throw new Error(
-                `Migration ${match[1]} from ${file.path} did not register after execution`,
-              );
+              throw new Error(`Migration ${version} from ${path} did not register after execution`);
             }
             return reg.migration();
           },
         },
       ];
     });
+  }
 }
 
 export interface TrailCliDeps {
@@ -142,18 +168,20 @@ export function createTrailCLI(deps: TrailCliDeps) {
     output.push(msg);
   }
 
-  async function withMigrator(fn: (migrator: Migrator) => Promise<void>): Promise<void> {
-    const proxies = discoverMigrations(vfs, deps.executeCode, deps.getMigrations);
-    if (proxies.length === 0) {
-      log("No migrations found in db/migrate/.");
-      return;
-    }
-    const migrator = new Migrator(
-      "up",
-      proxies,
+  async function withMigrationContext(
+    fn: (migrationContext: MigrationContext) => Promise<void>,
+  ): Promise<void> {
+    const migrationContext = new VfsMigrationContext(
+      vfs,
+      deps.executeCode,
+      deps.getMigrations,
       new SchemaMigration(adapter.pool),
       new InternalMetadata(adapter.pool),
     );
+    if (migrationContext.migrations.length === 0) {
+      log("No migrations found in db/migrate/.");
+      return;
+    }
     // Migration output goes to stdout (Rails' Migration#write is `puts`), and
     // the browser has no process — so the shim's stdout is pointed at this
     // CLI's output buffer for the duration of the run. Any adapter the host
@@ -162,7 +190,7 @@ export function createTrailCLI(deps: TrailCliDeps) {
     registerProcessAdapter(browserProcessAdapter);
     stdoutSink = (chunk) => log(chunk.replace(/\n$/, ""));
     try {
-      await fn(migrator);
+      await fn(migrationContext);
     } finally {
       stdoutSink = () => {};
       if (prevAdapter) registerProcessAdapter(prevAdapter);
@@ -214,9 +242,9 @@ export function createTrailCLI(deps: TrailCliDeps) {
 
       "db:migrate": async (_args, opts) => {
         const version = opts.version && opts.version !== "true" ? opts.version : null;
-        await withMigrator(async (migrator) => {
-          await migrator.migrate(version);
-          const pending = await migrator.pendingMigrations();
+        await withMigrationContext(async (migrationContext) => {
+          await migrationContext.migrate(version);
+          const pending = await migrationContext.open().pendingMigrations();
           log(
             pending.length === 0
               ? "All migrations are up to date."
@@ -228,14 +256,14 @@ export function createTrailCLI(deps: TrailCliDeps) {
       "db:rollback": async (_args, opts) => {
         const parsed = parseInt(opts.step ?? "1", 10);
         const step = Number.isNaN(parsed) ? 1 : parsed;
-        await withMigrator(async (migrator) => {
-          await migrator.rollback(step);
+        await withMigrationContext(async (migrationContext) => {
+          await migrationContext.rollback(step);
         });
       },
 
       "db:migrate:status": async () => {
-        await withMigrator(async (migrator) => {
-          const statuses = await migrator.migrationsStatus();
+        await withMigrationContext(async (migrationContext) => {
+          const statuses = await migrationContext.migrationsStatus();
           log("");
           log(" Status   Migration ID    Migration Name");
           log("--------------------------------------------------");

--- a/packages/website/src/lib/frontiers/trails-cli.ts
+++ b/packages/website/src/lib/frontiers/trails-cli.ts
@@ -117,7 +117,7 @@ class VfsMigrationContext extends MigrationContext {
   }
 }
 
-export interface TrailCliDeps {
+export interface TrailsCliDeps {
   vfs: VirtualFS;
   adapter: SqlJsAdapter;
   executeCode: (code: string) => Promise<unknown>;
@@ -167,7 +167,7 @@ const browserProcessAdapter: ProcessAdapter = {
   stdin: { isTTY: false, read: async () => null },
 };
 
-export function createTrailCLI(deps: TrailCliDeps) {
+export function createTrailsCLI(deps: TrailsCliDeps) {
   const { vfs, adapter } = deps;
   const output: string[] = [];
   function log(msg: string) {


### PR DESCRIPTION
## What

`Migrator` was carrying `MigrationContext`'s shape: `#migrate(targetVersion, block)`, `#run(direction, targetVersion)`, plus `migrationsStatus`, `getAllVersions`, `schemaMigrationTableExists`, `currentVersionReadOnly` and `pendingMigrationsReadOnly` — none of which Rails' `Migrator` (`migration.rb:1404-1620`) has.

- `Migrator#migrate` / `#run` are the no-arg advisory-lock gates Rails writes (`migration.rb:1444-1458`), reading `@direction` / `@target_version`, and they sit next to each other as Rails has them.
- `MigrationContext#up` / `#down` / `#run` call them directly (`migration.rb:1248-1270`) instead of spelling out `use_advisory_lock? ? with_advisory_lock { … } : …`; the `_migrateWithMigrator` helper is gone.
- `Migrator#current_version` is `migrated.max || 0` (`migration.rb:1435-1437`); `#invalid_target?` is `@target_version && != 0 && !target` (`migration.rb:1523-1525`), with the private `_invalidTarget` folded in.
- Everything with no `migration.rb:1404-1620` counterpart is deleted. The read-only variants existed on the premise that `Migrator` must not create the bookkeeping tables — Rails' `Migrator#initialize` (`migration.rb:1429-1430`) creates them, so `open.pending_migrations` writes on a fresh DB in Rails too.

## Callers

Every caller reaches the run surface through a `MigrationContext`:

- **trailties `db.ts`** — `createMigrator` becomes `migrationContextFor`, the equivalent of `pool.migration_context` (`connection_pool.rb:298-300`). Pending counts and `abort_if_pending_migrations` go through `open().pendingMigrations()`, as `databases.rake:333` does; that command's preflight discovery scan goes with it, matching `databases.rake:329-346`. `db version` interpolates `current_version`'s nil the way `databases.rake:311` does instead of substituting 0. `migrate:status` carries `migrate_status`'s missing-table abort (`tasks/database_tasks.rb:303-305`), which `Migrator#migrationsStatus`'s implicit table creation used to paper over. The last non-`MigrationContext` discovery helper, `discoverMigrations`, is gone.
- **website `trails-cli.ts`** — subclasses `MigrationContext` over its virtual FS, and answers integer versions as `migration.rb:1310` does. `migrationFiles` / `parseMigrationFilename` become `protected`: Ruby `private` still permits a subclass override, TS `private` does not, so `protected` is the spelling that keeps Rails' semantics. That is what lets the browser CLI inherit the whole run surface unchanged.
- `tasks/database-tasks.ts` and activerecord-cli already went through `pool.migrationContext`; `test-databases.ts`'s `Migrator.new(…).migrate` is already the Rails idiom.

## Tests

Targets move into the `Migrator` constructor exactly as `migrator_test.rb` writes them (`:65-90`, `:297-404`), the `migratorClass` helper collapses onto the `MigrationContext` subclass Rails' own helper returns (`migrator_test.rb:229-238`), and `migrations_status` is read off a `MigrationContext` over real migration directories — adding `to_copy`, Rails' `@path_b` (`multi_db_migrator_test.rb:34`). No test name changed; the new fixtures mirror `test/migrations/to_copy/` and touch only canonical `people` columns.

## Mechanical rename (deliberately in scope)

`packages/website/src/lib/frontiers/trail-cli.ts` is renamed to `trails-cli.ts`, with `TrailCliDeps` -> `TrailsCliDeps` and `createTrailCLI` -> `createTrailsCLI`: the framework and its CLI are `trails`, and this adapter was spelled singular. Importers and the three `docs/frontiers/` files that name it follow. No behavior change; the one test name that mentions the file is left verbatim, per CLAUDE.md's rule against rewording test names.

**Why it rides along rather than being split.** It was requested directly during this PR, and the maintainer confirmed keeping it here after the scope question was raised. CLAUDE.md names "a single mechanical rename" as the one exception to the no-fan-out rule, and this is one: no logic changes, no API semantics change, just a spelling.

Splitting it would also be worse, not better: `trails-cli.ts` is the *same file* this PR modifies for the `MigrationContext` subclass, so a rename PR branched from `main` would collide with this one on that file rather than being independent — precisely the file-overlap conflict the stacking rule exists to prevent. Whichever landed second would need a rebase.

## Note on size

869 LOC (365+/610-, of which 251 are the mechanical rename above), over the 700 ceiling. It cannot be split: removing the six methods and repointing their callers is one compile unit, and 610 of the 869 are deletions.

Closes-story: migrator-run-surface-caller-migration