### PR TITLE
feat(scripts): gate activerecord extra surface (RFC 0119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1476,14 +1476,15 @@ jobs:
         # seed PR lands — see the UNSEEDED arm in lint-call-args.ts.
         run: pnpm exec tsx scripts/api-compare/lint-call-args.ts
       - name: Extra-surface ratchet
-        # RFC 0117. Gates arel's extra-surface counts (public TS names in a
-        # Rails-matched file with no Ruby counterpart) against the committed
-        # marks in scripts/api-compare/extra-surface-mark.json. Only-shrink:
-        # fails on any increase in `novel` or `total`, reports a mark left
-        # above the current measurement, and never raises one. Converged
-        # surface? Narrow the mark with `pnpm parity:api:extra:tighten` — there
-        # is no reseed. Scoped to arel deliberately; widening it to
-        # activemodel/activerecord is a separate decision with its own burndown.
+        # RFC 0117. Gates arel's and activerecord's extra-surface counts (public
+        # TS names in a Rails-matched file with no Ruby counterpart) against the
+        # committed marks in scripts/api-compare/extra-surface-mark.json.
+        # Only-shrink: fails on any increase in `novel` or `total`, reports a
+        # mark left above the current measurement, and never raises one.
+        # Converged surface? Narrow the mark with `pnpm parity:api:extra:tighten`
+        # — there is no reseed. activerecord joined under RFC 0119 with the
+        # connection-adapter burndown behind it; activemodel stays ungated until
+        # it has one.
         run: pnpm exec tsx scripts/api-compare/lint-extra-surface-ratchet.ts
       - name: Ratchet baseline reseed drift
         # RFC 0083. The ratchet above only READS the committed baseline, so a

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,4 +1,8 @@
 {
+  "activerecord": {
+    "novel": 399,
+    "total": 1424
+  },
   "arel": {
     "novel": 0,
     "total": 63

--- a/scripts/api-compare/extra-surface-mark.test.ts
+++ b/scripts/api-compare/extra-surface-mark.test.ts
@@ -15,9 +15,27 @@ describe("extra-surface mark", () => {
   it("measures only the gated packages", () => {
     const measured = measure([
       { package: "arel", totalNovel: 0, totalExtras: 63 },
-      { package: "activerecord", totalNovel: 394, totalExtras: 1424 },
+      { package: "activerecord", totalNovel: 399, totalExtras: 1424 },
+      { package: "activemodel", totalNovel: 12, totalExtras: 34 },
     ]);
-    expect(measured).toEqual({ arel: { novel: 0, total: 63 } });
+    expect(measured).toEqual({
+      arel: { novel: 0, total: 63 },
+      activerecord: { novel: 399, total: 1424 },
+    });
+  });
+
+  // A gated package with no committed mark makes `exceedances` and `staleMarks`
+  // skip it — the gate would pass silently on the package it was just widened
+  // to cover. Adding a name to GATED_PACKAGES without seeding its mark is
+  // therefore a disarm, not a no-op.
+  it("does not gate a package whose mark was never seeded", () => {
+    expect(exceedances(marks, { arel: { novel: 0, total: 63 } })).toEqual([]);
+    expect(
+      exceedances(marks, {
+        arel: { novel: 0, total: 63 },
+        activerecord: { novel: 9999, total: 9999 },
+      }),
+    ).toEqual([]);
   });
 
   it("passes when both dimensions hold at the mark", () => {

--- a/scripts/api-compare/extra-surface-mark.test.ts
+++ b/scripts/api-compare/extra-surface-mark.test.ts
@@ -5,6 +5,7 @@ import {
   measure,
   staleMarks,
   tightened,
+  unmarkedPackages,
   unmeasuredPackages,
   type SurfaceMarks,
 } from "./extra-surface-mark.js";
@@ -24,16 +25,28 @@ describe("extra-surface mark", () => {
     });
   });
 
-  // A gated package with no committed mark makes `exceedances` and `staleMarks`
-  // skip it — the gate would pass silently on the package it was just widened
-  // to cover. Adding a name to GATED_PACKAGES without seeding its mark is
-  // therefore a disarm, not a no-op.
-  it("does not gate a package whose mark was never seeded", () => {
-    expect(exceedances(marks, { arel: { novel: 0, total: 63 } })).toEqual([]);
+  it("names a gated package the mark file never seeded", () => {
+    expect(unmarkedPackages({ arel: { novel: 0, total: 63 } })).toEqual(["activerecord"]);
+    expect(unmarkedPackages({})).toEqual([...GATED_PACKAGES]);
+    expect(
+      unmarkedPackages({
+        arel: { novel: 0, total: 63 },
+        activerecord: { novel: 399, total: 1424 },
+      }),
+    ).toEqual([]);
+  });
+
+  it("skips a package with no mark rather than gating it, which is why the seed is checked", () => {
     expect(
       exceedances(marks, {
         arel: { novel: 0, total: 63 },
         activerecord: { novel: 9999, total: 9999 },
+      }),
+    ).toEqual([]);
+    expect(
+      staleMarks(marks, {
+        arel: { novel: 0, total: 63 },
+        activerecord: { novel: 1, total: 1 },
       }),
     ).toEqual([]);
   });

--- a/scripts/api-compare/extra-surface-mark.ts
+++ b/scripts/api-compare/extra-surface-mark.ts
@@ -138,6 +138,17 @@ export function unmeasuredPackages(current: SurfaceMarks): string[] {
   return GATED_PACKAGES.filter((name) => current[name] === undefined);
 }
 
+/**
+ * A package the gate covers but the mark file never committed. {@link exceedances},
+ * {@link staleMarks} and {@link tightened} all skip a package with no mark, so
+ * adding a name to {@link GATED_PACKAGES} without seeding its numbers disarms
+ * the gate for that package instead of half-enabling it. The mark-side twin of
+ * {@link unmeasuredPackages}.
+ */
+export function unmarkedPackages(marks: SurfaceMarks): string[] {
+  return GATED_PACKAGES.filter((name) => marks[name] === undefined);
+}
+
 export async function loadMarks(): Promise<SurfaceMarks> {
   return JSON.parse(await fs.readFile(MARK_PATH, "utf-8")) as SurfaceMarks;
 }

--- a/scripts/api-compare/extra-surface-mark.ts
+++ b/scripts/api-compare/extra-surface-mark.ts
@@ -19,9 +19,18 @@
  * inside a flat total without the gate noticing, which is the opposite of what
  * a ratchet is for.
  *
- * Scope is deliberately arel-only (RFC 0117). activemodel and activerecord
- * carry a far larger population and gating them is a separate decision with its
- * own burndown behind it — widening GATED_PACKAGES is not a mechanical step.
+ * Scope was arel-only at RFC 0117. activerecord joined it under RFC 0119
+ * (connection-adapter fidelity): its adapter tree carries 100+ cited, verified
+ * divergences that no gate could see, because the call-set ratchet only detects
+ * a Rails call the TS body OMITS — it is blind to an invented extra branch, a
+ * JS-shaped public API, or an async/sync shape divergence, which is what most
+ * of that population is. Gating the package freezes the surface those stories
+ * burn down. The mark is seeded at the measured 399 novel / 1424 total: a
+ * high-water mark to shrink, NOT a budget to spend.
+ *
+ * activemodel remains ungated. The same reasoning would apply, but it has no
+ * burndown behind it yet, and widening GATED_PACKAGES without one is exactly
+ * the not-mechanical step this comment has always warned about.
  *
  * Hard rules: no node:* imports, no process.* in the library surface (the CLI
  * entry guard is the sole exception), async fs only, no third-party runtime deps.
@@ -38,7 +47,7 @@ export const MARK_PATH = path.join(SCRIPT_DIR, "extra-surface-mark.json");
  * The packages this gate covers. Everything else is measured by
  * `parity:api:extra` and left ungated — see the module comment.
  */
-export const GATED_PACKAGES = ["arel"] as const;
+export const GATED_PACKAGES = ["arel", "activerecord"] as const;
 
 export interface SurfaceMark {
   /**

--- a/scripts/api-compare/lint-extra-surface-ratchet.ts
+++ b/scripts/api-compare/lint-extra-surface-ratchet.ts
@@ -42,6 +42,7 @@ import {
   measure,
   staleMarks,
   tightened,
+  unmarkedPackages,
   unmeasuredPackages,
   writeMarks,
 } from "./extra-surface-mark.js";
@@ -73,6 +74,19 @@ async function main(tighten: boolean): Promise<number> {
   }
 
   const marks = await loadMarks();
+
+  const unmarked = unmarkedPackages(marks);
+  if (unmarked.length > 0) {
+    console.error(
+      `\nextra-surface gate: ${unmarked.length} gated package(s) carry no committed mark: ${unmarked.join(", ")}.\n` +
+        "A gated package with no mark is skipped by every comparison, so the gate\n" +
+        "would pass on it silently rather than half-enabling. Seed it from a clean\n" +
+        "measurement before gating:\n" +
+        "  pnpm parity:api:extra --package <pkg>\n",
+    );
+    return 1;
+  }
+
   const grew = exceedances(marks, current);
   const stale = staleMarks(marks, current);
 


### PR DESCRIPTION
## Why

RFC 0119 carved 118 cited, verified connection-adapter divergences out of the `0023-surfaced-deviations` catch-all. Measuring that cohort against the **existing** gates showed the adapter tree is almost entirely ungated:

- The whole of `connection_adapters/` carries **24** call-mismatch rows (23 `set`, 1 `args`). **20 already belong to RFC 0106 and RFC 0073** — their own `reason` strings say so. Only 4 map to an 0119 story.
- `parity:api:extra` covered **arel only** (`GATED_PACKAGES = ["arel"]`).
- `rails-file-structure-method-order` is registered for arel + activemodel only, so the adapter tree is outside it too.

The call-set ratchet detects one thing: a Rails call the TS body **omits**. It is structurally blind to an invented extra branch, a JS-shaped public API, an unescaped regex, or an async/sync shape divergence — which is what most of the 0119 population is. 106 verified divergences in a tree where the gates find 24 rows is the gap this closes.

## What

**1. Gate activerecord.**

- `GATED_PACKAGES = ["arel", "activerecord"]`.
- Mark seeded at the measured **399 novel / 1424 total** (232 files), stable across two consecutive runs on a clean tree with rebuilt manifests.
- Only-shrink, so this freezes the largest package's extra surface while the burndown runs. The mark is a high-water mark to shrink, **not a budget to spend**.
- `activemodel` stays ungated: same reasoning would apply, but it has no burndown behind it yet.

**2. Fix the disarm the seeding exposed.**

`exceedances`, `staleMarks` and `tightened` all skip a package absent from the mark file. So adding a name to `GATED_PACKAGES` **without** seeding its mark did not half-enable the gate — it **disarmed** it for that package, reporting `OK` while looking at nothing.

`unmarkedPackages` is the mark-side twin of the existing `unmeasuredPackages` guard, checked on the same path. The two failure modes — marked-but-unmeasured, and measured-but-unmarked — now both fail loudly.

Without this, the PR would have shipped the hazard it was documenting.

## Verification

```
pnpm vitest run scripts/api-compare/          # 40 files, 1345 tests passed
pnpm parity:api:extra:gate
  extra-surface gate: OK (arel novel 0/0, total 63/63; activerecord novel 399/399, total 1424/1424)
```

Behavioural checks, not just units:

| scenario | result |
|---|---|
| mark lowered to 398 (simulated growth) | reds: `+ activerecord novel: mark 398 → current 399` |
| activerecord mark removed entirely | reds: `1 gated package(s) carry no committed mark` — previously passed silently |
| `--tighten` round-trip | file byte-identical (same md5), `narrowed 0 dimension(s)` |

The last one confirms the committed JSON is exactly what `writeMarks`/`serializeBaseline` produces, since the reseed-drift CI step covers the call baselines but not this mark.

## Not in this PR

Widening `rails-file-structure-method-order` to the adapter tree is the other half of gating this tree, and it is **not** one PR: 57 violations across 57 files, autofixable, but the fix is **12,744 insertions / 12,744 deletions** of pure member reordering — it would conflict with essentially every agent working in the adapter tree right now. Needs sequencing per subdirectory; filed separately.