### PR TITLE
refactor(activerecord): inline AdapterNotFound message, cacheSql absorbs the hit path, Ruby Hash raise messages, NullColumn (RFC 0119)

### DIFF
--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -70,7 +70,8 @@ export function register(name: string, loader: AdapterLoader): void {
 
 /**
  * Synchronous half of `resolve(name)` — Rails does this check inline, but
- * trails' sync callers can't await the dynamic import.
+ * trails' sync callers can't await the dynamic import. Raises the same
+ * AdapterNotFound `resolve` raises (connection_adapters.rb:34-39).
  *
  * @internal
  */
@@ -87,7 +88,9 @@ export function validateAdapterName(adapterName: string): void {
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters.resolve
  *
- * Resolves an adapter name to its class.
+ * Resolves an adapter name to its class. The AdapterNotFound message is built
+ * inline as Rails builds it (connection_adapters.rb:34-39), with its
+ * gem/Gemfile pair rendered as the JS package/package.json one.
  */
 export async function resolve(adapterName: string): Promise<AdapterClass> {
   const cached = resolved.get(adapterName);
@@ -95,8 +98,6 @@ export async function resolve(adapterName: string): Promise<AdapterClass> {
 
   const loader = adapters.get(adapterName);
   if (!loader) {
-    // connection_adapters.rb:34-39 builds this message inline, with its
-    // gem/Gemfile pair rendered as the JS package/package.json one.
     const err = new AdapterNotFound(
       `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
         `Available adapters are: ${[...adapters.keys()].sort().join(", ")}. ` +

--- a/packages/activerecord/src/connection-adapters.ts
+++ b/packages/activerecord/src/connection-adapters.ts
@@ -68,18 +68,6 @@ export function register(name: string, loader: AdapterLoader): void {
   resolveErrors.delete(name);
 }
 
-// Builds the AdapterNotFound raised for an unregistered name. Rails' wording,
-// with its gem/Gemfile pair rendered as the JS package/package.json one.
-function adapterNotFoundError(adapterName: string): AdapterNotFound {
-  const available = [...adapters.keys()].sort().join(", ");
-  return new AdapterNotFound(
-    `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
-      `Available adapters are: ${available}. ` +
-      `Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary ` +
-      `adapter package to your package.json if it's not in the list of available adapters.`,
-  );
-}
-
 /**
  * Synchronous half of `resolve(name)` — Rails does this check inline, but
  * trails' sync callers can't await the dynamic import.
@@ -88,7 +76,12 @@ function adapterNotFoundError(adapterName: string): AdapterNotFound {
  */
 export function validateAdapterName(adapterName: string): void {
   if (adapters.has(adapterName)) return;
-  throw adapterNotFoundError(adapterName);
+  throw new AdapterNotFound(
+    `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
+      `Available adapters are: ${[...adapters.keys()].sort().join(", ")}. ` +
+      `Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary ` +
+      `adapter package to your package.json if it's not in the list of available adapters.`,
+  );
 }
 
 /**
@@ -102,7 +95,14 @@ export async function resolve(adapterName: string): Promise<AdapterClass> {
 
   const loader = adapters.get(adapterName);
   if (!loader) {
-    const err = adapterNotFoundError(adapterName);
+    // connection_adapters.rb:34-39 builds this message inline, with its
+    // gem/Gemfile pair rendered as the JS package/package.json one.
+    const err = new AdapterNotFound(
+      `Database configuration specifies nonexistent '${adapterName}' adapter. ` +
+        `Available adapters are: ${[...adapters.keys()].sort().join(", ")}. ` +
+        `Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary ` +
+        `adapter package to your package.json if it's not in the list of available adapters.`,
+    );
     resolveErrors.set(adapterName, err);
     throw err;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -504,7 +504,7 @@ export interface AbstractAdapter {
   /** @internal */
   checkConstraintForBang(
     tableName: string,
-    options?: { name?: string; expression?: string; validate?: boolean },
+    { expression, ...options }?: { name?: string; expression?: string; validate?: boolean },
   ): Promise<CheckConstraintDefinition>;
   removeCheckConstraint(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -504,7 +504,7 @@ export interface AbstractAdapter {
   /** @internal */
   checkConstraintForBang(
     tableName: string,
-    { expression, ...options }?: { name?: string; expression?: string; validate?: boolean },
+    kwargs?: { name?: string; expression?: string; validate?: boolean },
   ): Promise<CheckConstraintDefinition>;
   removeCheckConstraint(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -86,7 +86,7 @@ export class Store {
     if (entry) {
       this._map.delete(key);
       this._map.set(key, entry);
-      return Promise.resolve(entry.map((row) => ({ ...row })));
+      return Promise.resolve(entry);
     }
 
     if (this._maxSize != null && this._map.size >= this._maxSize) {
@@ -101,9 +101,9 @@ export class Store {
       // value stored while this compute was in flight, so a second concurrent
       // miss on the same key does not overwrite the first one's result.
       const stored = this._map.get(key);
-      if (stored) return stored.map((row) => ({ ...row }));
+      if (stored) return stored;
       this._map.set(key, result);
-      return result.map((row) => ({ ...row }));
+      return result;
     });
   }
 
@@ -509,23 +509,7 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
           : FutureResult.wrap(result);
       }
       // Rails' sync path is `cache_sql { super }` (query_cache.rb:249), which
-      // itself tracks `hit` and instruments (query_cache.rb:283,291-296).
-      // INVARIANT: there must be no `await` between this lookupSqlCache
-      // and the cacheSql below — lookupSqlCache runs synchronously and cacheSql
-      // reaches `Store.computeIfAbsent`'s synchronous `get` immediately, so
-      // nothing can populate the key in between. That is why trails' cacheSql
-      // carries no `hit`/instrument branch of its own: a hit is always caught
-      // and instrumented here by lookupSqlCache; Rails' hit branch effectively
-      // lives in `Store.computeIfAbsent` (the dup-on-hit path). Break the
-      // no-await invariant and a concurrent write could turn the cacheSql call
-      // into a silent, uninstrumented cache hit.
-      const cached = this.lookupSqlCache(sql, name, binds ?? []);
-      if (cached !== undefined) {
-        // Resolved, not bare: Ruby's callers reach `select_all(...).then`
-        // through Kernel#then, which every object answers (database_statements
-        // .rb:85,102); a trails `Result` deliberately defines no `then`.
-        return Promise.resolve(Result.fromRowHashes(cached.map((r) => ({ ...r }))));
-      }
+      // itself tracks `hit`, instruments and dups (query_cache.rb:278-297).
       return this.cacheSql(sql, name, binds ?? [], async () => {
         const result = await original.call(this, sql, name, binds, forwardOpts);
         return result.toArray();
@@ -686,7 +670,16 @@ function lookupSqlCache(
   return result;
 }
 
-/** @internal */
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache#cache_sql
+ * (query_cache.rb:278-297) — key, `compute_if_absent` with the miss block,
+ * the hit-path `sql.active_record` instrumentation, and `result.dup`.
+ *
+ * `hit` is settled synchronously: `computeIfAbsent` reaches its `get` before
+ * returning, so the miss block has already run (or not) by the time the `then`
+ * reads the flag — the JS stand-in for Rails' `@lock.synchronize`.
+ * @internal
+ */
 function cacheSql(
   this: QueryCacheHost,
   sql: string,
@@ -697,7 +690,22 @@ function cacheSql(
   const qc = this._queryCache;
   if (!qc) return block();
   const key = sqlCacheKey(sql, binds);
-  return qc.computeIfAbsent(key, () => block());
+  let hit = true;
+
+  return qc
+    .computeIfAbsent(key, () => {
+      hit = false;
+      return block();
+    })
+    .then((result) => {
+      if (hit) {
+        Notifications.instrument(
+          "sql.active_record",
+          this.cacheNotificationInfoResult(sql, name, binds, result),
+        );
+      }
+      return [...result];
+    });
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -59,7 +59,7 @@ import {
   wrap,
 } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
-import { rubyInspect } from "../../relation/ruby-inspect.js";
+import { rubyInspect, rubyInspectHash } from "../../relation/ruby-inspect.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
 import {
   globalPluralizeTableNames,
@@ -2141,7 +2141,7 @@ export class SchemaStatements {
     const fk = await this.foreignKeyFor(fromTable, options);
     if (!fk) {
       throw new ArgumentError(
-        `Table '${fromTable}' has no foreign key for ${options.toTable ?? JSON.stringify(options)}`,
+        `Table '${fromTable}' has no foreign key for ${options.toTable ?? rubyInspectHash(options)}`,
       );
     }
     return fk;
@@ -2235,12 +2235,14 @@ export class SchemaStatements {
   /** @internal */
   async checkConstraintForBang(
     tableName: string,
-    options: { name?: string; expression?: string; validate?: boolean } = {},
+    { expression, ...options }: { name?: string; expression?: string; validate?: boolean } = {},
   ): Promise<CheckConstraintDefinition> {
-    const chk = await this.checkConstraintFor(tableName, options);
+    const chk = await this.checkConstraintFor(tableName, { expression, ...options });
     if (!chk) {
+      // schema_statements.rb:1803-1806 interpolates the options Hash, so the
+      // message carries Ruby's `{name: "x"}` rendering, not JSON's.
       throw new ArgumentError(
-        `Table '${tableName}' has no check constraint for ${options.expression ?? JSON.stringify(options)}`,
+        `Table '${tableName}' has no check constraint for ${expression ?? rubyInspectHash(options)}`,
       );
     }
     return chk;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2232,15 +2232,18 @@ export class SchemaStatements {
     return constraints.find((chk) => chk.isDefinedFor({ name: chkName, ...options }));
   }
 
-  /** @internal */
+  /**
+   * Mirrors: SchemaStatements#check_constraint_for!
+   * (schema_statements.rb:1802-1806) — the raise interpolates the options
+   * Hash, so the message carries Ruby's `{name: "x"}` rendering, not JSON's.
+   * @internal
+   */
   async checkConstraintForBang(
     tableName: string,
     { expression, ...options }: { name?: string; expression?: string; validate?: boolean } = {},
   ): Promise<CheckConstraintDefinition> {
     const chk = await this.checkConstraintFor(tableName, { expression, ...options });
     if (!chk) {
-      // schema_statements.rb:1803-1806 interpolates the options Hash, so the
-      // message carries Ruby's `{name: "x"}` rendering, not JSON's.
       throw new ArgumentError(
         `Table '${tableName}' has no check constraint for ${expression ?? rubyInspectHash(options)}`,
       );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2236,12 +2236,17 @@ export class SchemaStatements {
    * Mirrors: SchemaStatements#check_constraint_for!
    * (schema_statements.rb:1802-1806) — the raise interpolates the options
    * Hash, so the message carries Ruby's `{name: "x"}` rendering, not JSON's.
+   * Ruby's `expression: nil, **options` split happens in the body: an optional
+   * parameter cannot be destructured in the AbstractAdapter interface
+   * declaration the mixin-declaration-drift guard compares against, so `kwargs`
+   * carries the bag and `options` keeps Rails' name for the interpolated rest.
    * @internal
    */
   async checkConstraintForBang(
     tableName: string,
-    { expression, ...options }: { name?: string; expression?: string; validate?: boolean } = {},
+    kwargs: { name?: string; expression?: string; validate?: boolean } = {},
   ): Promise<CheckConstraintDefinition> {
+    const { expression, ...options } = kwargs;
     const chk = await this.checkConstraintFor(tableName, { expression, ...options });
     if (!chk) {
       throw new ArgumentError(

--- a/packages/activerecord/src/connection-adapters/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column.trails.test.ts
@@ -97,12 +97,12 @@ describe("Column", () => {
 
 describe("NullColumn", () => {
   it("has empty name", () => {
-    const col = new NullColumn();
+    const col = new NullColumn("");
     expect(col.name).toBe("");
   });
 
   it("has null default", () => {
-    const col = new NullColumn();
+    const col = new NullColumn("");
     expect(col.default).toBeNull();
   });
 

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -225,7 +225,7 @@ export type ColumnCoder = Record<string, unknown>;
  * Mirrors: ActiveRecord::ConnectionAdapters::NullColumn
  */
 export class NullColumn extends Column {
-  constructor(name: string = "") {
+  constructor(name: string) {
     super(name, null);
   }
 }

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -225,7 +225,7 @@ export type ColumnCoder = Record<string, unknown>;
  * Mirrors: ActiveRecord::ConnectionAdapters::NullColumn
  */
 export class NullColumn extends Column {
-  constructor() {
-    super("", null, null, true);
+  constructor(name: string = "") {
+    super(name, null);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1,6 +1,7 @@
 import { ValueType, ArgumentError } from "@blazetrails/activemodel";
 import { Nodes } from "@blazetrails/arel";
 import { singularize, getCrypto } from "@blazetrails/activesupport";
+import { rubyInspectArray, rubyInspectHash } from "../../relation/ruby-inspect.js";
 import { SchemaStatements as AbstractSchemaStatements } from "../abstract/schema-statements.js";
 import type { CommentOrChanges } from "../abstract/schema-statements.js";
 import {
@@ -1290,7 +1291,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     });
     if (!result)
       throw new ArgumentError(
-        `Table '${tableName}' has no exclusion constraint for ${expression ?? JSON.stringify(options)}`,
+        `Table '${tableName}' has no exclusion constraint for ${expression ?? rubyInspectHash(options)}`,
       );
     return result;
   }
@@ -1425,7 +1426,7 @@ export class SchemaStatements extends AbstractSchemaStatements {
     });
     if (!result)
       throw new ArgumentError(
-        `Table '${tableName}' has no unique constraint for ${column != null ? JSON.stringify(column) : JSON.stringify(options)}`,
+        `Table '${tableName}' has no unique constraint for ${column != null ? (Array.isArray(column) ? rubyInspectArray(column) : column) : rubyInspectHash(options)}`,
       );
     return result;
   }

--- a/packages/activerecord/src/migration/check-constraint.test.ts
+++ b/packages/activerecord/src/migration/check-constraint.test.ts
@@ -4,6 +4,7 @@ import { Base } from "../base.js";
 import { NotImplementedError, StatementInvalid } from "../errors.js";
 import type { CheckConstraintDefinition } from "../connection-adapters/abstract/schema-definitions.js";
 import type { ValidateConstraintStatements } from "../connection-adapters/abstract/schema-statements.js";
+import { rubyInspectHash } from "../relation/ruby-inspect.js";
 import { ambientConnection } from "../support/rocket-tables.js";
 import { useTransactionalTests } from "../test-fixtures/use-transactional-tests.js";
 import { adapterSupports, describeIfSupports, itIfSupports } from "../support/supports.js";
@@ -429,7 +430,7 @@ describe("Migration", () => {
       ).rejects.toThrow(ArgumentError);
 
       expect(error?.message).toBe(
-        `Table 'trades' has no check constraint for {name: "quantity_check"}`,
+        `Table 'trades' has no check constraint for ${rubyInspectHash({ name: "quantity_check" })}`,
       );
 
       await assertNothingRaised(() =>

--- a/packages/activerecord/src/migration/check-constraint.test.ts
+++ b/packages/activerecord/src/migration/check-constraint.test.ts
@@ -429,7 +429,7 @@ describe("Migration", () => {
       ).rejects.toThrow(ArgumentError);
 
       expect(error?.message).toBe(
-        `Table 'trades' has no check constraint for ${JSON.stringify({ name: "quantity_check" })}`,
+        `Table 'trades' has no check constraint for {name: "quantity_check"}`,
       );
 
       await assertNothingRaised(() =>

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -19,6 +19,7 @@ import { TableNotSpecified } from "./errors.js";
 import { loadSchemaOverrides } from "./load-schema-overrides-slot.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
+import { NullColumn } from "./connection-adapters/column.js";
 import {
   threadedConnectionFor,
   connectionPool,
@@ -770,13 +771,14 @@ export function yamlEncoder(this: SchemaHost): YAMLEncoder {
  * exist only for actual DB columns; user-declared `attribute :virtual,
  * :string` defs have no column. Callers needing the AM Type — for
  * casting, dirty tracking, comparison — should use `typeForAttribute`
- * instead. Returns a NullColumn-shaped object for unknown names so
- * `column.null`, `column.type`, etc. remain safely accessible.
+ * instead. Returns a NullColumn for unknown names (model_schema.rb:463-468)
+ * so `column.null`, `column.type`, etc. remain safely accessible.
  */
 export function columnForAttribute(this: SchemaHost, name: string): any {
   loadSchema.call(this);
   const hash = getColumnsHash(this);
-  return hash[name] ?? { name, null: true, type: null };
+  // `fetch` with a block, not `??`: a stored column wins even when falsy.
+  return name in hash ? hash[name] : new NullColumn(name);
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -772,12 +772,12 @@ export function yamlEncoder(this: SchemaHost): YAMLEncoder {
  * :string` defs have no column. Callers needing the AM Type — for
  * casting, dirty tracking, comparison — should use `typeForAttribute`
  * instead. Returns a NullColumn for unknown names (model_schema.rb:463-468)
- * so `column.null`, `column.type`, etc. remain safely accessible.
+ * so `column.null`, `column.type`, etc. remain safely accessible. `fetch` with
+ * a block, not `??`: a stored column wins even when falsy.
  */
 export function columnForAttribute(this: SchemaHost, name: string): any {
   loadSchema.call(this);
   const hash = getColumnsHash(this);
-  // `fetch` with a block, not `??`: a stored column wins even when falsy.
   return name in hash ? hash[name] : new NullColumn(name);
 }
 

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -28,6 +28,7 @@ import {
 } from "./test-helpers/models/company-in-module.js";
 import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
+import { NullColumn } from "./connection-adapters/column.js";
 import { create as createReflection } from "./reflection.js";
 import { Customer } from "./test-helpers/models/customer.js";
 import { UserWithInvalidRelation } from "./test-helpers/models/user-with-invalid-relation.js";
@@ -510,6 +511,13 @@ describe("ReflectionTest", () => {
         "updated_at",
       ].sort(),
     );
+  });
+  it("non existent columns return null object", () => {
+    const column = (CanonicalTopic as any).columnForAttribute("attribute_that_doesnt_exist");
+    expect(column).toBeInstanceOf(NullColumn);
+    expect(column.name).toBe("attribute_that_doesnt_exist");
+    expect(column.sqlType).toBeNull();
+    expect(column.type).toBeNull();
   });
   it("non existent types are identity types", () => {
     class Topic2 extends Base {

--- a/packages/activerecord/src/relation/ruby-inspect.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.ts
@@ -59,7 +59,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
-export function rubyInspectHash(value: Record<string, unknown>): string {
+export function rubyInspectHash(value: object): string {
   const pairs = Object.entries(value).map(([key, val]) => `${key}: ${rubyInspect(val)}`);
   return `{${pairs.join(", ")}}`;
 }

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/connection-adapters.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters.ts",
-    "rubyName": "resolve",
-    "call": "join",
-    "reason": "Rails builds the AdapterNotFound message inline (connection_adapters.rb:34-39); the port extracts it into the private `adapterNotFoundError`, whose `[...adapters.keys()].sort().join(\", \")` (connection-adapters.ts:75) is outside the published call-set. Tracked by story adapter-not-found-message-should-be-built-inline; returned from a `@missingRailsCall` tag by the RFC 0106 permanence audit."
-  }
-]


### PR DESCRIPTION
Four RFC 0119 convergences, each removing a shape trails invented over the Rails source.

**`resolve` builds the AdapterNotFound message inline** — `connection_adapters.rb:34-39` builds it inside `resolve`; the port had extracted a private `adapterNotFoundError`, which pushed the `[...adapters.keys()].sort().join(", ")` out of `resolve`'s call set. Helper deleted, message inlined at both raise sites, and the `join` row in `call-mismatches-exclude/activerecord/connection-adapters.json` deleted rather than re-justified.

**`cacheSql` is Rails' single `cache_sql`** (`query_cache.rb:278-297`) — it now tracks `hit`, instruments `sql.active_record` with `cacheNotificationInfoResult` on the hit path, and returns the dup. `Store#computeIfAbsent` stops duping (Rails' `compute_if_absent` doesn't, `query_cache.rb:67-81` — the dup is `cache_sql`'s), and `select_all`'s sync arm is the bare `cache_sql { super }` of `query_cache.rb:249` instead of a `lookupSqlCache`-then-`cacheSql` pair. `lookupSqlCache` stays exactly as Rails writes it (it does instrument, `query_cache.rb:260-276`) and keeps its one Rails caller, the async arm.

**Ruby Hash rendering in the schema-statement raise messages** — `#{options}` calls `Hash#to_s`, which under Ruby 3.4 gives `{name: "quantity_check"}`; `JSON.stringify` gave `{"name":"quantity_check"}`. The four sites (`checkConstraintForBang`, `foreignKeyForBang`, PG's `uniqueConstraintForBang` / `exclusionConstraintForBang`) route through the existing `rubyInspectHash` — no new helper. `checkConstraintForBang` also takes `expression` as its own parameter the way `schema_statements.rb:1803` does, so the interpolated Hash is `**options` without it. `check-constraint.test.ts` now asserts Rails' verbatim message (`check_constraint_test.rb:283`).

**`columnForAttribute` returns a `NullColumn`** (`model_schema.rb:463-468`) instead of a `{ name, null: true, type: null }` literal, with `fetch`-not-`??` semantics, and `NullColumn` takes the name Rails passes it (`column.rb:115-119`). Ports `reflection_test.rb:101-110` (`test_non_existent_columns_return_null_object`).

Gates: `parity:api:calls` OK (one baseline row retired), `parity:api:calls:args` OK, `parity:api:extra:gate` OK, `parity:test` +1, lint and typecheck clean.

Two bundled stories are not in this PR:

- `converge-association-check-klass-onto-reflection-check-validity` — **blocked** on unmerged PR #7039. Its premise (`Association#klass` as the bare `reflection.klass` delegate, and the constructor backing the rich registered reflection) is not in `main`, so `checkKlass` cannot shed its own re-resolve + derive/constantize fallback without duplicating that PR inside the same method region. Blocked in tasks with that reason; re-ready once #7039 merges.
- `abstract-mysql-concurrency-tests-model-layer` — **released** back to the queue. Rewriting the two MySQL concurrency suites plus the PG sibling onto `Model.transaction({requiresNew})` + `lock!` across two concurrent connection leases is a self-contained ~200 LOC test-infra piece on adapter lanes that cannot be validated from this host; bundling it unverified would have put the four clean convergences here at risk.

Closes-story: adapter-not-found-message-should-be-built-inline
Closes-story: cache-sql-hit-path-instrumentation-split
Closes-story: check-constraint-raise-message-uses-json-stringify-not-ruby-hash-inspect
Closes-story: column-for-attribute-null-column
