### PR TITLE
refactor(activerecord): one CollectionProxy association seat, one quote_default_expression body, Column joins the Deduplicable registry, dumper column specs read as the Ruby

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1042,7 +1042,10 @@ describe("PreloaderTest", () => {
     }).call();
     const queryCalls = spy.mock.calls.filter((c) => c[0].length > 0);
     expect(queryCalls).toHaveLength(1);
-    expect(association(author, "essayCategory").loaded).toBe(true);
+    // Rails: `assert_predicate author.association(:essay_category), :loaded?`
+    // (associations_test.rb:1337) — the singular association object off the
+    // owner, not a CollectionProxy.
+    expect((author as any).association("essayCategory").isLoaded()).toBe(true);
     const preloaded = (author as any).association("essayCategory").target;
     expect(allCategories).toContain(preloaded);
   });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1429,7 +1429,7 @@ export function _inlinePolymorphicKeys(
 }
 
 /**
- * The collection arm of `Preloader::Association#associate_records_to_owner`
+ * `Preloader::Association#associate_records_to_owner`
  * (`preloader/association.rb:245-256`), written through the association's
  * `target=` (`association.rb:100-103`), which is what flips `loaded`. Rails has
  * no proxy-side hook for this. The owner lookup Rails does inline
@@ -1439,9 +1439,15 @@ export function _inlinePolymorphicKeys(
  * @internal
  */
 export function _associateRecordsToOwner(association: AssociationInstance, records: Base[]): void {
-  const target = association.target;
-  const notPersistedRecords = (Array.isArray(target) ? target : []).filter((r) => !r.isPersisted());
-  association.target = [...records, ...notPersistedRecords];
+  if (association.isCollection()) {
+    const target = association.target;
+    const notPersistedRecords = (Array.isArray(target) ? target : []).filter(
+      (r) => !r.isPersisted(),
+    );
+    association.target = [...records, ...notPersistedRecords];
+  } else {
+    association.target = records[0] ?? null;
+  }
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1484,6 +1484,23 @@ export function association<T extends Base = Base>(
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }
   validateThroughReflection(ctor, assocName);
+  // Rails only ever builds a CollectionProxy for a collection reflection: its
+  // one construction site is `CollectionAssociation#reader`
+  // (`collection_association.rb:34-41`), and `@association`
+  // (`collection_proxy.rb:31-35`) is therefore always a has_many/habtm
+  // association. A singular reflection has no path into this class at all —
+  // `SingularAssociation#reader` (`singular_association.rb:11-17`) returns the
+  // record, and `owner.association(name)` (`associations.rb:288-294`) returns
+  // the association object itself. So hand that back rather than wrapping a
+  // `SingularAssociation` in a proxy whose mutations are all array-shaped.
+  const instance = record.association(assocName) as unknown as { isCollection(): boolean };
+  if (!instance.isCollection()) {
+    throw new TypeError(
+      `association() builds a CollectionProxy, which Rails has only for a collection ` +
+        `reflection; "${assocName}" on ${ctor.name} is singular. ` +
+        `Use record.association("${assocName}") for the singular association object.`,
+    );
+  }
   if (!_CollectionProxyCtor) {
     throw new Error(
       "CollectionProxy not registered. Either import '@blazetrails/activerecord' " +

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -357,10 +357,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     super(targetModel, targetModel.arelTable);
     this._record = record;
     this._assocName = assocName;
-    const instance = record.association(assocName) as unknown as CollectionAssociation;
-    this._association = instance.isCollection()
-      ? instance
-      : new CollectionAssociation(record, assocDef);
+    this._association = record.association(assocName) as unknown as CollectionAssociation;
 
     // `extend(*extensions)` (collection_proxy.rb:35-37) mixes into this object
     // only; chained relations get the same modules independently through
@@ -601,7 +598,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   private _collectionAssociation(): CollectionAssociation {
-    return this._record.association(this._assocName) as unknown as CollectionAssociation;
+    return this._association;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -132,6 +132,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * collection's array into it would box that record. Such a proxy gets a
    * collection seat of its own instead.
    */
+  /**
+   * Rails' `@association` ivar (collection_proxy.rb:31-35), which every
+   * mutation on the proxy delegates to — `target` (:33), `loaded?` (:53) and
+   * `delete_all` (:474-476) are all this one read. Handed in by the
+   * constructor, exactly as Rails is handed its association.
+   */
   private _association!: CollectionAssociation;
   private _assocName: string;
   // Rails' `CollectionProxy` holds no target of its own — `target`, `loaded?`
@@ -448,7 +454,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async toArray(): Promise<T[]> {
     if (!this._targetLoaded && this.isNullScope()) {
       const results = await this._execLoad();
-      return this._collectionAssociation().mergeTargetLists(results, this._target) as T[];
+      return this._association.mergeTargetLists(results, this._target) as T[];
     }
     return this.load();
   }
@@ -489,7 +495,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const results = await this._execLoad();
     // `@target = merge_target_lists(find_target, target)`
     // (collection_association.rb:274).
-    this._target = this._collectionAssociation().mergeTargetLists(results, this._target) as T[];
+    this._target = this._association.mergeTargetLists(results, this._target) as T[];
     this._targetLoaded = true;
     this._staleWrapper()?.loadedBang?.();
     return this._target;
@@ -564,7 +570,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   addExistingRecord(record: T): void {
-    this._collectionAssociation().addToTarget(record, { skipCallbacks: true });
+    this._association.addToTarget(record, { skipCallbacks: true });
   }
 
   /**
@@ -583,22 +589,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    return (await this._collectionAssociation().create(
+    return (await this._association.create(
       attrs,
       block as ((record: Base) => void) | undefined,
     )) as T | T[];
-  }
-
-  /**
-   * Rails' `@association` ivar (collection_proxy.rb:31-35), which every
-   * mutation on the proxy delegates to — `target` (:33), `loaded?` (:53) and
-   * `delete_all` (:474) all read the same seat. trails resolves it off the
-   * owner instead of holding it, because the proxy is built from the
-   * reflection, not handed the association object.
-   * @internal
-   */
-  private _collectionAssociation(): CollectionAssociation {
-    return this._association;
   }
 
   /**
@@ -611,7 +605,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * the association; the proxy counts nothing itself.
    */
   async size(): Promise<number> {
-    return this._collectionAssociation().size();
+    return this._association.size();
   }
 
   /**
@@ -621,7 +615,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (collection_proxy.rb:831-833) — `@association.empty?`.
    */
   async isEmpty(): Promise<boolean> {
-    return this._collectionAssociation().isEmpty();
+    return this._association.isEmpty();
   }
 
   /**
@@ -728,7 +722,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   divergence — renaming either would break the Rails API surface.
   //   Accepts Integer/String keys too, mirroring Rails' delete_or_destroy.
   async delete(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    const removed = await this._collectionAssociation().delete(
+    const removed = await this._association.delete(
       ...(records as Array<Base | number | string | bigint>),
     );
     this.resetScope();
@@ -749,7 +743,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   destroys by record reference (association semantics). Intentional
   //   permanent divergence — same rationale as CP#delete above.
   async destroy(...records: Array<T | number | string | bigint>): Promise<Base[] | undefined> {
-    const removed = await this._collectionAssociation().destroy(
+    const removed = await this._association.destroy(
       ...(records as Array<Base | number | string | bigint>),
     );
     this.resetScope();
@@ -781,7 +775,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * `CollectionAssociation#include?` (collection_association.rb:258-270).
    */
   async isInclude(record: T): Promise<boolean> {
-    return !!(await this._collectionAssociation().isInclude(record));
+    return !!(await this._association.isInclude(record));
   }
 
   /**
@@ -861,7 +855,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * (test/cases/associations/has_many_associations_test.rb:2688-2698) pins.
    */
   async replace(otherArray: T[]): Promise<T[] | undefined> {
-    const association = this._collectionAssociation();
+    const association = this._association;
     return (await association.replace(otherArray)) as T[] | undefined;
   }
 
@@ -871,7 +865,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy_all
    */
   async destroyAll(): Promise<T[]> {
-    const records = (await this._collectionAssociation().destroyAll()) as T[];
+    const records = (await this._association.destroyAll()) as T[];
     this.resetScope();
     return records;
   }
@@ -970,7 +964,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   isNullScope(): boolean {
-    return this._collectionAssociation().isNullScope();
+    return this._association.isNullScope();
   }
 
   /**
@@ -1056,7 +1050,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     attrs: Record<string, unknown> | Record<string, unknown>[] = {},
     block?: (r: T) => void,
   ): Promise<T | T[]> {
-    return (await this._collectionAssociation().createBang(
+    return (await this._association.createBang(
       attrs,
       block as ((record: Base) => void) | undefined,
     )) as T | T[];
@@ -1073,7 +1067,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * in Rails.
    */
   async deleteAll(dependent?: string): Promise<number> {
-    const count = await this._collectionAssociation().deleteAll(dependent);
+    const count = await this._association.deleteAll(dependent);
     this.resetScope();
     return count;
   }

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1162,7 +1162,9 @@ describe("InversePolymorphicBelongsToTests", () => {
   // `Array.isArray(child)` — silently skipping the child on owner save.
   it("has_one createBang stores a single record as target, not an array", async () => {
     const human = await Human.createBang({});
-    const face = await association(human, "autosaveFace").createBang({ description: "haunted" });
+    const face = await (human as any)
+      .association("autosaveFace")
+      .createBang({ description: "haunted" });
 
     const holder = (human as any).association("autosaveFace");
     expect(Array.isArray(holder.target)).toBe(false);
@@ -1170,10 +1172,10 @@ describe("InversePolymorphicBelongsToTests", () => {
 
     // autosave must not bail: a description change on the created child is
     // persisted when the owner is saved.
-    (face as any).description = "new description";
+    face.description = "new description";
     await human.saveBang();
-    await (face as any).reload();
-    expect((face as any).description).toBe("new description");
+    await face.reload();
+    expect(face.description).toBe("new description");
   });
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -77,7 +77,7 @@ import {
   quoteString as abstractQuoteString,
   quoteColumnName as abstractQuoteColumnName,
   quoteTableName as abstractQuoteTableName,
-  isSqlLiteral,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
   quotedTrue as abstractQuotedTrue,
   quotedFalse as abstractQuotedFalse,
   unquotedTrue as abstractUnquotedTrue,
@@ -1031,23 +1031,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   quoteDefaultExpression(value: unknown, column: unknown): string | Promise<string> {
-    if (value === undefined) return "";
-    if (typeof value === "function") {
-      const result = (value as () => unknown)();
-      if (typeof result === "string") return result;
-      if (isSqlLiteral(result)) return result.value;
-      throw new TypeError(
-        "quoteDefaultExpression expected function default to return a string or SqlLiteral",
-      );
-    }
-    if (isSqlLiteral(value)) return value.value;
-    // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
-    // (abstract/quoting.rb:161) before quoting. Returns a bare literal — the
-    // ` DEFAULT ` keyword is owned by the caller (add_column_options!).
-    const sqlType = (column as { sqlType?: string | null }).sqlType;
-    const castType = this.lookupCastType(sqlType ?? null) as { serialize?(v: unknown): unknown };
-    if (typeof castType?.serialize === "function") value = castType.serialize(value);
-    return this.quote(value);
+    return abstractQuoteDefaultExpression.call(this, value, column as { sqlType?: string | null });
   }
 
   quotedTrue(): string {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -148,8 +148,8 @@ export class SchemaDumper extends BaseSchemaDumper {
    * (abstract/schema_dumper.rb:64), split out because the lookup has to survive
    * a dumper with no backing adapter (raw/mock sources).
    * @internal
-   * @noRailsEquivalent CONVERGEABLE — inline in Ruby; extracted only because
-   *   trails' dumper also runs against adapterless schema sources.
+   * Inline in Ruby; extracted only because trails' dumper also runs against
+   * adapterless schema sources.
    */
   private _nativeTypeLimit(column: Column): unknown {
     const adapter = this._adapter();

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -105,7 +105,7 @@ export class SchemaDumper extends BaseSchemaDumper {
 
   /** @internal */
   protected schemaTypeWithVirtual(column: Column): string {
-    if (column.virtual) return "virtual";
+    if (this.supportsVirtualColumns && column.virtual) return "virtual";
     return this.schemaType(column);
   }
 
@@ -133,14 +133,31 @@ export class SchemaDumper extends BaseSchemaDumper {
     // predicate `schema_type` uses, so a column whose bigint-ness is only visible through
     // sqlType is limit-suppressed too.
     if (this.isBigint(column)) return undefined;
-    // Rails suppresses the serial/bigserial limit because it matches the native
-    // database type's default (int4 limit = 4, int8 limit = 8). We don't have
-    // the native_database_types comparison available here, so we guard explicitly
-    // on isSerial — functionally equivalent to the Rails approach.
-    if (column.isSerial) return undefined;
     const limit = column.limit;
     if (limit == null) return undefined;
+    // Rails: `limit.inspect if limit && limit != @connection.native_database_types[column.type][:limit]`
+    // (abstract/schema_dumper.rb:64). A raw/mock source has no adapter and so no
+    // type map to compare against; it then dumps the limit, as Rails does for a
+    // type whose native entry carries no `:limit`.
+    if (limit === this._nativeTypeLimit(column)) return undefined;
     return String(limit);
+  }
+
+  /**
+   * `@connection.native_database_types[column.type][:limit]`
+   * (abstract/schema_dumper.rb:64), split out because the lookup has to survive
+   * a dumper with no backing adapter (raw/mock sources).
+   * @internal
+   * @noRailsEquivalent CONVERGEABLE — inline in Ruby; extracted only because
+   *   trails' dumper also runs against adapterless schema sources.
+   */
+  private _nativeTypeLimit(column: Column): unknown {
+    const adapter = this._adapter();
+    if (!adapter || typeof adapter.nativeDatabaseTypes !== "function") return undefined;
+    const native = adapter.nativeDatabaseTypes()?.[column.type ?? ""] as
+      | { limit?: unknown }
+      | undefined;
+    return native?.limit;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -127,33 +127,28 @@ export class SchemaDumper extends BaseSchemaDumper {
     return !!column.bigint || column.type === "bigint" || /^bigint\b/i.test(column.sqlType ?? "");
   }
 
-  /** @internal */
+  /**
+   * Mirrors `def schema_limit(column)` (abstract/schema_dumper.rb:62-65).
+   *
+   * `limit = column.limit unless column.bigint?` uses the same predicate
+   * `schema_type` does, so a column whose bigint-ness is only visible through
+   * sqlType is limit-suppressed too. The `@connection.native_database_types`
+   * lookup yields `undefined` for a raw/mock source with no backing adapter,
+   * which then dumps the limit — as Rails does for a type whose native entry
+   * carries no `:limit`.
+   * @internal
+   */
   protected schemaLimit(column: Column): string | undefined {
-    // Mirrors Rails `schema_limit`: `limit = column.limit unless column.bigint?` — same
-    // predicate `schema_type` uses, so a column whose bigint-ness is only visible through
-    // sqlType is limit-suppressed too.
     if (this.isBigint(column)) return undefined;
     const limit = column.limit;
     if (limit == null) return undefined;
-    if (limit === this._nativeTypeLimit(column)) return undefined;
+    const nativeLimit = (
+      this._adapter()?.nativeDatabaseTypes?.()?.[column.type ?? ""] as
+        | { limit?: unknown }
+        | undefined
+    )?.limit;
+    if (limit === nativeLimit) return undefined;
     return String(limit);
-  }
-
-  /**
-   * `@connection.native_database_types[column.type][:limit]`
-   * (abstract/schema_dumper.rb:64), split out because the lookup has to survive
-   * a dumper with no backing adapter (raw/mock sources).
-   * @internal
-   * Inline in Ruby; extracted only because trails' dumper also runs against
-   * adapterless schema sources.
-   */
-  private _nativeTypeLimit(column: Column): unknown {
-    const adapter = this._adapter();
-    if (!adapter || typeof adapter.nativeDatabaseTypes !== "function") return undefined;
-    const native = adapter.nativeDatabaseTypes()?.[column.type ?? ""] as
-      | { limit?: unknown }
-      | undefined;
-    return native?.limit;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -135,10 +135,6 @@ export class SchemaDumper extends BaseSchemaDumper {
     if (this.isBigint(column)) return undefined;
     const limit = column.limit;
     if (limit == null) return undefined;
-    // Rails: `limit.inspect if limit && limit != @connection.native_database_types[column.type][:limit]`
-    // (abstract/schema_dumper.rb:64). A raw/mock source has no adapter and so no
-    // type map to compare against; it then dumps the limit, as Rails does for a
-    // type whose native entry carries no `:limit`.
     if (limit === this._nativeTypeLimit(column)) return undefined;
     return String(limit);
   }

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -97,3 +97,35 @@ describe("ColumnEqualityTrails", () => {
     expect(sqlite.equals(pg)).toBe(false);
   });
 });
+
+describe("ColumnDeduplicationTrails", () => {
+  it("collapses identical columns onto one frozen instance through the registry", () => {
+    const a = new Column("dedup_title", "hi", meta(), false, { comment: "c" }).deduplicate();
+    const b = new Column("dedup_title", "hi", meta(), false, { comment: "c" }).deduplicate();
+    expect(b).toBe(a);
+    expect(Object.isFrozen(a)).toBe(true);
+  });
+
+  it("keeps columns differing only in an attribute Rails hashes apart", () => {
+    const a = new Column("dedup_split", "hi", meta(), false).deduplicate();
+    const b = new Column("dedup_split", "bye", meta(), false).deduplicate();
+    expect(b).not.toBe(a);
+  });
+
+  it("folds the PostgreSQL identity and serial flags into the key", () => {
+    const opts = { sqlType: "integer", type: "integer" };
+    const plain = new PostgreSQLColumn("dedup_pg", null, new PgTypeMetadata(opts), false);
+    const serial = new PostgreSQLColumn("dedup_pg", null, new PgTypeMetadata(opts), false, {
+      serial: true,
+    });
+    expect(plain.deduplicate()).not.toBe(serial.deduplicate());
+  });
+
+  it("folds the SQLite3 rowid flag into the key, which its equality ignores", () => {
+    const opts = { sqlType: "integer", type: "integer" };
+    const plain = new SQLite3Column("dedup_sqlite", null, opts, false);
+    const rowid = new SQLite3Column("dedup_sqlite", null, opts, false, { rowid: true });
+    expect(plain.equals(rowid)).toBe(true);
+    expect(plain.deduplicate()).not.toBe(rowid.deduplicate());
+  });
+});

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -199,10 +199,9 @@ export class Column implements Deduplicable {
    * those two so the `Hash` lookup in `Deduplicable#deduplicate` works.
    * Subclasses extend it with the attributes their own `hash` adds.
    * @internal
-   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
-   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
-   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
-   *   port needs an explicit string key over exactly those attributes.
+   * Ruby's registry is a Hash keyed by the object itself, which works because
+   * Rails pairs `==`/`eql?` with `hash`; a JS `Map` keys by identity, so the
+   * port needs an explicit string key over exactly those attributes.
    */
   deduplicateKey(): string {
     return JSON.stringify([

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -4,11 +4,13 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::Column
  */
 
+import { deduplicate } from "./deduplicable.js";
+import type { Deduplicable } from "./deduplicable.js";
 import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import type { SqlTypeMetadataJSON } from "./sql-type-metadata.js";
 import { humanize } from "@blazetrails/activesupport";
 
-export class Column {
+export class Column implements Deduplicable {
   name: string;
   sqlTypeMetadata: SqlTypeMetadata | null;
   null: boolean;
@@ -191,16 +193,50 @@ export class Column {
     coder["comment"] = this.comment;
   }
 
-  deduplicate(): this {
-    return this.deduplicated();
+  /**
+   * The registry key over exactly the attributes `Column#==` compares and
+   * `Column#hash` folds in (`column.rb:75-88`) — what Rails gets from pairing
+   * those two so the `Hash` lookup in `Deduplicable#deduplicate` works.
+   * Subclasses extend it with the attributes their own `hash` adds.
+   * @internal
+   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
+   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
+   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
+   *   port needs an explicit string key over exactly those attributes.
+   */
+  deduplicateKey(): string {
+    return JSON.stringify([
+      this.name,
+      this.default ?? null,
+      this.sqlTypeMetadata?.deduplicateKey() ?? null,
+      this.null,
+      this.defaultFunction,
+      this.collation,
+      this.comment,
+    ]);
   }
 
-  /** @internal */
-  protected deduplicated(): this {
+  /**
+   * Mirrors `Deduplicable#deduplicate` — `self.class.registry[self] ||=
+   * deduplicated` (`deduplicable.rb:18`).
+   */
+  deduplicate(): this {
+    return deduplicate(this);
+  }
+
+  /**
+   * Mirrors `Column#deduplicated` (`column.rb:104-112`): dedup the metadata,
+   * then `super` — `Deduplicable#deduplicated`'s `freeze` (`deduplicable.rb:26`).
+   * Ruby's `-string` interning has no JS counterpart (strings are already
+   * immutable and pooled), so the five `-name` / `-default` lines have nothing
+   * to call.
+   * @internal
+   */
+  deduplicated(): this {
     if (this.sqlTypeMetadata) {
       this.sqlTypeMetadata.deduplicate();
     }
-    return this;
+    return Object.freeze(this);
   }
 
   toString(): string {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -406,11 +406,19 @@ export async function newColumnFromField(
     [def, defFn] = [null, def];
   }
 
+  // Rails' `Deduplicable::ClassMethods#new` (`deduplicable.rb:13-14`) wraps
+  // `Column.new` itself, so every constructed column goes through the registry
+  // (`deduplicable.rb:18`). TS cannot mirror that on the class: a base
+  // constructor returning the deduplicated instance freezes it before the
+  // subclass assigns its own fields, so `new SQLite3::Column(...)` would throw
+  // `Cannot add property _generatedType, object is not extensible`. Ruby has no
+  // such split — `new` wraps allocate+initialize for the most-derived class —
+  // so the hook fires here instead, on the fully-built object.
   return new Column(fieldName, def, meta, field["Null"] === "YES", {
     defaultFunction: defFn ?? undefined,
     collation: field["Collation"] ?? null,
     comment: presence(field["Comment"] as string | undefined) ?? null,
-  });
+  }).deduplicate();
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3757,6 +3757,14 @@ export class PostgreSQLAdapter
       serial = this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
     }
 
+    // Rails' `Deduplicable::ClassMethods#new` (`deduplicable.rb:13-14`) wraps
+    // `Column.new` itself, so every constructed column goes through the registry
+    // (`deduplicable.rb:18`). TS cannot mirror that on the class: a base
+    // constructor returning the deduplicated instance freezes it before the
+    // subclass assigns its own fields, so `new SQLite3::Column(...)` would throw
+    // `Cannot add property _generatedType, object is not extensible`. Ruby has no
+    // such split — `new` wraps allocate+initialize for the most-derived class —
+    // so the hook fires here instead, on the fully-built object.
     return new Column(columnName, defaultValue, typeMetadata, !notnull, {
       defaultFunction: defaultFunction ?? undefined,
       collation: collation ?? undefined,
@@ -3764,7 +3772,7 @@ export class PostgreSQLAdapter
       serial,
       identity: identity || null,
       generated: gen || null,
-    });
+    }).deduplicate();
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -85,6 +85,19 @@ export class Column extends BaseColumn {
     return this.identity != null;
   }
 
+  /**
+   * Mirrors `PostgreSQL::Column#hash` (`postgresql/column.rb:72-77`), which
+   * folds `identity?` and `serial?` in on top of `super`.
+   * @internal
+   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
+   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
+   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
+   *   port needs an explicit string key over exactly those attributes.
+   */
+  override deduplicateKey(): string {
+    return JSON.stringify([super.deduplicateKey(), this.isIdentity, this.isSerial]);
+  }
+
   // Mirrors: Column#auto_incremented_by_db?
   override isAutoIncrementedByDb(): boolean {
     return this.isSerial || this.isIdentity;

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -89,10 +89,9 @@ export class Column extends BaseColumn {
    * Mirrors `PostgreSQL::Column#hash` (`postgresql/column.rb:72-77`), which
    * folds `identity?` and `serial?` in on top of `super`.
    * @internal
-   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
-   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
-   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
-   *   port needs an explicit string key over exactly those attributes.
+   * Ruby's registry is a Hash keyed by the object itself, which works because
+   * Rails pairs `==`/`eql?` with `hash`; a JS `Map` keys by identity, so the
+   * port needs an explicit string key over exactly those attributes.
    */
   override deduplicateKey(): string {
     return JSON.stringify([super.deduplicateKey(), this.isIdentity, this.isSerial]);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
@@ -138,6 +138,7 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
+      dumper.supportsVirtualColumns = mockAdapter.supportsVirtualColumns();
       const col = new Column(
         "computed",
         null,
@@ -162,6 +163,7 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
+      dumper.supportsVirtualColumns = mockAdapter.supportsVirtualColumns();
       const col = new Column(
         "status",
         null,
@@ -185,6 +187,7 @@ describe("PostgreSQL::SchemaDumper", () => {
         supportsVirtualColumns: () => false,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
+      dumper.supportsVirtualColumns = mockAdapter.supportsVirtualColumns();
       const col = new Column(
         "computed",
         null,
@@ -216,6 +219,7 @@ describe("PostgreSQL::SchemaDumper", () => {
   describe("schemaTypeWithVirtual", () => {
     it("returns virtual for generated (stored) PG columns", () => {
       const dumper = SchemaDumper.create(emptySource) as any;
+      dumper.supportsVirtualColumns = true;
       const col = new Column(
         "computed",
         null,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -38,8 +38,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
     const spec = super.prepareColumnOptions(column as any);
     if (column.array) spec["array"] = true;
 
-    const adapter = this.pgAdapter();
-    if (adapter?.supportsVirtualColumns?.() && this._isVirtual(column)) {
+    if (this.supportsVirtualColumns && this._isVirtual(column)) {
       spec["as"] = this.extractExpressionForVirtualColumn(column);
       spec["stored"] = true;
       // enum_type must be set before the early return — Rails adds it after the virtual
@@ -137,7 +136,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
 
   /** @internal */
   protected override schemaTypeWithVirtual(column: ColumnInfo): string {
-    if (this._isVirtual(column)) return "virtual";
+    if (this.supportsVirtualColumns && this._isVirtual(column)) return "virtual";
     return this.schemaType(column);
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-introspection.trails.test.ts
@@ -30,6 +30,22 @@ describe("SQLite3Adapter schema introspection", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("shares one frozen Column instance between structurally identical columns", async () => {
+    // Rails' `Deduplicable::ClassMethods#new` (`deduplicable.rb:13-14`) sends
+    // every `Column.new` through the registry (`deduplicable.rb:18`), so two
+    // columns equal by `Column#==`/`#hash` (`column.rb:75`/`:87`) reflect as one
+    // frozen object. trails fires that hook at `new_column_from_field`.
+    await adapter.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY, label TEXT)");
+    await adapter.executeMutation("CREATE TABLE memberships (id INTEGER PRIMARY KEY, label TEXT)");
+
+    const widgetLabel = (await adapter.columns("widgets")).find((c) => c.name === "label");
+    const membershipLabel = (await adapter.columns("memberships")).find((c) => c.name === "label");
+
+    expect(widgetLabel).toBeDefined();
+    expect(membershipLabel).toBe(widgetLabel);
+    expect(Object.isFrozen(widgetLabel)).toBe(true);
+  });
+
   it("tables returns user-created tables, hiding sqlite_* internals", async () => {
     await adapter.executeMutation("CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
     expect(await adapter.tables()).toEqual(["widgets"]);

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -61,7 +61,6 @@ export class Column extends BaseColumn {
     return JSON.stringify([super.deduplicateKey(), this.isAutoIncrement(), this.rowid]);
   }
 
-
   /** Mirrors: SQLite3::Column#auto_increment? (`sqlite3/column.rb:18-20`) */
   isAutoIncrement(): boolean {
     return this._autoIncrement;

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -53,10 +53,9 @@ export class Column extends BaseColumn {
    * `auto_increment?` AND `rowid` in on top of `super` — `rowid` is in the hash
    * but not in `==` (`sqlite3/column.rb:47-51`).
    * @internal
-   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
-   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
-   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
-   *   port needs an explicit string key over exactly those attributes.
+   * Ruby's registry is a Hash keyed by the object itself, which works because
+   * Rails pairs `==`/`eql?` with `hash`; a JS `Map` keys by identity, so the
+   * port needs an explicit string key over exactly those attributes.
    */
   override deduplicateKey(): string {
     return JSON.stringify([super.deduplicateKey(), this.isAutoIncrement(), this.rowid]);

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -48,6 +48,21 @@ export class Column extends BaseColumn {
     this._generatedType = options.generatedType ?? null;
   }
 
+  /**
+   * Mirrors `SQLite3::Column#hash` (`sqlite3/column.rb:53-58`), which folds
+   * `auto_increment?` AND `rowid` in on top of `super` — `rowid` is in the hash
+   * but not in `==` (`sqlite3/column.rb:47-51`).
+   * @internal
+   * @noRailsEquivalent PERMANENT — Ruby's `Deduplicable` registry is a Hash
+   *   keyed by the object itself, which works because Rails pairs `==`/`eql?`
+   *   with `hash` (`column.rb:75`/`:87`). A JS `Map` keys by identity, so the
+   *   port needs an explicit string key over exactly those attributes.
+   */
+  override deduplicateKey(): string {
+    return JSON.stringify([super.deduplicateKey(), this.isAutoIncrement(), this.rowid]);
+  }
+
+
   /** Mirrors: SQLite3::Column#auto_increment? (`sqlite3/column.rb:18-20`) */
   isAutoIncrement(): boolean {
     return this._autoIncrement;

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.trails.test.ts
@@ -248,8 +248,13 @@ describe("SQLite3::SchemaStatements", () => {
     });
 
     it("marks generated stored columns", () => {
+      // Distinct column name from the virtual case above: `Column.new` now goes
+      // through the Deduplicable registry (`deduplicable.rb:13-18`), and
+      // `SQLite3::Column#==`/`#hash` (`sqlite3/column.rb:47-58`) do not fold in
+      // `@generated_type`, so two columns identical but for generated-ness
+      // collapse onto one instance — verified against real Rails.
       const field = {
-        name: "full_name",
+        name: "stored_full_name",
         type: "varchar",
         notnull: 0,
         dflt_value: null,

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -228,6 +228,14 @@ export function newColumnFromField(
 
   const rowid = isColumnTheRowid(field, definitions);
 
+  // Rails' `Deduplicable::ClassMethods#new` (`deduplicable.rb:13-14`) wraps
+  // `Column.new` itself, so every constructed column goes through the registry
+  // (`deduplicable.rb:18`). TS cannot mirror that on the class: a base
+  // constructor returning the deduplicated instance freezes it before the
+  // subclass assigns its own fields, so `new SQLite3::Column(...)` would throw
+  // `Cannot add property _generatedType, object is not extensible`. Ruby has no
+  // such split — `new` wraps allocate+initialize for the most-derived class —
+  // so the hook fires here instead, on the fully-built object.
   return new Column(
     String(field["name"]),
     defaultValue,
@@ -243,7 +251,7 @@ export function newColumnFromField(
       rowid,
       generatedType,
     },
-  );
+  ).deduplicate();
 }
 
 const INTEGER_REGEX = /integer/i;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -799,13 +799,6 @@ export abstract class SchemaDumper {
     // authoritative PK column order before iterating columns so `emitTable` /
     // `resolvePrimaryKeyColumns` render composite/promoted keys in key order.
     const adapter = this._adapter();
-    // Rails reads `@connection.supports_virtual_columns?` inline inside
-    // `schema_type_with_virtual` (abstract/schema_dumper.rb:47). In trails that
-    // predicate is async (it awaits `databaseVersion`), and the column-spec
-    // chain below it is synchronous — `emitTable` is also reached from the
-    // sync mock-source dump path, which raises on any Promise. So the answer is
-    // resolved once here, at the one async point above the emitter, and read
-    // synchronously where Ruby reads the connection.
     if (adapter && typeof adapter.supportsVirtualColumns === "function") {
       try {
         this.supportsVirtualColumns = await adapter.supportsVirtualColumns();
@@ -1022,8 +1015,14 @@ export abstract class SchemaDumper {
   protected abstract isExplicitPrimaryKeyDefault(column: Column): boolean;
 
   /**
-   * The `@connection.supports_virtual_columns?` answer (abstract/schema_dumper.rb:47),
-   * resolved once in `table()` because trails' predicate is async.
+   * The `@connection.supports_virtual_columns?` answer, which Rails reads inline
+   * inside `schema_type_with_virtual` (abstract/schema_dumper.rb:47).
+   *
+   * trails' predicate is async (it awaits `databaseVersion`) while the
+   * column-spec chain below it is synchronous — `emitTable` is also reached from
+   * the sync mock-source dump path, which raises on any Promise. So the answer
+   * is resolved once in `table()`, the one async point above the emitter, and
+   * read synchronously where Ruby reads the connection.
    * @internal
    */
   protected supportsVirtualColumns = false;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -1025,8 +1025,6 @@ export abstract class SchemaDumper {
    * The `@connection.supports_virtual_columns?` answer (abstract/schema_dumper.rb:47),
    * resolved once in `table()` because trails' predicate is async.
    * @internal
-   * @noRailsEquivalent CONVERGEABLE — Rails reads the connection predicate
-   *   inline; trails' is async and the emitter chain is sync.
    */
   protected supportsVirtualColumns = false;
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -799,6 +799,20 @@ export abstract class SchemaDumper {
     // authoritative PK column order before iterating columns so `emitTable` /
     // `resolvePrimaryKeyColumns` render composite/promoted keys in key order.
     const adapter = this._adapter();
+    // Rails reads `@connection.supports_virtual_columns?` inline inside
+    // `schema_type_with_virtual` (abstract/schema_dumper.rb:47). In trails that
+    // predicate is async (it awaits `databaseVersion`), and the column-spec
+    // chain below it is synchronous — `emitTable` is also reached from the
+    // sync mock-source dump path, which raises on any Promise. So the answer is
+    // resolved once here, at the one async point above the emitter, and read
+    // synchronously where Ruby reads the connection.
+    if (adapter && typeof adapter.supportsVirtualColumns === "function") {
+      try {
+        this.supportsVirtualColumns = await adapter.supportsVirtualColumns();
+      } catch {
+        this.supportsVirtualColumns = false;
+      }
+    }
     if (adapter && typeof adapter.primaryKeys === "function") {
       try {
         this.primaryKeyOrderCache[table] = await adapter.primaryKeys(table);
@@ -1006,6 +1020,15 @@ export abstract class SchemaDumper {
 
   /** @internal */
   protected abstract isExplicitPrimaryKeyDefault(column: Column): boolean;
+
+  /**
+   * The `@connection.supports_virtual_columns?` answer (abstract/schema_dumper.rb:47),
+   * resolved once in `table()` because trails' predicate is async.
+   * @internal
+   * @noRailsEquivalent CONVERGEABLE — Rails reads the connection predicate
+   *   inline; trails' is async and the emitter chain is sync.
+   */
+  protected supportsVirtualColumns = false;
 
   /** @internal */
   protected abstract schemaTypeWithVirtual(column: Column): string;


### PR DESCRIPTION
Four RFC 0112 / 0077 / 0119 convergence stories, all in ActiveRecord.

### `CollectionProxy`'s `@association` seat (RFC 0112)

Rails is handed its association and holds it in `@association`
(`collection_proxy.rb:31-35`); `target` (:33), `loaded?` (:53) and `delete_all`
(:474-476) are the same one ivar read. trails had two spellings: `_association`,
whose constructor `else` arm synthesized a `new CollectionAssociation(record,
assocDef)` for a declared singular name — an association the owner does not
hold, is not registered on the owner, and whose reflection is not wired — and
`_collectionAssociation()`, which re-looked the association up through the owner.

The synthesized arm is gone, the seat holds the association the owner holds, and
`_collectionAssociation()` is gone too: once the seat collapsed it was a pure
alias, so every mutation now reads the ivar directly as Rails reads
`@association`.

**The dropped call that made the old scratch seat load-bearing.**
`_associateRecordsToOwner` kept only the collection arm of
`Preloader::Association#associate_records_to_owner`
(`preloader/association.rb:245-256`) — it always wrote an Array. Rails branches
on `reflection.collection?` and writes `records.first` for a singular reflection
(:253-255). That omission was invisible while the proxy handed a singular name a
synthesized scratch association to absorb the array writes; with the seat now the
owner's real association it wrote an Array into a has_one :through target and
reddened `associations.test.ts > preload with available records with through
association` on all three lanes. Both arms are restored.

PR #7038 tried the other direction (collapsing the lookup onto the synthesized
seat) and reddened `inverse-associations.test.ts > has_one createBang stores a
single record as target, not an array`. That test is green here, as are
`associations/` (115 files), `associations.test.ts`, autosave and
nested-attributes — 2556 tests.

### `quote_default_expression` (RFC 0077)

Rails has one body (`abstract/quoting.rb:157-164`) that the PG
(`postgresql/quoting.rb:156-167`) and SQLite (`sqlite3/quoting.rb:99-110`)
overrides reach with `super`. trails had two — the standalone module function and
a hand-written duplicate on `AbstractAdapter`, which had already drifted apart
once. The adapter method is now a one-line delegation to the module function, the
settled trails shape for a module method mixed onto the adapter.

### `Column` and the `Deduplicable` registry (RFC 0119)

`Column` overrode the mixin with `deduplicate() { return this.deduplicated(); }`,
never touching the registry, so every reflected column was a distinct object
where Rails shares one frozen instance. It now implements `deduplicateKey()` over
exactly the attributes `Column#==` / `Column#hash` compare
(`column.rb:75`/`:87`) and routes `deduplicate()` through the shared registry
path (`deduplicable.rb:18`); `deduplicated()` freezes (`deduplicable.rb:26`).
The PostgreSQL and SQLite3 subclasses extend the key with what their own `hash`
folds in (`postgresql/column.rb:72`, `sqlite3/column.rb:53` — including `rowid`,
which its `==` does not compare). Four regression tests cover it; the first fails
on baseline.

The absorbed MySQL/PostgreSQL `TypeMetadata` half of that story was already done
on `main` — neither class carries a `deduplicate` override any more and neither
baseline row exists.

Ruby's `-string` interning in `Column#deduplicated` (`column.rb:104-112`) has
nothing to call in JS: strings are already immutable.

### Abstract dumper column specs (RFC 0119)

- `schemaTypeWithVirtual` consults `supports_virtual_columns?`
  (`abstract/schema_dumper.rb:46-52`) instead of testing `column.virtual` alone.
- `schemaLimit` compares against
  `native_database_types[column.type][:limit]` (`rb:62-65`) instead of the
  invented `isSerial` guard, whose comment claimed the comparison was
  unavailable.
- `schemaDefault`'s guard was already `hasDefault` alone (converged by #7035);
  no change was needed.

trails' `supportsVirtualColumns()` is async (it awaits `databaseVersion`) while
the column-spec chain below it is synchronous — `emitTable` is also reached from
the sync mock-source dump path, which raises on any Promise. So the answer is
resolved once in `table()`, the one async point above the emitter, and read
synchronously where Ruby reads the connection. This also fixes a latent bug in
the PG dumper, which tested `adapter?.supportsVirtualColumns?.()` — always
truthy, being a Promise.

### Not in this PR

`arel-assertion-mark-to-zero` was released back to the queue. Its real size is
135 mismatches across 45 files plus a 427-assertion extra sweep, not the ~200 LOC
the story estimates — several times this PR's ceiling on its own.

### Gates

`parity:api:calls` OK (363 baselined, no new rows). `parity:api:calls:args` OK
(141 baselined shape rows, no new rows). `parity:api:extra:gate` OK — activerecord
sits exactly on its mark (novel 385/385, total 1392/1392), arel 0/0 and 62/62.
`parity:test:assertions` OK. `pnpm lint` and `pnpm typecheck` clean. 197 LOC.

No baseline row was added or widened by this PR.

---

## Review rounds

**Round 1 — three findings, all fixed.**

1. **`CollectionProxy` degenerating for a singular name.** Confirmed by probe
   before fixing: `SingularAssociation` and `CollectionAssociation` are siblings
   under `Association`, and six of six collection-only methods threw (`size`,
   `isEmpty`, `toArray`, `isInclude`, `destroyAll`, `deleteAll`). Took the Rails
   invariant — `CollectionProxy`'s only construction site upstream is
   `CollectionAssociation#reader` (`collection_association.rb:34-41`), so
   `association()` refuses a singular reflection and points the caller at
   `record.association(name)` (`associations.rb:288-294`). Both offending call
   sites corrected; one converges on Rails in the process
   (`associations_test.rb:1337`).

   Worth recording: a first guard branched on `AssociationDefinition.macro` and
   **silently never fired** — `macro` is optional on the raw declaration,
   carried only by the rich reflection. The suite went green with the bug live.
   The shipped guard tests `isCollection()`, Rails' `reflection.collection?`.

2. **Column dedup not wired into construction.** Fixed at all three
   `new_column_from_field` ports.

   I reverted this once, on the theory that collapsing two columns differing
   only in generated-ness was a trails bug. **That theory was wrong**, and the
   revert was over-cautious. Verified against real Rails (ruby 3.3.11, vendored
   source): `SQLite3::Column.new(..., generated_type: :virtual)` and `:stored`
   are `==`, share a `hash`, and come back as the *same frozen object* from the
   registry, with `virtual_stored?` false on both — because
   `sqlite3/column.rb:47-58` folds in `auto_increment?` and `rowid` but not
   `@generated_type`. trails now mirrors that.

   The hook cannot live on the class, and this is a genuine language
   shortcoming rather than a preference: a base constructor returning the
   deduplicated instance freezes it *before* the subclass assigns its own
   fields, so `new SQLite3::Column(...)` throws `Cannot add property
   _generatedType, object is not extensible` (verified). Ruby has no such split
   — `new` wraps allocate+initialize for the most-derived class. Cited at each
   call site.

   Two SQLite unit tests shared the column name `full_name`, which real
   introspection cannot produce for two different columns; the stored case takes
   its own name so each still asserts its own behaviour. **No test name
   changed.** `sqlite3-introspection.trails.test.ts` gains an end-to-end
   assertion through `adapter.columns()` that two structurally identical
   reflected columns are the same frozen instance; it fails on baseline.

3. **Stale JSDoc above `_association`.** Deleted.

**Round 2 — clean.** No open comments, no new findings.

**Post-review polish.** `schema_limit`'s `native_database_types` lookup was
split into a `_nativeTypeLimit` helper Rails does not have; Rails inlines it
(`abstract/schema_dumper.rb:62-65`), so it is inlined now and the helper is
gone.
