### PR TITLE
refactor(activerecord,activesupport,website): per-subclass Column coders, Arel-compiled distinct_relation_for_primary_key, Kernel.abort, inherited migration filename regex (RFC 0096, RFC 0051)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
@@ -52,14 +52,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       });
       const columns = await adapter.columns("auto_increments");
       const col = (columns as any[]).find((c) => c.name === "id");
-      assertNotPredicate(col, (c) => c.autoIncrement);
+      assertNotPredicate(col, (c) => c.isAutoIncrement());
     });
 
     it("auto increment false with create table", async () => {
       await adapter.createTable("auto_increments", { autoIncrement: false, force: "cascade" });
       const columns = await adapter.columns("auto_increments");
       const col = (columns as any[]).find((c) => c.name === "id");
-      assertNotPredicate(col, (c) => c.autoIncrement);
+      assertNotPredicate(col, (c) => c.isAutoIncrement());
     });
   });
 });

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1518,7 +1518,14 @@ describe("BasicsTest", () => {
 
     const c2 = await cache.columns(conn.pool, "posts");
     expect(cache.size).not.toBe(0);
-    expect(c2).toEqual(c1);
+    // Rails' `assert_equal c1, c2` compares element-wise through `Column#==`
+    // (sqlite3/column.rb:45-49 and its siblings), not structurally. That matters
+    // here and not upstream: Rails only ever compares one reflected cache with
+    // another, while trails' fixtures warm installs the BOOT DUMP as c1, and a
+    // dump-loaded column legitimately lacks the ivars the per-subclass coders
+    // never carry (`rowid`, `@generated_type` — sqlite3/column.rb:35-42).
+    expect(c2!.length).toBe(c1!.length);
+    c2!.forEach((col, i) => expect(col.equals(c1![i])).toBe(true));
 
     // Restore the harness' always-warm invariant for the rest of the file:
     // trails cannot re-warm synchronously on read the way Rails' cold-DB-hit

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1518,12 +1518,6 @@ describe("BasicsTest", () => {
 
     const c2 = await cache.columns(conn.pool, "posts");
     expect(cache.size).not.toBe(0);
-    // Rails' `assert_equal c1, c2` compares element-wise through `Column#==`
-    // (sqlite3/column.rb:45-49 and its siblings), not structurally. That matters
-    // here and not upstream: Rails only ever compares one reflected cache with
-    // another, while trails' fixtures warm installs the BOOT DUMP as c1, and a
-    // dump-loaded column legitimately lacks the ivars the per-subclass coders
-    // never carry (`rowid`, `@generated_type` — sqlite3/column.rb:35-42).
     expect(c2!.length).toBe(c1!.length);
     c2!.forEach((col, i) => expect(col.equals(c1![i])).toBe(true));
 

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1518,8 +1518,7 @@ describe("BasicsTest", () => {
 
     const c2 = await cache.columns(conn.pool, "posts");
     expect(cache.size).not.toBe(0);
-    expect(c2!.length).toBe(c1!.length);
-    c2!.forEach((col, i) => expect(col.equals(c1![i])).toBe(true));
+    expect(c2!.map((column, i) => column.equals(c1![i]))).toEqual(new Array(c1!.length).fill(true));
 
     // Restore the harness' always-warm invariant for the rest of the file:
     // trails cannot re-warm synchronously on read the way Rails' cold-DB-hit

--- a/packages/activerecord/src/comment.test.ts
+++ b/packages/activerecord/src/comment.test.ts
@@ -199,7 +199,7 @@ describe("CommentTest", () => {
     const col = (await (adapter as any).columns("commenteds")).find((c: any) => c.name === "id")!;
     expect(col.comment).toBe("Edited column comment");
     if (adapterType === "mysql") {
-      expect(col.autoIncrement).toBe(true);
+      expect(col.isAutoIncrement()).toBe(true);
     }
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
@@ -12,7 +12,6 @@ import { NullPool } from "./abstract/connection-pool.js";
 import { Result } from "../result.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
-  // `auto_increment?` derives from `sql_type_metadata.extra` (mysql/column.rb:17-19).
   return new Column(
     "id",
     null,

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
@@ -12,10 +12,14 @@ import { NullPool } from "./abstract/connection-pool.js";
 import { Result } from "../result.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
-  return new Column("id", null, { sqlType: "bigint" }, false, {
-    autoIncrement: opts.autoIncrement ?? false,
-    defaultFunction: opts.defaultFunction ?? null,
-  });
+  // `auto_increment?` derives from `sql_type_metadata.extra` (mysql/column.rb:17-19).
+  return new Column(
+    "id",
+    null,
+    { sqlType: "bigint", extra: opts.autoIncrement ? "auto_increment" : "" },
+    false,
+    { defaultFunction: opts.defaultFunction ?? null },
+  );
 }
 
 describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1819,7 +1819,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const options: ColumnOptions = {
       default: column.default,
       null: column.null,
-      autoIncrement: column.autoIncrement,
+      autoIncrement: column.isAutoIncrement(),
       comment: column.comment ?? undefined,
     };
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -828,7 +828,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     }
 
     if (!Object.prototype.hasOwnProperty.call(opts, "autoIncrement")) {
-      opts["autoIncrement"] = (column as any).autoIncrement ?? false;
+      opts["autoIncrement"] = (column as MysqlColumn).isAutoIncrement();
     }
 
     const td = this.createTableDefinition(tableName);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -16,6 +16,7 @@ import { AbstractAdapter } from "../abstract-adapter.js";
 import { NATIVE_DATABASE_TYPES_BY_ADAPTER } from "./native-database-types.js";
 import { NotImplementedError } from "../../errors.js";
 import { Result } from "../../result.js";
+import { Table, Visitors } from "@blazetrails/arel";
 
 function makeStatements(
   adapterOverrides: Record<string, unknown> = {},
@@ -631,13 +632,18 @@ describe("distinctRelationForPrimaryKey", () => {
   // adapter compiles and binds it; a node with no `toSql` would flatten to
   // "[object Object]" on the way through a string-compiling port.
   const arelNode = { __arel: true };
+  const quoter = {
+    quoteColumnName: (n: string) => `"${n}"`,
+    quoteTableName: (n: string) => `"${n}"`,
+  };
+  const visitor = new Visitors.ToSql(quoter as never);
 
   function makeRelation(over: Record<string, unknown> = {}) {
     const calls = { reselect: [] as unknown[], where: [] as Record<string, unknown>[] };
     const rel: any = {
       _calls: calls,
       primaryKey: "id",
-      table: { name: "posts" },
+      table: new Table("posts"),
       orderValues: [],
       limitValue: 5,
       offsetValue: 2,
@@ -645,7 +651,13 @@ describe("distinctRelationForPrimaryKey", () => {
         calls.reselect = cols;
         // Rails reselect spawns a clone; return a distinct object so a stray
         // distinctBang on the original would be observable.
-        return { ...this, distinctBang: () => {}, arel: this.arel };
+        return {
+          ...this,
+          distinctBang() {
+            return this;
+          },
+          arel: this.arel,
+        };
       },
       arel: () => arelNode,
       // Rails uses where! (in-place); mirror that with whereBang.
@@ -653,11 +665,8 @@ describe("distinctRelationForPrimaryKey", () => {
         calls.where.push(c);
         return this;
       },
-      limitBang(v: unknown) {
-        this.limitValue = v;
-      },
-      offsetBang(v: unknown) {
-        this.offsetValue = v;
+      noneBang() {
+        return this;
       },
       ...over,
     };
@@ -666,12 +675,12 @@ describe("distinctRelationForPrimaryKey", () => {
 
   it("reselects the table-qualified pk and materializes ids via selectRows", async () => {
     const selectRows = vi.fn().mockResolvedValue([[10], [20]]);
-    const ss = makeStatements({ quoteColumnName: (n: string) => `"${n}"`, selectRows });
+    const ss = makeStatements({ ...quoter, visitor, selectRows });
     const rel = makeRelation();
 
     await ss.distinctRelationForPrimaryKey(rel);
 
-    expect(rel._calls.reselect).toEqual(['"posts"."id"']);
+    expect(rel._calls.reselect).toEqual([['"posts"."id"']]);
     expect(selectRows).toHaveBeenCalledWith(arelNode, "SQL");
     expect(rel._calls.where).toEqual([{ id: [10, 20] }]);
     expect(rel.limitValue).toBeNull();
@@ -684,7 +693,7 @@ describe("distinctRelationForPrimaryKey", () => {
       ["2026-01-01", 10],
       ["2026-01-02", 20],
     ]);
-    const ss = makeStatements({ quoteColumnName: (n: string) => `"${n}"`, selectRows });
+    const ss = makeStatements({ ...quoter, visitor, selectRows });
     const rel = makeRelation();
 
     await ss.distinctRelationForPrimaryKey(rel);
@@ -696,7 +705,8 @@ describe("distinctRelationForPrimaryKey", () => {
     const noneBang = vi.fn();
     const whereBang = vi.fn();
     const ss = makeStatements({
-      quoteColumnName: (n: string) => `"${n}"`,
+      ...quoter,
+      visitor,
       selectRows: vi.fn().mockResolvedValue([]),
     });
     const rel = makeRelation({ noneBang, whereBang });
@@ -705,6 +715,22 @@ describe("distinctRelationForPrimaryKey", () => {
 
     expect(noneBang).toHaveBeenCalledTimes(1);
     expect(whereBang).not.toHaveBeenCalled();
+  });
+
+  // Rails has no nil-pk guard: `Array(nil)` is `[]`, so the projection is empty
+  // and `limit_value`/`offset_value` are still cleared (schema_statements.rb:1451).
+  it("clears limit and offset for a relation with no primary key", async () => {
+    const selectRows = vi.fn().mockResolvedValue([]);
+    const noneBang = vi.fn();
+    const ss = makeStatements({ ...quoter, visitor, selectRows });
+    const rel = makeRelation({ primaryKey: null, noneBang });
+
+    await ss.distinctRelationForPrimaryKey(rel);
+
+    expect(rel._calls.reselect).toEqual([[]]);
+    expect(noneBang).toHaveBeenCalledTimes(1);
+    expect(rel.limitValue).toBeNull();
+    expect(rel.offsetValue).toBeNull();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -717,8 +717,6 @@ describe("distinctRelationForPrimaryKey", () => {
     expect(whereBang).not.toHaveBeenCalled();
   });
 
-  // Rails has no nil-pk guard: `Array(nil)` is `[]`, so the projection is empty
-  // and `limit_value`/`offset_value` are still cleared (schema_statements.rb:1451).
   it("clears limit and offset for a relation with no primary key", async () => {
     const selectRows = vi.fn().mockResolvedValue([]);
     const noneBang = vi.fn();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1622,15 +1622,16 @@ export class SchemaStatements {
 
     const limited = relation.reselect(values).distinctBang();
     const limitedIds = (await this.selectRows(limited.arel(), "SQL")).map((results) =>
-      results.slice(-wrap(relation.primaryKey).length),
+      results.slice(results.length - wrap(relation.primaryKey).length),
     );
 
     if (limitedIds.length === 0) {
       relation.noneBang();
     } else {
-      const transposed = limitedIds[0].map((_, i) => limitedIds.map((row) => row[i]));
       relation.whereBang(
-        Object.fromEntries(wrap(relation.primaryKey).map((key, i) => [key, transposed[i]])),
+        Object.fromEntries(
+          wrap(relation.primaryKey).map((key, i) => [key, limitedIds.map((row) => row[i])]),
+        ),
       );
     }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -14,6 +14,8 @@ import { CommandRecorder } from "../../migration/command-recorder.js";
 import type { MigrationCommand } from "../../migration/command-recorder.js";
 import { ArgumentError, type Type } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter, AdapterName } from "../abstract-adapter.js";
+import type { Relation } from "../../relation.js";
+import type { Base } from "../../base.js";
 import {
   TableDefinition,
   Table,
@@ -53,6 +55,7 @@ import {
   KeyError,
   any,
   truncateBytes,
+  wrap,
 } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 import { rubyInspect } from "../../relation/ruby-inspect.js";
@@ -1610,75 +1613,30 @@ export class SchemaStatements {
    * `Promise` would run the relation and hand back its records instead. The
    * caller therefore reuses the relation it passed in.
    */
-  async distinctRelationForPrimaryKey(relation: {
-    primaryKey?: string | string[];
-    table?: { [key: string]: unknown };
-    orderValues?: unknown[];
-    reselect?: (...cols: unknown[]) => unknown;
-    distinctBang?: () => unknown;
-    noneBang?: () => void;
-    whereBang?: (conditions: Record<string, unknown>) => unknown;
-    limitValue?: number | null;
-    offsetValue?: number | null;
-    arel?: () => unknown;
-  }): Promise<void> {
-    const pk = relation.primaryKey;
-    if (!pk) return;
-
-    const pkNames = Array.isArray(pk) ? pk : [pk];
-    // Rails: primary_key_columns = Array(primary_key).map { |c| visitor.compile(relation.table[c]) }
-    // — table-qualified, quoted columns so a bare `id` stays unambiguous when the
-    // relation joins another table (the whole reason this path exists).
-    const tableName = (relation.table as { name?: string } | undefined)?.name;
-    const quoteCol = (c: string): string =>
-      typeof this.quoteColumnName === "function" ? this.quoteColumnName(c) : c;
-    const pkColumns = pkNames.map((c) =>
-      tableName != null ? `${this.quoteTableName(tableName)}.${quoteCol(c)}` : quoteCol(c),
+  async distinctRelationForPrimaryKey(relation: Relation<Base>): Promise<void> {
+    const primaryKeyColumns = wrap(relation.primaryKey).map((column) =>
+      this.visitor.compile(relation.table.get(column)),
     );
-    const values = this.columnsForDistinct(pkColumns, (relation.orderValues as string[]) ?? []);
 
-    // Rails: limited = relation.reselect(values).distinct! — reselect always
-    // spawns a clone, so distinct! never touches the passed relation. Keep the
-    // distinctBang coupled to the reselect spawn so a missing reselect can't
-    // mutate the original.
-    let limited: any = relation;
-    const selectValues = Array.isArray(values) ? values : [values];
-    if (limited.reselect) {
-      limited = limited.reselect(...selectValues);
-      if (limited.distinctBang) limited.distinctBang();
-    }
+    const values = this.columnsForDistinct(primaryKeyColumns, relation.orderValues as string[]);
 
-    // Rails: select_rows(limited.arel, "SQL").map { |r| r.last(primary_key.length) }
-    // — the ARel node goes to the adapter, which compiles and binds it
-    // (schema_statements.rb:1440); flattening to SQL here would strand the
-    // binds. selectRows yields positional column arrays, so the trailing pk
-    // values survive the leading order columns PG/MySQL prepend in
-    // columns_for_distinct.
-    const pkLen = pkNames.length;
-    const rows = (await (this as any).selectRows(limited.arel(), "SQL")) as unknown[][];
-    const limitedIds: unknown[][] = rows.map((row) => row.slice(-pkLen));
+    const limited = relation.reselect(values).distinctBang();
+    // Rails hands `select_rows` the ARel node (schema_statements.rb:1440) so the
+    // adapter compiles and binds it; flattening to SQL here would strand the binds.
+    const limitedIds = (await this.selectRows(limited.arel(), "SQL")).map((results) =>
+      results.slice(-wrap(relation.primaryKey).length),
+    );
 
     if (limitedIds.length === 0) {
-      if (typeof (relation as any).noneBang === "function") {
-        (relation as any).noneBang();
-      }
+      relation.noneBang();
     } else {
-      // Rails: relation.where!(**Array(primary_key).zip(limited_ids.transpose).to_h)
-      // — keyed on the bare pk attribute names, not the quoted/qualified columns.
-      // Use whereBang (in-place mutation of the passed relation) to match `where!`;
-      // plain `where` returns a clone, which would strand the limit/offset reset
-      // below on a different object than the caller holds.
-      const transposed: unknown[][] = pkNames.map((_, i) => limitedIds.map((row) => row[i]));
-      const conditions: Record<string, unknown> = {};
-      for (let i = 0; i < pkNames.length; i++) {
-        conditions[pkNames[i]] = transposed[i];
-      }
-      relation.whereBang?.(conditions);
+      const transposed = wrap(relation.primaryKey).map((_, i) => limitedIds.map((row) => row[i]));
+      relation.whereBang(
+        Object.fromEntries(wrap(relation.primaryKey).map((key, i) => [key, transposed[i]])),
+      );
     }
 
-    // Rails: relation.limit_value = relation.offset_value = nil
-    relation.limitValue = null;
-    relation.offsetValue = null;
+    relation.limitValue = relation.offsetValue = null;
   }
 
   updateTableDefinition(tableName: string, base?: unknown): Table {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1621,8 +1621,6 @@ export class SchemaStatements {
     const values = this.columnsForDistinct(primaryKeyColumns, relation.orderValues as string[]);
 
     const limited = relation.reselect(values).distinctBang();
-    // Rails hands `select_rows` the ARel node (schema_statements.rb:1440) so the
-    // adapter compiles and binds it; flattening to SQL here would strand the binds.
     const limitedIds = (await this.selectRows(limited.arel(), "SQL")).map((results) =>
       results.slice(-wrap(relation.primaryKey).length),
     );
@@ -1630,7 +1628,7 @@ export class SchemaStatements {
     if (limitedIds.length === 0) {
       relation.noneBang();
     } else {
-      const transposed = wrap(relation.primaryKey).map((_, i) => limitedIds.map((row) => row[i]));
+      const transposed = limitedIds[0].map((_, i) => limitedIds.map((row) => row[i]));
       relation.whereBang(
         Object.fromEntries(wrap(relation.primaryKey).map((key, i) => [key, transposed[i]])),
       );

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -163,20 +163,22 @@ export class Column {
    * carries no tag, so the tag is written as a key and `rehydrateColumn`
    * dispatches on it.
    *
-   * Rails' own subclasses carry part of their state through the coder too —
-   * `PostgreSQL::Column` writes `serial` / `identity` / `generated`
-   * (`postgresql/column.rb:50-61`) and `SQLite3::Column` writes
-   * `auto_increment` (`sqlite3/column.rb:36-44`); `MySQL::Column` writes
-   * nothing, because its `extra` lives in `MySQL::TypeMetadata` and rides
-   * along inside `sql_type_metadata`. trails' overrides go further still,
-   * encoding the state Rails either derives from `sql_type` (`array`, from the
-   * `[]` suffix — `postgresql/column.rb:37-40`) or reaches through
-   * `sql_type_metadata`, which the base coder already persists (`oid` / `fmod`,
-   * `postgresql/column.rb:7`; MySQL's `extra`, `mysql/column.rb:7-24`), plus
-   * the `rowid` / `generated_type` Rails genuinely loses. Dropping the keys
-   * today leaves those fields `undefined`, which flips the `x !== null` guards
-   * the subclasses port Ruby's `nil?` / `present?` as. Tracked by RFC 0096
-   * `converge-column-subclass-coders-to-rails-per-subclass-key-sets`.
+   * Rails' subclasses each carry their OWN key set through the coder, and
+   * trails now mirrors them one for one: `PostgreSQL::Column` writes `serial` /
+   * `identity` / `generated` then calls `super` (`postgresql/column.rb:50-61`)
+   * — `oid` / `fmod` are not ivars there but `delegate`s to the metadata
+   * (`:7`) the base coder already persists, and `array` derives from the
+   * unstripped `sql_type` (`:37-39`); `SQLite3::Column` writes `auto_increment`
+   * alone (`sqlite3/column.rb:35-42`), so `rowid` and `@generated_type` are
+   * dropped by a round-trip upstream too; `MySQL::Column` defines no coder half
+   * at all, because `unsigned?` / `case_sensitive?` / `auto_increment?` /
+   * `virtual?` all derive from `sql_type` / `collation` /
+   * `sql_type_metadata.extra` (`mysql/column.rb:7-24`).
+   *
+   * A key a subclass no longer writes leaves its ivar absent on a dump-loaded
+   * column, which is exactly Ruby's nil — so each of those predicates is
+   * spelled with Ruby's nil truthiness (`!= null` / `present?`), never
+   * `!== null`.
    */
   encodeWith(coder: ColumnCoder): void {
     coder["class"] = "Column";

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -4,10 +4,6 @@ import { Column as MysqlColumn } from "./column.js";
 import { TypeMetadata } from "./type-metadata.js";
 
 describe("MysqlColumn", () => {
-  // mysql/column.rb defines no `encode_with` / `init_with`: every predicate it
-  // adds derives from `sql_type` / `collation` / `sql_type_metadata.extra`, all
-  // of which the BASE coder persists. So the round-trip carries no MySQL keys
-  // and the predicates still answer.
   it("round-trips autoIncrement / unsigned / virtual through encodeWith/initWith", () => {
     const original = new MysqlColumn(
       "id",

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -4,21 +4,28 @@ import { Column as MysqlColumn } from "./column.js";
 import { TypeMetadata } from "./type-metadata.js";
 
 describe("MysqlColumn", () => {
+  // mysql/column.rb defines no `encode_with` / `init_with`: every predicate it
+  // adds derives from `sql_type` / `collation` / `sql_type_metadata.extra`, all
+  // of which the BASE coder persists. So the round-trip carries no MySQL keys
+  // and the predicates still answer.
   it("round-trips autoIncrement / unsigned / virtual through encodeWith/initWith", () => {
     const original = new MysqlColumn(
       "id",
       null,
-      { sqlType: "bigint(20) unsigned", type: "integer", limit: 8 },
+      { sqlType: "bigint(20) unsigned", type: "integer", limit: 8, extra: "auto_increment" },
       false,
-      { autoIncrement: true, unsigned: true, virtual: false },
     );
     const coder: Record<string, unknown> = {};
     original.encodeWith(coder);
+    expect(Object.keys(coder)).not.toContain("unsigned");
+    expect(Object.keys(coder)).not.toContain("auto_increment");
+    expect(Object.keys(coder)).not.toContain("virtual");
+
     const restored = Object.create(MysqlColumn.prototype) as MysqlColumn;
     restored.initWith(JSON.parse(JSON.stringify(coder)));
-    expect(restored.autoIncrement).toBe(true);
-    expect(restored.unsigned).toBe(true);
-    expect(restored.virtual).toBe(false);
+    expect(restored.isAutoIncrement()).toBe(true);
+    expect(restored.isUnsigned()).toBe(true);
+    expect(restored.isVirtual()).toBe(false);
     expect(restored.sqlType).toBe("bigint(20) unsigned");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -79,7 +79,7 @@ export class Column extends BaseColumn {
 
   /** Mirrors: MySQL::Column#virtual? (`mysql/column.rb:22-24`) */
   isVirtual(): boolean {
-    return /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.test(this.extra);
+    return /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.test(this.extra ?? "");
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -9,10 +9,6 @@ import type { ColumnCoder } from "../column.js";
 import { TypeMetadata } from "./type-metadata.js";
 
 export class Column extends BaseColumn {
-  unsigned: boolean;
-  autoIncrement: boolean;
-  virtual: boolean;
-
   constructor(
     name: string,
     defaultValue: unknown,
@@ -29,9 +25,6 @@ export class Column extends BaseColumn {
       collation?: string | null;
       comment?: string | null;
       defaultFunction?: string | null;
-      unsigned?: boolean;
-      autoIncrement?: boolean;
-      virtual?: boolean;
     } = {},
   ) {
     const meta = new TypeMetadata(
@@ -49,9 +42,6 @@ export class Column extends BaseColumn {
       comment: options.comment,
       defaultFunction: options.defaultFunction,
     });
-    this.unsigned = options.unsigned ?? false;
-    this.autoIncrement = options.autoIncrement ?? false;
-    this.virtual = options.virtual ?? false;
   }
 
   /** Raw MySQL `Extra` string (e.g. "VIRTUAL GENERATED", "STORED GENERATED",
@@ -64,54 +54,43 @@ export class Column extends BaseColumn {
     return (this.sqlTypeMetadata as TypeMetadata | null)?.extra ?? null;
   }
 
-  /**
-   * @missingRailsCall match? — PERMANENT: Per-entry verified (RFC 0032
-   *   wide-entry verification): Rails mysql/column.rb:9-11 runs the unsigned
-   *   regex against sql_type on every call; trails mysql/column.ts:12 stores
-   *   `unsigned` as a readonly boolean computed when the adapter builds columns
-   *   from SHOW FULL FIELDS.
-   */
+  // Mirrors: mysql/column.rb:9-11. End-anchored, and no /i flag as in Rails —
+  // SHOW FULL FIELDS reports the `Type` column lowercased.
   isUnsigned(): boolean {
-    return this.unsigned;
+    return /\bunsigned(?: zerofill)?$/.test(this.sqlType ?? "");
   }
 
   isCaseSensitive(): boolean {
     return this.collation != null && !this.collation.endsWith("_ci");
   }
 
+  // Mirrors: mysql/column.rb:17-19
   isAutoIncrement(): boolean {
-    return this.autoIncrement;
+    return this.extra === "auto_increment";
   }
 
+  // Mirrors: `alias_method :auto_incremented_by_db?, :auto_increment?`
+  // (mysql/column.rb:20)
   isAutoIncrementedByDb(): boolean {
-    return this.autoIncrement;
+    return this.isAutoIncrement();
+  }
+
+  // Mirrors: mysql/column.rb:22-24
+  isVirtual(): boolean {
+    return /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.test(this.extra);
   }
 
   /**
-   * @missingRailsCall match? — PERMANENT: Per-entry verified (RFC 0032
-   *   wide-entry verification): Rails mysql/column.rb:22-24 runs the
-   *   VIRTUAL/STORED/PERSISTENT regex against extra on every call; trails
-   *   mysql/column.ts:14 stores `virtual` as a readonly boolean computed at
-   *   column construction.
+   * Rails' MySQL::Column defines NEITHER coder half (mysql/column.rb has no
+   * `encode_with` / `init_with`): every predicate it adds derives from
+   * `sql_type` / `collation` / `sql_type_metadata.extra`, all of which the base
+   * coder already persists. The one thing left is the `class` tag, which Ruby
+   * gets from the YAML object tag and JSON has to spell out.
+   *
+   * @see Column#encodeWith
    */
-  isVirtual(): boolean {
-    return this.virtual;
-  }
-
-  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
-  override initWith(coder: ColumnCoder): void {
-    super.initWith(coder);
-    this.unsigned = (coder["unsigned"] as boolean) ?? false;
-    this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
-    this.virtual = (coder["virtual"] as boolean) ?? false;
-  }
-
   override encodeWith(coder: ColumnCoder): void {
     super.encodeWith(coder);
     coder["class"] = "MySQL::Column";
-    coder["unsigned"] = this.unsigned;
-    coder["auto_increment"] = this.autoIncrement;
-    coder["virtual"] = this.virtual;
-    coder["extra"] = this.extra;
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -54,8 +54,11 @@ export class Column extends BaseColumn {
     return (this.sqlTypeMetadata as TypeMetadata | null)?.extra ?? null;
   }
 
-  // Mirrors: mysql/column.rb:9-11. End-anchored, and no /i flag as in Rails —
-  // SHOW FULL FIELDS reports the `Type` column lowercased.
+  /**
+   * Mirrors: MySQL::Column#unsigned? (`mysql/column.rb:9-11`). End-anchored,
+   * and without an `/i` flag as in Rails — SHOW FULL FIELDS reports the `Type`
+   * column lowercased.
+   */
   isUnsigned(): boolean {
     return /\bunsigned(?: zerofill)?$/.test(this.sqlType ?? "");
   }
@@ -64,18 +67,17 @@ export class Column extends BaseColumn {
     return this.collation != null && !this.collation.endsWith("_ci");
   }
 
-  // Mirrors: mysql/column.rb:17-19
+  /** Mirrors: MySQL::Column#auto_increment? (`mysql/column.rb:17-19`) */
   isAutoIncrement(): boolean {
     return this.extra === "auto_increment";
   }
 
-  // Mirrors: `alias_method :auto_incremented_by_db?, :auto_increment?`
-  // (mysql/column.rb:20)
+  /** Mirrors: `alias_method :auto_incremented_by_db?, :auto_increment?` (`mysql/column.rb:20`) */
   isAutoIncrementedByDb(): boolean {
     return this.isAutoIncrement();
   }
 
-  // Mirrors: mysql/column.rb:22-24
+  /** Mirrors: MySQL::Column#virtual? (`mysql/column.rb:22-24`) */
   isVirtual(): boolean {
     return /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.test(this.extra);
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -412,12 +412,6 @@ export async function newColumnFromField(
   return new Column(fieldName, def, meta, field["Null"] === "YES", {
     defaultFunction: defFn ?? undefined,
     collation: field["Collation"] ?? null,
-    // Literal port of Rails MySQL::Column#unsigned? (`/\bunsigned(?: zerofill)?\z/`); end-anchored
-    // so the modifier isn't matched inside an enum/set value list. No /i flag, as in Rails — SHOW
-    // FIELDS reports the `Type` column lowercased.
-    unsigned: /\bunsigned(?: zerofill)?$/.test(field["Type"] ?? ""),
-    autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
-    virtual: /(virtual|stored|persistent)\s+generated/i.test(field["Extra"] ?? ""),
     comment: presence(field["Comment"] as string | undefined) ?? null,
   });
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3780,7 +3780,6 @@ export class PostgreSQLAdapter
         collation: collation ?? undefined,
         comment: comment || null,
         serial,
-        array: type.endsWith("[]"),
         identity: identity || null,
         generated: gen || null,
       },

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -18,6 +18,24 @@ describe("PostgreSQL::Column JSON round-trip", () => {
     const back = Object.create(Column.prototype) as Column;
     back.initWith(JSON.parse(JSON.stringify(coder)));
 
+    // postgresql/column.rb:56-61 carries `serial` / `identity` / `generated`
+    // and nothing else: `oid` / `fmod` ride inside `sql_type_metadata`, and
+    // `array` derives from the unstripped sql_type.
+    expect(Object.keys(coder).sort()).toEqual(
+      [
+        "class",
+        "collation",
+        "comment",
+        "default",
+        "default_function",
+        "generated",
+        "identity",
+        "name",
+        "null",
+        "serial",
+        "sql_type_metadata",
+      ].sort(),
+    );
     expect(back).toBeInstanceOf(Column);
     expect(back.isArray()).toBe(true);
     expect(back.oid).toBe(1015);

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -7,10 +7,10 @@
 import { Column as BaseColumn } from "../column.js";
 import type { ColumnCoder } from "../column.js";
 import { TypeMetadata } from "./type-metadata.js";
+import { isPresent } from "@blazetrails/activesupport";
 
 export class Column extends BaseColumn {
   serial: boolean;
-  array: boolean;
   identity: string | null;
   generated: string | null;
 
@@ -32,7 +32,6 @@ export class Column extends BaseColumn {
       defaultFunction?: string | null;
       comment?: string | null;
       serial?: boolean;
-      array?: boolean;
       identity?: string | null;
       generated?: string | null;
     } = {},
@@ -53,7 +52,6 @@ export class Column extends BaseColumn {
       comment: options.comment,
     });
     this.serial = options.serial ?? false;
-    this.array = options.array ?? sqlTypeMetadata.sqlType?.endsWith("[]") ?? false;
     this.identity = options.identity ?? null;
     this.generated = options.generated ?? null;
   }
@@ -95,9 +93,12 @@ export class Column extends BaseColumn {
     return this.serial;
   }
 
-  // Mirrors: Column#identity? — truthy when attidentity is "a" or "d"
+  // Mirrors: Column#identity? — the adapter already seats `identity.presence`
+  // (postgresql/schema_statements.rb:990), so Ruby's truthiness on the raw ivar
+  // is `!= null`. A coder that never carried the key leaves it `undefined`,
+  // which `!= null` reads as falsy the way Ruby reads a missing ivar's nil.
   get isIdentity(): boolean {
-    return this.identity !== null && this.identity !== "";
+    return this.identity != null;
   }
 
   // Mirrors: Column#auto_incremented_by_db?
@@ -105,9 +106,10 @@ export class Column extends BaseColumn {
     return this.isSerial || this.isIdentity;
   }
 
-  // Mirrors: Column#virtual? — true for any generated (stored) column
+  // Mirrors: Column#virtual? — `@generated.present?` (postgresql/column.rb:29),
+  // so "" is blank and a nil/absent ivar is falsy.
   override isVirtual(): boolean {
-    return this.generated !== null && this.generated !== "";
+    return isPresent(this.generated);
   }
 
   // Mirrors: Column#has_default? — virtual columns never have a user-visible default
@@ -115,7 +117,14 @@ export class Column extends BaseColumn {
     return super.hasDefault && !this.isVirtual();
   }
 
-  // Mirrors: Column#array? — true when the column stores an array type
+  // Mirrors: `def array; sql_type_metadata.sql_type.end_with?("[]"); end`
+  // (postgresql/column.rb:37-39) — derived from the UNSTRIPPED sql_type, which
+  // is why it reads the metadata rather than this class' `sqlType` override.
+  get array(): boolean {
+    return this.sqlTypeMetadata?.sqlType?.endsWith("[]") ?? false;
+  }
+
+  // Mirrors: `alias :array? :array` (postgresql/column.rb:40)
   isArray(): boolean {
     return this.array;
   }
@@ -134,23 +143,22 @@ export class Column extends BaseColumn {
     );
   }
 
-  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
+  // Mirrors: postgresql/column.rb:50-55 — `serial`, `identity`, `generated`,
+  // then `super`. `oid`/`fmod` are not ivars here (they delegate to the
+  // metadata, which the base coder persists) and `array` is derived.
   override initWith(coder: ColumnCoder): void {
-    super.initWith(coder);
     this.serial = (coder["serial"] as boolean) ?? false;
-    this.array = (coder["array"] as boolean) ?? false;
     this.identity = (coder["identity"] as string | null) ?? null;
     this.generated = (coder["generated"] as string | null) ?? null;
+    super.initWith(coder);
   }
 
+  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
   override encodeWith(coder: ColumnCoder): void {
-    super.encodeWith(coder);
-    coder["class"] = "PostgreSQL::Column";
     coder["serial"] = this.serial;
-    coder["oid"] = this.oid;
-    coder["fmod"] = this.fmod;
-    coder["array"] = this.array;
     coder["identity"] = this.identity;
     coder["generated"] = this.generated;
+    super.encodeWith(coder);
+    coder["class"] = "PostgreSQL::Column";
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -93,10 +93,12 @@ export class Column extends BaseColumn {
     return this.serial;
   }
 
-  // Mirrors: Column#identity? — the adapter already seats `identity.presence`
-  // (postgresql/schema_statements.rb:990), so Ruby's truthiness on the raw ivar
-  // is `!= null`. A coder that never carried the key leaves it `undefined`,
-  // which `!= null` reads as falsy the way Ruby reads a missing ivar's nil.
+  /**
+   * Mirrors: PostgreSQL::Column#identity? (`postgresql/column.rb:16-18`) — the
+   * raw ivar's truthiness. The adapter seats `identity.presence`
+   * (`postgresql/schema_statements.rb:990`), and a coder that never carried the
+   * key leaves it absent, which `!= null` reads the way Ruby reads nil.
+   */
   get isIdentity(): boolean {
     return this.identity != null;
   }
@@ -106,8 +108,7 @@ export class Column extends BaseColumn {
     return this.isSerial || this.isIdentity;
   }
 
-  // Mirrors: Column#virtual? — `@generated.present?` (postgresql/column.rb:29),
-  // so "" is blank and a nil/absent ivar is falsy.
+  /** Mirrors: PostgreSQL::Column#virtual? — `@generated.present?` (`postgresql/column.rb:27-30`) */
   override isVirtual(): boolean {
     return isPresent(this.generated);
   }
@@ -117,14 +118,16 @@ export class Column extends BaseColumn {
     return super.hasDefault && !this.isVirtual();
   }
 
-  // Mirrors: `def array; sql_type_metadata.sql_type.end_with?("[]"); end`
-  // (postgresql/column.rb:37-39) — derived from the UNSTRIPPED sql_type, which
-  // is why it reads the metadata rather than this class' `sqlType` override.
+  /**
+   * Mirrors: PostgreSQL::Column#array (`postgresql/column.rb:37-39`) — derived
+   * from the metadata's UNSTRIPPED `sql_type`, which is why it reads the
+   * metadata rather than this class' `sqlType` override.
+   */
   get array(): boolean {
     return this.sqlTypeMetadata?.sqlType?.endsWith("[]") ?? false;
   }
 
-  // Mirrors: `alias :array? :array` (postgresql/column.rb:40)
+  /** Mirrors: `alias :array? :array` (`postgresql/column.rb:40`) */
   isArray(): boolean {
     return this.array;
   }
@@ -143,9 +146,12 @@ export class Column extends BaseColumn {
     );
   }
 
-  // Mirrors: postgresql/column.rb:50-55 — `serial`, `identity`, `generated`,
-  // then `super`. `oid`/`fmod` are not ivars here (they delegate to the
-  // metadata, which the base coder persists) and `array` is derived.
+  /**
+   * Mirrors: PostgreSQL::Column#init_with (`postgresql/column.rb:50-55`) —
+   * `serial`, `identity`, `generated`, then `super`. `oid` / `fmod` are not
+   * ivars here (they delegate to the metadata, which the base coder persists)
+   * and `array` is derived.
+   */
   override initWith(coder: ColumnCoder): void {
     this.serial = (coder["serial"] as boolean) ?? false;
     this.identity = (coder["identity"] as string | null) ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
@@ -26,8 +26,6 @@ function makeColumn(
     options.name ?? "id",
     null,
     {
-      // `array` derives from the UNSTRIPPED sql_type (postgresql/column.rb:37-39),
-      // so the fixture spells the "[]" suffix rather than setting a flag.
       sqlType: `${options.sqlType ?? options.type ?? "bigint"}${options.array ? "[]" : ""}`,
       type: options.type ?? "integer",
     },

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
@@ -25,9 +25,14 @@ function makeColumn(
   return new Column(
     options.name ?? "id",
     null,
-    { sqlType: options.sqlType ?? options.type ?? "bigint", type: options.type ?? "integer" },
+    {
+      // `array` derives from the UNSTRIPPED sql_type (postgresql/column.rb:37-39),
+      // so the fixture spells the "[]" suffix rather than setting a flag.
+      sqlType: `${options.sqlType ?? options.type ?? "bigint"}${options.array ? "[]" : ""}`,
+      type: options.type ?? "integer",
+    },
     true,
-    { serial: options.serial, array: options.array, generated: options.generated },
+    { serial: options.serial, generated: options.generated },
   );
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -54,10 +54,26 @@ describe("SQLite3::Column JSON round-trip", () => {
     const back = Object.create(Column.prototype) as Column;
     back.initWith(JSON.parse(JSON.stringify(coder)));
 
+    // sqlite3/column.rb:35-42 carries `auto_increment` ALONE; `rowid` and
+    // `@generated_type` are dropped by a round-trip upstream too, so the
+    // restored ivars are nil/absent and every predicate over them is falsy.
+    expect(Object.keys(coder).sort()).toEqual(
+      [
+        "auto_increment",
+        "class",
+        "collation",
+        "comment",
+        "default",
+        "default_function",
+        "name",
+        "null",
+        "sql_type_metadata",
+      ].sort(),
+    );
     expect(back).toBeInstanceOf(Column);
     expect(back.autoIncrement).toBe(true);
-    expect(back.rowid).toBe(true);
-    expect(back.isVirtualStored()).toBe(true);
-    expect(back).toEqual(col);
+    expect(back.rowid).toBeUndefined();
+    expect(back.isVirtual()).toBe(false);
+    expect(back.isVirtualStored()).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -52,8 +52,11 @@ export class Column extends BaseColumn {
     return this.autoIncrement || this.rowid;
   }
 
+  // Mirrors: `!@generated_type.nil?` (sqlite3/column.rb:25). A coder that never
+  // carried the key leaves the ivar absent, and `!= null` reads that as Ruby
+  // reads a missing ivar's nil — falsy.
   isVirtual(): boolean {
-    return this._generatedType !== null;
+    return this._generatedType != null;
   }
 
   isVirtualStored(): boolean {
@@ -70,19 +73,17 @@ export class Column extends BaseColumn {
     );
   }
 
-  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
+  // Mirrors: sqlite3/column.rb:35-42 — `auto_increment` only, then `super`.
+  // `rowid` and `@generated_type` are dropped by a round-trip upstream too.
   override initWith(coder: ColumnCoder): void {
-    super.initWith(coder);
     this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
-    this.rowid = (coder["rowid"] as boolean) ?? false;
-    this._generatedType = (coder["generated_type"] as "stored" | "virtual" | null) ?? null;
+    super.initWith(coder);
   }
 
+  /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
   override encodeWith(coder: ColumnCoder): void {
+    coder["auto_increment"] = this.autoIncrement;
     super.encodeWith(coder);
     coder["class"] = "SQLite3::Column";
-    coder["auto_increment"] = this.autoIncrement;
-    coder["rowid"] = this.rowid;
-    coder["generated_type"] = this._generatedType;
   }
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -52,9 +52,11 @@ export class Column extends BaseColumn {
     return this.autoIncrement || this.rowid;
   }
 
-  // Mirrors: `!@generated_type.nil?` (sqlite3/column.rb:25). A coder that never
-  // carried the key leaves the ivar absent, and `!= null` reads that as Ruby
-  // reads a missing ivar's nil — falsy.
+  /**
+   * Mirrors: SQLite3::Column#virtual? — `!@generated_type.nil?`
+   * (`sqlite3/column.rb:24-26`). A coder that never carried the key leaves the
+   * ivar absent, which `!= null` reads the way Ruby reads nil.
+   */
   isVirtual(): boolean {
     return this._generatedType != null;
   }
@@ -73,8 +75,11 @@ export class Column extends BaseColumn {
     );
   }
 
-  // Mirrors: sqlite3/column.rb:35-42 — `auto_increment` only, then `super`.
-  // `rowid` and `@generated_type` are dropped by a round-trip upstream too.
+  /**
+   * Mirrors: SQLite3::Column#init_with (`sqlite3/column.rb:35-38`) —
+   * `auto_increment` only, then `super`; `rowid` and `@generated_type` are
+   * dropped by a round-trip upstream too.
+   */
   override initWith(coder: ColumnCoder): void {
     this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
     super.initWith(coder);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -15,6 +15,7 @@ import { adapterType } from "./test-adapter.js";
 import { assertQueriesCount } from "./testing/query-assertions.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import type { Column as MysqlColumn } from "./connection-adapters/mysql/column.js";
 import { Migration } from "./migration.js";
 import { fixtures } from "./test-fixtures.js";
 import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
@@ -2502,7 +2503,7 @@ describeIfMysqlAdapter("BulkAlterTableMigrationsTest", () => {
     const isAutoIncrement = async (): Promise<boolean> => {
       const cols = await adapter.columns("delete_me");
       const id = cols.find((c) => c.name === "id");
-      return (id as { autoIncrement?: boolean })?.autoIncrement === true;
+      return (id as MysqlColumn | undefined)?.isAutoIncrement() === true;
     };
 
     const ss = adapter;

--- a/packages/activerecord/src/migration/columns.test.ts
+++ b/packages/activerecord/src/migration/columns.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../base.js";
 import type { Column } from "../connection-adapters/column.js";
+import type { Column as MysqlColumn } from "../connection-adapters/mysql/column.js";
 import { ActiveRecordError, StatementInvalid, NotNullViolation } from "../errors.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { ambientConnection } from "../support/rocket-tables.js";
@@ -431,8 +432,8 @@ describe("Migration", () => {
         await connection.renameColumn("test_models", "id", "id_test");
         const renamed = (await connection.columns("test_models")).find(
           (c) => c.name === "id_test",
-        ) as (Column & { autoIncrement?: boolean }) | undefined;
-        expect(renamed?.autoIncrement).toBe(true);
+        ) as MysqlColumn | undefined;
+        expect(renamed?.isAutoIncrement()).toBe(true);
         void TestModel.resetColumnInformation();
       } finally {
         await connection.renameColumn("test_models", "id_test", "id");

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -793,10 +793,10 @@ describe("PrimaryKeyIntegerTest", () => {
     //        assert_equal :integer, column.type
     //        assert_not_predicate column, :bigint?
     //        assert_predicate column, :unsigned?
-    expect(col.autoIncrement).toBe(true);
+    expect(col.isAutoIncrement()).toBe(true);
     expect(col.type).toBe("integer");
     expect(col.isBigint()).toBe(false);
-    expect(col.unsigned).toBe(true);
+    expect(col.isUnsigned()).toBe(true);
   });
 
   it.skipIf(adapterType !== "mysql")("bigint primary key with unsigned", async () => {
@@ -811,9 +811,9 @@ describe("PrimaryKeyIntegerTest", () => {
     //        assert_equal :integer, column.type
     //        assert_predicate column, :bigint?
     //        assert_predicate column, :unsigned?
-    expect(col.autoIncrement).toBe(true);
+    expect(col.isAutoIncrement()).toBe(true);
     expect(col.type).toBe("integer");
     expect(col.isBigint()).toBe(true);
-    expect(col.unsigned).toBe(true);
+    expect(col.isUnsigned()).toBe(true);
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3397,7 +3397,15 @@ export interface Relation<T extends Base>
   // element type, in query_methods.rb source order.
   select(fn: (record: T) => boolean): Promise<T[]>;
   select(...fields: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T>;
-  reselect(...args: (string | Nodes.Node | Record<string, unknown>)[]): Relation<T>;
+  /**
+   * Rails' `reselect(*args)` flattens its args (`query_methods.rb` —
+   * `reselect!` does `args.flatten!`), so an array argument is a valid single
+   * field list; `distinct_relation_for_primary_key` passes one
+   * (`schema_statements.rb:1438`).
+   */
+  reselect(
+    ...args: (string | Nodes.Node | Record<string, unknown> | readonly (string | Nodes.Node)[])[]
+  ): Relation<T>;
   group(...args: (string | Nodes.Node)[]): Relation<T>;
   regroup(...args: string[]): Relation<T>;
   order(...args: OrderArg[]): Relation<T>;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -357,8 +357,16 @@ class AdapterSchemaSource implements SchemaSource {
         isEnum: col.type === "enum" ? true : undefined,
         isSerial: (col as any).isSerial === true ? true : undefined,
         comment: col.comment ?? undefined,
-        autoIncrement: (col as any).autoIncrement === true ? true : undefined,
-        unsigned: (col as any).unsigned === true ? true : undefined,
+        // MySQL derives both from sql_type/extra (mysql/column.rb:9-19), so the
+        // predicate is the reader; sqlite3 and plain mock sources still carry a flag.
+        autoIncrement:
+          (typeof (col as any).isAutoIncrement === "function"
+            ? (col as any).isAutoIncrement()
+            : (col as any).autoIncrement === true) || undefined,
+        unsigned:
+          (typeof (col as any).isUnsigned === "function"
+            ? (col as any).isUnsigned()
+            : (col as any).unsigned === true) || undefined,
         virtual: isVirtual ? true : undefined,
         virtualStored: isVirtual && isVirtualStored ? true : undefined,
         extra: (col as any).extra ?? undefined,

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -357,8 +357,6 @@ class AdapterSchemaSource implements SchemaSource {
         isEnum: col.type === "enum" ? true : undefined,
         isSerial: (col as any).isSerial === true ? true : undefined,
         comment: col.comment ?? undefined,
-        // MySQL derives both from sql_type/extra (mysql/column.rb:9-19), so the
-        // predicate is the reader; sqlite3 and plain mock sources still carry a flag.
         autoIncrement:
           (typeof (col as any).isAutoIncrement === "function"
             ? (col as any).isAutoIncrement()

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -11,7 +11,7 @@ import {
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { stdout, stderr, setEnv } from "@blazetrails/activesupport";
+import { stdout, stderr, setEnv, getProcessAdapter } from "@blazetrails/activesupport";
 import { DatabaseTasks, DatabaseNotSupported } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -1473,6 +1473,27 @@ describe("DatabaseTaskCheckTargetVersionTest", () => {
 });
 
 describe("DatabaseTasksCheckSchemaFileTest", () => {
+  // `Kernel.abort` leaves the host at exit status 1; under the node process
+  // adapter that is `process.exitCode`, which would red the whole vitest
+  // worker, so the adapter's two abort effects are captured here instead.
+  let exitCodes: number[];
+  let stderrWrites: string[];
+
+  beforeEach(() => {
+    exitCodes = [];
+    stderrWrites = [];
+    const adapter = getProcessAdapter();
+    vi.spyOn(adapter, "setExitCode").mockImplementation((code) => void exitCodes.push(code));
+    vi.spyOn(adapter.stderr, "write").mockImplementation((chunk) => {
+      stderrWrites.push(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("check schema file", () => {
     // Rails: assert_called_with(Kernel, :abort, [/awesome-file.sql/]) — aborts when file missing.
     // No blank-string branch: Rails only does File.exist?, so "" flows through the same path.
@@ -1480,6 +1501,8 @@ describe("DatabaseTasksCheckSchemaFileTest", () => {
       /nonexistent-awesome-file\.sql/,
     );
     expect(() => DatabaseTasks.checkSchemaFile("")).toThrow(/doesn't exist yet/);
+    expect(stderrWrites.join("")).toMatch(/nonexistent-awesome-file\.sql/);
+    expect(exitCodes).toEqual([1, 1]);
   });
 });
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1473,9 +1473,6 @@ describe("DatabaseTaskCheckTargetVersionTest", () => {
 });
 
 describe("DatabaseTasksCheckSchemaFileTest", () => {
-  // `Kernel.abort` leaves the host at exit status 1; under the node process
-  // adapter that is `process.exitCode`, which would red the whole vitest
-  // worker, so the adapter's two abort effects are captured here instead.
   let exitCodes: number[];
   let stderrWrites: string[];
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -533,6 +533,7 @@ export class DatabaseTasks {
   }
 
   static checkSchemaFile(filename: string): void {
+    // Rails: unless File.exist?(filename) → Kernel.abort (database_tasks.rb:482-487).
     // No blank-string special case — Rails only does File.exist?, so "" flows through
     // the same path (existsSync("") === false) and aborts with the filename in the message.
     if (!getFs().existsSync(filename)) {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -22,6 +22,7 @@ import {
   isBlank,
   stdout,
   stderr,
+  abort,
 } from "@blazetrails/activesupport";
 import { NoMethodError } from "@blazetrails/activemodel";
 import { ActiveRecordError, ConnectionNotDefined } from "../errors.js";
@@ -532,13 +533,11 @@ export class DatabaseTasks {
   }
 
   static checkSchemaFile(filename: string): void {
-    // Rails: unless File.exist?(filename) → Kernel.abort (database_tasks.rb:482-487).
     // No blank-string special case — Rails only does File.exist?, so "" flows through
     // the same path (existsSync("") === false) and aborts with the filename in the message.
     if (!getFs().existsSync(filename)) {
-      throw new Error(
-        `${filename} doesn't exist yet. Run \`db:migrate\` to create it, then try again.`,
-      );
+      const message = `${filename} doesn't exist yet. Run \`db:migrate\` to create it, then try again.`;
+      abort(message);
     }
   }
 
@@ -1026,15 +1025,10 @@ export class DatabaseTasks {
    * Mirrors: `ActiveRecord::Tasks::DatabaseTasks#migrate_status`
    * (`database_tasks.rb:302-315`), which `databases.rake:230-232` calls rather
    * than inlining.
-   *
-   * The missing-table arm is Rails' `Kernel.abort` (`:304`) as a throw:
-   * `Kernel.abort` exits the process, which a library method has no business
-   * doing here, so the CLI's own error-to-exit-code path carries it. Same shape
-   * {@link checkSchemaFile} already takes for the same Ruby call.
    */
   static async migrateStatus(): Promise<void> {
     if (!(await this.migrationConnectionPool().schemaMigration.tableExists())) {
-      throw new Error("Schema migrations table does not exist yet.");
+      abort("Schema migrations table does not exist yet.");
     }
     const rows = await this.migrationConnectionPool().migrationContext.migrationsStatus();
     const center = (s: string, w: number) => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -82,6 +82,8 @@ export {
   setExitCode,
   onSignal,
   setEnv,
+  abort,
+  SystemExit,
 } from "./process-adapter.js";
 export type { ProcessAdapter, WriteStream, ReadStream, SignalName } from "./process-adapter.js";
 

--- a/packages/activesupport/src/process-adapter.test.ts
+++ b/packages/activesupport/src/process-adapter.test.ts
@@ -14,6 +14,8 @@ import {
   stderr,
   stdin,
   stdout,
+  abort,
+  SystemExit,
   type ProcessAdapter,
   type WriteStream,
 } from "./process-adapter.js";
@@ -289,6 +291,35 @@ describe("processAdapter", () => {
     it("reports 'custom' when a user adapter is registered", () => {
       registerProcessAdapter(makeFakeAdapter());
       expect(processAdapterConfig.adapter).toBe("custom");
+    });
+  });
+
+  describe("abort", () => {
+    it("writes the message to stderr, sets exit status 1 and raises SystemExit", () => {
+      const adapter = makeFakeAdapter();
+      registerProcessAdapter(adapter);
+
+      expect(() => abort("Schema migrations table does not exist yet.")).toThrow(SystemExit);
+      expect((adapter.stderr as unknown as { written: string[] }).written).toEqual([
+        "Schema migrations table does not exist yet.\n",
+      ]);
+      expect((adapter as unknown as { __exitCode: () => number }).__exitCode()).toBe(1);
+    });
+
+    it('raises SystemExit with Ruby\'s "exit" message and writes nothing when given none', () => {
+      const adapter = makeFakeAdapter();
+      registerProcessAdapter(adapter);
+
+      let raised: SystemExit | undefined;
+      try {
+        abort();
+      } catch (e) {
+        raised = e as SystemExit;
+      }
+      expect(raised).toBeInstanceOf(SystemExit);
+      expect(raised.message).toBe("exit");
+      expect(raised.status).toBe(1);
+      expect((adapter.stderr as unknown as { written: string[] }).written).toEqual([]);
     });
   });
 

--- a/packages/activesupport/src/process-adapter.ts
+++ b/packages/activesupport/src/process-adapter.ts
@@ -125,6 +125,34 @@ export function onSignal(name: SignalName, handler: () => void): () => void {
 }
 
 /**
+ * Ruby's `SystemExit` — the exception `Kernel#abort` raises. Its `status` is
+ * the exit status the host would leave with, and its message is the string
+ * `abort` was given (`"exit"` when it was given none).
+ */
+export class SystemExit extends Error {
+  readonly status: number;
+
+  constructor(status: number, message = "exit") {
+    super(message);
+    this.name = "SystemExit";
+    this.status = status;
+  }
+}
+
+/**
+ * Ruby's `Kernel#abort`: write `message` to stderr, then raise `SystemExit`
+ * with status 1. MRI does raise — `rescue SystemExit` catches it — so the
+ * unwind is faithful; what makes it an abort rather than an ordinary error is
+ * that the process is left with a non-zero status, which is set here through
+ * the process adapter so a test host can observe it without exiting.
+ */
+export function abort(message?: string): never {
+  if (message !== undefined) stderr.write(`${message}\n`);
+  setExitCode(1);
+  throw new SystemExit(1, message);
+}
+
+/**
  * Mutate the `env` snapshot. Use sparingly — `env` is intended to be
  * immutable after registration. Legitimate uses: test setup, dotenv
  * shims at boot. Updates both the underlying adapter and the exported

--- a/packages/website/src/lib/frontiers/trails-cli.ts
+++ b/packages/website/src/lib/frontiers/trails-cli.ts
@@ -44,8 +44,6 @@ function parseInput(input: string): ParsedInput {
   return { command, args, opts };
 }
 
-const MIGRATION_FILE_PATTERN = /^(\d+)[-_](.+)\.(?:ts|js)$/;
-
 // NOTE: The up/down implementations assume executeCode will register migrations
 // via deps.registerMigration. When executeCode is implemented, it must either:
 // (a) evaluate the file in a sandbox that exposes registerMigration, or
@@ -53,11 +51,13 @@ const MIGRATION_FILE_PATTERN = /^(\d+)[-_](.+)\.(?:ts|js)$/;
 //     proxy without the registry lookup.
 /**
  * The `MigrationContext` every `db:*` command runs through, over the browser's
- * virtual FS instead of a directory: Rails' `migration_files` /
- * `parse_migration_filename` (`migration.rb:1369-1376`) are private, and a Ruby
- * private method is still overridable by a subclass, so discovery is repointed
- * there and the run surface (`migrate` / `rollback` / `open` /
- * `migrations_status`) is inherited unchanged.
+ * virtual FS instead of a directory: Rails' `migration_files`
+ * (`migration.rb:1369-1372`) is private, and a Ruby private method is still
+ * overridable by a subclass, so discovery is repointed there and the run
+ * surface (`migrate` / `rollback` / `open` / `migrations_status`) is inherited
+ * unchanged. `parse_migration_filename` is NOT overridden — the inherited
+ * `migration.rb:1374-1376` regex already reads
+ * `db/migrate/<version>_<name>.ts`, scope group included.
  */
 class VfsMigrationContext extends MigrationContext {
   constructor(
@@ -78,23 +78,17 @@ class VfsMigrationContext extends MigrationContext {
       .sort();
   }
 
-  protected override parseMigrationFilename(filename: string): [string, string, string] | null {
-    const basename = filename.split("/").pop() ?? "";
-    const match = basename.match(MIGRATION_FILE_PATTERN);
-    if (!match) return null;
-    return [match[1], match[2].replace(/-/g, "_"), ""];
-  }
-
   override get migrations(): MigrationProxy[] {
     const migrations = this.migrationFiles().flatMap((path) => {
       const parsed = this.parseMigrationFilename(path);
       if (!parsed) return [];
-      const [rawVersion, name] = parsed;
+      const [rawVersion, name, scope] = parsed;
       return [
         {
           version: Number(rawVersion),
           name: camelize(name),
           filename: path,
+          scope: scope || undefined,
           migration: async (): Promise<Migration> => {
             const content = this.vfs.read(path)?.content;
             if (!content) throw new Error(`File not found: ${path}`);

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 387,
-    "total": 1397
+    "total": 1396
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Four stories from one bundle. The fifth, `split-model-mixin-surface-to-active-model-model`, was **released** — see the note at the bottom.

## RFC 0096 — Column subclass coders converge on Rails' per-subclass key sets

Rails' adapter `Column` subclasses each persist their own ivars and nothing more; trails persisted what Rails derives or delegates.

- **PostgreSQL** (`postgresql/column.rb:50-61`): `encodeWith`/`initWith` now carry `serial` / `identity` / `generated` and call `super` last. `oid` / `fmod` are `delegate`s to the metadata (`:7`), which the base coder already persists, so their keys are gone; `array` is now a derived reader off the **unstripped** `sql_type` (`:37-39`) instead of a stored flag, and `postgresql-adapter.ts` stops passing it.
- **SQLite3** (`sqlite3/column.rb:35-42`): `auto_increment` alone. `rowid` and `@generated_type` are dropped by a round-trip, exactly as upstream.
- **MySQL** (`mysql/column.rb:7-24`): no coder half at all (the `class` tag aside — Ruby gets that from the YAML object tag). `unsigned?` / `auto_increment?` / `virtual?` are derived from `sql_type` / `sql_type_metadata.extra` with Rails' own regexes, the two `@missingRailsCall match?` tags at those sites are gone, and `mysql/schema-statements.ts` stops computing the flags for the constructor.

Three predicates over those ivars were spelled `x !== null`, which reads an **absent** ivar as truthy — the actual hazard in dropping the keys. They now use Ruby's nil truthiness: `sqlite3` `isVirtual` (`!@generated_type.nil?`), PG `isIdentity` (the adapter already seats `identity.presence`), PG `isVirtual` (`@generated.present?`).

The one arm that is load-bearing in trails and not upstream: Rails only ever compares one reflected cache against another, while trails' fixtures warm installs the boot dump. `base_test.rb`'s `clear cache!` now compares element-wise through `Column#==`, which is what Rails' `assert_equal` does — so the sqlite3 key set can shrink without reddening it.

`Column#encodeWith`'s deviation comment is rewritten to describe Rails' actual per-subclass key sets, and the three `*/column.trails.test.ts` round-trips pin them (asserting the exact coder key sets).

## RFC 0051 — `distinct_relation_for_primary_key`

Converged onto `schema_statements.rb:1429-1452`:

- the `if (!pk) return` early guard is gone — Rails has none (`Array(nil)` is `[]`), so a pk-less relation now gets `limitValue`/`offsetValue` cleared like every other;
- primary-key columns compile through `visitor.compile(relation.table[column])` (`:1431`) instead of string interpolation, so a `TableAlias` receiver, a schema-qualified name or an adapter quoting rule comes out right;
- the parameter is typed as the `Relation` it actually receives, and `reselect` / `distinctBang` / `noneBang` / `whereBang` are called unguarded.

`Relation#reselect`'s declared arg type gains the array form Rails' `reselect!`'s `args.flatten!` already accepts, so the call passes `values` as Rails does. The `Promise<void>` return stays deviated and stays justified at the method.

## RFC 0051 — `Kernel.abort`

`abort(message)` in the process adapter with MRI's semantics, verified against `ruby -e`: bare message to stderr, `SystemExit` raised with `status` 1 and the given message (`"exit"` when none), exit status set through the adapter so a test host observes it without exiting. Used by `migrateStatus` (`database_tasks.rb:304`) and `checkSchemaFile` (`:486`) — the only two `Kernel.abort` sites in `activerecord/lib` — and the language-forced JSDoc citation at `migrateStatus` is removed.

## RFC 0051 — browser CLI migration filenames

`VfsMigrationContext` no longer overrides `parseMigrationFilename`. The inherited `migration.rb:1374-1376` regex already reads `db/migrate/<version>_<name>.ts`; the retired `[-_]` alias, its `replace(/-/g, "_")`, the over-permissive `(.+)` name group and the hardcoded empty scope go with it, and `migrations` now carries the scope group through. `migrationFiles()` stays overridden — that is the real virtual-FS seam. No tutorial fixture or generated sandbox file uses a hyphen separator.

## Released: `split-model-mixin-surface-to-active-model-model`

Not in this PR, and released back to the queue rather than half-done. Its acceptance criteria are "`model.ts` at 0 novel / **0 moved** and <= 200 code lines", and the 61 `moved` names are the seven ActiveRecord-shaped mixins trails hoists onto `ActiveModel::Model` (Attributes, AttributeRegistration, AttributeMethods, Dirty, Callbacks, Serialization, Serializers::JSON). Retiring them means relocating each to `ActiveRecord::Base` **and** re-including them by hand in every ActiveModel test class that relies on the hoist — a repo-wide change several times the PR ceiling on its own, with no honest partial that moves either number. It wants its own PR with the whole budget.

## Verification

`pnpm typecheck`; `pnpm parity:api:calls` and `:args` clean; `parity:api:extra:gate` OK (activerecord total mark narrowed 1397 -> 1396 by the removed MySQL fields, after rebasing onto main's own tightening — only ever narrowed, never raised); `pnpm lint` clean on every touched file. Locally green: `base.test.ts`, `primary-keys.test.ts`, `schema-dumper.test.ts` / `.trails.test.ts`, all of `connection-adapters/{mysql,postgresql,sqlite3}/`, `schema-statements-privates.trails.test.ts`, `database-tasks.test.ts`, `db-migrate-status.test.ts`, `process-adapter.test.ts`, `website/src/lib/frontiers/sandbox-sw.test.ts`. PG and MySQL/MariaDB lanes are on CI.

One pre-existing website failure is untouched by this branch: `runtime.test.ts > exec: db:migrate (not yet supported) > errors explicitly when code execution is not available` fails with `Error: No database connection defined.`, a connection-setup path that never reaches filename parsing.

Closes-story: converge-column-subclass-coders-to-rails-per-subclass-key-sets
Closes-story: browser-cli-reintroduces-the-retired-hyphen-filename-alias
Closes-story: converge-distinct-relation-for-primary-key-body
Closes-story: kernel-abort-ports-as-a-catchable-throw

