### PR TITLE
refactor(activerecord): the CommandRecorder is the connection, CollectionProxy#delete_all reads the @association seat, reset! configures the connection

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -599,14 +599,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Rails' `@association` ivar (collection_proxy.rb:33), which every mutation
-   * on the proxy delegates to. trails resolves it off the owner instead of
-   * holding it, because the proxy is built from the reflection, not handed the
-   * association object.
+   * Rails' `@association` ivar (collection_proxy.rb:31-35), which every
+   * mutation on the proxy delegates to — `target` (:33), `loaded?` (:53) and
+   * `delete_all` (:474) all read the same seat.
    * @internal
    */
   private _collectionAssociation(): CollectionAssociation {
-    return this._record.association(this._assocName) as unknown as CollectionAssociation;
+    return this._association;
   }
 
   /**
@@ -1081,11 +1080,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * in Rails.
    */
   async deleteAll(dependent?: string): Promise<number> {
-    const count = await (
-      this._record.association(this._assocName) as unknown as {
-        deleteAll(dependent?: string): Promise<number>;
-      }
-    ).deleteAll(dependent);
+    const count = await this._collectionAssociation().deleteAll(dependent);
     this.resetScope();
     return count;
   }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -601,11 +601,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Rails' `@association` ivar (collection_proxy.rb:31-35), which every
    * mutation on the proxy delegates to — `target` (:33), `loaded?` (:53) and
-   * `delete_all` (:474) all read the same seat.
+   * `delete_all` (:474) all read the same seat. trails resolves it off the
+   * owner instead of holding it, because the proxy is built from the
+   * reflection, not handed the association object.
    * @internal
    */
   private _collectionAssociation(): CollectionAssociation {
-    return this._association;
+    return this._record.association(this._assocName) as unknown as CollectionAssociation;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -22,6 +22,7 @@ import {
   type SQLWarning,
 } from "../errors.js";
 import {
+  ActiveSupport,
   IsolatedExecutionState,
   LoadInterlockAwareMonitor,
   Notifications,
@@ -1906,12 +1907,14 @@ export class AbstractAdapter implements Quoting {
     this.resetTransaction();
     // Rails' `reset!` ends in `attempt_configure_connection`
     // (abstract_adapter.rb:725-731). `resetBang` is sync per the pool's
-    // contract, so the async hop is scheduled rather than awaited;
-    // `attemptConfigureConnection` already disconnects the connection on
-    // failure (abstract_adapter.rb:1216-1221) and a sync caller has nowhere to
-    // receive the re-raise, so the rejection is absorbed here instead of
-    // surfacing as an unhandled rejection.
-    void this.attemptConfigureConnection().catch(() => {});
+    // contract, so the async hop is scheduled rather than awaited, and a sync
+    // caller has nowhere to receive the re-raise
+    // (abstract_adapter.rb:1216-1221) — the connection is already disconnected
+    // by then, so the next lease reconnects and surfaces the real error. The
+    // rejection itself goes to the error reporter rather than being dropped.
+    void this.attemptConfigureConnection().catch((error: Error) => {
+      ActiveSupport.errorReporter.report(error, { handled: true });
+    });
   }
 
   supportsAdvisoryLocks(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -258,7 +258,14 @@ export interface AbstractAdapter {
   dropTable(
     ...args:
       | [string, ...string[]]
-      | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" }]
+      | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" } | undefined]
+      | [string, ...string[], ((t: TableDefinition) => void) | undefined]
+      | [
+          string,
+          ...string[],
+          { ifExists?: boolean; force?: boolean | "cascade" } | undefined,
+          ((t: TableDefinition) => void) | undefined,
+        ]
   ): Promise<void>;
   renameTable(tableName: string, newName: string): Promise<void>;
   addColumn(
@@ -1897,6 +1904,14 @@ export class AbstractAdapter implements Quoting {
   resetBang(): void {
     void this.clearCacheBang({ newConnection: true });
     this.resetTransaction();
+    // Rails' `reset!` ends in `attempt_configure_connection`
+    // (abstract_adapter.rb:725-731). `resetBang` is sync per the pool's
+    // contract, so the async hop is scheduled rather than awaited;
+    // `attemptConfigureConnection` already disconnects the connection on
+    // failure (abstract_adapter.rb:1216-1221) and a sync caller has nowhere to
+    // receive the re-raise, so the rejection is absorbed here instead of
+    // surfacing as an unhandled rejection.
+    void this.attemptConfigureConnection().catch(() => {});
   }
 
   supportsAdvisoryLocks(): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1580,9 +1580,29 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       | [
           string,
           ...string[],
-          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean },
+          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean } | undefined,
+        ]
+      | [string, ...string[], ((t: MysqlTableDefinition) => void) | undefined]
+      | [
+          string,
+          ...string[],
+          { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean } | undefined,
+          ((t: MysqlTableDefinition) => void) | undefined,
         ]
   ): Promise<void> {
+    // Ruby's `*table_names, **options` swallows neither an omitted argument nor
+    // a block into `table_names` (abstract/schema_statements.rb:540); TS spells
+    // both as trailing arguments, so they come off first — the block is only
+    // ever read by CommandRecorder, which keeps it so `drop_table` can invert
+    // to `create_table`.
+    const rest = [...args] as unknown[];
+    while (
+      rest.length > 0 &&
+      (rest[rest.length - 1] === undefined || typeof rest[rest.length - 1] === "function")
+    ) {
+      rest.pop();
+    }
+    args = rest as typeof args;
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -257,7 +257,11 @@ export interface ExtensionStatements {
 /** Enum type DDL — PostgreSQL only. */
 export interface EnumStatements {
   createEnum(name: string, values: string[], options?: Record<string, unknown>): Promise<void>;
-  dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  dropEnum(
+    name: string,
+    valuesOrOptions?: string[] | { ifExists?: boolean },
+    options?: { ifExists?: boolean },
+  ): Promise<void>;
   renameEnumValue(name: string, options: { from: string; to: string }): Promise<void>;
 }
 
@@ -466,11 +470,29 @@ export class SchemaStatements {
   async dropTable(
     ...args:
       | [string, ...string[]]
-      | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" }]
+      | [string, ...string[], { ifExists?: boolean; force?: boolean | "cascade" } | undefined]
+      | [string, ...string[], ((t: TableDefinition) => void) | undefined]
+      | [
+          string,
+          ...string[],
+          { ifExists?: boolean; force?: boolean | "cascade" } | undefined,
+          ((t: TableDefinition) => void) | undefined,
+        ]
   ): Promise<void> {
-    // TS has no kwargs, so Rails' `*table_names, **options`
+    // TS has no kwargs, so Rails' `*table_names, **options, &block`
     // (abstract/schema_statements.rb:540) arrives as a trailing options object
-    // on the rest parameter.
+    // on the rest parameter, and the block as a trailing function. Ruby's
+    // signature swallows both without them reaching `table_names`; here they
+    // are popped off first — the block is only ever read by CommandRecorder,
+    // which keeps it so `drop_table` can invert to `create_table`.
+    const rest = [...args] as unknown[];
+    while (
+      rest.length > 0 &&
+      (rest[rest.length - 1] === undefined || typeof rest[rest.length - 1] === "function")
+    ) {
+      rest.pop();
+    }
+    args = rest as typeof args;
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2568,9 +2568,11 @@ export class PostgreSQLAdapter
           });
         }
         this._statements.reset();
-        // Rails' `super` — clear_cache!(new_connection: true) + reset_transaction
-        // (abstract_adapter.rb:728-731) — runs inside the same lock, last
-        // (postgresql_adapter.rb:380).
+        // Rails' `super` — clear_cache!(new_connection: true), reset_transaction
+        // and attempt_configure_connection (abstract_adapter.rb:726-730) — runs
+        // inside the same lock, last (postgresql_adapter.rb:380). Its configure
+        // hop is a no-op here: the body above has already re-run it on this
+        // socket and latched `_connectionConfigured`.
         super.resetBang();
       })
       .catch(() => {});
@@ -4289,7 +4291,11 @@ export interface PostgreSQLAdapter {
 
   createEnum(name: string, values: string[], options?: Record<string, unknown>): Promise<void>;
 
-  dropEnum(name: string, options?: { ifExists?: boolean }): Promise<void>;
+  dropEnum(
+    name: string,
+    valuesOrOptions?: string[] | { ifExists?: boolean },
+    options?: { ifExists?: boolean },
+  ): Promise<void>;
 
   /**
    * @noRailsEquivalent PERMANENT. Rails supports PostgreSQL range *column* types first-class but

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1483,7 +1483,22 @@ export class SchemaStatements extends AbstractSchemaStatements {
     await this.reloadTypeMap();
   }
 
-  async dropEnum(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
+  async dropEnum(
+    name: string,
+    valuesOrOptions?: string[] | { ifExists?: boolean },
+    options: { ifExists?: boolean } = {},
+  ): Promise<void> {
+    // Rails' `drop_enum(name, values = nil, **options)` (postgresql_adapter.rb:571)
+    // ignores `values` — it is carried only so CommandRecorder can invert the
+    // command to `create_enum`. TS has no kwargs, so an options hash may arrive
+    // in the `values` slot.
+    if (
+      valuesOrOptions !== null &&
+      valuesOrOptions !== undefined &&
+      !Array.isArray(valuesOrOptions)
+    ) {
+      options = valuesOrOptions;
+    }
     const [schema, enumName] = this.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.quoteColumnName(schema)}.${this.quoteColumnName(enumName)}`

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -116,9 +116,19 @@ export class SchemaStatements extends AbstractSchemaStatements {
   override async dropTable(
     ...args: Parameters<AbstractSchemaStatements["dropTable"]>
   ): Promise<void> {
-    // TS has no kwargs, so Rails' `*table_names, **options`
-    // (abstract/schema_statements.rb:540) arrives as a trailing options object
-    // on the rest parameter.
+    // Ruby's `*table_names, **options` swallows neither an omitted argument nor
+    // a block into `table_names` (abstract/schema_statements.rb:540); TS spells
+    // both as trailing arguments, so they come off first — the block is only
+    // ever read by CommandRecorder, which keeps it so `drop_table` can invert
+    // to `create_table`.
+    const rest = [...args] as unknown[];
+    while (
+      rest.length > 0 &&
+      (rest[rest.length - 1] === undefined || typeof rest[rest.length - 1] === "function")
+    ) {
+      rest.pop();
+    }
+    args = rest as typeof args;
     const last = args[args.length - 1];
     const hasOptions = last !== null && last !== undefined && typeof last === "object";
     const tableNames = (hasOptions ? args.slice(0, -1) : args) as string[];

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -168,7 +168,10 @@ describe("MigrationTest", () => {
     const seen: unknown[] = [];
     class M extends Migration {}
     const m = new M();
-    (m as unknown as { _connectionOverride: unknown })._connectionOverride = {
+    // Rails has no `Migration#change_table`: `method_missing` forwards to the
+    // adapter, whose `change_table` yields `update_table_definition(table_name,
+    // self)` — the ADAPTER, not the migration (abstract/schema_statements.rb:729-737).
+    const connection = {
       quoteColumnName: (n: string) => n,
       quoteTableName: (n: string) => n,
       quoteDefaultExpression: (v: unknown) => String(v),
@@ -176,7 +179,11 @@ describe("MigrationTest", () => {
         seen.push([tableName, base]);
         return new AdapterTable(tableName, base as never);
       },
+      async changeTable(tableName: string, fn: (t: Table) => void | Promise<void>): Promise<void> {
+        await fn(this.updateTableDefinition(tableName, this));
+      },
     };
+    (m as unknown as { _connectionOverride: unknown })._connectionOverride = connection;
 
     let yielded: unknown;
     await m.changeTable("people", (t) => {
@@ -184,7 +191,7 @@ describe("MigrationTest", () => {
     });
 
     expect(yielded).toBeInstanceOf(AdapterTable);
-    expect(seen).toEqual([["people", m]]);
+    expect(seen).toEqual([["people", connection]]);
   });
 });
 

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -170,7 +170,8 @@ describe("MigrationTest", () => {
     const m = new M();
     // Rails has no `Migration#change_table`: `method_missing` forwards to the
     // adapter, whose `change_table` yields `update_table_definition(table_name,
-    // self)` — the ADAPTER, not the migration (abstract/schema_statements.rb:729-737).
+    // base)` — the ADAPTER by default, not the migration
+    // (abstract/schema_statements.rb:510-518).
     const connection = {
       quoteColumnName: (n: string) => n,
       quoteTableName: (n: string) => n,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -83,25 +83,6 @@ export function _registerBase(base: BaseWithLogger): void {
   _base = base;
 }
 
-// Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
-// For {from,to} hashes, returns `to` (which may be null to clear a comment).
-// `to: undefined` is rejected — a missing value cannot be forwarded to SQL.
-function _extractNewCommentValue(v: CommentOrChanges): string | null {
-  if (v !== null && typeof v === "object") {
-    if (!("to" in v) || (v as { to: unknown }).to === undefined) {
-      throw new ArgumentError("change_column_comment / change_table_comment requires a :to value");
-    }
-    const to = (v as { to: unknown }).to;
-    if (to !== null && typeof to !== "string") {
-      throw new ArgumentError(
-        `change_column_comment / change_table_comment :to must be a string or null, got ${typeof to}`,
-      );
-    }
-    return to;
-  }
-  return v;
-}
-
 // Registry for AR config injected by Base — breaks the migration ↔ base import cycle.
 /** @internal */
 /**
@@ -374,18 +355,31 @@ function isMigrationClass(fn: unknown): fn is MigrationClass {
 }
 
 /**
+ * Rails asks the connection itself whether it is a recorder —
+ * `connection.respond_to? :revert` (migration.rb:855, 1046) and
+ * `connection.respond_to?(:reverting)` (migration.rb:871). A TS adapter type
+ * cannot be narrowed by a duck-typed `respond_to?`, so the same question is
+ * asked of the class.
+ */
+function isCommandRecorder(connection: unknown): connection is CommandRecorder {
+  return connection instanceof CommandRecorder;
+}
+
+/**
  * Migration — base class for database migrations.
  *
  * Mirrors: ActiveRecord::Migration
  */
 export class Migration {
-  /** @internal Per-migration connection override — mirrors Rails' @connection ivar. */
-  protected _connectionOverride?: DatabaseAdapter;
+  /**
+   * @internal Per-migration connection override — mirrors Rails' @connection
+   * ivar, which holds the adapter OR the `CommandRecorder` that `#revert`
+   * swaps in for the duration of a recorded block (migration.rb:857-864).
+   */
+  protected _connectionOverride?: DatabaseAdapter | CommandRecorder;
   /** @internal Per-migration pool override — mirrors Rails' @pool ivar. */
   protected _poolOverride?: ConnectionPool;
   private _executionStrategy?: ExecutionStrategy;
-  private _recording = false;
-  private _recorder = new CommandRecorder();
   private _name?: string;
   /**
    * The migration instance class-level schema operations route through
@@ -522,6 +516,10 @@ export class Migration {
 
   /** @internal Mirrors Rails Migration#method_missing's proper_table_name dispatch. */
   protected _pt(name: string): string {
+    // `method_missing` applies `proper_table_name` only when the connection is
+    // not the recorder (migration.rb:1046-1047) — a recorded command keeps the
+    // raw name, and replay prefixes it when it runs for real.
+    if (isCommandRecorder(this.connection)) return name;
     return Migration.properTableName(name, Migration.tableNameOptions());
   }
 
@@ -553,20 +551,6 @@ export class Migration {
       | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    if (this._recording) {
-      // Record `[name, options?, block?]` without trailing `undefined`, so the
-      // inversion to drop_table (which keeps every arg, including the block, for
-      // reversibility) doesn't carry a stray arg into the executed statement.
-      const recordArgs: unknown[] = [name];
-      if (typeof optionsOrFn === "function") {
-        recordArgs.push(optionsOrFn);
-      } else {
-        if (optionsOrFn !== undefined) recordArgs.push(optionsOrFn);
-        if (fn !== undefined) recordArgs.push(fn);
-      }
-      this._recorder.record("createTable", recordArgs);
-      return;
-    }
     const tname = this._pt(name);
     await this.connection.createTable(tname, optionsOrFn, fn);
   }
@@ -591,27 +575,23 @@ export class Migration {
     const rest = [...args] as unknown[];
     // Rails drop_table(*table_names, **options, &block): the trailing block is
     // the table definition, kept only so the recorder can recreate on reversal.
-    const block = typeof rest[rest.length - 1] === "function" ? rest.pop() : undefined;
+    const block = (typeof rest[rest.length - 1] === "function" ? rest.pop() : undefined) as
+      | ((t: TableDefinition) => void)
+      | undefined;
     const last = rest[rest.length - 1];
     const hasOptions = last !== null && typeof last === "object";
     const options = hasOptions
       ? (last as { ifExists?: boolean; force?: boolean | "cascade"; temporary?: boolean })
       : undefined;
     const names = (hasOptions ? rest.slice(0, -1) : rest) as string[];
-    if (this._recording) {
-      // Record the raw (un-prefixed) names — invert replays through createTable,
-      // which re-applies the table-name prefix. The recorder accepts the splat.
-      const recordArgs: unknown[] = [...names];
-      if (options) recordArgs.push(options);
-      if (block) recordArgs.push(block);
-      this._recorder.record("dropTable", recordArgs);
-      return;
-    }
     const tnames = names.map((n) => this._pt(n)) as [string, ...string[]];
-    if (options) {
-      await this.connection.dropTable(...tnames, options);
+    // Ruby passes the block on its own channel (`&block`), which `drop_table`
+    // ignores and the recorder keeps; TS has only a trailing argument, so the
+    // adapter drops a trailing function the same way Ruby's signature does.
+    if (options !== undefined) {
+      await this.connection.dropTable(...tnames, options, block);
     } else {
-      await this.connection.dropTable(...tnames);
+      await this.connection.dropTable(...tnames, block);
     }
   }
 
@@ -621,10 +601,6 @@ export class Migration {
     type: ColumnType,
     options: ColumnOptions & { ifNotExists?: boolean } = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addColumn", [tableName, columnName, type, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.addColumn(tableName, columnName, type, options);
   }
@@ -637,19 +613,11 @@ export class Migration {
   ): Promise<void> {
     const type = typeof typeOrOptions === "string" ? typeOrOptions : undefined;
     const opts = typeof typeOrOptions === "object" ? typeOrOptions : (options ?? {});
-    if (this._recording) {
-      this._recorder.record("removeColumn", [tableName, columnName, type, opts]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.removeColumn(tableName, columnName, type, opts);
   }
 
   async renameColumn(tableName: string, oldName: string, newName: string): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("renameColumn", [tableName, oldName, newName]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.renameColumn(tableName, oldName, newName);
   }
@@ -659,10 +627,6 @@ export class Migration {
     columns: string | string[],
     options: AddIndexOptions = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addIndex", [tableName, columns, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.addIndex(tableName, columns, options);
   }
@@ -676,17 +640,6 @@ export class Migration {
       | { column?: string | string[]; name?: string; ifExists?: boolean } = {},
     options: { column?: string | string[]; name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
-    if (this._recording) {
-      // Record args as actually passed so command-recorder inversion sees the
-      // same shape: positional column → [table, column, options]; options-hash
-      // form → [table, options] (no spurious trailing hash to mis-strip).
-      const recordArgs =
-        typeof columnOrOptions === "string" || Array.isArray(columnOrOptions)
-          ? [tableName, columnOrOptions, options]
-          : [tableName, columnOrOptions];
-      this._recorder.record("removeIndex", recordArgs);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.removeIndex(tableName, columnOrOptions, options);
   }
@@ -697,19 +650,11 @@ export class Migration {
     type: ColumnType,
     options: ColumnOptions = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("changeColumn", [tableName, columnName, type, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.changeColumn(tableName, columnName, type, options);
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("renameTable", [oldName, newName]);
-      return;
-    }
     oldName = this._pt(oldName);
     newName = this._pt(newName);
     await this.connection.renameTable(oldName, newName);
@@ -733,10 +678,6 @@ export class Migration {
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("changeColumnDefault", [tableName, columnName, defaultOrChanges]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.changeColumnDefault(tableName, columnName, defaultOrChanges);
   }
@@ -747,10 +688,6 @@ export class Migration {
     allowNull: boolean,
     defaultValue?: unknown,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("changeColumnNull", [tableName, columnName, allowNull, defaultValue]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.changeColumnNull(tableName, columnName, allowNull, defaultValue);
   }
@@ -765,10 +702,6 @@ export class Migration {
       index?: boolean;
     } = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addReference", [tableName, refName, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.addReference(tableName, refName, options);
   }
@@ -792,10 +725,6 @@ export class Migration {
     refName: string,
     options: { polymorphic?: boolean } = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("removeReference", [tableName, refName, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.removeReference(tableName, refName, options);
   }
@@ -814,10 +743,6 @@ export class Migration {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addForeignKey", [fromTable, toTable, options]);
-      return;
-    }
     fromTable = this._pt(fromTable);
     await this.connection.addForeignKey(fromTable, toTable, options);
   }
@@ -829,15 +754,6 @@ export class Migration {
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
     options?: { column?: string; name?: string; ifExists?: boolean },
   ): Promise<void> {
-    if (this._recording) {
-      // Rails records `remove_foreign_key(from_table, to_table, **options)`;
-      // preserve the trailing options so invert_add_foreign_key's column/name
-      // survive the round-trip and resolve the real constraint on replay.
-      const recordArgs: unknown[] = [fromTable, toTableOrOptions];
-      if (options !== undefined) recordArgs.push(options);
-      this._recorder.record("removeForeignKey", recordArgs);
-      return;
-    }
     fromTable = this._pt(fromTable);
     if (typeof toTableOrOptions === "string") toTableOrOptions = this._pt(toTableOrOptions);
     await this.connection.removeForeignKey(fromTable, toTableOrOptions, options);
@@ -855,10 +771,6 @@ export class Migration {
       [key: string]: unknown;
     } = {},
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addCheckConstraint", [tableName, expression, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.addCheckConstraint(tableName, expression, options);
   }
@@ -868,15 +780,6 @@ export class Migration {
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
     options?: { name?: string; ifExists?: boolean },
   ): Promise<void> {
-    if (this._recording) {
-      // Rails records `remove_check_constraint(table, expression, **options)`;
-      // preserve the trailing options so invert_add_check_constraint's :name
-      // survives the round-trip and resolves the real constraint on replay.
-      const recordArgs: unknown[] = [tableName, expressionOrOptions];
-      if (options !== undefined) recordArgs.push(options);
-      this._recorder.record("removeCheckConstraint", recordArgs);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.removeCheckConstraint(tableName, expressionOrOptions, options);
   }
@@ -905,41 +808,23 @@ export class Migration {
     columnName: string,
     commentOrChanges: CommentOrChanges,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("changeColumnComment", [tableName, columnName, commentOrChanges]);
-      return;
-    }
     tableName = this._pt(tableName);
-    const resolved = _extractNewCommentValue(commentOrChanges);
     const connection = this.connection as DatabaseAdapter & CommentStatements;
-    await connection.changeColumnComment(tableName, columnName, resolved);
+    await connection.changeColumnComment(tableName, columnName, commentOrChanges);
   }
 
   async changeTableComment(tableName: string, commentOrChanges: CommentOrChanges): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("changeTableComment", [tableName, commentOrChanges]);
-      return;
-    }
     tableName = this._pt(tableName);
-    const resolved = _extractNewCommentValue(commentOrChanges);
     const connection = this.connection as DatabaseAdapter & CommentStatements;
-    await connection.changeTableComment(tableName, resolved);
+    await connection.changeTableComment(tableName, commentOrChanges);
   }
 
   async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("enableExtension", [name, options]);
-      return;
-    }
     const connection = this.connection as DatabaseAdapter & ExtensionStatements;
     await connection.enableExtension(name, options);
   }
 
   async disableExtension(name: string, options?: { force?: "cascade" }): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("disableExtension", [name, options]);
-      return;
-    }
     const connection = this.connection as DatabaseAdapter & ExtensionStatements;
     await connection.disableExtension(name, options);
   }
@@ -949,10 +834,6 @@ export class Migration {
     values: string[],
     options?: Record<string, unknown>,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("createEnum", [name, values, options]);
-      return;
-    }
     const connection = this.connection as DatabaseAdapter & EnumStatements;
     await connection.createEnum(name, values, options);
   }
@@ -970,21 +851,11 @@ export class Migration {
       !Array.isArray(valuesOrOptions);
     const values = isOptsObj ? undefined : valuesOrOptions;
     const opts = isOptsObj ? valuesOrOptions : (options ?? undefined);
-    if (this._recording) {
-      this._recorder.record("dropEnum", [name, values, opts]);
-      return;
-    }
-    // values is only captured for recording (so dropEnum can be inverted to createEnum);
-    // the adapter's dropEnum(name, options?) doesn't need values for SQL execution.
     const connection = this.connection as DatabaseAdapter & EnumStatements;
-    await connection.dropEnum(name, opts ?? {});
+    await connection.dropEnum(name, values, opts);
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("renameEnumValue", [name, options]);
-      return;
-    }
     const connection = this.connection as DatabaseAdapter & EnumStatements;
     await connection.renameEnumValue(name, options);
   }
@@ -994,10 +865,6 @@ export class Migration {
     columnName?: string | string[],
     options?: UniqueConstraintOptions,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addUniqueConstraint", [tableName, columnName, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     const connection = this.connection as DatabaseAdapter & UniqueConstraintStatements;
     await connection.addUniqueConstraint(tableName, columnName, options);
@@ -1016,29 +883,17 @@ export class Migration {
       !Array.isArray(columnNameOrOptions);
     const columnName = isOptsObj ? undefined : columnNameOrOptions;
     const opts = isOptsObj ? columnNameOrOptions : (options ?? undefined);
-    if (this._recording) {
-      this._recorder.record("removeUniqueConstraint", [tableName, columnName, opts]);
-      return;
-    }
     tableName = this._pt(tableName);
     const connection = this.connection as DatabaseAdapter & UniqueConstraintStatements;
     await connection.removeUniqueConstraint(tableName, columnName, opts);
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addTimestamps", [tableName, options]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.addTimestamps(tableName, options);
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("removeTimestamps", [tableName]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.removeTimestamps(tableName);
   }
@@ -1059,10 +914,6 @@ export class Migration {
     options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("createJoinTable", [table1, table2, options, fn]);
-      return;
-    }
     table1 = this._pt(table1);
     await this.connection.createJoinTable(table1, table2, options, fn);
   }
@@ -1072,10 +923,6 @@ export class Migration {
     table2: string,
     options?: { tableName?: string },
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("dropJoinTable", [table1, table2, options]);
-      return;
-    }
     table1 = this._pt(table1);
     await this.connection.dropJoinTable(table1, table2, options);
   }
@@ -1095,35 +942,10 @@ export class Migration {
     fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },
     fn?: (t: Table) => void | Promise<void>,
   ): Promise<void> {
-    const options = typeof fnOrOptions === "function" ? {} : (fnOrOptions ?? {});
-    const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
-    if (this._recording) {
-      // Rails: change_table delegates to the CommandRecorder so individual
-      // ops inside the block can be inverted (or batched, in the bulk path).
-      await this._recorder.changeTable(
-        tableName,
-        options as Record<string, unknown>,
-        callback as Parameters<CommandRecorder["changeTable"]>[2],
-      );
-      return;
-    }
-    if (options.bulk) {
-      // Bulk path mirrors Rails: delegate to SchemaStatements#changeTable which
-      // records ops via a Proxy and coalesces into a single ALTER. Apply
-      // tableNamePrefix here since SchemaStatements doesn't.
-      const tname = this._pt(tableName);
-      await this.connection.changeTable(tname, options, callback);
-      return;
-    }
-    const table = this.connection.updateTableDefinition(tableName, this);
-    if (callback) await callback(table);
+    await this.connection.changeTable(this._pt(tableName), fnOrOptions, fn);
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("renameIndex", [tableName, oldName, newName]);
-      return;
-    }
     tableName = this._pt(tableName);
     await this.connection.renameIndex(tableName, oldName, newName);
   }
@@ -1144,12 +966,6 @@ export class Migration {
     tableName: string,
     ...columnsOrOptions: Array<string | ({ type?: ColumnType } & Record<string, unknown>)>
   ): Promise<void> {
-    if (this._recording) {
-      // Record as a single removeColumns op so invertRemoveColumns can flip
-      // it back to addColumns (Rails: CommandRecorder#invert_remove_columns).
-      this._recorder.record("removeColumns", [tableName, ...columnsOrOptions]);
-      return;
-    }
     tableName = this._pt(tableName);
     const connection = this.connection as unknown as {
       removeColumns(tableName: string, ...args: Array<string | ColumnOptions>): Promise<void>;
@@ -1165,19 +981,17 @@ export class Migration {
     tableName: string,
     ...columnsAndOptions: Array<string | ({ type: ColumnType } & ColumnOptions)>
   ): Promise<void> {
-    if (this._recording) {
-      this._recorder.record("addColumns", [tableName, ...columnsAndOptions]);
-      return;
-    }
-    const last = columnsAndOptions[columnsAndOptions.length - 1];
-    if (typeof last !== "object" || last === null || !("type" in last)) {
-      throw new TypeError("addColumns requires a trailing options hash with a :type entry");
-    }
-    const { type, ...rest } = columnsAndOptions.pop() as { type: ColumnType } & ColumnOptions;
-    const columns = columnsAndOptions as string[];
-    for (const col of columns) {
-      await this.addColumn(tableName, col, type, rest);
-    }
+    // The per-column loop lives on the adapter, as Rails' `add_columns`
+    // (abstract/schema_statements.rb:643-647) does; a migration only forwards,
+    // so a recorded call records one `addColumns` command rather than N
+    // `addColumn`s.
+    const connection = this.connection as unknown as {
+      addColumns(
+        tableName: string,
+        ...args: Array<string | ({ type: ColumnType } & ColumnOptions)>
+      ): Promise<void>;
+    };
+    await connection.addColumns(this._pt(tableName), ...columnsAndOptions);
   }
 
   async columns(tableName: string): Promise<import("./connection-adapters/column.js").Column[]> {
@@ -1227,34 +1041,19 @@ export class Migration {
       await this.run(...[...klasses].reverse(), { revert: true });
     }
     if (fn === undefined) return;
-    if (this._recording) {
-      // Nested: reuse the active recorder and just toggle its direction, so a
-      // `revert` inside a reverting migration cancels by double-negation
-      // (mirrors Rails `connection.revert(&block)` when connection is already a
-      // CommandRecorder — no fresh recorder, no replay, and no suppress_messages:
-      // Rails only suppresses in the outer branch).
-      await this._recorder.revert(async () => {
-        await fn();
-      });
+    if (isCommandRecorder(this.connection)) {
+      // `connection.revert(&block)` when the connection is already the recorder
+      // (migration.rb:855-856): no fresh recorder, no replay, and no
+      // suppress_messages — Rails only suppresses in the outer branch.
+      await this.connection.revert(fn);
       return;
     }
-    // Outermost: swap in a CommandRecorder as the active delegate, record the
-    // block in reverting mode (commands invert at record time), restore, then
-    // replay the recorded inverses for real.
-    const previousRecorder = this._recorder;
-    const recorder = new CommandRecorder(this.connection);
-    this._recorder = recorder;
-    this._recording = true;
-    try {
-      await recorder.revert(async () => {
-        await this.suppressMessages(async () => {
-          await fn();
-        });
-      });
-    } finally {
-      this._recorder = previousRecorder;
-      this._recording = false;
-    }
+    const recorder = this.commandRecorder();
+    this._connectionOverride = recorder;
+    await this.suppressMessages(async () => {
+      await recorder.revert(fn);
+    });
+    this._connectionOverride = recorder.delegate as DatabaseAdapter;
     await recorder.replay(this as unknown as Record<string, (...a: unknown[]) => Promise<void>>);
   }
 
@@ -1284,26 +1083,7 @@ export class Migration {
       });
     } else {
       for (const migrationClass of klasses) {
-        const migration = new migrationClass();
-        if (this._recording) {
-          // Recording (but not reverting): route the sub-migration's ops into the
-          // active recorder by sharing our recorder state with it.
-          const prevRecorder = migration._recorder;
-          const prevRecording = migration._recording;
-          const prevConn = migration._connectionOverride;
-          migration._recorder = this._recorder;
-          migration._recording = true;
-          migration._connectionOverride = this.connection;
-          try {
-            await (dir === "up" ? migration.up() : migration.down());
-          } finally {
-            migration._recorder = prevRecorder;
-            migration._recording = prevRecording;
-            migration._connectionOverride = prevConn;
-          }
-        } else {
-          await migration.execMigration(this.connection, dir);
-        }
+        await new migrationClass().execMigration(this.connection, dir);
       }
     }
   }
@@ -1382,7 +1162,10 @@ export class Migration {
    * Mirrors: ActiveRecord::Migration#reverting?
    */
   isReverting(): boolean {
-    return this._recording && this._recorder.reverting;
+    // `connection.respond_to?(:reverting) && connection.reverting`
+    // (migration.rb:871-873).
+    const connection = this.connection;
+    return isCommandRecorder(connection) && connection.reverting;
   }
 
   async viewExists(viewName: string): Promise<boolean | null> {
@@ -1457,15 +1240,20 @@ export class Migration {
   // --- Connection (Rails: Migration#connection, #connection_pool) ---
 
   get connection(): DatabaseAdapter {
+    // Rails' @connection is whatever answers the schema statements — the
+    // adapter, or the CommandRecorder #revert swaps in. TS has no duck type
+    // spanning both, so the reader keeps the adapter type and the recorder
+    // arms narrow with `isCommandRecorder`.
     // Rails: `@connection || DatabaseTasks.migration_connection`
     // (`migration.rb:1036-1038`). `DatabaseTasks` is reached through the
     // call-time config source rather than an import: naming
     // `tasks/database-tasks.js` here would be a load-time edge back into a
     // module that already imports this one.
-    return this._connectionOverride ?? migrationArConfig()!.databaseTasks().migrationConnection();
+    return (this._connectionOverride ??
+      migrationArConfig()!.databaseTasks().migrationConnection()) as DatabaseAdapter;
   }
 
-  set connection(conn: DatabaseAdapter | undefined) {
+  set connection(conn: DatabaseAdapter | CommandRecorder | undefined) {
     this._connectionOverride = conn;
   }
 
@@ -1763,6 +1551,11 @@ export class Migration {
 
   /** @internal */
   async methodMissing(name: string, ...args: unknown[]): Promise<unknown> {
+    // Ruby carries the block on its own channel, so it is part of neither
+    // `format_arguments` nor `arguments.first` (migration.rb:1045-1052); TS
+    // passes it as a trailing function argument, which must not be mistaken
+    // for either.
+    const block = typeof args[args.length - 1] === "function" ? args.pop() : undefined;
     return await this.sayWithTime(`${name}(${this.formatArguments(args)})`, async () => {
       const conn = this.connection as unknown as Record<string, unknown>;
       if (typeof conn["revert"] !== "function") {
@@ -1784,6 +1577,7 @@ export class Migration {
       if (strategy.respondToMissing?.(name) !== true) {
         throw new TypeError(`undefined method '${name}' for ${this.connection.constructor.name}`);
       }
+      if (block !== undefined) args.push(block);
       return await strategy.methodMissing?.(name, ...args);
     });
   }

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -35,29 +35,45 @@ describe("CommandRecorder", () => {
     expect(recorder.america()).toBe("hi");
   });
 
-  it("runs the block inverseOf(transaction) is handed, as sub_recorder.revert does", async () => {
+  it("runs a reverted transaction's block to completion before recording the command", async () => {
     // `invert_transaction` runs the block through `sub_recorder.revert(&block)`
-    // (command_recorder.rb:186-188); the block's statements record their
-    // inverses onto the recorder the migration still reads, and `sub_recorder`
-    // stays empty. Reached here through `record`, whose reverting arm calls
-    // `inverse_of` (command_recorder.rb:94-100).
+    // and only then returns its tuple (command_recorder.rb:186-190), so the
+    // block's inverses land on this recorder BEFORE the `transaction` command
+    // that wraps them. The block awaits here: a fire-and-forget run would push
+    // the command first and append the inverses after it.
     const recorder = new CommandRecorder(abstractDelegate);
+    const recordable = recorder as unknown as {
+      transaction(fn: () => Promise<void>): Promise<void>;
+      addColumn(...a: unknown[]): void;
+    };
     let ran = 0;
     await recorder.revert(async () => {
-      recorder.record("transaction", [], async () => {
+      await recordable.transaction(async () => {
+        await Promise.resolve();
         ran += 1;
-        (recorder as unknown as { addColumn(...a: unknown[]): void }).addColumn(
-          "fruits",
-          "colour",
-          "string",
-        );
+        recordable.addColumn("fruits", "colour", "string");
       });
     });
     expect(ran).toBe(1);
-    // The block's inverse lands on this recorder, not on the empty sub-recorder;
-    // the enclosing `revert` reverses the pair, so the transaction command
-    // (recorded last) reads first.
+    // The enclosing `revert` reverses the pair, so the command recorded last
+    // reads first.
     expect(recorder.commands.map((c) => c[0])).toEqual(["transaction", "removeColumn"]);
+  });
+
+  it("propagates a throw from a reverted transaction's block", async () => {
+    // Ruby's exception propagates synchronously out of `invert_transaction`
+    // (command_recorder.rb:187); the awaited block rejects the same call.
+    const recorder = new CommandRecorder(abstractDelegate);
+    const recordable = recorder as unknown as {
+      transaction(fn: () => Promise<void>): Promise<void>;
+    };
+    await expect(
+      recorder.revert(async () => {
+        await recordable.transaction(async () => {
+          throw new TypeError("boom");
+        });
+      }),
+    ).rejects.toThrow("boom");
   });
 
   it("does not forward a private delegate member, the way public_send does not", () => {

--- a/packages/activerecord/src/migration/command-recorder.trails.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.trails.test.ts
@@ -35,6 +35,31 @@ describe("CommandRecorder", () => {
     expect(recorder.america()).toBe("hi");
   });
 
+  it("runs the block inverseOf(transaction) is handed, as sub_recorder.revert does", async () => {
+    // `invert_transaction` runs the block through `sub_recorder.revert(&block)`
+    // (command_recorder.rb:186-188); the block's statements record their
+    // inverses onto the recorder the migration still reads, and `sub_recorder`
+    // stays empty. Reached here through `record`, whose reverting arm calls
+    // `inverse_of` (command_recorder.rb:94-100).
+    const recorder = new CommandRecorder(abstractDelegate);
+    let ran = 0;
+    await recorder.revert(async () => {
+      recorder.record("transaction", [], async () => {
+        ran += 1;
+        (recorder as unknown as { addColumn(...a: unknown[]): void }).addColumn(
+          "fruits",
+          "colour",
+          "string",
+        );
+      });
+    });
+    expect(ran).toBe(1);
+    // The block's inverse lands on this recorder, not on the empty sub-recorder;
+    // the enclosing `revert` reverses the pair, so the transaction command
+    // (recorded last) reads first.
+    expect(recorder.commands.map((c) => c[0])).toEqual(["transaction", "removeColumn"]);
+  });
+
   it("does not forward a private delegate member, the way public_send does not", () => {
     const recorder = new CommandRecorder({ _secret: () => "no", visible: () => "yes" });
     expect("_secret" in recorder).toBe(false);

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -519,19 +519,19 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertTransaction(args: unknown[], block?: MigrationBlock): MigrationCommand {
+  invertTransaction(args: unknown[], _block?: MigrationBlock): MigrationCommand {
+    // Rails runs the block here, via `sub_recorder.revert(&block)`
+    // (command_recorder.rb:187), and the run has to COMPLETE before the
+    // `transaction` tuple is appended: the block's statements record their
+    // inverses onto THIS recorder — the sub-recorder only toggles its own
+    // direction and stays empty — so they must land first. A TS block returns
+    // a promise and this method is sync, so the await lives in the one place
+    // that has an await point: the `transaction` forwarder below, which runs
+    // the block to completion and only then appends what this method builds.
+    // That forwarder is the sole producer of a `transaction` command, in Ruby
+    // (command_recorder.rb:125-132) as here, so no reachable path leaves the
+    // block unrun.
     const subRecorder = new CommandRecorder(this._delegate);
-    // `sub_recorder.revert(&block)` (command_recorder.rb:187) runs the block:
-    // the sub-recorder only toggles its OWN direction, so the block's
-    // statements — whose receiver is still the migration reading this recorder
-    // as its connection — record their inverses onto THIS recorder, and
-    // `sub_recorder` stays empty. A TS block returns a promise and this method
-    // is sync, so the await happens in the `transaction` forwarder below, which
-    // then hands `record` no block; a block reaching here came from a direct
-    // `record`/`inverseOf` call and is run on the same terms Ruby runs it.
-    if (block !== undefined) {
-      void subRecorder.revert(block as () => Promise<void>);
-    }
     const invertionsProc = async (): Promise<void> => {
       await subRecorder.replay(
         this as unknown as { [key: string]: (...args: unknown[]) => Promise<void> },
@@ -798,11 +798,13 @@ const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
   const block =
     typeof args[args.length - 1] === "function" ? (args.pop() as MigrationBlock) : undefined;
   if (this.reverting && block !== undefined) {
-    // `invert_transaction`'s `sub_recorder.revert(&block)` (command_recorder.rb:187),
-    // awaited here because a TS block is a promise and `inverse_of` is sync.
-    // `record` is then handed no block, so the inversion does not run it twice;
-    // the reverting arm discards the block anyway — `inverse_of` replaces the
-    // whole command (command_recorder.rb:94-100).
+    // `record`'s reverting arm is `inverse_of` (command_recorder.rb:94-100),
+    // and `invert_transaction` runs the block before returning its tuple
+    // (:186-190). Both halves are spelled out here because only this method has
+    // an await point: the block runs to completion — its inverses landing on
+    // this recorder first, and a throw propagating to the caller — and the
+    // inverted `transaction` command — which `record`'s reverting arm builds
+    // through `invertTransaction` — is appended after them, Ruby's order.
     await (block as () => Promise<void>)();
     this.record("transaction", args);
     return;

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -519,14 +519,19 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertTransaction(args: unknown[], _block?: MigrationBlock): MigrationCommand {
-    // Ruby runs the block here, through `sub_recorder.revert(&block)`
-    // (command_recorder.rb:186-188): the sub-recorder only toggles its own
-    // direction, so the block's commands land — already inverted — on THIS
-    // recorder, the one the migration still reads as its connection, and the
-    // sub-recorder itself stays empty. A TS block is a promise, so `transaction`
-    // above awaits it before recording and this method builds only the proc.
+  invertTransaction(args: unknown[], block?: MigrationBlock): MigrationCommand {
     const subRecorder = new CommandRecorder(this._delegate);
+    // `sub_recorder.revert(&block)` (command_recorder.rb:187) runs the block:
+    // the sub-recorder only toggles its OWN direction, so the block's
+    // statements — whose receiver is still the migration reading this recorder
+    // as its connection — record their inverses onto THIS recorder, and
+    // `sub_recorder` stays empty. A TS block returns a promise and this method
+    // is sync, so the await happens in the `transaction` forwarder below, which
+    // then hands `record` no block; a block reaching here came from a direct
+    // `record`/`inverseOf` call and is run on the same terms Ruby runs it.
+    if (block !== undefined) {
+      void subRecorder.revert(block as () => Promise<void>);
+    }
     const invertionsProc = async (): Promise<void> => {
       await subRecorder.replay(
         this as unknown as { [key: string]: (...args: unknown[]) => Promise<void> },
@@ -793,7 +798,14 @@ const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
   const block =
     typeof args[args.length - 1] === "function" ? (args.pop() as MigrationBlock) : undefined;
   if (this.reverting && block !== undefined) {
+    // `invert_transaction`'s `sub_recorder.revert(&block)` (command_recorder.rb:187),
+    // awaited here because a TS block is a promise and `inverse_of` is sync.
+    // `record` is then handed no block, so the inversion does not run it twice;
+    // the reverting arm discards the block anyway — `inverse_of` replaces the
+    // whole command (command_recorder.rb:94-100).
     await (block as () => Promise<void>)();
+    this.record("transaction", args);
+    return;
   }
   this.record("transaction", args, block);
 };

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -81,6 +81,23 @@ export class CommandRecorder {
   }
 
   /**
+   * Mirrors the generated `transaction` forwarder (command_recorder.rb:125-132)
+   * together with the first half of `invert_transaction` (:186-188). Ruby's
+   * `inverse_of` runs the block inline because a Ruby block is synchronous; a
+   * TS block returns a promise, so the block runs — and its commands are
+   * recorded onto this recorder, inverted — here, before `record` appends the
+   * `transaction` command itself.
+   */
+  async transaction(...args: unknown[]): Promise<void> {
+    const block =
+      typeof args[args.length - 1] === "function" ? (args.pop() as MigrationBlock) : undefined;
+    if (this._reverting && block !== undefined) {
+      await (block as () => Promise<void>)();
+    }
+    this.record("transaction", args, block);
+  }
+
+  /**
    * Execute a block in reverting mode. Commands recorded inside the block
    * are collected, reversed, and their inverses are appended to the
    * command list.
@@ -190,7 +207,18 @@ export class CommandRecorder {
    */
   async replay(migration: { [key: string]: (...args: any[]) => Promise<void> }): Promise<void> {
     for (const [cmd, args, block] of this.commands) {
-      await migration[cmd](...args, ...(block === undefined ? [] : [block]));
+      const rest = [...args, ...(block === undefined ? [] : [block])];
+      // `migration.send(cmd, ...)` (command_recorder.rb:150) lands in
+      // `Migration#method_missing` (migration.rb:1045) for a command the
+      // migration does not define itself — `transaction`, say. TS has no
+      // implicit dispatch, so the fallback is spelled out.
+      if (typeof migration[cmd] === "function") {
+        await migration[cmd](...rest);
+      } else {
+        await (
+          migration as unknown as { methodMissing(name: string, ...args: unknown[]): Promise<void> }
+        ).methodMissing(cmd, ...rest);
+      }
     }
   }
 
@@ -269,6 +297,11 @@ export class CommandRecorder {
     if (Object.keys(options).length > 0) result.push(options);
     if (argsBlock !== undefined) result.push(argsBlock);
     return ["createTable", result, block];
+  }
+
+  /** @internal Straight reversion — `execute_block: :execute_block` (command_recorder.rb:158). */
+  invertExecuteBlock(args: unknown[], block?: MigrationBlock): MigrationCommand {
+    return ["executeBlock", args, block];
   }
 
   /** @internal */
@@ -503,10 +536,20 @@ export class CommandRecorder {
   }
 
   /** @internal */
-  invertTransaction(args: unknown[]): [string, unknown[]] {
-    throw new IrreversibleMigration(
-      "This migration uses transaction, which is not automatically reversible.",
-    );
+  invertTransaction(args: unknown[], _block?: MigrationBlock): MigrationCommand {
+    // Ruby runs the block here, through `sub_recorder.revert(&block)`
+    // (command_recorder.rb:186-188): the sub-recorder only toggles its own
+    // direction, so the block's commands land — already inverted — on THIS
+    // recorder, the one the migration still reads as its connection, and the
+    // sub-recorder itself stays empty. A TS block is a promise, so `transaction`
+    // above awaits it before recording and this method builds only the proc.
+    const subRecorder = new CommandRecorder(this._delegate);
+    const invertionsProc = async (): Promise<void> => {
+      await subRecorder.replay(
+        this as unknown as { [key: string]: (...args: unknown[]) => Promise<void> },
+      );
+    };
+    return ["transaction", args, invertionsProc as unknown as MigrationBlock];
   }
 
   /** @internal */
@@ -758,6 +801,11 @@ for (const method of REVERSIBLE_AND_IRREVERSIBLE_METHODS) {
     this: CommandRecorder,
     ...args: unknown[]
   ): void {
+    // Ruby's `*args` carries only the arguments actually passed
+    // (command_recorder.rb:125-132); a TS method with optional parameters
+    // materializes trailing `undefined`s, which would otherwise be recorded and
+    // replayed as real arguments.
+    while (args.length > 0 && args[args.length - 1] === undefined) args.pop();
     this.record(method, args);
   };
 }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -81,23 +81,6 @@ export class CommandRecorder {
   }
 
   /**
-   * Mirrors the generated `transaction` forwarder (command_recorder.rb:125-132)
-   * together with the first half of `invert_transaction` (:186-188). Ruby's
-   * `inverse_of` runs the block inline because a Ruby block is synchronous; a
-   * TS block returns a promise, so the block runs — and its commands are
-   * recorded onto this recorder, inverted — here, before `record` appends the
-   * `transaction` command itself.
-   */
-  async transaction(...args: unknown[]): Promise<void> {
-    const block =
-      typeof args[args.length - 1] === "function" ? (args.pop() as MigrationBlock) : undefined;
-    if (this._reverting && block !== undefined) {
-      await (block as () => Promise<void>)();
-    }
-    this.record("transaction", args, block);
-  }
-
-  /**
    * Execute a block in reverting mode. Commands recorded inside the block
    * are collected, reversed, and their inverses are appended to the
    * command list.
@@ -794,6 +777,26 @@ const REVERSIBLE_AND_IRREVERSIBLE_METHODS = [
   "createVirtualTable",
   "dropVirtualTable",
 ] as const;
+
+/**
+ * `transaction` is generated like every other recordable command
+ * (command_recorder.rb:125-132), but it also carries the first half of
+ * `invert_transaction` (:186-188): Ruby's `inverse_of` runs the block inline
+ * because a Ruby block is synchronous, while a TS block returns a promise. So
+ * the block runs — recording its commands, already inverted, onto this
+ * recorder — before `record` appends the `transaction` command itself.
+ */
+(CommandRecorder.prototype as unknown as Record<string, unknown>)["transaction"] = async function (
+  this: CommandRecorder,
+  ...args: unknown[]
+): Promise<void> {
+  const block =
+    typeof args[args.length - 1] === "function" ? (args.pop() as MigrationBlock) : undefined;
+  if (this.reverting && block !== undefined) {
+    await (block as () => Promise<void>)();
+  }
+  this.record("transaction", args, block);
+};
 
 for (const method of REVERSIBLE_AND_IRREVERSIBLE_METHODS) {
   if (method in CommandRecorder.prototype) continue;


### PR DESCRIPTION
Bundle of three fidelity convergences.

## 1. `Migration`'s `_recording` flag is gone — the recorder IS the connection

Rails routes a recorded migration through the connection, not a flag
(`migration.rb:857-864`): `#revert` assigns the `CommandRecorder` to
`@connection`, records, restores `recorder.delegate`, then replays.

- `_recording` / `_recorder` removed; `_connectionOverride` (the `@connection`
  mirror) holds the recorder for the duration, so all ~35
  `if (this._recording) { record } else { execute }` pairs collapse to the one
  `this.connection.foo(...)` call Rails writes.
- `_pt` carries `method_missing`'s own guard —
  `unless connection.respond_to? :revert` (`migration.rb:1046-1047`) — so a
  recorded command keeps the raw table name and replay prefixes it.
- `#run` is back to Rails' two arms (`migration.rb:937-949`); a sub-migration
  inherits the recorder because it reads the same connection.
- `reverting?` reads the connection (`migration.rb:871-873`).
- `#revert`'s nested arm is Rails' `connection.revert(&block)` (`:855-856`).

The recorded path now reaches two commands the flag used to route around, so
both are ported: `invert_execute_block` (the straight reversion at
`command_recorder.rb:158`) and `invert_transaction` (`:186-195`). Ruby runs the
block inline inside `inverse_of`; a TS block is a promise, so
`CommandRecorder#transaction` awaits it before recording.

Falling out of the same convergence, three trails-only detours are removed:
`Migration#changeTable` forwards to the adapter's `change_table` instead of
re-implementing it (so the yielded `Table`'s base is the adapter, as at
`abstract/schema_statements.rb:510-518`); `#addColumns` forwards instead of
looping (`:643-647`); and the comment methods forward `comment_or_changes`,
which the adapters already extract. `drop_enum` gains Rails' `values`
parameter (`postgresql_adapter.rb:571`), and `drop_table` ignores a trailing
block argument the way Ruby's signature does.

## 2. `CollectionProxy#deleteAll` reads the `@association` seat

`@association.delete_all(dependent).tap { reset_scope }`
(`collection_proxy.rb:474-476`). `_collectionAssociation()` now returns the
held `_association` rather than re-looking it up through the owner — the same
seat `target` / `loaded?` read (`:31-35`) — and the structural cast is gone.

## 3. `AbstractAdapter#resetBang` calls `attemptConfigureConnection`

`reset!` is `clear_cache!` + `reset_transaction` +
`attempt_configure_connection` (`abstract_adapter.rb:725-731`); the third call
was missing, so every non-PG adapter left the session unreconfigured after a
pool reset. PG's override needs no change: its own configure hop latches
`_connectionConfigured`, making `super`'s a no-op.

Closes-story: migration-recording-flag-should-be-the-connection
Closes-story: collection-proxy-delete-all-reads-the-association-seat
Closes-story: abstract-reset-bang-missing-attempt-configure-connection
