### PR TITLE
fix(activerecord): drop stale createSchemaDumper argument in PG trails test

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -120,7 +120,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         `CREATE UNIQUE INDEX "ex_idx_both_i" ON "ex_idx_both" ("n") INCLUDE ("d") NULLS NOT DISTINCT`,
       );
       const lines: string[] = [];
-      await adapter.createSchemaDumper(adapter).dumpTable(lines, "ex_idx_both");
+      await adapter.createSchemaDumper().dumpTable(lines, "ex_idx_both");
       const indexLine = lines.find((l) => l.includes("ex_idx_both_i"))!;
       expect(indexLine.indexOf("include:")).toBeGreaterThan(-1);
       expect(indexLine.indexOf("include:")).toBeLessThan(indexLine.indexOf("nullsNotDistinct:"));


### PR DESCRIPTION
## Root cause

Two PRs raced on `main`:

- #7014 (`441e92125`) converged `createSchemaDumper` to Rails'
  `create_schema_dumper(options)` arity — the parameter is now an options hash
  (`Record<string, unknown>`), not a connection
  (`connection-adapters/postgresql-adapter.ts:3716`, mirroring
  `activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb`'s
  `create_schema_dumper(options)`).
- #7017 (`d059b0dc4`) split off
  `packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts`,
  carrying over a call site written against the *old* arity:
  `adapter.createSchemaDumper(adapter)`.

Neither branch saw the other, so `tsc --build` only failed once both were on
`main`:

```
postgresql-adapter.trails.test.ts(123,40): error TS2345: Argument of type
'PostgreSQLAdapter' is not assignable to parameter of type 'Record<string, unknown>'.
```

`pnpm build` runs before the suite in every Active Record job, which is why
`Active Record MariaDB Tests (2)` died 90s in without running a single test.

## Fix

Drop the stale argument at that one call site — `adapter.createSchemaDumper()`,
matching the other 20-odd call sites in the PG test files. `pnpm exec tsc
--build --force` is clean locally.

Closes-story: red-d059b0dc
