### PR TITLE
refactor(arel): attr_accessor slots, Rails-shaped node slot types, Arel.sql bind arms, lazy visitor dispatch (RFC 0124)

### DIFF
--- a/packages/arel/src/arel.trails.test.ts
+++ b/packages/arel/src/arel.trails.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sql, Nodes, Visitors } from "./index.js";
+import { testConnection } from "./test-helpers/connection.js";
+
+// Trails-only: Rails has no unit test for `Arel.sql`'s two-arm dispatch
+// (arel.rb:51-57) — its bind arms are covered indirectly through Relation.
+describe("Arel.sql", () => {
+  const compile = (node: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(node);
+
+  it("builds a SqlLiteral with no binds", () => {
+    const literal = sql("id = 1");
+    expect(literal).toBeInstanceOf(Nodes.SqlLiteral);
+    expect(literal.retryable).toBe(false);
+  });
+
+  it("keeps the retryable kwarg out of the named binds", () => {
+    const literal = sql("id = 1", { retryable: true });
+    expect(literal).toBeInstanceOf(Nodes.SqlLiteral);
+    expect(literal.retryable).toBe(true);
+  });
+
+  it("builds a BoundSqlLiteral from positional binds", () => {
+    const literal = sql("id = ?", 1);
+    expect(literal).toBeInstanceOf(Nodes.BoundSqlLiteral);
+    expect(compile(literal as Nodes.Node)).toBe("id = ?");
+  });
+
+  it("builds a BoundSqlLiteral from named binds", () => {
+    const literal = sql("id = :id", { id: 1 });
+    expect(literal).toBeInstanceOf(Nodes.BoundSqlLiteral);
+    expect(compile(literal as Nodes.Node)).toBe("id = ?");
+  });
+});

--- a/packages/arel/src/arel.ts
+++ b/packages/arel/src/arel.ts
@@ -2,8 +2,8 @@
  * The bare `Arel.*` module functions (arel.rb:31-72).
  *
  * This file deliberately imports nothing at runtime beyond
- * `nodes/sql-literal.js` and `nodes/bound-sql-literal.js`, both leaves. Ruby resolves `Arel.sql` when the
- * calling method runs, so a Rails body anywhere in the package may name it;
+ * `nodes/sql-literal.js` and `nodes/bound-sql-literal.js`, both leaves. Ruby
+ * resolves `Arel.sql` when the calling method runs, so a Rails body anywhere in the package may name it;
  * in ESM every import is eager, and re-importing them from `index.ts` — which
  * re-exports `select-manager.js`, `visitors/index.js` and friends — would
  * close a cycle over index.ts's top-level `include()` / `registerNodeDeps()`
@@ -43,7 +43,7 @@ export function sql(
     namedBinds = rest;
   }
   if (positionalBinds.length === 0 && Object.keys(namedBinds).length === 0) {
-    return new SqlLiteral(sqlString, { retryable: retryable });
+    return new SqlLiteral(sqlString, { retryable });
   } else {
     return new BoundSqlLiteral(sqlString, positionalBinds, namedBinds);
   }

--- a/packages/arel/src/arel.ts
+++ b/packages/arel/src/arel.ts
@@ -2,7 +2,7 @@
  * The bare `Arel.*` module functions (arel.rb:31-72).
  *
  * This file deliberately imports nothing at runtime beyond
- * `nodes/sql-literal.js`, which is a leaf. Ruby resolves `Arel.sql` when the
+ * `nodes/sql-literal.js` and `nodes/bound-sql-literal.js`, both leaves. Ruby resolves `Arel.sql` when the
  * calling method runs, so a Rails body anywhere in the package may name it;
  * in ESM every import is eager, and re-importing them from `index.ts` — which
  * re-exports `select-manager.js`, `visitors/index.js` and friends — would
@@ -12,16 +12,41 @@
  */
 import type { Node } from "./nodes/node.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
+import { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
 
 /**
  * Arel.sql() — escape hatch for raw SQL.
  *
- * Mirrors: Arel.sql (arel.rb:51). The `positional_binds` / `named_binds`
- * arms (and with them `BoundSqlLiteral`) are not ported yet; the
- * `retryable:` kwarg is.
+ * Mirrors: Arel.sql (arel.rb:51-57). Ruby's `*positional_binds` +
+ * `retryable:` + `**named_binds` cannot be transcribed literally — a TS rest
+ * parameter must be last, so no trailing options object can sit behind it.
+ * Ruby splits a trailing Hash off the splat before it binds the kwargs, so
+ * that is what this does: a trailing plain object supplies `retryable:` and
+ * the named binds, everything before it is a positional bind.
  */
-export function sql(sqlString: string, options?: { retryable?: boolean }): SqlLiteral {
-  return new SqlLiteral(sqlString, { retryable: options?.retryable ?? false });
+export function sql(sqlString: string, options?: { retryable: boolean }): SqlLiteral;
+export function sql(sqlString: string, ...positionalBinds: unknown[]): SqlLiteral | BoundSqlLiteral;
+export function sql(
+  sqlString: string,
+  ...positionalBinds: unknown[]
+): SqlLiteral | BoundSqlLiteral {
+  let retryable = false;
+  let namedBinds: Record<string, unknown> = {};
+  const last = positionalBinds[positionalBinds.length - 1];
+  if (last !== null && typeof last === "object" && last.constructor === Object) {
+    positionalBinds.pop();
+    const { retryable: retryableBind, ...rest } = last as {
+      retryable?: boolean;
+      [key: string]: unknown;
+    };
+    retryable = retryableBind ?? false;
+    namedBinds = rest;
+  }
+  if (positionalBinds.length === 0 && Object.keys(namedBinds).length === 0) {
+    return new SqlLiteral(sqlString, { retryable: retryable });
+  } else {
+    return new BoundSqlLiteral(sqlString, positionalBinds, namedBinds);
+  }
 }
 
 /**

--- a/packages/arel/src/dist-entry-modules.trails.test.ts
+++ b/packages/arel/src/dist-entry-modules.trails.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readdir } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const distDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist");
+
+async function distModules(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await distModules(full)));
+    else if (entry.name.endsWith(".js")) files.push(full);
+  }
+  return files;
+}
+
+function loadAsEntryModule(module: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "node",
+      ["--input-type=module", "-e", `await import(${JSON.stringify(module)});`],
+      (error) =>
+        resolve(error ? `${module}: ${error.message.split("\n")[1] ?? error.message}` : null),
+    );
+  });
+}
+
+/**
+ * Every built module must load when it is the ESM *entry* module — the check
+ * CLAUDE.md's "Call-time constant resolution" section mandates, because a
+ * vitest run enters the package's funnel module first and masks a cycle. Two
+ * modules failed it before this file existed: `nodes/index.js` and
+ * `visitors/postgresql.js` both threw `Cannot access 'TableAlias' before
+ * initialization`, because a visitor's `static {}` block read `Nodes.*` at
+ * module-eval time while `nodes/index.js` was still evaluating.
+ *
+ * One `node` subprocess per module is load-bearing twice over: vitest's module
+ * runner has its own cycle semantics, and within a single process only the
+ * first import is an entry module — every later one reuses the graph the first
+ * one built, which is exactly what hides the failure.
+ */
+describe("arel dist modules", () => {
+  it("each load as an ESM entry module", async () => {
+    const modules = (await distModules(distDir)).filter((f) => !f.endsWith(".test.js"));
+    expect(modules.length).toBeGreaterThan(50);
+
+    const failures: string[] = [];
+    const queue = [...modules];
+    await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        for (let next = queue.pop(); next !== undefined; next = queue.pop()) {
+          const failure = await loadAsEntryModule(next);
+          if (failure) failures.push(failure);
+        }
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  }, 180_000);
+});

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -61,9 +61,7 @@ describe("TestFactoryMethods", () => {
   it("coalesce", () => {
     const relation = new Table("users");
     const fieldNode = relation.get("active");
-    // Rails' coalesce(*exprs) wraps nothing (factory_methods.rb:45-47), so the
-    // raw 0 reaches `expressions` untouched; trails types the splat as Node[].
-    const coalesce = factory.coalesce(fieldNode, 0 as unknown as Nodes.Node);
+    const coalesce = factory.coalesce(fieldNode, 0);
     expect(coalesce).toBeInstanceOf(Nodes.NamedFunction);
     expect(coalesce.name).toBe("COALESCE");
     expect(coalesce.expressions).toEqual([fieldNode, 0]);

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -1,7 +1,7 @@
 import type { Node } from "./nodes/node.js";
 import { And } from "./nodes/nary.js";
 import { buildQuoted } from "./nodes/casted.js";
-import type { Join } from "./nodes/binary.js";
+import type { Join, NodeOrValue } from "./nodes/binary.js";
 import { False } from "./nodes/false.js";
 import { Grouping } from "./nodes/grouping.js";
 import { InnerJoin } from "./nodes/inner-join.js";
@@ -43,7 +43,7 @@ export interface FactoryMethodsModule {
   createOn(expr: Node): On;
   grouping(expr: Node): Grouping;
   lower(column: unknown): NamedFunction;
-  coalesce(...exprs: Node[]): NamedFunction;
+  coalesce(...exprs: NodeOrValue[]): NamedFunction;
   cast(expr: Node & { as: (type: string) => Node }, type: string): NamedFunction;
 }
 
@@ -91,7 +91,10 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new NamedFunction("LOWER", [buildQuoted(column)]);
   },
 
-  coalesce(...exprs: Node[]): NamedFunction {
+  // Rails wraps nothing here — `NamedFunction.new "COALESCE", exprs`
+  // (factory_methods.rb:45-47) — so a raw value reaches `expressions`
+  // untouched (test/cases/arel/factory_methods_test.rb:69-76).
+  coalesce(...exprs: NodeOrValue[]): NamedFunction {
     return new NamedFunction("COALESCE", exprs);
   },
 

--- a/packages/arel/src/node-slots.ts
+++ b/packages/arel/src/node-slots.ts
@@ -82,3 +82,18 @@ export let _Attribute: (new (relation: any, name: string) => any) | undefined;
 export function _setAttribute(ctor: new (relation: any, name: string) => any): void {
   _Attribute = ctor;
 }
+
+/**
+ * `Arel::Visitors::Dot` — the constant `TreeManager#to_dot` names when it runs
+ * (tree_manager.rb:57-61). A value import of `visitors/dot.js` from
+ * `tree-manager.ts` closes a cycle back through `table.js` and
+ * `select-manager.js` onto the three `extends TreeManager` modules, so
+ * entering the graph at `update-manager.js` evaluates `DeleteManager` with
+ * `TreeManager` still in TDZ.
+ * @internal
+ */
+export let _Dot: (new () => { accept(node: any, collector: any): any }) | undefined;
+/** @internal */
+export function _setDot(ctor: new () => { accept(node: any, collector: any): any }): void {
+  _Dot = ctor;
+}

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -216,8 +216,8 @@ export class NotIn extends Binary {
 
 /** Join base class — Rails defines via const_set in binary.rb */
 export abstract class Join extends Binary {
-  declare readonly left: Node;
-  declare readonly right: Node | null;
+  declare left: Node;
+  declare right: Node | null;
 
   constructor(left: Node, right: Node | null = null) {
     super(left, right);
@@ -226,8 +226,8 @@ export abstract class Join extends Binary {
 
 /** Set operations — Rails defines via const_set in binary.rb */
 export class Union extends Binary {
-  declare readonly left: Node;
-  declare readonly right: Node;
+  declare left: Node;
+  declare right: Node;
 
   constructor(left: Node, right: Node) {
     super(left, right);
@@ -235,8 +235,8 @@ export class Union extends Binary {
 }
 
 export class UnionAll extends Binary {
-  declare readonly left: Node;
-  declare readonly right: Node;
+  declare left: Node;
+  declare right: Node;
 
   constructor(left: Node, right: Node) {
     super(left, right);
@@ -244,8 +244,8 @@ export class UnionAll extends Binary {
 }
 
 export class Intersect extends Binary {
-  declare readonly left: Node;
-  declare readonly right: Node;
+  declare left: Node;
+  declare right: Node;
 
   constructor(left: Node, right: Node) {
     super(left, right);
@@ -253,8 +253,8 @@ export class Intersect extends Binary {
 }
 
 export class Except extends Binary {
-  declare readonly left: Node;
-  declare readonly right: Node;
+  declare left: Node;
+  declare right: Node;
 
   constructor(left: Node, right: Node) {
     super(left, right);

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -13,7 +13,7 @@ import { Unary } from "./unary.js";
  * Mirrors: Arel::Nodes::Case
  */
 export class Case extends NodeExpression {
-  readonly case: Node | null;
+  case: Node | null;
   conditions: When[];
   default: Else | null;
 

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -2,6 +2,7 @@ import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Table } from "../table.js";
+import type { SelectManager } from "../select-manager.js";
 
 /**
  * Cte — a Common Table Expression node.
@@ -13,11 +14,19 @@ export class Cte extends Binary {
   // `Nodes::SqlLiteral` (rendered bare), so `TableAlias#to_cte` passes that
   // literal straight through to `Cte.new`. A plain-string name (e.g. a directly
   // constructed `Cte`) is quoted. Accept both.
-  readonly name: string | SqlLiteral;
-  readonly relation: Node;
+  name: string | SqlLiteral;
+  // Rails seats a manager here directly —
+  // `Cte.new("foo", Table.new(:bar).project(Arel.star))`
+  // (test/cases/arel/visitors/to_sql_test.rb:1008) — and
+  // `visit_Arel_SelectManager` (to_sql.rb:358-361) renders it.
+  relation: Node | SelectManager;
   readonly materialized: boolean | null;
 
-  constructor(name: string | SqlLiteral, relation: Node, materialized: boolean | null = null) {
+  constructor(
+    name: string | SqlLiteral,
+    relation: Node | SelectManager,
+    materialized: boolean | null = null,
+  ) {
     super(name, relation);
     this.name = name;
     this.relation = relation;

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel::Nodes::ExtractTest", () => {
   const users = new Table("users");
@@ -55,16 +56,13 @@ describe("Arel::Nodes::ExtractTest", () => {
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = new Nodes.TableAlias(users, "u");
-      const b = new Nodes.TableAlias(users, "u");
-      expect(a.name).toBe(b.name);
-      expect(a.relation).toBe(b.relation);
+      const array = [users.get("attr").extract("foo"), users.get("attr").extract("foo")];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.Not(users.get("id").eq(1));
-      const b = new Nodes.Not(users.get("id").eq(2));
-      expect(a).not.toBe(b);
+      const array = [users.get("attr").extract("foo"), users.get("attr").extract("bar")];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -9,7 +9,7 @@ import { SqlLiteral } from "./sql-literal.js";
  * Mirrors: Arel::Nodes::Extract (extends Unary)
  */
 export class Extract extends Unary {
-  readonly field: string;
+  field: string;
 
   constructor(expr: Node | Node[], field: string) {
     super(expr);

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -1,4 +1,5 @@
 import { Node } from "./node.js";
+import type { NodeOrValue } from "./binary.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
 
@@ -6,7 +7,11 @@ import { SqlLiteral } from "./sql-literal.js";
 // FilterPredications. Runtime mixin wiring lives in ../index.ts.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Function extends NodeExpression {
-  readonly expressions: Node[];
+  // Rails seats whatever the caller passed: `NamedFunction.new("generate_series",
+  // [4, 2])` (test/cases/arel/visitors/to_sql_test.rb:865) puts bare Integers
+  // here, and `visit_Integer` (to_sql.rb:824-826) renders them. The slot is
+  // `NodeOrValue`, not `Node`, for the same reason Math's operands are.
+  expressions: NodeOrValue[];
   // Rails' `count(nil)` stores nil (expressions.rb:5-7), which `must_be_nil`
   // asserts on (attribute_test.rb:377-381), so nil is part of the domain.
   distinct: boolean | null;
@@ -20,7 +25,7 @@ export class Function extends NodeExpression {
     this._alias = typeof value === "string" ? new SqlLiteral(value) : value;
   }
 
-  constructor(expr: Node[], aliaz: Node | string | null = null) {
+  constructor(expr: NodeOrValue[], aliaz: Node | string | null = null) {
     super();
     this.expressions = expr;
     this._alias = typeof aliaz === "string" ? new SqlLiteral(aliaz) : aliaz;

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -1,13 +1,6 @@
 import { Node } from "./node.js";
 import { buildQuoted } from "./casted.js";
-import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
-
-// Rails memoizes ActiveModel::Type.default_value as `@default_value ||= Value.new`.
-// Mirror that here so we don't allocate a fresh ValueType for every bind.
-let _defaultValue: ValueType | null = null;
-function defaultValue(): ValueType {
-  return (_defaultValue ??= new ValueType());
-}
+import { Attribute as AMAttribute, defaultValue } from "@blazetrails/activemodel";
 
 export class HomogeneousIn extends Node {
   readonly attribute: Node;

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -15,8 +15,8 @@ import type { Included } from "@blazetrails/activesupport";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class InfixOperation extends Binary {
   readonly operator: string;
-  readonly left: NodeOrValue;
-  readonly right: NodeOrValue;
+  left: NodeOrValue;
+  right: NodeOrValue;
 
   constructor(operator: string, left: NodeOrValue, right: NodeOrValue) {
     super(left, right);

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -1,4 +1,4 @@
-import { Node } from "./node.js";
+import type { NodeOrValue } from "./binary.js";
 import { Function } from "./function.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Over } from "./over.js";
@@ -10,9 +10,9 @@ import { NamedWindow, Window } from "./window.js";
  * Mirrors: Arel::Nodes::NamedFunction
  */
 export class NamedFunction extends Function {
-  readonly name: string;
+  name: string;
 
-  constructor(name: string, expressions: Node[], aliasName?: string, distinct = false) {
+  constructor(name: string, expressions: NodeOrValue[], aliasName?: string, distinct = false) {
     super(expressions, aliasName ?? null);
     this.name = name;
     this.distinct = distinct;

--- a/packages/arel/src/nodes/over.test.ts
+++ b/packages/arel/src/nodes/over.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel::Nodes::OverTest", () => {
   const users = new Table("users");
@@ -46,15 +47,13 @@ describe("Arel::Nodes::OverTest", () => {
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = users.get("id").eq(1);
-      const b = users.get("id").eq(1);
-      expect((a.left as Nodes.Attribute).name).toBe((b.left as Nodes.Attribute).name);
+      const array = [new Nodes.Over("foo", "bar"), new Nodes.Over("foo", "bar")];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.And([users.get("id").eq(1)]);
-      const b = new Nodes.And([users.get("id").eq(2)]);
-      expect(a).not.toBe(b);
+      const array = [new Nodes.Over("foo", "bar"), new Nodes.Over("foo", "baz")];
+      expect(uniq(array).length).toBe(2);
     });
   });
 

--- a/packages/arel/src/nodes/over.ts
+++ b/packages/arel/src/nodes/over.ts
@@ -1,5 +1,4 @@
-import { Node } from "./node.js";
-import { Binary } from "./binary.js";
+import { Binary, type NodeOrValue } from "./binary.js";
 
 /**
  * Over node — OVER (window) clause.
@@ -7,10 +6,12 @@ import { Binary } from "./binary.js";
  * Mirrors: Arel::Nodes::Over (extends Binary)
  */
 export class Over extends Binary {
-  // Rails' `initialize(left, right = nil)` puts no constraint on right; the
+  // Rails' `initialize(left, right = nil)` puts no constraint on either slot —
+  // its own test seats bare Strings in both (`Over.new("foo", "bar")`,
+  // test/cases/arel/nodes/over_test.rb:52-68) — and the
   // visitor branches on its runtime type, quoting a bare String window name
   // as an identifier and rendering a SqlLiteral bare (to_sql.rb:300-309).
-  constructor(left: Node, right: Node | string | null = null) {
+  constructor(left: NodeOrValue, right: NodeOrValue = null) {
     super(left, right);
   }
 

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -22,10 +22,10 @@ interface TypeCastable {
 }
 
 export class TableAlias extends Binary {
-  readonly relation: Node;
+  relation: Node;
   // Rails: `SelectManager#as` stores the alias as a `Nodes::SqlLiteral` (rendered
   // bare), while `Table#alias` stores a plain string (quoted). Accept both.
-  readonly name: string | SqlLiteral;
+  name: string | SqlLiteral;
 
   constructor(relation: Node, name: string | SqlLiteral) {
     super(relation, name);

--- a/packages/arel/src/nodes/unary-operation.ts
+++ b/packages/arel/src/nodes/unary-operation.ts
@@ -15,7 +15,7 @@ import { Descending } from "./descending.js";
  */
 export class UnaryOperation extends Unary {
   readonly operator: string;
-  declare readonly expr: Node;
+  declare expr: Node;
 
   constructor(operator: string, operand: Node) {
     super(operand);

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -3,7 +3,7 @@ import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 
 export class Unary extends NodeExpression {
-  readonly expr: unknown;
+  expr: unknown;
 
   // Mirrors Rails `alias :value :expr` (unary.rb:7).
   get value(): unknown {
@@ -27,7 +27,7 @@ export class On extends Unary {}
 // from NodeExpression. Field type narrowed to `Node` since callers always
 // pass an Arel node.
 export class Not extends Unary {
-  declare readonly expr: Node;
+  declare expr: Node;
   constructor(expr: Node) {
     super(expr);
   }
@@ -37,7 +37,7 @@ export class Not extends Unary {
 // the inherited `expr` slot — Rails' visit_Arel_Nodes_Lateral reads `o.expr`
 // (postgresql.rb:66).
 export class Lateral extends Unary {
-  declare readonly expr: Node;
+  declare expr: Node;
   constructor(expr: Node) {
     super(expr);
   }
@@ -65,7 +65,7 @@ export class Group extends Unary {}
  * (to_sql.rb:170-173).
  */
 export class OptimizerHints extends Unary {
-  declare readonly expr: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;
+  declare expr: ReadonlyArray<string | import("./sql-literal.js").SqlLiteral>;
 }
 
 _setNot(Not);

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -59,7 +59,7 @@ export class Window extends Node {
  * NamedWindow — a named window definition (WINDOW w AS (...))
  */
 export class NamedWindow extends Window {
-  readonly name: string;
+  name: string;
 
   constructor(name: string) {
     super();
@@ -93,14 +93,14 @@ export class Following extends Unary {
 export class CurrentRow extends Node {}
 
 export class Rows extends Unary {
-  declare readonly expr: Node | null;
+  declare expr: Node | null;
   constructor(expr: Node | null = null) {
     super(expr);
   }
 }
 
 export class Range extends Unary {
-  declare readonly expr: Node | null;
+  declare expr: Node | null;
   constructor(expr: Node | null = null) {
     super(expr);
   }

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -173,11 +173,15 @@ export class Table extends Node {
     return this.from().having(expr);
   }
 
-  get(name: string | null, table?: Attribute["relation"]): Attribute {
+  get(name: Node | string | null, table?: Attribute["relation"]): Attribute {
     // Rails' `Table#[]` accepts a nil name (`table[nil]` for a pkless model in
     // `Relation#delete_all`, relation.rb:1027-1031) and builds an Attribute
-    // whose name is nil; only a subquery-shaped statement ever renders it.
-    const resolved = name === null ? null : (this.klass?.attributeAliases?.[name] ?? name);
+    // whose name is nil; only a subquery-shaped statement ever renders it. It
+    // also takes a node name — `@table[Arel.star]`
+    // (test/cases/arel/visitors/to_sql_test.rb:50) — which the alias lookup
+    // skips and the visitor renders as-is (table.rb:110-113).
+    const resolved =
+      name === null || name instanceof Node ? name : (this.klass?.attributeAliases?.[name] ?? name);
     return new Attribute(table ?? this, resolved as string);
   }
 

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -1,6 +1,6 @@
 import { ArelEngine, Node, _engine } from "./nodes/node.js";
+import { _Dot } from "./node-slots.js";
 import { PlainString } from "./collectors/plain-string.js";
-import { Dot } from "./visitors/dot.js";
 import { Limit, Offset } from "./nodes/unary.js";
 import { buildQuoted } from "./nodes/casted.js";
 
@@ -66,7 +66,12 @@ export abstract class TreeManager {
 
   toDot(): string {
     const collector = new PlainString();
-    const dot = new Dot();
+    if (!_Dot) {
+      throw new Error(
+        'TreeManager#toDot requires the arel node slots. Import from "@blazetrails/arel" instead of deep-importing tree-manager.',
+      );
+    }
+    const dot = new _Dot();
     dot.accept(this.ast, collector);
     return collector.value;
   }

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -1,6 +1,7 @@
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
+import { _setDot } from "../node-slots.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { temporalClassName } from "../temporal-tag.js";
@@ -586,7 +587,13 @@ export class Dot extends Visitor {
     return ctor?.name ?? "Object";
   }
 
-  static {
+  /**
+   * Seeds this visitor's dispatch cache. Called once, lazily, the first time
+   * the cache is built — see the note in `Visitor.dispatchCache`.
+   *
+   * @internal
+   */
+  static registerDispatch(): void {
     const reg = (ctor: NodeCtor, m: string) => Dot.dispatchCache().set(ctor, m);
     reg(Nodes.Function, "visitArelNodesFunction");
     // Each aggregate has its own Rails alias chain; Trails dispatches them
@@ -642,3 +649,5 @@ export class Dot extends Visitor {
     reg(Nodes.Fragments, "visitNoEdges");
   }
 }
+
+_setDot(Dot);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -144,7 +144,13 @@ export class PostgreSQL extends ToSql {
     return collector;
   }
 
-  static {
+  /**
+   * Seeds this visitor's dispatch cache. Called once, lazily, the first time
+   * the cache is built — see the note in `Visitor.dispatchCache`.
+   *
+   * @internal
+   */
+  static registerDispatch(): void {
     PostgreSQL.dispatchCache().set(Nodes.Lateral, "visitArelNodesLateral");
   }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -174,7 +174,7 @@ describe("the to_sql visitor", () => {
   it("should not quote sql literals", () => {
     // Rails is `@table[Arel.star]`; trails' `Table#get` is typed to the string
     // name, so the star node is seated on the Attribute directly.
-    const node = table.get(star as unknown as string);
+    const node = table.get(star);
     expect(mustBeLike(compile(node))).toBe(mustBeLike(`"users".*`));
   });
 
@@ -236,7 +236,7 @@ describe("the to_sql visitor", () => {
     });
 
     it("should compile Arel nodes", () => {
-      const test = new Nodes.NamedFunction("generate_series", [4, 2] as unknown as Nodes.Node[]);
+      const test = new Nodes.NamedFunction("generate_series", [4, 2]);
       expect(mustBeLike(compile(test))).toBe(mustBeLike("generate_series(4, 2)"));
     });
   });
@@ -379,21 +379,21 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Cte", () => {
     it("handles CTEs with a MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star).ast, true);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star), true);
       expect(mustBeLike(compile(cte))).toBe(
         mustBeLike(`"foo" AS MATERIALIZED (SELECT * FROM "bar")`),
       );
     });
 
     it("handles CTEs with a NOT MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star).ast, false);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star), false);
       expect(mustBeLike(compile(cte))).toBe(
         mustBeLike(`"foo" AS NOT MATERIALIZED (SELECT * FROM "bar")`),
       );
     });
 
     it("handles CTEs with no MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star).ast);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star));
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
 
@@ -815,7 +815,7 @@ describe("the to_sql visitor", () => {
 
     it("should compile nodes with bind params", () => {
       const bp = new Nodes.BindParam(1);
-      const test = new Nodes.NamedFunction("generate_series", [4, bp] as unknown as Nodes.Node[]);
+      const test = new Nodes.NamedFunction("generate_series", [4, bp]);
       expect(mustBeLike(compile(test))).toBe(mustBeLike("generate_series(4, ?)"));
     });
   });
@@ -1403,13 +1403,8 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::BoundSqlLiteral", () => {
     it("supports other bound literals as binds", () => {
-      // Rails to_sql_test.rb: `Arel.sql("?", [1, 2, Arel.sql("?", 3)])` — one
-      // `?` bound to a mixed scalar/Arel-node list. The nested bound literal is
-      // visited (its own `?`), the scalars each `add_bind` → `?, ?, ?`.
-      const inner = new Nodes.BoundSqlLiteral("?", [3], {});
-      const node = new Nodes.BoundSqlLiteral("?", [[1, 2, inner]], {});
-      const sql = new Visitors.ToSql(testConnection).compile(node);
-      expect(sql).toBe("?, ?, ?");
+      const node = sql("?", [1, 2, sql("?", 3)]);
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe("?, ?, ?");
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -379,115 +379,6 @@ export class ToSql extends Visitor {
     return collector;
   }
 
-  static {
-    const d = ToSql.dispatchCache();
-    const reg = (ctor: NodeCtor, m: string) => {
-      if (typeof (ToSql.prototype as unknown as Record<string, unknown>)[m] !== "function") {
-        throw new Error(`ToSql dispatch: method '${m}' is not defined on the prototype`);
-      }
-      d.set(ctor, m);
-    };
-    reg(Nodes.SelectStatement, "visitArelNodesSelectStatement");
-    reg(Nodes.SelectCore, "visitArelNodesSelectCore");
-    reg(Nodes.InsertStatement, "visitArelNodesInsertStatement");
-    reg(Nodes.UpdateStatement, "visitArelNodesUpdateStatement");
-    reg(Nodes.DeleteStatement, "visitArelNodesDeleteStatement");
-    reg(Nodes.UnionAll, "visitArelNodesUnionAll");
-    reg(Nodes.Union, "visitArelNodesUnion");
-    reg(Nodes.Intersect, "visitArelNodesIntersect");
-    reg(Nodes.Except, "visitArelNodesExcept");
-    reg(Nodes.WithRecursive, "visitArelNodesWithRecursive");
-    reg(Nodes.With, "visitArelNodesWith");
-    reg(Nodes.TableAlias, "visitArelNodesTableAlias");
-    reg(Nodes.Cte, "visitArelNodesCte");
-    reg(Nodes.JoinSource, "visitArelNodesJoinSource");
-    reg(Nodes.InnerJoin, "visitArelNodesInnerJoin");
-    reg(Nodes.OuterJoin, "visitArelNodesOuterJoin");
-    reg(Nodes.RightOuterJoin, "visitArelNodesRightOuterJoin");
-    reg(Nodes.FullOuterJoin, "visitArelNodesFullOuterJoin");
-    reg(Nodes.StringJoin, "visitArelNodesStringJoin");
-    reg(Nodes.On, "visitArelNodesOn");
-    reg(Nodes.Equality, "visitArelNodesEquality");
-    reg(Nodes.NotEqual, "visitArelNodesNotEqual");
-    reg(Nodes.GreaterThan, "visitArelNodesGreaterThan");
-    reg(Nodes.GreaterThanOrEqual, "visitArelNodesGreaterThanOrEqual");
-    reg(Nodes.LessThan, "visitArelNodesLessThan");
-    reg(Nodes.LessThanOrEqual, "visitArelNodesLessThanOrEqual");
-    reg(Nodes.Matches, "visitArelNodesMatches");
-    reg(Nodes.DoesNotMatch, "visitArelNodesDoesNotMatch");
-    reg(Nodes.In, "visitArelNodesIn");
-    reg(Nodes.NotIn, "visitArelNodesNotIn");
-    reg(Nodes.Between, "visitArelNodesBetween");
-    reg(Nodes.Regexp, "visitArelNodesRegexp");
-    reg(Nodes.NotRegexp, "visitArelNodesNotRegexp");
-    reg(Nodes.IsDistinctFrom, "visitArelNodesIsDistinctFrom");
-    reg(Nodes.IsNotDistinctFrom, "visitArelNodesIsNotDistinctFrom");
-    reg(Nodes.Assignment, "visitArelNodesAssignment");
-    reg(Nodes.As, "visitArelNodesAs");
-    reg(Nodes.Ascending, "visitArelNodesAscending");
-    reg(Nodes.Descending, "visitArelNodesDescending");
-    reg(Nodes.Offset, "visitArelNodesOffset");
-    reg(Nodes.Limit, "visitArelNodesLimit");
-    reg(Nodes.Lock, "visitArelNodesLock");
-    reg(Nodes.DistinctOn, "visitArelNodesDistinctOn");
-    reg(Nodes.Bin, "visitArelNodesBin");
-    reg(Nodes.NullsFirst, "visitArelNodesNullsFirst");
-    reg(Nodes.NullsLast, "visitArelNodesNullsLast");
-    reg(Nodes.UnaryOperation, "visitArelNodesUnaryOperation");
-    reg(Nodes.And, "visitArelNodesAnd");
-    reg(Nodes.Or, "visitArelNodesOr");
-    reg(Nodes.Not, "visitArelNodesNot");
-    reg(Nodes.Grouping, "visitArelNodesGrouping");
-    reg(Nodes.Over, "visitArelNodesOver");
-    reg(Nodes.NamedWindow, "visitArelNodesNamedWindow");
-    reg(Nodes.Window, "visitArelNodesWindow");
-    reg(Nodes.Rows, "visitArelNodesRows");
-    reg(Nodes.Range, "visitArelNodesRange");
-    reg(Nodes.Preceding, "visitArelNodesPreceding");
-    reg(Nodes.Following, "visitArelNodesFollowing");
-    reg(Nodes.CurrentRow, "visitArelNodesCurrentRow");
-    reg(Nodes.Filter, "visitArelNodesFilter");
-    reg(Nodes.Case, "visitArelNodesCase");
-    reg(Nodes.When, "visitArelNodesWhen");
-    reg(Nodes.Else, "visitArelNodesElse");
-    reg(Nodes.Extract, "visitArelNodesExtract");
-    reg(Nodes.Concat, "visitArelNodesConcat");
-    reg(Nodes.InfixOperation, "visitArelNodesInfixOperation");
-    reg(Nodes.BoundSqlLiteral, "visitArelNodesBoundSqlLiteral");
-    reg(Nodes.BindParam, "visitArelNodesBindParam");
-    // Not an Arel node, but Rails' dispatch is by class for every object it
-    // visits (visitor.rb:29-30) and to_sql.rb:756 defines a handler for it,
-    // so ValuesList/Assignment's visit branch resolves here rather than
-    // raising UnsupportedVisitError.
-    reg(ModelAttribute, "visitActiveModelAttribute");
-    reg(Nodes.Fragments, "visitArelNodesFragments");
-    reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
-    reg(Nodes.Exists, "visitArelNodesExists");
-    reg(Nodes.Count, "visitArelNodesCount");
-    reg(Nodes.Sum, "visitArelNodesSum");
-    reg(Nodes.Max, "visitArelNodesMax");
-    reg(Nodes.Min, "visitArelNodesMin");
-    reg(Nodes.Avg, "visitArelNodesAvg");
-    reg(Nodes.Cube, "visitArelNodesCube");
-    reg(Nodes.RollUp, "visitArelNodesRollUp");
-    reg(Nodes.GroupingSet, "visitArelNodesGroupingSet");
-    reg(Nodes.Group, "visitArelNodesGroup");
-    reg(Nodes.GroupingElement, "visitArelNodesGroupingElement");
-    reg(Nodes.Comment, "visitArelNodesComment");
-    reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
-    reg(Nodes.HomogeneousIn, "visitArelNodesHomogeneousIn");
-    reg(Nodes.True, "visitArelNodesTrue");
-    reg(Nodes.False, "visitArelNodesFalse");
-    reg(Nodes.Distinct, "visitArelNodesDistinct");
-    reg(Nodes.SqlLiteral, "visitArelNodesSqlLiteral");
-    reg(Nodes.Quoted, "visitArelNodesQuoted");
-    reg(Nodes.Casted, "visitArelNodesCasted");
-    reg(Nodes.UnqualifiedColumn, "visitArelNodesUnqualifiedColumn");
-    reg(Nodes.Attribute, "visitArelAttributesAttribute");
-    reg(Nodes.ValuesList, "visitArelNodesValuesList");
-    reg(Table, "visitArelTable");
-  }
-
   // Mirrors Rails: visit_Arel_Nodes_OptimizerHints (to_sql.rb:170). The
   // OptimizerHints node carries a list of hint strings (Rails' `o.expr` is
   // an array); each hint is sanitized and the joined result wrapped in
@@ -1751,6 +1642,121 @@ export class ToSql extends Visitor {
       this.visit(child.toCte(), collector);
     });
     return collector;
+  }
+
+  /**
+   * Seeds this visitor's dispatch cache. Called once, lazily, the first time
+   * the cache is built — see the note in `Visitor.dispatchCache`.
+   *
+   * @internal
+   */
+  static registerDispatch(): void {
+    const d = ToSql.dispatchCache();
+    const reg = (ctor: NodeCtor, m: string) => {
+      if (typeof (ToSql.prototype as unknown as Record<string, unknown>)[m] !== "function") {
+        throw new Error(`ToSql dispatch: method '${m}' is not defined on the prototype`);
+      }
+      d.set(ctor, m);
+    };
+    reg(Nodes.SelectStatement, "visitArelNodesSelectStatement");
+    reg(Nodes.SelectCore, "visitArelNodesSelectCore");
+    reg(Nodes.InsertStatement, "visitArelNodesInsertStatement");
+    reg(Nodes.UpdateStatement, "visitArelNodesUpdateStatement");
+    reg(Nodes.DeleteStatement, "visitArelNodesDeleteStatement");
+    reg(Nodes.UnionAll, "visitArelNodesUnionAll");
+    reg(Nodes.Union, "visitArelNodesUnion");
+    reg(Nodes.Intersect, "visitArelNodesIntersect");
+    reg(Nodes.Except, "visitArelNodesExcept");
+    reg(Nodes.WithRecursive, "visitArelNodesWithRecursive");
+    reg(Nodes.With, "visitArelNodesWith");
+    reg(Nodes.TableAlias, "visitArelNodesTableAlias");
+    reg(Nodes.Cte, "visitArelNodesCte");
+    reg(Nodes.JoinSource, "visitArelNodesJoinSource");
+    reg(Nodes.InnerJoin, "visitArelNodesInnerJoin");
+    reg(Nodes.OuterJoin, "visitArelNodesOuterJoin");
+    reg(Nodes.RightOuterJoin, "visitArelNodesRightOuterJoin");
+    reg(Nodes.FullOuterJoin, "visitArelNodesFullOuterJoin");
+    reg(Nodes.StringJoin, "visitArelNodesStringJoin");
+    reg(Nodes.On, "visitArelNodesOn");
+    reg(Nodes.Equality, "visitArelNodesEquality");
+    reg(Nodes.NotEqual, "visitArelNodesNotEqual");
+    reg(Nodes.GreaterThan, "visitArelNodesGreaterThan");
+    reg(Nodes.GreaterThanOrEqual, "visitArelNodesGreaterThanOrEqual");
+    reg(Nodes.LessThan, "visitArelNodesLessThan");
+    reg(Nodes.LessThanOrEqual, "visitArelNodesLessThanOrEqual");
+    reg(Nodes.Matches, "visitArelNodesMatches");
+    reg(Nodes.DoesNotMatch, "visitArelNodesDoesNotMatch");
+    reg(Nodes.In, "visitArelNodesIn");
+    reg(Nodes.NotIn, "visitArelNodesNotIn");
+    reg(Nodes.Between, "visitArelNodesBetween");
+    reg(Nodes.Regexp, "visitArelNodesRegexp");
+    reg(Nodes.NotRegexp, "visitArelNodesNotRegexp");
+    reg(Nodes.IsDistinctFrom, "visitArelNodesIsDistinctFrom");
+    reg(Nodes.IsNotDistinctFrom, "visitArelNodesIsNotDistinctFrom");
+    reg(Nodes.Assignment, "visitArelNodesAssignment");
+    reg(Nodes.As, "visitArelNodesAs");
+    reg(Nodes.Ascending, "visitArelNodesAscending");
+    reg(Nodes.Descending, "visitArelNodesDescending");
+    reg(Nodes.Offset, "visitArelNodesOffset");
+    reg(Nodes.Limit, "visitArelNodesLimit");
+    reg(Nodes.Lock, "visitArelNodesLock");
+    reg(Nodes.DistinctOn, "visitArelNodesDistinctOn");
+    reg(Nodes.Bin, "visitArelNodesBin");
+    reg(Nodes.NullsFirst, "visitArelNodesNullsFirst");
+    reg(Nodes.NullsLast, "visitArelNodesNullsLast");
+    reg(Nodes.UnaryOperation, "visitArelNodesUnaryOperation");
+    reg(Nodes.And, "visitArelNodesAnd");
+    reg(Nodes.Or, "visitArelNodesOr");
+    reg(Nodes.Not, "visitArelNodesNot");
+    reg(Nodes.Grouping, "visitArelNodesGrouping");
+    reg(Nodes.Over, "visitArelNodesOver");
+    reg(Nodes.NamedWindow, "visitArelNodesNamedWindow");
+    reg(Nodes.Window, "visitArelNodesWindow");
+    reg(Nodes.Rows, "visitArelNodesRows");
+    reg(Nodes.Range, "visitArelNodesRange");
+    reg(Nodes.Preceding, "visitArelNodesPreceding");
+    reg(Nodes.Following, "visitArelNodesFollowing");
+    reg(Nodes.CurrentRow, "visitArelNodesCurrentRow");
+    reg(Nodes.Filter, "visitArelNodesFilter");
+    reg(Nodes.Case, "visitArelNodesCase");
+    reg(Nodes.When, "visitArelNodesWhen");
+    reg(Nodes.Else, "visitArelNodesElse");
+    reg(Nodes.Extract, "visitArelNodesExtract");
+    reg(Nodes.Concat, "visitArelNodesConcat");
+    reg(Nodes.InfixOperation, "visitArelNodesInfixOperation");
+    reg(Nodes.BoundSqlLiteral, "visitArelNodesBoundSqlLiteral");
+    reg(Nodes.BindParam, "visitArelNodesBindParam");
+    // Not an Arel node, but Rails' dispatch is by class for every object it
+    // visits (visitor.rb:29-30) and to_sql.rb:756 defines a handler for it,
+    // so ValuesList/Assignment's visit branch resolves here rather than
+    // raising UnsupportedVisitError.
+    reg(ModelAttribute, "visitActiveModelAttribute");
+    reg(Nodes.Fragments, "visitArelNodesFragments");
+    reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
+    reg(Nodes.Exists, "visitArelNodesExists");
+    reg(Nodes.Count, "visitArelNodesCount");
+    reg(Nodes.Sum, "visitArelNodesSum");
+    reg(Nodes.Max, "visitArelNodesMax");
+    reg(Nodes.Min, "visitArelNodesMin");
+    reg(Nodes.Avg, "visitArelNodesAvg");
+    reg(Nodes.Cube, "visitArelNodesCube");
+    reg(Nodes.RollUp, "visitArelNodesRollUp");
+    reg(Nodes.GroupingSet, "visitArelNodesGroupingSet");
+    reg(Nodes.Group, "visitArelNodesGroup");
+    reg(Nodes.GroupingElement, "visitArelNodesGroupingElement");
+    reg(Nodes.Comment, "visitArelNodesComment");
+    reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
+    reg(Nodes.HomogeneousIn, "visitArelNodesHomogeneousIn");
+    reg(Nodes.True, "visitArelNodesTrue");
+    reg(Nodes.False, "visitArelNodesFalse");
+    reg(Nodes.Distinct, "visitArelNodesDistinct");
+    reg(Nodes.SqlLiteral, "visitArelNodesSqlLiteral");
+    reg(Nodes.Quoted, "visitArelNodesQuoted");
+    reg(Nodes.Casted, "visitArelNodesCasted");
+    reg(Nodes.UnqualifiedColumn, "visitArelNodesUnqualifiedColumn");
+    reg(Nodes.Attribute, "visitArelAttributesAttribute");
+    reg(Nodes.ValuesList, "visitArelNodesValuesList");
+    reg(Table, "visitArelTable");
   }
 
   private subselectKey(key: Node): Node {

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -34,7 +34,7 @@ export type NodeCtor = abstract new (...args: never[]) => object;
  * @noRailsEquivalent TypeScript-only ctor type; Ruby dispatches on the class object directly.
  */
 type VisitorCtor = (abstract new (...args: never[]) => Visitor) &
-  Pick<typeof Visitor, "dispatchCache">;
+  Pick<typeof Visitor, "dispatchCache"> & { registerDispatch?: () => void };
 
 const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
 
@@ -87,6 +87,14 @@ export abstract class Visitor {
           : undefined;
       cache = new Map(inherited);
       PER_CLASS_CACHE.set(this, cache);
+      // Seeded here, not from a `static {}` block, because Ruby fills its
+      // dispatch cache when a node is first visited (visitor.rb:28-30) — the
+      // class objects a subclass registers are read at call time, exactly
+      // where Ruby resolves the constant. A `static {}` block reads them at
+      // module-eval time instead, which throws inside an import cycle
+      // (`Cannot access 'TableAlias' before initialization` when
+      // `nodes/index.js` is the ESM entry module).
+      if (Object.hasOwn(this, "registerDispatch")) this.registerDispatch?.();
     }
     return cache;
   }


### PR DESCRIPTION
Seven RFC 0124 surfaced-deviation stories in `packages/arel`, bundled because
they all move the same node files.

## 1. `attr_accessor` readers were `readonly`

Swept `packages/arel/src/nodes/` for readers declared `readonly` where the Ruby
node uses `attr_accessor`. Converged: `Case#case` (`case.rb:6`), `left`/`right`
on `Join`/`Union`/`UnionAll`/`Intersect`/`Except`/`InfixOperation`
(`binary.rb:6`), `Unary#expr` and the `declare readonly expr` narrowings on
`Not`/`Lateral`/`OptimizerHints`/`UnaryOperation`/`Rows`/`Range`
(`unary.rb:6`), `Function#expressions` (`function.rb:8`), `NamedFunction#name`
(`named_function.rb:6`), `Extract#field` (`extract.rb:6`), `NamedWindow#name`
(`window.rb:69`), and `Cte`/`TableAlias` `name`/`relation`, which alias
Binary's slots. The `attr_reader`-backed ones (`Fragments#values`,
`BindParam#value`, `Casted`, `Comment#values`, `HomogeneousIn`, `Nary#children`,
`InfixOperation#operator`, `UnaryOperation#operator`, `Matches#escape`,
`Cte#materialized`, `SqlLiteral#retryable`, `BoundSqlLiteral`) stay `readonly`.

## 2/4. Node slots typed narrower than the Ruby slot

`Table#get` takes a node name (`table.rb:110-113`, `to_sql_test.rb:50`);
`Function`/`NamedFunction` expressions take `NodeOrValue[]` so bare Integers
seat as they do in `to_sql_test.rb:865`; `Cte` takes a `SelectManager` body
(`to_sql_test.rb:1008`); `Over` takes `NodeOrValue` in both slots
(`over_test.rb:52-68`); `FactoryMethods#coalesce` takes the values
`factory_methods.rb:45-47` passes through untouched. Five `as unknown as` casts
are deleted from `to-sql.test.ts` / `factory-methods.test.ts`, and the three
`Nodes::Cte` to-sql tests now pass the manager Rails passes.

## 3. Duplicated `ActiveModel::Type.default_value`

`homogeneous-in.ts` imported nothing and redefined the memo, so there were two
`ValueType` singletons where Rails has one. It now imports `defaultValue` from
`@blazetrails/activemodel` — already exported from that package's index, so no
new surface was needed.

## 5. TDZ on entry modules

`nodes/index.js` and `visitors/postgresql.js` threw
`Cannot access 'TableAlias' before initialization` when imported as ESM entry
modules; with that fixed, four more surfaced behind it (`update-manager.js`,
`tree-manager.js`, `insert-manager.js`, `delete-manager.js`, all
`Cannot access 'TreeManager' before initialization`). Two causes:

- A visitor's `static {}` block read `Nodes.*` at module-eval time. Dispatch
  tables are now seeded lazily on first cache build, which is where Ruby fills
  its own (`visitor.rb:28-30`).
- `tree-manager.ts` imported `visitors/dot.js` eagerly for `#toDot`. `Dot` now
  comes from the existing zero-import slot module (`node-slots.ts`), the
  sanctioned shape for a Ruby constant resolved at call time.

`dist-entry-modules.trails.test.ts` loads every built arel module in its own
`node` subprocess — one process per module is load-bearing, since within a
single process only the first import is an entry module.

## 6. `over_test` equality bodies

Both bodies now assert `Over` value equality through the shared `uniq` test
helper, per `over_test.rb:52-68`. The audit for the same cannot-fail
`expect(a).not.toBe(b)` pattern found exactly one sibling — `extract.test.ts`,
whose `describe("equality")` also compared unrelated nodes — converged the same
way against `extract_test.rb:30-42`.

## 7. `Arel.sql` bind arms

`sql` implements both arms of `arel.rb:51-57`, guard in the same direction.
Ruby splits a trailing Hash off the splat before binding `retryable:` and
`**named_binds`; a TS rest parameter cannot sit in front of an options object,
so the port does the same split explicitly and keeps the Rails parameter names.
`Arel.sql("id = ?", 1)` and `Arel.sql("id = :id", { id: 1 })` both build a
`BoundSqlLiteral` and render through the existing visitor.

The direct `new Nodes.BoundSqlLiteral(...)` sites in
`relation/query-methods.ts` are **not** rerouted: Rails constructs the node
directly at both counterparts (`query_methods.rb:1696` and `:1716`), so routing
them through `Arel.sql` would be the deviation.

## Verification

- `pnpm vitest run packages/arel packages/activemodel` — 186 files, 3372 tests green.
- `pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate` — all OK, no new baseline rows.
- Every arel dist module loads as an ESM entry module (the new sweep test).

Closes-story: arel-case-reader-readonly-vs-attr-accessor
Closes-story: arel-coalesce-splat-typed-node-array-rejects-raw-values
Closes-story: arel-duplicates-activemodel-type-default-value
Closes-story: arel-node-slots-reject-rails-values
Closes-story: arel-nodes-index-tdz-on-entry-module
Closes-story: arel-over-test-equality-bodies-invented
Closes-story: arel-sql-drops-the-bound-sql-literal-arm
