### PR TITLE
refactor(activemodel,activerecord): fan out the Model dirty surface to dirty.ts

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -85,7 +85,10 @@ export class AttributeMethodPattern {
    * mutator, not a reader, so its `parameters: false` becomes an empty
    * parameter list — a zero-arg METHOD — rather than the accessor property
    * `defineCall` gives a zero-arg reader (CLAUDE.md, "Generated attribute
-   * readers are properties").
+   * readers are properties"). The bang survives in `proxy_target`, spelled
+   * `Bang` — Ruby dispatches `name_will_change!` to `attribute_will_change!`
+   * and `restore_name!` to `restore_attribute!` (dirty.rb:409,414), both bang
+   * methods.
    */
   constructor({
     prefix = "",
@@ -96,7 +99,9 @@ export class AttributeMethodPattern {
     this.prefix = prefix;
     this.suffix = bang ? suffix.slice(0, -1) : suffix;
     this.parameters = parameters == null ? "..." : bang && parameters === false ? "" : parameters;
-    this.proxyTarget = `${prefix}${this.camelJoined ? "Attribute" : "attribute"}${this.suffix}`;
+    this.proxyTarget = `${prefix}${this.camelJoined ? "Attribute" : "attribute"}${this.suffix}${
+      bang ? "Bang" : ""
+    }`;
   }
 
   match(method: string): { attr: string } | null {

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -456,21 +456,4 @@ export class AttributeSet {
     const next = attr.forgettingAssignment();
     if (next !== attr) this._attributes.set(name, next);
   }
-
-  /**
-   * Apply `forgettingAssignment()` to each attribute in place so that shared
-   * references (as in `becomes()`) see the updated baseline.
-   *
-   * Mirrors: ActiveModel::AttributeSet#map(&:forgetting_assignment) assigned
-   * back to `@attributes` in `forget_attribute_assignments`.
-   *
-   * @internal
-   */
-  forgetAssignmentsBang(): void {
-    this.assertNotFrozen();
-    for (const [name, attr] of this._attributes) {
-      const next = attr.forgettingAssignment();
-      if (next !== attr) this._attributes.set(name, next);
-    }
-  }
 }

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -24,7 +24,6 @@ export class Dirty {
   declare _dirty: DirtyTracker;
   declare _attributes: AttributeSet;
   /** @internal */
-  declare _readAttribute: (name: string) => unknown;
   /** @internal */
 
   /**
@@ -150,27 +149,11 @@ export class Dirty {
    * Check if an attribute value has changed in-place (by identity).
    *
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place? (dirty.rb:367-369)
-   *
-   * @missingRailsCall changed_in_place? — PERMANENT: Language shortcoming.
-   * Rails delegates to `mutations_from_database.changed_in_place?`, which is
-   * `attributes[attr_name].changed_in_place?` (attribute_mutation_tracker.rb:
-   * 50-52) — and that is `false` by definition on `Attribute::WithCastValue`
-   * (attribute.rb:243-245). Ruby reaches an in-place change by mutating the
-   * cast value the Attribute already holds (`aircraft.name.downcase!`,
-   * normalized_attribute_test.rb:36); JS strings, Numbers and Dates are
-   * immutable, so the port can only reach the same state by writing a new cast
-   * value onto the set — exactly the shape Rails classifies as not-in-place.
-   * Asking the Attribute therefore cannot answer the question here, so the
-   * before/after values are compared directly.
    */
   attributeChangedInPlace(name: string): boolean {
-    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
-    const current = this._readAttribute(name);
-    const recorded = this._dirty.mutationsFromDatabase[name];
-    if (recorded) return current !== recorded[1];
-    const original = this._dirty.attributeWas(name);
-    if (original === undefined) return false;
-    return original !== current;
+    return this._dirty.changedInPlace(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
   }
 
   /**
@@ -478,6 +461,32 @@ export class DirtyTracker {
    */
   attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
     return this.isChanged(this.mutationsBeforeLastSave, name, options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed_in_place?
+   * (attribute_mutation_tracker.rb:50-52).
+   *
+   * @missingRailsCall changed_in_place? — PERMANENT: Language shortcoming.
+   * Ruby's body is `attributes[attr_name].changed_in_place?`, and Ruby reaches
+   * an in-place change by mutating the cast value the `Attribute` already
+   * holds — `aircraft.name.downcase!` (normalized_attribute_test.rb:36), which
+   * leaves the same `Attribute` in the set with a different value. JS strings,
+   * Numbers and Dates are immutable, so the only way to reach that state here
+   * is to write a new cast value onto the set, which yields an
+   * `Attribute::WithCastValue` whose `changed_in_place?` is `false` by
+   * definition (attribute.rb:243-245). Asking the `Attribute` would therefore
+   * answer `false` for every in-place change the port can express, so this body
+   * compares the before and after values itself — the comparison
+   * `Type::Value#changed_in_place?` (attribute.rb:70) would have made.
+   */
+  changedInPlace(name: string): boolean {
+    const current = this.fetchValue(name);
+    const recorded = this.changes[name];
+    if (recorded) return current !== recorded[1];
+    const original = this.attributeWas(name);
+    if (original === undefined) return false;
+    return original !== current;
   }
 
   /**

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -17,7 +17,7 @@ export interface DirtyOptions {
  * attribute readers are properties"); an object literal is read by value and
  * would flatten each getter into a data property.
  *
- * Mirrors: ActiveModel::Dirty (dirty.rb:105-421)
+ * Mirrors: ActiveModel::Dirty (dirty.rb:123-421)
  */
 export class Dirty {
   /** The mutation tracker `mutations_from_database` returns (dirty.rb:379-386). */
@@ -151,9 +151,8 @@ export class Dirty {
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place? (dirty.rb:367-369)
    */
   attributeChangedInPlace(name: string): boolean {
-    const current = this._readAttribute(
-      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
-    );
+    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
+    const current = this._readAttribute(name);
     const recorded = this._dirty.mutationsFromDatabase[name];
     if (recorded) return current !== recorded[1];
     const original = this._dirty.attributeWas(name);
@@ -220,6 +219,19 @@ export class Dirty {
   }
 
   /**
+   * Dispatch target for `*_previous_change` per-attribute methods.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_previous_change (dirty.rb:404-406)
+   *
+   * @internal
+   */
+  attributePreviousChange(name: string): [unknown, unknown] | undefined {
+    return this._dirty.previousChanges[
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name)
+    ];
+  }
+
+  /**
    * Dispatch target for `*_will_change!` per-attribute methods. Force-marks an
    * attribute as changed for in-place mutations (e.g. array push) where the
    * object reference stays the same but the content has changed.
@@ -251,19 +263,6 @@ export class Dirty {
       this._attributes,
       (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
     );
-  }
-
-  /**
-   * Dispatch target for `*_previous_change` per-attribute methods.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_previous_change (dirty.rb:404-406)
-   *
-   * @internal
-   */
-  attributePreviousChange(name: string): [unknown, unknown] | undefined {
-    return this._dirty.previousChanges[
-      (this.constructor as unknown as DirtyClass).resolveAttributeName(name)
-    ];
   }
 }
 

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -8,34 +8,272 @@ export interface DirtyOptions {
 }
 
 /**
- * Dirty mixin contract — tracks attribute changes on a model.
+ * `ActiveModel::Dirty` — the instance half of the module, mixed onto a model
+ * by `include(Model, Dirty)`.
  *
- * Mirrors: ActiveModel::Dirty
+ * A class module rather than a plain-object one because only `include()`'s
+ * class branch copies accessor descriptors, and every Ruby body here that is a
+ * zero-arg reader ports as an accessor property (CLAUDE.md, "Generated
+ * attribute readers are properties"); an object literal is read by value and
+ * would flatten each getter into a data property.
  *
- * Model implements this interface via DirtyTracker delegation.
+ * Mirrors: ActiveModel::Dirty (dirty.rb:105-421)
  */
-export interface Dirty {
-  readonly isChanged: boolean;
-  readonly changed: string[];
-  readonly changedAttributes: Record<string, unknown>;
-  readonly changes: Record<string, [unknown, unknown]>;
-  readonly previousChanges: Record<string, [unknown, unknown]>;
-  readonly mutationsFromDatabase: Record<string, [unknown, unknown]>;
-  readonly mutationsBeforeLastSave: Record<string, [unknown, unknown]>;
-  attributeChanged(name: string, options?: DirtyOptions): boolean;
-  attributeWas(name: string): unknown;
-  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean;
-  attributePreviouslyWas(name: string): unknown;
-  restoreAttributes(attrNames?: string[]): void;
-  changesApplied(): void;
-  clearChangesInformation(): void;
-  clearAttributeChanges(attributes: string[]): void;
-  attributeChangedInPlace(name: string): boolean;
+export class Dirty {
+  /** The mutation tracker `mutations_from_database` returns (dirty.rb:379-386). */
+  declare _dirty: DirtyTracker;
+  declare _attributes: AttributeSet;
   /** @internal */
-  forgetAttributeAssignments(): void;
-  /** @internal */
-  clearAttributeChange(name: string): void;
+  declare _readAttribute: (name: string) => unknown;
+
+  /**
+   * Mirrors: ActiveModel::Dirty#changes_applied (dirty.rb:272-279)
+   */
+  changesApplied(): void {
+    this._dirty.changesApplied(this._attributes);
+    this.forgetAttributeAssignments();
+  }
+
+  /**
+   * Returns `true` if any of the attributes has unsaved changes.
+   *
+   * Mirrors: ActiveModel::Dirty#changed? (dirty.rb:286-288)
+   */
+  get isChanged(): boolean {
+    return this._dirty.changed;
+  }
+
+  /**
+   * Returns an array with the name of the attributes with unsaved changes.
+   *
+   * Mirrors: ActiveModel::Dirty#changed (dirty.rb:295-297)
+   */
+  get changed(): string[] {
+    return this._dirty.changedAttributeNames;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Dirty#attribute_changed? (dirty.rb:300-302) —
+   * `mutations_from_database.changed?(attr_name.to_s, **options)`.
+   */
+  attributeChanged(name: string, options?: DirtyOptions): boolean {
+    return this._dirty.attributeChanged(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+      options,
+    );
+  }
+
+  /**
+   * Mirrors: ActiveModel::Dirty#attribute_was (dirty.rb:305-307)
+   */
+  attributeWas(name: string): unknown {
+    return this._dirty.attributeWas(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
+  }
+
+  /**
+   * Check if a specific attribute changed in the last save.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_previously_changed?
+   * (dirty.rb:310-312)
+   */
+  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
+    return this._dirty.attributePreviouslyChanged(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+      options,
+    );
+  }
+
+  /**
+   * Get the value of an attribute before the last save.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_previously_was (dirty.rb:315-317)
+   */
+  attributePreviouslyWas(name: string): unknown {
+    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
+    const change = this._dirty.previousChanges[name];
+    return change ? change[0] : this._readAttribute(name);
+  }
+
+  /**
+   * Restore all previous data of the provided attributes.
+   *
+   * Mirrors: ActiveModel::Dirty#restore_attributes (dirty.rb:320-322)
+   */
+  restoreAttributes(attrNames: string[] = this.changed): void {
+    attrNames.forEach((attrName) => this.restoreAttributeBang(attrName));
+  }
+
+  /**
+   * Clears all dirty data: current changes and previous changes.
+   *
+   * Mirrors: ActiveModel::Dirty#clear_changes_information (dirty.rb:325-329)
+   */
+  clearChangesInformation(): void {
+    this._dirty.clearChangesInformation();
+    this.forgetAttributeAssignments();
+  }
+
+  /**
+   * Mirrors: ActiveModel::Dirty#clear_attribute_changes (dirty.rb:331-335)
+   */
+  clearAttributeChanges(attrNames: string[]): void {
+    attrNames.forEach((attrName) => this.clearAttributeChange(attrName));
+  }
+
+  /**
+   * Map of each changed attribute's name to its old (pre-change) value.
+   *
+   * Mirrors: ActiveModel::Dirty#changed_attributes (dirty.rb:343-345)
+   */
+  get changedAttributes(): Record<string, unknown> {
+    return this._dirty.changedAttributes;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Dirty#changes (dirty.rb:353-355)
+   */
+  get changes(): Record<string, [unknown, unknown]> {
+    return this._dirty.changes;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Dirty#previous_changes (dirty.rb:363-365)
+   */
+  get previousChanges(): Record<string, [unknown, unknown]> {
+    return this._dirty.previousChanges;
+  }
+
+  /**
+   * Check if an attribute value has changed in-place (by identity).
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_changed_in_place? (dirty.rb:367-369)
+   */
+  attributeChangedInPlace(name: string): boolean {
+    const current = this._readAttribute(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
+    const recorded = this._dirty.mutationsFromDatabase[name];
+    if (recorded) return current !== recorded[1];
+    const original = this._dirty.attributeWas(name);
+    if (original === undefined) return false;
+    return original !== current;
+  }
+
+  /**
+   * Drop a single attribute's pending change without reverting its value.
+   *
+   * Mirrors: ActiveModel::Dirty#clear_attribute_change (dirty.rb:378-380)
+   *
+   * @internal
+   */
+  clearAttributeChange(name: string): void {
+    this._dirty.clearAttributeChange(this._attributes, name);
+  }
+
+  /**
+   * Pending changes diff against the values loaded from the database.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_from_database (dirty.rb:382-388)
+   *
+   * @internal
+   */
+  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
+    return this._dirty.mutationsFromDatabase;
+  }
+
+  /**
+   * Drop all pending assignment tracking without reverting values.
+   *
+   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments (dirty.rb:390-392)
+   *
+   * @internal
+   */
+  forgetAttributeAssignments(): void {
+    this._attributes.forgetAssignmentsBang();
+    this._dirty.forgetAttributeAssignments(this._attributes);
+  }
+
+  /**
+   * Snapshot of the pending changes at the moment of the last save.
+   *
+   * Mirrors: ActiveModel::Dirty#mutations_before_last_save (dirty.rb:394-396)
+   *
+   * @internal
+   */
+  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
+    return this._dirty.mutationsBeforeLastSave;
+  }
+
+  /**
+   * Dispatch target for `*_change` per-attribute methods.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_change (dirty.rb:399-401)
+   *
+   * @internal
+   */
+  attributeChange(name: string): [unknown, unknown] | null {
+    return this._dirty.attributeChange(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
+  }
+
+  /**
+   * Dispatch target for `*_will_change!` per-attribute methods. Force-marks an
+   * attribute as changed for in-place mutations (e.g. array push) where the
+   * object reference stays the same but the content has changed.
+   *
+   * Returns the forced value, mirroring Rails where `attribute_will_change!`
+   * returns `mutations_from_database.force_change(...)` — a truthy value relied
+   * on by `assert pirate.catchphrase_will_change!` (dirty_test.rb:317).
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_will_change! (dirty.rb:409-411)
+   *
+   * @internal
+   */
+  attributeWillChangeBang(name: string): unknown {
+    return this._dirty.forceChange(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
+  }
+
+  /**
+   * Dispatch target for `restore_*!` per-attribute methods. Restores the
+   * attribute to its pre-change value and clears the dirty entry.
+   *
+   * Mirrors: ActiveModel::Dirty#restore_attribute! (dirty.rb:414-420)
+   *
+   * @internal
+   */
+  restoreAttributeBang(name: string): void {
+    this._dirty.restoreAttribute(
+      this._attributes,
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
+  }
+
+  /**
+   * Dispatch target for `*_previous_change` per-attribute methods.
+   *
+   * Mirrors: ActiveModel::Dirty#attribute_previous_change (dirty.rb:404-406)
+   *
+   * @internal
+   */
+  attributePreviousChange(name: string): [unknown, unknown] | undefined {
+    return this._dirty.previousChanges[
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name)
+    ];
+  }
 }
+
+/**
+ * The class half a `Dirty` body self-sends: Ruby's `attr_name.to_s` sits
+ * alongside the alias resolution `AttributeMethods::ClassMethods#resolve_attribute_name`
+ * (attribute_methods.rb:396-398) does, and a module body cannot name the
+ * including class.
+ */
+type DirtyClass = { resolveAttributeName(name: string): string };
 
 /**
  * Mirrors `Dirty#initialize_dup`'s `@mutations_from_database = nil`
@@ -95,20 +333,6 @@ export function initAttributes(
 export function initInternals(this: DirtyInternalsHost, super_: () => void): void {
   super_();
   this._dirty = new DirtyTracker();
-}
-
-/**
- * Mirrors: ActiveModel::Dirty#attribute_previous_change
- *
- * Dispatch target for `*_previous_change` per-attribute methods.
- *
- * @internal Rails-private helper.
- */
-export function attributePreviousChange(
-  this: DirtyDispatchHost,
-  attrName: string,
-): [unknown, unknown] | undefined {
-  return this._dirty.previousChanges[attrName];
 }
 
 /**
@@ -761,34 +985,6 @@ export class DirtyTracker {
   }
 }
 
-/**
- * Mirrors: ActiveModel::Dirty#attribute_will_change!
- *
- * Dispatch target for `*_will_change!` per-attribute methods. Force-marks
- * an attribute as changed for in-place mutations (e.g. array push) where
- * the object reference stays the same but the content has changed.
- *
- * @internal Rails-private helper.
- */
-export function attributeWillChangeBang(this: DirtyDispatchHost, attrName: string): unknown {
-  // Rails' receiver is `mutations_from_database` (dirty.rb:409-411); trails
-  // spells the mutation tracker `_dirty` — `mutationsFromDatabase` here is the
-  // Record-shaped reader over it, not the tracker itself.
-  return this._dirty.forceChange(attrName);
-}
-
-/**
- * Mirrors: ActiveModel::Dirty#restore_attribute!
- *
- * Dispatch target for `restore_*!` per-attribute methods. Restores the
- * attribute to its pre-change value and clears the dirty entry.
- *
- * @internal Rails-private helper.
- */
-export function restoreAttributeBang(this: DirtyDispatchHost, attrName: string): void {
-  this._dirty.restoreAttribute(this._attributes, attrName);
-}
-
 export function initializeDup(
   this: DirtyDupHost,
   super_: (other: unknown) => void,
@@ -801,12 +997,3 @@ export function initializeDup(
 function resolveValue(value: unknown): unknown {
   return AttributeSet.resolveSnapshotValue(value);
 }
-
-type DirtyDispatchHost = {
-  _dirty: DirtyTracker;
-  _attributes: AttributeSet;
-  restoreAttribute?(name: string): void;
-  attributeWas?(name: string): unknown;
-  writeAttribute?(name: string, value: unknown): void;
-  clearAttributeChange?(name: string): void;
-};

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -24,7 +24,6 @@ export class Dirty {
   declare _dirty: DirtyTracker;
   declare _attributes: AttributeSet;
   /** @internal */
-  declare _readAttribute: (name: string) => unknown;
 
   /**
    * Mirrors: ActiveModel::Dirty#changes_applied (dirty.rb:272-279)
@@ -91,9 +90,9 @@ export class Dirty {
    * Mirrors: ActiveModel::Dirty#attribute_previously_was (dirty.rb:315-317)
    */
   attributePreviouslyWas(name: string): unknown {
-    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
-    const change = this._dirty.previousChanges[name];
-    return change ? change[0] : this._readAttribute(name);
+    return this._dirty.originalValue(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
   }
 
   /**
@@ -151,13 +150,9 @@ export class Dirty {
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place? (dirty.rb:367-369)
    */
   attributeChangedInPlace(name: string): boolean {
-    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
-    const current = this._readAttribute(name);
-    const recorded = this._dirty.mutationsFromDatabase[name];
-    if (recorded) return current !== recorded[1];
-    const original = this._dirty.attributeWas(name);
-    if (original === undefined) return false;
-    return original !== current;
+    return this._dirty.changedInPlace(
+      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
+    );
   }
 
   /**
@@ -168,7 +163,7 @@ export class Dirty {
    * @internal
    */
   clearAttributeChange(name: string): void {
-    this._dirty.clearAttributeChange(this._attributes, name);
+    this._dirty.forgetChange(this._attributes, name);
   }
 
   /**
@@ -356,6 +351,13 @@ export class DirtyTracker {
   private _originalHas: Set<string> = new Set();
   private _changedAttributes: Map<string, [unknown, unknown]> = new Map();
   private _previousChanges: Map<string, [unknown, unknown]> = new Map();
+  /**
+   * Rails' `@mutations_before_last_save` is nil until `changes_applied` assigns
+   * the pre-save tracker (dirty.rb:276), and `mutations_before_last_save`
+   * substitutes the `NullMutationTracker` while it is (dirty.rb:394-396). One
+   * tracker holds both change sets here, so that nil is this flag.
+   */
+  private _hasMutationsBeforeLastSave = false;
   /** Names explicitly force-dirtied via attribute_will_change!. @internal */
   private _forcedNames: Set<string> = new Set();
   /** Live AttributeSet reference — set on first snapshot, used to detect changedInPlace(). */
@@ -403,6 +405,7 @@ export class DirtyTracker {
     copy._originalAttributes = attrs.snapshotValues();
     copy._originalHas = new Set(copy._originalAttributes.keys());
     copy._previousChanges = new Map(this._previousChanges);
+    copy._hasMutationsBeforeLastSave = this._hasMutationsBeforeLastSave;
     copy._attrs = attrs;
     copy._pendingNames = new Set(attrs.keys());
     return copy;
@@ -425,6 +428,7 @@ export class DirtyTracker {
       }
     });
     this._previousChanges = snapshot;
+    this._hasMutationsBeforeLastSave = true;
     if (currentAttributes instanceof Map) {
       this._originalAttributes = new Map(currentAttributes);
       this._originalHas = new Set(currentAttributes.keys());
@@ -459,6 +463,16 @@ export class DirtyTracker {
   }
 
   /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed_in_place?
+   * (attribute_mutation_tracker.rb:50-52) — `attributes[attr_name].changed_in_place?`.
+   * An attribute the set does not carry answers through `Attribute::Null`,
+   * whose `changed_in_place?` is false.
+   */
+  changedInPlace(name: string): boolean {
+    return this._attrs?.getAttribute(name).changedInPlace() ?? false;
+  }
+
+  /**
    * Mirrors: ActiveModel::AttributeMutationTracker#changed?
    * (attribute_mutation_tracker.rb:44-48) — the one body every
    * `attribute_changed?` / `attribute_previously_changed?` /
@@ -490,9 +504,35 @@ export class DirtyTracker {
     return resolveValue(this._originalAttributes.get(name));
   }
 
+  /**
+   * Mirrors: ActiveModel::AttributeMutationTracker#original_value
+   * (attribute_mutation_tracker.rb:59-61) over `mutations_before_last_save`.
+   * {@link attributeWas} is the same Ruby method read off
+   * `mutations_from_database`; one object holds both change sets here, so the
+   * two readings cannot share the Ruby name until DirtyTracker splits into two
+   * `AttributeMutationTracker`s (story `0023-surfaced-deviations/
+   * dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`).
+   *
+   * Before the first save Rails' `mutations_before_last_save` is the
+   * `NullMutationTracker`, whose `original_value` returns nil
+   * (attribute_mutation_tracker.rb:186-187, dirty.rb:394-396); this tracker
+   * holds both change sets in one object, so `_hasMutationsBeforeLastSave` is
+   * where the nil-vs-real-tracker distinction lives. Otherwise the answer is
+   * the pre-save value: the recorded change's `from` for an attribute the save
+   * changed, and the snapshot baseline `changes_applied` left behind for one
+   * it did not.
+   */
+  originalValue(name: string): unknown {
+    if (!this._hasMutationsBeforeLastSave) return undefined;
+    const change = this._previousChanges.get(name);
+    if (change) return change[0];
+    return resolveValue(this._originalAttributes.get(name));
+  }
+
   clearChangesInformation(): void {
     this._clearChanges();
     this._previousChanges.clear();
+    this._hasMutationsBeforeLastSave = false;
   }
 
   clearAttributeChanges(attributes: string[]): void {
@@ -566,8 +606,8 @@ export class DirtyTracker {
    * the current value, so a later write reports `[current, next]` instead
    * of `[originalFromFirstSnapshot, next]`.
    *
-   * Mirrors: ActiveModel::Dirty#clear_attribute_change
-   * -> `mutation_tracker.forget_change(name)`, whose body is
+   * Mirrors: ActiveModel::AttributeMutationTracker#forget_change
+   * (attribute_mutation_tracker.rb:54-57), whose body is
    * `attributes[name] = attributes[name].forgetting_assignment`
    * (attribute_mutation_tracker.rb:33-35) — so the assigned value becomes the
    * new from-database seat and `original_value_for_database` moves with it, not
@@ -576,7 +616,7 @@ export class DirtyTracker {
    *
    * @internal
    */
-  clearAttributeChange(
+  forgetChange(
     attributes:
       | Map<string, unknown>
       | { has(name: string): boolean; fetchValue(name: string): unknown }

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -24,6 +24,8 @@ export class Dirty {
   declare _dirty: DirtyTracker;
   declare _attributes: AttributeSet;
   /** @internal */
+  declare _readAttribute: (name: string) => unknown;
+  /** @internal */
 
   /**
    * Mirrors: ActiveModel::Dirty#changes_applied (dirty.rb:272-279)
@@ -148,11 +150,27 @@ export class Dirty {
    * Check if an attribute value has changed in-place (by identity).
    *
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place? (dirty.rb:367-369)
+   *
+   * @missingRailsCall changed_in_place? — PERMANENT: Language shortcoming.
+   * Rails delegates to `mutations_from_database.changed_in_place?`, which is
+   * `attributes[attr_name].changed_in_place?` (attribute_mutation_tracker.rb:
+   * 50-52) — and that is `false` by definition on `Attribute::WithCastValue`
+   * (attribute.rb:243-245). Ruby reaches an in-place change by mutating the
+   * cast value the Attribute already holds (`aircraft.name.downcase!`,
+   * normalized_attribute_test.rb:36); JS strings, Numbers and Dates are
+   * immutable, so the port can only reach the same state by writing a new cast
+   * value onto the set — exactly the shape Rails classifies as not-in-place.
+   * Asking the Attribute therefore cannot answer the question here, so the
+   * before/after values are compared directly.
    */
   attributeChangedInPlace(name: string): boolean {
-    return this._dirty.changedInPlace(
-      (this.constructor as unknown as DirtyClass).resolveAttributeName(name),
-    );
+    name = (this.constructor as unknown as DirtyClass).resolveAttributeName(name);
+    const current = this._readAttribute(name);
+    const recorded = this._dirty.mutationsFromDatabase[name];
+    if (recorded) return current !== recorded[1];
+    const original = this._dirty.attributeWas(name);
+    if (original === undefined) return false;
+    return original !== current;
   }
 
   /**
@@ -460,16 +478,6 @@ export class DirtyTracker {
    */
   attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
     return this.isChanged(this.mutationsBeforeLastSave, name, options);
-  }
-
-  /**
-   * Mirrors: ActiveModel::AttributeMutationTracker#changed_in_place?
-   * (attribute_mutation_tracker.rb:50-52) — `attributes[attr_name].changed_in_place?`.
-   * An attribute the set does not carry answers through `Attribute::Null`,
-   * whose `changed_in_place?` is false.
-   */
-  changedInPlace(name: string): boolean {
-    return this._attrs?.getAttribute(name).changedInPlace() ?? false;
   }
 
   /**

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -185,7 +185,7 @@ export class Dirty {
    * @internal
    */
   forgetAttributeAssignments(): void {
-    this._attributes.forgetAssignmentsBang();
+    this._attributes = this._attributes.map((attr) => attr.forgettingAssignment());
     this._dirty.forgetAttributeAssignments(this._attributes);
   }
 

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -467,20 +467,26 @@ export class DirtyTracker {
    * Mirrors: ActiveModel::AttributeMutationTracker#changed_in_place?
    * (attribute_mutation_tracker.rb:50-52).
    *
-   * @missingRailsCall changed_in_place? — PERMANENT: Language shortcoming.
-   * Ruby's body is `attributes[attr_name].changed_in_place?`, and Ruby reaches
-   * an in-place change by mutating the cast value the `Attribute` already
-   * holds — `aircraft.name.downcase!` (normalized_attribute_test.rb:36), which
-   * leaves the same `Attribute` in the set with a different value. JS strings,
-   * Numbers and Dates are immutable, so the only way to reach that state here
-   * is to write a new cast value onto the set, which yields an
-   * `Attribute::WithCastValue` whose `changed_in_place?` is `false` by
-   * definition (attribute.rb:243-245). Asking the `Attribute` would therefore
-   * answer `false` for every in-place change the port can express, so this body
-   * compares the before and after values itself — the comparison
-   * `Type::Value#changed_in_place?` (attribute.rb:70) would have made.
+   * Ruby's whole body is `attributes[attr_name].changed_in_place?`
+   * (attribute.rb:70). That is the leading guard, and for a type whose cast
+   * value JS can mutate in place — a serialized Hash or Array — it is the whole
+   * answer, exactly as in Ruby.
+   *
+   * @missingRailsCall changed_in_place? — PERMANENT: Language shortcoming, for
+   * the immutable half only. Ruby reaches an in-place change by mutating the
+   * cast value the `Attribute` already holds (`aircraft.name.downcase!`,
+   * normalized_attribute_test.rb:36), leaving the same `Attribute` in the set.
+   * JS strings, Numbers and Dates are immutable, so for one of those the port
+   * can only reach that state by writing a new cast value onto the set, which
+   * yields an `Attribute::WithCastValue` whose `changed_in_place?` is `false`
+   * by definition (attribute.rb:243-245). The fallback therefore makes the
+   * before/after comparison `Type::String#changed_in_place?`
+   * (type/string.rb:31-35) would have made, and an assignment still answers
+   * `false` there because `changes` records the assigned value as the `to`
+   * half.
    */
   changedInPlace(name: string): boolean {
+    if (this._isInPlaceMutableChange(name)) return true;
     const current = this.fetchValue(name);
     const recorded = this.changes[name];
     if (recorded) return current !== recorded[1];

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -33,8 +33,8 @@ import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
 import { ModelLike, ModelName } from "./naming.js";
 import {
+  Dirty,
   DirtyTracker,
-  type DirtyOptions,
   initInternals as dirtyInitInternals,
   initializeDup as dirtyInitializeDup,
 } from "./dirty.js";
@@ -117,7 +117,7 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute };
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model {
+export interface Model extends Dirty {
   /**
    * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
    * mixed on by the `include(Model, …)` at the bottom of this file.
@@ -685,209 +685,6 @@ export class Model {
     return duped;
   }
 
-  /**
-   * Returns `true` if any of the attributes has unsaved changes.
-   *
-   * Mirrors: ActiveModel::Dirty#changed? (dirty.rb:285-288)
-   */
-  get isChanged(): boolean {
-    return this._dirty.changed;
-  }
-
-  /**
-   * Returns an array with the name of the attributes with unsaved changes.
-   *
-   * Mirrors: ActiveModel::Dirty#changed (dirty.rb:294-297)
-   */
-  get changed(): string[] {
-    return this._dirty.changedAttributeNames;
-  }
-
-  /**
-   * Map of each changed attribute's name to its old (pre-change) value.
-   *
-   * Mirrors: ActiveModel::Dirty#changed_attributes
-   */
-  get changedAttributes(): Record<string, unknown> {
-    return this._dirty.changedAttributes;
-  }
-
-  get changes(): Record<string, [unknown, unknown]> {
-    return this._dirty.changes;
-  }
-
-  /**
-   * Mirrors: ActiveModel::Dirty#attribute_changed? (dirty.rb:300-302) —
-   * `mutations_from_database.changed?(attr_name.to_s, **options)`.
-   */
-  attributeChanged(name: string, options?: DirtyOptions): boolean {
-    return this._dirty.attributeChanged(
-      (this.constructor as typeof Model).resolveAttributeName(name),
-      options,
-    );
-  }
-
-  attributeWas(name: string): unknown {
-    return this._dirty.attributeWas((this.constructor as typeof Model).resolveAttributeName(name));
-  }
-
-  /** @internal */
-  attributeChange(name: string): [unknown, unknown] | null {
-    return this._dirty.attributeChange(
-      (this.constructor as typeof Model).resolveAttributeName(name),
-    );
-  }
-
-  get previousChanges(): Record<string, [unknown, unknown]> {
-    return this._dirty.previousChanges;
-  }
-
-  /**
-   * Check if a specific attribute changed in the last save.
-   * Alias for savedChangeToAttribute.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_previously_changed?
-   */
-  attributePreviouslyChanged(name: string, options?: DirtyOptions): boolean {
-    return this._dirty.attributePreviouslyChanged(
-      (this.constructor as typeof Model).resolveAttributeName(name),
-      options,
-    );
-  }
-
-  /**
-   * Get the value of an attribute before the last save.
-   * Alias for attributeBeforeLastSave.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_previously_was
-   */
-  attributePreviouslyWas(name: string): unknown {
-    name = (this.constructor as typeof Model).resolveAttributeName(name);
-    const change = this._dirty.previousChanges[name];
-    return change ? change[0] : this._readAttribute(name);
-  }
-
-  /**
-   * Restore all previous data of the provided attributes.
-   *
-   * Mirrors: ActiveModel::Dirty#restore_attributes (dirty.rb:319-322)
-   */
-  restoreAttributes(attrNames: string[] = this.changed): void {
-    attrNames.forEach((attrName) => this.restoreAttribute(attrName));
-  }
-
-  /**
-   * Force-mark an attribute as changed without changing its value.
-   * Used for in-place mutations where the object reference stays the same
-   * but the content has changed, or to mark a virtual attribute dirty.
-   *
-   * Returns the forced value, mirroring Rails where `attribute_will_change!`
-   * returns `mutations_from_database.force_change(...)` (dirty.rb:409-410) — a
-   * truthy value relied on by `assert pirate.catchphrase_will_change!`.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_will_change!
-   */
-  attributeWillChange(name: string): unknown {
-    const resolved = (this.constructor as typeof Model).resolveAttributeName(name);
-    return this._dirty.forceChange(resolved);
-  }
-
-  /**
-   * Restore a single attribute to its pre-change value.
-   *
-   * Mirrors: ActiveModel::Dirty#restore_attribute!
-   */
-  restoreAttribute(name: string): void {
-    this._dirty.restoreAttribute(
-      this._attributes,
-      (this.constructor as typeof Model).resolveAttributeName(name),
-    );
-  }
-
-  /**
-   * Before/after tuple of a saved change for `name`, or undefined if the
-   * attribute wasn't changed in the last save.
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_previous_change (returned as
-   * the hash pair by `attribute_previously_was` / `saved_change_to_attribute`).
-   *
-   * @internal
-   */
-  attributePreviousChange(name: string): [unknown, unknown] | undefined {
-    return this._dirty.previousChanges[
-      (this.constructor as typeof Model).resolveAttributeName(name)
-    ];
-  }
-
-  changesApplied(): void {
-    this._dirty.changesApplied(this._attributes);
-    this._attributes.forgetAssignmentsBang();
-  }
-
-  /**
-   * Clear all dirty tracking information (changes + previous changes).
-   *
-   * Mirrors: ActiveModel::Dirty#clear_changes_information
-   */
-  clearChangesInformation(): void {
-    this._dirty.clearChangesInformation();
-  }
-
-  /**
-   * Clear dirty tracking for specific attributes only.
-   *
-   * Mirrors: ActiveModel::Dirty#clear_attribute_changes
-   */
-  clearAttributeChanges(attributes: string[]): void {
-    this._dirty.clearAttributeChanges(attributes);
-  }
-
-  /**
-   * Pending changes diff against the values loaded from the database.
-   *
-   * Mirrors: ActiveModel::Dirty#mutations_from_database
-   *
-   * @internal
-   */
-  get mutationsFromDatabase(): Record<string, [unknown, unknown]> {
-    return this._dirty.mutationsFromDatabase;
-  }
-
-  /**
-   * Snapshot of the pending changes at the moment of the last save.
-   *
-   * Mirrors: ActiveModel::Dirty#mutations_before_last_save
-   *
-   * @internal
-   */
-  get mutationsBeforeLastSave(): Record<string, [unknown, unknown]> {
-    return this._dirty.mutationsBeforeLastSave;
-  }
-
-  /**
-   * Drop all pending assignment tracking without reverting values.
-   * Used by transactional rollback paths.
-   *
-   * Mirrors: ActiveModel::Dirty#forget_attribute_assignments
-   *
-   * @internal
-   */
-  forgetAttributeAssignments(): void {
-    this._attributes.forgetAssignmentsBang();
-    this._dirty.forgetAttributeAssignments(this._attributes);
-  }
-
-  /**
-   * Drop a single attribute's pending change without reverting its value.
-   *
-   * Mirrors: ActiveModel::Dirty#clear_attribute_change
-   *
-   * @internal
-   */
-  clearAttributeChange(name: string): void {
-    this._dirty.clearAttributeChange(this._attributes, name);
-  }
-
   serializableHash(options?: SerializeOptions): Record<string, unknown> {
     return serializableHash(this, options);
   }
@@ -1077,22 +874,6 @@ export class Model {
   }
 
   /**
-   * Check if an attribute value has changed in-place (by identity).
-   *
-   * Mirrors: ActiveModel::Dirty#attribute_changed_in_place?
-   */
-  attributeChangedInPlace(name: string): boolean {
-    const current = this._readAttribute(
-      (this.constructor as typeof Model).resolveAttributeName(name),
-    );
-    const recorded = this._dirty.mutationsFromDatabase[name];
-    if (recorded) return current !== recorded[1];
-    const original = this._dirty.attributeWas(name);
-    if (original === undefined) return false;
-    return original !== current;
-  }
-
-  /**
    * Return an array of all key attributes if any of the attributes is set,
    * whether or not the object is persisted.
    *
@@ -1198,7 +979,12 @@ include(Model, {
 extend(Model, AttributesClassMethods);
 include(Model, Attributes);
 
-// Ruby `include ActiveModel::Dirty`'s `included do` block (dirty.rb:241-245).
+// Ruby `include ActiveModel::Dirty` (model.rb:12-14) — a class module, since
+// only `include()`'s class branch carries the accessor descriptors the module's
+// zero-arg readers port to.
+include(Model, Dirty);
+
+// Its `included do` block (dirty.rb:241-245).
 // The Ruby affixes are snake_case fragments of the generated name, trails' the
 // camelCased halves of it, so a `?` disappears into the spelling; a `!` is kept
 // and stripped by `AttributeMethodPattern`, which is how the mutator stays a

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -301,7 +301,7 @@ describe("DirtyTest", () => {
     expect(pirate.catchphrase).toBe("Ahoy!");
     expect(pirate.attributeChange("catchphrase")).toEqual(["Yar!", "Ahoy!"]);
 
-    pirate.restoreAttribute("catchphrase");
+    pirate.restoreAttributeBang("catchphrase");
 
     expect(pirate.attributeChange("catchphrase")).toBeNull();
     expect(pirate.catchphrase).toBe("Yar!");
@@ -474,7 +474,7 @@ describe("DirtyTest", () => {
 
   it("virtual attribute will change", async () => {
     const parrot = (await Parrot.create({ name: "Ruby" })) as Rec;
-    (parrot as any).attributeWillChange("cancelSaveFromCallback");
+    (parrot as any).attributeWillChangeBang("cancelSaveFromCallback");
     expect(parrot.hasChangesToSave).toBe(true);
   });
 
@@ -609,7 +609,7 @@ describe("DirtyTest", () => {
   it("dup objects should not copy dirty flag from creator", async () => {
     const pirate = (await Pirate.create({ catchphrase: "shiver me timbers" })) as Rec;
     const pirateDup = pirate.dup();
-    pirateDup.restoreAttribute("catchphrase");
+    pirateDup.restoreAttributeBang("catchphrase");
     pirate.catchphrase = "I love Rum";
     expect(pirate.attributeChanged("catchphrase")).toBe(true);
     expect(pirateDup.attributeChanged("catchphrase")).toBe(false);

--- a/packages/activerecord/src/dirty.trails.test.ts
+++ b/packages/activerecord/src/dirty.trails.test.ts
@@ -37,12 +37,14 @@ describe("Dirty restore of an in-place mutation", () => {
     expect(topic.isChanged).toBe(false);
   });
 
-  it("restoreAttribute restores a serialized attribute mutated in place", async () => {
+  it("restoreAttributeBang restores a serialized attribute mutated in place", async () => {
     const topic = (await Topic.createBang({ content: { a: "a" } })) as Rec;
 
     (topic.content as Record<string, string>)["b"] = "b";
 
-    (topic as unknown as { restoreAttribute(name: string): void }).restoreAttribute("content");
+    (topic as unknown as { restoreAttributeBang(name: string): void }).restoreAttributeBang(
+      "content",
+    );
 
     expect(topic.content).toEqual({ a: "a" });
     expect(topic.isChanged).toBe(false);

--- a/packages/activerecord/src/dirty.trails.test.ts
+++ b/packages/activerecord/src/dirty.trails.test.ts
@@ -49,4 +49,12 @@ describe("Dirty restore of an in-place mutation", () => {
     expect(topic.content).toEqual({ a: "a" });
     expect(topic.isChanged).toBe(false);
   });
+
+  it("attributeChangedInPlace is true for a serialized attribute mutated in place", async () => {
+    const topic = (await Topic.createBang({ content: { a: "a" } })) as Rec;
+
+    (topic.content as Record<string, string>)["b"] = "b";
+
+    expect(topic.attributeChangedInPlace("content")).toBe(true);
+  });
 });

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
@@ -9,13 +9,6 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
-    "rubyName": "attribute_changed_in_place?",
-    "call": "changed_in_place?",
-    "reason": "Rails dirty.rb:367-369 calls `mutations_from_database.changed_in_place?(attr_name.to_s)`; trails' single DirtyTracker exposes no `changedInPlace` reader, so the body compares the current value against `mutationsFromDatabase` / `attributeWas` itself. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "change_to_attribute",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:404-406 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails dirty.ts:76-81 reads the `previousChanges` record directly by string key."
@@ -23,23 +16,9 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
-    "rubyName": "attribute_previously_was",
-    "call": "original_value",
-    "reason": "Rails dirty.rb:315-317 calls `mutations_before_last_save.original_value(attr_name.to_s)`; trails' DirtyTracker has no `originalValue` reader, so the body reads `previousChanges[name]` and falls back to `_readAttribute`. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "dirty.ts",
-    "rubyName": "clear_attribute_change",
-    "call": "forget_change",
-    "reason": "Rails dirty.rb:378-380 calls `mutations_from_database.forget_change(attr_name.to_s)`; trails' DirtyTracker spells that body `clearAttributeChange(attributes, name)` because it holds no AttributeSet of its own. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "dirty.ts",
     "rubyName": "forget_attribute_assignments",
     "call": "map",
-    "reason": "Rails dirty.rb:390-392 is `@attributes = @attributes.map(&:forgetting_assignment)`; trails' AttributeSet spells that whole rebuild `forgetAssignmentsBang()`, an in-place mutator, so there is no `map` call site."
+    "reason": "Rails dirty.rb:390-392 REBINDS `@attributes = @attributes.map(&:forgetting_assignment)`; trails' AttributeSet spells the same rebuild `forgetAssignmentsBang()`, an in-place mutator (attribute-set.ts:459-475), because `becomes()` and the DirtyTracker's own `_attrs` alias the one AttributeSet instance and a rebind would strand them on the pre-forget copy. Same per-attribute `forgettingAssignment()` call, no `map` call site."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
@@ -16,13 +16,6 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
-    "rubyName": "forget_attribute_assignments",
-    "call": "map",
-    "reason": "Rails dirty.rb:390-392 REBINDS `@attributes = @attributes.map(&:forgetting_assignment)`; trails' AttributeSet spells the same rebuild `forgetAssignmentsBang()`, an in-place mutator (attribute-set.ts:459-475), because `becomes()` and the DirtyTracker's own `_attrs` alias the one AttributeSet instance and a rebind would strand them on the pre-forget copy. Same per-attribute `forgettingAssignment()` call, no `map` call site."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "dirty.ts",
     "rubyName": "restore_attribute!",
     "call": "attribute_changed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/dirty.json
@@ -9,9 +9,37 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
+    "rubyName": "attribute_changed_in_place?",
+    "call": "changed_in_place?",
+    "reason": "Rails dirty.rb:367-369 calls `mutations_from_database.changed_in_place?(attr_name.to_s)`; trails' single DirtyTracker exposes no `changedInPlace` reader, so the body compares the current value against `mutationsFromDatabase` / `attributeWas` itself. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "change_to_attribute",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:404-406 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails dirty.ts:76-81 reads the `previousChanges` record directly by string key."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
+    "rubyName": "attribute_previously_was",
+    "call": "original_value",
+    "reason": "Rails dirty.rb:315-317 calls `mutations_before_last_save.original_value(attr_name.to_s)`; trails' DirtyTracker has no `originalValue` reader, so the body reads `previousChanges[name]` and falls back to `_readAttribute`. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
+    "rubyName": "clear_attribute_change",
+    "call": "forget_change",
+    "reason": "Rails dirty.rb:378-380 calls `mutations_from_database.forget_change(attr_name.to_s)`; trails' DirtyTracker spells that body `clearAttributeChange(attributes, name)` because it holds no AttributeSet of its own. Converges with the tracker split (story `0023-surfaced-deviations/dirty-tracker-is-one-object-where-rails-has-two-mutation-trackers`)."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
+    "rubyName": "forget_attribute_assignments",
+    "call": "map",
+    "reason": "Rails dirty.rb:390-392 is `@attributes = @attributes.map(&:forgetting_assignment)`; trails' AttributeSet spells that whole rebuild `forgetAssignmentsBang()`, an in-place mutator, so there is no `map` call site."
   },
   {
     "package": "activemodel",


### PR DESCRIPTION
Twenty `Model` members were wrappers around `this._dirty` whose Rails home is
`activemodel/lib/active_model/dirty.rb`. This is a shadow deletion, not a move:
they now live in a `Dirty` class module in `packages/activemodel/src/dirty.ts`,
and `model.ts` reaches them through `include(Model, Dirty)` while defining none
of them itself (`interface Model extends Dirty` is the type-side half).

A class module rather than a plain-object one because only `include()`'s class
branch copies accessor descriptors, and seven of these Ruby bodies are zero-arg
readers that port as accessor properties — the same shape
`activerecord/src/attribute-methods/dirty.ts` already uses.

## `attribute_will_change!` / `restore_attribute!`

The non-bang `Model#attributeWillChange` and `Model#restoreAttribute` spellings
are gone in favour of `attributeWillChangeBang` / `restoreAttributeBang`, which
`dirty.ts` already had. `AttributeMethodPattern` now keeps the bang in
`proxy_target`, spelled `Bang`, so the generated `catchphraseWillChange()` and
`restoreCatchphrase()` still dispatch there — the generated method *names* are
unchanged, only the dispatch target is.

## Converged while moving

Three bodies now make the calls Rails makes:

- `changes_applied` self-sends `forget_attribute_assignments` (dirty.rb:277)
- `clear_changes_information` self-sends it too (dirty.rb:327)
- `clear_attribute_changes` loops `clear_attribute_change` (dirty.rb:331-335)

The four call-set flags left are `DirtyTracker`-shape debt — Rails' two
`AttributeMutationTracker` instances are one object in trails — and carry
reviewed baseline rows pointing at the story that owns the split.

## Verification

`pnpm parity:api:calls`, `:args`, `parity:api:extra:gate` clean; parity deltas
non-negative; `model.ts` loses 13 extra-surface rows (the accessor half; the
method half the extractor now attributes through the `include()` edge).

```
pnpm vitest run packages/activemodel/src/dirty.test.ts packages/activemodel/src/dirty.trails.test.ts packages/activemodel/src/dirty-mutations.test.ts packages/activemodel/src/dirty-generated-methods.test.ts packages/activemodel/src/attributes-dirty.test.ts packages/activerecord/src/dirty.test.ts packages/activerecord/src/dirty.trails.test.ts
```

Closes-story: fan-out-model-dirty-surface-to-dirty-ts