### PR TITLE
refactor(activemodel,activerecord,arel): unconditional forgetChange, command-tuple block seat, select_manager assertion parity (RFC 0115, RFC 0051, RFC 0122)

### DIFF
--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -102,11 +102,8 @@ export class AttributeMutationTracker {
   }
 
   forgetChange(attrName: string): void {
+    this.attributes.set(attrName, this.attributes.getAttribute(attrName).forgettingAssignment());
     this.forcedChanges.delete(attrName);
-    if (this.attributes.isKey(attrName)) {
-      const attr = this.attributes.getAttribute(attrName);
-      this.attributes.set(attrName, attr.forgettingAssignment());
-    }
   }
 
   originalValue(attrName: string): unknown {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -11,6 +11,7 @@
 import { NotImplementedError } from "../../errors.js";
 import { joinTableName as _joinTableName } from "../../migration/join-table.js";
 import { CommandRecorder } from "../../migration/command-recorder.js";
+import type { MigrationCommand } from "../../migration/command-recorder.js";
 import { ArgumentError, type Type } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter, AdapterName } from "../abstract-adapter.js";
 import {
@@ -1803,7 +1804,7 @@ export class SchemaStatements {
     return this.supportsForeignKeys() && this.isForeignKeysEnabled();
   }
 
-  async bulkChangeTable(tableName: string, operations: Array<[string, unknown[]]>): Promise<void> {
+  async bulkChangeTable(tableName: string, operations: MigrationCommand[]): Promise<void> {
     const sqlFragments: string[] = [];
     const nonCombinable: Array<() => Promise<void>> = [];
 

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -514,13 +514,13 @@ describe("InvertibleMigrationTest", () => {
       recorder.record("createTable", ["grapes"]);
     });
     expect(recorder.commands).toEqual([
-      ["createTable", ["apples", block]],
-      ["dropTable", ["elderberries"]],
-      ["createTable", ["clementines"]],
-      ["createTable", ["dates"]],
-      ["dropTable", ["bananas", block]],
-      ["dropTable", ["grapes"]],
-      ["dropTable", ["figs"]],
+      ["createTable", ["apples", block], undefined],
+      ["dropTable", ["elderberries"], undefined],
+      ["createTable", ["clementines"], undefined],
+      ["createTable", ["dates"], undefined],
+      ["dropTable", ["bananas", block], undefined],
+      ["dropTable", ["grapes"], undefined],
+      ["dropTable", ["figs"], undefined],
     ]);
   });
 

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -147,7 +147,7 @@ describe("Migration", () => {
         });
       });
 
-      expect(recorder.commands.map(([cmd, args]) => [cmd, args.slice(0, -1)])).toEqual([
+      expect(recorder.commands.map((command) => command.slice(0, -1))).toEqual([
         ["changeTable", ["fruits"]],
         ["changeTable", ["fruits"]],
       ]);

--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -43,7 +43,7 @@ describe("Migration", () => {
       // The recorder only records the command — no DDL runs, so there is no table to tear down.
       // eslint-disable-next-line blazetrails/require-table-teardown
       (recorder as unknown as { createTable(name: string): void }).createTable("horses");
-      expect(recorder.commands).toEqual([["createTable", ["horses"]]]);
+      expect(recorder.commands).toEqual([["createTable", ["horses"], undefined]]);
     });
 
     it("unknown commands delegate", () => {
@@ -99,13 +99,13 @@ describe("Migration", () => {
       });
       /* eslint-enable blazetrails/require-table-teardown */
       expect(recorder.commands).toEqual([
-        ["createTable", ["apples", block]],
-        ["dropTable", ["elderberries"]],
-        ["createTable", ["clementines", block]],
-        ["createTable", ["dates"]],
-        ["dropTable", ["bananas", block]],
-        ["dropTable", ["grapes"]],
-        ["dropTable", ["figs", block]],
+        ["createTable", ["apples", block], undefined],
+        ["dropTable", ["elderberries"], undefined],
+        ["createTable", ["clementines", block], undefined],
+        ["createTable", ["dates"], undefined],
+        ["dropTable", ["bananas", block], undefined],
+        ["dropTable", ["grapes"], undefined],
+        ["dropTable", ["figs", block], undefined],
       ]);
     });
 
@@ -119,7 +119,7 @@ describe("Migration", () => {
 
       expect(recorder.commands).toEqual([
         ["renameColumn", ["fruits", "cultivar", "kind"]],
-        ["removeColumn", ["fruits", "name", "string"]],
+        ["removeColumn", ["fruits", "name", "string"], undefined],
       ]);
 
       await expect(
@@ -158,7 +158,7 @@ describe("Migration", () => {
         recorder.record("createTable", ["system_settings"]);
       });
       const dropTable = recorder.commands[0];
-      expect(dropTable).toEqual(["dropTable", ["system_settings"]]);
+      expect(dropTable).toEqual(["dropTable", ["system_settings"], undefined]);
     });
 
     it("invert create table with if not exists", async () => {
@@ -166,7 +166,7 @@ describe("Migration", () => {
         recorder.record("createTable", ["system_settings", { ifNotExists: true }]);
       });
       const dropTable = recorder.commands[0];
-      expect(dropTable).toEqual(["dropTable", ["system_settings", {}]]);
+      expect(dropTable).toEqual(["dropTable", ["system_settings", {}], undefined]);
     });
 
     it("invert create table with options and block", () => {
@@ -176,7 +176,11 @@ describe("Migration", () => {
         { id: false },
         block,
       ]);
-      expect(dropTable).toEqual(["dropTable", ["people_reminders", { id: false }, block]]);
+      expect(dropTable).toEqual([
+        "dropTable",
+        ["people_reminders", { id: false }, block],
+        undefined,
+      ]);
     });
 
     it("invert drop table", () => {
@@ -186,7 +190,11 @@ describe("Migration", () => {
         { id: false },
         block,
       ]);
-      expect(createTable).toEqual(["createTable", ["people_reminders", { id: false }, block]]);
+      expect(createTable).toEqual([
+        "createTable",
+        ["people_reminders", { id: false }, block],
+        undefined,
+      ]);
     });
 
     it("invert drop table with if exists", () => {
@@ -196,7 +204,11 @@ describe("Migration", () => {
         { id: false, ifExists: true },
         block,
       ]);
-      expect(createTable).toEqual(["createTable", ["people_reminders", { id: false }, block]]);
+      expect(createTable).toEqual([
+        "createTable",
+        ["people_reminders", { id: false }, block],
+        undefined,
+      ]);
     });
 
     it("invert drop table without a block nor option", () => {
@@ -234,7 +246,7 @@ describe("Migration", () => {
 
     it("invert create join table", () => {
       const dropJoinTable = recorder.inverseOf("createJoinTable", ["musics", "artists"]);
-      expect(dropJoinTable).toEqual(["dropJoinTable", ["musics", "artists"]]);
+      expect(dropJoinTable).toEqual(["dropJoinTable", ["musics", "artists"], undefined]);
     });
 
     it("invert create join table with table name", () => {
@@ -246,6 +258,7 @@ describe("Migration", () => {
       expect(dropJoinTable).toEqual([
         "dropJoinTable",
         ["musics", "artists", { tableName: "catalog" }],
+        undefined,
       ]);
     });
 
@@ -260,6 +273,7 @@ describe("Migration", () => {
       expect(createJoinTable).toEqual([
         "createJoinTable",
         ["musics", "artists", { tableName: "catalog" }, block],
+        undefined,
       ]);
     });
 
@@ -270,7 +284,7 @@ describe("Migration", () => {
 
     it("invert add column", () => {
       const remove = recorder.inverseOf("addColumn", ["table", "column", "type", {}]);
-      expect(remove).toEqual(["removeColumn", ["table", "column", "type", {}]]);
+      expect(remove).toEqual(["removeColumn", ["table", "column", "type", {}], undefined]);
     });
 
     it("invert change column", () => {
@@ -374,7 +388,7 @@ describe("Migration", () => {
 
     it("invert remove column", () => {
       const add = recorder.inverseOf("removeColumn", ["table", "column", "type", {}]);
-      expect(add).toEqual(["addColumn", ["table", "column", "type", {}]]);
+      expect(add).toEqual(["addColumn", ["table", "column", "type", {}], undefined]);
     });
 
     it("invert remove column without type", () => {
@@ -390,7 +404,7 @@ describe("Migration", () => {
 
     it("invert add index", () => {
       const remove = recorder.inverseOf("addIndex", ["table", ["one", "two"]]);
-      expect(remove).toEqual(["removeIndex", ["table", ["one", "two"]]]);
+      expect(remove).toEqual(["removeIndex", ["table", ["one", "two"]], undefined]);
     });
 
     it("invert add index with name", () => {
@@ -399,7 +413,11 @@ describe("Migration", () => {
         ["one", "two"],
         { name: "new_index" },
       ]);
-      expect(remove).toEqual(["removeIndex", ["table", ["one", "two"], { name: "new_index" }]]);
+      expect(remove).toEqual([
+        "removeIndex",
+        ["table", ["one", "two"], { name: "new_index" }],
+        undefined,
+      ]);
     });
 
     it("invert add index with algorithm option", () => {
@@ -408,7 +426,11 @@ describe("Migration", () => {
         "one",
         { algorithm: "concurrently" },
       ]);
-      expect(remove).toEqual(["removeIndex", ["table", "one", { algorithm: "concurrently" }]]);
+      expect(remove).toEqual([
+        "removeIndex",
+        ["table", "one", { algorithm: "concurrently" }],
+        undefined,
+      ]);
     });
 
     it("invert remove index", () => {
@@ -455,12 +477,12 @@ describe("Migration", () => {
 
     it("invert add timestamps", () => {
       const remove = recorder.inverseOf("addTimestamps", ["table"]);
-      expect(remove).toEqual(["removeTimestamps", ["table"]]);
+      expect(remove).toEqual(["removeTimestamps", ["table"], undefined]);
     });
 
     it("invert remove timestamps", () => {
       const add = recorder.inverseOf("removeTimestamps", ["table", { null: true }]);
-      expect(add).toEqual(["addTimestamps", ["table", { null: true }]]);
+      expect(add).toEqual(["addTimestamps", ["table", { null: true }], undefined]);
     });
 
     it("invert add reference", () => {
@@ -469,12 +491,16 @@ describe("Migration", () => {
         "taggable",
         { polymorphic: true },
       ]);
-      expect(remove).toEqual(["removeReference", ["table", "taggable", { polymorphic: true }]]);
+      expect(remove).toEqual([
+        "removeReference",
+        ["table", "taggable", { polymorphic: true }],
+        undefined,
+      ]);
     });
 
     it("invert add belongs to alias", () => {
       const remove = recorder.inverseOf("addBelongsTo", ["table", "user"]);
-      expect(remove).toEqual(["removeReference", ["table", "user"]]);
+      expect(remove).toEqual(["removeReference", ["table", "user"], undefined]);
     });
 
     it("invert remove reference", () => {
@@ -483,7 +509,11 @@ describe("Migration", () => {
         "taggable",
         { polymorphic: true },
       ]);
-      expect(add).toEqual(["addReference", ["table", "taggable", { polymorphic: true }]]);
+      expect(add).toEqual([
+        "addReference",
+        ["table", "taggable", { polymorphic: true }],
+        undefined,
+      ]);
     });
 
     it("invert remove reference with index and foreign key", () => {
@@ -495,37 +525,38 @@ describe("Migration", () => {
       expect(add).toEqual([
         "addReference",
         ["table", "taggable", { index: true, foreignKey: true }],
+        undefined,
       ]);
     });
 
     it("invert remove belongs to alias", () => {
       const add = recorder.inverseOf("removeBelongsTo", ["table", "user"]);
-      expect(add).toEqual(["addReference", ["table", "user"]]);
+      expect(add).toEqual(["addReference", ["table", "user"], undefined]);
     });
 
     it("invert enable extension", () => {
       const disable = recorder.inverseOf("enableExtension", ["uuid-ossp"]);
-      expect(disable).toEqual(["disableExtension", ["uuid-ossp"]]);
+      expect(disable).toEqual(["disableExtension", ["uuid-ossp"], undefined]);
     });
 
     it("invert disable extension", () => {
       const enable = recorder.inverseOf("disableExtension", ["uuid-ossp"]);
-      expect(enable).toEqual(["enableExtension", ["uuid-ossp"]]);
+      expect(enable).toEqual(["enableExtension", ["uuid-ossp"], undefined]);
     });
 
     it("invert create schema", () => {
       const disable = recorder.inverseOf("createSchema", ["myschema"]);
-      expect(disable).toEqual(["dropSchema", ["myschema"]]);
+      expect(disable).toEqual(["dropSchema", ["myschema"], undefined]);
     });
 
     it("invert drop schema", () => {
       const enable = recorder.inverseOf("dropSchema", ["myschema"]);
-      expect(enable).toEqual(["createSchema", ["myschema"]]);
+      expect(enable).toEqual(["createSchema", ["myschema"], undefined]);
     });
 
     it("invert add foreign key", () => {
       const enable = recorder.inverseOf("addForeignKey", ["dogs", "people"]);
-      expect(enable).toEqual(["removeForeignKey", ["dogs", "people"]]);
+      expect(enable).toEqual(["removeForeignKey", ["dogs", "people"], undefined]);
     });
 
     it("invert remove foreign key", () => {
@@ -539,7 +570,11 @@ describe("Migration", () => {
         "people",
         { column: "owner_id" },
       ]);
-      expect(enable).toEqual(["removeForeignKey", ["dogs", "people", { column: "owner_id" }]]);
+      expect(enable).toEqual([
+        "removeForeignKey",
+        ["dogs", "people", { column: "owner_id" }],
+        undefined,
+      ]);
     });
 
     it("invert remove foreign key with column", () => {
@@ -560,6 +595,7 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "removeForeignKey",
         ["dogs", "people", { column: "owner_id", name: "fk" }],
+        undefined,
       ]);
     });
 
@@ -646,6 +682,7 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "removeCheckConstraint",
         ["dogs", "speed > 0", { name: "speed_check" }],
+        undefined,
       ]);
     });
 
@@ -658,6 +695,7 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "removeCheckConstraint",
         ["dogs", "speed > 0", { name: "speed_check", ifExists: true }],
+        undefined,
       ]);
     });
 
@@ -670,6 +708,7 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "addCheckConstraint",
         ["dogs", "speed > 0", { name: "speed_check" }],
+        undefined,
       ]);
     });
 
@@ -688,6 +727,7 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "addCheckConstraint",
         ["dogs", "speed > 0", { name: "speed_check", ifNotExists: true }],
+        undefined,
       ]);
     });
 
@@ -706,12 +746,13 @@ describe("Migration", () => {
       expect(enable).toEqual([
         "addUniqueConstraint",
         ["dogs", ["speed"], { deferrable: "deferred", name: "uniq_speed" }],
+        undefined,
       ]);
     });
 
     it("invert remove unique constraint constraint without options", () => {
       const enable = recorder.inverseOf("removeUniqueConstraint", ["dogs", ["speed"]]);
-      expect(enable).toEqual(["addUniqueConstraint", ["dogs", ["speed"]]]);
+      expect(enable).toEqual(["addUniqueConstraint", ["dogs", ["speed"]], undefined]);
     });
 
     it("invert remove unique constraint constraint without columns", () => {
@@ -722,12 +763,12 @@ describe("Migration", () => {
 
     it("invert create enum", () => {
       const drop = recorder.inverseOf("createEnum", ["color", ["blue", "green"]]);
-      expect(drop).toEqual(["dropEnum", ["color", ["blue", "green"]]]);
+      expect(drop).toEqual(["dropEnum", ["color", ["blue", "green"]], undefined]);
     });
 
     it("invert drop enum", () => {
       const create = recorder.inverseOf("dropEnum", ["color", ["blue", "green"]]);
-      expect(create).toEqual(["createEnum", ["color", ["blue", "green"]]]);
+      expect(create).toEqual(["createEnum", ["color", ["blue", "green"]], undefined]);
     });
 
     it("invert drop enum without values", () => {
@@ -786,6 +827,7 @@ describe("Migration", () => {
       expect(drop).toEqual([
         "dropVirtualTable",
         ["searchables", "fts5", ["content", "meta UNINDEXED", "tokenize='porter ascii'"]],
+        undefined,
       ]);
     });
 
@@ -795,7 +837,11 @@ describe("Migration", () => {
         "fts5",
         ["title", "content"],
       ]);
-      expect(create).toEqual(["createVirtualTable", ["searchables", "fts5", ["title", "content"]]]);
+      expect(create).toEqual([
+        "createVirtualTable",
+        ["searchables", "fts5", ["title", "content"]],
+        undefined,
+      ]);
     });
 
     it("invert drop virtual table without options", () => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -177,7 +177,7 @@ describe("CommandRecorder", () => {
         await t.remove("name", "kind", { type: "string" });
       });
       expect(recorder.commands).toEqual([
-        ["removeColumns", ["fruits", "name", "kind", { type: "string" }]],
+        ["removeColumns", ["fruits", "name", "kind", { type: "string" }], undefined],
       ]);
     });
 
@@ -187,7 +187,7 @@ describe("CommandRecorder", () => {
         await t.removeIndex({ name: "index_fruits_on_kind" });
       });
       expect(recorder.commands).toEqual([
-        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }]],
+        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }], undefined],
       ]);
     });
 
@@ -197,7 +197,7 @@ describe("CommandRecorder", () => {
         await t.removeIndex(undefined, { name: "index_fruits_on_kind" });
       });
       expect(recorder.commands).toEqual([
-        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }]],
+        ["removeIndex", ["fruits", undefined, { name: "index_fruits_on_kind" }], undefined],
       ]);
     });
 
@@ -247,8 +247,8 @@ describe("CommandRecorder", () => {
         await columnMethods(t).bigserial("big_seq");
       });
       expect(recorder.commands).toEqual([
-        ["addColumn", ["fruits", "seq", "serial"]],
-        ["addColumn", ["fruits", "big_seq", "bigserial"]],
+        ["addColumn", ["fruits", "seq", "serial"], undefined],
+        ["addColumn", ["fruits", "big_seq", "bigserial"], undefined],
       ]);
     });
 
@@ -261,8 +261,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        ["removeColumn", ["fruits", "big_seq", "bigserial"]],
-        ["removeColumn", ["fruits", "seq", "serial"]],
+        ["removeColumn", ["fruits", "big_seq", "bigserial"], undefined],
+        ["removeColumn", ["fruits", "seq", "serial"], undefined],
       ]);
     });
 
@@ -273,7 +273,7 @@ describe("CommandRecorder", () => {
         await t.primaryKey("token", "uuid");
       });
       expect(recorder.commands).toEqual([
-        ["addColumn", ["fruits", "token", "uuid", { primaryKey: true }]],
+        ["addColumn", ["fruits", "token", "uuid", { primaryKey: true }], undefined],
       ]);
     });
 
@@ -282,7 +282,9 @@ describe("CommandRecorder", () => {
       await recorder.changeTable("fruits", async (t) => {
         await columnMethods(t).bitVarying("mask");
       });
-      expect(recorder.commands).toEqual([["addColumn", ["fruits", "mask", "bit_varying"]]]);
+      expect(recorder.commands).toEqual([
+        ["addColumn", ["fruits", "mask", "bit_varying"], undefined],
+      ]);
     });
   });
 
@@ -305,9 +307,9 @@ describe("CommandRecorder", () => {
         await columnMethods(t).longblob("payload");
       });
       expect(recorder.commands).toEqual([
-        ["addColumn", ["fruits", "qty", "unsigned_integer"]],
-        ["addColumn", ["fruits", "notes", "mediumtext"]],
-        ["addColumn", ["fruits", "payload", "longblob"]],
+        ["addColumn", ["fruits", "qty", "unsigned_integer"], undefined],
+        ["addColumn", ["fruits", "notes", "mediumtext"], undefined],
+        ["addColumn", ["fruits", "payload", "longblob"], undefined],
       ]);
     });
 
@@ -320,8 +322,8 @@ describe("CommandRecorder", () => {
         });
       });
       expect(recorder.commands).toEqual([
-        ["removeColumn", ["fruits", "notes", "mediumtext"]],
-        ["removeColumn", ["fruits", "qty", "unsigned_integer"]],
+        ["removeColumn", ["fruits", "notes", "mediumtext"], undefined],
+        ["removeColumn", ["fruits", "qty", "unsigned_integer"], undefined],
       ]);
     });
   });

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -143,17 +143,17 @@ describe("CommandRecorder", () => {
         await t.removeCheckConstraint();
       });
       expect(recorder.commands).toEqual([
-        ["removeColumns", ["fruits", "name"]],
-        ["addIndex", ["fruits", "kind"]],
-        ["addTimestamps", ["fruits"]],
-        ["removeTimestamps", ["fruits"]],
-        ["removeIndex", ["fruits", "kind"]],
-        ["addReference", ["fruits", "supplier"]],
-        ["removeReference", ["fruits", "supplier"]],
-        ["addForeignKey", ["fruits", "suppliers"]],
-        ["removeForeignKey", ["fruits"]],
-        ["addCheckConstraint", ["fruits", "qty > 0"]],
-        ["removeCheckConstraint", ["fruits"]],
+        ["removeColumns", ["fruits", "name"], undefined],
+        ["addIndex", ["fruits", "kind"], undefined],
+        ["addTimestamps", ["fruits"], undefined],
+        ["removeTimestamps", ["fruits"], undefined],
+        ["removeIndex", ["fruits", "kind"], undefined],
+        ["addReference", ["fruits", "supplier"], undefined],
+        ["removeReference", ["fruits", "supplier"], undefined],
+        ["addForeignKey", ["fruits", "suppliers"], undefined],
+        ["removeForeignKey", ["fruits"], undefined],
+        ["addCheckConstraint", ["fruits", "qty > 0"], undefined],
+        ["removeCheckConstraint", ["fruits"], undefined],
       ]);
     });
 
@@ -165,9 +165,9 @@ describe("CommandRecorder", () => {
         await t.removeCheckConstraint({ name: "chk" });
       });
       expect(recorder.commands).toEqual([
-        ["removeCheckConstraint", ["fruits", "qty > 0", { name: "chk" }]],
-        ["removeCheckConstraint", ["fruits", "qty > 0"]],
-        ["removeCheckConstraint", ["fruits", { name: "chk" }]],
+        ["removeCheckConstraint", ["fruits", "qty > 0", { name: "chk" }], undefined],
+        ["removeCheckConstraint", ["fruits", "qty > 0"], undefined],
+        ["removeCheckConstraint", ["fruits", { name: "chk" }], undefined],
       ]);
     });
 

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -136,6 +136,9 @@ export class CommandRecorder {
    * a single batched command (mirrors the Rails bulk alter path).
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#change_table
+   * (command_recorder.rb:141-152). The bulk path's recorded lambda reaches
+   * `bulkChangeTable` through the `methodMissingProxy`, as the Ruby lambda's
+   * `self` reaches it through `method_missing` (command_recorder.rb:142).
    */
   async changeTable(
     tableName: string,
@@ -161,9 +164,6 @@ export class CommandRecorder {
       recorder.reverting = this._reverting;
       await callback(delegate.updateTableDefinition(tableName, recorder));
       const commands = recorder.commands;
-      // `bulkChangeTable` is answered by the delegate through the
-      // `methodMissingProxy`, as the Ruby lambda's `self` answers it through
-      // `method_missing` (command_recorder.rb:142).
       this._commands.push([
         "changeTable",
         [tableName],
@@ -183,21 +183,15 @@ export class CommandRecorder {
    * Replay all recorded commands against the given migration.
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#replay
+   * (command_recorder.rb:148-152). TS has no block syntax: Ruby's `&block`
+   * passes nothing when the block is nil, so an absent block must not become a
+   * trailing `undefined` argument to a splat-taking method like
+   * `drop_table(*table_names)`.
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
     for (const [cmd, args, block] of this.commands) {
-      // TS has no block syntax: Ruby's `&block` passes nothing when the block
-      // is nil, so an absent block must not become a trailing `undefined`
-      // argument to a splat-taking method like `drop_table(*table_names)`.
       await migration[cmd](...args, ...(block === undefined ? [] : [block]));
     }
-  }
-
-  /** Returns the full inverse command list. */
-  inverse(): MigrationCommand[] {
-    return [...this._commands]
-      .reverse()
-      .map(([cmd, args, block]) => this.inverseOf(cmd, args, block));
   }
 
   // ---------------------------------------------------------------------------
@@ -230,13 +224,16 @@ export class CommandRecorder {
     return ["dropTable", a, block];
   }
 
-  /** @internal */
+  /**
+   * @internal
+   *
+   * TS has no block syntax, so a recordable method's trailing callback rides
+   * inside `args` where Ruby carries it in the block seat (the `revert order`
+   * test's `create_table("bananas", &block)`); either position is Rails'
+   * `block` for the reversibility check (command_recorder.rb:214).
+   */
   invertDropTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
-    // TS has no block syntax, so a recordable method's trailing callback rides
-    // inside `args` where Ruby would carry it in the block seat (the
-    // `revert order` test's `create_table("bananas", &block)`); either position
-    // is Rails' `block`.
     let argsBlock: unknown;
     if (a.length > 0 && typeof a[a.length - 1] === "function") {
       argsBlock = a.pop();

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -13,8 +13,17 @@ import {
   joinTableName as _joinTableName,
 } from "./join-table.js";
 
+/**
+ * A recorded migration block — the third element of a command tuple, Rails'
+ * `&block` (migration/command_recorder.rb:109).
+ */
+export type MigrationBlock = (...args: any[]) => unknown;
+
+/** A recorded command: `[cmd, args, block]` (migration/command_recorder.rb:109). */
+export type MigrationCommand = [string, unknown[], MigrationBlock?];
+
 export class CommandRecorder {
-  private _commands: Array<[string, unknown[]]> = [];
+  private _commands: MigrationCommand[] = [];
   private _delegate: unknown;
   private _reverting = false;
 
@@ -39,7 +48,7 @@ export class CommandRecorder {
     this._reverting = value;
   }
 
-  get commands(): Array<[string, unknown[]]> {
+  get commands(): MigrationCommand[] {
     return [...this._commands];
   }
 
@@ -49,11 +58,11 @@ export class CommandRecorder {
    * `inverse_of(...)` when `@reverting`), so nested `revert` blocks cancel out
    * by double-negation.
    */
-  record(cmd: string, args: unknown[]): void {
+  record(cmd: string, args: unknown[], block?: MigrationBlock): void {
     if (this._reverting) {
-      this._commands.push(this.inverseOf(cmd, args));
+      this._commands.push(this.inverseOf(cmd, args, block));
     } else {
-      this._commands.push([cmd, args]);
+      this._commands.push([cmd, args, block]);
     }
   }
 
@@ -103,7 +112,7 @@ export class CommandRecorder {
    * because a name the recorder does not answer reads back as the proxy's
    * `NoMethodError`-raising function rather than `undefined`.
    */
-  inverseOf(cmd: string, args: unknown[]): [string, unknown[]] {
+  inverseOf(cmd: string, args: unknown[], block?: MigrationBlock): MigrationCommand {
     const method = `invert${cmd.charAt(0).toUpperCase()}${cmd.slice(1)}` as keyof this;
     if (!(method in this)) {
       throw new IrreversibleMigration(
@@ -113,7 +122,11 @@ export class CommandRecorder {
           `2. Use the #reversible method to define reversible behavior.\n`,
       );
     }
-    return (this[method] as (args: unknown[]) => [string, unknown[]]).call(this, args);
+    return (this[method] as (args: unknown[], block?: MigrationBlock) => MigrationCommand).call(
+      this,
+      args,
+      block,
+    );
   }
 
   /**
@@ -123,12 +136,6 @@ export class CommandRecorder {
    * a single batched command (mirrors the Rails bulk alter path).
    *
    * Mirrors: ActiveRecord::Migration::CommandRecorder#change_table
-   *
-   * @missingRailsCall bulk_change_table — PERMANENT: Rails records the bulk path
-   *   as a lambda `-> t { bulk_change_table(table_name, commands) }`
-   *   (migration/command_recorder.rb:142); the port's command tuple carries no
-   *   block seat, so it records `[tableName, commands]` and `replay`
-   *   re-dispatches each sub-command (command-recorder.ts:138,152-160).
    */
   async changeTable(
     tableName: string,
@@ -153,7 +160,20 @@ export class CommandRecorder {
       const recorder = new CommandRecorder(this._delegate);
       recorder.reverting = this._reverting;
       await callback(delegate.updateTableDefinition(tableName, recorder));
-      this._commands.push(["changeTable", [tableName, recorder.commands]]);
+      const commands = recorder.commands;
+      // `bulkChangeTable` is answered by the delegate through the
+      // `methodMissingProxy`, as the Ruby lambda's `self` answers it through
+      // `method_missing` (command_recorder.rb:142).
+      this._commands.push([
+        "changeTable",
+        [tableName],
+        () =>
+          (
+            this as unknown as {
+              bulkChangeTable(tableName: string, operations: MigrationCommand[]): Promise<void>;
+            }
+          ).bulkChangeTable(tableName, commands),
+      ]);
     } else {
       await callback(delegate.updateTableDefinition(tableName, this));
     }
@@ -165,25 +185,19 @@ export class CommandRecorder {
    * Mirrors: ActiveRecord::Migration::CommandRecorder#replay
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
-    for (const [cmd, args] of this.commands) {
-      // Bulk changeTable stores [tableName, subCommands[]]. Replay each
-      // sub-command individually rather than forwarding the array as an arg.
-      if (cmd === "changeTable" && Array.isArray(args[1])) {
-        const subCmds = args[1] as Array<[string, unknown[]]>;
-        for (const [sub, subArgs] of subCmds) {
-          if (typeof migration[sub] === "function") {
-            await migration[sub](...subArgs);
-          }
-        }
-      } else if (typeof migration[cmd] === "function") {
-        await migration[cmd](...args);
-      }
+    for (const [cmd, args, block] of this.commands) {
+      // TS has no block syntax: Ruby's `&block` passes nothing when the block
+      // is nil, so an absent block must not become a trailing `undefined`
+      // argument to a splat-taking method like `drop_table(*table_names)`.
+      await migration[cmd](...args, ...(block === undefined ? [] : [block]));
     }
   }
 
   /** Returns the full inverse command list. */
-  inverse(): Array<[string, unknown[]]> {
-    return [...this._commands].reverse().map(([cmd, args]) => this.inverseOf(cmd, args));
+  inverse(): MigrationCommand[] {
+    return [...this._commands]
+      .reverse()
+      .map(([cmd, args, block]) => this.inverseOf(cmd, args, block));
   }
 
   // ---------------------------------------------------------------------------
@@ -197,7 +211,7 @@ export class CommandRecorder {
    *   (migration/command_recorder.rb:199); JS spells the same operation as the
    *   `delete` OPERATOR (command-recorder.ts:192), which records no callee.
    */
-  invertCreateTable(args: unknown[]): [string, unknown[]] {
+  invertCreateTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
     // createTable may be recorded as [name, options, fn] — find the trailing options hash
     let optsIdx = -1;
@@ -213,17 +227,19 @@ export class CommandRecorder {
       delete opts["ifNotExists"];
       a[optsIdx] = opts;
     }
-    return ["dropTable", a];
+    return ["dropTable", a, block];
   }
 
   /** @internal */
-  invertDropTable(args: unknown[]): [string, unknown[]] {
+  invertDropTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
-    // The reversal block (table definition) rides as a trailing function, the
-    // same convention create_table uses (see the `revert order` test).
-    let block: unknown;
+    // TS has no block syntax, so a recordable method's trailing callback rides
+    // inside `args` where Ruby would carry it in the block seat (the
+    // `revert order` test's `create_table("bananas", &block)`); either position
+    // is Rails' `block`.
+    let argsBlock: unknown;
     if (a.length > 0 && typeof a[a.length - 1] === "function") {
-      block = a.pop();
+      argsBlock = a.pop();
     }
     let options: Record<string, unknown> = {};
     if (
@@ -241,7 +257,12 @@ export class CommandRecorder {
         "To avoid mistakes, drop_table is only reversible if given a single table name.",
       );
     }
-    if (a.length === 1 && Object.keys(options).length === 0 && block === undefined) {
+    if (
+      a.length === 1 &&
+      Object.keys(options).length === 0 &&
+      block === undefined &&
+      argsBlock === undefined
+    ) {
       throw new IrreversibleMigration(
         "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty).",
       );
@@ -249,36 +270,36 @@ export class CommandRecorder {
 
     const result = [...a];
     if (Object.keys(options).length > 0) result.push(options);
-    if (block !== undefined) result.push(block);
-    return ["createTable", result];
+    if (argsBlock !== undefined) result.push(argsBlock);
+    return ["createTable", result, block];
   }
 
   /** @internal */
-  invertCreateJoinTable(args: unknown[]): [string, unknown[]] {
-    return ["dropJoinTable", args];
+  invertCreateJoinTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["dropJoinTable", args, block];
   }
 
   /** @internal */
-  invertDropJoinTable(args: unknown[]): [string, unknown[]] {
-    return ["createJoinTable", args];
+  invertDropJoinTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["createJoinTable", args, block];
   }
 
   /** @internal */
-  invertAddColumn(args: unknown[]): [string, unknown[]] {
-    return ["removeColumn", args];
+  invertAddColumn(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["removeColumn", args, block];
   }
 
   /** @internal */
-  invertRemoveColumn(args: unknown[]): [string, unknown[]] {
+  invertRemoveColumn(args: unknown[], block?: MigrationBlock): MigrationCommand {
     if (typeof args[2] !== "string") {
       throw new IrreversibleMigration("remove_column is only reversible if given a type.");
     }
-    return ["addColumn", args];
+    return ["addColumn", args, block];
   }
 
   /** @internal */
-  invertAddIndex(args: unknown[]): [string, unknown[]] {
-    return ["removeIndex", args];
+  invertAddIndex(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["removeIndex", args, block];
   }
 
   /** @internal */
@@ -310,33 +331,33 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertAddTimestamps(args: unknown[]): [string, unknown[]] {
-    return ["removeTimestamps", args];
+  invertAddTimestamps(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["removeTimestamps", args, block];
   }
 
   /** @internal */
-  invertRemoveTimestamps(args: unknown[]): [string, unknown[]] {
-    return ["addTimestamps", args];
+  invertRemoveTimestamps(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["addTimestamps", args, block];
   }
 
   /** @internal */
-  invertAddReference(args: unknown[]): [string, unknown[]] {
-    return ["removeReference", args];
+  invertAddReference(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["removeReference", args, block];
   }
 
   /** Alias of invertAddReference (Rails: `alias :invert_add_belongs_to :invert_add_reference`). @internal */
-  invertAddBelongsTo(args: unknown[]): [string, unknown[]] {
-    return this.invertAddReference(args);
+  invertAddBelongsTo(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return this.invertAddReference(args, block);
   }
 
   /** @internal */
-  invertRemoveReference(args: unknown[]): [string, unknown[]] {
-    return ["addReference", args];
+  invertRemoveReference(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["addReference", args, block];
   }
 
   /** Alias of invertRemoveReference (Rails: `alias :invert_remove_belongs_to :invert_remove_reference`). @internal */
-  invertRemoveBelongsTo(args: unknown[]): [string, unknown[]] {
-    return this.invertRemoveReference(args);
+  invertRemoveBelongsTo(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return this.invertRemoveReference(args, block);
   }
 
   /**
@@ -346,14 +367,14 @@ export class CommandRecorder {
    *   (migration/command_recorder.rb:288); JS spells the same operation as the
    *   `delete` OPERATOR (command-recorder.ts:326), which records no callee.
    */
-  invertAddForeignKey(args: unknown[]): [string, unknown[]] {
+  invertAddForeignKey(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
     if (a.length > 0 && typeof a[a.length - 1] === "object" && a[a.length - 1] !== null) {
       const opts = { ...(a[a.length - 1] as Record<string, unknown>) };
       delete opts["validate"];
       a[a.length - 1] = opts;
     }
-    return ["removeForeignKey", a];
+    return ["removeForeignKey", a, block];
   }
 
   /** @internal */
@@ -380,7 +401,7 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertAddCheckConstraint(args: unknown[]): [string, unknown[]] {
+  invertAddCheckConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
     if (a.length > 0 && typeof a[a.length - 1] === "object" && a[a.length - 1] !== null) {
       const opts = { ...(a[a.length - 1] as Record<string, unknown>) };
@@ -391,11 +412,11 @@ export class CommandRecorder {
       }
       a[a.length - 1] = opts;
     }
-    return ["removeCheckConstraint", a];
+    return ["removeCheckConstraint", a, block];
   }
 
   /** @internal */
-  invertRemoveCheckConstraint(args: unknown[]): [string, unknown[]] {
+  invertRemoveCheckConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
     if (args.length < 2) {
       throw new IrreversibleMigration(
         "remove_check_constraint is only reversible if given an expression.",
@@ -410,26 +431,26 @@ export class CommandRecorder {
       }
       a[a.length - 1] = opts;
     }
-    return ["addCheckConstraint", a];
+    return ["addCheckConstraint", a, block];
   }
 
   /** @internal */
-  invertAddExclusionConstraint(args: unknown[]): [string, unknown[]] {
-    return ["removeExclusionConstraint", args];
+  invertAddExclusionConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["removeExclusionConstraint", args, block];
   }
 
   /** @internal */
-  invertRemoveExclusionConstraint(args: unknown[]): [string, unknown[]] {
+  invertRemoveExclusionConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
     if (args.length < 2) {
       throw new IrreversibleMigration(
         "remove_exclusion_constraint is only reversible if given an expression.",
       );
     }
-    return ["addExclusionConstraint", args];
+    return ["addExclusionConstraint", args, block];
   }
 
   /** @internal */
-  invertAddUniqueConstraint(args: unknown[]): [string, unknown[]] {
+  invertAddUniqueConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const options =
       args.length > 0 && typeof args[args.length - 1] === "object" && args[args.length - 1] !== null
         ? (args[args.length - 1] as Record<string, unknown>)
@@ -439,11 +460,11 @@ export class CommandRecorder {
         "add_unique_constraint is not reversible if given an using_index.",
       );
     }
-    return ["removeUniqueConstraint", args];
+    return ["removeUniqueConstraint", args, block];
   }
 
   /** @internal */
-  invertRemoveUniqueConstraint(args: unknown[]): [string, unknown[]] {
+  invertRemoveUniqueConstraint(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const a = args.slice();
     // extract_options! only strips a trailing Hash, never an Array
     if (
@@ -460,7 +481,7 @@ export class CommandRecorder {
         "remove_unique_constraint is only reversible if given an column_name.",
       );
     }
-    return ["addUniqueConstraint", args];
+    return ["addUniqueConstraint", args, block];
   }
 
   /** @internal */
@@ -578,37 +599,37 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertCreateEnum(args: unknown[]): [string, unknown[]] {
-    return ["dropEnum", args];
+  invertCreateEnum(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["dropEnum", args, block];
   }
 
   /** @internal */
-  invertEnableExtension(args: unknown[]): [string, unknown[]] {
-    return ["disableExtension", args];
+  invertEnableExtension(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["disableExtension", args, block];
   }
 
   /** @internal */
-  invertDisableExtension(args: unknown[]): [string, unknown[]] {
-    return ["enableExtension", args];
+  invertDisableExtension(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["enableExtension", args, block];
   }
 
   /** @internal */
-  invertCreateSchema(args: unknown[]): [string, unknown[]] {
-    return ["dropSchema", args];
+  invertCreateSchema(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["dropSchema", args, block];
   }
 
   /** @internal */
-  invertDropSchema(args: unknown[]): [string, unknown[]] {
-    return ["createSchema", args];
+  invertDropSchema(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["createSchema", args, block];
   }
 
   /** @internal */
-  invertCreateVirtualTable(args: unknown[]): [string, unknown[]] {
-    return ["dropVirtualTable", args];
+  invertCreateVirtualTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["dropVirtualTable", args, block];
   }
 
   /** @internal */
-  invertDropEnum(args: unknown[]): [string, unknown[]] {
+  invertDropEnum(args: unknown[], block?: MigrationBlock): MigrationCommand {
     // Mirror Rails: extract_options! strips trailing hash, then check second positional arg
     const a = args.slice();
     if (
@@ -624,7 +645,7 @@ export class CommandRecorder {
         "drop_enum is only reversible if given a list of enum values.",
       );
     }
-    return ["createEnum", args];
+    return ["createEnum", args, block];
   }
 
   /** @internal */
@@ -659,7 +680,7 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertDropVirtualTable(args: unknown[]): [string, unknown[]] {
+  invertDropVirtualTable(args: unknown[], block?: MigrationBlock): MigrationCommand {
     // Mirror Rails: extract_options! strips trailing hash, then check second positional arg
     const a = args.slice();
     if (
@@ -673,7 +694,7 @@ export class CommandRecorder {
     if (a[1] === undefined) {
       throw new IrreversibleMigration("drop_virtual_table is only reversible if given options.");
     }
-    return ["createVirtualTable", args];
+    return ["createVirtualTable", args, block];
   }
 
   /** @internal */

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -29,8 +29,10 @@ export class Window extends Node {
     return this;
   }
 
-  // Mirrors `frame` (nodes/window.rb:30-32), whose value is the assignment —
-  // the framing node itself, which `rows`/`range` hand back to their caller.
+  /**
+   * Mirrors `frame` (nodes/window.rb:30-32), whose value is the assignment —
+   * the framing node itself, which `rows`/`range` hand back to their caller.
+   */
   frame(expr: Node): Node {
     this.framing = expr;
     return expr;
@@ -69,16 +71,20 @@ export class NamedWindow extends Window {
 // `Following`, `Rows`, `Range` all extend Unary; only `CurrentRow`
 // extends Node directly (it carries no expr).
 export class Preceding extends Unary {
-  // Rails' `Preceding.new(expr = nil)` (window.rb) puts no bound on the expr — the
-  // frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+  /**
+   * Rails' `Preceding.new(expr = nil)` (window.rb) puts no bound on the expr — the
+   * frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+   */
   constructor(expr: unknown = null) {
     super(expr);
   }
 }
 
 export class Following extends Unary {
-  // Rails' `Following.new(expr = nil)` (window.rb) puts no bound on the expr — the
-  // frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+  /**
+   * Rails' `Following.new(expr = nil)` (window.rb) puts no bound on the expr — the
+   * frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+   */
   constructor(expr: unknown = null) {
     super(expr);
   }

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -29,25 +29,27 @@ export class Window extends Node {
     return this;
   }
 
-  frame(node: Node): this {
-    this.framing = node;
-    return this;
+  // Mirrors `frame` (nodes/window.rb:30-32), whose value is the assignment —
+  // the framing node itself, which `rows`/`range` hand back to their caller.
+  frame(expr: Node): Node {
+    this.framing = expr;
+    return expr;
   }
 
-  rows(expr: Node | null = null): Rows | this {
+  rows(expr: Node | null = null): Node {
     if (this.framing) {
       return new Rows(expr);
+    } else {
+      return this.frame(new Rows(expr));
     }
-    this.frame(new Rows(expr));
-    return this;
   }
 
-  range(expr: Node | null = null): Range | this {
+  range(expr: Node | null = null): Node {
     if (this.framing) {
       return new Range(expr);
+    } else {
+      return this.frame(new Range(expr));
     }
-    this.frame(new Range(expr));
-    return this;
   }
 }
 
@@ -67,15 +69,17 @@ export class NamedWindow extends Window {
 // `Following`, `Rows`, `Range` all extend Unary; only `CurrentRow`
 // extends Node directly (it carries no expr).
 export class Preceding extends Unary {
-  declare readonly expr: Node | null;
-  constructor(expr: Node | null = null) {
+  // Rails' `Preceding.new(expr = nil)` (window.rb) puts no bound on the expr — the
+  // frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+  constructor(expr: unknown = null) {
     super(expr);
   }
 }
 
 export class Following extends Unary {
-  declare readonly expr: Node | null;
-  constructor(expr: Node | null = null) {
+  // Rails' `Following.new(expr = nil)` (window.rb) puts no bound on the expr — the
+  // frame offset is commonly a bare Integer — so it keeps `Unary`'s `expr`.
+  constructor(expr: unknown = null) {
     super(expr);
   }
 }

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -28,7 +28,7 @@ describe("SelectManagerTest", () => {
         const mgr = new SelectManager();
         mgr.project("id");
         mgr.from(users);
-        expect(mgr.toSql()).toContain("SELECT id");
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT id FROM "users"`));
       });
     });
 
@@ -38,8 +38,7 @@ describe("SelectManagerTest", () => {
         mgr.project(star);
         mgr.from(users);
         mgr.order(new Nodes.SqlLiteral("foo"));
-        expect(mgr.toSql()).toContain("ORDER BY");
-        expect(mgr.toSql()).toContain("foo");
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT * FROM "users" ORDER BY foo`));
       });
     });
 
@@ -48,8 +47,7 @@ describe("SelectManagerTest", () => {
         const mgr = new SelectManager();
         mgr.from(users);
         mgr.group("foo");
-        expect(mgr.toSql()).toContain("GROUP BY");
-        expect(mgr.toSql()).toContain("foo");
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" GROUP BY foo`));
       });
     });
 
@@ -57,29 +55,28 @@ describe("SelectManagerTest", () => {
       it("makes an AS node by grouping the AST", () => {
         const mgr = new SelectManager();
         const as = mgr.as("foo");
-        expect(as).toBeInstanceOf(Nodes.TableAlias);
-        expect((as.name as Nodes.SqlLiteral).value).toBe("foo");
+        expect(as.left).toBeInstanceOf(Nodes.Grouping);
+        expect((as.left as Nodes.Grouping).expr).toBe(mgr.ast);
+        expect(String(as.right)).toBe("foo");
       });
 
       it("converts right to SqlLiteral if a string", () => {
         const mgr = new SelectManager();
         const as = mgr.as("foo");
-        expect(as).toBeInstanceOf(Nodes.TableAlias);
-        const sql = new Visitors.ToSql(testConnection).compile(as);
-        expect(sql).toContain("foo");
+        expect(as.right).toBeInstanceOf(Nodes.SqlLiteral);
       });
 
       it("can make a subselect", () => {
         const mgr = new SelectManager();
         mgr.project(star);
-        mgr.from(new Nodes.SqlLiteral("zomg"));
+        mgr.from(sql("zomg"));
         const as = mgr.as("foo");
         const outer = new SelectManager();
-        outer.project(new Nodes.SqlLiteral("name"));
+        outer.project(sql("name"));
         outer.from(as);
-        const sql = outer.toSql();
-        expect(sql).toContain("name");
-        expect(sql).toContain("foo");
+        expect(mustBeLike(outer.toSql())).toBe(
+          mustBeLike("SELECT name FROM (SELECT * FROM zomg) foo"),
+        );
       });
     });
 
@@ -89,9 +86,7 @@ describe("SelectManagerTest", () => {
         mgr.from(users);
         mgr.from("users");
         mgr.project(users.get("id"));
-        const sql = mgr.toSql();
-        expect(sql).toContain('"users"."id"');
-        expect(sql).toContain("FROM");
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike('SELECT "users"."id" FROM users'));
       });
 
       it("should support any ast", () => {
@@ -100,9 +95,11 @@ describe("SelectManagerTest", () => {
         mgr2.project(star);
         mgr2.from(users);
         const as = mgr2.as("omg");
-        mgr1.project(new Nodes.SqlLiteral("lol"));
+        mgr1.project(sql("lol"));
         mgr1.from(as);
-        expect(mgr1.toSql()).toContain("lol");
+        expect(mustBeLike(mgr1.toSql())).toBe(
+          mustBeLike(`SELECT lol FROM (SELECT * FROM "users") omg`),
+        );
       });
 
       // Mirrors Rails: `from(table)` (select_manager.rb) routes a Join
@@ -125,24 +122,21 @@ describe("SelectManagerTest", () => {
     describe("having", () => {
       it("converts strings to SQLLiterals", () => {
         const mgr = users.from();
-        mgr.having(new Nodes.SqlLiteral("foo"));
-        expect(mgr.toSql()).toContain("HAVING");
-        expect(mgr.toSql()).toContain("foo");
+        mgr.having(sql("foo"));
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" HAVING foo`));
       });
 
       it("can have multiple items specified separately", () => {
         const mgr = users.from();
-        mgr.having(new Nodes.SqlLiteral("foo"));
-        mgr.having(new Nodes.SqlLiteral("bar"));
-        expect(mgr.toSql()).toContain("HAVING");
-        expect(mgr.toSql()).toContain("foo");
+        mgr.having(sql("foo"));
+        mgr.having(sql("bar"));
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" HAVING foo AND bar`));
       });
 
       it("can receive any node", () => {
         const mgr = users.from();
-        mgr.having(new Nodes.And([new Nodes.SqlLiteral("foo"), new Nodes.SqlLiteral("bar")]));
-        expect(mgr.toSql()).toContain("HAVING");
-        expect(mgr.toSql()).toContain("foo");
+        mgr.having(new Nodes.And([sql("foo"), sql("bar")]));
+        expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" HAVING foo AND bar`));
       });
     });
 
@@ -181,18 +175,18 @@ describe("SelectManagerTest", () => {
 
   describe("initialize", () => {
     it("uses alias in sql", () => {
-      const aliased = users.alias("u");
-      const mgr = new SelectManager();
-      mgr.from(aliased);
-      mgr.project(new Nodes.SqlLiteral("*"));
-      expect(mgr.toSql()).toContain('"u"');
+      const table = new Table("users", { as: "foo" });
+      const mgr = table.from();
+      mgr.skip(10);
+      expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" "foo" OFFSET 10`));
     });
   });
 
   describe("skip", () => {
     it("should add an offset", () => {
-      const mgr = users.project(star).skip(5);
-      expect(mgr.toSql()).toContain("OFFSET 5");
+      const mgr = users.from();
+      mgr.skip(10);
+      expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" OFFSET 10`));
     });
 
     // Mirrors Rails: `skip(amount)` flows the raw value into
@@ -272,72 +266,108 @@ describe("SelectManagerTest", () => {
 
   describe("offset", () => {
     it("should add an offset", () => {
-      const mgr = users.skip(5).project(star);
-      expect(mgr.toSql()).toContain("OFFSET 5");
+      const mgr = users.from();
+      mgr.offset = 10;
+      expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" OFFSET 10`));
     });
 
     it("should remove an offset", () => {
-      const mgr = new SelectManager(users);
-      mgr.skip(10);
-      expect(mgr.offset).not.toBeNull();
-      mgr.ast.offset = null;
-      expect(mgr.offset).toBeNull();
+      const mgr = users.from();
+      mgr.offset = 10;
+      expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users" OFFSET 10`));
+
+      mgr.offset = null;
+      expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT FROM "users"`));
     });
 
     it("should return the offset", () => {
-      const mgr = users.project(star).skip(5);
-      expect(mgr.offset).not.toBeNull();
+      const mgr = users.from();
+      mgr.offset = 10;
+      expect(mgr.offset).toBe(10);
     });
   });
 
   describe("exists", () => {
     it("should create an exists clause", () => {
-      const mgr = users.project(star).where(users.get("age").gt(21));
-      const exists = mgr.exists();
-      expect(exists).toBeInstanceOf(Nodes.Exists);
+      const manager = new SelectManager(users);
+      manager.project(new Nodes.SqlLiteral("*"));
+      const m2 = new SelectManager();
+      m2.project(manager.exists());
+      expect(mustBeLike(m2.toSql())).toBe(mustBeLike(`SELECT EXISTS (${manager.toSql()})`));
     });
 
     it("can be aliased", () => {
-      const mgr = users.project(users.get("id"));
-      const aliased = mgr.as("sub");
-      expect(aliased).toBeInstanceOf(Nodes.TableAlias);
-      expect((aliased.name as Nodes.SqlLiteral).value).toBe("sub");
+      const manager = new SelectManager(users);
+      manager.project(new Nodes.SqlLiteral("*"));
+      const m2 = new SelectManager();
+      m2.project(manager.exists().as("foo"));
+      expect(mustBeLike(m2.toSql())).toBe(mustBeLike(`SELECT EXISTS (${manager.toSql()}) AS foo`));
     });
   });
 
   describe("union", () => {
+    const m1 = new SelectManager(users);
+    m1.project(star);
+    m1.where(users.get("age").lt(18));
+
+    const m2 = new SelectManager(users);
+    m2.project(star);
+    m2.where(users.get("age").gt(99));
+
     it("should union two managers", () => {
-      const q1 = users.project(users.get("name")).where(users.get("age").gt(21));
-      const q2 = users.project(users.get("name")).where(users.get("age").lt(18));
-      const union = q1.union(q2);
-      const visitor = new Visitors.ToSql(testConnection);
-      const compiled = visitor.compile(union);
-      expect(compiled).toContain("UNION");
+      const node = m1.union(m2);
+      expect(mustBeLike(visitor.compile(node))).toBe(
+        mustBeLike(
+          `( SELECT * FROM "users" WHERE "users"."age" < 18 UNION SELECT * FROM "users" WHERE "users"."age" > 99 )`,
+        ),
+      );
     });
 
     it("should union all", () => {
-      const q1 = users.project(star);
-      const q2 = users.project(star);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(q1.union(":all", q2))).toContain("UNION ALL");
+      const node = m1.union(":all", m2);
+      expect(mustBeLike(visitor.compile(node))).toBe(
+        mustBeLike(
+          `( SELECT * FROM "users" WHERE "users"."age" < 18 UNION ALL SELECT * FROM "users" WHERE "users"."age" > 99 )`,
+        ),
+      );
     });
   });
 
   describe("intersect", () => {
     it("should intersect two managers", () => {
-      const q1 = users.project(star);
-      const q2 = users.project(star);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(q1.intersect(q2))).toContain("INTERSECT");
+      const m1 = new SelectManager(users);
+      m1.project(star);
+      m1.where(users.get("age").gt(18));
+
+      const m2 = new SelectManager(users);
+      m2.project(star);
+      m2.where(users.get("age").lt(99));
+
+      const node = m1.intersect(m2);
+      expect(mustBeLike(visitor.compile(node))).toBe(
+        mustBeLike(
+          `( SELECT * FROM "users" WHERE "users"."age" > 18 INTERSECT SELECT * FROM "users" WHERE "users"."age" < 99 )`,
+        ),
+      );
     });
   });
 
   describe("except", () => {
     it("should except two managers", () => {
-      const q1 = users.project(star);
-      const q2 = users.project(star);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(q1.except(q2))).toContain("EXCEPT");
+      const m1 = new SelectManager(users);
+      m1.project(star);
+      m1.where(users.get("age").between(18, 60));
+
+      const m2 = new SelectManager(users);
+      m2.project(star);
+      m2.where(users.get("age").between(40, 99));
+
+      const node = m1.except(m2);
+      expect(mustBeLike(visitor.compile(node))).toBe(
+        mustBeLike(
+          `( SELECT * FROM "users" WHERE "users"."age" BETWEEN 18 AND 60 EXCEPT SELECT * FROM "users" WHERE "users"."age" BETWEEN 40 AND 99 )`,
+        ),
+      );
     });
   });
 
@@ -412,15 +442,16 @@ describe("SelectManagerTest", () => {
 
   describe("ast", () => {
     it("should return the ast", () => {
-      const mgr = users.project(star);
-      expect(mgr.ast).toBeInstanceOf(Nodes.SelectStatement);
+      const mgr = users.from();
+      expect(mgr.ast).toBeTruthy();
     });
   });
 
   describe("taken", () => {
     it("should return limit", () => {
-      const mgr = users.project(star).take(10);
-      expect(mgr.limit).not.toBeNull();
+      const manager = new SelectManager();
+      manager.take(10);
+      expect(manager.taken).toBe(10);
     });
 
     it("taken aliases limit", () => {
@@ -432,22 +463,29 @@ describe("SelectManagerTest", () => {
 
   describe("lock", () => {
     it("adds a lock node", () => {
-      const mgr = users.project(star).lock();
-      expect(mgr.toSql()).toContain("FOR UPDATE");
+      const mgr = users.from();
+      expect(mustBeLike(mgr.lock().toSql())).toBe(mustBeLike(`SELECT FROM "users" FOR UPDATE`));
     });
   });
 
   describe("orders", () => {
     it("returns order clauses", () => {
-      const mgr = users.project(star).order(users.get("name").asc());
-      expect(mgr.orders.length).toBe(1);
+      const manager = new SelectManager();
+      const order = users.get("id");
+      manager.order(users.get("id"));
+      expect(manager.orders).toEqual([order]);
     });
   });
 
   describe("order", () => {
     it("generates order clauses", () => {
-      const mgr = users.project(star).order(users.get("name").asc());
-      expect(mgr.toSql()).toContain("ORDER BY");
+      const manager = new SelectManager();
+      manager.project(new Nodes.SqlLiteral("*"));
+      manager.from(users);
+      manager.order(users.get("id"));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT * FROM "users" ORDER BY "users"."id"`),
+      );
     });
 
     it("accepts string and wraps in SqlLiteral", () => {
@@ -471,33 +509,58 @@ describe("SelectManagerTest", () => {
 
   describe("order", () => {
     it("has order attributes", () => {
-      const mgr = users.project(star).order(users.get("name").asc());
-      expect(mgr.orders[0]).toBeInstanceOf(Nodes.Ascending);
+      const manager = new SelectManager();
+      manager.project(new Nodes.SqlLiteral("*"));
+      manager.from(users);
+      manager.order(users.get("id").desc());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT * FROM "users" ORDER BY "users"."id" DESC`),
+      );
     });
   });
 
   describe("on", () => {
     it("takes two params", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(users.get("id"), users.get("name"));
-      const sql = mgr.toSql();
-      expect(sql).toContain('"id"');
-      expect(sql).toContain('"name"');
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const manager = new SelectManager();
+
+      manager.from(left);
+      manager.join(right).on(predicate, predicate);
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT FROM "users"
+            INNER JOIN "users" "users_2"
+              ON "users"."id" = "users_2"."id" AND
+              "users"."id" = "users_2"."id"
+        `),
+      );
     });
 
     it("takes three params", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(users.get("id"), users.get("name"), users.get("email"));
-      const sql = mgr.toSql();
-      expect(sql).toContain('"id"');
-      expect(sql).toContain('"name"');
-      expect(sql).toContain('"email"');
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const manager = new SelectManager();
+
+      manager.from(left);
+      manager.join(right).on(predicate, predicate, left.get("name").eq(right.get("name")));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT FROM "users"
+            INNER JOIN "users" "users_2"
+              ON "users"."id" = "users_2"."id" AND
+              "users"."id" = "users_2"."id" AND
+              "users"."name" = "users_2"."name"
+        `),
+      );
     });
   });
 
   it("should hand back froms", () => {
-    const mgr = users.project(star);
-    expect(mgr.froms.length).toBe(1);
+    const relation = new SelectManager();
+    expect(relation.froms).toEqual([]);
   });
 
   it("froms filters null — fromless manager returns empty array", () => {
@@ -614,47 +677,62 @@ describe("SelectManagerTest", () => {
 
   describe("joins", () => {
     it("returns inner join sql", () => {
-      const mgr = users
-        .project(users.get("name"), posts.get("title"))
-        .join(posts)
-        .on(users.get("id").eq(posts.get("user_id")));
-      expect(mgr.toSql()).toContain("INNER JOIN");
+      const table = new Table("users");
+      const aliaz = table.alias();
+      const manager = new SelectManager();
+      manager.from(new Nodes.InnerJoin(aliaz, table.get("id").eq(aliaz.get("id"))));
+      expect(manager.toSql()).toMatch('INNER JOIN "users" "users_2" "users"."id" = "users_2"."id"');
     });
 
     it("returns outer join sql", () => {
-      const mgr = users
-        .project(star)
-        .outerJoin(posts)
-        .on(users.get("id").eq(posts.get("user_id")));
-      expect(mgr.toSql()).toContain("LEFT OUTER JOIN");
+      const table = new Table("users");
+      const aliaz = table.alias();
+      const manager = new SelectManager();
+      manager.from(new Nodes.OuterJoin(aliaz, table.get("id").eq(aliaz.get("id"))));
+      expect(manager.toSql()).toMatch(
+        'LEFT OUTER JOIN "users" "users_2" "users"."id" = "users_2"."id"',
+      );
     });
 
     it("can have a non-table alias as relation name", () => {
-      const subq = new SelectManager(users);
-      subq.project(star);
-      const alias = subq.as("subquery");
-      expect(alias).toBeInstanceOf(Nodes.TableAlias);
+      const comments = new Table("comments");
+
+      const counts = comments
+        .from()
+        .group(comments.get("user_id"))
+        .project(comments.get("user_id").as("user_id"), comments.get("user_id").count().as("count"))
+        .as("counts");
+
+      const joins = users.join(counts).on(counts.get("user_id").eq(10));
+      expect(mustBeLike(joins.toSql())).toBe(
+        mustBeLike(
+          `SELECT FROM "users" INNER JOIN (SELECT "comments"."user_id" AS user_id, COUNT("comments"."user_id") AS count FROM "comments" GROUP BY "comments"."user_id") counts ON counts."user_id" = 10`,
+        ),
+      );
     });
 
     it("joins itself", () => {
-      const mgr = users
-        .project(star)
-        .join(posts)
-        .on(users.get("id").eq(posts.get("user_id")));
-      const result = mgr.toSql();
-      expect(result).toContain("INNER JOIN");
-      expect(result).toContain('"posts"');
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+
+      const mgr = left.join(right);
+      mgr.project(new Nodes.SqlLiteral("*"));
+      expect(mgr.on(predicate)).toBe(mgr);
+
+      expect(mustBeLike(mgr.toSql())).toBe(
+        mustBeLike(`
+          SELECT * FROM "users"
+            INNER JOIN "users" "users_2"
+              ON "users"."id" = "users_2"."id"
+        `),
+      );
     });
 
     it("returns string join sql", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(star);
-      mgr.ast.cores[0].source.right.push(
-        new Nodes.StringJoin(
-          new Nodes.SqlLiteral('JOIN "posts" ON "posts"."user_id" = "users"."id"'),
-        ),
-      );
-      expect(mgr.toSql()).toContain('JOIN "posts"');
+      const manager = new SelectManager();
+      manager.from(new Nodes.StringJoin(new Nodes.Quoted("hello")));
+      expect(manager.toSql()).toMatch("'hello'");
     });
   });
 
@@ -676,119 +754,146 @@ describe("SelectManagerTest", () => {
 
   describe("project", () => {
     it("takes multiple args", () => {
-      const mgr = users.project(users.get("id"), users.get("name"));
-      expect(mgr.toSql()).toContain('"users"."id"');
-      expect(mgr.toSql()).toContain('"users"."name"');
+      const manager = new SelectManager();
+      manager.project(new Nodes.SqlLiteral("foo"), new Nodes.SqlLiteral("bar"));
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike(`SELECT foo, bar`));
     });
   });
 
   describe("window definition", () => {
     it("can be empty", () => {
-      const mgr = new SelectManager();
-      expect(mgr.toSql()).toBeDefined();
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window");
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS ()`),
+      );
     });
 
     it("takes a partition and an order", () => {
-      const w = new Nodes.Window();
-      w.partition(users.get("department_id"));
-      w.order(users.get("salary").desc());
-      const fn = new Nodes.NamedFunction("ROW_NUMBER", []);
-      const compiled = visitor.compile(new Nodes.Over(fn, w));
-      expect(compiled).toContain("ROW_NUMBER()");
-      expect(compiled).toContain("OVER");
-      expect(compiled).toContain("PARTITION BY");
-      expect(compiled).toContain("ORDER BY");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").partition(users.get("foo")).order(users.get("foo").asc());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(
+          `SELECT FROM "users" WINDOW "a_window" AS (PARTITION BY "users"."foo" ORDER BY "users"."foo" ASC)`,
+        ),
+      );
     });
 
     it("takes a rows frame, unbounded preceding", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Rows(new Nodes.Preceding()));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Over(fn, w))).toContain("ROWS UNBOUNDED PRECEDING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").rows(new Nodes.Preceding());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (ROWS UNBOUNDED PRECEDING)`),
+      );
     });
 
     it("takes a rows frame, bounded preceding", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Rows(new Nodes.Preceding(new Nodes.Quoted(3))));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Over(fn, w))).toContain("3 PRECEDING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").rows(new Nodes.Preceding(5));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (ROWS 5 PRECEDING)`),
+      );
     });
 
     it("takes a rows frame, unbounded following", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Following())).toBe("UNBOUNDED FOLLOWING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").rows(new Nodes.Following());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (ROWS UNBOUNDED FOLLOWING)`),
+      );
     });
 
     it("takes a rows frame, bounded following", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Following(new Nodes.Quoted(5)))).toBe("5 FOLLOWING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").rows(new Nodes.Following(5));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (ROWS 5 FOLLOWING)`),
+      );
     });
 
     it("takes a rows frame, current row", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.CurrentRow())).toBe("CURRENT ROW");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").rows(new Nodes.CurrentRow());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (ROWS CURRENT ROW)`),
+      );
     });
 
     it("takes a rows frame, between two delimiters", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Rows(new Nodes.Between(new Nodes.CurrentRow(), new Nodes.Following())));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      const result = visitor.compile(new Nodes.Over(fn, w));
-      expect(result).toContain("ROWS");
-      expect(result).toContain("CURRENT ROW");
+      const manager = new SelectManager();
+      manager.from(users);
+      const window = manager.window("a_window");
+      window.frame(
+        new Nodes.Between(
+          window.rows(),
+          new Nodes.And([new Nodes.Preceding(), new Nodes.CurrentRow()]),
+        ),
+      );
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(
+          `SELECT FROM "users" WINDOW "a_window" AS (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`,
+        ),
+      );
     });
 
     it("takes a range frame, unbounded preceding", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Range(new Nodes.Preceding()));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Over(fn, w))).toContain("RANGE UNBOUNDED PRECEDING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").range(new Nodes.Preceding());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (RANGE UNBOUNDED PRECEDING)`),
+      );
     });
 
     it("takes a range frame, bounded preceding", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Range(new Nodes.Preceding(new Nodes.Quoted(3))));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Over(fn, w))).toContain("3 PRECEDING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").range(new Nodes.Preceding(5));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (RANGE 5 PRECEDING)`),
+      );
     });
 
     it("takes a range frame, bounded following", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(users.get("id"));
-      const win = mgr.window("w");
-      win.frame(new Nodes.Range(new Nodes.Following(new Nodes.Quoted(3))));
-      const sql = mgr.toSql();
-      expect(sql).toContain("RANGE");
-      expect(sql).toContain("FOLLOWING");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").range(new Nodes.Following(5));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (RANGE 5 FOLLOWING)`),
+      );
     });
 
     it("takes a range frame, current row", () => {
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      w.frame(new Nodes.Range(new Nodes.CurrentRow()));
-      const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(new Nodes.Over(fn, w))).toContain("RANGE CURRENT ROW");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.window("a_window").range(new Nodes.CurrentRow());
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT FROM "users" WINDOW "a_window" AS (RANGE CURRENT ROW)`),
+      );
     });
 
     it("takes a range frame, between two delimiters", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(users.get("id"));
-      const win = mgr.window("w");
-      win.frame(new Nodes.Rows(new Nodes.Preceding()));
-      const sql = mgr.toSql();
-      expect(sql).toContain("ROWS");
-      expect(sql).toContain("UNBOUNDED PRECEDING");
+      const manager = new SelectManager();
+      manager.from(users);
+      const window = manager.window("a_window");
+      window.frame(
+        new Nodes.Between(
+          window.range(),
+          new Nodes.And([new Nodes.Preceding(), new Nodes.CurrentRow()]),
+        ),
+      );
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(
+          `SELECT FROM "users" WINDOW "a_window" AS (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)`,
+        ),
+      );
     });
   });
 
@@ -820,19 +925,20 @@ describe("SelectManagerTest", () => {
 
   describe("where_sql", () => {
     it("gives me back the where sql", () => {
-      const mgr = users
-        .project(star)
-        .where(users.get("name").eq("Alice"))
-        .where(users.get("age").gt(18));
-      expect(mgr.constraints.length).toBe(2);
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.where(users.get("id").eq(10));
+      expect(mustBeLike(manager.whereSql()!.value)).toBe(mustBeLike(`WHERE "users"."id" = 10`));
     });
 
     it("joins wheres with AND", () => {
-      const mgr = users
-        .project(star)
-        .where(users.get("name").eq("Alice"))
-        .where(users.get("age").gt(18));
-      expect(mgr.toSql()).toContain("AND");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.where(users.get("id").eq(10));
+      manager.where(users.get("id").eq(11));
+      expect(mustBeLike(manager.whereSql()!.value)).toBe(
+        mustBeLike(`WHERE "users"."id" = 10 AND "users"."id" = 11`),
+      );
     });
   });
 
@@ -901,15 +1007,15 @@ describe("SelectManagerTest", () => {
 
   describe("project", () => {
     it("takes sql literals", () => {
-      const mgr = users.project(new Nodes.SqlLiteral("*"));
-      expect(mgr.toSql()).toBe('SELECT * FROM "users"');
+      const manager = new SelectManager();
+      manager.project(new Nodes.SqlLiteral("*"));
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike(`SELECT *`));
     });
 
     it("takes strings", () => {
-      const mgr = users.project(new Nodes.SqlLiteral("id"), new Nodes.SqlLiteral("name"));
-      const result = mgr.toSql();
-      expect(result).toContain("id");
-      expect(result).toContain("name");
+      const manager = new SelectManager();
+      manager.project("*");
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike(`SELECT *`));
     });
   });
 
@@ -922,10 +1028,10 @@ describe("SelectManagerTest", () => {
 
   describe("projections=", () => {
     it("overwrites projections", () => {
-      const mgr = users.project(users.get("name"));
-      mgr.projections = [users.get("age")];
-      expect(mgr.projections.length).toBe(1);
-      expect(mgr.toSql()).toContain('"age"');
+      const manager = new SelectManager();
+      manager.project(sql("foo"));
+      manager.projections = [sql("bar")];
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike(`SELECT bar`));
     });
   });
 
@@ -938,15 +1044,27 @@ describe("SelectManagerTest", () => {
 
   describe("take", () => {
     it("removes LIMIT when nil is passed", () => {
-      const mgr = users.project(star).take(10);
-      expect(mgr.toSql()).toContain("LIMIT 10");
+      const manager = new SelectManager();
+      manager.limit = 10;
+      expect(manager.toSql()).toMatch("LIMIT");
+
+      manager.limit = null;
+      expect(manager.toSql()).not.toMatch("LIMIT");
     });
   });
 
   describe("where", () => {
     it("knows where", () => {
-      const mgr = users.project(star).where(users.get("id").eq(1));
-      expect(mgr.toSql()).toContain("WHERE");
+      const manager = new SelectManager();
+      manager.from(users).project(users.get("id"));
+      manager.where(users.get("id").eq(1));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id"
+          FROM "users"
+          WHERE "users"."id" = 1
+        `),
+      );
     });
 
     it("accepts a TreeManager and unwraps to ast", () => {
@@ -972,8 +1090,10 @@ describe("SelectManagerTest", () => {
 
   describe("from", () => {
     it("makes sql", () => {
-      const mgr = users.project(star);
-      expect(mgr.toSql()).toBe('SELECT * FROM "users"');
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.project(users.get("id"));
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike('SELECT "users"."id" FROM "users"'));
     });
 
     it("chains", () => {
@@ -986,8 +1106,8 @@ describe("SelectManagerTest", () => {
 
   describe("source", () => {
     it("returns the join source of the select core", () => {
-      const mgr = users.project(star);
-      expect(mgr.source).toBeDefined();
+      const manager = new SelectManager();
+      expect(manager.source).toBe(manager.ast.cores[manager.ast.cores.length - 1].source);
     });
   });
 
@@ -996,7 +1116,9 @@ describe("SelectManagerTest", () => {
       const mgr = new SelectManager();
 
       mgr.distinct();
-      expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier).toBeInstanceOf(Nodes.Distinct);
+      expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier?.constructor).toBe(
+        Nodes.Distinct,
+      );
 
       mgr.distinct(false);
       expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier).toBeNull();
@@ -1034,8 +1156,18 @@ describe("SelectManagerTest", () => {
 
   describe("comment", () => {
     it("appends a comment to the generated query", () => {
-      const mgr = users.project(star).comment("load users");
-      expect(mgr.toSql()).toContain("/* load users */");
+      const manager = new SelectManager();
+      manager.from(users).project(users.get("id"));
+
+      manager.comment("selecting");
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT "users"."id" FROM "users" /* selecting */`),
+      );
+
+      manager.comment("selecting", "with", "comment");
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT "users"."id" FROM "users" /* selecting */ /* with */ /* comment */`),
+      );
     });
 
     it("stores the Comment node on the SelectCore (Rails fidelity)", () => {
@@ -1301,38 +1433,56 @@ describe("SelectManagerTest", () => {
 
   describe("skip", () => {
     it("should chain", () => {
-      const mgr = new SelectManager(users);
-      expect(mgr.project(star)).toBe(mgr);
-      expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
-      expect(mgr.order(users.get("id").asc())).toBe(mgr);
+      const mgr = users.from();
+      expect(mustBeLike(mgr.skip(10).toSql())).toBe(mustBeLike(`SELECT FROM "users" OFFSET 10`));
     });
   });
 
   describe("order", () => {
     it("takes *args", () => {
-      const mgr = users.project(star).order(users.get("id").asc(), users.get("name").desc());
-      expect(mgr.orders.length).toBe(2);
-      expect(mgr.toSql()).toContain("ORDER BY");
+      const manager = new SelectManager();
+      manager.project(new Nodes.SqlLiteral("*"));
+      manager.from(users);
+      manager.order(users.get("id"), users.get("name"));
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`SELECT * FROM "users" ORDER BY "users"."id", "users"."name"`),
+      );
     });
   });
 
   describe("join", () => {
     it("takes the full outer join class", () => {
-      const mgr = users
-        .project(star)
-        .join(posts, Nodes.FullOuterJoin)
-        .on(users.get("id").eq(posts.get("user_id")));
-      expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.FullOuterJoin);
-      expect(mgr.toSql()).toContain("FULL OUTER JOIN");
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const manager = new SelectManager();
+
+      manager.from(left);
+      manager.join(right, Nodes.FullOuterJoin).on(predicate);
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT FROM "users"
+            FULL OUTER JOIN "users" "users_2"
+              ON "users"."id" = "users_2"."id"
+        `),
+      );
     });
 
     it("takes the right outer join class", () => {
-      const mgr = users
-        .project(star)
-        .join(posts, Nodes.RightOuterJoin)
-        .on(users.get("id").eq(posts.get("user_id")));
-      expect(mgr.joinSources()[0]).toBeInstanceOf(Nodes.RightOuterJoin);
-      expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const manager = new SelectManager();
+
+      manager.from(left);
+      manager.join(right, Nodes.RightOuterJoin).on(predicate);
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT FROM "users"
+            RIGHT OUTER JOIN "users" "users_2"
+              ON "users"."id" = "users_2"."id"
+        `),
+      );
     });
   });
 
@@ -1344,10 +1494,10 @@ describe("SelectManagerTest", () => {
     });
 
     it("makes strings literals", () => {
-      const mgr = new SelectManager();
-      mgr.from("users").project("*");
-      expect(mgr.froms[0]).toBeInstanceOf(Nodes.SqlLiteral);
-      expect(mgr.toSql()).toContain("FROM users");
+      const manager = new SelectManager();
+      manager.from(users);
+      manager.group("foo");
+      expect(mustBeLike(manager.toSql())).toBe(mustBeLike(`SELECT FROM "users" GROUP BY foo`));
     });
   });
 
@@ -1443,10 +1593,19 @@ describe("SelectManagerTest", () => {
 
   describe("take", () => {
     it("knows take", () => {
-      const mgr = new SelectManager(users).project(star).take(5);
-      expect(mgr.ast.limit).toBeInstanceOf(Nodes.Limit);
-      expect(mgr.limit).toBe(5);
-      expect(mgr.toSql()).toContain("LIMIT 5");
+      const manager = new SelectManager();
+      manager.from(users).project(users.get("id"));
+      manager.where(users.get("id").eq(1));
+      manager.take(1);
+
+      expect(mustBeLike(manager.toSql())).toBe(
+        mustBeLike(`
+          SELECT "users"."id"
+          FROM "users"
+          WHERE "users"."id" = 1
+          LIMIT 1
+        `),
+      );
     });
   });
 

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -36,9 +36,9 @@
       "value": 103
     },
     "arel": {
-      "assertionCount": 90,
-      "kind": 175,
-      "value": 24
+      "assertionCount": 63,
+      "kind": 116,
+      "value": 14
     },
     "date": {
       "assertionCount": 1,


### PR DESCRIPTION
Bundle of three convergence stories.

## 1. `forget_change` is unconditional (RFC 0115)

`attribute_mutation_tracker.rb:54-57` is two unconditional statements in this
order: rewrite the attribute through `forgetting_assignment`, then delete from
`forced_changes`. The port deleted first and guarded the rewrite on the name
being a key, so an unknown name wrote nothing where Rails writes back a
`forgetting_assignment` of the `Null` default (`attribute_set.rb:16-18`). Both
deviations are gone.

## 2. The command tuple's block seat (RFC 0051)

`command_recorder.rb:104-111` pushes `command << block` — a three-element array —
and `replay` (`:148-152`) splats it back apart with the block restored. The port
recorded `[cmd, args]`, so:

- `change_table`'s bulk path could not record Rails' lambda
  (`-> t { bulk_change_table(table_name, commands) }`, `:142`) and carried a
  `@missingRailsCall bulk_change_table` tag;
- `replay` carried an extra `changeTable`-with-an-array branch that
  re-dispatched each sub-command by hand.

`_commands` entries are now `[cmd, args, block]`; `record` and `inverseOf` take
and forward the block; every `invert_*` generated by `StraightReversions`
(`:163-179`) now takes and returns it (the ones Rails returns as a pair —
`invert_rename_table`, `invert_remove_index`, … — still return a pair).

**One exception, and it is not converged here:** `invert_transaction`
(`:186-194`) also takes `&block` and is reversible in Rails via a sub-recorder.
It is untouched and still throws. Converging it alone would be dead code —
trails has no `Migration#transaction` that records (`migration.ts:2767` uses
`connection.transaction` only, and the port of Rails'
`InvertibleTransactionMigration` calls `this.connection.transaction`), so
nothing but a direct `recorder.transaction(...)` reaches it. Both halves are
filed together as
`0051-migration-schema-statements-fidelity/invert-transaction-sub-recorder`. The bulk path records the
lambda, the tag is deleted, and `replay` is Rails' three-line body. Its one
concession to the language: Ruby's `&block` passes nothing when the block is
nil, so an absent block must not become a trailing `undefined` argument to a
splat-taking method like `drop_table(*table_names)` — that is spelled at the
call site.

The mirrored tests now assert the tuple Rails asserts, `nil` seat included
(`command_recorder_test.rb:32`, `:91`, `:144`).

`CommandRecorder#inverse` went with it: Rails has no such method and nothing
called it, so extending it with the block seat would have been widening invented
surface.

## 3. `select_manager` assertion parity (RFC 0122)

Rails `must_be_like` full-string assertions ported as substring `toContain`
checks — often split in two, inflating the count dimension as well. Each is now
a single `expect(mustBeLike(...)).toBe(mustBeLike(...))` on the SQL from the
Rails source, with the Ruby's setup, using the already-hoisted
`test-helpers/must-be-like.ts`. arel's marks:

| dimension | before | after | converged |
| --- | --- | --- | --- |
| assertion-count | 90 | 63 | 27 |
| kind | 175 | 116 | 59 |
| value | 24 | 14 | 10 |

(The "before" column tracks `main`, which siblings keep lowering — #7022 among
them. The converged column is what this PR removes and has been constant across
two rebases: each time the mark was re-measured rather than resolved to either
side of the conflict, and each time it landed on exactly `main - converged`,
confirming no row overlap with the sibling work.)

The other four packages' marks are unchanged; `pnpm parity:test:assertions` is
green.

Two implementation divergences surfaced by writing the Rails assertions and are
fixed here, since the tests cannot pass otherwise:

- `Nodes::Window#frame` returns the framing node (`window.rb:30-32` — the value
  of the assignment), and `rows`/`range` hand that back; the port returned
  `this`, so `Between.new(window.rows, ...)` got the window.
- `Preceding` / `Following` narrowed `expr` to `Node | null`; Rails puts no bound
  on it and the frame offset is commonly a bare Integer
  (`select_manager_test.rb:804`).

Two remaining mismatches in the file (`creates new cores`, `makes updates to the
correct copy`) need `TreeManager#initialize_copy`, and `SelectManager#as` does
not accept a `SqlLiteral` the way `SqlLiteral.new` does. Both are filed rather
than bodged:

- `0122-arel-assertion-parity/select-manager-clone-copy-semantics`
- `0122-arel-assertion-parity/select-manager-as-accepts-sql-literal`
- `0051-migration-schema-statements-fidelity/invert-transaction-sub-recorder`

## Size

~1090 LOC against the 700 ceiling, for a bundle the prompt required to ship as
one PR. The split is roughly 100 (story 1 + 2 source) / 270 (their mirrored test
tuples) / 720 (the arel test file — all assertion bodies, no new surface). Happy
to split if preferred.

## Verification

- `pnpm vitest run packages/activemodel/src/dirty.test.ts packages/activemodel/src/dirty-mutations.test.ts packages/activerecord/src/dirty.test.ts`
- `pnpm vitest run packages/activerecord/src/migration/ packages/activerecord/src/invertible-migration.test.ts`
- `pnpm vitest run packages/arel/src` — 1458 passed
- `pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate`,
  `parity:test:assertions` — all green

Closes-story: converge-forget-change-unconditional
Closes-story: command-recorder-tuple-has-no-block-seat
Closes-story: select-manager-assertion-parity
