### PR TITLE
refactor(activemodel,activerecord): converge serialization test layout, respond_to?, create_table raise, inverse_of (RFC 0115, RFC 0051)

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -221,16 +221,13 @@ export function attributeMissing(
  * `respond_to?(method, include_private_methods = false)` signature and answers
  * whether the receiver responds to `method` at all — including attribute
  * accessors exposed as getter/setter properties, not just plain functions. The
- * `in` check mirrors Ruby `respond_to?` across the prototype chain; trails has
- * no Ruby-private methods, so `includePrivateMethods` is accepted for signature
- * fidelity but does not change the answer.
+ * `in` check mirrors Ruby `respond_to?` across the prototype chain.
+ *
+ * Rails' `include_private_methods` parameter is dropped: a JS receiver has no
+ * string-named private methods for it to reveal, so it could never change the
+ * answer. See {@link respondTo} for the branch that drops with it.
  */
-export function isRespondToWithoutAttributes(
-  this: object,
-  method: string,
-  includePrivateMethods: boolean = false,
-): boolean {
-  void includePrivateMethods;
+export function isRespondToWithoutAttributes(this: object, method: string): boolean {
   return method in (this as Record<string, unknown>);
 }
 
@@ -685,7 +682,7 @@ export function defineCall(
 export type InstanceHost = {
   _attributes?: { has(name: string): boolean };
   attributes: Record<string, unknown>;
-  isRespondToWithoutAttributes(method: string, includePrivateMethods?: boolean): boolean;
+  isRespondToWithoutAttributes(method: string): boolean;
   attributeMethodPatterns?: AttributeMethodPattern[];
   constructor: AttributeMethodHost;
 };
@@ -701,7 +698,7 @@ type InstanceMethods = InstanceHost & {
 
 /** The receiver `respond_to?` (attribute_methods.rb:528-539) self-sends to. */
 type RespondToHost = {
-  isRespondToWithoutAttributes(method: string, includePrivateMethods?: boolean): boolean;
+  isRespondToWithoutAttributes(method: string): boolean;
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
 };
 
@@ -720,18 +717,26 @@ type RespondToHost = {
  *
  * Ruby's `super` here is the aliased original, which trails names
  * {@link isRespondToWithoutAttributes} — TS has no `super` for a module
- * outside the prototype chain, so the two `super` sends are spelled as sends
- * to that alias, in the same positions.
+ * outside the prototype chain, so the `super` send is spelled as a send to
+ * that alias, in the same position.
+ *
+ * @missingRailsCall super — PERMANENT: the middle arm (`elsif !include_private_methods
+ * && super(method, true)`, attribute_methods.rb:531-535) is omitted. It answers
+ * `false` for a name that exists ONLY as a Ruby-private method; a JS receiver
+ * has no string-named private methods, so `super(method, true)` and `super`
+ * always agree and the arm can never be taken. Porting it means porting a
+ * branch that reads as live and cannot run. `includePrivateMethods` stays in
+ * the signature — it is what Rails' callers pass — but no longer selects
+ * anything.
  */
 export function respondTo(
   this: RespondToHost,
   method: string,
   includePrivateMethods: boolean = false,
 ): boolean {
-  if (this.isRespondToWithoutAttributes(method, includePrivateMethods)) {
+  void includePrivateMethods;
+  if (this.isRespondToWithoutAttributes(method)) {
     return true;
-  } else if (!includePrivateMethods && this.isRespondToWithoutAttributes(method, true)) {
-    return false;
   } else {
     return this.matchedAttributeMethod(String(method)) !== null;
   }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -126,7 +126,7 @@ export interface Model extends Dirty {
   isAttributeMethod(attrName: string): boolean;
   matchedAttributeMethod(methodName: string): { proxyTarget: string; attrName: string } | null;
   missingAttribute(attrName: string, stack?: string): never;
-  isRespondToWithoutAttributes(method: string, includePrivateMethods?: boolean): boolean;
+  isRespondToWithoutAttributes(method: string): boolean;
   respondTo(method: string, includePrivateMethods?: boolean): boolean;
   /** @internal */
   _readAttribute(name: string, block?: (name: string) => unknown): unknown;

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
-import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
 import { NoMethodError } from "./attribute-assignment.js";
 
 // Plain ActiveModel serializes `include:` entries via `send(association)` —
@@ -28,101 +27,6 @@ describe("SerializationTest", () => {
       p as unknown as { readAttributeForSerialization(n: string): unknown }
     ).readAttributeForSerialization = () => "Jon";
     expect(p.serializableHash({ only: ["name"] })).toEqual({ name: "Jon" });
-  });
-
-  it("read_attribute_for_serialization dispatches the accessor, not a stale attributes hash", () => {
-    // Rails default `alias :read_attribute_for_serialization :send`: a host
-    // whose `attributes` only names keys while values live in accessors must
-    // serialize the accessor value, not re-read the hash.
-    const host = {
-      attributes: { name: "STALE" },
-      get name(): string {
-        return "FRESH";
-      },
-      constructor: { name: "Host" },
-    } as unknown as SerializationRecord;
-    expect(readAttributeForSerialization(host, "name")).toBe("FRESH");
-  });
-
-  it("read_attribute_for_serialization honors an overridden attribute reader (send)", () => {
-    // Rails `send(:name)` calls the reader, so a model overriding a declared
-    // attribute's getter serializes the override, not the raw store value.
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-      get name(): string {
-        return "OVERRIDE:" + (this._readAttribute("name") as string);
-      }
-    }
-    const p = new Person({ name: "Bob" });
-    expect(p.serializableHash()).toEqual({ name: "OVERRIDE:Bob" });
-  });
-
-  it("read_attribute_for_serialization invokes a method reader (send), not the attributes hash", () => {
-    // Rails' `send(:name)` calls the `name` method; a plain host with a method
-    // reader must serialize its return, not a stale `attributes[:name]`.
-    const host = {
-      attributes: { name: "STALE" },
-      name(): string {
-        return "i_am_name";
-      },
-      constructor: { name: "Host" },
-    } as unknown as SerializationRecord;
-    expect(readAttributeForSerialization(host, "name")).toBe("i_am_name");
-  });
-
-  it("read_attribute_for_serialization returns undefined for a present reader that returns undefined", () => {
-    // Ruby `send` keys off method existence, not return value: a reader that
-    // exists and returns nil yields nil, it does not raise.
-    const host = {
-      get name(): string | undefined {
-        return undefined;
-      },
-      constructor: { name: "Host" },
-    } as unknown as SerializationRecord;
-    expect(readAttributeForSerialization(host, "name")).toBeUndefined();
-  });
-
-  it("read_attribute_for_serialization raises NoMethodError-style for a missing reader", () => {
-    // Ruby `send(:nope)` raises NoMethodError; a name with no reader and no
-    // store/hash entry fails loud rather than silently serializing undefined.
-    const host = {
-      attributes: { name: "x" },
-      constructor: { name: "Host" },
-    } as unknown as SerializationRecord;
-    expect(() => readAttributeForSerialization(host, "nope")).toThrow(NoMethodError);
-    expect(() => readAttributeForSerialization(host, "nope")).toThrow(/undefined method 'nope'/);
-  });
-
-  it("read_attribute_for_serialization raises NoMethodError-style for a reader-less attributes key", () => {
-    // Rails `alias :… :send` has no `attributes`-hash fallback: a storeless host
-    // that names a key in `attributes` but exposes no reader for it fails loud
-    // like `send(:name)`, not silently serialize the hash value.
-    const host = {
-      attributes: { name: "x" },
-      constructor: { name: "Host" },
-    } as unknown as SerializationRecord;
-    expect(() => readAttributeForSerialization(host, "name")).toThrow(NoMethodError);
-    expect(() => readAttributeForSerialization(host, "name")).toThrow(/undefined method 'name'/);
-  });
-
-  it("read_attribute_for_serialization invokes a method reader on an _attributes-backed record", () => {
-    // Rails `send(:greeting)` calls the method even on a record with an attribute
-    // store; a genuine method (not a declared attribute) is invoked, not read
-    // from the store.
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-      greeting(): string {
-        return "Hi " + (this._readAttribute("name") as string);
-      }
-    }
-    const p = new Person({ name: "Bob" });
-    expect(readAttributeForSerialization(p as unknown as SerializationRecord, "greeting")).toBe(
-      "Hi Bob",
-    );
   });
 
   it("include option with empty association", () => {
@@ -159,23 +63,6 @@ describe("SerializationTest", () => {
     expect((hash["friends"] as Array<{ name: string }>)[0].name).toBe("Joe");
   });
 
-  it("a caller option named __sync does not hijack the internal sync re-entry", () => {
-    // The synchronous re-entry flag is a separate function parameter, not an
-    // option. A caller passing a castable option literally named `__sync` cannot
-    // reach it: the include-bearing call still returns the awaitable thenable
-    // (Rails' lazy `to_ary` contract) rather than building eagerly.
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    setAssociationAccessors(p, { posts: [] });
-    const hash = p.serializableHash({ include: "posts", __sync: true } as never);
-    expect(typeof (hash as unknown as PromiseLike<unknown>).then).toBe("function");
-    expect(hash["posts"]).toEqual([]);
-  });
-
   it("only include", () => {
     class Person extends Model {
       static {
@@ -200,45 +87,6 @@ describe("SerializationTest", () => {
     const hash = p.serializableHash({ except: ["age"] });
     expect(hash["name"]).toBe("Alice");
     expect(hash["age"]).toBeUndefined();
-  });
-
-  it("only include with scalar coerces via Array() like an array", () => {
-    // Rails `Array(only).map(&:to_s)`: `only: "name"` equals `only: ["name"]`
-    // (serialization.rb:130). trails must not substring-match a scalar string.
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 25 });
-    const hash = p.serializableHash({ only: "name" });
-    expect(hash["name"]).toBe("Alice");
-    expect(hash["age"]).toBeUndefined();
-  });
-
-  it("except include with scalar coerces via Array() like an array", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 25 });
-    const hash = p.serializableHash({ except: "age" });
-    expect(hash["name"]).toBe("Alice");
-    expect(hash["age"]).toBeUndefined();
-  });
-
-  it("asJson accepts a scalar only like the array form", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 25 });
-    expect(p.asJson({ only: "name" })).toEqual(p.asJson({ only: ["name"] }));
   });
 
   it("should raise NoMethodError for non existing method", () => {
@@ -402,24 +250,6 @@ describe("SerializationTest", () => {
     expect((result.comments as any[])[0].text).toBe("Great!");
   });
 
-  it("include accepts mixed array of strings and option hashes", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    const comment = {
-      _attributes: new Map([
-        ["text", "Great!"],
-        ["author", "Bob"],
-      ]),
-    };
-    const tag = { _attributes: new Map([["name", "rails"]]) };
-    setAssociationAccessors(p, { comments: [comment], tags: [tag] });
-    const result = p.serializableHash({
-      include: ["tags", { comments: { only: ["text"] } }],
-    });
-    expect((result.tags as any[])[0].name).toBe("rails");
-    expect((result.comments as any[])[0].text).toBe("Great!");
-    expect((result.comments as any[])[0].author).toBeUndefined();
-  });
-
   it("include with options", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
     const comment = {
@@ -432,34 +262,6 @@ describe("SerializationTest", () => {
     const result = p.serializableHash({ include: { comments: { only: ["text"] } } });
     expect((result.comments as any[])[0].text).toBe("Great!");
     expect((result.comments as any[])[0].author).toBeUndefined();
-  });
-
-  it("awaited nested include preloads through an attributes-less PORO", async () => {
-    // A singular `include` whose reader returns a plain PORO (no `_attributes`)
-    // that itself carries a nested, unloaded `include`. The `await` path must
-    // recurse through the PORO and lazy-load its nested collection (Rails'
-    // `to_ary`), even though the sync pass emits the PORO raw.
-    const comment = { _attributes: new Map([["text", "Nice"]]) };
-    const comments = {
-      loaded: false,
-      load(): Promise<void> {
-        this.loaded = true;
-        return Promise.resolve();
-      },
-      [Symbol.iterator](): Iterator<unknown> {
-        return [comment][Symbol.iterator]();
-      },
-    };
-    const author = { name: "Bob", comments };
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    setAssociationAccessors(p, { author });
-
-    expect(comments.loaded).toBe(false);
-    const result = await p.serializableHash({
-      include: { author: { include: "comments" } },
-    });
-    expect(comments.loaded).toBe(true);
-    expect((result.author as { name: string }).name).toBe("Bob");
   });
 
   it("method serializable hash should work with only option with order of given keys", () => {
@@ -487,225 +289,5 @@ describe("SerializationTest", () => {
     const p = new Person({ name: "Alice" });
     const result = p.serializableHash();
     expect(result.name).toBe("Alice");
-  });
-
-  describe("asJson type coercion (Rails ActiveSupport::JSON parity)", () => {
-    // Rails' JSON encoder routes every value through `as_json` — BigDecimal
-    // → string, Time/Date → ISO8601, Symbol → string. Our helper ports
-    // the subset that actually occurs in JS: BigInt → string, Date →
-    // ISO8601 (so the hash form already contains strings, not Date
-    // objects), and recursive coercion within arrays/objects.
-
-    it("asJson coerces Temporal attributes to ISO 8601 strings", () => {
-      class Event extends Model {
-        static {
-          this.attribute("startsAt", "datetime");
-        }
-      }
-      const e = new Event({ startsAt: "2026-04-24T10:00:00.123456Z" });
-      const json = e.asJson();
-      // `Time#as_json` renders at `ActiveSupport::JSON::Encoding.time_precision`
-      // (json.rb:200-208), which defaults to 3 (encoding.rb:135).
-      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.123Z");
-    });
-
-    it("asJson recurses into include: arrays and nested objects", () => {
-      class Post extends Model {
-        static {
-          this.attribute("id", "big_integer");
-          this.attribute("title", "string");
-        }
-      }
-      class Blog extends Model {
-        static {
-          this.attribute("name", "string");
-        }
-      }
-      const b = new Blog({ name: "b" });
-      setAssociationAccessors(b, {
-        posts: [
-          new Post({ id: "10000000000000000000", title: "p1" }),
-          new Post({ id: "20000000000000000000", title: "p2" }),
-        ],
-      });
-      const json = b.asJson({ include: "posts" });
-      expect(Array.isArray(json.posts)).toBe(true);
-      expect((json.posts as Array<{ id: string }>)[0].id).toBe("10000000000000000000");
-      expect(() => JSON.stringify(json)).not.toThrow();
-    });
-
-    it("attribute named toJSON does not shadow Model#toJSON", () => {
-      class Weird extends Model {
-        static {
-          this.attribute("toJSON", "string");
-          this.attribute("name", "string");
-        }
-      }
-      const w = new Weird({ toJSON: "raw-value", name: "w" });
-      expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
-      expect(w._readAttribute("toJSON")).toBe("raw-value");
-    });
-
-    it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
-      class Row extends Model {
-        static {
-          this.attribute("id", "big_integer");
-          this.attribute("name", "string");
-        }
-      }
-      const r = new Row({ id: "42", name: "row-1" });
-      expect(JSON.stringify(r)).toBe(r.toJSON());
-      const parsed = JSON.parse(JSON.stringify(r));
-      expect(parsed).toEqual({ id: 42, name: "row-1" });
-    });
-
-    it("JSON.stringify(model) with large bigint id above Number.MAX_SAFE_INTEGER", () => {
-      class Row extends Model {
-        static {
-          this.attribute("id", "big_integer");
-          this.attribute("name", "string");
-        }
-      }
-      const big = 2n ** 62n;
-      const r = new Row({ id: big, name: "row-2" });
-      expect(() => JSON.stringify(r)).not.toThrow();
-      const parsed = JSON.parse(JSON.stringify(r));
-      expect(typeof parsed.id).toBe("string");
-      expect(parsed.id).toBe("4611686018427387904");
-      expect(parsed.name).toBe("row-2");
-    });
-
-    it("asJson is idempotent on JSON-safe values", () => {
-      class Person extends Model {
-        static {
-          this.attribute("name", "string");
-          this.attribute("age", "integer");
-        }
-      }
-      const p = new Person({ name: "Alice", age: 30 });
-      expect(p.asJson()).toEqual({ name: "Alice", age: 30 });
-    });
-  });
-});
-describe("Serialization", () => {
-  class Post extends Model {
-    static {
-      this.attribute("title", "string");
-      this.attribute("body", "string");
-      this.attribute("rating", "integer");
-    }
-
-    get summary(): string {
-      return String(this._readAttribute("title")).slice(0, 10);
-    }
-  }
-
-  it("method serializable hash should work", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    expect(p.serializableHash()).toEqual({
-      title: "Hello",
-      body: "World",
-      rating: 5,
-    });
-  });
-
-  it("method serializable hash should work with only option", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    expect(p.serializableHash({ only: ["title"] })).toEqual({
-      title: "Hello",
-    });
-  });
-
-  it("method serializable hash should work with except option", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    expect(p.serializableHash({ except: ["body"] })).toEqual({
-      title: "Hello",
-      rating: 5,
-    });
-  });
-
-  it("method serializable hash should work with methods option", () => {
-    const p = new Post({ title: "Hello World!", body: "c", rating: 3 });
-    const result = p.serializableHash({ methods: ["summary"] });
-    expect(result.summary).toBe("Hello Worl");
-  });
-
-  it("method serializable hash should work with only and methods", () => {
-    const p = new Post({ title: "Test", body: "c", rating: 3 });
-    const result = p.serializableHash({
-      only: ["title"],
-      methods: ["summary"],
-    });
-    expect(Object.keys(result).sort()).toEqual(["summary", "title"]);
-  });
-
-  it("asJson returns same as serializableHash", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    expect(p.asJson()).toEqual(p.serializableHash());
-  });
-
-  it("toJson returns valid JSON string", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    const parsed = JSON.parse(p.toJSON());
-    expect(parsed.title).toBe("Hello");
-    expect(parsed.rating).toBe(5);
-  });
-
-  it("include as string for single association", () => {
-    const p = new Post({ title: "Hello", body: "World", rating: 5 });
-    const author = { _attributes: new Map([["name", "Alice"]]) };
-    setAssociationAccessors(p, { author });
-    const result = p.serializableHash({ include: "author" });
-    expect((result.author as any).name).toBe("Alice");
-  });
-});
-
-describe("fromJson", () => {
-  it("from_json should work without a root (class attribute)", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const u = new User({});
-    u.fromJson('{"name":"Alice","age":30}');
-    expect(u._readAttribute("name")).toBe("Alice");
-    expect(u._readAttribute("age")).toBe(30);
-  });
-
-  it("returns this for chaining", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const u = new User({});
-    const result = u.fromJson('{"name":"Bob"}');
-    expect(result).toBe(u);
-  });
-
-  it("from_json should work with a root (method parameter)", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const u = new User({});
-    u.fromJson('{"user":{"name":"Charlie"}}', true);
-    expect(u._readAttribute("name")).toBe("Charlie");
-  });
-
-  it("marks attributes as changed via dirty tracking", () => {
-    class User extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const u = new User({ name: "Original" });
-    u.changesApplied();
-    u.fromJson('{"name":"Updated"}');
-    expect(u.isChanged).toBe(true);
-    expect(u.changed).toContain("name");
   });
 });

--- a/packages/activemodel/src/serialization.trails.test.ts
+++ b/packages/activemodel/src/serialization.trails.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "./index.js";
+import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
+import { NoMethodError } from "./attribute-assignment.js";
+
+// Plain ActiveModel serializes `include:` entries via `send(association)` —
+// the value behind a Ruby `attr_accessor :address` / `:friends` (see Rails'
+// serialization_test.rb). The trails analog is a plain property on the
+// instance; serialization reads it through the same `send` baseline. (For
+// activerecord, `send` reaches the generated association reader instead.)
+function setAssociationAccessors(record: unknown, entries: Record<string, unknown>): void {
+  for (const [name, value] of Object.entries(entries)) {
+    (record as Record<string, unknown>)[name] = value;
+  }
+}
+
+// TS-only coverage that has no counterpart in
+// vendor/rails/activemodel/test/cases/serialization_test.rb. It lives here so
+// serialization.test.ts holds Rails test names only and a renamed or split
+// Rails test stays visible in review.
+describe("Serialization (trails)", () => {
+  // Duplicated from serialization.test.ts, where it sits beside the Rails
+  // tests that also use it.
+  class Post extends Model {
+    static {
+      this.attribute("title", "string");
+      this.attribute("body", "string");
+      this.attribute("rating", "integer");
+    }
+  }
+
+  it("read_attribute_for_serialization dispatches the accessor, not a stale attributes hash", () => {
+    // Rails default `alias :read_attribute_for_serialization :send`: a host
+    // whose `attributes` only names keys while values live in accessors must
+    // serialize the accessor value, not re-read the hash.
+    const host = {
+      attributes: { name: "STALE" },
+      get name(): string {
+        return "FRESH";
+      },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(readAttributeForSerialization(host, "name")).toBe("FRESH");
+  });
+
+  it("read_attribute_for_serialization honors an overridden attribute reader (send)", () => {
+    // Rails `send(:name)` calls the reader, so a model overriding a declared
+    // attribute's getter serializes the override, not the raw store value.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+      get name(): string {
+        return "OVERRIDE:" + (this._readAttribute("name") as string);
+      }
+    }
+    const p = new Person({ name: "Bob" });
+    expect(p.serializableHash()).toEqual({ name: "OVERRIDE:Bob" });
+  });
+
+  it("read_attribute_for_serialization invokes a method reader (send), not the attributes hash", () => {
+    // Rails' `send(:name)` calls the `name` method; a plain host with a method
+    // reader must serialize its return, not a stale `attributes[:name]`.
+    const host = {
+      attributes: { name: "STALE" },
+      name(): string {
+        return "i_am_name";
+      },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(readAttributeForSerialization(host, "name")).toBe("i_am_name");
+  });
+
+  it("read_attribute_for_serialization returns undefined for a present reader that returns undefined", () => {
+    // Ruby `send` keys off method existence, not return value: a reader that
+    // exists and returns nil yields nil, it does not raise.
+    const host = {
+      get name(): string | undefined {
+        return undefined;
+      },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(readAttributeForSerialization(host, "name")).toBeUndefined();
+  });
+
+  it("read_attribute_for_serialization raises NoMethodError-style for a missing reader", () => {
+    // Ruby `send(:nope)` raises NoMethodError; a name with no reader and no
+    // store/hash entry fails loud rather than silently serializing undefined.
+    const host = {
+      attributes: { name: "x" },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(() => readAttributeForSerialization(host, "nope")).toThrow(NoMethodError);
+    expect(() => readAttributeForSerialization(host, "nope")).toThrow(/undefined method 'nope'/);
+  });
+
+  it("read_attribute_for_serialization raises NoMethodError-style for a reader-less attributes key", () => {
+    // Rails `alias :… :send` has no `attributes`-hash fallback: a storeless host
+    // that names a key in `attributes` but exposes no reader for it fails loud
+    // like `send(:name)`, not silently serialize the hash value.
+    const host = {
+      attributes: { name: "x" },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(() => readAttributeForSerialization(host, "name")).toThrow(NoMethodError);
+    expect(() => readAttributeForSerialization(host, "name")).toThrow(/undefined method 'name'/);
+  });
+
+  it("read_attribute_for_serialization invokes a method reader on an _attributes-backed record", () => {
+    // Rails `send(:greeting)` calls the method even on a record with an attribute
+    // store; a genuine method (not a declared attribute) is invoked, not read
+    // from the store.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+      greeting(): string {
+        return "Hi " + (this._readAttribute("name") as string);
+      }
+    }
+    const p = new Person({ name: "Bob" });
+    expect(readAttributeForSerialization(p as unknown as SerializationRecord, "greeting")).toBe(
+      "Hi Bob",
+    );
+  });
+
+  it("a caller option named __sync does not hijack the internal sync re-entry", () => {
+    // The synchronous re-entry flag is a separate function parameter, not an
+    // option. A caller passing a castable option literally named `__sync` cannot
+    // reach it: the include-bearing call still returns the awaitable thenable
+    // (Rails' lazy `to_ary` contract) rather than building eagerly.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const p = new Person({ name: "Alice" });
+    setAssociationAccessors(p, { posts: [] });
+    const hash = p.serializableHash({ include: "posts", __sync: true } as never);
+    expect(typeof (hash as unknown as PromiseLike<unknown>).then).toBe("function");
+    expect(hash["posts"]).toEqual([]);
+  });
+
+  it("only include with scalar coerces via Array() like an array", () => {
+    // Rails `Array(only).map(&:to_s)`: `only: "name"` equals `only: ["name"]`
+    // (serialization.rb:130). trails must not substring-match a scalar string.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    const hash = p.serializableHash({ only: "name" });
+    expect(hash["name"]).toBe("Alice");
+    expect(hash["age"]).toBeUndefined();
+  });
+
+  it("except include with scalar coerces via Array() like an array", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    const hash = p.serializableHash({ except: "age" });
+    expect(hash["name"]).toBe("Alice");
+    expect(hash["age"]).toBeUndefined();
+  });
+
+  it("asJson accepts a scalar only like the array form", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    expect(p.asJson({ only: "name" })).toEqual(p.asJson({ only: ["name"] }));
+  });
+
+  it("include accepts mixed array of strings and option hashes", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    const comment = {
+      _attributes: new Map([
+        ["text", "Great!"],
+        ["author", "Bob"],
+      ]),
+    };
+    const tag = { _attributes: new Map([["name", "rails"]]) };
+    setAssociationAccessors(p, { comments: [comment], tags: [tag] });
+    const result = p.serializableHash({
+      include: ["tags", { comments: { only: ["text"] } }],
+    });
+    expect((result.tags as any[])[0].name).toBe("rails");
+    expect((result.comments as any[])[0].text).toBe("Great!");
+    expect((result.comments as any[])[0].author).toBeUndefined();
+  });
+
+  it("awaited nested include preloads through an attributes-less PORO", async () => {
+    // A singular `include` whose reader returns a plain PORO (no `_attributes`)
+    // that itself carries a nested, unloaded `include`. The `await` path must
+    // recurse through the PORO and lazy-load its nested collection (Rails'
+    // `to_ary`), even though the sync pass emits the PORO raw.
+    const comment = { _attributes: new Map([["text", "Nice"]]) };
+    const comments = {
+      loaded: false,
+      load(): Promise<void> {
+        this.loaded = true;
+        return Promise.resolve();
+      },
+      [Symbol.iterator](): Iterator<unknown> {
+        return [comment][Symbol.iterator]();
+      },
+    };
+    const author = { name: "Bob", comments };
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    setAssociationAccessors(p, { author });
+
+    expect(comments.loaded).toBe(false);
+    const result = await p.serializableHash({
+      include: { author: { include: "comments" } },
+    });
+    expect(comments.loaded).toBe(true);
+    expect((result.author as { name: string }).name).toBe("Bob");
+  });
+
+  describe("asJson type coercion (Rails ActiveSupport::JSON parity)", () => {
+    // Rails' JSON encoder routes every value through `as_json` — BigDecimal
+    // → string, Time/Date → ISO8601, Symbol → string. Our helper ports
+    // the subset that actually occurs in JS: BigInt → string, Date →
+    // ISO8601 (so the hash form already contains strings, not Date
+    // objects), and recursive coercion within arrays/objects.
+
+    it("asJson coerces Temporal attributes to ISO 8601 strings", () => {
+      class Event extends Model {
+        static {
+          this.attribute("startsAt", "datetime");
+        }
+      }
+      const e = new Event({ startsAt: "2026-04-24T10:00:00.123456Z" });
+      const json = e.asJson();
+      // `Time#as_json` renders at `ActiveSupport::JSON::Encoding.time_precision`
+      // (json.rb:200-208), which defaults to 3 (encoding.rb:135).
+      expect(json["startsAt"]).toBe("2026-04-24T10:00:00.123Z");
+    });
+
+    it("asJson recurses into include: arrays and nested objects", () => {
+      class Post extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("title", "string");
+        }
+      }
+      class Blog extends Model {
+        static {
+          this.attribute("name", "string");
+        }
+      }
+      const b = new Blog({ name: "b" });
+      setAssociationAccessors(b, {
+        posts: [
+          new Post({ id: "10000000000000000000", title: "p1" }),
+          new Post({ id: "20000000000000000000", title: "p2" }),
+        ],
+      });
+      const json = b.asJson({ include: "posts" });
+      expect(Array.isArray(json.posts)).toBe(true);
+      expect((json.posts as Array<{ id: string }>)[0].id).toBe("10000000000000000000");
+      expect(() => JSON.stringify(json)).not.toThrow();
+    });
+
+    it("attribute named toJSON does not shadow Model#toJSON", () => {
+      class Weird extends Model {
+        static {
+          this.attribute("toJSON", "string");
+          this.attribute("name", "string");
+        }
+      }
+      const w = new Weird({ toJSON: "raw-value", name: "w" });
+      expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
+      expect(w._readAttribute("toJSON")).toBe("raw-value");
+    });
+
+    it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
+      class Row extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("name", "string");
+        }
+      }
+      const r = new Row({ id: "42", name: "row-1" });
+      expect(JSON.stringify(r)).toBe(r.toJSON());
+      const parsed = JSON.parse(JSON.stringify(r));
+      expect(parsed).toEqual({ id: 42, name: "row-1" });
+    });
+
+    it("JSON.stringify(model) with large bigint id above Number.MAX_SAFE_INTEGER", () => {
+      class Row extends Model {
+        static {
+          this.attribute("id", "big_integer");
+          this.attribute("name", "string");
+        }
+      }
+      const big = 2n ** 62n;
+      const r = new Row({ id: big, name: "row-2" });
+      expect(() => JSON.stringify(r)).not.toThrow();
+      const parsed = JSON.parse(JSON.stringify(r));
+      expect(typeof parsed.id).toBe("string");
+      expect(parsed.id).toBe("4611686018427387904");
+      expect(parsed.name).toBe("row-2");
+    });
+
+    it("asJson is idempotent on JSON-safe values", () => {
+      class Person extends Model {
+        static {
+          this.attribute("name", "string");
+          this.attribute("age", "integer");
+        }
+      }
+      const p = new Person({ name: "Alice", age: 30 });
+      expect(p.asJson()).toEqual({ name: "Alice", age: 30 });
+    });
+  });
+});
+
+describe("Serialization", () => {
+  class Post extends Model {
+    static {
+      this.attribute("title", "string");
+      this.attribute("body", "string");
+      this.attribute("rating", "integer");
+    }
+
+    get summary(): string {
+      return String(this._readAttribute("title")).slice(0, 10);
+    }
+  }
+
+  it("method serializable hash should work", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    expect(p.serializableHash()).toEqual({
+      title: "Hello",
+      body: "World",
+      rating: 5,
+    });
+  });
+
+  it("method serializable hash should work with only option", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    expect(p.serializableHash({ only: ["title"] })).toEqual({
+      title: "Hello",
+    });
+  });
+
+  it("method serializable hash should work with except option", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    expect(p.serializableHash({ except: ["body"] })).toEqual({
+      title: "Hello",
+      rating: 5,
+    });
+  });
+
+  it("method serializable hash should work with methods option", () => {
+    const p = new Post({ title: "Hello World!", body: "c", rating: 3 });
+    const result = p.serializableHash({ methods: ["summary"] });
+    expect(result.summary).toBe("Hello Worl");
+  });
+
+  it("method serializable hash should work with only and methods", () => {
+    const p = new Post({ title: "Test", body: "c", rating: 3 });
+    const result = p.serializableHash({
+      only: ["title"],
+      methods: ["summary"],
+    });
+    expect(Object.keys(result).sort()).toEqual(["summary", "title"]);
+  });
+
+  it("asJson returns same as serializableHash", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    expect(p.asJson()).toEqual(p.serializableHash());
+  });
+
+  it("toJson returns valid JSON string", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    const parsed = JSON.parse(p.toJSON());
+    expect(parsed.title).toBe("Hello");
+    expect(parsed.rating).toBe(5);
+  });
+
+  it("include as string for single association", () => {
+    const p = new Post({ title: "Hello", body: "World", rating: 5 });
+    const author = { _attributes: new Map([["name", "Alice"]]) };
+    setAssociationAccessors(p, { author });
+    const result = p.serializableHash({ include: "author" });
+    expect((result.author as any).name).toBe("Alice");
+  });
+});
+
+describe("fromJson", () => {
+  it("from_json should work without a root (class attribute)", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const u = new User({});
+    u.fromJson('{"name":"Alice","age":30}');
+    expect(u._readAttribute("name")).toBe("Alice");
+    expect(u._readAttribute("age")).toBe(30);
+  });
+
+  it("returns this for chaining", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const u = new User({});
+    const result = u.fromJson('{"name":"Bob"}');
+    expect(result).toBe(u);
+  });
+
+  it("from_json should work with a root (method parameter)", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const u = new User({});
+    u.fromJson('{"user":{"name":"Charlie"}}', true);
+    expect(u._readAttribute("name")).toBe("Charlie");
+  });
+
+  it("marks attributes as changed via dirty tracking", () => {
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const u = new User({ name: "Original" });
+    u.changesApplied();
+    u.fromJson('{"name":"Updated"}');
+    expect(u.isChanged).toBe(true);
+    expect(u.changed).toContain("name");
+  });
+});

--- a/packages/activemodel/src/serialization.trails.test.ts
+++ b/packages/activemodel/src/serialization.trails.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Serialization tests — TS-only coverage with no counterpart in
+ * vendor/rails/activemodel/test/cases/serialization_test.rb. Relocated here
+ * verbatim under RFC 0115 so serialization.test.ts holds Rails test names only
+ * and a renamed or split Rails test stays visible in review.
+ */
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
@@ -14,13 +20,9 @@ function setAssociationAccessors(record: unknown, entries: Record<string, unknow
   }
 }
 
-// TS-only coverage that has no counterpart in
-// vendor/rails/activemodel/test/cases/serialization_test.rb. It lives here so
-// serialization.test.ts holds Rails test names only and a renamed or split
-// Rails test stays visible in review.
-describe("Serialization (trails)", () => {
-  // Duplicated from serialization.test.ts, where it sits beside the Rails
-  // tests that also use it.
+describe("Serialization — trails-only coverage", () => {
+  // Duplicated from serialization.test.ts rather than moved: the Rails tests
+  // there use it too.
   class Post extends Model {
     static {
       this.attribute("title", "string");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -401,8 +401,10 @@ export class SchemaStatements {
       this.validateTableLengthBang(tableName);
     }
 
-    if (force && options.ifNotExists) {
-      throw new Error("Options `:force` and `:if_not_exists` cannot be used simultaneously.");
+    if (force && "ifNotExists" in options) {
+      throw new ArgumentError(
+        "Options `:force` and `:if_not_exists` cannot be used simultaneously.",
+      );
     }
 
     const td = this.buildCreateTableDefinition(

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -803,6 +803,11 @@ describe("MigrationTest", () => {
 
   it("create table with force and if not exists", async () => {
     const adapter = Base.connection;
+    // Rails raises ArgumentError here (schema_statements.rb:297-299), which is
+    // what migration_test.rb:207 rescues.
+    await expect(adapter.createTable("things", { force: true, ifNotExists: true })).rejects.toThrow(
+      ArgumentError,
+    );
     await expect(adapter.createTable("things", { force: true, ifNotExists: true })).rejects.toThrow(
       /cannot be used simultaneously/i,
     );

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migration, IllegalMigrationNameError } from "./migration.js";
@@ -386,5 +387,17 @@ describe("Schema.verbose", () => {
     } finally {
       Migration.verbose = was;
     }
+  });
+});
+
+describe("createTable force + ifNotExists key presence", () => {
+  it("raises when ifNotExists is present but false", async () => {
+    // Rails guards on `options.key?(:if_not_exists)`, not on the value
+    // (schema_statements.rb:297-299), so `if_not_exists: false` raises too.
+    const adapter = Base.connection;
+    // The guard raises before any DDL runs, so no table is created.
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    const create = adapter.createTable("things", { force: true, ifNotExists: false });
+    await expect(create).rejects.toThrow(ArgumentError);
   });
 });

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -97,9 +97,24 @@ export class CommandRecorder {
    * Returns the inverse command and args for the given command.
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#inverse_of
+   * (command_recorder.rb:114-123). The `methodName in this` test is Ruby's
+   * `respond_to?(method, true)` guard (command_recorder.rb:116): membership is
+   * tested before the read, because a name the recorder does not answer takes
+   * the proxy's `method_missing` arm.
    */
   inverseOf(cmd: string, args: unknown[]): { cmd: string; args: unknown[] } {
-    const [invertedCmd, invertedArgs] = this._dispatchInvert(cmd, args);
+    const method = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
+    if (!(method in this) || typeof this[method] !== "function") {
+      throw new IrreversibleMigration(
+        `This migration uses ${cmd}, which is not automatically reversible.\n` +
+          `To make the migration reversible you can either:\n` +
+          `1. Define #up and #down methods in place of the #change method.\n` +
+          `2. Use the #reversible method to define reversible behavior.\n`,
+      );
+    }
+    const [invertedCmd, invertedArgs] = (
+      this[method] as (args: unknown[]) => [string, unknown[]]
+    ).call(this, args);
     return { cmd: invertedCmd, args: invertedArgs };
   }
 
@@ -170,10 +185,7 @@ export class CommandRecorder {
 
   /** Returns the full inverse command list. */
   inverse(): Array<{ cmd: string; args: unknown[] }> {
-    return [...this._commands].reverse().map(({ cmd, args }) => {
-      const [invertedCmd, invertedArgs] = this._dispatchInvert(cmd, args);
-      return { cmd: invertedCmd, args: invertedArgs };
-    });
+    return [...this._commands].reverse().map(({ cmd, args }) => this.inverseOf(cmd, args));
   }
 
   // ---------------------------------------------------------------------------
@@ -674,24 +686,6 @@ export class CommandRecorder {
   /** @internal */
   joinTableName(table1: string, table2: string): string {
     return _joinTableName(table1, table2);
-  }
-
-  // ---------------------------------------------------------------------------
-  // private dispatch
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Mirrors `inverse_of`'s `respond_to?(method, true)` guard
-   * (command_recorder.rb:116): membership is tested before the read, because a
-   * name the recorder does not answer takes the proxy's `method_missing` arm.
-   */
-  private _dispatchInvert(cmd: string, args: unknown[]): [string, unknown[]] {
-    const methodName = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
-    const method = methodName in this ? this[methodName] : undefined;
-    if (typeof method === "function") {
-      return (method as (args: unknown[]) => [string, unknown[]]).call(this, args);
-    }
-    throw new IrreversibleMigration(`${cmd} is not reversible`);
   }
 }
 

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -97,14 +97,15 @@ export class CommandRecorder {
    * Returns the inverse command and args for the given command.
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#inverse_of
-   * (command_recorder.rb:114-123). The `methodName in this` test is Ruby's
-   * `respond_to?(method, true)` guard (command_recorder.rb:116): membership is
-   * tested before the read, because a name the recorder does not answer takes
-   * the proxy's `method_missing` arm.
+   * (command_recorder.rb:114-123). The `method in this` test is Ruby's
+   * `respond_to?(method, true)` (command_recorder.rb:116), routed through the
+   * `methodMissingProxy` `has` trap; membership is tested before the read,
+   * because a name the recorder does not answer reads back as the proxy's
+   * `NoMethodError`-raising function rather than `undefined`.
    */
   inverseOf(cmd: string, args: unknown[]): { cmd: string; args: unknown[] } {
     const method = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
-    if (!(method in this) || typeof this[method] !== "function") {
+    if (!(method in this)) {
       throw new IrreversibleMigration(
         `This migration uses ${cmd}, which is not automatically reversible.\n` +
           `To make the migration reversible you can either:\n` +


### PR DESCRIPTION
Bundle of four convergence stories across RFC 0115 and RFC 0051.

## 1. Move the TS-only extras out of activemodel's mirrored serialization test file

Every `it(...)` `parity:test` reported as "extra (TS only)" for
`serialization_test.rb` moved to a new `serialization.trails.test.ts`, under a
`describe("Serialization (trails)")`. No test renamed, reworded or deleted; only
the enclosing `describe` changed. The two whole top-level describes that had no
Rails counterpart (`Serialization`, `fromJson`) moved verbatim, keeping their
own describe names. The `Post` helper class two moved tests used is **duplicated**
into the trails file, not moved out from under the Rails tests.

`pnpm parity:test --package activemodel`:

| | before | after |
| --- | --- | --- |
| `serialization_test.rb` OK | 20 | 20 |
| `serialization_test.rb` Extra | 31 | **0** |
| activemodel matched total | 963/963 | 963/963 |
| activemodel Extra total | 311 | 280 |

Assertion marks unchanged (301 count / 445 kind / 56 value before and after), and
`scripts/test-compare/lint-assertion-mismatches.ts` is OK — so the move did not
flip which body `parity:test` matched for the five duplicated Rails names.

Closes-story: move-ts-only-extras-out-of-mirrored-activemodel-serialization-test-file

## 2. `respond_to?`'s `include_private_methods` branch is dead

`activemodel/lib/active_model/attribute_methods.rb:528-539`'s middle arm
(`elsif !include_private_methods && super(method, true)`) answers `false` for a
name that exists **only** as a Ruby-private method. A JS receiver has no
string-named private methods, so `isRespondToWithoutAttributes(method)` and
`isRespondToWithoutAttributes(method, true)` always agreed and the arm could
never be taken.

Converged by removal, per the story's fallback: the arm is gone, justified at
the call site with the Rails cite and a `@missingRailsCall super — PERMANENT:`
tag. `isRespondToWithoutAttributes` no longer accepts the parameter it
discarded (the `void includePrivateMethods;` line is gone), and its two host
interface declarations plus `Model`'s follow. `respondTo` keeps
`includePrivateMethods` in its signature — that is what Rails' callers pass —
but it no longer selects anything.

The eslint `rails-private-methods` manifest was considered as the first option;
it is a lint-time artifact describing Rails' privacy, not a runtime notion of
privacy for a TS receiver, so it cannot make the arm fire.

`pnpm parity:api:calls` and `:args` are clean with no new baseline row.

Closes-story: respond-to-private-methods-branch-is-dead

## 3. `create_table` raised a bare `Error` for `force:` + `if_not_exists:`

`schema_statements.rb:297-299` raises `ArgumentError` and guards on
`options.key?(:if_not_exists)` — key presence, not truthiness. trails raised the
base `Error` and tested the value, so `ifNotExists: false` with `force:` passed
where Rails raises, and `migration_test.rb:207`'s `assert_raises(ArgumentError)`
would not have caught it.

Both halves converged. `options` is the rest object left after `id`,
`primaryKey` and `force` are split out, so `"ifNotExists" in options` is true
exactly when the caller supplied the key — Ruby's `key?`.

Regression coverage, both failing on the baseline:

- `migration.test.ts` "create table with force and if not exists" now asserts
  `ArgumentError` (a bare `Error` is not an instance of it).
- `migration.trails.test.ts` covers the key-presence arm with
  `ifNotExists: false`.

Closes-story: create-table-force-if-not-exists-raises-bare-error

## 4. `inverse_of` folds `_dispatchInvert` back in and raises Rails' message

`command_recorder.rb:114-123` has no `_dispatch_invert`; `inverse_of` does the
whole job. The private helper is gone and its body — including the
`respond_to?(method, true)` membership guard, which must precede the read
because a name the recorder does not answer reads back as the proxy's
`NoMethodError`-raising function — now lives in `inverseOf`. `record` and
`inverse` call `inverseOf` directly.

The raise now carries Rails' four-line message verbatim
(`command_recorder.rb:117-120`), naming the command and both ways to make the
migration reversible, instead of `` `${cmd} is not reversible` ``.

`inverseOf` still returns `{ cmd, args }` rather than Rails' `[method, args]`
pair: that object is trails' command-tuple representation throughout
`_commands`, `record`, `inverse` and `replay`, so flipping it is a separate
change touching ~100 call sites and is not in this story's acceptance criteria.

Closes-story: converge-command-recorder-inverse-of-message-and-decomposition

## Size

`git diff --shortstat origin/main...HEAD` (excluding lockfiles, snapshots, docs)
is over the 700 LOC ceiling, but ~890 of it is story 1's pure file relocation —
31 `it(...)` blocks deleted from one file and added verbatim to another, no
content change. The behavioural diff across stories 2–4 is ~60 lines.

## Verification

- `serialization.test.ts` (20) + `serialization.trails.test.ts` (31) green.
- `command-recorder.test.ts`, `command-recorder.trails.test.ts`,
  `invertible-migration.test.ts`, `migration.test.ts`,
  `migration.trails.test.ts`, `attribute-methods.test.ts`, `model.test.ts`,
  `attributes.test.ts` green.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
  `pnpm parity:api:extra:gate` OK, `lint-assertion-mismatches` OK,
  `pnpm typecheck`, `pnpm lint` clean.
