### PR TITLE
refactor(activerecord): TableDefinition and SchemaCreation store Rails' @conn as conn (RFC 0096)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -74,7 +74,7 @@ interface IndexVisitor {
 
 export class SchemaCreation {
   /** Rails' `SchemaCreation#initialize(conn)` (abstract/schema_creation.rb:6-9). */
-  constructor(protected adapter: SchemaCreationConn) {}
+  constructor(protected conn: SchemaCreationConn) {}
 
   // Capability probes. Eight of these are `delegate ... to: :@conn`
   // (abstract/schema_creation.rb:16-21): supports_indexes_in_create?,
@@ -84,7 +84,7 @@ export class SchemaCreation {
   // them, so its version gates reach the visitor.
 
   protected supportsPartialIndex(): boolean {
-    return this.adapter.supportsPartialIndex();
+    return this.conn.supportsPartialIndex();
   }
 
   /** Not delegated: Rails defines it on `SchemaCreation` itself
@@ -94,45 +94,45 @@ export class SchemaCreation {
   }
 
   protected async supportsIndexInclude(): Promise<boolean> {
-    return this.adapter.supportsIndexInclude();
+    return this.conn.supportsIndexInclude();
   }
 
   protected async supportsNullsNotDistinct(): Promise<boolean> {
-    return this.adapter.supportsNullsNotDistinct();
+    return this.conn.supportsNullsNotDistinct();
   }
 
   // Quoting delegations. Rails declares these as `delegate ... to: :@conn`
   // (abstract/schema_creation.rb:16-19); here `@conn` is the {@link SchemaQuoter}
-  // threaded in as `this.adapter`. `quote_column_name` maps to `quoteColumnName`.
+  // threaded in as `this.conn`. `quote_column_name` maps to `quoteColumnName`.
 
   /** @internal */
   protected quoteColumnName(name: string): string {
-    return this.adapter.quoteColumnName(name);
+    return this.conn.quoteColumnName(name);
   }
 
   /** @internal */
   protected quoteTableName(name: string): string {
-    return this.adapter.quoteTableName(name);
+    return this.conn.quoteTableName(name);
   }
 
   /** @internal */
   protected quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string> {
-    return this.adapter.quoteDefaultExpression(value, column);
+    return this.conn.quoteDefaultExpression(value, column);
   }
 
   /** @internal */
   protected supportsIndexesInCreate(): boolean {
-    return this.adapter.supportsIndexesInCreate();
+    return this.conn.supportsIndexesInCreate();
   }
 
   /** @internal */
   protected supportsExclusionConstraints(): boolean {
-    return this.adapter.supportsExclusionConstraints();
+    return this.conn.supportsExclusionConstraints();
   }
 
   /** @internal */
   protected supportsUniqueConstraints(): boolean {
-    return this.adapter.supportsUniqueConstraints();
+    return this.conn.supportsUniqueConstraints();
   }
 
   /**
@@ -144,7 +144,7 @@ export class SchemaCreation {
    */
   protected async quotedIncludeColumns(o: string | string[]): Promise<string> {
     if (typeof o === "string") return o;
-    return o.map((c) => this.adapter.quoteColumnName(c)).join(", ");
+    return o.map((c) => this.conn.quoteColumnName(c)).join(", ");
   }
 
   // Async since the PG quoter's default-expression path issues a live regtype
@@ -181,7 +181,7 @@ export class SchemaCreation {
   protected async visitTableDefinition(o: TableDefinition): Promise<string> {
     let createSql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) createSql += " IF NOT EXISTS";
-    createSql += ` ${this.adapter.quoteTableName(o.name)}`;
+    createSql += ` ${this.conn.quoteTableName(o.name)}`;
 
     // Rails: `statements = o.columns.map { |c| accept c }` — keep the map call
     // but map to thunks so each column visit runs only after the previous one
@@ -226,12 +226,12 @@ export class SchemaCreation {
 
   /** @internal */
   protected useForeignKeys(): boolean {
-    return this.adapter.useForeignKeys();
+    return this.conn.useForeignKeys();
   }
 
   /** @internal */
   protected async supportsCheckConstraints(): Promise<boolean> {
-    return this.adapter.supportsCheckConstraints();
+    return this.conn.supportsCheckConstraints();
   }
 
   /**
@@ -265,7 +265,7 @@ export class SchemaCreation {
       }
       throw e;
     }
-    let columnSql = `${this.adapter.quoteColumnName(o.name)} ${o.sqlType}`;
+    let columnSql = `${this.conn.quoteColumnName(o.name)} ${o.sqlType}`;
     if (o.type !== "primary_key") {
       columnSql = await this.addColumnOptionsBang(
         columnSql,
@@ -280,7 +280,7 @@ export class SchemaCreation {
   }
 
   protected async visitAlterTable(o: AlterTable): Promise<string> {
-    let sql = `ALTER TABLE ${this.adapter.quoteTableName(o.name)} `;
+    let sql = `ALTER TABLE ${this.conn.quoteTableName(o.name)} `;
 
     sql += (await Promise.all(o.adds.map((col) => this.accept(col)))).join(" ");
     sql += (await Promise.all(o.foreignKeyAdds.map((fk) => this.visitAddForeignKey(fk)))).join(" ");
@@ -337,7 +337,7 @@ export class SchemaCreation {
    * @internal
    */
   protected quotedIndexNameAndTable(index: IndexDefinition): string {
-    return `${this.adapter.quoteColumnName(index.name)} ON ${this.adapter.quoteTableName(index.table)}`;
+    return `${this.conn.quoteColumnName(index.name)} ON ${this.conn.quoteTableName(index.table)}`;
   }
 
   /**
@@ -360,25 +360,25 @@ export class SchemaCreation {
       opclass?: string | Record<string, string>;
     },
   ): Promise<string> {
-    const host = this.adapter as SchemaQuoter & {
+    const host = this.conn as SchemaQuoter & {
       quotedColumnsForIndex?(cols: string[], options: Record<string, unknown>): Promise<string>;
     };
     if (typeof host.quotedColumnsForIndex === "function") {
       return host.quotedColumnsForIndex(columnNames, options);
     }
-    return columnNames.map((c) => this.adapter.quoteColumnName(c)).join(", ");
+    return columnNames.map((c) => this.conn.quoteColumnName(c)).join(", ");
   }
 
   protected visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
     const quotedColumns = (Array.isArray(o.column) ? o.column : [o.column])
-      .map((c) => this.adapter.quoteColumnName(c))
+      .map((c) => this.conn.quoteColumnName(c))
       .join(", ");
     const quotedPrimaryKeys = (Array.isArray(o.primaryKey) ? o.primaryKey : [o.primaryKey])
-      .map((c) => this.adapter.quoteColumnName(c))
+      .map((c) => this.conn.quoteColumnName(c))
       .join(", ");
-    let sql = `CONSTRAINT ${this.adapter.quoteColumnName(o.name)} `;
+    let sql = `CONSTRAINT ${this.conn.quoteColumnName(o.name)} `;
     sql += `FOREIGN KEY (${quotedColumns}) `;
-    sql += `REFERENCES ${this.adapter.quoteTableName(o.toTable)} (${quotedPrimaryKeys})`;
+    sql += `REFERENCES ${this.conn.quoteTableName(o.toTable)} (${quotedPrimaryKeys})`;
     if (o.onDelete) sql += ` ${this.actionSql("DELETE", o.onDelete)}`;
     if (o.onUpdate) sql += ` ${this.actionSql("UPDATE", o.onUpdate)}`;
     return sql;
@@ -392,7 +392,7 @@ export class SchemaCreation {
     if (this.optionsIncludeDefault(options)) {
       // Rails: `sql << " DEFAULT #{quote_default_expression(...)}"`
       // (schema_creation.rb:150) — the keyword lives here, not in the quoter.
-      sql += ` DEFAULT ${await this.adapter.quoteDefaultExpression(
+      sql += ` DEFAULT ${await this.conn.quoteDefaultExpression(
         options.default,
         (options as Record<string, unknown>)["column"],
       )}`;
@@ -439,7 +439,7 @@ export class SchemaCreation {
 
   /** @internal */
   protected nativeDatabaseTypes(): NativeDatabaseTypes {
-    return this.adapter.nativeDatabaseTypes();
+    return this.conn.nativeDatabaseTypes();
   }
 
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
@@ -491,12 +491,12 @@ export class SchemaCreation {
 
   /** @internal */
   protected visitPrimaryKeyDefinition(o: PrimaryKeyDefinition): string {
-    return `PRIMARY KEY (${o.name.map((name) => this.adapter.quoteColumnName(name)).join(", ")})`;
+    return `PRIMARY KEY (${o.name.map((name) => this.conn.quoteColumnName(name)).join(", ")})`;
   }
 
   /** @internal */
   protected visitDropConstraint(name: string): string {
-    return `DROP CONSTRAINT ${this.adapter.quoteColumnName(name)}`;
+    return `DROP CONSTRAINT ${this.conn.quoteColumnName(name)}`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1086,7 +1086,7 @@ export class TableDefinition {
   readonly options?: string;
   readonly comment?: string;
   private _primaryKeys?: PrimaryKeyDefinition;
-  protected _adapter: TableDefinitionConn;
+  protected conn: TableDefinitionConn;
 
   constructor(
     conn: TableDefinitionConn,
@@ -1102,7 +1102,7 @@ export class TableDefinition {
       [key: string]: unknown;
     } = {},
   ) {
-    this._adapter = conn;
+    this.conn = conn;
     this.name = name;
     this.temporary = tdOptions.temporary ?? false;
     this.ifNotExists = tdOptions.ifNotExists ?? false;
@@ -1234,7 +1234,7 @@ export class TableDefinition {
 
   /** @internal */
   protected validColumnDefinitionOptions(): string[] {
-    return this._adapter.validColumnDefinitionOptions();
+    return this.conn.validColumnDefinitionOptions();
   }
 
   /** @internal */
@@ -1299,10 +1299,10 @@ export class TableDefinition {
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
   ): ForeignKeyDefinition {
-    const prefix = this._adapter.tableNamePrefix ?? globalTableNamePrefix();
-    const suffix = this._adapter.tableNameSuffix ?? globalTableNameSuffix();
+    const prefix = this.conn.tableNamePrefix ?? globalTableNamePrefix();
+    const suffix = this.conn.tableNameSuffix ?? globalTableNameSuffix();
     const prefixedToTable = `${prefix}${toTable}${suffix}`;
-    const opts = this._adapter.foreignKeyOptions(this.name, prefixedToTable, { ...options });
+    const opts = this.conn.foreignKeyOptions(this.name, prefixedToTable, { ...options });
     return new ForeignKeyDefinition(
       this.name,
       prefixedToTable,
@@ -1324,7 +1324,7 @@ export class TableDefinition {
     expression: string,
     options: { name?: string; validate?: boolean } = {},
   ): CheckConstraintDefinition {
-    options = this._adapter.checkConstraintOptions(this.name, expression, options) as {
+    options = this.conn.checkConstraintOptions(this.name, expression, options) as {
       name?: string;
       validate?: boolean;
     };

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -63,7 +63,7 @@ export interface VisitorHostAdapter extends TableDefinitionConn, SchemaCreationC
 export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal Widened from the base `SchemaQuoter` to the full `@conn` surface: the
    * `supports*` flags and `quote` for `add_sql_comment!`. */
-  declare protected adapter: VisitorHostAdapter;
+  declare protected conn: VisitorHostAdapter;
 
   constructor(host: VisitorHostAdapter) {
     super(host);
@@ -72,7 +72,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal Live MariaDB lookup — consults the host adapter every call so a late
    * `getFullVersion()` flip (lazy detection on first probe) is honored. */
   protected async isMariadb(): Promise<boolean> {
-    return this.adapter.isMariadb();
+    return this.conn.isMariadb();
   }
 
   /** @internal */
@@ -179,12 +179,12 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal Delegates to the adapter when wired (Rails: `@conn.supports_indexes_in_create?`). */
   protected supportsIndexesInCreate(): boolean {
-    return this.adapter.supportsIndexesInCreate();
+    return this.conn.supportsIndexesInCreate();
   }
 
   /** @internal Delegates to the adapter; honors MySQL 8.0.16+ / MariaDB 10.2.1+ version gating. */
   protected async supportsCheckConstraints(): Promise<boolean> {
-    return this.adapter.supportsCheckConstraints();
+    return this.conn.supportsCheckConstraints();
   }
 
   /** @internal */
@@ -202,7 +202,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal */
   protected async visitChangeColumnDefinition(o: ChangeColumnDefinition): Promise<string> {
-    const changeColumnSql = `CHANGE ${this.adapter.quoteColumnName(o.name)} ${await this.accept(o.column)}`;
+    const changeColumnSql = `CHANGE ${this.conn.quoteColumnName(o.name)} ${await this.accept(o.column)}`;
     return this.addColumnPositionBang(
       changeColumnSql,
       this.columnOptions(o.column) as MysqlColumnOptions,
@@ -213,11 +213,11 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected async visitChangeColumnDefaultDefinition(
     o: ChangeColumnDefaultDefinition,
   ): Promise<string> {
-    let sql = `ALTER COLUMN ${this.adapter.quoteColumnName(o.column.name)} `;
+    let sql = `ALTER COLUMN ${this.conn.quoteColumnName(o.column.name)} `;
     if (o.default == null && !o.column.null) {
       sql += "DROP DEFAULT";
     } else {
-      sql += `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+      sql += `SET DEFAULT ${await this.conn.quoteDefaultExpression(o.default, o.column)}`;
     }
     return sql;
   }
@@ -235,9 +235,9 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const parts: string[] = create ? ["CREATE"] : [];
     if (indexType) parts.push(indexType);
     parts.push("INDEX");
-    parts.push(this.adapter.quoteColumnName(o.name));
+    parts.push(this.conn.quoteColumnName(o.name));
     if (o.using) parts.push(`USING ${o.using}`);
-    if (create) parts.push(`ON ${this.adapter.quoteTableName(o.table)}`);
+    if (create) parts.push(`ON ${this.conn.quoteTableName(o.table)}`);
     parts.push(`(${await this.quotedColumns(o)})`);
 
     return this.addSqlCommentBang(parts.join(" "), o.comment);
@@ -289,7 +289,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   protected addColumnPositionBang(sql: string, options: MysqlColumnOptions): string {
     if (options.first) return `${sql} FIRST`;
-    if (options.after) return `${sql} AFTER ${this.adapter.quoteColumnName(options.after)}`;
+    if (options.after) return `${sql} AFTER ${this.conn.quoteColumnName(options.after)}`;
     return sql;
   }
 
@@ -299,13 +299,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
     columnName: string | string[],
     options: AddIndexOptions = {},
   ): Promise<string> {
-    const [index] = await this.adapter.addIndexOptions(tableName, columnName, options);
+    const [index] = await this.conn.addIndexOptions(tableName, columnName, options);
     return this.accept(index);
   }
 
   /** @internal */
   protected addSqlCommentBang(sql: string, comment: string | null | undefined): string {
     if (!comment?.trim()) return sql;
-    return `${sql} COMMENT ${this.adapter.quote(comment)}`;
+    return `${sql} COMMENT ${this.conn.quote(comment)}`;
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.trails.test.ts
@@ -138,7 +138,7 @@ describe("PostgreSQL SchemaCreation", () => {
     // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
     const col = new Column("id", null, new TypeMetadata({ sqlType: "uuid", type: "uuid" }));
     const host = s();
-    host.adapter.quoteDefaultExpression = (v: unknown, c: unknown) =>
+    host.conn.quoteDefaultExpression = (v: unknown, c: unknown) =>
       quoteDefaultExpression.call(null as never, v, c as never);
     expect(
       await host.visitChangeColumnDefaultDefinition(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -66,7 +66,7 @@ export function _pgGeneratedClause(
 }
 
 export class SchemaCreation extends AbstractSchemaCreation {
-  declare protected adapter: PgSchemaCreationHost;
+  declare protected conn: PgSchemaCreationHost;
 
   constructor(adapter: PgSchemaCreationHost) {
     super(adapter);
@@ -88,8 +88,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     // `delegate :type_to_sql, to: :@conn`). Fall back to the abstract
     // implementation when no real adapter is present (e.g. unit-test context
     // where only the minimal SchemaQuoter shim is wired).
-    if (typeof this.adapter.typeToSql === "function") {
-      return this.adapter.typeToSql(type as string, options as Record<string, unknown>);
+    if (typeof this.conn.typeToSql === "function") {
+      return this.conn.typeToSql(type as string, options as Record<string, unknown>);
     }
     return super.typeToSql(type, options);
   }
@@ -147,13 +147,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
 
   /** @internal */
   protected visitValidateConstraint(name: string): string {
-    return `VALIDATE CONSTRAINT ${this.adapter.quoteColumnName(name)}`;
+    return `VALIDATE CONSTRAINT ${this.conn.quoteColumnName(name)}`;
   }
 
   /** @internal */
   protected visitExclusionConstraintDefinition(o: ExclusionConstraintDefinition): string {
     const p: string[] = [];
-    if (o.name) p.push("CONSTRAINT", this.adapter.quoteColumnName(o.name));
+    if (o.name) p.push("CONSTRAINT", this.conn.quoteColumnName(o.name));
     p.push("EXCLUDE");
     if (o.using) p.push(`USING ${o.using}`);
     p.push(`(${o.expression})`);
@@ -165,17 +165,17 @@ export class SchemaCreation extends AbstractSchemaCreation {
   /** @internal */
   protected async visitUniqueConstraintDefinition(o: UniqueConstraintDefinition): Promise<string> {
     const p: string[] = [];
-    if (o.name) p.push("CONSTRAINT", this.adapter.quoteColumnName(o.name));
+    if (o.name) p.push("CONSTRAINT", this.conn.quoteColumnName(o.name));
     p.push("UNIQUE");
     if ((await this.supportsNullsNotDistinct()) && o.nullsNotDistinct) p.push("NULLS NOT DISTINCT");
     if (o.usingIndex) {
-      p.push(`USING INDEX ${this.adapter.quoteColumnName(o.usingIndex)}`);
+      p.push(`USING INDEX ${this.conn.quoteColumnName(o.usingIndex)}`);
     } else {
       // Rails wraps with `Array(o.column)`, so a nil column renders `UNIQUE ()`
       // and PostgreSQL owns the rejection — `[null]` would throw in the quoter
       // first (add_unique_constraint has no pre-raise for the empty case).
       const cols = wrap(o.column)
-        .map((column) => this.adapter.quoteColumnName(column))
+        .map((column) => this.conn.quoteColumnName(column))
         .join(", ");
       p.push(`(${cols})`);
     }
@@ -222,14 +222,14 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected async visitChangeColumnDefinition(o: ChangeColumnDefinition): Promise<string> {
     const column = o.column;
     column.sqlType = this.typeToSql(column.type, column.options);
-    const quotedName = this.adapter.quoteColumnName(o.name);
+    const quotedName = this.conn.quoteColumnName(o.name);
 
     let sql = `ALTER COLUMN ${quotedName} TYPE ${column.sqlType}`;
 
     const options = this.columnOptions(column);
 
     if (options["collation"]) {
-      sql += ` COLLATE ${this.adapter.quoteColumnName(String(options["collation"]))}`;
+      sql += ` COLLATE ${this.conn.quoteColumnName(String(options["collation"]))}`;
     }
     if (options["using"]) {
       sql += ` USING ${options["using"]}`;
@@ -245,7 +245,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
         // Mirrors Rails postgresql/schema_creation.rb:99 — pass column to
         // quote_default_expression so array/typeMap-aware serialization
         // is preserved on ALTER COLUMN SET DEFAULT.
-        sql += `, ALTER COLUMN ${quotedName} SET DEFAULT ${await this.adapter.quoteDefaultExpression(options["default"], column)}`;
+        sql += `, ALTER COLUMN ${quotedName} SET DEFAULT ${await this.conn.quoteDefaultExpression(options["default"], column)}`;
       }
     }
 
@@ -260,13 +260,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected async visitChangeColumnDefaultDefinition(
     o: ChangeColumnDefaultDefinition,
   ): Promise<string> {
-    const col = this.adapter.quoteColumnName(o.column.name);
+    const col = this.conn.quoteColumnName(o.column.name);
     // Mirrors Rails postgresql/schema_creation.rb:110 — column is passed
     // to quote_default_expression so PG's typeMap/array branch fires.
     const action =
       o.default == null
         ? "DROP DEFAULT"
-        : `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+        : `SET DEFAULT ${await this.conn.quoteDefaultExpression(o.default, o.column)}`;
     return `ALTER COLUMN ${col} ${action}`;
   }
 
@@ -274,7 +274,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   protected override addColumnOptionsBang(sql: string, options: AddColumnOptions): Promise<string> {
     const opts = options as Record<string, unknown>;
     if (opts["collation"]) {
-      sql += ` COLLATE ${this.adapter.quoteColumnName(String(opts["collation"]))}`;
+      sql += ` COLLATE ${this.conn.quoteColumnName(String(opts["collation"]))}`;
     }
     const col = opts["column"] as { type?: string; name?: string } | undefined;
     if (col?.type === "uuid" && opts["primaryKey"] && !("default" in opts)) {
@@ -320,14 +320,14 @@ export class SchemaCreation extends AbstractSchemaCreation {
    * @internal
    */
   protected async quotedIncludeColumnsForIndex(o: string | string[]): Promise<string> {
-    const host = this.adapter as PgSchemaCreationHost & {
+    const host = this.conn as PgSchemaCreationHost & {
       quotedIncludeColumnsForIndex?(columns: string | string[]): Promise<string>;
     };
     if (typeof host.quotedIncludeColumnsForIndex === "function") {
       return host.quotedIncludeColumnsForIndex(o);
     }
     if (typeof o === "string") return o;
-    return o.map((c) => this.adapter.quoteColumnName(c)).join(", ");
+    return o.map((c) => this.conn.quoteColumnName(c)).join(", ");
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.trails.test.ts
@@ -361,7 +361,7 @@ describeIfPostgresqlAdapter("TableDefinition#toSql", () => {
   // Rails generates CREATE TABLE SQL by accepting the TableDefinition into the
   // adapter's SchemaCreation visitor; there is no TableDefinition#to_sql.
   const toSql = (td: TableDefinition): Promise<string> => {
-    const adapter = (td as any)._adapter;
+    const adapter = (td as any).conn;
     return new PgSchemaCreation("typeToSql" in adapter ? adapter : undefined).accept(td);
   };
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -258,7 +258,7 @@ export class TableDefinition extends AbstractTableDefinition {
     // postgresql/schema_definitions.rb:265-268 — this is where a constraint
     // declared inside `create_table` gets its generated name and its
     // `deferrable` validation, not just the `add_exclusion_constraint` path.
-    options = (this._adapter as unknown as PgConstraintOptionsConn).exclusionConstraintOptions(
+    options = (this.conn as unknown as PgConstraintOptionsConn).exclusionConstraintOptions(
       this.name,
       expression,
       options as Record<string, unknown>,
@@ -270,7 +270,7 @@ export class TableDefinition extends AbstractTableDefinition {
     columnName: string | string[],
     options: UniqueConstraintOptions = {},
   ): UniqueConstraintDefinition {
-    options = (this._adapter as unknown as PgConstraintOptionsConn).uniqueConstraintOptions(
+    options = (this.conn as unknown as PgConstraintOptionsConn).uniqueConstraintOptions(
       this.name,
       columnName,
       options as Record<string, unknown>,

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -29,8 +29,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const schema = index.table.slice(0, dot);
     const bare = index.table.slice(dot + 1);
     return (
-      `${this.adapter.quoteColumnName(schema)}.${this.adapter.quoteColumnName(index.name)} ` +
-      `ON ${this.adapter.quoteColumnName(bare)}`
+      `${this.conn.quoteColumnName(schema)}.${this.conn.quoteColumnName(index.name)} ` +
+      `ON ${this.conn.quoteColumnName(bare)}`
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.trails.test.ts
@@ -46,7 +46,7 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
     td.column("full_name", "virtual" as any, { as: "a || b" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
-    const sql = await new SchemaCreation((td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation((td as any).conn).accept(td);
     expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b)');
     expect(sql).not.toContain("varchar");
     expect(sql).not.toContain("VARCHAR");
@@ -56,7 +56,7 @@ describeIfSqlite("SQLite3::TableDefinition", () => {
     const td = new TableDefinition(conn, "items");
     td.column("x", "integer");
     td.column("expr", "integer", { as: "x + 1", stored: true } as any);
-    const sql = await new SchemaCreation((td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation((td as any).conn).accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS (x + 1) STORED");
   });
 });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -25,7 +25,7 @@ import { SchemaCreation as MysqlSchemaCreation } from "./connection-adapters/mys
 import { SchemaCreation as SQLite3SchemaCreation } from "./connection-adapters/sqlite3/schema-creation.js";
 
 function emitTableSql(td: TableDefinition): Promise<string> {
-  const adapter = (td as any)._adapter;
+  const adapter = (td as any).conn;
   const adapterName = adapter.adapterName;
   // Every visitor takes its connection for identifier/default quoting (and, on MySQL,
   // the `supports*` / isMariadb() flags), so thread the table definition's through —


### PR DESCRIPTION
Rails' `TableDefinition` keeps its connection in `@conn`
(`activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:371-393`)
and `SchemaCreation` does the same (`abstract/schema_creation.rb:6-21`, whose
`delegate ... to: :@conn` is what the quoting helpers here mirror).

trails stored the same value under trails-only names — `TableDefinition#_adapter`
and `SchemaCreation#adapter` — so #7033's converged `conn` parameter was undone on
the very next line (`this._adapter = conn`).

This is a **pure mechanical rename** of the two protected fields and their read
sites (8 in `TableDefinition`, the visitor delegations in
`abstract`/`mysql`/`postgresql`/`sqlite3` `schema-creation.ts`, plus the test call
sites that reached the field through an `as any` cast). Both fields are
`protected`, so no public surface moves and `parity:api` cannot see the change
either way. No behaviour or signature change.

`TableDefinitionConn` (the host interface for the Ruby duck type) already carries
the Rails name and is left alone.

Verified: `pnpm typecheck` clean; `pnpm parity:api:calls` OK (363 baselined, 289
unreviewed) and `pnpm parity:api:calls:args` OK (141 baselined shape rows), both
unchanged; `connection-adapters/**` + `migration.test.ts` green on SQLite (114
files, 1771 tests).

Closes-story: table-definition-stores-conn-as-adapter
