### PR TITLE
refactor(activemodel,activerecord): split TS-only translation tests, converge Table option splats, dedupe MySQL create_table_definition (RFC 0115, RFC 0051)

### DIFF
--- a/packages/activemodel/src/translation.test.ts
+++ b/packages/activemodel/src/translation.test.ts
@@ -1,38 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
-import { I18n } from "./i18n.js";
-import { raiseOnMissingTranslations } from "./translation.js";
-import { resetI18n } from "./test-helpers/i18n.js";
 
 describe("ActiveModelI18nTests", () => {
-  it("translated model attributes", () => {
-    class Person extends Model {
-      static {
-        this.attribute("first_name", "string");
-      }
-    }
-    expect(Person.humanAttributeName("first_name")).toBe("First name");
-  });
-
-  it("translated model attributes with default", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(Person.humanAttributeName("name")).toBe("Name");
-  });
-
-  it("human attribute name does not modify options", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    expect(Person.humanAttributeName("name")).toBe("Name");
-    expect(Person.humanAttributeName("name")).toBe("Name");
-  });
-
   it("translated model attributes", () => {
     class Person extends Model {
       static {
@@ -126,26 +95,6 @@ describe("ActiveModelI18nTests", () => {
   });
 
   it("translated model with default value when missing translation", () => {
-    expect(Model.humanAttributeName("unknown_field")).toBe("Unknown field");
-  });
-
-  it("translated model with default key when missing both translations", () => {
-    expect(Model.humanAttributeName("unknown")).toBe("Unknown");
-  });
-
-  it("human does not modify options", () => {
-    const opts = {};
-    Model.humanAttributeName("name");
-    expect(opts).toEqual({});
-  });
-
-  it("human attribute name does not modify options", () => {
-    const opts = {};
-    Model.humanAttributeName("name");
-    expect(opts).toEqual({});
-  });
-
-  it("translated model with default value when missing translation", () => {
     class Person extends Model {}
     expect(Person.modelName.human({ default: "dude" })).toBe("dude");
   });
@@ -162,6 +111,12 @@ describe("ActiveModelI18nTests", () => {
     expect(options).toEqual({ default: "person model" });
   });
 
+  it("human attribute name does not modify options", () => {
+    const opts = {};
+    Model.humanAttributeName("name");
+    expect(opts).toEqual({});
+  });
+
   it("raise on missing translations", () => {
     expect(Model.humanAttributeName("missing_field")).toBe("Missing field");
   });
@@ -174,128 +129,5 @@ describe("ActiveModelI18nTests", () => {
     class Parent extends Model {}
     class Child extends Parent {}
     expect(Child.humanAttributeName("first_name")).toBe("First name");
-  });
-});
-
-describe("P11 humanAttributeName — dotted attributes, options, ancestor walk", () => {
-  beforeEach(() => {
-    resetI18n();
-    raiseOnMissingTranslations(false);
-  });
-  afterEach(() => {
-    raiseOnMissingTranslations(false);
-    resetI18n();
-  });
-
-  it("humanizes flat attribute with no locale entry", () => {
-    class Person extends Model {}
-    expect(Person.humanAttributeName("first_name")).toBe("First name");
-  });
-
-  it("returns locale entry for a flat attribute", () => {
-    class User extends Model {}
-    I18n.backend().storeTranslations("en", {
-      activemodel: { attributes: { user: { first_name: "Given Name" } } },
-    });
-    expect(User.humanAttributeName("first_name")).toBe("Given Name");
-  });
-
-  it("humanizes the tail segment of a dotted attribute when not found", () => {
-    class User extends Model {}
-    expect(User.humanAttributeName("address.street")).toBe("Street");
-  });
-
-  it("looks up dotted attribute in i18n before falling back", () => {
-    class User extends Model {}
-    // Rails key: "activemodel.attributes.user/address.street"
-    // I18n path: ["activemodel", "attributes", "user/address", "street"]
-    I18n.backend().storeTranslations("en", {
-      activemodel: { attributes: { "user/address": { street: "Street Address" } } },
-    });
-    expect(User.humanAttributeName("address.street")).toBe("Street Address");
-  });
-
-  it("uses options.default when no locale entry resolves", () => {
-    class User extends Model {}
-    expect(User.humanAttributeName("foo", { default: "Custom Foo" })).toBe("Custom Foo");
-  });
-
-  it("throws with options.raise when no key resolves", () => {
-    class User extends Model {}
-    expect(() => User.humanAttributeName("foo", { raise: true })).toThrow();
-  });
-
-  it("does not throw with options.raise when a locale entry resolves", () => {
-    class User extends Model {}
-    I18n.backend().storeTranslations("en", {
-      activemodel: { attributes: { user: { foo: "Foo" } } },
-    });
-    expect(User.humanAttributeName("foo", { raise: true })).toBe("Foo");
-  });
-
-  it("throws when raiseOnMissingTranslations is enabled globally", () => {
-    class User extends Model {}
-    raiseOnMissingTranslations(true);
-    expect(() => User.humanAttributeName("foo")).toThrow();
-  });
-
-  it("explicit raise:false suppresses the global raiseOnMissingTranslations toggle", () => {
-    class User extends Model {}
-    raiseOnMissingTranslations(true);
-    expect(User.humanAttributeName("foo", { raise: false })).toBe("Foo");
-  });
-
-  it("inherits humanAttributeName from parent class via ancestor walk", () => {
-    class Parent extends Model {}
-    class Child extends Parent {}
-    I18n.backend().storeTranslations("en", {
-      activemodel: { attributes: { parent: { foo: "Parent Foo" } } },
-    });
-    expect(Child.humanAttributeName("foo")).toBe("Parent Foo");
-  });
-
-  it("prefers subclass locale entry over parent", () => {
-    class Parent extends Model {}
-    class Child extends Parent {}
-    I18n.backend().storeTranslations("en", {
-      activemodel: {
-        attributes: {
-          parent: { foo: "Parent Foo" },
-          child: { foo: "Child Foo" },
-        },
-      },
-    });
-    expect(Child.humanAttributeName("foo")).toBe("Child Foo");
-  });
-
-  it("passes through interpolation options to I18n", () => {
-    class User extends Model {}
-    I18n.backend().storeTranslations("en", {
-      activemodel: { attributes: { user: { items: "%{count} item(s)" } } },
-    });
-    expect(User.humanAttributeName("items", { count: 2 })).toBe("2 item(s)");
-  });
-});
-
-describe("raise_on_missing_translations accessor", () => {
-  // Mirrors the singleton attr_accessor :raise_on_missing_translations
-  // from translation.rb:25 — reachable through the host modules that
-  // include/extend Translation in Rails (api.rb, validations.rb).
-  it("toggles the shared singleton via Translation, API, and Validations", async () => {
-    const translation = await import("./translation.js");
-    const api = await import("./api.js");
-    const validations = await import("./validations.js");
-    const original = translation.raiseOnMissingTranslations();
-    try {
-      api.raiseOnMissingTranslations(true);
-      expect(translation.raiseOnMissingTranslations()).toBe(true);
-      expect(validations.raiseOnMissingTranslations()).toBe(true);
-
-      validations.raiseOnMissingTranslations(false);
-      expect(api.raiseOnMissingTranslations()).toBe(false);
-      expect(translation.raiseOnMissingTranslations()).toBe(false);
-    } finally {
-      translation.raiseOnMissingTranslations(original);
-    }
   });
 });

--- a/packages/activemodel/src/translation.trails.test.ts
+++ b/packages/activemodel/src/translation.trails.test.ts
@@ -1,0 +1,181 @@
+/**
+ * trails-only companions to `translation.test.ts`, which mirrors
+ * `activemodel/test/cases/translation_test.rb` and holds only Rails test
+ * names. Everything here has no Rails counterpart: the duplicate-name TS
+ * copies that used to sit beside the mirrored cases, the dotted-attribute /
+ * options / ancestor-walk coverage of `human_attribute_name`
+ * (`activemodel/lib/active_model/translation.rb:44-70`), and the
+ * `raise_on_missing_translations` singleton accessor (`translation.rb:25`).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Model } from "./index.js";
+import { I18n } from "./i18n.js";
+import { raiseOnMissingTranslations } from "./translation.js";
+import { resetI18n } from "./test-helpers/i18n.js";
+
+describe("ActiveModelI18nTests — duplicate-name TS copies", () => {
+  it("translated model attributes", () => {
+    class Person extends Model {
+      static {
+        this.attribute("first_name", "string");
+      }
+    }
+    expect(Person.humanAttributeName("first_name")).toBe("First name");
+  });
+
+  it("translated model attributes with default", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    expect(Person.humanAttributeName("name")).toBe("Name");
+  });
+
+  it("human attribute name does not modify options", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    expect(Person.humanAttributeName("name")).toBe("Name");
+    expect(Person.humanAttributeName("name")).toBe("Name");
+  });
+
+  it("translated model with default value when missing translation", () => {
+    expect(Model.humanAttributeName("unknown_field")).toBe("Unknown field");
+  });
+
+  it("translated model with default key when missing both translations", () => {
+    expect(Model.humanAttributeName("unknown")).toBe("Unknown");
+  });
+
+  it("human does not modify options", () => {
+    const opts = {};
+    Model.humanAttributeName("name");
+    expect(opts).toEqual({});
+  });
+});
+
+describe("P11 humanAttributeName — dotted attributes, options, ancestor walk", () => {
+  beforeEach(() => {
+    resetI18n();
+    raiseOnMissingTranslations(false);
+  });
+  afterEach(() => {
+    raiseOnMissingTranslations(false);
+    resetI18n();
+  });
+
+  it("humanizes flat attribute with no locale entry", () => {
+    class Person extends Model {}
+    expect(Person.humanAttributeName("first_name")).toBe("First name");
+  });
+
+  it("returns locale entry for a flat attribute", () => {
+    class User extends Model {}
+    I18n.backend().storeTranslations("en", {
+      activemodel: { attributes: { user: { first_name: "Given Name" } } },
+    });
+    expect(User.humanAttributeName("first_name")).toBe("Given Name");
+  });
+
+  it("humanizes the tail segment of a dotted attribute when not found", () => {
+    class User extends Model {}
+    expect(User.humanAttributeName("address.street")).toBe("Street");
+  });
+
+  it("looks up dotted attribute in i18n before falling back", () => {
+    class User extends Model {}
+    // Rails key: "activemodel.attributes.user/address.street"
+    // I18n path: ["activemodel", "attributes", "user/address", "street"]
+    I18n.backend().storeTranslations("en", {
+      activemodel: { attributes: { "user/address": { street: "Street Address" } } },
+    });
+    expect(User.humanAttributeName("address.street")).toBe("Street Address");
+  });
+
+  it("uses options.default when no locale entry resolves", () => {
+    class User extends Model {}
+    expect(User.humanAttributeName("foo", { default: "Custom Foo" })).toBe("Custom Foo");
+  });
+
+  it("throws with options.raise when no key resolves", () => {
+    class User extends Model {}
+    expect(() => User.humanAttributeName("foo", { raise: true })).toThrow();
+  });
+
+  it("does not throw with options.raise when a locale entry resolves", () => {
+    class User extends Model {}
+    I18n.backend().storeTranslations("en", {
+      activemodel: { attributes: { user: { foo: "Foo" } } },
+    });
+    expect(User.humanAttributeName("foo", { raise: true })).toBe("Foo");
+  });
+
+  it("throws when raiseOnMissingTranslations is enabled globally", () => {
+    class User extends Model {}
+    raiseOnMissingTranslations(true);
+    expect(() => User.humanAttributeName("foo")).toThrow();
+  });
+
+  it("explicit raise:false suppresses the global raiseOnMissingTranslations toggle", () => {
+    class User extends Model {}
+    raiseOnMissingTranslations(true);
+    expect(User.humanAttributeName("foo", { raise: false })).toBe("Foo");
+  });
+
+  it("inherits humanAttributeName from parent class via ancestor walk", () => {
+    class Parent extends Model {}
+    class Child extends Parent {}
+    I18n.backend().storeTranslations("en", {
+      activemodel: { attributes: { parent: { foo: "Parent Foo" } } },
+    });
+    expect(Child.humanAttributeName("foo")).toBe("Parent Foo");
+  });
+
+  it("prefers subclass locale entry over parent", () => {
+    class Parent extends Model {}
+    class Child extends Parent {}
+    I18n.backend().storeTranslations("en", {
+      activemodel: {
+        attributes: {
+          parent: { foo: "Parent Foo" },
+          child: { foo: "Child Foo" },
+        },
+      },
+    });
+    expect(Child.humanAttributeName("foo")).toBe("Child Foo");
+  });
+
+  it("passes through interpolation options to I18n", () => {
+    class User extends Model {}
+    I18n.backend().storeTranslations("en", {
+      activemodel: { attributes: { user: { items: "%{count} item(s)" } } },
+    });
+    expect(User.humanAttributeName("items", { count: 2 })).toBe("2 item(s)");
+  });
+});
+
+describe("raise_on_missing_translations accessor", () => {
+  // Mirrors the singleton attr_accessor :raise_on_missing_translations
+  // from translation.rb:25 — reachable through the host modules that
+  // include/extend Translation in Rails (api.rb, validations.rb).
+  it("toggles the shared singleton via Translation, API, and Validations", async () => {
+    const translation = await import("./translation.js");
+    const api = await import("./api.js");
+    const validations = await import("./validations.js");
+    const original = translation.raiseOnMissingTranslations();
+    try {
+      api.raiseOnMissingTranslations(true);
+      expect(translation.raiseOnMissingTranslations()).toBe(true);
+      expect(validations.raiseOnMissingTranslations()).toBe(true);
+
+      validations.raiseOnMissingTranslations(false);
+      expect(api.raiseOnMissingTranslations()).toBe(false);
+      expect(translation.raiseOnMissingTranslations()).toBe(false);
+    } finally {
+      translation.raiseOnMissingTranslations(original);
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -201,21 +201,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   /**
-   * Override `SchemaStatements#createTableDefinition` to instantiate the
-   * MySQL-specific {@link MysqlTableDefinition} subclass, so its overrides
-   * (`newColumnDefinition` primary-key rewrite, `integerLikePrimaryKeyType`
-   * → `autoIncrement: true`, `aliasedTypes` identity, MySQL-only options)
-   * apply to `createTable` as well as `changeColumn`.
-   *
-   * Mirrors: `ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#create_table_definition`
-   * @internal
-   */
-  createTableDefinition(name: string, options: Record<string, unknown> = {}): MysqlTableDefinition {
-    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
-    return new MysqlTableDefinition(name, { ...rest, adapter: this });
-  }
-
-  /**
    * RESTRICT is MySQL's default referential action, so `extractForeignKeyAction`
    * reflects it back as `undefined` and a lookup keyed on `onDelete: "restrict"`
    * could never match the live constraint. Drop those keys before resolving.
@@ -2036,6 +2021,9 @@ export interface AbstractMysqlAdapter {
 
   /** @internal */
   validPrimaryKeyOptions(): string[];
+
+  /** @internal */
+  createTableDefinition(name: string, options?: Record<string, unknown>): MysqlTableDefinition;
 }
 /* eslint-enable @typescript-eslint/no-unsafe-declaration-merging */
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1642,7 +1642,11 @@ export class Table {
   }
   async index(columns: string | string[], options: AddIndexOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.addIndex(this.name, columns, options);
+    if (Object.keys(options).length === 0) {
+      await this._schema.addIndex(this.name, columns);
+    } else {
+      await this._schema.addIndex(this.name, columns, options);
+    }
   }
   // Rails: `Table#remove_index(column_name = nil, **options)` forwards to
   // `@base.remove_index(table_name, column_name, **options)`.
@@ -1656,7 +1660,11 @@ export class Table {
     // nil column with the options behind it keeps them.
     options = isColumn ? options : { ...columnOrOptions, ...options };
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.removeIndex(this.name, columnName, options);
+    if (Object.keys(options).length === 0) {
+      await this._schema.removeIndex(this.name, columnName);
+    } else {
+      await this._schema.removeIndex(this.name, columnName, options);
+    }
   }
   async references(...refNames: string[]): Promise<void>;
   async references(...args: [...refNames: string[], options: AddReferenceOptions]): Promise<void>;
@@ -1664,7 +1672,11 @@ export class Table {
     const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     for (const refName of names) {
-      await this._schema.addReference(this.name, refName, options);
+      if (Object.keys(options).length === 0) {
+        await this._schema.addReference(this.name, refName);
+      } else {
+        await this._schema.addReference(this.name, refName, options);
+      }
     }
   }
   async belongsTo(...refNames: string[]): Promise<void>;
@@ -1674,7 +1686,11 @@ export class Table {
   }
   async timestamps(options: ColumnOptions = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
-    await this._schema.addTimestamps(this.name, options);
+    if (Object.keys(options).length === 0) {
+      await this._schema.addTimestamps(this.name);
+    } else {
+      await this._schema.addTimestamps(this.name, options);
+    }
   }
 
   get name(): string {
@@ -1727,7 +1743,10 @@ export class Table {
     return this._schema.changeColumnNull(this.name, columnName, isNull, defaultValue);
   }
 
-  async removeTimestamps(options?: ColumnOptions): Promise<void> {
+  async removeTimestamps(options: ColumnOptions = {}): Promise<void> {
+    if (Object.keys(options).length === 0) {
+      return this._schema.removeTimestamps(this.name);
+    }
     return this._schema.removeTimestamps(this.name, options);
   }
 
@@ -1739,7 +1758,11 @@ export class Table {
     const { names, options } = this._splitRefNames(args);
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
     for (const refName of names) {
-      await this._schema.removeReference(this.name, refName, options);
+      if (Object.keys(options).length === 0) {
+        await this._schema.removeReference(this.name, refName);
+      } else {
+        await this._schema.removeReference(this.name, refName, options);
+      }
     }
   }
   async removeBelongsTo(...refNames: string[]): Promise<void>;
@@ -1761,6 +1784,9 @@ export class Table {
 
   async foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): Promise<void> {
     this.raiseOnIfExistOptions(options as Record<string, unknown>);
+    if (Object.keys(options).length === 0) {
+      return this._schema.addForeignKey(this.name, toTable);
+    }
     return this._schema.addForeignKey(this.name, toTable, options);
   }
 
@@ -1770,6 +1796,9 @@ export class Table {
     this.raiseOnIfExistOptions(
       (typeof toTableOrOptions === "object" ? toTableOrOptions : {}) as Record<string, unknown>,
     );
+    if (typeof toTableOrOptions === "object" && Object.keys(toTableOrOptions).length === 0) {
+      return this._schema.removeForeignKey(this.name);
+    }
     return this._schema.removeForeignKey(this.name, toTableOrOptions);
   }
 
@@ -1777,7 +1806,10 @@ export class Table {
     return this._schema.foreignKeyExists(this.name, toTableOrOptions);
   }
 
-  async checkConstraint(expression: string, options?: Record<string, unknown>): Promise<void> {
+  async checkConstraint(expression: string, options: Record<string, unknown> = {}): Promise<void> {
+    if (Object.keys(options).length === 0) {
+      return this._schema.addCheckConstraint(this.name, expression);
+    }
     return this._schema.addCheckConstraint(this.name, expression, options);
   }
 
@@ -1790,6 +1822,9 @@ export class Table {
         this.name,
         options?.name ? options : expressionOrOptions,
       );
+    }
+    if (expressionOrOptions === undefined || Object.keys(expressionOrOptions).length === 0) {
+      return this._schema.removeCheckConstraint(this.name);
     }
     return this._schema.removeCheckConstraint(this.name, expressionOrOptions);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1723,6 +1723,9 @@ export class Table {
     columnName: string | string[],
     options: Record<string, unknown> = {},
   ): Promise<boolean> {
+    if (Object.keys(options).length === 0) {
+      return this._schema.indexExists(this.name, columnName);
+    }
     return this._schema.indexExists(this.name, columnName, options);
   }
 
@@ -1803,6 +1806,9 @@ export class Table {
   }
 
   async foreignKeyExists(toTableOrOptions?: string | Record<string, unknown>): Promise<boolean> {
+    if (toTableOrOptions === undefined) {
+      return this._schema.foreignKeyExists(this.name);
+    }
     return this._schema.foreignKeyExists(this.name, toTableOrOptions);
   }
 
@@ -1832,6 +1838,9 @@ export class Table {
   async checkConstraintExists(
     options: { name?: string; expression?: string } = {},
   ): Promise<boolean> {
+    if (Object.keys(options).length === 0) {
+      return this._schema.checkConstraintExists(this.name);
+    }
     return this._schema.checkConstraintExists(this.name, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1821,18 +1821,21 @@ export class Table {
 
   async removeCheckConstraint(
     expressionOrOptions?: string | { name?: string },
-    options?: { name?: string },
+    options: { name?: string } = {},
   ): Promise<void> {
     if (typeof expressionOrOptions === "string") {
-      return this._schema.removeCheckConstraint(
-        this.name,
-        options?.name ? options : expressionOrOptions,
-      );
+      if (Object.keys(options).length === 0) {
+        return this._schema.removeCheckConstraint(this.name, expressionOrOptions);
+      }
+      return this._schema.removeCheckConstraint(this.name, expressionOrOptions, options);
     }
-    if (expressionOrOptions === undefined || Object.keys(expressionOrOptions).length === 0) {
+    // Ruby's `**options` collects the hash from either position, so an absent
+    // expression with the options behind it keeps them.
+    const opts = { ...expressionOrOptions, ...options };
+    if (Object.keys(opts).length === 0) {
       return this._schema.removeCheckConstraint(this.name);
     }
-    return this._schema.removeCheckConstraint(this.name, expressionOrOptions);
+    return this._schema.removeCheckConstraint(this.name, opts);
   }
 
   async checkConstraintExists(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -877,7 +877,8 @@ describe("buildCreateTableDefinition routing", () => {
 
   it("extracts _skipValidateOptions into the table definition options", () => {
     const createTableDefinition = vi.fn(
-      (name: string, options: Record<string, unknown>) => new TableDefinition(name, options as any),
+      (name: string, options: Record<string, unknown>) =>
+        new TableDefinition(name, { ...options, adapter: ss } as any),
     );
     const ss = makeStatements({ createTableDefinition });
 
@@ -895,7 +896,7 @@ describe("buildCreateTableDefinition routing", () => {
     const mysql = makeStatements({
       validPrimaryKeyOptions: () => ["limit", "unsigned", "autoIncrement"],
       createTableDefinition: (name: string, options: Record<string, unknown>) =>
-        new MysqlTableDefinition(name, options as any),
+        new MysqlTableDefinition(name, { ...options, adapter: mysql } as any),
     });
 
     expect(
@@ -941,7 +942,7 @@ describe("buildCreateTableDefinition routing", () => {
   it("builds the definition through the adapter's createTableDefinition", () => {
     const marker = Symbol("dialect-td");
     const createTableDefinition = vi.fn((name: string, options: Record<string, unknown>) => {
-      const td: any = new TableDefinition(name, options as any);
+      const td: any = new TableDefinition(name, { ...options, adapter: ss } as any);
       td[marker] = true;
       return td;
     });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1355,12 +1355,7 @@ export class SchemaStatements {
       }
     }
 
-    const ctdOptions = {
-      ...tdOptions,
-      adapterName: this.adapterName,
-      adapter: this,
-    };
-    const tableDefinition = this.createTableDefinition(tableName, ctdOptions);
+    const tableDefinition = this.createTableDefinition(tableName, tdOptions);
     tableDefinition.setPrimaryKey(tableName, id, primaryKey, pkOptions);
 
     if (fn) fn(tableDefinition);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -6,7 +6,6 @@ import { Table as MysqlTable } from "./schema-definitions.js";
 import {
   isRowFormatDynamicByDefault,
   defaultRowFormat,
-  createTableDefinition,
   defaultType,
   newColumnFromField,
   type MysqlColumnReflectionHost,
@@ -103,7 +102,9 @@ describe("MySQL::SchemaStatements", () => {
 
   it("createTableDefinition returns MySQL TableDefinition", async () => {
     const conn = await Base.leaseConnection();
-    expect(createTableDefinition.call(conn as never, "users").name).toBe("users");
+    expect(
+      MysqlSchemaStatements.prototype.createTableDefinition.call(conn as never, "users").name,
+    ).toBe("users");
   });
 
   const reflectionHost = (

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.trails.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "../../base.js";
 import { MysqlSchemaStatements } from "./schema-statements.js";
-import { Table as MysqlTable } from "./schema-definitions.js";
+import {
+  Table as MysqlTable,
+  TableDefinition as MysqlTableDefinition,
+} from "./schema-definitions.js";
 
 import {
   isRowFormatDynamicByDefault,
@@ -102,9 +105,9 @@ describe("MySQL::SchemaStatements", () => {
 
   it("createTableDefinition returns MySQL TableDefinition", async () => {
     const conn = await Base.leaseConnection();
-    expect(
-      MysqlSchemaStatements.prototype.createTableDefinition.call(conn as never, "users").name,
-    ).toBe("users");
+    const td = MysqlSchemaStatements.prototype.createTableDefinition.call(conn as never, "users");
+    expect(td.name).toBe("users");
+    expect(td).toBeInstanceOf(MysqlTableDefinition);
   });
 
   const reflectionHost = (

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -244,6 +244,18 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
   }
 
   /**
+   * Mirrors: MySQL::SchemaStatements#create_table_definition
+   * (mysql/schema_statements.rb:172-174)
+   * @internal
+   */
+  override createTableDefinition(
+    name: string,
+    options: Record<string, unknown> = {},
+  ): TableDefinition {
+    return new TableDefinition(name, { ...options, adapter: this as never });
+  }
+
+  /**
    * Mirrors: MySQL::SchemaStatements#add_index_length
    *
    * @internal
@@ -317,18 +329,6 @@ export async function defaultRowFormat(this: RowFormatHost): Promise<string | nu
   }
 
   return this._defaultRowFormat ?? null;
-}
-
-/**
- * Mirrors: MySQL::SchemaStatements#create_table_definition
- * @internal
- */
-export function createTableDefinition(
-  this: VisitorHostAdapter,
-  name: string,
-  options: { id?: boolean | "uuid"; charset?: string | null; collation?: string | null } = {},
-): TableDefinition {
-  return new TableDefinition(name, { ...options, adapter: this });
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -252,7 +252,10 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     name: string,
     options: Record<string, unknown> = {},
   ): TableDefinition {
-    return new TableDefinition(name, { ...options, adapter: this as never });
+    return new TableDefinition(name, {
+      ...options,
+      adapter: this as unknown as VisitorHostAdapter,
+    });
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -9,7 +9,10 @@ import { isPresent, presence } from "@blazetrails/activesupport";
 import { Version } from "../abstract-adapter.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { TypeMetadata } from "./type-metadata.js";
-import { TableDefinition, Table as MysqlTable } from "./schema-definitions.js";
+import {
+  TableDefinition as MysqlTableDefinition,
+  Table as MysqlTable,
+} from "./schema-definitions.js";
 import { Column } from "./column.js";
 import { SchemaStatements as BaseSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
@@ -251,8 +254,8 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
   override createTableDefinition(
     name: string,
     options: Record<string, unknown> = {},
-  ): TableDefinition {
-    return new TableDefinition(name, {
+  ): MysqlTableDefinition {
+    return new MysqlTableDefinition(name, {
       ...options,
       adapter: this as unknown as VisitorHostAdapter,
     });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3719,7 +3719,7 @@ export class PostgreSQLAdapter
 
   /** @internal */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): PgTableDefinition {
-    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
+    const rest = options;
     const unlogged =
       (rest.unlogged as boolean | undefined) ?? PostgreSQLAdapter.createUnloggedTables;
     return new PgTableDefinition(name, { ...rest, unlogged, adapter: this });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -208,8 +208,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     name: string,
     options: Record<string, unknown> = {},
   ): SQLite3TableDefinition {
-    const { adapter: _adapterOpt, adapterName: _adapterNameOpt, ...rest } = options;
-    return new SQLite3TableDefinition(name, { ...rest, adapter: this });
+    return new SQLite3TableDefinition(name, { ...options, adapter: this });
   }
 
   /**

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -128,9 +128,6 @@ describe("CommandRecorder", () => {
     });
 
     it("forwarders record no trailing options hash when the splat is empty", async () => {
-      // Ruby's `**options` passes no argument at all when the hash is empty
-      // (schema_definitions.rb:829, :756, :786, :852), and CommandRecorder
-      // stores the arguments verbatim.
       const recorder = new CommandRecorder(abstractDelegate);
       await recorder.changeTable("fruits", async (t) => {
         await t.remove("name");

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -127,6 +127,39 @@ describe("CommandRecorder", () => {
       expect(recorder.commands[0][0]).toBe("addColumn");
     });
 
+    it("forwarders record no trailing options hash when the splat is empty", async () => {
+      // Ruby's `**options` passes no argument at all when the hash is empty
+      // (schema_definitions.rb:829, :756, :786, :852), and CommandRecorder
+      // stores the arguments verbatim.
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.remove("name");
+        await t.index("kind");
+        await t.timestamps();
+        await t.removeTimestamps();
+        await t.removeIndex("kind");
+        await t.references("supplier");
+        await t.removeReferences("supplier");
+        await t.foreignKey("suppliers");
+        await t.removeForeignKey();
+        await t.checkConstraint("qty > 0");
+        await t.removeCheckConstraint();
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeColumns", args: ["fruits", "name"] },
+        { cmd: "addIndex", args: ["fruits", "kind"] },
+        { cmd: "addTimestamps", args: ["fruits"] },
+        { cmd: "removeTimestamps", args: ["fruits"] },
+        { cmd: "removeIndex", args: ["fruits", "kind"] },
+        { cmd: "addReference", args: ["fruits", "supplier"] },
+        { cmd: "removeReference", args: ["fruits", "supplier"] },
+        { cmd: "addForeignKey", args: ["fruits", "suppliers"] },
+        { cmd: "removeForeignKey", args: ["fruits"] },
+        { cmd: "addCheckConstraint", args: ["fruits", "qty > 0"] },
+        { cmd: "removeCheckConstraint", args: ["fruits"] },
+      ]);
+    });
+
     it("remove with multiple columns records a single removeColumns", async () => {
       const recorder = new CommandRecorder(abstractDelegate);
       await recorder.changeTable("fruits", async (t) => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -143,17 +143,17 @@ describe("CommandRecorder", () => {
         await t.removeCheckConstraint();
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumns", args: ["fruits", "name"] },
-        { cmd: "addIndex", args: ["fruits", "kind"] },
-        { cmd: "addTimestamps", args: ["fruits"] },
-        { cmd: "removeTimestamps", args: ["fruits"] },
-        { cmd: "removeIndex", args: ["fruits", "kind"] },
-        { cmd: "addReference", args: ["fruits", "supplier"] },
-        { cmd: "removeReference", args: ["fruits", "supplier"] },
-        { cmd: "addForeignKey", args: ["fruits", "suppliers"] },
-        { cmd: "removeForeignKey", args: ["fruits"] },
-        { cmd: "addCheckConstraint", args: ["fruits", "qty > 0"] },
-        { cmd: "removeCheckConstraint", args: ["fruits"] },
+        ["removeColumns", ["fruits", "name"]],
+        ["addIndex", ["fruits", "kind"]],
+        ["addTimestamps", ["fruits"]],
+        ["removeTimestamps", ["fruits"]],
+        ["removeIndex", ["fruits", "kind"]],
+        ["addReference", ["fruits", "supplier"]],
+        ["removeReference", ["fruits", "supplier"]],
+        ["addForeignKey", ["fruits", "suppliers"]],
+        ["removeForeignKey", ["fruits"]],
+        ["addCheckConstraint", ["fruits", "qty > 0"]],
+        ["removeCheckConstraint", ["fruits"]],
       ]);
     });
 
@@ -165,9 +165,9 @@ describe("CommandRecorder", () => {
         await t.removeCheckConstraint({ name: "chk" });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeCheckConstraint", args: ["fruits", "qty > 0", { name: "chk" }] },
-        { cmd: "removeCheckConstraint", args: ["fruits", "qty > 0"] },
-        { cmd: "removeCheckConstraint", args: ["fruits", { name: "chk" }] },
+        ["removeCheckConstraint", ["fruits", "qty > 0", { name: "chk" }]],
+        ["removeCheckConstraint", ["fruits", "qty > 0"]],
+        ["removeCheckConstraint", ["fruits", { name: "chk" }]],
       ]);
     });
 

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -157,6 +157,20 @@ describe("CommandRecorder", () => {
       ]);
     });
 
+    it("removeCheckConstraint records the expression alongside the options", async () => {
+      const recorder = new CommandRecorder(abstractDelegate);
+      await recorder.changeTable("fruits", async (t) => {
+        await t.removeCheckConstraint("qty > 0", { name: "chk" });
+        await t.removeCheckConstraint("qty > 0");
+        await t.removeCheckConstraint({ name: "chk" });
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "removeCheckConstraint", args: ["fruits", "qty > 0", { name: "chk" }] },
+        { cmd: "removeCheckConstraint", args: ["fruits", "qty > 0"] },
+        { cmd: "removeCheckConstraint", args: ["fruits", { name: "chk" }] },
+      ]);
+    });
+
     it("remove with multiple columns records a single removeColumns", async () => {
       const recorder = new CommandRecorder(abstractDelegate);
       await recorder.changeTable("fruits", async (t) => {


### PR DESCRIPTION
Three convergence stories, bundled.

## 1. `translation_test.rb` mirrored file holds only Rails names (RFC 0115)

`packages/activemodel/src/translation.test.ts` mirrors
`vendor/rails/activemodel/test/cases/translation_test.rb`. Its 19 TS-only
cases move to a `translation.trails.test.ts` sibling. No test renamed,
reworded or deleted.

The extras were 6 duplicate-name copies plus two TS-only describes (the
dotted-attribute / options / ancestor-walk group and the
`raise_on_missing_translations` singleton accessor). Where a Rails name
appeared twice, the copy kept in the mirrored file is the one whose body
follows the Ruby — `Person.model_name.human(default: "dude")`
(`translation_test.rb:121`), `human_does_not_modify_options` with a real
options hash (`:129`) — and the other copy moved.

`pnpm parity:test --package activemodel`:

| | before | after |
| --- | --- | --- |
| `translation_test.rb` OK | 26 | 26 |
| `translation_test.rb` Extra | 19 | 0 |
| activemodel matched total | 963/963 | 963/963 |

Assertion mismatches moved down, not up (count 301→300, kind 445→444,
value 56→54); `lint-assertion-mismatches.ts` is green.

## 2. `Table` forwarders drop the empty options splat (RFC 0051)

Every forwarder on Ruby's `Table` ends in `**options`, and `**{}` passes no
argument at all — `schema_definitions.rb:756` (`index`), `:786`
(`timestamps`), `:829` (`remove`), `:842` (`remove_index`), `:852`
(`remove_timestamps`), `:871` (`references`), `:885` (`remove_references`),
`:899` (`foreign_key`), `:910` (`remove_foreign_key`), `:929`
(`check_constraint`), `:939` (`remove_check_constraint`).

trails passed its defaulted-to-`{}` options object unconditionally. Against
a live adapter that is invisible, but `CommandRecorder#record` stores the
arguments verbatim, so under `change_table` inside a `revert` the recorded
command grew a trailing `{}` Rails does not have — the arity
`test_invert_change_table` (`command_recorder_test.rb:94`) asserts on.
PR #6175 converged `column` only; the siblings now carry the same guard,
repeated per forwarder the way Ruby's language-level splat is.

The same splat ends `index_exists?` (`:769`), `foreign_key_exists?` (`:917`)
and `check_constraint_exists?` (`:949`), so those converge too rather than
being left as a matching-but-unconverged shape next to their siblings.

Covered by a new case in `command-recorder.trails.test.ts` asserting the
recorded tuples for `remove` / `index` / `timestamps` / `remove_timestamps`
/ `remove_index` / `references` / `remove_references` / `foreign_key` /
`remove_foreign_key` / `check_constraint` / `remove_check_constraint`.

## 3. `create_table_definition` ported once for MySQL (RFC 0051)

Rails defines it once, on `MySQL::SchemaStatements`
(`mysql/schema_statements.rb:172-174`). trails had it twice after PR #5944:
a standalone `this`-typed function in `mysql/schema-statements.ts`
(exercised only by its own unit test) and the live `AbstractMysqlAdapter`
method every `createTable` / `changeColumn` path actually called.

It is now a single method on the `MysqlSchemaStatements` class in the file
that maps onto `mysql/schema_statements.rb`, mixed into the adapter by
`include(AbstractMysqlAdapter, MysqlSchemaStatements)` — Rails'
`include MySQL::SchemaStatements` (`abstract_mysql_adapter.rb:19`).

The `adapter` / `adapterName` strip is shown unnecessary rather than
relocated: `buildCreateTableDefinition` no longer injects them into
`ctdOptions`, since Rails passes only the table-definition options and each
implementation supplies `adapter: this` the way Rails' `self` does. The
same strip is deleted from the PostgreSQL and SQLite3 overrides.

`pnpm parity:api:extra:gate`: activerecord novel 391/391, total 1410/1410 —
unchanged.

### Review note: the mixin method does return `MySQL::TableDefinition`

Raised on `mysql/schema-statements.ts:251`: the return type reads
`TableDefinition`, but that is the file-local import on line 12 —
`import { TableDefinition, Table as MysqlTable } from "./schema-definitions.js"`
— i.e. `MySQL::TableDefinition` (`mysql/schema-definitions.ts:69`,
`export class TableDefinition extends AbstractTableDefinition`), not the
abstract one. The bare spelling is the same one Rails uses for the class
inside `module MySQL`; the abstract class is imported elsewhere in the file
under its own names (`ForeignKeyDefinition`, `IndexDefinition`).

No behavior is lost, but the ambiguity was real, so the trails-only test now
asserts the class rather than only the table name:
`expect(td).toBeInstanceOf(MysqlTableDefinition)`. It passes.

### 4. `Table#removeCheckConstraint` forwards the expression too

Raised in review, and correct: Ruby is
`@base.remove_check_constraint(name, *args, **options)`
(`schema_definitions.rb:938-940`), so an expression **and** a `name:`
forward both. trails collapsed them to the options hash alone, dropping the
expression from the lookup that `SchemaStatements#removeCheckConstraint`
then runs — that method already resolves on the expression and the options
together, mirroring `check_constraint_for!`
(`schema_statements.rb:1324-1335`), so the expression was simply being lost
on the way in.

Fixed here rather than deferred. The trailing options are still omitted when
empty, and the hash-from-either-position merge follows the `removeIndex`
forwarder in the same class. `command-recorder.trails.test.ts` pins all
three recorded tuples.

I had first filed this as
`0051/table-remove-check-constraint-drops-the-expression`; that story is now
closed by this PR instead.

Verified on all three lanes — `check_constraint_test.rb`'s "remove
constraint from change table with options"
(`check-constraint.test.ts:458`) is the case that now forwards both:

| lane | result |
| --- | --- |
| sqlite3 | green (check-constraint cases feature-skipped) |
| PostgreSQL 17 | 69 passed / 5 skipped |
| MariaDB 11 | 175 passed / 19 skipped |

## Gates

- `pnpm parity:api:calls` — OK (380 baselined, 311 unreviewed, tight)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows)
- `pnpm parity:api:extra:gate` — OK
- `lint-assertion-mismatches.ts` — OK
- `pnpm lint`, `pnpm typecheck` — clean
- Size: 514 LOC (ceiling 700)

Closes-story: move-ts-only-extras-out-of-mirrored-activemodel-translation-test-file
Closes-story: table-forwarders-drop-empty-options-splat
Closes-story: dedupe-mysql-create-table-definition
Closes-story: table-remove-check-constraint-drops-the-expression



