### PR TITLE
fix(scripts): map Minitest spec forms, must_be_like and assert_edge in assertion-kinds

### DIFF
--- a/scripts/test-compare/assertion-kinds.test.ts
+++ b/scripts/test-compare/assertion-kinds.test.ts
@@ -30,11 +30,13 @@ describe("normalizeRailsKind", () => {
     expect(normalizeRailsKind("must_be_instance_of")).toBe("instanceOf");
     expect(normalizeRailsKind("must_be_nil")).toBe("nil");
     expect(normalizeRailsKind("must_be_empty")).toBe("empty");
+    expect(normalizeRailsKind("wont_be_empty")).toBe("notEmpty");
     expect(normalizeRailsKind("must_be_same_as")).toBe("same");
     expect(normalizeRailsKind("wont_be_same_as")).toBe("notSame");
     expect(normalizeRailsKind("wont_be_nil")).toBe("notNil");
     expect(normalizeRailsKind("must_be")).toBe("operator");
     expect(normalizeRailsKind("must_be_within_delta")).toBe("inDelta");
+    expect(normalizeRailsKind("must_be_close_to")).toBe("inDelta");
   });
 
   it("maps the arel-local must_be_like and assert_edge helpers", () => {

--- a/scripts/test-compare/assertion-kinds.test.ts
+++ b/scripts/test-compare/assertion-kinds.test.ts
@@ -26,7 +26,6 @@ describe("normalizeRailsKind", () => {
   });
 
   it("maps the must_be_* spec family, which the prefix rewrite alone cannot reach", () => {
-    // `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`.
     expect(normalizeRailsKind("must_be_kind_of")).toBe("instanceOf");
     expect(normalizeRailsKind("must_be_instance_of")).toBe("instanceOf");
     expect(normalizeRailsKind("must_be_nil")).toBe("nil");
@@ -34,12 +33,12 @@ describe("normalizeRailsKind", () => {
     expect(normalizeRailsKind("must_be_same_as")).toBe("same");
     expect(normalizeRailsKind("wont_be_same_as")).toBe("notSame");
     expect(normalizeRailsKind("wont_be_nil")).toBe("notNil");
+    expect(normalizeRailsKind("must_be")).toBe("operator");
+    expect(normalizeRailsKind("must_be_within_delta")).toBe("inDelta");
   });
 
   it("maps the arel-local must_be_like and assert_edge helpers", () => {
-    // helper.rb:10-13 squeezes whitespace then delegates to must_equal.
     expect(normalizeRailsKind("must_be_like")).toBe("equal");
-    // visitors/dot_test.rb:13-15 wraps assert_match over a label regex.
     expect(normalizeRailsKind("assert_edge")).toBe("match");
   });
 
@@ -47,6 +46,7 @@ describe("normalizeRailsKind", () => {
     expect(normalizeRailsKind("assert_queries_count")).toBeNull();
     expect(normalizeRailsKind("assert_cycle")).toBeNull();
     expect(normalizeRailsKind("must_be_frobnicated")).toBeNull();
+    expect(normalizeRailsKind("wont_be_kind_of")).toBeNull();
   });
 });
 

--- a/scripts/test-compare/assertion-kinds.test.ts
+++ b/scripts/test-compare/assertion-kinds.test.ts
@@ -25,9 +25,28 @@ describe("normalizeRailsKind", () => {
     expect(normalizeRailsKind("wont_equal")).toBe("notEqual");
   });
 
+  it("maps the must_be_* spec family, which the prefix rewrite alone cannot reach", () => {
+    // `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`.
+    expect(normalizeRailsKind("must_be_kind_of")).toBe("instanceOf");
+    expect(normalizeRailsKind("must_be_instance_of")).toBe("instanceOf");
+    expect(normalizeRailsKind("must_be_nil")).toBe("nil");
+    expect(normalizeRailsKind("must_be_empty")).toBe("empty");
+    expect(normalizeRailsKind("must_be_same_as")).toBe("same");
+    expect(normalizeRailsKind("wont_be_same_as")).toBe("notSame");
+    expect(normalizeRailsKind("wont_be_nil")).toBe("notNil");
+  });
+
+  it("maps the arel-local must_be_like and assert_edge helpers", () => {
+    // helper.rb:10-13 squeezes whitespace then delegates to must_equal.
+    expect(normalizeRailsKind("must_be_like")).toBe("equal");
+    // visitors/dot_test.rb:13-15 wraps assert_match over a label regex.
+    expect(normalizeRailsKind("assert_edge")).toBe("match");
+  });
+
   it("returns null for an unmapped assertion helper", () => {
     expect(normalizeRailsKind("assert_queries_count")).toBeNull();
     expect(normalizeRailsKind("assert_cycle")).toBeNull();
+    expect(normalizeRailsKind("must_be_frobnicated")).toBeNull();
   });
 });
 

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -143,39 +143,52 @@ const TRAILS_MAP: Record<string, CanonicalKind> = {
   toBeCloseTo: "inDelta",
 };
 
-// Minitest spec-form expectations that are not a bare `must_<assert-suffix>`:
-// `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`. Keyed on the
-// spec spelling so the prefix fallback in normalizeRailsKind can stay small.
-const SPEC_MAP: Record<string, CanonicalKind> = {
-  must_be_nil: "nil",
-  wont_be_nil: "notNil",
-  must_be_empty: "empty",
-  wont_be_empty: "notEmpty",
-  must_be_kind_of: "instanceOf",
-  must_be_instance_of: "instanceOf",
-  must_be_same_as: "same",
-  wont_be_same_as: "notSame",
-  must_be: "operator",
-  must_be_close_to: "inDelta",
-  must_be_within_delta: "inDelta",
-  // Arel's own test helper: `sql.must_be_like "…"` whitespace-normalizes both
-  // sides and delegates to `must_equal`
+// Rails-side assertion helpers defined by the arel suite itself rather than by
+// Minitest, resolved to the builtin they delegate to.
+const AREL_HELPER_ALIAS: Record<string, string> = {
+  // `sql.must_be_like other` squeezes runs of whitespace and strips BOTH
+  // operands, then `must_equal`
   // (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13).
-  must_be_like: "equal",
-  // Arel's dot_test-local helper: `assert_edge(name, dot)` is an `assert_match`
-  // over a `->…label="name"` regex
+  must_be_like: "assert_equal",
+  // `assert_edge(name, dot)` is `assert_match(/->.*label="name"/, dot)`
   // (vendor/rails/activerecord/test/cases/arel/visitors/dot_test.rb:13-15).
-  assert_edge: "match",
+  assert_edge: "assert_match",
+};
+
+// Minitest spec-form expectations whose builtin twin is NOT the bare
+// `assert_<suffix>`/`refute_<suffix>` the prefix rewrite in normalizeRailsKind
+// produces: `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`.
+// Resolving to the builtin NAME (as minitest/expectations.rb itself does) keeps
+// RAILS_MAP the single source of canonical kinds. The `wont_be_*` forms with no
+// entry here — `wont_be_kind_of`, `wont_be`, `wont_be_close_to` — have no
+// negated twin in RAILS_MAP either (`refute_kind_of`, `refute_operator`), so
+// they stay unmapped, exactly as their `refute_*` spellings already do.
+const SPEC_FORM_ALIAS: Record<string, string> = {
+  must_be_nil: "assert_nil",
+  wont_be_nil: "refute_nil",
+  must_be_empty: "assert_empty",
+  wont_be_empty: "refute_empty",
+  must_be_kind_of: "assert_kind_of",
+  must_be_instance_of: "assert_instance_of",
+  must_be_same_as: "assert_same",
+  wont_be_same_as: "refute_same",
+  must_be: "assert_operator",
+  must_be_close_to: "assert_in_delta",
+  must_be_within_delta: "assert_in_delta",
 };
 
 /**
  * Normalize a raw Rails assertion method name (`assert_equal`, `refute_nil`,
  * `must_equal`, …) to a canonical kind, or `null` when there is no mapped twin.
- * Handles the minitest `must_*`/`wont_*` spec forms by rewriting them to their
- * `assert_*`/`refute_*` equivalents before lookup.
+ * Handles the minitest `must_*`/`wont_*` spec forms — which arel's suite uses
+ * throughout, `Arel::Spec < Minitest::Spec`
+ * (vendor/rails/activerecord/test/cases/arel/helper.rb:29) — by resolving them
+ * to their `assert_*`/`refute_*` builtin before lookup, via SPEC_FORM_ALIAS for
+ * the `must_be_*` family and the bare prefix rewrite for the rest.
  */
 export function normalizeRailsKind(name: string): CanonicalKind | null {
-  const direct = RAILS_MAP[name] ?? SPEC_MAP[name];
+  const builtin = AREL_HELPER_ALIAS[name] ?? SPEC_FORM_ALIAS[name] ?? name;
+  const direct = RAILS_MAP[builtin];
   if (direct) return direct;
   // Spec forms: `must_equal` ~ `assert_equal`, `wont_equal` ~ `refute_equal`.
   const must = /^must_(.+)$/.exec(name);

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -143,6 +143,31 @@ const TRAILS_MAP: Record<string, CanonicalKind> = {
   toBeCloseTo: "inDelta",
 };
 
+// Minitest spec-form expectations that are not a bare `must_<assert-suffix>`:
+// `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`. Keyed on the
+// spec spelling so the prefix fallback in normalizeRailsKind can stay small.
+const SPEC_MAP: Record<string, CanonicalKind> = {
+  must_be_nil: "nil",
+  wont_be_nil: "notNil",
+  must_be_empty: "empty",
+  wont_be_empty: "notEmpty",
+  must_be_kind_of: "instanceOf",
+  must_be_instance_of: "instanceOf",
+  must_be_same_as: "same",
+  wont_be_same_as: "notSame",
+  must_be: "operator",
+  must_be_close_to: "inDelta",
+  must_be_within_delta: "inDelta",
+  // Arel's own test helper: `sql.must_be_like "…"` whitespace-normalizes both
+  // sides and delegates to `must_equal`
+  // (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13).
+  must_be_like: "equal",
+  // Arel's dot_test-local helper: `assert_edge(name, dot)` is an `assert_match`
+  // over a `->…label="name"` regex
+  // (vendor/rails/activerecord/test/cases/arel/visitors/dot_test.rb:13-15).
+  assert_edge: "match",
+};
+
 /**
  * Normalize a raw Rails assertion method name (`assert_equal`, `refute_nil`,
  * `must_equal`, …) to a canonical kind, or `null` when there is no mapped twin.
@@ -150,7 +175,7 @@ const TRAILS_MAP: Record<string, CanonicalKind> = {
  * `assert_*`/`refute_*` equivalents before lookup.
  */
 export function normalizeRailsKind(name: string): CanonicalKind | null {
-  const direct = RAILS_MAP[name];
+  const direct = RAILS_MAP[name] ?? SPEC_MAP[name];
   if (direct) return direct;
   // Spec forms: `must_equal` ~ `assert_equal`, `wont_equal` ~ `refute_equal`.
   const must = /^must_(.+)$/.exec(name);

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -22,7 +22,7 @@
     },
     "activemodel": {
       "assertionCount": 307,
-      "kind": 448,
+      "kind": 446,
       "value": 59
     },
     "activerecord": {
@@ -36,9 +36,9 @@
       "value": 104
     },
     "arel": {
-      "assertionCount": 180,
-      "kind": 591,
-      "value": 17
+      "assertionCount": 178,
+      "kind": 416,
+      "value": 79
     },
     "date": {
       "assertionCount": 1,

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -122,4 +122,38 @@ describe("assertionValueMismatch", () => {
     ).toBeNull();
     expect(assertionValueMismatch(undefined, undefined, ["toEqual"], ["n:4"], false)).toBeNull();
   });
+
+  it("folds whitespace for must_be_like, which squeezes both operands", () => {
+    // helper.rb:10-13: `%{\n  SELECT id FROM "users"\n}` and the ported
+    // single-line literal are the SAME assertion.
+    expect(
+      assertionValueMismatch(
+        ["must_be_like"],
+        ['s:\n            SELECT id FROM "users"\n          '],
+        ["toEqual"],
+        ['s:SELECT id FROM "users"'],
+        false,
+      ),
+    ).toBeNull();
+  });
+
+  it("still flags a must_be_like pair whose SQL actually differs", () => {
+    expect(
+      assertionValueMismatch(
+        ["must_be_like"],
+        ['s: SELECT id FROM "users" '],
+        ["toEqual"],
+        ['s:SELECT * FROM "users"'],
+        false,
+      ),
+    ).toEqual([
+      { kind: "equal", rails: ['s:SELECT id FROM "users"'], trails: ['s:SELECT * FROM "users"'] },
+    ]);
+  });
+
+  it("does not fold whitespace for an ordinary must_equal pair", () => {
+    expect(
+      assertionValueMismatch(["must_equal"], ["s:a  b"], ["toEqual"], ["s:a b"], false),
+    ).toEqual([{ kind: "equal", rails: ["s:a  b"], trails: ["s:a b"] }]);
+  });
 });

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -154,4 +154,34 @@ describe("assertionValueMismatch", () => {
       assertionValueMismatch(["must_equal"], ["s:a  b"], ["toEqual"], ["s:a b"], false),
     ).toEqual([{ kind: "equal", rails: ["s:a  b"], trails: ["s:a b"] }]);
   });
+
+  it("squeezes only the must_be_like operand, not a must_equal beside it", () => {
+    expect(
+      assertionValueMismatch(
+        ["must_be_like", "must_equal"],
+        ['s: SELECT id FROM "users" ', "s:a  b"],
+        ["toEqual", "toEqual"],
+        ['s:SELECT id FROM "users"', "s:a b"],
+        false,
+      ),
+    ).toEqual([
+      {
+        kind: "equal",
+        rails: ['s:SELECT id FROM "users"', "s:a  b"],
+        trails: ['s:SELECT id FROM "users"', "s:a b"],
+      },
+    ]);
+  });
+
+  it("passes a mixed pair when the must_equal operand matches verbatim", () => {
+    expect(
+      assertionValueMismatch(
+        ["must_be_like", "must_equal"],
+        ['s:\n  SELECT id FROM "users"\n', "s:a  b"],
+        ["toEqual", "toEqual"],
+        ["s:a  b", 's:SELECT id FROM "users"'],
+        false,
+      ),
+    ).toBeNull();
+  });
 });

--- a/scripts/test-compare/assertion-values.test.ts
+++ b/scripts/test-compare/assertion-values.test.ts
@@ -124,8 +124,6 @@ describe("assertionValueMismatch", () => {
   });
 
   it("folds whitespace for must_be_like, which squeezes both operands", () => {
-    // helper.rb:10-13: `%{\n  SELECT id FROM "users"\n}` and the ported
-    // single-line literal are the SAME assertion.
     expect(
       assertionValueMismatch(
         ["must_be_like"],

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -71,6 +71,13 @@ interface SideKind {
   total: number;
   /** the literal tokens captured (length ≤ total; < total means some non-literal) */
   captured: string[];
+  /**
+   * Indices into `captured` whose assertion compares whitespace-insensitively
+   * (see LOOSE_RAILS_KINDS). Tracked per assertion, not per test case: a test
+   * that mixes `must_be_like` with a plain `must_equal` must still compare the
+   * `must_equal` operand verbatim.
+   */
+  loose: Set<number>;
 }
 
 /**
@@ -84,7 +91,6 @@ function collectSide(
   kinds: string[],
   values: (string | null)[] | undefined,
   side: "rails" | "trails",
-  squeezeEqual = false,
 ): Map<string, SideKind> {
   const normalize = side === "rails" ? normalizeRailsKind : normalizeTrailsKind;
   const map = new Map<string, SideKind>();
@@ -93,14 +99,14 @@ function collectSide(
     if (!kind || !VALUE_BEARING_KINDS.has(kind)) continue;
     let entry = map.get(kind);
     if (!entry) {
-      entry = { total: 0, captured: [] };
+      entry = { total: 0, captured: [], loose: new Set() };
       map.set(kind, entry);
     }
     entry.total++;
     const value = values?.[i];
     if (value != null) {
-      const folded = foldSymbolToken(value);
-      entry.captured.push(squeezeEqual && kind === "equal" ? squeezeToken(folded) : folded);
+      if (LOOSE_RAILS_KINDS.has(kinds[i])) entry.loose.add(entry.captured.length);
+      entry.captured.push(foldSymbolToken(value));
     }
   }
   return map;
@@ -118,6 +124,15 @@ function collectSide(
 function foldSymbolToken(token: string): string {
   return token.startsWith("s::") ? `s:${token.slice(3)}` : token;
 }
+
+/**
+ * Rails-side assertion helpers that compare their operands with runs of
+ * whitespace collapsed, so their captured value token must be compared the same
+ * way. Keyed on the RAW kind token, which is what makes the fold per-assertion:
+ * only the operand of this helper call is squeezed, never a sibling
+ * `must_equal` in the same test.
+ */
+const LOOSE_RAILS_KINDS: ReadonlySet<string> = new Set(["must_be_like"]);
 
 /**
  * Arel's `must_be_like` (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13)
@@ -153,11 +168,8 @@ export function assertionValueMismatch(
 ): ValueDelta[] | null {
   if (pending) return null;
   if (!railsKinds || !trailsKinds) return null;
-  // Whitespace-insensitive equality is a property of the Rails-side helper, so
-  // it is decided from the Rails kinds and then applied to BOTH sides.
-  const squeezeEqual = railsKinds.includes("must_be_like");
-  const rails = collectSide(railsKinds, railsValues, "rails", squeezeEqual);
-  const trails = collectSide(trailsKinds, trailsValues, "trails", squeezeEqual);
+  const rails = collectSide(railsKinds, railsValues, "rails");
+  const trails = collectSide(trailsKinds, trailsValues, "trails");
   const deltas: ValueDelta[] = [];
   for (const kind of [...new Set([...rails.keys(), ...trails.keys()])].sort()) {
     const r = rails.get(kind);
@@ -170,9 +182,46 @@ export function assertionValueMismatch(
     // Both multisets are fully-literal and equal-count (r.total === t.total), so
     // an element-wise compare of the sorted token lists is exact multiset
     // equality — not a joined string, since a token can itself contain spaces.
-    const rs = [...r.captured].sort();
-    const ts = [...t.captured].sort();
-    if (rs.some((tok, i) => tok !== ts[i])) deltas.push({ kind, rails: rs, trails: ts });
+    const mismatch =
+      r.loose.size > 0 ? looseMismatch(r, t.captured) : exactMismatch(r.captured, t.captured);
+    if (mismatch) deltas.push({ kind, ...mismatch });
   }
   return deltas.length > 0 ? deltas : null;
+}
+
+/** Multiset equality over two fully-literal, equal-length token lists. */
+function exactMismatch(rails: string[], trails: string[]): Omit<ValueDelta, "kind"> | null {
+  const rs = [...rails].sort();
+  const ts = [...trails].sort();
+  return rs.some((tok, i) => tok !== ts[i]) ? { rails: rs, trails: ts } : null;
+}
+
+/**
+ * Multiset equality where SOME of the Rails tokens compare whitespace-insensitively
+ * (their assertion was a LOOSE_RAILS_KINDS helper) and the rest compare verbatim.
+ * The strict tokens are matched first and must find an exact partner, so a plain
+ * `must_equal` sitting beside a `must_be_like` still catches a whitespace-only
+ * divergence. Whatever the strict pass leaves over is then squeezed and compared
+ * against the squeezed loose tokens.
+ *
+ * The trails side carries no such attribution — vitest spells both as `toEqual` —
+ * so a strict token that could equally have partnered a loose one is consumed by
+ * the strict pass. Where that guesses wrong it yields a false MISMATCH, never a
+ * false match, which is the safe direction (the same rule TRAILS_MAP applies to
+ * `toBe`).
+ */
+function looseMismatch(rails: SideKind, trails: string[]): Omit<ValueDelta, "kind"> | null {
+  const strict = rails.captured.filter((_tok, i) => !rails.loose.has(i));
+  const loose = rails.captured.filter((_tok, i) => rails.loose.has(i)).map(squeezeToken);
+  const remaining = [...trails];
+  const matched: string[] = [];
+  let unmatched = 0;
+  for (const tok of strict) {
+    const at = remaining.indexOf(tok);
+    if (at < 0) unmatched++;
+    else matched.push(...remaining.splice(at, 1));
+  }
+  const squeezed = remaining.map(squeezeToken);
+  if (unmatched === 0 && exactMismatch(loose, squeezed) === null) return null;
+  return { rails: [...strict, ...loose].sort(), trails: [...matched, ...squeezed].sort() };
 }

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -84,6 +84,7 @@ function collectSide(
   kinds: string[],
   values: (string | null)[] | undefined,
   side: "rails" | "trails",
+  squeezeEqual = false,
 ): Map<string, SideKind> {
   const normalize = side === "rails" ? normalizeRailsKind : normalizeTrailsKind;
   const map = new Map<string, SideKind>();
@@ -97,7 +98,10 @@ function collectSide(
     }
     entry.total++;
     const value = values?.[i];
-    if (value != null) entry.captured.push(foldSymbolToken(value));
+    if (value != null) {
+      const folded = foldSymbolToken(value);
+      entry.captured.push(squeezeEqual && kind === "equal" ? squeezeToken(folded) : folded);
+    }
   }
   return map;
 }
@@ -113,6 +117,18 @@ function collectSide(
  */
 function foldSymbolToken(token: string): string {
   return token.startsWith("s::") ? `s:${token.slice(3)}` : token;
+}
+
+/**
+ * Arel's `must_be_like` (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13)
+ * squeezes runs of whitespace and strips both operands before delegating to
+ * `must_equal`, so `%{\n  SELECT id FROM "users"\n}` and `SELECT id FROM
+ * "users"` are the SAME assertion. Its value token must be compared the same
+ * way, on both sides — the Ruby heredoc keeps its indentation and the ported
+ * string literal does not, and that is formatting, not a fidelity divergence.
+ */
+function squeezeToken(token: string): string {
+  return token.startsWith("s:") ? `s:${token.slice(2).replace(/\s+/g, " ").trim()}` : token;
 }
 
 /**
@@ -137,8 +153,11 @@ export function assertionValueMismatch(
 ): ValueDelta[] | null {
   if (pending) return null;
   if (!railsKinds || !trailsKinds) return null;
-  const rails = collectSide(railsKinds, railsValues, "rails");
-  const trails = collectSide(trailsKinds, trailsValues, "trails");
+  // Whitespace-insensitive equality is a property of the Rails-side helper, so
+  // it is decided from the Rails kinds and then applied to BOTH sides.
+  const squeezeEqual = railsKinds.includes("must_be_like");
+  const rails = collectSide(railsKinds, railsValues, "rails", squeezeEqual);
+  const trails = collectSide(trailsKinds, trailsValues, "trails", squeezeEqual);
   const deltas: ValueDelta[] = [];
   for (const kind of [...new Set([...rails.keys(), ...trails.keys()])].sort()) {
     const r = rails.get(kind);

--- a/scripts/test-compare/assertion-values.ts
+++ b/scripts/test-compare/assertion-values.ts
@@ -179,9 +179,6 @@ export function assertionValueMismatch(
     if (!r || !t || r.total !== t.total) continue;
     // Some expected argument was a non-literal on either side — can't compare.
     if (r.captured.length < r.total || t.captured.length < t.total) continue;
-    // Both multisets are fully-literal and equal-count (r.total === t.total), so
-    // an element-wise compare of the sorted token lists is exact multiset
-    // equality — not a joined string, since a token can itself contain spaces.
     const mismatch =
       r.loose.size > 0 ? looseMismatch(r, t.captured) : exactMismatch(r.captured, t.captured);
     if (mismatch) deltas.push({ kind, ...mismatch });
@@ -189,7 +186,12 @@ export function assertionValueMismatch(
   return deltas.length > 0 ? deltas : null;
 }
 
-/** Multiset equality over two fully-literal, equal-length token lists. */
+/**
+ * Multiset equality over two fully-literal, equal-length token lists. Both are
+ * equal-count by the caller's guard, so an element-wise compare of the sorted
+ * lists is exact multiset equality — not a joined string, since a token can
+ * itself contain spaces.
+ */
 function exactMismatch(rails: string[], trails: string[]): Omit<ValueDelta, "kind"> | null {
   const rs = [...rails].sort();
   const ts = [...trails].sort();


### PR DESCRIPTION
First story of RFC 0122 (arel assertion parity to zero).

## The bug

`normalizeRailsKind` (`scripts/test-compare/assertion-kinds.ts`) folded Minitest spec forms with a prefix rewrite — `must_<suffix>` → `assert_<suffix>`. That is correct for `must_equal` and wrong for the entire `must_be_*` family: `must_be_kind_of` rewrote to `assert_be_kind_of`, which is not a Minitest assertion and is not a key in `RAILS_MAP`, so it normalized to `null` and landed in `unmapped`.

arel is the only suite this hits at scale — `vendor/rails/activerecord/test/cases/arel/helper.rb:29` defines `Arel::Spec < Minitest::Spec`, so its tests assert through spec expectations rather than `assert_*`. That is why arel's kind-mismatch rate (83.5%) was nearly double every other package's (~47%).

Unmapped tokens measured across arel's 590 kind mismatches:

| token | tests | what it is |
|---|---|---|
| `must_be_like` | 326 | arel-local helper, `helper.rb:10-13` — `gsub(/\s+/, " ").strip`s **both** operands, then `must_equal` → `equal` |
| `must_be_kind_of` | 52 | spec form of `assert_kind_of` → `instanceOf` |
| `assert_edge` | 11 | `visitors/dot_test.rb:13-15`, wraps `assert_match(/->.*label="…"/)` → `match` |
| `must_be_nil` | 5 | → `nil` |
| `wont_be_same_as` | 4 | → `notSame` |

## The value dimension

Mapping `must_be_like` makes 326 assertions **value**-comparable for the first time, taking arel's value count 17 → 155. 76 of those 155 are pure whitespace: the Ruby `%{ … }` heredoc keeps its indentation, the ported TS literal does not, and the helper squeezes both. `assertion-values.ts` now folds whitespace in an `equal`-kind string token when the Rails kinds include `must_be_like` — decided from the Rails side, applied to both, because whitespace-insensitivity is a property of the Rails-side helper. That leaves exactly **79**, which are real content divergence (`should visit_Float` asserts `1.5` where Rails asserts `"products"."price" = 2.14`).

Those 79 are too many to bundle here, and they cannot be converged first: under the old mapping the Rails side of a `must_be_like` pair contributed nothing to the histogram, so a test fix was unmeasurable. RFC 0122 therefore authorises a **one-time, dimension-scoped** correction of arel's `value` mark, 17 → 79 — the old 17 measured almost nothing because 326 of the package's assertions were unmapped. It does not extend to `assertionCount` or `kind` (both move down here), to any other package, or to any later story in the RFC.

## All-package before/after

`pnpm parity:test -- --assertions`, count / kind / value:

| package | before | after |
|---|---|---|
| arel | 178 / 590 / 17 (marked 180 / 591 / 17) | **178 / 416 / 79** |
| activemodel | 304 / 448 / 59 | 304 / **446** / 59 |
| activerecord | 1940 / 3924 / 36 | unchanged |
| activesupport | 864 / 1213 / 104 | unchanged |

No package's numbers rose. `assertion-mismatch-mark.json` moves arel to 178/416/79 and tightens activemodel's `kind` 448 → 446; nothing else changes.

`pnpm parity:test:assertions` is green.

Closes-story: map-minitest-spec-assertion-forms

## Shape

Spec forms resolve to the builtin **name** (`must_be_kind_of` → `assert_kind_of`) and reuse `RAILS_MAP`, which is how `minitest/expectations.rb` itself defines them — one source of canonical kinds rather than two that can drift. Every key was verified against MRI (`Minitest::Expectations.instance_methods`). The `wont_be_*` forms deliberately absent — `wont_be_kind_of`, `wont_be`, `wont_be_close_to` — have no negated twin in `RAILS_MAP` either (`refute_kind_of`, `refute_operator` are unmapped today), so they stay unmapped exactly as their `refute_*` spellings already do. The two arel-local helpers sit in their own table because they are not spec forms.

## The trails side stays vitest-native

Worth stating since this PR maps two Ruby helpers: it does **not** imply a trails-side helper. Measured over all 58,551 trails assertion tokens, only 2,172 (3.7%) fail to normalize, and the tail is not vitest matchers — it is trails helpers mirroring Rails helpers whose Ruby twins are also unmapped (`assertQueriesCount` 230, `assertNoQueries` 189, `assertQueriesMatch` 102, …). `TRAILS_MAP` already covers what our tests use.

So `must_be_like` ports as a string normalizer inside a native matcher — the shape `select-manager.test.ts:15` already uses, where the extractor reads the terminal `toBe` with no special-casing — and `assert_edge` ports to a native `toMatch`. RFC 0122's README records this, and its burndown stories hoist that normalizer to a shared arel test helper rather than redefining it nine times.

The cross-package unmapped tail is filed separately as `0023-surfaced-deviations/map-rails-helper-twin-assertion-kinds`; it moves all five packages and is not arel's to own.
