### PR TITLE
refactor(activerecord): Migration#run takes migration classes variadically (RFC 0051)

### DIFF
--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./base.js";
-import { Migration, IrreversibleMigration } from "./migration.js";
+import { Migration, IrreversibleMigration, type MigrationClass } from "./migration.js";
 import { CommandRecorder } from "./migration/command-recorder.js";
 import { itIfSupports } from "./support/supports.js";
 import { adapterType } from "./test-adapter.js";
@@ -202,8 +202,8 @@ class LegacyMigration extends Migration {
 }
 
 class RevertWholeMigration extends SilentMigration {
-  protected _migration: Migration;
-  constructor(migration: Migration) {
+  protected _migration: MigrationClass;
+  constructor(migration: MigrationClass) {
     super();
     this._migration = migration;
   }
@@ -381,7 +381,7 @@ describe("InvertibleMigrationTest", () => {
   it("migrate revert whole migration", async () => {
     const migration = new InvertibleMigration();
     for (const klass of [LegacyMigration, InvertibleMigration]) {
-      const revert = new RevertWholeMigration(new klass());
+      const revert = new RevertWholeMigration(klass);
       await migration.migrate("up");
       await revert.migrate("up");
       expect(await migration.connection.tableExists("horses")).toBe(false);
@@ -393,7 +393,7 @@ describe("InvertibleMigrationTest", () => {
   });
 
   it("migrate nested revert whole migration", async () => {
-    const revert = new NestedRevertWholeMigration(new InvertibleRevertMigration());
+    const revert = new NestedRevertWholeMigration(InvertibleRevertMigration);
     await revert.migrate("down");
     expect(await revert.connection.tableExists("horses")).toBe(true);
     await revert.migrate("up");

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -432,4 +432,33 @@ describe("Migration#removeColumns forwards to the connection", () => {
       await connection.dropTable("my_table", { ifExists: true });
     }
   });
+
+  // `run` takes migration CLASSES (migration.rb:937-949) and constructs each;
+  // `revert` forwards them reversed (migration.rb:853). No Rails test covers the
+  // multi-class arms directly, so the ordering contract is pinned here.
+  it("run constructs each migration class in order and revert reverses them", async () => {
+    const order: string[] = [];
+    class RunOrderA extends Migration {
+      override write(): void {}
+      async change(): Promise<void> {
+        order.push(`A:${this.isReverting() ? "down" : "up"}`);
+      }
+    }
+    class RunOrderB extends Migration {
+      override write(): void {}
+      async change(): Promise<void> {
+        order.push(`B:${this.isReverting() ? "down" : "up"}`);
+      }
+    }
+    const host = new (class extends Migration {
+      override write(): void {}
+    })();
+
+    await host.run(RunOrderA, RunOrderB);
+    expect(order).toEqual(["A:up", "B:up"]);
+
+    order.length = 0;
+    await host.revert(RunOrderA, RunOrderB);
+    expect(order).toEqual(["B:down", "A:down"]);
+  });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -7,6 +7,7 @@ import {
   underscore,
   humanize,
   isPlainObject,
+  extractOptionsBang,
   stdout,
 } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -350,6 +351,25 @@ export class ReversibleBlockHelper {
   down(fn: () => Promise<void>): void {
     if (this.reverting) this[toRun].push(fn);
   }
+}
+
+/**
+ * A migration class, as `Migration#run` / `Migration#revert` take it
+ * (migration.rb:937, migration.rb:852) — Ruby passes the class object itself
+ * and calls `.new` on it.
+ */
+export type MigrationClass = new () => Migration;
+
+/** The trailing options hash `Migration#run` pops with `extract_options!`. */
+export type MigrationRunOptions = { direction?: "up" | "down"; revert?: boolean };
+
+/**
+ * @noRailsEquivalent Ruby gives a block its own slot, so `revert(*classes, &blk)`
+ * needs no test to tell a migration class from the block. In TS both arrive as
+ * trailing positional functions, so the two have to be told apart by shape.
+ */
+function isMigrationClass(fn: unknown): fn is MigrationClass {
+  return typeof fn === "function" && (fn === Migration || fn.prototype instanceof Migration);
 }
 
 /**
@@ -1193,18 +1213,21 @@ export class Migration {
   }
 
   /**
-   * Revert a migration or a block of operations.
+   * Reverts the given migration classes, and/or a block of operations.
    *
-   * Mirrors: ActiveRecord::Migration#revert
+   * Mirrors: ActiveRecord::Migration#revert (`migration.rb:852-869`) —
+   * `run(*migration_classes.reverse, revert: true) unless migration_classes.empty?`.
    */
-  async revert(migrationOrFn?: Migration | (() => Promise<void>)): Promise<void> {
-    if (migrationOrFn === undefined) return;
-    if (migrationOrFn instanceof Migration) {
-      // Mirrors Rails `revert(*migration_classes)` -> `run(..., revert: true)`.
-      await this.run(migrationOrFn, { revert: true });
-      return;
+  async revert(...migrationClasses: Array<MigrationClass | (() => Promise<void>)>): Promise<void> {
+    // Ruby's block is a slot of its own; in TS it arrives as a trailing
+    // positional, so it is split off before the migration classes are reversed.
+    const last = migrationClasses[migrationClasses.length - 1];
+    const fn = typeof last === "function" && !isMigrationClass(last) ? last : undefined;
+    const klasses = (fn ? migrationClasses.slice(0, -1) : migrationClasses) as MigrationClass[];
+    if (klasses.length > 0) {
+      await this.run(...[...klasses].reverse(), { revert: true });
     }
-    const fn = migrationOrFn;
+    if (fn === undefined) return;
     if (this._recording) {
       // Nested: reuse the active recorder and just toggle its direction, so a
       // `revert` inside a reverting migration cancels by double-negation
@@ -1248,34 +1271,41 @@ export class Migration {
    * executing it `down` without reverting, so it wraps the call in a nested
    * `revert`.
    */
-  async run(
-    migration: Migration,
-    opts: { direction?: "up" | "down"; revert?: boolean } = {},
-  ): Promise<void> {
+  async run(...migrationClasses: Array<MigrationClass | MigrationRunOptions>): Promise<void> {
+    const [klasses, opts] = extractOptionsBang(migrationClasses) as [
+      MigrationClass[],
+      MigrationRunOptions,
+    ];
     let dir = opts.direction ?? "up";
     if (opts.revert) dir = dir === "down" ? "up" : "down";
     if (this.isReverting()) {
+      // If in revert and going :up, say, we want to execute :down without reverting, so
       await this.revert(async () => {
-        await this.run(migration, { direction: dir, revert: true });
+        await this.run(...klasses, { direction: dir, revert: true });
       });
-    } else if (this._recording) {
-      // Recording (but not reverting): route the sub-migration's ops into the
-      // active recorder by sharing our recorder state with it.
-      const prevRecorder = migration._recorder;
-      const prevRecording = migration._recording;
-      const prevConn = migration._connectionOverride;
-      migration._recorder = this._recorder;
-      migration._recording = true;
-      migration._connectionOverride = this.connection;
-      try {
-        await (dir === "up" ? migration.up() : migration.down());
-      } finally {
-        migration._recorder = prevRecorder;
-        migration._recording = prevRecording;
-        migration._connectionOverride = prevConn;
-      }
     } else {
-      await migration.execMigration(this.connection, dir);
+      for (const migrationClass of klasses) {
+        const migration = new migrationClass();
+        if (this._recording) {
+          // Recording (but not reverting): route the sub-migration's ops into the
+          // active recorder by sharing our recorder state with it.
+          const prevRecorder = migration._recorder;
+          const prevRecording = migration._recording;
+          const prevConn = migration._connectionOverride;
+          migration._recorder = this._recorder;
+          migration._recording = true;
+          migration._connectionOverride = this.connection;
+          try {
+            await (dir === "up" ? migration.up() : migration.down());
+          } finally {
+            migration._recorder = prevRecorder;
+            migration._recording = prevRecording;
+            migration._connectionOverride = prevConn;
+          }
+        } else {
+          await migration.execMigration(this.connection, dir);
+        }
+      }
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -361,12 +361,13 @@ export class ReversibleBlockHelper {
 export type MigrationClass = new () => Migration;
 
 /** The trailing options hash `Migration#run` pops with `extract_options!`. */
-export type MigrationRunOptions = { direction?: "up" | "down"; revert?: boolean };
+type MigrationRunOptions = { direction?: "up" | "down"; revert?: boolean };
 
 /**
- * @noRailsEquivalent Ruby gives a block its own slot, so `revert(*classes, &blk)`
- * needs no test to tell a migration class from the block. In TS both arrive as
- * trailing positional functions, so the two have to be told apart by shape.
+ * @noRailsEquivalent PERMANENT — Ruby gives a block its own slot, so
+ * `revert(*migration_classes, &block)` (migration.rb:852) needs no test to tell
+ * a migration class from the block. In TS both arrive as trailing positional
+ * functions, so the two can only be told apart by shape.
  */
 function isMigrationClass(fn: unknown): fn is MigrationClass {
   return typeof fn === "function" && (fn === Migration || fn.prototype instanceof Migration);
@@ -1219,8 +1220,6 @@ export class Migration {
    * `run(*migration_classes.reverse, revert: true) unless migration_classes.empty?`.
    */
   async revert(...migrationClasses: Array<MigrationClass | (() => Promise<void>)>): Promise<void> {
-    // Ruby's block is a slot of its own; in TS it arrives as a trailing
-    // positional, so it is split off before the migration classes are reversed.
     const last = migrationClasses[migrationClasses.length - 1];
     const fn = typeof last === "function" && !isMigrationClass(last) ? last : undefined;
     const klasses = (fn ? migrationClasses.slice(0, -1) : migrationClasses) as MigrationClass[];


### PR DESCRIPTION
## `Migration#run` takes migration classes

Rails' `Migration#run(*migration_classes)` (`migration.rb:937-949`) takes a
splat of migration **classes**, pops the trailing options hash with
`extract_options!`, and calls `migration_class.new.exec_migration(connection, dir)`
on each. `Migration#revert` (`migration.rb:852-853`) forwards
`*migration_classes.reverse, revert: true`.

The port took a single already-constructed `Migration` plus an explicit `opts`
object, so the multi-class and reverse-order arms did not exist. Both
signatures now mirror Ruby:

- `run(...migrationClasses)` uses `extractOptionsBang` (the settled
  `extract_options!` idiom) and constructs each class in the Rails loop.
- `revert(...migrationClasses)` reverses and forwards them before handling the
  block.

The trails-only recording arm — routing a sub-migration's ops into the active
`CommandRecorder`, which Rails gets for free because its `connection` *is* the
recorder — moves inside Rails' per-class loop rather than sitting beside it as
a third top-level branch.

`isMigrationClass` is the one added helper and carries `@noRailsEquivalent`:
Ruby gives the block its own slot, so `revert(*classes, &blk)` needs no test to
tell a class from a block; in TS both arrive as trailing positional functions.

`RevertWholeMigration` in `invertible-migration.test.ts` now holds a class, as
`invertible_migration_test.rb:178-187` does, and its two call sites pass
`klass` rather than `new klass()`.

### Bundle notes

- `columns-primary-key-dispatch-on-adaptername` was **already done on main** by
  #7008 — `columns` and `primaryKey` are the Rails three-liners dispatching to
  per-adapter `columnDefinitions` / `newColumnFromField` / `primaryKeys`.
  Marked done against #7008, not included here.
- `attribute-dup-must-redup-mutable-value` is **blocked on open PR #7028**,
  which introduces the `Attribute#dup()` the story targets. Implementing it here
  would stack on that branch. Blocked with that reason; re-ready on merge.

### Gates

- `pnpm parity:api:calls` — OK (374 baselined, 306 unreviewed)
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows)
- `parity:api --arity` — no `run` / `revert` mismatch
- `parity:api:extra` — `migration.ts` unchanged at 3 novel
- `migration.test.ts`, `migration.trails.test.ts`, `invertible-migration.test.ts`,
  `migration/**` — 467 passed

Closes-story: migration-run-takes-migration-classes-variadic
