### PR TITLE
test(arel): converge attribute and CRUD-manager assertion parity (RFC 0122)

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -2,26 +2,56 @@ import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import { testConnection } from "../test-helpers/connection.js";
 import { Table, star, Nodes, Visitors } from "../index.js";
+import { Attribute } from "./attribute.js";
+import { mustBeLike } from "../test-helpers/must-be-like.js";
 
 describe("AttributeTest", () => {
   const users = new Table("users");
   const visitor = new Visitors.ToSql(testConnection);
+
+  // Mirrors Rails' private `quoted_range` (attribute_test.rb:1163-1169).
+  function quotedRange(beginVal: unknown, endVal: unknown, exclude: boolean) {
+    return {
+      begin: new Nodes.Quoted(beginVal),
+      end: new Nodes.Quoted(endVal),
+      excludeEnd: exclude,
+    };
+  }
+
+  // Mimic PG::TextDecoder::Array casting (attribute_test.rb:1171-1181).
+  function fakePgCaster() {
+    return {
+      typeCastForDatabase(attrName: string, value: unknown) {
+        return attrName === "tags" ? `{${(value as unknown[]).join(",")}}` : value;
+      },
+    };
+  }
   describe("#not_eq", () => {
     it("should create a NotEqual node", () => {
-      expect(users.project(star).where(users.get("id").notEq(10)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."id" != 10',
-      );
+      const relation = new Table("users");
+      expect(relation.get("id").notEq(10)).toBeInstanceOf(Nodes.NotEqual);
     });
 
     it("should generate != in sql", () => {
-      const result = users.project(star).where(users.get("id").notEq(10)).toSql();
-      expect(result).toBe('SELECT * FROM "users" WHERE "users"."id" != 10');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").notEq(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" != 10
+        `),
+      );
     });
 
     it("should handle nil", () => {
       const relation = new Table("users");
-      const node = relation.get("id").notEq(null);
-      expect(new Visitors.ToSql(testConnection).compile(node)).toContain("IS NOT NULL");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").notEq(null));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" IS NOT NULL
+        `),
+      );
     });
   });
 
@@ -62,29 +92,43 @@ describe("AttributeTest", () => {
 
   describe("#gt", () => {
     it("should create a GreaterThan node", () => {
-      expect(users.get("age").gt(10)).toBeInstanceOf(Nodes.GreaterThan);
-      expect(users.project(star).where(users.get("age").gt(10)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."age" > 10',
-      );
+      const relation = new Table("users");
+      expect(relation.get("id").gt(10)).toBeInstanceOf(Nodes.GreaterThan);
     });
 
     it("should generate > in sql", () => {
-      expect(users.project(star).where(users.get("age").gt(21)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."age" > 21',
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").gt(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" > 10
+        `),
       );
     });
 
     it("should handle comparing with a subquery", () => {
-      const subquery = users.project(users.get("id").maximum());
-      const node = users.get("age").gt(subquery);
-      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+      const avg = users.project(users.get("karma").average());
+      const mgr = users.project(star).where(users.get("karma").gt(avg));
+
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT * FROM "users" WHERE "users"."karma" > (SELECT AVG("users"."karma") FROM "users")
+        `),
+      );
     });
 
     it("should accept various data types.", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("name").gt("fake_name"));
-      expect(mgr.toSql()).toContain("fake_name");
+      expect(mgr.toSql()).toMatch(`"users"."name" > 'fake_name'`);
+
+      // Rails interpolates `::Time.now`; a fixed Instant keeps the assertion
+      // deterministic while reaching the same Ruby `Time#to_s` rendering arm.
+      const currentTime = Temporal.Instant.from("2024-01-01T00:00:00Z");
+      mgr.where(relation.get("created_at").gt(currentTime));
+      expect(mgr.toSql()).toMatch(`"users"."created_at" > '2024-01-01 00:00:00 +0000'`);
     });
   });
 
@@ -118,20 +162,32 @@ describe("AttributeTest", () => {
 
   describe("#gteq", () => {
     it("should create a GreaterThanOrEqual node", () => {
-      const node = users.get("age").gteq(10);
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const relation = new Table("users");
+      expect(relation.get("id").gteq(10)).toBeInstanceOf(Nodes.GreaterThanOrEqual);
     });
 
     it("should generate >= in sql", () => {
-      const result = users.project(star).where(users.get("age").gteq(10)).toSql();
-      expect(result).toBe('SELECT * FROM "users" WHERE "users"."age" >= 10');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").gteq(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" >= 10
+        `),
+      );
     });
 
     it("should accept various data types.", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("name").gteq("fake_name"));
-      expect(mgr.toSql()).toContain("fake_name");
+      expect(mgr.toSql()).toMatch(`"users"."name" >= 'fake_name'`);
+
+      // Rails interpolates `::Time.now`; a fixed Instant keeps the assertion
+      // deterministic while reaching the same Ruby `Time#to_s` rendering arm.
+      const currentTime = Temporal.Instant.from("2024-01-01T00:00:00Z");
+      mgr.where(relation.get("created_at").gteq(currentTime));
+      expect(mgr.toSql()).toMatch(`"users"."created_at" >= '2024-01-01 00:00:00 +0000'`);
     });
   });
 
@@ -165,22 +221,32 @@ describe("AttributeTest", () => {
 
   describe("#lt", () => {
     it("should create a LessThan node", () => {
-      expect(users.get("age").lt(10)).toBeInstanceOf(Nodes.LessThan);
-      expect(users.project(star).where(users.get("age").lt(10)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."age" < 10',
-      );
+      const relation = new Table("users");
+      expect(relation.get("id").lt(10)).toBeInstanceOf(Nodes.LessThan);
     });
 
     it("should generate < in sql", () => {
-      const result = users.project(star).where(users.get("age").lt(10)).toSql();
-      expect(result).toBe('SELECT * FROM "users" WHERE "users"."age" < 10');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").lt(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" < 10
+        `),
+      );
     });
 
     it("should accept various data types.", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("name").lt("fake_name"));
-      expect(mgr.toSql()).toContain("fake_name");
+      expect(mgr.toSql()).toMatch(`"users"."name" < 'fake_name'`);
+
+      // Rails interpolates `::Time.now`; a fixed Instant keeps the assertion
+      // deterministic while reaching the same Ruby `Time#to_s` rendering arm.
+      const currentTime = Temporal.Instant.from("2024-01-01T00:00:00Z");
+      mgr.where(relation.get("created_at").lt(currentTime));
+      expect(mgr.toSql()).toMatch(`"users"."created_at" < '2024-01-01 00:00:00 +0000'`);
     });
   });
 
@@ -214,27 +280,32 @@ describe("AttributeTest", () => {
 
   describe("#lteq", () => {
     it("should create a LessThanOrEqual node", () => {
-      const node = users.get("age").lteq(10);
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const relation = new Table("users");
+      expect(relation.get("id").lteq(10)).toBeInstanceOf(Nodes.LessThanOrEqual);
     });
 
     it("should generate <= in sql", () => {
-      const result = users.project(star).where(users.get("age").lteq(10)).toSql();
-      expect(result).toBe('SELECT * FROM "users" WHERE "users"."age" <= 10');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").lteq(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" <= 10
+        `),
+      );
     });
 
     it("should accept various data types.", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("name").lteq("fake_name"));
-      expect(mgr.toSql()).toContain(`"users"."name" <= 'fake_name'`);
+      expect(mgr.toSql()).toMatch(`"users"."name" <= 'fake_name'`);
 
-      // Rails compares against Time.now; a fixed value keeps the assertion
-      // deterministic. Instant is the Time analogue and reaches FakeRecord's
-      // `else` arm, which renders Ruby's `Time#to_s` shape.
+      // Rails interpolates `::Time.now`; a fixed Instant keeps the assertion
+      // deterministic while reaching the same Ruby `Time#to_s` rendering arm.
       const currentTime = Temporal.Instant.from("2024-01-01T00:00:00Z");
       mgr.where(relation.get("created_at").lteq(currentTime));
-      expect(mgr.toSql()).toContain(`"users"."created_at" <= '2024-01-01 00:00:00 +0000'`);
+      expect(mgr.toSql()).toMatch(`"users"."created_at" <= '2024-01-01 00:00:00 +0000'`);
     });
   });
 
@@ -261,172 +332,234 @@ describe("AttributeTest", () => {
 
   describe("#average", () => {
     it("should create a AVG node", () => {
-      const node = users.get("age").average();
-      expect(node).toBeInstanceOf(Nodes.Avg);
+      const relation = new Table("users");
+      expect(relation.get("id").average()).toBeInstanceOf(Nodes.Avg);
     });
 
     it("should generate the proper SQL", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id").average());
-      expect(mgr.toSql()).toContain("AVG");
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT AVG("users"."id")
+          FROM "users"
+        `),
+      );
     });
   });
 
   describe("#maximum", () => {
     it("should create a MAX node", () => {
-      const node = users.get("age").maximum();
-      expect(node).toBeInstanceOf(Nodes.Max);
+      const relation = new Table("users");
+      expect(relation.get("id").maximum()).toBeInstanceOf(Nodes.Max);
     });
 
     it("should generate proper SQL", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id").maximum());
-      expect(mgr.toSql()).toContain("MAX");
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT MAX("users"."id")
+          FROM "users"
+        `),
+      );
     });
   });
 
   describe("#minimum", () => {
     it("should create a Min node", () => {
-      const node = users.get("age").minimum();
-      expect(node).toBeInstanceOf(Nodes.Min);
+      const relation = new Table("users");
+      expect(relation.get("id").minimum()).toBeInstanceOf(Nodes.Min);
     });
 
     it("should generate proper SQL", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id").minimum());
-      expect(mgr.toSql()).toContain("MIN");
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT MIN("users"."id")
+          FROM "users"
+        `),
+      );
     });
   });
 
   describe("#sum", () => {
     it("should create a SUM node", () => {
-      const node = users.get("age").sum();
-      expect(node).toBeInstanceOf(Nodes.Sum);
+      const relation = new Table("users");
+      expect(relation.get("id").sum()).toBeInstanceOf(Nodes.Sum);
     });
 
     it("should generate the proper SQL", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id").sum());
-      expect(mgr.toSql()).toContain("SUM");
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT SUM("users"."id")
+          FROM "users"
+        `),
+      );
     });
   });
 
   describe("#count", () => {
     it("should return a count node", () => {
-      const node = users.get("id").count();
-      expect(node).toBeInstanceOf(Nodes.Count);
+      const relation = new Table("users");
+      expect(relation.get("id").count()).toBeInstanceOf(Nodes.Count);
     });
 
     it("should take a distinct param", () => {
-      expect(users.project(users.get("name").count(true)).toSql()).toBe(
-        'SELECT COUNT(DISTINCT "users"."name") FROM "users"',
-      );
+      const relation = new Table("users");
+      const count = relation.get("id").count(null);
+      expect(count).toBeInstanceOf(Nodes.Count);
+      expect(count.distinct).toBeNull();
     });
   });
 
   describe("#eq", () => {
     it("should return an equality node", () => {
-      expect(users.get("id").eq(10)).toBeInstanceOf(Nodes.Equality);
-      expect(users.project(star).where(users.get("id").eq(10)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."id" = 10',
-      );
+      const attribute = new Attribute(null, null);
+      const equality = attribute.eq(1);
+      expect(equality.left).toEqual(attribute);
+      expect((equality.right as Nodes.Casted).value).toEqual(1);
+      expect(equality).toBeInstanceOf(Nodes.Equality);
     });
 
     it("should generate = in sql", () => {
-      expect(users.project(star).where(users.get("id").eq(10)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."id" = 10',
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").eq(10));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" = 10
+        `),
       );
     });
 
     it("should handle nil", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      const node = users.get("name").eq(null);
-      expect(visitor.compile(node)).toBe('"users"."name" IS NULL');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").eq(null));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" IS NULL
+        `),
+      );
     });
   });
 
   describe("#matches_any", () => {
     it("should create a Grouping node", () => {
-      expect(users.get("name").matchesAny(["%foo%", "%bar%"])).toBeInstanceOf(Nodes.Grouping);
+      const relation = new Table("users");
+      expect(relation.get("name").matchesAny(["%chunky%", "%bacon%"])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
     });
 
     it("should generate ORs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("name").matchesAny(["%foo%", "%bar%"]));
-      expect(mgr.toSql()).toBe(
-        `SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%foo%' OR "users"."name" LIKE '%bar%')`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").matchesAny(["%chunky%", "%bacon%"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%chunky%' OR "users"."name" LIKE '%bacon%')
+        `),
       );
     });
   });
 
   describe("#matches_all", () => {
     it("should create a Grouping node", () => {
-      expect(users.get("name").matchesAll(["%foo%", "%bar%"])).toBeInstanceOf(Nodes.Grouping);
+      const relation = new Table("users");
+      expect(relation.get("name").matchesAll(["%chunky%", "%bacon%"])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
     });
 
     it("should generate ANDs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("name").matchesAll(["%foo%", "%bar%"]));
-      expect(mgr.toSql()).toBe(
-        `SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%foo%' AND "users"."name" LIKE '%bar%')`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").matchesAll(["%chunky%", "%bacon%"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%chunky%' AND "users"."name" LIKE '%bacon%')
+        `),
       );
     });
   });
 
   describe("#matches", () => {
     it("should create a Matches node", () => {
-      expect(users.get("name").matches("%bacon%")).toBeInstanceOf(Nodes.Matches);
-      expect(users.project(star).where(users.get("name").matches("%bacon%")).toSql()).toBe(
-        `SELECT * FROM "users" WHERE "users"."name" LIKE '%bacon%'`,
-      );
+      const relation = new Table("users");
+      expect(relation.get("name").matches("%bacon%")).toBeInstanceOf(Nodes.Matches);
     });
 
     it("should generate LIKE in sql", () => {
-      expect(users.project(star).where(users.get("name").matches("%bacon%")).toSql()).toBe(
-        `SELECT * FROM "users" WHERE "users"."name" LIKE '%bacon%'`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").matches("%bacon%"));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."name" LIKE '%bacon%'
+        `),
       );
     });
   });
 
   describe("#does_not_match_any", () => {
     it("should create a Grouping node", () => {
-      expect(users.get("name").doesNotMatchAny(["%foo%", "%bar%"])).toBeInstanceOf(Nodes.Grouping);
+      const relation = new Table("users");
+      expect(relation.get("name").doesNotMatchAny(["%chunky%", "%bacon%"])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
     });
 
     it("should generate ORs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("name").doesNotMatchAny(["%foo%", "%bar%"]));
-      expect(mgr.toSql()).toBe(
-        `SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%foo%' OR "users"."name" NOT LIKE '%bar%')`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").doesNotMatchAny(["%chunky%", "%bacon%"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%chunky%' OR "users"."name" NOT LIKE '%bacon%')
+        `),
       );
     });
   });
 
   describe("#does_not_match_all", () => {
     it("should create a Grouping node", () => {
-      expect(users.get("name").doesNotMatchAll(["%foo%", "%bar%"])).toBeInstanceOf(Nodes.Grouping);
+      const relation = new Table("users");
+      expect(relation.get("name").doesNotMatchAll(["%chunky%", "%bacon%"])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
     });
 
     it("should generate ANDs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("name").doesNotMatchAll(["%foo%", "%bar%"]));
-      expect(mgr.toSql()).toBe(
-        `SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%foo%' AND "users"."name" NOT LIKE '%bar%')`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").doesNotMatchAll(["%chunky%", "%bacon%"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%chunky%' AND "users"."name" NOT LIKE '%bacon%')
+        `),
       );
     });
   });
 
   describe("#does_not_match", () => {
     it("should create a DoesNotMatch node", () => {
-      expect(users.get("name").doesNotMatch("%bacon%")).toBeInstanceOf(Nodes.DoesNotMatch);
-      expect(users.project(star).where(users.get("name").doesNotMatch("%bacon%")).toSql()).toBe(
-        `SELECT * FROM "users" WHERE "users"."name" NOT LIKE '%bacon%'`,
-      );
+      const relation = new Table("users");
+      expect(relation.get("name").doesNotMatch("%bacon%")).toBeInstanceOf(Nodes.DoesNotMatch);
     });
 
     it("should generate NOT LIKE in sql", () => {
-      expect(users.project(star).where(users.get("name").doesNotMatch("%bacon%")).toSql()).toBe(
-        `SELECT * FROM "users" WHERE "users"."name" NOT LIKE '%bacon%'`,
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").doesNotMatch("%bacon%"));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."name" NOT LIKE '%bacon%'
+        `),
       );
     });
   });
@@ -481,189 +614,283 @@ describe("AttributeTest", () => {
 
   describe("#between", () => {
     it("can be constructed with a standard range", () => {
-      const node = users.get("id").between([1, 3]);
-      expect(node).toBeInstanceOf(Nodes.Between);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between([1, 3]);
+
+      expect(node).toEqual(
+        new Nodes.Between(
+          attribute,
+          new Nodes.And([new Nodes.Casted(1, attribute), new Nodes.Casted(3, attribute)]),
+        ),
+      );
     });
 
     it("can be constructed with a range starting from -Infinity", () => {
-      const node = users.get("id").between([-Infinity, 3]);
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between([-Infinity, 3]);
+
+      expect(node).toEqual(new Nodes.LessThanOrEqual(attribute, new Nodes.Casted(3, attribute)));
     });
 
     it("can be constructed with a quoted range starting from -Infinity", () => {
-      const node = users.get("id").between({ begin: -Infinity, end: 3 });
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between(quotedRange(-Infinity, 3, false));
+
+      expect(node).toEqual(new Nodes.LessThanOrEqual(attribute, new Nodes.Quoted(3)));
     });
 
     it("can be constructed with an exclusive range starting from -Infinity", () => {
-      const node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.LessThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: -Infinity, end: 3, excludeEnd: true });
+
+      expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Casted(3, attribute)));
     });
 
     it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
-      const node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.LessThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between(quotedRange(-Infinity, 3, true));
+
+      expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Quoted(3)));
     });
 
     it("can be constructed with an infinite range", () => {
-      const node = users.get("id").between([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between([-Infinity, Infinity]);
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, []));
     });
 
     it("can be constructed with a quoted infinite range", () => {
-      const node = users.get("id").between({ begin: -Infinity, end: Infinity });
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between(quotedRange(-Infinity, Infinity, false));
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, []));
     });
 
     it("can be constructed with a range ending at Infinity", () => {
-      const node = users.get("id").between([1, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between([0, Infinity]);
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a range implicitly starting at Infinity", () => {
-      const node = users.get("id").between({ begin: null, end: 3 });
-      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: null, end: 0 });
+
+      expect(node).toEqual(new Nodes.LessThanOrEqual(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a range implicitly ending at Infinity", () => {
-      const node = users.get("id").between({ begin: 1, end: null });
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: 0, end: null });
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with an exclusive range implicitly ending at Infinity", () => {
-      const node = users.get("id").between({ begin: 1, end: null, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: 0, end: null, excludeEnd: true });
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a quoted range ending at Infinity", () => {
-      const node = users.get("id").between({ begin: 1, end: Infinity });
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between(quotedRange(0, Infinity, false));
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Quoted(0)));
     });
 
     it("can be constructed with an endless range starting from Infinity", () => {
-      const node = users.get("id").between({ begin: Infinity, end: null });
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: Infinity, end: null });
+
+      expect(node).toEqual(new Nodes.In(attribute, []));
     });
 
     it("can be constructed with a beginless range ending in -Infinity", () => {
-      const node = users.get("id").between({ begin: null, end: -Infinity });
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: null, end: -Infinity });
+
+      expect(node).toEqual(new Nodes.In(attribute, []));
     });
 
     it("can be constructed with an exclusive range", () => {
-      const node = users.get("id").between({ begin: 1, end: 3, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.And);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between({ begin: 0, end: 3, excludeEnd: true });
+
+      expect(node).toEqual(
+        new Nodes.And([
+          new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(0, attribute)),
+          new Nodes.LessThan(attribute, new Nodes.Casted(3, attribute)),
+        ]),
+      );
     });
 
     it("can be constructed with a range where the begin and end are equal", () => {
-      const node = users.get("id").between([5, 5]);
-      expect(node).toBeInstanceOf(Nodes.Equality);
+      const attribute = new Attribute(null, null);
+      const node = attribute.between([1, 1]);
+
+      expect(node).toEqual(new Nodes.Equality(attribute, new Nodes.Casted(1, attribute)));
     });
   });
 
   describe("#not_between", () => {
     it("can be constructed with a standard range", () => {
-      const node = users.get("age").notBetween([18, 65]);
-      expect(node).toBeInstanceOf(Nodes.Grouping);
-      expect((node as Nodes.Grouping).expr).toBeInstanceOf(Nodes.Or);
-      expect(visitor.compile(node)).toBe('("users"."age" < 18 OR "users"."age" > 65)');
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween([1, 3]);
+
+      expect(node).toEqual(
+        new Nodes.Grouping(
+          new Nodes.Or([
+            new Nodes.LessThan(attribute, new Nodes.Casted(1, attribute)),
+            new Nodes.GreaterThan(attribute, new Nodes.Casted(3, attribute)),
+          ]),
+        ),
+      );
     });
 
     it("can be constructed with a range starting from -Infinity", () => {
-      const node = users.get("age").notBetween([-Infinity, 65]);
-      expect(node).toBeInstanceOf(Nodes.GreaterThan);
-      expect(visitor.compile(node)).toBe('"users"."age" > 65');
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween([-Infinity, 3]);
+
+      expect(node).toEqual(new Nodes.GreaterThan(attribute, new Nodes.Casted(3, attribute)));
     });
 
     it("can be constructed with a quoted range starting from -Infinity", () => {
-      const node = users.get("id").notBetween({ begin: -Infinity, end: 3 });
-      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween(quotedRange(-Infinity, 3, false));
+
+      expect(node).toEqual(new Nodes.GreaterThan(attribute, new Nodes.Quoted(3)));
     });
 
     it("can be constructed with an exclusive range starting from -Infinity", () => {
-      const node = users.get("id").notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(3, attribute)));
     });
 
     it("can be constructed with a quoted exclusive range starting from -Infinity", () => {
-      const node = users.get("id").notBetween({ begin: -Infinity, end: 3, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween(quotedRange(-Infinity, 3, true));
+
+      expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Quoted(3)));
     });
 
     it("can be constructed with an infinite range", () => {
-      const node = users.get("id").notBetween([-Infinity, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween([-Infinity, Infinity]);
+
+      expect(node).toEqual(new Nodes.In(attribute, []));
     });
 
     it("can be constructed with a quoted infinite range", () => {
-      const node = users.get("id").notBetween({ begin: -Infinity, end: Infinity });
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween(quotedRange(-Infinity, Infinity, false));
+
+      expect(node).toEqual(new Nodes.In(attribute, []));
     });
 
     it("can be constructed with a range ending at Infinity", () => {
-      const node = users.get("id").notBetween([1, Infinity]);
-      expect(node).toBeInstanceOf(Nodes.LessThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween([0, Infinity]);
+
+      expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a range implicitly starting at Infinity", () => {
-      const node = users.get("age").notBetween({ begin: null, end: 0 });
-      expect(node).toBeInstanceOf(Nodes.GreaterThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: null, end: 0 });
+
+      expect(node).toEqual(new Nodes.GreaterThan(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a range implicitly ending at Infinity", () => {
-      const node = users.get("age").notBetween({ begin: 0, end: null });
-      expect(node).toBeInstanceOf(Nodes.LessThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: 0, end: null });
+
+      expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Casted(0, attribute)));
     });
 
     it("can be constructed with a quoted range ending at Infinity", () => {
-      const node = users.get("age").notBetween({ begin: 18, end: Infinity });
-      expect(node).toBeInstanceOf(Nodes.LessThan);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween(quotedRange(0, Infinity, false));
+
+      expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Quoted(0)));
     });
 
     it("can be constructed with an endless range starting from Infinity", () => {
-      const node = users.get("age").notBetween({ begin: Infinity, end: null });
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: Infinity, end: null });
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, []));
     });
 
     it("can be constructed with a beginless range ending in -Infinity", () => {
-      const node = users.get("age").notBetween({ begin: null, end: -Infinity });
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: null, end: -Infinity });
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, []));
     });
 
     it("can be constructed with an exclusive range", () => {
-      const node = users.get("age").notBetween({ begin: 18, end: 65, excludeEnd: true });
-      expect(node).toBeInstanceOf(Nodes.Grouping);
-      const inner = (node as Nodes.Grouping).expr as Nodes.Or;
-      expect(inner.children[1]).toBeInstanceOf(Nodes.GreaterThanOrEqual);
-      expect(visitor.compile(node)).toBe('("users"."age" < 18 OR "users"."age" >= 65)');
+      const attribute = new Attribute(null, null);
+      const node = attribute.notBetween({ begin: 0, end: 3, excludeEnd: true });
+
+      expect(node).toEqual(
+        new Nodes.Grouping(
+          new Nodes.Or([
+            new Nodes.LessThan(attribute, new Nodes.Casted(0, attribute)),
+            new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(3, attribute)),
+          ]),
+        ),
+      );
     });
   });
 
   describe("#not_in", () => {
     it("can be constructed with a subquery", () => {
-      const mgr = users.project(users.get("id"));
-      const node = users.get("id").notIn(mgr);
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").doesNotMatchAll(["%chunky%", "%bacon%"]));
+      const attribute = new Attribute(null, null);
+
+      const node = attribute.notIn(mgr);
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, mgr.ast));
     });
 
     it("can be constructed with a Union", () => {
-      const mgr1 = users.project(users.get("id"));
-      const mgr2 = users.project(users.get("id"));
+      const relation = new Table("users");
+      const mgr1 = relation.project(relation.get("id"));
+      const mgr2 = relation.project(relation.get("id"));
+
       const union = mgr1.union(mgr2);
-      const node = users.get("id").in(union);
-      expect(visitor.compile(node)).toBe(
-        '"users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))',
+      const node = relation.get("id").in(union);
+      expect(mustBeLike(visitor.compile(node))).toBe(
+        mustBeLike(`
+          "users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))
+        `),
       );
     });
 
     it("can be constructed with a list", () => {
-      const node = users.get("id").notIn([1, 2, 3]);
-      expect(node).toBeInstanceOf(Nodes.NotIn);
-      expect(visitor.compile(node)).toBe('"users"."id" NOT IN (1, 2, 3)');
+      const attribute = new Attribute(null, null);
+      const node = attribute.notIn([1, 2, 3]);
+
+      expect(node).toEqual(
+        new Nodes.NotIn(attribute, [
+          new Nodes.Casted(1, attribute),
+          new Nodes.Casted(2, attribute),
+          new Nodes.Casted(3, attribute),
+        ]),
+      );
     });
 
     it("can be constructed with a random object", () => {
-      const attribute = users.get("id");
+      const attribute = new Attribute(null, null);
       const randomObject = {};
       const node = attribute.notIn(randomObject);
 
@@ -671,38 +898,55 @@ describe("AttributeTest", () => {
     });
 
     it("should generate NOT IN in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("id").notIn([1, 2, 3]));
-      expect(mgr.toSql()).toBe(
-        'SELECT "users"."id" FROM "users" WHERE "users"."id" NOT IN (1, 2, 3)',
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").notIn([1, 2, 3]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" NOT IN (1, 2, 3)
+        `),
       );
     });
   });
 
   describe("#in", () => {
     it("should generate IN in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("id").in([1, 2, 3]));
-      expect(mgr.toSql()).toBe('SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)');
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("id").in([1, 2, 3]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)
+        `),
+      );
     });
 
     it("can be constructed with a subquery", () => {
-      const mgr = users.project(users.get("id"));
-      const attribute = users.get("id");
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("name").doesNotMatchAll(["%chunky%", "%bacon%"]));
+      const attribute = new Attribute(null, null);
+
       const node = attribute.in(mgr);
 
       expect(node).toEqual(new Nodes.In(attribute, mgr.ast));
-      expect(visitor.compile(node)).toBe('"users"."id" IN (SELECT "users"."id" FROM "users")');
     });
 
     it("can be constructed with a list", () => {
-      const node = users.get("id").in([1, 2, 3]);
-      expect(node).toBeInstanceOf(Nodes.In);
-      expect(visitor.compile(node)).toBe('"users"."id" IN (1, 2, 3)');
+      const attribute = new Attribute(null, null);
+      const node = attribute.in([1, 2, 3]);
+
+      expect(node).toEqual(
+        new Nodes.In(attribute, [
+          new Nodes.Casted(1, attribute),
+          new Nodes.Casted(2, attribute),
+          new Nodes.Casted(3, attribute),
+        ]),
+      );
     });
 
     it("can be constructed with a random object", () => {
-      const attribute = users.get("id");
+      const attribute = new Attribute(null, null);
       const randomObject = {};
       const node = attribute.in(randomObject);
 
@@ -764,63 +1008,82 @@ describe("AttributeTest", () => {
 
   describe("#asc", () => {
     it("should create an Ascending node", () => {
-      const node = users.get("name").asc();
-      expect(node).toBeInstanceOf(Nodes.Ascending);
+      const relation = new Table("users");
+      expect(relation.get("id").asc()).toBeInstanceOf(Nodes.Ascending);
     });
 
     it("should generate ASC in sql", () => {
-      expect(users.project(star).order(users.get("name").asc()).toSql()).toBe(
-        'SELECT * FROM "users" ORDER BY "users"."name" ASC',
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.order(relation.get("id").asc());
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" ORDER BY "users"."id" ASC
+        `),
       );
     });
   });
 
   describe("#desc", () => {
     it("should create a Descending node", () => {
-      const node = users.get("name").desc();
-      expect(node).toBeInstanceOf(Nodes.Descending);
+      const relation = new Table("users");
+      expect(relation.get("id").desc()).toBeInstanceOf(Nodes.Descending);
     });
 
     it("should generate DESC in sql", () => {
-      expect(users.project(star).order(users.get("name").desc()).toSql()).toBe(
-        'SELECT * FROM "users" ORDER BY "users"."name" DESC',
+      const relation = new Table("users");
+      const mgr = relation.project(relation.get("id"));
+      mgr.order(relation.get("id").desc());
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id" FROM "users" ORDER BY "users"."id" DESC
+        `),
       );
     });
   });
 
   describe("#contains", () => {
     it("should create a Contains node", () => {
-      const node = users.get("tags").contains("foo");
-      expect(node).toBeInstanceOf(Nodes.InfixOperation);
+      const relation = new Table("products");
+      expect(relation.get("tags").contains(["foo", "bar"])).toBeInstanceOf(Nodes.Contains);
     });
 
     it("should generate @> in sql", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      const node = users.get("tags").contains("foo");
-      expect(visitor.compile(node)).toBe('"users"."tags" @> \'foo\'');
+      const relation = new Table("products", { typeCaster: fakePgCaster() });
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("tags").contains(["foo", "bar"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(
+          ` SELECT "products"."id" FROM "products" WHERE "products"."tags" @> '{foo,bar}' `,
+        ),
+      );
     });
   });
 
   describe("#overlaps", () => {
     it("should create an Overlaps node", () => {
-      const node = users.get("tags").overlaps("bar");
-      expect(node).toBeInstanceOf(Nodes.Overlaps);
+      const relation = new Table("products");
+      expect(relation.get("tags").overlaps(["foo", "bar"])).toBeInstanceOf(Nodes.Overlaps);
     });
 
     it("should generate && in sql", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      const node = users.get("tags").overlaps("bar");
-      expect(visitor.compile(node)).toBe('"users"."tags" && \'bar\'');
+      const relation = new Table("products", { typeCaster: fakePgCaster() });
+      const mgr = relation.project(relation.get("id"));
+      mgr.where(relation.get("tags").overlaps(["foo", "bar"]));
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(
+          ` SELECT "products"."id" FROM "products" WHERE "products"."tags" && '{foo,bar}' `,
+        ),
+      );
     });
   });
 
   describe("equality", () => {
     describe("#to_sql", () => {
       it("should produce sql", () => {
-        const relation = new Table("users");
-        const node = relation.get("id").eq(10);
-        const visitor = new Visitors.ToSql(testConnection);
-        expect(visitor.compile(node)).toContain('"users"."id" = 10');
+        const table = new Table("users");
+        const condition = table.get("id").eq(1);
+        expect(visitor.compile(condition)).toBe('"users"."id" = 1');
       });
     });
   });
@@ -830,7 +1093,7 @@ describe("AttributeTest", () => {
       const table = new Table("foo");
       const condition = table.get("id").eq("1");
 
-      expect(table.isAbleToTypeCast()).toBe(false);
+      expect(table.isAbleToTypeCast()).toBeFalsy();
       expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = \'1\'');
     });
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -46,10 +46,12 @@ export class Attribute extends Node {
   readonly relation: RelationLike;
   readonly name: string;
 
-  constructor(relation: RelationLike, name: string) {
+  // Rails' `Attribute.new(nil, nil)` is legal (attribute_test.rb:388); the
+  // relation-dependent methods below simply raise NoMethodError if reached.
+  constructor(relation: RelationLike | null, name: string | null) {
     super();
-    this.relation = relation;
-    this.name = name;
+    this.relation = relation as RelationLike;
+    this.name = name as string;
   }
 
   get typeCaster(): unknown {
@@ -149,7 +151,7 @@ export class Attribute extends Node {
   // (visitAggregate in to-sql.ts) renders them identically to a
   // NamedFunction with the same name.
 
-  count(distinct = false): Count {
+  count(distinct: boolean | null = false): Count {
     return new Count([this], distinct);
   }
 

--- a/packages/arel/src/crud.test.ts
+++ b/packages/arel/src/crud.test.ts
@@ -1,59 +1,41 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Table, InsertManager, UpdateManager, DeleteManager, SelectManager } from "./index.js";
+import { Attribute } from "./attributes/attribute.js";
+
+// Rails' `FakeCrudder` is a `SelectManager` that `include Crud` and carries a
+// `FakeEngine` double (crud_test.rb:6-29). trails' `Crud` methods are already
+// on `SelectManager`, and `toSql` takes the engine at the call site, so the
+// subclass is the whole of what the Ruby class body contributes here.
+class FakeCrudder extends SelectManager {}
 
 describe("crud", () => {
-  const users = new Table("users");
-
   describe("insert", () => {
     it("should call insert on the connection", () => {
-      const mgr = new InsertManager(users);
-      mgr.insert([[users.get("name"), "dean"]]);
-      expect(mgr.toSql()).toContain('INSERT INTO "users"');
+      const table = new Table("users");
+      const fc = new FakeCrudder();
+      fc.from(table);
+      const im = fc.compileInsert([[table.get("id"), "foo"]]);
+      expect(im).toBeInstanceOf(InsertManager);
     });
   });
 
   describe("update", () => {
     it("should call update on the connection", () => {
-      const mgr = new UpdateManager();
-      mgr
-        .table(users)
-        .set([[users.get("name"), "sam"]])
-        .where(users.get("id").eq(1));
-      expect(mgr.toSql()).toContain('UPDATE "users"');
+      const table = new Table("users");
+      const fc = new FakeCrudder();
+      fc.from(table);
+      const stmt = fc.compileUpdate([[table.get("id"), "foo"]], new Attribute(table, "id"));
+      expect(stmt).toBeInstanceOf(UpdateManager);
     });
   });
 
   describe("delete", () => {
     it("should call delete on the connection", () => {
-      const mgr = new DeleteManager();
-      mgr.from(users).where(users.get("id").eq(1));
-      expect(mgr.toSql()).toContain('DELETE FROM "users"');
-    });
-  });
-
-  describe("compileUpdate / compileDelete key assignment", () => {
-    // Mirrors Rails Arel::Crud (activerecord/lib/arel/crud.rb): `um.key = key`
-    // and `dm.key = key` are unconditional for Rails parity, so `null` is
-    // assigned explicitly rather than being skipped. We spy on the setter
-    // because the underlying statement initializes `key` to `null`, so a
-    // post-hoc `manager.key === null` check would pass even with the prior
-    // `if (key !== null)` guard in place.
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
-    it("compileUpdate always assigns key, including null", () => {
-      const setKey = vi.spyOn(UpdateManager.prototype, "key", "set");
-      const mgr = new SelectManager(users);
-      mgr.compileUpdate([[users.get("id"), 1]], null);
-      expect(setKey).toHaveBeenCalledWith(null);
-    });
-
-    it("compileDelete always assigns key, including null", () => {
-      const setKey = vi.spyOn(DeleteManager.prototype, "key", "set");
-      const mgr = new SelectManager(users);
-      mgr.compileDelete(null);
-      expect(setKey).toHaveBeenCalledWith(null);
+      const table = new Table("users");
+      const fc = new FakeCrudder();
+      fc.from(table);
+      const stmt = fc.compileDelete();
+      expect(stmt).toBeInstanceOf(DeleteManager);
     });
   });
 });

--- a/packages/arel/src/crud.trails.test.ts
+++ b/packages/arel/src/crud.trails.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Table, UpdateManager, DeleteManager, SelectManager } from "./index.js";
+
+describe("crud (trails)", () => {
+  const users = new Table("users");
+
+  describe("compileUpdate / compileDelete key assignment", () => {
+    // Mirrors Rails Arel::Crud (activerecord/lib/arel/crud.rb): `um.key = key`
+    // and `dm.key = key` are unconditional for Rails parity, so `null` is
+    // assigned explicitly rather than being skipped. We spy on the setter
+    // because the underlying statement initializes `key` to `null`, so a
+    // post-hoc `manager.key === null` check would pass even with the prior
+    // `if (key !== null)` guard in place.
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("compileUpdate always assigns key, including null", () => {
+      const setKey = vi.spyOn(UpdateManager.prototype, "key", "set");
+      const mgr = new SelectManager(users);
+      mgr.compileUpdate([[users.get("id"), 1]], null);
+      expect(setKey).toHaveBeenCalledWith(null);
+    });
+
+    it("compileDelete always assigns key, including null", () => {
+      const setKey = vi.spyOn(DeleteManager.prototype, "key", "set");
+      const mgr = new SelectManager(users);
+      mgr.compileDelete(null);
+      expect(setKey).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/packages/arel/src/delete-manager.test.ts
+++ b/packages/arel/src/delete-manager.test.ts
@@ -1,51 +1,48 @@
 import { describe, it, expect } from "vitest";
 import { Table, DeleteManager } from "./index.js";
+import { fakeRecordEngine } from "./test-helpers/connection.js";
+import { mustBeLike } from "./test-helpers/must-be-like.js";
 
 describe("DeleteManagerTest", () => {
-  const users = new Table("users");
+  it("handles limit properly", () => {
+    const table = new Table("users");
+    const dm = new DeleteManager();
+    dm.take(10);
+    dm.from(table);
+    dm.key = table.get("id");
+    expect(dm.toSql(fakeRecordEngine)).toMatch(/LIMIT 10/);
+  });
+
   describe("from", () => {
     it("uses from", () => {
-      const mgr = new DeleteManager();
-      mgr.from(users);
-      expect(mgr.toSql()).toContain('DELETE FROM "users"');
+      const table = new Table("users");
+      const dm = new DeleteManager();
+      dm.from(table);
+      expect(mustBeLike(dm.toSql(fakeRecordEngine))).toBe(mustBeLike(` DELETE FROM "users" `));
     });
 
     it("chains", () => {
-      const mgr = new DeleteManager();
-      expect(mgr.from(users)).toBe(mgr);
+      const table = new Table("users");
+      const dm = new DeleteManager();
+      expect(dm.from(table)).toEqual(dm);
     });
   });
 
   describe("where", () => {
     it("uses where values", () => {
-      const mgr = new DeleteManager();
-      mgr.from(users);
-      mgr.where(users.get("id").eq(1));
-      expect(mgr.toSql()).toBe('DELETE FROM "users" WHERE "users"."id" = 1');
+      const table = new Table("users");
+      const dm = new DeleteManager();
+      dm.from(table);
+      dm.where(table.get("id").eq(10));
+      expect(mustBeLike(dm.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(` DELETE FROM "users" WHERE "users"."id" = 10`),
+      );
     });
 
     it("chains", () => {
-      const mgr = new DeleteManager();
-      expect(mgr.from(users)).toBe(mgr);
-      expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
+      const table = new Table("users");
+      const dm = new DeleteManager();
+      expect(dm.where(table.get("id").eq(10))).toEqual(dm);
     });
-  });
-
-  it("handles limit properly", () => {
-    const mgr = new DeleteManager();
-    mgr.from(users);
-    mgr.where(users.get("active").eq(false));
-    mgr.order(users.get("created_at").asc());
-    mgr.take(10);
-    expect(mgr.toSql()).toBe(
-      `DELETE FROM "users" WHERE "users"."active" = 'f' ORDER BY "users"."created_at" ASC LIMIT 10`,
-    );
-  });
-
-  it("wheres getter returns WHERE conditions", () => {
-    const manager = new DeleteManager();
-    manager.from(users);
-    manager.where(users.get("id").eq(1));
-    expect(manager.wheres.length).toBe(1);
   });
 });

--- a/packages/arel/src/delete-manager.trails.test.ts
+++ b/packages/arel/src/delete-manager.trails.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { Table, DeleteManager } from "./index.js";
+
+// TS-only coverage: the full ORDER BY / LIMIT rendering and the `wheres`
+// reader, which Rails' delete_manager_test.rb exercises only through
+// `assert_match(/LIMIT 10/)`.
+describe("DeleteManagerTest (trails)", () => {
+  const users = new Table("users");
+
+  it("handles limit properly", () => {
+    const mgr = new DeleteManager();
+    mgr.from(users);
+    mgr.where(users.get("active").eq(false));
+    mgr.order(users.get("created_at").asc());
+    mgr.take(10);
+    expect(mgr.toSql()).toBe(
+      `DELETE FROM "users" WHERE "users"."active" = 'f' ORDER BY "users"."created_at" ASC LIMIT 10`,
+    );
+  });
+
+  it("wheres getter returns WHERE conditions", () => {
+    const manager = new DeleteManager();
+    manager.from(users);
+    manager.where(users.get("id").eq(1));
+    expect(manager.wheres.length).toBe(1);
+  });
+});

--- a/packages/arel/src/expressions.ts
+++ b/packages/arel/src/expressions.ts
@@ -10,7 +10,7 @@ import type { Node } from "./nodes/node.js";
  * Mixed into NodeExpression and SqlLiteral via include() in ./index.ts.
  */
 export interface ExpressionsModule {
-  count(distinct?: boolean): Count;
+  count(distinct?: boolean | null): Count;
   sum(): Sum;
   maximum(): Max;
   minimum(): Min;
@@ -19,7 +19,7 @@ export interface ExpressionsModule {
 }
 
 export const Expressions: ExpressionsModule = {
-  count(this: Node, distinct = false): Count {
+  count(this: Node, distinct: boolean | null = false): Count {
     return new Count([this], distinct);
   },
   sum(this: Node): Sum {

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/date";
-import { Table, sql, InsertManager, Nodes } from "./index.js";
-import { fakeRecordEngine } from "./test-helpers/connection.js";
+import { Table, sql, SelectManager, InsertManager, Nodes } from "./index.js";
+import { fakeRecordEngine, fakeRecordConnection } from "./test-helpers/connection.js";
+import { mustBeLike } from "./test-helpers/must-be-like.js";
 
 describe("InsertManagerTest", () => {
-  const users = new Table("users");
-  const posts = new Table("posts");
   describe("insert", () => {
     it("can create a ValuesList node", () => {
       const manager = new InsertManager();
@@ -22,218 +20,255 @@ describe("InsertManagerTest", () => {
     });
 
     it("allows sql literals", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([[users.get("name"), sql("NOW()")]]);
-      expect(mgr.toSql()).toContain("NOW()");
+      const manager = new InsertManager();
+      manager.into(new Table("users"));
+      manager.values = manager.createValues([sql("*")]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" VALUES (*)
+        `),
+      );
     });
 
     it("works with multiple values", () => {
-      const im = new InsertManager();
-      im.into(users);
-      im.insert([
-        [users.get("name"), "alice"],
-        [users.get("id"), 1],
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.columns.push(table.get("id"));
+      manager.columns.push(table.get("name"));
+
+      manager.values = manager.createValuesList([
+        ["1", "david"],
+        ["2", "kir"],
+        ["3", sql("DEFAULT")],
       ]);
-      const sql = im.toSql();
-      expect(sql).toContain('"name"');
-      expect(sql).toContain('"id"');
+
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id", "name") VALUES ('1', 'david'), ('2', 'kir'), ('3', DEFAULT)
+        `),
+      );
     });
 
     it("literals in multiple values are not escaped", () => {
-      const im = new InsertManager();
-      im.into(users);
-      im.insert([[users.get("name"), new Nodes.SqlLiteral("DEFAULT")]]);
-      const sql = im.toSql();
-      expect(sql).toContain("DEFAULT");
-      expect(sql).not.toContain("'DEFAULT'");
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.columns.push(table.get("name"));
+
+      manager.values = manager.createValuesList([[sql("*")], [sql("DEFAULT")]]);
+
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("name") VALUES (*), (DEFAULT)
+        `),
+      );
     });
 
     it("works with multiple single values", () => {
-      const im = new InsertManager();
-      im.into(users);
-      im.insert([[users.get("name"), "bob"]]);
-      const sql = im.toSql();
-      expect(sql).toContain("'bob'");
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.columns.push(table.get("name"));
+
+      manager.values = manager.createValuesList([["david"], ["kir"], [sql("DEFAULT")]]);
+
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("name") VALUES ('david'), ('kir'), (DEFAULT)
+        `),
+      );
     });
 
     it("inserts false", () => {
-      const mgr = new InsertManager();
-      mgr.insert([[users.get("bool"), false]]);
-      expect(mgr.toSql(fakeRecordEngine)).toBe(`INSERT INTO "users" ("bool") VALUES ('f')`);
+      const table = new Table("users");
+      const manager = new InsertManager();
+
+      manager.insert([[table.get("bool"), false]]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("bool") VALUES ('f')
+        `),
+      );
     });
 
     it("inserts null", () => {
-      const mgr = new InsertManager();
-      mgr.insert([[users.get("id"), null]]);
-      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("id") VALUES (NULL)`);
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.insert([[table.get("id"), null]]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id") VALUES (NULL)
+        `),
+      );
+    });
+
+    it("inserts time", () => {
+      const table = new Table("users");
+      const manager = new InsertManager();
+
+      const time = new Date();
+      const attribute = table.get("created_at");
+
+      manager.insert([[attribute, time]]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("created_at") VALUES (${fakeRecordConnection.quote(time)})
+        `),
+      );
     });
 
     it("takes a list of lists", () => {
-      const im = new InsertManager();
-      im.into(users);
-      const vl = im.createValuesList([[new Nodes.Quoted("alice")], [new Nodes.Quoted("bob")]]);
-      im.values = vl;
-      im.ast.columns = [users.get("name")];
-      const sql = im.toSql();
-      expect(sql).toContain("VALUES");
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+      manager.insert([
+        [table.get("id"), 1],
+        [table.get("name"), "aaron"],
+      ]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id", "name") VALUES (1, 'aaron')
+        `),
+      );
+    });
+
+    it("defaults the table", () => {
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.insert([
+        [table.get("id"), 1],
+        [table.get("name"), "aaron"],
+      ]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id", "name") VALUES (1, 'aaron')
+        `),
+      );
     });
 
     it("noop for empty list", () => {
-      const im = new InsertManager();
-      im.into(users);
-      const sql = im.toSql();
-      expect(sql).toContain("INSERT INTO");
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.insert([[table.get("id"), 1]]);
+      manager.insert([]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id") VALUES (1)
+        `),
+      );
+    });
+
+    it("is chainable", () => {
+      const table = new Table("users");
+      const manager = new InsertManager();
+      const insertResult = manager.insert([[table.get("id"), 1]]);
+      expect(insertResult).toEqual(manager);
     });
   });
 
   describe("into", () => {
     it("takes a Table and chains", () => {
-      const im = new InsertManager();
-      const result = im.into(users);
-      expect(result).toBe(im);
+      const manager = new InsertManager();
+      expect(manager.into(new Table("users"))).toEqual(manager);
     });
 
     it("converts to sql", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([
-        [users.get("name"), "dean"],
-        [users.get("age"), 30],
-      ]);
-      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("name", "age") VALUES ('dean', 30)`);
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users"
+        `),
+      );
     });
   });
 
   describe("columns", () => {
     it("converts to sql", () => {
+      const table = new Table("users");
       const manager = new InsertManager();
-      manager.into(users);
-      manager.columns.push(users.get("id"));
-      expect(manager.toSql()).toBe(`INSERT INTO "users" ("id")`);
+      manager.into(table);
+      manager.columns.push(table.get("id"));
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id")
+        `),
+      );
     });
   });
 
   describe("values", () => {
     it("converts to sql", () => {
-      const im = new InsertManager();
-      im.into(users);
-      im.insert([[users.get("id"), 1]]);
-      const sql = im.toSql();
-      expect(sql).toContain("INSERT INTO");
-      expect(sql).toContain('"users"');
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.values = new Nodes.ValuesList([[1], [2]]);
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" VALUES (1), (2)
+        `),
+      );
     });
 
     it("accepts sql literals", () => {
-      const im = new InsertManager();
-      im.into(users);
-      im.insert([[users.get("name"), new Nodes.SqlLiteral("DEFAULT")]]);
-      const sql = im.toSql();
-      expect(sql).toContain("DEFAULT");
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.values = sql("DEFAULT VALUES");
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" DEFAULT VALUES
+        `),
+      );
     });
   });
 
   describe("combo", () => {
     it("combines columns and values list in order", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([
-        [users.get("name"), "Alice"],
-        [users.get("email"), "alice@example.com"],
+      const table = new Table("users");
+      const manager = new InsertManager();
+      manager.into(table);
+
+      manager.values = new Nodes.ValuesList([
+        [1, "aaron"],
+        [2, "david"],
       ]);
-      expect(mgr.columns.length).toBe(2);
+      manager.columns.push(table.get("id"));
+      manager.columns.push(table.get("name"));
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id", "name") VALUES (1, 'aaron'), (2, 'david')
+        `),
+      );
     });
   });
 
   describe("select", () => {
     it("accepts a select query in place of a VALUES clause", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.ast.columns = [users.get("name")];
-      const selectMgr = posts.project(posts.get("title"));
-      mgr.select(selectMgr);
-      expect(mgr.toSql()).toContain("SELECT");
-    });
-  });
+      const table = new Table("users");
 
-  it("generates INSERT", () => {
-    const mgr = new InsertManager();
-    mgr.into(users);
-    mgr.insert([
-      [users.get("name"), "dean"],
-      [users.get("age"), 30],
-    ]);
-    expect(mgr.toSql()).toBe(`INSERT INTO "users" ("name", "age") VALUES ('dean', 30)`);
-  });
+      const manager = new InsertManager();
+      manager.into(table);
 
-  it("returns empty array before insert", () => {
-    const manager = new InsertManager();
-    expect(manager.columns).toEqual([]);
-  });
+      const select = new SelectManager();
+      select.project(sql("1"));
+      select.project(sql('"aaron"'));
 
-  describe("insert", () => {
-    it("inserts time", () => {
-      const mgr = new InsertManager(users);
-      const at = Temporal.PlainDateTime.from("2020-01-02T12:34:56");
-      mgr.insert([[users.get("created_at"), at]]);
-      expect(mgr.toSql()).toContain("2020-01-02");
-    });
-
-    it("defaults the table", () => {
-      const mgr = new InsertManager(users);
-      mgr.insert([[users.get("name"), "dean"]]);
-      expect(mgr.toSql()).toContain('INSERT INTO "users"');
-    });
-
-    it("is chainable", () => {
-      const mgr = new InsertManager();
-      expect(mgr.into(users)).toBe(mgr);
-      expect(mgr.insert([[users.get("name"), "dean"]])).toBe(mgr);
-      expect(mgr.toSql()).toContain("INSERT");
-    });
-  });
-
-  // Mirrors Rails: `Arel::InsertManager#insert` (insert_manager.rb).
-  describe("insert (Rails parity)", () => {
-    it("is a no-op for an empty fields array", () => {
-      const mgr = new InsertManager();
-      mgr.insert([]);
-      expect(mgr.ast.values).toBeNull();
-      expect(mgr.ast.relation).toBeNull();
-      expect(mgr.ast.columns).toEqual([]);
-    });
-
-    it("stores a string `fields` value as a SqlLiteral on ast.values", () => {
-      const mgr = new InsertManager(users);
-      mgr.insert("foo");
-      expect(mgr.ast.values).toBeInstanceOf(Nodes.SqlLiteral);
-      expect((mgr.ast.values as Nodes.SqlLiteral).value).toBe("foo");
-    });
-
-    it("infers ast.relation from the first column when not yet set", () => {
-      const mgr = new InsertManager();
-      mgr.insert([[users.get("name"), "alice"]]);
-      expect(mgr.ast.relation).toBe(users);
-    });
-
-    it("preserves an explicit ast.relation rather than inferring", () => {
-      const mgr = new InsertManager(posts);
-      mgr.insert([[users.get("name"), "alice"]]);
-      expect(mgr.ast.relation).toBe(posts);
-    });
-  });
-
-  // Mirrors Rails: `InsertManager#select` stores the manager itself
-  // (insert_manager.rb), not its inner `.ast`. The visitor handles
-  // the SelectManager-shaped duck-type via `visit`.
-  describe("select (Rails parity)", () => {
-    it("stores the SelectManager itself on ast.select", () => {
-      const mgr = new InsertManager(users);
-      mgr.ast.columns = [users.get("name")];
-      const selectMgr = posts.project(posts.get("title"));
-      mgr.select(selectMgr);
-      expect(mgr.ast.select).toBe(selectMgr);
-      expect(mgr.toSql()).toContain("SELECT");
+      manager.select(select);
+      manager.columns.push(table.get("id"));
+      manager.columns.push(table.get("name"));
+      expect(mustBeLike(manager.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          INSERT INTO "users" ("id", "name") (SELECT 1, "aaron")
+        `),
+      );
     });
   });
 });

--- a/packages/arel/src/insert-manager.trails.test.ts
+++ b/packages/arel/src/insert-manager.trails.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { Table, InsertManager, Nodes } from "./index.js";
+
+// TS-only coverage for `InsertManager#insert`'s and `#select`'s AST bookkeeping.
+// Rails asserts these arms only indirectly, through the SQL the manager renders.
+describe("InsertManagerTest (trails)", () => {
+  const users = new Table("users");
+  const posts = new Table("posts");
+
+  it("returns empty array before insert", () => {
+    const manager = new InsertManager();
+    expect(manager.columns).toEqual([]);
+  });
+
+  // Mirrors Rails: `Arel::InsertManager#insert` (insert_manager.rb).
+  describe("insert (Rails parity)", () => {
+    it("is a no-op for an empty fields array", () => {
+      const mgr = new InsertManager();
+      mgr.insert([]);
+      expect(mgr.ast.values).toBeNull();
+      expect(mgr.ast.relation).toBeNull();
+      expect(mgr.ast.columns).toEqual([]);
+    });
+
+    it("stores a string `fields` value as a SqlLiteral on ast.values", () => {
+      const mgr = new InsertManager(users);
+      mgr.insert("foo");
+      expect(mgr.ast.values).toBeInstanceOf(Nodes.SqlLiteral);
+      expect((mgr.ast.values as Nodes.SqlLiteral).value).toBe("foo");
+    });
+
+    it("infers ast.relation from the first column when not yet set", () => {
+      const mgr = new InsertManager();
+      mgr.insert([[users.get("name"), "alice"]]);
+      expect(mgr.ast.relation).toBe(users);
+    });
+
+    it("preserves an explicit ast.relation rather than inferring", () => {
+      const mgr = new InsertManager(posts);
+      mgr.insert([[users.get("name"), "alice"]]);
+      expect(mgr.ast.relation).toBe(posts);
+    });
+  });
+
+  // Mirrors Rails: `InsertManager#select` stores the manager itself
+  // (insert_manager.rb), not its inner `.ast`. The visitor handles
+  // the SelectManager-shaped duck-type via `visit`.
+  describe("select (Rails parity)", () => {
+    it("stores the SelectManager itself on ast.select", () => {
+      const mgr = new InsertManager(users);
+      mgr.ast.columns = [users.get("name")];
+      const selectMgr = posts.project(posts.get("title"));
+      mgr.select(selectMgr);
+      expect(mgr.ast.select).toBe(selectMgr);
+      expect(mgr.toSql()).toContain("SELECT");
+    });
+  });
+});

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -65,10 +65,13 @@ describe("Arel::Nodes.build_quoted", () => {
     expect(binds).toEqual([amAttr]);
   });
 
-  it("unwraps a TreeManager-shaped .ast so the visitor receives a real Node", () => {
+  it("passes a TreeManager-shaped .ast holder through unchanged", () => {
+    // Rails' `build_quoted` returns an `Arel::SelectManager` as-is
+    // (casted.rb:47-51) so `visit_Arel_SelectManager` supplies the subquery
+    // parens; matching on `.ast` is only how the class arm is spelled here.
     const sub = new SelectManager(users).project(users.get("id"));
     const node = buildQuoted(sub);
-    expect(node).toBeInstanceOf(Nodes.SelectStatement);
+    expect(node).toBe(sub);
   });
 
   it("wraps in Casted when the second arg is an Arel::Attribute", () => {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -14,10 +14,11 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
  * in Casted (when an attribute is supplied) or Quoted.
  *
  * TS deviations, all narrower/safer:
- * - Table / SelectManager aren't Arel nodes here and our visitor only
- *   handles them via duck-type in specific contexts (see visitIn). When
- *   their AST is what's wanted, unwrap to the ast node so downstream
- *   visitors always receive a real Node.
+ * - Table / SelectManager aren't Arel nodes here, so the SelectManager arm is
+ *   matched on its `ast` duck-type rather than by class (importing
+ *   `SelectManager` from a node module closes a require cycle). The manager
+ *   itself is returned, as Rails does (casted.rb:47-51), so
+ *   `visit_Arel_SelectManager` supplies the subquery parens.
  * - ActiveModel::Attribute isn't an Arel node either. Rails has
  *   visit_ActiveModel_Attribute that routes it through add_bind; we
  *   wrap it in BindParam so the value participates in prepared-statement
@@ -32,7 +33,7 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
     // returning `other`. Class dispatch, like Rails.
     if (other instanceof ModelAttribute) return new BindParam(other);
     const maybeAst = (other as { ast?: unknown }).ast;
-    if (maybeAst instanceof Node) return maybeAst;
+    if (maybeAst instanceof Node) return other as Node;
   }
   if (_Attribute && attribute instanceof _Attribute)
     return new Casted(other, attribute as Attribute);

--- a/packages/arel/src/nodes/count.ts
+++ b/packages/arel/src/nodes/count.ts
@@ -2,7 +2,7 @@ import { Node } from "./node.js";
 import { Function } from "./function.js";
 
 export class Count extends Function {
-  constructor(expr: Node | Node[], distinct = false, alias: string | null = null) {
+  constructor(expr: Node | Node[], distinct: boolean | null = false, alias: string | null = null) {
     super(Array.isArray(expr) ? expr : [expr], alias);
     this.distinct = distinct;
   }

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -7,7 +7,9 @@ import { SqlLiteral } from "./sql-literal.js";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Function extends NodeExpression {
   readonly expressions: Node[];
-  distinct: boolean;
+  // Rails' `count(nil)` stores nil (expressions.rb:5-7), which `must_be_nil`
+  // asserts on (attribute_test.rb:377-381), so nil is part of the domain.
+  distinct: boolean | null;
   private _alias: Node | null;
 
   get alias(): Node | null {

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -10,11 +10,7 @@ import {
   EmptyJoinError,
 } from "./index.js";
 import { testConnection, fakeRecordConnection } from "./test-helpers/connection.js";
-
-/** Minitest's `must_be_like`: compare SQL with runs of whitespace collapsed. */
-function mustBeLike(sql: string): string {
-  return sql.trim().replace(/\s+/g, " ");
-}
+import { mustBeLike } from "./test-helpers/must-be-like.js";
 
 describe("SelectManagerTest", () => {
   const users = new Table("users");

--- a/packages/arel/src/test-helpers/must-be-like.ts
+++ b/packages/arel/src/test-helpers/must-be-like.ts
@@ -1,0 +1,14 @@
+/**
+ * Minitest's `must_be_like`: compare SQL with runs of whitespace collapsed.
+ *
+ * Mirrors Rails' `Minitest::Expectation#must_be_like`
+ * (`vendor/rails/activerecord/test/cases/arel/helper.rb:10-13`), which squeezes
+ * `\s+` to a single space and strips before deferring to `must_equal`. It is a
+ * string normalizer, not an assertion wrapper, so the call site keeps a native
+ * `expect(...).toBe(...)`.
+ *
+ * @internal
+ */
+export function mustBeLike(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -1,275 +1,190 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Table, UpdateManager, Nodes } from "./index.js";
+import { fakeRecordEngine } from "./test-helpers/connection.js";
+import { mustBeLike } from "./test-helpers/must-be-like.js";
 
 describe("UpdateManagerTest", () => {
-  const users = new Table("users");
   it("should not quote sql literals", () => {
+    const table = new Table("users");
     const um = new UpdateManager();
-    um.table(users);
-    um.set([[users.get("name"), new Nodes.SqlLiteral("NOW()")]]);
-    const sql = um.toSql();
-    expect(sql).toContain("NOW()");
-    expect(sql).not.toContain("'NOW()'");
+    um.table(table);
+    um.set([[table.get("name"), new Nodes.BindParam(1)]]);
+    expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+      mustBeLike(` UPDATE "users" SET "name" =  ? `),
+    );
+  });
+
+  it("handles limit properly", () => {
+    const table = new Table("users");
+    const um = new UpdateManager();
+    um.key = "id";
+    um.take(10);
+    um.table(table);
+    um.set([[table.get("name"), null]]);
+    expect(um.toSql(fakeRecordEngine)).toMatch(/LIMIT 10/);
   });
 
   describe("having", () => {
     it("sets having", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.having(users.get("id").gt(0));
-      expect(um.ast.havings.length).toBe(1);
+      const usersTable = new Table("users");
+      const postsTable = new Table("posts");
+      const joinSource = new Nodes.InnerJoin(usersTable, postsTable);
+
+      const updateManager = new UpdateManager();
+      updateManager.table(joinSource);
+      updateManager.group(["posts.id"]);
+      updateManager.having("count(posts.id) >= 2");
+
+      expect(updateManager.ast.havings).toEqual([new Nodes.SqlLiteral("count(posts.id) >= 2")]);
     });
   });
 
   describe("group", () => {
     it("adds columns to the AST when group value is a String", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.group(["name"]);
-      expect(um.ast.groups.length).toBe(1);
+      const usersTable = new Table("users");
+      const postsTable = new Table("posts");
+      const joinSource = new Nodes.InnerJoin(usersTable, postsTable);
+
+      const updateManager = new UpdateManager();
+      updateManager.table(joinSource);
+      updateManager.group(["posts.id"]);
+      updateManager.having("count(posts.id) >= 2");
+
+      expect(updateManager.ast.groups.length).toEqual(1);
+      const groupAst = updateManager.ast.groups[0] as Nodes.Group;
+      expect(groupAst).toBeInstanceOf(Nodes.Group);
+      expect(String(groupAst.expr)).toEqual("posts.id");
+      expect(updateManager.ast.havings).toEqual([new Nodes.SqlLiteral("count(posts.id) >= 2")]);
     });
 
     it("adds columns to the AST when group value is a Symbol", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.group([users.get("name")]);
-      expect(um.ast.groups.length).toBe(1);
-    });
-  });
+      const usersTable = new Table("users");
+      const postsTable = new Table("posts");
+      const joinSource = new Nodes.InnerJoin(usersTable, postsTable);
 
-  describe("UnqualifiedColumn", () => {
-    it("renders without a table qualifier on the RHS of an UPDATE SET", () => {
-      // Mirrors Rails' ActiveRecord::CounterCache pattern:
-      //   SET "counter" = COALESCE("counter", 0) + 1
-      // without a `"posts"."counter"` table prefix on the RHS, which some
-      // adapters reject inside UPDATE statements.
-      const posts = new Table("posts");
-      const counter = posts.get("counter");
-      const unqual = new Nodes.UnqualifiedColumn(counter);
-      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
-      const expr = new Nodes.Addition(coalesced, new Nodes.Quoted(1));
+      const updateManager = new UpdateManager();
+      updateManager.table(joinSource);
+      updateManager.group(["posts.id"]);
+      updateManager.having("count(posts.id) >= 2");
 
-      const um = new UpdateManager();
-      um.table(posts);
-      um.set([[counter, expr]]);
-      const sql = um.toSql();
-
-      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) + 1`);
-      expect(sql).not.toContain(`"posts"."counter", 0`);
-    });
-
-    it("supports Subtraction for negative counter deltas", () => {
-      const posts = new Table("posts");
-      const counter = posts.get("counter");
-      const unqual = new Nodes.UnqualifiedColumn(counter);
-      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
-      const expr = new Nodes.Subtraction(coalesced, new Nodes.Quoted(3));
-
-      const um = new UpdateManager();
-      um.table(posts);
-      um.set([[counter, expr]]);
-      const sql = um.toSql();
-
-      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) - 3`);
+      expect(updateManager.ast.groups.length).toEqual(1);
+      const groupAst = updateManager.ast.groups[0] as Nodes.Group;
+      expect(groupAst).toBeInstanceOf(Nodes.Group);
+      expect(String(groupAst.expr)).toEqual("posts.id");
+      expect(updateManager.ast.havings).toEqual([new Nodes.SqlLiteral("count(posts.id) >= 2")]);
     });
   });
 
   describe("set", () => {
     it("updates with null", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([[users.get("name"), null]]);
-      mgr.where(users.get("id").eq(1));
-      expect(mgr.toSql()).toContain("= NULL");
+      const table = new Table("users");
+      const um = new UpdateManager();
+      um.table(table);
+      um.set([[table.get("name"), null]]);
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(` UPDATE "users" SET "name" =  NULL `),
+      );
     });
 
     it("takes a string", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set(new Nodes.SqlLiteral("foo = bar"));
-      expect(mgr.toSql()).toBe('UPDATE "users" SET foo = bar');
+      const table = new Table("users");
+      const um = new UpdateManager();
+      um.table(table);
+      um.set(new Nodes.SqlLiteral("foo = bar"));
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(` UPDATE "users" SET foo = bar `),
+      );
     });
 
-    it("takes a plain string literal", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set("foo = bar");
-      expect(mgr.toSql()).toBe('UPDATE "users" SET foo = bar');
+    it("takes a list of lists", () => {
+      const table = new Table("users");
+      const um = new UpdateManager();
+      um.table(table);
+      um.set([
+        [table.get("id"), 1],
+        [table.get("name"), "hello"],
+      ]);
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          UPDATE "users" SET "id" = 1, "name" =  'hello'
+        `),
+      );
     });
 
-    it("takes a BoundSqlLiteral", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set(new Nodes.BoundSqlLiteral("name = ?", ["dean"], {}));
-      // `to_sql` compiles through a plain SQLString collector, where the
-      // BoundSqlLiteral's `add_bind` emits a `?` placeholder (Rails parity) —
-      // not the inlined value.
-      expect(mgr.toSql()).toBe(`UPDATE "users" SET name = ?`);
-    });
-
-    // Mirrors Rails: `set` wraps each LHS in `Nodes::UnqualifiedColumn`
-    // (update_manager.rb), so the visitor strips the table qualifier
-    // structurally rather than via a stateful flag.
-    it("wraps each column in an UnqualifiedColumn", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([[users.get("name"), "dean"]]);
-      const assignment = mgr.ast.values[0] as Nodes.Assignment;
-      expect(assignment).toBeInstanceOf(Nodes.Assignment);
-      expect(assignment.left).toBeInstanceOf(Nodes.UnqualifiedColumn);
-    });
-
-    // Mirrors Rails: values pass through raw (no Quoted wrap); the
-    // visitor's `visit` class dispatch quotes primitives.
-    it("stores the raw value on the Assignment (no Quoted wrap)", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([[users.get("age"), 42]]);
-      const assignment = mgr.ast.values[0] as Nodes.Assignment;
-      expect(assignment.right).toBe(42);
-    });
-
-    it("renders SET col = … without the table qualifier", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([[users.get("name"), "dean"]]);
-      expect(mgr.toSql()).toBe(`UPDATE "users" SET "name" = 'dean'`);
+    it("chains", () => {
+      const table = new Table("users");
+      const um = new UpdateManager();
+      expect(
+        um.set([
+          [table.get("id"), 1],
+          [table.get("name"), "hello"],
+        ]),
+      ).toEqual(um);
     });
   });
 
   describe("table", () => {
     it("generates an update statement", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([[users.get("name"), "dean"]]);
-      expect(mgr.toSql()).toContain("UPDATE");
+      const um = new UpdateManager();
+      um.table(new Table("users"));
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(mustBeLike(` UPDATE "users" `));
+    });
+
+    it("chains", () => {
+      const um = new UpdateManager();
+      expect(um.table(new Table("users"))).toEqual(um);
     });
 
     it("generates an update statement with joins", () => {
       const um = new UpdateManager();
-      um.table(users);
-      um.set([[users.get("name"), "bob"]]);
-      const sql = um.toSql();
-      expect(sql).toContain("UPDATE");
-      expect(sql).toContain("SET");
+
+      const table = new Table("users");
+      const joinSource = new Nodes.JoinSource(table, [table.createJoin(new Table("posts"))]);
+
+      um.table(joinSource);
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(` UPDATE "users" INNER JOIN "posts" `),
+      );
     });
   });
 
   describe("where", () => {
     it("generates a where clause", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      mgr.set([
-        [users.get("name"), "dean"],
-        [users.get("age"), 31],
-      ]);
-      mgr.where(users.get("id").eq(1));
-      expect(mgr.toSql()).toBe(
-        `UPDATE "users" SET "name" = 'dean', "age" = 31 WHERE "users"."id" = 1`,
+      const table = new Table("users");
+      const um = new UpdateManager();
+      um.table(table);
+      um.where(table.get("id").eq(1));
+      expect(mustBeLike(um.toSql(fakeRecordEngine))).toBe(
+        mustBeLike(`
+          UPDATE "users" WHERE "users"."id" = 1
+        `),
       );
+    });
+
+    it("chains", () => {
+      const table = new Table("users");
+      const um = new UpdateManager();
+      um.table(table);
+      expect(um.where(table.get("id").eq(1))).toEqual(um);
     });
   });
 
   describe("key", () => {
+    let table: Table;
+    let um: UpdateManager;
+
+    beforeEach(() => {
+      table = new Table("users");
+      um = new UpdateManager();
+      um.key = table.get("foo");
+    });
+
     it("can be set", () => {
-      const manager = new UpdateManager();
-      manager.table(users);
-      manager.key = users.get("id").eq(1);
-      expect(manager.ast.key).not.toBeNull();
+      expect(um.ast.key).toEqual(table.get("foo"));
     });
 
     it("can be accessed", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.where(users.get("id").eq(1));
-      expect(um.wheres.length).toBe(1);
-    });
-  });
-
-  it("UPDATE with ORDER BY and LIMIT", () => {
-    const mgr = new UpdateManager();
-    mgr.table(users);
-    mgr.set([[users.get("active"), false]]);
-    mgr.where(users.get("age").lt(18));
-    mgr.order(users.get("name").asc());
-    mgr.take(5);
-    expect(mgr.toSql()).toBe(
-      `UPDATE "users" SET "active" = 'f' WHERE "users"."age" < 18 ORDER BY "users"."name" ASC LIMIT 5`,
-    );
-  });
-
-  it("wheres getter returns WHERE conditions", () => {
-    const manager = new UpdateManager();
-    manager.table(users);
-    manager.where(users.get("id").eq(1));
-    expect(manager.wheres.length).toBe(1);
-  });
-
-  it("updates with false", () => {
-    const mgr = new UpdateManager();
-    mgr.table(users);
-    mgr.set([[users.get("active"), false]]);
-    expect(mgr.toSql()).toContain("'f'");
-  });
-
-  it("handles limit properly", () => {
-    const um = new UpdateManager();
-    um.table(users);
-    um.take(10);
-    um.set([[users.get("name"), null]]);
-    expect(um.toSql()).toContain("LIMIT 10");
-  });
-
-  describe("set", () => {
-    it("takes a list of lists", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.set([
-        [users.get("id"), 1],
-        [users.get("name"), "hello"],
-      ]);
-      const sql = um.toSql();
-      expect(sql).toContain('"id" = 1');
-      expect(sql).toContain('"name" =');
-    });
-  });
-
-  describe("where", () => {
-    it("chains", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
-    });
-  });
-
-  // Mirrors Rails: `tree_manager.rb` `key=` calls `Nodes.build_quoted` on
-  // scalar values and maps over arrays, so the AST always holds Quoted
-  // (or pass-through Node) values rather than raw primitives.
-  describe("key=", () => {
-    it("wraps a scalar value in Quoted", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.key = 5;
-      expect(um.ast.key).toBeInstanceOf(Nodes.Quoted);
-      expect((um.ast.key as Nodes.Quoted).value).toBe(5);
-    });
-
-    it("maps an array, wrapping each element in Quoted", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      um.key = [1, 2];
-      const arr = um.ast.key as unknown as Nodes.Quoted[];
-      expect(Array.isArray(arr)).toBe(true);
-      expect(arr.every((q) => q instanceof Nodes.Quoted)).toBe(true);
-      expect(arr.map((q) => q.value)).toEqual([1, 2]);
-    });
-
-    it("passes existing Nodes through unwrapped", () => {
-      const um = new UpdateManager();
-      um.table(users);
-      const lit = new Nodes.SqlLiteral("id");
-      um.key = lit;
-      expect(um.ast.key).toBe(lit);
+      expect(um.key).toEqual(table.get("foo"));
     });
   });
 });

--- a/packages/arel/src/update-manager.trails.test.ts
+++ b/packages/arel/src/update-manager.trails.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { Table, UpdateManager, Nodes } from "./index.js";
+
+// TS-only coverage for AST bookkeeping and rendering arms Rails covers only
+// indirectly, plus the string/BoundSqlLiteral `set` forms and the
+// `UnqualifiedColumn` counter-cache shape.
+describe("UpdateManagerTest (trails)", () => {
+  const users = new Table("users");
+
+  describe("UnqualifiedColumn", () => {
+    it("renders without a table qualifier on the RHS of an UPDATE SET", () => {
+      // Mirrors Rails' ActiveRecord::CounterCache pattern:
+      //   SET "counter" = COALESCE("counter", 0) + 1
+      // without a `"posts"."counter"` table prefix on the RHS, which some
+      // adapters reject inside UPDATE statements.
+      const posts = new Table("posts");
+      const counter = posts.get("counter");
+      const unqual = new Nodes.UnqualifiedColumn(counter);
+      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
+      const expr = new Nodes.Addition(coalesced, new Nodes.Quoted(1));
+
+      const um = new UpdateManager();
+      um.table(posts);
+      um.set([[counter, expr]]);
+      const sql = um.toSql();
+
+      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) + 1`);
+      expect(sql).not.toContain(`"posts"."counter", 0`);
+    });
+
+    it("supports Subtraction for negative counter deltas", () => {
+      const posts = new Table("posts");
+      const counter = posts.get("counter");
+      const unqual = new Nodes.UnqualifiedColumn(counter);
+      const coalesced = new Nodes.NamedFunction("COALESCE", [unqual, new Nodes.Quoted(0)]);
+      const expr = new Nodes.Subtraction(coalesced, new Nodes.Quoted(3));
+
+      const um = new UpdateManager();
+      um.table(posts);
+      um.set([[counter, expr]]);
+      const sql = um.toSql();
+
+      expect(sql).toContain(`SET "counter" = COALESCE("counter", 0) - 3`);
+    });
+  });
+
+  describe("set", () => {
+    it("takes a plain string literal", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set("foo = bar");
+      expect(mgr.toSql()).toBe('UPDATE "users" SET foo = bar');
+    });
+
+    it("takes a BoundSqlLiteral", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set(new Nodes.BoundSqlLiteral("name = ?", ["dean"], {}));
+      // `to_sql` compiles through a plain SQLString collector, where the
+      // BoundSqlLiteral's `add_bind` emits a `?` placeholder (Rails parity) —
+      // not the inlined value.
+      expect(mgr.toSql()).toBe(`UPDATE "users" SET name = ?`);
+    });
+
+    // Mirrors Rails: `set` wraps each LHS in `Nodes::UnqualifiedColumn`
+    // (update_manager.rb), so the visitor strips the table qualifier
+    // structurally rather than via a stateful flag.
+    it("wraps each column in an UnqualifiedColumn", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set([[users.get("name"), "dean"]]);
+      const assignment = mgr.ast.values[0] as Nodes.Assignment;
+      expect(assignment).toBeInstanceOf(Nodes.Assignment);
+      expect(assignment.left).toBeInstanceOf(Nodes.UnqualifiedColumn);
+    });
+
+    // Mirrors Rails: values pass through raw (no Quoted wrap); the
+    // visitor's `visit` class dispatch quotes primitives.
+    it("stores the raw value on the Assignment (no Quoted wrap)", () => {
+      const mgr = new UpdateManager();
+      mgr.table(users);
+      mgr.set([[users.get("age"), 42]]);
+      const assignment = mgr.ast.values[0] as Nodes.Assignment;
+      expect(assignment.right).toBe(42);
+    });
+  });
+
+  it("UPDATE with ORDER BY and LIMIT", () => {
+    const mgr = new UpdateManager();
+    mgr.table(users);
+    mgr.set([[users.get("active"), false]]);
+    mgr.where(users.get("age").lt(18));
+    mgr.order(users.get("name").asc());
+    mgr.take(5);
+    expect(mgr.toSql()).toBe(
+      `UPDATE "users" SET "active" = 'f' WHERE "users"."age" < 18 ORDER BY "users"."name" ASC LIMIT 5`,
+    );
+  });
+
+  it("wheres getter returns WHERE conditions", () => {
+    const manager = new UpdateManager();
+    manager.table(users);
+    manager.where(users.get("id").eq(1));
+    expect(manager.wheres.length).toBe(1);
+  });
+
+  it("updates with false", () => {
+    const mgr = new UpdateManager();
+    mgr.table(users);
+    mgr.set([[users.get("active"), false]]);
+    expect(mgr.toSql()).toContain("'f'");
+  });
+
+  // Mirrors Rails: `tree_manager.rb` `key=` calls `Nodes.build_quoted` on
+  // scalar values and maps over arrays, so the AST always holds Quoted
+  // (or pass-through Node) values rather than raw primitives.
+  describe("key=", () => {
+    it("wraps a scalar value in Quoted", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      um.key = 5;
+      expect(um.ast.key).toBeInstanceOf(Nodes.Quoted);
+      expect((um.ast.key as Nodes.Quoted).value).toBe(5);
+    });
+
+    it("maps an array, wrapping each element in Quoted", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      um.key = [1, 2];
+      const arr = um.ast.key as unknown as Nodes.Quoted[];
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr.every((q) => q instanceof Nodes.Quoted)).toBe(true);
+      expect(arr.map((q) => q.value)).toEqual([1, 2]);
+    });
+
+    it("passes existing Nodes through unwrapped", () => {
+      const um = new UpdateManager();
+      um.table(users);
+      const lit = new Nodes.SqlLiteral("id");
+      um.key = lit;
+      expect(um.ast.key).toBe(lit);
+    });
+  });
+});

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -36,7 +36,7 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#table
    */
-  table(table: Table): this {
+  table(table: Table | Node): this {
     this.ast.relation = table;
     return this;
   }
@@ -98,8 +98,11 @@ export class UpdateManager extends TreeManager {
    *
    * Mirrors: Arel::UpdateManager#having
    */
-  having(condition: Node): this {
-    this.ast.havings.push(condition);
+  having(expr: Node | string): this {
+    // Rails pushes the raw expression and lets `visit_String` render it
+    // (update_manager.rb:43-46). A TS AST holds Nodes only, so a String arrives
+    // as the SqlLiteral it is in Ruby — the same wrap `group` above applies.
+    this.ast.havings.push(typeof expr === "string" ? new SqlLiteral(expr) : expr);
     return this;
   }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -142,7 +142,7 @@ describe("the to_sql visitor", () => {
       const mgr = users.project(users.get("name"));
       const node = users.get("name").doesNotMatch(mgr);
       const sql = new Visitors.ToSql(testConnection).compile(node);
-      expect(sql).toContain("NOT LIKE SELECT");
+      expect(sql).toContain("NOT LIKE (SELECT");
     });
   });
 
@@ -1627,7 +1627,7 @@ describe("the to_sql visitor", () => {
       const mgr = users.project(users.get("name"));
       const node = users.get("name").matches(mgr);
       const sql = new Visitors.ToSql(testConnection).compile(node);
-      expect(sql).toContain("LIKE SELECT");
+      expect(sql).toContain("LIKE (SELECT");
     });
   });
 

--- a/scripts/test-compare/assertion-kinds.ts
+++ b/scripts/test-compare/assertion-kinds.ts
@@ -155,6 +155,24 @@ const AREL_HELPER_ALIAS: Record<string, string> = {
   assert_edge: "assert_match",
 };
 
+/**
+ * trails-side `must*`-named helpers that are NOT assertions, and so must not be
+ * counted as one by the TS extractor's `must*` prefix rule.
+ *
+ * The Ruby `must_be_like` above IS an assertion — it squeezes whitespace and
+ * then delegates to `must_equal` (helper.rb:10-13), which is why it aliases to
+ * `assert_equal` in AREL_HELPER_ALIAS. The trails port splits those two halves:
+ * `packages/arel/src/test-helpers/must-be-like.ts` keeps only the squeezing,
+ * and a native `expect(mustBeLike(a)).toBe(mustBeLike(b))` does the asserting.
+ * The terminal `toBe` is therefore the whole assertion, and counting the two
+ * normalizer calls beside it scores one Rails assertion as three.
+ *
+ * This lives next to AREL_HELPER_ALIAS because it is the same fact about the
+ * same Rails helper, read from the other side: the Ruby name maps to an
+ * assertion, the TS name deliberately does not.
+ */
+export const NON_ASSERTION_TRAILS_HELPERS = new Set(["mustBeLike"]);
+
 // Minitest spec-form expectations whose builtin twin is NOT the bare
 // `assert_<suffix>`/`refute_<suffix>` the prefix rewrite in normalizeRailsKind
 // produces: `must_be_kind_of` is `assert_kind_of`, not `assert_be_kind_of`.

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,18 +21,18 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 304,
+      "assertionCount": 307,
       "kind": 446,
       "value": 59
     },
     "activerecord": {
-      "assertionCount": 1940,
-      "kind": 3924,
-      "value": 36
+      "assertionCount": 1943,
+      "kind": 3926,
+      "value": 37
     },
     "activesupport": {
-      "assertionCount": 863,
-      "kind": 1212,
+      "assertionCount": 882,
+      "kind": 1227,
       "value": 104
     },
     "arel": {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,24 +21,24 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 307,
+      "assertionCount": 304,
       "kind": 446,
       "value": 59
     },
     "activerecord": {
-      "assertionCount": 1943,
-      "kind": 3926,
-      "value": 37
+      "assertionCount": 1940,
+      "kind": 3924,
+      "value": 36
     },
     "activesupport": {
-      "assertionCount": 882,
-      "kind": 1227,
+      "assertionCount": 863,
+      "kind": 1212,
       "value": 104
     },
     "arel": {
-      "assertionCount": 178,
-      "kind": 416,
-      "value": 79
+      "assertionCount": 151,
+      "kind": 334,
+      "value": 58
     },
     "date": {
       "assertionCount": 1,

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -5,7 +5,7 @@
 
 import * as path from "path";
 import * as ts from "typescript";
-import { normalizeTrailsKind } from "./assertion-kinds.js";
+import { NON_ASSERTION_TRAILS_HELPERS, normalizeTrailsKind } from "./assertion-kinds.js";
 import { VALUE_BEARING_KINDS } from "./assertion-values.js";
 import {
   ADAPTER_GATE_WRAPPERS,
@@ -18,9 +18,6 @@ import {
 import type { TestFileInfo, TestGate } from "./types.js";
 
 const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
-
-/** `must*`-prefixed trails helpers that are normalizers, not assertions. */
-const NON_ASSERTION_MUST_HELPERS = new Set(["mustBeLike"]);
 
 /**
  * Does a call's callee identifier name it an assertion? The camelCase twin of
@@ -35,15 +32,11 @@ const NON_ASSERTION_MUST_HELPERS = new Set(["mustBeLike"]);
  * `expect(x)` call in an `expect(x).toEqual(y)` chain has an identifier callee,
  * so each chain counts once.
  *
- * `mustBeLike` is the one `must*` name that is NOT an assertion: Rails'
- * `must_be_like` squeezes whitespace and then defers to `must_equal`
- * (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13), and the trails
- * port keeps only the squeezing half — a pure string normalizer used on BOTH
- * sides of a native `expect(mustBeLike(a)).toBe(mustBeLike(b))`. Counting it
- * would score one Rails assertion as three.
+ * NON_ASSERTION_TRAILS_HELPERS (assertion-kinds.ts) carves out the `must*`
+ * names that are normalizers rather than assertions; see it for why.
  */
 function isAssertionCallee(name: string): boolean {
-  if (NON_ASSERTION_MUST_HELPERS.has(name)) return false;
+  if (NON_ASSERTION_TRAILS_HELPERS.has(name)) return false;
   return /^(assert|refute|expect)([A-Z]|$)/.test(name) || /^(must|wont)[A-Z]/.test(name);
 }
 

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -31,8 +31,18 @@ const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
  * look-alikes (`assertion`, `asserted`, `expected`) out. Only the inner
  * `expect(x)` call in an `expect(x).toEqual(y)` chain has an identifier callee,
  * so each chain counts once.
+ *
+ * `mustBeLike` is the one `must*` name that is NOT an assertion: Rails'
+ * `must_be_like` squeezes whitespace and then defers to `must_equal`
+ * (vendor/rails/activerecord/test/cases/arel/helper.rb:10-13), and the trails
+ * port keeps only the squeezing half — a pure string normalizer used on BOTH
+ * sides of a native `expect(mustBeLike(a)).toBe(mustBeLike(b))`. Counting it
+ * would score one Rails assertion as three.
  */
+const NON_ASSERTION_MUST_HELPERS = new Set(["mustBeLike"]);
+
 function isAssertionCallee(name: string): boolean {
+  if (NON_ASSERTION_MUST_HELPERS.has(name)) return false;
   return /^(assert|refute|expect)([A-Z]|$)/.test(name) || /^(must|wont)[A-Z]/.test(name);
 }
 

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -19,6 +19,9 @@ import type { TestFileInfo, TestGate } from "./types.js";
 
 const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
 
+/** `must*`-prefixed trails helpers that are normalizers, not assertions. */
+const NON_ASSERTION_MUST_HELPERS = new Set(["mustBeLike"]);
+
 /**
  * Does a call's callee identifier name it an assertion? The camelCase twin of
  * the Ruby extractor's `assertion_method?` (extract-ruby-tests.rb) — matched by
@@ -39,8 +42,6 @@ const GATING_MODIFIERS = new Set(["skipIf", "runIf"]);
  * sides of a native `expect(mustBeLike(a)).toBe(mustBeLike(b))`. Counting it
  * would score one Rails assertion as three.
  */
-const NON_ASSERTION_MUST_HELPERS = new Set(["mustBeLike"]);
-
 function isAssertionCallee(name: string): boolean {
   if (NON_ASSERTION_MUST_HELPERS.has(name)) return false;
   return /^(assert|refute|expect)([A-Z]|$)/.test(name) || /^(must|wont)[A-Z]/.test(name);


### PR DESCRIPTION
RFC 0122's per-file assertion-parity burndown for two bundled stories:
`attributes/attribute_test.rb` and the three CRUD managers + `crud_test.rb`.

## What changed

Rails asserts complete statements with `must_be_like`; the port asserted
substrings with `toContain`, often split in two, over different literals
(`SELECT * FROM …` instead of the Rails `SELECT "users"."id" FROM …`,
`%foo%`/`%bar%` instead of `%chunky%`/`%bacon%`, a `users` table instead of
`products` + the fake PG caster). Each mirrored test now takes the Rails
statement, verbatim, through one `expect(mustBeLike(...)).toBe(mustBeLike(...))`.

- **`packages/arel/src/test-helpers/must-be-like.ts`** — the shared normalizer,
  mirroring Rails putting it in
  `vendor/rails/activerecord/test/cases/arel/helper.rb:10-13`. It is a string
  normalizer inside a native `expect().toBe()`, not an assertion wrapper. The
  local copy at `select-manager.test.ts:15` is gone; there is no second copy.
- **TS-only extras moved out** to `*.trails.test.ts` siblings
  (`insert-manager`, `update-manager`, `delete-manager`, `crud`) so they stop
  inflating a mirrored test's counts. No rigour deleted.
- **No test name renamed or reworded.**

## Tooling gap fixed

`scripts/test-compare/extract-ts-core.ts`: `isAssertionCallee` matches the
`must*` prefix, so `mustBeLike` counted as an assertion — twice per call, on
both sides of the `toBe`. Rails' `must_be_like` *is* an assertion, but the
trails port keeps only its squeezing half (helper.rb:10-13) and lets a native
`toBe` do the asserting; scoring it turned one Rails assertion into three.
The carveout lives in `assertion-kinds.ts` as `NON_ASSERTION_TRAILS_HELPERS`,
beside the `AREL_HELPER_ALIAS` entry for the same Rails helper: the Ruby
`must_be_like` *is* an assertion and aliases to `assert_equal`; the trails
normalizer that keeps only its squeezing half is not.

**Only the arel mark moves:**

| package | count | kind | value |
| --- | --- | --- | --- |
| arel | 178 → 151 | 416 → 334 | 79 → 58 |
| all others | unchanged | unchanged | unchanged |

`mustBeLike` exists only under `packages/arel`, so the carveout cannot affect
another package's counts. (An earlier revision of this PR also lowered the
activemodel / activerecord / activesupport marks. That was a `--write` reseed
sweeping in *pre-existing* drift, not movement this PR caused: with the carveout
reverted to main's extractor those three still measure 304 / 1940+3924+36 /
863+1212 — exactly the reseeded values. Restored; they are not this PR's to
tighten.)

`pnpm parity:test:assertions` is green against the tightened mark.

## Port divergences the converged assertions surfaced

- `Arel::Nodes.build_quoted` unwrapped a `SelectManager` to its `.ast`, so
  `visit_Arel_SelectManager` never ran and a subquery RHS lost its parens
  (`"users"."karma" > SELECT AVG(…)`). Rails returns the manager unchanged
  (`arel/nodes/casted.rb:47-51`). Fixed; the two `to_sql` `LIKE`-subquery
  assertions and the `build_quoted` trails test move with it.
- `Attribute.new(nil, nil)` (attribute_test.rb:388) and `count(nil)`
  (expressions.rb:5-7, asserted by `must_be_nil`) are legal in Rails; the TS
  signatures rejected them.
- `UpdateManager#having` takes a String in Rails (update_manager.rb:43-46); the
  TS signature took a Node only. It now wraps a String in `SqlLiteral`, the same
  wrap `group` directly above already applies.
- `UpdateManager#table` takes any relation, including a `JoinSource` /
  `InnerJoin`, not just a `Table`.

## Size

1582 LOC against the 700 ceiling. The work is a rewrite of five mirrored test
files in place, so nearly every line counts twice (890 added / 690 deleted);
the two stories were scoped at ~440 LOC of new assertions between them. There is
no split that keeps a story whole — both are single-file-cluster burndowns and
the bundle was assigned as one PR.

## Verification

- `pnpm vitest run packages/arel` — 79 files, 1454 tests, green
- `pnpm typecheck`, `pnpm lint` — clean
- `pnpm parity:api:calls`, `pnpm parity:api:calls:args`,
  `pnpm parity:api:extra:gate` — OK
- `pnpm parity:test` — arel 707/707 tests, 59/59 files, 0 misplaced

Closes-story: attribute-assertion-parity
Closes-story: crud-manager-assertion-parity
