### PR TITLE
test(activemodel): port test_user_input_in_time_zone; parse user input in the zone

### DIFF
--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import { Types } from "../index.js";
-import { useZone } from "@blazetrails/activesupport";
+import { TimeWithZone, useZone, zone } from "@blazetrails/activesupport";
 
 /** `::Time.utc(...)`, the value Rails' own assertions are written against. */
 function timeUtc(
@@ -44,6 +44,24 @@ describe("TimeTest", () => {
     expect(type.cast("2023-01-01T00:00:00-03:30")).toEqual(timeUtc(2000, 1, 1, 3, 30, 0));
   });
 
+  it("user input in time zone", () => {
+    useZone("Pacific Time (US & Canada)", () => {
+      const type = new Types.TimeType();
+      expect(type.userInputInTimeZone(null)).toBeNull();
+      expect(type.userInputInTimeZone("")).toBeNull();
+      expect(type.userInputInTimeZone("ABC")).toBeNull();
+      expect(type.userInputInTimeZone(" ".repeat(129))).toBeNull();
+
+      const offset = zone()!.formattedOffset();
+      const timeString = `2015-02-09T19:45:54${offset}`;
+
+      expect((type.userInputInTimeZone(timeString) as TimeWithZone).hour).toEqual(19);
+      expect((type.userInputInTimeZone(timeString) as TimeWithZone).formattedOffset()).toEqual(
+        offset,
+      );
+    });
+  });
+
   it("extracts time from full datetime string", () => {
     expect(type.cast("2015-02-09T19:45:54+00:00")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
   });
@@ -83,33 +101,6 @@ describe("TimeTest", () => {
   it("PlainDateTime input extracts time (multiparameter support)", () => {
     const pdt = Temporal.PlainDateTime.from("2024-06-15T14:23:55");
     expect(type.cast(pdt)).toEqual(timeUtc(2024, 6, 15, 14, 23, 55));
-  });
-
-  it("user input in time zone wraps plain time in Time.zone", () => {
-    useZone("Eastern Time (US & Canada)", () => {
-      const result = type.userInputInTimeZone("14:30:00");
-      expect(result).toBeInstanceOf(Temporal.ZonedDateTime);
-      expect((result as Temporal.ZonedDateTime).hour).toBe(14);
-      expect((result as Temporal.ZonedDateTime).timeZoneId).toBe("America/New_York");
-    });
-  });
-
-  it("user input in time zone answers a zoneless value when Time.zone is unset", () => {
-    const result = type.userInputInTimeZone("14:30:00");
-    expect(result).toBeInstanceOf(Temporal.PlainDateTime);
-    expect((result as Temporal.PlainDateTime).hour).toBe(14);
-  });
-
-  it("user input in time zone returns null for null", () => {
-    expect(type.userInputInTimeZone(null)).toBe(null);
-    expect(type.userInputInTimeZone("")).toBe(null);
-    expect(type.userInputInTimeZone("ABC")).toBe(null);
-    expect(type.userInputInTimeZone(" ".repeat(129))).toBe(null);
-  });
-
-  it("user input in time zone passthrough for ZonedDateTime", () => {
-    const zdt = Temporal.ZonedDateTime.from("2024-01-15T14:30:00[America/New_York]");
-    expect(type.userInputInTimeZone(zdt)).toBe(zdt);
   });
 
   it("cast 3pm returns 15:00", () => {

--- a/packages/activemodel/src/type/time.trails.test.ts
+++ b/packages/activemodel/src/type/time.trails.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/date";
+import { TimeWithZone, useZone } from "@blazetrails/activesupport";
 import { Types, ValueType } from "../index.js";
 
 describe("TimeTypeTrails", () => {
@@ -82,5 +84,36 @@ describe("TimeType Helpers::TimeValue ancestry", () => {
     expect(
       Object.prototype.hasOwnProperty.call(Types.TimeType.prototype, "userInputInTimeZone"),
     ).toBe(true);
+  });
+});
+
+describe("TimeType userInputInTimeZone", () => {
+  const type = new Types.TimeType();
+
+  it("user input in time zone wraps plain time in Time.zone", () => {
+    useZone("Eastern Time (US & Canada)", () => {
+      const result = type.userInputInTimeZone("14:30:00") as TimeWithZone;
+      expect(result).toBeInstanceOf(TimeWithZone);
+      expect(result.hour).toBe(14);
+      expect(result.timeZone.tzinfo.identifier).toBe("America/New_York");
+    });
+  });
+
+  it("user input in time zone answers a zoneless value when Time.zone is unset", () => {
+    const result = type.userInputInTimeZone("14:30:00") as Temporal.ZonedDateTime;
+    expect(result).toBeInstanceOf(Temporal.ZonedDateTime);
+    expect(result.hour).toBe(14);
+  });
+
+  it("user input in time zone returns null for null", () => {
+    expect(type.userInputInTimeZone(null)).toBe(null);
+    expect(type.userInputInTimeZone("")).toBe(null);
+    expect(type.userInputInTimeZone("ABC")).toBe(null);
+    expect(type.userInputInTimeZone(" ".repeat(129))).toBe(null);
+  });
+
+  it("user input in time zone passthrough for ZonedDateTime", () => {
+    const zdt = Temporal.ZonedDateTime.from("2024-01-15T14:30:00[America/New_York]");
+    expect(type.userInputInTimeZone(zdt)).toBe(zdt);
   });
 });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -5,7 +5,7 @@ import {
   Time as RubyTime,
   type DateParts,
 } from "@blazetrails/date";
-import { zone, isBlank, include, type Included } from "@blazetrails/activesupport";
+import { TimeWithZone, isBlank, include, type Included } from "@blazetrails/activesupport";
 import {
   AcceptsMultiparameterTime,
   type InstanceMethods,
@@ -74,17 +74,19 @@ export class TimeType extends ValueType<Temporal.Instant> {
    * `zoneDefault()`; with no zone set at all Ruby answers a bare `to_time`
    * (`date_and_time/zones.rb:20-27`), which is the zoneless
    * `Temporal.PlainDateTime` this returns in that arm, as the helper does.
-   * `in_time_zone` is the tail below: the components
-   * `cast_value` built are read back out of the `::Time` and re-anchored in
-   * that zone, which is what `Time.zone.parse` of the dummy-dated string
-   * answers.
+   * `super` is the tail below: the mixed-in `TimeValue.userInputInTimeZone`,
+   * which is `Time.zone.parse` for the dummy-dated string. Parsing in the zone
+   * is what preserves an offset the string carries — re-anchoring a cast
+   * instant's wall clock instead reads `"…T19:45:54-08:00"` back as hour 3.
    *
    * The `present?` guard is spelled out rather than routed through
    * `isBlank`: Ruby's `blank?` is `respond_to?(:empty?) ? !!empty? : !self`, so
    * a `::Time` is present, while `isBlank` reads any object with no own
    * enumerable keys as blank — which every Temporal value is.
    */
-  userInputInTimeZone(value: unknown): Temporal.ZonedDateTime | Temporal.PlainDateTime | null {
+  userInputInTimeZone(
+    value: unknown,
+  ): TimeWithZone | Temporal.ZonedDateTime | Temporal.Instant | null {
     if (value == null || value === false) return null;
     if (typeof value === "string" && isBlank(value)) return null;
 
@@ -97,8 +99,6 @@ export class TimeType extends ValueType<Temporal.Instant> {
         if (!(error instanceof RubyArgumentError)) throw error;
       }
       if (timeHash == null || timeHash.hour == null) return null;
-    } else if (value instanceof Temporal.ZonedDateTime) {
-      return value;
     } else if (value instanceof Temporal.Instant) {
       value = value
         .toZonedDateTimeISO(this.#zoneId())
@@ -106,12 +106,7 @@ export class TimeType extends ValueType<Temporal.Instant> {
         .toInstant();
     }
 
-    const cast = this.cast(value);
-    if (cast === null) return null;
-    const timeZone = zone();
-    const time = cast.toZonedDateTimeISO(this.#zoneId()).toPlainDateTime();
-    if (timeZone) return time.toZonedDateTime(timeZone.tzinfo.identifier);
-    return time;
+    return TimeValue.userInputInTimeZone.call(this, value);
   }
 
   /**

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -69,15 +69,14 @@ export class TimeType extends ValueType<Temporal.Instant> {
    *   end
    *
    * `super` is `Helpers::TimeValue#user_input_in_time_zone`, `value.in_time_zone`
-   * (time_value.rb:44-46). The zone is the thread-local `Time.zone`, read here
-   * through ActiveSupport's `zone()` the way `isUtc()` reads
-   * `zoneDefault()`; with no zone set at all Ruby answers a bare `to_time`
-   * (`date_and_time/zones.rb:20-27`), which is the zoneless
-   * `Temporal.PlainDateTime` this returns in that arm, as the helper does.
-   * `super` is the tail below: the mixed-in `TimeValue.userInputInTimeZone`,
-   * which is `Time.zone.parse` for the dummy-dated string. Parsing in the zone
-   * is what preserves an offset the string carries — re-anchoring a cast
-   * instant's wall clock instead reads `"…T19:45:54-08:00"` back as hour 3.
+   * (time_value.rb:42-44) — `Time.zone.parse` of the dummy-dated string, which
+   * is what preserves an offset the string carries. TypeScript has no `super`
+   * for a mixed-in module, so the tail calls the mixin member on `this`; the
+   * mixin also answers Ruby's fall-through arms, so a value that is neither a
+   * `::String` nor a `::Time` reaches it untouched, as in Rails. The zone is
+   * the thread-local `Time.zone`; with no zone set at all Ruby answers a bare
+   * `to_time` (`date_and_time/zones.rb:20-27`), which the mixin reads in the
+   * system zone.
    *
    * The `present?` guard is spelled out rather than routed through
    * `isBlank`: Ruby's `blank?` is `respond_to?(:empty?) ? !!empty? : !self`, so


### PR DESCRIPTION
Closes-story: port-user-input-in-time-zone-and-close-the-activemodel-test-gap

## What

`parity:test` reported activemodel at **961/963**, with `type/time_test.rb` at
Miss=1. The Rails test `test_user_input_in_time_zone`
(`activemodel/test/cases/type/time_test.rb:24-38`) was not absent — it had been
split into four renamed tests, none carrying the Rails name, so `parity:test`
could match none of them.

- `packages/activemodel/src/type/time.test.ts` gains `it("user input in time zone")`
  under the Rails name exactly, mirroring the Ruby line by line: the four nil
  arms, then the offset round-trip built from `Time.zone.formattedOffset()`
  derived at runtime (not hardcoded), asserting `.hour === 19` and that
  `formattedOffset()` comes back unchanged.
- The four TS-only `user input in time zone …` extras move to
  `type/time.trails.test.ts`, where TS-only extras belong. No test was renamed.

## The divergence the restored test surfaced

The offset round-trip was the one arm nothing covered, and it failed: hour `3`
instead of `19`.

`Type::Time#user_input_in_time_zone` ends in `super(value)` —
`Helpers::TimeValue#user_input_in_time_zone`, which is `value.in_time_zone`,
i.e. `Time.zone.parse` of the dummy-dated string
(`activemodel/lib/active_model/type/helpers/time_value.rb:41-43`). trails instead
ran a bespoke tail: `this.cast(value)` to an instant, then re-anchored that
instant's wall clock in `Time.zone`. Re-anchoring discards an offset the string
carries — `"2015-02-09T19:45:54-08:00"` casts to `03:45:54Z` and reads back as
hour 3. `packages/activemodel/src/type/time.ts` now delegates to the mixed-in
helper, as Rails does; the redundant `ZonedDateTime` early-return arm (which Rails
does not have, and which `super` already answers identically) is dropped.

The two trails-only extras that had encoded the old return shape are updated to
the Rails one (`TimeWithZone` with a zone set; a system-zone reading without).
Consumers checked green: `time-zone-conversion.trails.test.ts`,
`time-zone-converter.test.ts`, PG `oid/array` and `oid/range`.

## parity:test

| | before | after |
| --- | --- | --- |
| activemodel | 961/963 (99.8%) | **962/963 (99.9%)** |
| `type/time_test.rb` | 2 OK, Miss 1 | **3 OK, Miss 0** |

The remaining 1 is the documented numericality skip.

## The numericality `PERMANENT-SKIP` — left as-is

`validations/numericality-validation.test.ts:434-447` is left untouched and its
reason is not reworded. On re-read the `PERMANENT` claim is overstated — JS has
`BigInt`, and the reason itself names the shape that would work — but converging
it means threading exact integer arithmetic through `parse_as_number` /
`Comparability`, which feeds every numericality option including the float arms;
that is a separate change, filed as
`0115-activemodel-fidelity-convergence/converge-numericality-bigint-exponent-skip`.

## Verification

- `pnpm vitest run packages/activemodel/src/type/time.test.ts packages/activemodel/src/type/time.trails.test.ts` — 33 passed.
- `pnpm vitest run packages/activemodel/src/type/` — 328 passed.
- `pnpm parity:api:calls` — OK. `pnpm parity:api:calls:args` — OK. `pnpm lint`, `pnpm typecheck` — clean.
