### PR TITLE
refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096)

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -116,7 +116,7 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("schema raises an error for invalid column type", () => {
-    const td = new TableDefinition("test_invalid", { adapter });
+    const td = new TableDefinition(adapter, "test_invalid");
     expect(() => (td as any).unknownType("col")).toThrow();
   });
 
@@ -148,7 +148,7 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("timestamps with and without zones", async () => {
-    const td = new TableDefinition("tz_test", { adapter });
+    const td = new TableDefinition(adapter, "tz_test");
     td.timestamps();
     const colNames = td.columns.map((c) => c.name);
     expect(colNames).toContain("created_at");
@@ -158,14 +158,14 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("timestamps with implicit default on create table", async () => {
-    const td = new TableDefinition("ts_default", { adapter });
+    const td = new TableDefinition(adapter, "ts_default");
     td.timestamps();
     const createdAt = td.columns.find((c) => c.name === "created_at");
     expect(createdAt!.options.null).toBe(false);
   });
 
   it("timestamps with custom options on create table", async () => {
-    const td = new TableDefinition("ts_custom", { adapter });
+    const td = new TableDefinition(adapter, "ts_custom");
     td.timestamps({ null: true, precision: 6 });
     const createdAt = td.columns.find((c) => c.name === "created_at");
     const updatedAt = td.columns.find((c) => c.name === "updated_at");

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Base } from "../base.js";
 import { describeIfMysqlAdapter } from "../support/describe-if-mysql-adapter.js";
 import { Column } from "./mysql/column.js";
+import { TypeMetadata } from "./mysql/type-metadata.js";
 import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
@@ -12,6 +13,7 @@ import { NullPool } from "./abstract/connection-pool.js";
 import { Result } from "../result.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
+<<<<<<< HEAD
   return new Column(
     "id",
     null,
@@ -19,6 +21,17 @@ function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | 
     false,
     { defaultFunction: opts.defaultFunction ?? null },
   );
+||||||| parent of 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
+  return new Column("id", null, { sqlType: "bigint" }, false, {
+    autoIncrement: opts.autoIncrement ?? false,
+    defaultFunction: opts.defaultFunction ?? null,
+  });
+=======
+  return new Column("id", null, new TypeMetadata({ sqlType: "bigint" }), false, {
+    autoIncrement: opts.autoIncrement ?? false,
+    defaultFunction: opts.defaultFunction ?? null,
+  });
+>>>>>>> 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
 }
 
 describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {
@@ -192,10 +205,16 @@ describeIfMysqlAdapter("AbstractMysqlAdapter#buildChangeColumnDefinition", () =>
   function makeTextColumn(
     opts: { collation?: string | null; defaultFunction?: string | null } = {},
   ) {
-    return new Column("body", "hello", { sqlType: "varchar(255)", type: "string" }, true, {
-      collation: opts.collation ?? "utf8mb4_unicode_ci",
-      defaultFunction: opts.defaultFunction ?? null,
-    });
+    return new Column(
+      "body",
+      "hello",
+      new TypeMetadata({ sqlType: "varchar(255)", type: "string" }),
+      true,
+      {
+        collation: opts.collation ?? "utf8mb4_unicode_ci",
+        defaultFunction: opts.defaultFunction ?? null,
+      },
+    );
   }
 
   async function makeAdapter(column: Column) {
@@ -406,7 +425,7 @@ function makeChangeColumnTextColumn(opts: { null_?: boolean; default_?: unknown 
   return new Column(
     "body",
     opts.default_ === undefined ? "hello" : opts.default_,
-    { sqlType: "varchar(255)", type: "string" },
+    new TypeMetadata({ sqlType: "varchar(255)", type: "string" }),
     opts.null_ ?? true,
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
@@ -13,25 +13,13 @@ import { NullPool } from "./abstract/connection-pool.js";
 import { Result } from "../result.js";
 
 function makeColumn(opts: { autoIncrement?: boolean; defaultFunction?: string | null } = {}) {
-<<<<<<< HEAD
   return new Column(
     "id",
     null,
-    { sqlType: "bigint", extra: opts.autoIncrement ? "auto_increment" : "" },
+    new TypeMetadata({ sqlType: "bigint" }, { extra: opts.autoIncrement ? "auto_increment" : "" }),
     false,
     { defaultFunction: opts.defaultFunction ?? null },
   );
-||||||| parent of 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
-  return new Column("id", null, { sqlType: "bigint" }, false, {
-    autoIncrement: opts.autoIncrement ?? false,
-    defaultFunction: opts.defaultFunction ?? null,
-  });
-=======
-  return new Column("id", null, new TypeMetadata({ sqlType: "bigint" }), false, {
-    autoIncrement: opts.autoIncrement ?? false,
-    defaultFunction: opts.defaultFunction ?? null,
-  });
->>>>>>> 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
 }
 
 describe("AbstractMysqlAdapter#returnValueAfterInsert", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.trails.test.ts
@@ -70,10 +70,7 @@ describeIfSqlite("SchemaCreation#visit_TableDefinition inline indexes", () => {
   }
 
   it("emits index_in_create for each index when supports_indexes_in_create? is true", async () => {
-    const td = new TableDefinition("users", {
-      adapter: conn,
-      adapterName: "sqlite",
-    });
+    const td = new TableDefinition(conn, "users");
     td.string("email");
     td.index("email");
 
@@ -82,10 +79,7 @@ describeIfSqlite("SchemaCreation#visit_TableDefinition inline indexes", () => {
   });
 
   it("emits no inline index when supports_indexes_in_create? is false", async () => {
-    const td = new TableDefinition("users", {
-      adapter: conn,
-      adapterName: "sqlite",
-    });
+    const td = new TableDefinition(conn, "users");
     td.string("email");
     td.index("email");
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -309,9 +309,7 @@ export class SchemaCreation {
     if (o.algorithm) parts.push(o.algorithm);
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
     if (index.type) parts.push(index.type.toUpperCase());
-    parts.push(
-      `${this.adapter.quoteColumnName(index.name)} ON ${this.adapter.quoteTableName(index.table)}`,
-    );
+    parts.push(this.quotedIndexNameAndTable(index));
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     parts.push(`(${await this.quotedColumns(index)})`);
     if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
@@ -321,6 +319,24 @@ export class SchemaCreation {
       parts.push("NULLS NOT DISTINCT");
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
+  }
+
+  /**
+   * The `<index name> ON <table>` fragment of `visit_CreateIndexDefinition`
+   * (abstract/schema_creation.rb:120), inlined there in Rails.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT: SQLite spells an ATTACHed schema on the INDEX
+   *   name rather than on the table — `CREATE INDEX "aux"."by_name" ON
+   *   "widgets" (...)`, where qualifying the table is a syntax error. Rails has
+   *   no ATTACHed-schema notion in this adapter, so upstream never grew the
+   *   seam; trails does (`SQLite3Adapter#_splitTableName`, reached through
+   *   `alter_table` / `copy_table` with an `aux.posts` name). Keeping it a
+   *   one-line seam rather than a forked copy of the whole body means the arm
+   *   order and every capability gate live in one place.
+   */
+  protected quotedIndexNameAndTable(index: IndexDefinition): string {
+    return `${this.adapter.quoteColumnName(index.name)} ON ${this.adapter.quoteTableName(index.table)}`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -325,15 +325,16 @@ export class SchemaCreation {
    * The `<index name> ON <table>` fragment of `visit_CreateIndexDefinition`
    * (abstract/schema_creation.rb:120), inlined there in Rails.
    *
+   * Extracted only so SQLite3 can override this one fragment: SQLite spells an
+   * ATTACHed schema on the INDEX name rather than on the table — `CREATE INDEX
+   * "aux"."by_name" ON "widgets" (...)` — where qualifying the table is a
+   * syntax error. Rails has no ATTACHed-schema notion in this adapter, so
+   * upstream never grew the seam; trails does
+   * (`SQLite3Adapter#_splitTableName`, reached through `alter_table` /
+   * `copy_table` with an `aux.posts` name). A one-line seam rather than a
+   * forked copy of the whole body keeps the arm order and every capability
+   * gate in one place.
    * @internal
-   * @noRailsEquivalent PERMANENT: SQLite spells an ATTACHed schema on the INDEX
-   *   name rather than on the table — `CREATE INDEX "aux"."by_name" ON
-   *   "widgets" (...)`, where qualifying the table is a syntax error. Rails has
-   *   no ATTACHed-schema notion in this adapter, so upstream never grew the
-   *   seam; trails does (`SQLite3Adapter#_splitTableName`, reached through
-   *   `alter_table` / `copy_table` with an `aux.posts` name). Keeping it a
-   *   one-line seam rather than a forked copy of the whole body means the arm
-   *   order and every capability gate live in one place.
    */
   protected quotedIndexNameAndTable(index: IndexDefinition): string {
     return `${this.adapter.quoteColumnName(index.name)} ON ${this.adapter.quoteTableName(index.table)}`;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -102,7 +102,7 @@ describe("CheckConstraintDefinition#defined_for?", () => {
 
 describe("TableDefinition#remove_column", () => {
   const td = (): TableDefinition => {
-    const t = new TableDefinition("astronauts", { adapter: conn });
+    const t = new TableDefinition(conn, "astronauts");
     t.setPrimaryKey("astronauts", true);
     t.string("name");
     t.integer("rocket_id");
@@ -216,7 +216,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
   it("targets the singular table when Base.pluralizeTableNames is false", () => {
     Base.pluralizeTableNames = false;
     const ref = new ReferenceDefinition("user", { foreignKey: true, index: false });
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("user");
   });
@@ -227,7 +227,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
       foreignKey: { toTable: "accounts" },
       index: false,
     });
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
@@ -235,7 +235,7 @@ describe("ReferenceDefinition#foreign_table_name", () => {
 
 describe("TableDefinition column methods", () => {
   it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     td.string("goat", "sheep", { limit: 40 });
 
     expect(td.columns.map((c) => c.name)).toEqual(["goat", "sheep"]);
@@ -243,14 +243,14 @@ describe("TableDefinition column methods", () => {
   });
 
   it("defines a single column when no options are passed", () => {
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     td.integer("votes");
 
     expect(td.columns.map((c) => c.name)).toEqual(["votes"]);
   });
 
   it("raises when called with no column name", () => {
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
 
     expect(() => (td.timestamp as () => unknown)()).toThrow("Missing column name(s) for timestamp");
     expect(() => (td.string as (o: object) => unknown)({ limit: 40 })).toThrow(
@@ -261,7 +261,7 @@ describe("TableDefinition column methods", () => {
 
 describe("ColumnMethods#primary_key", () => {
   it("merges primary_key: true and honours the type argument on create_table", () => {
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     td.primaryKey("id", "uuid", { default: "gen_random_uuid()" });
 
     expect(td.columns.map((c) => c.name)).toEqual(["id"]);
@@ -271,7 +271,7 @@ describe("ColumnMethods#primary_key", () => {
   });
 
   it("defaults the type to primary_key", () => {
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     td.primaryKey("id");
 
     expect(td.columns[0].type).toBe("primary_key");
@@ -294,7 +294,7 @@ describe("IndexDefinition concise options", () => {
 });
 
 describe("TableDefinition#create_column_definition", () => {
-  const td = () => new TableDefinition("articles", { adapter: conn, adapterName: "sqlite" });
+  const td = () => new TableDefinition(conn, "articles");
 
   it("raises on a column option outside valid_column_definition_options", () => {
     expect(() => td().column("title", "string", { preccision: true } as never)).toThrow(
@@ -437,9 +437,7 @@ describe("ForeignKeyDefinition#defined_for?", () => {
   it("slices out lookup keys the definition does not store", () => {
     // Mirrors `options = options.slice(*self.options.keys)`: a key the FK never
     // carried is dropped before the generic compare, so it is ignored.
-    const fkDef = new TableDefinition("astronauts", {
-      adapter: conn,
-    }).newForeignKeyDefinition("rockets");
+    const fkDef = new TableDefinition(conn, "astronauts").newForeignKeyDefinition("rockets");
     expect(fkDef.isDefinedFor({ primaryKey: "wrong" })).toBe(true);
     expect(fkDef.isDefinedFor({ onDelete: "cascade" })).toBe(true);
     expect(fkDef.isDefinedFor({ onUpdate: "cascade" })).toBe(true);
@@ -448,9 +446,7 @@ describe("ForeignKeyDefinition#defined_for?", () => {
     // so they still compare.
     expect(fkDef.isDefinedFor({ column: "rocket_id" })).toBe(true);
     expect(fkDef.isDefinedFor({ column: "wrong_id" })).toBe(false);
-    const withPk = new TableDefinition("astronauts", {
-      adapter: conn,
-    }).newForeignKeyDefinition("rockets", {
+    const withPk = new TableDefinition(conn, "astronauts").newForeignKeyDefinition("rockets", {
       primaryKey: "uuid",
     });
     expect(withPk.isDefinedFor({ primaryKey: "uuid" })).toBe(true);
@@ -497,9 +493,7 @@ describe("ForeignKeyDefinition#defined_for?", () => {
 
 describe("TableDefinition#new_foreign_key_definition", () => {
   it("defaults the name to fk_rails_<hex>, not fk_<table>_<column>", () => {
-    const fk = new TableDefinition("astronauts", {
-      adapter: conn,
-    }).newForeignKeyDefinition("rockets");
+    const fk = new TableDefinition(conn, "astronauts").newForeignKeyDefinition("rockets");
     expect(fk.column).toBe("rocket_id");
     expect(fk.name).toMatch(/^fk_rails_[0-9a-f]{10}$/);
   });
@@ -510,7 +504,7 @@ describe("TableDefinition#new_foreign_key_definition", () => {
         return { ...options, column: "custom_id", name: `fk_${fromTable}_${toTable}` };
       },
     } as any;
-    const td = new TableDefinition("astronauts", { adapter });
+    const td = new TableDefinition(adapter, "astronauts");
     const fk = td.newForeignKeyDefinition("rockets");
     expect(fk.column).toBe("custom_id");
     expect(fk.name).toBe("fk_astronauts_rockets");
@@ -519,9 +513,7 @@ describe("TableDefinition#new_foreign_key_definition", () => {
   it("maps a composite primaryKey array to a composite column array (bare-adapter fallback)", () => {
     // Mirrors foreign_key_options' array branch: each PK column gets its own
     // singularized foreign-key column.
-    const fk = new TableDefinition("astronauts", {
-      adapter: conn,
-    }).newForeignKeyDefinition("rockets", {
+    const fk = new TableDefinition(conn, "astronauts").newForeignKeyDefinition("rockets", {
       primaryKey: ["tenant_id", "id"],
     });
     expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
@@ -531,7 +523,7 @@ describe("TableDefinition#new_foreign_key_definition", () => {
     // Mirrors foreign_key_options' arity guard (schema_statements.rb:1258-1266):
     // a composite primaryKey must be matched by an equal-arity column.
     expect(() =>
-      new TableDefinition("astronauts", { adapter: conn }).newForeignKeyDefinition("rockets", {
+      new TableDefinition(conn, "astronauts").newForeignKeyDefinition("rockets", {
         column: "rocket_id",
         primaryKey: ["tenant_id", "id"],
       }),
@@ -546,7 +538,7 @@ describe("TableDefinition#new_foreign_key_definition", () => {
         return { ...options, column: "rocket_id", name: "fk_rails_deadbeef00", toTable };
       },
     } as any;
-    const td = new TableDefinition("app_astronauts_v2", { adapter });
+    const td = new TableDefinition(adapter, "app_astronauts_v2");
     const fk = td.newForeignKeyDefinition("rockets");
     expect(fk.toTable).toBe("app_rockets_v2");
   });
@@ -554,9 +546,7 @@ describe("TableDefinition#new_foreign_key_definition", () => {
 
 describe("TableDefinition#new_check_constraint_definition", () => {
   it("defaults the name to chk_rails_<hex> (bare-adapter fallback)", () => {
-    const chk = new TableDefinition("products", {
-      adapter: conn,
-    }).newCheckConstraintDefinition("price > 0");
+    const chk = new TableDefinition(conn, "products").newCheckConstraintDefinition("price > 0");
     expect(chk.name).toMatch(/^chk_rails_[0-9a-f]{10}$/);
     expect(chk.validate).toBe(true);
   });
@@ -573,7 +563,7 @@ describe("TableDefinition#new_check_constraint_definition", () => {
         return { ...options, name: `chk_${tableName}` };
       },
     } as any;
-    const td = new TableDefinition("products", { adapter });
+    const td = new TableDefinition(adapter, "products");
     const chk = td.newCheckConstraintDefinition("price > 0", { validate: false });
     expect(calls).toEqual([["products", "price > 0", { validate: false }]]);
     expect(chk.name).toBe("chk_products");
@@ -590,7 +580,7 @@ describe("TableDefinition#new_check_constraint_definition", () => {
         return { ...options, name: `chk_${tableName}` };
       },
     } as any;
-    const td = new TableDefinition("products", { adapter });
+    const td = new TableDefinition(adapter, "products");
     td.checkConstraint("price > 0");
     expect(td.checkConstraints.map((c) => c.name)).toEqual(["chk_products"]);
   });
@@ -599,14 +589,14 @@ describe("TableDefinition#new_check_constraint_definition", () => {
 describe("ReferenceDefinition helpers", () => {
   it("addTo adds id column by default", () => {
     const ref = new ReferenceDefinition("user", { index: false });
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     ref.addTo(td);
     expect(td.columns.map((c) => c.name)).toContain("user_id");
   });
 
   it("addTo adds type column when polymorphic", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true, index: false });
-    const td = new TableDefinition("taggings", { adapter: conn });
+    const td = new TableDefinition(conn, "taggings");
     ref.addTo(td);
     const names = td.columns.map((c) => c.name);
     expect(names).toContain("taggable_id");
@@ -615,14 +605,14 @@ describe("ReferenceDefinition helpers", () => {
 
   it("addTo adds index with polymorphic name", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true });
-    const td = new TableDefinition("taggings", { adapter: conn });
+    const td = new TableDefinition(conn, "taggings");
     ref.addTo(td);
     expect(td.indexes[0][1].name).toBe("index_taggings_on_taggable");
   });
 
   it("addTo adds foreign key when foreignKey: true", () => {
     const ref = new ReferenceDefinition("user", { foreignKey: true, index: false });
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     ref.addTo(td);
     expect(td.foreignKeys).toHaveLength(1);
     expect(td.foreignKeys[0].toTable).toBe("users");
@@ -633,7 +623,7 @@ describe("ReferenceDefinition helpers", () => {
       foreignKey: { toTable: "accounts" },
       index: false,
     });
-    const td = new TableDefinition("posts", { adapter: conn });
+    const td = new TableDefinition(conn, "posts");
     ref.addTo(td);
     expect(td.foreignKeys[0].toTable).toBe("accounts");
   });
@@ -646,7 +636,7 @@ describe("ReferenceDefinition helpers", () => {
 
   it("polymorphic columns are ordered type before id", () => {
     const ref = new ReferenceDefinition("taggable", { polymorphic: true, index: false });
-    const td = new TableDefinition("taggings", { adapter: conn });
+    const td = new TableDefinition(conn, "taggings");
     ref.addTo(td);
     expect(td.columns[0].name).toBe("taggable_type");
     expect(td.columns[1].name).toBe("taggable_id");
@@ -655,7 +645,7 @@ describe("ReferenceDefinition helpers", () => {
 
 describe("TableDefinition#toSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", async () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.column("bad", "" as any);
     await expect(new SchemaCreation(conn).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
@@ -663,7 +653,7 @@ describe("TableDefinition#toSql blank type guard", () => {
   });
 
   it("throws a descriptive error for a whitespace-only custom type", async () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.column("bad", "   " as any);
     await expect(new SchemaCreation(conn).accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
@@ -673,13 +663,13 @@ describe("TableDefinition#toSql blank type guard", () => {
 
 describe("TableDefinition#raise_on_duplicate_column", () => {
   it("raises when adding a duplicate non-pk column", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.string("name");
     expect(() => td.string("name")).toThrow("already defined column");
   });
 
   it("raises with pk-specific message for primary key columns", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.setPrimaryKey("t", true);
     expect(() => td.column("id", "integer", { primaryKey: true })).toThrow(
       "redefine the primary key",
@@ -689,7 +679,7 @@ describe("TableDefinition#raise_on_duplicate_column", () => {
 
 describe("TableDefinition#primary_key option", () => {
   it("treats primaryKey: 'uuid' as a custom PK column name", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.setPrimaryKey("t", true, "uuid");
     const pk = td.columns.find((c) => c.options.primaryKey);
     expect(pk?.name).toBe("uuid");
@@ -698,7 +688,7 @@ describe("TableDefinition#primary_key option", () => {
 
 describe("TableDefinition#integer_like_primary_key?", () => {
   it("newColumnDefinition preserves integer pk type in base class", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     const col = td.newColumnDefinition("id", "integer", { primaryKey: true });
     expect(col.type).toBe("integer");
   });
@@ -706,7 +696,7 @@ describe("TableDefinition#integer_like_primary_key?", () => {
 
 describe("TableDefinition#aliased_types", () => {
   it("maps timestamp to datetime", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.column("ts", "timestamp");
     expect(td.columns[0].type).toBe("datetime");
   });
@@ -783,7 +773,7 @@ describe("Table#aliasedTypes", () => {
 
 describe("TableDefinition id hash form", () => {
   it("extracts type and merges remaining keys as pk column options", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.setPrimaryKey("t", { type: "string", collation: "utf8mb4_bin" });
     const id = td.columns.find((c) => c.name === "id")!;
     expect(id.type).toBe("string");
@@ -792,7 +782,7 @@ describe("TableDefinition id hash form", () => {
   });
 
   it("defaults type to primary_key when hash omits type", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.setPrimaryKey("t", { collation: "utf8mb4_bin" });
     const id = td.columns.find((c) => c.name === "id")!;
     expect(id.type).toBe("primary_key");
@@ -800,7 +790,7 @@ describe("TableDefinition id hash form", () => {
   });
 
   it("outer default is merged first, hash content overrides", () => {
-    const td = new TableDefinition("t", { adapterName: "mysql2", adapter: conn });
+    const td = new TableDefinition(conn, "t");
     td.setPrimaryKey("t", { type: "string", default: "generated" }, undefined, {
       default: "outer",
     });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1086,14 +1086,12 @@ export class TableDefinition {
   readonly options?: string;
   readonly comment?: string;
   private _primaryKeys?: PrimaryKeyDefinition;
-  private _adapterName: "sqlite" | "postgres" | "mysql2";
   protected _adapter: TableDefinitionConn;
 
   constructor(
+    conn: TableDefinitionConn,
     name: string,
     tdOptions: {
-      adapterName?: "sqlite" | "postgres" | "mysql2";
-      adapter: TableDefinitionConn;
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
@@ -1101,11 +1099,11 @@ export class TableDefinition {
       comment?: string;
       charset?: string;
       collation?: string;
-    },
+      [key: string]: unknown;
+    } = {},
   ) {
+    this._adapter = conn;
     this.name = name;
-    this._adapterName = tdOptions.adapterName ?? "sqlite";
-    this._adapter = tdOptions.adapter;
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
     this.as = tdOptions.as;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.trails.test.ts
@@ -903,7 +903,7 @@ describe("buildCreateTableDefinition routing", () => {
   it("extracts _skipValidateOptions into the table definition options", () => {
     const createTableDefinition = vi.fn(
       (name: string, options: Record<string, unknown>) =>
-        new TableDefinition(name, { ...options, adapter: ss } as any),
+        new TableDefinition(ss, name, { ...options } as any),
     );
     const ss = makeStatements({ createTableDefinition });
 
@@ -921,7 +921,7 @@ describe("buildCreateTableDefinition routing", () => {
     const mysql = makeStatements({
       validPrimaryKeyOptions: () => ["limit", "unsigned", "autoIncrement"],
       createTableDefinition: (name: string, options: Record<string, unknown>) =>
-        new MysqlTableDefinition(name, { ...options, adapter: mysql } as any),
+        new MysqlTableDefinition(mysql as any, name, { ...options } as any),
     });
 
     expect(
@@ -967,7 +967,7 @@ describe("buildCreateTableDefinition routing", () => {
   it("builds the definition through the adapter's createTableDefinition", () => {
     const marker = Symbol("dialect-td");
     const createTableDefinition = vi.fn((name: string, options: Record<string, unknown>) => {
-      const td: any = new TableDefinition(name, { ...options, adapter: ss } as any);
+      const td: any = new TableDefinition(ss, name, { ...options } as any);
       td[marker] = true;
       return td;
     });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2007,11 +2007,7 @@ export class SchemaStatements {
 
   /** @internal */
   createTableDefinition(name: string, options: Record<string, unknown> = {}): TableDefinition {
-    return new TableDefinition(name, {
-      ...options,
-      adapterName: this.adapterName as any,
-      adapter: this,
-    });
+    return new TableDefinition(this, name, options);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Column } from "./column.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import { Column as PostgreSQLColumn } from "./postgresql/column.js";
+import { TypeMetadata as PgTypeMetadata } from "./postgresql/type-metadata.js";
 import { Column as SQLite3Column } from "./sqlite3/column.js";
 
 function meta(overrides: NonNullable<ConstructorParameters<typeof SqlTypeMetadata>[0]> = {}) {
@@ -54,7 +55,12 @@ describe("ColumnEqualityTrails", () => {
   });
 
   it("narrows the guard to the adapter class in PostgreSQL::Column", () => {
-    const pg = new PostgreSQLColumn("id", null, { sqlType: "integer", type: "integer" }, false);
+    const pg = new PostgreSQLColumn(
+      "id",
+      null,
+      new PgTypeMetadata({ sqlType: "integer", type: "integer" }),
+      false,
+    );
     const metadata = new SqlTypeMetadata({ sqlType: "integer", type: "integer" });
     const base = new Column("id", null, metadata, false);
     expect(pg.equals(base)).toBe(false);
@@ -62,7 +68,7 @@ describe("ColumnEqualityTrails", () => {
   });
 
   it("compares the PostgreSQL identity and serial flags", () => {
-    const opts = { sqlType: "integer", type: "integer" };
+    const opts = new PgTypeMetadata({ sqlType: "integer", type: "integer" });
     const plain = new PostgreSQLColumn("id", null, opts, false);
     expect(plain.equals(new PostgreSQLColumn("id", null, opts, false))).toBe(true);
     expect(plain.equals(new PostgreSQLColumn("id", null, opts, false, { serial: true }))).toBe(
@@ -85,7 +91,7 @@ describe("ColumnEqualityTrails", () => {
 
   it("does not equal a sibling adapter's column", () => {
     const opts = { sqlType: "integer", type: "integer" };
-    const pg = new PostgreSQLColumn("id", null, opts, false);
+    const pg = new PostgreSQLColumn("id", null, new PgTypeMetadata(opts), false);
     const sqlite = new SQLite3Column("id", null, opts, false);
     expect(pg.equals(sqlite)).toBe(false);
     expect(sqlite.equals(pg)).toBe(false);

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -8,13 +8,10 @@ describe("MysqlColumn", () => {
     const original = new MysqlColumn(
       "id",
       null,
-<<<<<<< HEAD
-      { sqlType: "bigint(20) unsigned", type: "integer", limit: 8, extra: "auto_increment" },
-||||||| parent of 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
-      { sqlType: "bigint(20) unsigned", type: "integer", limit: 8 },
-=======
-      new TypeMetadata({ sqlType: "bigint(20) unsigned", type: "integer", limit: 8 }),
->>>>>>> 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
+      new TypeMetadata(
+        { sqlType: "bigint(20) unsigned", type: "integer", limit: 8 },
+        { extra: "auto_increment" },
+      ),
       false,
     );
     const coder: Record<string, unknown> = {};
@@ -66,7 +63,11 @@ describe("MySQL::TypeMetadata JSON round-trip", () => {
     const meta = new TypeMetadata({ sqlType: "varchar(255)", type: "string", limit: 255 });
     expect(meta.extra).toBeNull();
 
-    const col = new MysqlColumn("name", null, { sqlType: "varchar(255)", type: "string" });
+    const col = new MysqlColumn(
+      "name",
+      null,
+      new TypeMetadata({ sqlType: "varchar(255)", type: "string" }),
+    );
     expect(col.extra).toBeNull();
     expect(col.isAutoIncrement()).toBe(false);
     expect(col.isVirtual()).toBe(false);

--- a/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.trails.test.ts
@@ -8,7 +8,13 @@ describe("MysqlColumn", () => {
     const original = new MysqlColumn(
       "id",
       null,
+<<<<<<< HEAD
       { sqlType: "bigint(20) unsigned", type: "integer", limit: 8, extra: "auto_increment" },
+||||||| parent of 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
+      { sqlType: "bigint(20) unsigned", type: "integer", limit: 8 },
+=======
+      new TypeMetadata({ sqlType: "bigint(20) unsigned", type: "integer", limit: 8 }),
+>>>>>>> 735272b86 (refactor(activerecord): positional conn in TableDefinition, adapter TypeMetadata in Column subclasses, one CREATE INDEX body (RFC 0051, RFC 0096))
       false,
     );
     const coder: Record<string, unknown> = {};
@@ -41,11 +47,11 @@ describe("MySQL::TypeMetadata JSON round-trip", () => {
   });
 
   it("delegates the Column reader to the metadata object", () => {
-    const col = new MysqlColumn("id", null, {
-      sqlType: "bigint(20)",
-      type: "integer",
-      extra: "auto_increment",
-    });
+    const col = new MysqlColumn(
+      "id",
+      null,
+      new TypeMetadata({ sqlType: "bigint(20)", type: "integer" }, { extra: "auto_increment" }),
+    );
     expect(col.sqlTypeMetadata).toBeInstanceOf(TypeMetadata);
     expect(col.extra).toBe("auto_increment");
 

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -12,14 +12,7 @@ export class Column extends BaseColumn {
   constructor(
     name: string,
     defaultValue: unknown,
-    sqlTypeMetadata: {
-      sqlType?: string | null;
-      type?: string;
-      limit?: number | null;
-      precision?: number | null;
-      scale?: number | null;
-      extra?: string | null;
-    } = {},
+    sqlTypeMetadata: TypeMetadata | null = null,
     null_: boolean = true,
     options: {
       collation?: string | null;
@@ -27,17 +20,7 @@ export class Column extends BaseColumn {
       defaultFunction?: string | null;
     } = {},
   ) {
-    const meta = new TypeMetadata(
-      {
-        sqlType: sqlTypeMetadata.sqlType ?? undefined,
-        type: sqlTypeMetadata.type,
-        limit: sqlTypeMetadata.limit ?? null,
-        precision: sqlTypeMetadata.precision ?? null,
-        scale: sqlTypeMetadata.scale ?? null,
-      },
-      { extra: sqlTypeMetadata.extra },
-    );
-    super(name, defaultValue, meta, null_, {
+    super(name, defaultValue, sqlTypeMetadata, null_, {
       collation: options.collation,
       comment: options.comment,
       defaultFunction: options.defaultFunction,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.trails.test.ts
@@ -1,5 +1,6 @@
 import { it, expect, beforeAll } from "vitest";
 import { SchemaCreation, type VisitorHostAdapter } from "./schema-creation.js";
+import { TypeMetadata } from "./type-metadata.js";
 import {
   AddColumnDefinition,
   ChangeColumnDefinition,
@@ -51,7 +52,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   });
 
   it("visitAlterTable routes FK/check drops through the MySQL visitors", async () => {
-    const at = new AlterTable(new TableDefinition("posts", { adapter: mysqlConn() }));
+    const at = new AlterTable(new TableDefinition(mysqlConn(), "posts"));
     at.dropForeignKey("fk_name");
     at.checkConstraintDrops.push("chk");
     const sql = await (
@@ -70,7 +71,11 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition generates SET DEFAULT", async () => {
-    const col = new Column("status", null, { sqlType: "varchar(255)", type: "string" });
+    const col = new Column(
+      "status",
+      null,
+      new TypeMetadata({ sqlType: "varchar(255)", type: "string" }),
+    );
     const def = new ChangeColumnDefaultDefinition(col, "active");
     expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toMatch(
       /ALTER COLUMN `status` SET DEFAULT/,
@@ -78,7 +83,12 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition generates DROP DEFAULT when null:false + null value", async () => {
-    const col = new Column("status", null, { sqlType: "varchar(255)", type: "string" }, false);
+    const col = new Column(
+      "status",
+      null,
+      new TypeMetadata({ sqlType: "varchar(255)", type: "string" }),
+      false,
+    );
     const def = new ChangeColumnDefaultDefinition(col, null);
     expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toBe(
       "ALTER COLUMN `status` DROP DEFAULT",
@@ -135,7 +145,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation", () => {
   });
 
   it("addTableOptionsBang appends charset and collation", async () => {
-    const td = new TableDefinition("users", { adapter: mysqlConn(), adapterName: "mysql2" });
+    const td = new TableDefinition(mysqlConn(), "users");
     (td as any).charset = "utf8mb4";
     (td as any).collation = "utf8mb4_unicode_ci";
     const result = (sc as any).addTableOptionsBang("CREATE TABLE `users` ()", td);
@@ -213,7 +223,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
     new SchemaCreation(host).accept(td);
 
   it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", async () => {
-    const td = new MyTd("users", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "users");
     td.setPrimaryKey("users", true);
     td.string("name");
     expect(await toSql(td)).toBe(
@@ -222,7 +232,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new MyTd("t", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "t");
     td.column("full_name", "virtual" as any, { as: "CONCAT(a, b)" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -232,15 +242,14 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("honors id: false (no primary key column)", async () => {
-    const td = new MyTd("logs", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "logs");
     td.setPrimaryKey("logs", false);
     td.string("body");
     expect(await toSql(td)).toBe("CREATE TABLE `logs` (`body` varchar(255))");
   });
 
   it("appends DEFAULT CHARSET and COLLATE from table options", async () => {
-    const td = new MyTd("posts", {
-      adapter: mysqlConn(),
+    const td = new MyTd(mysqlConn(), "posts", {
       charset: "utf8mb4",
       collation: "utf8mb4_unicode_ci",
     });
@@ -251,17 +260,13 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("emits IF NOT EXISTS and TEMPORARY modifiers", async () => {
-    const td = new MyTd("tmp", {
-      adapter: mysqlConn(),
-      temporary: true,
-      ifNotExists: true,
-    });
+    const td = new MyTd(mysqlConn(), "tmp", { temporary: true, ifNotExists: true });
     td.integer("n");
     expect(await toSql(td)).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
   });
 
   it("emits composite PRIMARY KEY clause", async () => {
-    const td = new MyTd("memberships", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "memberships");
     td.setPrimaryKey("memberships", true, ["user_id", "group_id"]);
     td.bigint("user_id", { null: false });
     td.bigint("group_id", { null: false });
@@ -270,7 +275,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("inlines indexes when supportsIndexesInCreate (MySQL)", async () => {
-    const td = new MyTd("users", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "users");
     td.string("email");
     td.index(["email"], { unique: true, name: "idx_users_email" });
     const sql = await toSql(td);
@@ -278,7 +283,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("inlines FOREIGN KEY constraints", async () => {
-    const td = new MyTd("posts", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "posts");
     td.bigint("author_id");
     td.foreignKey("authors", { column: "author_id" });
     const sql = await toSql(td);
@@ -287,7 +292,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("inlines CHECK constraints", async () => {
-    const td = new MyTd("products", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "products");
     td.integer("price");
     td.checkConstraint("price > 0", { name: "price_positive" });
     const sql = await toSql(td);
@@ -295,19 +300,19 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
   });
 
   it("appends MySQL COMMENT on table option", async () => {
-    const td = new MyTd("notes", { adapter: mysqlConn(), comment: "user-supplied" });
+    const td = new MyTd(mysqlConn(), "notes", { comment: "user-supplied" });
     td.string("body");
     expect(await toSql(td)).toContain("COMMENT 'user-supplied'");
   });
 
   it("emits AS clause after table options for CTAS", async () => {
-    const td = new MyTd("snapshot", { adapter: mysqlConn(), as: "SELECT 1" });
+    const td = new MyTd(mysqlConn(), "snapshot", { as: "SELECT 1" });
     expect(await toSql(td)).toMatch(/CREATE TABLE `snapshot`.* AS SELECT 1$/);
   });
 
   it("skips FK emission when host adapter has foreignKeys disabled", async () => {
     const host = mysqlConn({ supportsForeignKeys: () => true, _config: { foreignKeys: false } });
-    const td = new MyTd("posts", { adapter: host });
+    const td = new MyTd(host, "posts");
     td.bigint("author_id");
     td.foreignKey("authors", { column: "author_id" });
     expect(await toSql(td, host)).not.toContain("FOREIGN KEY");
@@ -315,7 +320,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition#toSql via SchemaCreation.accept",
 
   it("skips CHECK emission when host adapter reports !supportsCheckConstraints", async () => {
     const host = mysqlConn({ supportsCheckConstraints: () => false });
-    const td = new MyTd("products", { adapter: host });
+    const td = new MyTd(host, "products");
     td.integer("price");
     td.checkConstraint("price > 0", { name: "p_pos" });
     expect(await toSql(td, host)).not.toContain("CHECK");
@@ -328,7 +333,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition column methods", () => {
   });
 
   it("defines one column per name, mirroring `names.each` in define_column_methods", () => {
-    const td = new MyTd("t", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "t");
     td.longtext("body", "summary");
     td.unsignedInteger("hits", "misses");
 
@@ -342,7 +347,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition column methods", () => {
   });
 
   it("applies the shared options and per-name sizing to every blob name", () => {
-    const td = new MyTd("t", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "t");
     td.blob("thumb", "preview", { limit: 300 });
 
     expect(td.columns.map((c) => c.name)).toEqual(["thumb", "preview"]);
@@ -350,7 +355,7 @@ describeIfMysqlAdapter("MySQL::TableDefinition column methods", () => {
   });
 
   it("raises when called with no column name", () => {
-    const td = new MyTd("t", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "t");
 
     expect(() => (td.blob as () => unknown)()).toThrow("Missing column name(s) for blob");
     expect(() => (td.tinytext as () => unknown)()).toThrow("Missing column name(s) for tinytext");
@@ -374,7 +379,7 @@ describeIfMysqlAdapter("MySQL::SchemaCreation inline index options (trails)", ()
   });
 
   it("routes an inline index's length option through addIndexOptions", async () => {
-    const td = new MyTd("users", { adapter: mysqlConn() });
+    const td = new MyTd(mysqlConn(), "users");
     td.string("email");
     td.index(["email"], { length: 10 });
     expect(await sc.accept(td)).toContain("INDEX `index_users_on_email` (`email`(10))");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -71,7 +71,8 @@ export class TableDefinition extends AbstractTableDefinition {
   readonly collation?: string;
 
   constructor(
-    tableName: string,
+    conn: VisitorHostAdapter,
+    name: string,
     options: {
       id?: boolean | PrimaryKeyType | IdHashOptions;
       charset?: string | null;
@@ -82,16 +83,10 @@ export class TableDefinition extends AbstractTableDefinition {
       as?: string;
       options?: string;
       comment?: string;
-      adapter: VisitorHostAdapter;
-      adapterName?: "sqlite" | "postgres" | "mysql2";
-    },
+    } = {},
   ) {
-    const { adapter, adapterName: _ignoredAdapterName, charset, collation, ...rest } = options;
-    super(tableName, {
-      ...rest,
-      adapterName: "mysql2",
-      adapter,
-    });
+    const { charset, collation, ...rest } = options;
+    super(conn, name, rest);
     this.charset = charset ?? undefined;
     this.collation = collation ?? undefined;
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -255,10 +255,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
     name: string,
     options: Record<string, unknown> = {},
   ): MysqlTableDefinition {
-    return new MysqlTableDefinition(name, {
-      ...options,
-      adapter: this as unknown as VisitorHostAdapter,
-    });
+    return new MysqlTableDefinition(this as unknown as VisitorHostAdapter, name, options);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3704,7 +3704,7 @@ export class PostgreSQLAdapter
     const rest = options;
     const unlogged =
       (rest.unlogged as boolean | undefined) ?? PostgreSQLAdapter.createUnloggedTables;
-    return new PgTableDefinition(name, { ...rest, unlogged, adapter: this });
+    return new PgTableDefinition(this, name, { ...rest, unlogged });
   }
 
   /** @internal */
@@ -3768,28 +3768,14 @@ export class PostgreSQLAdapter
       serial = this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
     }
 
-    return new Column(
-      columnName,
-      defaultValue,
-      {
-        sqlType: typeMetadata.sqlType,
-        type: typeMetadata.type,
-        oid: Number(oid),
-        fmod: Number(fmod),
-        limit: typeMetadata.limit,
-        precision: typeMetadata.precision,
-        scale: typeMetadata.scale,
-      },
-      !notnull,
-      {
-        defaultFunction: defaultFunction ?? undefined,
-        collation: collation ?? undefined,
-        comment: comment || null,
-        serial,
-        identity: identity || null,
-        generated: gen || null,
-      },
-    );
+    return new Column(columnName, defaultValue, typeMetadata, !notnull, {
+      defaultFunction: defaultFunction ?? undefined,
+      collation: collation ?? undefined,
+      comment: comment || null,
+      serial,
+      identity: identity || null,
+      generated: gen || null,
+    });
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.trails.test.ts
@@ -8,7 +8,7 @@ describe("PostgreSQL::Column JSON round-trip", () => {
     const col = new Column(
       "tags",
       null,
-      { sqlType: "character varying[]", type: "string", oid: 1015, fmod: -1 },
+      new TypeMetadata({ sqlType: "character varying[]", type: "string" }, { oid: 1015, fmod: -1 }),
       true,
       { serial: false, identity: "a", generated: "s" },
     );
@@ -62,7 +62,11 @@ describe("PostgreSQL::TypeMetadata JSON round-trip", () => {
   });
 
   it("delegates the Column readers to the metadata object", () => {
-    const col = new Column("n", null, { sqlType: "int4", type: "integer", oid: 23, fmod: -1 });
+    const col = new Column(
+      "n",
+      null,
+      new TypeMetadata({ sqlType: "int4", type: "integer" }, { oid: 23, fmod: -1 }),
+    );
     expect(col.sqlTypeMetadata).toBeInstanceOf(TypeMetadata);
     expect(col.oid).toBe(23);
     expect(col.fmod).toBe(-1);

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -17,15 +17,7 @@ export class Column extends BaseColumn {
   constructor(
     name: string,
     defaultValue: unknown,
-    sqlTypeMetadata: {
-      sqlType?: string | null;
-      type?: string;
-      oid?: number;
-      fmod?: number;
-      limit?: number | null;
-      precision?: number | null;
-      scale?: number | null;
-    } = {},
+    sqlTypeMetadata: TypeMetadata | null = null,
     null_: boolean = true,
     options: {
       collation?: string | null;
@@ -36,17 +28,7 @@ export class Column extends BaseColumn {
       generated?: string | null;
     } = {},
   ) {
-    const meta = new TypeMetadata(
-      {
-        sqlType: sqlTypeMetadata.sqlType ?? undefined,
-        type: sqlTypeMetadata.type,
-        limit: sqlTypeMetadata.limit ?? undefined,
-        precision: sqlTypeMetadata.precision ?? undefined,
-        scale: sqlTypeMetadata.scale ?? undefined,
-      },
-      { oid: sqlTypeMetadata.oid, fmod: sqlTypeMetadata.fmod },
-    );
-    super(name, defaultValue, meta, null_, {
+    super(name, defaultValue, sqlTypeMetadata, null_, {
       collation: options.collation,
       defaultFunction: options.defaultFunction,
       comment: options.comment,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.trails.test.ts
@@ -4,6 +4,7 @@ import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import { quoteDefaultExpression } from "./quoting.js";
 import { ExclusionConstraintDefinition, UniqueConstraintDefinition } from "./schema-definitions.js";
 import { Column } from "./column.js";
+import { TypeMetadata } from "./type-metadata.js";
 import {
   ForeignKeyDefinition,
   ChangeColumnDefinition,
@@ -119,7 +120,11 @@ describe("PostgreSQL SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition", async () => {
-    const col = new Column("x", null, { sqlType: "character varying", type: "string" });
+    const col = new Column(
+      "x",
+      null,
+      new TypeMetadata({ sqlType: "character varying", type: "string" }),
+    );
     expect(
       await s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, null)),
     ).toContain("DROP DEFAULT");
@@ -131,7 +136,7 @@ describe("PostgreSQL SchemaCreation", () => {
   it("visitChangeColumnDefaultDefinition: uuid function default stays bare", async () => {
     // postgresql/quoting.rb:159-160 — a `()`-bearing string default on a
     // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
-    const col = new Column("id", null, { sqlType: "uuid", type: "uuid" });
+    const col = new Column("id", null, new TypeMetadata({ sqlType: "uuid", type: "uuid" }));
     const host = s();
     host.adapter.quoteDefaultExpression = (v: unknown, c: unknown) =>
       quoteDefaultExpression.call(null as never, v, c as never);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.trails.test.ts
@@ -148,7 +148,7 @@ describe("UniqueConstraintDefinition", () => {
 
 describeIfPostgresqlAdapter("TableDefinition", () => {
   it("accumulates exclusion constraints", () => {
-    const td = new TableDefinition("products", { adapter: leased });
+    const td = new TableDefinition(leased, "products");
     td.exclusionConstraint("price WITH =, range WITH &&", { name: "price_check", using: "gist" });
 
     expect(td.exclusionConstraints).toHaveLength(1);
@@ -159,7 +159,7 @@ describeIfPostgresqlAdapter("TableDefinition", () => {
   });
 
   it("accumulates unique constraints", () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     td.uniqueConstraint("position", { name: "unique_position", deferrable: "deferred" });
 
     expect(td.uniqueConstraints).toHaveLength(1);
@@ -170,17 +170,17 @@ describeIfPostgresqlAdapter("TableDefinition", () => {
   });
 
   it("defaults unlogged to false", () => {
-    const td = new TableDefinition("t", { adapter: leased });
+    const td = new TableDefinition(leased, "t");
     expect(td.unlogged).toBe(false);
   });
 
   it("accepts unlogged option", () => {
-    const td = new TableDefinition("t", { adapter: leased, unlogged: true });
+    const td = new TableDefinition(leased, "t", { unlogged: true });
     expect(td.unlogged).toBe(true);
   });
 
   it("newExclusionConstraintDefinition returns definition without pushing", () => {
-    const td = new TableDefinition("products", { adapter: leased });
+    const td = new TableDefinition(leased, "products");
     const defn = td.newExclusionConstraintDefinition("price WITH =", { name: "pc" });
     expect(defn).toBeInstanceOf(ExclusionConstraintDefinition);
     expect(defn.tableName).toBe("products");
@@ -188,7 +188,7 @@ describeIfPostgresqlAdapter("TableDefinition", () => {
   });
 
   it("newUniqueConstraintDefinition returns definition without pushing", () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     const defn = td.newUniqueConstraintDefinition("col", { name: "uc" });
     expect(defn).toBeInstanceOf(UniqueConstraintDefinition);
     expect(defn.tableName).toBe("orders");
@@ -205,7 +205,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition#enum", () => {
     ).typeToSql(type, options);
 
   it("passes :enum through as the column type with enum_type forwarded", () => {
-    const td = new TableDefinition("t", { adapter: leased });
+    const td = new TableDefinition(leased, "t");
     td.enum("current_mood", { enum_type: "mood" });
     const [col] = td.columns;
     expect(col.type).toBe("enum");
@@ -214,13 +214,13 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition#enum", () => {
   });
 
   it("defines one column per name", () => {
-    const td = new TableDefinition("t", { adapter: leased });
+    const td = new TableDefinition(leased, "t");
     td.enum("a", "b", { enum_type: "mood" });
     expect(td.columns.map((c) => c.name)).toEqual(["a", "b"]);
   });
 
   it("raises when enum_type is missing", () => {
-    const td = new TableDefinition("t", { adapter: leased });
+    const td = new TableDefinition(leased, "t");
     td.enum("current_mood");
     const [col] = td.columns;
     expect(() => typeToSql(col.type, col.options)).toThrow(
@@ -266,7 +266,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
   it("defines one column per name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { adapter: leased });
+      const td = new TableDefinition(leased, "t");
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", "c");
       expect(td.columns.map((c) => c.name)).toEqual(["a", "b", "c"]);
     }
@@ -274,7 +274,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
   it("applies the trailing options to every name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { adapter: leased });
+      const td = new TableDefinition(leased, "t");
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", {
         null: false,
       });
@@ -287,7 +287,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
   it("raises when given no column name", () => {
     for (const [method, railsType] of types) {
-      const td = new TableDefinition("t", { adapter: leased });
+      const td = new TableDefinition(leased, "t");
       expect(() =>
         (td as unknown as Record<string, (...args: unknown[]) => void>)[method](),
       ).toThrow(`Missing column name(s) for ${railsType}`);
@@ -299,7 +299,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
   it("creates an index for every name when index is passed", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { adapter: leased });
+      const td = new TableDefinition(leased, "t");
       (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "b", {
         index: true,
       });
@@ -310,7 +310,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
   it("raises on a duplicate column name", () => {
     for (const [method] of types) {
-      const td = new TableDefinition("t", { adapter: leased });
+      const td = new TableDefinition(leased, "t");
       expect(() =>
         (td as unknown as Record<string, (...args: unknown[]) => void>)[method]("a", "a"),
       ).toThrow("you can't define an already defined column 'a' on 't'.");
@@ -318,7 +318,7 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
   });
 
   it("keeps type-specific SQL types when defining multiple columns", () => {
-    const td = new TableDefinition("t", { adapter: leased });
+    const td = new TableDefinition(leased, "t");
     td.bit("a", "b", { limit: 8 });
     td.bitVarying("c", { limit: 4 });
     td.bigserial("d", "e");
@@ -334,14 +334,14 @@ describeIfPostgresqlAdapter("PostgreSQL::TableDefinition column methods", () => 
 
 describeIfPostgresqlAdapter("AlterTable", () => {
   it("validateConstraint pushes to constraintValidations", () => {
-    const td = new TableDefinition("products", { adapter: leased });
+    const td = new TableDefinition(leased, "products");
     const at = new AlterTable(td);
     at.validateConstraint("price_check");
     expect(at.constraintValidations).toEqual(["price_check"]);
   });
 
   it("addExclusionConstraint pushes to exclusionConstraintAdds", () => {
-    const td = new TableDefinition("products", { adapter: leased });
+    const td = new TableDefinition(leased, "products");
     const at = new AlterTable(td);
     at.addExclusionConstraint("price WITH =", { name: "pc", using: "gist" });
     expect(at.exclusionConstraintAdds).toHaveLength(1);
@@ -349,7 +349,7 @@ describeIfPostgresqlAdapter("AlterTable", () => {
   });
 
   it("addUniqueConstraint pushes to uniqueConstraintAdds", () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     const at = new AlterTable(td);
     at.addUniqueConstraint("position", { name: "unique_position" });
     expect(at.uniqueConstraintAdds).toHaveLength(1);
@@ -366,23 +366,20 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   };
 
   it("emits UNLOGGED when unlogged: true", async () => {
-    const td = new TableDefinition("products", {
-      adapter: leased,
-      unlogged: true,
-    });
+    const td = new TableDefinition(leased, "products", { unlogged: true });
     td.string("name");
     expect(await toSql(td)).toMatch(/^CREATE UNLOGGED TABLE/);
   });
 
   it("does not emit UNLOGGED by default", async () => {
-    const td = new TableDefinition("products", { adapter: leased });
+    const td = new TableDefinition(leased, "products");
     td.string("name");
     expect(await toSql(td)).toMatch(/^CREATE TABLE/);
     expect(await toSql(td)).not.toContain("UNLOGGED");
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new TableDefinition("articles", { adapter: leased });
+    const td = new TableDefinition(leased, "articles");
     td.column("full_name", "virtual" as any, { as: "a || b", stored: true } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -392,7 +389,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("emits exclusion constraint in CREATE TABLE", async () => {
-    const td = new TableDefinition("meetings", { adapter: leased });
+    const td = new TableDefinition(leased, "meetings");
     td.exclusionConstraint("room WITH =, during WITH &&", { name: "no_overlap", using: "gist" });
     const sql = await toSql(td);
     expect(sql).toContain(
@@ -401,7 +398,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint in CREATE TABLE", async () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     td.uniqueConstraint("position", { name: "unique_pos", deferrable: "deferred" });
     const sql = await toSql(td);
     expect(sql).toContain(
@@ -410,14 +407,14 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint with nulls not distinct", async () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     td.uniqueConstraint("position", { name: "unique_pos", nullsNotDistinct: true });
     const sql = await toSql(td);
     expect(sql).toContain("NULLS NOT DISTINCT");
   });
 
   it("emits exclusion constraint with a generated name when name is omitted", async () => {
-    const td = new TableDefinition("meetings", { adapter: leased });
+    const td = new TableDefinition(leased, "meetings");
     td.exclusionConstraint("room WITH =", { using: "gist" });
     const sql = await toSql(td);
     expect(sql).toContain("EXCLUDE USING gist (room WITH =)");
@@ -425,7 +422,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("emits unique constraint with a generated name when name is omitted", async () => {
-    const td = new TableDefinition("orders", { adapter: leased });
+    const td = new TableDefinition(leased, "orders");
     td.uniqueConstraint("position");
     const sql = await toSql(td);
     expect(sql).toContain('UNIQUE ("position")');
@@ -433,7 +430,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("handles constraint-only table with no columns (id: false)", async () => {
-    const td = new TableDefinition("link_table", { adapter: leased });
+    const td = new TableDefinition(leased, "link_table");
     td.uniqueConstraint("ref", { name: "unique_ref" });
     const sql = await toSql(td);
     expect(sql).not.toContain("(,");
@@ -441,8 +438,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("injects constraints before trailing table options clause", async () => {
-    const td = new TableDefinition("logs", {
-      adapter: leased,
+    const td = new TableDefinition(leased, "logs", {
       options: "WITH (autovacuum_enabled = false)",
     });
     td.string("message");
@@ -455,8 +451,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   });
 
   it("skips constraint injection for CREATE TABLE ... AS queries", async () => {
-    const td = new TableDefinition("archived_orders", {
-      adapter: leased,
+    const td = new TableDefinition(leased, "archived_orders", {
       as: "SELECT (1) AS id, amount FROM orders WHERE archived = true",
     });
     td.uniqueConstraint("id", { name: "unique_id" });
@@ -470,7 +465,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
     // whose default branch returns an unrecognized type verbatim (Rails parity:
     // `type.to_s` — it never uppercases). This matches the real-PostgreSQLAdapter
     // path, where typeToSql("cidr") also returns "cidr" via NATIVE_DATABASE_TYPES.
-    const td = new TableDefinition("widgets", { adapter: leased });
+    const td = new TableDefinition(leased, "widgets");
     td.cidr("net");
     td.inet("addr");
     td.hstore("props");
@@ -517,7 +512,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
       supportsUniqueConstraints: () => true,
       useForeignKeys: () => true,
     };
-    const td = new TableDefinition("widgets", { adapter: stubAdapter as any });
+    const td = new TableDefinition(stubAdapter as any, "widgets");
     td.cidr("net");
     td.inet("addr");
     td.hstore("props");
@@ -536,7 +531,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
 
 describeIfPostgresqlAdapter("TableDefinition#toSql default quoting", () => {
   it("handles default values containing doubled single-quotes without mis-parsing", async () => {
-    const td = new TableDefinition("messages", { adapter: leased });
+    const td = new TableDefinition(leased, "messages");
     td.string("body", { default: "Bob's" });
     td.uniqueConstraint("body", { name: "unique_body" });
     const sql = await new PgSchemaCreation(leased as unknown as PgSchemaCreationHost).accept(td);
@@ -610,7 +605,7 @@ describe("Table delegation", () => {
 
 describeIfPostgresqlAdapter("TableDefinition#validColumnDefinitionOptions", () => {
   it("adds the PostgreSQL-specific option keys to the abstract set", () => {
-    const td = new TableDefinition("articles", { adapter: leased });
+    const td = new TableDefinition(leased, "articles");
     const opts = (td as any).validColumnDefinitionOptions() as string[];
     for (const key of ["array", "using", "castAs", "as", "type", "enumType", "stored"]) {
       expect(opts).toContain(key);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -225,7 +225,8 @@ export class TableDefinition extends AbstractTableDefinition {
   readonly unlogged: boolean;
 
   constructor(
-    tableName: string,
+    conn: TableDefinitionConn,
+    name: string,
     options: {
       id?: boolean | "uuid";
       unlogged?: boolean;
@@ -234,10 +235,9 @@ export class TableDefinition extends AbstractTableDefinition {
       temporary?: boolean;
       ifNotExists?: boolean;
       as?: string;
-      adapter: TableDefinitionConn;
-    },
+    } = {},
   ) {
-    super(tableName, { ...options, adapterName: "postgres" });
+    super(conn, name, options);
     this.unlogged = options.unlogged ?? false;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { ValueType } from "@blazetrails/activemodel";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Column } from "./column.js";
+import { TypeMetadata } from "./type-metadata.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
 const emptySource: SchemaSource = {
@@ -25,10 +26,10 @@ function makeColumn(
   return new Column(
     options.name ?? "id",
     null,
-    {
+    new TypeMetadata({
       sqlType: `${options.sqlType ?? options.type ?? "bigint"}${options.array ? "[]" : ""}`,
       type: options.type ?? "integer",
-    },
+    }),
     true,
     { serial: options.serial, generated: options.generated },
   );
@@ -137,10 +138,16 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
-      const col = new Column("computed", null, { sqlType: "integer", type: "integer" }, true, {
-        defaultFunction: "(a + b)",
-        generated: "s",
-      });
+      const col = new Column(
+        "computed",
+        null,
+        new TypeMetadata({ sqlType: "integer", type: "integer" }),
+        true,
+        {
+          defaultFunction: "(a + b)",
+          generated: "s",
+        },
+      );
       const spec = dumper.prepareColumnOptions(col);
       expect(spec["as"]).toBe(JSON.stringify("(a + b)"));
       expect(spec["stored"]).toBe(true);
@@ -155,10 +162,16 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
-      const col = new Column("status", null, { sqlType: "mood", type: "enum" }, true, {
-        defaultFunction: "('happy'::mood)",
-        generated: "s",
-      });
+      const col = new Column(
+        "status",
+        null,
+        new TypeMetadata({ sqlType: "mood", type: "enum" }),
+        true,
+        {
+          defaultFunction: "('happy'::mood)",
+          generated: "s",
+        },
+      );
       const spec = dumper.prepareColumnOptions(col);
       expect(spec["stored"]).toBe(true);
       expect(spec["enum_type"]).toBe(JSON.stringify("mood"));
@@ -172,17 +185,29 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => false,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
-      const col = new Column("computed", null, { sqlType: "integer", type: "integer" }, true, {
-        defaultFunction: "(a + b)",
-        generated: "s",
-      });
+      const col = new Column(
+        "computed",
+        null,
+        new TypeMetadata({ sqlType: "integer", type: "integer" }),
+        true,
+        {
+          defaultFunction: "(a + b)",
+          generated: "s",
+        },
+      );
       const spec = dumper.prepareColumnOptions(col);
       expect(spec["as"]).toBeUndefined();
     });
 
     it("adds enum_type for enum columns", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
-      const col = new Column("status", null, { sqlType: "mood", type: "enum" }, true, {});
+      const col = new Column(
+        "status",
+        null,
+        new TypeMetadata({ sqlType: "mood", type: "enum" }),
+        true,
+        {},
+      );
       const spec = dumper.prepareColumnOptions(col);
       expect(spec["enum_type"]).toBe(JSON.stringify("mood"));
     });
@@ -191,9 +216,15 @@ describe("PostgreSQL::SchemaDumper", () => {
   describe("schemaTypeWithVirtual", () => {
     it("returns virtual for generated (stored) PG columns", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
-      const col = new Column("computed", null, { sqlType: "integer", type: "integer" }, true, {
-        generated: "s",
-      });
+      const col = new Column(
+        "computed",
+        null,
+        new TypeMetadata({ sqlType: "integer", type: "integer" }),
+        true,
+        {
+          generated: "s",
+        },
+      );
       expect(dumper.schemaTypeWithVirtual(col)).toBe("virtual");
     });
 
@@ -207,10 +238,16 @@ describe("PostgreSQL::SchemaDumper", () => {
   describe("extractExpressionForVirtualColumn", () => {
     it("returns JSON-stringified defaultFunction", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
-      const col = new Column("full_name", null, { sqlType: "text", type: "string" }, true, {
-        defaultFunction: "concat(first_name, ' ', last_name)",
-        generated: "s",
-      });
+      const col = new Column(
+        "full_name",
+        null,
+        new TypeMetadata({ sqlType: "text", type: "string" }),
+        true,
+        {
+          defaultFunction: "concat(first_name, ' ', last_name)",
+          generated: "s",
+        },
+      );
       expect(dumper.extractExpressionForVirtualColumn(col)).toBe(
         JSON.stringify("concat(first_name, ' ', last_name)"),
       );

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -646,7 +646,7 @@ class MockAdapter {
   useForeignKeys = () => true;
   createTableDefinition = (n: string, opts: Record<string, unknown>) =>
     // Rails' create_table_definition passes `self` (schema_statements.rb:1041).
-    new TableDefinition(n, { adapter: this as never, ...opts, adapterName: "sqlite" });
+    new TableDefinition(this as never, n, { ...opts });
 
   constructor(cache: SchemaCache) {
     this.schemaCache = BoundSchemaReflection.forLoneConnection(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -208,7 +208,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     name: string,
     options: Record<string, unknown> = {},
   ): SQLite3TableDefinition {
-    return new SQLite3TableDefinition(name, { ...options, adapter: this });
+    return new SQLite3TableDefinition(this, name, options);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2636,7 +2636,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
    * Rails calls `add_index` unconditionally (`sqlite3_adapter.rb:674`) and so
    * does this, for a schema-qualified destination as much as a bare one: the
    * qualifier lands on the INDEX name, which is where SQLite takes it, in
-   * `SQLite3::SchemaCreation#visit_CreateIndexDefinition`.
+   * `SQLite3::SchemaCreation#quotedIndexNameAndTable`.
    * @internal
    */
   private async copyTableIndexes(

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.trails.test.ts
@@ -55,19 +55,13 @@ describeIfSqlite("SQLite3::SchemaCreation", () => {
   });
 
   it("appends COLLATE clause when collation option is set", async () => {
-    const td = new TableDefinition("articles", {
-      adapter: conn,
-      adapterName: "sqlite",
-    });
+    const td = new TableDefinition(conn, "articles");
     td.column("title", "string", { collation: "BINARY" } as any);
     expect(await sc.accept(td)).toContain('COLLATE "BINARY"');
   });
 
   it("appends GENERATED ALWAYS AS VIRTUAL for virtual columns", async () => {
-    const td = new TableDefinition("articles", {
-      adapter: conn,
-      adapterName: "sqlite",
-    });
+    const td = new TableDefinition(conn, "articles");
     td.column("full_name", "string", { as: "first_name || ' ' || last_name" } as any);
     const sql = await sc.accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS");
@@ -75,10 +69,7 @@ describeIfSqlite("SQLite3::SchemaCreation", () => {
   });
 
   it("appends STORED for stored virtual columns", async () => {
-    const td = new TableDefinition("articles", {
-      adapter: conn,
-      adapterName: "sqlite",
-    });
+    const td = new TableDefinition(conn, "articles");
     td.column("full_name", "string", { as: "first_name || ' ' || last_name", stored: true } as any);
     expect(await sc.accept(td)).toContain("STORED");
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -5,53 +5,33 @@
  */
 
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
-import type {
-  CreateIndexDefinition,
-  ForeignKeyDefinition,
-} from "../abstract/schema-definitions.js";
+import type { ForeignKeyDefinition, IndexDefinition } from "../abstract/schema-definitions.js";
 import type { ColumnOptions } from "../abstract/schema-definitions.js";
 
 export class SchemaCreation extends AbstractSchemaCreation {
   /**
-   * The abstract `visit_CreateIndexDefinition`
-   * (abstract/schema_creation.rb:114-127) with the qualifier moved: SQLite puts
-   * an ATTACHed schema on the INDEX name, not on the table it indexes —
-   * `CREATE INDEX "aux"."by_name" ON "widgets" (...)` — and qualifying the table
-   * instead is a syntax error. Rails emits `quote_column_name(index.name) ON
-   * quote_table_name(index.table)` because it has no ATTACHed-schema notion at
-   * all; trails does (`SQLite3Adapter#_splitTableName`, reached through
-   * `alter_table` / `copy_table` with an `aux.posts` name), and this is the one
-   * place the difference is expressible, so `add_index` can serve a qualified
-   * destination and `copy_table_indexes` needs no hand-built statement.
+   * SQLite puts an ATTACHed schema on the INDEX name, not on the table it
+   * indexes — `CREATE INDEX "aux"."by_name" ON "widgets" (...)` — and
+   * qualifying the table instead is a syntax error. Rails emits
+   * `quote_column_name(index.name) ON quote_table_name(index.table)` inline
+   * (abstract/schema_creation.rb:120) because it has no ATTACHed-schema notion
+   * at all; trails does (`SQLite3Adapter#_splitTableName`, reached through
+   * `alter_table` / `copy_table` with an `aux.posts` name), so `add_index` can
+   * serve a qualified destination and `copy_table_indexes` needs no hand-built
+   * statement.
    *
-   * An unqualified table takes the inherited body untouched.
+   * An unqualified table takes the inherited fragment untouched.
    * @internal
    */
-  protected override async visitCreateIndexDefinition(o: CreateIndexDefinition): Promise<string> {
-    const index = o.index;
+  protected override quotedIndexNameAndTable(index: IndexDefinition): string {
     const dot = index.table.lastIndexOf(".");
-    if (dot === -1) return super.visitCreateIndexDefinition(o);
+    if (dot === -1) return super.quotedIndexNameAndTable(index);
     const schema = index.table.slice(0, dot);
     const bare = index.table.slice(dot + 1);
-    const parts: string[] = ["CREATE"];
-    if (index.unique) parts.push("UNIQUE");
-    parts.push("INDEX");
-    if (o.algorithm) parts.push(o.algorithm);
-    if (o.ifNotExists) parts.push("IF NOT EXISTS");
-    if (index.type) parts.push(index.type.toUpperCase());
-    parts.push(
+    return (
       `${this.adapter.quoteColumnName(schema)}.${this.adapter.quoteColumnName(index.name)} ` +
-        `ON ${this.adapter.quoteColumnName(bare)}`,
+      `ON ${this.adapter.quoteColumnName(bare)}`
     );
-    if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
-    parts.push(`(${await this.quotedColumns(index)})`);
-    if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
-      parts.push(`INCLUDE (${await this.quotedIncludeColumns(index.include)})`);
-    }
-    if ((await this.supportsNullsNotDistinct()) && index.nullsNotDistinct)
-      parts.push("NULLS NOT DISTINCT");
-    if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
-    return parts.join(" ");
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.trails.test.ts
@@ -16,33 +16,33 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
   });
 
   it("forces type: integer for references", () => {
-    const td = new TableDefinition("orders", { adapter: conn });
+    const td = new TableDefinition(conn, "orders");
     td.references("customer");
     const col = td.columns.find((c) => c.name === "customer_id");
     expect(col!.type).toBe("integer");
   });
 
   it("returns primary_key for integer primary key columns (integerLikePrimaryKeyType)", () => {
-    const td = new TableDefinition("orders", { adapter: conn });
+    const td = new TableDefinition(conn, "orders");
     td.column("order_id", "integer", { primaryKey: true });
     expect(td.columns.find((c) => c.name === "order_id")!.type).toBe("primary_key");
   });
 
   it("includes as, type, stored in validColumnDefinitionOptions", () => {
-    const td = new TableDefinition("t", { adapter: conn });
+    const td = new TableDefinition(conn, "t");
     const opts = (td as any).validColumnDefinitionOptions() as string[];
     expect(opts).toContain("as");
     expect(opts).toContain("stored");
   });
 
   it("resolves virtual type to the actual type option", () => {
-    const td = new TableDefinition("articles", { adapter: conn });
+    const td = new TableDefinition(conn, "articles");
     const col = td.newColumnDefinition("full_name", "virtual" as any, { type: "string" } as any);
     expect(col.type).toBe("string");
   });
 
   it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
-    const td = new TableDefinition("articles", { adapter: conn });
+    const td = new TableDefinition(conn, "articles");
     td.column("full_name", "virtual" as any, { as: "a || b" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
@@ -53,7 +53,7 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
   });
 
   it("emits GENERATED ALWAYS AS ... STORED via visitor", async () => {
-    const td = new TableDefinition("items", { adapter: conn });
+    const td = new TableDefinition(conn, "items");
     td.column("x", "integer");
     td.column("expr", "integer", { as: "x + 1", stored: true } as any);
     const sql = await new SchemaCreation((td as any)._adapter).accept(td);

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -13,10 +13,11 @@ import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
 
 export class TableDefinition extends AbstractTableDefinition {
   constructor(
-    tableName: string,
-    options: { id?: boolean | "uuid"; adapter: TableDefinitionConn; [key: string]: unknown },
+    conn: TableDefinitionConn,
+    name: string,
+    options: { id?: boolean | "uuid"; [key: string]: unknown } = {},
   ) {
-    super(tableName, { ...options, adapterName: "sqlite" });
+    super(conn, name, options);
   }
 
   override references(name: string, options: Record<string, unknown> = {}): this {

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -9,17 +9,8 @@ import {
   ColumnDefinition,
 } from "../abstract/schema-definitions.js";
 import type { ColumnOptions, ColumnType } from "../abstract/schema-definitions.js";
-import type { TableDefinitionConn } from "../abstract/schema-definitions.js";
 
 export class TableDefinition extends AbstractTableDefinition {
-  constructor(
-    conn: TableDefinitionConn,
-    name: string,
-    options: { id?: boolean | "uuid"; [key: string]: unknown } = {},
-  ) {
-    super(conn, name, options);
-  }
-
   override references(name: string, options: Record<string, unknown> = {}): this {
     return super.references(name, { type: "integer", ...options } as any);
   }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -25,8 +25,8 @@ import { SchemaCreation as MysqlSchemaCreation } from "./connection-adapters/mys
 import { SchemaCreation as SQLite3SchemaCreation } from "./connection-adapters/sqlite3/schema-creation.js";
 
 function emitTableSql(td: TableDefinition): Promise<string> {
-  const adapterName = (td as any)._adapterName;
   const adapter = (td as any)._adapter;
+  const adapterName = adapter.adapterName;
   // Every visitor takes its connection for identifier/default quoting (and, on MySQL,
   // the `supports*` / isMariadb() flags), so thread the table definition's through —
   // matching the real adapter call sites and the production `*.toSql()` overrides.
@@ -253,7 +253,7 @@ describe("MigrationTest", () => {
   });
 
   it("decimal scale without precision should raise", async () => {
-    const td = new TableDefinition("products", { adapter: await Base.leaseConnection() });
+    const td = new TableDefinition(await Base.leaseConnection(), "products");
     td.decimal("price", { scale: 2 });
     await expect(emitTableSql(td)).rejects.toThrow(
       "Error adding decimal column: precision cannot be empty if scale is specified",

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 387,
-    "total": 1396
+    "total": 1394
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
TableDefinition takes the connection as its first positional parameter,
mirroring `TableDefinition#initialize(conn, name, ...)`
(abstract/schema_definitions.rb:371-393) and every Rails
`create_table_definition` — `TableDefinition.new(self, name, **options)`
(abstract/schema_statements.rb:1705, mysql/schema_statements.rb:172-174).
The invented `adapterName` option and its write-only `_adapterName` field
are deleted; the one test helper that read it takes the connection's own
`adapterName` instead.

PostgreSQL::Column and MySQL::Column accept the `TypeMetadata` their
adapter's `fetch_type_metadata` already built and hand it to `super`
unchanged, as Rails does (postgresql/column.rb:9-14, mysql/column.rb —
no `initialize` at all, abstract/column.rb:14-24), instead of rebuilding
an equal one from a flat plain object. `oid` / `fmod` / `extra` still
read through the delegation from PR #7026.

The SQLite3 `visit_CreateIndexDefinition` override is no longer a
whole-body copy of the abstract one: the abstract body grows a
`quotedIndexNameAndTable` seam for the single differing fragment, so the
arm order and every capability gate live in one place. `copy_table_indexes`
keeps its single unconditional `add_index` call.

Closes-story: table-definition-takes-conn-positionally-and-invents-adaptername
Closes-story: accept-adapter-type-metadata-in-column-subclass-constructors
Closes-story: collapse-the-sqlite-create-index-visitor-fork