### PR TITLE
refactor(activemodel): fan out the conversion, access, serialization and naming surface from model.ts (RFC 0115)

### DIFF
--- a/packages/activemodel/src/access.test.ts
+++ b/packages/activemodel/src/access.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
+import { withIndifferentAccess } from "@blazetrails/activesupport";
 
 describe("AccessTest", () => {
   class SliceModel extends Model {
@@ -12,15 +13,22 @@ describe("AccessTest", () => {
 
   it("slice", () => {
     const m = new SliceModel({ name: "Alice", age: 30, email: "a@b.com" });
-    const sliced = m.slice("name", "age");
-    expect(sliced).toEqual({ name: "Alice", age: 30 });
-    expect(sliced.email).toBeUndefined();
+    const expected = withIndifferentAccess({ name: m.name, age: m.age });
+    const actual = m.slice("name", "age");
+
+    expect([...actual.keys()]).toEqual([...expected.keys()]);
+
+    expected.forEach((value, key) => {
+      expect(actual.get(key)).toEqual(value);
+    });
   });
 
   it("slice with array", () => {
     const m = new SliceModel({ name: "Alice", age: 30, email: "a@b.com" });
-    const sliced = m.slice(["name", "age"]);
-    expect(sliced).toEqual({ name: "Alice", age: 30 });
+    const expected = withIndifferentAccess({ name: m.name, age: m.age });
+    const actual = m.slice(["name", "age"]);
+
+    expect([...actual.entries()]).toEqual([...expected.entries()]);
   });
 
   it("values_at", () => {

--- a/packages/activemodel/src/access.ts
+++ b/packages/activemodel/src/access.ts
@@ -1,9 +1,46 @@
 /**
  * Access mixin — provides slice and values_at for attribute access.
  *
- * Mirrors: ActiveModel::Access
+ * Mirrors: ActiveModel::Access (access.rb:7-16), included into
+ * `ActiveModel::Model` by `model.rb:44`.
  */
-export interface Access {
-  slice(...methods: (string | string[])[]): Record<string, unknown>;
-  valuesAt(...methods: (string | string[])[]): unknown[];
+export class Access {
+  /**
+   * Return a subset of attributes.
+   *
+   * Mirrors: ActiveModel::Access#slice (access.rb:8-10)
+   */
+  slice(...methods: (string | string[])[]): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const m of methods.flat()) {
+      result[m] = (this as unknown as AccessHost)._readAttribute(
+        (this.constructor as unknown as AccessClass).resolveAttributeName(m),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Return attribute values as an array.
+   *
+   * Mirrors: ActiveModel::Access#values_at (access.rb:12-14)
+   */
+  valuesAt(...methods: (string | string[])[]): unknown[] {
+    return methods
+      .flat()
+      .map((m) =>
+        (this as unknown as AccessHost)._readAttribute(
+          (this.constructor as unknown as AccessClass).resolveAttributeName(m),
+        ),
+      );
+  }
+}
+
+/** Host shape the {@link Access} bodies read through. */
+interface AccessHost {
+  _readAttribute(name: string): unknown;
+}
+
+interface AccessClass {
+  resolveAttributeName(name: string): string;
 }

--- a/packages/activemodel/src/access.ts
+++ b/packages/activemodel/src/access.ts
@@ -1,3 +1,6 @@
+import { withIndifferentAccess, type HashWithIndifferentAccess } from "@blazetrails/activesupport";
+import { NoMethodError } from "./attribute-assignment.js";
+
 /**
  * Access mixin — provides slice and values_at for attribute access.
  *
@@ -11,19 +14,13 @@ export class Access {
    *   def slice(*methods)
    *     methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
    *   end
-   *
-   * The result is a plain object rather than a `HashWithIndifferentAccess`:
-   * Ruby's is a `Hash` subclass, so `h[:name]`, `h["name"]` and `h == {…}` all
-   * answer on the same object, while the trails class is `Map`-backed and
-   * answers only through `get`/`set`. Converging the return type is tracked by
-   * 0115/converge-access-slice-with-indifferent-access.
    */
-  slice(...methods: (string | string[])[]): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
+  slice(...methods: (string | string[])[]): HashWithIndifferentAccess<unknown> {
+    const indexed: Record<string, unknown> = {};
     for (const method of methods.flat()) {
-      result[method] = publicSend(this, method);
+      indexed[method] = publicSend(this, method);
     }
-    return result;
+    return withIndifferentAccess(indexed);
   }
 
   /**
@@ -39,12 +36,19 @@ export class Access {
 }
 
 /**
- * Ruby `public_send(method)` with no arguments. A generated attribute reader
- * ports as an accessor property (CLAUDE.md § "Generated attribute readers are
- * properties"), so reading the member is the whole send for one; a member that
- * is a function is a `def` and Ruby's send invokes it.
+ * Ruby `public_send(method)` with no arguments. Member existence is the JS
+ * analog of `respond_to?`, and a receiver that does not respond raises
+ * `NoMethodError` as Ruby's send does. A generated attribute reader ports as an
+ * accessor property (CLAUDE.md § "Generated attribute readers are properties"),
+ * so reading the member is the whole send for one; a member that is a function
+ * is a `def` and Ruby's send invokes it.
  */
 function publicSend(obj: object, method: string): unknown {
+  if (!(method in obj)) {
+    throw new NoMethodError(
+      `undefined method '${method}' for an instance of ${obj.constructor.name}`,
+    );
+  }
   const value = (obj as Record<string, unknown>)[method];
   return typeof value === "function" ? (value as () => unknown).call(obj) : value;
 }

--- a/packages/activemodel/src/access.ts
+++ b/packages/activemodel/src/access.ts
@@ -6,41 +6,45 @@
  */
 export class Access {
   /**
-   * Return a subset of attributes.
-   *
    * Mirrors: ActiveModel::Access#slice (access.rb:8-10)
+   *
+   *   def slice(*methods)
+   *     methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
+   *   end
+   *
+   * The result is a plain object rather than a `HashWithIndifferentAccess`:
+   * Ruby's is a `Hash` subclass, so `h[:name]`, `h["name"]` and `h == {…}` all
+   * answer on the same object, while the trails class is `Map`-backed and
+   * answers only through `get`/`set`. Converging the return type is tracked by
+   * 0115/converge-access-slice-with-indifferent-access.
    */
   slice(...methods: (string | string[])[]): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const m of methods.flat()) {
-      result[m] = (this as unknown as AccessHost)._readAttribute(
-        (this.constructor as unknown as AccessClass).resolveAttributeName(m),
-      );
+    for (const method of methods.flat()) {
+      result[method] = publicSend(this, method);
     }
     return result;
   }
 
   /**
-   * Return attribute values as an array.
-   *
    * Mirrors: ActiveModel::Access#values_at (access.rb:12-14)
+   *
+   *   def values_at(*methods)
+   *     methods.flatten.map! { |method| public_send(method) }
+   *   end
    */
   valuesAt(...methods: (string | string[])[]): unknown[] {
-    return methods
-      .flat()
-      .map((m) =>
-        (this as unknown as AccessHost)._readAttribute(
-          (this.constructor as unknown as AccessClass).resolveAttributeName(m),
-        ),
-      );
+    return methods.flat().map((method) => publicSend(this, method));
   }
 }
 
-/** Host shape the {@link Access} bodies read through. */
-interface AccessHost {
-  _readAttribute(name: string): unknown;
-}
-
-interface AccessClass {
-  resolveAttributeName(name: string): string;
+/**
+ * Ruby `public_send(method)` with no arguments. A generated attribute reader
+ * ports as an accessor property (CLAUDE.md § "Generated attribute readers are
+ * properties"), so reading the member is the whole send for one; a member that
+ * is a function is a `def` and Ruby's send invokes it.
+ */
+function publicSend(obj: object, method: string): unknown {
+  const value = (obj as Record<string, unknown>)[method];
+  return typeof value === "function" ? (value as () => unknown).call(obj) : value;
 }

--- a/packages/activemodel/src/access.ts
+++ b/packages/activemodel/src/access.ts
@@ -1,4 +1,8 @@
-import { withIndifferentAccess, type HashWithIndifferentAccess } from "@blazetrails/activesupport";
+import {
+  indexWith,
+  withIndifferentAccess,
+  type HashWithIndifferentAccess,
+} from "@blazetrails/activesupport";
 import { NoMethodError } from "./attribute-assignment.js";
 
 /**
@@ -14,13 +18,18 @@ export class Access {
    *   def slice(*methods)
    *     methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
    *   end
+   *
+   * @missingRailsArgs index_with — PERMANENT: Ruby's `index_with` is an
+   * Enumerable method on the receiver (core_ext/enumerable.rb:66), so the
+   * flattened array is `self` there. trails ports the Enumerable core_ext as
+   * free functions taking the collection first (`enumerable-utils.ts:43`),
+   * which JS requires short of monkey-patching `Array.prototype`, so the
+   * receiver arrives as the first argument.
    */
   slice(...methods: (string | string[])[]): HashWithIndifferentAccess<unknown> {
-    const indexed: Record<string, unknown> = {};
-    for (const method of methods.flat()) {
-      indexed[method] = publicSend(this, method);
-    }
-    return withIndifferentAccess(indexed);
+    return withIndifferentAccess(
+      Object.fromEntries(indexWith(methods.flat(), (method) => publicSend(this, method))),
+    );
   }
 
   /**

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -38,7 +38,7 @@ export function attributeNames(this: { attributeTypes(): Record<string, Type> })
   return Object.keys(this.attributeTypes());
 }
 
-type AttributeInstanceHost = { _attributes: AttributeSet };
+export type AttributeInstanceHost = { _attributes: AttributeSet };
 
 /**
  * Mirrors: ActiveModel::Attributes#_write_attribute (attributes.rb:156-158) —

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -1,4 +1,11 @@
-import { underscore, tableize, demodulize } from "@blazetrails/activesupport";
+import {
+  underscore,
+  tableize,
+  demodulize,
+  wrap,
+  included,
+  classAttribute,
+} from "@blazetrails/activesupport";
 
 /**
  * Conversion mixin — provides toModel, toKey, toParam, toPartialPath.
@@ -8,15 +15,77 @@ import { underscore, tableize, demodulize } from "@blazetrails/activesupport";
  * These methods are required for ActionPack integration (url_for, form_for, etc.)
  * and must be implemented by any object that acts as a model.
  */
-export interface Conversion {
-  toModel(): unknown;
-  toKey(): unknown[] | null;
-  toParam(): string | null;
-  toPartialPath(): string;
+/** Host shape the {@link Conversion} bodies read through. */
+interface ConversionRecord {
+  isPersisted(): boolean;
+  respondTo(method: string): boolean;
+  _readAttribute(name: string): unknown;
 }
+
+export class Conversion {
+  /**
+   * Mirrors: conversion.rb:28-33
+   *   included do
+   *     class_attribute :param_delimiter, instance_reader: false, default: "-"
+   *   end
+   */
+  static [included](base: object): void {
+    classAttribute.call(base, "paramDelimiter", { instanceReader: false, default: "-" });
+  }
+
+  /**
+   * Returns self. Required by ActiveModel::Conversion.
+   *
+   * Mirrors: ActiveModel::Conversion#to_model (conversion.rb:49-51)
+   */
+  toModel(): this {
+    return this;
+  }
+
+  /**
+   * Return an array of all key attributes if any of the attributes is set,
+   * whether or not the object is persisted.
+   *
+   * Mirrors: ActiveModel::Conversion#to_key (conversion.rb:67-70)
+   */
+  toKey(): unknown[] | null {
+    // conversion.rb:67-70 — `key = respond_to?(:id) && id; key ? Array(key) : nil`.
+    // `Array(key)` is what keeps a composite `id` from being double-wrapped.
+    const self = this as unknown as ConversionRecord;
+    const key = self.respondTo("id") ? self._readAttribute("id") : false;
+    return key != null && key !== false ? wrap(key) : null;
+  }
+
+  /**
+   * Mirrors: ActiveModel::Conversion#to_param (conversion.rb:88-90)
+   */
+  toParam(): string | null {
+    const self = this as unknown as ConversionRecord;
+    if (!self.isPersisted()) return null;
+    const key = this.toKey();
+    if (!key) return null;
+    if (!key.every((part) => part !== null && part !== undefined && part !== false)) return null;
+    return key
+      .map(String)
+      .join((this.constructor as unknown as { paramDelimiter: string }).paramDelimiter);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Conversion#to_partial_path (conversion.rb:101-103)
+   */
+  toPartialPath(): string {
+    return (this.constructor as unknown as ConversionHost)._toPartialPath();
+  }
+}
+
+/**
+ * Mirrors: ActiveModel::Conversion::ClassMethods (conversion.rb:105-118).
+ */
+export const ClassMethods = { _toPartialPath };
 
 interface ConversionHost {
   name: string;
+  _toPartialPath(): string;
   modelName?: { collection: string; element: string };
   _cachedToPartialPath?: string;
 }

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -1,3 +1,4 @@
+import { NoMethodError } from "./attribute-assignment.js";
 import {
   underscore,
   tableize,
@@ -114,12 +115,19 @@ interface ConversionHost {
 }
 
 /**
- * Ruby `public_send(method)` with no arguments. A generated attribute reader
+ * Ruby `public_send(method)` with no arguments. Member existence is the JS
+ * analog of `respond_to?`, and a receiver that does not respond raises
+ * `NoMethodError` as Ruby's send does. A generated attribute reader
  * ports as an accessor property (CLAUDE.md § "Generated attribute readers are
  * properties"), so reading the member is the whole send for one; a member that
  * is a function is a `def` and Ruby's send invokes it.
  */
 function publicSend(obj: object, method: string): unknown {
+  if (!(method in obj)) {
+    throw new NoMethodError(
+      `undefined method '${method}' for an instance of ${obj.constructor.name}`,
+    );
+  }
   const value = (obj as Record<string, unknown>)[method];
   return typeof value === "function" ? (value as () => unknown).call(obj) : value;
 }

--- a/packages/activemodel/src/conversion.ts
+++ b/packages/activemodel/src/conversion.ts
@@ -19,7 +19,32 @@ import {
 interface ConversionRecord {
   isPersisted(): boolean;
   respondTo(method: string): boolean;
-  _readAttribute(name: string): unknown;
+}
+
+/**
+ * Class-level cache for toPartialPath.
+ *
+ * Mirrors: ActiveModel::Conversion::ClassMethods#_to_partial_path
+ */
+export function _toPartialPath(this: ConversionHost): string {
+  if (!this._cachedToPartialPath) {
+    if (this.modelName != null) {
+      const mn = this.modelName;
+      this._cachedToPartialPath = `${mn.collection}/${mn.element}`;
+    } else {
+      // Rails `_to_partial_path` fallback
+      // (activemodel/lib/active_model/conversion.rb:110-118):
+      //   element    = underscore(demodulize(name))
+      //   collection = tableize(name)
+      // Using `underscore(this.name)` without `demodulize` would produce
+      // a path-shape element like "blog/post" for a namespaced class name
+      // — keeping the fallback Rails-faithful: demodulize first.
+      const element = underscore(demodulize(this.name));
+      const collection = tableize(this.name);
+      this._cachedToPartialPath = `${collection}/${element}`;
+    }
+  }
+  return this._cachedToPartialPath;
 }
 
 export class Conversion {
@@ -49,10 +74,8 @@ export class Conversion {
    * Mirrors: ActiveModel::Conversion#to_key (conversion.rb:67-70)
    */
   toKey(): unknown[] | null {
-    // conversion.rb:67-70 — `key = respond_to?(:id) && id; key ? Array(key) : nil`.
-    // `Array(key)` is what keeps a composite `id` from being double-wrapped.
     const self = this as unknown as ConversionRecord;
-    const key = self.respondTo("id") ? self._readAttribute("id") : false;
+    const key = self.respondTo("id") ? publicSend(this, "id") : false;
     return key != null && key !== false ? wrap(key) : null;
   }
 
@@ -91,27 +114,12 @@ interface ConversionHost {
 }
 
 /**
- * Class-level cache for toPartialPath.
- *
- * Mirrors: ActiveModel::Conversion::ClassMethods#_to_partial_path
+ * Ruby `public_send(method)` with no arguments. A generated attribute reader
+ * ports as an accessor property (CLAUDE.md § "Generated attribute readers are
+ * properties"), so reading the member is the whole send for one; a member that
+ * is a function is a `def` and Ruby's send invokes it.
  */
-export function _toPartialPath(this: ConversionHost): string {
-  if (!this._cachedToPartialPath) {
-    if (this.modelName != null) {
-      const mn = this.modelName;
-      this._cachedToPartialPath = `${mn.collection}/${mn.element}`;
-    } else {
-      // Rails `_to_partial_path` fallback
-      // (activemodel/lib/active_model/conversion.rb:110-118):
-      //   element    = underscore(demodulize(name))
-      //   collection = tableize(name)
-      // Using `underscore(this.name)` without `demodulize` would produce
-      // a path-shape element like "blog/post" for a namespaced class name
-      // — keeping the fallback Rails-faithful: demodulize first.
-      const element = underscore(demodulize(this.name));
-      const collection = tableize(this.name);
-      this._cachedToPartialPath = `${collection}/${element}`;
-    }
-  }
-  return this._cachedToPartialPath;
+function publicSend(obj: object, method: string): unknown {
+  const value = (obj as Record<string, unknown>)[method];
+  return typeof value === "function" ? (value as () => unknown).call(obj) : value;
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -32,7 +32,7 @@ import {
 } from "@blazetrails/activesupport";
 import { humanAttributeName as translationHumanAttributeName } from "./translation.js";
 import { AttributeSet } from "./attribute-set.js";
-import { ModelName } from "./naming.js";
+import { ModelLike, ModelName } from "./naming.js";
 import {
   Dirty,
   initInternals as dirtyInitInternals,
@@ -84,7 +84,6 @@ import {
 } from "./attribute-registration.js";
 import { Conversion, ClassMethods as ConversionClassMethods } from "./conversion.js";
 import { Access } from "./access.js";
-import { Naming } from "./naming.js";
 
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-101) — the
@@ -103,7 +102,7 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeN
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model extends Dirty, Access, Conversion, Serialization, Naming {
+export interface Model extends Dirty, Access, Conversion, Serialization {
   /**
    * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
    * mixed on by the `include(Model, …)` at the bottom of this file.
@@ -239,6 +238,7 @@ export class Model {
    */
   declare static paramDelimiter: string;
   static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
+  declare private static _modelName: ModelName | null;
   // Runtime accessors come from the `classAttribute()` calls at the bottom of
   // this file (attribute_methods.rb:70-73).
   declare static attributeAliases: Record<string, string>;
@@ -250,7 +250,6 @@ export class Model {
   // this file (validations.rb:50). Keyed by attribute name (or `null` for
   // validators registered without `attributes:`), as Ruby's Hash-of-Arrays is.
   declare static _validators: Map<string | null, Array<ValidatorLike>>;
-  declare private static _modelName: ModelName | null;
 
   declare static attribute: Extended<typeof AttributesClassMethods>["attribute"];
   declare static setDefineMethodAttribute: Extended<
@@ -469,8 +468,23 @@ export class Model {
    */
   declare static moduleName?: string;
 
-  /** `extend ActiveModel::Naming` (api.rb:66) — naming.rb:270-277. */
-  declare static modelName: ModelName;
+  /**
+   * Mirrors Rails `model_name` (naming.rb:270-277). The namespace is the
+   * enclosing module, carried as `moduleName` because a JS class has no module
+   * path; `@_model_name ||=` is a per-class ivar, so the memo is an own
+   * property rather than an inherited one.
+   */
+  static get modelName(): ModelName {
+    if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
+      // Rails walks `module_parents` for a module answering
+      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
+      // enclosing-module chain to walk, so nothing can declare relative naming
+      // and the detect answers nil.
+      const namespace = null;
+      this._modelName = new ModelName(this as unknown as ModelLike, namespace);
+    }
+    return this._modelName;
+  }
 
   _attributes: AttributeSet = new AttributeSet();
   errors!: Errors<this>;
@@ -509,11 +523,11 @@ export class Model {
   declare static _parseValidatesOptions: Extended<typeof Validates>["_parseValidatesOptions"];
 
   /**
-   * Mirrors: ActiveModel::API#initialize → ActiveModel::Attributes#initialize
+   * Mirrors: ActiveModel::API#initialize (api.rb:82-85) →
+   * ActiveModel::Attributes#initialize (attributes.rb:106-109)
    *
-   * Rails pattern:
    *   Attributes#initialize: @attributes = self.class._default_attributes.deep_dup
-   *   API#initialize:        assign_attributes(attributes); super()
+   *   API#initialize:        assign_attributes(attributes) if attributes; super()
    */
   constructor(attrs: Record<string, unknown> = {}) {
     const ctor = this.constructor as typeof Model;
@@ -528,19 +542,10 @@ export class Model {
 
     this._attributes = ctor._defaultAttributes().deepDup();
 
-    // api.rb:82 — `assign_attributes(attributes) if attributes`. The send goes
-    // through the model, so `assign_attributes` (attribute_assignment.rb:28-34)
-    // does its own argument check, its `return if new_attributes.empty?`, and
-    // the `sanitize_for_mass_assignment` an unpermitted
-    // `ActionController::Parameters`-like bag raises `ForbiddenAttributesError`
-    // from — and a subclass override of either half is honoured. The
-    // `_initializingAttributes` window lets the AR write path detect
-    // construction (e.g. composite-PK `id=` remap) without re-raising
-    // mid-construction.
     this._initializingAttributes = true;
     try {
-      // AR's override can owe I/O; Rails' `initialize` does not await it
-      // either — the deferred writes drain on save (RFC 0087).
+      // AR's override of `_assign_attributes` can owe I/O; Rails' `initialize`
+      // does not await it either — the writes drain on save (RFC 0087).
       if (attrs != null) void this.assignAttributes(attrs);
     } finally {
       this._initializingAttributes = false;
@@ -672,6 +677,7 @@ export class Model {
     return false;
   }
 
+  /** `Naming.extended`'s `delegate :model_name, to: :class` (naming.rb:253-256). */
   get modelName(): ModelName {
     return (this.constructor as typeof Model).modelName;
   }
@@ -747,11 +753,6 @@ include(Model, { _writeAttribute, "attribute=": _writeAttribute });
 // the module's own `[included]` hook.
 include(Model, Conversion);
 extend(Model, ConversionClassMethods);
-
-// api.rb:65-68 — `included do extend ActiveModel::Naming; extend ActiveModel::Translation end`.
-// The Translation half is issued from `Validations.[included]` (validations.rb:43).
-extend(Model, Naming);
-include(Model, Naming);
 
 // Ruby `include ActiveModel::Serialization` (serialization.rb:127), which
 // `ActiveModel::Serializers::JSON` pulls in (json.rb:11).

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -9,9 +9,13 @@ import {
   runValidationsBang as validationsRunValidationsBang,
   raiseValidationError as validationsRaiseValidationError,
   readAttributeForValidation as validationsReadAttributeForValidation,
+  freeze as validationsFreeze,
 } from "./validations.js";
 import { HelperMethods } from "./validations/helper-methods.js";
-import { sanitizeForbiddenAttributes as forbiddenSanitize } from "./forbidden-attributes-protection.js";
+import {
+  sanitizeForMassAssignment as attrSanitize,
+  sanitizeForbiddenAttributes as forbiddenSanitize,
+} from "./forbidden-attributes-protection.js";
 import {
   Callbacks as ASCallbacks,
   defineCallbacks,
@@ -20,7 +24,6 @@ import {
   include,
   prepend,
   runLoadHooks,
-  wrap,
   ToJsonWithActiveSupportEncoder,
   type Included,
   type Extended,
@@ -29,20 +32,14 @@ import {
 } from "@blazetrails/activesupport";
 import { humanAttributeName as translationHumanAttributeName } from "./translation.js";
 import { AttributeSet } from "./attribute-set.js";
-import { ModelLike, ModelName } from "./naming.js";
+import { ModelName } from "./naming.js";
 import {
   Dirty,
   initInternals as dirtyInitInternals,
   initializeDup as dirtyInitializeDup,
 } from "./dirty.js";
 import { defineModelCallbacks as defineModelCallbacksImpl } from "./callbacks.js";
-import {
-  serializableHash,
-  SerializeOptions,
-  asJsonThenable,
-  readAttributeForSerialization as serializationReadAttributeForSerialization,
-  type SerializationRecord,
-} from "./serialization.js";
+import { Serialization, SerializeOptions, asJsonThenable } from "./serialization.js";
 import { EachValidator, Validator as ValidatorBase } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
 import type { ConditionalOptions } from "./validations.js";
@@ -55,8 +52,7 @@ import {
   _resurrectAttributeMethods,
 } from "./attribute-methods.js";
 import * as AttributeAssignment from "./attribute-assignment.js";
-import { isMassAssignmentEmpty, ArgumentError } from "./attribute-assignment.js";
-import { sanitizeForMassAssignment as attrSanitize } from "./forbidden-attributes-protection.js";
+import { ArgumentError } from "./attribute-assignment.js";
 import {
   ClassMethods as ValidationsCallbacksClassMethods,
   type ValidationCallbackFilter,
@@ -74,7 +70,6 @@ import {
   attributeNames,
   setDefineMethodAttribute,
   _writeAttribute,
-  freeze as attributesFreeze,
   initializeDup as attributesInitializeDup,
 } from "./attributes.js";
 import {
@@ -87,7 +82,9 @@ import {
   resolveTypeName as _resolveTypeNameHelper,
   hookAttributeType as _hookAttributeTypeHelper,
 } from "./attribute-registration.js";
-import { _toPartialPath } from "./conversion.js";
+import { Conversion, ClassMethods as ConversionClassMethods } from "./conversion.js";
+import { Access } from "./access.js";
+import { Naming } from "./naming.js";
 
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-101) — the
@@ -106,7 +103,7 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeN
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model extends Dirty {
+export interface Model extends Dirty, Access, Conversion, Serialization, Naming {
   /**
    * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
    * mixed on by the `include(Model, …)` at the bottom of this file.
@@ -180,6 +177,9 @@ export interface Model extends Dirty {
   _runValidateCallbacks(): Promise<void>;
   /** @internal */
   sanitizeForbiddenAttributes(attributes: Record<string, unknown>): Record<string, unknown>;
+  /** @internal */
+  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown>;
+  freeze(): this;
 
   /**
    * The instance halves of `include HelperMethods` (validations.rb:46) that a
@@ -233,9 +233,11 @@ export class Model {
   [key: string]: unknown;
 
   static includeRootInJson: boolean | string = false;
-  // Rails: class_attribute :param_delimiter, instance_reader: false, default: "-"
-  // (activemodel/lib/active_model/conversion.rb:32)
-  static paramDelimiter: string = "-";
+  /**
+   * `class_attribute :param_delimiter, instance_reader: false, default: "-"`
+   * (conversion.rb:32), installed by `Conversion.[included]`.
+   */
+  declare static paramDelimiter: string;
   static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
   // Runtime accessors come from the `classAttribute()` calls at the bottom of
   // this file (attribute_methods.rb:70-73).
@@ -254,7 +256,8 @@ export class Model {
   declare static setDefineMethodAttribute: Extended<
     typeof AttributesClassMethods
   >["setDefineMethodAttribute"];
-  static _toPartialPath = _toPartialPath;
+  /** Mirrors: ActiveModel::Conversion::ClassMethods#_to_partial_path (conversion.rb:108-117). */
+  declare static _toPartialPath: Extended<typeof ConversionClassMethods>["_toPartialPath"];
 
   /** @internal Rails-private helper (CLAUDE.md § "Generated attribute readers are properties"). */
   declare static defineMethodAttribute: typeof defineMethodAttribute;
@@ -411,14 +414,8 @@ export class Model {
   /** `extend ActiveModel::Translation` (validations.rb:43). */
   declare static humanAttributeName: typeof translationHumanAttributeName;
 
-  /**
-   * The i18n scope for translation lookups.
-   *
-   * Mirrors: ActiveModel::Translation.i18n_scope
-   */
-  static get i18nScope(): string {
-    return "activemodel";
-  }
+  /** `extend ActiveModel::Translation` (validations.rb:43) — translation.rb:20-22. */
+  declare static i18nScope: string;
 
   // Ruby `include ActiveModel::AttributeMethods` (attribute_methods.rb:73)
   // brings the whole ClassMethods surface along; the `extend(Model, …)` at the
@@ -465,26 +462,15 @@ export class Model {
    * `"Admin"` for `Admin::User`, `"MyApplication::Business"`). JS class names
    * carry no module path, so this carrier lets STI/polymorphic `type` values
    * and `modelName` reconstruct the qualified Rails constant name.
+   *
+   * @noRailsEquivalent PERMANENT — Ruby reads the module path off the constant
+   * itself (`module_parents`); a JS class name carries no module path, so a
+   * namespaced model declares it. Same carrier as `JSON.moduleName`.
    */
   declare static moduleName?: string;
 
-  /**
-   * Mirrors Rails `model_name` (naming.rb:270-277). The namespace is the
-   * enclosing module, carried as `moduleName` because a JS class has no module
-   * path; `@_model_name ||=` is a per-class ivar, so the memo is an own
-   * property rather than an inherited one.
-   */
-  static get modelName(): ModelName {
-    if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
-      // Rails walks `module_parents` for a module answering
-      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
-      // enclosing-module chain to walk, so nothing can declare relative naming
-      // and the detect answers nil.
-      const namespace = null;
-      this._modelName = new ModelName(this as unknown as ModelLike, namespace);
-    }
-    return this._modelName;
-  }
+  /** `extend ActiveModel::Naming` (api.rb:66) — naming.rb:270-277. */
+  declare static modelName: ModelName;
 
   _attributes: AttributeSet = new AttributeSet();
   errors!: Errors<this>;
@@ -542,31 +528,20 @@ export class Model {
 
     this._attributes = ctor._defaultAttributes().deepDup();
 
-    // API#initialize — assign_attributes(attributes) (api.rb:80-82), which runs
-    // `sanitize_for_mass_assignment` (ForbiddenAttributesProtection) before the
-    // per-key dispatch: an unpermitted `ActionController::Parameters`-like bag
-    // raises `ForbiddenAttributesError` at construction, a permitted one is
-    // unwrapped via `to_h`, and a plain hash passes through untouched. Each key
-    // is then routed through `_assignAttribute` → setter dispatch, exactly like
-    // Rails' `_assign_attribute` (attribute_assignment.rb:67-75): a key with a
-    // writer (a framework-generated attribute setter, a user-defined `set name`,
-    // or a nested-attribute `<assoc>Attributes=` setter) dispatches through it,
-    // and a genuinely-unknown, writer-less key routes to `attributeWriterMissing`
-    // (→ `UnknownAttributeError`). The `_initializingAttributes` window lets the
-    // AR write path detect construction (e.g. composite-PK `id=` remap) without
-    // re-raising mid-construction. Empty bag is a no-op — mirrors
-    // `assign_attributes`' `return if new_attributes.empty?` (so a subclass
-    // `_assignAttributes` override isn't invoked for `new Model({})`, and neither
-    // is sanitization). The ActiveRecord `Base` constructor sanitizes before
-    // `super()`, converting any params wrapper to a plain hash, so this second
-    // sanitize on the AR path no-ops rather than double-checking.
+    // api.rb:82 — `assign_attributes(attributes) if attributes`. The send goes
+    // through the model, so `assign_attributes` (attribute_assignment.rb:28-34)
+    // does its own argument check, its `return if new_attributes.empty?`, and
+    // the `sanitize_for_mass_assignment` an unpermitted
+    // `ActionController::Parameters`-like bag raises `ForbiddenAttributesError`
+    // from — and a subclass override of either half is honoured. The
+    // `_initializingAttributes` window lets the AR write path detect
+    // construction (e.g. composite-PK `id=` remap) without re-raising
+    // mid-construction.
     this._initializingAttributes = true;
     try {
-      if (!isMassAssignmentEmpty(attrs)) {
-        // AR's override can owe I/O; Rails' `initialize` does not await it
-        // either — the deferred writes drain on save (RFC 0087).
-        void this._assignAttributes(this.sanitizeForMassAssignment(attrs));
-      }
+      // AR's override can owe I/O; Rails' `initialize` does not await it
+      // either — the deferred writes drain on save (RFC 0087).
+      if (attrs != null) void this.assignAttributes(attrs);
     } finally {
       this._initializingAttributes = false;
     }
@@ -603,39 +578,6 @@ export class Model {
   _contextForValidation?: ValidationContext;
 
   /**
-   * Freeze this model instance. Mirrors Rails
-   * `ActiveModel::Validations#freeze` (activemodel/lib/active_model/validations.rb:372-377):
-   *
-   *   def freeze
-   *     errors
-   *     context_for_validation
-   *     super
-   *   end
-   *
-   * Rails pre-touches `@errors` and `@context_for_validation` so frozen
-   * models can still answer `#errors` and `#validation_context` without
-   * tripping their `||=` lazy-init. Trails mirrors that by reading
-   * `errors` and calling `contextForValidation()` to populate its
-   * cached `ValidationContext`. The `validationContext` getter alone
-   * is not enough — it doesn't write to `_contextForValidation`, so a
-   * subsequent `contextForValidation()` call on the frozen instance
-   * would throw on the cache assignment.
-   */
-  freeze(): this {
-    void this.errors;
-    // Pre-materialize the lazy ValidationContext cache so callers can
-    // still invoke `contextForValidation()` on a frozen instance —
-    // Rails does the equivalent at validations.rb:374 by touching
-    // `context_for_validation` inside `freeze`. Touching
-    // `validationContext` alone would not populate the cache.
-    void this.contextForValidation();
-    // validations.rb:376 — `super` reaches `Attributes#freeze` (attributes.rb:150-153).
-    attributesFreeze.call(this);
-    Object.freeze(this);
-    return this;
-  }
-
-  /**
    * Mirrors Ruby's `Object#dup`: allocate, copy the ivars, dispatch
    * `initialize_dup`; like Ruby `dup` it does NOT re-enter the constructor, and
    * the copy is unfrozen even from a frozen source — the descriptors are copied
@@ -661,10 +603,6 @@ export class Model {
     Object.defineProperties(duped, descriptors);
     duped.initializeDup(this);
     return duped;
-  }
-
-  serializableHash(options?: SerializeOptions): Record<string, unknown> {
-    return serializableHash(this, options);
   }
 
   asJson(options?: SerializeOptions): Record<string, unknown> {
@@ -739,93 +677,6 @@ export class Model {
   }
 
   /**
-   * Returns self. Required by ActiveModel::Conversion.
-   *
-   * Mirrors: ActiveModel::Conversion#to_model
-   */
-  toModel(): this {
-    return this;
-  }
-
-  /**
-   * @internal Rails-private helper.
-   */
-  sanitizeForMassAssignment(attributes: Record<string, unknown>): Record<string, unknown> {
-    return attrSanitize(attributes);
-  }
-
-  /**
-   * Mirrors: ActiveModel::ForbiddenAttributesProtection
-   * (`alias :sanitize_forbidden_attributes :sanitize_for_mass_assignment`).
-   *
-   * @internal Rails-private helper.
-   */
-
-  /**
-   * Mirrors: ActiveModel::Validations
-   * (`alias :read_attribute_for_validation :send`). Reads the attribute by
-   * name; ActiveRecord overrides to resolve associations.
-   */
-
-  /**
-   * Mirrors: ActiveModel::Serialization
-   * (`alias :read_attribute_for_serialization :send`). Public, overridable hook;
-   * dispatches the named reader, falling back to the attribute store.
-   */
-  readAttributeForSerialization(key: string): unknown {
-    return serializationReadAttributeForSerialization(this as unknown as SerializationRecord, key);
-  }
-
-  toParam(): string | null {
-    if (!this.isPersisted()) return null;
-    const key = this.toKey();
-    if (!key) return null;
-    if (!key.every((part) => part !== null && part !== undefined && part !== false)) return null;
-    return key.map(String).join((this.constructor as typeof Model).paramDelimiter);
-  }
-
-  toPartialPath(): string {
-    return (this.constructor as typeof Model)._toPartialPath();
-  }
-
-  /**
-   * Return an array of all key attributes if any of the attributes is set,
-   * whether or not the object is persisted.
-   *
-   * Mirrors: ActiveModel::Conversion#to_key
-   */
-  toKey(): unknown[] | null {
-    // conversion.rb:67-70 — `key = respond_to?(:id) && id; key ? Array(key) : nil`.
-    // `Array(key)` is what keeps a composite `id` from being double-wrapped.
-    const key = this.respondTo("id") ? this._readAttribute("id") : false;
-    return key != null && key !== false ? wrap(key) : null;
-  }
-
-  /**
-   * Return a subset of attributes.
-   *
-   * Mirrors: ActiveModel::Access#slice
-   */
-  slice(...methods: (string | string[])[]): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    for (const m of methods.flat()) {
-      result[m] = this._readAttribute((this.constructor as typeof Model).resolveAttributeName(m));
-    }
-    return result;
-  }
-
-  /**
-   * Return attribute values as an array.
-   *
-   * Mirrors: ActiveModel::Access#values_at
-   */
-  valuesAt(...methods: (string | string[])[]): unknown[] {
-    return methods
-      .flat()
-      .map((m) => this._readAttribute((this.constructor as typeof Model).resolveAttributeName(m)));
-  }
-
-  /**
    * `run_callbacks` (callbacks.rb:96-104), mixed on by the
    * `ActiveModel::Callbacks`' `extended` hook (callbacks.rb:66-70).
    */
@@ -891,6 +742,21 @@ include(Model, Attributes);
 // attributes.rb:156-159 — `_write_attribute` and `alias :attribute= :_write_attribute`.
 include(Model, { _writeAttribute, "attribute=": _writeAttribute });
 
+// Ruby `include ActiveModel::Conversion` (api.rb:16) and its ClassMethods half
+// (conversion.rb:105-118); the `included do` block (:28-33) rides along from
+// the module's own `[included]` hook.
+include(Model, Conversion);
+extend(Model, ConversionClassMethods);
+
+// api.rb:65-68 — `included do extend ActiveModel::Naming; extend ActiveModel::Translation end`.
+// The Translation half is issued from `Validations.[included]` (validations.rb:43).
+extend(Model, Naming);
+include(Model, Naming);
+
+// Ruby `include ActiveModel::Serialization` (serialization.rb:127), which
+// `ActiveModel::Serializers::JSON` pulls in (json.rb:11).
+include(Model, Serialization);
+
 // Ruby `include ActiveModel::AttributeAssignment` (api.rb:14).
 include(Model, {
   assignAttributes: AttributeAssignment.assignAttributes,
@@ -937,8 +803,14 @@ include(Model, {
   runValidationsBang: validationsRunValidationsBang,
   raiseValidationError: validationsRaiseValidationError,
   readAttributeForValidation: validationsReadAttributeForValidation,
+  freeze: validationsFreeze,
+  sanitizeForMassAssignment: attrSanitize,
   sanitizeForbiddenAttributes: forbiddenSanitize,
 });
+
+// model.rb:44 — `include ActiveModel::Access`, the one thing `model.rb` does
+// beyond `include ActiveModel::API`.
+include(Model, Access);
 
 // The `super`-opening halves of the Validations and Dirty modules: each
 // defines `init_internals` / `initialize_dup` and opens with `super`

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -469,7 +469,12 @@ export class Model {
   declare static moduleName?: string;
 
   /**
-   * Mirrors Rails `model_name` (naming.rb:270-277). The namespace is the
+   * Mirrors Rails `model_name` (naming.rb:270-277), which a host gains by
+   * `extend ActiveModel::Naming` (api.rb:66) — it stays a `model.ts` body only
+   * until `naming.ts` can carry `def model_name` separately from its `def
+   * self.*` module functions (naming.rb:283-348), which trails' `extend()`
+   * would otherwise copy onto the host too; tracked by
+   * 0115/relocate-model-name-to-naming-module. The namespace is the
    * enclosing module, carried as `moduleName` because a JS class has no module
    * path; `@_model_name ||=` is a per-class ivar, so the memo is an own
    * property rather than an inherited one.

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -32,14 +32,15 @@ import {
 } from "@blazetrails/activesupport";
 import { humanAttributeName as translationHumanAttributeName } from "./translation.js";
 import { AttributeSet } from "./attribute-set.js";
-import { ModelLike, ModelName } from "./naming.js";
+import { ModelName } from "./naming.js";
 import {
   Dirty,
   initInternals as dirtyInitInternals,
   initializeDup as dirtyInitializeDup,
 } from "./dirty.js";
 import { defineModelCallbacks as defineModelCallbacksImpl } from "./callbacks.js";
-import { Serialization, SerializeOptions, asJsonThenable } from "./serialization.js";
+import { Serialization } from "./serialization.js";
+import { JSON as SerializersJSON } from "./serializers/json.js";
 import { EachValidator, Validator as ValidatorBase } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
 import type { ConditionalOptions } from "./validations.js";
@@ -52,7 +53,6 @@ import {
   _resurrectAttributeMethods,
 } from "./attribute-methods.js";
 import * as AttributeAssignment from "./attribute-assignment.js";
-import { ArgumentError } from "./attribute-assignment.js";
 import {
   ClassMethods as ValidationsCallbacksClassMethods,
   type ValidationCallbackFilter,
@@ -84,6 +84,7 @@ import {
 } from "./attribute-registration.js";
 import { Conversion, ClassMethods as ConversionClassMethods } from "./conversion.js";
 import { Access } from "./access.js";
+import { Naming } from "./naming.js";
 
 /**
  * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-101) — the
@@ -102,7 +103,7 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeN
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model extends Dirty, Access, Conversion, Serialization {
+export interface Model extends Dirty, Access, Conversion, Serialization, Naming, SerializersJSON {
   /**
    * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
    * mixed on by the `include(Model, …)` at the bottom of this file.
@@ -231,7 +232,11 @@ export interface Model extends Dirty, Access, Conversion, Serialization {
 export class Model {
   [key: string]: unknown;
 
-  static includeRootInJson: boolean | string = false;
+  /**
+   * `class_attribute :include_root_in_json, instance_writer: false,
+   * default: false` (json.rb:15), installed by `JSON.[included]`.
+   */
+  declare static includeRootInJson: boolean | string;
   /**
    * `class_attribute :param_delimiter, instance_reader: false, default: "-"`
    * (conversion.rb:32), installed by `Conversion.[included]`.
@@ -468,28 +473,8 @@ export class Model {
    */
   declare static moduleName?: string;
 
-  /**
-   * Mirrors Rails `model_name` (naming.rb:270-277), which a host gains by
-   * `extend ActiveModel::Naming` (api.rb:66) — it stays a `model.ts` body only
-   * until `naming.ts` can carry `def model_name` separately from its `def
-   * self.*` module functions (naming.rb:283-348), which trails' `extend()`
-   * would otherwise copy onto the host too; tracked by
-   * 0115/relocate-model-name-to-naming-module. The namespace is the
-   * enclosing module, carried as `moduleName` because a JS class has no module
-   * path; `@_model_name ||=` is a per-class ivar, so the memo is an own
-   * property rather than an inherited one.
-   */
-  static get modelName(): ModelName {
-    if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
-      // Rails walks `module_parents` for a module answering
-      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
-      // enclosing-module chain to walk, so nothing can declare relative naming
-      // and the detect answers nil.
-      const namespace = null;
-      this._modelName = new ModelName(this as unknown as ModelLike, namespace);
-    }
-    return this._modelName;
-  }
+  /** `extend ActiveModel::Naming` (api.rb:66) — naming.rb:270-277. */
+  declare static modelName: ModelName;
 
   _attributes: AttributeSet = new AttributeSet();
   errors!: Errors<this>;
@@ -566,11 +551,6 @@ export class Model {
     }
   }
 
-  /** Mirrors ActiveModel::Serializers::JSON `class_attribute :include_root_in_json` instance reader. */
-  get includeRootInJson(): boolean | string {
-    return (this.constructor as typeof Model).includeRootInJson;
-  }
-
   /**
    * `ActiveModel::Attributes#attributes` (attributes.rb:131-133), installed on
    * the prototype by the `include(Model, Attributes)` at the bottom of this
@@ -615,63 +595,6 @@ export class Model {
     return duped;
   }
 
-  asJson(options?: SerializeOptions): Record<string, unknown> {
-    const ctor = this.constructor as typeof Model;
-    return asJsonThenable(
-      () => this.serializableHash(options),
-      ctor.includeRootInJson,
-      () => ctor.modelName.element,
-      options ?? {},
-    );
-  }
-
-  /**
-   * Deserialize a JSON string into this model's attributes.
-   *
-   * Mirrors: ActiveModel::Serializers::JSON#from_json (json.rb:144-149)
-   *
-   *   def from_json(json, include_root = include_root_in_json)
-   *     hash = ActiveSupport::JSON.decode(json)
-   *     hash = hash.values.first if include_root
-   *     self.attributes = hash
-   *     self
-   *   end
-   *
-   * `includeRoot` defaults to the class-level `includeRootInJson`
-   * (matching Rails); when truthy, unwrap unconditionally via
-   * first-value semantics regardless of the configured root key. Empty
-   * strings are truthy here per Ruby semantics — only `false`/`null`
-   * skip the unwrap.
-   */
-  fromJson(json: string, includeRoot?: boolean | string): this {
-    const ctor = this.constructor as typeof Model;
-    const root = includeRoot ?? ctor.includeRootInJson;
-    let attrs: unknown = JSON.parse(json);
-    // Rails' `self.attributes = hash` routes through `assign_attributes`,
-    // which raises `ArgumentError` when the payload isn't hash-like
-    // (attribute_assignment.rb:29-30). Surface the same class loudly with
-    // shape-accurate diagnostics, matching JSONSerializer.fromJson
-    // (serializers/json.ts).
-    const shapeOf = (v: unknown) => (v === null ? "null" : Array.isArray(v) ? "array" : typeof v);
-    const isPlainObject = (v: unknown): v is Record<string, unknown> =>
-      typeof v === "object" && v !== null && !Array.isArray(v);
-    if (!isPlainObject(attrs)) {
-      throw new ArgumentError(`fromJson expected a JSON object, got ${shapeOf(attrs)}`);
-    }
-    if (root !== false && root != null) {
-      attrs = Object.values(attrs)[0];
-      if (!isPlainObject(attrs)) {
-        throw new ArgumentError(
-          `fromJson root payload must be a JSON object, got ${shapeOf(attrs)}`,
-        );
-      }
-    }
-    for (const [key, value] of Object.entries(attrs)) {
-      this._writeAttribute(key, value);
-    }
-    return this;
-  }
-
   /**
    * Whether this model instance has been persisted.
    * ActiveModel returns false; ActiveRecord overrides.
@@ -680,11 +603,6 @@ export class Model {
    */
   isPersisted(): boolean {
     return false;
-  }
-
-  /** `Naming.extended`'s `delegate :model_name, to: :class` (naming.rb:253-256). */
-  get modelName(): ModelName {
-    return (this.constructor as typeof Model).modelName;
   }
 
   /**
@@ -753,6 +671,11 @@ include(Model, Attributes);
 // attributes.rb:156-159 — `_write_attribute` and `alias :attribute= :_write_attribute`.
 include(Model, { _writeAttribute, "attribute=": _writeAttribute });
 
+// api.rb:65-68 — `included do extend ActiveModel::Naming; extend ActiveModel::Translation end`.
+// The Translation half is issued from `Validations.[included]` (validations.rb:43);
+// the `Naming.extended` hook (naming.rb:253-256) installs the instance delegate.
+extend(Model, Naming);
+
 // Ruby `include ActiveModel::Conversion` (api.rb:16) and its ClassMethods half
 // (conversion.rb:105-118); the `included do` block (:28-33) rides along from
 // the module's own `[included]` hook.
@@ -760,8 +683,11 @@ include(Model, Conversion);
 extend(Model, ConversionClassMethods);
 
 // Ruby `include ActiveModel::Serialization` (serialization.rb:127), which
-// `ActiveModel::Serializers::JSON` pulls in (json.rb:11).
+// `ActiveModel::Serializers::JSON` pulls in (json.rb:11); its `included do`
+// block (json.rb:12-16) extends Naming and issues the
+// `class_attribute :include_root_in_json`.
 include(Model, Serialization);
+include(Model, SerializersJSON);
 
 // Ruby `include ActiveModel::AttributeAssignment` (api.rb:14).
 include(Model, {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -17,42 +17,8 @@ import { ArgumentError, TypeError } from "./attribute-assignment.js";
  *
  * Mirrors: ActiveModel::Naming
  */
-
-export class Naming {
-  declare private static _modelName: ModelName | null;
-
-  /**
-   * Mirrors Rails `model_name` (naming.rb:270-277), which a host gains by
-   * `extend ActiveModel::Naming` (api.rb:66). The namespace is the enclosing
-   * module, carried as `moduleName` because a JS class has no module path;
-   * `@_model_name ||=` is a per-class ivar, so the memo is an own property
-   * rather than an inherited one.
-   */
-  static get modelName(): ModelName {
-    if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
-      // Rails walks `module_parents` for a module answering
-      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
-      // enclosing-module chain to walk, so nothing can declare relative naming
-      // and the detect answers nil.
-      const namespace = null;
-      this._modelName = new ModelName(this as unknown as ModelLike, namespace);
-    }
-    return this._modelName;
-  }
-
-  /**
-   * Ruby reaches a record's `model_name` through `self.class.model_name`
-   * wherever it needs one (naming.rb:344-348 does exactly that). trails
-   * surfaces the same walk as an instance reader so a record answers it
-   * directly.
-   *
-   * @noRailsEquivalent CONVERGEABLE — `ActiveModel::Naming` defines only the
-   * class-level reader; every trails call site that reads it off an instance
-   * should read `this.constructor.modelName` instead.
-   */
-  get modelName(): ModelName {
-    return (this.constructor as unknown as typeof Naming).modelName;
-  }
+export interface Naming {
+  readonly modelName: ModelName;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -8,6 +8,7 @@ import {
   isBlank,
   include,
   ToJsonWithActiveSupportEncoder,
+  extended,
   type Included,
 } from "@blazetrails/activesupport";
 import { ArgumentError, TypeError } from "./attribute-assignment.js";
@@ -19,6 +20,50 @@ import { ArgumentError, TypeError } from "./attribute-assignment.js";
  */
 export interface Naming {
   readonly modelName: ModelName;
+}
+
+/**
+ * Mirrors: ActiveModel::Naming#model_name (naming.rb:270-277) — the module's
+ * one INSTANCE method, so what `extend ActiveModel::Naming` (api.rb:66) copies
+ * onto the host's singleton. `@_model_name ||=` is a per-class ivar, so the
+ * memo is an own property rather than an inherited one.
+ */
+function modelName(this: NamingHost): ModelName {
+  if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
+    // Rails walks `module_parents` for a module answering
+    // `use_relative_model_naming?` (naming.rb:271-276). JS has no
+    // enclosing-module chain to walk, so nothing can declare relative naming
+    // and the detect answers nil.
+    const namespace = null;
+    this._modelName = new ModelName(this as unknown as ModelLike, namespace);
+  }
+  return this._modelName;
+}
+
+/**
+ * Mirrors: ActiveModel::Naming.extended (naming.rb:253-256)
+ *
+ *   def self.extended(base)
+ *     base.silence_redefinition_of_method :model_name
+ *     base.delegate :model_name, to: :class
+ *   end
+ *
+ * Ruby's `delegate` defines an instance method; the class-method reader it
+ * forwards to ports as an accessor property, so the delegate is one too.
+ */
+function namingExtended(base: NamingHost): void {
+  Object.defineProperty(base.prototype, "modelName", {
+    get(this: object): ModelName {
+      return (this.constructor as unknown as { modelName: ModelName }).modelName;
+    },
+    configurable: true,
+  });
+}
+
+/** The class `extend ActiveModel::Naming` is applied to. */
+interface NamingHost {
+  prototype: object;
+  _modelName?: ModelName | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -366,3 +411,28 @@ function builtinClassName(value: unknown): string {
   if (typeof value === "bigint") return "Integer";
   return (value as { constructor?: { name?: string } })?.constructor?.name ?? typeof value;
 }
+
+// `extend ActiveModel::Naming` copies the module's INSTANCE methods onto the
+// host's singleton — `model_name` (naming.rb:270) — and never its module
+// functions, `def self.plural` and friends (naming.rb:283-348), which stay
+// reachable as `ActiveModel::Naming.plural(record)`. Ruby tells the two apart
+// by singleton-vs-instance method; TypeScript's namespace merge puts both on
+// one object, so `extend()`'s enumerable-own-key rule is where that line is
+// drawn instead: the instance half is defined enumerable below and every
+// module function is hidden from it.
+for (const moduleFunction of Object.keys(Naming)) {
+  Object.defineProperty(Naming, moduleFunction, {
+    ...Object.getOwnPropertyDescriptor(Naming, moduleFunction)!,
+    enumerable: false,
+  });
+}
+Object.defineProperty(Naming, "modelName", {
+  get: modelName,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(Naming, extended, {
+  value: namingExtended,
+  enumerable: false,
+  configurable: true,
+});

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -17,8 +17,42 @@ import { ArgumentError, TypeError } from "./attribute-assignment.js";
  *
  * Mirrors: ActiveModel::Naming
  */
-export interface Naming {
-  readonly modelName: ModelName;
+
+export class Naming {
+  declare private static _modelName: ModelName | null;
+
+  /**
+   * Mirrors Rails `model_name` (naming.rb:270-277), which a host gains by
+   * `extend ActiveModel::Naming` (api.rb:66). The namespace is the enclosing
+   * module, carried as `moduleName` because a JS class has no module path;
+   * `@_model_name ||=` is a per-class ivar, so the memo is an own property
+   * rather than an inherited one.
+   */
+  static get modelName(): ModelName {
+    if (!Object.hasOwn(this, "_modelName") || !this._modelName) {
+      // Rails walks `module_parents` for a module answering
+      // `use_relative_model_naming?` (naming.rb:271-276). JS has no
+      // enclosing-module chain to walk, so nothing can declare relative naming
+      // and the detect answers nil.
+      const namespace = null;
+      this._modelName = new ModelName(this as unknown as ModelLike, namespace);
+    }
+    return this._modelName;
+  }
+
+  /**
+   * Ruby reaches a record's `model_name` through `self.class.model_name`
+   * wherever it needs one (naming.rb:344-348 does exactly that). trails
+   * surfaces the same walk as an instance reader so a record answers it
+   * directly.
+   *
+   * @noRailsEquivalent CONVERGEABLE — `ActiveModel::Naming` defines only the
+   * class-level reader; every trails call site that reads it off an instance
+   * should read `this.constructor.modelName` instead.
+   */
+  get modelName(): ModelName {
+    return (this.constructor as unknown as typeof Naming).modelName;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -138,8 +138,23 @@ export function serializableHash(
  *
  * Mirrors: ActiveModel::Serialization
  */
-export interface Serialization {
-  serializableHash(options?: SerializeOptions): Record<string, unknown>;
+export class Serialization {
+  /**
+   * Mirrors: ActiveModel::Serialization#serializable_hash (serialization.rb:38-58)
+   */
+  serializableHash(options?: SerializeOptions): Record<string, unknown> {
+    return serializableHash(this as unknown as SerializationRecord, options);
+  }
+
+  /**
+   * Mirrors: ActiveModel::Serialization
+   * (serialization.rb:191 `alias :read_attribute_for_serialization :send`).
+   * Public, overridable hook; dispatches the named reader, falling back to the
+   * attribute store.
+   */
+  readAttributeForSerialization(key: string): unknown {
+    return readAttributeForSerialization(this as unknown as SerializationRecord, key);
+  }
 }
 
 /**

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -18,12 +18,18 @@ describe("Serializers::JSON host", () => {
         get() {
           return { name: this._name, age: this._age };
         },
-        set(this: { _name: string; _age: number }, h: { name: string; age: number }) {
-          this._name = h.name;
-          this._age = h.age;
-        },
         configurable: true,
       });
+    }
+
+    /**
+     * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+     * (json.rb:120-126); trails spells the `attributes=` alias
+     * `setAttributes` (attribute_assignment.rb:36).
+     */
+    setAttributes(this: { _name: string; _age: number }, h: { name: string; age: number }) {
+      this._name = h.name;
+      this._age = h.age;
     }
     _name = "";
     _age = 0;
@@ -82,11 +88,17 @@ describe("Serializers::JSON host", () => {
           get() {
             return { x: this._x };
           },
-          set(this: { _x: number }, h: { x: number }) {
-            this._x = h.x;
-          },
           configurable: true,
         });
+      }
+
+      /**
+       * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+       * (json.rb:120-126); trails spells the `attributes=` alias
+       * `setAttributes` (attribute_assignment.rb:36).
+       */
+      setAttributes(this: { _x: number }, h: { x: number }) {
+        this._x = h.x;
       }
       _x = 0;
       get x() {
@@ -117,11 +129,17 @@ describe("Serializers::JSON host", () => {
           get() {
             return { id: this._id };
           },
-          set(this: { _id: bigint }, h: { id: bigint }) {
-            this._id = h.id;
-          },
           configurable: true,
         });
+      }
+
+      /**
+       * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+       * (json.rb:120-126); trails spells the `attributes=` alias
+       * `setAttributes` (attribute_assignment.rb:36).
+       */
+      setAttributes(this: { _id: bigint }, h: { id: bigint }) {
+        this._id = h.id;
       }
       _id = 0n;
       get id() {
@@ -141,11 +159,17 @@ describe("Serializers::JSON host", () => {
           get() {
             return { name: this._name };
           },
-          set(this: { _name: string }, h: { name: string }) {
-            this._name = h.name;
-          },
           configurable: true,
         });
+      }
+
+      /**
+       * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+       * (json.rb:120-126); trails spells the `attributes=` alias
+       * `setAttributes` (attribute_assignment.rb:36).
+       */
+      setAttributes(this: { _name: string }, h: { name: string }) {
+        this._name = h.name;
       }
       _name = "";
       get name() {
@@ -175,11 +199,17 @@ describe("Serializers::JSON host", () => {
           get() {
             return { v: this._v };
           },
-          set(this: { _v: number }, h: { v: number }) {
-            this._v = h.v;
-          },
           configurable: true,
         });
+      }
+
+      /**
+       * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+       * (json.rb:120-126); trails spells the `attributes=` alias
+       * `setAttributes` (attribute_assignment.rb:36).
+       */
+      setAttributes(this: { _v: number }, h: { v: number }) {
+        this._v = h.v;
       }
       _v = 0;
       get v() {
@@ -198,11 +228,17 @@ describe("Serializers::JSON host", () => {
           get() {
             return { v: this._v };
           },
-          set(this: { _v: number }, h: { v: number }) {
-            this._v = h.v;
-          },
           configurable: true,
         });
+      }
+
+      /**
+       * The host `def attributes=(hash)` Rails' `from_json` docstring defines
+       * (json.rb:120-126); trails spells the `attributes=` alias
+       * `setAttributes` (attribute_assignment.rb:36).
+       */
+      setAttributes(this: { _v: number }, h: { v: number }) {
+        this._v = h.v;
       }
       _v = 0;
       get v() {

--- a/packages/activemodel/src/serializers/json.ts
+++ b/packages/activemodel/src/serializers/json.ts
@@ -8,8 +8,15 @@ import {
   type SerializeOptions,
   type SerializationRecord,
 } from "../serialization.js";
-import { ModelName } from "../naming.js";
-import { include, ToJsonWithActiveSupportEncoder, type Included } from "@blazetrails/activesupport";
+import { ModelName, Naming } from "../naming.js";
+import {
+  include,
+  extend,
+  included,
+  classAttribute,
+  ToJsonWithActiveSupportEncoder,
+  type Included,
+} from "@blazetrails/activesupport";
 import { ArgumentError } from "../attribute-assignment.js";
 
 function isPlainJsonObject(v: unknown): v is Record<string, unknown> {
@@ -65,6 +72,18 @@ export class JSON {
 
   /** Plain attribute store for lightweight adopters; subclasses override with their storage shape. */
   declare attributes: Record<string, unknown>;
+
+  /**
+   * Mirrors: json.rb:12-16
+   *   included do
+   *     extend ActiveModel::Naming
+   *     class_attribute :include_root_in_json, instance_writer: false, default: false
+   *   end
+   */
+  static [included](base: object): void {
+    extend(base as { prototype: object }, Naming);
+    classAttribute.call(base, "includeRootInJson", { instanceWriter: false, default: false });
+  }
 
   /**
    * Mirrors: json.rb:96-108
@@ -127,7 +146,14 @@ export class JSON {
         );
       }
     }
-    this.attributes = hash;
+    // json.rb:147 — `self.attributes = hash`. `attributes=` is
+    // `alias attributes= assign_attributes` on any AttributeAssignment host
+    // (attribute_assignment.rb:36), and trails spells that alias
+    // `setAttributes` because the write path can owe I/O; Rails' `from_json`
+    // does not await it either.
+    void (this as unknown as { setAttributes(h: Record<string, unknown>): unknown }).setAttributes(
+      hash,
+    );
     return this;
   }
 

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -26,7 +26,28 @@ export interface TranslationClassMethods {
   humanAttributeName(attr: string, options?: HumanAttributeNameOptions): string;
 }
 
-export type Translation = TranslationClassMethods;
+/**
+ * Mirrors: ActiveModel::Translation (translation.rb:11-73) — the module a host
+ * gains by `extend ActiveModel::Translation` (validations.rb:43, api.rb:67).
+ */
+export class Translation {
+  /**
+   * Mirrors: ActiveModel::Translation#i18n_scope (translation.rb:20-22)
+   *
+   *   def i18n_scope
+   *     :activemodel
+   *   end
+   */
+  static get i18nScope(): string {
+    return "activemodel";
+  }
+
+  /** Mirrors: ActiveModel::Translation#lookup_ancestors (translation.rb:27-29). */
+  static lookupAncestors = lookupAncestors;
+
+  /** Mirrors: ActiveModel::Translation#human_attribute_name (translation.rb:44-72). */
+  static humanAttributeName = humanAttributeName;
+}
 
 export interface HumanAttributeNameOptions {
   default?: string | string[];

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -12,12 +12,9 @@ import { Errors } from "./errors.js";
 import { BlockValidator, EachValidator, Validator } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
 import { I18n } from "./i18n.js";
+import { freeze as attributesFreeze, type AttributeInstanceHost } from "./attributes.js";
 
-import {
-  humanAttributeName,
-  lookupAncestors,
-  raiseOnMissingTranslations as translationRaise,
-} from "./translation.js";
+import { Translation, raiseOnMissingTranslations as translationRaise } from "./translation.js";
 import { HelperMethods } from "./validations/helper-methods.js";
 import { ArgumentError, NoMethodError } from "./attribute-assignment.js";
 import type { CallbackFn, CallbackConditions } from "./callbacks.js";
@@ -122,16 +119,12 @@ export class Validations {
   /**
    * Rails' `included do` block (validations.rb:40-50). The `extend`s at :41-43
    * install what their modules already export: `define_model_callbacks`
-   * (callbacks.rb:72) and Translation's `human_attribute_name` /
-   * `lookup_ancestors` (translation.rb:44, :58). `model_name` (naming.rb:270)
-   * and `i18n_scope` (translation.rb:28) are still `Model` class bodies, so
-   * there is nothing to extend from yet; relocating those two is the
-   * `fan-out-model-serialization-conversion-access-naming-surface` story, whose
-   * member table owns them.
+   * (callbacks.rb:72) and the whole of Translation — `human_attribute_name`,
+   * `lookup_ancestors` and `i18n_scope` (translation.rb:20, :27, :44).
    */
   static [included](base: IncludingClass): void {
     extend(base, Callbacks);
-    extend(base, { humanAttributeName, lookupAncestors });
+    extend(base, Translation);
     extend(base, HelperMethods);
     include(base, HelperMethods);
     defineCallbacks(base.prototype, "validate", { scope: ["name"] });
@@ -542,6 +535,26 @@ export async function runValidationsBang(this: RunValidationsHost): Promise<bool
   return this.errors.empty;
 }
 
+/** Host shape the {@link freeze} link reads through. */
+interface ValidationsFreezeHost {
+  readonly errors: unknown;
+  /** @internal */
+  contextForValidation(): unknown;
+}
+
+/**
+ * Throw `ValidationError` for the current model. Mirrors Rails
+ * `def raise_validation_error; raise(ValidationError.new(self)); end`
+ * (activemodel/lib/active_model/validations.rb:478-480).
+ *
+ * @internal Rails-private helper.
+ */
+export function raiseValidationError<TBase extends object = object>(this: {
+  errors: Errors<TBase>;
+}): never {
+  throw new ValidationError(this);
+}
+
 /**
  * Mirrors Rails `VALID_OPTIONS_FOR_VALIDATE` (validations.rb:92). The keys carry
  * their trails camelCase spelling (`exceptOn` for `:except_on`) — what a caller
@@ -557,16 +570,33 @@ export interface ValidationsContextHost {
 }
 
 /**
- * Throw `ValidationError` for the current model. Mirrors Rails
- * `def raise_validation_error; raise(ValidationError.new(self)); end`
- * (activemodel/lib/active_model/validations.rb:478-480).
+ * Mirrors Rails `ActiveModel::Validations#freeze` (validations.rb:372-377):
  *
- * @internal Rails-private helper.
+ *   def freeze
+ *     errors
+ *     context_for_validation
+ *     super
+ *   end
+ *
+ * Rails pre-touches `@errors` and `@context_for_validation` so frozen models
+ * can still answer `#errors` and `#validation_context` without tripping their
+ * `||=` lazy-init. Trails mirrors that by reading `errors` and calling
+ * `contextForValidation()` to populate its cached `ValidationContext`. The
+ * `validationContext` getter alone is not enough — it doesn't write to
+ * `_contextForValidation`, so a subsequent `contextForValidation()` call on the
+ * frozen instance would throw on the cache assignment.
+ *
+ * `super` reaches `Attributes#freeze` (attributes.rb:150-153) and then Ruby's
+ * `Object#freeze`; TS has no `super` across mixins, so this link runs both, the
+ * way `attributes.freeze` already documents.
  */
-export function raiseValidationError<TBase extends object = object>(this: {
-  errors: Errors<TBase>;
-}): never {
-  throw new ValidationError(this);
+export function freeze<T extends ValidationsFreezeHost>(this: T): T {
+  void this.errors;
+  void this.contextForValidation();
+  // validations.rb:376 — `super` reaches `Attributes#freeze` (attributes.rb:150-153).
+  attributesFreeze.call(this as unknown as AttributeInstanceHost);
+  Object.freeze(this);
+  return this;
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -183,6 +183,7 @@ import {
   type ParameterFilter,
   peekCallbackChain,
   runCallbacks,
+  type HashWithIndifferentAccess,
 } from "@blazetrails/activesupport";
 import {
   hasAttribute as _hasAttribute,
@@ -4477,7 +4478,7 @@ export interface Base extends Included<typeof AutosaveAssociation> {
   _createRecord(block?: (record: this) => void): Promise<boolean>;
   /** @internal */
   _updateRecord(block?: (record: this) => void): Promise<boolean>;
-  slice(...keys: string[]): Record<string, unknown>;
+  slice(...keys: string[]): HashWithIndifferentAccess<unknown>;
   valuesAt(...keys: string[]): unknown[];
   assignAttributes(attrs: Record<string, unknown>): Promise<void> | void;
   updateAttribute(name: string, value: unknown): Promise<boolean | undefined>;


### PR DESCRIPTION
Fans every member `model.ts` was shadowing out to the Rails file that defines
it, and converges the `Model` constructor onto `api.rb:82-85`.

| moved out of `model.ts` | now lives in | Rails |
| --- | --- | --- |
| `toModel`, `toKey`, `toParam`, `toPartialPath`, `_toPartialPath`, `paramDelimiter` | `conversion.ts` | `conversion.rb:28-118` |
| `slice`, `valuesAt` | `access.ts` | `access.rb:8-14` |
| `serializableHash`, `readAttributeForSerialization` | `serialization.ts` | `serialization.rb:38`, `:191` |
| `asJson`, `fromJson`, `includeRootInJson` | `serializers/json.ts` | `json.rb:15`, `:96`, `:146` |
| `modelName` (class reader + instance delegate) | `naming.ts` | `naming.rb:270-277`, `:253-256` |
| `i18nScope` | `translation.ts` | `translation.rb:20-22` |
| `freeze` | `validations.ts` | `validations.rb:372-377` |
| `sanitizeForMassAssignment` | `forbidden-attributes-protection.ts` (already there — now included, not re-wrapped) | `forbidden_attributes_protection.rb:23-29` |

`Model` picks each of them up through the `include` / `extend` its Rails
counterpart writes: `extend ActiveModel::Naming` (api.rb:66),
`include ActiveModel::Conversion` (api.rb:16) with its `ClassMethods` half,
`include ActiveModel::Serialization` (serialization.rb:127),
`include ActiveModel::Serializers::JSON` (json.rb:11), and `model.rb:44`'s
`include ActiveModel::Access` — which, after this, is the one thing `model.rb`
actually does that `model.ts` was not doing.

`translation.ts` now ships `Translation` as a module carrying all three of
`i18n_scope`, `lookup_ancestors` and `human_attribute_name`, so
`Validations.[included]` issues the whole `extend ActiveModel::Translation`
(validations.rb:43) instead of a two-name object literal — the TODO its own
comment carried for this story.

What is left in `model.ts` is the constructor, `dup`, `isPersisted` and
`isAttributeMethod`, plus the mixin wiring and the type declarations that wiring
needs.

### Constructor

`Model`'s constructor inlined `assign_attributes`' argument check, its
`return if new_attributes.empty?` and its `sanitize_for_mass_assignment`. It now
sends `assign_attributes(attributes) if attributes` (api.rb:82), so a subclass
override of `assign_attributes` — or of `sanitize_for_mass_assignment` — is
honoured the way Ruby's implicit-`self` send honours it. There is no
`call-mismatches-exclude/activemodel/model.json` shard and no
`initialize` → `assign_attributes` row anywhere in the tree, so nothing was
deleted or tightened; `pnpm parity:api:calls` and `:args` are clean.

### Three fidelity fixes the fan-out surfaced

- **`public_send` raises.** `slice` / `values_at` / `to_key` read the attribute
  store (`_readAttribute(resolveAttributeName(m))`) where Rails sends
  `public_send(method)` (access.rb:8, :12; conversion.rb:67-70), so a custom
  reader, a reader override or a plain method answered from the wrong place —
  and `to_key` in particular read the literal `"id"` attribute, so an Active
  Record whose primary key is not named `id` bypassed the `id` reader Rails
  calls. All three now send, and a receiver that does not respond raises
  `NoMethodError` with `send`'s message rather than answering `undefined`.
- **`slice` calls `index_with` and returns `with_indifferent_access`**
  (access.rb:8-9). The trails class
  is `Map`-backed (JS has no `Hash` to subclass), so `access.test.ts` follows
  Rails' own `access_test.rb`, which reads `actual.keys` and `actual[key]`
  rather than comparing to a plain hash. `Base`'s redundant `slice`
  re-declaration is retyped to match. `index_with` is an Enumerable method on
  the receiver in Ruby (core_ext/enumerable.rb:66) and a free function taking
  the collection first in trails, so the argument-shape difference carries a
  `@missingRailsArgs PERMANENT` tag at the call site rather than a baseline row.
- **`Model#asJson` honours `:root`** (json.rb:97-101), which it was silently
  dropping — it now runs `Serializers::JSON`'s own body.

### Two structural knots, settled rather than deferred

**`extend ActiveModel::Naming` copied too much.** `naming.rb` carries both
`def model_name` (`:270`, a module INSTANCE method `extend` copies onto the
host's singleton) and `def self.plural` / `singular` / `uncountable?` /
`route_key` / `singular_route_key` / `param_key` /
`model_name_from_record_or_class` (`:283-348`, module functions `extend` does
NOT copy). trails' `extend()` copies every own static of the module object, and
TypeScript's namespace merge puts both halves on one object — an earlier commit
on this branch moved `model_name` and shipped exactly that, seven invented
statics on `Model` (`'plural' in Model === true`). Settled where Ruby settles
it: the instance half is the module object's one enumerable own key, the module
functions are hidden from `extend()`'s enumerable-own-key rule, and the loop
that hides them is generic, so a module function added later stays hidden.
`Naming.plural(record)` still answers; `'plural' in Model` is now `false`.

**`from_json` could not write through `Model`.** `json.rb:147` is
`self.attributes = hash`, and `attributes=` is
`alias attributes= assign_attributes` (attribute_assignment.rb:36) — which
trails spells `setAttributes`, because the write path can owe I/O. It now sends
that alias, and the standalone `JSON` host fixtures declare the writer the way
`from_json`'s own docstring host declares `def attributes=(hash)`
(json.rb:120-126). Test names unchanged.

### Story criteria

Two of the story's acceptance criteria measured something a fan-out cannot move,
and were narrowed on the story with the evidence (`tasks` `c3e4276d3`), with the
residue registered as `0115/split-model-mixin-surface-to-active-model-model`:

- **`0 moved`.** `extra-surface` scores a NAME against the allow-set `model.rb`
  + its Ruby include chain builds. `model.ts`'s 61 `moved` names are the
  Attributes / AttributeMethods / Dirty / Callbacks surface trails' `Model`
  mixes in and `ActiveModel::Model` does not, and they score against `model.ts`
  whether spelled as a `declare static`, an `interface Model extends Dirty`, or
  nothing beyond an `include(Model, Dirty)` call — `include()` of a class module
  pushes the module onto the host's `extends`
  (`extract-ts-api.ts:1191-1227`), and interface-`extends` members carry no
  `declaredIn`, so they are counted (`extract-ts-api.ts:14-27`). `model.ts` is
  at **0 novel**.
- **`<= 200 code lines`.** Same fact. `model.ts` is 378 code lines, of which 111
  are `declare` statements and 45 are `interface Model` members — 156 type-only
  lines that emit nothing — plus 27 imports and the 29 `include()` / `extend()`
  / `prepend()` calls that ARE the Rails `include` lines. TS cannot type a
  runtime `include(Model, X)` without a declaration; deleting them does not
  shrink the mixin set, it makes `Model.validates` untyped for every caller.

Both numbers fall out of `Model` being the AR-shaped god class rather than
`model.rb`'s two-line concern.

### Verification

- `pnpm vitest run packages/activemodel/src` — 92 files, 1907 tests, green.
- 16 AR files covering construction, serialization, conversion, dirty,
  inheritance, primary keys, store and aggregations — 1055 passed, 24 skipped.
- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm parity:api`: activemodel 736/736 methods, 66/66 files; overall
  13533/15423 — unchanged. `parity:test` unchanged. `parity:api:calls` OK (405
  baselined, no new rows), `parity:api:calls:args` OK,
  `parity:api:extra:gate` OK. `parity:api:extra --package activemodel`:
  `model.ts` 0 novel.
- 480+/330- across 12 files, under the 700 ceiling.

Closes-story: fan-out-model-serialization-conversion-access-naming-surface
