### PR TITLE
refactor(activemodel,activerecord,activesupport): dup runs initialize_dup, required quote_default_expression column, _read_attribute miss path, from_json via ActiveSupport::JSON

### DIFF
--- a/packages/activemodel/src/attribute-methods.trails.test.ts
+++ b/packages/activemodel/src/attribute-methods.trails.test.ts
@@ -98,4 +98,21 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(Employee.attributeMethodPatterns.length).toBe(Person.attributeMethodPatterns.length + 1);
     expect(Model.attributeMethodPatterns.length).toBe(Person.attributeMethodPatterns.length);
   });
+
+  it("_read_attribute raises for a name with no reader, as __send__ does", () => {
+    // Ruby's `_read_attribute` is `__send__(attr)` (attribute_methods.rb:556),
+    // which raises NoMethodError for an undefined name; `method_missing`
+    // (:507-514) re-raises it through `super` when nothing matched.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const person = new Person({ name: "Alexander" });
+
+    expect(person._readAttribute("name")).toBe("Alexander");
+    expect(() => person._readAttribute("nope")).toThrow(
+      /undefined method 'nope' for an instance of Person/,
+    );
+  });
 });

--- a/packages/activemodel/src/attribute-methods.trails.test.ts
+++ b/packages/activemodel/src/attribute-methods.trails.test.ts
@@ -100,9 +100,6 @@ describe("AttributeMethodsTest (trails)", () => {
   });
 
   it("_read_attribute raises for a name with no reader, as __send__ does", () => {
-    // Ruby's `_read_attribute` is `__send__(attr)` (attribute_methods.rb:556),
-    // which raises NoMethodError for an undefined name; `method_missing`
-    // (:507-514) re-raises it through `super` when nothing matched.
     class Person extends Model {
       static {
         this.attribute("name", "string");

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -15,6 +15,7 @@ import {
   include,
   included,
   Module,
+  NameError,
 } from "@blazetrails/activesupport";
 
 export interface AttributeMethods {
@@ -268,6 +269,20 @@ export function missingAttribute(this: InstanceHost, attrName: string, stack?: s
 }
 
 /**
+ * Ruby's `NoMethodError`, which `__send__` raises for an undefined name and
+ * `method_missing`'s `else super` arm re-raises (attribute_methods.rb:507-514).
+ * It subclasses `NameError` because Ruby's does (`NoMethodError < NameError`).
+ * Local to this module, as in activesupport's `method-missing-proxy.ts`: the
+ * raise site is here and callers identify it by `name` and message.
+ */
+class NoMethodError extends NameError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
  * Mirrors: attribute_methods.rb:555-558
  *   private
  *     def _read_attribute(attr)
@@ -280,9 +295,24 @@ export function missingAttribute(this: InstanceHost, attrName: string, stack?: s
  * § "Generated attribute readers are properties"), so `__send__(attr)` is a
  * property read rather than a call.
  *
+ * A name the receiver does not answer is where Ruby's `__send__` raises
+ * `NoMethodError` and `method_missing` (attribute_methods.rb:507-514) takes
+ * over: a `matched_attribute_method` goes to `attribute_missing`, and anything
+ * else falls to `super` and propagates. JS has no `method_missing`, so a bare
+ * property read would answer `undefined` there instead — the cascade is spelled
+ * out here.
+ *
  * @internal Rails-private helper.
  */
 export function _readAttribute(this: InstanceHost, attr: string): unknown {
+  const self = this as unknown as InstanceMethods & AttributeMethods;
+  if (!self.isRespondToWithoutAttributes(attr)) {
+    const match = matchedAttributeMethod.call(self, attr);
+    if (match) return self.attributeMissing(match);
+    throw new NoMethodError(
+      `undefined method '${attr}' for an instance of ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+    );
+  }
   return (this as unknown as Record<string, unknown>)[attr];
 }
 

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -305,9 +305,9 @@ class NoMethodError extends NameError {
  * @internal Rails-private helper.
  */
 export function _readAttribute(this: InstanceHost, attr: string): unknown {
-  const self = this as unknown as InstanceMethods & AttributeMethods;
+  const self = this as unknown as RespondToHost & AttributeMethods;
   if (!self.isRespondToWithoutAttributes(attr)) {
-    const match = matchedAttributeMethod.call(self, attr);
+    const match = self.matchedAttributeMethod(attr);
     if (match) return self.attributeMissing(match);
     throw new NoMethodError(
       `undefined method '${attr}' for an instance of ${(this.constructor as { name?: string }).name ?? "unknown"}`,

--- a/packages/activemodel/src/attribute-set/builder-defaults.test.ts
+++ b/packages/activemodel/src/attribute-set/builder-defaults.test.ts
@@ -24,6 +24,22 @@ describe("LazyAttributeHash defaultAttributes", () => {
     expect(hash.getAttribute("status").value).toBe("archived");
   });
 
+  it("materializing a mutable schema default twice does not share the value", () => {
+    const arrayType = Object.create(typeRegistry.lookup("value")) as typeof strType;
+    const types = new Map([["tags", arrayType]]);
+    const prototype = Attribute.withCastValue("tags", ["a"], arrayType);
+    void prototype.value;
+    const defaults = new Map([["tags", prototype]]);
+
+    const first = new LazyAttributeHash(types, {}, new Map(), defaults).getAttribute("tags");
+    const second = new LazyAttributeHash(types, {}, new Map(), defaults).getAttribute("tags");
+    (first.value as string[]).push("b");
+
+    expect(first.value).toEqual(["a", "b"]);
+    expect(second.value).toEqual(["a"]);
+    expect(prototype.value).toEqual(["a"]);
+  });
+
   it("returns Uninitialized when key is absent from both values and defaultAttributes", () => {
     const types = new Map([["age", intType]]);
     const hash = new LazyAttributeHash(types, {});

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -264,9 +264,7 @@ export abstract class Attribute {
    * copy by reference.
    */
   deepDup(): Attribute {
-    const dup = Object.assign(Object.create(Object.getPrototypeOf(this) as object), this) as this;
-    dup.initializeDup(this);
-    return dup;
+    return this.dup();
   }
 
   /**
@@ -308,18 +306,16 @@ export abstract class Attribute {
   }
 
   /**
-   * Ruby `Object#dup` for one Attribute — the call `LazyAttributeHash#deep_dup`
-   * and `#assign_default_value` make (`builder.rb:120`, `builder.rb:175`). A
-   * shallow copy that keeps the prototype and shares the `original_attribute`
-   * graph, exactly as Ruby's `dup` does. `initialize_dup` (attribute.rb:155-159)
-   * additionally re-dups a duplicable `@value`; this copy does not, so two
-   * Attributes off one `dup()` share a mutable cast value (a `Date`, an array)
-   * where Ruby would have separated them. That gap predates this method — both
-   * spellings it replaces had it — and is tracked by the RFC 0115 story
-   * `attribute-dup-must-redup-mutable-value`.
+   * Ruby `Object#dup` for one Attribute — the call `LazyAttributeSet#default_attribute`,
+   * `LazyAttributeHash#deep_dup` and `#assign_default_value` make
+   * (`builder.rb:84`, `builder.rb:120`, `builder.rb:175`). A shallow copy that
+   * keeps the prototype and shares the `original_attribute` graph, then runs
+   * {@link initializeDup} (attribute.rb:155-159) exactly as Ruby's `dup` does.
    */
   dup(): Attribute {
-    return Object.assign(Object.create(Object.getPrototypeOf(this) as object), this) as Attribute;
+    const dup = Object.assign(Object.create(Object.getPrototypeOf(this) as object), this) as this;
+    dup.initializeDup(this);
+    return dup;
   }
 
   /** Access the original attribute for cloning. */

--- a/packages/activemodel/src/serializers/json.trails.test.ts
+++ b/packages/activemodel/src/serializers/json.trails.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { setParseJsonTimes } from "@blazetrails/activesupport";
+import { JSON as JSONHost } from "./json.js";
+
+// `from_json` decodes with `ActiveSupport::JSON.decode` (json.rb:147), not the
+// JSON gem, so Rails' own decoding applies — notably `parse_json_times`
+// (json/decoding.rb:22-32), which the plain parser has no notion of.
+describe("Serializers::JSON decoding (trails)", () => {
+  class Event extends JSONHost {
+    static {
+      Object.defineProperty(this.prototype, "attributes", {
+        get(this: Event) {
+          return { occurredAt: this._occurredAt };
+        },
+        configurable: true,
+      });
+    }
+
+    _occurredAt: unknown = null;
+
+    setAttributes(hash: unknown): void {
+      const { occurredAt } = hash as { occurredAt?: unknown };
+      this._occurredAt = occurredAt;
+    }
+
+    get occurredAt(): unknown {
+      return this._occurredAt;
+    }
+  }
+
+  it("fromJson converts a date string when parseJsonTimes is on", () => {
+    setParseJsonTimes(true);
+    try {
+      const event = new Event().fromJson('{"occurredAt":"2012-01-01"}');
+      expect(typeof event._occurredAt).not.toBe("string");
+    } finally {
+      setParseJsonTimes(undefined);
+    }
+  });
+
+  it("fromJson leaves the string alone when parseJsonTimes is off", () => {
+    const event = new Event().fromJson('{"occurredAt":"2012-01-01"}');
+    expect(event._occurredAt).toBe("2012-01-01");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1036,7 +1036,7 @@ export class AbstractAdapter implements Quoting {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
-  quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
+  quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string> {
     if (value === undefined) return "";
     if (typeof value === "function") {
       const result = (value as () => unknown)();
@@ -1050,11 +1050,9 @@ export class AbstractAdapter implements Quoting {
     // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
     // (abstract/quoting.rb:161) before quoting. Returns a bare literal — the
     // ` DEFAULT ` keyword is owned by the caller (add_column_options!).
-    const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
-    if (sqlType) {
-      const castType = this.lookupCastType(sqlType) as { serialize?(v: unknown): unknown };
-      if (typeof castType?.serialize === "function") value = castType.serialize(value);
-    }
+    const sqlType = (column as { sqlType?: string | null }).sqlType;
+    const castType = this.lookupCastType(sqlType ?? null) as { serialize?(v: unknown): unknown };
+    if (typeof castType?.serialize === "function") value = castType.serialize(value);
     return this.quote(value);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -229,7 +229,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * (abstract_mysql_adapter.rb:975) and never exposes. trails' constructors
    * destructure the adapter-level keys out of the config hash, so the value is
    * held here — read by `buildStatementPool` and, in Mysql2Adapter, by
-   * `_getStmtPool` / `_shouldPrepare`.
+   * `_getStmtPool`.
    *
    * @internal
    */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -294,7 +294,7 @@ export function quoteTableNameForAssignment(
 export function quoteDefaultExpression(
   this: QuotingDispatchHost & QuotingHost,
   value: unknown,
-  column?: { sqlType?: string | null } | null,
+  column: { sqlType?: string | null },
 ): string {
   if (value === undefined) return "";
   if (typeof value === "function") {
@@ -308,18 +308,12 @@ export function quoteDefaultExpression(
   if (isSqlLiteral(value)) return value.value;
   // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
   // (abstract/quoting.rb:161) — dispatched unconditionally, since every host of
-  // this module is an adapter carrying a type map. `column` stays optional only
-  // because trails' DDL callers reach `SET DEFAULT` with no column in hand
-  // (schema-statements.ts:600); Rails' signature requires it.
-  let serialized: unknown = value;
-  if (column != null) {
-    const castType = this.lookupCastType(column.sqlType ?? null) as {
-      serialize?(v: unknown): unknown;
-    } | null;
-    if (castType && typeof castType.serialize === "function") {
-      serialized = castType.serialize(value);
-    }
-  }
+  // this module is an adapter carrying a type map.
+  const castType = this.lookupCastType(column.sqlType ?? null) as {
+    serialize?(v: unknown): unknown;
+  } | null;
+  const serialized: unknown =
+    castType && typeof castType.serialize === "function" ? castType.serialize(value) : value;
   // Rails: `quote(value)` (abstract/quoting.rb:162) — self-sent, so the receiver's
   // dialect quoting applies, including the raw-view branches the abstract `quote`
   // deliberately lacks.
@@ -608,7 +602,7 @@ export interface Quoting {
    * `SELECT '<sql_type>'::regtype::oid` query (postgresql/quoting.rb:195),
    * so callers must `await` the result; the other adapters return plain
    * strings. */
-  quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string>;
+  quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string>;
 
   /** Mirrors: Quoting#quoted_true. Abstract/PG/MySQL: `"TRUE"`; SQLite: `"1"`. */
   quotedTrue(): string;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -116,7 +116,7 @@ export class SchemaCreation {
   }
 
   /** @internal */
-  protected quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
+  protected quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string> {
     return this.adapter.quoteDefaultExpression(value, column);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
@@ -246,8 +246,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       static override quoteColumnName(name: string) {
         return `"${name}"`;
       }
-      // `change_column_default` resolves the column before quoting
-      // (postgresql/schema_statements.rb:490), and this stub has no live table.
       override async columns(_tableName: string) {
         return [{ name: "title", sqlType: "varchar" }] as any;
       }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
@@ -246,6 +246,11 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
       static override quoteColumnName(name: string) {
         return `"${name}"`;
       }
+      // `change_column_default` resolves the column before quoting
+      // (postgresql/schema_statements.rb:490), and this stub has no live table.
+      override async columns(_tableName: string) {
+        return [{ name: "title", sqlType: "varchar" }] as any;
+      }
       async changeColumnDefault(tableName: string, columnName: string, options: any) {
         this.changeColumnDefaultCalls += 1;
         return super.changeColumnDefault(tableName, columnName, options);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -587,7 +587,7 @@ export class SchemaStatements {
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${await this.quoteDefaultExpression(options.default)}`;
+          : ` DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`;
       await this.execute(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -600,7 +600,7 @@ export class SchemaStatements {
       }
       if (options.default !== undefined) {
         clauses.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${await this.quoteDefaultExpression(options.default)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`,
         );
       }
       await this.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
@@ -609,7 +609,7 @@ export class SchemaStatements {
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${await this.quoteDefaultExpression(options.default)}`;
+          : ` DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`;
       await this.execute(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -689,7 +689,9 @@ export class SchemaStatements {
     // (extract_new_default_value, schema_statements.rb:1820); a bare structured
     // default like `{ to: 1 }` without :from is the literal default.
     const defaultVal = this.extractNewDefaultValue(defaultOrChanges);
-    const clause = await this.quoteDefaultExpression(defaultVal);
+    // Rails resolves the column before quoting (postgresql/schema_statements.rb:490).
+    const column = await this.columnFor(tableName, columnName);
+    const clause = await this.quoteDefaultExpression(defaultVal, column);
     await this.execute(
       `ALTER TABLE ${this.quoteColumnName(tableName)} ALTER COLUMN ${this.quoteColumnName(columnName)} SET DEFAULT ${clause || "NULL"}`,
     );
@@ -703,7 +705,10 @@ export class SchemaStatements {
   ): Promise<void> {
     this.validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = await this.quoteDefaultExpression(defaultValue);
+      // Rails: `column = column_for(table_name, column_name)` before quoting
+      // (postgresql/schema_statements.rb:502-503).
+      const column = await this.columnFor(tableName, columnName);
+      const quoted = await this.quoteDefaultExpression(defaultValue, column);
       await this.execute(
         `UPDATE ${this.quoteColumnName(tableName)} SET ${this.quoteColumnName(columnName)} = ${quoted} WHERE ${this.quoteColumnName(columnName)} IS NULL`,
       );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -705,8 +705,6 @@ export class SchemaStatements {
   ): Promise<void> {
     this.validateChangeColumnNullArgumentBang(allowNull);
     if (!allowNull && defaultValue !== undefined) {
-      // Rails: `column = column_for(table_name, column_name)` before quoting
-      // (postgresql/schema_statements.rb:502-503).
       const column = await this.columnFor(tableName, columnName);
       const quoted = await this.quoteDefaultExpression(defaultValue, column);
       await this.execute(

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -278,19 +278,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Gate named-prepared-statement routing through our pool. Rails' gate is
-   * `prepared_statements && !binds.empty?` (the inverse of
-   * `without_prepared_statement?`, abstract_adapter.rb:1177) and nothing more.
-   * In particular it does not consult `statement_limit`: a limit of 0 is
-   * unsupported in Rails, whose `StatementPool#[]=` loop raises on the empty
-   * cache (statement_pool.rb:31-33), so there is nothing for this gate to
-   * degrade around.
-   */
-  _shouldPrepare(binds: unknown[]): boolean {
-    return this.preparedStatements && binds.length > 0;
-  }
-
-  /**
    * Track a SQL string in the statement pool BEFORE handing it to
    * `conn.execute()`. If the insert evicts an older entry, our pool's
    * `dealloc` sends COM_STMT_CLOSE via `unprepare` so the mysql2

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -116,7 +116,7 @@ interface PerformQueryHost {
   _statements?: Map<string, unknown>;
   handleWarnings?(sql: string): void | Promise<void>;
   verified?(): void;
-  _shouldPrepare?(binds: unknown[]): boolean;
+  preparedStatements?: boolean;
   _trackPrepared?(conn: unknown, sql: string): void;
 }
 
@@ -295,8 +295,9 @@ export async function performQuery(
 ): Promise<Mysql2RawResult> {
   const { notificationPayload } = options;
   // Rails' `raw_execute` always states `prepare:`; where a trails caller does
-  // not, fall back to the adapter's own `_shouldPrepare`.
-  const prepare = options.prepare ?? this._shouldPrepare?.(binds) ?? false;
+  // not, fall back to Rails' own gate, `prepared_statements && preparable`
+  // (abstract/database_statements.rb:74).
+  const prepare = options.prepare ?? (this.preparedStatements === true && binds.length > 0);
   const hasBinds = binds != null && binds.length > 0;
 
   // Rails' prepared arm is `@statements[sql] ||= raw_connection.prepare(sql)`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1133,7 +1133,10 @@ export class PostgreSQLAdapter
                   binds ?? [],
                   bindArray,
                   {
-                    prepare: options?.prepare === false ? false : this._shouldPrepare(bindArray),
+                    prepare:
+                      options?.prepare === false
+                        ? false
+                        : this.preparedStatements && bindArray.length > 0,
                     notificationPayload: payload,
                     rowMode: "array",
                   },
@@ -1423,22 +1426,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * True when the adapter should try a named prepared statement for
-   * this call. Rails' gate: `prepared_statements && !binds.empty?`
-   * (there's no point naming an unparameterized statement — the
-   * parse cost is the same either way and the name never gets
-   * reused without binds).
-   */
-  private _shouldPrepare(binds: unknown[]): boolean {
-    // Rails' gate and nothing more (the inverse of
-    // `without_prepared_statement?`, abstract_adapter.rb:1177). It does not
-    // consult `statement_limit`: a limit of 0 is unsupported in Rails, whose
-    // `StatementPool#[]=` loop raises on the empty cache
-    // (statement_pool.rb:31-33), so there is no zero-limit case to branch on.
-    return this.preparedStatements && binds.length > 0;
-  }
-
-  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /
@@ -1461,7 +1448,7 @@ export class PostgreSQLAdapter
           return await this.withRawConnection({ allowRetry }, async (conn) => {
             const client = conn as unknown as pg.Client;
             const result = await this._performQuery(client, rewritten, binds, bindArray, {
-              prepare: this._shouldPrepare(bindArray),
+              prepare: this.preparedStatements && bindArray.length > 0,
               notificationPayload: payload,
             });
             return result?.rows ?? [];
@@ -1581,7 +1568,7 @@ export class PostgreSQLAdapter
                 await client.query(`SAVEPOINT "${spName}"`);
               }
               const result = await this._performQuery(client, withReturning, originalBinds, binds, {
-                prepare: this._shouldPrepare(binds),
+                prepare: this.preparedStatements && binds.length > 0,
                 notificationPayload: payload,
               });
               if (useSavepoint) {
@@ -1614,7 +1601,7 @@ export class PostgreSQLAdapter
               }
               payload.sql = pgSql;
               const result = await this._performQuery(client, pgSql, originalBinds, binds, {
-                prepare: this._shouldPrepare(binds),
+                prepare: this.preparedStatements && binds.length > 0,
                 notificationPayload: payload,
               });
               const affected = this.affectedRows(result);
@@ -1625,7 +1612,7 @@ export class PostgreSQLAdapter
 
           if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
             const result = await this._performQuery(client, pgSql, originalBinds, binds, {
-              prepare: this._shouldPrepare(binds),
+              prepare: this.preparedStatements && binds.length > 0,
               notificationPayload: payload,
             });
             const affected = this.affectedRows(result);
@@ -1637,7 +1624,7 @@ export class PostgreSQLAdapter
           }
 
           const result = await this._performQuery(client, pgSql, originalBinds, binds, {
-            prepare: this._shouldPrepare(binds),
+            prepare: this.preparedStatements && binds.length > 0,
             notificationPayload: payload,
           });
           const affected = this.affectedRows(result);
@@ -2062,7 +2049,7 @@ export class PostgreSQLAdapter
           // Rails' internal_execute forwards `prepare:` to raw_execute →
           // perform_query (abstract/database_statements.rb:552-558, 589-591).
           const runResult = await this._performQuery(client, runSql, binds, bindArray, {
-            prepare: prepare === false ? false : this._shouldPrepare(bindArray),
+            prepare: prepare === false ? false : this.preparedStatements && bindArray.length > 0,
             notificationPayload: payload,
             rowMode: "array",
           });
@@ -3111,7 +3098,7 @@ export class PostgreSQLAdapter
    * correctly. Async: a ColumnDefinition (no OID) resolves its cast type via
    * `lookupCastType`'s live regtype query, as Rails does.
    */
-  override quoteDefaultExpression(value: unknown, column?: unknown): Promise<string> {
+  override quoteDefaultExpression(value: unknown, column: unknown): Promise<string> {
     const col = column as
       | {
           sqlType?: string | null;
@@ -3154,17 +3141,15 @@ export class PostgreSQLAdapter
     return pgQuoteDefaultExpression.call(
       this,
       value,
-      col != null
-        ? {
-            array: isArray,
-            sqlType: rawSqlType,
-            oid: col.oid ?? null,
-            fmod: col.fmod ?? null,
-            // Rails' uuid branch tests `column.type` (the AR type symbol), not
-            // sql_type, so forward it separately from `rawSqlType`.
-            type: col.type ?? null,
-          }
-        : null,
+      {
+        array: isArray,
+        sqlType: rawSqlType,
+        oid: col?.oid ?? null,
+        fmod: col?.fmod ?? null,
+        // Rails' uuid branch tests `column.type` (the AR type symbol), not
+        // sql_type, so forward it separately from `rawSqlType`.
+        type: col?.type ?? null,
+      },
       lookup,
     );
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.trails.test.ts
@@ -117,9 +117,11 @@ describe("PostgreSQL quoting", () => {
     // form, not the abstract byte-string fallback. Cover both shapes here —
     // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
     // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
-    expect(await quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
+    expect(await quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]), {})).toBe(
+      "'\\x1f8b'",
+    );
     expect(
-      await quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0x1f, 0x8b]))),
+      await quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0x1f, 0x8b])), {}),
     ).toBe("'\\x1f8b'");
   });
 
@@ -127,9 +129,9 @@ describe("PostgreSQL quoting", () => {
     // Dates self-dispatch through the host, so they must reach PG's BC-suffixing
     // quotedDate (postgresql/quoting.rb:143), not the abstract formatter which
     // drops " BC".
-    expect(await quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"))).toBe(
-      "'0044-03-15 BC'",
-    );
+    expect(
+      await quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"), {}),
+    ).toBe("'0044-03-15 BC'");
   });
 
   it("quotes a binary default produced by BinaryType#serialize", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -214,7 +214,7 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
 export async function quoteDefaultExpression(
   this: QuotingDispatchHost,
   value: unknown,
-  column?: DefaultExpressionColumn | null,
+  column: DefaultExpressionColumn,
   castTypeLookup?: CastTypeLookup | null,
 ): Promise<string> {
   if (value === undefined) return "";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1009,7 +1009,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   // string and apply the same paren-wrap branch rather than special-casing it.
   // Return type carries the widened base union for the super call; this
   // implementation itself never returns a Promise.
-  override quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
+  override quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string> {
     if (typeof value === "function") {
       const result = (value as () => unknown)();
       const str = typeof result === "string" ? result : isSqlLiteral(result) ? result.value : null;

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.trails.test.ts
@@ -217,19 +217,19 @@ describe("SQLite3::Quoting", () => {
 
   describe("quoteDefaultExpression", () => {
     it("returns empty string for undefined", () => {
-      expect(quoteDefaultExpression.call(HOST, undefined)).toBe("");
+      expect(quoteDefaultExpression.call(HOST, undefined, {})).toBe("");
     });
 
     it("returns NULL for null", () => {
-      expect(quoteDefaultExpression.call(HOST, null)).toBe("NULL");
+      expect(quoteDefaultExpression.call(HOST, null, {})).toBe("NULL");
     });
 
     it("wraps function results in parens", () => {
-      expect(quoteDefaultExpression.call(HOST, () => "NOW()")).toBe("(NOW())");
+      expect(quoteDefaultExpression.call(HOST, () => "NOW()", {})).toBe("(NOW())");
     });
 
     it("returns non-function results as raw SQL", () => {
-      expect(quoteDefaultExpression.call(HOST, () => "CURRENT_TIMESTAMP")).toBe(
+      expect(quoteDefaultExpression.call(HOST, () => "CURRENT_TIMESTAMP", {})).toBe(
         "CURRENT_TIMESTAMP",
       );
     });
@@ -240,18 +240,18 @@ describe("SQLite3::Quoting", () => {
       // that reach here — the `BinaryData` that `BinaryType#serialize` returns
       // (activemodel/.../binary.rb:31) and the raw `Uint8Array` view, which
       // takes the abstract `ArrayBuffer.isView` branch back to `quotedBinary`.
-      expect(quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
-      expect(quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
-        "x'dead'",
-      );
+      expect(quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]), {})).toBe("x'dead'");
+      expect(
+        quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0xde, 0xad])), {}),
+      ).toBe("x'dead'");
       // A *bare* `ArrayBuffer` has no Rails counterpart — Rails only ever
       // reaches `quote` with a `Type::Binary::Data`, and `ArrayBuffer.isView`
       // is false for a bare buffer — so it falls to the abstract
       // `else raise TypeError, "can't quote ..."` (abstract/quoting.rb:87) like
       // any other unquotable object. Hand a view instead.
-      expect(() => quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]).buffer)).toThrow(
-        /can't quote ArrayBuffer/,
-      );
+      expect(() =>
+        quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]).buffer, {}),
+      ).toThrow(/can't quote ArrayBuffer/);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -173,7 +173,11 @@ export function quotedBinary(value: Uint8Array | ArrayBuffer | BinaryData): stri
   return `x'${hex}'`;
 }
 
-export function quoteDefaultExpression(this: QuotingDispatchHost, value: unknown): string {
+export function quoteDefaultExpression(
+  this: QuotingDispatchHost,
+  value: unknown,
+  _column: unknown,
+): string {
   if (value === undefined) return "";
   if (value === null) return "NULL";
   if (typeof value === "function") {

--- a/packages/activerecord/src/sql-default.trails.test.ts
+++ b/packages/activerecord/src/sql-default.trails.test.ts
@@ -25,7 +25,7 @@ const DEFAULT_EXPRESSION_HOST = quotingHost({
     return lookupCastType.call({ typeMap: TYPE_MAP }, sqlType);
   },
 });
-const quoteDefaultExpression = (value: unknown, column?: { sqlType?: string | null } | null) =>
+const quoteDefaultExpression = (value: unknown, column: { sqlType?: string | null } = {}) =>
   quoteDefaultExpressionFn.call(DEFAULT_EXPRESSION_HOST, value, column);
 
 describe("quote", () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -543,7 +543,7 @@ export { TagStack, Formatter, LocalTagStorage } from "./tagged-logging.js";
 export { TaggedLogging } from "./tagged-logging.js";
 export { DeepMergeable } from "./deep-mergeable.js";
 export { DelegationError, Delegation } from "./delegation.js";
-export { ActiveSupportJSON } from "./json.js";
+export { ActiveSupportJSON, parseJsonTimes, setParseJsonTimes } from "./json.js";
 export { JSON } from "./json-stdlib.js";
 export {
   presence,


### PR DESCRIPTION
Bundle of five RFC 0115 / 0077 fidelity convergences.

**`Attribute#dup` runs `initialize_dup`** (`attribute.rb:155-159`). `main` carried
two halves of one Ruby method: `deepDup()` copied + ran `initializeDup`, while
`dup()` was a bare shallow copy. Ruby has one method — `Object#dup` is what
*triggers* `initialize_dup`, and `deep_dup` is `duplicable? ? dup : self`
(`deep_dup.rb:16`). Now `dup()` owns the copy and the re-dup, and `deepDup()`
delegates to it, so `builder.rb`'s three `.dup` call sites (`:84`, `:120`,
`:175`) re-dup a mutable cast value the way Ruby does. Regression test in
`builder-defaults.test.ts` fails on baseline.

**`_shouldPrepare` deleted from both adapters.** The story asked for
`withoutPreparedStatement` on `AbstractAdapter` per `abstract_adapter.rb:1177` —
but that method **no longer exists** in vendored Rails (`grep
without_prepared_statement vendor/rails/**/lib` finds nothing; it survives only
in test config names). Adding it would invent surface rather than converge, so
the convergence here is deletion: the gate is inlined as Rails spells it,
`prepared_statements && preparable` (`abstract/database_statements.rb:74`), and
the two novel private methods are gone.

**`quote_default_expression`'s `column` is required** (`abstract/quoting.rb:157`).
`column?` is now required on the abstract standalone, `AbstractAdapter`, and the
PG/SQLite overrides; the `if (column != null)` guard is deleted so
`lookup_cast_type(column.sql_type).serialize` runs unconditionally at rb:161.
The column-less DDL callers were given their column: `changeColumn` passes the
new `sqlType`, and `changeColumnDefault` / `changeColumnNull` resolve it with
`columnFor` as Rails does (`postgresql/schema_statements.rb:490`, `:502-503`).

**`_read_attribute`'s miss path raises.** Ruby's `__send__(attr)`
(`attribute_methods.rb:556`) raises `NoMethodError` on an undefined name, which
`method_missing` (`:507-514`) turns into `attribute_missing` for a matched
pattern and re-raises through `super` otherwise. trails' property read answered
`undefined`. The cascade is spelled out now; a local `NoMethodError extends
NameError` mirrors the shape already used in activesupport's
`method-missing-proxy.ts`.

**`from_json` decodes with `ActiveSupport::JSON.decode`** (`json.rb:147`), not
`globalThis.JSON.parse` — so `parse_json_times` conversion
(`json/decoding.rb:22-32`) applies. The decoder already existed in
`activesupport/src/json.ts`; this wires the call site and exports
`parseJsonTimes` / `setParseJsonTimes` alongside `ActiveSupportJSON`. The
`from_json` → `decode` call-mismatch baseline row is deleted (converged) and its
unreviewed mark tightened.

Gates: `parity:api:calls`, `:args`, `parity:api:extra:gate` clean; parity deltas
non-negative.

Closes-story: attribute-dup-must-redup-mutable-value
Closes-story: should-prepare-should-be-without-prepared-statement
Closes-story: quote-default-expression-column-is-required
Closes-story: read-attribute-miss-path-answers-undefined-not-nomethoderror
Closes-story: from-json-decodes-with-the-json-gem-not-activesupport

---

## Review round 1

**Story text corrected, not just the PR body.** `should-prepare-should-be-without-prepared-statement`'s
premise and acceptance criteria were rewritten in the tasks repo (`0f5bc31d7`)
so the record no longer claims a criterion this diff intentionally does not
satisfy. The story now carries the correction note, cites Rails' real gate
(`abstract/database_statements.rb:74`), and its criteria read "no named
replacement predicate is introduced (Rails has none)".

**`preparable` ≈ `binds.length > 0` filed, not propagated.** Correct that the
mysql2 fallback approximates Arel's `Collector#preparable` with a bind count.
It predates this PR (it lived inside `_shouldPrepare`), and converging it means
threading `prepare:` explicitly from `to_sql_and_binds` through every mysql2
caller — out of scope here. Filed as
`0077-quoting-binds-fidelity/mysql2-raw-execute-preparable-is-a-bind-count-approximation`
with the Rails `file:line` and the acceptance criteria, and the shipping story
links to it under "Known remaining approximation" rather than leaving the shape
unrecorded.

## Review round 2

Clean — no findings. One note answered: the inline `// Rails: …` comments trimmed
in `45ed8678c` were removed on explicit instruction for this PR (no code comments
in the diff; JSDoc on exported APIs kept). They were legitimate under CLAUDE.md's
"non-obvious context" allowance, so this is a house-style trim for this diff, not
a rule being read differently — every Rails `file:line` they carried survives in
this description and in the `Mirrors:` JSDoc above each method.

Also note `from_json`'s call-site fix landed on main via a sibling PR while this
was in review; the rebase took main's version, so story 5's remaining content
here is the `parseJsonTimes` / `setParseJsonTimes` export and the decoder
round-trip test.
