### PR TITLE
fix(scripts,actionpack): derive rails-privates PACKAGE_DIRS from api-compare config; drop ?-candidate collisions

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -283,6 +283,8 @@ export class AbstractController {
    * dispatcher in `callbacks.ts`, which then invokes `_dispatchAction` as
    * the inner step (mirrors Rails AC::Callbacks#process_action overriding
    * Base#process_action with a `run_callbacks { super }` wrapper).
+   *
+   * @internal
    */
   async processAction(action: string, ...args: unknown[]): Promise<void> {
     this.actionName = action;

--- a/packages/actionpack/src/abstract-controller/caching.ts
+++ b/packages/actionpack/src/abstract-controller/caching.ts
@@ -69,6 +69,8 @@ export class ConfigMethods {
 /**
  * Mirrors `AbstractController::Caching::ConfigMethods#cache_configured?`.
  * Truthy when caching is on AND a store is wired up.
+ *
+ * @internal
  */
 export function cacheConfigured(host: CachingHost): boolean {
   const cls = host.constructor;

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -116,6 +116,7 @@ export function _helpers(
  */
 const helperMethodsByClass = new WeakMap<HelpersClassMethods, HelperMethodsModule>();
 
+/** @internal */
 export function defineHelpersModule(
   cls: HelpersClassMethods,
   helpers?: HelperMethodsModule | null,
@@ -388,6 +389,8 @@ export async function helperModulesFromPaths(
  * `NameError` for the specific missing constant; we swallow only the
  * matching `uninitialized constant` error raised by
  * `modulesForHelpers`, so unrelated resolver failures still propagate.
+ *
+ * @internal
  */
 export function defaultHelperModuleBang(
   cls: HelpersClassMethods,

--- a/packages/actionpack/src/abstract-controller/rendering.ts
+++ b/packages/actionpack/src/abstract-controller/rendering.ts
@@ -50,8 +50,11 @@ export interface RenderOptions {
 export interface RenderingHost {
   responseBody: unknown;
   renderToBody(options: RenderOptions): unknown;
+  /** @internal */
   _setHtmlContentType?(): void;
+  /** @internal */
   _setRenderedContentType?(format: unknown): void;
+  /** @internal */
   _setVaryHeader?(): void;
   renderedFormat?(): unknown;
 }
@@ -152,7 +155,11 @@ export function _normalizeRender(...args: unknown[]): RenderOptions {
   return _normalizeOptions(options);
 }
 
-/** Hook — subclasses override to handle `:variant` option. */
+/**
+ * Hook — subclasses override to handle `:variant` option.
+ *
+ * @internal
+ */
 export function _processVariant(_options: RenderOptions): void {
   // Empty in the abstract layer.
 }

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -812,7 +812,11 @@ export class Base extends Metal {
 
   // --- Send File / Send Data ---
 
-  /** Mirrors Rails `send_file_headers!`; wired below via `Base.prototype`. */
+  /**
+   * Mirrors Rails `send_file_headers!`; wired below via `Base.prototype`.
+   *
+   * @internal
+   */
   declare sendFileHeadersBang: typeof sendFileHeadersBang;
 
   /** Send file content. */

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -283,6 +283,7 @@ export function prepareCacheControlBang(this: ResponseCacheHost): CacheControlHa
   return cacheControlHeaders.call(this);
 }
 
+/** @internal */
 export function handleConditionalGetBang(this: ResponseCacheHost): void {
   if (
     (isEtag.call(this) !== undefined || isLastModified.call(this)) &&

--- a/packages/actionpack/src/action-dispatch/http/content-disposition.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-disposition.ts
@@ -47,6 +47,7 @@ export class ContentDisposition {
   }
 }
 
+/** @internal */
 function percentEscape(str: string, pattern: RegExp): string {
   return str.replace(pattern, (char) => {
     const bytes = utf8Encoder.encode(char);

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -989,9 +989,13 @@ export class Request {
 
   // --- Mime-negotiation privates (declared; bound below via prototype) ---
 
+  /** @internal */
   declare validAcceptHeader: () => boolean;
+  /** @internal */
   declare useAcceptHeader: () => boolean;
+  /** @internal */
   declare formatFromPathExtension: () => MimeType | undefined;
+  /** @internal */
   declare isParamsReadable: () => boolean;
 
   // --- Controller dispatch ---

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -381,7 +381,9 @@ export class Response {
   declare strongEtag: (validators: unknown) => void;
   declare isWeakEtag: () => boolean;
   declare isStrongEtag: () => boolean;
+  /** @internal */
   declare handleConditionalGetBang: () => void;
+  /** @internal */
   declare mergeAndNormalizeCacheControlBang: (cacheControl: CacheControlHash) => void;
   /**
    * Parsed `Cache-Control` directives as a hash, mirroring Rails'
@@ -617,17 +619,29 @@ export class Response {
 
   // --- ETag generators (delegated to cache module) ---
 
-  /** Rails: `generate_weak_etag(validators)`. */
+  /**
+   * Rails: `generate_weak_etag(validators)`.
+   *
+   * @internal
+   */
   generateWeakEtag(validators: unknown): string {
     return _generateWeakEtag(validators);
   }
 
-  /** Rails: `generate_strong_etag(validators)`. */
+  /**
+   * Rails: `generate_strong_etag(validators)`.
+   *
+   * @internal
+   */
   generateStrongEtag(validators: unknown): string {
     return _generateStrongEtag(validators);
   }
 
-  /** Rails: `prepare_cache_control!` private. */
+  /**
+   * Rails: `prepare_cache_control!` private.
+   *
+   * @internal
+   */
   prepareCacheControlBang(): CacheControlHash {
     return _prepareCacheControlBang.call(this);
   }

--- a/packages/actionpack/src/action-dispatch/http/url.ts
+++ b/packages/actionpack/src/action-dispatch/http/url.ts
@@ -41,15 +41,18 @@ export interface UrlOptions {
   domain?: string;
 }
 
+/** @internal */
 function namedHost(host: string): boolean {
   return !IP_HOST_REGEXP.test(host);
 }
 
+/** @internal */
 function extractDomainFrom(host: string, tldLength: number): string {
   const parts = host.split(".");
   return parts.slice(-(1 + tldLength)).join(".");
 }
 
+/** @internal */
 function extractSubdomainsFrom(host: string, tldLength: number): string[] {
   const parts = host.split(".");
   // Rails: `parts[0..-(tld_length + 2)]` returns `[]` (not the tail) when the
@@ -59,6 +62,7 @@ function extractSubdomainsFrom(host: string, tldLength: number): string[] {
   return parts.slice(0, Math.max(0, parts.length - (tldLength + 1)));
 }
 
+/** @internal */
 function addParams(parts: string[], params: unknown): void {
   let hash: Record<string, unknown>;
   if (params && typeof params === "object" && !Array.isArray(params)) {
@@ -73,6 +77,7 @@ function addParams(parts: string[], params: unknown): void {
   if (query.length > 0) parts.push(`?${query}`);
 }
 
+/** @internal */
 function addAnchor(parts: string[], anchor: unknown): void {
   if (anchor !== null && anchor !== undefined && anchor !== false) {
     const p = toParam(anchor);
@@ -80,6 +85,7 @@ function addAnchor(parts: string[], anchor: unknown): void {
   }
 }
 
+/** @internal */
 function normalizeProtocol(protocol: string | false | null | undefined): string {
   if (protocol === null || protocol === undefined) {
     return URL.secureProtocol ? "https://" : "http://";
@@ -92,6 +98,7 @@ function normalizeProtocol(protocol: string | false | null | undefined): string 
   throw new Error(`Invalid :protocol option: ${JSON.stringify(protocol)}`);
 }
 
+/** @internal */
 function normalizeHost(rawHost: string, options: UrlOptions): string {
   if (!namedHost(rawHost)) return rawHost;
 
@@ -111,6 +118,7 @@ function normalizeHost(rawHost: string, options: UrlOptions): string {
   return host;
 }
 
+/** @internal */
 function normalizePort(
   port: number | string | null | undefined,
   protocol: string,
@@ -122,6 +130,7 @@ function normalizePort(
   return n === 80 ? null : port;
 }
 
+/** @internal */
 function buildHostUrl(
   hostIn: string,
   portIn: number | string | null | undefined,

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -187,6 +187,7 @@ export class Permissions {
   }
 }
 
+/** @internal */
 function sanitizeHosts(
   hosts: HostPermission[] | HostPermission | undefined | null,
 ): (RegExp | IPAddr)[] {
@@ -198,10 +199,12 @@ function sanitizeHosts(
   });
 }
 
+/** @internal */
 function sanitizeRegexp(host: RegExp): RegExp {
   return new RegExp(`^(?:${host.source})${PORT_REGEX}?$`, host.flags.replace(/[gym]/g, ""));
 }
 
+/** @internal */
 function sanitizeString(host: string): RegExp {
   if (host.startsWith(".")) {
     return new RegExp(`^${SUBDOMAIN_REGEX}?${escapeRegExp(host.slice(1))}${PORT_REGEX}?$`, "i");

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -67,6 +67,7 @@ export class RoutesProxy implements UrlForHost {
   urlFor = urlFor;
   fullUrlFor = fullUrlFor;
   routeFor = routeFor;
+  /** @internal */
   optimizeRoutesGeneration = optimizeRoutesGeneration;
   /** @internal Rails: `private def _with_routes` */
   _withRoutes = _withRoutes;

--- a/packages/actionpack/src/action-dispatch/routing/url-for.ts
+++ b/packages/actionpack/src/action-dispatch/routing/url-for.ts
@@ -45,6 +45,7 @@ export {
  */
 export interface UrlForRoutes {
   urlFor(options: Record<string, unknown>, routeName?: string | null): string;
+  /** @internal */
   optimizeRoutesGeneration?(): boolean;
   /**
    * Rails' UrlFor includes PolymorphicRoutes, whose helpers read

--- a/packages/actionpack/src/action-dispatch/system-testing/test-helpers/screenshot-helper.ts
+++ b/packages/actionpack/src/action-dispatch/system-testing/test-helpers/screenshot-helper.ts
@@ -42,6 +42,7 @@ export async function takeFailedScreenshot(this: ScreenshotHelperHost): Promise<
   }
 }
 
+/** @internal */
 function htmlFromEnv(): boolean {
   return (
     env("RAILS_SYSTEM_TESTING_SCREENSHOT_HTML") === "1" ||
@@ -86,15 +87,18 @@ export function screenshotsDir(): string {
   return env("CAPYBARA_SAVE_PATH") || "tmp/screenshots";
 }
 
+/** @internal */
 function absolutePath(this: ScreenshotHelperHost): string {
   const { join } = getPath();
   return join(projectRoot(), screenshotsDir(), imageName.call(this));
 }
 
+/** @internal */
 function absoluteImagePath(this: ScreenshotHelperHost): string {
   return `${absolutePath.call(this)}.png`;
 }
 
+/** @internal */
 function relativeImagePath(this: ScreenshotHelperHost): string {
   const { relative } = getPath();
   const abs = absolutePath.call(this);
@@ -102,6 +106,7 @@ function relativeImagePath(this: ScreenshotHelperHost): string {
   return `${relative!(root, abs)}.png`;
 }
 
+/** @internal */
 function absoluteHtmlPath(this: ScreenshotHelperHost): string {
   return `${absolutePath.call(this)}.html`;
 }
@@ -167,10 +172,12 @@ export function inlineBase64(str: string): string {
   return Buffer.from(str).toString("base64");
 }
 
+/** @internal */
 function show(message: string): void {
   console.log(message);
 }
 
+/** @internal */
 function failed(this: ScreenshotHelperHost): boolean {
   return this._testFailed === true;
 }

--- a/packages/actionpack/src/action-dispatch/testing/assertion-response.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertion-response.ts
@@ -45,6 +45,7 @@ export class AssertionResponse {
   }
 }
 
+/** @internal */
 function codeFromName(name: string): string | undefined {
   if (Object.hasOwn(GENERIC_RESPONSE_CODES, name)) return GENERIC_RESPONSE_CODES[name];
   try {
@@ -54,6 +55,7 @@ function codeFromName(name: string): string | undefined {
   }
 }
 
+/** @internal */
 function nameFromCode(code: number): string | undefined {
   // Faithful Rails behavior: GENERIC_RESPONSE_CODES.invert keys are
   // Strings ("2XX", "404", ...) and we look up by Integer, which

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -691,13 +691,16 @@ export class IntegrationTest {
   declare assertGenerates: typeof routingAssertions.assertGenerates;
   declare assertRouting: typeof routingAssertions.assertRouting;
   declare withRouting: typeof routingAssertions.withRouting;
+  /** @internal */
   declare createRoutes: typeof routingAssertions.createRoutes;
+  /** @internal */
   declare resetRoutes: typeof routingAssertions.resetRoutes;
   declare recognizedRequestFor: typeof routingAssertions.recognizedRequestFor;
   declare failOn: typeof routingAssertions.failOn;
   declare urlFor: typeof urlForMod.urlFor;
   declare fullUrlFor: typeof urlForMod.fullUrlFor;
   declare routeFor: typeof urlForMod.routeFor;
+  /** @internal */
   declare optimizeRoutesGeneration: typeof urlForMod.optimizeRoutesGeneration;
   declare _withRoutes: typeof urlForMod._withRoutes;
   declare _routesContext: typeof urlForMod._routesContext;

--- a/scripts/api-compare/config.test.ts
+++ b/scripts/api-compare/config.test.ts
@@ -1,0 +1,70 @@
+import * as fs from "fs";
+import * as path from "path";
+import { describe, it, expect } from "vitest";
+
+import { MANIFEST_PACKAGES, PACKAGE_DIRS, ROOT_DIR, packageSrcDir } from "./config.js";
+
+describe("PACKAGE_DIRS", () => {
+  // The regression this guards: the map used to be hand-copied into
+  // scripts/build-rails-privates-manifest.ts, where it spelled
+  // `actiondispatch` / `actioncontroller` against the real `action-dispatch` /
+  // `action-controller`. Every actionpack key in
+  // eslint/rails-private-methods.json then pointed at a path that does not
+  // exist, so `rails-private-jsdoc` silently matched nothing for the whole
+  // package. A dead key is indistinguishable from "Rails privatises nothing
+  // here", which is why this asserts the DIRECTORY exists rather than
+  // asserting anything about the manifest's keys — most of those legitimately
+  // name Rails files trails has not ported yet.
+  it.each(MANIFEST_PACKAGES)("%s resolves to a directory that exists", (pkg) => {
+    const dir = PACKAGE_DIRS[pkg];
+    expect(dir).toBeDefined();
+    expect(fs.statSync(path.join(ROOT_DIR, dir)).isDirectory()).toBe(true);
+  });
+
+  it("covers exactly the manifest packages", () => {
+    expect(Object.keys(PACKAGE_DIRS).sort()).toEqual([...MANIFEST_PACKAGES].sort());
+  });
+
+  it("agrees with packageSrcDir", () => {
+    for (const pkg of MANIFEST_PACKAGES) {
+      expect(path.join(ROOT_DIR, PACKAGE_DIRS[pkg])).toBe(packageSrcDir(pkg));
+    }
+  });
+});
+
+// `eslint/rails-private-methods.json` is gitignored and built only by the
+// Ruby-bearing `rails-comparison` CI job; `railsApiAvailable` also writes an
+// EMPTY one when rails-api.json is absent. Either way there is nothing to
+// assert, so skip rather than red every other job.
+const manifestPath = path.join(ROOT_DIR, "eslint/rails-private-methods.json");
+const manifest: { files: Record<string, string[]> } = fs.existsSync(manifestPath)
+  ? JSON.parse(fs.readFileSync(manifestPath, "utf8"))
+  : { files: {} };
+const describeManifest = Object.keys(manifest.files).length > 0 ? describe : describe.skip;
+
+describeManifest("rails-private-methods manifest", () => {
+  it("has no key under a package dir that does not exist", () => {
+    const dirs = Object.values(PACKAGE_DIRS);
+    const dead = Object.keys(manifest.files).filter(
+      (k) => !dirs.some((d) => k.startsWith(`${d}/`)),
+    );
+    expect(dead).toEqual([]);
+  });
+
+  // `rubyMethodToTs` gives a `?` method the bare stem as a candidate, so a
+  // private `content_security_policy?` used to contribute `contentSecurityPolicy`
+  // — the spelling of the PUBLIC `content_security_policy` class DSL beside it —
+  // and `rails-private-jsdoc` then demanded `@internal` on a public Rails method.
+  // The all-private guard runs on Ruby names and cannot see that collision; the
+  // builder subtracts every `mixed` name's candidates to close it.
+  it.each([
+    ["packages/actionpack/src/action-controller/base.ts", "contentSecurityPolicy"],
+    [
+      "packages/actionpack/src/action-controller/metal/content-security-policy.ts",
+      "contentSecurityPolicy",
+    ],
+    ["packages/activemodel/src/attributes.ts", "attribute"],
+  ])("%s does not claim %s is Rails-private", (file, name) => {
+    expect(manifest.files[file] ?? []).not.toContain(name);
+  });
+});

--- a/scripts/api-compare/config.test.ts
+++ b/scripts/api-compare/config.test.ts
@@ -2,61 +2,44 @@ import * as fs from "fs";
 import * as path from "path";
 import { describe, it, expect } from "vitest";
 
-import { MANIFEST_PACKAGES, PACKAGE_DIRS, ROOT_DIR, packageSrcDir } from "./config.js";
+import { MANIFEST_PACKAGES, PACKAGE_DIRS, ROOT_DIR } from "./config.js";
 
-describe("PACKAGE_DIRS", () => {
-  // The regression this guards: the map used to be hand-copied into
-  // scripts/build-rails-privates-manifest.ts, where it spelled
-  // `actiondispatch` / `actioncontroller` against the real `action-dispatch` /
-  // `action-controller`. Every actionpack key in
-  // eslint/rails-private-methods.json then pointed at a path that does not
-  // exist, so `rails-private-jsdoc` silently matched nothing for the whole
-  // package. A dead key is indistinguishable from "Rails privatises nothing
-  // here", which is why this asserts the DIRECTORY exists rather than
-  // asserting anything about the manifest's keys — most of those legitimately
-  // name Rails files trails has not ported yet.
-  it.each(MANIFEST_PACKAGES)("%s resolves to a directory that exists", (pkg) => {
-    const dir = PACKAGE_DIRS[pkg];
-    expect(dir).toBeDefined();
-    expect(fs.statSync(path.join(ROOT_DIR, dir)).isDirectory()).toBe(true);
-  });
-
-  it("covers exactly the manifest packages", () => {
-    expect(Object.keys(PACKAGE_DIRS).sort()).toEqual([...MANIFEST_PACKAGES].sort());
-  });
-
-  it("agrees with packageSrcDir", () => {
-    for (const pkg of MANIFEST_PACKAGES) {
-      expect(path.join(ROOT_DIR, PACKAGE_DIRS[pkg])).toBe(packageSrcDir(pkg));
-    }
-  });
-});
-
-// `eslint/rails-private-methods.json` is gitignored and built only by the
-// Ruby-bearing `rails-comparison` CI job; `railsApiAvailable` also writes an
-// EMPTY one when rails-api.json is absent. Either way there is nothing to
-// assert, so skip rather than red every other job.
 const manifestPath = path.join(ROOT_DIR, "eslint/rails-private-methods.json");
 const manifest: { files: Record<string, string[]> } = fs.existsSync(manifestPath)
   ? JSON.parse(fs.readFileSync(manifestPath, "utf8"))
   : { files: {} };
 const describeManifest = Object.keys(manifest.files).length > 0 ? describe : describe.skip;
 
-describeManifest("rails-private-methods manifest", () => {
-  it("has no key under a package dir that does not exist", () => {
-    const dirs = Object.values(PACKAGE_DIRS);
-    const dead = Object.keys(manifest.files).filter(
-      (k) => !dirs.some((d) => k.startsWith(`${d}/`)),
-    );
-    expect(dead).toEqual([]);
+describe("PACKAGE_DIRS", () => {
+  it.each(MANIFEST_PACKAGES)("%s resolves to a directory that exists on disk", (pkg) => {
+    const dir = PACKAGE_DIRS[pkg];
+    expect(dir).toBeDefined();
+    expect(fs.statSync(path.join(ROOT_DIR, dir)).isDirectory()).toBe(true);
   });
 
-  // `rubyMethodToTs` gives a `?` method the bare stem as a candidate, so a
-  // private `content_security_policy?` used to contribute `contentSecurityPolicy`
-  // — the spelling of the PUBLIC `content_security_policy` class DSL beside it —
-  // and `rails-private-jsdoc` then demanded `@internal` on a public Rails method.
-  // The all-private guard runs on Ruby names and cannot see that collision; the
-  // builder subtracts every `mixed` name's candidates to close it.
+  it.each([
+    ["actiondispatch", "packages/actionpack/src/action-dispatch"],
+    ["actioncontroller", "packages/actionpack/src/action-controller"],
+    ["arel", "packages/arel/src"],
+    ["trailties", "packages/trailties/src"],
+  ])("spells %s's src dir the way the repo does", (pkg, dir) => {
+    expect(PACKAGE_DIRS[pkg]).toBe(dir);
+  });
+
+  it("covers exactly the manifest packages", () => {
+    expect(Object.keys(PACKAGE_DIRS).sort()).toEqual([...MANIFEST_PACKAGES].sort());
+  });
+});
+
+describeManifest("rails-private-methods manifest", () => {
+  it("keys every entry under a package dir PACKAGE_DIRS knows", () => {
+    const dirs = Object.values(PACKAGE_DIRS);
+    const orphans = Object.keys(manifest.files).filter(
+      (k) => !dirs.some((d) => k.startsWith(`${d}/`)),
+    );
+    expect(orphans).toEqual([]);
+  });
+
   it.each([
     ["packages/actionpack/src/action-controller/base.ts", "contentSecurityPolicy"],
     [
@@ -64,7 +47,7 @@ describeManifest("rails-private-methods manifest", () => {
       "contentSecurityPolicy",
     ],
     ["packages/activemodel/src/attributes.ts", "attribute"],
-  ])("%s does not claim %s is Rails-private", (file, name) => {
+  ])("does not claim %s's %s is Rails-private on a `?` sibling's candidate", (file, name) => {
     expect(manifest.files[file] ?? []).not.toContain(name);
   });
 });

--- a/scripts/api-compare/config.test.ts
+++ b/scripts/api-compare/config.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { describe, it, expect } from "vitest";
 
-import { MANIFEST_PACKAGES, PACKAGE_DIRS, ROOT_DIR } from "./config.js";
+import { DIR_TO_PACKAGES, MANIFEST_PACKAGES, PACKAGE_DIRS, ROOT_DIR } from "./config.js";
 
 const manifestPath = path.join(ROOT_DIR, "eslint/rails-private-methods.json");
 const manifest: { files: Record<string, string[]> } = fs.existsSync(manifestPath)
@@ -20,10 +20,18 @@ describe("PACKAGE_DIRS", () => {
   it.each([
     ["actiondispatch", "packages/actionpack/src/action-dispatch"],
     ["actioncontroller", "packages/actionpack/src/action-controller"],
+    ["abstractcontroller", "packages/actionpack/src/abstract-controller"],
+    ["actionpackversion", "packages/actionpack/src/action-pack"],
     ["arel", "packages/arel/src"],
     ["trailties", "packages/trailties/src"],
   ])("spells %s's src dir the way the repo does", (pkg, dir) => {
     expect(PACKAGE_DIRS[pkg]).toBe(dir);
+  });
+
+  it("covers every api-compared package sharing the actionpack dir", () => {
+    expect([...(DIR_TO_PACKAGES.actionpack ?? [])].sort()).toEqual(
+      [...(DIR_TO_PACKAGES.actionpack ?? [])].filter((p) => p in PACKAGE_DIRS).sort(),
+    );
   });
 
   it("covers exactly the manifest packages", () => {

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -117,3 +117,39 @@ export function packageSrcDir(pkg: string): string {
     ? path.join(ROOT_DIR, "packages", dirName, "src", subDir)
     : path.join(ROOT_DIR, "packages", dirName, "src");
 }
+
+/**
+ * The api-compare packages `scripts/build-rails-privates-manifest.ts` projects
+ * Rails visibility onto. Deliberately a subset of `PACKAGES`: the gem ports
+ * (`rack`, `globalid`, `i18n`, `did-you-mean`) have no entry yet, so their
+ * `@internal` tags are unvalidatable in both directions — tracked by
+ * `rails-privates-manifest-missing-gem-packages`.
+ */
+export const MANIFEST_PACKAGES = [
+  "arel",
+  "activemodel",
+  "activerecord",
+  "activesupport",
+  "actiondispatch",
+  "actioncontroller",
+  "actionview",
+  "trailties",
+] as const;
+
+/**
+ * Manifest package → repo-relative POSIX src dir, derived from `packageSrcDir`
+ * rather than hand-copied in the manifest builder. It lives here so the two can
+ * never drift: the builder's own copy spelled `actiondispatch` /
+ * `actioncontroller` against the real `action-dispatch` / `action-controller`,
+ * which voided every actionpack key in `eslint/rails-private-methods.json` and
+ * with it the `rails-private-jsdoc` rule for the whole package.
+ *
+ * Forward slashes because the ESLint rule looks entries up by
+ * `path.relative(...).split(path.sep).join("/")`.
+ */
+export const PACKAGE_DIRS: Record<string, string> = Object.fromEntries(
+  MANIFEST_PACKAGES.map((pkg) => [
+    pkg,
+    path.relative(ROOT_DIR, packageSrcDir(pkg)).split(path.sep).join("/"),
+  ]),
+);

--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -120,9 +120,10 @@ export function packageSrcDir(pkg: string): string {
 
 /**
  * The api-compare packages `scripts/build-rails-privates-manifest.ts` projects
- * Rails visibility onto. Deliberately a subset of `PACKAGES`: the gem ports
- * (`rack`, `globalid`, `i18n`, `did-you-mean`) have no entry yet, so their
- * `@internal` tags are unvalidatable in both directions — tracked by
+ * Rails visibility onto — every api-compared package of a Rails framework,
+ * actionpack's four included. Deliberately still a subset of `PACKAGES`: the
+ * gem ports (`rack`, `globalid`, `i18n`, `did-you-mean`) have no entry yet, so
+ * their `@internal` tags are unvalidatable in both directions — tracked by
  * `rails-privates-manifest-missing-gem-packages`.
  */
 export const MANIFEST_PACKAGES = [
@@ -132,6 +133,8 @@ export const MANIFEST_PACKAGES = [
   "activesupport",
   "actiondispatch",
   "actioncontroller",
+  "abstractcontroller",
+  "actionpackversion",
   "actionview",
   "trailties",
 ] as const;

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -36,25 +36,12 @@ import {
   beginManifestBatch,
   flushManifestBatch,
 } from "@blazetrails/parity/write-json-manifest";
+import { PACKAGE_DIRS } from "./api-compare/config.js";
 import { railsApiAvailable } from "./api-compare/require-rails-api.js";
 import { diffDeprecatedManifest } from "./deprecated-manifest-diff.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
-
-// Reuses the package layout from scripts/api-compare/config.ts so the
-// two stay in lockstep. Paths are POSIX (forward slashes) — the ESLint
-// rule looks up entries built from `path.relative(...).split(sep).join("/")`.
-const PACKAGE_DIRS: Record<string, string> = {
-  arel: "packages/arel/src",
-  activemodel: "packages/activemodel/src",
-  activerecord: "packages/activerecord/src",
-  activesupport: "packages/activesupport/src",
-  actiondispatch: "packages/actionpack/src/actiondispatch",
-  actioncontroller: "packages/actionpack/src/actioncontroller",
-  actionview: "packages/actionview/src",
-  trailties: "packages/trailties/src",
-};
 
 const RAILS_API_PATH = path.join(ROOT, "scripts/api-compare/output/rails-api.json");
 const OUT = path.join(ROOT, "eslint/rails-private-methods.json");
@@ -244,6 +231,19 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
     for (const [ruby, status] of names) {
       if (status !== "all-private") continue;
       for (const c of rubyMethodToTs(ruby) ?? []) tsNames.add(c);
+    }
+    // The all-private decision above is made per RUBY name, but the manifest is
+    // keyed by TS name, and the two are not one-to-one: `rubyMethodToTs` gives a
+    // `?` method the bare stem as a candidate, so a private `content_security_policy?`
+    // contributes `contentSecurityPolicy` — the spelling of the PUBLIC
+    // `content_security_policy` sitting beside it in the same file. Left in, the
+    // manifest demands `@internal` on a public Rails DSL method and hides it from
+    // the website API reference. Subtracting every candidate of a `mixed` name
+    // restores the all-private guard's intent in the TS namespace it actually
+    // gates on.
+    for (const [ruby, status] of names) {
+      if (status === "all-private") continue;
+      for (const c of rubyMethodToTs(ruby) ?? []) tsNames.delete(c);
     }
     if (tsNames.size === 0) continue;
     const existing = manifest.files[tsRel] ?? [];

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -23,6 +23,14 @@
  * spurious matches against unrelated Rails-private accessors that
  * happen to share a name.
  *
+ * That all-private decision is made per RUBY name while the manifest is keyed
+ * by TS name, and the two are not one-to-one: `rubyMethodToTs` gives a `?`
+ * method the bare stem as a candidate, so private `content_security_policy?`
+ * yields `contentSecurityPolicy` — the spelling of the PUBLIC
+ * `content_security_policy` class DSL beside it. Every `mixed` name's
+ * candidates are therefore subtracted after projection, applying the guard in
+ * the TS namespace it actually gates on.
+ *
  * Run after `pnpm parity:api` (or `ruby scripts/api-compare/extract-ruby-api.rb`):
  *   pnpm rails-privates:manifest
  */
@@ -232,15 +240,6 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
       if (status !== "all-private") continue;
       for (const c of rubyMethodToTs(ruby) ?? []) tsNames.add(c);
     }
-    // The all-private decision above is made per RUBY name, but the manifest is
-    // keyed by TS name, and the two are not one-to-one: `rubyMethodToTs` gives a
-    // `?` method the bare stem as a candidate, so a private `content_security_policy?`
-    // contributes `contentSecurityPolicy` — the spelling of the PUBLIC
-    // `content_security_policy` sitting beside it in the same file. Left in, the
-    // manifest demands `@internal` on a public Rails DSL method and hides it from
-    // the website API reference. Subtracting every candidate of a `mixed` name
-    // restores the all-private guard's intent in the TS namespace it actually
-    // gates on.
     for (const [ruby, status] of names) {
       if (status === "all-private") continue;
       for (const c of rubyMethodToTs(ruby) ?? []) tsNames.delete(c);


### PR DESCRIPTION
`scripts/build-rails-privates-manifest.ts` hand-copied its package → src dir map
and had drifted from `scripts/api-compare/config.ts`, in two distinct ways:

| package | manifest emitted | actual path |
|---|---|---|
| `actiondispatch` | `src/actiondispatch/` | `src/action-dispatch/` |
| `actioncontroller` | `src/actioncontroller/` | `src/action-controller/` |
| `abstractcontroller` | *(absent from the map)* | `src/abstract-controller/` |
| `actionpackversion` | *(absent from the map)* | `src/action-pack/` |

So **219 of 604 keys in `eslint/rails-private-methods.json` named paths that do
not exist**, two more actionpack packages were never projected at all, and
`eslint/rails-private-jsdoc.mjs` had **never fired on actionpack** — despite
`rails-private-jsdoc.config.mjs` listing all four sub-packages in its `files`
glob.

```console
npx eslint --no-inline-config -c eslint/rails-private-jsdoc.config.mjs "packages/**/src/**/*.ts"
  before: 0 violations
  after:  46 violations   (all autofixable, all fixed here)
```

## What changed

**Derive the map, and move it where it can't drift.** `MANIFEST_PACKAGES` and
`PACKAGE_DIRS` now live in `api-compare/config.ts` and are computed from
`packageSrcDir`. They had to move rather than just be imported: the builder has
top-level side effects (it writes three manifests and can `process.exit`), so
nothing can import a constant from it — including the test.

`MANIFEST_PACKAGES` now covers all four actionpack packages, not the two the old
map happened to list; a test pins that every api-compared package mapping to the
`actionpack` dir is present, so the set cannot fall behind `PACKAGES` again.
`actionpackversion` contributes no keys (Rails' `action_pack/` has no private
methods) but costs nothing and closes the gap by construction.

**A second defect the autofix exposed.** The all-private guard runs on *Ruby*
names, but the manifest is keyed by *TS* name, and `rubyMethodToTs` gives a `?`
method the bare stem as a candidate. The private `content_security_policy?`
therefore contributed `contentSecurityPolicy` — the spelling of the **public**
`content_security_policy` class DSL beside it
(`action_controller/metal/content_security_policy.rb:40`). The rule then demanded
`@internal` on a public Rails method, hiding it from the website API reference:
the exact inversion of its purpose. Subtracting every `mixed` name's candidates
removes 66 such names across 7 packages, including `permitted`, `nestedScope`,
`setContentType`, and activemodel's `attribute` — the case
`rails-private-jsdoc.mjs:10-13` cites in its own header as what the guard is for.

Net: 87 dead actionpack keys become live, 6 new abstract-controller keys, 88
removed, 46 real violations fixed.
Each fix was checked against `vendor/rails` (e.g. `named_host?`, `show`,
`failed?` are all under `private` in their Ruby files).

## Verification

Every one of the 46 tags was checked against `vendor/rails`, not sampled — each
distinct Ruby counterpart is under `private` or `protected` in its own file:
`percent_escape`, `handle_conditional_get!`, `valid_accept_header`,
`use_accept_header`, `format_from_path_extension`, `params_readable?`,
`code_from_name`, `name_from_code`, `send_file_headers!`, `sanitize_hosts`,
`build_host_url`, `named_host?`, `show`, `failed?`, `create_routes`,
`reset_routes` (both arities), and `optimize_routes_generation?` (protected,
`url_for.rb:227`).

The eight abstract-controller tags added on review are likewise all `private` in
`vendor/rails/actionpack/lib/abstract_controller/`: `process_action`
(`base.rb:225`), `cache_configured?` (`caching.rb:24`), `define_helpers_module`
(`helpers.rb:226`), `default_helper_module!` (`helpers.rb:237`),
`_process_variant` (`rendering.rb:101`), `_set_html_content_type`
(`rendering.rb:104`), `_set_vary_header` (`rendering.rb:107`) and
`_set_rendered_content_type` (`rendering.rb:110`).

## Notes for review

- `eslint/rails-private-methods.json` is **gitignored** and rebuilt by the
  Ruby-bearing `rails-comparison` job, so there is no manifest in the diff — the
  fix ships as code only.
- `scripts/stale-story-references.test.ts` is red on `origin/main` as of
  bcf0036c2 (#6980 left `column.ts:153` citing the now-landed
  `converge-column-encode-with-init-with`). It is not from this branch and is
  not fixed here.
- The test asserts each package **directory** exists, not that each manifest key
  resolves to a file: 134 keys legitimately name Rails files trails has not
  ported yet, and a dead key is indistinguishable from an unported one. The
  directory prefix is the level at which this drift is detectable. Its
  manifest-reading half skips when the file is absent or empty (verified both
  ways) so it can't red the jobs without Ruby.

## Split out on review

`scripts/build-rails-file-structure-manifest.ts:40-50` carries the **same**
hand-copied map, under a comment reading "Mirrors
scripts/build-rails-privates-manifest.ts", with the same two misspellings and
the same two missing packages — 124 dead actionpack keys. It is latent today
because `rails-file-structure-method-order` is enrolled for arel and activemodel
only (`eslint.config.mjs:447-455`).

That is a different manifest feeding a different lint rule, and outside this
story's acceptance criteria, so it is **not** in this PR. Filed as
`rails-file-structure-manifest-package-dirs-drift` (RFC 0025), `ready`, with the
measurements and a `deps` on this story — it imports the `PACKAGE_DIRS` this PR
exports, so it starts after this merges rather than branching off it.

## Context

First story of RFC 0121 (`internal-tag-accounting`). The RFC's measurement — 53%
of trails' 4,267 `@internal` tags are backed by a Rails-private counterpart,
1,156 are not — depends on this manifest being correct, and actionpack cannot be
enrolled in the follow-up rule while 36% of its enforcement is dead.

Refs story rails-privates-manifest-package-dirs-drift
