### PR TITLE
fix(website): frontiers sandbox uses db/migrate, not db/migrations

### DIFF
--- a/packages/website/src/lib/frontiers/components/sandbox/FileTree.test.ts
+++ b/packages/website/src/lib/frontiers/components/sandbox/FileTree.test.ts
@@ -23,7 +23,7 @@ function seedFiles() {
   vfs.write("src/app/models/post.ts", "class Post {}");
   vfs.write("src/app/controllers/application-controller.ts", "class AppController {}");
   vfs.write("src/config/routes.ts", "// routes");
-  vfs.write("db/migrations/001_create_users.ts", "migration");
+  vfs.write("db/migrate/001_create_users.ts", "migration");
   vfs.write("package.json", "{}");
 }
 

--- a/packages/website/src/lib/frontiers/runtime.test.ts
+++ b/packages/website/src/lib/frontiers/runtime.test.ts
@@ -36,7 +36,7 @@ describe("exec: new", () => {
     expect(runtime.vfs.exists("src/app/models/application-record.ts")).toBe(true);
     expect(runtime.vfs.exists("src/app/controllers/application-controller.ts")).toBe(true);
     expect(runtime.vfs.exists("db/seeds.ts")).toBe(true);
-    expect(runtime.vfs.exists("db/migrations/.gitkeep")).toBe(true);
+    expect(runtime.vfs.exists("db/migrate/.gitkeep")).toBe(true);
   });
 
   it("clears existing files", async () => {
@@ -62,7 +62,7 @@ describe("exec: generate model", () => {
     // Migration uses trailties format
     const migFiles = runtime.vfs
       .list()
-      .filter((f) => f.path.startsWith("db/migrations/") && f.path.includes("create-users"));
+      .filter((f) => f.path.startsWith("db/migrate/") && f.path.includes("create_users"));
     expect(migFiles.length).toBe(1);
     expect(migFiles[0].content).toContain("class CreateUsers extends Migration");
     expect(migFiles[0].content).toContain('t.string("name")');
@@ -88,7 +88,7 @@ describe("exec: generate migration", () => {
     expect(result.success).toBe(true);
     const migFiles = runtime.vfs
       .list()
-      .filter((f) => f.path.startsWith("db/migrations/") && f.path.includes("add-age-to-users"));
+      .filter((f) => f.path.startsWith("db/migrate/") && f.path.includes("add_age_to_users"));
     expect(migFiles.length).toBe(1);
     expect(migFiles[0].content).toContain("AddAgeToUsers");
   });

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -58,7 +58,7 @@ function discoverMigrations(
 ): MigrationProxy[] {
   return vfs
     .list()
-    .filter((f) => f.path.startsWith("db/migrations/"))
+    .filter((f) => f.path.startsWith("db/migrate/"))
     .flatMap((file) => {
       const basename = file.path.split("/").pop() ?? "";
       const match = basename.match(MIGRATION_FILE_PATTERN);
@@ -145,7 +145,7 @@ export function createTrailCLI(deps: TrailCliDeps) {
   async function withMigrator(fn: (migrator: Migrator) => Promise<void>): Promise<void> {
     const proxies = discoverMigrations(vfs, deps.executeCode, deps.getMigrations);
     if (proxies.length === 0) {
-      log("No migrations found in db/migrations/.");
+      log("No migrations found in db/migrate/.");
       return;
     }
     const migrator = new Migrator(

--- a/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
+++ b/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
@@ -51,7 +51,7 @@ describe("generator fixtures", () => {
       expect(fileExists("src/config/database.ts")).toBe(true);
       expect(fileExists("src/app/models/application-record.ts")).toBe(true);
       expect(fileExists("src/app/controllers/application-controller.ts")).toBe(true);
-      expect(fileExists("db/migrations/.gitkeep")).toBe(true);
+      expect(fileExists("db/migrate/.gitkeep")).toBe(true);
       expect(fileExists("db/seeds.ts")).toBe(true);
     });
 
@@ -79,7 +79,7 @@ describe("generator fixtures", () => {
     });
 
     it("creates migration file", () => {
-      const migFile = files.find((f) => f.startsWith("db/migrations/"));
+      const migFile = files.find((f) => f.startsWith("db/migrate/"));
       expect(migFile).toBeDefined();
       const content = readFile(migFile!);
       expect(content).toContain("class CreateUsers extends Migration");
@@ -112,7 +112,7 @@ describe("generator fixtures", () => {
     });
 
     it("creates migration with correct columns", () => {
-      const migFile = files.find((f) => f.startsWith("db/migrations/"));
+      const migFile = files.find((f) => f.startsWith("db/migrate/"));
       expect(migFile).toBeDefined();
       const content = readFile(migFile!);
       expect(content).toContain("class CreateFolders extends Migration");
@@ -147,7 +147,7 @@ describe("generator fixtures", () => {
     });
 
     it("creates migration with correct columns", () => {
-      const migFile = files.find((f) => f.startsWith("db/migrations/"));
+      const migFile = files.find((f) => f.startsWith("db/migrate/"));
       expect(migFile).toBeDefined();
       const content = readFile(migFile!);
       expect(content).toContain("class CreateDocuments extends Migration");
@@ -195,7 +195,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("name", "string")');
       expect(content).toContain('this.attribute("bio", "text")');
 
-      const mig = findMigration(artistFiles, /db\/migrations\/.+_create_artists\.ts$/);
+      const mig = findMigration(artistFiles, /db\/migrate\/.+_create_artists\.ts$/);
       expect(mig).toContain('t.string("name")');
       expect(mig).toContain('t.text("bio")');
     });
@@ -207,7 +207,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("artist_id", "integer")');
       expect(content).toContain('this.attribute("release_date", "date")');
 
-      const mig = findMigration(albumFiles, /db\/migrations\/.+_create_albums\.ts$/);
+      const mig = findMigration(albumFiles, /db\/migrate\/.+_create_albums\.ts$/);
       expect(mig).toContain('t.integer("artist_id")');
       expect(mig).toContain('t.date("release_date")');
     });
@@ -219,7 +219,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("track_number", "integer")');
       expect(content).toContain('this.attribute("duration", "integer")');
 
-      const mig = findMigration(trackFiles, /db\/migrations\/.+_create_tracks\.ts$/);
+      const mig = findMigration(trackFiles, /db\/migrate\/.+_create_tracks\.ts$/);
       expect(mig).toContain('t.integer("track_number")');
       expect(mig).toContain('t.integer("duration")');
     });
@@ -229,7 +229,7 @@ describe("generator fixtures", () => {
       const content = readFile("src/app/models/genre.ts");
       expect(content).toContain("class Genre extends Base");
 
-      const mig = findMigration(genreFiles, /db\/migrations\/.+_create_genres\.ts$/);
+      const mig = findMigration(genreFiles, /db\/migrate\/.+_create_genres\.ts$/);
       expect(mig).toContain('t.string("name")');
     });
   });
@@ -272,7 +272,7 @@ describe("generator fixtures", () => {
       expect(content).toContain("class Account extends Base");
       expect(content).toContain('this.attribute("balance", "decimal")');
 
-      const mig = findMigration(accountFiles, /db\/migrations\/.+_create_accounts\.ts$/);
+      const mig = findMigration(accountFiles, /db\/migrate\/.+_create_accounts\.ts$/);
       expect(mig).toContain('t.decimal("balance")');
     });
 
@@ -282,7 +282,7 @@ describe("generator fixtures", () => {
       expect(content).toContain("class Category extends Base");
       expect(content).toContain('this.attribute("parent_id", "integer")');
 
-      const mig = findMigration(categoryFiles, /db\/migrations\/.+_create_categories\.ts$/);
+      const mig = findMigration(categoryFiles, /db\/migrate\/.+_create_categories\.ts$/);
       expect(mig).toContain('t.integer("parent_id")');
     });
 
@@ -294,7 +294,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("account_id", "integer")');
       expect(content).toContain('this.attribute("category_id", "integer")');
 
-      const mig = findMigration(transactionFiles, /db\/migrations\/.+_create_transactions\.ts$/);
+      const mig = findMigration(transactionFiles, /db\/migrate\/.+_create_transactions\.ts$/);
       expect(mig).toContain('t.decimal("amount")');
       expect(mig).toContain('t.integer("account_id")');
       expect(mig).toContain('t.date("date")');
@@ -307,7 +307,7 @@ describe("generator fixtures", () => {
       expect(content).toContain('this.attribute("period_start", "date")');
       expect(content).toContain('this.attribute("period_end", "date")');
 
-      const mig = findMigration(budgetFiles, /db\/migrations\/.+_create_budgets\.ts$/);
+      const mig = findMigration(budgetFiles, /db\/migrate\/.+_create_budgets\.ts$/);
       expect(mig).toContain('t.date("period_start")');
       expect(mig).toContain('t.date("period_end")');
     });
@@ -346,7 +346,7 @@ describe("exported fixtures", () => {
   beforeAll(async () => {
     fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-fixture-validation-"));
     fs.writeFileSync(path.join(fixtureDir, "tsconfig.json"), "{}");
-    fs.mkdirSync(path.join(fixtureDir, "db/migrations"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureDir, "db/migrate"), { recursive: true });
 
     const allFixtures = [...fixtures.docs, ...fixtures.music, ...fixtures.finances];
     for (const fixture of allFixtures) {

--- a/packages/website/src/lib/frontiers/tutorials/generator-fixtures.ts
+++ b/packages/website/src/lib/frontiers/tutorials/generator-fixtures.ts
@@ -12,7 +12,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/user.ts",
         "test/models/user.test.ts",
-        "db/migrations/*_create_users.ts",
+        "db/migrate/*_create_users.ts",
       ],
     },
     {
@@ -21,7 +21,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/folder.ts",
         "test/models/folder.test.ts",
-        "db/migrations/*_create_folders.ts",
+        "db/migrate/*_create_folders.ts",
       ],
     },
     {
@@ -30,7 +30,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/document.ts",
         "test/models/document.test.ts",
-        "db/migrations/*_create_documents.ts",
+        "db/migrate/*_create_documents.ts",
       ],
     },
   ] satisfies GeneratorFixture[],
@@ -42,7 +42,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/artist.ts",
         "test/models/artist.test.ts",
-        "db/migrations/*_create_artists.ts",
+        "db/migrate/*_create_artists.ts",
       ],
     },
     {
@@ -51,7 +51,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/album.ts",
         "test/models/album.test.ts",
-        "db/migrations/*_create_albums.ts",
+        "db/migrate/*_create_albums.ts",
       ],
     },
     {
@@ -61,7 +61,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/track.ts",
         "test/models/track.test.ts",
-        "db/migrations/*_create_tracks.ts",
+        "db/migrate/*_create_tracks.ts",
       ],
     },
     {
@@ -70,7 +70,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/genre.ts",
         "test/models/genre.test.ts",
-        "db/migrations/*_create_genres.ts",
+        "db/migrate/*_create_genres.ts",
       ],
     },
   ] satisfies GeneratorFixture[],
@@ -82,7 +82,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/account.ts",
         "test/models/account.test.ts",
-        "db/migrations/*_create_accounts.ts",
+        "db/migrate/*_create_accounts.ts",
       ],
     },
     {
@@ -91,7 +91,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/category.ts",
         "test/models/category.test.ts",
-        "db/migrations/*_create_categories.ts",
+        "db/migrate/*_create_categories.ts",
       ],
     },
     {
@@ -101,7 +101,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/transaction.ts",
         "test/models/transaction.test.ts",
-        "db/migrations/*_create_transactions.ts",
+        "db/migrate/*_create_transactions.ts",
       ],
     },
     {
@@ -111,7 +111,7 @@ export const fixtures = {
       expectedFiles: [
         "src/app/models/budget.ts",
         "test/models/budget.test.ts",
-        "db/migrations/*_create_budgets.ts",
+        "db/migrate/*_create_budgets.ts",
       ],
     },
   ] satisfies GeneratorFixture[],

--- a/packages/website/src/routes/dev/filetree/+page.svelte
+++ b/packages/website/src/routes/dev/filetree/+page.svelte
@@ -24,8 +24,8 @@
     v.write("src/app/models/post.ts", 'import { Base } from "@blazetrails/activerecord";\n\nexport class Post extends Base {\n  static {\n    this.attribute("title", "string");\n    this.attribute("body", "text");\n  }\n}');
     v.write("src/app/controllers/application-controller.ts", "class ApplicationController {}");
     v.write("src/app/controllers/posts-controller.ts", "class PostsController {}");
-    v.write("db/migrations/20260401120000_create_users.ts", "class CreateUsers extends Migration {}");
-    v.write("db/migrations/20260401120001_create_posts.ts", "class CreatePosts extends Migration {}");
+    v.write("db/migrate/20260401120000_create_users.ts", "class CreateUsers extends Migration {}");
+    v.write("db/migrate/20260401120001_create_posts.ts", "class CreatePosts extends Migration {}");
     v.write("db/seeds.ts", "// seeds");
     v.write("db/schema.ts", "// schema");
     v.write("test/models/user.test.ts", "// user tests");

--- a/packages/website/vitest.config.ts
+++ b/packages/website/vitest.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const aliases = {
+  "@blazetrails/activesupport/": path.resolve(__dirname, "../activesupport/src") + "/",
   "@blazetrails/activesupport": path.resolve(__dirname, "../activesupport/src/index.ts"),
   "@blazetrails/arel/src": path.resolve(__dirname, "../arel/src"),
   "@blazetrails/arel": path.resolve(__dirname, "../arel/src/index.ts"),


### PR DESCRIPTION
PR #6977 converged trailties' migration directory to Rails' `db/migrate` (`Migrator.migrations_paths`, `vendor/rails/activerecord/lib/active_record/migration.rb:1419`). The Frontiers sandbox CLI is a second implementation over a VFS and was left out of that PR, so it still scanned and taught `db/migrations/`.

- `trail-cli.ts` discovery filter and the "No migrations found in …" message now name `db/migrate/`.
- `generator-fixtures.ts` globs and the `dev/filetree` seed match.
- Tests updated to the paths the generators actually write; names unchanged. The generated basenames are underscored (`create_users`), so `runtime.test.ts` matches on those.
- `vitest.config.ts` gains the `@blazetrails/activesupport/` subpath alias — without it the generic alias rewrote `@blazetrails/activesupport/temporal` into `…/src/index.ts/temporal` and the suites failed to collect.

Three of the four runtime.test.ts failures present on main are fixed by this. Two pre-existing failures remain and are out of scope, filed as `website-frontiers-runtime-dbmigrate-and-sandbox-sw-tests-red`: `db:migrate` erroring "No database connection defined." before the eval-context error, and a sandbox-sw timeout.

Closes-story: website-frontiers-sandbox-still-scaffolds-db-migrations