### PR TITLE
feat(activesupport): port Delegation.generate's Module target and reserved receivers

### DIFF
--- a/packages/activesupport/src/core-ext/module.test.ts
+++ b/packages/activesupport/src/core-ext/module.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { delegate } from "../module-ext.js";
+import { registerConstant, unregisterConstant } from "../inflector.js";
 
 describe("ModuleTest", () => {
   it("delegation to index get method", () => {
@@ -654,5 +655,37 @@ describe("ModuleTest", () => {
     delegate(Service.prototype, "compute", { to: "helper" });
     const s = new Service() as Service & { compute: (x: number) => number };
     expect(s.compute(4)).toBe(16);
+  });
+  it("module nesting is empty", () => {
+    class Json {
+      static parse(source: string) {
+        return JSON.parse(source);
+      }
+    }
+    registerConstant("Json", Json);
+    try {
+      class C {}
+      delegate(C, "parse", { to: Json });
+      const c = C as typeof C & { parse(source: string): unknown };
+      expect(c.parse("[1]")).toEqual([1]);
+    } finally {
+      unregisterConstant("Json", Json);
+    }
+  });
+
+  it("delegation unreacheable module", () => {
+    const anonymousClass = [class {}][0];
+
+    expect(() => {
+      class C {}
+      delegate(C.prototype, "something", { to: anonymousClass });
+    }).toThrow(/Can't delegate to anonymous class or module/);
+
+    Object.defineProperty(anonymousClass, "name", { value: "FakeName" });
+
+    expect(() => {
+      class C {}
+      delegate(C.prototype, "something", { to: anonymousClass });
+    }).toThrow(/Can't delegate to detached class or module: FakeName/);
   });
 });

--- a/packages/activesupport/src/core-ext/module.test.ts
+++ b/packages/activesupport/src/core-ext/module.test.ts
@@ -116,9 +116,20 @@ describe("ModuleTest", () => {
   });
 
   it("module nesting is empty", () => {
-    class Foo {}
-    expect(Foo.name).toBe("Foo");
-    expect(Foo.name.includes("::")).toBe(false);
+    class Json {
+      static parse(source: string) {
+        return JSON.parse(source);
+      }
+    }
+    registerConstant("Admin::Json", Json);
+    try {
+      class C {}
+      delegate(C, "parse", { to: Json });
+      const c = C as typeof C & { parse(source: string): unknown };
+      expect(c.parse("[1]")).toEqual([1]);
+    } finally {
+      unregisterConstant("Admin::Json", Json);
+    }
   });
 
   it("delegation to methods", () => {
@@ -621,12 +632,19 @@ describe("ModuleTest", () => {
   });
 
   it("delegation unreacheable module", () => {
-    class Container {
-      val: undefined = undefined;
-    }
-    delegate(Container.prototype, "something", { to: "val" });
-    const c = new Container() as Container & { something(): unknown };
-    expect(() => c.something()).toThrow();
+    const anonymousClass = [class {}][0];
+
+    expect(() => {
+      class C {}
+      delegate(C.prototype, "something", { to: anonymousClass });
+    }).toThrow(/Can't delegate to anonymous class or module/);
+
+    Object.defineProperty(anonymousClass, "name", { value: "FakeName" });
+
+    expect(() => {
+      class C {}
+      delegate(C.prototype, "something", { to: anonymousClass });
+    }).toThrow(/Can't delegate to detached class or module: FakeName/);
   });
 
   it("delegation arity to module", () => {
@@ -655,37 +673,5 @@ describe("ModuleTest", () => {
     delegate(Service.prototype, "compute", { to: "helper" });
     const s = new Service() as Service & { compute: (x: number) => number };
     expect(s.compute(4)).toBe(16);
-  });
-  it("module nesting is empty", () => {
-    class Json {
-      static parse(source: string) {
-        return JSON.parse(source);
-      }
-    }
-    registerConstant("Json", Json);
-    try {
-      class C {}
-      delegate(C, "parse", { to: Json });
-      const c = C as typeof C & { parse(source: string): unknown };
-      expect(c.parse("[1]")).toEqual([1]);
-    } finally {
-      unregisterConstant("Json", Json);
-    }
-  });
-
-  it("delegation unreacheable module", () => {
-    const anonymousClass = [class {}][0];
-
-    expect(() => {
-      class C {}
-      delegate(C.prototype, "something", { to: anonymousClass });
-    }).toThrow(/Can't delegate to anonymous class or module/);
-
-    Object.defineProperty(anonymousClass, "name", { value: "FakeName" });
-
-    expect(() => {
-      class C {}
-      delegate(C.prototype, "something", { to: anonymousClass });
-    }).toThrow(/Can't delegate to detached class or module: FakeName/);
   });
 });

--- a/packages/activesupport/src/delegation.test.ts
+++ b/packages/activesupport/src/delegation.test.ts
@@ -93,6 +93,15 @@ describe("Delegation.generate", () => {
       Delegation.generate({}, ["greet"], { to: "" });
     }).toThrow("Delegation needs a target");
   });
+
+  it("prefixes a reserved receiver with self.", () => {
+    class Person {
+      args: null = null;
+    }
+    Delegation.generate(Person.prototype, ["greet"], { to: "args" });
+    const p = new Person() as Person & { greet: () => unknown };
+    expect(() => p.greet()).toThrow("greet delegated to self.args, but self.args is nil");
+  });
 });
 
 describe("Delegation.generateMethodMissing", () => {

--- a/packages/activesupport/src/delegation.ts
+++ b/packages/activesupport/src/delegation.ts
@@ -4,7 +4,15 @@
  */
 
 import { NameError } from "./core-ext/name-error.js";
+import { constantize, safeConstantize } from "./inflector.js";
 import { PROTOCOL_PROBES } from "./method-missing-proxy.js";
+
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
 
 /**
  * Ruby's `NoMethodError`, raised when the delegator calls a method the target
@@ -30,12 +38,28 @@ export class DelegationError extends Error {
 }
 
 export interface DelegateOptions {
-  to: string;
+  /**
+   * A method name, or the trails spelling of a Ruby Module — a class or module
+   * object, whose registered constant name is the receiver (`delegation.rb:36-47`).
+   */
+  to: string | object;
   prefix?: boolean | string;
   allowNil?: boolean;
 }
 
 export namespace Delegation {
+  // prettier-ignore
+  export const RUBY_RESERVED_KEYWORDS = ["__ENCODING__", "__LINE__", "__FILE__", "alias", "and", "BEGIN", "begin", "break",
+    "case", "class", "def", "defined?", "do", "else", "elsif", "END", "end", "ensure", "false", "for", "if", "in", "module", "next", "nil",
+    "not", "or", "redo", "rescue", "retry", "return", "self", "super", "then", "true", "undef", "unless", "until", "when", "while", "yield"];
+  export const RESERVED_METHOD_NAMES: ReadonlySet<string> = new Set([
+    ...RUBY_RESERVED_KEYWORDS,
+    "_",
+    "arg",
+    "args",
+    "block",
+  ]);
+
   /**
    * Mirrors: `ActiveSupport::Delegation.generate`
    * (`activesupport/lib/active_support/delegation.rb:23-158`). Ruby builds the
@@ -51,11 +75,6 @@ export namespace Delegation {
    * answer at all still raises: Rails converts the generated body's
    * `NoMethodError` to a `DelegationError` only when `_` is nil, and otherwise
    * re-raises it (`:132-140`).
-   *
-   * `to:` accepts only a method name. Rails also takes a `Module`, and prefixes
-   * a `RESERVED_METHOD_NAMES` receiver with `self.` (`:36-58`) — neither is
-   * ported; see story `0106-wide-call-set-direct-burndown/
-   * port-delegation-generate-module-and-reserved-receivers`.
    */
   export function generate<T extends object>(
     owner: T,
@@ -65,18 +84,40 @@ export namespace Delegation {
     const { to, prefix, allowNil } = options;
 
     if (!to) {
-      throw new Error(
+      throw new ArgumentError(
         "Delegation needs a target. Supply a keyword argument 'to' (e.g. delegate :hello, to: :greeter).",
       );
     }
 
-    if (prefix === true && /^[^a-z_]/.test(to)) {
-      throw new Error(
+    if (prefix === true && (typeof to !== "string" || /^[^a-z_]/.test(to))) {
+      throw new ArgumentError(
         "Can only automatically set the delegation prefix when delegating to a method.",
       );
     }
 
-    const methodPrefix = prefix ? `${prefix === true ? to : prefix}_` : "";
+    const methodPrefix = prefix ? `${prefix === true ? String(to) : prefix}_` : "";
+
+    let receiver: string;
+    if (typeof to !== "string") {
+      const name = (to as { name?: string }).name;
+      if (name == null || name === "") {
+        throw new ArgumentError(`Can't delegate to anonymous class or module: ${String(to)}`);
+      }
+
+      if (safeConstantize(name) !== to) {
+        throw new ArgumentError(`Can't delegate to detached class or module: ${name}`);
+      }
+
+      receiver = `::${name}`;
+    } else {
+      receiver = to;
+    }
+    if (RESERVED_METHOD_NAMES.has(receiver)) receiver = `self.${receiver}`;
+
+    // The `self.` Ruby prepends is a parser disambiguation for a keyword-named
+    // method; a JS member read is never ambiguous, so the generated body reads
+    // the same member either way.
+    const receiverName = receiver.startsWith("self.") ? receiver.slice("self.".length) : receiver;
 
     const methodNames: string[] = [];
 
@@ -89,10 +130,12 @@ export namespace Delegation {
         enumerable: false,
         writable: true,
         value(...args: unknown[]) {
-          const _ = (this as Record<string, unknown>)[to];
+          const _ = receiver.startsWith("::")
+            ? constantize(receiver)
+            : (this as Record<string, unknown>)[receiverName];
           if (_ == null) {
             if (allowNil) return undefined;
-            throw DelegationError.nilTarget(methodName, to);
+            throw DelegationError.nilTarget(methodName, receiver);
           }
           if (!(method in Object(_))) {
             throw new NoMethodError(`undefined method '${method}' for ${String(_)}`);

--- a/packages/activesupport/src/delegation.ts
+++ b/packages/activesupport/src/delegation.ts
@@ -75,6 +75,16 @@ export namespace Delegation {
    * answer at all still raises: Rails converts the generated body's
    * `NoMethodError` to a `DelegationError` only when `_` is nil, and otherwise
    * re-raises it (`:132-140`).
+   *
+   * Two arms of the receiver step (`:36-58`) read differently in TS. The `self.`
+   * Ruby prepends to a `RESERVED_METHOD_NAMES` receiver (`:58`) disambiguates a
+   * keyword from a method call in the source it compiles; a JS member read is
+   * never ambiguous, so the generated body reads the same member with or without
+   * it — the prefix survives only where Rails also shows it, in the
+   * `DelegationError` message (`:135`). And `prefix: true` with a Module target
+   * raises here: Ruby reaches `TypeError` from `/^[^a-z_]/.match?(to)` (`:27`)
+   * because a Module has no implicit String conversion, where TS has to test the
+   * type itself, so it raises the `ArgumentError` that line is guarding for.
    */
   export function generate<T extends object>(
     owner: T,
@@ -114,9 +124,6 @@ export namespace Delegation {
     }
     if (RESERVED_METHOD_NAMES.has(receiver)) receiver = `self.${receiver}`;
 
-    // The `self.` Ruby prepends is a parser disambiguation for a keyword-named
-    // method; a JS member read is never ambiguous, so the generated body reads
-    // the same member either way.
     const receiverName = receiver.startsWith("self.") ? receiver.slice("self.".length) : receiver;
 
     const methodNames: string[] = [];

--- a/packages/activesupport/src/delegation.ts
+++ b/packages/activesupport/src/delegation.ts
@@ -4,7 +4,7 @@
  */
 
 import { NameError } from "./core-ext/name-error.js";
-import { constantize, safeConstantize } from "./inflector.js";
+import { constantize, registeredConstantName, safeConstantize } from "./inflector.js";
 import { PROTOCOL_PROBES } from "./method-missing-proxy.js";
 
 class ArgumentError extends Error {
@@ -85,6 +85,11 @@ export namespace Delegation {
    * raises here: Ruby reaches `TypeError` from `/^[^a-z_]/.match?(to)` (`:27`)
    * because a Module has no implicit String conversion, where TS has to test the
    * type itself, so it raises the `ArgumentError` that line is guarding for.
+   *
+   * `to.name` (`:38`, `:41`, `:45`) is Ruby's full constant path, so a nested
+   * `Admin::Json` delegates through `::Admin::Json`; a JS class carries only its
+   * own identifier, so the registered path comes from `registeredConstantName`
+   * and the class's own `name` is the fallback for a top-level registration.
    */
   export function generate<T extends object>(
     owner: T,
@@ -109,7 +114,7 @@ export namespace Delegation {
 
     let receiver: string;
     if (typeof to !== "string") {
-      const name = (to as { name?: string }).name;
+      const name = registeredConstantName(to) ?? (to as { name?: string }).name;
       if (name == null || name === "") {
         throw new ArgumentError(`Can't delegate to anonymous class or module: ${String(to)}`);
       }

--- a/packages/activesupport/src/inflector.ts
+++ b/packages/activesupport/src/inflector.ts
@@ -254,6 +254,24 @@ export function privateConstant(name: string): void {
   _privateConstants.add(name);
 }
 
+/**
+ * @noRailsEquivalent PERMANENT
+ *   (`vendor/rails/activesupport/lib/active_support/inflector/methods.rb:289` — the reverse of the
+ *   invented registry; Ruby needs none because `Module#name` already IS the full constant path).
+ * The name half of Ruby's `Module#name` for a namespaced class. Ruby names a
+ * constant as a side effect of definition, so `Admin::Json.name` is
+ * `"Admin::Json"`; a JS class carries only its own identifier, so the path a
+ * host registered through {@link registerConstant} is the only place it exists.
+ * Returns the registered name for `value`, or `undefined` when nothing
+ * registered it — the trails spelling of Ruby's anonymous `name.nil?`.
+ */
+export function registeredConstantName(value: unknown): string | undefined {
+  for (const [name, registered] of _constants) {
+    if (registered === value) return name;
+  }
+  return undefined;
+}
+
 /** @internal — test use only: clear the registered constant table. */
 export function _resetConstants(): void {
   _constants.clear();


### PR DESCRIPTION
`ActiveSupport::Delegation.generate` accepted only a method name as `to:`. Rails
also takes a Module (`activesupport/lib/active_support/delegation.rb:36-47`) —
guarding an anonymous or detached one with two `ArgumentError`s — and prefixes a
`RESERVED_METHOD_NAMES` receiver with `self.` (`delegation.rb:15-17, 58`).

- `DelegateOptions.to` now takes a class/module object as well as a method name.
  Its registered constant name (`safeConstantize`, `delegation.rb:41`) becomes
  the `::Name` receiver, resolved at call time the way Ruby resolves the
  constant in the generated body.
- `RUBY_RESERVED_KEYWORDS` / `RESERVED_METHOD_NAMES` ported at the Rails names
  and consulted at `delegation.rb:58`. The `self.` prefix is a Ruby parser
  disambiguation with no JS analogue, so the generated body strips it back off
  for the member read — but it is observable in the `DelegationError` message,
  which now carries the receiver rather than `to` (`delegation.rb:135`).
- All four raises are `ArgumentError`, matching Rails.
- The JSDoc pointer at this story is removed.

Tests: `module nesting is empty` and `delegation unreacheable module` from
`activesupport/test/core_ext/module_test.rb:605-630`, plus a trails case for the
reserved-receiver message.

Gates: `parity:api:calls`, `parity:api:calls:args` green;
`parity:api:extra --package activesupport` shows 0 novel for `delegation.ts`.

Closes-story: port-delegation-generate-module-and-reserved-receivers