### PR TITLE
refactor(activerecord): strip free-form comments from connection-adapters top-level src

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -754,6 +754,19 @@ export default defineConfig(
     },
   },
 
+  // ── no-freeform-comments, activerecord/connection-adapters top-level: the
+  //    implementation files at the root of the tree are swept; the test files
+  //    beside them are still outstanding (story
+  //    strip-freeform-comments-ar-connection-adapters-toplevel-tests), so they
+  //    are ignored here rather than holding the rule off the whole slice. ──
+  {
+    files: ["packages/activerecord/src/connection-adapters/*.ts"],
+    ignores: ["packages/activerecord/src/connection-adapters/*.test.ts"],
+    rules: {
+      "blazetrails/no-freeform-comments": "error",
+    },
+  },
+
   // ── no-freeform-comments, activerecord/associations: swept a slice at a
   //    time. The implementation files are done; the test files under the same
   //    tree are still outstanding (story

--- a/packages/activerecord/src/connection-adapters/abandon-raw-socket.ts
+++ b/packages/activerecord/src/connection-adapters/abandon-raw-socket.ts
@@ -39,8 +39,5 @@ export function abandonRawSocket(rawConnection: unknown): void {
   try {
     socket.removeAllListeners?.();
     socket.unref?.();
-  } catch {
-    // Best-effort: a partially torn-down socket may throw. Abandoning it
-    // (the reference is already dropped by the caller) is still correct.
-  }
+  } catch {}
 }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -232,11 +232,6 @@ export class Version {
 // Rails: `AbstractAdapter` includes `SchemaStatements` so `connection.create_table(...)` works.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AbstractAdapter {
-  // --- SchemaStatements (DDL) ---
-  // The abstract base signatures are declared here. Concrete adapter subclasses
-  // that override with dialect-specific variants (PG's createTable callback-first)
-  // carry // @ts-expect-error on those overrides. Callers typed as AbstractAdapter
-  // should use the base call forms; PG-specific forms require a concrete type.
   createTable(
     tableName: string,
     optionsOrFn?:
@@ -407,9 +402,6 @@ export interface AbstractAdapter {
   extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
   tableExists(tableName: string): Promise<boolean>;
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
-  // Options SchemaMigration / InternalMetadata pass to `t.string` for their
-  // primary key. Mixed in from SchemaStatements; declared here so those
-  // callers can reach it through the AbstractAdapter type.
   internalStringOptionsForPrimaryKey(): Record<string, unknown>;
   // Rails' `column_exists?(table, column, type = nil, **options)` narrows the
   // match by column `type` and the columnOptionsKeys when given.
@@ -554,14 +546,11 @@ export interface AbstractAdapter {
   /** @internal */
   extractNewCommentValue(defaultOrChanges: CommentOrChanges): string | null;
   tableAliasFor(tableName: string): string;
-  // Provided by the DatabaseLimits mixin (included below); tableAliasFor
-  // resolves it through here rather than a duplicate on SchemaStatements.
   tableAliasLength(): number;
   nativeDatabaseTypes(): Record<string, unknown>;
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
   dataSources(): Promise<string[]>;
   dataSourceExists(name: string): Promise<boolean>;
-  // --- DatabaseStatements ---
   /** Mirrors `DatabaseStatements#sanitize_limit` (abstract/database_statements.rb). */
   sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral;
   /**
@@ -708,9 +697,6 @@ export interface AbstractAdapter {
   /** @internal */
   preprocessQuery(sql: string): string;
 
-  // --- Members previously only on DatabaseAdapter interface ---
-  // Declaring them here makes AbstractAdapter a structural superset of
-  // DatabaseAdapter, prerequisite for collapsing the two types.
   execute(
     sql: string,
     binds?: unknown[],
@@ -767,13 +753,6 @@ export interface AbstractAdapter {
   currentDatabase?(): Promise<string>;
   /** @internal */
   createAlterTable?(name: string): AlterTable;
-
-  // --- SchemaStatements / DatabaseStatements members provided only by the
-  // SchemaStatements mixin or concrete-adapter subclasses, not the base class.
-  // Declared optional here so a value typed as the base `AbstractAdapter` (the
-  // superset that replaces the deleted `DatabaseAdapter` interface — RFC 0010)
-  // can still reach them with `?.` / `!`. See migration.ts, relation.ts#explain,
-  // and abstract/schema-statements.ts#createTable for the base-typed call sites.
 
   /**
    * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#explain
@@ -884,11 +863,6 @@ export class AbstractAdapter implements Quoting {
    *   0094 constructor reshape (abstract_adapter.rb:167).
    */
   constructor() {
-    // The module-level `include(...)` / callback / query-cache wiring is applied
-    // lazily on first construction rather than at module-evaluation time. This
-    // avoids a TDZ crash when the adapter graph is imported from a non-runtime
-    // entry point (e.g. `support/schema-types` → SchemaStatements) that
-    // re-enters this module mid-cycle before the mixin classes have initialized.
     ensureAbstractAdapterMixinsApplied();
     // Mirrors Rails abstract_adapter.rb:155 — @visitor = arel_visitor
     this._visitor = this.arelVisitor();
@@ -1061,7 +1035,6 @@ export class AbstractAdapter implements Quoting {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
-  // Return union: awaitable surface (PG's regtype lookup); this base stays sync.
   quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     if (value === undefined) return "";
     if (typeof value === "function") {
@@ -1174,8 +1147,6 @@ export class AbstractAdapter implements Quoting {
   clearQueryCache(): void {
     clearQueryCacheMixin.call(this as unknown as QueryCacheHost);
   }
-
-  // --- End QueryCache mixin ---
 
   get inUse(): boolean {
     return this._inUse;
@@ -1299,8 +1270,6 @@ export class AbstractAdapter implements Quoting {
   get adapterName(): string {
     return "Abstract";
   }
-
-  // --- Identity & lifecycle ---
 
   isConnected(): boolean {
     return this._connection !== null;
@@ -1466,9 +1435,7 @@ export class AbstractAdapter implements Quoting {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#clear_cache!
    */
-  clearCacheBang(_opts: { newConnection?: boolean } = {}): void | Promise<void> {
-    // Subclasses with statement caches override this
-  }
+  clearCacheBang(_opts: { newConnection?: boolean } = {}): void | Promise<void> {}
 
   /**
    * The key under which `sql` is stored in the connection's statement pool.
@@ -1522,8 +1489,6 @@ export class AbstractAdapter implements Quoting {
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.inspect();
   }
-
-  // --- Capability introspection ---
 
   isValidType(type: string | null | undefined): boolean {
     if (type == null) return false;
@@ -1581,9 +1546,6 @@ export class AbstractAdapter implements Quoting {
    * async `BoundSchemaReflection` can't serve.
    */
   get internalSchemaCache(): SchemaCache {
-    // Same object the bound reflection reads: PoolConfig#schemaCache is backed
-    // by the pool SchemaReflection's cache slot, and the lone-connection
-    // reflection below owns the standalone-adapter one.
     const reflection = this._poolSchemaReflection();
     if (!reflection.loadedCache) reflection.loadedCache = new SchemaCache();
     return reflection.loadedCache;
@@ -1673,8 +1635,6 @@ export class AbstractAdapter implements Quoting {
   async supportsInsertOnDuplicateUpdate(): Promise<boolean> {
     return false;
   }
-
-  // --- Private helpers ---
 
   protected stripSqlComments(sql: string): string {
     return stripSqlComments(sql);
@@ -1816,7 +1776,6 @@ export class AbstractAdapter implements Quoting {
     let block: (tx?: unknown) => Promise<T> | T;
     if (typeof fnOrOpts === "function") {
       block = fnOrOpts;
-      // Support both (fn) and (fn, opts) — fixture loading uses the latter
       if (fnOrOpts2 && typeof fnOrOpts2 !== "function") opts = fnOrOpts2;
     } else {
       opts = fnOrOpts ?? {};
@@ -1860,8 +1819,6 @@ export class AbstractAdapter implements Quoting {
       return conn;
     });
   }
-
-  // --- Config accessors ---
 
   get connectionRetries(): number {
     const v = this._config.connectionRetries;
@@ -1914,8 +1871,6 @@ export class AbstractAdapter implements Quoting {
     );
   }
 
-  // --- Lifecycle ---
-
   stealBang(): void {
     if (!this._inUse) {
       throw new ActiveRecordError("Cannot steal connection, it is not currently leased.");
@@ -1942,8 +1897,6 @@ export class AbstractAdapter implements Quoting {
     void this.clearCacheBang({ newConnection: true });
     this.resetTransaction();
   }
-
-  // --- Capability flags (batch 2) ---
 
   supportsAdvisoryLocks(): boolean {
     return false;
@@ -1983,8 +1936,6 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  // --- Static utilities ---
-
   static typeCastConfigToInteger(config: unknown): number | unknown {
     if (typeof config === "number") return config;
     if (typeof config === "string" && /^\d+$/.test(config)) return parseInt(config, 10);
@@ -1999,8 +1950,6 @@ export class AbstractAdapter implements Quoting {
   isAsyncEnabled(): boolean {
     return false;
   }
-
-  // --- Capability flags (batch 3) ---
 
   async supportsIndexInclude(): Promise<boolean> {
     return false;
@@ -2105,8 +2054,6 @@ export class AbstractAdapter implements Quoting {
 
   lockThread: boolean = false;
 
-  // --- DDL: extensions, enums, virtual tables ---
-
   async enableExtension(_name: string): Promise<void> {}
 
   async disableExtension(_name: string): Promise<void> {}
@@ -2140,8 +2087,6 @@ export class AbstractAdapter implements Quoting {
 
   async dropVirtualTable(_name: string): Promise<void> {}
 
-  // --- Advisory locks ---
-
   // Mirrors AbstractAdapter#advisory_locks_enabled? (abstract_adapter.rb:603).
   // `supportsAdvisoryLocks()` is false on SQLite, so this returns false there
   // (Rails' `respond_to?`/`supports_advisory_locks?` gate); PG/MySQL combine
@@ -2158,8 +2103,6 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  // --- Extensions & algorithms ---
-
   extensions(): string[] | Promise<string[]> {
     return [];
   }
@@ -2168,15 +2111,11 @@ export class AbstractAdapter implements Quoting {
     return {};
   }
 
-  // --- Referential integrity & FK validation ---
-
   async disableReferentialIntegrity(fn: () => Promise<void>, _tables?: string[]): Promise<void> {
     await fn();
   }
 
   async checkAllForeignKeysValidBang(): Promise<void> {}
-
-  // --- Connection lifecycle ---
 
   throwAwayBang(): void {
     // Mirrors Rails AbstractAdapter#throw_away! (abstract_adapter.rb:733):
@@ -2205,8 +2144,6 @@ export class AbstractAdapter implements Quoting {
     this._rawConnectionDirty = false;
     this._verified = false;
   }
-
-  // --- Comparison helpers ---
 
   defaultUniquenessComparison(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
     return attribute.eq(value);
@@ -2239,8 +2176,6 @@ export class AbstractAdapter implements Quoting {
     return true;
   }
 
-  // --- Insert SQL ---
-
   // Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#build_insert_sql.
   // The base adapter only knows plain inserts; adapters that support upsert /
   // skip-duplicates override this. `into()` already bundles the VALUES list,
@@ -2254,8 +2189,6 @@ export class AbstractAdapter implements Quoting {
     }
     return `INSERT ${insert.into()}`;
   }
-
-  // --- Version introspection ---
 
   // Rails' `get_database_version` returns whatever the adapter uses to
   // represent a server version. PG returns the `server_version` integer;
@@ -2283,8 +2216,6 @@ export class AbstractAdapter implements Quoting {
     return 0;
   }
 
-  // --- Timezone validation ---
-
   static validateDefaultTimezone(timezone: string): string {
     const valid = ["utc", "local"];
     if (!valid.includes(timezone)) {
@@ -2293,13 +2224,9 @@ export class AbstractAdapter implements Quoting {
     return timezone;
   }
 
-  // --- Query classification ---
-
   buildReadQueryRegexp(): RegExp {
     return /^\s*(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|DESCRIBE|DESC)\b/i;
   }
-
-  // --- Console ---
 
   static findCmdAndExec(_commands: string[]): void {}
 
@@ -2456,10 +2383,6 @@ export class AbstractAdapter implements Quoting {
       // Rails: `connect! if @raw_connection.nil? && reconnect_can_restore_state?`
       // (abstract_adapter.rb:985), and `connect!` is `verify!` (rb:778-781).
       if (this._connection === null && this.isReconnectCanRestoreState()) await this.connectBang();
-      // Drain any deferred connection-readiness work (PostgreSQLAdapter
-      // re-opens a socket a failed reconfigure tore down, and drains orphaned
-      // prepared statements) ONCE here, before any query runs. Pre-loop (not
-      // per-iteration) — a no-op for adapters with no deferred work.
       await this.awaitRawConnectionReady();
       if (materializeTransactions) await this.materializeTransactions();
 
@@ -2758,8 +2681,6 @@ export class AbstractAdapter implements Quoting {
     relation: { name: string | Nodes.SqlLiteral };
     name: string;
   }): Promise<import("./column.js").Column | undefined> {
-    // A `TableAlias` relation may carry a `SqlLiteral` name (set-op / subquery
-    // derived table); unwrap to the bare identifier for the schema-cache lookup.
     const tableName = String(attribute.relation.name);
     // `schemaCache` is Rails' `schema_cache` (abstract_adapter.rb:298): the
     // pool's BoundSchemaReflection, or one bound to this connection when the
@@ -2851,15 +2772,6 @@ export class AbstractAdapter implements Quoting {
   }
 }
 
-// Whether the module-level mixin wiring below has been applied yet. Applying it
-// eagerly at module-evaluation time re-references the mixin classes
-// (SchemaStatements, DatabaseStatements, …) which, on a circular import edge
-// (schema-types → SchemaStatements → schema-dumper → base → abstract-adapter),
-// are still in their temporal dead zone — crashing with a ReferenceError. We
-// therefore defer the whole block into a function run once, lazily, from the
-// first AbstractAdapter construction, by which point every module has finished
-// evaluating. Instance methods only matter on instances, so first-construction
-// is early enough.
 let abstractAdapterMixinsApplied = false;
 
 let abstractTypeMap: TypeMap | undefined;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -125,14 +125,8 @@ import {
  * (float64 cannot distinguish 2^63 from 2^63-1: Number(2^63n) === Number((2^63-1)n)).
  */
 class MysqlBigInteger extends BigIntegerType {
-  // MySQL schema introspection uses castType.name to derive the column type string.
-  // BigIntegerType.name is "big_integer"; override to "integer" so columns()
-  // reports the same type as IntegerType({limit:8}) would.
   override readonly name: string = "integer";
 
-  // Re-establish the 8-byte signed bound that BigIntegerType drops
-  // (max_value = Infinity). IntegerType's isInRange/isSerializable already
-  // compare in BigInt space, so an exactly-2^63 value is detected out of range.
   protected override maxValue(): number {
     return 2 ** (this._limit() * 8 - 1);
   }
@@ -217,11 +211,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * @internal
    */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
-    // Strip caller-supplied adapter/adapterName (abstract SchemaStatements#createTable forwards
-    // a bare SchemaQuoter shape) and substitute `this` — the full MySQL adapter — so the
-    // TableDefinition carries a host-aware schema quoter when the SchemaCreation visitor
-    // accepts it. Matches the PG sibling (postgresql-adapter.ts) so the dispatch is symmetric
-    // across dialects.
     const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
     return new MysqlTableDefinition(name, { ...rest, adapter: this });
   }
@@ -994,9 +983,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         }
         expression = this.stripWhitespaceCharacters(expression);
         if (!(await this.isMariadb())) {
-          // MySQL returns check constraints expression in an already escaped form.
-          // This leads to duplicate escaping later (e.g. when the expression is
-          // used in the SchemaDumper).
           expression = expression.replace(/\\'/g, "'");
         }
         return new CheckConstraintDefinition(tableName, expression, options);
@@ -1007,8 +993,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   async tableOptions(tableName: string): Promise<Record<string, string>> {
     const createInfo = await this.createTableInfo(tableName);
     if (!createInfo) return {};
-    // Check only the options tail (after column defs) so per-column COMMENT clauses
-    // don't trigger an extra tableComment() round-trip.
     const tail = createInfo.replace(/[\s\S]*\n\) ?/, "");
     const comment = /COMMENT='/.test(tail) ? await this.tableComment(tableName) : null;
     return parseTableOptions(createInfo, comment);
@@ -1139,12 +1123,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *   pass.
    */
   override async buildInsertSql(insert: InsertBuilder): Promise<string> {
-    // Can use any column as it will be assigned to itself.
     const [first] = insert.keys;
     const noOpColumn = first !== undefined ? this.quoteColumnName(first) : undefined;
 
-    // MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
-    // then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .
     let sql: string;
     if (await this.supportsInsertRawAliasSyntax()) {
       const quotedTableName = insert.model.quotedTableName();
@@ -1432,8 +1413,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     message: string;
     sql: string;
   }): Partial<MismatchedForeignKeyOptions> {
-    // Extract the referencing column name from MySQL's error message when
-    // available (MySQL 8+ includes it: "Referencing column 'x' and referenced")
     const fkFromMsg = /Referencing column '(\w+)' and referenced/i.exec(message)?.[1];
     const fkPat = fkFromMsg ?? "\\w+";
 
@@ -1456,8 +1435,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       primary_key: primaryKey,
     } = match.groups;
 
-    // Return the parsed names; _enrichMismatchedForeignKey does the async
-    // column type lookup so the full human-readable message can be built.
     return { table, foreignKey, targetTable, primaryKey };
   }
 
@@ -1562,11 +1539,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
         case ER_CLIENT_INTERACTION_TIMEOUT:
           return new ConnectionFailed(msg, { sql, binds, connectionPool: this.pool });
         default:
-          // Driver errors expose a positive MySQL errno and usually a
-          // sqlState. Node/system errors (ECONNREFUSED etc.) also carry
-          // an `errno`, often negative, so gate on a positive numeric
-          // errno to avoid re-tagging network failures as
-          // StatementInvalid (which would attach misleading sql/binds).
           return typeof errno === "number" && errno > 0 && e instanceof StatementInvalid === false
             ? new StatementInvalid(msg, { sql, binds, connectionPool: this.pool })
             : e;
@@ -1958,7 +1930,6 @@ export function parseTableOptions(
 
   const opts: Record<string, string> = {};
 
-  // Extract DEFAULT CHARSET and optional COLLATE, then remove from raw.
   const charsetMatch = / DEFAULT CHARSET=(?<charset>\w+)(?: COLLATE=(?<collation>\w+))?/.exec(raw);
   if (charsetMatch) {
     raw = raw.slice(0, charsetMatch.index) + raw.slice(charsetMatch.index + charsetMatch[0].length);
@@ -1969,7 +1940,6 @@ export function parseTableOptions(
   // Strip AUTO_INCREMENT — mirrors Rails: sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
   raw = raw.replace(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, "$1");
 
-  // Strip COMMENT= and use the pre-fetched comment value for accuracy.
   if (/ COMMENT='/.test(raw)) {
     raw = raw.replace(/ COMMENT='.+'/, "");
     if (tableComment != null) opts["comment"] = tableComment;
@@ -2002,8 +1972,6 @@ export interface MysqlPreparedStatement {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::StatementPool
  */
-// Named to avoid collision with the base StatementPool import — consumers
-// can import this under the AbstractMysqlAdapter namespace.
 export class StatementPool extends ConnectionStatementPool<MysqlPreparedStatement> {
   private _counter = 0;
 

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -139,18 +139,8 @@ export function buildAdapterArg(
   const url = configuration.url as string | undefined;
   const database = configuration.database as string | undefined;
   if (normalized === "sqlite") {
-    // Remote libsql URLs (`libsql://`, `https://`, etc.) in `url` take
-    // precedence over `database` — the URL is the connection endpoint, not a
-    // local filename. For local adapters, prefer `database` over `url` so
-    // caller-mutated configs (e.g. autoConnect per-worker slots) win.
     const resolvedUrl = url !== undefined && isRemoteLibsqlUrl(url) ? url : undefined;
-    // Use `||` (not `??`) so empty-string database/url values fall through to
-    // the next candidate, matching the pre-existing behaviour of this function.
     const filename = parseSqliteUrl(resolvedUrl || database || url || ":memory:");
-    // Keep only the SQLite3Adapter constructor's `options` keys so we don't
-    // forward unrelated database.yml entries (pool, host, etc.) into the
-    // options object. The adapter ignores unknown keys today but accepting
-    // them here would lock in a foot-gun.
     const {
       readonly,
       driver,
@@ -181,11 +171,6 @@ export function buildAdapterArg(
     if (statementLimit !== undefined) options.statementLimit = statementLimit;
     if (preparedStatements !== undefined) options.preparedStatements = preparedStatements;
     if (driverOptions !== undefined) options.driverOptions = driverOptions;
-    // Merge authToken into any pre-existing driverOptions so callers that pass
-    // both { authToken, driverOptions: { tls: true } } don't lose the latter.
-    // syncUrl (embedded-replica mode) and authToken both belong in
-    // driverOptions; merge so callers that also pass a driverOptions object
-    // keep its keys.
     if (authToken !== undefined || syncUrl !== undefined) {
       const merged = { ...(options.driverOptions as Record<string, unknown> | undefined) };
       if (authToken !== undefined) merged.authToken = authToken;
@@ -223,8 +208,6 @@ export function buildAdapterArg(
   // shadowing the constructor entirely. Mysql2Adapter#constructor owns the
   // single `socket` -> `socketPath` mapping; forward Rails' spelling untouched.
   if (normalized === "mysql") {
-    // The host default must still look at BOTH spellings — a `socket`-only
-    // config is socket-bound even though `socketPath` is not set yet.
     if (adapterConfig.host === undefined && !adapterConfig.socketPath && !adapterConfig.socket) {
       adapterConfig.host = "localhost";
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -65,10 +65,6 @@ class Mysql2StatementPool extends MysqlStatementPool {
   protected override dealloc(stmt: MysqlPreparedStatement): void {
     const conn = this._conn;
     if (!conn) return;
-    // `unprepare` is synchronous in node-mysql2 (it only touches the
-    // client-side cache and queues COM_STMT_CLOSE on the socket), but
-    // wrap in try/catch in case the client was already destroyed —
-    // eviction can't throw or it escapes the base class's loop.
     try {
       (conn as unknown as { unprepare: (sql: string) => void }).unprepare(stmt.sql);
     } catch {
@@ -175,14 +171,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private set _client(value: mysql.Connection | null) {
     this._connection = value as unknown as AbstractAdapter | null;
   }
-  // Serializes concurrent lazy-connect calls so only one createConnection
-  // is in flight at a time. NOT nulled by disconnectBang() so close() can
-  // still await it for clean teardown.
   private _connectingPromise: Promise<mysql.Connection> | null = null;
-  // Generation of the current _connectingPromise. Incremented by
-  // disconnectBang()/close(); _ensureClient() starts a fresh attempt when the
-  // stored generation no longer matches, without dropping the old promise
-  // reference so close() can await it.
   private _connectGeneration = 0;
   private _connectingPromiseGen = -1;
   // Generations orphaned by discardBang() (Rails' discard!). A connect at one
@@ -191,16 +180,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // server. disconnectBang()/close() bump the generation too but are NOT
   // recorded here, so their stale connects still end() the socket as before.
   private _discardedConnectGenerations = new Set<number>();
-  // Tracks the in-flight _client.end() from disconnectBang() so close() can
-  // await full socket teardown even though _client was already nulled.
   private _endingClient: Promise<void> | null = null;
-  // Set by close() to distinguish permanent teardown from disconnectBang(),
-  // which is reconnectable. _ensureClient() refuses to lazy-reconnect after close().
   private _permanentlyClosed = false;
-  // Set by the _fakeConnection constructor path — prevents _ensureClient() from
-  // lazily creating a real connection when _client is null.
   private _isFakeConnection = false;
-  // Normalized config stored for reconnect.
   private _poolConfig: mysql.PoolOptions & MysqlAdapterOptions;
   private _inTransaction = false;
   // Gates the connect-once portion of configureConnection() (super/checkVersion
@@ -213,8 +195,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // down so the next connect re-configures — matching Rails' connect-time
   // `configure_connection`.
   private _connectionConfigured = false;
-  // Per-adapter StatementPool. Single connection → single pool.
-  // Cleared on disconnect/reconnect; re-created on first query after reconnect.
   private _statementPool: Mysql2StatementPool | null = null;
 
   /**
@@ -307,8 +287,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * cache (statement_pool.rb:31-33), so there is nothing for this gate to
    * degrade around.
    */
-  // Non-private (underscore-public) so the extracted `performQuery` in
-  // mysql2/database-statements.ts can reach it through PerformQueryHost.
   _shouldPrepare(binds: unknown[]): boolean {
     return this.preparedStatements && binds.length > 0;
   }
@@ -322,14 +300,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * none: its `[]=` raises on the empty cache (statement_pool.rb:31-33), so a
    * limit of 0 is unsupported rather than a caching switch.
    */
-  // Non-private (underscore-public) so the extracted `performQuery` in
-  // mysql2/database-statements.ts can reach it through PerformQueryHost.
   _trackPrepared(conn: mysql.Connection, sql: string): void {
     const pool = this._getStmtPool(conn);
-    // Use `get` (not `has`) so an already-cached entry is moved to
-    // the MRU end of the LRU. Otherwise a hot statement executed
-    // repeatedly would keep its original insertion position and get
-    // evicted the moment any other distinct query came along.
     if (pool.get(sql)) return;
     void pool.set(sql, { sql, key: pool.nextKey() });
   }
@@ -377,8 +349,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   ): Promise<boolean> {
     const adapter = new Mysql2Adapter(config);
     try {
-      // Any query that requires a real database will trigger ER_BAD_DB_ERROR
-      // if the DB doesn't exist — _ensureClient() already translates it to NoDatabaseError.
       await adapter._ensureClient();
       return true;
     } catch (e) {
@@ -466,13 +436,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         if (wt !== null) {
           const n = parseInt(wt, 10);
           if (Number.isInteger(n)) waitTimeout = n;
-          // Strip from URI so mysql2 doesn't warn about an unknown connection option.
           url.searchParams.delete("wait_timeout");
           uri = url.toString();
         }
-      } catch {
-        // malformed URI — leave _database undefined
-      }
+      } catch {}
       // Mirrors Rails Mysql2Adapter#initialize: always ensure FOUND_ROWS is set.
       this._poolConfig = { uri, waitTimeout, flags: ["FOUND_ROWS"] };
       return;
@@ -584,7 +551,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (fake) {
       this._isFakeConnection = true;
     }
-    // Connection is created lazily on first _ensureClient() call.
   }
 
   /**
@@ -659,10 +625,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   private async _ensureClient(): Promise<mysql.Connection> {
     if (this._client) return this._client;
-    // Return the in-flight promise only if it belongs to the current generation.
-    // After disconnectBang() the generation advances, so stale in-flight
-    // promises are bypassed and a fresh attempt is started — without nulling
-    // the old promise so close() can still await it for clean teardown.
     if (this._connectingPromise && this._connectingPromiseGen === this._connectGeneration) {
       return this._connectingPromise;
     }
@@ -676,10 +638,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }).then(
       async (conn): Promise<mysql.Connection> => {
         if (this._connectGeneration !== gen) {
-          // disconnectBang()/close() happened while we were connecting. Clear
-          // the promise ref then end the socket as part of this chain so
-          // close() awaiting _connectingPromise can drain the socket cleanly
-          // (rather than a fire-and-forget that close() can't wait on).
           if (this._connectingPromiseGen === gen) this._connectingPromise = null;
           const discardErr = new ConnectionNotEstablished(
             "Mysql2Adapter: connection was closed during connect",
@@ -772,15 +730,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * quoteColumnName(..., "mysql") directly where appropriate.
    */
   private mysqlQuote(sql: string): string {
-    // Replace "identifier" with `identifier`, but not inside single-quoted strings.
-    // Split on single-quoted strings, only transform non-string parts.
     const parts = sql.split(/('(?:[^'\\]|\\.)*')/);
     for (let i = 0; i < parts.length; i += 2) {
       parts[i] = parts[i].replace(/"/g, "`");
     }
     let result = parts.join("");
 
-    // MySQL requires LIMIT when using OFFSET; add a large LIMIT if missing
     if (/\bOFFSET\b/i.test(result) && !/\bLIMIT\b/i.test(result)) {
       result = result.replace(/\bOFFSET\b/i, "LIMIT 18446744073709551615 OFFSET");
     }
@@ -818,8 +773,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   private mysqlBinds(binds: unknown[]): unknown[] {
     return binds.map((v) => {
-      // `valueForDatabase` is a getter on Attribute/QueryAttribute, so reading
-      // it yields the unwrapped DB value directly.
       if (v && typeof v === "object" && "valueForDatabase" in v) {
         v = (v as { valueForDatabase: unknown }).valueForDatabase;
       }
@@ -931,11 +884,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           const raw = await this.performQuery(mysqlConn, driverSql, binds, driverBinds, {
             notificationPayload: payload,
           });
-          // A non-row-returning statement (DML passed to execute) has null rows.
-          // Rebuild hash-keyed row objects from the array-mode positional rows +
-          // field descriptors `perform_query` returns — the same objects a
-          // non-array-mode driver query would have produced (duplicate column
-          // names collapse either way).
           if (raw.rows == null) return [];
           const names = raw.fields.map((f) => f.name);
           return raw.rows.map((row) => {
@@ -987,7 +935,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           // (0 for a write) — Rails reports the count only via `affected_rows`.
           const affected = this.affectedRows(raw);
 
-          // For INSERT, return the last inserted ID (or affected rows for multi-row)
           if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
             if (affected > 1) {
               return affected;
@@ -995,7 +942,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             return raw.insertId ?? 0;
           }
 
-          // For UPDATE/DELETE, return affected rows
           return affected;
         });
       } catch (e: any) {
@@ -1014,7 +960,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Begin a transaction. Acquires the persistent connection and issues BEGIN.
    */
   async beginTransaction(): Promise<void> {
-    // Force materialization (_lazy: false) so _inTransaction is set immediately.
     await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
@@ -1196,8 +1141,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             },
           );
         } catch (e: any) {
-          // The loop already translated for its retry classification; guard
-          // against re-translating an ActiveRecordError (see execute()).
           const translated =
             e instanceof MismatchedForeignKey
               ? await this._translateAndEnrich(e.cause ?? e, driverSql, driverBinds)
@@ -1261,12 +1204,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return printer.pp(result, elapsed);
   }
 
-  // `quote()` and `typeCast()` are inherited from AbstractMysqlAdapter,
-  // which delegates to `mysql/quoting.ts`. No Mysql2-specific override
-  // needed — they'd be duplicates.
-  //
-  // `buildExplainClause` lives on AbstractMysqlAdapter.
-
   /**
    * Execute raw SQL (for DDL and other non-query statements).
    */
@@ -1327,8 +1264,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // schema to parse, so short-circuit before mysqlParseName (which trims).
     if (!name) return false;
     const { schema, table } = mysqlParseName(name);
-    // Use `schema_placeholder OR database()` via COALESCE so the same
-    // query shape serves qualified + unqualified callers.
     const rows = (
       await this.internalExecQuery(
         `SELECT 1 AS one FROM information_schema.tables
@@ -1447,14 +1382,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors Rails' `Mysql2Adapter#disconnect!`.
    */
   override disconnectBang(): void {
-    // Advance generation — _ensureClient() will bypass the stale
-    // _connectingPromise (gen mismatch) and start a fresh attempt, while
-    // close() can still await the old promise for clean teardown.
     this._connectGeneration++;
-    // Tear the raw handle down FIRST: `_closeRawHandle` reads `_client` to
-    // `end()` the live socket, but `_client` is unified onto the base
-    // `_connection` field, which `super.disconnectBang()` nulls — so ending the
-    // socket must happen before super, or the handle is lost and leaks.
     this._closeRawHandle();
     super.disconnectBang();
   }
@@ -1474,8 +1402,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._statementPool?._detach();
     this._statementPool = null;
     if (this._client) {
-      // Chain onto any in-flight teardown so repeated disconnect/reconnect
-      // cycles don't lose earlier end() promises.
       const ending = this._client.end().catch(() => {});
       this._endingClient = this._endingClient ? this._endingClient.then(() => ending) : ending;
       this._client = null;
@@ -1499,19 +1425,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     if (this._connectingPromise && this._connectingPromiseGen === this._connectGeneration) {
       this._discardedConnectGenerations.add(this._connectGeneration);
     }
-    // Advance generation so any in-flight connect attempt is bypassed by
-    // _ensureClient() rather than adopted onto a discarded adapter.
     this._connectGeneration++;
     super.discardBang();
     this._inTransaction = false;
     this._connectionConfigured = false;
     this._statementPool?._detach();
     this._statementPool = null;
-    // Safe to read `_client` after `super.discardBang()` — unlike
-    // `disconnectBang`, the base `discardBang` (abstract-adapter.ts) is a true
-    // no-op that never touches `_connection`, so the live handle survives here
-    // (`_client` is the unified `_connection` field). No end() — discard! must
-    // not talk to the server; abandonRawSocket neutralizes the fd instead.
     const conn = this._client;
     this._client = null;
     abandonRawSocket(conn);
@@ -1532,20 +1451,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       await this._client.end();
       this._client = null;
     }
-    // Await any in-flight end() from disconnectBang()/reconnectBang() so
-    // callers (e.g. afterEach) can be sure all sockets are drained.
     if (this._endingClient) {
       await this._endingClient;
       this._endingClient = null;
     }
-    // If a connection is still being established, wait for it then close.
     if (this._connectingPromise) {
       try {
         const conn = await this._connectingPromise;
         await conn.end();
-      } catch {
-        // ignore — connection may have failed or was discarded by gen-mismatch
-      }
+      } catch {}
       this._connectingPromise = null;
     }
   }
@@ -1665,25 +1579,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   static async newClient(
     config: mysql.PoolOptions & MysqlAdapterOptions,
   ): Promise<mysql.Connection> {
-    // With supportBigNumbers:true, mysql2 returns a decimal string for BIGINT
-    // values with ≥15 digits (i.e. ≥ 10^14) where parseInt would lose precision,
-    // and a JS number for smaller values. Both are handled by BigIntegerType.cast().
-    // Note: the threshold is mysql2's internal digit count (≥15), not
-    // Number.MAX_SAFE_INTEGER (2^53-1 ≈ 9×10^15, 16 digits). Callers may
-    // override via explicit false in config.
-    // Compose our Temporal typeCast with any user-supplied typeCast so callers
-    // can still intercept non-temporal fields (e.g. custom ENUM handling) without
-    // losing Temporal parsing on temporal columns.
-
     const {
       typeCast: userTypeCast,
       strict: _strict,
       waitTimeout: _wt,
       variables: _vars,
-      // Session init SQL is carried on the config (see MysqlAdapterOptions#initSql)
-      // and run below — strip it so it isn't passed to the mysql2 driver.
       initSql,
-      // Strip pool-only options — irrelevant for a single connection.
       connectionLimit: _connLimit,
       queueLimit: _queueLimit,
       waitForConnections: _waitFor,
@@ -1740,7 +1641,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       try {
         await conn.query(initSql);
       } catch (err) {
-        // Init SQL failed — close the socket so it isn't leaked, then rethrow.
         conn.end().catch(() => {});
         throw err;
       }
@@ -1759,8 +1659,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       ...(configVars ?? {}),
     };
 
-    // Validate variable names before interpolating into SQL — matches the pattern used
-    // by PostgreSQLAdapter and SQLite3Adapter to catch misconfigured keys early.
     const SAFE_VAR_NAME = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
     for (const k of Object.keys(vars)) {
       if (!SAFE_VAR_NAME.test(k)) {
@@ -1790,8 +1688,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       }
       sqlMode = `CONCAT(${sqlMode}, ',NO_AUTO_VALUE_ON_ZERO')`;
     } else {
-      // strict: "default" — sync session to global, counteracting mysql2 Node.js
-      // CLIENT_IGNORE_SPACE flag which otherwise adds IGNORE_SPACE to session sql_mode.
       sqlMode = "@@GLOBAL.sql_mode";
     }
 

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -90,17 +90,6 @@ export class PoolConfig {
       schemaCachePath?: string | null;
     };
     const dbDir = this._resolveDbDir();
-    // Presence-based (not truthy): if the user explicitly set
-    // schemaCachePath — even to "" — that's a deliberate "no cache"
-    // signal. Fall through to defaultSchemaCachePath(dbDir) only when
-    // the user didn't supply a value at all. Matches Phase 6's
-    // resolveSchemaFormat treating empty strings as "explicitly
-    // unset" rather than "use a default".
-    //
-    // Calling defaultSchemaCachePath(dbDir) directly (not
-    // lazySchemaCachePath()) because that HashConfig method takes no
-    // dbDir arg and would hardcode "db", defeating the alignment
-    // with DatabaseTasks.dbDir.
     let raw: string | null | undefined;
     if (cfg && "schemaCachePath" in cfg && cfg.schemaCachePath != null) {
       raw = cfg.schemaCachePath;
@@ -413,8 +402,6 @@ export interface SQLite3AdapterOptions extends TrailsAdapterOptions {
   // (`sqlite3_adapter.rb:821-826` sets `busy_handler_timeout`).
   timeout?: number | string | false;
   retries?: number | string | false;
-  // Driver-specific options passed through to SqliteOpenConfig.driverOptions.
-  // Used by e.g. libsql-remote to forward `authToken` to the Database constructor.
   driverOptions?: Record<string, unknown>;
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -181,9 +181,6 @@ function fetch<T>(hash: Record<string, unknown>, key: string, defaultValue: T): 
   return key in hash ? (hash[key] as T) : defaultValue;
 }
 
-// Internal liveness flags node-pg sets on its `pg.Client` (lib/client.js).
-// Not part of pg's public typings, so we narrow the client through this shape
-// to mirror libpq's `PGconn#finished?`. See `rawConnectionFinished()`.
 interface PgClientLiveness {
   _ending?: boolean;
   _ended?: boolean;
@@ -485,9 +482,6 @@ export class PostgreSQLAdapter
   }
 
   private _pgClientOptions: pg.ClientConfig | null = null;
-  // Non-null when a transaction is open on _rawConnection. Always equals
-  // _rawConnection while set — kept as a field for legibility of the
-  // "in TX?" check at call sites that mirror the prior shape.
   private _client: pg.Client | null = null;
   private _inTransaction = false;
   /**
@@ -529,15 +523,7 @@ export class PostgreSQLAdapter
   private _schemaSearchPathMemo: string | null = null;
   private _warnedOids = new Set<number>();
   private _caseInsensitiveCache: Map<string, boolean> = new Map([["citext", false]]);
-  // Whether _maybeConfigureConnection has run for the current _rawConnection.
-  // Reset on reconnect.
   private _connectionConfigured = false;
-  // Whether the eager load_additional_types pass has run for the current
-  // physical connection. Reset on disconnect/discard (a brand-new socket needs
-  // it) but NOT on resetBang: DISCARD ALL leaves the in-memory type map intact,
-  // and the reset reconfigure runs while the reset holds the connection lock —
-  // routing the pg_type queries back through withRawConnection would re-enter
-  // it needlessly.
   private _typeMapEagerLoaded = false;
   // Rails' `@statements = build_statement_pool` (abstract_adapter.rb:156): one
   // pool per adapter, built in the constructor and never replaced. PG prepared
@@ -549,13 +535,7 @@ export class PostgreSQLAdapter
   // names `@statements`.
   /** @internal */
   _statements!: StatementPool;
-  // True when the next checkout should run DEALLOCATE ALL to drain
-  // orphaned server-side prepared statements (set by clearCacheBang's
-  // reset branch after a rollback).
   private _needsDeallocateAll = false;
-  // True after disconnectBang/discardBang/close until the next reconnect.
-  // Backs the `active` getter so a torn-down adapter reports inactive
-  // even before the next lazy acquire would notice the missing connection.
   private _closed = false;
   private _closingDriver: Promise<void> | null = null;
   // Per-acquire generation. Each _doAcquire captures the current value; a
@@ -567,7 +547,6 @@ export class PostgreSQLAdapter
   // (b) abandons its raw socket instead of `end()`ing or adopting it when it
   // resolves — surviving a later reconnect that would reset a mutable flag.
   private _acquireGeneration = 0;
-  // Generation stamped on the currently-stored `_acquiring` promise.
   private _acquiringGen = -1;
   private _discardedAcquireGenerations = new Set<number>();
   // In-flight connect/configure promise. Concurrent _acquireFreshClient
@@ -575,8 +554,6 @@ export class PostgreSQLAdapter
   // parallel — mirrors Rails' @lock.synchronize around connect (Rails
   // postgresql_adapter.rb:349, abstract_adapter.rb:984).
   private _acquiring: Promise<pg.Client> | null = null;
-  // Accumulates PG NOTICE/WARNING messages fired during the current query.
-  // Cleared before each query; processed by handleWarnings after.
   _noticeReceiverSqlWarnings: SQLWarning[] = [];
   /**
    * `database.yml`'s `statement_limit`, which Rails reads as
@@ -666,10 +643,6 @@ export class PostgreSQLAdapter
                 ? pg.types.getTypeParser(OID_INTERVAL, "binary")
                 : (v: unknown) => v;
             }
-            // PG interval[] (OID 1187): pg-types hard-codes parseInterval as
-            // the element parser, bypassing our OID 1186 override. Return the
-            // raw array literal so AR Array.deserialize parses the elements
-            // through Interval.castValue (Duration.parse on ISO 8601).
             if (oid === OID_INTERVAL_ARRAY && format !== "binary") return (v: unknown) => v;
             if ((oid === OID_JSON || oid === OID_JSONB) && format !== "binary")
               return (v: unknown) => v;
@@ -784,10 +757,6 @@ export class PostgreSQLAdapter
                 : (v: unknown) => v;
             return userGetTypeParser?.(oid, format) ?? fallback;
           }
-          // PG interval[] (OID 1187): pg-types hard-codes parseInterval as
-          // the element parser, so we must override the array OID too. Raw
-          // array literal is handed to AR Array.deserialize, which routes
-          // each element through Interval.castValue.
           if (oid === OID_INTERVAL_ARRAY && format !== "binary") {
             const fallback = (v: unknown) => v;
             return userGetTypeParser?.(oid, format) ?? fallback;
@@ -809,8 +778,6 @@ export class PostgreSQLAdapter
               format === "binary" ? pg.types.getTypeParser(oid, "binary") : (v: unknown) => v;
             return userGetTypeParser?.(oid, format) ?? fallback;
           }
-          // For all other OIDs, respect any user-supplied parser first, then
-          // delegate to getTemporalTypeParser which falls back to pg built-ins.
           if (TEMPORAL_OIDS.has(oid) && (format === "text" || !format)) {
             return getTemporalTypeParser(oid, format);
           }
@@ -863,8 +830,6 @@ export class PostgreSQLAdapter
     // Mirrors: SET intervalstyle — ISO 8601 so intervals parse cleanly.
     await client.query("SET intervalstyle = iso_8601");
     await client.query(`SET client_min_messages TO ${this.quoteLiteral(this._minMessages)}`);
-    // SET statements from :variables config hash
-    // https://www.postgresql.org/docs/current/static/sql-set.html
     for (const [key, val] of Object.entries(variables)) {
       if (val === null) continue;
       if (val === "default") {
@@ -1127,10 +1092,6 @@ export class PostgreSQLAdapter
     options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
     sql = this.preprocessQuery(sql);
-    // Release the query client BEFORE any loadAdditionalTypes call —
-    // that path re-enters execute() and acquires its own pooled client,
-    // and holding both would consume 2 connections per query during
-    // type-map warmup.
     interface ArrayQueryResult {
       fields: Array<{ name: string; dataTypeID: number }>;
       rows: unknown[][];
@@ -1194,9 +1155,6 @@ export class PostgreSQLAdapter
     const fields = pgResult.fields ?? [];
     if (fields.length === 0) return Result.fromRowHashes([]);
 
-    // Batch-load any unknown dataTypeIDs in a single pg_type roundtrip.
-    // Without this, a SELECT with N distinct unknown OIDs would trigger
-    // N sequential getOidType → loadAdditionalTypes queries.
     const missing = new Set<number>();
     for (const f of fields) {
       if (!this.typeMap.has(f.dataTypeID)) missing.add(f.dataTypeID);
@@ -1206,11 +1164,6 @@ export class PostgreSQLAdapter
     }
 
     const columns = fields.map((f) => f.name);
-    // Store types under BOTH name and numeric index so Result's
-    // columnType lookup works with duplicate column names. Skip the
-    // name entry when the field name is an integer-like string — JS
-    // object keys are all strings, so `{0: type, "0": other}` would
-    // collide and Result would pick the wrong type for one of them.
     const columnTypes: Record<string | number, Type> = {};
     for (let i = 0; i < fields.length; i++) {
       const f = fields[i];
@@ -1223,7 +1176,6 @@ export class PostgreSQLAdapter
         columnTypes[f.name] = type;
       }
     }
-    // pgResult.rows is already positional arrays thanks to rowMode.
     const rowArrays = pgResult.rows;
     return new Result(columns, rowArrays, columnTypes as Record<string, Type>);
   }
@@ -1278,9 +1230,6 @@ export class PostgreSQLAdapter
     ].join("\n");
 
     if (oids && oids.length > 0) {
-      // Validate every OID is a finite integer before interpolating
-      // into SQL. loadAdditionalTypes is public, so untrusted input
-      // could reach us.
       const safe = oids.map((oid) => {
         const n = Number(oid);
         if (!Number.isInteger(n) || n < 0) {
@@ -1293,10 +1242,6 @@ export class PostgreSQLAdapter
     }
     yield `${baseQuery}\n${initializer.queryConditionsForKnownTypeNames()}`;
     yield `${baseQuery}\n${initializer.queryConditionsForKnownTypeTypes()}`;
-    // Generated AFTER the prior two yields have been awaited and run,
-    // so the initializer has already registered numeric OIDs via
-    // aliasType. If we computed this up front, the array query would
-    // typically be empty and fall through to `WHERE 1=0`.
     yield `${baseQuery}\n${initializer.queryConditionsForArrayTypes()}`;
   }
 
@@ -1319,18 +1264,6 @@ export class PostgreSQLAdapter
       }
 
       await this.initializeTypeMap();
-      // A type-map reload signals the database's type universe changed — an
-      // extension or user type (hstore, enum, composite) was created or dropped,
-      // reassigning OIDs. A cached prepared statement that bound or returned one
-      // of those types embeds the now-stale OID in its server-side plan, so
-      // re-executing it raises "cache lookup failed for type <oid>". Drop the
-      // client-side statement map (NOT clearCacheBang) so the next prepare gets a
-      // fresh monotonic name and re-parses against the current OIDs. We
-      // deliberately skip the DEALLOCATE: reloadTypeMap runs mid-DDL-transaction
-      // (e.g. createEnum), and queuing DEALLOCATEs onto the pinned client there
-      // interleaves with the in-flight statement and desyncs the pg protocol.
-      // The orphaned server statements keep their old names — never reused — and
-      // are reclaimed on session reset/close.
       this._statements.reset();
     });
   }
@@ -1359,20 +1292,13 @@ export class PostgreSQLAdapter
     if (this._closed || this._pgClientOptions == null) {
       throw new Error("PostgreSQLAdapter: connection is closed");
     }
-    // Fast path: connection already opened and configured, no drain pending.
     if (this._rawConnection && this._connectionConfigured && !this._needsDeallocateAll) {
       return this._rawConnection;
     }
-    // Reuse the in-flight acquire only if it belongs to the current
-    // generation. A discardBang() bumps the generation, so its orphaned
-    // acquire is bypassed here (a fresh one is opened) rather than adopted
-    // — mirrors mysql2's `_connectingPromiseGen === _connectGeneration`.
     if (!this._acquiring || this._acquiringGen !== this._acquireGeneration) {
       const acquireGen = this._acquireGeneration;
       const acquiring = this._doAcquire(acquireGen).finally(() => {
         this._discardedAcquireGenerations.delete(acquireGen);
-        // Only clear if we still own the slot — a newer-generation acquire
-        // may have replaced us while this one was in flight.
         if (this._acquiring === acquiring) this._acquiring = null;
       });
       this._acquiring = acquiring;
@@ -1382,10 +1308,6 @@ export class PostgreSQLAdapter
   }
 
   private async _doAcquire(acquireGen: number): Promise<pg.Client> {
-    // Snapshot the connection into a local so a concurrent
-    // disconnectBang / discardBang / reconnect that nulls
-    // _rawConnection between awaits can't smuggle null into the
-    // configure/drain calls or the final return.
     let client = this._rawConnection;
     if (client == null) {
       // Route through newClient so a failed connect is translated to
@@ -1407,18 +1329,7 @@ export class PostgreSQLAdapter
         }
         throw error;
       }
-      // Guard against a close / disconnect / discard / reconnect
-      // that raced with the in-flight connect(). If the adapter was
-      // torn down between the await above and this point, do NOT
-      // publish `newClient` — tear it down instead so we don't leak
-      // a live socket onto a closed adapter.
       const racedDiscard = this._discardedAcquireGenerations.has(acquireGen);
-      // A disconnectBang/close/discardBang bumps _acquireGeneration when this
-      // acquire is in flight, so a mismatch means this acquire was orphaned by
-      // one of them. Checking the captured generation (not the mutable _closed
-      // flag) keeps the decision correct even when a racing reconnect clears
-      // _closed before the connect resolves — otherwise the stale acquire would
-      // adopt/publish its pre-disconnect newClient onto the reconnected adapter.
       const staleGeneration = acquireGen !== this._acquireGeneration;
       if (
         this._closed ||
@@ -1428,33 +1339,12 @@ export class PostgreSQLAdapter
         staleGeneration
       ) {
         this._teardownRacedClient(newClient, acquireGen);
-        // A stale-generation acquire ALWAYS fails, uniformly — even in the
-        // narrow sub-case where a racing reconnect has already published a
-        // valid _rawConnection (i.e. we'd otherwise fall through to adopt it
-        // below). This is a deliberate behavior change: an acquire orphaned by
-        // disconnect!/close/discard! belongs to a connection epoch that was
-        // explicitly torn down, so adopting a POST-teardown connection would
-        // silently paper over the disconnect (the mirror of the adoption bug
-        // this guard fixes). Only same-generation callers that merely lost a
-        // benign open race are allowed to adopt the winner's connection below.
         if (this._closed || this._pgClientOptions == null || racedDiscard || staleGeneration) {
           throw new Error("PostgreSQLAdapter: connection is closed");
         }
-        // Another caller raced ahead and already published a
-        // connection — use theirs instead of ours.
         client = this._rawConnection!;
       } else {
-        // Suppress unhandled error events from the idle connection
-        // (e.g. server-side FATAL from pg_terminate_backend). Without
-        // this listener node emits an uncaughtException.
         newClient.on("error", () => {});
-        // Attach the notice listener exactly once per pg.Client. We
-        // can't do this inside _maybeConfigureConnection because
-        // resetBang resets _connectionConfigured to re-run the SET
-        // queries after DISCARD ALL; re-running configure on the same
-        // client would otherwise accumulate notice listeners on every
-        // reset (node-pg's EventEmitter, unlike libpq's
-        // set_notice_receiver, doesn't replace).
         this._attachNoticeListener(newClient);
         this._attachReadyForQueryListener(newClient);
         this._rawConnection = newClient;
@@ -1463,8 +1353,6 @@ export class PostgreSQLAdapter
     }
     try {
       await this.configureConnection();
-      // Re-check teardown after every await: a concurrent reconnect
-      // can null _rawConnection while configure is in flight.
       if (this._closed || this._rawConnection !== client) {
         throw new Error("PostgreSQLAdapter: connection is closed");
       }
@@ -1473,11 +1361,6 @@ export class PostgreSQLAdapter
         throw new Error("PostgreSQLAdapter: connection is closed");
       }
     } catch (error) {
-      // Configure/drain failure (or mid-flight teardown) leaves the
-      // connection in an unknown state — tear it down so the next
-      // caller reconnects cleanly. Only touch shared state if this
-      // local snapshot is still the published connection; otherwise
-      // a concurrent reconnect already swapped in a new one.
       if (this._rawConnection === client) {
         this._rawConnection = null;
         this._connectionConfigured = false;
@@ -1532,18 +1415,9 @@ export class PostgreSQLAdapter
    * @internal
    */
   protected override async awaitRawConnectionReady(): Promise<void> {
-    // If the reset's reconfigure step failed it tore down the socket; re-open
-    // a fresh, configured connection so the loop never yields an unconfigured
-    // (or null) one. connect() throws here only if the server is truly down —
-    // the same pre-loop failure shape as a failed initial connectBang().
     if (!this._closed && this._rawConnection === null && this._pgClientOptions !== null) {
       await this.connect();
     }
-    // Drain server-side prepared statements orphaned by a prior PSCE event
-    // (clearCacheBang's reset branch tagged `_needsDeallocateAll` while the
-    // socket was torn down). When the connection is reopened by connectBang's
-    // `_acquireFreshClient` this already ran; this covers the case where the
-    // live socket survives so the loop never yields it un-drained.
     const client = this._rawConnection;
     if (client && !this._closed) await this._maybeDrainOrphanedPreparedStatements(client);
   }
@@ -1581,9 +1455,6 @@ export class PostgreSQLAdapter
     // normalizer the execQuery path uses.
     const bindArray = this.typeCastedBinds(binds) ?? [];
     const rewritten = this.rewriteBinds(sql, bindArray);
-    // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber
-    // stores something that can be re-EXPLAIN'd on the same adapter
-    // without re-running rewriteBinds.
     try {
       return await this.log(rewritten, name, binds, bindArray, false, async (payload) => {
         try {
@@ -1687,10 +1558,6 @@ export class PostgreSQLAdapter
     const originalBinds = binds;
     binds = this.typeCastedBinds(binds) ?? [];
     const pgSql = this.rewriteBinds(sql, binds);
-    // payload.sql records the rewritten SQL — ExplainSubscriber captures
-    // something that can be re-EXPLAIN'd without re-running rewriteBinds
-    // (and without re-appending RETURNING for bare INSERTs, which isn't
-    // part of the logical query).
     return await this.log(pgSql, name, originalBinds, binds, false, async (payload) => {
       try {
         return await this.withRawConnection(async (conn) => {
@@ -1707,11 +1574,6 @@ export class PostgreSQLAdapter
             const withReturning = `${pgSql} RETURNING id`;
             const useSavepoint = this._inTransaction;
             const spName = useSavepoint ? `_bt_ret_${++PostgreSQLAdapter._spCounter}` : "";
-            // Update payload.sql to the exact statement we're about to
-            // run so subscribers (LogSubscriber / ExplainSubscriber /
-            // QueryCache keys) see what actually hit pg. The fallback
-            // branch below resets it to pgSql if the RETURNING attempt
-            // fails and we re-run without it.
             payload.sql = withReturning;
             try {
               if (useSavepoint) {
@@ -1761,7 +1623,6 @@ export class PostgreSQLAdapter
             }
           }
 
-          // For INSERT with explicit RETURNING
           if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
             const result = await this._performQuery(client, pgSql, originalBinds, binds, {
               prepare: this._shouldPrepare(binds),
@@ -1775,7 +1636,6 @@ export class PostgreSQLAdapter
             return affected;
           }
 
-          // For UPDATE/DELETE, return affected rows
           const result = await this._performQuery(client, pgSql, originalBinds, binds, {
             prepare: this._shouldPrepare(binds),
             notificationPayload: payload,
@@ -1795,10 +1655,6 @@ export class PostgreSQLAdapter
    * Begin a transaction. Acquires a dedicated client from the pool.
    */
   async beginTransaction(): Promise<void> {
-    // Force materialization (_lazy: false) so _client is acquired and
-    // _inTransaction is set immediately. createSavepoint() runs on the raw
-    // client which falls back to a fresh connection when _client is null,
-    // causing "SAVEPOINT can only be used in transaction blocks".
     await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
@@ -1813,9 +1669,6 @@ export class PostgreSQLAdapter
     } catch (error) {
       this._client = null;
       this._inTransaction = false;
-      // Connection-level error on BEGIN poisons the single pg.Client.
-      // Tear down so the next caller gets a fresh connection — mirrors
-      // the pre-collapse PoolClient.release(err) discard.
       if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
       throw error;
     }
@@ -1844,10 +1697,6 @@ export class PostgreSQLAdapter
     try {
       await this.internalExecute("COMMIT", "TRANSACTION");
     } catch (e) {
-      // Connection-level error (08P01, broken socket, etc.) leaves the
-      // single pg.Client unusable. Tear down so the next caller gets a
-      // fresh connection — mirrors the pool-discard safety net the
-      // pre-collapse design got for free via PoolClient.release(err).
       if (PostgreSQLAdapter._isConnectionError(e)) this._discardRawConnection();
       throw e;
     } finally {
@@ -2057,7 +1906,6 @@ export class PostgreSQLAdapter
       processID?: number | null;
       secretKey?: number | null;
     };
-    // connect() and cancel() exist at runtime but are not in @types/pg Connection.
     type PgConnectionWithCancel = pg.Connection & {
       connect(portOrPath: string | number, host?: string): void;
       cancel(processID: number, secretKey: number): void;
@@ -2068,10 +1916,6 @@ export class PostgreSQLAdapter
     }
     if (txClient?.processID == null) return;
     try {
-      // `@raw_connection.cancel` — open a FRESH TCP connection, send the
-      // 16-byte CancelRequest, and wait for the server to close it, exactly as
-      // libpq PQcancel does. Leaves the original transaction socket untouched;
-      // does NOT consume a pool slot.
       await new Promise<void>((resolve, reject) => {
         const cancelCon = new pg.Connection() as PgConnectionWithCancel;
         // A failed PQcancel raises PG::Error in Ruby, so `block` never runs.
@@ -2087,9 +1931,6 @@ export class PostgreSQLAdapter
           cancelCon.connect(port, host);
         }
       });
-      // `@raw_connection.block` — the cancelled command still has to come back.
-      // Returning before it does would leave the cancel's effect (and the
-      // command's own rejection) to land after this chain is gone.
       await this._blockUntilCommandSettles(txClient);
     } catch {
       // cancel is best-effort — a drain failure must not mask the rollback,
@@ -2146,8 +1987,6 @@ export class PostgreSQLAdapter
     } catch (error) {
       this._client = null;
       this._inTransaction = false;
-      // See beginDbTransaction — discard the poisoned client on
-      // connection-level failure so callers can recover.
       if (PostgreSQLAdapter._isConnectionError(error)) this._discardRawConnection();
       throw error;
     }
@@ -2213,12 +2052,6 @@ export class PostgreSQLAdapter
       const bindArray = hasBinds ? (this.typeCastedBinds(binds) ?? []) : [];
       const runSql = hasBinds ? this.rewriteBinds(sql, bindArray) : sql;
       const result = await this.log(runSql, name, binds, bindArray, false, (payload) =>
-        // materializeTransactions is handled above (not delegated to
-        // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/
-        // SAVEPOINT — keeps its exact pre-existing materialize semantics. The
-        // loop's own `finally dirtyCurrentTransaction()` does not fire (false is
-        // passed); this method's finally handles it instead. The leaf still gains
-        // the retry/verify/reconnect loop.
         this.withRawConnection({ materializeTransactions: false, allowRetry }, async (conn) => {
           const client = conn as unknown as pg.Client;
           // Errors propagate raw: withRawConnection translates the driver error to
@@ -2558,8 +2391,6 @@ export class PostgreSQLAdapter
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
     this._closed = true;
-    // Bump the in-flight acquire's generation (see disconnectBang) so a stale
-    // connect end()s its socket instead of adopting it onto a racing reconnect.
     if (this._acquiring) this._acquireGeneration++;
     const conn = this._rawConnection;
     this._rawConnection = null;
@@ -2692,8 +2523,6 @@ export class PostgreSQLAdapter
       super.resetBang();
       return;
     }
-    // Capture the live connection so DISCARD ALL still chains onto it even if
-    // a concurrent reconnect later nulls _rawConnection.
     const live = this._rawConnection;
     // DISCARD ALL also resets session-level GUCs (standard_conforming_
     // strings, intervalstyle, client_min_messages, custom variables) —
@@ -2725,11 +2554,6 @@ export class PostgreSQLAdapter
           this._inTransaction = false;
         }
         await live.query("DISCARD ALL");
-        // Guard on socket identity: a concurrent reconnect may have swapped in
-        // a new client, in which case its own acquire handles configuration.
-        // On configure failure, tear down the socket (mirroring _doAcquire's
-        // catch) so awaitRawConnectionReady re-opens a fresh, configured
-        // connection rather than yielding an unconfigured one.
         if (this._rawConnection === live && !this._closed) {
           // Rails' reset! ends in configure_connection via super
           // (postgresql_adapter.rb:380), so the dispatch goes through the
@@ -2745,8 +2569,6 @@ export class PostgreSQLAdapter
             throw error;
           });
         }
-        // DISCARD ALL drops server-side prepared statements — reset the
-        // local pool so a later PREPARE name (a1, a2, ...) doesn't collide.
         this._statements.reset();
         // Rails' `super` — clear_cache!(new_connection: true) + reset_transaction
         // (abstract_adapter.rb:728-731) — runs inside the same lock, last
@@ -2876,9 +2698,6 @@ export class PostgreSQLAdapter
     this._needsDeallocateAll = false;
     this._inTransaction = false;
     this._closed = true;
-    // If a connect is in flight, record its generation so it abandons (not
-    // ends/adopts) its socket when it resolves, then bump so a later
-    // reconnect opens a fresh acquire instead of reusing the orphaned one.
     if (this._acquiring) this._discardedAcquireGenerations.add(this._acquireGeneration);
     this._acquireGeneration++;
     abandonRawSocket(conn);
@@ -3014,7 +2833,6 @@ export class PostgreSQLAdapter
   // (postgresql_adapter.rb:669-673).
   override async checkVersion(): Promise<void> {
     if ((await this.databaseVersion) < 9_03_00) {
-      // < 9.3
       throw new Error(
         `Your version of PostgreSQL (${await this.databaseVersion}) is too old. Active Record supports PostgreSQL >= 9.3.`,
       );
@@ -3248,8 +3066,6 @@ export class PostgreSQLAdapter
    *   name. Nothing to converge.
    */
   override quote(value: unknown): string {
-    // `.call(this)` so the inherited date/time dispatch resolves to this
-    // adapter's `quotedDate` (BC-suffixing), mirroring PG#quote's `super`.
     return pgQuote.call(this, value);
   }
 
@@ -3280,8 +3096,6 @@ export class PostgreSQLAdapter
   }
 
   override typeCast(value: unknown): unknown {
-    // `.call(this)` so the inherited date/time dispatch resolves to this
-    // adapter's `quotedDate` (BC-suffixing), mirroring PG#type_cast's `super`.
     return pgTypeCast.call(this, value);
   }
 
@@ -3325,10 +3139,6 @@ export class PostgreSQLAdapter
           options?: { array?: boolean };
         }
       | undefined;
-    // ColumnDefinition stores `array` under `options`; live PG Column
-    // instances expose it as a top-level boolean. Accept both shapes so
-    // DDL paths (addColumn/changeColumn → ColumnDefinition) and dump/SET
-    // DEFAULT paths (live Column) both fire the array branch.
     const isArray = col?.array === true || col?.options?.array === true;
     const rawSqlType = col?.sqlType ?? col?.type ?? null;
     const self = this;
@@ -3551,7 +3361,6 @@ export class PostgreSQLAdapter
     // on first use; warm the memo so the truncation limit is the real server
     // value rather than the synchronous fallback.
     const maxLen = await this.warmMaxIdentifierLength();
-    // After rename the table lives in the old schema; build the correct name for lookup.
     const renamedName = oldSchema
       ? `${this.quoteColumnName(oldSchema)}.${this.quoteColumnName(unqualifiedNew)}`
       : unqualifiedNew;
@@ -3569,7 +3378,6 @@ export class PostgreSQLAdapter
       await this.exec(
         `ALTER INDEX IF EXISTS ${qualifiedOldIdx} RENAME TO ${this.quoteColumnName(newIdx)}`,
       );
-      // Only rename the sequence when the PK has one (SERIAL/BIGSERIAL; not UUID).
       if (seq) {
         const seqSuffix = `_${pk}_seq`;
         const maxSeqPrefix = maxLen - seqSuffix.length;
@@ -3693,10 +3501,6 @@ export class PostgreSQLAdapter
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!
   checkAllForeignKeysValidBang = checkAllForeignKeysValidBang;
 
-  // ---------------------------------------------------------------------------
-  // Private helpers
-  // ---------------------------------------------------------------------------
-
   /**
    * Mirrors: PostgreSQL::Quoting#quote_table_name_for_assignment
    * (`postgresql/quoting.rb:136`) — PG ignores the table and quotes
@@ -3782,25 +3586,25 @@ export class PostgreSQLAdapter
       const code = (e as { code?: string }).code;
       const msg = e.message;
       switch (code) {
-        case "23505": // unique_violation
+        case "23505":
           return new RecordNotUnique(msg, { sql, binds, connectionPool: this.pool });
-        case "23503": // foreign_key_violation
+        case "23503":
           return new InvalidForeignKey(msg, { sql, binds, connectionPool: this.pool });
-        case "23502": // not_null_violation
+        case "23502":
           return new NotNullViolation(msg, { sql, binds, connectionPool: this.pool });
-        case "22001": // string_data_right_truncation
+        case "22001":
           return new ValueTooLong(msg, { sql, binds, connectionPool: this.pool });
-        case "22003": // numeric_value_out_of_range
+        case "22003":
           return new ActiveRecordRangeError(msg, { sql, binds, connectionPool: this.pool });
-        case "40001": // serialization_failure
+        case "40001":
           return new SerializationFailure(msg, { sql, binds, connectionPool: this.pool });
-        case "40P01": // deadlock_detected
+        case "40P01":
           return new Deadlocked(msg, { sql, binds, connectionPool: this.pool });
-        case "42P04": // duplicate_database
+        case "42P04":
           return new DatabaseAlreadyExists(msg, { sql, binds, connectionPool: this.pool });
-        case "55P03": // lock_not_available
+        case "55P03":
           return new LockWaitTimeout(msg, { sql, binds, connectionPool: this.pool });
-        case "57014": // query_canceled
+        case "57014":
           return new QueryCanceled(msg, { sql, binds, connectionPool: this.pool });
         default:
           // A severed connection (08xxx, "Connection terminated", pg's
@@ -3837,12 +3641,6 @@ export class PostgreSQLAdapter
           if (PostgreSQLAdapter._isConnectionError(e)) {
             return new ConnectionFailed(e, { connectionPool: this.pool });
           }
-          // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
-          // 5-char shape alone isn't enough — Node system errors like
-          // `EPIPE` / `EBADF` also match it, so gating on
-          // instanceof pg.DatabaseError avoids re-tagging socket /
-          // network failures as StatementInvalid with misleading
-          // sql/binds attached.
           if (e instanceof pg.DatabaseError && e instanceof StatementInvalid === false) {
             return new StatementInvalid(msg, { sql, binds, connectionPool: this.pool });
           }
@@ -3973,8 +3771,6 @@ export class PostgreSQLAdapter
         string | null,
       ];
     const typeMetadata = await this.fetchTypeMetadata(columnName, type, Number(oid), Number(fmod));
-    // The literal stays a raw String: deserialization is deferred to
-    // Attribute.from_database so *_before_type_cast reads back the raw default.
     const defaultValue = this.extractValueFromDefault(default_);
 
     let defaultFunction: string | null;
@@ -4127,10 +3923,8 @@ export class PostgreSQLAdapter
       return quoted[1].replace(/''/g, "'");
     }
     if (defaultExpr === "true" || defaultExpr === "false") return defaultExpr;
-    // Numeric: optional parens, optional ::bigint cast
     const num = /^\(?(-?\d+(?:\.\d*)?)\)?(?:::bigint)?$/.exec(defaultExpr);
     if (num) return num[1];
-    // Object identifier (bare integer)
     if (/^-?\d+$/.test(defaultExpr)) return defaultExpr;
     // Deviation from Rails, which only allows an optional `::bigint` suffix on
     // the numeric branch above and therefore reflects these as *function*
@@ -4189,8 +3983,6 @@ export class PostgreSQLAdapter
    * @internal
    */
   isRetryableQueryError(exception: unknown): boolean {
-    // We cannot retry anything if we're inside a broken transaction; we need to at
-    // least raise until the innermost savepoint is rolled back
     return this.transactionStatus !== PQTRANS_INERROR && super.isRetryableQueryError(exception);
   }
 
@@ -4287,17 +4079,6 @@ export class PostgreSQLAdapter
     const variables = fetch<SessionVariables>(this._config, "variables", {});
     if (variables["timezone"]) return;
     const tz = ActiveRecord.defaultTimezone;
-    // Off the withRawConnection loop. This runs as the first step of
-    // `_performQuery` (the adapter's one perform_query), which is itself the block
-    // executing inside withRawConnection on the same async chain. Re-entering
-    // withRawConnection would NOT deadlock — the adapter's `lock.synchronize` is
-    // reentrant per async chain (the ported MonitorMixin: getStore() === data.owner
-    // passes straight through). It is bypassed because this SET SESSION is a
-    // sub-step of an already-in-flight query on the already-acquired live
-    // handle: re-entering the leaf loop would redundantly re-run its verify /
-    // materialize / dirtyCurrentTransaction bookkeeping for a session variable.
-    // Acquire the raw client directly via _acquireFreshClient(); tear down on a dead
-    // socket so the next caller gets a fresh connection.
     const client = await this._acquireFreshClient();
     try {
       if (tz === "utc") {
@@ -4329,9 +4110,7 @@ export class PostgreSQLAdapter
    * types (Integer, Boolean). Mirrors: PostgreSQLAdapter#add_pg_encoders
    * @internal
    */
-  addPgEncoders(): void {
-    // node-pg handles parameter encoding natively; no extra type map needed.
-  }
+  addPgEncoders(): void {}
 
   /**
    * Update the timestamp decoder after default_timezone changes.
@@ -4356,9 +4135,7 @@ export class PostgreSQLAdapter
    * registered at pool construction. Mirrors: PostgreSQLAdapter#add_pg_decoders
    * @internal
    */
-  addPgDecoders(): void {
-    // node-pg decodes results via getTypeParser registered in the constructor.
-  }
+  addPgDecoders(): void {}
 
   /**
    * Build a type-coder descriptor from a pg_type row and a coder class name.
@@ -4800,10 +4577,6 @@ export class StatementPool extends GenericStatementPool<PreparedStatement> {
     const deallocSql = `DEALLOCATE ${pgQuoteColumnName(stmt.name)}`;
     this._deallocating = this._deallocating
       .then(() => {
-        // Keeps `_commandSettled`'s invariant across the eviction DEALLOCATE,
-        // guarded on the client still being the pinned one: a DEALLOCATE
-        // outliving a reconnect would strand the flag false, since the
-        // ReadyForQuery listener that re-arms it is attached per `pg.Client`.
         if (this._connection._rawConnection === client) this._connection._commandSettled = false;
         return client.query(deallocSql);
       })

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -16,10 +16,6 @@ import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
 import { IndexDefinition } from "./abstract/schema-definitions.js";
 
-// ---------------------------------------------------------------------------
-// Helper: run callback inside pool.withConnection if available
-// ---------------------------------------------------------------------------
-
 async function withConnection<T>(
   pool: unknown,
   callback: (connection: any) => T | Promise<T>,
@@ -30,14 +26,8 @@ async function withConnection<T>(
   return callback(pool);
 }
 
-// ---------------------------------------------------------------------------
-// Helper: rehydrate a column from plain JSON or pass through if already Column
-// ---------------------------------------------------------------------------
-
 function serializeColumn(col: any): ColumnJSON {
   if (typeof col.toJSON === "function") return col.toJSON();
-  // Fallback for adapter-specific Column classes (e.g. PostgreSQL::Column)
-  // that don't extend the base Column
   return {
     name: col.name,
     default: col.default,
@@ -126,10 +116,6 @@ function rehydrateIndex(data: unknown): IndexDefinition {
     },
   );
 }
-
-// ---------------------------------------------------------------------------
-// SchemaCache
-// ---------------------------------------------------------------------------
 
 export class SchemaCache {
   private _columns = new Map<string, Column[]>();
@@ -434,10 +420,6 @@ export class SchemaCache {
     if (this._primaryKeys.has(tableName)) return this._primaryKeys.get(tableName);
     const cols = this._columns.get(tableName);
     if (!cols) return undefined;
-    // Composite-PK ordering follows reflected column order. That matches the
-    // constraint order for the canonical fixtures; a table whose PK columns are
-    // declared out of column order would need the async `primaryKeys` query
-    // (which sorts by the constraint's key ordinal) to disambiguate.
     const pkCols = cols.filter((c) => c.primaryKey).map((c) => c.name);
     if (pkCols.length === 0) return undefined;
     return pkCols.length === 1 ? pkCols[0] : pkCols;
@@ -686,10 +668,6 @@ export class SchemaCache {
   }
 }
 
-// ---------------------------------------------------------------------------
-// SchemaReflection
-// ---------------------------------------------------------------------------
-
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::SchemaReflection
  */
@@ -887,10 +865,8 @@ export class SchemaReflection {
   private async cache(pool: unknown): Promise<SchemaCache> {
     if (this._cache) return this._cache;
 
-    // Memoize in-flight load so concurrent callers share one disk read
     if (!this._cachePromise) {
       const promise = this.loadCache(pool).then((loaded) => {
-        // Guard against clearBang() racing with an in-flight load
         if (this._cachePromise === promise) {
           this._cache = loaded ?? this.emptyCache();
           this._cachePromise = null;
@@ -963,10 +939,6 @@ export class SchemaReflection {
     return newCache;
   }
 }
-
-// ---------------------------------------------------------------------------
-// BoundSchemaReflection
-// ---------------------------------------------------------------------------
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::BoundSchemaReflection
@@ -1058,10 +1030,6 @@ export class BoundSchemaReflection {
     return this._schemaReflection.dumpTo(this._pool, filename);
   }
 }
-
-// ---------------------------------------------------------------------------
-// FakePool
-// ---------------------------------------------------------------------------
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::BoundSchemaReflection::FakePool

--- a/packages/activerecord/src/connection-adapters/sql-classification.ts
+++ b/packages/activerecord/src/connection-adapters/sql-classification.ts
@@ -6,10 +6,6 @@
  * duplicating the logic.
  */
 
-// Shared read-only statement allowlist used for cross-adapter SQL
-// classification, including adapter-specific additions such as PostgreSQL
-// cursor operations. CLOSE/DECLARE/FETCH/MOVE read or manage cursors — not
-// data writes.
 const READ_ONLY_STATEMENTS =
   /^(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|DESCRIBE|DESC|USE|KILL|CLOSE|DECLARE|FETCH|MOVE)$/;
 
@@ -45,7 +41,6 @@ export function isWriteQuerySql(sql: string): boolean {
   if (READ_ONLY_STATEMENTS.test(stmt)) return false;
   if (stmt !== "WITH") return true;
 
-  // CTE: check the statement after the WITH clause
   const afterWith = stripped.replace(/^\s*WITH\b/i, "").replace(/\([^)]*\)/g, "");
   const innerMatch = afterWith.match(/\b(SELECT|INSERT|UPDATE|DELETE|MERGE)\b/i);
   return !innerMatch || innerMatch[1].toUpperCase() !== "SELECT";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -174,15 +174,9 @@ function _driverBind(this: QuotingDispatchHost, value: unknown): unknown {
     bindsAsFloat = attr.type instanceof FloatType;
     value = attr.valueForDatabase;
   }
-  // `.call(this)` so date/time dispatch lands on the adapter's quotedDate /
-  // quotedTime overrides (2000-01-01-prefixed times).
   return sqliteTypeCast.call(this, value, bindsAsFloat);
 }
 
-// A structured column default: an array or a plain object literal (`default: {}`
-// / `default: []`). Excludes null, SqlLiteral, Date, and other class instances,
-// which have their own quoting paths and must not be routed through the column
-// type's `serialize`.
 function isStructuredDefault(value: unknown): boolean {
   if (Array.isArray(value)) return true;
   if (value === null || typeof value !== "object" || isSqlLiteral(value)) return false;
@@ -427,8 +421,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
           ? options.preparedStatements
           : this.defaultPreparedStatements(),
       );
-    // Apply adapter-level options FIRST so invalid values fail before
-    // the native driver opens a file handle that would otherwise leak.
     if (options.statementLimit !== undefined) {
       this._statementLimit = options.statementLimit;
       void this._statementPool.setMaxSize(
@@ -436,10 +428,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       );
     }
     this.connect();
-    // Async-only drivers (e.g. expo-sqlite) can't open in a sync constructor;
-    // connect() flags them for the async path instead. See completeAsyncConnect.
-    // Sync-driver path resolves synchronously; the async path is flagged out
-    // above and configured later via completeAsyncConnect. Fire-and-forget here.
     if (!this._asyncConnectPending) void this.configureConnection();
     this._nativeTypeMap = SQLite3Adapter._buildTypeMap();
   }
@@ -504,10 +492,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     await this.ensureConnected();
     await this.materializeTransactions();
 
-    // Type-cast binds to driver-compatible primitives. Phase 2 threads
-    // bind values through the visitor rather than inlining them, so the
-    // `execute` path now receives non-empty bind arrays where it received
-    // empty ones before.
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
     // Rails dirties in with_raw_connection's ensure (abstract_adapter.rb:1046),
     // gated only on materialize_transactions — which this path always does —
@@ -587,8 +571,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return stmt;
   }
 
-  // Non-private (underscore-public) so the extracted `performQuery` in
-  // sqlite3/database-statements.ts can reach it through PerformQueryHost.
   async _cachedStatement(sql: string): Promise<SqliteStatement> {
     await this.ensureConnected();
     // When preparedStatements is off, skip the pool and prepare per call —
@@ -609,9 +591,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return stmt;
   }
 
-  // Enable readBigInts on row-returning statements that expose bigint-declared
-  // columns so the driver returns JS bigint rather than a lossy number.
-  // stmt.reader gates out PRAGMA/EXPLAIN and other non-row statements.
   private _maybeEnableReadBigInts(sql: string, stmt: SqliteStatement): void {
     if (isWriteQuerySql(sql) || !stmt.reader) return;
     const cols = stmt.columns();
@@ -690,11 +669,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
         false,
         async (payload) => {
           try {
-            // performQuery fills this in the same synchronous turn it writes
-            // `this._last*`; reading those shared fields back here instead
-            // would race, since a concurrent write's performQuery can overwrite
-            // them before this post-await continuation runs (the Promise.all
-            // insert race). See the `counters` note on performQuery.
             const counters = { affectedRows: 0, insertRowid: 0 as number | bigint };
             await this.performQuery(this.driver, sql, binds, driverBinds, {
               prepare: this.preparedStatements,
@@ -702,16 +676,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
               counters,
             });
             const { affectedRows, insertRowid } = counters;
-            // perform_query reports the returned-row count (0 for a write); this
-            // path has always reported affected rows, and subscribers rely on it.
             payload.row_count = affectedRows;
 
-            // For INSERT, return the last inserted rowid
             if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
               return Number(insertRowid);
             }
 
-            // For UPDATE/DELETE, return affected rows
             return affectedRows;
           } catch (e: any) {
             const translated = this._translateException(e, sql, binds);
@@ -879,7 +849,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   async beginTransaction(): Promise<void> {
-    // Force materialization (_lazy: false) so _inTransaction is set immediately.
     await this._transactionManager.beginTransaction({ _lazy: false });
   }
 
@@ -1001,8 +970,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   }
 
   override typeCast(value: unknown): unknown {
-    // `.call(this)` so the inherited date/time dispatch resolves to this
-    // adapter's `quotedDate` / `quotedTime` (2000-01-01-prefixed times).
     return sqliteTypeCast.call(this, value);
   }
 
@@ -1104,10 +1071,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * Close the database connection.
    */
   async close(): Promise<void> {
-    // If disconnectBang() already fired an async driver.close(), drain that
-    // in-flight promise rather than issuing a second close() — a concurrent
-    // double-close could race or throw on drivers that aren't double-close-safe
-    // while the first is still settling. Sync drivers leave _closingDriver null.
     if (this._closingDriver) {
       const closing = this._closingDriver;
       this._closingDriver = null;
@@ -1183,9 +1146,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * is `sqlite3-native-type-map-converges-onto-type-map`.
    */
   lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
-    // Pass the full sql type to the map so regex registrations (e.g. /decimal/i)
-    // can inspect precision/scale. Fall back to the bare normalized key when
-    // no full-string match is found.
     const lower = sqlType?.toLowerCase().trim() ?? null;
     const full = this._nativeTypeMap.fetch(lower);
     if (full.type() != null) return full;
@@ -1372,8 +1332,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return false;
   }
 
-  // --- Connection lifecycle ---
-
   override isConnected(): boolean {
     return this.driver?.isOpen() ?? false;
   }
@@ -1423,18 +1381,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   private _disconnect(): void {
     super.disconnectBang();
-    // driver is undefined when an async-only connection was never completed
-    // (constructed-but-pending); optional-chain like the `active` getter so a
-    // pre-verifyBang cleanup/error path doesn't throw.
     if (this.driver?.isOpen()) {
-      // driver.close() returns void | Promise<void>; for inProcessSync drivers
-      // (better-sqlite3) this is sync. Async-only drivers return a Promise we
-      // can't await here (sync void contract), so retain it for close() to drain
-      // and chain repeated disconnect cycles so no earlier teardown is lost.
       const closing = this.driver.close();
       if (closing) this._chainClose(closing);
     }
-    // Closing the handle implicitly rolls back any in-flight raw transaction.
     this._inTransaction = false;
   }
 
@@ -1464,14 +1414,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       // active transaction raises, which we swallow like Rails does.
       try {
         await this.driver.exec("ROLLBACK");
-      } catch {
-        // no active transaction
-      }
+      } catch {}
     } else {
       this.connect();
-      // connect() defers async-only drivers (leaving the handle undefined); open
-      // it here so the base reconnectBang lifecycle has a live driver before it
-      // runs configure_connection. Sync drivers opened eagerly above no-op here.
       if (this._asyncConnectPending) {
         this._asyncConnectPending = false;
         await this.connectAsync();
@@ -1479,8 +1424,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     }
     this._inTransaction = false;
   }
-
-  // --- Database info ---
 
   // SQLite has no adapter-specific `ColumnMethods` module (sqlite3/schema_definitions.rb
   // defines none), so it inherits the abstract `_columnMethodNames()` list unchanged —
@@ -1617,8 +1560,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return args;
   }
 
-  // --- Schema operations ---
-
   async primaryKeys(tableName: string): Promise<string[]> {
     const pks = (await this.tableStructure(tableName)).filter((f) => Number(f["pk"]) > 0);
     return pks.sort((a, b) => Number(a["pk"]) - Number(b["pk"])).map((f) => String(f["name"]));
@@ -1745,7 +1686,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     optionsOrModuleName?: unknown,
     values?: unknown,
   ): Promise<void> {
-    // Support both (name, options) and (name, moduleName, values) signatures
     const opts =
       optionsOrModuleName !== null &&
       typeof optionsOrModuleName === "object" &&
@@ -1761,9 +1701,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (!safeIdent.test(mod)) {
       throw new Error("moduleName must be a valid SQLite identifier");
     }
-    // Virtual table module arguments are passed through as-is (e.g. FTS
-    // tokenize='porter', content='posts'). Only the module name is validated
-    // as an identifier since it occupies a SQL keyword position.
     const args = Array.isArray(virtualValues) ? virtualValues.map(String) : [];
     const rawArgs = args.join(", ");
     await this.execQuery(
@@ -1945,7 +1882,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       group.push(row);
     }
 
-    // Use explicit CONSTRAINT names from DDL when available (PRAGMA doesn't expose them).
     const namesByColumn = await this._parseForeignKeyNames(tableName);
 
     const results: ForeignKeyDefinition[] = [];
@@ -2043,9 +1979,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     }
   }
 
-  // The declared type of a `t.virtual` column comes from its :type option
-  // (SQLite3::TableDefinition resolves :virtual that way; no type when the
-  // option is absent).
   private _baseColumnType(type: string, options?: Record<string, unknown>): string {
     const opts = (options ?? {}) as ColumnOptions;
     if (type !== "virtual") return this.typeToSql(type as ColumnType, opts);
@@ -2091,12 +2024,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (typeof value === "function") return String(value());
     // boundary: defensive Date branch in SQLite adapter literal quoting.
     if (value instanceof globalThis.Date) return `'${sqliteQuoteString(value.toISOString())}'`;
-    // SqlLiteral or objects with toSql
     if (typeof (value as any)?.toSql === "function") return String((value as any).toSql());
     return `'${sqliteQuoteString(String(value))}'`;
   }
-
-  // --- Schema introspection (drives SchemaCache.addAll) ---
 
   /**
    * List user tables. Excludes SQLite's internal `sqlite_*` tables and
@@ -2171,7 +2101,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     // `table_exists?(nil)` result rather than dereferencing a null name.
     if (name == null) return false;
     if (name.includes(".")) {
-      // Schema-qualified name (e.g. "aux.widgets") — query the attached schema's catalog.
       const { sqliteMaster, bare } = this._sqliteMasterFor(name);
       const rows = (
         await this.internalExecQuery(
@@ -2256,8 +2185,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   override validateIndexLengthBang(tableName: string, newName: string, internal = false): void {
     sqliteValidateIndexLengthBang.call(this, tableName, newName, internal);
   }
-
-  // --- FK / Check constraint operations (SQLite requires table rebuild) ---
 
   /**
    * Parse CHECK constraints from the CREATE TABLE SQL.
@@ -2463,9 +2390,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   /** @internal */
   private async tableInfo(tableName: string): Promise<Record<string, unknown>[]> {
-    // Schema-qualified names (ATTACHed DBs) must use the `PRAGMA aux.table_info(t)`
-    // prefix form; `PRAGMA table_info("aux"."t")` treats the whole quoted argument
-    // as a bare table name and returns zero rows.
     const { schema, bare } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteTableName(schema)}.` : "";
     const pragma = (await this.supportsVirtualColumns()) ? "table_xinfo" : "table_info";
@@ -2514,12 +2438,8 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
 
     if (!result) return [];
 
-    // Splitting with left parentheses and discarding the first part will return all
-    // columns separated with comma(,).
     const openParens = SQLite3Adapter.UNQUOTED_OPEN_PARENS_REGEX.exec(result);
     const partitioned = openParens ? result.slice(openParens.index + openParens[0].length) : "";
-    // column definitions can have a comma in them, so split on commas followed
-    // by a space and a column name in quotes or followed by the keyword CONSTRAINT
     const union =
       columnNames.length > 0
         ? columnNames.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
@@ -2692,11 +2612,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     const { bare: bareTo } = this._splitTableName(to);
     for (const idx of idxRows) {
       let name = idx.name;
-      // Compared on the bare names: alter_table's buffer is a TEMPORARY table,
-      // so it is unqualified even when the source is `aux.posts`, and comparing
-      // the qualified names would miss the "a"-prefix relationship — leaving an
-      // index whose name doesn't embed the table name (a custom `name:`) unrenamed
-      // and colliding with the still-live original.
       if (bareTo === `a${bareFrom}`) name = `t${name}`;
       else if (bareFrom === `a${bareTo}`) name = name.slice(1);
       // Rails gates the rename/filter on `columns.is_a?(Array)` — and with it
@@ -2733,7 +2648,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     columns: string[],
     rename: Record<string, string> = {},
   ): Promise<void> {
-    // rename maps {srcCol: destCol}; build dest→src for lookup
     const columnMappings: Record<string, string> = Object.fromEntries(
       columns.map((name) => [name, name]),
     );
@@ -2752,9 +2666,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
     if (e instanceof ActiveRecordError) return e;
     const msg = e instanceof Error ? e.message : String(e);
-    // Wrap non-Error throws so translateException always receives an Error.
-    // Preserve the original value as .cause and copy .code so code-based
-    // classification in translateException still works for non-Error throws.
     let exc: Error;
     if (e instanceof Error) {
       exc = e;
@@ -2806,9 +2717,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       }
       return driverOpt;
     }
-    // No driver configured: concrete subclasses (e.g. BetterSQLite3Adapter)
-    // bind their bundled driver via defaultSqliteDriver(). The abstract base
-    // returns undefined and cannot be opened directly.
     const def = this.defaultSqliteDriver();
     if (!def) {
       throw new Error(
@@ -2825,7 +2733,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     try {
       const factory = this.resolveDriverFactory();
       if (!factory.openSync) {
-        // Async-only driver: defer to completeAsyncConnect() / openAsync().
         this._asyncConnectPending = true;
         return;
       }
@@ -2869,8 +2776,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     try {
       const factory = this.resolveDriverFactory();
       const conn = await factory.open(openConfig);
-      // Memoize encoding while we can still await the async pragma, so the sync
-      // `encoding` getter serves a cached value rather than a Promise.
       this._encoding = SQLite3Adapter.parseEncoding(await conn.pragma("encoding"));
       this.driver = conn;
     } catch (e) {
@@ -2894,8 +2799,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
    */
   async completeAsyncConnect(): Promise<void> {
     if (!this._asyncConnectPending) return;
-    // Dedupe concurrent callers (e.g. racing pool checkouts) onto one open so we
-    // don't open the database twice and leak the first handle.
     if (!this._connectingPromise) {
       this._connectingPromise = this._doAsyncConnect().finally(() => {
         this._connectingPromise = null;
@@ -2922,11 +2825,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
   /** @internal */
   private async _doAsyncConnect(): Promise<void> {
     await this.connectAsync();
-    // configureConnection() returns a Promise for async-only drivers; await it
-    // so every PRAGMA is applied before the connection is handed out.
     await this.configureConnection();
-    // Clear only after a successful open+configure: a failed attempt leaves the
-    // adapter pending so the next verifyBang() retries rather than no-opping.
     this._asyncConnectPending = false;
   }
 
@@ -2981,8 +2880,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       ];
       for (const [p, v] of defaults) stmts.push([`${p} = ${v}`, `SQLite default pragma '${p}'`]);
     }
-    // DQS for drivers that support it (e.g. node:sqlite). better-sqlite3 builds
-    // with SQLITE_DQS=0 and silently ignores it; others may throw — guarded below.
     const dqsValue = this._strict ? "OFF" : "ON";
     stmts.push(
       [`dqs_ddl = ${dqsValue}`, "SQLite DQS pragma 'dqs_ddl'"],
@@ -2990,7 +2887,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     );
     const pragmas = (this._config as SQLite3AdapterOptions).pragmas;
     if (pragmas) {
-      // Validate pragma name/value as safe SQLite identifiers before interpolating.
       const SAFE = /^\w+$/;
       for (const [pragma, value] of Object.entries(pragmas)) {
         if (!SAFE.test(pragma)) {
@@ -3111,13 +3007,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     });
     m.registerType("decimal", new DecimalType());
     m.registerType("boolean", new BooleanType());
-    // Temporal types resolve precision at lookup time via register_class_with_precision,
-    // mirroring AbstractAdapter#initialize_type_map so a raw `datetime(6)` reaches a
-    // precision-parsing factory. Registration order matters: /date/i and /time/i both
-    // match "datetime", so datetime is registered last — reverse-registration lookup
-    // matches it first (mirrors the base-map date/time/datetime ordering). better-sqlite3
-    // returns datetime columns as TEXT; SQLite3DateTime converts offset-less strings
-    // to Temporal.Instant using the configured default_timezone.
     this.registerClassWithPrecision(m, /date/i, DateType);
     this.registerClassWithPrecision(m, /time/i, TimeType);
     this.registerClassWithPrecision(m, /datetime/i, SQLite3DateTime);

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -47,7 +47,6 @@ export class StatementPool<T = unknown> {
   get(key: string): T | undefined {
     if (!this.cache.has(key)) return undefined;
     const stmt = this.cache.get(key) as T;
-    // Move to end for LRU
     this.cache.delete(key);
     this.cache.set(key, stmt);
     return stmt;
@@ -146,7 +145,5 @@ export class StatementPool<T = unknown> {
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::StatementPool#dealloc
    */
-  protected dealloc(_stmt: T): void | Promise<void> {
-    // Base implementation is a no-op; adapter-specific pools override.
-  }
+  protected dealloc(_stmt: T): void | Promise<void> {}
 }


### PR DESCRIPTION
Slice 4 of `strip-freeform-comments-ar-connection-adapters`: the **implementation** files at the root of `packages/activerecord/src/connection-adapters/`.

`blazetrails/no-freeform-comments` autofix applied to all 22 non-test top-level files (heaviest: `postgresql-adapter.ts` 77 findings, `sqlite3-adapter.ts` 46, `mysql2-adapter.ts` 41, `abstract-adapter.ts` 34, `abstract-mysql-adapter.ts` 13, `schema-cache.ts` 10), and the directory registered in `eslint.config.mjs`'s `no-freeform-comments` block.

The top-level `*.test.ts` files (~145 findings) do not fit under the LOC ceiling in the same PR, so they are `ignores`d in the new block and tracked by the follow-up story `strip-freeform-comments-ar-connection-adapters-toplevel-tests`. No deferred work (TODO/FIXME) was found in any deleted comment.

- `pnpm eslint` clean over `connection-adapters/**`; a second `--fix` is a no-op.
- `pnpm typecheck` clean.
- The connection-adapters suite runs green (108 files, 1706 tests).

Closes-story: strip-freeform-comments-ar-connection-adapters-toplevel