### PR TITLE
fix(activemodel): exact integer numericality past 2^53; declare the instance HelperMethods arms

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -170,7 +170,16 @@ export interface Model {
    * (RFC 0063), so these settle where Ruby's return straight away.
    */
   validatesPresenceOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesAbsenceOf(...attrNames: AttrNameArg[]): Promise<void>;
   validatesLengthOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesSizeOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesNumericalityOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesInclusionOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesExclusionOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesFormatOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesAcceptanceOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesConfirmationOf(...attrNames: AttrNameArg[]): Promise<void>;
+  validatesComparisonOf(...attrNames: AttrNameArg[]): Promise<void>;
 
   /**
    * `ActiveModel::Attributes#attribute_names` (attributes.rb:146-148),

--- a/packages/activemodel/src/validations/comparability.ts
+++ b/packages/activemodel/src/validations/comparability.ts
@@ -53,13 +53,18 @@ export interface Comparability {
  * (ComparisonValidator's Temporal/string/number mix) pass their `<=>`
  * result against `0`, exactly as Ruby's Comparable defines the operators.
  *
+ * `:==` / `:!=` are JS `==` / `!=`, not `===` / `!==`: Ruby's `==` is value
+ * equality across Integer and Float (`1 == 1.0`), which for a mixed
+ * number/bigint pair — numericality carries a bigint for an Integer past 2^53
+ * — only the loose operators express.
+ *
  * @noRailsEquivalent PERMANENT: TypeScript has no `public_send` and no operator
  * methods, so a Ruby comparison-operator Symbol cannot be dispatched off the value
  */
 export function compareOperator(
   op: (typeof COMPARE_CHECKS)[CompareKey],
-  a: number,
-  b: number,
+  a: number | bigint,
+  b: number | bigint,
 ): boolean {
   switch (op) {
     case ":>":
@@ -67,12 +72,12 @@ export function compareOperator(
     case ":>=":
       return a >= b;
     case ":==":
-      return a === b;
+      return a == b;
     case ":<":
       return a < b;
     case ":<=":
       return a <= b;
     case ":!=":
-      return a !== b;
+      return a != b;
   }
 }

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -431,17 +431,11 @@ describe("NumericalityValidationTest", () => {
     assertPredicate(await topic.isValid(), (valid) => valid);
   });
 
-  // PERMANENT-SKIP: the assertion needs exact integer arithmetic past 2^53.
-  // Ruby's `"10000000000000001".to_i` is an arbitrary-precision Integer that
-  // compares greater than 10_000_000_000_000_000; every JS number is a double,
-  // so both sides round to the same 1e16 and the value is (correctly, for a
-  // double) less-than-or-equal. Only a BigInt-typed parse pipeline through
-  // Comparability could express this, which no other option needs.
-  it.skip("validates numericality with exponent number", async () => {
+  it("validates numericality with exponent number", async () => {
     const base = 10_000_000_000_000_000;
     Topic.validatesNumericalityOf("approved", { lessThanOrEqualTo: base });
     const topic = new Topic();
-    topic.approved = String(base + 1);
+    topic.approved = String(BigInt(base) + 1n);
 
     assertPredicate(await topic.isInvalid(), (invalid) => invalid);
   });

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -7,7 +7,7 @@ import { resolveValue } from "./resolve-value.js";
 import { ArgumentError } from "../attribute-assignment.js";
 import type { AttrNameArg, HelperMethodsHost } from "./helper-methods.js";
 
-type NumericValue = number | ((record: ValidatableRecord) => number) | string;
+type NumericValue = number | bigint | ((record: ValidatableRecord) => number) | string;
 
 /**
  * Mirrors: ActiveModel::Validations::NumericalityValidator (numericality.rb)
@@ -98,7 +98,7 @@ export class NumericalityValidator extends EachValidator {
 
     // Rails reassigns `value` (numericality.rb:47), so every filtered_options
     // below interpolates the PARSED value, not the raw input.
-    const num = parseAsNumber(value, precision, scale) as number;
+    const num = parseAsNumber(value, precision, scale) as number | bigint;
     value = num;
 
     // Rails uses filtered_options(value).merge!(count: option_value)
@@ -121,7 +121,7 @@ export class NumericalityValidator extends EachValidator {
       if (option in NUMBER_CHECKS) {
         // Rails: value.to_i.public_send(NUMBER_CHECKS[option]) — TS has no
         // public_send, so the check Symbol selects the parity test.
-        const odd = Math.trunc(num) % 2 !== 0;
+        const odd = typeof num === "bigint" ? num % 2n !== 0n : Math.trunc(num) % 2 !== 0;
         if (NUMBER_CHECKS[option as keyof typeof NUMBER_CHECKS] === ":odd?" ? !odd : odd) {
           record.errors.add(attribute, `:${option}`, this.filteredOptions(value));
         }
@@ -129,7 +129,7 @@ export class NumericalityValidator extends EachValidator {
         // Rails: value.public_send(:in?, range) — Object#in? delegates to
         // Range#include?, and :count interpolates the range's own to_s.
         const range = optionValue as unknown as Range<number>;
-        if (!range.isInclude(num)) {
+        if (!range.isInclude(num as number)) {
           record.errors.add(attribute, `:${option}`, withCount(range.toS()));
         }
       } else if (option in COMPARE_CHECKS) {
@@ -195,7 +195,7 @@ export function optionAsNumber(
   optionValue: unknown,
   precision: number,
   scale?: number,
-): number | undefined {
+): number | bigint | undefined {
   return parseAsNumber(this.resolveValue(record, optionValue), precision, scale);
 }
 
@@ -218,6 +218,12 @@ export function optionAsNumber(
  * implicit-nil from the `elsif` chain falling through, and the
  * `rescue ArgumentError, TypeError` around `Kernel.Float` in `is_number?`).
  *
+ * Ruby's `String#to_i` is an arbitrary-precision Integer, so the `is_integer?`
+ * branch answers a bigint once the digits fall outside the safe-integer range —
+ * `"10000000000000001"` has to stay greater than `10_000_000_000_000_000`,
+ * which a double cannot express. Inside that range it answers a plain number,
+ * leaving every float arm untouched.
+ *
  * Ruby's Float-vs-Integer split has no JS counterpart — both are `number` —
  * so integrality stands in for it: a non-integral number takes the `Float`
  * branch, an integral one the `Numeric` (pass-through) branch. That is what
@@ -234,7 +240,7 @@ export function parseAsNumber(
   rawValue: unknown,
   precision: number,
   scale?: number,
-): number | undefined {
+): number | bigint | undefined {
   if (typeof rawValue === "number") {
     // Ruby `Float::NAN.to_d` raises, so the chain yields no number.
     if (Number.isNaN(rawValue)) return undefined;
@@ -243,7 +249,12 @@ export function parseAsNumber(
     return rawValue % 1 === 0 ? rawValue : parseFloat(rawValue, precision, scale);
   }
   if (rawValue instanceof BigDecimal) return round(Number(rawValue.toString("F")), scale);
-  if (isInteger(rawValue)) return Number.parseInt(String(rawValue), 10);
+  if (isInteger(rawValue)) {
+    const int = BigInt(String(rawValue));
+    return int >= BigInt(Number.MIN_SAFE_INTEGER) && int <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(int)
+      : int;
+  }
   if (!isHexadecimalLiteral(rawValue)) {
     const float = kernelFloat(rawValue);
     if (float === undefined) return undefined;
@@ -252,9 +263,12 @@ export function parseAsNumber(
   return undefined;
 }
 
-/** Ruby's `value.is_a?(Numeric)` over the two numeric types trails carries. */
+/**
+ * Ruby's `value.is_a?(Numeric)` over the numeric types trails carries — a
+ * bigint among them, since it is how an Integer past 2^53 is spelled here.
+ */
 function isNumeric(value: unknown): boolean {
-  return typeof value === "number" || value instanceof BigDecimal;
+  return typeof value === "number" || typeof value === "bigint" || value instanceof BigDecimal;
 }
 
 /** Ruby's `value.is_a?(Symbol)` — a colon-prefixed string in trails. */


### PR DESCRIPTION
Two RFC 0115 stories. The third story in this bundle,
`delete-dead-schema-migration-table-exists-probe`, was **already done in
`origin/main`** — #6982 removed `Migrator#schemaMigrationTableExists` (along
with `currentVersionReadOnly`) as part of trimming Migrator to its
migration.rb:1404 surface. It is marked done against #6982 and is not part of
this diff.

## 1. converge-numericality-bigint-exponent-skip

`parse_as_number`'s integer branch (numericality.rb:72-84) is Ruby's
`String#to_i` — an arbitrary-precision Integer. `Number.parseInt` rounded
`"10000000000000001"` down to `1e16`, so it compared *equal* to a
`less_than_or_equal_to: 10_000_000_000_000_000` option and the record validated.

The branch now returns a `bigint` when the parsed integer falls outside the
safe-integer range, and a plain `number` inside it — so every float arm
(`parse_float`, `round`, the `Kernel.Float` fallback) is untouched.
`compareOperator` widens to `number | bigint`; `:==` / `:!=` become `==` / `!=`,
which is Ruby's cross-type value equality (`1 == 1.0`) and the only spelling
that works for a mixed number/bigint pair. `is_numeric?` accepts a bigint for
the same reason (a Ruby Integer is Numeric). The odd/even branch tests parity on
the bigint directly rather than through `Math.trunc`.

The `PERMANENT-SKIP` block is **deleted** (not reworded) and
`it("validates numericality with exponent number")` runs, with its name
unchanged. Verified it fails on the baseline: forcing the branch back through
`Number()` reds exactly that test and nothing else.

`parity:test`, `validations/numericality_validation_test.rb`:

- before: 40 OK / 1 Skip / 41
- after: **41 OK / 0 Skip / 0 Miss / 41 ✓**

The activemodel package total is 962/963 before and after — the skip was not the
ratio gap. The one remaining activemodel gap is a **Miss** in
`type/time_test.rb`, unrelated to this story.

## 2. declare-the-nine-undeclared-instance-helper-method-arms

`interface Model` declared only `validatesPresenceOf` / `validatesLengthOf` on
the instance side; the other nine fell through the index signature and needed a
cast from a `validate do … end` body, even though `Validations.[included]`
already does both `extend(base, HelperMethods)` and
`include(base, HelperMethods)` (validations.rb:45-46). All eleven are now
declared, each `Promise<void>` — the instance `validates_with`
(with.rb:144-151) is async under RFC 0063. No runtime change.

## Gates

- `pnpm parity:api:calls` — OK (416 baselined, marks tight)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows)
- `pnpm parity:api:extra:gate` — OK (arel novel 0/0, total 63/63)
- `pnpm typecheck`, `pnpm lint` — clean
- `packages/activemodel/src/validations/` — 386 tests green

Closes-story: converge-numericality-bigint-exponent-skip
Closes-story: declare-the-nine-undeclared-instance-helper-method-arms
