### PR TITLE
refactor(activerecord): Association#klass is the reflection delegate; drop the validates override (RFC 0112)

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -193,7 +193,7 @@ export class Association {
   constructor(owner: Base, reflection: AssociationDefinition) {
     this.owner = owner;
     this.reflection = _richReflectionFor(owner, reflection);
-    this.disableJoins = reflection.options.disableJoins || false;
+    this.disableJoins = this.reflection.options.disableJoins || false;
 
     // Rails' `check_validity! → klass → compute_class` raises NameError
     // synchronously in the constructor, so `record.association(:name)` itself

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -25,6 +25,29 @@ import {
 } from "../errors.js";
 
 /**
+ * Back an ad-hoc definition with the registered reflection for its name, so an
+ * `Association` built from one answers `klass`, `extensions` and `scopeFor` the
+ * way one built from the reflection does. Rails always constructs from the
+ * reflection (`associations.rb:290-296`:
+ * `reflection.association_class.new(self, reflection)`), which is why `klass`
+ * can be the plain `reflection.klass` delegate `association.rb:36-38` writes;
+ * trails has loader-local holders carrying a synthesised `options`/`scope`, and
+ * those own properties still win over the reflection's.
+ *
+ * @noRailsEquivalent Rails has no ad-hoc holder to re-home; this exists only to
+ *   give the trails-only ones a real reflection to delegate to.
+ */
+function _richReflectionFor(owner: Base, reflection: AssociationDefinition): AssociationDefinition {
+  if (Object.getPrototypeOf(reflection) !== Object.prototype) return reflection;
+  const rich = (owner.constructor as typeof Base)._reflectOnAssociation?.(reflection.name);
+  if (!rich) return reflection;
+  return Object.create(
+    rich as object,
+    Object.getOwnPropertyDescriptors(reflection),
+  ) as AssociationDefinition;
+}
+
+/**
  * Base class for all association proxies. An Association wraps a single
  * association between an owner record and its target(s).
  *
@@ -169,7 +192,7 @@ export class Association {
 
   constructor(owner: Base, reflection: AssociationDefinition) {
     this.owner = owner;
-    this.reflection = reflection;
+    this.reflection = _richReflectionFor(owner, reflection);
     this.disableJoins = reflection.options.disableJoins || false;
 
     // Rails' `check_validity! → klass → compute_class` raises NameError
@@ -525,16 +548,7 @@ export class Association {
   }
 
   get klass(): typeof Base {
-    // Use the rich reflection's klass getter when available — it does
-    // namespace-relative resolution, matching Rails' compute_type walk.
-    const ctor = this.owner.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
-    };
-    const richKlass = ctor._reflectOnAssociation?.(this.reflection.name)?.klass;
-    if (richKlass) return richKlass;
-    const className = this.reflection.options.className ?? this.deriveClassName();
-    autoloadModel(className);
-    return constantize(className) as typeof Base;
+    return this.reflection.klass as typeof Base;
   }
 
   /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -34,8 +34,9 @@ import {
  * trails has loader-local holders carrying a synthesised `options`/`scope`, and
  * those own properties still win over the reflection's.
  *
- * @noRailsEquivalent Rails has no ad-hoc holder to re-home; this exists only to
- *   give the trails-only ones a real reflection to delegate to.
+ * @noRailsEquivalent CONVERGEABLE: Rails has no ad-hoc holder to re-home; this
+ *   exists only to give the trails-only ones a real reflection to delegate to,
+ *   and retires with the last holder that is not built from a reflection.
  */
 function _richReflectionFor(owner: Base, reflection: AssociationDefinition): AssociationDefinition {
   if (Object.getPrototypeOf(reflection) !== Object.prototype) return reflection;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -91,7 +91,6 @@ import {
   isValid as validationsIsValid,
   defaultValidationContext,
   _setSuperIsValid,
-  _setSuperValidates,
   type ValidationContextArg,
 } from "./validations.js";
 import * as _Validations from "./validations.js";
@@ -1822,7 +1821,7 @@ export class Base extends Model {
   declare static reflectOnAllAutosaveAssociations: typeof _Reflection.ClassMethods.reflectOnAllAutosaveAssociations;
 
   // --- Validations::ClassMethods (wired via extend() after class body) ---
-  declare static validates: typeof _Validations.validates;
+  declare static validates: typeof Model.validates;
   declare static validatesAssociated: typeof _Validations.validatesAssociated;
 
   // -- Enums (wired via extend() after class body) --
@@ -4531,6 +4530,24 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, _Validations.ClassMethods);
+// Ruby resolves `validates`' `const_get("#{key.to_s.camelize}Validator")`
+// (activemodel/lib/active_model/validations/validates.rb:121) against the model
+// class, and `ActiveRecord::Base`'s ancestors include `ActiveRecord::Validations`
+// — so `validates :x, presence: true` on an AR model finds THAT module's
+// column/association-aware `PresenceValidator`, not ActiveModel's, with no
+// `validates` override anywhere. JS has no ancestry constant lookup, so the
+// module's validator constants ride onto `Base` as statics, which every model
+// inherits exactly as Ruby inherits the constant.
+// (`extend()` deliberately skips constants, as Ruby's `extend` does, so these
+// are assigned rather than extended on.)
+Object.assign(Base, {
+  AbsenceValidator: _Validations.AbsenceValidator,
+  AssociatedValidator: _Validations.AssociatedValidator,
+  LengthValidator: _Validations.LengthValidator,
+  NumericalityValidator: _Validations.NumericalityValidator,
+  PresenceValidator: _Validations.PresenceValidator,
+  UniquenessValidator: _Validations.UniquenessValidator,
+});
 include(Base, CallbacksInstanceMethods);
 // Ruby `include ActiveRecord::Transactions` (transactions.rb:10-14).
 include(Base, TransactionsInstanceMethods);
@@ -4944,11 +4961,9 @@ for (const [name, fn] of [
   });
 }
 
-// Register Model's super methods for the Validations module.
-// Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid)
-// and on validates (AR's validates routes remaining rules through Model.validates).
+// Register Model's super method for the Validations module.
+// Breaks the recursion on isValid (Base.isValid → validations.isValid → Model.isValid).
 _setSuperIsValid(Model.prototype.isValid);
-_setSuperValidates(Model.validates);
 
 // Add attributes= setter (Rails: alias for assign_attributes) while preserving
 // the existing Model getter. Can't go through include() since object-literal

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4537,13 +4537,14 @@ extend(Base, _Validations.ClassMethods);
 // constant lookup, so they ride on `Base` as statics, inherited the way Ruby
 // inherits the constant. Assigned, not extended: `extend()` skips constants
 // because Ruby's `extend` copies methods only.
+// Listed in the require order of validations.rb:96-101.
 Object.assign(Base, {
-  AbsenceValidator: _Validations.AbsenceValidator,
   AssociatedValidator: _Validations.AssociatedValidator,
+  UniquenessValidator: _Validations.UniquenessValidator,
+  PresenceValidator: _Validations.PresenceValidator,
+  AbsenceValidator: _Validations.AbsenceValidator,
   LengthValidator: _Validations.LengthValidator,
   NumericalityValidator: _Validations.NumericalityValidator,
-  PresenceValidator: _Validations.PresenceValidator,
-  UniquenessValidator: _Validations.UniquenessValidator,
 });
 include(Base, CallbacksInstanceMethods);
 // Ruby `include ActiveRecord::Transactions` (transactions.rb:10-14).

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4530,16 +4530,13 @@ extend(Base, CounterCache.ClassMethods);
 extend(Base, Timestamp.ClassMethods);
 extend(Base, NamedScoping.ClassMethods);
 extend(Base, _Validations.ClassMethods);
-// Ruby resolves `validates`' `const_get("#{key.to_s.camelize}Validator")`
-// (activemodel/lib/active_model/validations/validates.rb:121) against the model
-// class, and `ActiveRecord::Base`'s ancestors include `ActiveRecord::Validations`
-// — so `validates :x, presence: true` on an AR model finds THAT module's
-// column/association-aware `PresenceValidator`, not ActiveModel's, with no
-// `validates` override anywhere. JS has no ancestry constant lookup, so the
-// module's validator constants ride onto `Base` as statics, which every model
-// inherits exactly as Ruby inherits the constant.
-// (`extend()` deliberately skips constants, as Ruby's `extend` does, so these
-// are assigned rather than extended on.)
+// `validates`' `const_get("#{key.to_s.camelize}Validator")`
+// (activemodel/lib/active_model/validations/validates.rb:121) resolves against
+// the model's ancestors, which include `ActiveRecord::Validations` — so an AR
+// model finds THAT module's column-aware validators. JS has no ancestry
+// constant lookup, so they ride on `Base` as statics, inherited the way Ruby
+// inherits the constant. Assigned, not extended: `extend()` skips constants
+// because Ruby's `extend` copies methods only.
 Object.assign(Base, {
   AbsenceValidator: _Validations.AbsenceValidator,
   AssociatedValidator: _Validations.AssociatedValidator,

--- a/packages/activerecord/src/validations.trails.test.ts
+++ b/packages/activerecord/src/validations.trails.test.ts
@@ -1,0 +1,64 @@
+/**
+ * trails-only coverage for the constant lookup `validates` performs.
+ *
+ * Rails has no `ActiveRecord::Validations::ClassMethods#validates` override:
+ * `validates :x, presence: true` on an AR model reaches ActiveModel's generic
+ * macro, whose `const_get("#{key.to_s.camelize}Validator")`
+ * (activemodel/lib/active_model/validations/validates.rb:121) resolves against
+ * the model's ancestry — which includes `ActiveRecord::Validations` and so its
+ * column/association-aware validators. These assert that the AR constants win.
+ */
+import { describe, expect, it } from "vitest";
+import { Base } from "./index.js";
+import {
+  AbsenceValidator,
+  AssociatedValidator,
+  LengthValidator,
+  NumericalityValidator,
+  PresenceValidator,
+  UniquenessValidator,
+} from "./validations.js";
+
+describe("ValidatesConstantLookupTest", () => {
+  it("resolves the ActiveRecord validator constants", () => {
+    expect(
+      [
+        AbsenceValidator,
+        AssociatedValidator,
+        LengthValidator,
+        NumericalityValidator,
+        PresenceValidator,
+        UniquenessValidator,
+      ].map((validatorClass) => (Base as unknown as Record<string, unknown>)[validatorClass.name]),
+    ).toEqual([
+      AbsenceValidator,
+      AssociatedValidator,
+      LengthValidator,
+      NumericalityValidator,
+      PresenceValidator,
+      UniquenessValidator,
+    ]);
+  });
+
+  it("registers the ActiveRecord validator for a built-in key", () => {
+    class Klass extends Base {
+      static tableName = "topics";
+    }
+    Klass.validates("title", { presence: true, uniqueness: true });
+
+    expect(Klass.validators().map((v: { constructor: unknown }) => v.constructor)).toEqual([
+      PresenceValidator,
+      UniquenessValidator,
+    ]);
+  });
+
+  it("raises ArgumentError for an unknown validator key", () => {
+    class Klass extends Base {
+      static tableName = "topics";
+    }
+
+    expect(() => Klass.validates("title", { unknown: true })).toThrow(
+      "Unknown validator: 'UnknownValidator'",
+    );
+  });
+});

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -238,117 +238,6 @@ export function readAttributeForValidation(this: ValidationsHost, attribute: str
 // Wired onto Base via extend(Base, Validations.ClassMethods) in base.ts.
 // ---------------------------------------------------------------------------
 
-// Options passed alongside any validator: on/if/unless/strict plus
-// allowNil/allowBlank that are shared across all validators.
-function extractShared(rules: Record<string, unknown>): Record<string, unknown> {
-  const shared: Record<string, unknown> = {};
-  if (rules.on !== undefined) shared.on = rules.on;
-  if (rules.if !== undefined) shared.if = rules.if;
-  if (rules.unless !== undefined) shared.unless = rules.unless;
-  if (rules.strict) shared.strict = rules.strict;
-  if (rules.allowNil !== undefined) shared.allowNil = rules.allowNil;
-  if (rules.allowBlank !== undefined) shared.allowBlank = rules.allowBlank;
-  return shared;
-}
-
-/**
- * Route AR-specific rules (presence/absence/length/numericality) through AR
- * validator classes that add association/column awareness, and delegate the
- * rest (inclusion/exclusion/format/...) to ActiveModel's `validates`.
- *
- * Mirrors: ActiveRecord::Validations::ClassMethods#validates (the override
- * over ActiveModel::Validations::ClassMethods#validates).
- */
-export function validates(
-  this: {
-    validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
-    // The Model.validates class method is reached via _parentValidates,
-    // registered by Base at module load via _setSuperValidates.
-  },
-  ...args: [...attributes: string[], rules: Record<string, unknown>]
-): void {
-  const rules = args[args.length - 1] as Record<string, unknown>;
-  const attributes = args.slice(0, -1) as string[];
-  const arRules = { ...rules };
-  const shared = extractShared(arRules);
-  const { allowNil: sharedAllowNil, allowBlank: sharedAllowBlank, ...sharedRest } = shared;
-
-  const buildOpts = (opts: Record<string, unknown>) => ({
-    ...opts,
-    attributes,
-    ...sharedRest,
-    ...(opts.allowNil === undefined && sharedAllowNil !== undefined
-      ? { allowNil: sharedAllowNil }
-      : {}),
-    ...(opts.allowBlank === undefined && sharedAllowBlank !== undefined
-      ? { allowBlank: sharedAllowBlank }
-      : {}),
-  });
-
-  if (arRules.presence) {
-    const opts = arRules.presence === true ? {} : (arRules.presence as Record<string, unknown>);
-    delete arRules.presence;
-    this.validatesWith(PresenceValidator, buildOpts(opts));
-  }
-  if (arRules.absence) {
-    const opts = arRules.absence === true ? {} : (arRules.absence as Record<string, unknown>);
-    delete arRules.absence;
-    this.validatesWith(AbsenceValidator, buildOpts(opts));
-  }
-  if (arRules.length) {
-    const opts = arRules.length as Record<string, unknown>;
-    delete arRules.length;
-    this.validatesWith(LengthValidator, buildOpts(opts));
-  }
-  if (arRules.numericality) {
-    const opts =
-      arRules.numericality === true ? {} : (arRules.numericality as Record<string, unknown>);
-    delete arRules.numericality;
-    this.validatesWith(NumericalityValidator, buildOpts(opts));
-  }
-  if (arRules.uniqueness) {
-    const opts = arRules.uniqueness === true ? {} : (arRules.uniqueness as Record<string, unknown>);
-    delete arRules.uniqueness;
-    // Uniqueness registers a UniquenessValidator via validatesUniqueness (which
-    // routes to validatesWith); its async validateEach runs the existence check
-    // inline in the async validation chain, honoring on/if/unless/strict.
-    const { attributes: _attributes, ...uniqOpts } = buildOpts(opts) as Record<string, unknown>;
-    for (const attribute of attributes) {
-      validatesUniqueness.call(
-        this,
-        attribute,
-        uniqOpts as Parameters<typeof validatesUniqueness>[1],
-      );
-    }
-  }
-  // Delegate remaining rules (inclusion/exclusion/format/...) to ActiveModel's validates.
-  const hasRemaining = Object.keys(arRules).some(
-    (k) => !["on", "if", "unless", "strict", "allowNil", "allowBlank"].includes(k),
-  );
-  if (hasRemaining) {
-    if (_parentValidates == null) {
-      throw new ActiveRecordError(
-        "ActiveRecord::Validations#validates called before Base registered the super validates",
-      );
-    }
-    // `super.validates` — delegate to Model's `validates` class method.
-    _parentValidates.call(this, ...attributes, arRules);
-  }
-}
-
-// Late-bound reference to Model's `validates` class method — registered by
-// Base to break the circular-import chain.
-let _parentValidates:
-  | ((this: unknown, ...args: [...attributes: string[], rules: Record<string, unknown>]) => void)
-  | null = null;
-
-/** @internal Called by Base to register Model's validates as the super. */
-export function _setSuperValidates(
-  fn: (this: unknown, ...args: [...attributes: string[], rules: Record<string, unknown>]) => void,
-): void {
-  _parentValidates = fn;
-}
-
 /**
  * Host shape for the `validates_*_of` helper overrides: the AR-specific
  * `validatesWith` plus `_mergeAttributes` (inherited from Model).
@@ -402,7 +291,6 @@ export function validatesNumericalityOf(this: HelperMethodHost, ...attrNames: un
  * matching Rails' file layout.
  */
 export const ClassMethods = {
-  validates,
   validatesAssociated,
   validatesUniqueness,
   validatesUniquenessOf,


### PR DESCRIPTION
Two RFC 0112 convergences: one Rails thing that trails had grown extra machinery around.

## `Association#klass` (`converge-association-klass-to-reflection-klass-delegate`)

Rails' getter is a plain delegate (`activerecord/lib/active_record/associations/association.rb:36-38`):

```ruby
def klass
  reflection.klass
end
```

trails re-resolved the reflection off the owner's class and then fell back to a
second copy of the reflection's own name derivation (`deriveClassName` +
`constantize`). Both arms existed only because the loader-local ad-hoc holders
(a through step with a synthesised `scope`, a `CollectionProxy` standing in for
the owner's holder) carry the thin macro definition instead of the registered
reflection.

Fixed at the root: `Association`'s constructor now backs a plain-object
definition with the registered reflection for its name — Rails always
constructs from one (`associations.rb:290-296`,
`reflection.association_class.new(self, reflection)`) — with the caller's
synthesised `options`/`scope` kept as own properties so they still win. `klass`
is then `return this.reflection.klass;` and nothing else. No call site re-adds a
derivation fallback.

## `Model.validates` (`converge-model-validates-onto-rails-generic-lookup`)

ActiveModel's half landed in #6963/#7034 — the generic macro at
`activemodel/src/validations/validates.ts` already mirrors
`validates.rb:110-133`, with `_validatesDefaultKeys`, `_parseValidatesOptions`,
the `ArgumentError` arms, and the camelized-key lookup.

What remained was ActiveRecord's `validates` override — a hardcoded
`if (rules.presence) … if (rules.uniqueness) …` chain with the shared
`allowNil`/`allowBlank` merge open-coded per arm, delegating whatever it did not
recognise to `Model.validates` through a late-bound `_setSuperValidates` hook.
**Rails has no such override.** `validates :x, presence: true` on an AR model
reaches ActiveModel's macro, whose
`const_get("#{key.to_s.camelize}Validator")` (`validates.rb:121`) resolves
against the model's ancestry — which includes `ActiveRecord::Validations`, so
the AR column/association-aware `PresenceValidator` / `UniquenessValidator` wins
over ActiveModel's with no dispatch code anywhere.

So: delete the override (and `extractShared` / `_parentValidates` /
`_setSuperValidates` with it), and put the module's validator constants on
`Base`, which every model inherits the way Ruby inherits the constant. That
restores the three behaviours the chain could not have — lookup by option key,
`ArgumentError: Unknown validator: '…'` on an unknown key, and the
`_parseValidatesOptions` shorthands — on the AR side too.

`extend()` deliberately skips `/^[A-Z]/` names because Ruby's `extend` copies
methods, not constants, so the constants are assigned rather than extended on.

## Verification

- `packages/activerecord/src/associations/` — 115 files, 2048 passed.
- `packages/activerecord/src/validations*` — 137 passed; `packages/activemodel/src/validations` — 574 passed.
- `pnpm parity:api:calls` OK (363 baselined / 289 unreviewed, down from 372/301 — no new rows).
- `pnpm parity:api:calls:args` OK (141 baselined). `pnpm parity:api:extra --package activerecord` shows no new novel names.

Closes-story: converge-association-klass-to-reflection-klass-delegate
Closes-story: converge-model-validates-onto-rails-generic-lookup
