### PR TITLE
refactor(activemodel,arel,activerecord): converge AttributeSet#deepDup onto Ruby dup, arel tests onto FakeRecord, MySQL TypeMetadata#extra nil

### DIFF
--- a/packages/activemodel/src/attribute-set.test.ts
+++ b/packages/activemodel/src/attribute-set.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
+import { Builder } from "./attribute-set/builder.js";
 import { typeRegistry } from "./type/registry.js";
 
 describe("AttributeSetTest", () => {
@@ -50,15 +51,23 @@ describe("AttributeSetTest", () => {
   });
 
   it("deep_duping creates a new hash and dups each attribute", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    const attrs = { ...p.attributes };
-    attrs.name = "Bob";
-    expect(p._readAttribute("name")).toBe("Alice");
+    const builder = new Builder(
+      new Map([
+        ["foo", typeRegistry.lookup("integer")],
+        ["bar", typeRegistry.lookup("string")],
+      ]),
+    );
+    const attributes = builder.buildFromDatabase({ foo: 1, bar: "foo" });
+
+    void attributes.getAttribute("foo").value;
+    void attributes.getAttribute("bar").value;
+
+    const duped = attributes.deepDup();
+    duped.writeFromDatabase("foo", 2);
+
+    expect(attributes.getAttribute("foo").value).toBe(1);
+    expect(duped.getAttribute("foo").value).toBe(2);
+    expect(attributes.getAttribute("bar").value).toBe("foo");
   });
 
   it("freezing cloned set does not freeze original", () => {

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -193,12 +193,9 @@ export class AttributeSet {
     this._attributes.set(name, this.getAttribute(name).withCastValue(value));
   }
 
+  /** Mirrors: attribute_set.rb:72-74. */
   deepDup(): AttributeSet {
-    let cache: Map<Attribute, Attribute> | undefined;
-    const newAttributes = transformValues(this.attributes(), (attr) =>
-      this.cloneAttribute(attr, (cache ??= new Map())),
-    );
-    return new AttributeSet(newAttributes);
+    return new AttributeSet(transformValues(this.attributes(), (attr) => attr.deepDup()));
   }
 
   reset(key: string): void {
@@ -216,12 +213,16 @@ export class AttributeSet {
     return new AttributeSet(newAttributes);
   }
 
+  /**
+   * Mirrors: `attributes.reverse_merge!(target_attributes.attributes) && self`
+   * (attribute_set.rb:100-102) — Hash#reverse_merge! copies references and
+   * clones nothing.
+   */
   reverseMergeBang(target: AttributeSet): this {
     this.assertNotFrozen();
-    const cache = new Map<Attribute, Attribute>();
     for (const [name, attr] of target.attributes()) {
       if (!this.isKey(name)) {
-        this._attributes.set(name, this.cloneAttribute(attr, cache));
+        this._attributes.set(name, attr);
       }
     }
     return this;
@@ -308,33 +309,6 @@ export class AttributeSet {
       err.name = "FrozenError";
       throw err;
     }
-  }
-
-  /**
-   * `Object#deep_dup` for one Attribute — `attributes.transform_values(&:deep_dup)`
-   * in `deep_dup` (attribute_set.rb:72-74). The cache keeps a shared
-   * `original_attribute` shared in the copy, as Ruby's object graph does.
-   */
-  private cloneAttribute(attr: Attribute, cache: Map<Attribute, Attribute>): Attribute {
-    const existing = cache.get(attr);
-    if (existing) return existing;
-
-    // UserProvidedDefault needs a fresh construction so function defaults
-    // re-evaluate per instance — matching Rails' Proc-per-deep_dup behavior.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const asAny = attr as Record<string, any>;
-    const cloned =
-      typeof asAny.dupForDeepClone === "function"
-        ? asAny.dupForDeepClone()
-        : Object.assign(Object.create(Object.getPrototypeOf(attr)), attr);
-    cache.set(attr, cloned);
-
-    const orig = attr.getOriginalAttribute();
-    if (orig) {
-      cloned.setOriginalAttribute(this.cloneAttribute(orig, cache));
-    }
-
-    return cloned;
   }
 
   /**

--- a/packages/activemodel/src/attribute.trails.test.ts
+++ b/packages/activemodel/src/attribute.trails.test.ts
@@ -203,4 +203,33 @@ describe("Attribute — trails-only coverage", () => {
       expect(attr.valueForDatabase).toBe('{"x":99}');
     });
   });
+  describe("#deepDup", () => {
+    it("shares originalAttribute by reference, as Attribute#initialize_dup does", () => {
+      const type = typeRegistry.lookup("string");
+      const original = Attribute.fromDatabase("name", "Alice", type);
+      const assigned = original.withValueFromUser("Bob");
+
+      const duped = assigned.deepDup();
+
+      expect(duped).not.toBe(assigned);
+      expect(duped.getOriginalAttribute()).toBe(assigned.getOriginalAttribute());
+      expect(duped.originalValue).toBe("Alice");
+      expect(duped.isChanged()).toBe(true);
+    });
+
+    it("dups the memoized cast value so an in-place mutation does not bleed back", () => {
+      const type = Object.create(typeRegistry.lookup("value")) as {
+        deserialize(v: unknown): unknown;
+      };
+      type.deserialize = (v: unknown) => (typeof v === "string" ? JSON.parse(v) : v);
+
+      const attr = Attribute.fromDatabase("data", '["a"]', type as never);
+      void attr.value;
+      const duped = attr.deepDup();
+      (duped.value as string[]).push("b");
+
+      expect(attr.value).toEqual(["a"]);
+      expect(duped.value).toEqual(["a", "b"]);
+    });
+  });
 });

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -2,6 +2,28 @@ import { Type } from "./type/value.js";
 import { defaultValue } from "./type.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 import { RuntimeError } from "./attribute-assignment.js";
+import { isDuplicable } from "@blazetrails/activesupport";
+
+/**
+ * Ruby `Object#dup` on the memoized cast value — the shallow copy
+ * `@value = @value.dup` makes in `Attribute#initialize_dup`
+ * (attribute.rb:155-157). Ruby's immutable-ish scalars are already immutable in
+ * JS, so only the mutable built-ins need a copy. Not exported: Ruby gets `dup`
+ * from Object, so it is not part of Attribute's surface.
+ */
+function dupValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.slice();
+  if (value instanceof Map) return new Map(value);
+  if (value instanceof Set) return new Set(value);
+  if (typeof value === "object" && value !== null) {
+    // A copy is only safe for a plain object: a built-in with internal slots
+    // (Temporal, BigDecimal) throws on a slot-less clone, and every such value
+    // in a cast attribute is immutable anyway, so Ruby's `dup` of it is unobservable.
+    const proto = Object.getPrototypeOf(value) as object | null;
+    if (proto === Object.prototype || proto === null) return { ...value };
+  }
+  return value;
+}
 
 /**
  * Symbol so identity comparisons work across module copies and can't collide with any user value.
@@ -229,6 +251,27 @@ export abstract class Attribute {
   private changedFromAssignment(): boolean {
     if (!this.isAssigned()) return false;
     return this.type.isChanged(this.originalValue, this.value, this.valueBeforeTypeCast);
+  }
+
+  /**
+   * `Object#deep_dup` for an Attribute — `duplicable? ? dup : self`
+   * (activesupport/lib/active_support/core_ext/object/deep_dup.rb:16), which is
+   * what `attributes.transform_values(&:deep_dup)` reaches
+   * (attribute_set.rb:72-74). Ruby's `dup` shallow-copies every ivar and then
+   * runs {@link initializeDup}, so `@original_attribute` is carried into the
+   * copy by reference.
+   */
+  deepDup(): Attribute {
+    const dup = Object.assign(Object.create(Object.getPrototypeOf(this) as object), this) as this;
+    dup.initializeDup(this);
+    return dup;
+  }
+
+  /** Mirrors: `def initialize_dup(other)` (attribute.rb:155-157). */
+  private initializeDup(_other: Attribute): void {
+    if (this._hasValue && isDuplicable(this._value)) {
+      this._value = dupValue(this._value);
+    }
   }
 
   /**

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -7,18 +7,20 @@ import { isDuplicable } from "@blazetrails/activesupport";
 /**
  * Ruby `Object#dup` on the memoized cast value — the shallow copy
  * `@value = @value.dup` makes in `Attribute#initialize_dup`
- * (attribute.rb:155-157). Ruby's immutable-ish scalars are already immutable in
- * JS, so only the mutable built-ins need a copy. Not exported: Ruby gets `dup`
- * from Object, so it is not part of Attribute's surface.
+ * (attribute.rb:155-157). Not exported: Ruby gets `dup` from Object, so it is
+ * not part of Attribute's surface.
+ *
+ * Only Ruby's mutable built-ins need a copy here; the scalars are already
+ * immutable in JS. The generic-object arm is restricted to a plain object
+ * because a built-in carrying internal slots (Temporal) throws on a slot-less
+ * clone, and every such value in a cast attribute is immutable anyway, so
+ * Ruby's `dup` of it is unobservable.
  */
 function dupValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.slice();
   if (value instanceof Map) return new Map(value);
   if (value instanceof Set) return new Set(value);
   if (typeof value === "object" && value !== null) {
-    // A copy is only safe for a plain object: a built-in with internal slots
-    // (Temporal, BigDecimal) throws on a slot-less clone, and every such value
-    // in a cast attribute is immutable anyway, so Ruby's `dup` of it is unobservable.
     const proto = Object.getPrototypeOf(value) as object | null;
     if (proto === Object.prototype || proto === null) return { ...value };
   }
@@ -267,9 +269,13 @@ export abstract class Attribute {
     return dup;
   }
 
-  /** Mirrors: `def initialize_dup(other)` (attribute.rb:155-157). */
+  /**
+   * Mirrors: `def initialize_dup(other)` (attribute.rb:155-157). The guard
+   * reads the memo field rather than the `value` getter, because Ruby's
+   * `@value&.duplicable?` reads the ivar — nil until something forces the cast.
+   */
   private initializeDup(_other: Attribute): void {
-    if (this._hasValue && isDuplicable(this._value)) {
+    if (isDuplicable(this._value)) {
       this._value = dupValue(this._value);
     }
   }

--- a/packages/activemodel/src/attribute/user-provided-default.ts
+++ b/packages/activemodel/src/attribute/user-provided-default.ts
@@ -8,8 +8,8 @@ import { Type } from "../type/value.js";
  *
  * Rails stores the raw Proc in @user_provided_value and lazily evaluates it
  * via value_before_type_cast. The class-level _default_attributes cache holds
- * unevaluated UserProvidedDefault instances; each deep_dup creates a fresh
- * copy that re-evaluates the Proc, giving each model instance its own default.
+ * unevaluated UserProvidedDefault instances, so each `deep_dup` copy memoizes
+ * the Proc's result for itself — Rails defines no `initialize_dup` here.
  *
  * We pass a sentinel to the super constructor so valueBeforeTypeCast is never
  * read from the base class — all access goes through our override.
@@ -51,22 +51,6 @@ export class UserProvidedDefault extends FromUser {
 
   static marshalLoad(data: [string, unknown, Type, Attribute | null]): UserProvidedDefault {
     return new UserProvidedDefault(data[0], data[1], data[2], data[3]);
-  }
-
-  /**
-   * Create a fresh instance from the original function/value so function
-   * defaults re-evaluate — called by AttributeSet.deepDup.
-   */
-  dupForDeepClone(): UserProvidedDefault {
-    // Functions re-evaluate on each construction. Non-function objects need
-    // cloning to prevent cross-instance mutation (JS has no Ruby-style dup
-    // that copies value semantics for built-in types).
-    const val = this.userProvidedValue;
-    const clonedVal =
-      typeof val === "function" || val === null || typeof val !== "object"
-        ? val
-        : structuredClone(val);
-    return new UserProvidedDefault(this.name, clonedVal, this.type, this.originalAttribute);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -52,4 +52,14 @@ describe("MySQL::TypeMetadata JSON round-trip", () => {
     restored.initWith(JSON.parse(JSON.stringify(coder)));
     expect(restored.extra).toBe("auto_increment");
   });
+
+  it("is null when no extra was given, mirroring `extra: nil` / `allow_nil: true`", () => {
+    const meta = new TypeMetadata({ sqlType: "varchar(255)", type: "string", limit: 255 });
+    expect(meta.extra).toBeNull();
+
+    const col = new MysqlColumn("name", null, { sqlType: "varchar(255)", type: "string" });
+    expect(col.extra).toBeNull();
+    expect(col.isAutoIncrement()).toBe(false);
+    expect(col.isVirtual()).toBe(false);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -22,7 +22,7 @@ export class Column extends BaseColumn {
       limit?: number | null;
       precision?: number | null;
       scale?: number | null;
-      extra?: string;
+      extra?: string | null;
     } = {},
     null_: boolean = true,
     options: {
@@ -60,8 +60,8 @@ export class Column extends BaseColumn {
    *
    *  Mirrors: `delegate :extra, to: :sql_type_metadata, allow_nil: true`
    *  (mysql/column.rb:7). */
-  get extra(): string {
-    return (this.sqlTypeMetadata as TypeMetadata | null)?.extra ?? "";
+  get extra(): string | null {
+    return (this.sqlTypeMetadata as TypeMetadata | null)?.extra ?? null;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -27,6 +27,12 @@ export interface TypeMetadataJSON extends SqlTypeMetadataJSON {
  * `__getobj__`.
  */
 export class TypeMetadata extends SqlTypeMetadata {
+  /**
+   * `attr_reader :extra`, whose `initialize` default is `extra: nil`
+   * (mysql/type_metadata.rb:12-16) — `null` where none was given, not a `""`
+   * stand-in. `fetch_type_metadata`'s own `extra = ""` default
+   * (mysql/schema_statements.rb:221-223) is what live introspection passes.
+   */
   readonly extra: string | null;
 
   constructor(
@@ -43,8 +49,6 @@ export class TypeMetadata extends SqlTypeMetadata {
     // SqlTypeMetadata, which is nil for an unmapped sql_type — no sqlType
     // fallback. Keep it nil-faithful.
     super(typeMetadata);
-    // `def initialize(type_metadata, extra: nil)` (mysql/type_metadata.rb:13-16) —
-    // `nil` where none was given, not a `""` stand-in.
     this.extra = options.extra ?? null;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -17,7 +17,7 @@ import {
 /** The `class`-tagged payload `toJSON` writes, so `extra` survives the
  *  schema-cache round trip the way Ruby's YAML tag carries it. */
 export interface TypeMetadataJSON extends SqlTypeMetadataJSON {
-  extra: string;
+  extra: string | null;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface TypeMetadataJSON extends SqlTypeMetadataJSON {
  * `__getobj__`.
  */
 export class TypeMetadata extends SqlTypeMetadata {
-  readonly extra: string;
+  readonly extra: string | null;
 
   constructor(
     typeMetadata: {
@@ -37,13 +37,15 @@ export class TypeMetadata extends SqlTypeMetadata {
       precision?: number | null;
       scale?: number | null;
     },
-    options: { extra?: string } = {},
+    options: { extra?: string | null } = {},
   ) {
     // Rails' MySQL TypeMetadata delegates `type` to the wrapped
     // SqlTypeMetadata, which is nil for an unmapped sql_type — no sqlType
     // fallback. Keep it nil-faithful.
     super(typeMetadata);
-    this.extra = options.extra ?? "";
+    // `def initialize(type_metadata, extra: nil)` (mysql/type_metadata.rb:13-16) —
+    // `nil` where none was given, not a `""` stand-in.
+    this.extra = options.extra ?? null;
   }
 
   override equals(other: unknown): boolean {

--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors, Collectors } from "./index.js";
 
 const users = new Table("users");
-const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
+const compile = (n: Nodes.Node): string => new Visitors.ToSql(fakeRecordConnection).compile(n);
 
 describe("Attribute aggregates return typed Function subclasses", () => {
   it("count compiles to COUNT(...) and is a Count", () => {
@@ -96,7 +96,7 @@ describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
   // collector.retryable to false.
 
   const collectorIsRetryableAfter = (n: Nodes.Node): boolean =>
-    new Visitors.ToSql(testConnection).accept(n, new Collectors.SQLString()).retryable;
+    new Visitors.ToSql(fakeRecordConnection).accept(n, new Collectors.SQLString()).retryable;
 
   it("Attribute#as keeps the collector retryable", () => {
     expect(collectorIsRetryableAfter(users.get("id").as("aliased"))).toBe(true);

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, star, Nodes, Visitors } from "../index.js";
 import { Attribute } from "./attribute.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
 
 describe("AttributeTest", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql(testConnection);
+  const visitor = new Visitors.ToSql(fakeRecordConnection);
 
   // Mirrors Rails' private `quoted_range` (attribute_test.rb:1163-1169).
   function quotedRange(beginVal: unknown, endVal: unknown, exclude: boolean) {
@@ -1094,7 +1094,9 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq("1");
 
       expect(table.isAbleToTypeCast()).toBeFalsy();
-      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = \'1\'');
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(condition)).toBe(
+        '"foo"."id" = \'1\'',
+      );
     });
 
     it("type casts when given an explicit caster", () => {
@@ -1107,7 +1109,7 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq("1").and(table.get("other_id").eq("2"));
 
       expect(table.isAbleToTypeCast()).toBe(true);
-      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe(
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(condition)).toBe(
         '"foo"."id" = 1 AND "foo"."other_id" = \'2\'',
       );
     });
@@ -1122,7 +1124,9 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq(new Nodes.SqlLiteral("(select 1)"));
 
       expect(table.isAbleToTypeCast()).toBe(true);
-      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = (select 1)');
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(condition)).toBe(
+        '"foo"."id" = (select 1)',
+      );
     });
   });
 

--- a/packages/arel/src/attributes/math.test.ts
+++ b/packages/arel/src/attributes/math.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Visitors } from "../index.js";
 
 describe("MathTest", () => {
-  const visitor = new Visitors.ToSql(testConnection);
+  const visitor = new Visitors.ToSql(fakeRecordConnection);
   const table = new Table("users");
 
   // These test names match the Ruby convention (interpolation-stripped names)
@@ -246,35 +246,41 @@ describe("MathTest", () => {
 
   it("average should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").average().divide(2));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+      table.get("id").average().divide(2),
+    );
     expect(sql).toContain("AVG");
     expect(sql).toContain("/");
   });
 
   it("count should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").count().divide(2));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(table.get("id").count().divide(2));
     expect(sql).toContain("COUNT");
     expect(sql).toContain("/");
   });
 
   it("maximum should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").maximum().divide(2));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+      table.get("id").maximum().divide(2),
+    );
     expect(sql).toContain("MAX");
     expect(sql).toContain("/");
   });
 
   it("minimum should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").minimum().divide(2));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+      table.get("id").minimum().divide(2),
+    );
     expect(sql).toContain("MIN");
     expect(sql).toContain("/");
   });
 
   it("attribute node should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").divide(2));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(table.get("id").divide(2));
     expect(sql).toContain("/");
   });
 });

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 import { Nodes, Visitors } from "./index.js";
 
-const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
+const compile = (n: Nodes.Node): string => new Visitors.ToSql(fakeRecordConnection).compile(n);
 
 // Behavior tests for the mixin surface added in this PR — Expressions,
 // AliasPredication, OrderPredications, FilterPredications,

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("TestFactoryMethods", () => {
@@ -49,14 +49,14 @@ describe("TestFactoryMethods", () => {
   it("lower wraps non-Node arguments via buildQuoted", () => {
     const fn = users.lower("name");
     expect(fn.expressions[0]).toBeInstanceOf(Nodes.Quoted);
-    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe("LOWER('name')");
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(fn)).toBe("LOWER('name')");
   });
 
   it("coalesce", () => {
     const fn = users.coalesce(users.get("name"), new Nodes.Quoted("default"));
     expect(fn).toBeInstanceOf(Nodes.NamedFunction);
     expect(fn.name).toBe("COALESCE");
-    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe(
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(fn)).toBe(
       'COALESCE("users"."name", \'default\')',
     );
   });
@@ -68,7 +68,9 @@ describe("TestFactoryMethods", () => {
     // Mirrors Rails: `cast` builds NamedFunction("CAST", [name.as(type)]),
     // not a string-interpolated SqlLiteral. The compiled SQL must reference
     // the column properly rather than "[object Object] AS VARCHAR".
-    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe('CAST("users"."age" AS VARCHAR)');
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(fn)).toBe(
+      'CAST("users"."age" AS VARCHAR)',
+    );
   });
 
   // Mirrors Rails: delegating to `name.as(type)` produces an `As` whose
@@ -86,13 +88,13 @@ describe("TestFactoryMethods", () => {
   it("create true", () => {
     const t = users.createTrue();
     expect(t).toBeInstanceOf(Nodes.True);
-    expect(new Visitors.ToSql(testConnection).compile(t)).toBe("TRUE");
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(t)).toBe("TRUE");
   });
 
   it("create false", () => {
     const f = users.createFalse();
     expect(f).toBeInstanceOf(Nodes.False);
-    expect(new Visitors.ToSql(testConnection).compile(f)).toBe("FALSE");
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(f)).toBe("FALSE");
   });
 
   describe("FactoryMethods is mixed into every Node subclass", () => {

--- a/packages/arel/src/math.test.ts
+++ b/packages/arel/src/math.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("Math", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql(testConnection);
+  const visitor = new Visitors.ToSql(fakeRecordConnection);
 
   describe("operands pass through raw (no Quoted wrapper)", () => {
     const arg = new Nodes.SqlLiteral("42");

--- a/packages/arel/src/nodes/bin.test.ts
+++ b/packages/arel/src/nodes/bin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection, mysqlTestConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection, mysqlTestConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("TestBin", () => {
@@ -22,7 +22,7 @@ describe("TestBin", () => {
 
   it("default to sql", () => {
     const node = new Nodes.Bin(new Nodes.SqlLiteral("zomg"));
-    const sql = new Visitors.ToSql(testConnection).compile(node);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
     expect(sql).toBe("zomg");
   });
 

--- a/packages/arel/src/nodes/case.test.ts
+++ b/packages/arel/src/nodes/case.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("NodesTest", () => {
@@ -20,7 +20,7 @@ describe("NodesTest", () => {
       const caseNode = new Nodes.Case(users.get("status"));
       const withDefault = caseNode.else("unknown");
       expect(withDefault.default).not.toBeNull();
-      expect(new Visitors.ToSql(testConnection).compile(withDefault)).toContain("ELSE");
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(withDefault)).toContain("ELSE");
     });
 
     it("clones case, conditions and default", () => {

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors, Collectors } from "../index.js";
 import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
@@ -60,7 +60,7 @@ describe("Arel::Nodes.build_quoted", () => {
 
     // compileWithBinds should collect it (not inline it) — matches Rails'
     // visit_ActiveModel_Attribute routing through add_bind.
-    const [sql, binds] = compileWithBinds(new Visitors.ToSql(testConnection), node);
+    const [sql, binds] = compileWithBinds(new Visitors.ToSql(fakeRecordConnection), node);
     expect(sql).toBe("?");
     expect(binds).toEqual([amAttr]);
   });
@@ -146,7 +146,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
     expect(new Nodes.Quoted(undefined).isNil()).toBe(true);
 
     const [sql] = compileWithBinds(
-      new Visitors.ToSql(testConnection),
+      new Visitors.ToSql(fakeRecordConnection),
       users.get("id").eq(undefined),
     );
     expect(sql).toBe('"users"."id" IS NULL');
@@ -156,7 +156,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
   // identically to Casted's, so an undefined-valued Quoted spells IS NULL too.
   it("renders IS NULL for a Quoted(undefined) right-hand side", () => {
     const eq = new Nodes.Equality(users.get("id"), new Nodes.Quoted(undefined));
-    const [sql] = compileWithBinds(new Visitors.ToSql(testConnection), eq);
+    const [sql] = compileWithBinds(new Visitors.ToSql(fakeRecordConnection), eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 
@@ -179,7 +179,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
     const eq = attr.eq(null);
     expect(eq.right).toBeInstanceOf(Nodes.Casted);
     expect((eq.right as Nodes.Casted).attribute).toBe(attr);
-    const [sql] = compileWithBinds(new Visitors.ToSql(testConnection), eq);
+    const [sql] = compileWithBinds(new Visitors.ToSql(fakeRecordConnection), eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 });

--- a/packages/arel/src/nodes/count.test.ts
+++ b/packages/arel/src/nodes/count.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::CountTest", () => {
@@ -8,7 +8,7 @@ describe("Arel::Nodes::CountTest", () => {
     it("should alias the count", () => {
       const count = users.get("id").count();
       const aliased = count.as("user_count");
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(aliased)).toBe('COUNT("users"."id") AS user_count');
     });
   });

--- a/packages/arel/src/nodes/equality.test.ts
+++ b/packages/arel/src/nodes/equality.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel", () => {
@@ -67,7 +67,7 @@ describe("Arel", () => {
         it("takes an engine", () => {
           const attr = users.get("id");
           const test = attr.eq(10);
-          const sql = new Visitors.ToSql(testConnection).compile(test);
+          const sql = new Visitors.ToSql(fakeRecordConnection).compile(test);
           expect(sql).toContain('"users"."id"');
           expect(sql).toContain("10");
         });

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::ExtractTest", () => {
@@ -7,7 +7,7 @@ describe("Arel::Nodes::ExtractTest", () => {
   it("should extract field", () => {
     const createdAt = users.get("created_at");
     const node = new Nodes.Extract(createdAt, "YEAR");
-    const visitor = new Visitors.ToSql(testConnection);
+    const visitor = new Visitors.ToSql(fakeRecordConnection);
     const sql = visitor.compile(node);
     expect(sql).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
@@ -18,7 +18,7 @@ describe("Arel::Nodes::ExtractTest", () => {
     // of how it was constructed.
     const createdAt = users.get("created_at");
     const node = new Nodes.Extract(createdAt, "month");
-    const sql = new Visitors.ToSql(testConnection).compile(node);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
     expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at")');
   });
 
@@ -31,7 +31,7 @@ describe("Arel::Nodes::ExtractTest", () => {
     const node = createdAt.extract("year");
     expect(Array.isArray(node.expr)).toBe(true);
     expect((node.expr as Nodes.Node[])[0]).toBe(createdAt);
-    expect(new Visitors.ToSql(testConnection).compile(node)).toBe(
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(node)).toBe(
       'EXTRACT(YEAR FROM "users"."created_at")',
     );
   });
@@ -40,7 +40,7 @@ describe("Arel::Nodes::ExtractTest", () => {
     it("should alias the extract", () => {
       const createdAt = users.get("created_at");
       const node = new Nodes.Extract(createdAt, "MONTH").as("birth_month");
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       const sql = visitor.compile(node);
       expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at") AS birth_month');
     });

--- a/packages/arel/src/nodes/filter.test.ts
+++ b/packages/arel/src/nodes/filter.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("FilterTest", () => {
   const users = new Table("users");
   describe("Filter", () => {
     it("should add filter to expression", () => {
-      const count = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
-      const filter = new Nodes.Filter(count, users.get("active").eq(true));
-      const visitor = new Visitors.ToSql(testConnection);
-      expect(visitor.compile(filter)).toBe('COUNT(*) FILTER (WHERE "users"."active" = TRUE)');
+      const count = users.get("id").count();
+      const filter = new Nodes.Filter(count, users.get("income").gteq(40000));
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
+      expect(visitor.compile(filter)).toBe(
+        'COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000)',
+      );
     });
 
     it("should alias the expression", () => {
@@ -24,7 +26,7 @@ describe("FilterTest", () => {
       const w = new Nodes.Window();
       w.order(users.get("id").asc());
       const over = new Nodes.Over(fn, w);
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       const result = visitor.compile(over);
       expect(result).toContain("OVER");
       expect(result).toContain("ORDER BY");
@@ -37,7 +39,7 @@ describe("FilterTest", () => {
         const window = new Nodes.Window();
         window.partition(users.get("year"));
         const over = new Nodes.Over(filter, window);
-        const sql = new Visitors.ToSql(testConnection).compile(over);
+        const sql = new Visitors.ToSql(fakeRecordConnection).compile(over);
         expect(sql).toContain("FILTER");
         expect(sql).toContain("OVER");
         expect(sql).toContain("PARTITION BY");
@@ -49,7 +51,7 @@ describe("FilterTest", () => {
         const count = users.get("id").count();
         const filter = new Nodes.Filter(count, users.get("income").gteq(40000));
         const aliased = filter.as("rich_users_count");
-        const sql = new Visitors.ToSql(testConnection).compile(aliased);
+        const sql = new Visitors.ToSql(fakeRecordConnection).compile(aliased);
         expect(sql).toContain("FILTER");
         expect(sql).toContain("AS rich_users_count");
       });

--- a/packages/arel/src/nodes/fragments.test.ts
+++ b/packages/arel/src/nodes/fragments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("FragmentsTest", () => {
@@ -26,7 +26,7 @@ describe("FragmentsTest", () => {
     it("can be joined with other nodes", () => {
       const a = new Nodes.Fragments([new Nodes.SqlLiteral("foo")]);
       const joined = a.join(new Nodes.SqlLiteral("bar"));
-      const sql = new Visitors.ToSql(testConnection).compile(joined);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(joined);
       expect(sql).toBe("foo bar");
     });
   });

--- a/packages/arel/src/nodes/function.test.ts
+++ b/packages/arel/src/nodes/function.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 import { SqlLiteral } from "./sql-literal.js";
 
@@ -67,7 +67,7 @@ describe("Arel::Nodes::ExistsTest", () => {
   it("renders EXISTS(subquery) correctly", () => {
     const inner = users.project(users.get("id")).ast;
     const node = new Nodes.Exists(inner);
-    const sql = new Visitors.ToSql(testConnection).compile(node);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
     expect(sql).toBe('EXISTS (SELECT "users"."id" FROM "users")');
   });
 });

--- a/packages/arel/src/nodes/grouping.test.ts
+++ b/packages/arel/src/nodes/grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("GroupingTest", () => {
@@ -21,7 +21,7 @@ describe("GroupingTest", () => {
 
   it("should create Equality nodes", () => {
     const grouped = new Nodes.Grouping(users.get("id").eq(1));
-    const sql = new Visitors.ToSql(testConnection).compile(grouped);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(grouped);
     expect(sql).toBe('("users"."id" = 1)');
   });
 });

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
 
@@ -25,21 +25,21 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
   const users = new Table("users", { typeCaster: fakePgCaster });
   it("in", () => {
     const node = new Nodes.HomogeneousIn(["Bobby", "Robert"], users.get("name"), "in");
-    const sql = new Visitors.ToSql(testConnection).compile(node);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
     expect(sql).toBe('"users"."name" IN (?, ?)');
   });
 
   it("custom attribute node", () => {
     const node = new TypedNode("COALESCE", [users.get("nickname"), users.get("name")], STRING_TYPE);
     const expr = new Nodes.HomogeneousIn(["Bobby", "Robert"], node, "in");
-    const sql = new Visitors.ToSql(testConnection).compile(expr);
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
     expect(sql).toBe('COALESCE("users"."nickname", "users"."name") IN (?, ?)');
   });
 
   describe("HomogeneousIn visitor", () => {
     it("compiles IN with values", () => {
       const node = new Nodes.HomogeneousIn([1, 2, 3], users.get("id"), "in");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       // HomogeneousIn keeps add_binds + bind_block (to_sql.rb:352), so a bare
       // SQLString collector emits `?` placeholders — mirrors Rails test_in.
       expect(sql).toBe('"users"."id" IN (?, ?, ?)');
@@ -47,7 +47,7 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
 
     it("compiles NOT IN with values", () => {
       const node = new Nodes.HomogeneousIn([4, 5], users.get("id"), "notin");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('"users"."id" NOT IN (?, ?)');
     });
 
@@ -55,13 +55,13 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
       // Mirrors Rails to_sql.rb:347-349 — empty casted_values emits
       // `quote(nil)` inside the parens, not a `1=0` short-circuit.
       const node = new Nodes.HomogeneousIn([], users.get("id"), "in");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('"users"."id" IN (NULL)');
     });
 
     it("compiles empty NOT IN as NOT IN (NULL)", () => {
       const node = new Nodes.HomogeneousIn([], users.get("id"), "notin");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('"users"."id" NOT IN (NULL)');
     });
 
@@ -72,13 +72,13 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
       };
       const attr = new Nodes.Attribute(filteringRelation as never, "id");
       const node = new Nodes.HomogeneousIn([1, 2], attr, "in");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('"users"."id" IN (NULL)');
     });
 
     it("compiles string values", () => {
       const node = new Nodes.HomogeneousIn(["a", "b"], users.get("name"), "in");
-      const sql = new Visitors.ToSql(testConnection).compile(node);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('"users"."name" IN (?, ?)');
     });
   });

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors, Collectors } from "../index.js";
 
 function compileWithBinds(visitor: Visitors.ToSql, node: unknown): [string, unknown[]] {
@@ -33,7 +33,7 @@ describe("MatchesTest", () => {
     it("inlines a string escape literal even in bind-extraction mode", async () => {
       const { Visitors } = await import("../index.js");
       const node = users.get("name").matches("x%", "!");
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       const [sql] = compileWithBinds(visitor, node);
       expect(sql).toContain("ESCAPE '!'");
       expect(sql).not.toContain("ESCAPE ?");

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, SelectManager, Nodes, Visitors } from "../index.js";
 
 describe("TestNode", () => {
@@ -53,13 +53,13 @@ describe("TestNode", () => {
 
   it("should extract field", () => {
     const node = new Nodes.Extract(users.get("created_at"), "YEAR");
-    const visitor = new Visitors.ToSql(testConnection);
+    const visitor = new Visitors.ToSql(fakeRecordConnection);
     expect(visitor.compile(node)).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
 
   it("should alias the extract", () => {
     const node = new Nodes.Extract(users.get("created_at"), "MONTH").as("birth_month");
-    const visitor = new Visitors.ToSql(testConnection);
+    const visitor = new Visitors.ToSql(fakeRecordConnection);
     expect(visitor.compile(node)).toBe('EXTRACT(MONTH FROM "users"."created_at") AS birth_month');
   });
 
@@ -69,7 +69,7 @@ describe("TestNode", () => {
   });
 
   it("operation ordering via sql", () => {
-    const visitor = new Visitors.ToSql(testConnection);
+    const visitor = new Visitors.ToSql(fakeRecordConnection);
     const node = new Nodes.InfixOperation("+", users.get("a"), new Nodes.Quoted(1));
     expect(visitor.compile(node)).toBe('"users"."a" + 1');
   });
@@ -77,7 +77,7 @@ describe("TestNode", () => {
   it("construct with alias via constructor", () => {
     const fn = new Nodes.NamedFunction("SUM", [users.get("age")], "total");
     expect(fn.alias).toBeInstanceOf(Nodes.SqlLiteral);
-    const visitor = new Visitors.ToSql(testConnection);
+    const visitor = new Visitors.ToSql(fakeRecordConnection);
     expect(visitor.compile(fn)).toBe('SUM("users"."age") AS total');
   });
 
@@ -175,7 +175,7 @@ describe("Node base polymorphic defaults", () => {
 });
 
 describe("Table.engine", () => {
-  const sqliteEngine = { connection: { visitor: new Visitors.SQLite(testConnection) } };
+  const sqliteEngine = { connection: { visitor: new Visitors.SQLite(fakeRecordConnection) } };
 
   it("Node#toSql() compiles through the engine connection's visitor", () => {
     const users = new Table("users");

--- a/packages/arel/src/nodes/over.test.ts
+++ b/packages/arel/src/nodes/over.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::OverTest", () => {
@@ -7,7 +7,7 @@ describe("Arel::Nodes::OverTest", () => {
   describe("as", () => {
     it("should alias the expression", () => {
       const over = users.get("id").count().over().as("foo");
-      expect(new Visitors.ToSql(testConnection).compile(over)).toBe(
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(over)).toBe(
         'COUNT("users"."id") OVER () AS foo',
       );
     });
@@ -16,7 +16,9 @@ describe("Arel::Nodes::OverTest", () => {
   describe("with SQL literal", () => {
     it("should reference the window definition by name", () => {
       const over = users.get("id").count().over(new Nodes.SqlLiteral("foo"));
-      expect(new Visitors.ToSql(testConnection).compile(over)).toBe('COUNT("users"."id") OVER foo');
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(over)).toBe(
+        'COUNT("users"."id") OVER foo',
+      );
     });
   });
 
@@ -24,7 +26,7 @@ describe("Arel::Nodes::OverTest", () => {
     it("should use empty definition", () => {
       const fn = new Nodes.NamedFunction("ROW_NUMBER", []);
       const over = new Nodes.Over(fn);
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(over)).toBe("ROW_NUMBER() OVER ()");
     });
   });
@@ -35,7 +37,7 @@ describe("Arel::Nodes::OverTest", () => {
       const w = new Nodes.Window();
       w.partition(users.get("department_id"));
       const over = new Nodes.Over(fn, w);
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       const result = visitor.compile(over);
       expect(result).toContain("SUM");
       expect(result).toContain("PARTITION BY");
@@ -58,7 +60,9 @@ describe("Arel::Nodes::OverTest", () => {
 
   describe("with literal", () => {
     it("should reference the window definition by name", () => {
-      const sql = new Visitors.ToSql(testConnection).compile(users.get("id").count().over("foo"));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+        users.get("id").count().over("foo"),
+      );
       expect(sql).toBe('COUNT("users"."id") OVER "foo"');
     });
   });

--- a/packages/arel/src/nodes/sql-literal.test.ts
+++ b/packages/arel/src/nodes/sql-literal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("SqlLiteralTest", () => {
@@ -15,14 +15,14 @@ describe("SqlLiteralTest", () => {
     it("makes a count node", () => {
       const lit = new Nodes.SqlLiteral("*");
       const count = new Nodes.NamedFunction("COUNT", [lit]);
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(count)).toBe("COUNT(*)");
     });
 
     it("makes a distinct node", () => {
       const lit = new Nodes.SqlLiteral("zomg");
       const count = new Nodes.NamedFunction("COUNT", [lit], undefined, true);
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(count)).toBe("COUNT(DISTINCT zomg)");
     });
   });
@@ -31,7 +31,7 @@ describe("SqlLiteralTest", () => {
     it("makes an equality node", () => {
       const lit = new Nodes.SqlLiteral("foo");
       const eq = new Nodes.Equality(lit, new Nodes.Quoted(1));
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(eq)).toBe("foo = 1");
     });
 
@@ -92,7 +92,7 @@ describe("SqlLiteralTest", () => {
       const b = new Nodes.SqlLiteral("bar");
       const fragments = a.join(b);
       expect(fragments).toBeInstanceOf(Nodes.Fragments);
-      const sql = new Visitors.ToSql(testConnection).compile(fragments);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(fragments);
       expect(sql).toBe("foo bar");
     });
 
@@ -101,7 +101,7 @@ describe("SqlLiteralTest", () => {
       const b = new Nodes.SqlLiteral("bar");
       const fragments = a.plus(b);
       expect(fragments).toBeInstanceOf(Nodes.Fragments);
-      expect(new Visitors.ToSql(testConnection).compile(fragments)).toBe("foo bar");
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(fragments)).toBe("foo bar");
     });
   });
 });

--- a/packages/arel/src/nodes/sum.test.ts
+++ b/packages/arel/src/nodes/sum.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::SumTest", () => {
@@ -8,7 +8,7 @@ describe("Arel::Nodes::SumTest", () => {
     it("should alias the sum", () => {
       const sum = users.get("age").sum();
       const aliased = sum.as("total_age");
-      const visitor = new Visitors.ToSql(testConnection);
+      const visitor = new Visitors.ToSql(fakeRecordConnection);
       expect(visitor.compile(aliased)).toBe('SUM("users"."age") AS total_age');
     });
   });

--- a/packages/arel/src/nodes/unary-operation.test.ts
+++ b/packages/arel/src/nodes/unary-operation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("TestUnaryOperation", () => {
@@ -51,6 +51,6 @@ describe("TestUnaryOperation", () => {
   // is preserved rather than trimmed.
   it("visitor preserves operator whitespace verbatim", () => {
     const node = new Nodes.UnaryOperation("- ", users.get("age"));
-    expect(new Visitors.ToSql(testConnection).compile(node)).toBe(' -  "users"."age"');
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(node)).toBe(' -  "users"."age"');
   });
 });

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("PredicationsMixin", () => {
@@ -8,19 +8,19 @@ describe("PredicationsMixin", () => {
   describe("on InfixOperation (Math chain)", () => {
     it("Division#subtract chains via the Math mixin", () => {
       const expr = users.get("age").divide(3).subtract(users.get("other"));
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe('("users"."age" / 3 - "users"."other")');
     });
 
     it("BitwiseAnd#gt produces a GROUP BY / HAVING-style comparison", () => {
       const expr = users.get("bitmap").bitwiseAnd(16).gt(0);
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" & 16) > 0');
     });
 
     it("BitwiseShiftLeft#gt chains through Predications", () => {
       const expr = users.get("bitmap").bitwiseShiftLeft(1).gt(0);
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" << 1) > 0');
     });
   });
@@ -28,13 +28,13 @@ describe("PredicationsMixin", () => {
   describe("on UnaryOperation (via NodeExpression mixin)", () => {
     it("BitwiseNot#gt produces a predicate", () => {
       const expr = new Nodes.BitwiseNot(users.get("bitmap")).gt(0);
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe(' ~ "users"."bitmap" > 0');
     });
 
     it("BitwiseNot#eq produces an equality predicate", () => {
       const expr = new Nodes.BitwiseNot(users.get("flags")).eq(0);
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe(' ~ "users"."flags" = 0');
     });
   });
@@ -46,19 +46,19 @@ describe("PredicationsMixin", () => {
       // Rails' `Or.inject` on [] returns nil and the visitor renders
       // NULL — we preserve that, since NULL is not the same as FALSE
       // under SQL three-valued logic.
-      const sql = new Visitors.ToSql(testConnection).compile(bn.eqAny([]));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(bn.eqAny([]));
       expect(sql).toBe("(NULL)");
     });
 
     it("eqAll([]) does not crash and renders as an empty grouped AND", () => {
       // Matches Attribute#groupedAll: an empty And inside a Grouping
       // visits to `()`, the same as Rails' empty-And rendering.
-      const sql = new Visitors.ToSql(testConnection).compile(bn.eqAll([]));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(bn.eqAll([]));
       expect(sql).toBe("()");
     });
 
     it("in(scalar) wraps the scalar (Rails quoted_node fallthrough)", () => {
-      const sql = new Visitors.ToSql(testConnection).compile(bn.in(7));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(bn.in(7));
       expect(sql).toBe(' ~ "users"."flags" IN (7)');
     });
   });
@@ -66,13 +66,13 @@ describe("PredicationsMixin", () => {
   describe("on NamedFunction (via Function → NodeExpression mixin)", () => {
     it("count().gt(n) produces HAVING-ready comparison", () => {
       const expr = users.get("id").count().gt(5);
-      const sql = new Visitors.ToSql(testConnection).compile(expr);
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(expr);
       expect(sql).toBe('COUNT("users"."id") > 5');
     });
 
     it("NamedFunction#in accepts a value list", () => {
       const fn = new Nodes.NamedFunction("LOWER", [users.get("name")]);
-      const sql = new Visitors.ToSql(testConnection).compile(fn.in(["a", "b"]));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(fn.in(["a", "b"]));
       expect(sql).toBe("LOWER(\"users\".\"name\") IN ('a', 'b')");
     });
   });
@@ -196,7 +196,7 @@ describe("Predications range semantics", () => {
   });
 
   describe("#between SQL output", () => {
-    const sql = (n: Nodes.Node) => new Visitors.ToSql(testConnection).compile(n);
+    const sql = (n: Nodes.Node) => new Visitors.ToSql(fakeRecordConnection).compile(n);
 
     it("inclusive standard range → BETWEEN", () => {
       expect(sql(id.between({ begin: 1, end: 3 }))).toBe('"users"."id" BETWEEN 1 AND 3');
@@ -222,7 +222,7 @@ describe("Predications range semantics", () => {
   });
 
   describe("#not_between SQL output", () => {
-    const sql = (n: Nodes.Node) => new Visitors.ToSql(testConnection).compile(n);
+    const sql = (n: Nodes.Node) => new Visitors.ToSql(fakeRecordConnection).compile(n);
 
     it("inclusive range → (col < b OR col > e)", () => {
       expect(sql(id.notBetween({ begin: 1, end: 3 }))).toBe(

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -15,7 +15,7 @@ import { mustBeLike } from "./test-helpers/must-be-like.js";
 describe("SelectManagerTest", () => {
   const users = new Table("users");
   const posts = new Table("posts");
-  const visitor = new Visitors.ToSql(testConnection);
+  const visitor = new Visitors.ToSql(fakeRecordConnection);
   it("join sources", () => {
     const manager = new SelectManager();
     manager.joinSources().push(new Nodes.StringJoin(new Nodes.Quoted("foo")));
@@ -375,7 +375,7 @@ describe("SelectManagerTest", () => {
     it("minus aliases except", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
-      expect(new Visitors.ToSql(testConnection).compile(q1.minus(q2))).toContain("EXCEPT");
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(q1.minus(q2))).toContain("EXCEPT");
     });
   });
 
@@ -1262,7 +1262,7 @@ describe("SelectManagerTest", () => {
       const mgr = new SelectManager(users).project(users.get("id"));
       const lat = mgr.lateral();
       expect(lat).toBeInstanceOf(Nodes.Lateral);
-      const sql = new Visitors.PostgreSQL(testConnection).compile(lat);
+      const sql = new Visitors.PostgreSQL(fakeRecordConnection).compile(lat);
       expect(sql).toBe('LATERAL (SELECT "users"."id" FROM "users")');
     });
 
@@ -1274,7 +1274,7 @@ describe("SelectManagerTest", () => {
       const lat = mgr.lateral("u");
       expect(lat).toBeInstanceOf(Nodes.Lateral);
       expect(lat.expr).toBeInstanceOf(Nodes.TableAlias);
-      const sql = new Visitors.PostgreSQL(testConnection).compile(lat);
+      const sql = new Visitors.PostgreSQL(fakeRecordConnection).compile(lat);
       expect(sql).toBe('LATERAL (SELECT "users"."id" FROM "users") u');
     });
   });

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -9,7 +9,11 @@ import {
   Visitors,
   EmptyJoinError,
 } from "./index.js";
-import { testConnection, mysqlTestConnection } from "./test-helpers/connection.js";
+import {
+  testConnection,
+  fakeRecordConnection,
+  mysqlTestConnection,
+} from "./test-helpers/connection.js";
 
 describe("TableTest", () => {
   const users = new Table("users");
@@ -295,7 +299,7 @@ describe("TableTest", () => {
       const aliased = users.alias("u");
       expect(aliased).toBeInstanceOf(Nodes.TableAlias);
       expect(aliased.relation).toBe(users);
-      const sql = new Visitors.ToSql(testConnection).compile(aliased.get("id"));
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(aliased.get("id"));
       expect(sql).toBe('"u"."id"');
     });
   });
@@ -318,7 +322,7 @@ describe("TableTest", () => {
       const aliased = users.alias("u");
       const attr = users.get("id", aliased);
       expect(attr.relation).toBe(aliased);
-      expect(new Visitors.ToSql(testConnection).compile(attr)).toBe('"u"."id"');
+      expect(new Visitors.ToSql(fakeRecordConnection).compile(attr)).toBe('"u"."id"');
     });
   });
 

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
 import { buildQuoted } from "../nodes/casted.js";
 import { Table, star, sql, Nodes, Visitors, Collectors } from "../index.js";
@@ -7,7 +7,7 @@ import { Table, star, sql, Nodes, Visitors, Collectors } from "../index.js";
 describe("MysqlTest", () => {
   let visitor: Visitors.MySQL;
   beforeEach(() => {
-    visitor = new Visitors.MySQL(testConnection);
+    visitor = new Visitors.MySQL(fakeRecordConnection);
   });
 
   function compile(node: Nodes.Node): string {

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { postgresqlTestConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
 import { Table, sql, Nodes, Visitors, Collectors } from "../index.js";
 import { buildQuoted } from "../nodes/casted.js";
 
 describe("PostgresTest", () => {
-  const visitor = new Visitors.PostgreSQL(postgresqlTestConnection);
+  const visitor = new Visitors.PostgreSQL(fakeRecordConnection);
   const table = new Table("users");
   const attr = table.get("id");
 

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
 import { buildQuoted } from "../nodes/casted.js";
 import { Table, sql, Nodes, Visitors, Collectors } from "../index.js";
@@ -7,7 +7,7 @@ import { Table, sql, Nodes, Visitors, Collectors } from "../index.js";
 describe("SqliteTest", () => {
   let visitor: Visitors.SQLite;
   beforeEach(() => {
-    visitor = new Visitors.SQLite(testConnection);
+    visitor = new Visitors.SQLite(fakeRecordConnection);
   });
 
   function compile(node: Nodes.Node): string {

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -21,9 +21,9 @@
       "value": 0
     },
     "activemodel": {
-      "assertionCount": 301,
-      "kind": 445,
-      "value": 56
+      "assertionCount": 300,
+      "kind": 444,
+      "value": 54
     },
     "activerecord": {
       "assertionCount": 1941,
@@ -38,7 +38,7 @@
     "arel": {
       "assertionCount": 63,
       "kind": 116,
-      "value": 14
+      "value": 13
     },
     "date": {
       "assertionCount": 1,


### PR DESCRIPTION
Three related fidelity convergences.

### `AttributeSet#deepDup` onto Ruby's `dup` semantics

`deep_dup` is one line (`attribute_set.rb:72-74`); `&:deep_dup` is
`Object#deep_dup` — `duplicable? ? dup : self`
(`core_ext/object/deep_dup.rb:16`) — which reaches `Attribute#initialize_dup`
(`attribute.rb:155-157`), dupping **only** `@value` and carrying
`@original_attribute` into the copy by reference.

- `Attribute#deepDup` + private `initializeDup` with that shape.
- `AttributeSet#deepDup` is `transformValues(..., attr => attr.deepDup())` — no
  cache, no chain walk. `cloneAttribute` deleted.
- `reverseMergeBang` copies references; `Hash#reverse_merge!`
  (`attribute_set.rb:100-102`) clones nothing.
- `UserProvidedDefault#dupForDeepClone` deleted — Rails defines no
  `initialize_dup` there, so a dup memoizes the Proc for itself, which is what
  the class-level `_default_attributes` cache relies on.

The module-private `dupValue` copies only Array/Map/Set/plain objects: a
built-in with internal slots (Temporal) throws on a slot-less clone and is
immutable anyway, so Ruby's `dup` of it is unobservable.

### arel tests build visitors on `fakeRecordConnection`

Rails' `Arel::Spec` sets `Table.engine = FakeRecord::Base.new`
(`test/cases/arel/helper.rb:31-33`), so the entire arel suite compiles through
that double's quoting (`support/fake_record.rb:55-90`) — `'t'`/`'f'`, `\'`
escaping. Every arel test file with a Rails counterpart now names it, including
the three adapter visitor suites, which open the same way
(`visitors/sqlite_test.rb:8-10`, `mysql_test.rb:8-10`, `postgres_test.rb:8-11`:
`@visitor = <Visitor>.new Table.engine.lease_connection`).
`FilterTest > should add filter to expression` takes the Rails body and literal
(`nodes/filter_test.rb:10-14`).

Two groups deliberately keep `testConnection` / the adapter quoters:

- Tests with no Rails counterpart that exist to exercise adapter-shaped quoting
  or `sanitize_as_sql_comment` — comment and optimizer-hint sanitization
  (FakeRecord returns the comment unchanged, `fake_record.rb:63-65`),
  schema-qualified `star`, MySQL backticks.
- `visitors/to-sql.test.ts`, left as PR #7022 converged it: its shared visitor
  is already on FakeRecord and its remaining sites are trails-only extras.

`assertion-mismatch-mark.json` tightens: arel value 14→13, activemodel
301/445/56 → 300/444/54. (Recomputed against `main` after the rebase — a sibling
had already pulled arel's counters down to 63/116/14, so the mark is `main`'s
numbers minus this PR's own win, never a merge of two sides.)

`deep_duping creates a new hash and dups each attribute` also takes the Rails
body (`attribute_set_test.rb:53-70`) — it previously spread `p.attributes` and
never called `deep_dup`. The `duped[:bar].value << "bar"` arm has no JS analogue
(strings are immutable), so the array case sits in `attribute.trails.test.ts`
next to the shared-`original_attribute` assertion. Both trails tests were
verified red against `origin/main`.

### `MySQL::TypeMetadata#extra` is `nil`, not `""`

`initialize(type_metadata, extra: nil)` (`mysql/type_metadata.rb:13-16`) and
`delegate :extra, to: :sql_type_metadata, allow_nil: true`
(`mysql/column.rb:7`), so `extra` is `string | null`.
`fetch_type_metadata`'s own `extra = ""` default
(`mysql/schema_statements.rb:221-223`) is unchanged, so live column
introspection is byte-identical; only the metadata-without-extra case moves.

### Filed, not fixed

`reverseMergeBang` skips a name on `isKey` (AttributeSet's `key?`, an
*initialized* check) where `Hash#reverse_merge!` uses plain key presence. Out of
scope here — filed as
`0115-activemodel-fidelity-convergence/converge-reverse-merge-bang-key-presence`.

Closes-story: converge-attribute-deep-dup-onto-ruby-dup
Closes-story: arel-tests-visitor-on-fake-record-connection
Closes-story: mysql-type-metadata-extra-substitutes-empty-string-for-nil
