### PR TITLE
refactor(activerecord): drop the SQLite3 ATTACHed-schema notion, restore the Rails bodies (RFC 0051, RFC 0119)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -60,17 +60,15 @@ describeIfPg("PostgreSQLAdapter", () => {
           await connection.changeTable("citexts", async (t) => {
             await (t as PgTable).citext("username");
           });
-          void Citext.resetColumnInformation();
-          // Rails: assert_equal :citext, Citext.columns_hash["username"].type (citext_test.rb:47-48)
-          // TODO: restore once InstrumentationAlreadyStartedError after DDL inside
-          //   connection.transaction() is fixed in the PG driver.
+          await Citext.resetColumnInformation();
+          const column = Citext.columnsHash()["username"] as unknown as PgColumn;
+          expect(column.type).toBe("citext");
+
           throw new Rollback();
         });
       } finally {
         void Citext.resetColumnInformation();
       }
-      const colsAfter = await connection.columns("citexts");
-      expect(colsAfter.find((c) => c.name === "username")).toBeUndefined();
     });
 
     it("write", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -309,7 +309,9 @@ export class SchemaCreation {
     if (o.algorithm) parts.push(o.algorithm);
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
     if (index.type) parts.push(index.type.toUpperCase());
-    parts.push(this.quotedIndexNameAndTable(index));
+    parts.push(
+      `${this.conn.quoteColumnName(index.name)} ON ${this.conn.quoteTableName(index.table)}`,
+    );
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
     parts.push(`(${await this.quotedColumns(index)})`);
     if ((await this.supportsIndexInclude()) && index.include && index.include.length > 0) {
@@ -319,25 +321,6 @@ export class SchemaCreation {
       parts.push("NULLS NOT DISTINCT");
     if (this.supportsPartialIndex() && index.where) parts.push(`WHERE ${index.where}`);
     return parts.join(" ");
-  }
-
-  /**
-   * The `<index name> ON <table>` fragment of `visit_CreateIndexDefinition`
-   * (abstract/schema_creation.rb:120), inlined there in Rails.
-   *
-   * Extracted only so SQLite3 can override this one fragment: SQLite spells an
-   * ATTACHed schema on the INDEX name rather than on the table — `CREATE INDEX
-   * "aux"."by_name" ON "widgets" (...)` — where qualifying the table is a
-   * syntax error. Rails has no ATTACHed-schema notion in this adapter, so
-   * upstream never grew the seam; trails does
-   * (`SQLite3Adapter#_splitTableName`, reached through `alter_table` /
-   * `copy_table` with an `aux.posts` name). A one-line seam rather than a
-   * forked copy of the whole body keeps the arm order and every capability
-   * gate in one place.
-   * @internal
-   */
-  protected quotedIndexNameAndTable(index: IndexDefinition): string {
-    return `${this.conn.quoteColumnName(index.name)} ON ${this.conn.quoteTableName(index.table)}`;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.trails.test.ts
@@ -134,8 +134,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(sqlite.allSql[0]).toBe('PRAGMA index_list("things")');
     await sqlite.indexes('a"b');
     expect(sqlite.allSql.at(-1)).toBe('PRAGMA index_list("a""b")');
-    await sqlite.indexes("aux.widgets");
-    expect(sqlite.allSql.at(-1)).toBe('PRAGMA "aux".index_list("widgets")');
   });
 
   it("indexes() sqlite arm quotes the index name as a string literal in the index_info PRAGMA", async () => {
@@ -151,18 +149,6 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
         `UNION ALL ` +
         `SELECT sql FROM sqlite_temp_master WHERE name = 'idx"x' AND type = 'index'`,
       `PRAGMA index_info('idx"x')`,
-    ]);
-  });
-
-  it("indexes() sqlite arm carries the schema prefix into the index_info PRAGMA", async () => {
-    const sqlite = new SqliteCapturingAdapter([{ name: "idx_widgets_name", unique: 0 }]);
-    await sqlite.indexes("aux.widgets");
-    expect(sqlite.allSql).toEqual([
-      'PRAGMA "aux".index_list("widgets")',
-      `SELECT sql FROM "aux".sqlite_master WHERE name = 'idx_widgets_name' AND type = 'index' ` +
-        `UNION ALL ` +
-        `SELECT sql FROM sqlite_temp_master WHERE name = 'idx_widgets_name' AND type = 'index'`,
-      `PRAGMA "aux".index_info('idx_widgets_name')`,
     ]);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -336,21 +336,6 @@ export class SchemaStatements {
     return new SchemaCreation(this as unknown as SchemaCreationConn);
   }
 
-  /**
-   * Split a (possibly schema-qualified) table name into the introspection-PRAGMA
-   * schema prefix and bare name, converged with SQLite3Adapter's
-   * `_splitTableName` form. The schema qualifier comes BEFORE the PRAGMA keyword
-   * (`PRAGMA aux.table_info("widgets")`) — `PRAGMA table_info("aux"."widgets")`
-   * makes SQLite treat the whole quoted string as one bare table name and
-   * return zero rows for ATTACHed databases.
-   */
-  protected _sqliteSchemaPrefix(tableName: string): { prefix: string; bare: string } {
-    const dot = tableName.lastIndexOf(".");
-    const schema = dot === -1 ? "" : tableName.slice(0, dot);
-    const bare = dot === -1 ? tableName : tableName.slice(dot + 1);
-    return { prefix: schema ? `${this.quoteColumnName(schema)}.` : "", bare };
-  }
-
   async createTable(
     tableName: string,
     optionsOrFn?:

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1586,48 +1586,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return pks.sort((a, b) => Number(a["pk"]) - Number(b["pk"])).map((f) => String(f["name"]));
   }
 
-  private _splitTableName(tableName: string): { schema: string; bare: string } {
-    const dot = tableName.lastIndexOf(".");
-    return dot === -1
-      ? { schema: "", bare: tableName }
-      : { schema: tableName.slice(0, dot), bare: tableName.slice(dot + 1) };
-  }
-
-  /**
-   * The abstract `index_name` (abstract/schema_statements.rb) with the schema
-   * qualifier taken off the table before the default name is built. Rails
-   * embeds `table_name` verbatim, so an ATTACHed `aux.customers` yields the
-   * dotted identifier `index_aux.customers_on_name`, which the CREATE INDEX
-   * emission then reads as a schema qualifier and rejects. Every other
-   * qualified path in this adapter (`columns`, `foreignKeys`, `primaryKeys`)
-   * already derives from the bare table; the qualifier is re-applied to the
-   * INDEX name by `SQLite3::SchemaCreation#visit_CreateIndexDefinition`.
-   *
-   * @noRailsEquivalent PERMANENT — SQLite ATTACHed-schema support, which Rails
-   * has no notion of at all, so there is no Ruby `index_name` behaviour to
-   * converge toward. Same deviation as
-   * `SQLite3::SchemaCreation#visit_CreateIndexDefinition`.
-   */
-  override indexName(
-    tableName: string,
-    options:
-      | { column?: string | string[]; name?: string; _usesLegacyIndexName?: boolean }
-      | string
-      | string[],
-  ): string {
-    return super.indexName(this._splitTableName(tableName).bare, options);
-  }
-
   /**
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#remove_index
-   * (`sqlite3_adapter.rb:286-292`), with the schema qualifier put back on the
-   * INDEX name for a qualified table — the same fork
-   * `SQLite3::SchemaCreation#visit_CreateIndexDefinition` takes on create, and
-   * ratified in the same place. Rails emits the bare name because it has no
-   * ATTACHed-schema notion; SQLite resolves a bare `DROP INDEX` name across
-   * main, temp and each ATTACHed database in attach order, so two schemas
-   * carrying one index name would otherwise drop whichever it reaches first.
-   * An unqualified table takes the Rails emission untouched.
+   * (`sqlite3_adapter.rb:286-292`).
    */
   async removeIndex(
     tableName: string,
@@ -1653,13 +1614,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
     const indexName = await this.indexNameForRemove(tableName, columnName, options);
 
-    const { schema } = this._splitTableName(tableName);
-
-    await this.execQuery(
-      schema === ""
-        ? `DROP INDEX ${quoteColumnName(indexName)}`
-        : `DROP INDEX ${quoteColumnName(schema)}.${quoteColumnName(indexName)}`,
-    );
+    await this.execQuery(`DROP INDEX ${quoteColumnName(indexName)}`);
   }
 
   createSchemaDumper(options: Record<string, unknown> = {}): Sqlite3SchemaDumper {
@@ -1853,13 +1808,8 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   private static readonly DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/;
 
   async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
-    const { schema, bare } = this._splitTableName(tableName);
-    const prefix = schema ? `${quoteColumnName(schema)}.` : "";
     const rows = (
-      await this.internalExecQuery(
-        `PRAGMA ${prefix}foreign_key_list(${quoteColumnName(bare)})`,
-        "SCHEMA",
-      )
+      await this.internalExecQuery(`PRAGMA foreign_key_list(${this.quote(tableName)})`, "SCHEMA")
     ).toArray();
     // Deferred or immediate foreign keys can only be seen in the CREATE TABLE sql
     // Rails: `table_structure_sql(table_name).select { |column_string|
@@ -1919,7 +1869,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       const columnKey = fromCols.join(",");
       const primaryKeyKey = toCols.join(",");
       const nameKey = columnKey.replace(/,/g, "_");
-      const name = namesByColumn.get(columnKey) ?? `fk_${bare}_${nameKey}`;
+      const name = namesByColumn.get(columnKey) ?? `fk_${tableName}_${nameKey}`;
       const deferrable = fkDefs[`${toTable},${columnKey},${primaryKeyKey}`];
       results.push(
         // Rails' SQLite foreign_keys options hash carries on_delete/on_update/
@@ -2099,35 +2049,11 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return sqliteDataSourceSql(name ?? undefined, { type: opts.type });
   }
 
-  /**
-   * Resolve the sqlite_master reference for a possibly-schema-qualified
-   * name. SQLite stores each attached DB's schema in its own
-   * `<schema>.sqlite_master`; `aux.widgets` is row `name='widgets'` in
-   * `aux.sqlite_master`, never `name='aux.widgets'` in the main catalog.
-   */
-  private _sqliteMasterFor(name: string): { sqliteMaster: string; bare: string } {
-    const { schema, bare } = this._splitTableName(name);
-    return {
-      sqliteMaster: schema ? `${quoteColumnName(schema)}.sqlite_master` : "sqlite_master",
-      bare,
-    };
-  }
-
   async tableExists(name: string): Promise<boolean> {
     // Rails guards with `if table_name.present?` and returns nil for nil/blank
     // names (schema_statements.rb:61); we return false for the same observable
     // `table_exists?(nil)` result rather than dereferencing a null name.
     if (name == null) return false;
-    if (name.includes(".")) {
-      const { sqliteMaster, bare } = this._sqliteMasterFor(name);
-      const rows = (
-        await this.internalExecQuery(
-          `SELECT 1 AS one FROM ${sqliteMaster} WHERE type='table' AND name='${sqliteQuoteString(bare)}'`,
-          "SCHEMA",
-        )
-      ).toArray() as Array<{ one: number }>;
-      return rows.length > 0;
-    }
     const rows = (
       await this.internalExecQuery(
         `SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = '${sqliteQuoteString(name)}' AND type IN ('table')`,
@@ -2142,20 +2068,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    * scalar PKs, an array for composite PKs, or null for rowid-only
    * tables (no explicit PK column). Matches Rails' SchemaCache which
    * stores `string | string[] | null` for primary_keys entries.
-   *
-   * Uses the `PRAGMA schema.table_info(table)` form for schema-qualified
-   * names (e.g. `temp.widgets`). The `PRAGMA table_info("schema"."table")`
-   * form does NOT work — SQLite treats the whole quoted string as a
-   * single table name and returns no rows.
    */
   async primaryKey(tableName: string): Promise<string | string[] | null> {
-    const { schema, bare } = this._splitTableName(tableName);
-    const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
     const rows = (
-      await this.internalExecQuery(
-        `PRAGMA ${pragmaPrefix}table_info(${quoteColumnName(bare)})`,
-        "SCHEMA",
-      )
+      await this.internalExecQuery(`PRAGMA table_info(${quoteTableName(tableName)})`, "SCHEMA")
     ).toArray() as Array<{ name: string; pk: number }>;
     const pks = rows.filter((r) => r.pk > 0).sort((a, b) => a.pk - b.pk);
     if (pks.length === 0) return null;
@@ -2368,13 +2284,9 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
   ): Promise<void> {
     await this.ensureConnected();
     const rename = options.rename ?? {};
-    const { bare: bareTable } = this._splitTableName(tableName);
 
     // Rails: altered_table_name = "a#{table_name}" (sqlite3_adapter.rb:566).
-    // Kept bare even for a schema-qualified table: the buffer is a TEMPORARY
-    // table, which always lives in the `temp` schema, so a qualifier would be
-    // rejected.
-    const alteredTableName = `a${bareTable}`;
+    const alteredTableName = `a${tableName}`;
 
     // No explicit missing-table guard: the first move's `columns` reaches
     // table_structure, which already raises StatementInvalid naming the table
@@ -2417,27 +2329,14 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
 
   // --- Rails: table-rebuild helpers (move_table / copy_table family) ---
 
-  /**
-   * @internal
-   *
-   * @missingRailsArgs quote_table_name — PERMANENT: Rails passes `table_name`
-   *   whole (sqlite3_adapter.rb:790-795); PRAGMA takes an attached-schema
-   *   qualifier as two separately-quoted identifiers rather than one quoted
-   *   name, so the two halves are quoted apart (see the split rationale on
-   *   `indexes` in sqlite3/schema-statements.ts).
-   */
+  /** @internal */
   private async tableInfo(tableName: string): Promise<Record<string, unknown>[]> {
-    const { schema, bare } = this._splitTableName(tableName);
-    const pragmaPrefix = schema ? `${quoteTableName(schema)}.` : "";
     const pragma = (await this.supportsVirtualColumns()) ? "table_xinfo" : "table_info";
     // Rails: `internal_exec_query("PRAGMA table_xinfo(#{quote_table_name(table_name)})",
     // "SCHEMA")` (sqlite3_adapter.rb:792-794); `toArray` hands back the plain
     // rows every reader of `tableInfo` here consumes.
     return (
-      await this.internalExecQuery(
-        `PRAGMA ${pragmaPrefix}${pragma}(${quoteTableName(bare)})`,
-        "SCHEMA",
-      )
+      await this.internalExecQuery(`PRAGMA ${pragma}(${quoteTableName(tableName)})`, "SCHEMA")
     ).toArray();
   }
 
@@ -2633,10 +2532,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
   /**
    * Mirrors: SQLite3Adapter#copy_table_indexes (sqlite3_adapter.rb:651-677)
    *
-   * Rails calls `add_index` unconditionally (`sqlite3_adapter.rb:674`) and so
-   * does this, for a schema-qualified destination as much as a bare one: the
-   * qualifier lands on the INDEX name, which is where SQLite takes it, in
-   * `SQLite3::SchemaCreation#quotedIndexNameAndTable`.
+   * Rails calls `add_index` unconditionally (`sqlite3_adapter.rb:674`).
    * @internal
    */
   private async copyTableIndexes(
@@ -2645,12 +2541,10 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     rename: Record<string, string> = {},
   ): Promise<void> {
     const idxRows = await this.indexes(from);
-    const { bare: bareFrom } = this._splitTableName(from);
-    const { bare: bareTo } = this._splitTableName(to);
     for (const idx of idxRows) {
       let name = idx.name;
-      if (bareTo === `a${bareFrom}`) name = `t${name}`;
-      else if (bareFrom === `a${bareTo}`) name = name.slice(1);
+      if (to === `a${from}`) name = `t${name}`;
+      else if (from === `a${to}`) name = name.slice(1);
       // Rails gates the rename/filter on `columns.is_a?(Array)` — and with it
       // the `columns(to)` reflection: an expression index carries its
       // parenthesized expression as a bare string, copied across verbatim.
@@ -2662,8 +2556,8 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
         cols = idx.columns;
       }
       if (!cols.length) continue;
-      const escapedFrom = bareFrom.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${bareTo}_`);
+      const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${to}_`);
       const options: {
         name: string;
         internal: boolean;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2557,7 +2557,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
       }
       if (!cols.length) continue;
       const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`), `$1${to}_`);
+      const newName = name.replace(new RegExp(`(^|_)(${escapedFrom})_`, "g"), `$1${to}_`);
       const options: {
         name: string;
         internal: boolean;

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
@@ -19,13 +19,11 @@ describe("SQLite3Adapter schema introspection", () => {
   });
 
   afterEach(async () => {
-    // Throwaway file-backed tables (the TEMP table and attached `aux` db are
-    // discarded with tmpDir); these IF EXISTS drops balance
-    // require-table-teardown by name. `aux.widgets` only resolves while aux is
-    // attached, so swallow the "unknown database" error in other tests.
+    // Throwaway file-backed tables (the TEMP table is discarded with tmpDir);
+    // these IF EXISTS drops balance require-table-teardown by name.
     await adapter
       .exec(
-        "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS memberships; DROP TABLE IF EXISTS temp_widgets; DROP TABLE IF EXISTS aux.widgets",
+        "DROP TABLE IF EXISTS widgets; DROP TABLE IF EXISTS memberships; DROP TABLE IF EXISTS temp_widgets",
       )
       .catch(() => undefined);
     await pool.disconnect();
@@ -140,48 +138,14 @@ describe("SQLite3Adapter schema introspection", () => {
       "CREATE TEMP TABLE temp_widgets (id INTEGER PRIMARY KEY, name TEXT)",
     );
     await adapter.executeMutation(
-      "CREATE INDEX temp.temp_widgets_on_name ON temp_widgets (name) WHERE name IS NOT NULL",
+      "CREATE INDEX temp_widgets_on_name ON temp_widgets (name) WHERE name IS NOT NULL",
     );
-    const indexes = (await adapter.indexes("temp.temp_widgets")) as Array<{
+    const indexes = (await adapter.indexes("temp_widgets")) as Array<{
       name: string;
       where?: string;
     }>;
     const idx = indexes.find((i) => i.name === "temp_widgets_on_name");
     expect(idx?.where).toBe("name IS NOT NULL");
-  });
-
-  it("introspection PRAGMAs work against schema-qualified names", async () => {
-    // Attach a separate sqlite file under the `aux` alias. PRAGMAs that
-    // accept a schema prefix must use the `PRAGMA aux.table_info(widgets)`
-    // form; `PRAGMA table_info("aux"."widgets")` returns zero rows
-    // because SQLite treats the whole quoted argument as a bare table
-    // name. This test guards against that regression — which is what
-    // Copilot flagged on #527.
-    const auxPath = path.join(tmpDir, "aux.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    await adapter.executeMutation(
-      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
-    );
-    await adapter.executeMutation("CREATE INDEX aux.widgets_on_name ON widgets (name)");
-
-    expect(await adapter.primaryKey("aux.widgets")).toBe("id");
-    const cols = await adapter.columns("aux.widgets");
-    expect(cols.map((c) => c.name)).toEqual(["id", "name"]);
-    const indexes = (await adapter.indexes("aux.widgets")) as Array<{
-      table: string;
-      name: string;
-      columns: string[];
-      orders: Record<string, string>;
-    }>;
-    expect(indexes).toMatchObject([
-      {
-        table: "widgets",
-        name: "widgets_on_name",
-        columns: ["name"],
-        unique: false,
-        orders: {},
-      },
-    ]);
   });
 
   it("alterTable preserves expression, partial and unique indexes across the rebuild", async () => {
@@ -218,131 +182,6 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(byName["widgets_on_name_desc"]?.orders).toBe("desc");
   });
 
-  it("alterTable rebuilds a schema-qualified table whose index has a custom name", async () => {
-    // The alter_table buffer is a TEMPORARY table, so it is unqualified even
-    // when the source is `aux.widgets`. copy_table_indexes has to spot the
-    // "a"-prefix relationship on the bare names to reach its `t`-prefix rename;
-    // otherwise an index name that doesn't embed the table name is copied onto
-    // the buffer under its original name and collides with the live original.
-    const auxPath = path.join(tmpDir, "aux-alter.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    await adapter.executeMutation(
-      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT, doomed TEXT)",
-    );
-    await adapter.executeMutation("CREATE INDEX aux.by_name ON widgets (name)");
-    await adapter.executeMutation("INSERT INTO aux.widgets (name) VALUES ('gizmo')");
-
-    await adapter.removeColumn("aux.widgets", "doomed");
-
-    expect((await adapter.columns("aux.widgets")).map((c) => c.name)).toEqual(["id", "name"]);
-    const indexes = (await adapter.indexes("aux.widgets")) as Array<{ name: string }>;
-    expect(indexes.map((i) => i.name)).toEqual(["by_name"]);
-    const rows = await adapter.selectAll("SELECT name FROM aux.widgets");
-    expect(rows.rows).toEqual([["gizmo"]]);
-  });
-
-  it("copyTableIndexes puts an ATTACHed schema on the index name, not the table", async () => {
-    // SQLite qualifies the INDEX, not the table it indexes; `CREATE INDEX
-    // by_name ON aux.widgets (...)` is a syntax error. copy_table_indexes
-    // therefore reaches add_index for a qualified destination too — the
-    // qualifier is moved in SQLite3::SchemaCreation#visit_CreateIndexDefinition.
-    const auxPath = path.join(tmpDir, "aux-copy-index.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    await adapter.executeMutation(
-      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT, doomed TEXT)",
-    );
-    await adapter.executeMutation("CREATE INDEX aux.by_name ON widgets (name)");
-
-    await adapter.removeColumn("aux.widgets", "doomed");
-
-    // sqlite_master strips the schema qualifier from the stored DDL, so the
-    // qualifier is read back as WHICH catalog holds the index: aux, not main.
-    // Qualifying the table instead would have raised a syntax error.
-    const inAux = (
-      await adapter.selectAll("SELECT sql FROM aux.sqlite_master WHERE type='index'")
-    ).rows.map((row) => String(row[0]));
-    expect(inAux).toEqual(['CREATE INDEX "by_name" ON "widgets" ("name")']);
-    const inMain = await adapter.selectAll(
-      "SELECT name FROM main.sqlite_master WHERE type='index'",
-    );
-    expect(inMain.rows).toEqual([]);
-    expect(
-      ((await adapter.indexes("aux.widgets")) as Array<{ name: string }>).map((i) => i.name),
-    ).toEqual(["by_name"]);
-  });
-
-  it("addIndex derives the default index name from the bare qualified table", async () => {
-    // index_name embeds the table name verbatim, so a schema-qualified table
-    // would produce `index_aux.customers_on_name` — a dotted identifier the
-    // CREATE INDEX emission reads as a schema qualifier. SQLite3Adapter#indexName
-    // strips the qualifier; SchemaCreation puts it back on the INDEX name.
-    const auxPath = path.join(tmpDir, "aux-default-index-name.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    // No teardown: the table lives in a per-test ATTACHed database file under
-    // tmpDir, which afterEach removes wholesale, so it cannot leak to a sibling.
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await adapter.executeMutation("CREATE TABLE aux.customers (id INTEGER PRIMARY KEY, name TEXT)");
-
-    await adapter.addIndex("aux.customers", ["name"]);
-
-    const inAux = (
-      await adapter.selectAll("SELECT sql FROM aux.sqlite_master WHERE type='index'")
-    ).rows.map((row) => String(row[0]));
-    expect(inAux).toEqual(['CREATE INDEX "index_customers_on_name" ON "customers" ("name")']);
-    expect(await adapter.indexExists("aux.customers", ["name"])).toBe(true);
-
-    await adapter.removeIndex("aux.customers", ["name"]);
-
-    expect(await adapter.indexExists("aux.customers", ["name"])).toBe(false);
-  });
-
-  it("removeIndex drops the index in the named schema, not another attached one", async () => {
-    // An unqualified DROP INDEX name resolves across main, temp and every
-    // ATTACHed database in attach order, so an identically-named index in an
-    // earlier-attached schema would be the one dropped.
-    const onePath = path.join(tmpDir, "one-dup-index.sqlite3");
-    const twoPath = path.join(tmpDir, "two-dup-index.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${onePath}' AS one`);
-    await adapter.executeMutation(`ATTACH DATABASE '${twoPath}' AS two`);
-    // No teardown: both tables live in per-test ATTACHed database files under
-    // tmpDir, which afterEach removes wholesale.
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await adapter.executeMutation("CREATE TABLE one.customers (id INTEGER PRIMARY KEY, name TEXT)");
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await adapter.executeMutation("CREATE TABLE two.customers (id INTEGER PRIMARY KEY, name TEXT)");
-    await adapter.addIndex("one.customers", ["name"]);
-    await adapter.addIndex("two.customers", ["name"]);
-
-    await adapter.removeIndex("two.customers", ["name"]);
-
-    expect(await adapter.indexExists("two.customers", ["name"])).toBe(false);
-    expect(await adapter.indexExists("one.customers", ["name"])).toBe(true);
-  });
-
-  it("copyTableIndexes copies a default-named index on an ATTACHed schema", async () => {
-    // The other half of the default-name fix: copy_table_indexes reaches
-    // add_index for every index it copies (sqlite3_adapter.rb:668-674), so a
-    // rebuild of a qualified table whose index carries the DEFAULT name is the
-    // path that used to need an explicit `name:` to get past
-    // `index_aux.widgets_on_name`. Nothing is hand-named here.
-    const auxPath = path.join(tmpDir, "aux-copy-default-index.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    await adapter.executeMutation(
-      "CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY, name TEXT, doomed TEXT)",
-    );
-    await adapter.addIndex("aux.widgets", ["name"]);
-
-    await adapter.removeColumn("aux.widgets", "doomed");
-
-    expect((await adapter.columns("aux.widgets")).map((c) => c.name)).toEqual(["id", "name"]);
-    expect(
-      ((await adapter.indexes("aux.widgets")) as Array<{ name: string }>).map((i) => i.name),
-    ).toEqual(["index_widgets_on_name"]);
-    expect(
-      (await adapter.selectAll("SELECT name FROM main.sqlite_master WHERE type='index'")).rows,
-    ).toEqual([]);
-  });
-
   it("dataSourceExists matches both tables and views, hides sqlite_* internals", async () => {
     await adapter.executeMutation(
       "CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)",
@@ -353,22 +192,5 @@ describe("SQLite3Adapter schema introspection", () => {
     expect(await adapter.dataSourceExists("missing")).toBe(false);
     expect(await adapter.dataSourceExists("sqlite_sequence")).toBe(false);
     expect(await adapter.dataSourceExists("sqlite_schema")).toBe(false);
-  });
-
-  it("tableExists/dataSourceExists resolve schema-qualified names correctly", async () => {
-    // Companion to the PRAGMA test: sqlite_master lookups must route to
-    // `<schema>.sqlite_master` for ATTACHed DBs. Matching on
-    // `name='aux.widgets'` in the main catalog would return false even
-    // though the table does exist in aux.
-    const auxPath = path.join(tmpDir, "aux2.sqlite3");
-    await adapter.executeMutation(`ATTACH DATABASE '${auxPath}' AS aux`);
-    await adapter.executeMutation("CREATE TABLE aux.widgets (id INTEGER PRIMARY KEY)");
-    await adapter.executeMutation("CREATE VIEW aux.widget_view AS SELECT id FROM aux.widgets");
-
-    expect(await adapter.tableExists("aux.widgets")).toBe(true);
-    expect(await adapter.tableExists("aux.missing")).toBe(false);
-    expect(await adapter.dataSourceExists("widgets")).toBe(true);
-    expect(await adapter.dataSourceExists("widget_view")).toBe(true);
-    expect(await adapter.dataSourceExists("aux.widgets")).toBe(false);
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -5,35 +5,10 @@
  */
 
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
-import type { ForeignKeyDefinition, IndexDefinition } from "../abstract/schema-definitions.js";
+import type { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import type { ColumnOptions } from "../abstract/schema-definitions.js";
 
 export class SchemaCreation extends AbstractSchemaCreation {
-  /**
-   * SQLite puts an ATTACHed schema on the INDEX name, not on the table it
-   * indexes — `CREATE INDEX "aux"."by_name" ON "widgets" (...)` — and
-   * qualifying the table instead is a syntax error. Rails emits
-   * `quote_column_name(index.name) ON quote_table_name(index.table)` inline
-   * (abstract/schema_creation.rb:120) because it has no ATTACHed-schema notion
-   * at all; trails does (`SQLite3Adapter#_splitTableName`, reached through
-   * `alter_table` / `copy_table` with an `aux.posts` name), so `add_index` can
-   * serve a qualified destination and `copy_table_indexes` needs no hand-built
-   * statement.
-   *
-   * An unqualified table takes the inherited fragment untouched.
-   * @internal
-   */
-  protected override quotedIndexNameAndTable(index: IndexDefinition): string {
-    const dot = index.table.lastIndexOf(".");
-    if (dot === -1) return super.quotedIndexNameAndTable(index);
-    const schema = index.table.slice(0, dot);
-    const bare = index.table.slice(dot + 1);
-    return (
-      `${this.conn.quoteColumnName(schema)}.${this.conn.quoteColumnName(index.name)} ` +
-      `ON ${this.conn.quoteColumnName(bare)}`
-    );
-  }
-
   /** @internal */
   protected override visitForeignKeyDefinition(o: ForeignKeyDefinition): string {
     let sql = super.visitForeignKeyDefinition(o);

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -17,7 +17,7 @@ import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema
 import { SchemaDumper as AbstractSchemaDumper } from "../abstract/schema-dumper.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Column } from "./column.js";
-import { quoteColumnName } from "./quoting.js";
+import { quoteTableName } from "./quoting.js";
 
 interface SQLite3SchemaAdapter extends DatabaseAdapter {
   addForeignKey(
@@ -99,30 +99,15 @@ const INDEX_ON_REGEX =
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#indexes
  *
  * Houses the SQLite index introspection in the file Rails keeps it in; the
- * adapter delegates here. Schema-qualified names (e.g. `temp.widgets`) place
- * the qualifier before the PRAGMA keyword.
- *
- * @missingRailsCall quote_table_name — PERMANENT: Per-site verified (RFC 0106
- *   wave 4b): sqlite3/schema_statements.rb:9 is `PRAGMA
- *   index_list(#{quote_table_name(table_name)})`; trails splits an
- *   attached-schema-qualified name first and quotes the two halves with
- *   `quoteColumnName` (sqlite3/schema-statements.ts:109-116), because PRAGMA
- *   takes `schema.table` as two separately-quoted identifiers, not one quoted
- *   string.
+ * adapter delegates here.
  */
 export async function indexes(
   adapter: DatabaseAdapter,
   tableName: string,
 ): Promise<IndexDefinition[]> {
-  const { schema, bare } = splitTableName(tableName);
-  const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
   const rows = (
-    await adapter.internalExecQuery(
-      `PRAGMA ${pragmaPrefix}index_list(${quoteColumnName(bare)})`,
-      "SCHEMA",
-    )
+    await adapter.internalExecQuery(`PRAGMA index_list(${quoteTableName(tableName)})`, "SCHEMA")
   ).toArray() as Array<{ name: string; unique: number; origin: string }>;
-  const sqliteMaster = schema ? `${quoteColumnName(schema)}.sqlite_master` : "sqlite_master";
   const result: IndexDefinition[] = [];
   for (const idx of rows) {
     // Skip SQLite's internal auto-indexes (named `sqlite_*`); user-visible
@@ -130,7 +115,7 @@ export async function indexes(
     if (idx.name.startsWith("sqlite_")) continue;
 
     const indexSql = (await adapter.queryValue(
-      `SELECT sql FROM ${sqliteMaster} WHERE name = ${adapter.quote(idx.name)} AND type = 'index' ` +
+      `SELECT sql FROM sqlite_master WHERE name = ${adapter.quote(idx.name)} AND type = 'index' ` +
         `UNION ALL ` +
         `SELECT sql FROM sqlite_temp_master WHERE name = ${adapter.quote(idx.name)} AND type = 'index'`,
       "SCHEMA",
@@ -141,10 +126,7 @@ export async function indexes(
     if (where != null) where = where.replace(/\s*\/\*.*\*\/$/, "");
 
     const cols = (
-      await adapter.internalExecQuery(
-        `PRAGMA ${pragmaPrefix}index_info(${adapter.quote(idx.name)})`,
-        "SCHEMA",
-      )
+      await adapter.internalExecQuery(`PRAGMA index_info(${adapter.quote(idx.name)})`, "SCHEMA")
     ).toArray() as Array<{ name: string | null; seqno: number }>;
     const columnNames = cols.sort((a, b) => a.seqno - b.seqno).map((c) => c.name);
 
@@ -161,16 +143,11 @@ export async function indexes(
       }
     }
 
-    result.push(new IndexDefinition(bare, idx.name, idx.unique !== 0, columns, { orders, where }));
+    result.push(
+      new IndexDefinition(tableName, idx.name, idx.unique !== 0, columns, { orders, where }),
+    );
   }
   return result;
-}
-
-function splitTableName(tableName: string): { schema: string; bare: string } {
-  const dot = tableName.lastIndexOf(".");
-  return dot === -1
-    ? { schema: "", bare: tableName }
-    : { schema: tableName.slice(0, dot), bare: tableName.slice(dot + 1) };
 }
 
 /**


### PR DESCRIPTION
Bundle of two stories. A third, `arel-assertion-mark-to-zero`, was claimed with
them, found to be far larger than its estimate, and released — see the bottom.

## `sqlite-attached-schema-notion-has-no-rails-counterpart` (RFC 0051)

The story asked a question first: does any trails consumer actually pass a
schema-qualified table name into the SQLite3 adapter?

**No.** The only exercisers were `sqlite3-introspection.trails.test.ts` and
three cases in `schema-statements-on-adapter.trails.test.ts` — both trails-only.
The canonical schema does not, and neither does Rails' suite.
`database-tasks.test.ts` does `ATTACH DATABASE`, but only to `execute()` raw
SQL for a backup; it never hands a qualified name to an adapter method. So the
notion is **removed**, not given a `@noRailsEquivalent` receipt.

Removed, each call site restored to the Rails body it diverged from:

| removed | restored to |
| --- | --- |
| `SQLite3Adapter#_splitTableName` + its ten call sites | `sqlite3_adapter.rb:417-424`, `:561-575`, `:651-677`, `:790-795` — `table_name` passed whole |
| the `indexName` override | Rails has none; the abstract `index_name` stands |
| `remove_index`'s qualified `DROP INDEX` arm | `sqlite3_adapter.rb:286-292`, bare index name |
| `_sqliteMasterFor` + `table_exists?`'s dotted branch | the single `pragma_table_list` probe |
| `SQLite3::SchemaCreation#quotedIndexNameAndTable` **and the abstract seam it existed for** | fragment inlined; `visit_CreateIndexDefinition` mirrors `abstract/schema_creation.rb:106-123` with no extraction |
| `SQLite3::SchemaStatements#indexes`' split | `PRAGMA index_list(#{quote_table_name(table_name)})` against plain `sqlite_master` (`sqlite3/schema_statements.rb:8-9`); `IndexDefinition` carries `table_name` |
| `SchemaStatements#_sqliteSchemaPrefix` | callerless once the above landed |

`copy_table_indexes` keeps its single unconditional `add_index`
(`sqlite3_adapter.rb:674`).

**Three deviation receipts retire with the code they justified** — two
`@missingRailsCall` / `@missingRailsArgs` tags and one `@noRailsEquivalent`.
This was the last seam standing; the whole-body visitor fork went in #7033.

### Driveby: `copy_table_indexes` now rewrites every occurrence

Converging the variable names above put a pre-existing divergence in plain
sight, so it goes rather than getting propagated. `sqlite3_adapter.rb:672` is
`name.gsub(/(^|_)(#{from})_/, "\\1#{to}_")` — **global**; the port used a
non-global `String#replace`, so `index_widgets_on_widgets_id` had only its
first occurrence rewritten.

Shipped **without** a test, deliberately: the out-and-back rename is symmetric,
so an occurrence the outbound pass leaves alone the inbound pass also leaves
alone, and the round trip lands on the original name either way. I wrote the
test, confirmed it passes on the *unfixed* baseline, and deleted it rather than
ship one that cannot red. The fix is to the intermediate buffer's index names.

## `columns-hash-stale-after-in-transaction-ddl` (RFC 0119)

The `TODO` in `citext.test.ts` blamed `InstrumentationAlreadyStartedError` in
the PG driver. The story already suspected that was stale. It is — and so was
the story's own diagnosis that this is a schema-reflection wall.

`columnsHash()` **does** re-reflect after `resetColumnInformation()` inside an
open transaction. `resetColumnInformation` returns the `rewarmDataSourceCache`
thenable precisely so a caller that needs the re-warmed entry can await it, and
its doc comment says so. The test wrote `void Citext.resetColumnInformation()`,
which starts nothing — the thenable only begins work when first awaited. **No
production change was needed.**

So `citext_test.rb:47-48` is restored verbatim and the `TODO` is gone:

```ts
await Citext.resetColumnInformation();
const column = Citext.columnsHash()["username"] as unknown as PgColumn;
expect(column.type).toBe("citext");
```

Verified against a real PostgreSQL 17 instance (the CI image), not sqlite3 —
including that the assertion reads `'citext'` rather than passing vacuously
(flipped the expectation to a wrong value and confirmed it reds).

The trailing trails-only rollback probe is dropped: Rails' test ends at the
`Rollback` and its `ensure`, `afterEach` drops the table outright, and keeping
it put a second assertion in a mirrored one-assertion test — which is what the
`parity:test:assertions` ratchet flagged.

## Released: `arel-assertion-mark-to-zero`

Released rather than half-shipped. The story's premise is a residue sweep;
the measurement says otherwise — 40 / 84 / 11 across **135 tests in ~40 files**,
which does not fit this PR's remaining budget and cannot be partially closed
(the story's acceptance is `0 / 0 / 0` plus a tightened mark).

Scoping it surfaced something worth more than the sweep, now filed as
**`0122-arel-assertion-parity/arel-node-tests-assert-on-wrong-node-class`**: a
family of arel node tests carries a body copy-pasted from a *different* node's
test file, so the test never exercises the node its file is named for. The
names are correct Rails mirrors, which is why `parity:test` scores them 100% on
presence while the assertion dimensions stay red. `count.test.ts` constructs
`Nodes.TableAlias`; `sum.test.ts` constructs `Nodes.NamedFunction`;
`extract.test.ts` constructs `Nodes.Not`; `grouping.test.ts` constructs
`Nodes.Window`; `comment.test.ts` constructs `Nodes.SqlLiteral` — eight files
confirmed, with the per-file table and a worked `count_test.rb` diff in the
story. That is a prerequisite for the mark-to-zero story and a correctness fix
independent of it.

## Review follow-up: `primaryKey` filed, not fixed here

Review flagged (non-blocking) that `SQLite3Adapter#primaryKey`
(`sqlite3-adapter.ts:2072`) is a bespoke singular override with no Rails
counterpart — its body was touched here to unqualify the PRAGMA, but the
larger divergence predates this PR. Confirmed: `sqlite3_adapter.rb` defines
only `primary_keys` (`:281-284`), and the singular reader is the abstract
delegation at `abstract/schema_statements.rb:145-149`. trails already mirrors
**both** halves faithfully and independently
(`abstract/schema-statements.ts:1205-1212` and `sqlite3-adapter.ts:1584-1587`),
so the override is duplication shadowing a working delegation.

Not converged here — it is a different story's scope and would widen this
diff past the deletion it is scoped to. Filed as
**`0023-surfaced-deviations/sqlite3-primary-key-singular-override-has-no-rails-counterpart`**
with the citations above and the one trap the deletion has to clear: the
override hard-codes `PRAGMA table_info`, while `primaryKeys` reads through
`tableStructure`, which selects `table_xinfo` when `supportsVirtualColumns()`
— so the swap needs a generated-column case pinned before the override goes.

Separately, this PR retires the outcome of the already-`done`
`abstract-sqlite-introspection-arm-dead-or-diverges-from-concrete` (#3958),
which converged the abstract arm *to* the schema-prefix form. That form is the
debt this story removes, so deleting `_sqliteSchemaPrefix` is the correct
resolution, not a regression of that story.

## Verification

- `pnpm parity:api:calls` — OK (363 baselined, 289 unreviewed); no baseline row
  added, none left stale.
- `pnpm parity:api:calls:args` — OK (141 baselined shape rows).
- `pnpm parity:api:extra:gate` — OK; activerecord novel 385/385, unchanged.
- `pnpm parity:test:assertions` — OK, no counter over its high-water mark.
- SQLite lane: 2044 passed / 245 skipped across 130 files.
- PostgreSQL 17 lane: 410 passed across 25 files.
- 34 insertions, 414 deletions.
- `pnpm parity:api:detached` / `pnpm parity:api:reasons` — clean (three JSDoc
  deviation tags were deleted; neither left a detached block nor an orphan).

Closes-story: sqlite-attached-schema-notion-has-no-rails-counterpart
Closes-story: columns-hash-stale-after-in-transaction-ddl
