### PR TITLE
fix(activerecord): cite the open follow-up story from Column#encodeWith's deviation note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,18 @@ jobs:
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
           TSE_COMPILER_PKGS_RE='^packages/tse-compiler/'
           RACK_PKGS_RE='^packages/(rack|activesupport|date)/'
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport|date|i18n)/|eslint/|scripts/(tasks|guides-typecheck|parity|api-compare|test-compare|fixtures-compare|test-deps|rails-find|sync-stats)/|scripts/ci/check-control-bytes\.sh$|scripts/(strip-asany|tasks-shim|rails-file-structure-mixins|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references|non-transactional-row-writes|generate-canonical-zone-identifiers|generate-tzdata-isdst)(\.test)?\.ts$|scripts/db-init/mysql/01-rails-user\.sql$|packages/activerecord-cli/src/__e2e__/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
+          # `packages/`, `scripts/` and `eslint/` are listed whole rather than
+          # enumerated, because several tests in this lane report on the WHOLE
+          # tree rather than on their own package: stale-story-references
+          # scans exactly those three SOURCE_ROOTS
+          # (scripts/stale-story-references.ts:31), as do
+          # non-transactional-row-writes and mixin-declaration-drift. Listing
+          # only the packages whose own tests live here let a citation under
+          # packages/activerecord/ invalidate a guard result in a lane that
+          # never ran — #6980 closed a story cited in
+          # connection-adapters/column.ts, and the red surfaced a push later
+          # on main against an unrelated diff (#6989).
+          UNIT_TESTS_PKGS_RE='^(packages/|scripts/|eslint/|eslint\.config\.mjs$|vendor/(sources\.ts|sources\.lock\.json|sources\.test\.ts|fetch\.ts)$)'
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|date|did-you-mean|trails-tsc)/|packages/website/docs/guides/|scripts/guides-typecheck/)'
           GUIDES_EXCL_RE='(/src/test-helpers(/|\.ts$)|/test-fixtures?(/|\.ts$)|/__fixtures__/|/__snapshots__/|\.test\.ts$)'
           WEBSITE_PKGS_RE='^packages/website/'

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -169,7 +169,7 @@ export class Column {
    * cache against another reflected one, while trails' fixtures warm compares a
    * dump-loaded cache against a reflected one — dropping `array` / `serial` /
    * `rowid` & co. reds `base_test.rb`'s `test_clear_cache!`. Tracked by RFC
-   * 0096 `converge-column-encode-with-init-with`.
+   * 0096 `converge-column-subclass-state-out-of-encode-with`.
    */
   encodeWith(coder: ColumnCoder): void {
     coder["class"] = "Column";

--- a/packages/activesupport/src/cache/file-store-atomic-write.trails.test.ts
+++ b/packages/activesupport/src/cache/file-store-atomic-write.trails.test.ts
@@ -45,6 +45,13 @@ describe("FileStore atomic write and inspect", () => {
     const iterations = 100;
     try {
       const store = new FileStore(dir);
+      // Seed the key first: `lock_file` yields UNLOCKED when the file does not
+      // exist (file_store.rb:148-158) and `modify_value` is what creates it
+      // (:228), so Rails itself loses an increment when two writers race the
+      // seeding write. The mutual exclusion under test is the existing-file
+      // arm, and racing the create instead made this assert a guarantee Rails
+      // does not make — it dropped exactly one increment in CI.
+      store.write("counter", 0);
       const worker = new Worker(new URL("./file-store-lock-worker.trails.mjs", import.meta.url), {
         workerData: { dir, iterations },
         execArgv: [


### PR DESCRIPTION
`Unit Tests` went red on `main` at d5f0f7a38 with one failure in
`scripts/stale-story-references.test.ts`:

```
packages/activerecord/src/connection-adapters/column.ts:153 converge-column-encode-with-init-with
```

Nothing to do with d5f0f7a38's own diff. Three distinct defects, one per
commit.

## 1. A citation pointing at a story that landed — `column.ts`

`converge-column-encode-with-init-with` landed as #6980 (the commit
immediately before), while `Column#encodeWith`'s deviation note still read
"Tracked by RFC 0096 `converge-column-encode-with-init-with`".

The deviation the note describes is real and still shipped: trails' subclass
`encodeWith` / `initWith` overrides carry `array` / `serial` / `rowid` & co.,
which Rails does not — `encode_with` writes only the seven base keys
(`column.rb:56`) and `init_with` (`column.rb:46-53`) fills only those, leaving
the subclass ivars nil. #6980's acceptance criteria settled that explicitly
("if it stays, that is the one documented deviation"), so the citation is not
obsolete prose to delete; it points at a closed story.

Filed the residual as its own open story,
`0096-naming-identifier-burndown/converge-column-subclass-state-out-of-encode-with`
— carrying the `test_clear_cache!` constraint and the fixtures-warm
dump-loaded-vs-reflected comparison that forces it — and repointed the note.
One JSDoc line; no behavior change.

## 2. The lane could not see its own inputs — `ci.yml`

`UNIT_TESTS_PKGS_RE` enumerated `packages/(arel|activemodel|activesupport|date|i18n)/`
— the packages whose *own* tests run in this lane. But several tests here
report on the **whole tree**: `stale-story-references` scans
`SOURCE_ROOTS = ["packages", "scripts", "eslint"]`
(`scripts/stale-story-references.ts:31`), as do `non-transactional-row-writes`
and `mixin-declaration-drift`.

So #6980 could close a story cited under `packages/activerecord/` without ever
running the guard that checks citations, and the break surfaced a push later
on `main` against an unrelated diff (#6989). Fixing the citation alone leaves
that trap armed — and is why `Unit Tests` reported `skipped` on this PR's
first run.

The gate now lists `packages/`, `scripts/` and `eslint/` whole, which is the
guards' actual input set. The enumerated `scripts/*.ts` and
`packages/activerecord-cli/src/__e2e__/` clauses are subsumed by it.

## 3. A concurrency test racing the unlocked arm — `file-store-atomic-write.trails.test.ts`

Uncovered once the lane actually ran: `does not lose concurrent increments`
failed with `expected 199 to be 200`.

The implementation is right and the test was wrong. `lock_file` locks only
when the file already exists and otherwise yields **unlocked**
(`file_store.rb:148-158`), and `modify_value` is what *creates* the file —
its miss branch calls `write(name, amount, options)` (`file_store.rb:228`).
On a cold key both racers take the unlocked `else`, both read no entry, both
write `1`, and exactly one increment is lost. Rails has the identical window;
trails' `lockFile` (`file-store.ts:219-235`) mirrors it branch-for-branch, and
`flockSync` is present and working (`fs-adapter.ts:197`, a `.lock` sentinel) —
it simply is not reached on the create.

So locking the create would be a deviation from Rails, not a fix. Instead the
trails-only test now seeds `counter` to `0` before spawning the worker, so
both threads race an **existing** file — the locked arm, which is the one its
own docstring says it covers ("`lock_file` around `modify_value`
(file_store.rb:140-153, :228)") and the one where 200 is a guarantee Rails
actually makes. Test name unchanged; 5/5 clean local runs.

## Verification

- `pnpm vitest run scripts/stale-story-references.test.ts` — 17 passed (was 1 failed).
- `pnpm vitest run packages/activesupport/src/cache/file-store-atomic-write.trails.test.ts` — 5 passed, five times running.
- No skip, no baseline row, no `@ts-expect-error`, no `eslint-disable`.

The only non-test source change is one JSDoc line, so no call-set,
call-argument, extra-surface or compare-delta movement is possible.

Closes-story: red-d5f0f7a3
