### PR TITLE
refactor(activerecord): retire CollectionProxy's anonymous-inline reflection fallback; route add_constraints' referenced-joins arm through Merger

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1,4 +1,3 @@
-import { isPlainObject } from "@blazetrails/activesupport";
 import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
 import type { Base } from "../base.js";
@@ -7,9 +6,8 @@ import { RuntimeReflection } from "../reflection.js";
 import { AliasTracker, aliasedArelTableForReflection } from "./alias-tracker.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
-import { JoinDependency } from "./join-dependency.js";
 import { WhereClause } from "../relation/where-clause.js";
-import { constructJoinDependency, structuralUnionEq } from "../relation/query-methods.js";
+import { constructJoinDependency } from "../relation/query-methods.js";
 import { drop } from "../ruby-drop.js";
 
 /**
@@ -708,96 +706,26 @@ export class AssociationScope {
               []) as unknown[]
           ).length > 0
         ) {
-          // Rails: `scope.merge! item.only(:joins, :left_outer_joins)`, then
+          // Rails: `scope.merge! item.only(:joins, :left_outer_joins)` then
           // `associations = item.eager_load_values | item.includes_values` and
           // `scope.joins! item.construct_join_dependency(associations,
-          // OuterJoin)` (association_scope.rb:139-146). A through scope such as
-          // `-> { where("comments.id" => nil).includes(:comments) }` relies on
-          // this to actually JOIN comments; without it the WHERE references a
-          // missing table.
+          // Arel::Nodes::OuterJoin)` (association_scope.rb:139-146). A through
+          // scope such as `-> { where("comments.id" => nil).includes(:comments) }`
+          // relies on this to actually JOIN comments; without it the WHERE
+          // references a missing table.
           //
-          // `merge!` routes the named `joins` / `left_outer_joins` through
-          // Merger#merge_joins / #merge_outer_joins (merger.rb:118-150), which
-          // branch on `other.model == relation.model`: when the item's klass
-          // equals the target scope's klass the names union directly into
-          // `joins_values` / `left_outer_joins_values`; otherwise a cross-klass
-          // JoinDependency is built against the ITEM and stashed. Both branches
-          // are mirrored here (the same split Relation::Merger implements) so a
-          // same-klass entry — e.g. a self-through whose chain entry resolves to
-          // the association's own target — folds its join names in for the
-          // receiver to resolve rather than pre-building a JD.
+          // `merge!` is what routes the named `joins` / `left_outer_joins`
+          // through `Merger#merge_joins` / `#merge_outer_joins`
+          // (merger.rb:116-152) — the same-model union and the cross-model
+          // partition + `construct_join_dependency` both live there, ported once.
+          (scope as { mergeBang: (other: unknown) => unknown }).mergeBang(
+            (item as { only: (...onlies: string[]) => unknown }).only("joins", "leftOuterJoins"),
+          );
+
           const itemValues = item as {
-            joinsValues?: unknown[];
-            leftOuterJoinsValues?: unknown[];
             includesValues?: unknown[];
             eagerLoadValues?: unknown[];
-            _model?: typeof Base;
           };
-          const target = scope as {
-            joinsValues: unknown[];
-            leftOuterJoinsValues: unknown[];
-            _model?: typeof Base;
-          };
-          const sameKlass = itemValues._model !== undefined && itemValues._model === target._model;
-          // merger.rb:123-126 — `other.joins_values.partition { |join| case join
-          // when Hash, Symbol, Array; true end }`: association specs on one
-          // side, raw SQL / Arel nodes and stashed JoinDependencies on the other.
-          const namedInner: unknown[] = [];
-          const others: unknown[] = [];
-          for (const v of itemValues.joinsValues ?? []) {
-            if (
-              isPlainObject(v) ||
-              Array.isArray(v) ||
-              (typeof v === "string" && v.startsWith(":"))
-            ) {
-              namedInner.push(v);
-            } else {
-              others.push(v);
-            }
-          }
-          for (const v of others) target.joinsValues = [...target.joinsValues, v];
-          if (namedInner.length > 0) {
-            if (sameKlass) {
-              for (const v of namedInner)
-                if (!target.joinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
-                  target.joinsValues = [...target.joinsValues, v];
-            } else {
-              target.joinsValues = [
-                ...target.joinsValues,
-                constructJoinDependency.call(
-                  itemValues as never,
-                  namedInner as never,
-                  Nodes.InnerJoin,
-                ),
-              ];
-            }
-          }
-          const namedLeft = (itemValues.leftOuterJoinsValues ?? []).filter(
-            (v) => !(v instanceof JoinDependency),
-          );
-          const leftDeps = (itemValues.leftOuterJoinsValues ?? []).filter(
-            (v) => v instanceof JoinDependency,
-          );
-          if (namedLeft.length > 0) {
-            if (sameKlass) {
-              for (const v of namedLeft)
-                if (
-                  !target.leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v))
-                )
-                  target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, v];
-            } else {
-              target.leftOuterJoinsValues = [
-                ...target.leftOuterJoinsValues,
-                constructJoinDependency.call(
-                  itemValues as never,
-                  namedLeft as never,
-                  Nodes.OuterJoin,
-                ),
-              ];
-            }
-          }
-          target.leftOuterJoinsValues = [...target.leftOuterJoinsValues, ...leftDeps];
-          // associations = eager_load_values | includes_values → OuterJoin.
           // Rails' `|` unions with dedup, so an association named in BOTH
           // eager_load and includes yields a single JoinDependency entry (not a
           // double join).
@@ -808,14 +736,13 @@ export class AssociationScope {
             ]),
           ];
           if (associations.length > 0) {
-            target.leftOuterJoinsValues = [
-              ...target.leftOuterJoinsValues,
+            (scope as { joinsBang: (...values: unknown[]) => unknown }).joinsBang(
               constructJoinDependency.call(
                 itemValues as never,
                 associations as never,
                 Nodes.OuterJoin,
               ),
-            ];
+            );
           }
         }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -134,7 +134,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private _association!: CollectionAssociation;
   private _assocName: string;
-  private _assocDef: AssociationDefinition;
   // Rails' `CollectionProxy` holds no target of its own — `target`, `loaded?`
   // and `@replaced_or_added_targets` all read `@association`
   // (collection_proxy.rb:33, 53). trails keeps that direction: these accessors
@@ -255,19 +254,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Mirrors Rails' `Association#reflection` (association.rb:16), which is the
    * rich `AssociationReflection` the constructor was handed off the owner's
-   * class (`associations.rb:290-296`). The proxy is built from the thin macro
-   * definition, so the reader resolves the reflection here — once — instead of
-   * every rich-predicate call site re-resolving `_reflectOnAssociation`. An
-   * anonymous inline association has no registered reflection; it falls back to
-   * the macro definition.
+   * class (`associations.rb:290-296`). Every macro declaration registers one
+   * (`associations.ts:704,723,742,813`, beside the `_associations` push the
+   * proxy is built from), so there is no reflection-less association to fall
+   * back for.
    * @internal
    */
   get reflection(): AssociationDefinition {
     const ctor = this._record.constructor as typeof Base;
-    return (
-      (ctor._reflectOnAssociation?.(this._assocName) as AssociationDefinition | null) ??
-      this._assocDef
-    );
+    return ctor._reflectOnAssociation(this._assocName) as unknown as AssociationDefinition;
   }
 
   /**
@@ -278,7 +273,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private get _callbackHost(): CallbackHost {
     return {
       owner: this._record,
-      reflection: this._assocDef,
+      reflection: this.reflection,
       callback: assocCallback,
       callbacksFor: assocCallbacksFor,
     };
@@ -362,7 +357,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     super(targetModel, targetModel.arelTable);
     this._record = record;
     this._assocName = assocName;
-    this._assocDef = assocDef;
     const instance = record.association(assocName) as unknown as CollectionAssociation;
     this._association = instance.isCollection()
       ? instance
@@ -432,7 +426,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    */
   private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
     const { _buildAssociationInstance } = await import("./instance-methods.js");
-    const assoc = _buildAssociationInstance.call(this._record, this._assocDef) as unknown as {
+    const assoc = _buildAssociationInstance.call(this._record, this.reflection) as unknown as {
       _queryExecutor?: () => Promise<Base[]>;
       findTarget(): Promise<Base[]>;
     };
@@ -662,7 +656,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * callbacks all land on this proxy too.
    */
   async push(...records: T[]): Promise<Omit<this, "then"> | false> {
-    if (this._assocDef.options.through) {
+    if (this.reflection.options.through) {
       await this._pushThrough(records);
       return stripThenable(this._proxySelf ?? this);
     }
@@ -920,7 +914,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Convergence story: 0106-wide-call-set-direct-burndown/
     // djar-eager-chain-ids-drop-disable-joins-arms.
     if (this.isNullScope()) return this.scope().pluck(...columnNames);
-    if (this._assocDef.options.disableJoins) {
+    if (this.reflection.options.disableJoins) {
       return this.scope().pluck(...columnNames);
     }
     return super.pluck(...columnNames);
@@ -1121,7 +1115,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Convergence story: 0106-wide-call-set-direct-burndown/
     // djar-eager-chain-ids-drop-disable-joins-arms.
     if (this.isNullScope()) return this.scope().calculate(operation, columnName);
-    if (this._assocDef.options.disableJoins) {
+    if (this.reflection.options.disableJoins) {
       return this.scope().calculate(operation, columnName);
     }
     return super.calculate(operation, columnName);


### PR DESCRIPTION
Two RFC 0112 convergences in `activerecord/associations`.

## `CollectionProxy#reflection` — the `?? this._assocDef` fallback is unreachable

Rails' `Association#reflection` (`association.rb:16`) is handed the rich
reflection off the owner's class (`associations.rb:290-296`) and has no
fallback. trails' getter kept one for an "anonymous inline association with no
registered reflection" — but there is no such thing: every `_associations` push
happens inside `BelongsToBuilder`/`HasOne`/`HasMany`/`Habtm`'s
`createReflection` (`builder/association.ts:139`), and each of the four macro
entry points pairs it with `Reflection.addReflection`
(`associations.ts:704,723,742,813`). `associationProxy` resolves `assocDef` out
of that same `_associations` list, so `_reflectOnAssociation(name)` on the
owner's class always answers.

The arm and the `_assocDef` field are deleted together; its five remaining
reads (`_callbackHost`, `_buildAssociationInstance`, the `options.through` and
two `options.disableJoins` branches) go through `reflection`.
`_buildAssociationInstance` already dispatches on `assocDef.macro ?? assocDef.type`
(`instance-methods.ts:35`), so the rich reflection lands in the same arms.

## `add_constraints`' referenced-joins arm reimplemented `Merger`

The `!item.references_values.empty?` branch (`association-scope.ts`) carried its
own copy of `Merger#merge_joins` / `#merge_outer_joins` (`merger.rb:116-152`):
an `itemValues._model === target._model` same-model test, a
Hash/Symbol/Array partition into `namedInner`/`others`, and its own
`constructJoinDependency` on both the inner and outer side. Those bodies are
already ported, once, onto `Merger` itself (`merger.ts:168`, `:201`) — including
the `structuralUnionEq` union (`merger.rb:121`) the copy did with reference
identity, and the `joinsBang(joinDependency, ...others)` union
(`merger.rb:137`) it had no counterpart for.

The arm is now Rails' own two lines (`association_scope.rb:139-146`):

```ts
scope.mergeBang(item.only("joins", "leftOuterJoins"));
const associations = [...new Set([...eagerLoadValues, ...includesValues])];
if (associations.length > 0) scope.joinsBang(constructJoinDependency(associations, Nodes.OuterJoin));
```

`merge!` is what routes the two named keys through the `Merger` methods. This
also restores Rails' `scope.joins!` for the eager/includes JoinDependency — the
trails copy pushed it into `leftOuterJoinsValues`.

## Already in main

`converge-ids-eager-arm-onto-apply-join-dependency` is done: `applyJoinDependency`
(`relation.ts:1715`) carries no `_eagerLoadingForSql()` early return and mirrors
`finder_methods.rb:456-488`, `ids`' eager arm is
`applyJoinDependency({}, (relation) => relation.group(...primaryKeyArray).ids())`
(`calculations.ts:775`) with the `DIVERGENCE` comment gone, and `pluck`'s eager
arm collapsed onto the same call (`calculations.ts:625`). Landed by #6634;
marked done against that PR and not included here.

## Verification

- `packages/activerecord/src/associations/` — 115 files, 2048 passed.
- `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
  `pnpm parity:api:extra:gate` OK. No baseline row added.

Closes-story: converge-collection-proxy-anonymous-inline-reflection-guards
Closes-story: converge-merge-referenced-joins-onto-merge-joins-folders