### PR TITLE
fix(activerecord): void the initializeAttributes _assignAttributes call

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -844,15 +844,24 @@ export class Association {
     // (association.rb:384-387); ours needs it twice because of the plain-`new`
     // fallback below, so it is bound once here.
     //
-    // Rails yields inside `build_record` and returns after, so
-    // `set_new_record`/`save` (singular_association.rb:29-32, :67-70) see a
-    // fully initialized record. When `_assignAttributes` defers —
-    // `scope_for_create`'s `create_with` half can name an association writer
-    // (relation.rb:1231-1235) — a JS constructor cannot await it back into this
-    // synchronous return, so the assign is parked on the record for `save` to
-    // drain, exactly as `populate_with_current_scope_attributes` is
-    // (`_applyScopeAttributes`, base.ts). The yield and the return keep Rails'
-    // order.
+    //
+    // Rails completes `initialize_attributes` before the yield and before
+    // `build_record` returns (association.rb:383-388). When `_assignAttributes`
+    // defers — `scope_for_create`'s `create_with` half can name an association
+    // writer (relation.rb:1231-1235) — TS cannot reproduce that: JS has no
+    // synchronous await, so a sync method cannot complete a promise before
+    // returning. The only shape that could is an awaited `buildRecord`, and
+    // that trades this invisible ordering for a Rails-VISIBLE regression:
+    // `CollectionAssociation#build` returns the record itself
+    // (collection_association.rb:117-122), so `post.comments.build` would
+    // become a promise. Preserving the sync return is the higher fidelity.
+    //
+    // So the assign is parked on the record and drained before any write
+    // (`awaitPendingNestedReaderLoads`, nested-attributes.ts) — the same
+    // deferral `populate_with_current_scope_attributes` takes
+    // (`_applyScopeAttributes`, base.ts:657-681), and the one RFC 0087 ratified
+    // for the constructor itself. The yield and the return keep Rails' order;
+    // only the parked writes settle later, and nothing saves against them.
     const initializeAndYield = (record: Base): void => {
       const pending = this.initializeAttributes(record, attributes);
       if (pending) parkNestedReaderLoad(record, pending);

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -842,6 +842,16 @@ export class Association {
     // Rails' block is one literal shared by both construction paths
     // (association.rb:384-387); ours needs it twice because of the plain-`new`
     // fallback below, so it is bound once here.
+    //
+    // Rails yields inside `build_record`, so the block has run by the time
+    // `build_record` returns and `set_new_record`/`save` follow
+    // (singular_association.rb:29-32, :67-70). When `_assignAttributes` defers
+    // — `scope_for_create`'s `create_with` half can name an association writer
+    // (relation.rb:1231-1235) — a JS constructor cannot await it back into this
+    // synchronous return, so the block is yielded from the continuation
+    // instead; the writes drain on save (RFC 0087). Converging this needs an
+    // awaited `buildRecord` across all seven call sites: story
+    // 0023-surfaced-deviations/build-record-await-deferred-initialize.
     const initializeAndYield = (record: Base): void => {
       const pending = this.initializeAttributes(record, attributes);
       if (pending) {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -10,6 +10,7 @@ import { associationKeysEqual } from "./key-normalization.js";
 import { getDjasScopeBuilder, getAssociationRelationFactory } from "./_scope-slots.js";
 import { validateReflectionValidity } from "./validate-through-reflection.js";
 import { ThroughAssociation } from "./through-association.js";
+import { parkNestedReaderLoad } from "../nested-attributes.js";
 import {
   camelize,
   constantize,
@@ -843,23 +844,18 @@ export class Association {
     // (association.rb:384-387); ours needs it twice because of the plain-`new`
     // fallback below, so it is bound once here.
     //
-    // Rails yields inside `build_record`, so the block has run by the time
-    // `build_record` returns and `set_new_record`/`save` follow
-    // (singular_association.rb:29-32, :67-70). When `_assignAttributes` defers
-    // — `scope_for_create`'s `create_with` half can name an association writer
+    // Rails yields inside `build_record` and returns after, so
+    // `set_new_record`/`save` (singular_association.rb:29-32, :67-70) see a
+    // fully initialized record. When `_assignAttributes` defers —
+    // `scope_for_create`'s `create_with` half can name an association writer
     // (relation.rb:1231-1235) — a JS constructor cannot await it back into this
-    // synchronous return, so the block is yielded from the continuation
-    // instead; the writes drain on save (RFC 0087). Converging this needs an
-    // awaited `buildRecord` across all seven call sites: story
-    // 0023-surfaced-deviations/build-record-await-deferred-initialize.
+    // synchronous return, so the assign is parked on the record for `save` to
+    // drain, exactly as `populate_with_current_scope_attributes` is
+    // (`_applyScopeAttributes`, base.ts). The yield and the return keep Rails'
+    // order.
     const initializeAndYield = (record: Base): void => {
       const pending = this.initializeAttributes(record, attributes);
-      if (pending) {
-        void pending.then(() => {
-          if (block) block(record);
-        });
-        return;
-      }
+      if (pending) parkNestedReaderLoad(record, pending);
       if (block) block(record);
     };
     if (reflection?.buildAssociation) {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -695,7 +695,10 @@ export class Association {
     }
   }
 
-  initializeAttributes(record: Base, exceptFromScopeAttributes?: Record<string, unknown>): void {
+  initializeAttributes(
+    record: Base,
+    exceptFromScopeAttributes?: Record<string, unknown>,
+  ): Promise<void> | void {
     exceptFromScopeAttributes ??= {};
     const skipAssign: (string | string[])[] = [
       this.reflection.foreignKey,
@@ -707,7 +710,15 @@ export class Association {
       this.scopeForCreate(),
       ...assignedKeys.filter((key) => !skipAssign.includes(key)),
     );
-    if (Object.keys(attributes).length > 0) void record._assignAttributes(attributes);
+    const pending =
+      Object.keys(attributes).length > 0
+        ? (record._assignAttributes(attributes) as Promise<void> | undefined)
+        : undefined;
+    if (pending) {
+      return pending.then(() => {
+        this.setInverseInstance(record);
+      });
+    }
     this.setInverseInstance(record);
   }
 
@@ -830,12 +841,12 @@ export class Association {
     )._reflectOnAssociation?.(this.reflection.name);
     if (reflection?.buildAssociation) {
       return reflection.buildAssociation(attributes ?? {}, (record: Base) => {
-        this.initializeAttributes(record, attributes);
+        void this.initializeAttributes(record, attributes);
         if (block) block(record);
       });
     }
     return new (Klass as any)(attributes ?? {}, (record: Base) => {
-      this.initializeAttributes(record, attributes);
+      void this.initializeAttributes(record, attributes);
       if (block) block(record);
     });
   }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -707,7 +707,7 @@ export class Association {
       this.scopeForCreate(),
       ...assignedKeys.filter((key) => !skipAssign.includes(key)),
     );
-    if (Object.keys(attributes).length > 0) record._assignAttributes(attributes);
+    if (Object.keys(attributes).length > 0) void record._assignAttributes(attributes);
     this.setInverseInstance(record);
   }
 

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -839,16 +839,23 @@ export class Association {
         } | null;
       }
     )._reflectOnAssociation?.(this.reflection.name);
-    if (reflection?.buildAssociation) {
-      return reflection.buildAssociation(attributes ?? {}, (record: Base) => {
-        void this.initializeAttributes(record, attributes);
-        if (block) block(record);
-      });
-    }
-    return new (Klass as any)(attributes ?? {}, (record: Base) => {
-      void this.initializeAttributes(record, attributes);
+    // Rails' block is one literal shared by both construction paths
+    // (association.rb:384-387); ours needs it twice because of the plain-`new`
+    // fallback below, so it is bound once here.
+    const initializeAndYield = (record: Base): void => {
+      const pending = this.initializeAttributes(record, attributes);
+      if (pending) {
+        void pending.then(() => {
+          if (block) block(record);
+        });
+        return;
+      }
       if (block) block(record);
-    });
+    };
+    if (reflection?.buildAssociation) {
+      return reflection.buildAssociation(attributes ?? {}, initializeAndYield);
+    }
+    return new (Klass as any)(attributes ?? {}, initializeAndYield);
   }
 
   private inverseAssociationFor(record: Base): Association | null {

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -618,7 +618,7 @@ interface OneToOneAssociation {
   // displacement removal can sit between them, where Rails puts it.
   buildRecord(attrs: Record<string, unknown>): Base | null;
   setNewRecord(record: Base): void;
-  initializeAttributes(record: Base): void;
+  initializeAttributes(record: Base): Promise<void> | void;
   isLoaded(): boolean;
   // Rails' `send(association_name)` — `SingularAssociation#reader`, which is
   // where trails raises strict-loading violations (singular-association.ts:210).
@@ -806,7 +806,7 @@ export function assignNestedAttributesForOneToOneAssociation(
       if (pending) {
         return pending.then(() => assoc.initializeAttributes(existingRecord));
       }
-      assoc.initializeAttributes(existingRecord);
+      return assoc.initializeAttributes(existingRecord);
     } else {
       // Rails nested_attributes.rb:451 — `method = :"build_#{association_name}";
       // respond_to?(method) ? public_send(method, ...) : raise`. A plain


### PR DESCRIPTION
## Root cause

`Lint` went red on `main` at 05cce73c with a single error:

```
packages/activerecord/src/associations/association.ts
  710:45  error  Promises must be awaited ... @typescript-eslint/no-floating-promises
```

The call site itself is unchanged since #6381. What changed is its *type*: #7000
(`refactor(activemodel): fan out the Model attribute-methods and registration
surface`) declared `_assignAttributes` on the `Model` instance interface as
`_assignAttributes(attributes): Promise<void> | void`
(`packages/activemodel/src/model.ts:158`). That union turned the pre-existing
synchronous call in `Association#initializeAttributes` into a floating promise.
Both commits were green on their own branches and only collide once both are on
`main`.

## Fix

Keep Rails' sequencing. `initialize_attributes` assigns to completion **before**
`set_inverse_instance`:

```ruby
# activerecord/lib/active_record/associations/association.rb:223
record.send(:_assign_attributes, attributes) if attributes.any?
```

```ruby
# activerecord/lib/active_record/associations/association.rb:217-224
record.send(:_assign_attributes, attributes) if attributes.any?
set_inverse_instance(record)
```

so `initializeAttributes` now returns `Promise<void> | void` and chains
`setInverseInstance` behind the assign when the writers owe I/O, using the same
`pending` shape `_assignAttributes` itself uses
(`packages/activerecord/src/attribute-assignment.ts:63-83`). Where the assign
stays in memory the body runs inline exactly as before, matching Ruby.

`assignNestedAttributesForOneToOneAssociation` now returns that promise
(`nested-attributes.ts:809`) — its sibling branch two lines up already chained
it — so the caller keeps awaiting through to completion.

`buildRecord` keeps the same order. Rails runs `initialize_attributes` before
`yield(record)` inside one block literal:

```ruby
# activerecord/lib/active_record/associations/association.rb:383-388
reflection.build_association(attributes) do |record|
  initialize_attributes(record, attributes)
  yield(record) if block_given?
end
```

so the caller block is now yielded from the `initializeAttributes` continuation
when the assign defers, and inline when it does not. The block is bound once as
a local rather than written twice, matching Rails' single block literal — ours
otherwise needs it in both the rich-reflection and plain-`new` branches.

### `buildRecord`: why the deferred case cannot fully match, and why that is the right trade

Rails completes `initialize_attributes` before the yield and before
`build_record` returns (`association.rb:383-388`). When `_assignAttributes`
defers, TypeScript cannot reproduce that: **JS has no synchronous await**, so a
method with a synchronous return type cannot complete a promise before
returning. There are exactly three places the continuation can go, and all three
were tried:

1. `void pending` — drops the sequencing (the original lint fix).
2. `pending.then(() => block(record))` — block runs, but after `buildRecord` has
   returned.
3. park + synchronous yield (**current**) — block and return keep Rails' order;
   the parked writes settle before any save.

The fourth option is an awaited `buildRecord`, and it trades this invisible
ordering for a **Rails-visible** regression: `CollectionAssociation#build`
returns the record itself (`collection_association.rb:117-122`), so
`post.comments.build` would become a promise. Preserving that synchronous return
is the higher-fidelity choice — it is a contract a Rails developer can observe,
where the deferred-assign ordering is not.

Option 3 is also not a new decision. It is the deferral RFC 0087 ratified for the
constructor itself (`model.ts:572`) and that `populate_with_current_scope_attributes`
already takes one layer up (`scoping.rb:60-66` → `_applyScopeAttributes`,
`base.ts:657-681`), and the parked assign is drained before any write by
`awaitPendingNestedReaderLoads`, which exists "so the owner is never saved
against a half-assigned graph" (`nested-attributes.ts:686-700`).

Per CLAUDE.md this is a genuine TypeScript language shortcoming rather than a
preference, and it is justified at the call site. It is also strictly narrower
than `main`, which discards the same promise *and* runs `setInverseInstance`
ahead of it.

## Gates

- `npx eslint packages/activerecord/src/{associations/association,nested-attributes}.ts` — clean (reproduced the failure first, then fixed it)
- `pnpm typecheck` — clean
- `pnpm vitest run packages/activerecord/src/associations packages/activerecord/src/nested-attributes.test.ts` — 117 files, 2355 tests, all passing
- `pnpm parity:api:calls` — OK (410 baselined, 315 unreviewed; no new rows)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows; no new rows)
- `pnpm parity:api:extra:gate` — OK (arel 0/0, 63/63)
- No public surface added, so `parity:api` / `parity:test` deltas are unchanged.

Closes-story: red-05cce73c
