### PR TITLE
docs(activerecord): retarget Column#encodeWith's story citation to the re-specified RFC 0096 story

### DIFF
--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -169,14 +169,14 @@ export class Column {
    * `auto_increment` (`sqlite3/column.rb:36-44`); `MySQL::Column` writes
    * nothing, because its `extra` lives in `MySQL::TypeMetadata` and rides
    * along inside `sql_type_metadata`. trails' overrides go further still,
-   * encoding the state Rails either derives (`array` from the `[]` suffix) or
-   * holds in an adapter `TypeMetadata` trails has not ported (`oid` / `fmod` /
-   * `extra`), plus the `rowid` / `generated_type` Rails genuinely loses. That
-   * last one is load-bearing here and not upstream: Rails only ever compares a
-   * reflected cache against another reflected one, while trails' fixtures warm
-   * compares a dump-loaded cache against a reflected one, so dropping them reds
-   * `base_test.rb`'s `test_clear_cache!`. Tracked by RFC 0096
-   * `converge-column-subclass-state-out-of-encode-with`.
+   * encoding the state Rails either derives from `sql_type` (`array`, from the
+   * `[]` suffix — `postgresql/column.rb:37-40`) or reaches through
+   * `sql_type_metadata`, which the base coder already persists (`oid` / `fmod`,
+   * `postgresql/column.rb:7`; MySQL's `extra`, `mysql/column.rb:7-24`), plus
+   * the `rowid` / `generated_type` Rails genuinely loses. Dropping the keys
+   * today leaves those fields `undefined`, which flips the `x !== null` guards
+   * the subclasses port Ruby's `nil?` / `present?` as. Tracked by RFC 0096
+   * `converge-column-subclass-coders-to-rails-per-subclass-key-sets`.
    */
   encodeWith(coder: ColumnCoder): void {
     coder["class"] = "Column";


### PR DESCRIPTION
## Root cause

`Unit Tests` on `main` @8b3ee340 failed on exactly one test:

```
× stale story references > no comment or markdown paragraph in the tree
  names a story that has already landed
+ [ "packages/activerecord/src/connection-adapters/column.ts:153
    converge-column-subclass-state-out-of-encode-with" ]
```

The `Column#encodeWith` JSDoc cites RFC 0096
`converge-column-subclass-state-out-of-encode-with` as tracking its
deviation. That story was **closed as misspecified** the same day, so the
gate correctly reports the citation as naming a landed story. Nothing in
#6996 touched `column.ts` — the red is the tasks-side status flip meeting
a code citation, which is precisely what this gate exists to catch.

The story's `closed-reason` re-files the work as
`converge-column-subclass-coders-to-rails-per-subclass-key-sets` (same
RFC, `status: ready`). The deviation is still real and still tracked; only
the pointer was stale.

## The fix

Retarget the citation to the re-specified story. The surrounding prose
carried the misspecified premise too ("state Rails … holds in an adapter
`TypeMetadata` trails has not ported"), so it is corrected against
`vendor/rails`:

- `oid` / `fmod` are not lost upstream — they `delegate … to:
  :sql_type_metadata` (`postgresql/column.rb:7`), which the base
  `encode_with` already persists.
- `array` derives from `sql_type` (`postgresql/column.rb:37-40`).
- MySQL's `extra` delegates the same way (`mysql/column.rb:7-24`).
- The residual breakage is the one the new story carries: dropping the
  keys leaves the fields `undefined`, flipping the `x !== null` guards the
  subclasses port Ruby's `nil?` / `present?` as.

Comment-only; no behaviour change, no skip, no baseline entry. The gate
passes locally (`17 passed`).

Closes-story: red-8b3ee340


## CI result

Run [32764551065](https://github.com/blazetrailsdev/trails/actions/runs/32764551065) @79f3e13d1 is green — `gh run watch --exit-status` exits 0, with **zero** non-pass checks on that run.

The originally-red job passes:

| check | result |
| --- | --- |
| `Unit Tests` (the red this story tracks) | pass |
| `Rails API/Test Comparison` | pass |
| `Active Record PostgreSQL Tests (1)` / `(2)` | pass |
| `Active Record MariaDB Tests (1)` / `(2)` | pass |
| `Active Record SQLite Tests` | pass |
| `Lint`, `Build & Type Check`, `CI` (aggregate gate) | pass |

Two rows named `Active Record PostgreSQL Tests` and `Active Record MariaDB Tests` still show `fail` in the checks list. Those are **cancellation artifacts from superseded runs** on the same SHA — `32764339225` and `32764341827`, both `completed/cancelled`, created within 2s of each other at 18:46 and replaced by `32764551065` at 18:49. The live run's sharded equivalents (`(1)` / `(2)`) all pass, and the aggregate `CI` job — which fails on any `failure` or `cancelled` need — passes.
