### PR TITLE
refactor(activemodel,activerecord): retire narrowTo, adapter-typed createTable callbacks, PG-only column methods (RFC 0115, RFC 0051, RFC 0096)

### DIFF
--- a/packages/activemodel/src/attribute-set.test.ts
+++ b/packages/activemodel/src/attribute-set.test.ts
@@ -384,43 +384,6 @@ describe("AttributeSetTest", () => {
     expect(a.fetchValue("age")).toBe(30);
   });
 
-  it("#narrowTo keeps only the named attributes initialized", () => {
-    const strType = typeRegistry.lookup("string");
-    const intType = typeRegistry.lookup("integer");
-    const set = new AttributeSet(
-      new Map([
-        ["id", Attribute.fromDatabase("id", 1, intType)],
-        ["name", Attribute.fromDatabase("name", "Alice", strType)],
-        ["salary", Attribute.fromDatabase("salary", 80000, intType)],
-      ]),
-    );
-    set.narrowTo(["id", "name"]);
-    expect(set.isKey("id")).toBe(true);
-    expect(set.isKey("name")).toBe(true);
-    expect(set.isKey("salary")).toBe(false);
-    expect(set.keys().sort()).toEqual(["id", "name"]);
-  });
-
-  it("#narrowTo preserves the type of narrowed attributes", () => {
-    const intType = typeRegistry.lookup("integer");
-    const set = new AttributeSet(
-      new Map([["salary", Attribute.fromDatabase("salary", 80000, intType)]]),
-    );
-    set.narrowTo([]);
-    expect(set.isKey("salary")).toBe(false);
-    expect(set.getAttribute("salary").type).toBe(intType);
-  });
-
-  it("#narrowTo accepts a Set and is a no-op when all names are kept", () => {
-    const strType = typeRegistry.lookup("string");
-    const set = new AttributeSet(
-      new Map([["name", Attribute.fromDatabase("name", "Alice", strType)]]),
-    );
-    set.narrowTo(new Set(["name"]));
-    expect(set.isKey("name")).toBe(true);
-    expect(set.fetchValue("name")).toBe("Alice");
-  });
-
   it("fetch returns the attribute for the given name", () => {
     const intType = typeRegistry.lookup("integer");
     const foo = Attribute.fromDatabase("foo", 1, intType);

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -268,37 +268,6 @@ export class AttributeSet {
   }
 
   /**
-   * Narrow the set to the given attribute names, resetting every other
-   * attribute to its uninitialized state (type preserved).
-   *
-   * Mirrors the effect of `AttributeSet::Builder#build_from_database` when a
-   * SELECT projects only a subset of columns: unselected columns are absent
-   * from the materialized set, so `isKey`/`keys` no longer report them.
-   *
-   * `overrideTypes` threads the per-query `additional_types` (Rails' second
-   * `build_from_database` arg): a narrowed column becomes
-   * `Attribute.uninitialized(name, additional_types.fetch(name, types[name]))`
-   * (builder.rb:76-87), so an override supplied for a column absent from the
-   * projected row wins over the declared schema type — matching Rails' resolved
-   * `type` in the `elsif types.key?(name)` / `else Attribute.uninitialized`
-   * branch. Absent that, the declared type is preserved.
-   *
-   * @internal Rails-private helper.
-   */
-  narrowTo(
-    names: Iterable<string>,
-    overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-  ): void {
-    this.assertNotFrozen();
-    const keep = names instanceof Set ? names : new Set(names);
-    for (const [name, attr] of this._attributes) {
-      if (keep.has(name)) continue;
-      const type = (overrideTypes?.[name] as Type) ?? attr.type;
-      this._attributes.set(name, Attribute.uninitialized(name, type));
-    }
-  }
-
-  /**
    * The JS spelling of `attributes.freeze`: a `Map` is unaffected by
    * `Object.freeze`, so each writer checks the frozen set explicitly and raises
    * what Ruby's frozen Hash raises.

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -1,5 +1,6 @@
 import { Attribute, Uninitialized } from "../attribute.js";
 import { Type } from "../type/value.js";
+import { defaultValue } from "../type.js";
 import { AttributeSet } from "../attribute-set.js";
 
 export class Builder {
@@ -19,7 +20,16 @@ export class Builder {
   }
 }
 
-/** Mirrors: ActiveModel::LazyAttributeSet */
+/**
+ * Mirrors: ActiveModel::LazyAttributeSet
+ *
+ * Rails' `types` here is `attribute_types`, a Hash whose `default` is
+ * `Type.default_value` (attribute_registration.rb:37-41), so
+ * `additional_types.fetch(name, types[name])` still resolves a type for a name
+ * the model does not declare — an extra/computed select column. A JS `Map` has
+ * no such default, so it is applied at each of those lookups here and in
+ * {@link LazyAttributeHash}.
+ */
 export class LazyAttributeSet extends AttributeSet {
   private values: Record<string, unknown>;
   private types: Map<string, Type>;
@@ -80,7 +90,7 @@ export class LazyAttributeSet extends AttributeSet {
     }
 
     if (valuePresent) {
-      const type = this.additionalTypes.get(name) ?? this.types.get(name)!;
+      const type = this.additionalTypes.get(name) ?? this.types.get(name) ?? defaultValue();
       const casted = type.deserialize(value);
       this.castedValues.set(name, casted);
       return casted;
@@ -117,19 +127,19 @@ export class LazyAttributeSet extends AttributeSet {
       value = valuePresent ? this.values[name] : undefined;
     }
 
-    const type = this.additionalTypes.get(name) ?? this.types.get(name);
+    const type = this.additionalTypes.get(name) ?? this.types.get(name) ?? defaultValue();
 
     if (valuePresent) {
       const castedValue = this.castedValues.get(name);
       const attr =
         castedValue === undefined
-          ? Attribute.fromDatabase(name, value, type!)
-          : Attribute.fromDatabase(name, value, type!, castedValue);
+          ? Attribute.fromDatabase(name, value, type)
+          : Attribute.fromDatabase(name, value, type, castedValue);
       this._attributes.set(name, attr);
       return attr;
     } else if (this.types.has(name)) {
       const attr = this.defaultAttributes.get(name);
-      const built = attr ? attr.dup() : Attribute.uninitialized(name, type!);
+      const built = attr ? attr.dup() : Attribute.uninitialized(name, type);
       this._attributes.set(name, built);
       return built;
     } else {
@@ -321,7 +331,7 @@ export class LazyAttributeHash {
    * Attribute, and TS has no nil that answers `value`.
    */
   assignDefaultValue(name: string): Attribute {
-    const type = this.additionalTypes.get(name) ?? this.types.get(name);
+    const type = this.additionalTypes.get(name) ?? this.types.get(name) ?? defaultValue();
     let valuePresent = true;
     let value: unknown;
     if (Object.hasOwn(this.values, name)) {
@@ -331,12 +341,12 @@ export class LazyAttributeHash {
     }
 
     if (valuePresent) {
-      const attr = Attribute.fromDatabase(name, value, type!);
+      const attr = Attribute.fromDatabase(name, value, type);
       this.delegate.set(name, attr);
       return attr;
     } else if (this.types.has(name)) {
       const attr = this.defaultAttributes.get(name);
-      const built = attr ? attr.dup() : Attribute.uninitialized(name, type!);
+      const built = attr ? attr.dup() : Attribute.uninitialized(name, type);
       this.delegate.set(name, built);
       return built;
     }

--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -6,10 +6,7 @@ import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Base, Rollback } from "../../index.js";
 import { fixtures } from "../../test-fixtures.js";
-import type {
-  TableDefinition as PgTableDefinition,
-  Table as PgTable,
-} from "../../connection-adapters/postgresql/schema-definitions.js";
+import type { Table as PgTable } from "../../connection-adapters/postgresql/schema-definitions.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
 class Citext extends Base {
@@ -29,7 +26,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     connection = Base.connection as PostgreSQLAdapter;
     await connection.enableExtension("citext");
     await connection.createTable("citexts", (t) => {
-      (t as PgTableDefinition).citext("cival");
+      t.citext("cival");
     });
     void Citext.resetColumnInformation();
     await Citext.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/collation.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/collation.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -12,8 +11,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     // Rails: @connection.create_table :postgresql_collations, force: true { |t| ... }
-    await adapter.createTable("postgresql_collations", { force: true }, (table) => {
-      const t = table as PgTableDefinition;
+    await adapter.createTable("postgresql_collations", { force: true }, (t) => {
       t.string("string_c", { collation: "C" });
       t.text("text_posix", { collation: "POSIX" });
     });

--- a/packages/activerecord/src/adapters/postgresql/ltree.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/ltree.test.ts
@@ -7,7 +7,6 @@ import { SchemaDumper } from "../../schema-dumper.js";
 import { Base } from "../../index.js";
 import { fixtures } from "../../test-fixtures.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 
 // Rails: class Ltree < ActiveRecord::Base
 //   self.table_name = "ltrees"
@@ -33,7 +32,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     // Rails: @connection.create_table("ltrees") { |t| t.ltree "path" }
     await connection.createTable("ltrees", (t) => {
-      (t as PgTableDefinition).ltree("path");
+      t.ltree("path");
     });
 
     void Ltree.resetColumnInformation();

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -8,7 +8,6 @@ import { SchemaDumper } from "../../schema-dumper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base } from "../../index.js";
 import { sql as arelSql } from "@blazetrails/arel";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
 // Rails: class PostgresqlMoney < ActiveRecord::Base
@@ -33,8 +32,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     await connection.execute("set lc_monetary = 'C'");
     // Rails: @connection.create_table("postgresql_moneys", force: true) { |t| ... }
     await connection.createTable("postgresql_moneys", { force: true }, (t) => {
-      (t as PgTableDefinition).money("wealth");
-      (t as PgTableDefinition).money("depth", { default: "150.55" });
+      t.money("wealth");
+      t.money("depth", { default: "150.55" });
     });
     void PostgresqlMoney.resetColumnInformation();
     await PostgresqlMoney.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -7,7 +7,6 @@ import { SchemaDumper } from "../../schema-dumper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base } from "../../index.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 
 // Rails: class PostgresqlNetworkAddress < ActiveRecord::Base; end
 class PostgresqlNetworkAddress extends Base {
@@ -25,9 +24,9 @@ describeIfPg("PostgreSQLAdapter", () => {
   beforeEach(async () => {
     connection = Base.connection as PostgreSQLAdapter;
     await connection.createTable("postgresql_network_addresses", { force: true }, (t) => {
-      (t as PgTableDefinition).inet("inet_address", { default: "192.168.1.1" });
-      (t as PgTableDefinition).cidr("cidr_address", { default: "192.168.1.0/24" });
-      (t as PgTableDefinition).macaddr("mac_address", { default: "ff:ff:ff:ff:ff:ff" });
+      t.inet("inet_address", { default: "192.168.1.1" });
+      t.cidr("cidr_address", { default: "192.168.1.0/24" });
+      t.macaddr("mac_address", { default: "ff:ff:ff:ff:ff:ff" });
     });
     void PostgresqlNetworkAddress.resetColumnInformation();
     await PostgresqlNetworkAddress.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/serial.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/serial.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { Column } from "../../connection-adapters/postgresql/column.js";
-import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -34,8 +33,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgresqlSerialTest", () => {
     beforeEach(async () => {
       await adapter.dropTable("postgresql_serials", { ifExists: true });
-      await adapter.createTable("postgresql_serials", { force: true }, (table) => {
-        const t = table as PgTableDefinition;
+      await adapter.createTable("postgresql_serials", { force: true }, (t) => {
         t.serial("seq");
         t.integer("serials_id", {
           default: () => "nextval('postgresql_serials_id_seq')",
@@ -76,8 +74,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgresqlBigSerialTest", () => {
     beforeEach(async () => {
       await adapter.dropTable("postgresql_big_serials", { ifExists: true });
-      await adapter.createTable("postgresql_big_serials", { force: true }, (table) => {
-        const t = table as PgTableDefinition;
+      await adapter.createTable("postgresql_big_serials", { force: true }, (t) => {
         t.bigserial("seq");
         t.bigint("serials_id", {
           default: () => "nextval('postgresql_big_serials_id_seq')",
@@ -119,10 +116,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     beforeEach(async () => {
       await adapter.dropTable("foo_bar", "foo", { ifExists: true });
       await adapter.createTable("foo_bar", { force: true }, (table) => {
-        (table as PgTableDefinition).serial("baz_id");
+        table.serial("baz_id");
       });
-      await adapter.createTable("foo", { force: true }, (table) => {
-        const t = table as PgTableDefinition;
+      await adapter.createTable("foo", { force: true }, (t) => {
         t.serial("bar_id");
         t.bigserial("bar_baz_id");
       });
@@ -155,8 +151,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         { force: true, _usesLegacyTableName: true } as Parameters<
           PostgreSQLAdapter["createTable"]
         >[1],
-        (table) => {
-          const t = table as PgTableDefinition;
+        (t) => {
           t.serial("seq");
           t.bigserial("bigseq");
         },

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -12,6 +12,7 @@
 
 import { Notifications } from "@blazetrails/activesupport";
 import type { Base } from "../base.js";
+import type { Result } from "../result.js";
 import type { AssociationSpec } from "../relation/query-methods.js";
 import { Nodes, Table } from "@blazetrails/arel";
 import { isAssociationCached, _cacheSingularTarget } from "../associations.js";
@@ -581,19 +582,41 @@ export class JoinDependency {
    * (returns `parents.values`).
    */
   instantiate(
-    resultSet: Record<string, unknown>[],
+    resultSet: Result,
     strictLoadingValue?: boolean | null,
-    columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
     block?: (record: any) => void,
   ): any[] {
+    // join_dependency.rb:120-132: every result column that is not one of the
+    // `t<n>_r<n>` join aliases keeps the result set's reported type, minus the
+    // names the join root already declares — so a decorated (serialized,
+    // encrypted, enum) attribute is never superseded, and an extra select like
+    // `posts.id * 1.1 AS foo` still type-casts.
+    const columnNames = resultSet.columns.filter((name) => !/^t\d+_r\d+$/.test(name));
+    let columnTypes: Record<string, { deserialize(value: unknown): unknown }> = {};
+    if (columnNames.length !== 0) {
+      const reported = resultSet.columnTypes as Record<
+        string,
+        { deserialize(value: unknown): unknown }
+      >;
+      if (Object.keys(reported).length !== 0) {
+        const attributeTypes = this._baseModel.attributeTypes();
+        columnTypes = Object.fromEntries(
+          columnNames
+            .filter((name) => Object.hasOwn(reported, name) && !Object.hasOwn(attributeTypes, name))
+            .map((name) => [name, reported[name]]),
+        );
+      }
+    }
+
+    const rows = resultSet.toArray();
     const payload = {
-      record_count: resultSet.length,
+      record_count: rows.length,
       class_name: this._baseModel.baseClass.name,
     };
     const { parents, associations, parentKeys } = Notifications.instrument(
       "instantiation.active_record",
       payload,
-      () => this.instantiateFromRows(resultSet, strictLoadingValue, columnTypes),
+      () => this.instantiateFromRows(rows, strictLoadingValue, columnTypes),
     );
 
     const inverseMap = new Map<string, string | undefined>();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2736,6 +2736,17 @@ export class Base extends Model {
 
   /**
    * Instantiate a model from a database row (marks it as persisted).
+   *
+   * Mirrors `instantiate_instance_of` (persistence.rb:82-87):
+   * `klass.attributes_builder.build_from_database(attributes, column_types)`,
+   * installed by `init_with_attributes`. The resulting LazyAttributeSet reports
+   * only the projected columns from `keys`/`key?`, because the unprojected ones
+   * were never in `values` (attribute_set/builder.rb:32-39).
+   *
+   * trails carries a per-query `overrideTypes` map Rails has no counterpart
+   * for; it is merged into Rails' single `additional_types` argument, an
+   * override winning over the result set's reported column type for the same
+   * name.
    */
   static _instantiate<T extends typeof Base>(
     this: T,
@@ -2761,9 +2772,9 @@ export class Base extends Model {
     }
 
     // Ensure schema reflection has populated _attributeDefinitions with
-    // adapter-resolved cast types before hydrating from the row —
-    // otherwise writeFromDatabase falls back to ValueType and PG OID
-    // casts (uuid/jsonb/hstore/inet/range) are lost. Sync path only
+    // adapter-resolved cast types before hydrating from the row — otherwise
+    // `attributes_builder`'s `attribute_types` falls back to ValueType and PG
+    // OID casts (uuid/jsonb/hstore/inet/range) are lost. Sync path only
     // reads an already-populated schema cache; the preceding query
     // would have populated it.
 
@@ -2796,14 +2807,6 @@ export class Base extends Model {
         delete (this as any)._suppressAbstractCheck;
       }
     }
-    // Rails: `klass.attributes_builder.build_from_database(attributes,
-    // column_types)` then `allocate.init_with_attributes(attributes)`
-    // (persistence.rb:82-87). The LazyAttributeSet reports only the projected
-    // columns from `keys`/`key?` because the unprojected ones were never in
-    // `values` (attribute_set/builder.rb:32-39), so there is no narrowing pass.
-    // trails merges its per-query `overrideTypes` into Rails' single
-    // `additional_types` argument, an override winning over the result set's
-    // reported column type for the same name.
     const additionalTypes = new Map<string, any>();
     for (const [key, type] of Object.entries(columnTypes ?? {})) additionalTypes.set(key, type);
     for (const [key, type] of Object.entries(overrideTypes ?? {})) additionalTypes.set(key, type);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -31,7 +31,6 @@ import type {
 } from "@blazetrails/globalid/signed-global-id";
 import {
   ArgumentError,
-  Attribute,
   AttributeMethodPattern,
   Model,
   Type,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -72,7 +72,6 @@ import {
   baseClass as _inheritanceBaseClass,
   isBaseClass as _isBaseClass,
   ensureProperType as _ensureProperType,
-  narrowToProjectedColumns,
   defineDynamicSelectReaders,
   subclassFromAttributesForNew,
   isDescendsFromActiveRecord as _isDescendsFromActiveRecord,
@@ -2797,35 +2796,19 @@ export class Base extends Model {
         delete (this as any)._suppressAbstractCheck;
       }
     }
-    // Load DB values through deserialize (not cast) so encrypted types decrypt.
-    // Extra/computed select columns aren't in the schema, so pass the result
-    // set's column type (when the adapter reported one) to cast them — mirrors
-    // Rails' `instantiate(record, column_types)` slice in find_by_sql /
-    // JoinDependency#instantiate.
-    for (const [key, value] of Object.entries(row)) {
-      const override = overrideTypes?.[key];
-      if (override) {
-        // An explicit per-attribute `types` override supersedes the schema
-        // type, the way LazyAttributeHash resolves
-        // `additional_types.fetch(name, types[name])` (builder.rb:76).
-        record._attributes.set(key, Attribute.fromDatabase(key, value, override as Type));
-      } else {
-        record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
-      }
-    }
-    // A SELECT that projects only a subset of columns yields a row with just
-    // those keys, so hasAttribute() must reflect what was loaded rather than
-    // the full schema. Mirrors Rails' attributes_builder narrowing (see
-    // narrowToProjectedColumns). Shared with the STI path in inheritance.ts.
-    // `overrideTypes` is threaded so a schema column absent from the row adopts
-    // the per-query override type when narrowed to uninitialized (builder.rb's
-    // `else Attribute.uninitialized(name, type)` branch, where `type` resolves
-    // via `additional_types.fetch(name, types[name])`).
-    narrowToProjectedColumns(
-      this as unknown as typeof Base,
-      record as unknown as Base,
-      row,
-      overrideTypes,
+    // Rails: `klass.attributes_builder.build_from_database(attributes,
+    // column_types)` then `allocate.init_with_attributes(attributes)`
+    // (persistence.rb:82-87). The LazyAttributeSet reports only the projected
+    // columns from `keys`/`key?` because the unprojected ones were never in
+    // `values` (attribute_set/builder.rb:32-39), so there is no narrowing pass.
+    // trails merges its per-query `overrideTypes` into Rails' single
+    // `additional_types` argument, an override winning over the result set's
+    // reported column type for the same name.
+    const additionalTypes = new Map<string, any>();
+    for (const [key, type] of Object.entries(columnTypes ?? {})) additionalTypes.set(key, type);
+    for (const [key, type] of Object.entries(overrideTypes ?? {})) additionalTypes.set(key, type);
+    (record as any).initWithAttributes(
+      (this as any).attributesBuilder().buildFromDatabase(row, additionalTypes),
     );
     defineDynamicSelectReaders(record as unknown as Base);
     record._newRecord = false;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -108,6 +108,7 @@ import {
 import type {
   AlterTable,
   TableDefinition,
+  TableDefinitionOf,
   Table,
   ForeignKeyDefinition,
   IndexDefinition,
@@ -251,8 +252,8 @@ export interface AbstractAdapter {
           limit?: number;
           precision?: number;
         }
-      | ((t: TableDefinition) => void),
-    fn?: (t: TableDefinition) => void,
+      | ((t: TableDefinitionOf<this>) => void),
+    fn?: (t: TableDefinitionOf<this>) => void,
   ): Promise<void>;
   dropTable(
     ...args:

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -172,6 +172,7 @@ const CR_SERVER_LOST = 2013;
 const ER_CLIENT_INTERACTION_TIMEOUT = 4031;
 
 type CreateTableArgs = Parameters<MysqlSchemaStatements["createTable"]>;
+type CreateTableOptions = Extract<CreateTableArgs[1], { options?: string }>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractMysqlAdapter extends AbstractAdapter {
@@ -2009,9 +2010,7 @@ export interface AbstractMysqlAdapter {
 
   createTable(
     name: string,
-    optionsOrFn?:
-      | Extract<CreateTableArgs[1], { options?: string }>
-      | ((t: TableDefinitionOf<this>) => void),
+    optionsOrFn?: CreateTableOptions | ((t: TableDefinitionOf<this>) => void),
     fn?: (t: TableDefinitionOf<this>) => void,
   ): Promise<void>;
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -75,6 +75,7 @@ import type {
   ColumnType,
   IndexDefinition,
   RemoveForeignKeyOptions,
+  TableDefinitionOf,
 } from "./abstract/schema-definitions.js";
 import type { CommentOrChanges } from "./abstract/schema-statements.js";
 import {
@@ -2008,8 +2009,10 @@ export interface AbstractMysqlAdapter {
 
   createTable(
     name: string,
-    optionsOrFn?: CreateTableArgs[1],
-    fn?: CreateTableArgs[2],
+    optionsOrFn?:
+      | Extract<CreateTableArgs[1], { options?: string }>
+      | ((t: TableDefinitionOf<this>) => void),
+    fn?: (t: TableDefinitionOf<this>) => void,
   ): Promise<void>;
 
   removeColumn(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1045,11 +1045,6 @@ export class AlterTable {
 }
 
 /**
- * TableDefinition — used inside create_table blocks.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition
- */
-/**
  * The table-definition type an adapter's own `create_table_definition` builds.
  *
  * Ruby resolves a yielded object's methods at call time, so a PostgreSQL
@@ -1058,6 +1053,10 @@ export class AlterTable {
  * TypeScript resolves against the DECLARED parameter type instead, so the
  * `create_table` yield has to name the receiver's own definition class for the
  * same names to resolve.
+ *
+ * @noRailsEquivalent PERMANENT: Ruby needs no type to express what a
+ *   `create_table` block yields, so there is nothing to mirror. This is the
+ *   declaration-site expression of that same fact.
  */
 export type TableDefinitionOf<A> = A extends {
   createTableDefinition(name: string, options?: Record<string, unknown>): infer T;
@@ -1065,6 +1064,11 @@ export type TableDefinitionOf<A> = A extends {
   ? T
   : TableDefinition;
 
+/**
+ * TableDefinition — used inside create_table blocks.
+ *
+ * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition
+ */
 export class TableDefinition {
   readonly name: string;
   readonly columns: ColumnDefinition[] = [];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1049,6 +1049,22 @@ export class AlterTable {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition
  */
+/**
+ * The table-definition type an adapter's own `create_table_definition` builds.
+ *
+ * Ruby resolves a yielded object's methods at call time, so a PostgreSQL
+ * `create_table` block reaches `PostgreSQL::ColumnMethods` names
+ * (postgresql/schema_definitions.rb:245) with nothing declared anywhere.
+ * TypeScript resolves against the DECLARED parameter type instead, so the
+ * `create_table` yield has to name the receiver's own definition class for the
+ * same names to resolve.
+ */
+export type TableDefinitionOf<A> = A extends {
+  createTableDefinition(name: string, options?: Record<string, unknown>): infer T;
+}
+  ? T
+  : TableDefinition;
+
 export class TableDefinition {
   readonly name: string;
   readonly columns: ColumnDefinition[] = [];
@@ -1451,22 +1467,6 @@ export class TableDefinition {
   ): this;
   virtual(...args: unknown[]): this {
     return this.definedColumn("virtual" as ColumnType, args);
-  }
-
-  jsonb(...names: string[]): this;
-  jsonb(...args: [...names: string[], options: ColumnOptions]): this;
-  jsonb(...args: unknown[]): this {
-    const { names, options } = splitColumnNames(args, "jsonb");
-    for (const name of names) this.column(name, "jsonb", options);
-    return this;
-  }
-
-  char(name: string, options: ColumnOptions = {}): this {
-    return this.column(name, "char", options);
-  }
-
-  array(name: string, type: ColumnType, options: ColumnOptions = {}): this {
-    return this.column(name, type, { ...options, array: true });
   }
 
   timestamps(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -11,6 +11,7 @@ import {
   TableDefinition,
   type ColumnType,
 } from "./schema-definitions.js";
+import type { TableDefinitionOf } from "./schema-definitions.js";
 import { TableDefinition as MysqlTableDefinition } from "../mysql/schema-definitions.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { NATIVE_DATABASE_TYPES_BY_ADAPTER } from "./native-database-types.js";
@@ -1127,8 +1128,8 @@ describe("SchemaStatements#createTable statement ordering", () => {
       override buildCreateTableDefinition(
         tableName: string,
         options: Parameters<SchemaStatements["buildCreateTableDefinition"]>[1] = {},
-        fn?: (td: TableDefinition) => void,
-      ): TableDefinition {
+        fn?: (td: TableDefinitionOf<this>) => void,
+      ): TableDefinitionOf<this> {
         return super.buildCreateTableDefinition(
           tableName,
           { ...options, comment: "from the definition" },

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -37,6 +37,7 @@ import {
   type ForeignKeyLookupOptions,
   type RemoveForeignKeyOptions,
 } from "./schema-definitions.js";
+import type { TableDefinitionOf } from "./schema-definitions.js";
 import type { UniqueConstraintOptions } from "../postgresql/schema-definitions.js";
 import { SchemaCreation, type SchemaCreationConn } from "./schema-creation.js";
 import { maxIdentifierLength } from "./database-limits.js";
@@ -362,8 +363,8 @@ export class SchemaStatements {
           limit?: number;
           precision?: number;
         }
-      | ((t: TableDefinition) => void),
-    fn?: (t: TableDefinition) => void,
+      | ((t: TableDefinitionOf<this>) => void),
+    fn?: (t: TableDefinitionOf<this>) => void,
   ): Promise<void> {
     let kwargs: {
       id?: boolean | ColumnType | IdHashOptions;
@@ -381,7 +382,7 @@ export class SchemaStatements {
       limit?: number;
       precision?: number;
     } = {};
-    let definer: ((t: TableDefinition) => void) | undefined;
+    let definer: ((t: TableDefinitionOf<this>) => void) | undefined;
 
     if (typeof optionsOrFn === "function") {
       definer = optionsOrFn;
@@ -1342,8 +1343,8 @@ export class SchemaStatements {
       force?: boolean | "cascade";
       [key: string]: unknown;
     } = {},
-    fn?: (td: TableDefinition) => void,
-  ): TableDefinition {
+    fn?: (td: TableDefinitionOf<this>) => void,
+  ): TableDefinitionOf<this> {
     const { id = true, primaryKey, force: _force, ...rest } = options;
     // Rails uses `options.extract!`, which *deletes* what it returns — so
     // `_skipValidateOptions` only ever reaches the first extraction.
@@ -1362,7 +1363,10 @@ export class SchemaStatements {
       }
     }
 
-    const tableDefinition = this.createTableDefinition(tableName, tdOptions);
+    const tableDefinition = this.createTableDefinition(
+      tableName,
+      tdOptions,
+    ) as TableDefinitionOf<this>;
     tableDefinition.setPrimaryKey(tableName, id, primaryKey, pkOptions);
 
     if (fn) fn(tableDefinition);
@@ -1378,8 +1382,8 @@ export class SchemaStatements {
       tableName?: string;
       [key: string]: unknown;
     } = {},
-    fn?: (td: TableDefinition) => void,
-  ): TableDefinition {
+    fn?: (td: TableDefinitionOf<this>) => void,
+  ): TableDefinitionOf<this> {
     const joinTableName = this.findJoinTableName(table1, table2, options);
     const { columnOptions = {}, tableName: _, ...rest } = options;
     const mergedColOpts = { null: false, index: false, ...columnOptions };
@@ -1805,44 +1809,37 @@ export class SchemaStatements {
   }
 
   async bulkChangeTable(tableName: string, operations: MigrationCommand[]): Promise<void> {
-    const sqlFragments: string[] = [];
-    const nonCombinable: Array<() => Promise<void>> = [];
+    let sqlFragments: string[] = [];
+    let nonCombinableOperations: Array<() => Promise<void>> = [];
 
     for (const [command, args] of operations) {
       const [table, ...arguments_] = args as [string, ...unknown[]];
-      const forAlterTarget =
-        typeof (this as any)[`${command}ForAlter`] === "function"
-          ? (this as any)
-          : typeof (this as any)[`${command}ForAlter`] === "function"
-            ? (this as any)
-            : null;
-      const forAlterMethod = forAlterTarget ? forAlterTarget[`${command}ForAlter`] : null;
-      if (typeof forAlterMethod === "function") {
-        const result = await forAlterMethod.call(forAlterTarget, table, ...arguments_);
-        const results = Array.isArray(result) ? result : [result];
-        for (const r of results) {
-          if (typeof r === "string") {
-            sqlFragments.push(r);
-          } else if (typeof r === "function") {
-            nonCombinable.push(r);
-          }
+      const method = `${command}ForAlter`;
+
+      if (typeof (this as any)[method] === "function") {
+        const sqls: string[] = [];
+        const procs: Array<() => Promise<void>> = [];
+        const result = await (this as any)[method](table, ...arguments_);
+        for (const v of Array.isArray(result) ? result : [result]) {
+          if (typeof v === "string") sqls.push(v);
+          else if (typeof v === "function") procs.push(v);
         }
+        sqlFragments = sqlFragments.concat(sqls);
+        nonCombinableOperations = nonCombinableOperations.concat(procs);
       } else {
         if (sqlFragments.length > 0) {
           await this.execute(
             `ALTER TABLE ${this.quoteTableName(tableName)} ${sqlFragments.join(", ")}`,
           );
-          sqlFragments.length = 0;
         }
-        for (const proc of nonCombinable) await proc();
-        nonCombinable.length = 0;
+        for (const proc of nonCombinableOperations) await proc();
+        sqlFragments = [];
+        nonCombinableOperations = [];
 
-        const method = (this as any)[command];
-        if (typeof method === "function") {
-          await method.call(this, table, ...arguments_);
-        } else {
+        if (typeof (this as any)[command] !== "function") {
           throw new Error(`Unknown bulk change command: ${command}`);
         }
+        await (this as any)[command](table, ...arguments_);
       }
     }
 
@@ -1851,7 +1848,7 @@ export class SchemaStatements {
         `ALTER TABLE ${this.quoteTableName(tableName)} ${sqlFragments.join(", ")}`,
       );
     }
-    for (const proc of nonCombinable) await proc();
+    for (const proc of nonCombinableOperations) await proc();
   }
 
   validTableDefinitionOptions(): string[] {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1817,12 +1817,16 @@ export class SchemaStatements {
       const method = `${command}ForAlter`;
 
       if (typeof (this as any)[method] === "function") {
+        const result = await (this as any)[method](table, ...arguments_);
+        // Ruby `Array(x)`: nil is [], an Array passes through, anything else
+        // wraps. `partition` then splits it on String, so every non-String —
+        // not only a callable — lands in `procs`.
+        const values = result == null ? [] : Array.isArray(result) ? result : [result];
         const sqls: string[] = [];
         const procs: Array<() => Promise<void>> = [];
-        const result = await (this as any)[method](table, ...arguments_);
-        for (const v of Array.isArray(result) ? result : [result]) {
+        for (const v of values) {
           if (typeof v === "string") sqls.push(v);
-          else if (typeof v === "function") procs.push(v);
+          else procs.push(v as () => Promise<void>);
         }
         sqlFragments = sqlFragments.concat(sqls);
         nonCombinableOperations = nonCombinableOperations.concat(procs);
@@ -1835,10 +1839,6 @@ export class SchemaStatements {
         for (const proc of nonCombinableOperations) await proc();
         sqlFragments = [];
         nonCombinableOperations = [];
-
-        if (typeof (this as any)[command] !== "function") {
-          throw new Error(`Unknown bulk change command: ${command}`);
-        }
         await (this as any)[command](table, ...arguments_);
       }
     }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -18,7 +18,7 @@ import { SchemaStatements as BaseSchemaStatements } from "../abstract/schema-sta
 import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
 import { ForeignKeyDefinition, IndexDefinition } from "../abstract/schema-definitions.js";
 import { quoteColumnName, unquoteIdentifier } from "./quoting.js";
-import type { SchemaStatementsLike } from "../abstract/schema-definitions.js";
+import type { SchemaStatementsLike, TableDefinitionOf } from "../abstract/schema-definitions.js";
 import type { VisitorHostAdapter } from "./schema-creation.js";
 import type { Result } from "../../result.js";
 
@@ -209,8 +209,8 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
    */
   override async createTable(
     name: string,
-    optionsOrFn?: CreateTableArgs[1],
-    fn?: CreateTableArgs[2],
+    optionsOrFn?: CreateTableOptions | ((t: TableDefinitionOf<this>) => void),
+    fn?: (t: TableDefinitionOf<this>) => void,
   ): Promise<void> {
     const definer = typeof optionsOrFn === "function" ? optionsOrFn : fn;
     const options: CreateTableOptions =

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3439,15 +3439,18 @@ export class PostgreSQLAdapter
     // Rails resolves the name against `table.to_s` — the SCHEMA-QUALIFIED name,
     // so a generated index name matches the one addIndex produced for the same
     // argument. Passing the bare identifier here silently misses those.
+    // Rails passes the PostgreSQL::Name itself to `quote_table_name`, which
+    // `to_s`es it; trails' `quoteTableName` takes a string, so the `to_s`
+    // happens here rather than at the call site.
     const indexToRemove = new Name(
       table.schema,
       await this.indexNameForRemove(table.toString(), columnName, options),
-    );
+    ).toString();
 
     await this.execute(
       // `?? ""` is Ruby's `#{nil}` — `index_algorithm` returns nil with no
       // `:algorithm`, so the statement carries the empty slot Rails emits.
-      `DROP INDEX ${this.indexAlgorithm(options.algorithm) ?? ""} ${this.quoteTableName(indexToRemove.toString())}`,
+      `DROP INDEX ${this.indexAlgorithm(options.algorithm) ?? ""} ${this.quoteTableName(indexToRemove)}`,
     );
   }
 
@@ -3918,6 +3921,11 @@ export class PostgreSQLAdapter
    * Return the default expression as-is when it is a SQL function/expression.
    * Mirrors: PostgreSQLAdapter#extract_default_function
    * @internal
+   *
+   * @missingRailsArgs has_default_function? — PERMANENT: Rails passes the local
+   *   `default` (postgresql_adapter.rb:781-782); `default` is a reserved word in
+   *   JavaScript and cannot be a binding identifier, so the parameter is spelled
+   *   `defaultExpr`. Same value, same position.
    */
   extractDefaultFunction(defaultValue: unknown, defaultExpr: string | null): string | null {
     if (defaultExpr != null && this.hasDefaultFunction(defaultValue, defaultExpr)) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3395,7 +3395,13 @@ export class PostgreSQLAdapter
     }
   }
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#remove_index
+  /**
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#remove_index
+   *
+   * Rails hands the `PostgreSQL::Name` itself to `quote_table_name`
+   * (postgresql/schema_statements.rb:561), which `to_s`es it; trails'
+   * `quoteTableName` takes a string, so `indexToRemove` holds the `to_s`ed name.
+   */
   async removeIndex(
     tableName: string,
     columnOrOptions?:
@@ -3439,9 +3445,6 @@ export class PostgreSQLAdapter
     // Rails resolves the name against `table.to_s` — the SCHEMA-QUALIFIED name,
     // so a generated index name matches the one addIndex produced for the same
     // argument. Passing the bare identifier here silently misses those.
-    // Rails passes the PostgreSQL::Name itself to `quote_table_name`, which
-    // `to_s`es it; trails' `quoteTableName` takes a string, so the `to_s`
-    // happens here rather than at the call site.
     const indexToRemove = new Name(
       table.schema,
       await this.indexNameForRemove(table.toString(), columnName, options),

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2418,6 +2418,13 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // --- Rails: table-rebuild helpers (move_table / copy_table family) ---
 
   /** @internal */
+  /**
+   * @missingRailsArgs quote_table_name — PERMANENT: Rails passes `table_name`
+   *   whole (sqlite3_adapter.rb:790-795); PRAGMA takes an attached-schema
+   *   qualifier as two separately-quoted identifiers rather than one quoted
+   *   name, so the two halves are quoted apart (see the split rationale on
+   *   `indexes` in sqlite3/schema-statements.ts).
+   */
   private async tableInfo(tableName: string): Promise<Record<string, unknown>[]> {
     const { schema, bare } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteTableName(schema)}.` : "";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2417,8 +2417,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // --- Rails: table-rebuild helpers (move_table / copy_table family) ---
 
-  /** @internal */
   /**
+   * @internal
+   *
    * @missingRailsArgs quote_table_name — PERMANENT: Rails passes `table_name`
    *   whole (sqlite3_adapter.rb:790-795); PRAGMA takes an attached-schema
    *   qualifier as two separately-quoted identifiers rather than one quoted

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -220,7 +220,16 @@ export function validateIndexLengthBang(
   );
 }
 
-/** @internal */
+/**
+ * @internal
+ *
+ * @missingRailsArgs extract_value_from_default — PERMANENT: Rails passes the
+ *   local `default` (sqlite3/schema_statements.rb:144-147); `default` is a
+ *   reserved word in JavaScript and cannot be a binding identifier, so the local
+ *   keeps the PRAGMA column's own spelling, `dfltValue`.
+ * @missingRailsArgs extract_default_function — PERMANENT: same `default`
+ *   reserved-word substitution (sqlite3/schema_statements.rb:153).
+ */
 export function newColumnFromField(
   adapter: SQLite3SchemaAdapter,
   _tableName: string,

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -523,58 +523,6 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
   return subclass;
 }
 
-/**
- * Narrow a freshly-hydrated record's attribute set to the columns actually
- * returned by the query, so `hasAttribute()` reflects a projected SELECT.
- *
- * Mirrors Rails' `attributes_builder`, which builds from
- * `_default_attributes.except(column_names - [primary_key])` (model_schema.rb):
- * only the primary key and virtual (non-column) attributes keep their
- * defaults — every other unselected column is left uninitialized. Applied in
- * both the direct and STI instantiation paths so projected loads narrow
- * regardless of STI, matching the net result of Rails'
- * `instantiate_instance_of`. (Rails narrows in `build_from_database` before
- * `discriminate_class_for_record`; trails resolves the STI subclass first in
- * `_instantiate` and narrows here per concrete class — same end state.)
- *
- * `column_names` is the right narrowing set here: in trails every declared
- * attribute is a real DB column (an `attribute()` with no backing column fails
- * on INSERT), and the confirmation/acceptance validators don't register
- * attribute definitions — so unlike Rails there are no in-set virtual
- * attributes to wrongly uninitialize. On a full `SELECT *` every declared
- * column is in the row, so `narrowable` is empty and the hot path returns
- * early.
- *
- * @internal Rails-private helper.
- */
-export function narrowToProjectedColumns(
-  klass: typeof Base,
-  record: Base,
-  row: Record<string, unknown>,
-  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-): void {
-  const pk = (klass as any).primaryKey as string | string[] | undefined;
-  const pkSet = new Set(Array.isArray(pk) ? pk : pk != null ? [pk] : []);
-  const rowKeys = new Set(Object.keys(row));
-  const narrowable = klass.columnNames().filter((c) => !pkSet.has(c) && !rowKeys.has(c));
-  // Hot path: a full SELECT projects every column, so there is nothing to
-  // narrow — skip the attribute-set scan entirely.
-  if (narrowable.length === 0) return;
-  const attrs = (record as any)._attributes as {
-    keys(): Iterable<string>;
-    narrowTo(
-      names: Iterable<string>,
-      overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-    ): void;
-  };
-  const keep = new Set(rowKeys);
-  const drop = new Set(narrowable);
-  for (const name of attrs.keys()) {
-    if (!drop.has(name)) keep.add(name);
-  }
-  attrs.narrowTo(keep, overrideTypes);
-}
-
 const SELECT_ALIAS_READERS = Symbol.for("activerecord.selectAliasReaders");
 
 /**
@@ -618,10 +566,10 @@ export function defineDynamicSelectReaders(record: Base): void {
   // hasProtoMember check. This covers Rails' method_missing reaching `key?` for
   // BOTH a bare select alias and an ignored column whose value a raw `SELECT *`
   // actually projected (`AttributedDeveloper#name` → "Developer: name"): Rails
-  // makes both respond via `attribute_missing`. narrowToProjectedColumns has
-  // already uninitialized any ignored column the row did not carry, so a narrowed
-  // reload leaves its declared-but-ignored default out of `keys()` and no reader
-  // is installed — matching Rails' `key?` being false for that uninitialized slot.
+  // makes both respond via `attribute_missing`. `build_from_database` never put
+  // a column the row did not carry into `values`, so a projected reload leaves
+  // that declared-but-ignored default out of `keys()` and no reader is
+  // installed — matching Rails' `key?` being false for that uninitialized slot.
   const proto = Object.getPrototypeOf(record) as object;
   for (const name of attrs.keys()) {
     if (installed.has(name)) continue;

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -25,7 +25,6 @@ import {
   registerModel,
 } from "./index.js";
 import type { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
-import type { TableDefinition as PgTableDefinition } from "./connection-adapters/postgresql/schema-definitions.js";
 
 import { fixtures } from "./test-fixtures.js";
 import { adapterType } from "./test-adapter.js";
@@ -1880,8 +1879,7 @@ describe("PersistenceTest", () => {
       // Mirror postgresql_specific_schema.rb `create_table :defaults`.
       const pg = connection as PostgreSQLAdapter;
       const supportsVirtualColumns = await pg.supportsVirtualColumns();
-      await pg.createTable("defaults", { force: true }, (t) => {
-        const d = t as PgTableDefinition;
+      await pg.createTable("defaults", { force: true }, (d) => {
         if (supportsVirtualColumns) {
           d.virtual("virtual_stored_number", {
             type: "integer",

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1,5 +1,5 @@
 import { Temporal } from "@blazetrails/date";
-import { except, hexdigest, isBlank, Notifications, toFs } from "@blazetrails/activesupport";
+import { except, hexdigest, isBlank, toFs } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { first } from "./ruby-first.js";
 import { Table, SelectManager, Nodes, sql } from "@blazetrails/arel";
@@ -1937,23 +1937,15 @@ export class Relation<T extends Base> {
    */
   private instantiateRecords(result: Result): T[] {
     if (result.isEmpty()) return [];
-    const rows = result.toArray();
-    const columnTypes = result.columnTypes as Record<
-      string,
-      { deserialize(value: unknown): unknown }
-    >;
     const block = this._instantiateBlock;
 
     const joinDependency = this._joinDependency;
     if (joinDependency) {
       this._joinDependency = null;
-      return joinDependency.instantiate(rows, this.strictLoadingValue, columnTypes, block) as T[];
+      return joinDependency.instantiate(result, this.strictLoadingValue, block) as T[];
     }
 
-    const payload = { record_count: rows.length, class_name: this._model.name };
-    return Notifications.instrument("instantiation.active_record", payload, () =>
-      rows.map((row) => this._model._instantiate(row, block as never, columnTypes) as T),
-    );
+    return this._model._loadFromSql(result, block as never) as T[];
   }
 
   /**

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -987,7 +987,7 @@ describe("RelationTest", () => {
     const post = postsEager.find((p) => Number(p.id) === 1)!;
     const freshPost = await Post.find(1);
     const directLastComment = await freshPost.loadHasOne("lastComment");
-    expect(post.lastComment).toEqual(directLastComment);
+    expect(post.lastComment!.equals(directLastComment)).toBe(true);
   });
 
   it("dynamic find by attributes", async () => {

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 387,
-    "total": 1397
+    "total": 1396
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Five convergence stories across three RFCs.

## `retire-attribute-set-narrow-to` (RFC 0115)

`Base.instantiate` now does what `persistence.rb:82-87` does — build the
attribute set through `AttributeSet::Builder#build_from_database(row,
column_types)` and install it via `init_with_attributes` — instead of writing
the row attribute-by-attribute over a set eagerly filled from the full schema
and then retrofitting a narrowing pass over it. A projected-subset SELECT now
reports the loaded columns from `keys`/`isKey` because the unprojected ones were
never in `values` (`attribute_set/builder.rb:32-39`), so
`AttributeSet#narrowTo` and `inheritance.ts`'s `narrowToProjectedColumns` are
both deleted, and the STI path shares the same builder entry.

trails carries a per-query `overrideTypes` map that Rails does not; it is merged
into Rails' single `additional_types` argument, an override winning over the
result set's reported column type for the same name.

Two supporting fixes, both convergences the write-time path was masking:

**Rails' `attribute_types` hash default.** It is a Hash whose `default` is
`Type.default_value` (`attribute_registration.rb:37-41`), so a name it does not
carry — an extra/computed select column — still resolves to a type. A JS `Map`
has no such default, so it is applied at each of the builder's three
`additional_types.fetch(name, types[name])` sites.

**`additional_types` must not carry a declared name.** It wins over the model's
own `attribute_types`, so a result set's reported column type reaching it for a
declared name hydrates a decorated (serialized, encrypted, enum, custom)
attribute with the adapter's raw type. Rails rejects those names in
`_load_from_sql` (`querying.rb:76-78`) and again, sliced to the non-`t<n>_r<n>`
columns, in `JoinDependency#instantiate` (`join_dependency.rb:120-132`); trails'
write-time path preferred the declared type instead, so neither reject had to be
right. So `Relation#instantiateRecords` now routes its non-eager arm through
`model._load_from_sql` exactly as `relation.rb:1455-1464` does, and
`JoinDependency#instantiate` takes the `Result` and derives its own
`column_types` where Rails derives them — retiring the invented `columnTypes`
parameter that was threaded in from the caller.

`AttributeSet#overrideFromDatabase`, a trails invention with no Rails
counterpart, is deleted along with the narrowing pass: it had no callers left.

One assertion changed: `relations_test.rb:768`'s `assert_equal` on two records
is `Core#==` — id and exact class — so the port asserts through `equals` rather
than deep-comparing two attribute sets, which differ only in the index-keyed
`additional_types` entries Rails carries too (`result.rb#column_type` looks up
by index first, which is why the PG adapter keys them that way on both sides).

## `create-table-callback-yields-abstract-table-definition` (RFC 0051)

`createTable`, `buildCreateTableDefinition` and
`buildCreateJoinTableDefinition` yield the receiver's own table-definition type
rather than the abstract one, via a `TableDefinitionOf<this>` conditional type.
Ruby resolves the yielded object's methods at call time, so a PG `create_table`
block reaches `PostgreSQL::ColumnMethods`
(`postgresql/schema_definitions.rb:245`) with nothing declared; TypeScript
resolves against the declared parameter type, so the yield has to name the
receiver's own class for the same names to resolve. The
`(t as PgTableDefinition)` casts in `ltree`, `citext`, `money`, `network`,
`serial`, `collation`, `enum` and `persistence` tests are gone.

One cast remains, in `enum.test.ts`: that call site goes through
`Schema.define`, whose Migration-level `createTable` has no
`createTableDefinition` of its own. Converging the Migration surface is separate
work.

## `abstract-table-definition-declares-pg-only-column-methods` (RFC 0051)

Abstract `TableDefinition` drops `jsonb`, `char` and `array`. `jsonb` is a PG
`define_column_methods` name (`postgresql/schema_definitions.rb:186-189`) and
was already declared on PG's own `TableDefinition`; `char` and `array` have no
Rails `TableDefinition` counterpart at all (`array` is an option and a
`PostgreSQL::Column` reader, never a DSL method). None had a call site.
`parity:api:extra:tighten` narrowed the activerecord total mark 1408 → 1407.

## `bulk-change-table-for-alter-dispatch-is-a-dead-double-ternary` (RFC 0051)

The dispatch tested `typeof this[`${command}ForAlter`] === "function"` three
times through a ternary whose two arms were byte-identical. It now tests
membership once, standing in for `respond_to?(method, true)`, and splits
`Array(...)` the way Rails' `partition` splits it, with Rails' locals — `method`,
`sqls`, `procs`, `nonCombinableOperations`
(`schema_statements.rb:1555-1578`). Emitted SQL is unchanged.

## `converge-adapter-schema-statement-call-arg-locals` (RFC 0096)

`pk_and_sequence_for` now takes `newName` as Rails passes it
(`postgresql/schema_statements.rb:440`) rather than a re-qualified, pre-quoted
name, and `quote_table_name` takes `indexToRemove` (`:559-561`); the
`PostgreSQL::Name` is `to_s`ed at the assignment rather than at the call site,
since trails' `quoteTableName` takes a string.

Three rows do not converge and carry `@missingRailsArgs` at the call site
instead:

- `extract_default_function` / `extract_value_from_default` pass Rails' local
  `default`, which cannot be a JavaScript binding identifier — the same
  reserved-word substitution already ratified on `normalizes`' `with`
  (`normalization.ts:59`).
- sqlite3 `table_info` passes `table_name` whole; PRAGMA takes an
  attached-schema qualifier as two separately-quoted identifiers rather than one
  quoted name, which is the split already documented on `indexes`.

## Not in this PR

`table-and-factory-assertion-parity` (RFC 0122) is released back to the queue.
Triaging 32 assertion-kind mismatches plus their share of arel's count and value
dimensions across `table.test.ts`, `factory-methods.test.ts` and
`attributes/math.test.ts`, then tightening the arel mark on three dimensions, is
a PR's worth on its own and does not fit under this one's LOC ceiling. It shares
no files with anything here.

## Verification

`pnpm typecheck` clean. `parity:api:calls`, `parity:api:calls:args`,
`parity:api:extra:gate` and `parity:test:assertions` all green; `parity:test`
deltas non-negative.

- **SQLite**: `scripts/`, activemodel in full, `relations`, `relation/**`,
  `associations/**`, `migration`, `migration/change-table`,
  `connection-adapters/**`, `adapters/sqlite3/**` — 7737 passing.
- **PostgreSQL** (`ARCONN=postgresql`): the whole `packages/activerecord` suite
  — 13090 passing. Two remaining failures are environmental on this host and
  unrelated to the diff: `postgresql-rake > structure dump` (pg_dump refuses a
  newer server) and `BasicsTest > connection in local time` (a 5h host-timezone
  offset in `Temporal.Now.timeZoneId()`).
- **MariaDB** (`ARCONN=mysql2`): `enum`, `relations`, `relation/**`,
  `test-fixtures`, `migration/change-table` — 1424 passing.

Closes-story: retire-attribute-set-narrow-to
Closes-story: abstract-table-definition-declares-pg-only-column-methods
Closes-story: bulk-change-table-for-alter-dispatch-is-a-dead-double-ternary
Closes-story: create-table-callback-yields-abstract-table-definition
Closes-story: converge-adapter-schema-statement-call-arg-locals
