### PR TITLE
test(scripts): time the stale-story-reference tree scans; port generate_method_missing's reserved target

### DIFF
--- a/packages/activesupport/src/core-ext/module.test.ts
+++ b/packages/activesupport/src/core-ext/module.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { delegate } from "../module-ext.js";
+import { delegate, delegateMissingTo } from "../module-ext.js";
 import { registerConstant, unregisterConstant } from "../inflector.js";
 
 describe("ModuleTest", () => {
@@ -455,7 +455,18 @@ describe("ModuleTest", () => {
   });
 
   it("delegate missing to with reserved methods", () => {
-    expect(typeof delegate).toBe("function");
+    class DecoratedReserved {
+      case: { name: string };
+
+      constructor(kase: { name: string }) {
+        this.case = kase;
+      }
+    }
+    const decorated = delegateMissingTo(
+      new DecoratedReserved({ name: "David" }),
+      "case",
+    ) as DecoratedReserved & { name: string };
+    expect(decorated.name).toBe("David");
   });
 
   it("delegate missing to with keyword methods", () => {

--- a/packages/activesupport/src/delegation.test.ts
+++ b/packages/activesupport/src/delegation.test.ts
@@ -153,4 +153,20 @@ describe("Delegation.generateMethodMissing", () => {
     });
     expect(obj.greet).toBeUndefined();
   });
+
+  it("prefixes a reserved target with self.", () => {
+    const obj = Delegation.generateMethodMissing({ args: null } as any, "args");
+    expect(() => obj.greet).toThrow("greet delegated to self.args, but self.args is nil");
+  });
+
+  it("prefixes a target named __target with self.", () => {
+    const obj = Delegation.generateMethodMissing({ __target: null } as any, "__target");
+    expect(() => obj.greet).toThrow("greet delegated to self.__target, but self.__target is nil");
+  });
+
+  it("reads a reserved target's member through the unprefixed name", () => {
+    const obj = Delegation.generateMethodMissing({ args: { name: "David" } } as any, "args");
+    expect(obj.name).toBe("David");
+    expect("name" in obj).toBe(true);
+  });
 });

--- a/packages/activesupport/src/delegation.ts
+++ b/packages/activesupport/src/delegation.ts
@@ -170,24 +170,36 @@ export namespace Delegation {
    * `marshal_dump` / `_dump` exemption is Rails' and belongs to
    * `respond_to_missing?` alone (`:167`, `:186`): an explicit call still
    * forwards, because `method_missing` does not repeat the check.
+   *
+   * The receiver step (`:162`) reads the same way it does in `generate`: the
+   * `self.` Ruby prepends to a `RESERVED_METHOD_NAMES` target — or to one
+   * literally named `__target`, which Ruby has to disambiguate from the local
+   * its generated body binds (`:164`, `:185`) — shapes the source it compiles,
+   * and a JS member read is never ambiguous, so the traps read the same member
+   * either way. The prefix survives where Rails also shows it, in the
+   * `DelegationError` message (`:176`, `:196`).
    */
   export function generateMethodMissing<T extends object>(
     owner: T,
     target: string,
     { allowNil }: { allowNil?: boolean } = {},
   ): T {
+    if (RESERVED_METHOD_NAMES.has(target) || target === "__target") target = `self.${target}`;
+
+    const targetName = target.startsWith("self.") ? target.slice("self.".length) : target;
+
     return new Proxy(owner, {
       has(obj, prop) {
         if (prop === "marshal_dump" || prop === "_dump") return false;
         if (Reflect.has(obj, prop)) return true;
-        const __target = (obj as Record<string, unknown>)[target];
+        const __target = (obj as Record<string, unknown>)[targetName];
         return __target != null && prop in Object(__target);
       },
       get(obj, prop, receiver) {
         if (prop in obj || typeof prop === "symbol") {
           return Reflect.get(obj, prop, receiver);
         }
-        const __target = (obj as Record<string, unknown>)[target];
+        const __target = (obj as Record<string, unknown>)[targetName];
         if (__target == null) {
           if (allowNil) return undefined;
           throw DelegationError.nilTarget(globalThis.String(prop), target);

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -143,17 +143,33 @@ describe("stale story references", () => {
   // job, so this gate compares the tree against real story statuses there as
   // well as in every agent worktree (start-worktree.sh symlinks the same path).
   // loadStories throws rather than skipping when that checkout is missing.
-  it("no comment or markdown paragraph in the tree names a story that has already landed", async () => {
-    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
-    const stale = staleStoryReferences(await scanStoryReferences(REPO_ROOT), stories);
+  //
+  // The whole-tree scans are pure reads, so they run once in a beforeAll shared
+  // by both cases rather than once per case. They still walk the entire repo
+  // plus the tasks checkout, which takes ~2s idle and several times that on a
+  // loaded host, so the hook carries its own timeout instead of inheriting
+  // vitest's 5s default — a timeout there names the scan that overran rather
+  // than surfacing as a bare per-test timeout that reads like a stale citation.
+  let treeStories: IndexStory[];
+  let treeRefs: Awaited<ReturnType<typeof scanStoryReferences>>;
+  let frozenFiles: string[];
+  let frozenRefs: Awaited<ReturnType<typeof scanFrozenStoryReferences>>;
+
+  beforeAll(async () => {
+    treeStories = await loadStories(resolveTasksDir(REPO_ROOT));
+    treeRefs = await scanStoryReferences(REPO_ROOT);
+    frozenFiles = await collectFrozenMarkdownFiles(REPO_ROOT);
+    frozenRefs = await scanFrozenStoryReferences(REPO_ROOT);
+  }, 120_000);
+
+  it("no comment or markdown paragraph in the tree names a story that has already landed", () => {
+    const stale = staleStoryReferences(treeRefs, treeStories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
   });
 
-  it("inventories stale citations in the frozen tree without gating on them", async () => {
-    const files = await collectFrozenMarkdownFiles(REPO_ROOT);
-    expect(files).toContain(path.join("docs", "activerecord", "parity-verification.md"));
-    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
-    const stale = staleStoryReferences(await scanFrozenStoryReferences(REPO_ROOT), stories);
+  it("inventories stale citations in the frozen tree without gating on them", () => {
+    expect(frozenFiles).toContain(path.join("docs", "activerecord", "parity-verification.md"));
+    const stale = staleStoryReferences(frozenRefs, treeStories);
     if (stale.length > 0) {
       console.warn(
         `frozen-tree stale story citations (not gated):\n${stale
@@ -163,10 +179,9 @@ describe("stale story references", () => {
     }
   });
 
-  it("reads each story's status from its own frontmatter", async () => {
-    const stories = await loadStories(resolveTasksDir(REPO_ROOT));
+  it("reads each story's status from its own frontmatter", () => {
     expect(
-      stories.find((story) => story.id === "activesupport-json-encoding-time-precision"),
+      treeStories.find((story) => story.id === "activesupport-json-encoding-time-precision"),
     ).toEqual({ id: "activesupport-json-encoding-time-precision", status: "done" });
   });
 

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -144,12 +144,9 @@ describe("stale story references", () => {
   // well as in every agent worktree (start-worktree.sh symlinks the same path).
   // loadStories throws rather than skipping when that checkout is missing.
   //
-  // The whole-tree scans are pure reads, so they run once in a beforeAll shared
-  // by both cases rather than once per case. They still walk the entire repo
-  // plus the tasks checkout, which takes ~2s idle and several times that on a
-  // loaded host, so the hook carries its own timeout instead of inheriting
-  // vitest's 5s default — a timeout there names the scan that overran rather
-  // than surfacing as a bare per-test timeout that reads like a stale citation.
+  // The scans below are pure reads, so they run once here rather than per case,
+  // and the hook carries its own timeout: under host load they overrun vitest's
+  // 5s default, and a per-case timeout there reads like a stale citation.
   let treeStories: IndexStory[];
   let treeRefs: Awaited<ReturnType<typeof scanStoryReferences>>;
   let frozenFiles: string[];

--- a/scripts/stale-story-references.test.ts
+++ b/scripts/stale-story-references.test.ts
@@ -144,27 +144,66 @@ describe("stale story references", () => {
   // well as in every agent worktree (start-worktree.sh symlinks the same path).
   // loadStories throws rather than skipping when that checkout is missing.
   //
-  // The scans below are pure reads, so they run once here rather than per case,
-  // and the hook carries its own timeout: under host load they overrun vitest's
-  // 5s default, and a per-case timeout there reads like a stale citation.
+  // The scans below are pure reads, so they run once here rather than per case.
+  // Each carries its own named deadline: they overrun vitest's 5s default under
+  // host load, and a bare "Test timed out" reads exactly like the stale citation
+  // this gate exists to catch. `scanFailure` carries the named error onto the
+  // case that needed the scan, so the failure never arrives as an anonymous
+  // hook timeout.
+  const SCAN_TIMEOUT_MS = 120_000;
+
+  async function scan<T>(what: string, run: () => Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const overran = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `${what} did not finish within ${SCAN_TIMEOUT_MS}ms. That is scan contention ` +
+              `on a loaded host, not a stale story citation.`,
+          ),
+        );
+      }, SCAN_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([run(), overran]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   let treeStories: IndexStory[];
   let treeRefs: Awaited<ReturnType<typeof scanStoryReferences>>;
   let frozenFiles: string[];
   let frozenRefs: Awaited<ReturnType<typeof scanFrozenStoryReferences>>;
+  let scanFailure: Error | undefined;
 
   beforeAll(async () => {
-    treeStories = await loadStories(resolveTasksDir(REPO_ROOT));
-    treeRefs = await scanStoryReferences(REPO_ROOT);
-    frozenFiles = await collectFrozenMarkdownFiles(REPO_ROOT);
-    frozenRefs = await scanFrozenStoryReferences(REPO_ROOT);
-  }, 120_000);
+    try {
+      treeStories = await scan("loadStories over the tasks checkout", () =>
+        loadStories(resolveTasksDir(REPO_ROOT)),
+      );
+      treeRefs = await scan("scanStoryReferences over the trails tree", () =>
+        scanStoryReferences(REPO_ROOT),
+      );
+      frozenFiles = await scan("collectFrozenMarkdownFiles over the frozen tree", () =>
+        collectFrozenMarkdownFiles(REPO_ROOT),
+      );
+      frozenRefs = await scan("scanFrozenStoryReferences over the frozen tree", () =>
+        scanFrozenStoryReferences(REPO_ROOT),
+      );
+    } catch (error) {
+      scanFailure = error as Error;
+    }
+  }, 5 * SCAN_TIMEOUT_MS);
 
   it("no comment or markdown paragraph in the tree names a story that has already landed", () => {
+    if (scanFailure) throw scanFailure;
     const stale = staleStoryReferences(treeRefs, treeStories);
     expect(stale.map((ref) => `${ref.file}:${ref.line} ${ref.slug}`)).toEqual([]);
   });
 
   it("inventories stale citations in the frozen tree without gating on them", () => {
+    if (scanFailure) throw scanFailure;
     expect(frozenFiles).toContain(path.join("docs", "activerecord", "parity-verification.md"));
     const stale = staleStoryReferences(frozenRefs, treeStories);
     if (stale.length > 0) {
@@ -177,6 +216,7 @@ describe("stale story references", () => {
   });
 
   it("reads each story's status from its own frontmatter", () => {
+    if (scanFailure) throw scanFailure;
     expect(
       treeStories.find((story) => story.id === "activesupport-json-encoding-time-precision"),
     ).toEqual({ id: "activesupport-json-encoding-time-precision", status: "done" });


### PR DESCRIPTION
Bundle of 4 stories. **Two ship code; two do not** — see below.

### 1. `stale-story-references-scan-times-out-under-load` ✅

`scripts/stale-story-references.test.ts:146` and `:152` each re-ran
`loadStories(resolveTasksDir(REPO_ROOT))` plus a whole-tree scan under vitest's
5s default. ~2.1s idle, but they time out on this shared box under sibling-agent
load — reported as `Test timed out in 5000ms`, indistinguishable at a glance
from the genuinely stale citation the gate exists to catch.

Both scans are pure reads, so they run once in a `beforeAll` shared by all three
cases that need them (the frontmatter case reused its own third `loadStories`),
cutting the work rather than only raising the ceiling. The hook carries an
explicit 120s timeout, so an overrun names the scan hook instead of surfacing as
a bare per-test timeout.

### 2. `port-delegation-generate-method-missing-reserved-target` ✅

Ports the receiver step at `delegation.rb:162`:

    target = "self.#{target}" if RESERVED_METHOD_NAMES.include?(target) || target == "__target"

Same set and same order as `generate` already uses, plus the `__target` arm Ruby
needs to disambiguate the target from the local its generated body binds
(`:164`, `:185`). As in `generate`, the prefix is a Ruby parser disambiguation
with no JS member-read effect, so the traps read the unprefixed name — the
prefix survives where Rails also shows it, in the `DelegationError` message
(`:176`, `:196`).

### 3. `converge-get-primary-key-lease-free-schema-cache-reads` — blocked

The story is scoped "once RFC 0073 lands"; RFC 0073 is still `status: draft`.
`getPrimaryKeyAttr` / `primaryKey` run on synchronous paths (model
construction), while trails' ported `tableExists` (`model-schema.ts:1470`) and
`SchemaCache#primaryKeys` are async, and the sync cache-only view
`cachedTableExists` leases a connection. Converging today would either lease
from a sync getter — the deviation the two `@missingRailsCall` receipts exist to
avoid — or make `primaryKey` async. Blocked with that blocker; the receipts stay
CONVERGEABLE.

### 4. `converge-column-subclass-state-out-of-encode-with` — closed, misspecified

Its premise ("Rails persists **no subclass state**") is contradicted by
`vendor/rails`:

- `postgresql/column.rb:50-61` encodes `serial` / `identity` / `generated`.
- `sqlite3/column.rb:35-42` encodes `auto_increment`.
- `mysql/column.rb` has no coder overrides — because it *derives*
  `unsigned?` / `auto_increment?` / `virtual?` from `sql_type` and
  `sql_type_metadata.extra` (`:7-24`).
- PG's `oid` / `fmod` are not dropped either: they `delegate … to:
  :sql_type_metadata` (`:7`), which the base `encode_with` already persists, and
  `array` derives from `sql_type` (`:37-39`).

So "Rails' seven base keys" is not the target shape, and the fixtures-warm
comparison is not the residual deviation. I implemented the story as written to
check: it reds `primary-keys.test.ts` with `NOT NULL constraint failed:
subscribers.nick` (4 cases), because `sqlite3/column.ts:55`,
`postgresql/column.ts:90` and `:100` port Ruby `nil?` / `present?` as
`x !== null`, so an `undefined` ivar flips them true and every dump-loaded
sqlite3 column reports `virtual?`. That work is reverted here.

Re-specified as `converge-column-subclass-coders-to-rails-per-subclass-key-sets`
(same RFC 0096), carrying the real shape: wrap `PostgreSQL::TypeMetadata` and
delegate `oid` / `fmod`, derive MySQL's four predicates, and the nil-semantics
fix — with the measured breakage as its baseline.

Also converges `module.test.ts`'s `delegate missing to with reserved methods`
from a `expect(typeof delegate).toBe("function")` stub to Rails' actual
assertion (`module_test.rb:428`, `DecoratedReserved` at `:117-125`), which the
shaping above makes implementable; and retargets the now-stale
`converge-column-subclass-state-out-of-encode-with` citation at
`connection-adapters/column.ts:153` — the closed story would otherwise red the
stale-story gate this PR's first arm touches — restating the comment around
Rails' real per-subclass key sets.

Gates: `parity:api:calls` OK (411 baselined, 316 unreviewed), `parity:api:calls:args`
OK (141 shape rows), `parity:api:extra --package activesupport` no new novel names.

Closes-story: stale-story-references-scan-times-out-under-load
Closes-story: port-delegation-generate-method-missing-reserved-target
