### PR TITLE
refactor(activerecord): strip freeform comments from connection-adapters/abstract

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -743,6 +743,7 @@ export default defineConfig(
       // activerecord/src root files, swept alphabetically one slice per PR
       // (story strip-freeform-comments-ar-root-b onward for the rest).
       "packages/activerecord/src/a*.ts",
+      "packages/activerecord/src/connection-adapters/abstract/**/*.ts",
       "packages/activerecord/src/connection-adapters/mysql/**/*.ts",
       "packages/activerecord/src/connection-adapters/mysql2/**/*.ts",
       "packages/activerecord/src/connection-adapters/postgresql/**/*.ts",

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -28,9 +28,6 @@ import {
 } from "../../connection-adapters.js";
 import { buildAdapterArg } from "../adapter-args.js";
 
-// Register the resolvers/builder so DatabaseConfig#adapterClass and
-// #newConnection work for any consumer that imports ConnectionHandler —
-// even those that don't pull in connection-handling.ts.
 _setAdapterClassResolver(
   (adapterName) => resolveConnectionAdapter(adapterName),
   (adapterName) => resolveConnectionAdapterSync(adapterName),

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -473,8 +473,6 @@ export class ConnectionPool implements ReapablePool {
     return this.inspect();
   }
 
-  // --- Delegation to PoolConfig ---
-
   get schemaReflection(): SchemaReflection {
     return this.poolConfig.schemaReflection;
   }
@@ -486,14 +484,6 @@ export class ConnectionPool implements ReapablePool {
     // next schemaCache access wraps the new reflection, not the
     // stale one.
     this._boundSchemaCache = undefined;
-    // Also reset the lazy-load guard AND the raw cache so the new
-    // reflection's on-disk cache path gets loaded on the next first-
-    // connection event. Without resetting _lazyLoadTriggered the
-    // guard would still be true from the old reflection; without
-    // resetting poolConfig.schemaCache the `!this.poolConfig.schemaCache`
-    // guard in newConnection would prevent the new lazy-load from
-    // triggering, and adapter-side consumers would keep seeing stale
-    // cache data from the old reflection.
     this._lazyLoadTriggered = false;
     this._lazyLoadPromise = null;
     this._eagerWarmTriggered = false;
@@ -528,8 +518,6 @@ export class ConnectionPool implements ReapablePool {
   get connectionDescriptor(): ConnectionDescriptor {
     return this.poolConfig.connectionDescriptor;
   }
-
-  // --- Migration / Schema ---
 
   private _adapterProxy?: DatabaseAdapter;
 
@@ -646,8 +634,6 @@ export class ConnectionPool implements ReapablePool {
     this._cacheConfig.clearQueryCache();
   }
 
-  // --- Pool state ---
-
   get activeConnection(): DatabaseAdapter | null {
     return this.connectionLease().connection;
   }
@@ -664,15 +650,11 @@ export class ConnectionPool implements ReapablePool {
     return this._connections === null;
   }
 
-  // --- Install executor hooks ---
-
   static installExecutorHooks(
     executor: { registerHook(hooks: typeof ExecutorHooks): void } = Executor,
   ): void {
     executor.registerHook(ExecutorHooks);
   }
-
-  // --- Lease management ---
 
   // Async for the same reason as `checkout` (see its comment): the pinned-reuse
   // path routes through `checkout`, which awaits `verifyBang`. Intentional
@@ -735,8 +717,6 @@ export class ConnectionPool implements ReapablePool {
     return false;
   }
 
-  // --- Pin / Unpin ---
-
   async pinConnectionBang(_lockThread: boolean | { fixture?: boolean } = false): Promise<void> {
     // Accept `pinConnectionBang(true)` (Rails-compat boolean), `pinConnectionBang()`,
     // and `pinConnectionBang({ fixture: true })`. The boolean form is retained for
@@ -751,19 +731,11 @@ export class ConnectionPool implements ReapablePool {
     let pin: { connection: DatabaseAdapter; depth: number } | undefined =
       slot === "fixture" ? (this._fixturePin ?? undefined) : this._pinnedConnections.get(ctxId);
 
-    // Fixture pins can't rely on the per-context lease — vitest's
-    // beforeEach/it/afterEach often run in different AsyncLocalStorage
-    // contexts, so the current context's lease may be empty even when
-    // another context already leased the only connection. Reuse the first
-    // established connection in fixture mode so pool size 1 doesn't trip
-    // ConnectionTimeoutError on `_acquireConnection`.
     const fixtureSharedConnection = slot === "fixture" ? (this._connections?.[0] ?? null) : null;
     const leasedConnection = fixtureSharedConnection ?? this.connectionLease().connection;
     const connection = pin?.connection ?? leasedConnection ?? this._acquireConnection();
     const newlyCheckedOut = !pin && leasedConnection == null;
 
-    // Record the pin before any async work to prevent concurrent
-    // pinConnectionBang calls in the same context from double-acquiring.
     if (!pin) {
       pin = { connection, depth: 0 };
       if (slot === "fixture") {
@@ -870,8 +842,6 @@ export class ConnectionPool implements ReapablePool {
 
     return clean;
   }
-
-  // --- Checkout / Checkin ---
 
   // `checkout` is async in trails even though Rails' `ConnectionPool#checkout`
   // (connection_pool.rb:547) is synchronous. This is an intentional, documented
@@ -980,9 +950,6 @@ export class ConnectionPool implements ReapablePool {
       const expireBlock = () => c.expire?.();
       if (typeof c._runCheckinCallbacks === "function") c._runCheckinCallbacks(expireBlock);
       else {
-        // Defensive fallback for a connection without the callback runner.
-        // Mirror the registry order: block (expire) first, then the `:after`
-        // unset_query_cache! teardown.
         expireBlock();
         QueryCache.unsetQueryCacheBang.call(conn as unknown as QueryCacheHost);
       }
@@ -1027,8 +994,6 @@ export class ConnectionPool implements ReapablePool {
     }
   }
 
-  // --- Pool statistics ---
-
   numWaitingInQueue(): number {
     return this._available?.numWaiting() ?? 0;
   }
@@ -1058,8 +1023,6 @@ export class ConnectionPool implements ReapablePool {
       checkoutTimeout: this.checkoutTimeout,
     };
   }
-
-  // --- Lifecycle ---
 
   /**
    * Converges Rails' `ConnectionPool#disconnect`: tears down synchronously, then
@@ -1339,8 +1302,6 @@ export class ConnectionPool implements ReapablePool {
     await Promise.all(this._pendingCloseDrains);
   }
 
-  // --- Connection creation ---
-
   /**
    * Mirrors Rails:
    *
@@ -1402,39 +1363,16 @@ export class ConnectionPool implements ReapablePool {
       !this.poolConfig.schemaCache
     ) {
       this._lazyLoadTriggered = true;
-      // Use BoundSchemaReflection.forLoneConnection so the version-
-      // check in loadCache routes through a FakePool that yields the
-      // just-created connection — never re-enters the real pool's
-      // checkout. Without this, pool size=1 would deadlock: loadCache
-      // calls pool.withConnection to query schemaVersion(), which tries
-      // to checkout a second connection that doesn't exist.
-      //
-      // The loneRef shares the same SchemaReflection as `this.schemaCache`,
-      // so a successful load populates both.
       const loneRef = BoundSchemaReflection.forLoneConnection(this.schemaReflection, conn);
       this._lazyLoadPromise = loneRef
         .loadBang()
         .then(() => {
-          // Propagate the loaded SchemaCache into poolConfig.schemaCache
-          // so adapter-side consumers (AbstractAdapter.schemaCache,
-          // TypeCaster::Connection) see the preloaded data.
           const loaded = this.schemaReflection.loadedCache;
           if (loaded) {
-            // Always assign: poolConfig.schemaCache may have been
-            // populated with an empty SchemaCache during the in-flight
-            // load (e.g., AbstractAdapter.schemaCache accessed
-            // synchronously by TypeCaster::Connection before the
-            // promise resolved). Overwriting that empty cache with the
-            // fully-populated one is the correct outcome — the preloaded
-            // data should win.
             this.poolConfig.schemaCache = loaded;
           }
         })
         .catch((err) => {
-          // loadCache swallows read/parse/version errors internally;
-          // this is a belt-and-suspenders guard. Log enough context to
-          // diagnose if a future change adds an unexpected rejection.
-
           console.warn(
             `[trails] Failed to lazily load schema cache for pool ` +
               `${this.poolConfig.connectionSpecName}: ` +
@@ -1574,8 +1512,6 @@ export class ConnectionPool implements ReapablePool {
     }
   }
 
-  // --- Private ---
-
   private _isConnectionPinned(conn: DatabaseAdapter): boolean {
     if (this._fixturePin?.connection === conn) return true;
     for (const pin of this._pinnedConnections.values()) {
@@ -1595,10 +1531,6 @@ export class ConnectionPool implements ReapablePool {
    * @internal
    */
   private _resolvePinnedConnection(): DatabaseAdapter | undefined {
-    // Pool-level fixture pin (set by `pinConnectionBang({ fixture: true })`)
-    // wins across all execution contexts — that's the whole point of the
-    // fixture slot. Falls back to the per-context map for production
-    // request-scoped pins.
     if (this._fixturePin) return this._fixturePin.connection;
     if (this._pinnedConnections.size === 0) return undefined;
     return this._pinnedConnections.get(executionContextId())?.connection;
@@ -1730,7 +1662,6 @@ function attemptToCheckoutAllExistingConnections(
       if (this._checkedOut.has(conn)) continue;
       try {
         if (this._available && this._available.delete(conn) === undefined) {
-          // Not idle — fall back to a generic checkout to surface a timeout.
           const acquired = checkoutForExclusiveAccess(this, this.checkoutTimeout);
           if (acquired) newlyCheckedOut.push(acquired);
           continue;
@@ -1776,17 +1707,6 @@ function attemptToCheckoutAllExistingConnections(
  */
 function checkoutForExclusiveAccess(pool: Pool, checkoutTimeout: number): DatabaseAdapter | null {
   try {
-    // Synchronous acquisition: this is the exclusive-access sweep on the sync
-    // disconnect/discard lifecycle path, which cannot await. `checkout` is now
-    // async (it awaits verifyBang), so we call the sync `_acquireConnection`
-    // directly. This fallback only exists to grab ownership / surface a timeout
-    // for a busy connection — the acquired connection is immediately blocked and
-    // discarded by the sweep, so it deliberately skips checkout_and_verify's
-    // clean!/query-cache wiring (running it here regresses disconnect/discard
-    // tests). The sweep only reaches here when connections are busy, so
-    // acquisition raises `ConnectionTimeoutError` (converted below).
-    // (Lifecycle-path async convergence is tracked by
-    // `converge-connection-pool-lifecycle-exclusive-access-async`.)
     return pool._acquireConnection();
   } catch (err) {
     if (err instanceof ConnectionTimeoutError) {
@@ -1865,7 +1785,7 @@ function acquireConnection(
     let conn = this._available?.poll() as DatabaseAdapter | undefined;
     if (conn) return accept(conn);
     conn = this.tryToCheckoutNewConnection() ?? undefined;
-    if (conn) return conn; // tryToCheckoutNewConnection already adds to _checkedOut
+    if (conn) return conn;
     this.reap();
     conn = this._available?.poll() as DatabaseAdapter | undefined;
     if (conn) return accept(conn);
@@ -1953,9 +1873,6 @@ function tryToCheckoutNewConnection(this: Pool): DatabaseAdapter | null {
  * @internal
  */
 function adoptConnection(this: Pool, conn: DatabaseAdapter): void {
-  // Only AbstractAdapter has a `pool` slot reserved for this back-reference;
-  // concrete driver adapters use `pool` for their own driver pool. Mirror the
-  // gate already used by ConnectionPool#newConnection.
   if (conn instanceof AbstractAdapter) {
     (conn as unknown as { pool?: ConnectionPool }).pool = this;
   }
@@ -2022,10 +1939,6 @@ function checkoutAndVerify(pool: Pool, c: DatabaseAdapter): DatabaseAdapter {
   } catch (err) {
     pool.remove(c);
     (c as unknown as { disconnectBang?: () => void }).disconnectBang?.();
-    // disconnectBang on an async-only driver fires a promise-returning close it
-    // can't await under its sync contract; stash it on the pool so a caller can
-    // drain it (pool.drainPendingCloses) before re-opening the same DB. Sync
-    // drivers contribute a resolved no-op.
     pool._trackCloseDrain((c as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.());
     throw err;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/execution-context.ts
@@ -37,8 +37,6 @@ export function withExecutionContext<T>(fn: () => T): T {
       throw err;
     }
     if (result && typeof (result as unknown as PromiseLike<unknown>).then === "function") {
-      // Wrap via Promise.resolve so bare PromiseLike thenables (which only
-      // need `then`) still get `.finally` for the exit hook.
       return Promise.resolve(result as unknown as PromiseLike<unknown>).finally(
         runHooks,
       ) as unknown as T;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.trails.test.ts
@@ -17,7 +17,6 @@ describe("ConnectionPool::Queue", () => {
     q.add(c2);
     expect(q.length).toBe(2);
 
-    // poll without timeout returns LIFO (pop)
     const out = q.poll();
     expect(out).toBe(c2);
     expect(q.length).toBe(1);
@@ -36,7 +35,6 @@ describe("ConnectionPool::Queue", () => {
     expect(q.isAnyWaiting()).toBe(true);
     expect(q.numWaiting()).toBe(1);
 
-    // add resolves the waiting poll via signal
     q.add(c);
     const result = await promise;
     expect(result).toBe(c);
@@ -60,15 +58,12 @@ describe("ConnectionPool::Queue", () => {
     const q = new Queue();
     const c = fakeConn();
 
-    // Start a waiter
     const promise = q.poll(1) as Promise<DatabaseAdapter>;
     expect(q.numWaiting()).toBe(1);
 
-    // Add a connection — it is pushed and the waiter is signalled
     q.add(c);
     expect(q.length).toBe(1);
 
-    // A no-wait poll should get nothing — the waiter is ahead in line
     expect(q.poll()).toBeUndefined();
 
     await promise;
@@ -137,7 +132,6 @@ describe("ConnectionPool::Queue", () => {
 });
 
 describe("ConnectionPool::BiasedConditionVariable", () => {
-  // The plain `@lock.new_cond` a Queue starts with — the leaf `@other_cond`.
   function newCond(): any {
     return (new Queue() as any)._cond;
   }
@@ -216,11 +210,9 @@ describe("ConnectionPool::BiasableQueue", () => {
 
     q.withABiasFor("ctx", () => {
       innerCond = (q as any)._cond;
-      // innerCond is the temporary biased cond
       expect(innerCond).not.toBe(outerCond);
     });
 
-    // After withABiasFor, cond should be restored to the original
     expect((q as any)._cond).toBe(outerCond);
   });
 
@@ -233,8 +225,6 @@ describe("ConnectionPool::BiasableQueue", () => {
       innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
     });
 
-    // The waiter was on the biased cond, but should have been
-    // transferred to the restored cond. An add() should reach it.
     q.add(c);
     const result = await innerPromise!;
     expect(result).toBe(c);
@@ -251,12 +241,10 @@ describe("ConnectionPool::BiasableQueue", () => {
         innerPromise = q.poll(5) as Promise<DatabaseAdapter>;
       });
 
-      // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection
       const rejection = expect(innerPromise!).rejects.toBeInstanceOf(ConnectionTimeoutError);
       await vi.advanceTimersByTimeAsync(6000);
       await rejection;
 
-      // A subsequent add should go to the queue, not a stale waiter
       q.add(c);
       expect(q.poll()).toBe(c);
     } finally {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -118,8 +118,6 @@ export class BiasedConditionVariable implements Cond {
   }
 
   wait(timeout: number): Promise<void> {
-    // Node is single-threaded, so a waiter reaching here always belongs to the
-    // context that entered `withABiasFor` — `Thread.current == @preferred_thread`.
     let cond: Cond;
     if (this._preferredThread != null) {
       this._numWaitingOnRealCond += 1;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/reaper.ts
@@ -93,10 +93,6 @@ export class Reaper {
         const p = ref.deref();
         if (p) {
           p.reap?.();
-          // Reaper runs on an unref'd timer with nothing awaiting it, so the
-          // async flush drains idle adapters' `driver.close()` best-effort; a
-          // rejected drain is swallowed rather than surfaced as an unhandled
-          // rejection that could crash the process.
           void p.flush?.()?.catch(() => {});
         }
       }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements-select-async.trails.test.ts
@@ -22,8 +22,6 @@ describe("DatabaseStatements select async kwarg", () => {
     return Base.connection as unknown as AbstractAdapter;
   }
 
-  // Spy on the instance, not the prototype: the fixture harness restores its
-  // own property and would shadow a prototype spy so it never fires.
   const spySelectAll = () => vi.spyOn(conn(), "selectAll");
 
   afterEach(() => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.trails.test.ts
@@ -71,9 +71,6 @@ const log: NonNullable<DatabaseStatementsHost["log"]> = async (
   }
 };
 
-// `typeCastedBinds` is likewise mixed in on every adapter by
-// `include(AbstractAdapter, QuotingMixin)` (abstract-adapter.ts), so it is a
-// required member of DatabaseStatementsHost rather than an optional one.
 const typeCastedBinds: DatabaseStatementsHost["typeCastedBinds"] = (binds) => binds ?? [];
 
 describe("DatabaseStatements", () => {
@@ -509,7 +506,6 @@ describe("DatabaseStatements", () => {
         "users",
       ]);
 
-      // Union of fixture keys and delete targets, de-duplicated.
       expect(scopedTables && [...scopedTables].sort()).toEqual(["old_table", "posts", "users"]);
     });
   });
@@ -532,7 +528,6 @@ describe("DatabaseStatements", () => {
         quoteTableName: (n: string) => `"${n}"`,
       };
 
-      // schema_migrations / ar_internal_metadata are filtered out before scoping.
       await truncateTables.call(host, "users", "posts", "schema_migrations");
 
       expect(scopedTables).toEqual(["users", "posts"]);
@@ -553,7 +548,6 @@ describe("DatabaseStatements", () => {
         pool,
         typeCastedBinds,
         async execute(sql: string, _binds?: unknown[], name?: string | null) {
-          // captures `this` to verify receiver is preserved
           executed.push({ sql, name, receiver: this });
         },
         quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
@@ -611,9 +605,6 @@ describe("DatabaseStatements", () => {
 
     it("sanitize limit with string integer", () => {
       expect(sanitizeLimit("10")).toBe(10);
-      // `Integer(str)` parses with base detection, not as plain decimal: a bare
-      // leading `0` is octal, `0x`/`0b`/`0o`/`0d` set the radix, and `_`
-      // separates digits. Every pair below was taken from `ruby -e`.
       expect(sanitizeLimit("012")).toBe(10);
       expect(sanitizeLimit("0x1f")).toBe(31);
       expect(sanitizeLimit("0b101")).toBe(5);
@@ -739,8 +730,6 @@ describe("preprocessQuery", () => {
         [
           {
             call(sql) {
-              // A transformer that issues its own query on the same connection
-              // must reuse the already-transformed SQL, not re-comment it.
               nested = preprocessQuery.call(host, "SELECT inner");
               return `${sql} /*outer*/`;
             },
@@ -995,10 +984,6 @@ describe("returningColumnValues", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Fixture / truncate builders
-// ---------------------------------------------------------------------------
-
 describe("buildFixtureSql / buildFixtureStatements / buildTruncateStatement(s) / combineMultiStatements", () => {
   type FixtureHost = DatabaseStatementsHost &
     Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName" | "quoteString">;
@@ -1069,7 +1054,6 @@ describe("buildFixtureSql / buildFixtureStatements / buildTruncateStatement(s) /
     });
 
     it("single-row: strips missing columns (DEFAULT-strip optimisation)", () => {
-      // Two-column union but only one fixture row — missing column must be omitted
       const sql = buildFixtureSql.call(makeHost(), [{ name: "Alice" }], "users");
       expect(sql).toContain('"name"');
       expect(sql).not.toContain("DEFAULT");

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -212,8 +212,6 @@ export class DatabaseStatementsBase {
   }
 }
 
-// --- Query conversion ---
-
 /**
  * Compile an Arel node to a SQL string with its bind values inlined via the
  * connection's own `quote`. Mirrors Rails' `to_sql` under
@@ -252,7 +250,6 @@ export function toSql(
 ): string {
   if (typeof arel === "string") return arel;
 
-  // Unwrap TreeManager → Node
   let node = arel;
   if (node && (node as any).ast != null && typeof (node as any).ast === "object") {
     node = (node as any).ast;
@@ -305,7 +302,6 @@ export function toSqlAndBinds(
     node = (node as any).ast;
   }
 
-  // Arel node — compile via adapter visitor when available, else generic toSql()
   if (node instanceof Nodes.Node || (node && typeof (node as any).toSql === "function")) {
     if (binds.length > 0) {
       throw new Error(
@@ -382,13 +378,11 @@ export function cacheableQuery(
   const host = this as DatabaseStatementsHost;
   const visitor = (host as any)?.visitor as Visitors.ToSql | undefined;
 
-  // Unwrap TreeManager → Node
   let node = arel;
   if (node && (node as any).ast != null && typeof (node as any).ast === "object") {
     node = (node as any).ast;
   }
 
-  // Prepared path: compile with bind extraction, return Query + raw binds
   if (host?.preparedStatements && klass.query && visitor && node instanceof Nodes.Node) {
     const [sql, binds] = visitor.compile(node, host.collector!() as Collectors.Composite) as [
       string,
@@ -406,12 +400,10 @@ export function cacheableQuery(
     return [klass.partialQuery(parts), collectedBinds];
   }
 
-  // Fallback: compile to SQL string
   let sql: string;
   if (typeof arel === "string") {
     sql = arel;
   } else if (visitor && node instanceof Nodes.Node) {
-    // Returns empty binds below, so inline any BindParams into the SQL string.
     [sql] = compileInlined(visitor, node, host);
   } else {
     sql = (node as any).toSql?.() ?? String(node);
@@ -423,8 +415,6 @@ export function cacheableQuery(
   const queryObj = klass.query ? klass.query(sql) : sql;
   return [queryObj, []];
 }
-
-// --- Query execution ---
 
 /**
  * Returns a single value via internal_exec_query.
@@ -505,8 +495,6 @@ export function explain(_arel: unknown, _binds?: unknown[], _options?: unknown[]
   throw new Error("explain must be implemented by adapter subclass");
 }
 
-// --- Data modification ---
-
 /**
  * Executes a TRUNCATE statement.
  *
@@ -570,8 +558,6 @@ export async function truncateTables(
   }
 }
 
-// --- Transaction ---
-
 /**
  * Runs the given block in a database transaction.
  * Supports nested transactions via savepoints, isolation levels,
@@ -586,8 +572,6 @@ export async function transaction<T>(
 ): Promise<T | undefined> {
   const { requiresNew, isolation, joinable = true } = options;
 
-  // Check if we can join the current transaction.
-  // joinable may be a boolean property or a function — support both.
   const currentTxn = this.currentTransaction?.();
   const currentTxnJoinable =
     typeof currentTxn?.joinable === "function" ? currentTxn.joinable() : currentTxn?.joinable;
@@ -614,7 +598,6 @@ export async function transaction<T>(
     }
   }
 
-  // Fallback: simple begin/commit/rollback — delegate through this, preserving context
   if (isolation) {
     await beginDeferredTransaction.call(this, isolation);
   } else {
@@ -640,8 +623,6 @@ export async function transaction<T>(
     }
   }
 }
-
-// --- Transaction lifecycle ---
 
 /**
  * The transaction manager for this connection.
@@ -748,9 +729,7 @@ export function addTransactionRecord(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#begin_db_transaction
  */
-export async function beginDbTransaction(): Promise<void> {
-  // No-op in abstract base
-}
+export async function beginDbTransaction(): Promise<void> {}
 
 /**
  * Begins a deferred transaction, optionally with an isolation level.
@@ -806,18 +785,14 @@ export async function beginIsolatedDbTransaction(
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#reset_isolation_level
  */
-export function resetIsolationLevel(): void {
-  // No-op in abstract base
-}
+export function resetIsolationLevel(): void {}
 
 /**
  * Commits the database transaction. No-op in abstract base.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#commit_db_transaction
  */
-export async function commitDbTransaction(): Promise<void> {
-  // No-op in abstract base
-}
+export async function commitDbTransaction(): Promise<void> {}
 
 /**
  * Rolls back the database transaction.
@@ -836,9 +811,7 @@ export async function rollbackDbTransaction(this: DatabaseStatementsHost | void)
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_rollback_db_transaction
  */
-export async function execRollbackDbTransaction(): Promise<void> {
-  // No-op in abstract base
-}
+export async function execRollbackDbTransaction(): Promise<void> {}
 
 /**
  * Restarts the database transaction (ROLLBACK + BEGIN).
@@ -857,9 +830,7 @@ export async function restartDbTransaction(this: DatabaseStatementsHost | void):
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_restart_db_transaction
  */
-export async function execRestartDbTransaction(): Promise<void> {
-  // No-op in abstract base
-}
+export async function execRestartDbTransaction(): Promise<void> {}
 
 /**
  * Rolls back to a savepoint.
@@ -875,8 +846,6 @@ export async function rollbackToSavepoint(
     await host.execRollbackToSavepoint(name);
   }
 }
-
-// --- Utility methods ---
 
 /**
  * Returns the default sequence name for a table/column pair.
@@ -896,9 +865,7 @@ export async function resetSequenceBang(
   _table: string,
   _column: string,
   _sequence?: string | null,
-): Promise<void> {
-  // No-op by default. Implement for PostgreSQL, Oracle, etc.
-}
+): Promise<void> {}
 
 /**
  * Inserts a single fixture row into a table.
@@ -993,8 +960,6 @@ export async function insertFixturesSet(
     }
   };
 
-  // The wrapped block only touches the fixture tables and the delete targets, so
-  // scope the trigger toggle to that set rather than the whole catalog.
   const affectedTables = [...new Set([...Object.keys(fixtureSet), ...tablesToDelete])];
 
   // Rails wraps fixture loading in a transaction with requires_new: true
@@ -1068,8 +1033,6 @@ function integerFromString(str: string): number {
     radix = { x: 16, b: 2, o: 8, d: 10 }[prefix[1].toLowerCase()]!;
     body = body.slice(2);
   } else if (/^0./.test(body)) {
-    // A bare leading `0` is the octal prefix, and like the lettered prefixes it
-    // may be followed by an `_` separator: `Integer("0_1") # => 1`.
     radix = 8;
     body = body.slice(1).replace(/^_/, "");
   }
@@ -1222,13 +1185,10 @@ export async function internalExecQuery(
       "internalExecQuery requires internalExecute on the adapter when binds are provided",
     );
   }
-  // Fallback: delegate through this.execute only when there are no binds
   const doExecute = this?.execute?.bind(this) ?? execute;
   const result = await doExecute(sql, [], name);
   return normalizeResult(result);
 }
-
-// --- Private helpers ---
 
 function normalizeResult(result: unknown): Result {
   if (result instanceof Result) return result;
@@ -1953,7 +1913,6 @@ export function select(
       );
     }
 
-    // We make sure to run query transformers on the original thread
     sql = this.preprocessQuery ? this.preprocessQuery(sql) : sql;
     const futureResult = new (async as FutureResultClass)(
       this.pool as unknown as FutureResultPool,

--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.trails.test.ts
@@ -19,9 +19,6 @@ import {
 import { quote as quoteFn, typeCast as typeCastFn } from "./quoting.js";
 import { quotedTime as sqliteQuotedTime } from "../sqlite3/quoting.js";
 
-// `quote` / `typeCast` self-send `quoted_date` / `quoted_time`, so they need a
-// receiver that defines them; an override-free adapter host routes date/time
-// values through the abstract module helpers.
 const quote = (value: unknown): string => quoteFn.call(quotingHost(), value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(quotingHost(), value);
 
@@ -52,8 +49,6 @@ describe("formatInstantForSql", () => {
   });
 
   it("converts a non-UTC instant to UTC when default_timezone is utc (the default)", () => {
-    // defaultTimezone is "utc" in tests; local-tz path is
-    // integration-tested in PR 7 (timestamp.test.ts with time-travel).
     const v = Temporal.Instant.from("2026-04-26T16:23:55+02:00");
     expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
   });
@@ -86,10 +81,6 @@ describe("formatPlainDateForSql", () => {
   });
 
   it("formats a negative (BCE) year the way the date gem's %Y does", () => {
-    // year -43 = 44 BC in proleptic Gregorian. `to_fs(:db)` is
-    // `strftime("%Y-%m-%d")`, and the gem's `%Y` pads the digits to four behind
-    // the sign (`Date.new(-43, 3, 15).to_fs(:db)` → "-0043-03-15"), so routing
-    // this through packages/date drops the old unpadded "-43-03-15".
     expect(formatPlainDateForSql(Temporal.PlainDate.from({ year: -43, month: 3, day: 15 }))).toBe(
       "-0043-03-15",
     );
@@ -112,7 +103,6 @@ describe("formatPlainTimeForSql", () => {
   });
 
   it("pads to a fixed 6-digit microsecond field", () => {
-    // millisecond only — padded out to 6 digits
     expect(formatPlainTimeForSql(Temporal.PlainTime.from("12:00:00.100"))).toBe("12:00:00.100000");
   });
 });
@@ -213,8 +203,6 @@ describe("typeCast on a SQLite receiver uses 2000-01-01 prefix for PlainTime", (
   });
 });
 
-// abstract quote() / typeCast() — used by the Postgres adapter which has no
-// adapter-specific override for datetime quoting.
 describe("abstract quote() with Temporal (Postgres path)", () => {
   it("quotes an Instant", () => {
     const v = Temporal.Instant.from("2026-04-26T14:23:55.123456Z");

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -68,7 +68,6 @@ export class Store {
     if (!this.enabled) return undefined;
     const entry = this._map.get(key);
     if (entry) {
-      // Move to end (LRU)
       this._map.delete(key);
       this._map.set(key, entry);
     }
@@ -555,12 +554,6 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
  * @internal
  */
 function clearCurrentThreadQueryCaches(host: QueryCacheHost): void {
-  // Mirror `each_connection_pool { pool.clear_query_cache }`: clear the pool's
-  // per-thread Store directly, NOT `pool.active_connection.clear_query_cache`.
-  // A pool whose connection is currently checked in still holds this thread's
-  // cached rows in its registry (they survive checkin, keyed by execution
-  // context), so a re-read after checkout would hit stale results unless the
-  // Store itself is cleared here.
   const cleared = new Set<Store>();
   ExecutorHooks.connectionHandler()?.eachConnectionPool((pool) => {
     const p = pool as unknown as QueryCachePool & { queryCache?: Store };

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
@@ -73,8 +73,6 @@ describe("quotedTime", () => {
   });
 
   it("dispatches through this.quotedDate (mirrors Rails quoted_time → self.quoted_date)", () => {
-    // Override quotedDate to prove the self-dispatch chain is live; the prefix
-    // is then stripped by quotedTime's date-removal regex.
     const host = quotingHost({ quotedDate: () => "2000-01-01 11:22:33" });
     const v = Temporal.PlainTime.from("11:22:33");
     expect(quotedTime.call(host, v)).toBe("11:22:33");
@@ -167,8 +165,9 @@ describe("quote dispatches through quoted_binary", () => {
     const expected = `'${bytes.map((b) => String.fromCharCode(b)).join("")}'`;
     expect(quotedBinary(new BinaryData(new Uint8Array(bytes)))).toBe(expected);
     expect(quotedBinary(new Uint8Array(bytes))).toBe(expected);
-    expect(Array.from(quotedBinary(new Uint8Array(bytes)).slice(1, -1), (c) => c.charCodeAt(0))) //
-      .toEqual(bytes);
+    expect(
+      Array.from(quotedBinary(new Uint8Array(bytes)).slice(1, -1), (c) => c.charCodeAt(0)),
+    ).toEqual(bytes);
   });
 });
 
@@ -216,11 +215,6 @@ describe("quote_table_name dispatches through quote_column_name", () => {
   });
 
   it("raises on a receiver with no quoter rather than answering with ANSI quotes", () => {
-    // rb:141-143 is an unconditional `quote_column_name(table_name)`, so a
-    // receiver that defines no quoter raises from the abstract
-    // `quote_column_name` (rb:61). It must NOT fall back to a module-level
-    // default and hand back a plausible-but-wrong `"people"` — that silent
-    // degradation is what the retired `dispatch*` probes produced.
     expect(() => quoteTableName.call(quotingHost(), "people")).toThrow(NotImplementedError);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -369,10 +369,6 @@ export function unquotedFalse(): boolean {
  */
 export function toBytes(value: unknown): Uint8Array | null {
   if (value instanceof BinaryData) return value.bytes;
-  // `ArrayBuffer.isView` (#4868) rather than `instanceof Uint8Array`: it also
-  // catches a DataView or a non-byte typed array, and threading
-  // byteOffset/byteLength keeps a subarray view from reading its whole backing
-  // buffer. A bare ArrayBuffer is not a view, so it needs its own branch.
   if (ArrayBuffer.isView(value)) {
     return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
   }
@@ -549,10 +545,6 @@ function typeCastedBinds(
   binds: unknown[] | null | undefined,
 ): unknown[] | undefined {
   return binds?.map((value: any) => {
-    // Attribute detection is duck-typed rather than `instanceof ModelAttribute`:
-    // when the dep tree resolves two copies of `@blazetrails/activemodel` the
-    // instanceof check silently misses and the raw Attribute object reaches
-    // `typeCast`, which throws "can't cast Attribute".
     if (
       value instanceof ModelAttribute ||
       (value && typeof value === "object" && "valueForDatabase" in value)

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -264,7 +264,6 @@ export class SchemaCreation {
     try {
       o.sqlType ??= this.typeToSql(o.type, o.options);
     } catch (e) {
-      // typeToSql lacks the column name; re-throw with it for a diagnosable message.
       if (e instanceof Error && /empty or blank type/.test(e.message)) {
         throw new Error(
           `Column ${JSON.stringify(o.name)} has an empty or blank type — specify a valid SQL type`,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -377,7 +377,6 @@ describe("ForeignKeyDefinition#defined_for?", () => {
   it("treats an unset stored option as Array(nil) => [], not a 'undefined' string", () => {
     const noActions = new ForeignKeyDefinition("astronauts", "rockets", "rocket_id", "id", "fk_x");
     expect(noActions.onDelete).toBeUndefined();
-    // [] vs ["cascade"] => false, mirroring Array(nil).map(&:to_s) == ["cascade"]
     expect(noActions.isDefinedFor({ onDelete: "cascade" })).toBe(false);
   });
 
@@ -427,8 +426,6 @@ describe("ForeignKeyDefinition#defined_for?", () => {
     const fkDef = new TableDefinition("astronauts", {
       adapter: conn,
     }).newForeignKeyDefinition("rockets");
-    // primaryKey/onDelete/onUpdate/deferrable were not passed, so they are not
-    // stored — a lookup on them is sliced out and matches.
     expect(fkDef.isDefinedFor({ primaryKey: "wrong" })).toBe(true);
     expect(fkDef.isDefinedFor({ onDelete: "cascade" })).toBe(true);
     expect(fkDef.isDefinedFor({ onUpdate: "cascade" })).toBe(true);
@@ -437,7 +434,6 @@ describe("ForeignKeyDefinition#defined_for?", () => {
     // so they still compare.
     expect(fkDef.isDefinedFor({ column: "rocket_id" })).toBe(true);
     expect(fkDef.isDefinedFor({ column: "wrong_id" })).toBe(false);
-    // An explicitly-set key is stored and compared.
     const withPk = new TableDefinition("astronauts", {
       adapter: conn,
     }).newForeignKeyDefinition("rockets", {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -75,10 +75,6 @@ export type ColumnType =
   | "char"
   | "primary_key"
   | "uuid"
-  // Accept arbitrary adapter-specific type strings (e.g. "timestamptz",
-  // "inet", custom PG enum names) emitted by SchemaDumper's
-  // `t.column(name, sqlType, ...)` fallback. The `& {}` preserves
-  // literal autocomplete for the known types above.
   | (string & {});
 
 export type PrimaryKeyType = "uuid";
@@ -150,9 +146,6 @@ export class ColumnDefinition {
   ];
 
   sqlType?: string;
-  // PostgreSQL only: physical storage type ("timestamp" / "timestamptz") for
-  // datetime-family columns, recorded at creation time so the schema dumper
-  // can re-derive the dumped type against the live datetime_type.
   datetimePhysicalType?: string;
   constructor(
     readonly name: string,
@@ -331,12 +324,6 @@ export class ForeignKeyDefinition {
     // leave it absent), driving the fetch-fallback in isDefinedFor.
     this.storesValidate = validate !== undefined;
     this.validate = this.storesValidate ? (validate as boolean | null) : true;
-    // Default: every generic key is stored, matching the DB-introspection paths
-    // (pg/mysql/sqlite `foreignKeys`) whose options hash always carries
-    // column/name/primaryKey/onDelete/onUpdate/deferrable — present even when
-    // nil, so an unset action still compares as `Array(nil) => []`. When a
-    // caller knows exactly which keys were explicitly set (e.g. the hand-built
-    // DSL path), it passes `storedOptionKeys` to slice the comparison.
     this.storedOptionKeys = new Set(
       storedOptionKeys ?? ["column", "name", "primaryKey", "onDelete", "onUpdate", "deferrable"],
     );
@@ -409,8 +396,6 @@ export class ForeignKeyDefinition {
       // introspection, or an add/DSL path that didn't pass it), the fetch falls
       // back to the lookup value, so the comparison is trivially true.
       (options.validate == null || !this.storesValidate || options.validate === this.validate) &&
-      // Generic key compare, mirroring defined_for?'s `options.all?` over the
-      // remaining stored option keys (column, name, primary_key, on_delete, …).
       (options.column === undefined ||
         !stored("column") ||
         optionEqual(options.column, this.column)) &&
@@ -1671,8 +1656,6 @@ export class Table {
     options: { column?: string | string[]; name?: string } = {},
   ): Promise<void> {
     const isColumn = typeof columnOrOptions === "string" || Array.isArray(columnOrOptions);
-    // `remove_index(column_name = nil, **options)`: an options-only call leaves
-    // column_name nil rather than passing the hash as the column.
     const columnName = isColumn ? columnOrOptions : undefined;
     // Ruby's `**options` collects the hash from either position, so an explicit
     // nil column with the options behind it keeps them.
@@ -1710,8 +1693,6 @@ export class Table {
   ): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     const { index: indexOpt, ...colOpts } = options;
-    // `@base.add_column(name, column_name, type, **options)` passes no fourth
-    // argument when `options` is empty, and CommandRecorder records args verbatim.
     if (Object.keys(colOpts).length === 0) {
       await this._schema.addColumn(this.name, columnName, type);
     } else {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
@@ -140,8 +140,6 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
   });
 
   it("still dumps the table normally when every column type is a valid native type", async () => {
-    // The valid_type? gate must not over-reject: a table whose columns all map
-    // to native types dumps its create_table body unchanged.
     const validSource = {
       tables: () => ["widgets"],
       columns: (_t: string) => [

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -62,7 +62,6 @@ export class SchemaDumper extends BaseSchemaDumper {
   protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
     const spec: Record<string, unknown> = {};
     if (!this.isDefaultPrimaryKey(column)) {
-      // Pre-format the id value as a TS-DSL string literal for formatColspec.
       spec["id"] = JSON.stringify(this.schemaType(column));
     }
     const colOpts = this.prepareColumnOptions(column);
@@ -112,8 +111,6 @@ export class SchemaDumper extends BaseSchemaDumper {
   /** @internal */
   protected schemaType(column: Column): string {
     if (this.isBigint(column)) return "bigint";
-    // `column.type` is non-null here: `emitTable` runs `validType?` over every
-    // column first and raises on a nil type, so a null never reaches schemaType.
     return column.type ?? "";
   }
 
@@ -279,7 +276,6 @@ export class SchemaDumper extends BaseSchemaDumper {
     const singlePkName = !hasCompositePk && pkColumn ? pkColumn.name : undefined;
     const stripped = this.removePrefixAndSuffix(tableName);
 
-    // All values in tableOpts are pre-formatted TS-DSL text for formatColspec.
     const tableOpts: Record<string, unknown> = {};
     if (hasCompositePk) {
       // Rails (Array case) emits only `primary_key: [...]` — schema_dumper.rb:182.
@@ -290,10 +286,6 @@ export class SchemaDumper extends BaseSchemaDumper {
       // Rails (String case): print `primary_key: <name>` for a non-"id" key, then the
       // column spec unless empty. Mirrors schema_dumper.rb:170-179.
       if (pkColumn.name !== "id") tableOpts["primaryKey"] = JSON.stringify(pkColumn.name);
-      // columnSpecForPrimaryKey returns a FLAT spec (dialect overrides post-process it,
-      // e.g. MySQL deletes auto_increment); wrap into `id: { ... }` here at the call site,
-      // after those overrides, so the PK's own `comment:` doesn't collide with the
-      // table-level `comment:`.
       const pkSpec = this.columnSpecForPrimaryKey(pkColumn);
       if (Object.keys(pkSpec).length > 0) {
         if (Object.keys(pkSpec).every((k) => k === "id" || k === "default")) {
@@ -330,7 +322,6 @@ export class SchemaDumper extends BaseSchemaDumper {
       } else if ((col as any).isEnum && typeName === "enum") {
         stream.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
       } else {
-        // Generic fallback: pass arbitrary SQL type verbatim via t.column.
         const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
         stream.push(
           `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-assume-migrated-upto-version-pool.trails.test.ts
@@ -16,9 +16,7 @@ import { fixtures } from "../../test-fixtures.js";
 const migrationsDir = (name: string) =>
   new URL(`../../test-helpers/migrations/${name}`, import.meta.url).pathname;
 
-// versions 1, 2, 3
 const VALID = migrationsDir("valid");
-// versions 230, 231, 20210716122844, 20210716123013
 const OLD_AND_NEW_VERSIONS = migrationsDir("old_and_new_versions");
 
 /** `assumeMigratedUptoVersion` is mixed onto the adapter by `SchemaStatements`. */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
@@ -114,8 +114,6 @@ class SqliteCapturingAdapter extends AbstractAdapter {
 }
 
 describe("SchemaStatements mixed into AbstractAdapter", () => {
-  // Non-transactional: MySQL's implicit commit on DDL would otherwise commit
-  // the fixture transaction mid-test.
   fixtures([], { useTransactionalTests: false });
 
   it("tableAliasFor resolves tableAliasLength via the DatabaseLimits mixin", () => {
@@ -136,9 +134,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(sqlite.lastSql).toBe('PRAGMA table_info("things")');
     await sqlite.columns('a"b');
     expect(sqlite.lastSql).toBe('PRAGMA table_info("a""b")');
-    // Converged with SQLite3Adapter: a schema-qualified name uses the
-    // `PRAGMA schema.table_info(table)` prefix form (works for ATTACHed DBs),
-    // NOT `PRAGMA table_info("schema"."table")` which returns zero rows.
     await sqlite.columns("aux.widgets");
     expect(sqlite.lastSql).toBe('PRAGMA "aux".table_info("widgets")');
   });
@@ -154,7 +149,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   });
 
   it("indexes() sqlite arm quotes the index name as a string literal in the index_info PRAGMA", async () => {
-    // First call is index_list; surface one index whose name has a quote.
     const sqlite = new SqliteCapturingAdapter([{ name: 'idx"x', unique: 1 }]);
     await sqlite.indexes("things");
     // Converged with SQLite3Adapter: between index_list and index_info the
@@ -171,8 +165,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   });
 
   it("indexes() sqlite arm carries the schema prefix into the index_info PRAGMA", async () => {
-    // The index lives in the table's schema, so index_info must use the same
-    // prefix as index_list — not query the default schema for the index name.
     const sqlite = new SqliteCapturingAdapter([{ name: "idx_widgets_name", unique: 0 }]);
     await sqlite.indexes("aux.widgets");
     expect(sqlite.allSql).toEqual([
@@ -197,8 +189,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     await stub.columns("myschema.things");
     expect(stub.lastSql).toContain("c.table_schema = $3");
     expect(stub.lastSql).not.toContain("current_schemas(false)");
-    // bare name for table_name match ($1), qualified name for to_regclass ($2),
-    // schema bound as $3.
     expect(stub.lastParams).toEqual(["things", "myschema.things", "myschema"]);
   });
 
@@ -210,9 +200,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
   });
 
   it("columnExists() postgres fallback scopes table_schema to an explicit schema.table", async () => {
-    // columnExists delegates to columns(), so the schema.table qualification is
-    // resolved there: bare name ($1), qualified name for to_regclass ($2),
-    // schema bound as $3.
     const stub = new CapturingAdapter("postgres");
     await stub.columnExists("myschema.things", "name");
     expect(stub.lastSql).toContain("c.table_schema = $3");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -39,9 +39,6 @@ function makeStatements(
     schemaCache: { clearDataSourceCacheBang: vi.fn().mockResolvedValue(undefined) },
     ...adapterOverrides,
   };
-  // Real hosts reflect through `internal_exec_query(sql, "SCHEMA")`. Route the
-  // stub's through whichever `execute` this call installed so reflection probes
-  // stay visible to per-test `execute` spies.
   adapter["internalExecQuery"] ??= async (
     sql: string,
     _name?: string | null,
@@ -66,11 +63,7 @@ function makeStatements(
   adapter["supportsExclusionConstraints"] ??= () => false;
   adapter["supportsUniqueConstraints"] ??= () => false;
   adapter["useForeignKeys"] ??= () => true;
-  // Real hosts override AbstractAdapter#native_database_types (the abstract one
-  // is `{}`); the stub answers with SQLite's table so typeToSql resolves.
   adapter["nativeDatabaseTypes"] ??= () => NATIVE_DATABASE_TYPES_BY_ADAPTER["sqlite"];
-  // The catalog probes go through data_source_sql; the stub answers with a
-  // simple catalog query unless a test installs its own.
   adapter["dataSourceSql"] ??= (name?: string | null) =>
     name == null
       ? "SELECT name FROM catalog"
@@ -83,8 +76,6 @@ function makeStatements(
     )(sql, binds, "SCHEMA")) as Record<string, unknown>[];
     return rows.map((row) => Object.values(row)[0]);
   };
-  // The bodies under test are prototype methods mixed into the adapter, so
-  // give the stub adapter that prototype and call them the way production does.
   return Object.setPrototypeOf(adapter, Statements.prototype) as SchemaStatements;
 }
 
@@ -193,7 +184,7 @@ describe("SchemaStatements privates (PR 8)", () => {
   it("indexNameForRemove applies the generate_index_name length/hash fallback to a long expression", async () => {
     const longExpr = `lower(${"a".repeat(80)})`;
     const expected = makeStatements().generateIndexName("users", `lower_${"a".repeat(80)}`);
-    expect(expected).toMatch(/_[0-9a-f]{10}$/); // fallback fired
+    expect(expected).toMatch(/_[0-9a-f]{10}$/);
     const ss = makeStatements({
       indexes: vi.fn().mockResolvedValue([{ name: expected, columns: ["x"], unique: false }]),
     });
@@ -256,8 +247,6 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(ss.checkConstraintName("users", { expression: "age > 0" })).toMatch(
       /^chk_rails_[0-9a-f]{10}$/,
     );
-    // The inner `options.fetch(:expression)` is the same rule: a stored nil
-    // interpolates as "" ("users__chk"), and only an ABSENT key raises.
     expect(ss.checkConstraintName("users", { expression: undefined })).toBe(
       ss.checkConstraintName("users", { expression: "" }),
     );
@@ -341,7 +330,6 @@ describe("SchemaStatements privates (PR 8)", () => {
     ).toBe(false);
   });
 
-  // PR 8b helpers
   it("validateIndexLengthBang throws when name too long", () => {
     const ss = makeStatements();
     expect(() => ss.validateIndexLengthBang("users", "a".repeat(65))).toThrow(/too long/);
@@ -513,7 +501,6 @@ describe("SchemaStatements privates (PR 8)", () => {
     );
     vi.spyOn(ss, "foreignKeys").mockResolvedValue([fk]);
 
-    // A distinct array instance with the same elements must still match.
     expect(
       await ss.foreignKeyExists("astronauts", "rockets", {
         column: ["rocket_tenant_id", "rocket_id"],
@@ -545,7 +532,6 @@ describe("SchemaStatements privates (PR 8)", () => {
       ifNotExists: true,
     });
 
-    // The composite column matches by value, so no ALTER TABLE is issued.
     expect(executeMutation).not.toHaveBeenCalled();
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -325,9 +325,6 @@ export class SchemaStatements {
 
   /** Mirrors: SchemaStatements#schema_creation — `SchemaCreation.new(self)`. */
   get schemaCreation(): SchemaCreation {
-    // `SchemaStatements` types its host as `DatabaseAdapter & SchemaQuoter`,
-    // which does not surface the capability probes; every runtime `this` is an
-    // AbstractAdapter, which defines all of them (abstract-adapter.ts:1576-1962).
     return new SchemaCreation(this as unknown as SchemaCreationConn);
   }
 
@@ -765,10 +762,6 @@ export class SchemaStatements {
     // foreign_key_exists? matches via foreign_keys(from).detect { defined_for? },
     // scoping on to_table plus column when one is given.
     if (options.ifNotExists === true) {
-      // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
-      // compares `column` element-wise, so composite (array) columns match by
-      // value rather than by array identity (a bare `===` is always false for
-      // distinct array instances).
       if (await this.foreignKeyExists(fromTable, toTable, { column: options.column })) {
         return;
       }
@@ -981,7 +974,6 @@ export class SchemaStatements {
     newName = String(newName);
     this.validateIndexLengthBang(tableName, newName);
 
-    // this is a naive implementation; some DBs may support this more efficiently (PostgreSQL, for instance)
     const oldIndexDef = (await this.indexes(tableName)).find((i) => i.name === oldName);
     if (!oldIndexDef) return;
     await this.addIndex(tableName, oldIndexDef.columns, {
@@ -1182,16 +1174,8 @@ export class SchemaStatements {
   async indexes(tableName: string): Promise<IndexDefinition[]> {
     switch (this.adapterName as AdapterName) {
       case "sqlite":
-        // Share the concrete SQLite3 introspection so this fallback arm
-        // produces the same result shape (skips `sqlite_*` auto-indexes,
-        // recovers partial-index WHERE clauses and expression/DESC columns
-        // from the index SQL) rather than a lower-fidelity subset.
         return sqliteIndexes(this as unknown as DatabaseAdapter, tableName);
       case "postgres": {
-        // The LEFT JOIN on pg_attribute (below) is deliberate: an expression
-        // key has attnum 0 with no pg_attribute row, so an inner join would drop
-        // the entire index. LEFT JOIN keeps the row (attname NULL) so the
-        // has_expressions arm can substitute the raw pg_get_indexdef expression.
         const rows = (
           await this.internalExecQuery(
             `SELECT i.relname AS name, ix.indisunique AS unique, array_agg(a.attname ORDER BY k.n) AS columns,
@@ -1209,9 +1193,6 @@ export class SchemaStatements {
           )
         ).toArray();
         return rows.map((row: any) => {
-          // Recover the partial-index WHERE predicate and per-column DESC
-          // directions from the index definition, mirroring the concrete
-          // PostgreSQL::SchemaStatements#indexes parsing.
           const def = (row.definition as string) ?? "";
           const defMatch = def.match(
             / USING \w+? \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?$/s,
@@ -1713,7 +1694,6 @@ export class SchemaStatements {
       await this.execute(`INSERT INTO ${smTable} (version) VALUES (${this.quote(version)})`);
     }
 
-    // Insert all known migration versions below the target that haven't been run
     const inserting = allVersions.filter((v) => v < version && !migrated.includes(v));
     if (inserting.length > 0) {
       const duplicate = inserting.find((v) => inserting.filter((x) => x === v).length > 1);
@@ -2418,9 +2398,6 @@ export class SchemaStatements {
 
   /** @internal */
   validateIndexLengthBang(tableName: string, newName: string, _internal = false): void {
-    // Resolve through the adapter (which carries the DatabaseLimits mixin) so an
-    // adapter overriding indexNameLength/maxIdentifierLength propagates here,
-    // falling back to the DatabaseLimits base default for a bare adapter.
     const adapter = this as unknown as { indexNameLength?(): number };
     const limit = adapter.indexNameLength ? adapter.indexNameLength() : maxIdentifierLength();
     if (newName.length > limit) {

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.trails.test.ts
@@ -25,8 +25,6 @@ describe("parsePostgresInstant", () => {
   });
 
   it("truncates sub-nanosecond digits beyond 9", () => {
-    // No DB emits >9 fractional digits, but guard against corrupt input
-    // shifting the slice boundaries. "1234567899" → treat as "123456789".
     const result = parsePostgresInstant("2026-04-26 14:23:55.1234567899+00") as Temporal.Instant;
     const zdt = result.toZonedDateTimeISO("UTC");
     expect(zdt.millisecond).toBe(123);
@@ -58,10 +56,8 @@ describe("parsePostgresInstant", () => {
   });
 
   it("parses a BC timestamp", () => {
-    // Postgres 0044-03-15 BC = ISO year -43
     const result = parsePostgresInstant("0044-03-15 12:00:00+00 BC") as Temporal.Instant;
     expect(result.epochNanoseconds).toBeLessThan(0n);
-    // year -43 in proleptic Gregorian = 44 BC
     const zdt = result.toZonedDateTimeISO("UTC");
     expect(zdt.year).toBe(-43);
     expect(zdt.month).toBe(3);
@@ -209,12 +205,9 @@ describe("naive parsers honor ActiveRecord.default_timezone", () => {
 
   it("naive parsers + formatInstantForSql round-trip symmetrically under default_timezone=local", () => {
     ActiveRecord.defaultTimezone = "local";
-    // Pick a wall-clock that is unambiguous in any timezone.
     const wireString = "2026-06-15 12:00:00";
     const parsed = parsePostgresTimestampAsInstant(wireString) as Temporal.Instant;
     expect(parsed).toBeInstanceOf(Temporal.Instant);
-    // Symmetry: formatting the parsed instant under the same default_timezone
-    // setting must yield the original wire string.
     expect(formatInstantForSql(parsed)).toBe(wireString);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/temporal-wire.ts
@@ -41,10 +41,6 @@ function naiveIsoToInstant(iso: string): Temporal.Instant {
   return Temporal.PlainDateTime.from(iso).toZonedDateTime(defaultSqlTimezone()).toInstant();
 }
 
-// ---------------------------------------------------------------------------
-// Postgres
-// ---------------------------------------------------------------------------
-
 /**
  * Parse a Postgres `timestamptz` wire string to `Temporal.Instant`.
  *
@@ -98,9 +94,6 @@ export function parsePostgresDate(
   if (trimmed === "-infinity") return DateNegativeInfinity;
   const { iso, bc } = extractBcSuffix(trimmed);
   if (!bc) return Temporal.PlainDate.from(iso);
-  // Parse components directly — do not construct an intermediate PlainDate from
-  // the CE year string. "0005-02-29 BC" is Feb 29, ISO year -4 (a leap year),
-  // but year 5 CE is not; Temporal.PlainDate.from("0005-02-29") would throw.
   const m = /^(\d+)-(\d{2})-(\d{2})$/.exec(iso);
   if (!m) throw new RangeError(`Cannot parse BC date: ${JSON.stringify(text)}`);
   return Temporal.PlainDate.from(
@@ -108,10 +101,6 @@ export function parsePostgresDate(
     { overflow: "reject" },
   );
 }
-
-// ---------------------------------------------------------------------------
-// MySQL
-// ---------------------------------------------------------------------------
 
 /**
  * Parse a MySQL `TIMESTAMP` wire string to `Temporal.Instant`.
@@ -125,7 +114,6 @@ export function parsePostgresDate(
  */
 export function parseMysqlInstant(text: string): Temporal.Instant | null {
   const trimmed = text.trim();
-  // MySQL can emit zero timestamps from legacy schemas even on TIMESTAMP columns.
   if (isZeroDatetime(trimmed)) return null;
   const iso = clampFraction(trimmed.replace(" ", "T") + "Z");
   return Temporal.Instant.from(iso);
@@ -156,10 +144,6 @@ export function parseMysqlDate(text: string): Temporal.PlainDate | null {
   if (isZeroDate(trimmed)) return null;
   return Temporal.PlainDate.from(trimmed);
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Normalize a Postgres `timestamptz` string (no BC suffix) to strict
@@ -203,7 +187,6 @@ function bcYearToIso(pgYear: number): number {
  * Input has already had " BC" stripped.
  */
 function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
-  // e.g. "0044-03-15 12:00:00.123456+00" or "0044-03-15 12:00:00+02:30"
   const match =
     /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?([-+]\d{2}(?::\d{2})?)$/.exec(
       withoutBc,
@@ -236,7 +219,6 @@ function parseBcTimestampTzAsInstant(withoutBc: string): Temporal.Instant {
  * Input has already had " BC" stripped.
  */
 function parseBcTimestampAsInstant(withoutBc: string): Temporal.Instant {
-  // e.g. "0044-03-15 12:00:00.123456" or "0044-03-15 12:00:00"
   const match = /^(\d+)-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(withoutBc);
   if (!match) throw new RangeError(`Cannot parse BC timestamp: ${JSON.stringify(withoutBc)}`);
   const [, y, mo, d, h, mi, s, frac] = match;
@@ -270,9 +252,6 @@ function parseFraction(frac: string | undefined): {
   nanosecond: number;
 } {
   if (!frac) return { millisecond: 0, microsecond: 0, nanosecond: 0 };
-  // Clamp to 9 digits before padding so extra digits don't silently corrupt
-  // the slice boundaries (e.g. a 10-digit input would shift microsecond into
-  // the nanosecond slot without this guard).
   const clamped = frac.slice(0, 9).padEnd(9, "0");
   return {
     millisecond: Number(clamped.slice(0, 3)),
@@ -294,7 +273,5 @@ function isZeroDate(text: string): boolean {
 }
 
 function isZeroDatetime(text: string): boolean {
-  // Match "0000-00-00 00:00:00" / "0000-00-00T00:00:00" and the fractional
-  // variants emitted by DATETIME(N) columns, e.g. "0000-00-00 00:00:00.000000".
   return /^0000-00-00[T ]00:00:00(\.\d+)?$/.test(text);
 }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -593,9 +593,7 @@ export class Transaction {
     }
   }
 
-  async restart(): Promise<void> {
-    // No-op: subclasses (RealTransaction, SavepointTransaction) override with actual restart logic
-  }
+  async restart(): Promise<void> {}
 
   isFullRollback(): boolean {
     return true;
@@ -789,19 +787,10 @@ export class RestartParentTransaction extends Transaction {
   }
 
   /** @internal */
-  override incompleteBang(): void {
-    // RestartParentTransaction has no own instrumentation lifecycle —
-    // materializeBang() delegates to parent, so _instrumenter is never started.
-  }
+  override incompleteBang(): void {}
 
   /** @internal */
-  override async restoreBang(): Promise<void> {
-    // No-op: RestartParentTransaction delegates materializeBang() to the parent.
-    // The base restoreBang() calls materializeBang() after clearing _materialized,
-    // which would invoke the parent's _instrumenter.start() a second time while it
-    // is already running — raising InstrumentationAlreadyStartedError during
-    // retry-on-deadlock.
-  }
+  override async restoreBang(): Promise<void> {}
 
   override isFullRollback(): boolean {
     return false;
@@ -1056,9 +1045,7 @@ export class TransactionManager {
         this._connection.supportsLazyTransactions?.() &&
         this.isLazyTransactionsEnabled() &&
         _lazy &&
-        !isolation // isolated transactions must materialize eagerly so the
-        // snapshot is taken before the first read (mirrors Rails' per-query
-        // materialize_transactions call in with_raw_connection)
+        !isolation
       ) {
         this._hasUnmaterializedTransactions = true;
       } else {


### PR DESCRIPTION
Slice 3 of `strip-freeform-comments-ar-connection-adapters`.

Enrolls `packages/activerecord/src/connection-adapters/abstract/**/*.ts` in the `no-freeform-comments` block in `eslint.config.mjs` and applies the autofix — 145 rule findings, heaviest in `connection-pool.ts` (25), `database-statements.ts` (25), `temporal-wire.ts` (9), `schema-statements.ts` (8).

Reviewed the deletions: no block was emptied, nothing deleted recorded deferred work (no TODO/FIXME among the removed text), and the surviving comments are JSDoc or carry a Rails citation. Two follow-ups on top of the autofix:

- collapsed the double blank lines the deletions left behind in `connection-pool.ts`, `database-statements.ts`, `temporal-wire.ts`, `database-statements.trails.test.ts`;
- removed an orphaned sentence fragment in `transaction.ts` whose leading clause was a trailing comment the rule deleted.

`pnpm eslint` is clean over the glob (a second `--fix` is a no-op), `pnpm typecheck` is clean, and the 11 touched test files run green (426 passed, 2 skipped).

Closes-story: strip-freeform-comments-ar-connection-adapters-abstract