### PR TITLE
chore(api-compare): route every residual call-set row to a live owner (RFC 0106)

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -105,6 +105,16 @@ export class DisableJoinsAssociationScope extends AssociationScope {
    * signature (`DisableJoinsAssociationScope#scope` at
    * disable_joins_association_scope.rb:6-15) without the boxing
    * workaround our async pluck would otherwise force.
+   *
+   * @missingRailsCall add_constraints — PERMANENT: this body calls it at Rails'
+   * call site (disable_joins_association_scope.rb:13), spelled
+   * `_addConstraintsDj`. Rails' subclass shadows `AssociationScope#add_constraints`
+   * with a different arity, which Ruby permits; TypeScript rejects a derived
+   * declaration of a name the base declares `private` (TS2415) and the two
+   * signatures are not override-compatible, so the `Dj` suffix is the only
+   * spelling available. The landed `add-leading-underscore-call-candidate-to-conventions`
+   * candidate (PR #6825) does not reach it: that candidate is `"_" + camel`, and
+   * this name carries the `Dj` suffix on top of the underscore.
    */
   override scope(association: AssociationScopeable): unknown {
     const sourceReflection = association.reflection;

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -107,7 +107,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
    * workaround our async pluck would otherwise force.
    *
    * @missingRailsCall add_constraints — PERMANENT: this body calls it at Rails'
-   * call site (disable_joins_association_scope.rb:13), spelled
+   * call site (disable_joins_association_scope.rb:14), spelled
    * `_addConstraintsDj`. Rails' subclass shadows `AssociationScope#add_constraints`
    * with a different arity, which Ruby permits; TypeScript rejects a derived
    * declaration of a name the base declares `private` (TS2415) and the two

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/associations/disable-joins-association-scope.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/associations/disable-joins-association-scope.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
-    "call": "add_constraints",
-    "reason": "Reviewed (wave 4d): `scope` DOES call the ported body at both Rails call sites, spelled `_addConstraintsDj` — Ruby lets the subclass shadow AssociationScope#add_constraints with a different arity, TS rejects a derived declaration of a base-private name (TS2415) and the two signatures are not override-compatible. See the @missingRailsCall tag at the call site."
-  }
-]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -4,34 +4,34 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "checkout",
     "call": "acquire_connection",
-    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:548 is `checkout_and_verify(acquire_connection(checkout_timeout))`; trails inlines the acquire at connection-pool.ts:906-925 because its `acquire_connection` does not block on the queue (the wait is `_available.poll`, which is async). Owned by 0073's checkout reshape, not by this burndown."
+    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:548 is `checkout_and_verify(acquire_connection(checkout_timeout))`; trails inlines the acquire at connection-pool.ts:906-925 because its `acquire_connection` does not block on the queue (the wait is `_available.poll`, which is async). Owned by 0073's checkout reshape, not by this burndown. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "checkout",
     "call": "lock",
-    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:550 is `@pinned_connection.lock.synchronize`; trails has no per-connection Monitor — JS is single-threaded and the pinned path is guarded by the same-tick `_resolvePinnedConnection`. Owned by 0073."
+    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:550 is `@pinned_connection.lock.synchronize`; trails has no per-connection Monitor — JS is single-threaded and the pinned path is guarded by the same-tick `_resolvePinnedConnection`. Owned by 0073. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "clear_reloadable_connections",
     "call": "checkin",
-    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:510-511 is `conn.steal!; checkin conn`; trails' _clearReloadableConnections (connection-pool.ts:1209-1218) inlines the checkin as `_checkedOut.delete` + `_leases._peek(ctx).clear` + `expire()` because `checkin` is async here. Owned by 0073's checkin reshape."
+    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:510-511 is `conn.steal!; checkin conn`; trails' _clearReloadableConnections (connection-pool.ts:1209-1218) inlines the checkin as `_checkedOut.delete` + `_leases._peek(ctx).clear` + `expire()` because `checkin` is async here. Owned by 0073's checkin reshape. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "disconnect",
     "call": "checkin",
-    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:457-458 is `conn.steal!; checkin conn`; trails' _disconnect clears `_checkedOut`/`_leases` wholesale instead, for the same async-checkin reason. Owned by 0073."
+    "reason": "Tracked debt (RFC 0073 pool-checkout convergence): connection_pool.rb:457-458 is `conn.steal!; checkin conn`; trails' _disconnect clears `_checkedOut`/`_leases` wholesale instead, for the same async-checkin reason. Owned by 0073. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "pin_connection!",
     "call": "checkout",
-    "reason": "pinConnectionBang acquires the pinned connection via the sync `_acquireConnection` helper (the trails pinned-checkout path); `checkout` is now async (converge-connection-pool-checkout-lease-async) and cannot be awaited from this path."
+    "reason": "pinConnectionBang acquires the pinned connection via the sync `_acquireConnection` helper (the trails pinned-checkout path); `checkout` is now async (converge-connection-pool-checkout-lease-async) and cannot be awaited from this path. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/connection-pool/reaper.json
@@ -4,6 +4,6 @@
     "tsFile": "connection-adapters/abstract/connection-pool/reaper.ts",
     "rubyName": "register_pool",
     "call": "spawn_thread",
-    "reason": "connection_pool/reaper.rb:59 `spawn_thread` starts a background Thread; trails' Reaper drives the same period from a timer, so there is no thread to spawn. Tracked with the rest of the threadless pool surface by RFC 0073; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+    "reason": "connection_pool/reaper.rb:59 `spawn_thread` starts a background Thread; trails' Reaper drives the same period from a timer, so there is no thread to spawn. Tracked with the rest of the threadless pool surface by RFC 0073; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -4,34 +4,34 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "columns",
     "call": "column_definitions",
-    "reason": "RFC 0106: the TS `columns` switches on `adapterName` instead of Rails' per-adapter overrides, so `column_definitions`/`new_column_from_field` have no seam yet — the adapter-layout deviation tracked by RFC 0023 (schema_statements.rb:107-113)."
+    "reason": "RFC 0106: the TS `columns` switches on `adapterName` instead of Rails' per-adapter overrides, so `column_definitions`/`new_column_from_field` have no seam yet — the adapter-layout deviation tracked by RFC 0023 (schema_statements.rb:107-113). Tracked by story `converge-schema-statements-adapter-layout-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "columns",
     "call": "new_column_from_field",
-    "reason": "RFC 0106: see the column_definitions row — the `adapterName` switch in TS `columns` has no per-adapter hook to call (schema_statements.rb:107-113)."
+    "reason": "RFC 0106: see the column_definitions row — the `adapterName` switch in TS `columns` has no per-adapter hook to call (schema_statements.rb:107-113). Tracked by story `converge-schema-statements-adapter-layout-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "generate_index_name",
     "call": "limit",
-    "reason": "RFC 0106: Ruby String#limit (byte-truncation) — the port truncates by JS UTF-16 length; the byte-aware convergence is RFC 0082 idiom work (schema_statements.rb:1606-1609)."
+    "reason": "RFC 0106: Ruby String#limit (byte-truncation) — the port truncates by JS UTF-16 length; the byte-aware convergence is RFC 0082 idiom work (schema_statements.rb:1606-1609). Tracked by story `converge-schema-statements-ruby-idiom-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "index_algorithm",
     "call": "fetch",
-    "reason": "RFC 0106: Ruby Hash#fetch with a raising block — the port throws inline off a Map lookup; converging needs the Hash#fetch idiom class of RFC 0082 (schema_statements.rb:1504-1508)."
+    "reason": "RFC 0106: Ruby Hash#fetch with a raising block — the port throws inline off a Map lookup; converging needs the Hash#fetch idiom class of RFC 0082 (schema_statements.rb:1504-1508). Tracked by story `converge-schema-statements-ruby-idiom-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "primary_key",
     "call": "primary_keys",
-    "reason": "RFC 0106: the TS `primaryKey` switches on `adapterName` instead of delegating to a per-adapter `primaryKeys` — the adapter-layout deviation tracked by RFC 0023 (schema_statements.rb:145-149)."
+    "reason": "RFC 0106: the TS `primaryKey` switches on `adapterName` instead of delegating to a per-adapter `primaryKeys` — the adapter-layout deviation tracked by RFC 0023 (schema_statements.rb:145-149). Tracked by story `converge-schema-statements-adapter-layout-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -4,13 +4,13 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "last_insert_id_result",
     "call": "internal_exec_query",
-    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/database_statements.rb's `last_insert_id_result` is `internal_exec_query(\"SELECT currval(...)\")`; trails reads the sequence value through the same adapter entry point spelled `queryValue`, which is `internal_exec_query` plus `.rows.first.first` — the row extraction is folded in."
+    "reason": "Per-site verified (RFC 0106 wave 4b): postgresql/database_statements.rb's `last_insert_id_result` is `internal_exec_query(\"SELECT currval(...)\")`; trails reads the sequence value through the same adapter entry point spelled `queryValue`, which is `internal_exec_query` plus `.rows.first.first` — the row extraction is folded in. Tracked by story `converge-postgresql-database-statements-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Per-site verified (RFC 0106 wave 4b): `result.rows.first` is `result.rows[0]` on a JS array; `Array#first` is not a ported method name."
+    "reason": "Per-site verified (RFC 0106 wave 4b): `result.rows.first` is `result.rows[0]` on a JS array; `Array#first` is not a ported method name. Tracked by story `converge-postgresql-database-statements-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/quoting.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/postgresql/quoting.json
@@ -4,6 +4,6 @@
     "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote_string",
     "call": "with_raw_connection",
-    "reason": "Tracked debt (RFC 0073 permanent-checkout flip): postgresql/quoting.rb's `quote_string` escapes through `with_raw_connection { |c| c.escape(s) }`; trails escapes with the pure PG rules rather than checking a connection out, because `quote_string` is called from synchronous quoting paths and `withRawConnection` is async. Same escaping (PG standard_conforming_strings)."
+    "reason": "Tracked debt (RFC 0073 permanent-checkout flip): postgresql/quoting.rb's `quote_string` escapes through `with_raw_connection { |c| c.escape(s) }`; trails escapes with the pure PG rules rather than checking a connection out, because `quote_string` is called from synchronous quoting paths and `withRawConnection` is async. Same escaping (PG standard_conforming_strings). Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -4,34 +4,34 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "configure_connection",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:837: `@config.fetch(:pragmas, {}).stringify_keys`. `Hash#fetch` with a default has no JS analogue that preserves a stored `nil`; the port reads the pragmas option directly. Tracked by RFC 0094."
+    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:837: `@config.fetch(:pragmas, {}).stringify_keys`. `Hash#fetch` with a default has no JS analogue that preserves a stored `nil`; the port reads the pragmas option directly. Tracked by RFC 0094. Tracked by story `converge-sqlite3-adapter-construction-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "connect",
     "call": "new_client",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:807: `@raw_connection = self.class.new_client(@connection_parameters)` hands the sqlite3 gem the whole config hash. trails has no `@connection_parameters` hash and its `newClient` returns an adapter rather than a raw driver handle, so `connect()` opens the driver directly from the expanded filename. Tracked by RFC 0094 (sqlite3-adapter-construction-fidelity)."
+    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:807: `@raw_connection = self.class.new_client(@connection_parameters)` hands the sqlite3 gem the whole config hash. trails has no `@connection_parameters` hash and its `newClient` returns an adapter rather than a raw driver handle, so `connect()` opens the driver directly from the expanded filename. Tracked by RFC 0094 (sqlite3-adapter-construction-fidelity). Tracked by story `converge-sqlite3-adapter-construction-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "initialize",
     "call": "merge",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:128-132: Rails merges `@config` into `@connection_parameters` because the sqlite3 gem takes the whole config hash as driver options. trails' constructor takes `(filename, options)` — the driver (node:sqlite / better-sqlite3) accepts no config hash — so there is no parameters hash to merge into. Tracked for construction convergence by RFC 0094 (sqlite3-adapter-construction-fidelity)."
+    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:128-132: Rails merges `@config` into `@connection_parameters` because the sqlite3 gem takes the whole config hash as driver options. trails' constructor takes `(filename, options)` — the driver (node:sqlite / better-sqlite3) accepts no config hash — so there is no parameters hash to merge into. Tracked for construction convergence by RFC 0094 (sqlite3-adapter-construction-fidelity). Tracked by story `converge-sqlite3-adapter-construction-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "new_client",
     "call": "include?",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:36-41: Rails rescues `Errno::ENOENT` and re-raises `NoDatabaseError` only when `error.message.include?(\"No such file or directory\")`. trails' `newClient` constructs an adapter rather than opening a file, so there is no open-time errno to classify; the missing-database mapping happens in `translateException`. Tracked by RFC 0094."
+    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:36-41: Rails rescues `Errno::ENOENT` and re-raises `NoDatabaseError` only when `error.message.include?(\"No such file or directory\")`. trails' `newClient` constructs an adapter rather than opening a file, so there is no open-time errno to classify; the missing-database mapping happens in `translateException`. Tracked by RFC 0094. Tracked by story `converge-sqlite3-adapter-construction-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "shared_cache?",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:473: Rails reads `@config.fetch(:flags, 0).anybits?(SHAREDCACHE)`. There is no `flags` bitmask in trails' config — no JS sqlite driver exposes SQLITE_OPEN_SHAREDCACHE — so `isSharedCache` inspects the `cache=shared` query parameter of the database URI instead, which is the only way shared cache can be requested here. Tracked by RFC 0094."
+    "reason": "Per-entry verified (RFC 0106 sqlite3 construction cluster), sqlite3_adapter.rb:473: Rails reads `@config.fetch(:flags, 0).anybits?(SHAREDCACHE)`. There is no `flags` bitmask in trails' config — no JS sqlite driver exposes SQLITE_OPEN_SHAREDCACHE — so `isSharedCache` inspects the `cache=shared` query parameter of the database URI instead, which is the only way shared cache can be requested here. Tracked by RFC 0094. Tracked by story `converge-sqlite3-adapter-construction-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations.json
@@ -4,6 +4,6 @@
     "tsFile": "database-configurations.ts",
     "rubyName": "default_env",
     "call": "call",
-    "reason": "Verified per-site (RFC 0106): `ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s` (`database_configurations.rb:189`) — `DEFAULT_ENV` is an unported Proc constant, so there is no receiver to send `call` to; porting it is filed as `port-connection-handling-default-env-proc`."
+    "reason": "Verified per-site (RFC 0106): `ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_s` (`database_configurations.rb:189`) — `DEFAULT_ENV` is an unported Proc constant, so there is no receiver to send `call` to; porting it is filed as `converge-establish-connection-default-env-funnel`. (RFC 0106 exit ledger, 2026-08-24: repointed off the closed predecessor story onto this live successor.)"
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/database-configurations/database-config.json
@@ -4,6 +4,6 @@
     "tsFile": "database-configurations/database-config.ts",
     "rubyName": "for_current_env?",
     "call": "call",
-    "reason": "Verified per-site (RFC 0106): `env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call` (`database_configurations/database_config.rb:92`) — same unported `DEFAULT_ENV` Proc as `default_env`; filed as `port-connection-handling-default-env-proc`."
+    "reason": "Verified per-site (RFC 0106): `env_name == ActiveRecord::ConnectionHandling::DEFAULT_ENV.call` (`database_configurations/database_config.rb:92`) — same unported `DEFAULT_ENV` Proc as `default_env`; filed as `converge-establish-connection-default-env-funnel`. (RFC 0106 exit ledger, 2026-08-24: repointed off the closed predecessor story onto this live successor.)"
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/delegated-type.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/delegated-type.json
@@ -4,6 +4,6 @@
     "tsFile": "delegated-type.ts",
     "rubyName": "define_delegated_type_methods",
     "call": "define_method",
-    "reason": "delegated_type.rb:246, :250, :254, :265, :269, :273 — `define_method \"#{role}_class\"` and its siblings. Ruby's `define_method` is `Object.defineProperty` on the prototype in JS, so the generated methods now live in this body (the decomposition converged) but there is no `defineMethod` to call. Kept as a row rather than a `@missingRailsCall` receipt: RFC 0106 ruled this file CONVERGEABLE and its rows non-migratable."
+    "reason": "delegated_type.rb:246, :250, :254, :265, :269, :273 — `define_method \"#{role}_class\"` and its siblings. Ruby's `define_method` is `Object.defineProperty` on the prototype in JS, so the generated methods now live in this body (the decomposition converged) but there is no `defineMethod` to call. Kept as a row rather than a `@missingRailsCall` receipt: RFC 0106 ruled this file CONVERGEABLE and its rows non-migratable. Tracked by story `converge-delegated-type-and-default-scope-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/middleware/shard-selector.json
@@ -4,6 +4,6 @@
     "tsFile": "middleware/shard-selector.ts",
     "rubyName": "call",
     "call": "new",
-    "reason": "shard_selector.rb:41 wraps env in `ActionDispatch::Request.new(env)`; trails has no ActionDispatch, so `call()` receives the request itself and constructs nothing. Convergeable once ActionDispatch::Request is ported; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+    "reason": "shard_selector.rb:41 wraps env in `ActionDispatch::Request.new(env)`; trails has no ActionDispatch, so `call()` receives the request itself and constructs nothing. Convergeable once ActionDispatch::Request is ported; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit. Tracked by story `converge-shard-selector-request-construction-call-set-row` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema.json
@@ -4,6 +4,6 @@
     "tsFile": "schema.ts",
     "rubyName": "define",
     "call": "with_connection",
-    "reason": "`connection_pool.with_connection` (schema.rb:54) checks a connection out for the block; the port's `Schema.define` is handed the adapter explicitly (schema.ts:51-64). Tracked by RFC 0059, the one-schema convergence; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
+    "reason": "`connection_pool.with_connection` (schema.rb:54) checks a connection out for the block; the port's `Schema.define` is handed the adapter explicitly (schema.ts:51-64). Tracked by RFC 0059, the one-schema convergence; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit. Tracked by story `converge-schema-define-with-connection-call-set-row` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/scoping/default.json
@@ -4,6 +4,6 @@
     "tsFile": "scoping/default.ts",
     "rubyName": "build_default_scope",
     "call": "any?",
-    "reason": "default.rb:157 `elsif default_scopes.any?` — Ruby Array#any? on a plain array has no trails port; the port spells it `scopes.length === 0` and inverts it into an early return (default.ts:71-72), so the `elsif` becomes a guard. Same predicate, inverted branch shape; tracked."
+    "reason": "default.rb:157 `elsif default_scopes.any?` — Ruby Array#any? on a plain array has no trails port; the port spells it `scopes.length === 0` and inverts it into an early return (default.ts:71-72), so the `elsif` becomes a guard. Same predicate, inverted branch shape; tracked. Tracked by story `converge-delegated-type-and-default-scope-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/transactions.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/transactions.json
@@ -4,6 +4,6 @@
     "tsFile": "transactions.ts",
     "rubyName": "add_to_transaction",
     "call": "with_connection",
-    "reason": "Reviewed (RFC 0106 wave 4c): trails resolves the adapter through `threadedConnectionFor(ctor) ?? ctor.connection` instead of the `with_connection` block form, which the pool-checkout convergence (RFC 0073) owns; converging here would fork that flip."
+    "reason": "Reviewed (RFC 0106 wave 4c): trails resolves the adapter through `threadedConnectionFor(ctor) ?? ctor.connection` instead of the `with_connection` block form, which the pool-checkout convergence (RFC 0073) owns; converging here would fork that flip. Tracked by story `converge-residual-connection-lease-call-set-rows` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/type-caster/connection.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/type-caster/connection.json
@@ -4,6 +4,6 @@
     "tsFile": "type-caster/connection.ts",
     "rubyName": "type_for_attribute",
     "call": "with_connection",
-    "reason": "Verified per-site (RFC 0106 wave 4g): `@klass.with_connection { |connection| connection.lookup_cast_type_from_column(column) }` (type_caster/connection.rb:21). trails' `withConnection` returns a Promise (connection-handling.ts:366) and `typeForAttribute` is called from synchronous Arel type-casting, so the body reads the adapter directly and takes a permanent checkout where Rails scopes a lease. Same sync/async shortcoming as the `data_source_exists?` gate two lines above it; both are documented at the call site and tracked by RFC 0073."
+    "reason": "Verified per-site (RFC 0106 wave 4g): `@klass.with_connection { |connection| connection.lookup_cast_type_from_column(column) }` (type_caster/connection.rb:21). trails' `withConnection` returns a Promise (connection-handling.ts:366) and `typeForAttribute` is called from synchronous Arel type-casting, so the body reads the adapter directly and takes a permanent checkout where Rails scopes a lease. Same sync/async shortcoming as the `data_source_exists?` gate two lines above it; both are documented at the call site and tracked by RFC 0073. Tracked by story `typecaster-connection-drops-datasource-gate-and-with-connection` (RFC 0106 exit ledger, 2026-08-24)."
   }
 ]


### PR DESCRIPTION
RFC 0106's **exit ledger**: walk the residual `kind: "set"` baseline row by row and give each one a disposition that is either a converged call or a live, claimable story.

## Re-measurement

Clean `pnpm build`, then `API_COMPARE_FORCE=1 pnpm parity:api --calls`, counted over the exclude tree at `kind: "set"` for `activerecord` / `arel` / `activesupport`:

| package | rows | files |
| --- | ---: | ---: |
| `activerecord` | 36 | 22 |
| `activesupport` | 0 | 0 |
| `arel` | 0 | 0 |

**36**, not the 42 the story recorded on 2026-08-24. The two dependency stories landed in between: `converge-activesupport-residual-set-rows-to-zero` took `activesupport` 3 → 0 and `converge-get-primary-key-schema-cache-call-set-rows` took 2 `activerecord` rows; this PR converges one more.

## Converged (1 row)

`associations/disable-joins-association-scope.ts` `scope -> add_constraints`. The PERMANENT `@missingRailsCall` receipt existed but was sited on `lastScopeChain` and `_addConstraintsDj`, not on `scope` — the method the flag is raised against — so it suppressed nothing and the baseline row shadowed it. Tag moved to `scope`, row deleted.

Per the acceptance criteria, the receipt records why the landed `add-leading-underscore-call-candidate-to-conventions` (done, PR #6825) does not retire it: that candidate is `"_" + camel`, and this name carries a `Dj` suffix on top of the underscore. The conventions table is **not** widened here.

## Routed (35 rows)

Every surviving row's `reason` now names an **open, claimable** story.

- **Two `DEFAULT_ENV` rows repointed.** `database-configurations.ts` `default_env -> call` and `database-configurations/database-config.ts` `for_current_env? -> call` named `port-connection-handling-default-env-proc`, which is **closed**. They now name its live successor `converge-establish-connection-default-env-funnel`. No row's reason names a closed story (verified across the whole exclude tree, not just activerecord).
- **Eight delegated stories flipped `draft` → `ready`** so the rows that already named a story are claimable: `adapter-not-found-message-should-be-built-inline`, `pg-cidr-cast-value-should-build-an-ipaddr`, `legacy-point-serialize-should-extract-number-for-point`, `sqlite3-table-change-column-should-redeclare-the-column`, `converge-establish-connection-default-env-funnel`, `discriminate-class-for-record-should-call-find-sti-class`, `decompose-instantiate-onto-allocate-init-with-attributes`, `port-promise-complete-for-async-loaded-arms`.
- **Eight new stories filed under RFC 0106** for rows delegated to an RFC with no story naming them — this RFC's stated charter ("converges any row in its scope regardless of which RFC owns the underlying defect"):

  | story | rows | was delegated to |
  | --- | ---: | --- |
  | `converge-residual-connection-lease-call-set-rows` | 8 | RFC 0073 (no story) |
  | `converge-sqlite3-adapter-construction-call-set-rows` | 5 | RFC 0094 (no story) |
  | `converge-schema-statements-adapter-layout-call-set-rows` | 3 | RFC 0023 (postponed) |
  | `converge-schema-statements-ruby-idiom-call-set-rows` | 2 | RFC 0082 (postponed) |
  | `converge-postgresql-database-statements-call-set-rows` | 2 | nobody |
  | `converge-delegated-type-and-default-scope-call-set-rows` | 2 | nobody |
  | `converge-schema-define-with-connection-call-set-row` | 1 | RFC 0059 (**closed**) |
  | `converge-shard-selector-request-construction-call-set-row` | 1 | nobody |

  The remaining routed rows go to already-live stories: `type-caster/connection.ts` → `typecaster-connection-drops-datasource-gate-and-with-connection` (RFC 0073, ready), `tasks/mysql-database-tasks.ts` → `mysql-purge-does-not-call-recreate-database` (RFC 0051, ready), plus the eight flipped above.

## RFC README

Open question 1 (`relation.ts` cross-file mixin attribution noise) is **resolved**: `relation.ts` is at 0 rows, retired by ordinary per-row convergence across waves 1–4, with no extractor change made — the 117 were real. Changelog records the 36-row measurement and this routing pass.

RFC 0106 stays `active`: the exit number is 0, and it is 36.

## Where the ledger evidence lives (review note)

The RFC README/changelog update this story requires is **not in this diff by design** — RFC 0106 lives in the `blazetrailsdev/tasks` repo, not in trails (`docs/activerecord/` is frozen by RFC 0011 Phase 4 and CI's `Docs ActiveRecord Freeze` job fails any PR that touches it; AR work tracking is the tasks repo per CLAUDE.md). It is already landed on that repo's `main`:

- `08bb3641e docs(0106): exit ledger — resolve open question 1, record the 36-row residual` — `rfcs/0106-wide-call-set-direct-burndown/README.md`, +30/-6: the clean-build re-measure (36 in-scope `kind: "set"` rows, and why it is 36 and not the story's 42), open question 1 marked resolved, and the routing pass recorded in the changelog.
- Eight new stories under `rfcs/0106-wide-call-set-direct-burndown/stories/`, each auto-committed by `pnpm tasks new` (`0b5855624`, `b6d4ff87c`, `1d12a5ce1`, `05cd69926`, `83e2e25ac`, `6d68e9978`, and two more), plus the eight `status-set … ready` commits.

What belongs in *this* repo is exactly what is here: the converged call site and the baseline `reason` strings that name the live stories. The two halves of the ledger are verifiable together — every reason in the changed JSON names a slug that exists and is claimable in the tasks repo at the commits above.

## Verification

- `pnpm parity:api:calls` — OK (409 baselined, 315 unreviewed, 116 marks totalling 315 tight)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows)
- No `--write`, no reseed, no widened allowlist, no new rows.
- `scripts/api-compare` lint tests green.

Closes-story: route-residual-call-set-rows-to-a-live-owner
