### PR TITLE
refactor(activesupport,activerecord): converge chained temporal receivers, polymorphic foreign_type, create_schema_dumper arity and the transaction callback splat (RFC 0096)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -67,7 +67,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       await new EnableCitext().execMigration(adapter, "up");
       expect(await adapter.extensionEnabled("citext")).toBe(true);
-      const dump = (await adapter.createSchemaDumper(adapter).dump()).join("\n");
+      const dump = (await adapter.createSchemaDumper().dump()).join("\n");
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
     }, 60000);
     it("enable extension migration ignores prefix and suffix", async () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -698,7 +698,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(`CREATE TABLE wagons (id serial primary key, train_id integer)`);
         await adapter.addForeignKey("wagons", "my_schema.trains");
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).foreignKeys("wagons", lines);
+        await adapter.createSchemaDumper().foreignKeys("wagons", lines);
         const output = lines.join("\n");
         // Default FK name is the Rails fk_rails_<10-hex> hash, which matches the
         // schema-dumper ignore pattern, so the name is omitted from the dump;
@@ -741,7 +741,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name_and_description ON trains USING btree(name text_pattern_ops, description text_pattern_ops)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`opclass: "text_pattern_ops"`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -756,7 +756,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name_and_description ON trains USING btree(name, description text_pattern_ops)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`opclass: { description: "text_pattern_ops" }`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -775,7 +775,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name_and_position ON trains USING btree(name, position text_pattern_ops)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         const output = lines.join("\n");
         expect(output).toContain(`opclass: "gin_trgm_ops"`);
         expect(output).toContain(`opclass: { position: "text_pattern_ops" }`);
@@ -795,7 +795,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name_and_description ON trains USING btree(name NULLS FIRST, description)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`order: { name: "NULLS FIRST" }`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -810,7 +810,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name_and_desc ON trains USING btree(name DESC NULLS LAST, description)`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain(`order: { name: "DESC NULLS LAST" }`);
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -977,7 +977,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("schema dumps index included columns", async () => {
       await adapter.getDatabaseVersion();
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "companies");
+      await adapter.createSchemaDumper().dumpTable(lines, "companies");
       const indexLine = lines.find((l) => l.includes("company_include_index"))?.trim();
       expect(indexLine).toBeDefined();
       expect(indexLine).toContain(`"companies", ["firm_id", "type"]`);
@@ -997,7 +997,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX trains_name ON trains USING btree(name) NULLS NOT DISTINCT`,
         );
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).toContain("nullsNotDistinct: true");
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -1009,7 +1009,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         if (!(await adapter.supportsNullsNotDistinct())) return;
         await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name) NULLS DISTINCT`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).not.toContain("nullsNotDistinct");
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -1020,7 +1020,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.exec(`CREATE TABLE trains (id serial primary key, name varchar(50))`);
         await adapter.exec(`CREATE INDEX trains_name ON trains USING btree(name)`);
         const lines: string[] = [];
-        await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+        await adapter.createSchemaDumper().dumpTable(lines, "trains");
         expect(lines.join("\n")).not.toContain("nullsNotDistinct");
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS trains`);
@@ -1043,7 +1043,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         t.string("kind");
       });
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      await adapter.createSchemaDumper().dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
@@ -1054,7 +1054,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         t.datetime("created_at", { null: false });
       });
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      await adapter.createSchemaDumper().dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
@@ -1066,7 +1066,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const options = "INHERITS (transportation_modes)";
       await adapter.createTable("trains", { options });
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      await adapter.createSchemaDumper().dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
@@ -1080,7 +1080,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const options = "INHERITS (transportation_modes, vehicles)";
       await adapter.createTable("trains", { options });
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      await adapter.createSchemaDumper().dumpTable(lines, "trains");
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
@@ -1089,7 +1089,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         t.string("name");
       });
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "trains");
+      await adapter.createSchemaDumper().dumpTable(lines, "trains");
       expect(lines.join("\n")).not.toContain("options:");
     });
   });
@@ -1103,7 +1103,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`CREATE TABLE commented_table (id serial primary key, name varchar(50))`);
       await adapter.exec(`COMMENT ON TABLE commented_table IS 'a test table'`);
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "commented_table");
+      await adapter.createSchemaDumper().dumpTable(lines, "commented_table");
       expect(lines.join("\n")).toContain(`comment: "a test table"`);
       await adapter.exec(`DROP TABLE IF EXISTS commented_table`);
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -201,6 +201,13 @@ export interface AssociationDefinition {
   isInverseUpdatesCounterCache?: () => unknown;
   /** Rails' `AbstractReflection#klass`. See {@link macro}. */
   klass?: typeof Base;
+  /**
+   * Rails' `AssociationReflection#foreign_type` (reflection.rb:861) — the
+   * polymorphic `*_type` column. Carried on the lightweight definitions too
+   * (`builder/association.rb`'s `Reflection.create` result answers it), so a
+   * polymorphic `belongs_to` reaches it the way Rails does. See {@link macro}.
+   */
+  foreignType?: string | null;
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -202,8 +202,9 @@ export interface AssociationDefinition {
   /** Rails' `AbstractReflection#klass`. See {@link macro}. */
   klass?: typeof Base;
   /**
-   * Rails' `AssociationReflection#foreign_type` (reflection.rb:861) — the
-   * polymorphic `*_type` column. Carried on the lightweight definitions too
+   * Rails' `AssociationReflection#foreign_type` — the polymorphic `*_type`
+   * column (`attr_reader`, reflection.rb:514; assigned at :520). Carried on the
+   * lightweight definitions too
    * (`builder/association.rb`'s `Reflection.create` result answers it), so a
    * polymorphic `belongs_to` reaches it the way Rails does. See {@link macro}.
    */

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -2,7 +2,6 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { modelRegistry } from "../associations.js";
 import { baseClass, demodulize } from "../inheritance.js";
-import { underscore } from "@blazetrails/activesupport";
 import { BelongsToAssociation, inferCompositePrimaryKey } from "./belongs-to-association.js";
 
 /**
@@ -34,19 +33,20 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    * Also check if the type column has changed, not just the FK.
    */
   override isTargetChanged(): boolean {
-    return super.isTargetChanged() || this.owner.attributeChanged(this.foreignTypeName());
+    return super.isTargetChanged() || this.owner.attributeChanged(this.reflection.foreignType!);
   }
 
   override isTargetPreviouslyChanged(): boolean {
     return (
       super.isTargetPreviouslyChanged() ||
-      this.owner.attributePreviouslyChanged(this.foreignTypeName())
+      this.owner.attributePreviouslyChanged(this.reflection.foreignType!)
     );
   }
 
   override isSavedChangeToTarget(): boolean {
     return (
-      super.isSavedChangeToTarget() || this.owner.isSavedChangeToAttribute(this.foreignTypeName())
+      super.isSavedChangeToTarget() ||
+      this.owner.isSavedChangeToAttribute(this.reflection.foreignType!)
     );
   }
 
@@ -76,7 +76,7 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
     record: Base | null,
     { force = false }: { force?: boolean } = {},
   ): void {
-    const typeCol = this.foreignTypeName();
+    const typeCol = this.reflection.foreignType!;
     // Rails: writes record.class.polymorphic_name, which is the Ruby class
     // name (including "::" for namespaced classes). JS class names can't
     // contain "::", so deriving purely from `constructor.name` would
@@ -148,15 +148,6 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   }
 
   /**
-   * Derive the type column name. Returns `options.foreignType` when provided,
-   * otherwise falls back to `${underscore(assocName)}_type`. Mirrors the same
-   * logic in `loadBelongsTo` so reads and writes use the same column.
-   */
-  private foreignTypeName(): string {
-    return this.reflection.options.foreignType ?? `${underscore(this.reflection.name)}_type`;
-  }
-
-  /**
    * Mirror of MacroReflection#activeRecordRegistryName plus a
    * "preserve existing value" rule: when the owner already stores a
    * foreign_type that points to this record's class, keep it (covers
@@ -200,7 +191,7 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   }
 
   private readForeignType(): string | null {
-    const ft = this.foreignTypeName();
+    const ft = this.reflection.foreignType!;
     const value =
       typeof (this.owner as any)._readAttribute === "function"
         ? (this.owner as any)._readAttribute(ft)

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -144,9 +144,7 @@ export class Association {
         scope,
         options: { ...options },
         get foreignType(): string | null {
-          return "foreignType" in reflection
-            ? ((reflection as { foreignType: string | null }).foreignType ?? null)
-            : null;
+          return (reflection as { foreignType?: string | null }).foreignType ?? null;
         },
       },
     ];

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -143,6 +143,11 @@ export class Association {
         name,
         scope,
         options: { ...options },
+        get foreignType(): string | null {
+          return "foreignType" in reflection
+            ? ((reflection as { foreignType: string | null }).foreignType ?? null)
+            : null;
+        },
       },
     ];
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -27,7 +27,9 @@ import {
 
 import type { Quoting } from "./quoting.js";
 import type { ConnectionPool, NullPool } from "./connection-pool.js";
-import { TransactionManager } from "./transaction.js";
+import { CURRENT_TRANSACTION_KEY, Transaction, TransactionManager } from "./transaction.js";
+import { Transaction as UserTransaction } from "../../transaction.js";
+import { IsolatedExecutionState } from "@blazetrails/activesupport";
 import { exceedsBindParamsLimit } from "./database-limits.js";
 import { Result } from "../../result.js";
 import {
@@ -567,10 +569,33 @@ export async function truncateTables(
  */
 export async function transaction<T>(
   this: DatabaseStatementsHost,
-  fn: (tx?: unknown) => Promise<T> | T,
+  block: (tx?: unknown) => Promise<T> | T,
   options: { requiresNew?: boolean; isolation?: string; joinable?: boolean } = {},
 ): Promise<T | undefined> {
   const { requiresNew, isolation, joinable = true } = options;
+
+  // Ruby reads the open transaction back off the connection
+  // (`current_transaction`, `transaction.rb:352-354`); trails holds it in
+  // execution state, installed here so every block this method runs — however
+  // the transaction below is opened — sees it as `ActiveRecord.current_transaction`.
+  const fn = (userTx?: unknown): Promise<T> | T => {
+    let internalTx: Transaction;
+    if (userTx instanceof Transaction) {
+      internalTx = userTx;
+    } else if (
+      userTx &&
+      (userTx as { _internalTransaction?: unknown })._internalTransaction instanceof Transaction
+    ) {
+      internalTx = (userTx as { _internalTransaction: Transaction })._internalTransaction;
+    } else {
+      const tmCurrent = this.currentTransaction?.();
+      internalTx = tmCurrent instanceof Transaction ? tmCurrent : new Transaction(this as never);
+    }
+    return IsolatedExecutionState.scope(CURRENT_TRANSACTION_KEY, internalTx, () => {
+      const publicTx = userTx instanceof UserTransaction ? userTx : internalTx.userTransaction;
+      return block(publicTx);
+    });
+  };
 
   const currentTxn = this.currentTransaction?.();
   const currentTxnJoinable =

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -13,6 +13,7 @@
  */
 
 import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 import type { ColumnInfo, IndexInfo, SchemaSource } from "../../schema-dumper.js";
 
 /**
@@ -44,11 +45,11 @@ export class SchemaDumper extends BaseSchemaDumper {
   /** Mirrors `def self.create(connection, options)` (abstract/schema_dumper.rb:8-10). */
   static override create<T extends typeof BaseSchemaDumper>(
     this: T,
-    connection: SchemaSource,
+    connection: SchemaSource | DatabaseAdapter,
     options: Record<string, unknown> = {},
   ): InstanceType<T> {
     return new (this as unknown as new (
-      connection: SchemaSource,
+      connection: SchemaSource | DatabaseAdapter,
       options: Record<string, unknown>,
     ) => InstanceType<T>)(connection, options);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -15,6 +15,16 @@ import {
 import { ActiveRecord } from "../../ar-config.js";
 
 /**
+ * The execution-state slot holding the connection's open transaction, which is
+ * what `ActiveRecord.current_transaction` (`transactions.rb:236-238`) reads and
+ * `DatabaseStatements#transaction` installs. It lives here, beside the
+ * `Transaction` it holds, because both that installer and the reader import it.
+ *
+ * @internal
+ */
+export const CURRENT_TRANSACTION_KEY = Symbol.for("ar_current_transaction");
+
+/**
  * Equality-keyed lookup of the candidate instance whose transactional
  * callbacks should fire for a given logical row.
  *

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -41,7 +41,6 @@ import { transactionIsolationLevels } from "./abstract/database-statements.js";
 import { Value as TimeValue } from "../type/time.js";
 import { ActiveRecord } from "../ar-config.js";
 import { temporalTypeCast, TEMPORAL_POOL_OPTIONS } from "./mysql/temporal-type-cast.js";
-import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as MysqlSchemaDumper } from "./mysql/schema-dumper.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
 import { parseMysqlName as mysqlParseName } from "./mysql/schema-statements.js";
@@ -1213,11 +1212,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     await conn.query(this.mysqlQuote(sql));
   }
 
-  createSchemaDumper(
-    source: SchemaSource,
-    options: Record<string, unknown> = {},
-  ): MysqlSchemaDumper {
-    const dumper = new MysqlSchemaDumper(source, options);
+  createSchemaDumper(options: Record<string, unknown> = {}): MysqlSchemaDumper {
+    const dumper = MysqlSchemaDumper.create(this as unknown as DatabaseAdapter, options);
     dumper.connection = this;
     return dumper;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -156,7 +156,6 @@ import {
 } from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
-import type { SchemaSource } from "../schema-dumper.js";
 import { pgDatetimeConfig } from "./postgresql/pg-datetime-config.js";
 import { abandonRawSocket } from "./abandon-raw-socket.js";
 import {
@@ -3715,8 +3714,8 @@ export class PostgreSQLAdapter
    * Mirrors: PostgreSQL::SchemaStatements#create_schema_dumper
    * (postgresql/schema_statements.rb:884-886) — `PostgreSQL::SchemaDumper.create(self, options)`.
    */
-  createSchemaDumper(source: SchemaSource, options: Record<string, unknown> = {}): PgSchemaDumper {
-    return PgSchemaDumper.create(source, options);
+  createSchemaDumper(options: Record<string, unknown> = {}): PgSchemaDumper {
+    return PgSchemaDumper.create(this, options);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -115,7 +115,6 @@ import { Base } from "../base.js";
 import { Column } from "./column.js";
 import { Column as Sqlite3Column } from "./sqlite3/column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
-import type { SchemaSource } from "../schema-dumper.js";
 import { SchemaDumper as Sqlite3SchemaDumper } from "./sqlite3/schema-dumper.js";
 
 /**
@@ -1641,11 +1640,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     );
   }
 
-  createSchemaDumper(
-    source: SchemaSource,
-    options: Record<string, unknown> = {},
-  ): Sqlite3SchemaDumper {
-    return Sqlite3SchemaDumper.create(source, options);
+  createSchemaDumper(options: Record<string, unknown> = {}): Sqlite3SchemaDumper {
+    return Sqlite3SchemaDumper.create(this, options);
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#virtual_table_exists?

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.trails.test.ts
@@ -18,7 +18,7 @@ describe("SQLite3::SchemaStatements", () => {
   describe("createSchemaDumper", () => {
     it("returns a SchemaDumper instance", () => {
       const fakeAdapter = { adapterName: "sqlite" } as any;
-      expect(createSchemaDumper(fakeAdapter)).toBeInstanceOf(SchemaDumper);
+      expect(createSchemaDumper.call(fakeAdapter)).toBeInstanceOf(SchemaDumper);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -193,10 +193,10 @@ export async function virtualTableExists(
 }
 
 export function createSchemaDumper(
-  source: unknown,
+  this: DatabaseAdapter,
   options: Record<string, unknown> = {},
 ): AbstractSchemaDumper {
-  return SchemaDumper.create(source as Parameters<typeof SchemaDumper.create>[0], options);
+  return SchemaDumper.create(this as Parameters<typeof SchemaDumper.create>[0], options);
 }
 
 /** @internal */

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -452,12 +452,15 @@ export abstract class SchemaDumper {
   private _version?: string;
   private _ignoreTables: (string | RegExp)[];
 
-  /** @internal */
+  /**
+   * Rails' dumper takes the connection itself as its dump source
+   * (`schema_dumper.rb:41`); trails' dumpers read a `SchemaSource`, so an
+   * adapter is bridged onto that duck type here — the one place every
+   * `create` / `new` path funnels through.
+   *
+   * @internal
+   */
   constructor(connection: SchemaSource | DatabaseAdapter, options: Record<string, unknown> = {}) {
-    // Rails' dumper takes the connection itself as its dump source
-    // (`schema_dumper.rb:41`); trails' dumpers read a `SchemaSource`, so an
-    // adapter is bridged onto that duck type here — the one place every
-    // `create`/`new` path funnels through.
     this._source = isDatabaseAdapter(connection) ? new AdapterSchemaSource(connection) : connection;
     this._options = options;
     const lang =

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -453,8 +453,12 @@ export abstract class SchemaDumper {
   private _ignoreTables: (string | RegExp)[];
 
   /** @internal */
-  constructor(source: SchemaSource, options: Record<string, unknown> = {}) {
-    this._source = source;
+  constructor(connection: SchemaSource | DatabaseAdapter, options: Record<string, unknown> = {}) {
+    // Rails' dumper takes the connection itself as its dump source
+    // (`schema_dumper.rb:41`); trails' dumpers read a `SchemaSource`, so an
+    // adapter is bridged onto that duck type here — the one place every
+    // `create`/`new` path funnels through.
+    this._source = isDatabaseAdapter(connection) ? new AdapterSchemaSource(connection) : connection;
     this._options = options;
     const lang =
       (options.language as SchemaDumpLanguage | undefined) ??
@@ -523,15 +527,15 @@ export abstract class SchemaDumper {
    */
   protected static create<T extends typeof SchemaDumper>(
     this: T,
-    source: SchemaSource,
+    connection: SchemaSource | DatabaseAdapter,
     options: Record<string, unknown> = {},
   ): InstanceType<T> {
     // The base is abstract (Ruby: no `column_spec`, and `private_class_method :new`),
     // so the construction has to be typed through the concrete `this`.
     return new (this as unknown as new (
-      source: SchemaSource,
+      connection: SchemaSource | DatabaseAdapter,
       options: Record<string, unknown>,
-    ) => InstanceType<T>)(source, options);
+    ) => InstanceType<T>)(connection, options);
   }
 
   /**
@@ -566,7 +570,7 @@ export abstract class SchemaDumper {
       const createDialectDumper = (pool as { createSchemaDumper?: unknown }).createSchemaDumper;
       const dumper =
         (typeof createDialectDumper === "function"
-          ? (createDialectDumper.call(pool, source, options) as SchemaDumper | undefined | null)
+          ? (createDialectDumper.call(pool, options) as SchemaDumper | undefined | null)
           : undefined) ?? this.create(source, options);
       return dumper.dump(stream) as Promise<string[]>;
     }
@@ -593,7 +597,7 @@ export abstract class SchemaDumper {
     // the single emitTable/columnSpec dispatch, never the bare base.
     let dumper: SchemaDumper;
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
-      dumper = (source as any).createSchemaDumper(wrappedSource, {}) as SchemaDumper;
+      dumper = (source as any).createSchemaDumper({}) as SchemaDumper;
     } else {
       dumper = this.create(wrappedSource);
     }

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -166,6 +166,14 @@ type TransactionCallbackFilter<T extends typeof Model> =
   | ((record: InstanceType<T>) => void | boolean | Promise<void | boolean>)
   | CallbackObject
   | string;
+/**
+ * Rails' `*args` on the transaction macros: the filters `set_callback` takes,
+ * optionally closed by the options Hash `set_options_for_callbacks!` extracts.
+ */
+type TransactionCallbackArgs<T extends typeof Model> = (
+  | TransactionCallbackFilter<T>
+  | CallbackOptions
+)[];
 type CallbackOptions = {
   // Rails takes any Symbol here and rejects a bad one at runtime, in
   // `assert_valid_transaction_action` (transactions.rb:344-348) — so the type
@@ -190,89 +198,76 @@ export const InstanceMethods = {
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#before_commit */
 export function beforeCommit<T extends typeof Base>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(options as Record<string, unknown> | undefined);
-  setCallback.call(this, "before_commit", "before", fn, args);
+  setOptionsForCallbacksBang(args);
+  setCallback.call(this, "before_commit", "before", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_commit */
 export function afterCommit<T extends typeof Model>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(
-    options as Record<string, unknown> | undefined,
-    prependOption(),
-  );
-  setCallback.call(this, "commit", "after", fn, args);
+  setOptionsForCallbacksBang(args, prependOption());
+  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_save_commit */
 export function afterSaveCommit<T extends typeof Base>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(options as Record<string, unknown> | undefined, {
+  setOptionsForCallbacksBang(args, {
     on: ["create", "update"],
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", fn, args);
+  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_create_commit */
 export function afterCreateCommit<T extends typeof Base>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(options as Record<string, unknown> | undefined, {
+  setOptionsForCallbacksBang(args, {
     on: "create",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", fn, args);
+  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_update_commit */
 export function afterUpdateCommit<T extends typeof Base>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(options as Record<string, unknown> | undefined, {
+  setOptionsForCallbacksBang(args, {
     on: "update",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", fn, args);
+  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_destroy_commit */
 export function afterDestroyCommit<T extends typeof Base>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(options as Record<string, unknown> | undefined, {
+  setOptionsForCallbacksBang(args, {
     on: "destroy",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", fn, args);
+  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_rollback */
 export function afterRollback<T extends typeof Model>(
   this: T,
-  fn: TransactionCallbackFilter<T>,
-  options?: CallbackOptions,
+  ...args: TransactionCallbackArgs<T>
 ): void {
-  const args = setOptionsForCallbacksBang(
-    options as Record<string, unknown> | undefined,
-    prependOption(),
-  );
-  setCallback.call(this, "rollback", "after", fn, args);
+  setOptionsForCallbacksBang(args, prependOption());
+  setCallback.call(this, "rollback", "after", ...(args as FilterListEntry<any>[]));
 }
 
 /**
@@ -471,6 +466,17 @@ export function restoreTransactionRecordState(this: Base, forceRestoreState = fa
  *
  * Mirrors: ActiveRecord::Transactions#with_transaction_returning_status
  */
+/**
+ * @missingRailsArgs connection.transaction — CONVERGEABLE: `transactions.rb:413`
+ * opens the transaction on the yielded `connection`; the connection-level
+ * `DatabaseStatements#transaction` exists in trails
+ * (`connection-adapters/abstract/database-statements.ts:568`) but does not
+ * establish the `ar_current_transaction` execution-state scope that
+ * `ClassMethods#transaction` above installs, so reaching it directly would drop
+ * `currentTransaction()` inside the block. Converging means moving that scope
+ * down to the connection — tracked as
+ * `converge-current-transaction-scope-onto-connection`.
+ */
 export async function withTransactionReturningStatus<T>(
   this: Base,
   fn: () => Promise<T>,
@@ -489,9 +495,9 @@ export async function withTransactionReturningStatus<T>(
   // `permanent_connection_checkout = :deprecated | :disallowed`. The yielded
   // connection is taken from the block parameter rather than re-read off the
   // deprecated `.connection` getter, matching Rails.
-  await modelClass.withConnection(async (adapter) => {
+  await modelClass.withConnection(async (connection) => {
     // Mirrors Rails' `ensure_finalize = !connection.transaction_open?`.
-    const hadOuterTransaction = currentTransaction() !== null || adapter.inTransaction;
+    const hadOuterTransaction = currentTransaction() !== null || connection.inTransaction;
 
     await transaction(modelClass, async () => {
       // Enroll record with the TransactionManager so it fires committedBang/
@@ -666,25 +672,28 @@ const VALID_TRANSACTION_ACTIONS = new Set(["create", "update", "destroy"]);
  *   `merge!` to name.
  */
 export function setOptionsForCallbacksBang(
-  options: Record<string, unknown> | undefined,
+  args: unknown[],
   enforcedOptions: Record<string, unknown> = {},
-): Record<string, unknown> {
-  const merged = { ...options, ...enforcedOptions };
+): void {
+  const [rest, extracted] = extractOptionsBang(args);
+  const options: Record<string, unknown> = { ...extracted, ...enforcedOptions };
+  // `extractOptionsBang` answers `args` itself when the last element is not a
+  // Hash, so the filters are copied out before `args` — Ruby's `args << options`
+  // mutates the caller's splat array — is rewritten.
+  const filterList = [...rest];
+  args.length = 0;
+  args.push(...filterList, options);
 
-  if (merged.on !== undefined) {
-    const fireOn = (Array.isArray(merged.on) ? merged.on : [merged.on]) as string[];
+  if (options.on !== undefined) {
+    const fireOn = (Array.isArray(options.on) ? options.on : [options.on]) as string[];
     assertValidTransactionAction(fireOn);
-    const { on: _on, if: existingIf, ...rest } = merged;
-    return {
-      ...rest,
-      if: [
-        (record: Base): boolean => isTransactionIncludeAnyAction.call(record, fireOn),
-        ...(existingIf === undefined ? [] : Array.isArray(existingIf) ? existingIf : [existingIf]),
-      ],
-    };
+    const existingIf = options.if;
+    delete options.on;
+    options.if = [
+      (record: Base): boolean => isTransactionIncludeAnyAction.call(record, fireOn),
+      ...(existingIf === undefined ? [] : Array.isArray(existingIf) ? existingIf : [existingIf]),
+    ];
   }
-
-  return merged;
 }
 
 // Mirrors: ActiveRecord::Transactions::ClassMethods#assert_valid_transaction_action

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -21,13 +21,14 @@ import { Rollback } from "./errors.js";
 export { Rollback };
 import { threadedConnectionFor } from "./connection-handling.js";
 
-import { Transaction } from "./connection-adapters/abstract/transaction.js";
+import {
+  CURRENT_TRANSACTION_KEY,
+  Transaction,
+} from "./connection-adapters/abstract/transaction.js";
 import { Transaction as PublicTransaction } from "./transaction.js";
 import { transaction as dbTransaction } from "./connection-adapters/abstract/database-statements.js";
 
 type TransactionAction = "create" | "update" | "destroy";
-
-const CURRENT_TRANSACTION_KEY = Symbol.for("ar_current_transaction");
 
 /**
  * Get the currently active transaction, if any.
@@ -97,38 +98,17 @@ export async function transaction<T>(
     }
   }
 
-  // Mirrors Rails `ActiveRecord::Transactions::ClassMethods#transaction`, which
-  // runs inside `with_connection { |c| c.transaction(...) }` and threads the
-  // yielded connection. Taking the yielded connection (the block parameter
-  // connection) instead of the deprecated `.connection` getter keeps the build/
-  // callback path from flipping the lease permanent under
-  // `permanent_connection_checkout = :deprecated | :disallowed`, so the pool
-  // releases the connection once the transaction completes.
-  return modelClass.withConnection(async (adapter) => {
-    const result = await dbTransaction.call(
-      adapter as any,
-      async (userTx?: unknown) => {
-        let internalTx: Transaction;
-        if (userTx instanceof Transaction) {
-          internalTx = userTx;
-        } else if (userTx && (userTx as any)._internalTransaction instanceof Transaction) {
-          internalTx = (userTx as any)._internalTransaction;
-        } else {
-          const tmCurrent = (adapter as any).currentTransaction?.();
-          internalTx = tmCurrent instanceof Transaction ? tmCurrent : new Transaction(adapter);
-        }
-        return IsolatedExecutionState.scope(CURRENT_TRANSACTION_KEY, internalTx, () => {
-          const publicTx =
-            userTx instanceof PublicTransaction ? userTx : internalTx.userTransaction;
-          return fn(publicTx);
-        });
-      },
-      {
-        requiresNew: options?.requiresNew,
-        isolation: options?.isolation,
-        joinable: options?.joinable,
-      },
-    );
+  // Taking the yielded connection (the block parameter connection) instead of
+  // the deprecated `.connection` getter keeps the build/callback path from
+  // flipping the lease permanent under `permanent_connection_checkout =
+  // :deprecated | :disallowed`, so the pool releases the connection once the
+  // transaction completes.
+  return modelClass.withConnection(async (connection) => {
+    const result = await dbTransaction.call(connection as any, fn as (tx?: unknown) => Promise<T>, {
+      requiresNew: options?.requiresNew,
+      isolation: options?.isolation,
+      joinable: options?.joinable,
+    });
     return result as T | undefined;
   });
 }
@@ -280,7 +260,9 @@ export function afterRollback<T extends typeof Model>(
  * `*filter_list` is untyped in Ruby and stays open here so the macros above can
  * forward their own `TransactionCallbackFilter<T>` through it. Rails leaves
  * `:on` in the Hash it hands to `super`, where an unknown key is ignored;
- * trails' `assertValidKeys` rejects it, so it comes off first.
+ * trails' `assertValidKeys` rejects it, so it comes off at that seam — after
+ * this body's own guard, and for every event, since `before_commit` reaches
+ * `super` with the `:on` `set_options_for_callbacks!` left in place.
  */
 export function setCallback<T extends typeof Model>(
   this: T,
@@ -297,8 +279,8 @@ export function setCallback<T extends typeof Model>(
       (record: Base): boolean => isTransactionIncludeAnyAction.call(record, fireOn),
       ...kernelArray(options.if),
     ];
-    delete options.on;
   }
+  delete options.on;
 
   (Model.setCallback as (this: T, name: string, ...args: unknown[]) => void).call(
     this,
@@ -465,16 +447,6 @@ export function restoreTransactionRecordState(this: Base, forceRestoreState = fa
  * scheduling.
  *
  * Mirrors: ActiveRecord::Transactions#with_transaction_returning_status
- *
- * @missingRailsArgs connection.transaction — CONVERGEABLE: `transactions.rb:413`
- * opens the transaction on the yielded `connection`; the connection-level
- * `DatabaseStatements#transaction` exists in trails
- * (`connection-adapters/abstract/database-statements.ts:568`) but does not
- * establish the `ar_current_transaction` execution-state scope that
- * `ClassMethods#transaction` above installs, so reaching it directly would drop
- * `currentTransaction()` inside the block. Converging means moving that scope
- * down to the connection — tracked as
- * `converge-current-transaction-scope-onto-connection`.
  */
 export async function withTransactionReturningStatus<T>(
   this: Base,
@@ -498,7 +470,7 @@ export async function withTransactionReturningStatus<T>(
     // Mirrors Rails' `ensure_finalize = !connection.transaction_open?`.
     const hadOuterTransaction = currentTransaction() !== null || connection.inTransaction;
 
-    await transaction(modelClass, async () => {
+    await dbTransaction.call(connection as any, async () => {
       // Enroll record with the TransactionManager so it fires committedBang/
       // rolledbackBang after the transaction commits or rolls back. The TM-driven
       // rolledbackBang path calls restoreTransactionRecordState which reads the
@@ -656,11 +628,9 @@ const VALID_TRANSACTION_ACTIONS = new Set(["create", "update", "destroy"]);
  *
  * Ruby's `args << options` mutates the caller's splat array, and so does this;
  * the filters are copied out first because `extractOptionsBang` answers `args`
- * itself when the last element is not a Hash. `on:` is dropped from the options
- * rather than left in place as Ruby leaves it: ActiveModel's chain validates
- * `on:` itself and has no ActiveRecord `transaction_include_any_action?` to
- * build, so a surviving `on:` would be re-validated against the `before_commit`
- * event and rejected.
+ * itself when the last element is not a Hash. `:on` stays in the options
+ * afterwards, exactly as `transactions.rb:334-341` leaves it, so `set_callback`
+ * sees it again.
  *
  * @internal
  *
@@ -684,7 +654,6 @@ export function setOptionsForCallbacksBang(
     const fireOn = (Array.isArray(options.on) ? options.on : [options.on]) as string[];
     assertValidTransactionAction(fireOn);
     const existingIf = options.if;
-    delete options.on;
     options.if = [
       (record: Base): boolean => isTransactionIncludeAnyAction.call(record, fireOn),
       ...(existingIf === undefined ? [] : Array.isArray(existingIf) ? existingIf : [existingIf]),

--- a/packages/activerecord/src/transactions.ts
+++ b/packages/activerecord/src/transactions.ts
@@ -201,7 +201,7 @@ export function beforeCommit<T extends typeof Base>(
   ...args: TransactionCallbackArgs<T>
 ): void {
   setOptionsForCallbacksBang(args);
-  setCallback.call(this, "before_commit", "before", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "before_commit", "before", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_commit */
@@ -210,7 +210,7 @@ export function afterCommit<T extends typeof Model>(
   ...args: TransactionCallbackArgs<T>
 ): void {
   setOptionsForCallbacksBang(args, prependOption());
-  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "commit", "after", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_save_commit */
@@ -222,7 +222,7 @@ export function afterSaveCommit<T extends typeof Base>(
     on: ["create", "update"],
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "commit", "after", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_create_commit */
@@ -234,7 +234,7 @@ export function afterCreateCommit<T extends typeof Base>(
     on: "create",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "commit", "after", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_update_commit */
@@ -246,7 +246,7 @@ export function afterUpdateCommit<T extends typeof Base>(
     on: "update",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "commit", "after", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_destroy_commit */
@@ -258,7 +258,7 @@ export function afterDestroyCommit<T extends typeof Base>(
     on: "destroy",
     ...prependOption(),
   });
-  setCallback.call(this, "commit", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "commit", "after", ...args);
 }
 
 /** Mirrors: ActiveRecord::Transactions::ClassMethods#after_rollback */
@@ -267,7 +267,7 @@ export function afterRollback<T extends typeof Model>(
   ...args: TransactionCallbackArgs<T>
 ): void {
   setOptionsForCallbacksBang(args, prependOption());
-  setCallback.call(this, "rollback", "after", ...(args as FilterListEntry<any>[]));
+  setCallback.call(this, "rollback", "after", ...args);
 }
 
 /**
@@ -465,8 +465,7 @@ export function restoreTransactionRecordState(this: Base, forceRestoreState = fa
  * scheduling.
  *
  * Mirrors: ActiveRecord::Transactions#with_transaction_returning_status
- */
-/**
+ *
  * @missingRailsArgs connection.transaction — CONVERGEABLE: `transactions.rb:413`
  * opens the transaction on the yielded `connection`; the connection-level
  * `DatabaseStatements#transaction` exists in trails
@@ -655,21 +654,21 @@ const VALID_TRANSACTION_ACTIONS = new Set(["create", "update", "destroy"]);
 /**
  * Mirrors: ActiveRecord::Transactions::ClassMethods#set_options_for_callbacks!
  *
- * Ruby mutates `args` in place; TS returns the merged option hash instead —
- * the callers bind it straight back into the `set_callback` call, so the
- * mutation is not observable. `on:` is dropped from the returned hash rather
- * than left in place as Ruby leaves it: ActiveModel's chain validates `on:`
- * itself and has no ActiveRecord `transaction_include_any_action?` to build,
- * so a surviving `on:` would be re-validated against the `before_commit`
+ * Ruby's `args << options` mutates the caller's splat array, and so does this;
+ * the filters are copied out first because `extractOptionsBang` answers `args`
+ * itself when the last element is not a Hash. `on:` is dropped from the options
+ * rather than left in place as Ruby leaves it: ActiveModel's chain validates
+ * `on:` itself and has no ActiveRecord `transaction_include_any_action?` to
+ * build, so a surviving `on:` would be re-validated against the `before_commit`
  * event and rejected.
  *
  * @internal
  *
  * @missingRailsCall merge! — PERMANENT: Reviewed (RFC 0106 wave 4c): Ruby's
  *   `args.extract_options!.merge!(enforced_options)` mutates the extracted hash
- *   in place; TS returns a fresh merged object via spread because the caller
- *   binds the result straight into `set_callback`, so there is no in-place
- *   `merge!` to name.
+ *   in place; TS builds the merged object with a spread rather than writing the
+ *   enforced keys into the caller's own options literal, so there is no
+ *   in-place `merge!` to name.
  */
 export function setOptionsForCallbacksBang(
   args: unknown[],
@@ -677,9 +676,6 @@ export function setOptionsForCallbacksBang(
 ): void {
   const [rest, extracted] = extractOptionsBang(args);
   const options: Record<string, unknown> = { ...extracted, ...enforcedOptions };
-  // `extractOptionsBang` answers `args` itself when the last element is not a
-  // Hash, so the filters are copied out before `args` — Ruby's `args << options`
-  // mutates the caller's splat array — is rewritten.
   const filterList = [...rest];
   args.length = 0;
   args.push(...filterList, options);

--- a/packages/activesupport/src/core-ext/date-and-time/calculations.ts
+++ b/packages/activesupport/src/core-ext/date-and-time/calculations.ts
@@ -48,9 +48,10 @@ export const DAYS_INTO_WEEK: Record<string, number> = {
 export const WEEKEND_DAYS = [6, 0];
 
 function advance(
-  dateOrTime: DateOrTime,
+  dateOrTime: DateOrTime | Temporal.Instant,
   options: { years?: number; months?: number; weeks?: number; days?: number },
 ): DateOrInstant {
+  dateOrTime = receiver(dateOrTime);
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date
     ? time.advance(dateOrTime, options)
@@ -62,7 +63,8 @@ function toDate(dateOrTime: DateOrTime): Temporal.PlainDate {
   return dateOrTime instanceof Date ? time.toDate(dateOrTime) : dateOrTime;
 }
 
-function wday(dateOrTime: DateOrTime): number {
+function wday(dateOrTime: DateOrTime | Temporal.Instant): number {
+  dateOrTime = receiver(dateOrTime);
   // `Temporal.PlainDate#dayOfWeek` is ISO (Monday 1 … Sunday 7); Ruby's `wday`
   // counts from Sunday 0, which is what `WEEKEND_DAYS` is written in.
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
@@ -96,7 +98,7 @@ function toInstant(dateOrTime: Comparable): Temporal.Instant {
  * `Date#change` (`date/calculations.rb:143-149`) does.
  */
 function change(
-  dateOrTime: DateOrTime,
+  dateOrTime: DateOrTime | Temporal.Instant,
   options: {
     year?: number;
     month?: number;
@@ -107,6 +109,7 @@ function change(
     nsec?: number;
   },
 ): DateOrInstant {
+  dateOrTime = receiver(dateOrTime);
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date
     ? time.change(dateOrTime, options)
@@ -114,12 +117,13 @@ function change(
 }
 
 /**
- * Re-enters the mixin with a value one of its members answered. Ruby's members
- * return the receiver's own class, so a chained call needs no conversion; the
- * `Time` arm here answers a `Temporal.Instant` while its receiver is a JS
- * `Date`, so the chain converts back.
+ * Normalizes a value one of the mixin's members answered back to the receiver
+ * representation the arm dispatch is keyed on. Ruby's members return the
+ * receiver's own class, so a chained call needs no conversion; the `Time` arm
+ * here answers a `Temporal.Instant` while its receiver is a JS `Date`, so the
+ * arm boundary — never the chained call site — converts back.
  */
-function receiver(dateOrTime: DateOrInstant): DateOrTime {
+function receiver(dateOrTime: DateOrTime | Temporal.Instant): DateOrTime {
   // boundary: the `Time` arm's receiver is a JS `Date`, which is what this rebuilds.
   return dateOrTime instanceof Temporal.Instant
     ? new Date(dateOrTime.epochMilliseconds)
@@ -127,17 +131,20 @@ function receiver(dateOrTime: DateOrInstant): DateOrTime {
 }
 
 /** `self.year` / `self.month` / `self.day`, across both arms. */
-function year(dateOrTime: DateOrTime): number {
+function year(dateOrTime: DateOrTime | Temporal.Instant): number {
+  dateOrTime = receiver(dateOrTime);
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getFullYear() : dateOrTime.year;
 }
 
-function month(dateOrTime: DateOrTime): number {
+function month(dateOrTime: DateOrTime | Temporal.Instant): number {
+  dateOrTime = receiver(dateOrTime);
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getMonth() + 1 : dateOrTime.month;
 }
 
-function day(dateOrTime: DateOrTime): number {
+function day(dateOrTime: DateOrTime | Temporal.Instant): number {
+  dateOrTime = receiver(dateOrTime);
   // boundary: a JS `Date` is the `Time` arm's receiver, and this dispatch is keyed on being one.
   return dateOrTime instanceof Date ? dateOrTime.getDate() : dateOrTime.day;
 }
@@ -275,7 +282,7 @@ export function isFuture(dateOrTime: DateOrTime): boolean {
  *
  * Mirrors: `DateAndTime::Calculations#on_weekend?` (`:57-59`)
  */
-export function isOnWeekend(dateOrTime: DateOrTime): boolean {
+export function isOnWeekend(dateOrTime: DateOrTime | Temporal.Instant): boolean {
   return WEEKEND_DAYS.includes(wday(dateOrTime));
 }
 
@@ -324,7 +331,8 @@ export function daysAgo(dateOrTime: DateOrTime, days: number): DateOrInstant {
  */
 export function daysSince(dateOrTime: Temporal.PlainDate, days: number): Temporal.PlainDate;
 export function daysSince(dateOrTime: Date, days: number): Temporal.Instant;
-export function daysSince(dateOrTime: DateOrTime, days: number): DateOrInstant {
+export function daysSince(dateOrTime: DateOrInstant, days: number): DateOrInstant;
+export function daysSince(dateOrTime: DateOrTime | Temporal.Instant, days: number): DateOrInstant {
   return advance(dateOrTime, { days: days });
 }
 
@@ -373,7 +381,8 @@ export function yearsSince(dateOrTime: DateOrTime, years: number): DateOrInstant
 /** Mirrors: `DateAndTime::Calculations#beginning_of_month` (`:125-127`) */
 export function beginningOfMonth(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function beginningOfMonth(dateOrTime: Date): Temporal.Instant;
-export function beginningOfMonth(dateOrTime: DateOrTime): DateOrInstant {
+export function beginningOfMonth(dateOrTime: DateOrInstant): DateOrInstant;
+export function beginningOfMonth(dateOrTime: DateOrTime | Temporal.Instant): DateOrInstant {
   return firstHour(change(dateOrTime, { day: 1 }));
 }
 
@@ -385,7 +394,7 @@ export function beginningOfQuarter(dateOrTime: Temporal.PlainDate): Temporal.Pla
 export function beginningOfQuarter(dateOrTime: Date): Temporal.Instant;
 export function beginningOfQuarter(dateOrTime: DateOrTime): DateOrInstant {
   const firstQuarterMonth = month(dateOrTime) - ((2 + month(dateOrTime)) % 3);
-  return change(receiver(beginningOfMonth(dateOrTime as Date)), { month: firstQuarterMonth });
+  return change(beginningOfMonth(dateOrTime as Date), { month: firstQuarterMonth });
 }
 
 /** Mirrors: `alias :at_beginning_of_quarter :beginning_of_quarter` (`:143`) */
@@ -396,11 +405,7 @@ export function endOfQuarter(dateOrTime: Temporal.PlainDate): Temporal.PlainDate
 export function endOfQuarter(dateOrTime: Date): Temporal.Instant;
 export function endOfQuarter(dateOrTime: DateOrTime): DateOrInstant {
   const lastQuarterMonth = month(dateOrTime) + ((12 - month(dateOrTime)) % 3);
-  return endOfMonth(
-    receiver(
-      change(receiver(beginningOfMonth(dateOrTime as Date)), { month: lastQuarterMonth }),
-    ) as Date,
-  );
+  return endOfMonth(change(beginningOfMonth(dateOrTime as Date), { month: lastQuarterMonth }));
 }
 
 /** Mirrors: `alias :at_end_of_quarter :end_of_quarter` (`:158`) */
@@ -415,7 +420,7 @@ export function quarter(dateOrTime: DateOrTime): number {
 export function beginningOfYear(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function beginningOfYear(dateOrTime: Date): Temporal.Instant;
 export function beginningOfYear(dateOrTime: DateOrTime): DateOrInstant {
-  return beginningOfMonth(receiver(change(dateOrTime, { month: 1 })) as Date);
+  return beginningOfMonth(change(dateOrTime, { month: 1 }));
 }
 
 /** Mirrors: `alias :at_beginning_of_year :beginning_of_year` (`:182`) */
@@ -438,10 +443,7 @@ export function nextWeek(
   { sameTime = false }: { sameTime?: boolean } = {},
 ): DateOrInstant {
   const result = firstHour(
-    daysSince(
-      receiver(beginningOfWeek(receiver(weeksSince(dateOrTime as Date, 1)) as Date)) as Date,
-      daysSpan(givenDayInNextWeek),
-    ),
+    daysSince(beginningOfWeek(weeksSince(dateOrTime as Date, 1)), daysSpan(givenDayInNextWeek)),
   );
   return sameTime ? copyTimeTo(dateOrTime, result) : result;
 }
@@ -450,7 +452,7 @@ export function nextWeek(
 export function nextWeekday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function nextWeekday(dateOrTime: Date): Temporal.Instant;
 export function nextWeekday(dateOrTime: DateOrTime): DateOrInstant {
-  if (isOnWeekend(receiver(nextDay(dateOrTime)))) {
+  if (isOnWeekend(nextDay(dateOrTime))) {
     return nextWeek(dateOrTime as Date, "monday", { sameTime: true });
   } else {
     return nextDay(dateOrTime);
@@ -481,10 +483,7 @@ export function prevWeek(
   { sameTime = false }: { sameTime?: boolean } = {},
 ): DateOrInstant {
   const result = firstHour(
-    daysSince(
-      receiver(beginningOfWeek(receiver(weeksAgo(dateOrTime as Date, 1)) as Date)) as Date,
-      daysSpan(startDay),
-    ),
+    daysSince(beginningOfWeek(weeksAgo(dateOrTime as Date, 1)), daysSpan(startDay)),
   );
   return sameTime ? copyTimeTo(dateOrTime, result) : result;
 }
@@ -496,7 +495,7 @@ export const lastWeek = prevWeek;
 export function prevWeekday(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function prevWeekday(dateOrTime: Date): Temporal.Instant;
 export function prevWeekday(dateOrTime: DateOrTime): DateOrInstant {
-  if (isOnWeekend(receiver(prevDay(dateOrTime)))) {
+  if (isOnWeekend(prevDay(dateOrTime))) {
     return copyTimeTo(dateOrTime, beginningOfWeek(dateOrTime as Date, "friday"));
   } else {
     return prevDay(dateOrTime);
@@ -532,7 +531,7 @@ export function lastYear(dateOrTime: DateOrTime): DateOrInstant {
 
 /** Mirrors: `DateAndTime::Calculations#days_to_week_start` (`:258-261`) */
 export function daysToWeekStart(
-  dateOrTime: DateOrTime,
+  dateOrTime: DateOrTime | Temporal.Instant,
   startDay: string = date.beginningOfWeek(),
 ): number {
   const startDayNumber = fetch(DAYS_INTO_WEEK, startDay);
@@ -545,8 +544,9 @@ export function beginningOfWeek(
   startDay?: string,
 ): Temporal.PlainDate;
 export function beginningOfWeek(dateOrTime: Date, startDay?: string): Temporal.Instant;
+export function beginningOfWeek(dateOrTime: DateOrInstant, startDay?: string): DateOrInstant;
 export function beginningOfWeek(
-  dateOrTime: DateOrTime,
+  dateOrTime: DateOrTime | Temporal.Instant,
   startDay: string = date.beginningOfWeek(),
 ): DateOrInstant {
   const result = daysAgo(dateOrTime as Date, daysToWeekStart(dateOrTime, startDay));
@@ -586,7 +586,8 @@ export function sunday(dateOrTime: DateOrTime): DateOrInstant {
 /** Mirrors: `DateAndTime::Calculations#end_of_month` (`:296-299`) */
 export function endOfMonth(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function endOfMonth(dateOrTime: Date): Temporal.Instant;
-export function endOfMonth(dateOrTime: DateOrTime): DateOrInstant {
+export function endOfMonth(dateOrTime: DateOrInstant): DateOrInstant;
+export function endOfMonth(dateOrTime: DateOrTime | Temporal.Instant): DateOrInstant {
   const lastDay = time.daysInMonth(month(dateOrTime), year(dateOrTime));
   return lastHour(daysSince(dateOrTime as Date, lastDay - day(dateOrTime)));
 }
@@ -598,7 +599,7 @@ export const atEndOfMonth = endOfMonth;
 export function endOfYear(dateOrTime: Temporal.PlainDate): Temporal.PlainDate;
 export function endOfYear(dateOrTime: Date): Temporal.Instant;
 export function endOfYear(dateOrTime: DateOrTime): DateOrInstant {
-  return endOfMonth(receiver(change(dateOrTime, { month: 12 })) as Date);
+  return endOfMonth(change(dateOrTime, { month: 12 }));
 }
 
 /** Mirrors: `alias :at_end_of_year :end_of_year` (`:307`) */
@@ -682,7 +683,7 @@ function daysSpan(day: string): number {
 
 /** Mirrors: `DateAndTime::Calculations#copy_time_to` (`:370-372`) @internal */
 function copyTimeTo(self: DateOrTime, other: DateOrInstant): DateOrInstant {
-  return change(receiver(other), {
+  return change(other, {
     hour: hour(self),
     min: min(self),
     sec: sec(self),

--- a/packages/activesupport/src/time-ext.ts
+++ b/packages/activesupport/src/time-ext.ts
@@ -355,7 +355,7 @@ export function advance(
   } else if (timeAdvancedByDate instanceof RubyTime) {
     return timeAdvancedByDate.plus(secondsToAdvance);
   } else {
-    return since(new Date(timeAdvancedByDate.epochMilliseconds), secondsToAdvance);
+    return since(timeAdvancedByDate, secondsToAdvance);
   }
 }
 
@@ -434,8 +434,11 @@ export function ago(date: Date, seconds: number): Temporal.Instant {
   return since(date, -seconds);
 }
 
-export function since(date: Date, seconds: number): Temporal.Instant {
-  return instantFrom(new Date(date.getTime() + seconds * 1000));
+export function since(date: Date | Temporal.Instant, seconds: number): Temporal.Instant {
+  // boundary: the `Time` arm's receiver is a JS `Date`, and a chained call — as
+  // `advance` makes below — answers the same moment as a `Temporal.Instant`.
+  const epochMilliseconds = date instanceof Date ? date.getTime() : date.epochMilliseconds;
+  return instantFrom(new Date(epochMilliseconds + seconds * 1000));
 }
 
 // `alias :in :since` — time/calculations.rb:235.


### PR DESCRIPTION
Four RFC 0096 wave-5 residual arg-shape findings, bundled.

## 1. `converge-activesupport-temporal-receiver-chaining`

The private `receiver()` in `core-ext/date-and-time/calculations.ts` no longer
stands between chained calls. The arm dispatch it feeds — `advance`, `change`,
`year`, `month`, `day`, `wday` — normalizes at its own boundary instead, exactly
where `firstHour` / `lastHour` (`calculations.rb:358-364`) already did, so
`beginning_of_quarter` (`:140`), `end_of_quarter` (`:155`), `next_weekday`
(`:209`) and `prev_weekday` (`:236`) chain on the value Rails chains on.
`time-ext.ts#since` takes the chained `Temporal.Instant` too, so `advance`
passes `time_advanced_by_date` straight through
(`core_ext/time/calculations.rb:215`).

All five rows are gone from `parity:api:calls:args:report`; the remaining rows
for the file are the pre-existing baselined `shape` rows from the
free-function-receiver convention.

## 2. `converge-belongs-to-polymorphic-foreign-type`

`BelongsToPolymorphicAssociation`'s private `foreignTypeName()` is deleted. The
three call sites read `reflection.foreignType` as
`belongs_to_polymorphic_association.rb:12,16,20` do. `AssociationDefinition`
gains the member (`reflection.rb:861`), resolved **lazily** off the reflection
`Builder::Association.createReflection` already builds — eager evaluation
resolves a through reflection's source class at declaration time, which is not
loadable yet.

Three `naming` rows gone. The remaining `inverse_reflection_for` row is the
standard `record.class` → `record.constructor` rename, not this finding.

## 3. `converge-create-schema-dumper-source-arity`

`createSchemaDumper` takes Rails' `(options)` and passes `this`
(`postgresql/schema_statements.rb:884`, `sqlite3/schema_statements.rb:122`,
`mysql/schema_statements.rb:107`, `abstract/schema_statements.rb:1541`). The
adapter→`SchemaSource` bridging the dumper needs moves into the `SchemaDumper`
constructor — the one place every `create` / `new` path funnels through — so no
extra leading parameter survives on the Rails-matched signature. No new
`arity-exclude.json` row; the arity delta is non-negative.

## 4. `converge-transactions-splat-and-transaction-receiver`

The seven transaction callback macros take Rails' `*args` splat and
`set_options_for_callbacks!` mutates it in place (`transactions.rb:248-300`,
`:330-342`), so the forwarded argument list lines up with `set_callback`. Three
rows gone.

The fourth row converged too, after review: `DatabaseStatements#transaction`
now installs the `ar_current_transaction` execution-state scope itself — beside
the `Transaction` it holds, which is where Ruby reads it back from
(`transaction.rb:352-354`) — so `with_transaction_returning_status` opens on the
yielded `connection` as `transactions.rb:409-414` does, and
`ClassMethods#transaction` is the `with_connection { |c| c.transaction(...) }`
of `transactions.rb:231-235`. All four rows are gone and no receipt is left
behind.

`set_options_for_callbacks!` also leaves `:on` in the options hash it appends
(`transactions.rb:334-341`), so `set_callback` sees it again; `:on` comes off at
the ActiveModel seam instead, for every event, since trails' `assertValidKeys`
is stricter than ActiveSupport's.

## Not in this PR

`converge-column-subclass-coders-to-rails-per-subclass-key-sets` was claimed
with this bundle and has been **released**. Converging the PG/MySQL Column
coders requires the adapter `TypeMetadata` classes to round-trip through the
schema-cache coder (a class-tagged `sql_type_metadata` JSON payload plus
rehydration), and the story's own fourth bullet requires converging
`base_test.rb`'s `test_clear_cache!` reflected-vs-dumped comparison. That is a
schema-cache serialization-format change needing its own PG and MySQL lane
verification, not a rider on four arg-shape convergences.

## Verification

- `pnpm parity:api:calls` — OK (405 baselined, 311 unreviewed, marks tight)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows)
- `pnpm parity:api:extra:gate` — OK
- Call-arg mismatches 428 → 414; no new `call-mismatches-exclude/` row
- activesupport suite: 935 files / 18694 tests green
- activerecord `schema-dumper` / `schema-cache` / `association` / `polymorphic`
  selection: 133 files / 2647 tests green
- activerecord `transaction` / `persistence` / `callback` / `fixture` / `lock` /
  `migration` / `nested` / `autosave` / `save` / `destroy` selection (the blast
  radius of moving the current-transaction scope onto the connection): 74 files
  / 1703 tests green

Closes-story: converge-current-transaction-scope-onto-connection
