### PR TITLE
refactor(activerecord): converge the command-recorder tuple, exists predicates, currentMigration and AlterTable (RFC 0051)

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -279,7 +279,7 @@ describe("AdapterTest", () => {
     expect(await conn.tableExists("accounts")).toBe(true);
     expect(await conn.tableExists("nonexistingtable")).toBe(false);
     expect(await conn.tableExists("'")).toBe(false);
-    expect(await conn.tableExists(null as unknown as string)).toBe(false);
+    expect(await conn.tableExists(null as unknown as string)).toBeFalsy();
   });
 
   it("data sources", async () => {
@@ -295,7 +295,7 @@ describe("AdapterTest", () => {
     expect(await conn.dataSourceExists("accounts")).toBe(true);
     expect(await conn.dataSourceExists("nonexistingtable")).toBe(false);
     expect(await conn.dataSourceExists("'")).toBe(false);
-    expect(await conn.dataSourceExists(null as unknown as string)).toBe(false);
+    expect(await conn.dataSourceExists(null as unknown as string)).toBeFalsy();
   });
 
   it("indexes", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -120,7 +120,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         `CREATE UNIQUE INDEX "ex_idx_both_i" ON "ex_idx_both" ("n") INCLUDE ("d") NULLS NOT DISTINCT`,
       );
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "ex_idx_both");
+      await adapter.createSchemaDumper().dumpTable(lines, "ex_idx_both");
       const indexLine = lines.find((l) => l.includes("ex_idx_both_i"))!;
       expect(indexLine.indexOf("include:")).toBeGreaterThan(-1);
       expect(indexLine.indexOf("include:")).toBeLessThan(indexLine.indexOf("nullsNotDistinct:"));

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -400,7 +400,7 @@ export interface AbstractAdapter {
   ): Promise<string>;
   /** @internal */
   extractForeignKeyAction(specifier: string): "cascade" | "nullify" | "restrict" | undefined;
-  tableExists(tableName: string): Promise<boolean>;
+  tableExists(tableName: string): Promise<boolean | null>;
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
   internalStringOptionsForPrimaryKey(): Record<string, unknown>;
   // Rails' `column_exists?(table, column, type = nil, **options)` narrows the
@@ -421,7 +421,7 @@ export interface AbstractAdapter {
   ): Promise<boolean>;
   tables(): Promise<string[]>;
   views(): Promise<string[]>;
-  viewExists(viewName: string): Promise<boolean>;
+  viewExists(viewName: string): Promise<boolean | null>;
   /** @internal */
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   /**
@@ -550,7 +550,7 @@ export interface AbstractAdapter {
   nativeDatabaseTypes(): Record<string, unknown>;
   typeToSql(type: ColumnType, options?: ColumnOptions): string;
   dataSources(): Promise<string[]>;
-  dataSourceExists(name: string): Promise<boolean>;
+  dataSourceExists(name: string): Promise<boolean | null>;
   /** Mirrors `DatabaseStatements#sanitize_limit` (abstract/database_statements.rb). */
   sanitizeLimit(limit: unknown): number | Nodes.SqlLiteral;
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -300,22 +300,6 @@ export class SchemaCreation {
     ).join(" ");
     sql += o.constraintDrops.map((con) => this.visitDropConstraint(con)).join(" ");
 
-    // Not in Rails' visit_AlterTable (schema_creation.rb:24-32): trails'
-    // AlterTable carries column-default changes as their own group.
-    const parts: string[] = [];
-    for (const change of o.columnDefaultChanges) {
-      const col = this.adapter.quoteColumnName(change.columnName);
-      if (change.defaultValue == null) {
-        parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
-      } else {
-        parts.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(change.defaultValue)}`,
-        );
-      }
-    }
-
-    sql += parts.join(" ");
-
     return sql;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1005,11 +1005,6 @@ export class AlterTable {
   readonly checkConstraintAdds: CheckConstraintDefinition[] = [];
   readonly checkConstraintDrops: string[] = [];
   readonly constraintDrops: string[] = [];
-  readonly columnDefaultChanges: Array<{
-    columnName: string;
-    defaultValue: unknown;
-  }> = [];
-
   constructor(td: TableDefinition) {
     this._td = td;
   }
@@ -1046,10 +1041,6 @@ export class AlterTable {
 
   dropConstraint(name: string): void {
     this.constraintDrops.push(name);
-  }
-
-  changeColumnDefault(columnName: string, defaultValue: unknown): void {
-    this.columnDefaultChanges.push({ columnName, defaultValue });
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -802,8 +802,6 @@ describe("dataSourceExists NotImplementedError fallback", () => {
       dataSourceSql: (n: string) => `SELECT 1 WHERE name = '${n}'`,
     });
 
-    // Rails' trailing `if name.present?` modifier (schema_statements.rb:45)
-    // falls off the end of the method, so the value is nil — not false.
     expect(await ss.dataSourceExists("")).toBeNull();
     expect(await ss.dataSourceExists("   ")).toBeNull();
     expect(execute).not.toHaveBeenCalled();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -725,12 +725,12 @@ describe("unsupported-adapter bodies", () => {
 });
 
 describe("tableExists NotImplementedError fallback", () => {
-  it("returns false for a blank table name without querying", async () => {
+  it("returns null for a blank table name without querying", async () => {
     const execute = vi.fn().mockResolvedValue([]);
     const ss = makeStatements({ quote: (v: string) => `'${v}'`, execute });
 
-    expect(await ss.tableExists("")).toBe(false);
-    expect(await ss.tableExists("   ")).toBe(false);
+    expect(await ss.tableExists("")).toBeNull();
+    expect(await ss.tableExists("   ")).toBeNull();
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -795,15 +795,17 @@ describe("dataSources NotImplementedError fallback", () => {
 });
 
 describe("dataSourceExists NotImplementedError fallback", () => {
-  it("returns false for a blank data source name without querying", async () => {
+  it("returns null for a blank data source name without querying", async () => {
     const execute = vi.fn().mockResolvedValue([]);
     const ss = makeStatements({
       execute,
       dataSourceSql: (n: string) => `SELECT 1 WHERE name = '${n}'`,
     });
 
-    expect(await ss.dataSourceExists("")).toBe(false);
-    expect(await ss.dataSourceExists("   ")).toBe(false);
+    // Rails' trailing `if name.present?` modifier (schema_statements.rb:45)
+    // falls off the end of the method, so the value is nil — not false.
+    expect(await ss.dataSourceExists("")).toBeNull();
+    expect(await ss.dataSourceExists("   ")).toBeNull();
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
@@ -39,8 +39,10 @@ describe("SchemaStatements#viewExists", () => {
   });
 
   it("treats a blank name as absent, like Rails' present? guard", async () => {
-    expect(await conn().viewExists("")).toBe(false);
-    expect(await conn().viewExists("   ")).toBe(false);
-    expect(await conn().viewExists(null as unknown as string)).toBe(false);
+    // `if view_name.present?` (schema_statements.rb:75) is a trailing modifier,
+    // so a blank name falls off the end of the method and answers nil.
+    expect(await conn().viewExists("")).toBeNull();
+    expect(await conn().viewExists("   ")).toBeNull();
+    expect(await conn().viewExists(null as unknown as string)).toBeNull();
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-view-exists.trails.test.ts
@@ -39,8 +39,6 @@ describe("SchemaStatements#viewExists", () => {
   });
 
   it("treats a blank name as absent, like Rails' present? guard", async () => {
-    // `if view_name.present?` (schema_statements.rb:75) is a trailing modifier,
-    // so a blank name falls off the end of the method and answers nil.
     expect(await conn().viewExists("")).toBeNull();
     expect(await conn().viewExists("   ")).toBeNull();
     expect(await conn().viewExists(null as unknown as string)).toBeNull();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -617,9 +617,12 @@ export class SchemaStatements {
     );
   }
 
-  // Rails guards with a trailing `if table_name.present?` modifier
-  // (schema_statements.rb:60), so a blank name falls off the end of the method
-  // and the value is `nil` — not `false`.
+  /**
+   * Rails guards with a trailing `if table_name.present?` modifier
+   * (schema_statements.rb:60), so a blank name falls off the end of the method
+   * and the value is `nil` — not `false`. Same shape at schema_statements.rb:45
+   * (`data_source_exists?`) and :75 (`view_exists?`).
+   */
   async tableExists(tableName: string): Promise<boolean | null> {
     if (!isPresent(tableName)) return null;
     try {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -617,8 +617,11 @@ export class SchemaStatements {
     );
   }
 
-  async tableExists(tableName: string): Promise<boolean> {
-    if (!isPresent(tableName)) return false;
+  // Rails guards with a trailing `if table_name.present?` modifier
+  // (schema_statements.rb:60), so a blank name falls off the end of the method
+  // and the value is `nil` — not `false`.
+  async tableExists(tableName: string): Promise<boolean | null> {
+    if (!isPresent(tableName)) return null;
     try {
       return any(
         await this.queryValues(this.dataSourceSql(tableName, { type: "BASE TABLE" }), "SCHEMA"),
@@ -1199,7 +1202,7 @@ export class SchemaStatements {
     return (await this.queryValues(this.dataSourceSql({ type: "VIEW" }), "SCHEMA")).map(String);
   }
 
-  async viewExists(viewName: string): Promise<boolean> {
+  async viewExists(viewName: string): Promise<boolean | null> {
     // Mirrors Rails:
     //   query_values(data_source_sql(view_name, type: "VIEW"), "SCHEMA").any?
     //     if view_name.present?
@@ -1208,7 +1211,7 @@ export class SchemaStatements {
     //
     // present? covers blank strings including whitespace-only.
     // The "SCHEMA" name is what keeps the probe out of assertQueries counts.
-    if (!isPresent(viewName)) return false;
+    if (!isPresent(viewName)) return null;
     try {
       return any(await this.queryValues(this.dataSourceSql(viewName, { type: "VIEW" }), "SCHEMA"));
     } catch (e) {
@@ -1311,8 +1314,8 @@ export class SchemaStatements {
     }
   }
 
-  async dataSourceExists(name: string): Promise<boolean> {
-    if (!isPresent(name)) return false;
+  async dataSourceExists(name: string): Promise<boolean | null> {
+    if (!isPresent(name)) return null;
     try {
       return any(await this.queryValues(this.dataSourceSql(name), "SCHEMA"));
     } catch (error) {
@@ -1796,14 +1799,11 @@ export class SchemaStatements {
     return this.supportsForeignKeys() && this.isForeignKeysEnabled();
   }
 
-  async bulkChangeTable(
-    tableName: string,
-    operations: Array<{ cmd: string; args: unknown[] }>,
-  ): Promise<void> {
+  async bulkChangeTable(tableName: string, operations: Array<[string, unknown[]]>): Promise<void> {
     const sqlFragments: string[] = [];
     const nonCombinable: Array<() => Promise<void>> = [];
 
-    for (const { cmd: command, args } of operations) {
+    for (const [command, args] of operations) {
       const [table, ...arguments_] = args as [string, ...unknown[]];
       const forAlterTarget =
         typeof (this as any)[`${command}ForAlter`] === "function"

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -514,13 +514,13 @@ describe("InvertibleMigrationTest", () => {
       recorder.record("createTable", ["grapes"]);
     });
     expect(recorder.commands).toEqual([
-      { cmd: "createTable", args: ["apples", block] },
-      { cmd: "dropTable", args: ["elderberries"] },
-      { cmd: "createTable", args: ["clementines"] },
-      { cmd: "createTable", args: ["dates"] },
-      { cmd: "dropTable", args: ["bananas", block] },
-      { cmd: "dropTable", args: ["grapes"] },
-      { cmd: "dropTable", args: ["figs"] },
+      ["createTable", ["apples", block]],
+      ["dropTable", ["elderberries"]],
+      ["createTable", ["clementines"]],
+      ["createTable", ["dates"]],
+      ["dropTable", ["bananas", block]],
+      ["dropTable", ["grapes"]],
+      ["dropTable", ["figs"]],
     ]);
   });
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -694,7 +694,7 @@ export class Migration {
     await this.connection.renameTable(oldName, newName);
   }
 
-  async tableExists(tableName: string): Promise<boolean> {
+  async tableExists(tableName: string): Promise<boolean | null> {
     return this.connection.tableExists(this._pt(tableName));
   }
 
@@ -1361,7 +1361,7 @@ export class Migration {
     return this._recording && this._recorder.reverting;
   }
 
-  async viewExists(viewName: string): Promise<boolean> {
+  async viewExists(viewName: string): Promise<boolean | null> {
     return this.connection.viewExists(viewName);
   }
 
@@ -2794,9 +2794,8 @@ export class Migrator {
 
   /** @internal Mirrors: ActiveRecord::Migrator#current_migration (`migration.rb:1439-1441`) */
   async currentMigration(): Promise<MigrationProxy | null> {
-    const version = await this.currentVersion();
-    if (version === 0) return null;
-    return this._migrations.find((m) => m.version === version) ?? null;
+    const currentVersion = await this.currentVersion();
+    return this.migrations.find((m) => m.version === currentVersion) ?? null;
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator `alias :current :current_migration` (`migration.rb:1442`) */

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -43,7 +43,7 @@ describe("Migration", () => {
       // The recorder only records the command — no DDL runs, so there is no table to tear down.
       // eslint-disable-next-line blazetrails/require-table-teardown
       (recorder as unknown as { createTable(name: string): void }).createTable("horses");
-      expect(recorder.commands).toEqual([{ cmd: "createTable", args: ["horses"] }]);
+      expect(recorder.commands).toEqual([["createTable", ["horses"]]]);
     });
 
     it("unknown commands delegate", () => {
@@ -77,7 +77,7 @@ describe("Migration", () => {
         recorder.record("createTable", ["hello"]);
         recorder.record("createTable", ["world"]);
       });
-      const tables = recorder.commands.map(({ args }) => args);
+      const tables = recorder.commands.map(([, args]) => args);
       expect(tables).toEqual([["world"], ["hello"]]);
     });
 
@@ -99,13 +99,13 @@ describe("Migration", () => {
       });
       /* eslint-enable blazetrails/require-table-teardown */
       expect(recorder.commands).toEqual([
-        { cmd: "createTable", args: ["apples", block] },
-        { cmd: "dropTable", args: ["elderberries"] },
-        { cmd: "createTable", args: ["clementines", block] },
-        { cmd: "createTable", args: ["dates"] },
-        { cmd: "dropTable", args: ["bananas", block] },
-        { cmd: "dropTable", args: ["grapes"] },
-        { cmd: "dropTable", args: ["figs", block] },
+        ["createTable", ["apples", block]],
+        ["dropTable", ["elderberries"]],
+        ["createTable", ["clementines", block]],
+        ["createTable", ["dates"]],
+        ["dropTable", ["bananas", block]],
+        ["dropTable", ["grapes"]],
+        ["dropTable", ["figs", block]],
       ]);
     });
 
@@ -118,8 +118,8 @@ describe("Migration", () => {
       });
 
       expect(recorder.commands).toEqual([
-        { cmd: "renameColumn", args: ["fruits", "cultivar", "kind"] },
-        { cmd: "removeColumn", args: ["fruits", "name", "string"] },
+        ["renameColumn", ["fruits", "cultivar", "kind"]],
+        ["removeColumn", ["fruits", "name", "string"]],
       ]);
 
       await expect(
@@ -147,9 +147,9 @@ describe("Migration", () => {
         });
       });
 
-      expect(recorder.commands.map(({ cmd, args }) => ({ cmd, args: args.slice(0, -1) }))).toEqual([
-        { cmd: "changeTable", args: ["fruits"] },
-        { cmd: "changeTable", args: ["fruits"] },
+      expect(recorder.commands.map(([cmd, args]) => [cmd, args.slice(0, -1)])).toEqual([
+        ["changeTable", ["fruits"]],
+        ["changeTable", ["fruits"]],
       ]);
     });
 
@@ -158,7 +158,7 @@ describe("Migration", () => {
         recorder.record("createTable", ["system_settings"]);
       });
       const dropTable = recorder.commands[0];
-      expect(dropTable).toEqual({ cmd: "dropTable", args: ["system_settings"] });
+      expect(dropTable).toEqual(["dropTable", ["system_settings"]]);
     });
 
     it("invert create table with if not exists", async () => {
@@ -166,7 +166,7 @@ describe("Migration", () => {
         recorder.record("createTable", ["system_settings", { ifNotExists: true }]);
       });
       const dropTable = recorder.commands[0];
-      expect(dropTable).toEqual({ cmd: "dropTable", args: ["system_settings", {}] });
+      expect(dropTable).toEqual(["dropTable", ["system_settings", {}]]);
     });
 
     it("invert create table with options and block", () => {
@@ -176,10 +176,7 @@ describe("Migration", () => {
         { id: false },
         block,
       ]);
-      expect(dropTable).toEqual({
-        cmd: "dropTable",
-        args: ["people_reminders", { id: false }, block],
-      });
+      expect(dropTable).toEqual(["dropTable", ["people_reminders", { id: false }, block]]);
     });
 
     it("invert drop table", () => {
@@ -189,10 +186,7 @@ describe("Migration", () => {
         { id: false },
         block,
       ]);
-      expect(createTable).toEqual({
-        cmd: "createTable",
-        args: ["people_reminders", { id: false }, block],
-      });
+      expect(createTable).toEqual(["createTable", ["people_reminders", { id: false }, block]]);
     });
 
     it("invert drop table with if exists", () => {
@@ -202,10 +196,7 @@ describe("Migration", () => {
         { id: false, ifExists: true },
         block,
       ]);
-      expect(createTable).toEqual({
-        cmd: "createTable",
-        args: ["people_reminders", { id: false }, block],
-      });
+      expect(createTable).toEqual(["createTable", ["people_reminders", { id: false }, block]]);
     });
 
     it("invert drop table without a block nor option", () => {
@@ -243,7 +234,7 @@ describe("Migration", () => {
 
     it("invert create join table", () => {
       const dropJoinTable = recorder.inverseOf("createJoinTable", ["musics", "artists"]);
-      expect(dropJoinTable).toEqual({ cmd: "dropJoinTable", args: ["musics", "artists"] });
+      expect(dropJoinTable).toEqual(["dropJoinTable", ["musics", "artists"]]);
     });
 
     it("invert create join table with table name", () => {
@@ -252,10 +243,10 @@ describe("Migration", () => {
         "artists",
         { tableName: "catalog" },
       ]);
-      expect(dropJoinTable).toEqual({
-        cmd: "dropJoinTable",
-        args: ["musics", "artists", { tableName: "catalog" }],
-      });
+      expect(dropJoinTable).toEqual([
+        "dropJoinTable",
+        ["musics", "artists", { tableName: "catalog" }],
+      ]);
     });
 
     it("invert drop join table", () => {
@@ -266,20 +257,20 @@ describe("Migration", () => {
         { tableName: "catalog" },
         block,
       ]);
-      expect(createJoinTable).toEqual({
-        cmd: "createJoinTable",
-        args: ["musics", "artists", { tableName: "catalog" }, block],
-      });
+      expect(createJoinTable).toEqual([
+        "createJoinTable",
+        ["musics", "artists", { tableName: "catalog" }, block],
+      ]);
     });
 
     it("invert rename table", () => {
       const rename = recorder.inverseOf("renameTable", ["old", "new"]);
-      expect(rename).toEqual({ cmd: "renameTable", args: ["new", "old"] });
+      expect(rename).toEqual(["renameTable", ["new", "old"]]);
     });
 
     it("invert add column", () => {
       const remove = recorder.inverseOf("addColumn", ["table", "column", "type", {}]);
-      expect(remove).toEqual({ cmd: "removeColumn", args: ["table", "column", "type", {}] });
+      expect(remove).toEqual(["removeColumn", ["table", "column", "type", {}]]);
     });
 
     it("invert change column", () => {
@@ -300,10 +291,10 @@ describe("Migration", () => {
         "column",
         { from: "old_value", to: "new_value" },
       ]);
-      expect(change).toEqual({
-        cmd: "changeColumnDefault",
-        args: ["table", "column", { from: "new_value", to: "old_value" }],
-      });
+      expect(change).toEqual([
+        "changeColumnDefault",
+        ["table", "column", { from: "new_value", to: "old_value" }],
+      ]);
     });
 
     it("invert change column default with from and to with boolean", () => {
@@ -312,10 +303,10 @@ describe("Migration", () => {
         "column",
         { from: true, to: false },
       ]);
-      expect(change).toEqual({
-        cmd: "changeColumnDefault",
-        args: ["table", "column", { from: false, to: true }],
-      });
+      expect(change).toEqual([
+        "changeColumnDefault",
+        ["table", "column", { from: false, to: true }],
+      ]);
     });
 
     itIfSupports("comments", "invert change column comment", () => {
@@ -330,10 +321,10 @@ describe("Migration", () => {
         "column",
         { from: "old_value", to: "new_value" },
       ]);
-      expect(change).toEqual({
-        cmd: "changeColumnComment",
-        args: ["table", "column", { from: "new_value", to: "old_value" }],
-      });
+      expect(change).toEqual([
+        "changeColumnComment",
+        ["table", "column", { from: "new_value", to: "old_value" }],
+      ]);
     });
 
     itIfSupports("comments", "invert change column comment with from and to with nil", () => {
@@ -342,10 +333,10 @@ describe("Migration", () => {
         "column",
         { from: undefined, to: "new_value" },
       ]);
-      expect(change).toEqual({
-        cmd: "changeColumnComment",
-        args: ["table", "column", { from: "new_value", to: undefined }],
-      });
+      expect(change).toEqual([
+        "changeColumnComment",
+        ["table", "column", { from: "new_value", to: undefined }],
+      ]);
     });
 
     itIfSupports("comments", "invert change table comment", () => {
@@ -359,10 +350,10 @@ describe("Migration", () => {
         "table",
         { from: "old_value", to: "new_value" },
       ]);
-      expect(change).toEqual({
-        cmd: "changeTableComment",
-        args: ["table", { from: "new_value", to: "old_value" }],
-      });
+      expect(change).toEqual([
+        "changeTableComment",
+        ["table", { from: "new_value", to: "old_value" }],
+      ]);
     });
 
     itIfSupports("comments", "invert change table comment with from and to with nil", () => {
@@ -370,20 +361,20 @@ describe("Migration", () => {
         "table",
         { from: undefined, to: "new_value" },
       ]);
-      expect(change).toEqual({
-        cmd: "changeTableComment",
-        args: ["table", { from: "new_value", to: undefined }],
-      });
+      expect(change).toEqual([
+        "changeTableComment",
+        ["table", { from: "new_value", to: undefined }],
+      ]);
     });
 
     it("invert change column null", () => {
       const add = recorder.inverseOf("changeColumnNull", ["table", "column", true]);
-      expect(add).toEqual({ cmd: "changeColumnNull", args: ["table", "column", false] });
+      expect(add).toEqual(["changeColumnNull", ["table", "column", false]]);
     });
 
     it("invert remove column", () => {
       const add = recorder.inverseOf("removeColumn", ["table", "column", "type", {}]);
-      expect(add).toEqual({ cmd: "addColumn", args: ["table", "column", "type", {}] });
+      expect(add).toEqual(["addColumn", ["table", "column", "type", {}]]);
     });
 
     it("invert remove column without type", () => {
@@ -394,12 +385,12 @@ describe("Migration", () => {
 
     it("invert rename column", () => {
       const rename = recorder.inverseOf("renameColumn", ["table", "old", "new"]);
-      expect(rename).toEqual({ cmd: "renameColumn", args: ["table", "new", "old"] });
+      expect(rename).toEqual(["renameColumn", ["table", "new", "old"]]);
     });
 
     it("invert add index", () => {
       const remove = recorder.inverseOf("addIndex", ["table", ["one", "two"]]);
-      expect(remove).toEqual({ cmd: "removeIndex", args: ["table", ["one", "two"]] });
+      expect(remove).toEqual(["removeIndex", ["table", ["one", "two"]]]);
     });
 
     it("invert add index with name", () => {
@@ -408,10 +399,7 @@ describe("Migration", () => {
         ["one", "two"],
         { name: "new_index" },
       ]);
-      expect(remove).toEqual({
-        cmd: "removeIndex",
-        args: ["table", ["one", "two"], { name: "new_index" }],
-      });
+      expect(remove).toEqual(["removeIndex", ["table", ["one", "two"], { name: "new_index" }]]);
     });
 
     it("invert add index with algorithm option", () => {
@@ -420,20 +408,17 @@ describe("Migration", () => {
         "one",
         { algorithm: "concurrently" },
       ]);
-      expect(remove).toEqual({
-        cmd: "removeIndex",
-        args: ["table", "one", { algorithm: "concurrently" }],
-      });
+      expect(remove).toEqual(["removeIndex", ["table", "one", { algorithm: "concurrently" }]]);
     });
 
     it("invert remove index", () => {
       const add = recorder.inverseOf("removeIndex", ["table", "one"]);
-      expect(add).toEqual({ cmd: "addIndex", args: ["table", "one"] });
+      expect(add).toEqual(["addIndex", ["table", "one"]]);
     });
 
     it("invert remove index with positional column", () => {
       const add = recorder.inverseOf("removeIndex", ["table", ["one", "two"], { options: true }]);
-      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"], { options: true }] });
+      expect(add).toEqual(["addIndex", ["table", ["one", "two"], { options: true }]]);
     });
 
     it("invert remove index with column", () => {
@@ -441,7 +426,7 @@ describe("Migration", () => {
         "table",
         { column: ["one", "two"], options: true },
       ]);
-      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"], { options: true }] });
+      expect(add).toEqual(["addIndex", ["table", ["one", "two"], { options: true }]]);
     });
 
     it("invert remove index with name", () => {
@@ -449,15 +434,12 @@ describe("Migration", () => {
         "table",
         { column: ["one", "two"], name: "new_index" },
       ]);
-      expect(add).toEqual({
-        cmd: "addIndex",
-        args: ["table", ["one", "two"], { name: "new_index" }],
-      });
+      expect(add).toEqual(["addIndex", ["table", ["one", "two"], { name: "new_index" }]]);
     });
 
     it("invert remove index with no special options", () => {
       const add = recorder.inverseOf("removeIndex", ["table", { column: ["one", "two"] }]);
-      expect(add).toEqual({ cmd: "addIndex", args: ["table", ["one", "two"]] });
+      expect(add).toEqual(["addIndex", ["table", ["one", "two"]]]);
     });
 
     it("invert remove index with no column", () => {
@@ -468,17 +450,17 @@ describe("Migration", () => {
 
     it("invert rename index", () => {
       const rename = recorder.inverseOf("renameIndex", ["table", "old", "new"]);
-      expect(rename).toEqual({ cmd: "renameIndex", args: ["table", "new", "old"] });
+      expect(rename).toEqual(["renameIndex", ["table", "new", "old"]]);
     });
 
     it("invert add timestamps", () => {
       const remove = recorder.inverseOf("addTimestamps", ["table"]);
-      expect(remove).toEqual({ cmd: "removeTimestamps", args: ["table"] });
+      expect(remove).toEqual(["removeTimestamps", ["table"]]);
     });
 
     it("invert remove timestamps", () => {
       const add = recorder.inverseOf("removeTimestamps", ["table", { null: true }]);
-      expect(add).toEqual({ cmd: "addTimestamps", args: ["table", { null: true }] });
+      expect(add).toEqual(["addTimestamps", ["table", { null: true }]]);
     });
 
     it("invert add reference", () => {
@@ -487,15 +469,12 @@ describe("Migration", () => {
         "taggable",
         { polymorphic: true },
       ]);
-      expect(remove).toEqual({
-        cmd: "removeReference",
-        args: ["table", "taggable", { polymorphic: true }],
-      });
+      expect(remove).toEqual(["removeReference", ["table", "taggable", { polymorphic: true }]]);
     });
 
     it("invert add belongs to alias", () => {
       const remove = recorder.inverseOf("addBelongsTo", ["table", "user"]);
-      expect(remove).toEqual({ cmd: "removeReference", args: ["table", "user"] });
+      expect(remove).toEqual(["removeReference", ["table", "user"]]);
     });
 
     it("invert remove reference", () => {
@@ -504,10 +483,7 @@ describe("Migration", () => {
         "taggable",
         { polymorphic: true },
       ]);
-      expect(add).toEqual({
-        cmd: "addReference",
-        args: ["table", "taggable", { polymorphic: true }],
-      });
+      expect(add).toEqual(["addReference", ["table", "taggable", { polymorphic: true }]]);
     });
 
     it("invert remove reference with index and foreign key", () => {
@@ -516,45 +492,45 @@ describe("Migration", () => {
         "taggable",
         { index: true, foreignKey: true },
       ]);
-      expect(add).toEqual({
-        cmd: "addReference",
-        args: ["table", "taggable", { index: true, foreignKey: true }],
-      });
+      expect(add).toEqual([
+        "addReference",
+        ["table", "taggable", { index: true, foreignKey: true }],
+      ]);
     });
 
     it("invert remove belongs to alias", () => {
       const add = recorder.inverseOf("removeBelongsTo", ["table", "user"]);
-      expect(add).toEqual({ cmd: "addReference", args: ["table", "user"] });
+      expect(add).toEqual(["addReference", ["table", "user"]]);
     });
 
     it("invert enable extension", () => {
       const disable = recorder.inverseOf("enableExtension", ["uuid-ossp"]);
-      expect(disable).toEqual({ cmd: "disableExtension", args: ["uuid-ossp"] });
+      expect(disable).toEqual(["disableExtension", ["uuid-ossp"]]);
     });
 
     it("invert disable extension", () => {
       const enable = recorder.inverseOf("disableExtension", ["uuid-ossp"]);
-      expect(enable).toEqual({ cmd: "enableExtension", args: ["uuid-ossp"] });
+      expect(enable).toEqual(["enableExtension", ["uuid-ossp"]]);
     });
 
     it("invert create schema", () => {
       const disable = recorder.inverseOf("createSchema", ["myschema"]);
-      expect(disable).toEqual({ cmd: "dropSchema", args: ["myschema"] });
+      expect(disable).toEqual(["dropSchema", ["myschema"]]);
     });
 
     it("invert drop schema", () => {
       const enable = recorder.inverseOf("dropSchema", ["myschema"]);
-      expect(enable).toEqual({ cmd: "createSchema", args: ["myschema"] });
+      expect(enable).toEqual(["createSchema", ["myschema"]]);
     });
 
     it("invert add foreign key", () => {
       const enable = recorder.inverseOf("addForeignKey", ["dogs", "people"]);
-      expect(enable).toEqual({ cmd: "removeForeignKey", args: ["dogs", "people"] });
+      expect(enable).toEqual(["removeForeignKey", ["dogs", "people"]]);
     });
 
     it("invert remove foreign key", () => {
       const enable = recorder.inverseOf("removeForeignKey", ["dogs", "people"]);
-      expect(enable).toEqual({ cmd: "addForeignKey", args: ["dogs", "people"] });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people"]]);
     });
 
     it("invert add foreign key with column", () => {
@@ -563,10 +539,7 @@ describe("Migration", () => {
         "people",
         { column: "owner_id" },
       ]);
-      expect(enable).toEqual({
-        cmd: "removeForeignKey",
-        args: ["dogs", "people", { column: "owner_id" }],
-      });
+      expect(enable).toEqual(["removeForeignKey", ["dogs", "people", { column: "owner_id" }]]);
     });
 
     it("invert remove foreign key with column", () => {
@@ -575,10 +548,7 @@ describe("Migration", () => {
         "people",
         { column: "owner_id" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { column: "owner_id" }],
-      });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people", { column: "owner_id" }]]);
     });
 
     it("invert add foreign key with column and name", () => {
@@ -587,10 +557,10 @@ describe("Migration", () => {
         "people",
         { column: "owner_id", name: "fk" },
       ]);
-      expect(enable).toEqual({
-        cmd: "removeForeignKey",
-        args: ["dogs", "people", { column: "owner_id", name: "fk" }],
-      });
+      expect(enable).toEqual([
+        "removeForeignKey",
+        ["dogs", "people", { column: "owner_id", name: "fk" }],
+      ]);
     });
 
     it("invert remove foreign key with column and name", () => {
@@ -599,10 +569,10 @@ describe("Migration", () => {
         "people",
         { column: "owner_id", name: "fk" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { column: "owner_id", name: "fk" }],
-      });
+      expect(enable).toEqual([
+        "addForeignKey",
+        ["dogs", "people", { column: "owner_id", name: "fk" }],
+      ]);
     });
 
     it("invert remove foreign key with primary key", () => {
@@ -611,10 +581,7 @@ describe("Migration", () => {
         "people",
         { primaryKey: "person_id" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { primaryKey: "person_id" }],
-      });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people", { primaryKey: "person_id" }]]);
     });
 
     it("invert remove foreign key with primary key and to table in options", () => {
@@ -622,10 +589,7 @@ describe("Migration", () => {
         "dogs",
         { toTable: "people", primaryKey: "uuid" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { primaryKey: "uuid" }],
-      });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people", { primaryKey: "uuid" }]]);
     });
 
     it("invert remove foreign key with on delete on update", () => {
@@ -634,24 +598,21 @@ describe("Migration", () => {
         "people",
         { onDelete: "nullify", onUpdate: "cascade" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { onDelete: "nullify", onUpdate: "cascade" }],
-      });
+      expect(enable).toEqual([
+        "addForeignKey",
+        ["dogs", "people", { onDelete: "nullify", onUpdate: "cascade" }],
+      ]);
     });
 
     it("invert remove foreign key with to table in options", () => {
       let enable = recorder.inverseOf("removeForeignKey", ["dogs", { toTable: "people" }]);
-      expect(enable).toEqual({ cmd: "addForeignKey", args: ["dogs", "people"] });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people"]]);
 
       enable = recorder.inverseOf("removeForeignKey", [
         "dogs",
         { toTable: "people", column: "owner_id" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addForeignKey",
-        args: ["dogs", "people", { column: "owner_id" }],
-      });
+      expect(enable).toEqual(["addForeignKey", ["dogs", "people", { column: "owner_id" }]]);
     });
 
     it("invert remove foreign key is irreversible without to table", () => {
@@ -682,10 +643,10 @@ describe("Migration", () => {
         "speed > 0",
         { name: "speed_check" },
       ]);
-      expect(enable).toEqual({
-        cmd: "removeCheckConstraint",
-        args: ["dogs", "speed > 0", { name: "speed_check" }],
-      });
+      expect(enable).toEqual([
+        "removeCheckConstraint",
+        ["dogs", "speed > 0", { name: "speed_check" }],
+      ]);
     });
 
     it("invert add check constraint if not exists", () => {
@@ -694,10 +655,10 @@ describe("Migration", () => {
         "speed > 0",
         { name: "speed_check", ifNotExists: true },
       ]);
-      expect(enable).toEqual({
-        cmd: "removeCheckConstraint",
-        args: ["dogs", "speed > 0", { name: "speed_check", ifExists: true }],
-      });
+      expect(enable).toEqual([
+        "removeCheckConstraint",
+        ["dogs", "speed > 0", { name: "speed_check", ifExists: true }],
+      ]);
     });
 
     it("invert remove check constraint", () => {
@@ -706,10 +667,10 @@ describe("Migration", () => {
         "speed > 0",
         { name: "speed_check" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addCheckConstraint",
-        args: ["dogs", "speed > 0", { name: "speed_check" }],
-      });
+      expect(enable).toEqual([
+        "addCheckConstraint",
+        ["dogs", "speed > 0", { name: "speed_check" }],
+      ]);
     });
 
     it("invert remove check constraint without expression", () => {
@@ -724,10 +685,10 @@ describe("Migration", () => {
         "speed > 0",
         { name: "speed_check", ifExists: true },
       ]);
-      expect(enable).toEqual({
-        cmd: "addCheckConstraint",
-        args: ["dogs", "speed > 0", { name: "speed_check", ifNotExists: true }],
-      });
+      expect(enable).toEqual([
+        "addCheckConstraint",
+        ["dogs", "speed > 0", { name: "speed_check", ifNotExists: true }],
+      ]);
     });
 
     it("invert add unique constraint constraint with using index", () => {
@@ -742,15 +703,15 @@ describe("Migration", () => {
         ["speed"],
         { deferrable: "deferred", name: "uniq_speed" },
       ]);
-      expect(enable).toEqual({
-        cmd: "addUniqueConstraint",
-        args: ["dogs", ["speed"], { deferrable: "deferred", name: "uniq_speed" }],
-      });
+      expect(enable).toEqual([
+        "addUniqueConstraint",
+        ["dogs", ["speed"], { deferrable: "deferred", name: "uniq_speed" }],
+      ]);
     });
 
     it("invert remove unique constraint constraint without options", () => {
       const enable = recorder.inverseOf("removeUniqueConstraint", ["dogs", ["speed"]]);
-      expect(enable).toEqual({ cmd: "addUniqueConstraint", args: ["dogs", ["speed"]] });
+      expect(enable).toEqual(["addUniqueConstraint", ["dogs", ["speed"]]]);
     });
 
     it("invert remove unique constraint constraint without columns", () => {
@@ -761,12 +722,12 @@ describe("Migration", () => {
 
     it("invert create enum", () => {
       const drop = recorder.inverseOf("createEnum", ["color", ["blue", "green"]]);
-      expect(drop).toEqual({ cmd: "dropEnum", args: ["color", ["blue", "green"]] });
+      expect(drop).toEqual(["dropEnum", ["color", ["blue", "green"]]]);
     });
 
     it("invert drop enum", () => {
       const create = recorder.inverseOf("dropEnum", ["color", ["blue", "green"]]);
-      expect(create).toEqual({ cmd: "createEnum", args: ["color", ["blue", "green"]] });
+      expect(create).toEqual(["createEnum", ["color", ["blue", "green"]]]);
     });
 
     it("invert drop enum without values", () => {
@@ -779,12 +740,12 @@ describe("Migration", () => {
 
     it("invert rename enum", () => {
       const enumCmd = recorder.inverseOf("renameEnum", ["dog_breed", "breed"]);
-      expect(enumCmd).toEqual({ cmd: "renameEnum", args: ["breed", "dog_breed"] });
+      expect(enumCmd).toEqual(["renameEnum", ["breed", "dog_breed"]]);
     });
 
     it("invert rename enum with to option", () => {
       const enumCmd = recorder.inverseOf("renameEnum", ["dog_breed", { to: "breed" }]);
-      expect(enumCmd).toEqual({ cmd: "renameEnum", args: ["breed", "dog_breed"] });
+      expect(enumCmd).toEqual(["renameEnum", ["breed", "dog_breed"]]);
     });
 
     it("invert add enum value", () => {
@@ -798,10 +759,10 @@ describe("Migration", () => {
         "dog_breed",
         { from: "retriever", to: "beagle" },
       ]);
-      expect(enumValue).toEqual({
-        cmd: "renameEnumValue",
-        args: ["dog_breed", { from: "beagle", to: "retriever" }],
-      });
+      expect(enumValue).toEqual([
+        "renameEnumValue",
+        ["dog_breed", { from: "beagle", to: "retriever" }],
+      ]);
     });
 
     it("invert rename enum value without from", () => {
@@ -822,10 +783,10 @@ describe("Migration", () => {
         "fts5",
         ["content", "meta UNINDEXED", "tokenize='porter ascii'"],
       ]);
-      expect(drop).toEqual({
-        cmd: "dropVirtualTable",
-        args: ["searchables", "fts5", ["content", "meta UNINDEXED", "tokenize='porter ascii'"]],
-      });
+      expect(drop).toEqual([
+        "dropVirtualTable",
+        ["searchables", "fts5", ["content", "meta UNINDEXED", "tokenize='porter ascii'"]],
+      ]);
     });
 
     it("invert drop virtual table", () => {
@@ -834,10 +795,7 @@ describe("Migration", () => {
         "fts5",
         ["title", "content"],
       ]);
-      expect(create).toEqual({
-        cmd: "createVirtualTable",
-        args: ["searchables", "fts5", ["title", "content"]],
-      });
+      expect(create).toEqual(["createVirtualTable", ["searchables", "fts5", ["title", "content"]]]);
     });
 
     it("invert drop virtual table without options", () => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -124,7 +124,7 @@ describe("CommandRecorder", () => {
       await recorder.changeTable("fruits", async (t) => {
         await t.string("name");
       });
-      expect(recorder.commands[0].cmd).toBe("addColumn");
+      expect(recorder.commands[0][0]).toBe("addColumn");
     });
 
     it("remove with multiple columns records a single removeColumns", async () => {
@@ -133,7 +133,7 @@ describe("CommandRecorder", () => {
         await t.remove("name", "kind", { type: "string" });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumns", args: ["fruits", "name", "kind", { type: "string" }] },
+        ["removeColumns", ["fruits", "name", "kind", { type: "string" }]],
       ]);
     });
 
@@ -143,7 +143,7 @@ describe("CommandRecorder", () => {
         await t.removeIndex({ name: "index_fruits_on_kind" });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }]],
       ]);
     });
 
@@ -153,7 +153,7 @@ describe("CommandRecorder", () => {
         await t.removeIndex(undefined, { name: "index_fruits_on_kind" });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeIndex", args: ["fruits", undefined, { name: "index_fruits_on_kind" }] },
+        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }]],
       ]);
     });
 
@@ -164,7 +164,7 @@ describe("CommandRecorder", () => {
           await t.removeIndex("kind");
         });
       });
-      expect(recorder.commands).toEqual([{ cmd: "addIndex", args: ["fruits", "kind"] }]);
+      expect(recorder.commands).toEqual([["addIndex", ["fruits", "kind"]]]);
     });
 
     it("raises IrreversibleMigration when removeIndex lacks a column", async () => {
@@ -203,8 +203,8 @@ describe("CommandRecorder", () => {
         await columnMethods(t).bigserial("big_seq");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "seq", "serial"] },
-        { cmd: "addColumn", args: ["fruits", "big_seq", "bigserial"] },
+        ["addColumn", ["fruits", "seq", "serial"]],
+        ["addColumn", ["fruits", "big_seq", "bigserial"]],
       ]);
     });
 
@@ -217,8 +217,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "big_seq", "bigserial"] },
-        { cmd: "removeColumn", args: ["fruits", "seq", "serial"] },
+        ["removeColumn", ["fruits", "big_seq", "bigserial"]],
+        ["removeColumn", ["fruits", "seq", "serial"]],
       ]);
     });
 
@@ -229,7 +229,7 @@ describe("CommandRecorder", () => {
         await t.primaryKey("token", "uuid");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "token", "uuid", { primaryKey: true }] },
+        ["addColumn", ["fruits", "token", "uuid", { primaryKey: true }]],
       ]);
     });
 
@@ -238,9 +238,7 @@ describe("CommandRecorder", () => {
       await recorder.changeTable("fruits", async (t) => {
         await columnMethods(t).bitVarying("mask");
       });
-      expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying"] },
-      ]);
+      expect(recorder.commands).toEqual([["addColumn", ["fruits", "mask", "bit_varying"]]]);
     });
   });
 
@@ -263,9 +261,9 @@ describe("CommandRecorder", () => {
         await columnMethods(t).longblob("payload");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer"] },
-        { cmd: "addColumn", args: ["fruits", "notes", "mediumtext"] },
-        { cmd: "addColumn", args: ["fruits", "payload", "longblob"] },
+        ["addColumn", ["fruits", "qty", "unsigned_integer"]],
+        ["addColumn", ["fruits", "notes", "mediumtext"]],
+        ["addColumn", ["fruits", "payload", "longblob"]],
       ]);
     });
 
@@ -278,8 +276,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext"] },
-        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer"] },
+        ["removeColumn", ["fruits", "notes", "mediumtext"]],
+        ["removeColumn", ["fruits", "qty", "unsigned_integer"]],
       ]);
     });
   });

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -14,7 +14,7 @@ import {
 } from "./join-table.js";
 
 export class CommandRecorder {
-  private _commands: Array<{ cmd: string; args: unknown[] }> = [];
+  private _commands: Array<[string, unknown[]]> = [];
   private _delegate: unknown;
   private _reverting = false;
 
@@ -39,7 +39,7 @@ export class CommandRecorder {
     this._reverting = value;
   }
 
-  get commands(): Array<{ cmd: string; args: unknown[] }> {
+  get commands(): Array<[string, unknown[]]> {
     return [...this._commands];
   }
 
@@ -53,7 +53,7 @@ export class CommandRecorder {
     if (this._reverting) {
       this._commands.push(this.inverseOf(cmd, args));
     } else {
-      this._commands.push({ cmd, args });
+      this._commands.push([cmd, args]);
     }
   }
 
@@ -103,7 +103,7 @@ export class CommandRecorder {
    * because a name the recorder does not answer reads back as the proxy's
    * `NoMethodError`-raising function rather than `undefined`.
    */
-  inverseOf(cmd: string, args: unknown[]): { cmd: string; args: unknown[] } {
+  inverseOf(cmd: string, args: unknown[]): [string, unknown[]] {
     const method = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
     if (!(method in this)) {
       throw new IrreversibleMigration(
@@ -113,10 +113,7 @@ export class CommandRecorder {
           `2. Use the #reversible method to define reversible behavior.\n`,
       );
     }
-    const [invertedCmd, invertedArgs] = (
-      this[method] as (args: unknown[]) => [string, unknown[]]
-    ).call(this, args);
-    return { cmd: invertedCmd, args: invertedArgs };
+    return (this[method] as (args: unknown[]) => [string, unknown[]]).call(this, args);
   }
 
   /**
@@ -156,7 +153,7 @@ export class CommandRecorder {
       const recorder = new CommandRecorder(this._delegate);
       recorder.reverting = this._reverting;
       await callback(delegate.updateTableDefinition(tableName, recorder));
-      this._commands.push({ cmd: "changeTable", args: [tableName, recorder.commands] });
+      this._commands.push(["changeTable", [tableName, recorder.commands]]);
     } else {
       await callback(delegate.updateTableDefinition(tableName, this));
     }
@@ -168,12 +165,12 @@ export class CommandRecorder {
    * Mirrors: ActiveRecord::Migration::CommandRecorder#replay
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
-    for (const { cmd, args } of this._commands) {
+    for (const [cmd, args] of this._commands) {
       // Bulk changeTable stores [tableName, subCommands[]]. Replay each
       // sub-command individually rather than forwarding the array as an arg.
       if (cmd === "changeTable" && Array.isArray(args[1])) {
-        const subCmds = args[1] as Array<{ cmd: string; args: unknown[] }>;
-        for (const { cmd: sub, args: subArgs } of subCmds) {
+        const subCmds = args[1] as Array<[string, unknown[]]>;
+        for (const [sub, subArgs] of subCmds) {
           if (typeof migration[sub] === "function") {
             await migration[sub](...subArgs);
           }
@@ -185,8 +182,8 @@ export class CommandRecorder {
   }
 
   /** Returns the full inverse command list. */
-  inverse(): Array<{ cmd: string; args: unknown[] }> {
-    return [...this._commands].reverse().map(({ cmd, args }) => this.inverseOf(cmd, args));
+  inverse(): Array<[string, unknown[]]> {
+    return [...this._commands].reverse().map(([cmd, args]) => this.inverseOf(cmd, args));
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -165,7 +165,7 @@ export class CommandRecorder {
    * Mirrors: ActiveRecord::Migration::CommandRecorder#replay
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
-    for (const [cmd, args] of this._commands) {
+    for (const [cmd, args] of this.commands) {
       // Bulk changeTable stores [tableName, subCommands[]]. Replay each
       // sub-command individually rather than forwarding the array as an arg.
       if (cmd === "changeTable" && Array.isArray(args[1])) {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -165,7 +165,7 @@ export class SchemaMigration {
   }
 
   // Rails: connection.data_source_exists?(table_name) (schema_migration.rb:100-104).
-  async tableExists(): Promise<boolean> {
+  async tableExists(): Promise<boolean | null> {
     return await this._withConnection((connection) => connection.dataSourceExists(this.tableName));
   }
 

--- a/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-migrate-all-metadata.trails.test.ts
@@ -52,8 +52,8 @@ describe("DatabaseTasksMigrateAllMetadataTest", () => {
     });
   }
 
-  async function metadataTablesExist(): Promise<boolean[]> {
-    const results: boolean[] = [];
+  async function metadataTablesExist(): Promise<Array<boolean | null>> {
+    const results: Array<boolean | null> = [];
     for (const config of DatabaseTasks.configsFor({ envName: DatabaseTasks.env })) {
       await DatabaseTasks.withTemporaryConnection(config, async (adapter) => {
         results.push(await adapter.tableExists("ar_internal_metadata"));

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1561,7 +1561,7 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
   const { NoDatabaseError } = await import("../errors.js");
   const { SchemaMigration } = await import("../schema-migration.js");
   return DatabaseTasks.withTemporaryPool(dbConfig, async (pool) => {
-    let alreadyInitialized = false;
+    let alreadyInitialized: boolean | null = false;
     for (;;) {
       try {
         const adapter = await pool.leaseConnection();

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 391,
-    "total": 1410
+    "novel": 390,
+    "total": 1408
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Four convergences from RFC 0051, plus one sibling-merge typecheck fix.

> The bundle's fifth story, `relocate-model-name-to-naming-module` (RFC 0115),
> landed on main in #7010 while this branch was in flight — `naming.ts` already
> holds `modelName` and the `extended` hook that installs the instance
> delegate. Nothing was left to build, so it is not in this diff and its
> trailer is not below.

### `CommandRecorder`'s command tuple is Rails' pair

Deferred out of #7012, whose body called out the return shape as the one
deviation left standing. `inverseOf` now returns the `[method, args]` pair
(`command_recorder.rb:122`) and `_commands` holds pairs the way `@commands` does
(`command_recorder.rb:106-111`), so `record`, `revert`, `inverse`, `replay` and
`changeTable`'s bulk path destructure it as Rails' callers do. `bulkChangeTable`
comes along for the same reason: `operations.each do |command, args|`
(`schema_statements.rb:1559`) is a pair destructure too.

The bulk of the diff is `command-recorder.test.ts`'s ~95 assertions moving from
`{ cmd, args }` to the pair — mechanical, no test name touched.

### The exists predicates' blank arm answers `nil`

`data_source_exists?` / `table_exists?` / `view_exists?` guard with a trailing
`if name.present?` modifier (`schema_statements.rb:45,60,75`), so a blank name
falls off the end of the method and the value is `nil` — not `false`. All three
return `null` now, typed `Promise<boolean | null>`.

Every forwarding wrapper widens with it — `Migration#tableExists`,
`Migration#viewExists`, `SchemaMigration#tableExists` (`schema_migration.rb:100`
is a bare `data_source_exists?` forward), and `initializeDatabase`'s
`alreadyInitialized`. Each reads the result only for truthiness, so `nil` and
`false` behave identically at every call site, which is why nothing else moved.
`adapter_test.rb:60,76` assert with `assert_not`, so those two assertions become
`toBeFalsy()` rather than `toBe(false)`.

### `Migrator#currentMigration` drops its invented guard

The `version === 0` short-circuit has no counterpart in
`migration.rb:1439-1441`, and it read the private `_migrations` rather than the
public `migrations` getter, which is `down? ? reverse : sort_by(&:version)`
(`migration.rb:1470-1472`) — so on a `:down` migrator the two could disagree.
Both are gone.

`MigrationContext#move` needed no re-derivation: its
`current_version != 0 && !migrator.current_migration` guard was already
`migration.rb:1388-1390` verbatim, not a consequence of the removed null.

### `AlterTable`'s `columnDefaultChanges` group is gone

`grep -rn "column_default_changes" vendor/rails/activerecord/lib` returns
nothing. The field, its pusher, and `visitAlterTable`'s seventh group with its
deviation comment are removed, leaving that body Rails' six groups
(`schema_creation.rb:24-32`).

The pusher had no caller anywhere in the repo, so no emitted SQL changes:
default changes already route through `ChangeColumnDefaultDefinition` /
`change_column_default_for_alter` on the PG and MySQL adapters, which is where
Rails puts them.

### Sibling-merge fix

#7017 landed a test calling `createSchemaDumper(adapter)` while #7014 converged
that arity to `create_schema_dumper(options)` (`schema_statements.rb:1541`).
Neither PR conflicted with the other, so their merge order left main's typecheck
red. One argument dropped.

### Verification

- `pnpm parity:api:calls` / `:calls:args` / `:test:assertions` green.
- `pnpm parity:api:extra:gate` green after `:extra:tighten` narrowed
  activerecord's marks to 390 novel / 1408 total — the `AlterTable` deletion
  shrank the surface, and the mark is written down, never up.
- `pnpm lint` clean; `pnpm build` clean.
- `command-recorder{,.trails}`, `invertible-migration`, `migrator`,
  `multi-db-migrator`, `migration`, `adapter`, `schema-statements-privates`,
  `schema-statements-view-exists`, `schema-creation`, `tasks/` — all green.

Closes-story: converge-command-recorder-command-tuple-to-rails-pair
Closes-story: exists-predicates-blank-arm-returns-false-not-nil
Closes-story: migrator-current-migration-invents-a-zero-version-guard
Closes-story: alter-table-column-default-changes-is-not-a-rails-group
