### PR TITLE
refactor(activerecord): Rails' table_name/reset_table_name/compute_table_name split; sync reflection warms a sync-columns adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -163,13 +163,20 @@ export class Column {
    * carries no tag, so the tag is written as a key and `rehydrateColumn`
    * dispatches on it.
    *
-   * The subclass overrides below then go one step further than Rails and encode
-   * their own state too. That is a deliberate deviation, not an oversight:
-   * Rails' data loss is invisible because Rails only ever compares a reflected
-   * cache against another reflected one, while trails' fixtures warm compares a
-   * dump-loaded cache against a reflected one — dropping `array` / `serial` /
-   * `rowid` & co. reds `base_test.rb`'s `test_clear_cache!`. Tracked by RFC
-   * 0096 `converge-column-subclass-state-out-of-encode-with`.
+   * Rails' own subclasses carry part of their state through the coder too —
+   * `PostgreSQL::Column` writes `serial` / `identity` / `generated`
+   * (`postgresql/column.rb:50-61`) and `SQLite3::Column` writes
+   * `auto_increment` (`sqlite3/column.rb:36-44`); `MySQL::Column` writes
+   * nothing, because its `extra` lives in `MySQL::TypeMetadata` and rides
+   * along inside `sql_type_metadata`. trails' overrides go further still,
+   * encoding the state Rails either derives (`array` from the `[]` suffix) or
+   * holds in an adapter `TypeMetadata` trails has not ported (`oid` / `fmod` /
+   * `extra`), plus the `rowid` / `generated_type` Rails genuinely loses. That
+   * last one is load-bearing here and not upstream: Rails only ever compares a
+   * reflected cache against another reflected one, while trails' fixtures warm
+   * compares a dump-loaded cache against a reflected one, so dropping them reds
+   * `base_test.rb`'s `test_clear_cache!`. Tracked by RFC 0096
+   * `converge-column-subclass-state-out-of-encode-with`.
    */
   encodeWith(coder: ColumnCoder): void {
     coder["class"] = "Column";

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -5,6 +5,7 @@ import { IndexDefinition } from "./connection-adapters/abstract/schema-definitio
 import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 
+import { isSchemaLoaded } from "./model-schema.js";
 import { isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import { Result } from "./result.js";
@@ -309,8 +310,14 @@ export class InsertAll {
   /** @internal */
   private verifyAttributeNamesAreKnown(): void {
     // Rails raises UnknownAttributeError in extract_types_from_columns_on against
-    // schema_cache.columns_hash; we mirror the same intent against the model's
-    // declared attribute set so the error surfaces before any SQL is built.
+    // schema_cache.columns_hash (insert_all.rb:306-313); we mirror the same
+    // intent against the model's declared attribute set so the error surfaces
+    // before any SQL is built. Rails reads that hash through a blocking
+    // reflect, so it never judges a model whose schema is not loaded — this
+    // check must not either, or a table_name= that reset the schema
+    // (`Book.table_name = "db.books"`, insert_all_test.rb) would raise on a
+    // column the reflect is about to produce.
+    if (!isSchemaLoaded.call(this.model as never)) return;
     const known = new Set(this.model.attributeNames());
     if (known.size === 0) return;
     for (const pk of this.primaryKeys()) known.add(pk);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -19,7 +19,12 @@ import { TableNotSpecified } from "./errors.js";
 import { loadSchemaOverrides } from "./load-schema-overrides-slot.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
-import { threadedConnectionFor, connectionPool, withConnection } from "./connection-handling.js";
+import {
+  threadedConnectionFor,
+  connectionPool,
+  withConnection,
+  connectedQ,
+} from "./connection-handling.js";
 
 /**
  * Adapter for a schema-reflection read: prefer the connection threaded by the
@@ -1448,17 +1453,12 @@ export function tableName(this: SchemaHost, value?: string | null): string {
     value = value == null ? null : String(value);
     if (Object.prototype.hasOwnProperty.call(this, "_tableName")) {
       if (value === this._tableName) return this._tableName ?? "";
-      // Rails table_name= runs `reset_column_information if connected?`, which
-      // resets the predicate builder and (via initialize_find_by_cache) the
-      // find_by statement cache. We have no connection-pool `connected?`
-      // gate, so we clear these two caches eagerly and directly (rather than
-      // routing through the heavier resetColumnInformation/schema reload) so
-      // the next query rebuilds against the new table.
-      (this as { _findByStatementCache?: unknown })._findByStatementCache = undefined;
-      // Rails' reset_column_information also nils @attribute_names (on the
-      // class and, recursively, its descendants); drop the memos now so reads
-      // before the next load don't see the old table's names.
-      clearAttributeNamesMemo(this);
+      if (connectedQ.call(this as unknown as typeof Base)) {
+        // It runs before the store, so the caches it drops are the OLD table's,
+        // as in Rails. Its data-source rewarm is the one async tail — Rails'
+        // `reset_column_information` has none — and nothing here awaits it.
+        void Promise.resolve(resetColumnInformation.call(this)).catch(() => {});
+      }
     }
     this._tableName = value;
     (this as { _predicateBuilder?: unknown })._predicateBuilder = null;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -68,39 +68,29 @@ function ownSchemaMemo<K extends keyof SchemaHost>(
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the table name for a model class.
- * Inferred from class name if not explicitly set. STI subclasses
- * inherit the base class's table name.
- *
- * Mirrors: ActiveRecord::ModelSchema::ClassMethods#table_name
- *
- * Also folds in `reset_table_name` (model_schema.rb:290-300), whose arms Rails
- * evaluates eagerly at `inherited` time and trails evaluates lazily here (the
- * `table_name` reader routes through this function, not through
- * `resetTableName`): `self == Base` is nil, and an abstract class takes
- * `superclass.table_name` rather than a name computed from its own class name.
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#compute_table_name
+ * (model_schema.rb:604-618)
  *
  * @internal
  */
-export function resolveTableName(this: typeof Base): string {
-  if ((this as any)._tableName != null) return (this as any)._tableName;
-  if (this.name === "Base") return "";
-  if ((this as any).abstractClass) {
-    const superclass = Object.getPrototypeOf(this) as typeof Base | null;
-    return superclass ? resolveTableName.call(superclass) : "";
+function computeTableName(this: typeof Base): string {
+  if (isBaseClass(this)) {
+    // Nested classes are prefixed with singular parent table name.
+    const contained = containedTableNamePrefix.call(this);
+    const pluralizes = (this as any).pluralizeTableNames ?? true;
+    return `${fullTableNamePrefix.call(this as any)}${contained}${undecoratedTableName(
+      String(this.modelName),
+      pluralizes,
+    )}${fullTableNameSuffix.call(this as any)}`;
   }
-  // Rails compute_table_name: non-base subclasses always use base_class.table_name.
-  // This covers both STI hierarchies and any subclass of a non-abstract AR model.
-  if (!isBaseClass(this)) {
-    const base = baseClass.call(this);
-    if (base !== this) return resolveTableName.call(base);
-  }
-  const prefix = fullTableNamePrefix.call(this as any);
-  const suffix = fullTableNameSuffix.call(this as any);
-  const contained = containedTableNamePrefix.call(this as any);
-  const pluralizes = (this as any).pluralizeTableNames ?? true;
-  const inferred = undecoratedTableName(String(this.modelName), pluralizes);
-  return `${prefix}${contained}${inferred}${suffix}`;
+  // STI subclasses always use their superclass's table.
+  const base = baseClass.call(this);
+  // Rails' `base_class` never answers `self` here — `base_class? == false` is
+  // exactly `base_class != self` (inheritance.rb:119-121). trails' `baseClass`
+  // reaches the same answer through a separate memo, so guard the self-call
+  // rather than recurse forever if the two ever disagree.
+  if (base === this) return "";
+  return base.tableName;
 }
 
 /**
@@ -489,7 +479,7 @@ function sqlTypeFor(typeName: string, adapterName?: string): string {
  * Mirrors: used by test infrastructure, not a direct Rails API
  */
 export async function createTable(this: typeof Base): Promise<void> {
-  const table = resolveTableName.call(this);
+  const table = this.tableName;
   const pks = Array.isArray(this.primaryKey) ? this.primaryKey : [this.primaryKey];
   const adapterName = this.connection.adapterName;
   const isMysql = adapterName === "mysql2";
@@ -619,17 +609,28 @@ export function quotedTableName(this: SchemaHost): string {
 }
 
 /**
- * Rails: resets and recomputes table name, handling abstract classes
- * and STI inheritance.
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#reset_table_name
+ * (model_schema.rb:289-300)
+ *
+ * Reaches its value by assigning through `table_name=`, so a first read gets
+ * the writer's cache invalidation exactly where Rails has it.
  */
 export function resetTableName(this: SchemaHost): string {
-  this._tableName = null;
-  if (this.name === "Base") {
-    return "";
-  }
-  const name = resolveTableName.call(this as any);
-  this._tableName = name;
-  return name;
+  const klass = this as unknown as typeof Base;
+  const superclass = Object.getPrototypeOf(klass) as typeof Base | null;
+  tableName.call(
+    this,
+    // `self == Base`, spelled through the own-property sentinel `setBaseClass`
+    // uses for the same test (inheritance.ts).
+    Object.prototype.hasOwnProperty.call(klass, "_isActiveRecordBase")
+      ? null
+      : klass.abstractClass
+        ? (superclass?.tableName ?? null)
+        : superclass?.abstractClass
+          ? superclass.tableName || computeTableName.call(klass)
+          : computeTableName.call(klass),
+  );
+  return this._tableName ?? "";
 }
 
 export function fullTableNamePrefix(this: SchemaHost): string {
@@ -1375,16 +1376,74 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   const table = host.tableName;
   // Gate on `_columnsHash` (the map we read) rather than `isCached`/`_columns`,
   // so an out-of-sync `_columns` entry can't pass the guard and yield undefined.
-  const hash = cache.getCachedColumnsHash(table);
+  let hash = cache.getCachedColumnsHash(table);
+  if (!hash) hash = warmColumnsHashSync(adapter, cache, table);
   if (!hash) return false;
   applyColumnsHash(host, hash);
   return true;
 }
 
-export function tableName(this: SchemaHost, value?: string): string {
+/**
+ * Rails' `schema_cache.columns_hash` is synchronous, so `load_schema!` reflects
+ * a cold table right where it stands (model_schema.rb:534-546). trails' cache
+ * read is async, which leaves this path with nothing to reflect and — before
+ * this — silently yielding an empty attribute set for any model whose columns
+ * never came from a query, e.g. `Contact`, whose columns come from the fake
+ * adapter's `merge_column` (test/models/contact.rb:30-32).
+ *
+ * An adapter whose `columns` answers synchronously is exactly that case, so
+ * reflect and warm the cache here. A real adapter's `columns` returns a
+ * promise; drop it (with its rejection handled) and leave the cold-cache
+ * fallback below to run, so DB-backed models are unaffected.
+ *
+ * @noRailsEquivalent Bridges trails' async `SchemaCache#columns_hash` back to
+ * the synchronous read Rails has; retire it when the cache read can block.
+ */
+function warmColumnsHashSync(
+  adapter: NonNullable<SchemaHost["connection"]>,
+  cache: {
+    setColumns?: (table: string, cols: any[]) => void;
+    getCachedColumnsHash: (table: string) => Record<string, unknown> | undefined;
+  },
+  table: string,
+): Record<string, unknown> | undefined {
+  if (typeof adapter.columns !== "function" || typeof cache.setColumns !== "function") {
+    return undefined;
+  }
+  let cols: unknown;
+  try {
+    cols = adapter.columns(table);
+  } catch {
+    return undefined;
+  }
+  if (cols != null && typeof (cols as any).then === "function") {
+    void (cols as Promise<unknown>).catch(() => {});
+    return undefined;
+  }
+  if (!Array.isArray(cols) || cols.length === 0) return undefined;
+  cache.setColumns(table, cols);
+  return cache.getCachedColumnsHash(table);
+}
+
+/**
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#table_name (model_schema.rb:260-263)
+ * and #table_name= (model_schema.rb:270-282).
+ *
+ * The reader is lazy and memoizes into `_tableName` via `reset_table_name`.
+ * Ruby class ivars are not inherited but JS statics are, so the `defined?`
+ * guard is an own-property check — a plain read would hand a subclass on
+ * another table its base's name.
+ */
+export function tableName(this: SchemaHost, value?: string | null): string {
   if (value !== undefined) {
     const changed = this._tableName !== value;
     this._tableName = value;
+    // `@arel_table = nil`: trails' `arelTable` builds a fresh Table per call
+    // (core.ts:835), so there is no memo to clear.
+    // `@sequence_name = nil unless @explicit_sequence_name`: trails has no
+    // separate explicit flag because a non-null `_sequenceName` IS one — only
+    // `sequence_name=` sets it, and `reset_sequence_name` nils it — so the
+    // clear would be a no-op on every reachable state.
     if (changed) {
       // Rails table_name= runs `reset_column_information if connected?`, which
       // resets the predicate builder and (via initialize_find_by_cache) the
@@ -1406,8 +1465,10 @@ export function tableName(this: SchemaHost, value?: string): string {
       // before the next load don't see the old table's names.
       clearAttributeNamesMemo(this);
     }
+    return this._tableName ?? "";
   }
-  return resolveTableName.call(this as any);
+  if (!Object.prototype.hasOwnProperty.call(this, "_tableName")) resetTableName.call(this);
+  return this._tableName ?? "";
 }
 
 export function protectedEnvironments(this: SchemaHost, value?: string[]): string[] {
@@ -1425,14 +1486,29 @@ export function inheritanceColumn(this: SchemaHost, value?: string | null): stri
   return this._inheritanceColumn ?? "type";
 }
 
+/**
+ * Mirrors: ActiveRecord::ModelSchema::ClassMethods#sequence_name
+ * (model_schema.rb:371-377) and #sequence_name= (:398-401).
+ *
+ * A non-base class answers its own `@sequence_name` if it has one and the base
+ * class's otherwise; only a base class computes one.
+ *
+ * Rails memoizes `reset_sequence_name`, which reaches the default through
+ * `with_connection { |c| c.default_sequence_name(...) }` (model_schema.rb:379-382)
+ * — async in trails, and this reader is synchronous — so the conventional name
+ * every adapter builds is spelled here instead.
+ */
 export function sequenceName(this: SchemaHost, value?: string | null): string | null {
   if (value !== undefined) {
     this._sequenceName = value;
     return value;
   }
-  const pk = this.primaryKey;
-  if (Array.isArray(pk)) return this._sequenceName;
-  return this._sequenceName ?? `${this.tableName}_${pk}_seq`;
+  if (isBaseClass(this as unknown as typeof Base)) {
+    const pk = this.primaryKey;
+    if (Array.isArray(pk)) return this._sequenceName;
+    return this._sequenceName ?? `${this.tableName}_${pk}_seq`;
+  }
+  return this._sequenceName ?? baseClass.call(this as unknown as typeof Base).sequenceName;
 }
 
 export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
@@ -1481,7 +1557,7 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
  * mixin surface colocated with the implementations.
  *
  * Not included:
- * - `resolveTableName`, `buildPkWhere`, `buildPkWhereNode` — internal helpers
+ * - `computeTableName`, `buildPkWhere`, `buildPkWhereNode` — internal helpers
  *   that back the `tableName` getter and the underscore-prefixed
  *   `_buildPkWhere*` accessors. They use the `this:` convention for internal
  *   consistency but aren't Rails-style class methods.
@@ -1540,11 +1616,6 @@ function initializeLoadSchemaMonitor(this: SchemaHost): void {
 /** @internal */
 export function isSchemaLoaded(this: SchemaHost): boolean {
   return ownSchemaMemo(this, "_schemaLoaded") ?? false;
-}
-
-/** @internal */
-function computeTableName(this: SchemaHost): string {
-  return resolveTableName.call(this as any);
 }
 
 /** @internal */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1446,29 +1446,29 @@ function warmColumnsHashSync(
 export function tableName(this: SchemaHost, value?: string | null): string {
   if (value !== undefined) {
     value = value == null ? null : String(value);
-    const changed = this._tableName !== value;
-    this._tableName = value;
-    if (changed) {
+    if (Object.prototype.hasOwnProperty.call(this, "_tableName")) {
+      if (value === this._tableName) return this._tableName ?? "";
       // Rails table_name= runs `reset_column_information if connected?`, which
       // resets the predicate builder and (via initialize_find_by_cache) the
       // find_by statement cache. We have no connection-pool `connected?`
       // gate, so we clear these two caches eagerly and directly (rather than
       // routing through the heavier resetColumnInformation/schema reload) so
       // the next query rebuilds against the new table.
-      (this as { _predicateBuilder?: unknown })._predicateBuilder = null;
       (this as { _findByStatementCache?: unknown })._findByStatementCache = undefined;
-      // Rails reset_column_information also reloads the schema so the new
-      // table's columns are re-reflected. A subclass created with a different
-      // table_name (e.g. `Class.new(Minimalistic) { self.table_name = "aircraft" }`)
-      // inherits the parent's `_schemaLoaded = true` through the prototype
-      // chain and would otherwise never reflect its own table. Shadow the
-      // inherited flag with an own `false` so the next load re-reflects.
-      (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
       // Rails' reset_column_information also nils @attribute_names (on the
       // class and, recursively, its descendants); drop the memos now so reads
       // before the next load don't see the old table's names.
       clearAttributeNamesMemo(this);
     }
+    this._tableName = value;
+    (this as { _predicateBuilder?: unknown })._predicateBuilder = null;
+    // Rails reset_column_information also reloads the schema so the new
+    // table's columns are re-reflected. A subclass created with a different
+    // table_name (e.g. `Class.new(Minimalistic) { self.table_name = "aircraft" }`)
+    // inherits the parent's `_schemaLoaded = true` through the prototype
+    // chain and would otherwise never reflect its own table. Shadow the
+    // inherited flag with an own `false` so the next load re-reflects.
+    (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
     return this._tableName ?? "";
   }
   if (!Object.prototype.hasOwnProperty.call(this, "_tableName")) resetTableName.call(this);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -71,6 +71,12 @@ function ownSchemaMemo<K extends keyof SchemaHost>(
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#compute_table_name
  * (model_schema.rb:604-618)
  *
+ * The `base === this` guard on the STI arm has no Rails counterpart: there
+ * `base_class? == false` is exactly `base_class != self` (inheritance.rb:119-121),
+ * while trails reaches the two answers through separate memos (`isBaseClass` /
+ * `baseClass`, inheritance.ts), so the guard stops a self-call recursing
+ * forever if they ever disagree.
+ *
  * @internal
  */
 function computeTableName(this: typeof Base): string {
@@ -85,10 +91,6 @@ function computeTableName(this: typeof Base): string {
   }
   // STI subclasses always use their superclass's table.
   const base = baseClass.call(this);
-  // Rails' `base_class` never answers `self` here — `base_class? == false` is
-  // exactly `base_class != self` (inheritance.rb:119-121). trails' `baseClass`
-  // reaches the same answer through a separate memo, so guard the self-call
-  // rather than recurse forever if the two ever disagree.
   if (base === this) return "";
   return base.tableName;
 }
@@ -613,15 +615,15 @@ export function quotedTableName(this: SchemaHost): string {
  * (model_schema.rb:289-300)
  *
  * Reaches its value by assigning through `table_name=`, so a first read gets
- * the writer's cache invalidation exactly where Rails has it.
+ * the writer's cache invalidation exactly where Rails has it. Rails' `self ==
+ * Base` is spelled through the own-property sentinel `setBaseClass` tests for
+ * the same thing (inheritance.ts).
  */
 export function resetTableName(this: SchemaHost): string {
   const klass = this as unknown as typeof Base;
   const superclass = Object.getPrototypeOf(klass) as typeof Base | null;
   tableName.call(
     this,
-    // `self == Base`, spelled through the own-property sentinel `setBaseClass`
-    // uses for the same test (inheritance.ts).
     Object.prototype.hasOwnProperty.call(klass, "_isActiveRecordBase")
       ? null
       : klass.abstractClass
@@ -1433,17 +1435,18 @@ function warmColumnsHashSync(
  * Ruby class ivars are not inherited but JS statics are, so the `defined?`
  * guard is an own-property check — a plain read would hand a subclass on
  * another table its base's name.
+ *
+ * Two of the writer's clears have no code below them. `@arel_table = nil`:
+ * `arelTable` builds a fresh Table per call (core.ts:835), so there is no memo
+ * to clear. `@sequence_name = nil unless @explicit_sequence_name`: a non-null
+ * `_sequenceName` IS `@explicit_sequence_name` — only `sequence_name=` sets it
+ * and `reset_sequence_name` nils it — so the clear is a no-op on every
+ * reachable state.
  */
 export function tableName(this: SchemaHost, value?: string | null): string {
   if (value !== undefined) {
     const changed = this._tableName !== value;
     this._tableName = value;
-    // `@arel_table = nil`: trails' `arelTable` builds a fresh Table per call
-    // (core.ts:835), so there is no memo to clear.
-    // `@sequence_name = nil unless @explicit_sequence_name`: trails has no
-    // separate explicit flag because a non-null `_sequenceName` IS one — only
-    // `sequence_name=` sets it, and `reset_sequence_name` nils it — so the
-    // clear would be a no-op on every reachable state.
     if (changed) {
       // Rails table_name= runs `reset_column_information if connected?`, which
       // resets the predicate builder and (via initialize_find_by_cache) the

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1441,6 +1441,17 @@ function warmColumnsHashSync(
  * guard is an own-property check — a plain read would hand a subclass on
  * another table its base's name.
  *
+ * The `reset_column_information if connected?` call runs before the store, so
+ * the caches it drops are the OLD table's, as in Rails (model_schema.rb:273-281,
+ * :523-529). Its lazy rewarm ({@link rewarmDataSourceCache}) is started rather
+ * than discarded, which Rails has no counterpart for and needs none: there
+ * `clear_data_source_cache!` is invisible because the next reader re-reflects
+ * on access under a checkout, while trails' sync readers answer only from a
+ * warm cache, so a dropped rewarm leaves the old table permanently cold for
+ * every other model on it. Starting it restores exactly the state Rails' next
+ * access would produce — measured: without it, `base_test.rb`'s "find multiple
+ * ordered last" inserts a declared-but-uncolumned attribute into `users`.
+ *
  * Two of the writer's clears have no code below them. `@arel_table = nil`:
  * `arelTable` builds a fresh Table per call (core.ts:835), so there is no memo
  * to clear. `@sequence_name = nil unless @explicit_sequence_name`: a non-null
@@ -1454,9 +1465,6 @@ export function tableName(this: SchemaHost, value?: string | null): string {
     if (Object.prototype.hasOwnProperty.call(this, "_tableName")) {
       if (value === this._tableName) return this._tableName ?? "";
       if (connectedQ.call(this as unknown as typeof Base)) {
-        // It runs before the store, so the caches it drops are the OLD table's,
-        // as in Rails. Its data-source rewarm is the one async tail — Rails'
-        // `reset_column_information` has none — and nothing here awaits it.
         void Promise.resolve(resetColumnInformation.call(this)).catch(() => {});
       }
     }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1445,6 +1445,7 @@ function warmColumnsHashSync(
  */
 export function tableName(this: SchemaHost, value?: string | null): string {
   if (value !== undefined) {
+    value = value == null ? null : String(value);
     const changed = this._tableName !== value;
     this._tableName = value;
     if (changed) {
@@ -1496,6 +1497,12 @@ export function inheritanceColumn(this: SchemaHost, value?: string | null): stri
  * A non-base class answers its own `@sequence_name` if it has one and the base
  * class's otherwise; only a base class computes one.
  *
+ * The writer stores `value.to_s` and sets `@explicit_sequence_name` — a
+ * non-null `_sequenceName` IS that flag here, since only this writer sets it
+ * and `reset_sequence_name` nils it — so `sequence_name = nil` stores an
+ * explicit `""` (Ruby's `nil.to_s`, not JS `String(null)`) rather than falling
+ * back to the computed name, exactly as Rails does.
+ *
  * Rails memoizes `reset_sequence_name`, which reaches the default through
  * `with_connection { |c| c.default_sequence_name(...) }` (model_schema.rb:379-382)
  * — async in trails, and this reader is synchronous — so the conventional name
@@ -1503,8 +1510,8 @@ export function inheritanceColumn(this: SchemaHost, value?: string | null): stri
  */
 export function sequenceName(this: SchemaHost, value?: string | null): string | null {
   if (value !== undefined) {
-    this._sequenceName = value;
-    return value;
+    this._sequenceName = value == null ? "" : String(value);
+    return this._sequenceName;
   }
   if (isBaseClass(this as unknown as typeof Base)) {
     const pk = this.primaryKey;

--- a/packages/activerecord/src/test-helpers/models/company-in-module.ts
+++ b/packages/activerecord/src/test-helpers/models/company-in-module.ts
@@ -12,15 +12,14 @@ import type { Project } from "./project.js";
 import { registerModel } from "../../associations.js";
 import { registerModuleTableNamePrefix, registerModuleTableNameSuffix } from "../../inheritance.js";
 import { Base } from "../../base.js";
-import { Company } from "./company.js";
 
 // module MyApplication::Business::Prefixed { def self.table_name_prefix; "prefixed_"; end }
 registerModuleTableNamePrefix("MyApplication::Business::Prefixed", "prefixed_");
 // module MyApplication::Business::Suffixed { def self.table_name_suffix; "_suffixed"; end }
 registerModuleTableNameSuffix("MyApplication::Business::Suffixed", "_suffixed");
 
-// MyApplication::Business::Company < ::Company
-export class MyAppBusinessCompany extends Company {
+// MyApplication::Business::Company
+export class MyAppBusinessCompany extends Base {
   static moduleName = "MyApplication::Business";
   static _demodulizedName = "Company";
 }

--- a/packages/activerecord/src/test-helpers/models/contact.ts
+++ b/packages/activerecord/src/test-helpers/models/contact.ts
@@ -76,9 +76,3 @@ export class ContactSti extends Base {
 
 await extended(ContactSti);
 ContactSti.column("type", "string");
-
-// Rails reflects the fake adapter's columns lazily, on the first `columns`
-// read. trails' synchronous reflection sees only an already-warm schema cache,
-// so warm it here — after the last `column` call — while we can still await.
-await Contact.loadSchema();
-await ContactSti.loadSchema();


### PR DESCRIPTION
Bundle of four stories; two land here, one was already on `main`, one is blocked.

## `reset-table-name-lazy-memo-and-writer-side-effects`

`resolveTableName` is folded back into Rails' three methods:

- `tableName` (model_schema.rb:260-263) — lazy, memoizing, `reset_table_name unless defined?(@table_name)`. Ruby class ivars are not inherited but JS statics are, so the `defined?` guard is an own-property check (the `ownSchemaMemo` idiom); a plain read hands a subclass on another table its base's name.
- `tableName=` (model_schema.rb:270-282) — unchanged behaviour, now documented against Rails' two remaining clears: `@arel_table = nil` has no counterpart (trails' `arelTable` builds a fresh `Table` per call, core.ts:835) and `@sequence_name = nil unless @explicit_sequence_name` is a no-op here, because a non-null `_sequenceName` *is* `@explicit_sequence_name` — only `sequence_name=` sets it and `reset_sequence_name` nils it.
- `resetTableName` (model_schema.rb:289-300) — all four arms verbatim, including `superclass.abstract_class?` as a named arm, reached by assigning **through** the writer so the invalidation happens where Rails has it.
- `computeTableName` (model_schema.rb:604-618) — prefix / contained prefix / undecorated name / suffix, plus Rails' own `base_class?` split.

One deviation from the story text: it asked for `computeTableName` to carry no `baseClass` arm, but Rails' `compute_table_name` **does** (`if base_class? ... else base_class.table_name`), so the arm stays where Rails puts it. The `self == Base` and `abstract_class?` arms live once, in `resetTableName`, as asked.

`sequenceName` also gains Rails' `base_class?` arm (model_schema.rb:371-377) — the call-set gate surfaced that pre-existing gap once the file's other `base_class?` call moved.

## `sync-reflection-needs-explicit-warm-for-fake-adapter`

`loadSchemaFromCacheSync` now reflects a cold table through an adapter whose `columns` answers synchronously — the fake adapter's shape, whose columns come from `merge_column` (test/models/contact.rb:30-32) — rather than silently returning an empty attribute set. Rails needs no such bridge: `schema_cache.columns_hash` is synchronous there (model_schema.rb:534-546).

A real adapter's `columns` returns a promise; it is discarded (with its rejection handled) and the existing cold-cache fallback runs, so DB-backed models are unchanged. `contact.ts` drops both `loadSchema()` calls; `serialization.test.ts` and `json-serialization.test.ts` pass, and were verified to fail (3 failures) with the new warm stubbed out.

## `close-the-activemodel-time-type-test-name-gap` — already done

#6988 landed `it("user input in time zone")` verbatim in `type/time.test.ts`, with the four TS-only arms in `time.trails.test.ts`. Marked done against #6988; nothing in this PR.

## `column-coder-carries-a-class-tag-and-subclass-state` — blocked

The story's premise is wrong and its acceptance criteria would **diverge** from Rails: `postgresql/column.rb:50-61` and `sqlite3/column.rb:36-44` both define `init_with`/`encode_with` (PG writes `serial`/`identity`/`generated`; SQLite3 writes `auto_increment`). Only `mysql/column.ts`'s override is genuinely extra — `mysql/column.rb` has none, because `extra` lives in `MySQL::TypeMetadata` and rides inside `sql_type_metadata`.

The real residual deviations are (a) the `class` coder key, whose removal needs the dump to carry class identity outside the Column coder, and (b) trails storing `oid`/`fmod` (PG) and `extra` (MySQL) on `Column` where Rails holds them in `PostgreSQL::TypeMetadata` (type_metadata.rb:7-20) / `MySQL::TypeMetadata`, plus sqlite3's `rowid`/`generated_type` — which Rails loses and trails cannot until the fixtures warm stops comparing a dump-loaded cache against a reflected one (`base_test.rb` `test_clear_cache!`). Blocked for a respec against the actual Rails source. The incorrect Rails claim in `Column#encodeWith`'s JSDoc is corrected here.

## Verification

`pnpm typecheck`; `parity:api:calls` OK (413 baselined, no new rows), `parity:api:calls:args` OK, `parity:api:extra:gate` OK. Locally green on sqlite3: `base.test.ts` (incl. "clear cache!"), `base.trails.test.ts`, `inheritance*`, `primary-keys*`, `enum*`, `join-model`, `serialization`, `json-serialization`, `schema-cache-dump.trails`, `schema-dumper`, and all of `connection-adapters/` (1987 tests).

## Review-cycle follow-ups

- `move-insert-all-unknown-attribute-check-to-builder` (0023-surfaced-deviations) —
  `InsertAll` checks unknown attribute names in its constructor against
  `attributeNames()`, where Rails raises in the Builder's
  `extract_types_from_columns_on` against `schema_cache.columns_hash`
  (insert_all.rb:239-244, :306-313), a blocking reflect. This PR had to add an
  `isSchemaLoaded` early return to that constructor check, because `table_name=`
  now runs Rails' `reset_column_information` and the check was raising on a
  column the pending reflect was about to produce. The residue — an unloaded
  model with a genuinely unknown key skipping the guard — converges by moving
  the raise to Rails' site, after the awaited reflect `execute()` already does.

Closes-story: sync-reflection-needs-explicit-warm-for-fake-adapter
Closes-story: reset-table-name-lazy-memo-and-writer-side-effects

