### PR TITLE
test(activemodel): move the TS-only extras out of the decimal, date and big-integer type tests

### DIFF
--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -1,24 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Types, BigIntegerType, IntegerType } from "../index.js";
+import { BigIntegerType } from "../index.js";
 
 describe("BigIntegerTest", () => {
   it("type cast big integer", () => {
     const type = new BigIntegerType();
     expect(type.cast(1)).toEqual(1);
     expect(type.cast("1")).toEqual(1);
-  });
-
-  it("BigInteger small values", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast("0")).toBe(0);
-    expect(type.cast("1")).toBe(1);
-    expect(type.cast("-1")).toBe(-1);
-  });
-
-  it("BigInteger large values", () => {
-    const type = Types.typeRegistry.lookup("big_integer");
-    const large = "9999999999999999999999";
-    expect(type.cast(large)).toBe(BigInt(large));
   });
 
   it("serialize_cast_value is equivalent to serialize after cast", () => {
@@ -41,72 +28,5 @@ describe("BigIntegerTest", () => {
     expect(type.serialize(9999999999999999999999999999999n)).toEqual(
       9999999999999999999999999999999n,
     );
-  });
-
-  it("inherits from IntegerType", () => {
-    expect(new BigIntegerType()).toBeInstanceOf(IntegerType);
-  });
-
-  it("plain object {} casts to null (non-numeric string path)", () => {
-    const type = new BigIntegerType();
-    expect(type.cast({})).toBeNull();
-  });
-
-  it("large numeric string beyond MAX_SAFE_INTEGER casts to bigint with precision", () => {
-    const type = new BigIntegerType();
-    const large = "99999999999999999999";
-    expect(type.cast(large)).toBe(BigInt(large));
-  });
-
-  it("leading + in numeric string casts to bigint (Rails to_i accepts leading +)", () => {
-    const type = new BigIntegerType();
-    expect(type.cast("+42")).toBe(42);
-    expect(type.cast("+99999999999999999999")).toBe(BigInt("99999999999999999999"));
-  });
-
-  it("numeric string with trailing characters extracts leading digits (Rails to_i)", () => {
-    const type = new BigIntegerType();
-    expect(type.cast("123abc")).toBe(123);
-    expect(type.cast("99999999999999999999trailing")).toBe(BigInt("99999999999999999999"));
-  });
-
-  it("numeric string in safe range casts to number", () => {
-    const type = new BigIntegerType();
-    expect(type.cast("42")).toBe(42);
-    expect(typeof type.cast("42")).toBe("number");
-  });
-
-  it("serialize returns numeric (number or bigint), never string", () => {
-    const type = new BigIntegerType();
-    const BIG = 2n ** 62n;
-    expect(type.serialize(42n)).toBe(42);
-    expect(type.serialize("42")).toBe(42);
-    expect(typeof type.serialize(BIG)).toBe("bigint");
-    expect(type.serialize(BIG)).toBe(BIG);
-  });
-
-  it("maxValue returns Infinity", () => {
-    const type = new BigIntegerType();
-    expect((type as unknown as { maxValue(): number }).maxValue()).toBe(Number.POSITIVE_INFINITY);
-  });
-
-  it("no range error for absurdly large values", () => {
-    const type = new BigIntegerType();
-    const huge = BigInt("9".repeat(100));
-    expect(() => type.serialize(huge)).not.toThrow();
-  });
-
-  it("no range error for values outside int8 range even when limit is set", () => {
-    // BigIntegerType is unconditionally unlimited (big_integer.rb:33 — max_value = Infinity).
-    // The 8-byte guard belongs on the adapter column type, not on BigIntegerType itself.
-    const type = new BigIntegerType({ limit: 8 });
-    expect(() => type.serialize(9223372036854775808n)).not.toThrow();
-    expect(type.isSerializable(BigInt("9".repeat(100)))).toBe(true);
-  });
-
-  it("blank string casts to null", () => {
-    const type = new BigIntegerType();
-    expect(type.cast("")).toBeNull();
-    expect(type.cast("   ")).toBeNull();
   });
 });

--- a/packages/activemodel/src/type/big-integer.trails.test.ts
+++ b/packages/activemodel/src/type/big-integer.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BigIntegerType, IntegerType } from "../index.js";
+import { Types, BigIntegerType, IntegerType } from "../index.js";
 
 // Trails-only coverage for ActiveModel::Type::BigInteger — behavior with no
 // counterpart test in activemodel/test/cases/type/big_integer_test.rb. The
@@ -16,5 +16,87 @@ describe("BigIntegerType", () => {
   it("serialize answers null for a non-numeric string, via Integer#serialize", () => {
     const type = new BigIntegerType();
     expect(type.serialize("bad")).toBeNull();
+  });
+});
+
+describe("BigIntegerType cast and serialize coverage", () => {
+  it("BigInteger small values", () => {
+    const type = Types.typeRegistry.lookup("big_integer");
+    expect(type.cast("0")).toBe(0);
+    expect(type.cast("1")).toBe(1);
+    expect(type.cast("-1")).toBe(-1);
+  });
+
+  it("BigInteger large values", () => {
+    const type = Types.typeRegistry.lookup("big_integer");
+    const large = "9999999999999999999999";
+    expect(type.cast(large)).toBe(BigInt(large));
+  });
+
+  it("inherits from IntegerType", () => {
+    expect(new BigIntegerType()).toBeInstanceOf(IntegerType);
+  });
+
+  it("plain object {} casts to null (non-numeric string path)", () => {
+    const type = new BigIntegerType();
+    expect(type.cast({})).toBeNull();
+  });
+
+  it("large numeric string beyond MAX_SAFE_INTEGER casts to bigint with precision", () => {
+    const type = new BigIntegerType();
+    const large = "99999999999999999999";
+    expect(type.cast(large)).toBe(BigInt(large));
+  });
+
+  it("leading + in numeric string casts to bigint (Rails to_i accepts leading +)", () => {
+    const type = new BigIntegerType();
+    expect(type.cast("+42")).toBe(42);
+    expect(type.cast("+99999999999999999999")).toBe(BigInt("99999999999999999999"));
+  });
+
+  it("numeric string with trailing characters extracts leading digits (Rails to_i)", () => {
+    const type = new BigIntegerType();
+    expect(type.cast("123abc")).toBe(123);
+    expect(type.cast("99999999999999999999trailing")).toBe(BigInt("99999999999999999999"));
+  });
+
+  it("numeric string in safe range casts to number", () => {
+    const type = new BigIntegerType();
+    expect(type.cast("42")).toBe(42);
+    expect(typeof type.cast("42")).toBe("number");
+  });
+
+  it("serialize returns numeric (number or bigint), never string", () => {
+    const type = new BigIntegerType();
+    const BIG = 2n ** 62n;
+    expect(type.serialize(42n)).toBe(42);
+    expect(type.serialize("42")).toBe(42);
+    expect(typeof type.serialize(BIG)).toBe("bigint");
+    expect(type.serialize(BIG)).toBe(BIG);
+  });
+
+  it("maxValue returns Infinity", () => {
+    const type = new BigIntegerType();
+    expect((type as unknown as { maxValue(): number }).maxValue()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("no range error for absurdly large values", () => {
+    const type = new BigIntegerType();
+    const huge = BigInt("9".repeat(100));
+    expect(() => type.serialize(huge)).not.toThrow();
+  });
+
+  it("no range error for values outside int8 range even when limit is set", () => {
+    // BigIntegerType is unconditionally unlimited (big_integer.rb:33 — max_value = Infinity).
+    // The 8-byte guard belongs on the adapter column type, not on BigIntegerType itself.
+    const type = new BigIntegerType({ limit: 8 });
+    expect(() => type.serialize(9223372036854775808n)).not.toThrow();
+    expect(type.isSerializable(BigInt("9".repeat(100)))).toBe(true);
+  });
+
+  it("blank string casts to null", () => {
+    const type = new BigIntegerType();
+    expect(type.cast("")).toBeNull();
+    expect(type.cast("   ")).toBeNull();
   });
 });

--- a/packages/activemodel/src/type/date.test.ts
+++ b/packages/activemodel/src/type/date.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types } from "../index.js";
 
 describe("DateTest", () => {
@@ -27,103 +26,5 @@ describe("DateTest", () => {
     const valuesHashForMultiparameterAssignment = { 1: 1, 2: 1, 3: 1 };
 
     expect(type.cast(valuesHashForMultiparameterAssignment)).toEqual(date);
-  });
-
-  it("Temporal.PlainDate passthrough", () => {
-    const original = plainDate("2024-01-15");
-    expect(type.cast(original)).toBe(original);
-  });
-
-  it("has name 'date'", () => {
-    expect(type.name).toBe("date");
-  });
-
-  it("casts null to null", () => {
-    expect(type.cast(null)).toBe(null);
-  });
-
-  it("casts undefined to null", () => {
-    expect(type.cast(undefined)).toBe(null);
-  });
-
-  it("casts empty string to null", () => {
-    expect(type.cast("")).toBe(null);
-  });
-
-  it("casts invalid string to null", () => {
-    expect(type.cast("not-a-date")).toBe(null);
-  });
-
-  it("serialize returns the cast PlainDate (not a SQL string)", () => {
-    const d = plainDate("2024-01-15");
-    expect((type.serialize(d) as Temporal.PlainDate).toString()).toBe("2024-01-15");
-  });
-
-  it("serialize null returns null", () => {
-    expect(type.serialize(null)).toBe(null);
-  });
-
-  it("PlainDateTime input extracts date (multiparameter support)", () => {
-    const pdt = Temporal.PlainDateTime.from("2024-06-15T10:30:00");
-    const result = type.cast(pdt);
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2024-06-15");
-  });
-
-  it("typeCastForSchema returns quoted string for PlainDate", () => {
-    const d = plainDate("2024-01-15");
-    expect(type.typeCastForSchema(d)).toBe('"2024-01-15"');
-  });
-
-  it("newDate rejects out-of-range components (rescue nil parity)", () => {
-    class Probe extends Types.DateType {
-      newDateFor(y: number, m: number, d: number) {
-        return this.newDate(y, m, d);
-      }
-    }
-    const p = new Probe();
-    expect(p.newDateFor(2024, 2, 30)).toBe(null);
-    expect(p.newDateFor(0, 0, 0)).toBe(null);
-    expect(p.newDateFor(2024, 1, 15)?.toString()).toBe("2024-01-15");
-  });
-
-  it("cast month-name string", () => {
-    const result = type.cast("July 4, 2020");
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
-  });
-
-  it("cast slash string", () => {
-    const result = type.cast("7/4/2020");
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2020-04-07");
-  });
-
-  it("cast garbage string returns null", () => {
-    expect(type.cast("garbage")).toBe(null);
-  });
-
-  it("cast ISO string still works (regression guard)", () => {
-    const result = type.cast("2020-07-04");
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
-  });
-
-  it("cast datetime with non-zero offset near midnight preserves local date", () => {
-    // Ruby Date._parse("2020-07-04T00:30:00+02:00") reports mday=4, not the UTC day (3).
-    const result = type.cast("2020-07-04T00:30:00+02:00");
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
-  });
-
-  it("multiparameter hash missing day returns null (no defaults for DateType — P21 regression guard)", () => {
-    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7 });
-    expect(result).toBeNull();
-  });
-
-  it("multiparameter hash with all date parts returns PlainDate (P21 regression guard)", () => {
-    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7, 3: 4 });
-    expect(result).toBeInstanceOf(Temporal.PlainDate);
-    expect((result as Temporal.PlainDate).toString()).toBe("2025-07-04");
   });
 });

--- a/packages/activemodel/src/type/date.trails.test.ts
+++ b/packages/activemodel/src/type/date.trails.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/date";
+import { plainDate } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Types, ValueType } from "../index.js";
 
 // AcceptsMultiparameterTime::InstanceMethods#assert_valid_value
@@ -37,5 +39,107 @@ describe("DateType serialize_cast_value_compatible?", () => {
   it("is compatible", () => {
     const type = new Types.DateType();
     expect(type.itselfIfSerializeCastValueCompatible()).toBe(type);
+  });
+});
+
+describe("DateType cast and serialize coverage", () => {
+  const type = new Types.DateType();
+
+  it("Temporal.PlainDate passthrough", () => {
+    const original = plainDate("2024-01-15");
+    expect(type.cast(original)).toBe(original);
+  });
+
+  it("has name 'date'", () => {
+    expect(type.name).toBe("date");
+  });
+
+  it("casts null to null", () => {
+    expect(type.cast(null)).toBe(null);
+  });
+
+  it("casts undefined to null", () => {
+    expect(type.cast(undefined)).toBe(null);
+  });
+
+  it("casts empty string to null", () => {
+    expect(type.cast("")).toBe(null);
+  });
+
+  it("casts invalid string to null", () => {
+    expect(type.cast("not-a-date")).toBe(null);
+  });
+
+  it("serialize returns the cast PlainDate (not a SQL string)", () => {
+    const d = plainDate("2024-01-15");
+    expect((type.serialize(d) as Temporal.PlainDate).toString()).toBe("2024-01-15");
+  });
+
+  it("serialize null returns null", () => {
+    expect(type.serialize(null)).toBe(null);
+  });
+
+  it("PlainDateTime input extracts date (multiparameter support)", () => {
+    const pdt = Temporal.PlainDateTime.from("2024-06-15T10:30:00");
+    const result = type.cast(pdt);
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2024-06-15");
+  });
+
+  it("typeCastForSchema returns quoted string for PlainDate", () => {
+    const d = plainDate("2024-01-15");
+    expect(type.typeCastForSchema(d)).toBe('"2024-01-15"');
+  });
+
+  it("newDate rejects out-of-range components (rescue nil parity)", () => {
+    class Probe extends Types.DateType {
+      newDateFor(y: number, m: number, d: number) {
+        return this.newDate(y, m, d);
+      }
+    }
+    const p = new Probe();
+    expect(p.newDateFor(2024, 2, 30)).toBe(null);
+    expect(p.newDateFor(0, 0, 0)).toBe(null);
+    expect(p.newDateFor(2024, 1, 15)?.toString()).toBe("2024-01-15");
+  });
+
+  it("cast month-name string", () => {
+    const result = type.cast("July 4, 2020");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
+
+  it("cast slash string", () => {
+    const result = type.cast("7/4/2020");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-04-07");
+  });
+
+  it("cast garbage string returns null", () => {
+    expect(type.cast("garbage")).toBe(null);
+  });
+
+  it("cast ISO string still works (regression guard)", () => {
+    const result = type.cast("2020-07-04");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
+
+  it("cast datetime with non-zero offset near midnight preserves local date", () => {
+    // Ruby Date._parse("2020-07-04T00:30:00+02:00") reports mday=4, not the UTC day (3).
+    const result = type.cast("2020-07-04T00:30:00+02:00");
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2020-07-04");
+  });
+
+  it("multiparameter hash missing day returns null (no defaults for DateType — P21 regression guard)", () => {
+    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7 });
+    expect(result).toBeNull();
+  });
+
+  it("multiparameter hash with all date parts returns PlainDate (P21 regression guard)", () => {
+    const result = (type as any).valueFromMultiparameterAssignment({ 1: 2025, 2: 7, 3: 4 });
+    expect(result).toBeInstanceOf(Temporal.PlainDate);
+    expect((result as Temporal.PlainDate).toString()).toBe("2025-07-04");
   });
 });

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Rational } from "@blazetrails/date";
-import { Types } from "../index.js";
 import { DecimalType as Decimal } from "./decimal.js";
 
 // DecimalType#cast returns a BigDecimal (Rails: cast_value -> BigDecimal), so
@@ -83,111 +82,5 @@ describe("DecimalTest", () => {
 
     expect(type.cast(1.250473853637869)).toEqual(bd("1.250"));
     expect(type.cast("1.250473853637869")).toEqual(bd("1.250"));
-  });
-});
-describe("DecimalType", () => {
-  const type = new Types.DecimalType();
-
-  it("has name 'decimal'", () => {
-    expect(type.name).toBe("decimal");
-  });
-
-  it("type cast decimal", () => {
-    expect(type.cast(42.5)).toEqual(bd("42.5"));
-  });
-
-  it("casts string number to string", () => {
-    expect(type.cast("3.14")).toEqual(bd("3.14"));
-  });
-
-  it("casts integer to string", () => {
-    expect(type.cast(100)).toEqual(bd("100"));
-  });
-
-  it("casts null to null", () => {
-    expect(type.cast(null)).toBe(null);
-  });
-
-  it("type cast decimal from invalid string", () => {
-    // Mirrors Rails decimal_test.rb — "" nils out; leading-numeric
-    // prefix is kept; no-numeric-prefix returns BigDecimal(0).
-    expect(type.cast("")).toBe(null);
-    expect(type.cast("1ignore")).toEqual(bd("1"));
-    expect(type.cast("bad1")).toEqual(bd("0"));
-    expect(type.cast("bad")).toEqual(bd("0"));
-  });
-
-  it("blank string casts to null via Helpers::Numeric", () => {
-    const type = new Types.DecimalType();
-    expect(type.cast("   ")).toBeNull();
-  });
-
-  it("serialize delegates to cast via Helpers::Numeric", () => {
-    const type = new Types.DecimalType();
-    expect(type.serialize("1.5")).toEqual(bd("1.5"));
-    expect(type.serialize("")).toBeNull();
-  });
-
-  it("casting booleans via Helpers::Numeric — true → '1', false → '0'", () => {
-    const type = new Types.DecimalType();
-    expect(type.cast(true)).toEqual(bd("1"));
-    expect(type.cast(false)).toEqual(bd("0"));
-  });
-
-  it("isChanged returns true for number_to_non_number? path — same cast value, non-numeric raw", () => {
-    const type = new Types.DecimalType();
-    expect(type.isChanged("0", "0", "wibble")).toBe(true);
-  });
-
-  it("isChanged returns false for genuine revert — same cast and numeric raw", () => {
-    const type = new Types.DecimalType();
-    expect(type.isChanged("5", "5", "5")).toBe(false);
-  });
-
-  it("casts NaN (BigDecimal NaN sentinel) — number and string forms", () => {
-    const type = new Types.DecimalType();
-    expect(type.cast(NaN)).toBe("NaN");
-    expect(type.cast("NaN")).toBe("NaN");
-  });
-
-  it("casts ±Infinity (BigDecimal Infinity sentinel) — number and string forms", () => {
-    // Rails routes Float through `value.to_d`, and `Float::INFINITY.to_d`
-    // yields BigDecimal::INFINITY ("Infinity") rather than nil. With decimals
-    // modelled as strings the value round-trips as the "Infinity"/"-Infinity"
-    // sentinel (the JS ±Infinity on assignment, the string from PG on load).
-    const type = new Types.DecimalType();
-    expect(type.cast(Infinity)).toBe("Infinity");
-    expect(type.cast(-Infinity)).toBe("-Infinity");
-    expect(type.cast("Infinity")).toBe("Infinity");
-    expect(type.cast("-Infinity")).toBe("-Infinity");
-  });
-
-  it("serialize bridges to BigDecimal F-form for quoting", () => {
-    const type = new Types.DecimalType();
-    expect((type.serialize(42) as BigDecimal).toString("F")).toBe("42.0");
-    expect((type.serialize("1.5") as BigDecimal).toString("F")).toBe("1.5");
-    expect(type.serialize(null)).toBeNull();
-  });
-
-  it("serialize keeps the NaN sentinel as a string (BigDecimal has no NaN)", () => {
-    const type = new Types.DecimalType();
-    expect(type.serialize(NaN)).toBe("NaN");
-  });
-
-  it("serialize leaves adversarial exponents as the raw cast string", () => {
-    const type = new Types.DecimalType({ scale: 2 });
-    expect(type.serialize("1e10000000")).toBe("1e10000000");
-  });
-
-  it("applyScale leaves the NaN sentinel untouched", () => {
-    const type = new Types.DecimalType({ precision: 10, scale: 2 });
-    expect(type.cast(NaN)).toBe("NaN");
-    expect(type.cast("NaN")).toBe("NaN");
-  });
-
-  it("applyScale leaves the Infinity sentinel untouched", () => {
-    const type = new Types.DecimalType({ precision: 10, scale: 2 });
-    expect(type.cast(Infinity)).toBe("Infinity");
-    expect(type.cast(-Infinity)).toBe("-Infinity");
   });
 });

--- a/packages/activemodel/src/type/decimal.trails.test.ts
+++ b/packages/activemodel/src/type/decimal.trails.test.ts
@@ -54,3 +54,110 @@ describe("DecimalTypeTrails", () => {
     expect(m.attributeChanged("price")).toBe(false);
   });
 });
+
+describe("DecimalType cast and serialize coverage", () => {
+  const type = new Types.DecimalType();
+
+  it("has name 'decimal'", () => {
+    expect(type.name).toBe("decimal");
+  });
+
+  it("type cast decimal", () => {
+    expect(type.cast(42.5)).toEqual(bd("42.5"));
+  });
+
+  it("casts string number to string", () => {
+    expect(type.cast("3.14")).toEqual(bd("3.14"));
+  });
+
+  it("casts integer to string", () => {
+    expect(type.cast(100)).toEqual(bd("100"));
+  });
+
+  it("casts null to null", () => {
+    expect(type.cast(null)).toBe(null);
+  });
+
+  it("type cast decimal from invalid string", () => {
+    // Mirrors Rails decimal_test.rb — "" nils out; leading-numeric
+    // prefix is kept; no-numeric-prefix returns BigDecimal(0).
+    expect(type.cast("")).toBe(null);
+    expect(type.cast("1ignore")).toEqual(bd("1"));
+    expect(type.cast("bad1")).toEqual(bd("0"));
+    expect(type.cast("bad")).toEqual(bd("0"));
+  });
+
+  it("blank string casts to null via Helpers::Numeric", () => {
+    const type = new Types.DecimalType();
+    expect(type.cast("   ")).toBeNull();
+  });
+
+  it("serialize delegates to cast via Helpers::Numeric", () => {
+    const type = new Types.DecimalType();
+    expect(type.serialize("1.5")).toEqual(bd("1.5"));
+    expect(type.serialize("")).toBeNull();
+  });
+
+  it("casting booleans via Helpers::Numeric — true → '1', false → '0'", () => {
+    const type = new Types.DecimalType();
+    expect(type.cast(true)).toEqual(bd("1"));
+    expect(type.cast(false)).toEqual(bd("0"));
+  });
+
+  it("isChanged returns true for number_to_non_number? path — same cast value, non-numeric raw", () => {
+    const type = new Types.DecimalType();
+    expect(type.isChanged("0", "0", "wibble")).toBe(true);
+  });
+
+  it("isChanged returns false for genuine revert — same cast and numeric raw", () => {
+    const type = new Types.DecimalType();
+    expect(type.isChanged("5", "5", "5")).toBe(false);
+  });
+
+  it("casts NaN (BigDecimal NaN sentinel) — number and string forms", () => {
+    const type = new Types.DecimalType();
+    expect(type.cast(NaN)).toBe("NaN");
+    expect(type.cast("NaN")).toBe("NaN");
+  });
+
+  it("casts ±Infinity (BigDecimal Infinity sentinel) — number and string forms", () => {
+    // Rails routes Float through `value.to_d`, and `Float::INFINITY.to_d`
+    // yields BigDecimal::INFINITY ("Infinity") rather than nil. With decimals
+    // modelled as strings the value round-trips as the "Infinity"/"-Infinity"
+    // sentinel (the JS ±Infinity on assignment, the string from PG on load).
+    const type = new Types.DecimalType();
+    expect(type.cast(Infinity)).toBe("Infinity");
+    expect(type.cast(-Infinity)).toBe("-Infinity");
+    expect(type.cast("Infinity")).toBe("Infinity");
+    expect(type.cast("-Infinity")).toBe("-Infinity");
+  });
+
+  it("serialize bridges to BigDecimal F-form for quoting", () => {
+    const type = new Types.DecimalType();
+    expect((type.serialize(42) as BigDecimal).toString("F")).toBe("42.0");
+    expect((type.serialize("1.5") as BigDecimal).toString("F")).toBe("1.5");
+    expect(type.serialize(null)).toBeNull();
+  });
+
+  it("serialize keeps the NaN sentinel as a string (BigDecimal has no NaN)", () => {
+    const type = new Types.DecimalType();
+    expect(type.serialize(NaN)).toBe("NaN");
+  });
+
+  it("serialize leaves adversarial exponents as the raw cast string", () => {
+    const type = new Types.DecimalType({ scale: 2 });
+    expect(type.serialize("1e10000000")).toBe("1e10000000");
+  });
+
+  it("applyScale leaves the NaN sentinel untouched", () => {
+    const type = new Types.DecimalType({ precision: 10, scale: 2 });
+    expect(type.cast(NaN)).toBe("NaN");
+    expect(type.cast("NaN")).toBe("NaN");
+  });
+
+  it("applyScale leaves the Infinity sentinel untouched", () => {
+    const type = new Types.DecimalType({ precision: 10, scale: 2 });
+    expect(type.cast(Infinity)).toBe("Infinity");
+    expect(type.cast(-Infinity)).toBe("-Infinity");
+  });
+});


### PR DESCRIPTION
Follow-up to #6991. Moves every `it(...)` that `parity:test` reports as "extra
(TS only)" out of three mirrored ActiveModel type test files and into their
`.trails.test.ts` siblings, so each mirrored file's `it` list is exactly the
Rails test list.

No test is renamed, reworded, or deleted — only the enclosing `describe`
changes. Each moved group lands under a descriptive top-level `describe`, the
shape #6991 established for `time` and `date-time`. `date.trails.test.ts` gains
the `Temporal` / `plainDate` imports the moved tests need, and each new
`describe` re-declares its own `const type = ...` rather than moving the shared
one out from under the Rails tests.

`pnpm parity:test --package activemodel`:

| Ruby file                  | OK before | Extra before | OK after | Extra after |
| -------------------------- | --------- | ------------ | -------- | ----------- |
| `type/decimal_test.rb`     | 10        | 18           | 10       | 0           |
| `type/date_test.rb`        | 2         | 18           | 2        | 0           |
| `type/big_integer_test.rb` | 4         | 13           | 4        | 0           |

activemodel's matched total is unchanged at 963/963 (100%), 56/56 files, 0
misplaced; the assertion-mismatch counts are unchanged (304 / 446 / 59).
Package-wide extras: 465 → 416.

All six touched files green (76 tests). No source file changed, so no call- or
extra-surface gate applies.

The remaining five files in the story — `string`, `immutable-string`, `value`,
`registry` (34 extras between them) and `type_test.rb` — did not fit under the
LOC ceiling and are filed as
`0115-activemodel-fidelity-convergence/move-ts-only-extras-out-of-the-remaining-activemodel-type-test-files-part-2`,
as the story anticipated.

Closes-story: move-ts-only-extras-out-of-the-remaining-mirrored-activemodel-type-test-files
