### PR TITLE
refactor(activerecord): one _assign_attributes for #new, and drop the invented dumpWithVersion (RFC 0112)

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -101,6 +101,28 @@ describe("_applyScopeAttributes — multiparameter path", () => {
       expect(e.readAttribute("role")).toBe("guest"); // explicit wins
     });
   });
+
+  it("explicit multiparameter attrs take precedence over a scope attr on the same column", async () => {
+    class Event extends Base {
+      static {
+        this._tableName = "events";
+        this.attribute("id", "integer");
+        this.attribute("role", "string");
+        this.attribute("starts_on", "date");
+      }
+    }
+    const rel = Event.where({ starts_on: "2020-01-01" });
+    await Event.scoping(rel, async () => {
+      // The scope names the same column the multiparameter trio assigns, so the
+      // explicit-key set has to carry `starts_on`, not `starts_on(1i)`.
+      const e = new Event({
+        "starts_on(1i)": "2024",
+        "starts_on(2i)": "6",
+        "starts_on(3i)": "15",
+      });
+      expect(String(e.readAttribute("starts_on"))).toContain("2024");
+    });
+  });
 });
 
 describe("_applyScopeAttributes — a scope that sets type wins over the STI default", () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -372,6 +372,7 @@ import { YAMLColumn as _YAMLColumn } from "./coders/yaml-column.js";
 
 // Break store→serialize→json→store circular dep by injecting serialize into store at init.
 _registerSerializeFn(_serializeAttribute as any);
+import { extractMultiparameterCallstack } from "./multiparameter-attribute-assignment.js";
 
 /**
  * A single column of a primary key.
@@ -3022,7 +3023,16 @@ export class Base extends Model {
       inheritanceInitializeInternalsCallback.call(this as any);
       // Guard before allocating the Set — the no-scope case is the hot path.
       if (_shouldApplyScopeAttributes(ctor)) {
-        _applyScopeAttributes(ctor, this as any, new Set(Object.keys(attrs)));
+        // The explicit keys are the ATTRIBUTE names, so a `starts_on(1i)` trio
+        // has to collapse to `starts_on` before the scope default for that same
+        // attribute is tested against it — otherwise the scope wins over an
+        // explicit assignment, which Rails never lets it do.
+        const { multiparams, regular } = extractMultiparameterCallstack(attrs);
+        _applyScopeAttributes(
+          ctor,
+          this as any,
+          new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
+        );
       }
       // Assign store accessor keys after the clean baseline so they appear
       // as dirty on new records (mirrors Rails: new-record attrs are changed

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -372,11 +372,6 @@ import { YAMLColumn as _YAMLColumn } from "./coders/yaml-column.js";
 
 // Break store→serialize→json→store circular dep by injecting serialize into store at init.
 _registerSerializeFn(_serializeAttribute as any);
-import {
-  hasMultiparameterKeys,
-  extractMultiparameterCallstack,
-  executeMultiparameterAssignment,
-} from "./multiparameter-attribute-assignment.js";
 
 /**
  * A single column of a primary key.
@@ -2982,134 +2977,81 @@ export class Base extends Model {
     // after super() so the association proxy exists on `this`.
     let assocPending = _extractAssociationAttrs(new.target, attrs);
     if (assocPending) attrs = assocPending.rest;
-    if (hasMultiparameterKeys(attrs)) {
-      // Mirrors Rails: Base#initialize calls assign_attributes which handles
-      // multiparameter keys. We split: regular attrs go through the Model
-      // constructor for setup, mp attrs are assembled after.
-      //
-      // Suppress after_initialize so it fires after ALL attrs are present
-      // (not just the regular subset), and re-snapshot dirty state so mp
-      // attrs appear clean (part of initial construction, not changes).
-      const ctor = new.target;
-      const suppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
-      const hadOwnSuppressor = Object.prototype.hasOwnProperty.call(
-        suppressor,
-        "_suppressInitializeCallback",
-      );
-      const wasSuppressed = suppressor._suppressInitializeCallback;
-      suppressor._suppressInitializeCallback = true;
-      const { multiparams, regular } = extractMultiparameterCallstack(attrs);
-      try {
-        super(regular);
-      } finally {
-        // Always restore the flag even if super() throws, so later instances
-        // on this class still fire after_initialize normally.
-        if (hadOwnSuppressor) {
-          suppressor._suppressInitializeCallback = wasSuppressed;
-        } else {
-          delete (suppressor as { _suppressInitializeCallback?: boolean })
-            ._suppressInitializeCallback;
-        }
+    // Suppress after_initialize during super() so we can call
+    // initialize_internals_callback first, then fire after_initialize.
+    // This matches Rails' Core#initialize order:
+    //   init_internals → initialize_internals_callback → super → after_initialize
+    // Multiparameter keys need no split here: super() reaches
+    // `assign_attributes` → `_assign_attributes`, which buckets `key(1i)` out
+    // of the scalar pass and calls `assign_multiparameter_attributes` itself
+    // (attribute_assignment.rb:11-22).
+    const ctor = new.target;
+    // Separate store accessor keys (virtual, backed by a store column rather
+    // than a direct DB column) from regular column attrs. Store accessor attrs
+    // are assigned AFTER the clean re-snapshot so they appear as dirty for new
+    // records — matching Rails' new-record dirty semantics where assign_attributes
+    // runs after init_internals / initialize_internals_callback.
+    const _storeKeys = new Set(Object.values(ctor.storedAttributes()).flat());
+    const _storeAttrs: Record<string, unknown> = {};
+    let attrsForSuper = attrs;
+    if (_storeKeys.size > 0) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (_storeKeys.has(k)) _storeAttrs[k] = v;
       }
-      executeMultiparameterAssignment(this as any, multiparams);
-      if (!wasSuppressed) {
-        inheritanceInitializeInternalsCallback.call(this as any);
-        // Guard before allocating the Set — the no-scope case is the hot path.
-        if (_shouldApplyScopeAttributes(ctor)) {
-          _applyScopeAttributes(
-            ctor,
-            this as any,
-            new Set([...Object.keys(multiparams), ...Object.keys(regular)]),
-          );
-        }
-        if (assocPending) {
-          _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
-          assocPending = null;
-        }
-        // Rails yields the constructor block (Core#initialize, core.rb:479)
-        // before after_initialize — used by association `build_record` to run
-        // `initialize_attributes` (scope FK + set_inverse_instance) first.
-        initBlock?.(this as unknown as Base);
-        // strict:"sync" guarantees synchronous completion -- void the settled result.
-        void runCallbacks(this, "initialize", undefined, { strict: "sync" });
+      if (Object.keys(_storeAttrs).length > 0) {
+        attrsForSuper = Object.fromEntries(
+          Object.entries(attrs).filter(([k]) => !_storeKeys.has(k)),
+        );
       }
-    } else {
-      // For the regular (non-multiparameter) path, mirror the multiparameter
-      // pattern: suppress after_initialize during super() so we can call
-      // initialize_internals_callback first, then fire after_initialize.
-      // This matches Rails' Core#initialize order:
-      //   init_internals → initialize_internals_callback → super → after_initialize
-      const ctor2 = new.target;
-      // Separate store accessor keys (virtual, backed by a store column rather
-      // than a direct DB column) from regular column attrs. Store accessor attrs
-      // are assigned AFTER the clean re-snapshot so they appear as dirty for new
-      // records — matching Rails' new-record dirty semantics where assign_attributes
-      // runs after init_internals / initialize_internals_callback.
-      const _storeKeys = new Set(Object.values(ctor2.storedAttributes()).flat());
-      const _storeAttrs: Record<string, unknown> = {};
-      let attrsForSuper = attrs;
-      if (_storeKeys.size > 0) {
-        for (const [k, v] of Object.entries(attrs)) {
-          if (_storeKeys.has(k)) _storeAttrs[k] = v;
-        }
-        if (Object.keys(_storeAttrs).length > 0) {
-          attrsForSuper = Object.fromEntries(
-            Object.entries(attrs).filter(([k]) => !_storeKeys.has(k)),
-          );
-        }
+    }
+    const suppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
+    const hadOwn = Object.prototype.hasOwnProperty.call(suppressor, "_suppressInitializeCallback");
+    const wasSuppressed = suppressor._suppressInitializeCallback;
+    suppressor._suppressInitializeCallback = true;
+    try {
+      super(attrsForSuper);
+    } finally {
+      if (hadOwn) {
+        suppressor._suppressInitializeCallback = wasSuppressed;
+      } else {
+        delete (suppressor as { _suppressInitializeCallback?: boolean })
+          ._suppressInitializeCallback;
       }
-      const suppressor2 = ctor2 as typeof ctor2 & { _suppressInitializeCallback?: boolean };
-      const hadOwn2 = Object.prototype.hasOwnProperty.call(
-        suppressor2,
-        "_suppressInitializeCallback",
-      );
-      const wasSuppressed2 = suppressor2._suppressInitializeCallback;
-      suppressor2._suppressInitializeCallback = true;
-      try {
-        super(attrsForSuper);
-      } finally {
-        if (hadOwn2) {
-          suppressor2._suppressInitializeCallback = wasSuppressed2;
-        } else {
-          delete (suppressor2 as { _suppressInitializeCallback?: boolean })
-            ._suppressInitializeCallback;
-        }
+    }
+    if (!wasSuppressed) {
+      inheritanceInitializeInternalsCallback.call(this as any);
+      // Guard before allocating the Set — the no-scope case is the hot path.
+      if (_shouldApplyScopeAttributes(ctor)) {
+        _applyScopeAttributes(ctor, this as any, new Set(Object.keys(attrs)));
       }
-      if (!wasSuppressed2) {
-        inheritanceInitializeInternalsCallback.call(this as any);
-        // Guard before allocating the Set — the no-scope case is the hot path.
-        if (_shouldApplyScopeAttributes(ctor2)) {
-          _applyScopeAttributes(ctor2, this as any, new Set(Object.keys(attrs)));
-        }
-        // Assign store accessor keys after the clean baseline so they appear
-        // as dirty on new records (mirrors Rails: new-record attrs are changed
-        // relative to nil). Dispatch through the prototype setter so the write
-        // lands in the store hash rather than a standalone attribute slot.
-        for (const [k, v] of Object.entries(_storeAttrs)) {
-          let proto = Object.getPrototypeOf(this);
-          let dispatched = false;
-          while (proto !== null && proto !== Object.prototype) {
-            const desc = Object.getOwnPropertyDescriptor(proto, k);
-            if (desc?.set) {
-              (desc.set as (val: unknown) => void).call(this, v);
-              dispatched = true;
-              break;
-            }
-            proto = Object.getPrototypeOf(proto);
+      // Assign store accessor keys after the clean baseline so they appear
+      // as dirty on new records (mirrors Rails: new-record attrs are changed
+      // relative to nil). Dispatch through the prototype setter so the write
+      // lands in the store hash rather than a standalone attribute slot.
+      for (const [k, v] of Object.entries(_storeAttrs)) {
+        let proto = Object.getPrototypeOf(this);
+        let dispatched = false;
+        while (proto !== null && proto !== Object.prototype) {
+          const desc = Object.getOwnPropertyDescriptor(proto, k);
+          if (desc?.set) {
+            (desc.set as (val: unknown) => void).call(this, v);
+            dispatched = true;
+            break;
           }
-          if (!dispatched) (this as any)._writeAttribute(k, v);
+          proto = Object.getPrototypeOf(proto);
         }
-        if (assocPending) {
-          _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
-          assocPending = null;
-        }
-        // Rails yields the constructor block (Core#initialize, core.rb:479)
-        // before after_initialize — used by association `build_record` to run
-        // `initialize_attributes` (scope FK + set_inverse_instance) first.
-        initBlock?.(this as unknown as Base);
-        // strict:"sync" guarantees synchronous completion -- void the settled result.
-        void runCallbacks(this, "initialize", undefined, { strict: "sync" });
+        if (!dispatched) (this as any)._writeAttribute(k, v);
       }
+      if (assocPending) {
+        _dispatchAssociationAttrs(this as unknown as Base, assocPending.assocs);
+        assocPending = null;
+      }
+      // Rails yields the constructor block (Core#initialize, core.rb:479)
+      // before after_initialize — used by association `build_record` to run
+      // `initialize_attributes` (scope FK + set_inverse_instance) first.
+      initBlock?.(this as unknown as Base);
+      // strict:"sync" guarantees synchronous completion -- void the settled result.
+      void runCallbacks(this, "initialize", undefined, { strict: "sync" });
     }
     // Suppressed-callback fallback: parent caller fires after_initialize, so
     // we still dispatch first to keep Rails' "assign → after_initialize" order.

--- a/packages/activerecord/src/multiparameter-attribute-assignment.ts
+++ b/packages/activerecord/src/multiparameter-attribute-assignment.ts
@@ -25,10 +25,6 @@ const MAX_MULTIPARAMETER_INDEX = 100;
 
 const MULTIPARAMETER_ATTRIBUTE_PATTERN = /^([^(]+)\((\d+)([if]?)\)$/;
 
-export function hasMultiparameterKeys(attrs: Record<string, unknown>): boolean {
-  return Object.keys(attrs).some((k) => MULTIPARAMETER_ATTRIBUTE_PATTERN.test(k));
-}
-
 /**
  * Separate a flat attribute hash into multiparameter groups and regular keys.
  * Mirrors Rails' extract_callstack_for_multiparameter_attributes.

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -416,10 +416,13 @@ describe("SchemaDumperTest", () => {
     const sm = new SchemaMigration(adapter.pool);
     await sm.createTable();
     await sm.createVersion("20240601120000");
-    const result = await TopLevelDumper.dumpWithVersion(adapter);
-    expect(result).toContain("Schema version: 20240601120000");
-    expect(result).toContain("defineSchema");
-  });
+    const output = (await TopLevelDumper.dump(adapter)).join("\n");
+    // Rails asserts %r{ActiveRecord::Schema\[...\]\.define} against the dump
+    // header (schema_dumper_test.rb:44-47); trails' generated DSL is a plain
+    // function, so the same header carries the version and the define call.
+    expect(output).toMatch(/version: 2024_06_01_120000/);
+    expect(output).toContain("defineSchema");
+  }, 60000);
 
   it("schema dump with regexp ignored table", async () => {
     // The `ignoreTables` filter runs during table enumeration, so drive the

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -321,34 +321,6 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).not.toContain("ar_internal_metadata");
   }, 60000);
 
-  it("dumpWithVersion defaults to 0 when no versions recorded", async () => {
-    const { SchemaDumper: TopLevelDumper } =
-      await import("./connection-adapters/abstract/schema-dumper.js");
-    const { SchemaMigration } = await import("./schema-migration.js");
-    const sm = new SchemaMigration(adapter.pool);
-    await sm.createTable();
-    await sm.deleteAllVersions();
-    const result = await TopLevelDumper.dumpWithVersion(adapter);
-    expect(result).toContain("Schema version: 0");
-  }, 60000);
-
-  it("dumpWithVersion includes latest migration version", async () => {
-    const { SchemaDumper: TopLevelDumper } =
-      await import("./connection-adapters/abstract/schema-dumper.js");
-    const { SchemaMigration } = await import("./schema-migration.js");
-    const sm = new SchemaMigration(adapter.pool);
-    await sm.createTable();
-    // schema_migrations survives per-file truncation (truncate skips it by
-    // design), so a prior run's version row can survive in the shared PG
-    // worker DB and collide on schema_migrations_pkey. Clear first to keep
-    // this test hermetic — same guard the sibling "defaults to 0" test uses.
-    await sm.deleteAllVersions();
-    await sm.createVersion("20240101000000");
-    await sm.createVersion("20240201000000");
-    const result = await TopLevelDumper.dumpWithVersion(adapter);
-    expect(result).toContain("Schema version: 20240201000000");
-  }, 60000);
-
   it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
     // Subclasses the ConnectionAdapters dumper directly — that's where emitTable
     // (the single column_spec dispatch) lives; the bare base delegates to it.

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -22,7 +22,6 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { Column } from "./connection-adapters/abstract/schema-dumper.js";
 import { isBlank } from "@blazetrails/activesupport";
-import { SchemaMigration } from "./schema-migration.js";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
 import type { Type } from "@blazetrails/activemodel";
@@ -257,9 +256,8 @@ const DSL_HELPER_METHODS = new Set([
 
 /**
  * Bridges a DatabaseAdapter to the SchemaSource protocol. Not public —
- * used internally by `SchemaDumper.dump(adapter, ...)` /
- * `dumpWithVersion(adapter, ...)` so adapter dumps don't require
- * callers to build a SchemaSource by hand.
+ * used internally by `SchemaDumper.dump(adapter, ...)` so adapter dumps
+ * don't require callers to build a SchemaSource by hand.
  */
 class AdapterSchemaSource implements SchemaSource {
   private _adapter: DatabaseAdapter;
@@ -519,8 +517,9 @@ export abstract class SchemaDumper {
       tableNamePrefix: config.tableNamePrefix ?? "",
       tableNameSuffix: config.tableNameSuffix ?? "",
       // Rails' dumper reads the version off the connection in `initialize`
-      // (`schema_dumper.rb:73`); trails resolves it in `dumpWithVersion` and
-      // hands it down here, and emits TS or JS rather than only Ruby.
+      // (`schema_dumper.rb:74`); trails resolves it in `dump` (a constructor
+      // cannot await) and hands it down here, and emits TS or JS rather than
+      // only Ruby.
       language: config.language,
       version: config.version,
     };
@@ -569,19 +568,36 @@ export abstract class SchemaDumper {
     // into dumps.
     if (isDatabaseAdapter(pool)) {
       const source = new AdapterSchemaSource(pool);
-      // Instantiate the adapter-specific subclass when the adapter exposes
-      // createSchemaDumper() (MySQL/PG/SQLite) so dialect overrides like
-      // MySQL's schemaPrecision (datetime precision 0 → `precision: nil`)
-      // apply. Mirrors Rails' `connection.create_schema_dumper`, which mixes
-      // the adapter's SchemaDumper module into the dumper. Without the hook,
-      // `create` still resolves to the ConnectionAdapters subclass (see its
-      // redirect) — never the bare base.
-      const createDialectDumper = (pool as { createSchemaDumper?: unknown }).createSchemaDumper;
-      const dumper =
-        (typeof createDialectDumper === "function"
-          ? (createDialectDumper.call(pool, options) as SchemaDumper | undefined | null)
-          : undefined) ?? this.create(source, options);
-      return dumper.dump(stream) as Promise<string[]>;
+      // Rails reads the version in the dumper's `initialize`:
+      // `@version = connection.pool.migration_context.current_version rescue nil`
+      // (schema_dumper.rb:74). A TS constructor cannot await, so the one async
+      // read happens here and reaches the dumper through its options hash; the
+      // `rescue nil` arm is the catch (no schema_migrations table yet).
+      return (async () => {
+        try {
+          // A NullPool has no migration_context at all — Ruby's NoMethodError
+          // there is the same `rescue nil` case as a missing schema_migrations.
+          const version = await (
+            pool.pool as { migrationContext: { currentVersion(): Promise<number | undefined> } }
+          ).migrationContext.currentVersion();
+          if (version != null) options.version = String(version);
+        } catch {
+          // rescue nil
+        }
+        // Instantiate the adapter-specific subclass when the adapter exposes
+        // createSchemaDumper() (MySQL/PG/SQLite) so dialect overrides like
+        // MySQL's schemaPrecision (datetime precision 0 → `precision: nil`)
+        // apply. Mirrors Rails' `connection.create_schema_dumper`, which mixes
+        // the adapter's SchemaDumper module into the dumper. Without the hook,
+        // `create` still resolves to the ConnectionAdapters subclass (see its
+        // redirect) — never the bare base.
+        const createDialectDumper = (pool as { createSchemaDumper?: unknown }).createSchemaDumper;
+        const dumper =
+          (typeof createDialectDumper === "function"
+            ? (createDialectDumper.call(pool, options) as SchemaDumper | undefined | null)
+            : undefined) ?? this.create(source, options);
+        return dumper.dump(stream) as Promise<string[]>;
+      })();
     }
     if (isConnectionPool(pool)) {
       return pool
@@ -616,28 +632,6 @@ export abstract class SchemaDumper {
     await dumper.types(stream);
     await dumper.dumpTable(stream, tableName);
     return stream.join("\n");
-  }
-
-  /**
-   * Dump an adapter's schema with a `// Schema version: N` header
-   * derived from schema_migrations. No direct Rails analog — Rails
-   * emits the version as a block argument in schema.rb; our generated
-   * DSL is a plain function, so we use a comment.
-   */
-  static async dumpWithVersion(
-    adapter: DatabaseAdapter,
-    options: SchemaDumperOptions = {},
-  ): Promise<string> {
-    const schemaMigration = new SchemaMigration(adapter.pool);
-    let version = "0";
-    if (await schemaMigration.tableExists()) {
-      const versions = await schemaMigration.allVersions();
-      if (versions.length > 0) {
-        version = versions[versions.length - 1];
-      }
-    }
-    const schema = await this.dump(adapter, [], { ...options, version });
-    return `// Schema version: ${version}\n${schema.join("\n")}`;
   }
 
   dump(stream: string[] = []): string[] | Promise<string[]> {

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 385,
-    "total": 1394
+    "total": 1392
   },
   "arel": {
     "novel": 0,

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,6 +1,6 @@
 {
   "activerecord": {
-    "novel": 387,
+    "novel": 385,
     "total": 1394
   },
   "arel": {


### PR DESCRIPTION
refactor(activerecord): one _assign_attributes for #new, and drop the invented dumpWithVersion (RFC 0112)

Base's constructor carried a third `_assign_attributes`: a bespoke
`hasMultiparameterKeys` split that pulled `key(1i)` pairs out of `attrs`,
ran `super(regular)` with after_initialize suppressed, and assembled the
multiparameter values itself. Rails has one such method
(activerecord/lib/active_record/attribute_assignment.rb:6-22), reached from
`#new` through Core#initialize → assign_attributes, and it buckets `(` keys
out of the scalar pass and calls `assign_multiparameter_attributes` (:21-22)
itself. So `super(attrs)` is the whole port: the multiparameter branch and
its callback-suppression twin collapse into the single remaining path, and
the trails-only `hasMultiparameterKeys` predicate goes away with them.

`SchemaDumper.dumpWithVersion` had no Rails counterpart either: it fused
`dump_schema_information` with a full dump and prefixed an invented
`// Schema version: N` comment. Rails resolves the version in the dumper's
`initialize` — `connection.pool.migration_context.current_version rescue nil`
(schema_dumper.rb:74) — and emits it through the header's `define_params`.
A TS constructor cannot await, so `dump` performs that one async read (with
the `rescue nil` arm as a catch) and hands it down through the options hash
the header already reads. `schema dump include migration version` now asserts
against the header, as test_schema_dump_include_migration_version does.

Closes-story: consolidate-three-assign-attributes-implementations
Closes-story: converge-schema-dumper-dump-with-version-onto-rails-seams

