### PR TITLE
test(activemodel): move the TS-only extras out of the mirrored type test files

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { Temporal, strftime } from "@blazetrails/date";
-import { instant, plainDateTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { TimeZone, setZoneDefault, toS } from "@blazetrails/activesupport";
 import { Types } from "../index.js";
 
@@ -17,71 +16,6 @@ describe("DateTimeTest", () => {
 
     const datetimeString = strftime(Temporal.Now.instant(), "%FT%T");
     expect(strftime(type.cast(datetimeString) as Temporal.Instant, "%FT%T")).toBe(datetimeString);
-  });
-
-  it("string with offset produces Instant", () => {
-    const result = type.cast("2024-01-15T10:30:00+05:00");
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    expect((result as Temporal.Instant).epochMilliseconds).toBe(
-      Temporal.Instant.from("2024-01-15T05:30:00Z").epochMilliseconds,
-    );
-  });
-
-  it("string without offset produces Instant (treated as UTC)", () => {
-    const result = type.cast("2024-01-15T10:30:00") as Temporal.Instant;
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    const zdt = result.toZonedDateTimeISO("UTC");
-    expect(zdt.hour).toBe(10);
-    expect(zdt.minute).toBe(30);
-  });
-
-  it("Postgres wire format (space separator, short offset) produces Instant", () => {
-    const result = type.cast("2026-04-26 14:23:55.123456+00");
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    const i = result as Temporal.Instant;
-    expect(i.toString({ smallestUnit: "microsecond" })).toBe("2026-04-26T14:23:55.123456Z");
-  });
-
-  it("Postgres naive wire format produces Instant (treated as UTC)", () => {
-    const result = type.cast("2026-04-26 14:23:55.123456") as Temporal.Instant;
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    expect(result.toZonedDateTimeISO("UTC").microsecond).toBe(456);
-  });
-
-  it("microsecond precision is preserved through cast", () => {
-    const result = type.cast("2026-04-26T14:23:55.123456Z");
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
-    expect(zdt.millisecond).toBe(123);
-    expect(zdt.microsecond).toBe(456);
-  });
-
-  it("Temporal.Instant passthrough", () => {
-    const original = instant("2026-04-26T14:23:55.123456Z");
-    expect(type.cast(original)).toBe(original);
-  });
-
-  it("Temporal.PlainDateTime is converted to Instant (treated as UTC)", () => {
-    const pdt = plainDateTime("2026-04-26T14:23:55.123456");
-    const result = type.cast(pdt) as Temporal.Instant;
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    expect(result.toZonedDateTimeISO("UTC").microsecond).toBe(456);
-  });
-
-  it("has name 'datetime'", () => {
-    expect(type.name).toBe("datetime");
-  });
-
-  it("casts null to null", () => {
-    expect(type.cast(null)).toBe(null);
-  });
-
-  it("casts undefined to null", () => {
-    expect(type.cast(undefined)).toBe(null);
-  });
-
-  it("casts empty string to null", () => {
-    expect(type.cast("")).toBe(null);
   });
 
   it("string to time with timezone", () => {
@@ -123,130 +57,10 @@ describe("DateTimeTest", () => {
     );
   });
 
-  it("serialize returns the cast Instant (not a SQL string)", () => {
-    const i = instant("2026-04-26T14:23:55.123456Z");
-    expect((type.serialize(i) as Temporal.Instant).toString()).toBe("2026-04-26T14:23:55.123456Z");
-  });
-
-  it("serialize returns the cast Instant for PlainDateTime (cast to Instant first)", () => {
-    const pdt = plainDateTime("2026-04-26T14:23:55.123456");
-    expect((type.serialize(pdt) as Temporal.Instant).toString()).toBe(
-      "2026-04-26T14:23:55.123456Z",
-    );
-  });
-
-  it("serialize null returns null", () => {
-    expect(type.serialize(null)).toBe(null);
-  });
-
-  it("serialize respects column precision", () => {
-    const t = new Types.DateTimeType({ precision: 3 });
-    const i = instant("2026-04-26T14:23:55.123456Z");
-    expect((t.serialize(i) as Temporal.Instant).toString()).toBe("2026-04-26T14:23:55.123Z");
-  });
-
-  it("PlainDateTime input is converted to Instant (multiparameter support)", () => {
-    const pdt = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
-    const result = type.cast(pdt);
-    expect(result).toBeInstanceOf(Temporal.Instant);
-  });
-
-  it("valueFromMultiparameterAssignment reconstructs an Instant from {1..6}", () => {
-    class Probe extends Types.DateTimeType {
-      call(values: Record<number, unknown>) {
-        return this.valueFromMultiparameterAssignment(values);
-      }
-    }
-    const result = new Probe().call({ 1: 2024, 2: 1, 3: 2, 4: 12, 5: 30, 6: 0 });
-    expect(result).toBeInstanceOf(Temporal.Instant);
-  });
-
-  it("valueFromMultiparameterAssignment throws when keys 1/2/3 missing", () => {
-    class Probe extends Types.DateTimeType {
-      call(values: Record<number, unknown>) {
-        return this.valueFromMultiparameterAssignment(values);
-      }
-    }
-    expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(
-      expect.objectContaining({ name: "ArgumentError" }),
-    );
-  });
-
-  it("cast accepts numeric-keyed multiparameter hash and returns Temporal.Instant", () => {
-    const type = new Types.DateTimeType();
-    const result = type.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 30 });
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
-    expect(zdt.year).toBe(2024);
-    expect(zdt.month).toBe(6);
-    expect(zdt.day).toBe(15);
-    expect(zdt.hour).toBe(10);
-    expect(zdt.minute).toBe(30);
-  });
-
-  it("valueFromMultiparameterAssignment defaults hour/minute to 0 when only date parts given (P21)", () => {
-    class Probe extends Types.DateTimeType {
-      call(values: Record<number, unknown>) {
-        return this.valueFromMultiparameterAssignment(values);
-      }
-    }
-    const result = new Probe().call({ 1: 2025, 2: 7, 3: 4 }) as Temporal.Instant;
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    const zdt = result.toZonedDateTimeISO("UTC");
-    expect(zdt.year).toBe(2025);
-    expect(zdt.month).toBe(7);
-    expect(zdt.day).toBe(4);
-    expect(zdt.hour).toBe(0);
-    expect(zdt.minute).toBe(0);
-  });
   it("serialize_cast_value is equivalent to serialize after cast", () => {
     const type = new Types.DateTimeType({ precision: 1 });
     const value = type.cast("1999-12-31 12:34:56.789 -1000");
 
     expect(type.serialize(value)).toEqual(type.serializeCastValue(value));
-  });
-});
-
-describe("DateTimeType#isChanged", () => {
-  const MS1 = 1_000_000n;
-
-  it("two identical Temporal.Instant references are unchanged", () => {
-    const t = new Types.DateTimeType();
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    expect(t.isChanged(a, a)).toBe(false);
-  });
-
-  it("two distinct Temporal.Instant objects with same epoch are unchanged (precision=null)", () => {
-    const t = new Types.DateTimeType();
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1);
-    expect(t.isChanged(a, b)).toBe(false);
-  });
-
-  it("instants differing by one full microsecond are changed (precision=null)", () => {
-    const t = new Types.DateTimeType();
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1000n);
-    expect(t.isChanged(a, b)).toBe(true);
-  });
-
-  it("instants differing by one full millisecond are changed (precision=3)", () => {
-    const t = new Types.DateTimeType({ precision: 3 });
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n);
-    expect(t.isChanged(a, b)).toBe(true);
-  });
-
-  it("instants differing by one full nanosecond are changed (precision=9)", () => {
-    const t = new Types.DateTimeType({ precision: 9 });
-    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
-    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1n);
-    expect(t.isChanged(a, b)).toBe(true);
-  });
-
-  it("non-Instant values fall back to reference equality", () => {
-    const t = new Types.DateTimeType();
-    expect(t.isChanged(null, null)).toBe(false);
-    expect(t.isChanged(null, "2024-01-01")).toBe(true);
   });
 });

--- a/packages/activemodel/src/type/date-time.trails.test.ts
+++ b/packages/activemodel/src/type/date-time.trails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { instant, plainDateTime } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types, ValueType } from "../index.js";
 
 // Fallback-parser coverage for shapes `Date._parse` accepts that no Rails test
@@ -191,5 +192,197 @@ describe("DateTimeType type_cast_for_schema", () => {
   it("quotes the to_fs(:db) form", () => {
     const type = new Types.DateTimeType();
     expect(type.typeCastForSchema(type.cast("2000-01-01T12:34:56Z"))).toBe('"2000-01-01 12:34:56"');
+  });
+});
+
+// TS-only coverage moved out of the mirrored `type/date-time.test.ts` so every
+// `it(...)` there is a Rails test name `parity:test` matches on.
+describe("DateTimeType cast and serialize coverage", () => {
+  const type = new Types.DateTimeType();
+
+  it("string with offset produces Instant", () => {
+    const result = type.cast("2024-01-15T10:30:00+05:00");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect((result as Temporal.Instant).epochMilliseconds).toBe(
+      Temporal.Instant.from("2024-01-15T05:30:00Z").epochMilliseconds,
+    );
+  });
+
+  it("string without offset produces Instant (treated as UTC)", () => {
+    const result = type.cast("2024-01-15T10:30:00") as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.hour).toBe(10);
+    expect(zdt.minute).toBe(30);
+  });
+
+  it("Postgres wire format (space separator, short offset) produces Instant", () => {
+    const result = type.cast("2026-04-26 14:23:55.123456+00");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const i = result as Temporal.Instant;
+    expect(i.toString({ smallestUnit: "microsecond" })).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("Postgres naive wire format produces Instant (treated as UTC)", () => {
+    const result = type.cast("2026-04-26 14:23:55.123456") as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect(result.toZonedDateTimeISO("UTC").microsecond).toBe(456);
+  });
+
+  it("microsecond precision is preserved through cast", () => {
+    const result = type.cast("2026-04-26T14:23:55.123456Z");
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
+    expect(zdt.millisecond).toBe(123);
+    expect(zdt.microsecond).toBe(456);
+  });
+
+  it("Temporal.Instant passthrough", () => {
+    const original = instant("2026-04-26T14:23:55.123456Z");
+    expect(type.cast(original)).toBe(original);
+  });
+
+  it("Temporal.PlainDateTime is converted to Instant (treated as UTC)", () => {
+    const pdt = plainDateTime("2026-04-26T14:23:55.123456");
+    const result = type.cast(pdt) as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    expect(result.toZonedDateTimeISO("UTC").microsecond).toBe(456);
+  });
+
+  it("has name 'datetime'", () => {
+    expect(type.name).toBe("datetime");
+  });
+
+  it("casts null to null", () => {
+    expect(type.cast(null)).toBe(null);
+  });
+
+  it("casts undefined to null", () => {
+    expect(type.cast(undefined)).toBe(null);
+  });
+
+  it("casts empty string to null", () => {
+    expect(type.cast("")).toBe(null);
+  });
+
+  it("serialize returns the cast Instant (not a SQL string)", () => {
+    const i = instant("2026-04-26T14:23:55.123456Z");
+    expect((type.serialize(i) as Temporal.Instant).toString()).toBe("2026-04-26T14:23:55.123456Z");
+  });
+
+  it("serialize returns the cast Instant for PlainDateTime (cast to Instant first)", () => {
+    const pdt = plainDateTime("2026-04-26T14:23:55.123456");
+    expect((type.serialize(pdt) as Temporal.Instant).toString()).toBe(
+      "2026-04-26T14:23:55.123456Z",
+    );
+  });
+
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
+  });
+
+  it("serialize respects column precision", () => {
+    const t = new Types.DateTimeType({ precision: 3 });
+    const i = instant("2026-04-26T14:23:55.123456Z");
+    expect((t.serialize(i) as Temporal.Instant).toString()).toBe("2026-04-26T14:23:55.123Z");
+  });
+
+  it("PlainDateTime input is converted to Instant (multiparameter support)", () => {
+    const pdt = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
+    const result = type.cast(pdt);
+    expect(result).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("valueFromMultiparameterAssignment reconstructs an Instant from {1..6}", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return this.valueFromMultiparameterAssignment(values);
+      }
+    }
+    const result = new Probe().call({ 1: 2024, 2: 1, 3: 2, 4: 12, 5: 30, 6: 0 });
+    expect(result).toBeInstanceOf(Temporal.Instant);
+  });
+
+  it("valueFromMultiparameterAssignment throws when keys 1/2/3 missing", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return this.valueFromMultiparameterAssignment(values);
+      }
+    }
+    expect(() => new Probe().call({ 1: 2024, 4: 12 })).toThrow(
+      expect.objectContaining({ name: "ArgumentError" }),
+    );
+  });
+
+  it("cast accepts numeric-keyed multiparameter hash and returns Temporal.Instant", () => {
+    const type = new Types.DateTimeType();
+    const result = type.cast({ 1: 2024, 2: 6, 3: 15, 4: 10, 5: 30 });
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = (result as Temporal.Instant).toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(2024);
+    expect(zdt.month).toBe(6);
+    expect(zdt.day).toBe(15);
+    expect(zdt.hour).toBe(10);
+    expect(zdt.minute).toBe(30);
+  });
+
+  it("valueFromMultiparameterAssignment defaults hour/minute to 0 when only date parts given (P21)", () => {
+    class Probe extends Types.DateTimeType {
+      call(values: Record<number, unknown>) {
+        return this.valueFromMultiparameterAssignment(values);
+      }
+    }
+    const result = new Probe().call({ 1: 2025, 2: 7, 3: 4 }) as Temporal.Instant;
+    expect(result).toBeInstanceOf(Temporal.Instant);
+    const zdt = result.toZonedDateTimeISO("UTC");
+    expect(zdt.year).toBe(2025);
+    expect(zdt.month).toBe(7);
+    expect(zdt.day).toBe(4);
+    expect(zdt.hour).toBe(0);
+    expect(zdt.minute).toBe(0);
+  });
+});
+
+describe("DateTimeType#isChanged", () => {
+  const MS1 = 1_000_000n;
+
+  it("two identical Temporal.Instant references are unchanged", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    expect(t.isChanged(a, a)).toBe(false);
+  });
+
+  it("two distinct Temporal.Instant objects with same epoch are unchanged (precision=null)", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1);
+    expect(t.isChanged(a, b)).toBe(false);
+  });
+
+  it("instants differing by one full microsecond are changed (precision=null)", () => {
+    const t = new Types.DateTimeType();
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1000n);
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("instants differing by one full millisecond are changed (precision=3)", () => {
+    const t = new Types.DateTimeType({ precision: 3 });
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1_000_000n);
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("instants differing by one full nanosecond are changed (precision=9)", () => {
+    const t = new Types.DateTimeType({ precision: 9 });
+    const a = Temporal.Instant.fromEpochNanoseconds(MS1);
+    const b = Temporal.Instant.fromEpochNanoseconds(MS1 + 1n);
+    expect(t.isChanged(a, b)).toBe(true);
+  });
+
+  it("non-Instant values fall back to reference equality", () => {
+    const t = new Types.DateTimeType();
+    expect(t.isChanged(null, null)).toBe(false);
+    expect(t.isChanged(null, "2024-01-01")).toBe(true);
   });
 });

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -62,94 +62,10 @@ describe("TimeTest", () => {
     });
   });
 
-  it("extracts time from full datetime string", () => {
-    expect(type.cast("2015-02-09T19:45:54+00:00")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
-  });
-
-  it("microsecond precision is preserved through cast", () => {
-    const result = type.cast("14:23:55.123456") as Temporal.Instant;
-    expect(result.toString()).toBe("2000-01-01T14:23:55.123456Z");
-  });
-
-  it("Temporal.Instant passthrough", () => {
-    const original = timeUtc(2000, 1, 1, 14, 23, 55);
-    expect(type.cast(original)).toBe(original);
-  });
-
-  it("has name 'time'", () => {
-    expect(type.name).toBe("time");
-  });
-
-  it("casts undefined to null", () => {
-    expect(type.cast(undefined)).toBe(null);
-  });
-
-  it("serialize returns the cast Instant (not a SQL string)", () => {
-    const t = type.cast("14:23:55.123456") as Temporal.Instant;
-    expect(String(type.serialize(t))).toBe("2000-01-01T14:23:55.123456Z");
-  });
-
-  it("serialize null returns null", () => {
-    expect(type.serialize(null)).toBe(null);
-  });
-
-  it("serialize respects column precision", () => {
-    const t = new Types.TimeType({ precision: 3 });
-    expect(String(t.serialize("14:23:55.123456"))).toBe("2000-01-01T14:23:55.123Z");
-  });
-
-  it("PlainDateTime input extracts time (multiparameter support)", () => {
-    const pdt = Temporal.PlainDateTime.from("2024-06-15T14:23:55");
-    expect(type.cast(pdt)).toEqual(timeUtc(2024, 6, 15, 14, 23, 55));
-  });
-
-  it("cast 3pm returns 15:00", () => {
-    expect(type.cast("3pm")).toEqual(timeUtc(2000, 1, 1, 15, 0, 0));
-  });
-
-  it("cast 3:30 PM returns 15:30", () => {
-    expect(type.cast("3:30 PM")).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
-  });
-
-  it("cast 15:30 returns 15:30", () => {
-    expect(type.cast("15:30")).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
-  });
-
-  it("cast garbage string returns null", () => {
-    expect(type.cast("garbage")).toBe(null);
-  });
-
-  it("cast ISO time string still works (regression guard)", () => {
-    expect(type.cast("19:45:54")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
-  });
-
-  it("cast datetime with non-zero offset shifts the instant", () => {
-    expect(type.cast("2015-02-09T19:45:54+02:00")).toEqual(timeUtc(2000, 1, 1, 17, 45, 54));
-  });
-
-  it("valueFromMultiparameterAssignment: hour-only hash returns Time on 2000-01-01 base (P21)", () => {
-    expect(type.cast({ "4": 15 })).toEqual(timeUtc(2000, 1, 1, 15, 0, 0));
-  });
-
-  it("valueFromMultiparameterAssignment: hour and minute hash returns Time", () => {
-    expect(type.cast({ "4": 15, "5": 30 })).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
-  });
-
-  it("valueFromMultiparameterAssignment: full hash with year/month/day/hour still works", () => {
-    expect(type.cast({ "1": 2025, "2": 6, "3": 15, "4": 10, "5": 20 })).toEqual(
-      timeUtc(2025, 6, 15, 10, 20, 0),
-    );
-  });
-
   it("serialize_cast_value is equivalent to serialize after cast", () => {
     const type = new Types.TimeType({ precision: 1 });
     const value = type.cast("1999-12-31T12:34:56.789-10:00");
 
     expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
-  });
-
-  it("sec_fraction reaches new_time as Time.utc's microsecond argument", () => {
-    const result = type.cast("3:30:15.5 PM") as Temporal.Instant;
-    expect(result.toString()).toBe("2000-01-01T15:30:15.0000005Z");
   });
 });

--- a/packages/activemodel/src/type/time.trails.test.ts
+++ b/packages/activemodel/src/type/time.trails.test.ts
@@ -3,6 +3,20 @@ import { Temporal } from "@blazetrails/date";
 import { TimeWithZone, useZone } from "@blazetrails/activesupport";
 import { Types, ValueType } from "../index.js";
 
+/** `::Time.utc(...)`, the value Rails' own assertions are written against. */
+function timeUtc(
+  year: number,
+  mon: number,
+  mday: number,
+  hour = 0,
+  min = 0,
+  sec = 0,
+): Temporal.Instant {
+  return new Temporal.PlainDateTime(year, mon, mday, hour, min, sec)
+    .toZonedDateTime("UTC")
+    .toInstant();
+}
+
 describe("TimeTypeTrails", () => {
   it("serialize_cast_value applies the declared precision", () => {
     const type = new Types.TimeType({ precision: 1 });
@@ -115,5 +129,95 @@ describe("TimeType userInputInTimeZone", () => {
   it("user input in time zone passthrough for ZonedDateTime", () => {
     const zdt = Temporal.ZonedDateTime.from("2024-01-15T14:30:00[America/New_York]");
     expect(type.userInputInTimeZone(zdt)).toBe(zdt);
+  });
+});
+
+// TS-only coverage moved out of the mirrored `type/time.test.ts` so every
+// `it(...)` there is a Rails test name `parity:test` matches on.
+describe("TimeType cast and serialize coverage", () => {
+  const type = new Types.TimeType();
+
+  it("extracts time from full datetime string", () => {
+    expect(type.cast("2015-02-09T19:45:54+00:00")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
+  });
+
+  it("microsecond precision is preserved through cast", () => {
+    const result = type.cast("14:23:55.123456") as Temporal.Instant;
+    expect(result.toString()).toBe("2000-01-01T14:23:55.123456Z");
+  });
+
+  it("Temporal.Instant passthrough", () => {
+    const original = timeUtc(2000, 1, 1, 14, 23, 55);
+    expect(type.cast(original)).toBe(original);
+  });
+
+  it("has name 'time'", () => {
+    expect(type.name).toBe("time");
+  });
+
+  it("casts undefined to null", () => {
+    expect(type.cast(undefined)).toBe(null);
+  });
+
+  it("serialize returns the cast Instant (not a SQL string)", () => {
+    const t = type.cast("14:23:55.123456") as Temporal.Instant;
+    expect(String(type.serialize(t))).toBe("2000-01-01T14:23:55.123456Z");
+  });
+
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
+  });
+
+  it("serialize respects column precision", () => {
+    const t = new Types.TimeType({ precision: 3 });
+    expect(String(t.serialize("14:23:55.123456"))).toBe("2000-01-01T14:23:55.123Z");
+  });
+
+  it("PlainDateTime input extracts time (multiparameter support)", () => {
+    const pdt = Temporal.PlainDateTime.from("2024-06-15T14:23:55");
+    expect(type.cast(pdt)).toEqual(timeUtc(2024, 6, 15, 14, 23, 55));
+  });
+
+  it("cast 3pm returns 15:00", () => {
+    expect(type.cast("3pm")).toEqual(timeUtc(2000, 1, 1, 15, 0, 0));
+  });
+
+  it("cast 3:30 PM returns 15:30", () => {
+    expect(type.cast("3:30 PM")).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
+  });
+
+  it("cast 15:30 returns 15:30", () => {
+    expect(type.cast("15:30")).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
+  });
+
+  it("cast garbage string returns null", () => {
+    expect(type.cast("garbage")).toBe(null);
+  });
+
+  it("cast ISO time string still works (regression guard)", () => {
+    expect(type.cast("19:45:54")).toEqual(timeUtc(2000, 1, 1, 19, 45, 54));
+  });
+
+  it("cast datetime with non-zero offset shifts the instant", () => {
+    expect(type.cast("2015-02-09T19:45:54+02:00")).toEqual(timeUtc(2000, 1, 1, 17, 45, 54));
+  });
+
+  it("valueFromMultiparameterAssignment: hour-only hash returns Time on 2000-01-01 base (P21)", () => {
+    expect(type.cast({ "4": 15 })).toEqual(timeUtc(2000, 1, 1, 15, 0, 0));
+  });
+
+  it("valueFromMultiparameterAssignment: hour and minute hash returns Time", () => {
+    expect(type.cast({ "4": 15, "5": 30 })).toEqual(timeUtc(2000, 1, 1, 15, 30, 0));
+  });
+
+  it("valueFromMultiparameterAssignment: full hash with year/month/day/hour still works", () => {
+    expect(type.cast({ "1": 2025, "2": 6, "3": 15, "4": 10, "5": 20 })).toEqual(
+      timeUtc(2025, 6, 15, 10, 20, 0),
+    );
+  });
+
+  it("sec_fraction reaches new_time as Time.utc's microsecond argument", () => {
+    const result = type.cast("3:30:15.5 PM") as Temporal.Instant;
+    expect(result.toString()).toBe("2000-01-01T15:30:15.0000005Z");
   });
 });


### PR DESCRIPTION
Moves the 45 TS-only tests out of activemodel's two mirrored type test files
into their existing `.trails.test.ts` siblings, so every `it(...)` left in
`type/time.test.ts` and `type/date-time.test.ts` is a Rails test name that
`parity:test` matches on.

This is the follow-up to #6988, which moved four renamed splits of
`test_user_input_in_time_zone` out of `type/time.test.ts` after they hid a real
`Type::Time#user_input_in_time_zone` divergence. Same class of risk, the rest of
the file.

## What moved

- `type/time.test.ts` → `type/time.trails.test.ts`: 19 tests, under a new
  `describe("TimeType cast and serialize coverage")`.
- `type/date-time.test.ts` → `type/date-time.trails.test.ts`: 26 tests — 20
  under a new `describe("DateTimeType cast and serialize coverage")`, plus the
  whole `describe("DateTimeType#isChanged")` block, which has no Rails
  counterpart at all.

No test is renamed, reworded, or deleted; only the enclosing `describe` differs,
as in #6988. The `timeUtc` helper is duplicated into `time.trails.test.ts`
rather than moved out from under the Rails tests. Import lines follow their
users (`temporal-helpers` moves to the trails file; `strftime`/`TimeZone`/
`setZoneDefault`/`toS` stay).

## parity:test (activemodel)

| Ruby file | before OK/Extra | after OK/Extra |
| --- | --- | --- |
| `type/time_test.rb` | 3 / 19 | 3 / **0** |
| `type/date_time_test.rb` | 5 / 26 | 5 / **0** |

Package total unchanged by this PR; package extras 510 → 465. Assertion
count/kind/value mismatch counts unchanged (304 / 446 / 59).

On the branch point this PR was first opened from, the package read 962/963;
after the rebase onto current `main` (a sibling cleared the last skip) it reads
**963/963 (100%)** both before and after this diff.

All four files green (`time.test.ts` 3, `time.trails.test.ts` 30,
`date-time.test.ts` 5, `date-time.trails.test.ts` 52).

Closes-story: move-ts-only-extras-out-of-mirrored-activemodel-type-test-files
