### PR TITLE
refactor(parity,activerecord): report inert @missingRailsCall tags, round-trip adapter TypeMetadata, converge check_constraints_in_create and PG rename_table

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -233,12 +233,8 @@ export class DisableJoinsAssociationScope extends AssociationScope {
    *
    * Mirrors: DisableJoinsAssociationScope#add_constraints (lines 33-56).
    *
-   * @missingRailsCall add_constraints — PERMANENT: Rails' subclass method shadows
-   * `AssociationScope#add_constraints` with a different arity, which Ruby
-   * permits. TypeScript rejects a derived declaration of a name the base
-   * declares `private` (TS2415), and the two signatures are not
-   * override-compatible, so the `Dj` suffix is the only spelling available;
-   * `scope()` still calls it at both of Rails' call sites.
+   * The `Dj` suffix is a TS2415 workaround, justified where the flag is
+   * actually raised — `scope()`'s `@missingRailsCall` receipt above.
    */
   private _addConstraintsDj(
     reflection: ChainEntry,

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { Column as MysqlColumn } from "./column.js";
+import { TypeMetadata } from "./type-metadata.js";
 
 describe("MysqlColumn", () => {
   it("round-trips autoIncrement / unsigned / virtual through encodeWith/initWith", () => {
@@ -18,5 +20,36 @@ describe("MysqlColumn", () => {
     expect(restored.unsigned).toBe(true);
     expect(restored.virtual).toBe(false);
     expect(restored.sqlType).toBe("bigint(20) unsigned");
+  });
+});
+
+describe("MySQL::TypeMetadata JSON round-trip", () => {
+  it("recovers its own class and ivars from the sql_type_metadata payload", () => {
+    const meta = new TypeMetadata(
+      { sqlType: "bigint(20)", type: "integer", limit: 8 },
+      { extra: "auto_increment" },
+    );
+    const back = SqlTypeMetadata.fromJSON(JSON.parse(JSON.stringify(meta.toJSON())));
+
+    expect(back).toBeInstanceOf(TypeMetadata);
+    expect((back as TypeMetadata).extra).toBe("auto_increment");
+    expect(back.limit).toBe(8);
+    expect(back.equals(meta)).toBe(true);
+  });
+
+  it("delegates the Column reader to the metadata object", () => {
+    const col = new MysqlColumn("id", null, {
+      sqlType: "bigint(20)",
+      type: "integer",
+      extra: "auto_increment",
+    });
+    expect(col.sqlTypeMetadata).toBeInstanceOf(TypeMetadata);
+    expect(col.extra).toBe("auto_increment");
+
+    const coder: Record<string, unknown> = {};
+    col.encodeWith(coder);
+    const restored = Object.create(MysqlColumn.prototype) as MysqlColumn;
+    restored.initWith(JSON.parse(JSON.stringify(coder)));
+    expect(restored.extra).toBe("auto_increment");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -6,17 +6,12 @@
 
 import { Column as BaseColumn } from "../column.js";
 import type { ColumnCoder } from "../column.js";
-import { SqlTypeMetadata } from "../sql-type-metadata.js";
+import { TypeMetadata } from "./type-metadata.js";
 
 export class Column extends BaseColumn {
   unsigned: boolean;
   autoIncrement: boolean;
   virtual: boolean;
-  /** Raw MySQL `Extra` string (e.g. "VIRTUAL GENERATED", "STORED GENERATED",
-   *  "auto_increment"). Mirrors Rails' `MySQL::Column#extra` (delegated from
-   *  sql_type_metadata); the schema dumper reads it to distinguish stored from
-   *  virtual generated columns. */
-  extra: string;
 
   constructor(
     name: string,
@@ -27,6 +22,7 @@ export class Column extends BaseColumn {
       limit?: number | null;
       precision?: number | null;
       scale?: number | null;
+      extra?: string;
     } = {},
     null_: boolean = true,
     options: {
@@ -36,16 +32,18 @@ export class Column extends BaseColumn {
       unsigned?: boolean;
       autoIncrement?: boolean;
       virtual?: boolean;
-      extra?: string;
     } = {},
   ) {
-    const meta = new SqlTypeMetadata({
-      sqlType: sqlTypeMetadata.sqlType ?? undefined,
-      type: sqlTypeMetadata.type,
-      limit: sqlTypeMetadata.limit ?? null,
-      precision: sqlTypeMetadata.precision ?? null,
-      scale: sqlTypeMetadata.scale ?? null,
-    });
+    const meta = new TypeMetadata(
+      {
+        sqlType: sqlTypeMetadata.sqlType ?? undefined,
+        type: sqlTypeMetadata.type,
+        limit: sqlTypeMetadata.limit ?? null,
+        precision: sqlTypeMetadata.precision ?? null,
+        scale: sqlTypeMetadata.scale ?? null,
+      },
+      { extra: sqlTypeMetadata.extra },
+    );
     super(name, defaultValue, meta, null_, {
       collation: options.collation,
       comment: options.comment,
@@ -54,7 +52,16 @@ export class Column extends BaseColumn {
     this.unsigned = options.unsigned ?? false;
     this.autoIncrement = options.autoIncrement ?? false;
     this.virtual = options.virtual ?? false;
-    this.extra = options.extra ?? "";
+  }
+
+  /** Raw MySQL `Extra` string (e.g. "VIRTUAL GENERATED", "STORED GENERATED",
+   *  "auto_increment"); the schema dumper reads it to distinguish stored from
+   *  virtual generated columns.
+   *
+   *  Mirrors: `delegate :extra, to: :sql_type_metadata, allow_nil: true`
+   *  (mysql/column.rb:7). */
+  get extra(): string {
+    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.extra : "";
   }
 
   /**
@@ -97,7 +104,6 @@ export class Column extends BaseColumn {
     this.unsigned = (coder["unsigned"] as boolean) ?? false;
     this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
     this.virtual = (coder["virtual"] as boolean) ?? false;
-    this.extra = (coder["extra"] as string) ?? "";
   }
 
   override encodeWith(coder: ColumnCoder): void {

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -61,7 +61,7 @@ export class Column extends BaseColumn {
    *  Mirrors: `delegate :extra, to: :sql_type_metadata, allow_nil: true`
    *  (mysql/column.rb:7). */
   get extra(): string {
-    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.extra : "";
+    return (this.sqlTypeMetadata as TypeMetadata | null)?.extra ?? "";
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -418,7 +418,6 @@ export async function newColumnFromField(
     unsigned: /\bunsigned(?: zerofill)?$/.test(field["Type"] ?? ""),
     autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
     virtual: /(virtual|stored|persistent)\s+generated/i.test(field["Extra"] ?? ""),
-    extra: field["Extra"] ?? "",
     comment: presence(field["Comment"] as string | undefined) ?? null,
   });
 }

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -8,17 +8,30 @@
  * "VIRTUAL GENERATED", etc.
  */
 
-export class TypeMetadata {
-  readonly sqlType: string | null;
-  readonly type: string | undefined;
-  readonly limit: number | null;
-  readonly precision: number | null;
-  readonly scale: number | null;
+import {
+  SqlTypeMetadata,
+  TYPE_METADATA_CLASSES,
+  type SqlTypeMetadataJSON,
+} from "../sql-type-metadata.js";
+
+/** The `class`-tagged payload `toJSON` writes, so `extra` survives the
+ *  schema-cache round trip the way Ruby's YAML tag carries it. */
+export interface TypeMetadataJSON extends SqlTypeMetadataJSON {
+  extra: string;
+}
+
+/**
+ * Rails' `DelegateClass(SqlTypeMetadata)` forwards every base reader to the
+ * wrapped metadata; TypeScript's equivalent of that forwarding is inheritance,
+ * so the wrapped object's state lives on `super` rather than in an
+ * `__getobj__`.
+ */
+export class TypeMetadata extends SqlTypeMetadata {
   readonly extra: string;
 
   constructor(
     typeMetadata: {
-      sqlType: string | null;
+      sqlType?: string | null;
       type?: string;
       limit?: number | null;
       precision?: number | null;
@@ -26,45 +39,25 @@ export class TypeMetadata {
     },
     options: { extra?: string } = {},
   ) {
-    this.sqlType = typeMetadata.sqlType;
-    // Rails' MySQL TypeMetadata delegates `type` to the wrapped SqlTypeMetadata
-    // (DelegateClass), which is nil for an unmapped sql_type — no sqlType
+    // Rails' MySQL TypeMetadata delegates `type` to the wrapped
+    // SqlTypeMetadata, which is nil for an unmapped sql_type — no sqlType
     // fallback. Keep it nil-faithful.
-    this.type = typeMetadata.type ?? undefined;
-    this.limit = typeMetadata.limit ?? null;
-    this.precision = typeMetadata.precision ?? null;
-    this.scale = typeMetadata.scale ?? null;
+    super(typeMetadata);
     this.extra = options.extra ?? "";
   }
 
-  equals(other: TypeMetadata): boolean {
-    return (
-      this.sqlType === other.sqlType &&
-      this.type === other.type &&
-      this.limit === other.limit &&
-      this.precision === other.precision &&
-      this.scale === other.scale &&
-      this.extra === other.extra
-    );
+  override equals(other: unknown): boolean {
+    return other instanceof TypeMetadata && super.equals(other) && this.extra === other.extra;
   }
 
-  hashKey(): string {
-    return JSON.stringify([
-      this.sqlType,
-      this.type,
-      this.limit,
-      this.precision,
-      this.scale,
-      this.extra,
-    ]);
-  }
-
-  deduplicate(): this {
-    return this.deduplicated();
-  }
-
-  /** @internal */
-  protected deduplicated(): this {
-    return this;
+  override toJSON(): TypeMetadataJSON {
+    return { ...super.toJSON(), class: "MySQL::TypeMetadata", extra: this.extra };
   }
 }
+
+TYPE_METADATA_CLASSES["MySQL::TypeMetadata"] = {
+  fromJSON(data: SqlTypeMetadataJSON): TypeMetadata {
+    const row = data as TypeMetadataJSON;
+    return new TypeMetadata(row, { extra: row.extra });
+  },
+};

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3056,12 +3056,6 @@ export class PostgreSQLAdapter
    * (XmlData, BitData, Range, ArrayData) fall through to the base dispatch.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote
-   *
-   * @missingRailsCall check_int_in_range — PERMANENT: Equivalent (RFC 0072
-   *   activerecord-unrouted-privates-remaining-inventory): `checkIntInRange` is
-   *   a bare alias — `export const checkIntInRange = checkIntegerRange` — so the
-   *   routed call is the alias target and the extractor never sees the alias
-   *   name. Nothing to converge.
    */
   override quote(value: unknown): string {
     return pgQuote.call(this, value);
@@ -3071,15 +3065,6 @@ export class PostgreSQLAdapter
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote_string
    * (postgresql/quoting.rb:127-131) — escape-only, so the inherited `quote`
    * dispatches here instead of the abstract backslash-doubling escape.
-   *
-   * @missingRailsCall with_raw_connection — PERMANENT: Language shortcoming: Rails'
-   *   quote_string escapes through the live connection (`with_raw_connection {
-   *   |c| c.escape(s) }`, postgresql/quoting.rb:127-131), but node-postgres
-   *   exposes no escape entry point at all — sync or async — and `quote_string`
-   *   is a sync method every `quote` call site depends on. The override
-   *   reproduces libpq's standard_conforming_strings escaping inline in
-   *   postgresql/quoting.ts (same divergence already baselined for that module's
-   *   quote_string).
    */
   override quoteString(s: string): string {
     return pgQuoteString(s);
@@ -3348,44 +3333,35 @@ export class PostgreSQLAdapter
   async renameTable(tableName: string, newName: string): Promise<void> {
     this.validateTableLengthBang(newName);
     await this.clearCacheBang();
-    const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(tableName);
-    const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
     await this.schemaCache.clearDataSourceCacheBang(tableName);
     await this.schemaCache.clearDataSourceCacheBang(newName);
     await this.execute(
-      `ALTER TABLE ${this.quoteTableName(tableName)} RENAME TO ${this.quoteColumnName(unqualifiedNew)}`,
+      `ALTER TABLE ${this.quoteTableName(tableName)} RENAME TO ${this.quoteTableName(newName)}`,
     );
     // Rails reads max_identifier_length here, which lazily runs the SHOW query
     // on first use; warm the memo so the truncation limit is the real server
     // value rather than the synchronous fallback.
-    const maxLen = await this.warmMaxIdentifierLength();
-    const renamedName = oldSchema
-      ? `${this.quoteColumnName(oldSchema)}.${this.quoteColumnName(unqualifiedNew)}`
-      : unqualifiedNew;
-    const result = await this.pkAndSequenceFor(renamedName).catch(() => null);
+    const maxIdentifierLength = await this.warmMaxIdentifierLength();
+    const result = await this.pkAndSequenceFor(newName);
     if (result) {
       const [pk, seq] = result;
-      const pkeySuffix = "_pkey";
-      const maxPkeyPrefix = maxLen - pkeySuffix.length;
-      const oldIdx = `${unqualifiedOld.slice(0, maxPkeyPrefix)}${pkeySuffix}`;
-      const newIdx = `${unqualifiedNew.slice(0, maxPkeyPrefix)}${pkeySuffix}`;
-      const qualifiedOldIdx = oldSchema
-        ? `${this.quoteColumnName(oldSchema)}.${this.quoteColumnName(oldIdx)}`
-        : this.quoteColumnName(oldIdx);
-      // Always rename the pkey index when a PK exists (mirrors Rails schema_statements.rb:443-445).
-      await this.exec(
-        `ALTER INDEX IF EXISTS ${qualifiedOldIdx} RENAME TO ${this.quoteColumnName(newIdx)}`,
+      // postgresql/schema_statements.rb:442-443: PostgreSQL automatically creates an index for
+      // PRIMARY KEY with name consisting of truncated table name and "_pkey" suffix fitting into
+      // max_identifier_length number of characters.
+      const maxPkeyPrefix = maxIdentifierLength - "_pkey".length;
+      const idx = `${tableName.slice(0, maxPkeyPrefix)}_pkey`;
+      const newIdx = `${newName.slice(0, maxPkeyPrefix)}_pkey`;
+      await this.execute(
+        `ALTER INDEX ${this.quoteTableName(idx)} RENAME TO ${this.quoteTableName(newIdx)}`,
       );
-      if (seq) {
-        const seqSuffix = `_${pk}_seq`;
-        const maxSeqPrefix = maxLen - seqSuffix.length;
-        const expectedOldSeq = `${unqualifiedOld.slice(0, maxSeqPrefix)}${seqSuffix}`;
-        if (seq.identifier === expectedOldSeq) {
-          const newSeqName = `${unqualifiedNew.slice(0, maxSeqPrefix)}${seqSuffix}`;
-          await this.exec(
-            `ALTER SEQUENCE IF EXISTS ${seq.quoted()} RENAME TO ${this.quoteColumnName(newSeqName)}`,
-          );
-        }
+
+      // postgresql/schema_statements.rb:448-449: PostgreSQL automatically creates a sequence for
+      // PRIMARY KEY with name consisting of truncated table name and "#{primary_key}_seq" suffix
+      // fitting into max_identifier_length number of characters.
+      const maxSeqPrefix = maxIdentifierLength - `_${pk}_seq`.length;
+      if (seq && seq.identifier === `${tableName.slice(0, maxSeqPrefix)}_${pk}_seq`) {
+        const newSeq = `${newName.slice(0, maxSeqPrefix)}_${pk}_seq`;
+        await this.execute(`ALTER TABLE ${seq.quoted()} RENAME TO ${this.quoteTableName(newSeq)}`);
       }
     }
     await this.renameTableIndexes(tableName, newName);
@@ -3738,15 +3714,16 @@ export class PostgreSQLAdapter
     fmod: number,
   ): Promise<PgTypeMetadata> {
     const castType = await this.getOidType(oid, fmod, columnName, sqlType);
-    return new PgTypeMetadata({
-      sqlType,
-      type: castType.type(),
-      oid,
-      fmod,
-      limit: castType.limit ?? null,
-      precision: castType.precision ?? null,
-      scale: castType.scale ?? null,
-    });
+    return new PgTypeMetadata(
+      {
+        sqlType,
+        type: castType.type(),
+        limit: castType.limit ?? null,
+        precision: castType.precision ?? null,
+        scale: castType.scale ?? null,
+      },
+      { oid, fmod },
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { Column } from "./column.js";
+import { TypeMetadata } from "./type-metadata.js";
 
 describe("PostgreSQL::Column JSON round-trip", () => {
   it("preserves the subclass and its state through the schema-cache dump", () => {
@@ -23,5 +25,28 @@ describe("PostgreSQL::Column JSON round-trip", () => {
     expect(back.isIdentity).toBe(true);
     expect(back.isVirtual()).toBe(true);
     expect(back).toEqual(col);
+  });
+});
+
+describe("PostgreSQL::TypeMetadata JSON round-trip", () => {
+  it("recovers its own class and ivars from the sql_type_metadata payload", () => {
+    const meta = new TypeMetadata(
+      { sqlType: "numeric(10,2)", type: "decimal", precision: 10, scale: 2 },
+      { oid: 1700, fmod: 655366 },
+    );
+    const back = SqlTypeMetadata.fromJSON(JSON.parse(JSON.stringify(meta.toJSON())));
+
+    expect(back).toBeInstanceOf(TypeMetadata);
+    expect((back as TypeMetadata).oid).toBe(1700);
+    expect((back as TypeMetadata).fmod).toBe(655366);
+    expect(back.sqlType).toBe("numeric(10,2)");
+    expect(back.equals(meta)).toBe(true);
+  });
+
+  it("delegates the Column readers to the metadata object", () => {
+    const col = new Column("n", null, { sqlType: "int4", type: "integer", oid: 23, fmod: -1 });
+    expect(col.sqlTypeMetadata).toBeInstanceOf(TypeMetadata);
+    expect(col.oid).toBe(23);
+    expect(col.fmod).toBe(-1);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -60,11 +60,11 @@ export class Column extends BaseColumn {
 
   // Mirrors: `delegate :oid, :fmod, to: :sql_type_metadata` (postgresql/column.rb:7).
   get oid(): number | null {
-    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.oid : null;
+    return (this.sqlTypeMetadata as TypeMetadata | null)?.oid ?? null;
   }
 
   get fmod(): number | null {
-    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.fmod : null;
+    return (this.sqlTypeMetadata as TypeMetadata | null)?.fmod ?? null;
   }
 
   // Mirrors: Column#sql_type — strips the array suffix so callers get the

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -6,12 +6,10 @@
 
 import { Column as BaseColumn } from "../column.js";
 import type { ColumnCoder } from "../column.js";
-import { SqlTypeMetadata } from "../sql-type-metadata.js";
+import { TypeMetadata } from "./type-metadata.js";
 
 export class Column extends BaseColumn {
   serial: boolean;
-  oid: number | null;
-  fmod: number | null;
   array: boolean;
   identity: string | null;
   generated: string | null;
@@ -39,24 +37,34 @@ export class Column extends BaseColumn {
       generated?: string | null;
     } = {},
   ) {
-    const meta = new SqlTypeMetadata({
-      sqlType: sqlTypeMetadata.sqlType ?? undefined,
-      type: sqlTypeMetadata.type,
-      limit: sqlTypeMetadata.limit ?? undefined,
-      precision: sqlTypeMetadata.precision ?? undefined,
-      scale: sqlTypeMetadata.scale ?? undefined,
-    });
+    const meta = new TypeMetadata(
+      {
+        sqlType: sqlTypeMetadata.sqlType ?? undefined,
+        type: sqlTypeMetadata.type,
+        limit: sqlTypeMetadata.limit ?? undefined,
+        precision: sqlTypeMetadata.precision ?? undefined,
+        scale: sqlTypeMetadata.scale ?? undefined,
+      },
+      { oid: sqlTypeMetadata.oid, fmod: sqlTypeMetadata.fmod },
+    );
     super(name, defaultValue, meta, null_, {
       collation: options.collation,
       defaultFunction: options.defaultFunction,
       comment: options.comment,
     });
     this.serial = options.serial ?? false;
-    this.oid = sqlTypeMetadata.oid ?? null;
-    this.fmod = sqlTypeMetadata.fmod ?? null;
     this.array = options.array ?? sqlTypeMetadata.sqlType?.endsWith("[]") ?? false;
     this.identity = options.identity ?? null;
     this.generated = options.generated ?? null;
+  }
+
+  // Mirrors: `delegate :oid, :fmod, to: :sql_type_metadata` (postgresql/column.rb:7).
+  get oid(): number | null {
+    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.oid : null;
+  }
+
+  get fmod(): number | null {
+    return this.sqlTypeMetadata instanceof TypeMetadata ? this.sqlTypeMetadata.fmod : null;
   }
 
   // Mirrors: Column#sql_type — strips the array suffix so callers get the
@@ -130,8 +138,6 @@ export class Column extends BaseColumn {
   override initWith(coder: ColumnCoder): void {
     super.initWith(coder);
     this.serial = (coder["serial"] as boolean) ?? false;
-    this.oid = (coder["oid"] as number | null) ?? null;
-    this.fmod = (coder["fmod"] as number | null) ?? null;
     this.array = (coder["array"] as boolean) ?? false;
     this.identity = (coder["identity"] as string | null) ?? null;
     this.generated = (coder["generated"] as string | null) ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -4,66 +4,64 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata
  */
 
-export class TypeMetadata {
-  readonly sqlType: string;
-  readonly type: string | undefined;
+import {
+  SqlTypeMetadata,
+  TYPE_METADATA_CLASSES,
+  type SqlTypeMetadataJSON,
+} from "../sql-type-metadata.js";
+
+/** The `class`-tagged payload `toJSON` writes, so `oid` / `fmod` survive the
+ *  schema-cache round trip the way Ruby's YAML tag carries them. */
+export interface TypeMetadataJSON extends SqlTypeMetadataJSON {
+  oid: number | null;
+  fmod: number | null;
+}
+
+/**
+ * Rails' `DelegateClass(SqlTypeMetadata)` forwards every base reader to the
+ * wrapped metadata; TypeScript's equivalent of that forwarding is inheritance,
+ * so the wrapped object's state lives on `super` rather than in an
+ * `__getobj__`.
+ */
+export class TypeMetadata extends SqlTypeMetadata {
   readonly oid: number | null;
   readonly fmod: number | null;
-  readonly limit: number | null;
-  readonly precision: number | null;
-  readonly scale: number | null;
 
-  constructor(options: {
-    sqlType: string;
-    type?: string;
-    oid?: number | null;
-    fmod?: number | null;
-    limit?: number | null;
-    precision?: number | null;
-    scale?: number | null;
-  }) {
-    this.sqlType = options.sqlType;
-    // Rails' PG TypeMetadata delegates `type` to the wrapped SqlTypeMetadata
-    // (DelegateClass), which is nil for an unmapped sql_type — no sqlType
-    // fallback. Keep it nil-faithful so Column#type is null for e.g. composites.
-    this.type = options.type ?? undefined;
+  constructor(
+    typeMetadata: {
+      sqlType?: string | null;
+      type?: string;
+      limit?: number | null;
+      precision?: number | null;
+      scale?: number | null;
+    },
+    options: { oid?: number | null; fmod?: number | null } = {},
+  ) {
+    // Rails' PG TypeMetadata delegates `type` to the wrapped SqlTypeMetadata,
+    // which is nil for an unmapped sql_type — no sqlType fallback. Keep it
+    // nil-faithful so Column#type is null for e.g. composites.
+    super(typeMetadata);
     this.oid = options.oid ?? null;
     this.fmod = options.fmod ?? null;
-    this.limit = options.limit ?? null;
-    this.precision = options.precision ?? null;
-    this.scale = options.scale ?? null;
   }
 
-  equals(other: TypeMetadata): boolean {
+  override equals(other: unknown): boolean {
     return (
-      this.sqlType === other.sqlType &&
-      this.type === other.type &&
+      other instanceof TypeMetadata &&
+      super.equals(other) &&
       this.oid === other.oid &&
-      this.fmod === other.fmod &&
-      this.limit === other.limit &&
-      this.precision === other.precision &&
-      this.scale === other.scale
+      this.fmod === other.fmod
     );
   }
 
-  hashKey(): string {
-    return JSON.stringify([
-      this.sqlType,
-      this.type,
-      this.oid,
-      this.fmod,
-      this.limit,
-      this.precision,
-      this.scale,
-    ]);
-  }
-
-  deduplicate(): this {
-    return this.deduplicated();
-  }
-
-  /** @internal */
-  protected deduplicated(): this {
-    return this;
+  override toJSON(): TypeMetadataJSON {
+    return { ...super.toJSON(), class: "PostgreSQL::TypeMetadata", oid: this.oid, fmod: this.fmod };
   }
 }
+
+TYPE_METADATA_CLASSES["PostgreSQL::TypeMetadata"] = {
+  fromJSON(data: SqlTypeMetadataJSON): TypeMetadata {
+    const row = data as TypeMetadataJSON;
+    return new TypeMetadata(row, { oid: row.oid, fmod: row.fmod });
+  },
+};

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -48,8 +48,12 @@ export class SqlTypeMetadata implements Deduplicable {
     );
   }
 
+  // Keyed off the serialized form, so a subclass' own state (PG's oid/fmod,
+  // MySQL's extra) is part of the key without an override — Rails gets the
+  // same from Deduplicable's `hash`/`eql?` reaching through `__getobj__`
+  // (postgresql/type_metadata.rb:24-31, mysql/type_metadata.rb:23-30).
   deduplicateKey(): string {
-    return JSON.stringify([this.sqlType, this.type, this.limit, this.precision, this.scale]);
+    return JSON.stringify(this.toJSON());
   }
 
   toJSON(): SqlTypeMetadataJSON {
@@ -62,7 +66,19 @@ export class SqlTypeMetadata implements Deduplicable {
     };
   }
 
+  /**
+   * Psych's restore step for the `sql_type_metadata` payload
+   * `Column#encodeWith` writes: allocate the class the document names, then
+   * fill it. Rails gets the class from YAML's `!ruby/object:` tag — an adapter
+   * `TypeMetadata` is a `DelegateClass(SqlTypeMetadata)` tagged with its own
+   * class, so `PostgreSQL::TypeMetadata` round-trips with its own ivars
+   * (postgresql/type_metadata.rb:7, mysql/type_metadata.rb:6). JSON carries no
+   * tag, so {@link TYPE_METADATA_CLASSES} dispatches on the `class` key, the
+   * same way `rehydrateColumn` (schema-cache.ts) dispatches the Column tag.
+   */
   static fromJSON(data: SqlTypeMetadataJSON): SqlTypeMetadata {
+    const klass = TYPE_METADATA_CLASSES[data.class ?? ""];
+    if (klass) return klass.fromJSON(data);
     return new SqlTypeMetadata({
       sqlType: data.sqlType,
       type: data.type,
@@ -87,9 +103,26 @@ export class SqlTypeMetadata implements Deduplicable {
 }
 
 export interface SqlTypeMetadataJSON {
+  /** JSON's stand-in for YAML's `!ruby/object:` tag. Absent on a base
+   *  `SqlTypeMetadata`, whose class is the fallback. */
+  class?: string;
   sqlType: string | null;
   type: string | undefined;
   limit: number | null;
   precision: number | null;
   scale: number | null;
 }
+
+/**
+ * The `SqlTypeMetadata` subclasses a dump can name, keyed by the `class` tag
+ * their `toJSON` writes. Each subclass module registers itself here, so this
+ * module takes no import on them and the `extends` edge stays acyclic.
+ *
+ * @noRailsEquivalent PERMANENT: YAML tags an object with its class and Psych
+ * looks it up; a JSON document carries no tag, so the tag is a key and its
+ * resolution a table. Mirrors `COLUMN_CLASSES` in schema-cache.ts.
+ */
+export const TYPE_METADATA_CLASSES: Record<
+  string,
+  { fromJSON(data: SqlTypeMetadataJSON): SqlTypeMetadata }
+> = {};

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -48,10 +48,12 @@ export class SqlTypeMetadata implements Deduplicable {
     );
   }
 
-  // Keyed off the serialized form, so a subclass' own state (PG's oid/fmod,
-  // MySQL's extra) is part of the key without an override — Rails gets the
-  // same from Deduplicable's `hash`/`eql?` reaching through `__getobj__`
-  // (postgresql/type_metadata.rb:24-31, mysql/type_metadata.rb:23-30).
+  /**
+   * Keyed off the serialized form, so a subclass' own state (PG's `oid`/`fmod`,
+   * MySQL's `extra`) is in the key with no override — what Rails gets from
+   * `Deduplicable`'s `hash` / `eql?` reaching through `__getobj__`
+   * (postgresql/type_metadata.rb:24-31, mysql/type_metadata.rb:23-30).
+   */
   deduplicateKey(): string {
     return JSON.stringify(this.toJSON());
   }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -904,7 +904,10 @@ export abstract class SchemaDumper {
    * createTable block. Mirrors Rails' `SchemaDumper#check_constraints_in_create`:
    * only the validated constraints go inline; the not-valid ones are returned as
    * the `remaining` block of `ctx.addCheckConstraint(...)` calls the caller
-   * prints after the block.
+   * prints after the block. Rails' `remaining` StringIO takes one `puts`
+   * (schema_dumper.rb:303), so its analogue is one joined block — the shape the
+   * valid arm pushes (`:292`) — rather than a stream object: `table()` already
+   * treats a pushed entry containing newlines as one block.
    * @internal
    *
    * @missingRailsCall any? — PERMANENT: Ruby's block-less `any?` (schema_dumper.rb:284) is
@@ -952,11 +955,6 @@ export abstract class SchemaDumper {
         const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
         return `  await ctx.addCheckConstraint(${tableNameStr}, ${expr}${optStr});`;
       });
-      // Rails' `remaining` StringIO holds ONE `puts`
-      // (schema_dumper.rb:303), so its analogue here is one joined block —
-      // the same shape the valid arm pushes — rather than a stream object:
-      // `table()` already treats a pushed entry containing newlines as one
-      // block, which is all `remaining` ever carried.
       return [addCheckConstraintStatements.sort().join("\n")];
     }
     return undefined;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -903,7 +903,7 @@ export abstract class SchemaDumper {
    * Emit inline check-constraint `t.checkConstraint(...)` lines inside the
    * createTable block. Mirrors Rails' `SchemaDumper#check_constraints_in_create`:
    * only the validated constraints go inline; the not-valid ones are returned as
-   * the `remaining` stream of `ctx.addCheckConstraint(...)` calls the caller
+   * the `remaining` block of `ctx.addCheckConstraint(...)` calls the caller
    * prints after the block.
    * @internal
    *
@@ -952,7 +952,12 @@ export abstract class SchemaDumper {
         const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
         return `  await ctx.addCheckConstraint(${tableNameStr}, ${expr}${optStr});`;
       });
-      return addCheckConstraintStatements.sort();
+      // Rails' `remaining` StringIO holds ONE `puts`
+      // (schema_dumper.rb:303), so its analogue here is one joined block —
+      // the same shape the valid arm pushes — rather than a stream object:
+      // `table()` already treats a pushed entry containing newlines as one
+      // block, which is all `remaining` ever carried.
+      return [addCheckConstraintStatements.sort().join("\n")];
     }
     return undefined;
   }

--- a/scripts/api-compare/build.test.ts
+++ b/scripts/api-compare/build.test.ts
@@ -354,10 +354,10 @@ describe("reconcileFileText", () => {
     const expectations = new Map([anyClass("bar", ["bar"], new Set(["save"]))]);
     const r = reconcileFileText("foo.ts", FILE, expectations, () => DEFAULT_TAG_REASON);
     expect(r.harvested.map((h) => h.entry.reason)).toEqual(["placeholder to drop"]);
-    expect(r.preserved).toEqual([]);
+    expect(r.inert).toEqual([]);
   });
 
-  it("preserves a pre-existing tag on a declaration the artifact knows nothing about", () => {
+  it("reports a pre-existing tag on a declaration the artifact knows nothing about as inert", () => {
     // The PR #6873 loss: migrating one method's rows rewrote the JSDoc of every
     // declaration in the file, and a reviewed receipt on an unrelated one — with
     // no baseline row anywhere to put it back — was deleted on a `harvested`
@@ -380,13 +380,35 @@ describe("reconcileFileText", () => {
     expect(r.text!).toContain("@missingRailsCall save — PERMANENT: x");
     expect(r.text!).toContain("@missingRailsCall with_raw_connection — PERMANENT: escapes inline.");
     expect(r.harvested).toEqual([]);
-    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([
+    expect(r.inert.map((p) => [p.tsName, p.entry.call])).toEqual([
       ["quoteString", "with_raw_connection"],
     ]);
     // And a second run over the result is still a no-op.
     expect(
       reconcileFileText("foo.ts", r.text!, expectations, () => "PERMANENT: x").text,
     ).toBeNull();
+  });
+
+  it("names the file:line an inert tag is written on", () => {
+    // The INERT report has to name a site the operator can open: the tag is on
+    // a declaration with no Rails counterpart, so nothing else in the run
+    // points at it (RFC 0106).
+    const src = [
+      "export class Foo {",
+      "  /**",
+      "   * Mirrors Rails `Foo#bar`.",
+      "   */",
+      "  bar(): void {}",
+      "",
+      "  /**",
+      "   * @missingRailsCall with_raw_connection — PERMANENT: escapes inline.",
+      "   */",
+      "  _quoteStringTs(): void {}",
+      "}",
+    ].join("\n");
+    const expectations = new Map([owned("Foo", "bar", new Set(["save"]))]);
+    const r = reconcileFileText("foo.ts", src, expectations, () => "PERMANENT: x");
+    expect(r.inert.map((p) => [p.tsName, p.entry.line])).toEqual([["_quoteStringTs", 8]]);
   });
 
   it("retires a tag compare.ts reports stale, and only that one", () => {
@@ -417,7 +439,7 @@ describe("reconcileFileText", () => {
     expect(r.text!).not.toContain("@missingRailsCall logger");
     expect(r.text!).toContain("@missingRailsCall with_raw_connection — PERMANENT: escapes inline.");
     expect(r.harvested.map((h) => [h.tsName, h.entry.call])).toEqual([["bar", "logger"]]);
-    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([
+    expect(r.inert.map((p) => [p.tsName, p.entry.call])).toEqual([
       ["quoteString", "with_raw_connection"],
     ]);
   });
@@ -450,7 +472,7 @@ describe("reconcileFileText", () => {
     expect(r.text!).toContain("@missingRailsCall logger — PERMANENT: reviewed elsewhere.");
     expect(r.text!).not.toContain("@missingRailsCall logger — PERMANENT: no logger yet.");
     expect(r.harvested.map((h) => [h.tsName, h.entry.call])).toEqual([["bar", "logger"]]);
-    expect(r.preserved.map((p) => [p.tsName, p.entry.call])).toEqual([["bar", "logger"]]);
+    expect(r.inert.map((p) => [p.tsName, p.entry.call])).toEqual([["bar", "logger"]]);
   });
 
   it("is idempotent: a second run produces zero edits", () => {
@@ -967,7 +989,7 @@ describe("@missingRailsArgs receipts (--kind args)", () => {
       ARGS_TAG,
     );
     expect(r.text!).not.toContain(ARGS_TAG);
-    expect(r.preserved).toEqual([]);
+    expect(r.inert).toEqual([]);
   });
 
   it("justifiesArgs demands a permanence claim the call-set tag does not", () => {

--- a/scripts/api-compare/build.ts
+++ b/scripts/api-compare/build.ts
@@ -17,7 +17,8 @@
  *   - tags for now-satisfied calls are dropped (human-authored reasons are
  *     harvested to stdout, never destroyed unseen). A call is "now-satisfied"
  *     only where the artifact carries an expectation for the declaration; a tag
- *     on a declaration the artifact says nothing about is preserved verbatim;
+ *     on a declaration the artifact says nothing about is preserved verbatim
+ *     and reported INERT — it suppresses nothing and never will (RFC 0106);
  *   - existing tags that still apply are kept byte-for-byte (idempotent:
  *     a second run produces zero edits);
  *   - a tag with no reason fails the run (see the empty-reason contract in
@@ -506,9 +507,13 @@ export function reconcileFileText(
    *  declaration the artifact does know — a genuine convergence, reported so
    *  the receipt does not vanish unseen. */
   harvested: { tsName: string; entry: TagEntry }[];
-  /** Tags left exactly as written on a declaration the artifact carries no
-   *  expectation for. Nothing here was migrated, and nothing here was dropped. */
-  preserved: { tsName: string; entry: TagEntry }[];
+  /** Tags on a declaration the artifact carries no expectation for: compare.ts
+   *  matched no Ruby method onto it, so the tag suppresses nothing and never
+   *  will. Distinct from a STALE tag, which DID suppress a flag that has since
+   *  converged. Left exactly as written — nothing here was migrated, and
+   *  nothing here was dropped — and reported so the tree can be swept
+   *  (RFC 0106). */
+  inert: { tsName: string; entry: TagEntry }[];
   /** Every (rubyName, call) the file now tags with a real justification — kept
    *  and newly-added alike. These are the baseline rows the tag supersedes, so
    *  `main` drops them from the split baseline in the same operation (RFC
@@ -527,7 +532,7 @@ export function reconcileFileText(
   const sf = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
   const edits: Edit[] = [];
   const harvested: { tsName: string; entry: TagEntry }[] = [];
-  const preserved: { tsName: string; entry: TagEntry }[] = [];
+  const inert: { tsName: string; entry: TagEntry }[] = [];
   const tagged: { rubyName: string; call: string }[] = [];
   const seen = new Set<string>();
   const skipped: string[] = [];
@@ -591,7 +596,7 @@ export function reconcileFileText(
         onlyCall,
       );
       if (!exp) {
-        preserved.push(
+        inert.push(
           ...entries
             .filter((entry) => !isStale(entry.call))
             .map((entry) => ({ tsName: name, entry })),
@@ -635,12 +640,12 @@ export function reconcileFileText(
     .filter(([k]) => !seen.has(k))
     .map(([, e]) => e.tsName)
     .sort();
-  if (edits.length === 0) return { text: null, harvested, preserved, tagged, unmatched, skipped };
+  if (edits.length === 0) return { text: null, harvested, inert, tagged, unmatched, skipped };
   let out = text;
   for (const e of edits.sort((a, b) => b.start - a.start)) {
     out = out.slice(0, e.start) + e.text + out.slice(e.end);
   }
-  return { text: out, harvested, preserved, tagged, unmatched, skipped };
+  return { text: out, harvested, inert, tagged, unmatched, skipped };
 }
 
 /** (tsFile → tsName → expectation) for one package: every call the artifact
@@ -1003,14 +1008,7 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parity:api:build: ${err instanceof Error ? err.message : String(err)}`);
         return 1;
       }
-      const {
-        text: next,
-        harvested,
-        preserved,
-        tagged,
-        unmatched,
-        skipped: fileSkipped,
-      } = reconciled;
+      const { text: next, harvested, inert, tagged, unmatched, skipped: fileSkipped } = reconciled;
       skipped += fileSkipped.length;
       for (const t of tagged) migrated.add(keyOf({ package: pkg, tsFile, ...t }));
       for (const h of harvested) {
@@ -1019,10 +1017,13 @@ async function main(argv: string[]): Promise<number> {
             `longer flagged there, so its receipt is retired. Reason it carried: ${h.entry.reason}`,
         );
       }
-      for (const kept of preserved) {
+      for (const dead of inert) {
+        const at = dead.entry.line === undefined ? declFile : `${declFile}:${dead.entry.line}`;
         console.log(
-          `preserved ${tag} on ${declFile} ${kept.tsName} for \`${kept.entry.call}\` — no ` +
-            "expectation for that declaration in the artifact; the tag is left exactly as written.",
+          `INERT ${tag} at ${at} on ${dead.tsName} for \`${dead.entry.call}\` — no expectation ` +
+            "for that declaration in the artifact, so the tag suppresses nothing and never " +
+            "will; delete it, or re-site it on the declaration whose flag it is meant to " +
+            "suppress. Left exactly as written.",
         );
       }
       if (unmatched.length > 0) {

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 390,
-    "total": 1408
+    "novel": 388,
+    "total": 1398
   },
   "arel": {
     "novel": 0,

--- a/scripts/api-compare/missing-rails-call-tags.ts
+++ b/scripts/api-compare/missing-rails-call-tags.ts
@@ -50,6 +50,10 @@ export interface TagEntry {
   call: string;
   reason: string;
   rawLines: string[];
+  /** 1-based line in the declaring file this tag was written on, when
+   *  `parseJsdoc` was given an origin — so a consumer can report the tag at a
+   *  `file:line` the operator can open (RFC 0106). */
+  line?: number;
   /** Index in `parseJsdoc`'s `rest` this tag was lifted from, so `renderJsdoc`
    *  can put it back where it stood even when prose separates it from its
    *  same-family neighbours (RFC 0106). Absent on a newly minted entry. */
@@ -182,6 +186,7 @@ export function parseJsdoc(
         reason: (m[2] ?? "").trim(),
         rawLines: synthetic ? [] : [line],
         slot: rest.length,
+        line: origin ? origin.startLine + sourceIndex : undefined,
       };
       entries.push(open);
       tagLineOf.set(open, sourceIndex);


### PR DESCRIPTION
Four related convergences.

### 1. INERT `@missingRailsCall` tags (RFC 0106)

`parity:api:build` preserved a tag on a declaration the compare artifact carries
no expectation for, and reported it as `preserved` — indistinguishable from a
tag doing work. Such a tag suppresses nothing and never will: compare.ts matched
no Ruby method onto the declaration, so it raises no flag there.

It is now reported as **INERT**, distinct from STALE (which means "it did
suppress, and no longer needs to"), with the `file:line` of the tag —
`TagEntry` carries the source line `parseJsdoc` already knew.

The three tags the report surfaces are deleted, not re-justified:

- `associations/disable-joins-association-scope.ts` `_addConstraintsDj` — its
  content is already carried verbatim on `scope`, where the flag is raised
  (`disable_joins_association_scope.rb:14`).
- `postgresql-adapter.ts` `quote` / `quoteString` — duplicates of receipts
  correctly sited in `postgresql/quoting.ts` (one of which the duplicate
  contradicted, claiming PERMANENT where the live one says CONVERGEABLE).

### 2. Adapter `TypeMetadata` round-trip (RFC 0096)

Rails' adapter `Column` subclasses do not persist `oid` / `fmod` / `extra` —
they delegate to `sql_type_metadata` (`postgresql/column.rb:7`,
`mysql/column.rb:7`), which the base `encode_with` persists, and YAML tags that
object with its class so `PostgreSQL::TypeMetadata` round-trips with its own
ivars.

- `PostgreSQL::TypeMetadata` / `MySQL::TypeMetadata` now extend
  `SqlTypeMetadata` — TypeScript's equivalent of Ruby's
  `DelegateClass(SqlTypeMetadata)` forwarding.
- Their `toJSON` writes a `class` tag; `SqlTypeMetadata.fromJSON` dispatches on
  it through `TYPE_METADATA_CLASSES`, mirroring how `rehydrateColumn`
  dispatches the Column tag. Each subclass module registers itself, so the base
  takes no import on them and the `extends` edge stays acyclic.
- `deduplicateKey` now keys off `toJSON()`, so a subclass' own state is in the
  key with no override — what Rails gets from `Deduplicable` reaching through
  `__getobj__`.
- `PostgreSQL::Column#oid` / `#fmod` and `MySQL::Column#extra` are getters
  delegating to the metadata object; the coder key sets are unchanged, so
  `converge-column-subclass-coders-to-rails-per-subclass-key-sets` becomes a
  pure deletion.

### 3. `check_constraints_in_create`'s invalid arm (RFC 0051)

Both arms now produce their block through one `sort().join("\n")`
(`schema_dumper.rb:292` and `:303`). The one-joined-block form IS the settled
port of `StringIO` + a single `puts` — `table()` already treats a pushed entry
containing newlines as one block — stated at the call site. Emitted dump text
is byte-identical.

### 4. PG `renameTable` (RFC 0051)

- Passes `newName` to `pkAndSequenceFor` (`schema_statements.rb:440`); the
  invented `renamedName` local and the schema re-qualification are gone, and the
  standing `naming` row (`ref:newName` vs `ref:renamedName`) is gone from
  `parity:api --calls`.
- The call-site `.catch(() => null)` is dropped: `pkAndSequenceFor` already
  carries Rails' `rescue nil` (`schema_statements.rb:408`).
- Quotes with `quoteTableName` at Rails' three sites (`:441`, `:446`, `:452`),
  which subsumes the hand-built qualified index name — `quote_table_name` splits
  the dot itself.

### Verification

`pnpm parity:api:calls`, `:args` and `parity:api:extra:gate` green (the
extra-surface mark narrowed 390→388 / 1408→1398 by deletion — `:tighten`, never
raised). Lint, typecheck, `scripts/`, the adapter suites and the AR
schema/migration slice pass locally; MySQL/PG lanes run in CI.

Closes-story: missing-rails-call-tag-inert-on-non-rails-class-member
Closes-story: converge-adapter-type-metadata-coder-round-trip
Closes-story: check-constraints-in-create-invalid-arm-skips-the-remaining-stream-join
Closes-story: pg-rename-table-rebuilds-qualified-name-for-pk-and-sequence-for
