### PR TITLE
refactor(activerecord,activesupport): one SchemaDumper#tables body, EncryptedFile's Marshal serializer (RFC 0112)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -235,10 +235,8 @@ export class SchemaDumper extends AbstractSchemaDumper {
    */
   override async table(tableName: string, stream: string[]): Promise<void> {
     await super.table(tableName, stream);
-    if (stream[stream.length - 1] === "") stream.pop();
     await this.exclusionConstraintsInCreate(tableName, stream);
     await this.uniqueConstraintsInCreate(tableName, stream);
-    stream.push("");
   }
 
   /**

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -45,6 +45,33 @@ describe("SchemaDumper trails-only cases", () => {
     expect(output).toContain(`() => "gen_random_uuid()"`);
   });
 
+  it("schema dump separates tables with one blank line and ends the last table without one", async () => {
+    const { SchemaDumper: TopLevelDumper } =
+      await import("./connection-adapters/abstract/schema-dumper.js");
+    const columns = [{ name: "id", type: "integer", primaryKey: true }];
+
+    const one = (
+      await TopLevelDumper.dump({
+        tables: () => ["books"],
+        columns: () => columns,
+        indexes: () => [],
+        lookupCastTypeFromColumn: () => new ValueType(),
+      })
+    ).join("\n");
+    expect(one).not.toContain("});\n\n}");
+
+    const two = (
+      await TopLevelDumper.dump({
+        tables: () => ["authors", "books"],
+        columns: () => columns,
+        indexes: () => [],
+        lookupCastTypeFromColumn: () => new ValueType(),
+      })
+    ).join("\n");
+    expect(two).toContain('});\n\n  await ctx.createTable("books"');
+    expect(two).not.toContain("});\n\n}");
+  });
+
   it("schema dump round-trips PG range/network/bit-varying types via DSL helpers", async () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -41,7 +41,7 @@ describe("SchemaDumper trails-only cases", () => {
       indexes: () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
-    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
+    const output = (await TopLevelDumper.dump(source)).join("\n");
     expect(output).toContain(`() => "gen_random_uuid()"`);
   });
 
@@ -72,7 +72,7 @@ describe("SchemaDumper trails-only cases", () => {
       indexes: () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
-    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
+    const output = (await TopLevelDumper.dump(source)).join("\n");
     for (const helper of [
       "int4range",
       "int8range",
@@ -109,7 +109,7 @@ describe("SchemaDumper trails-only cases", () => {
       indexes: () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
-    const output = (TopLevelDumper.dump(source) as string[]).join("\n");
+    const output = (await TopLevelDumper.dump(source)).join("\n");
     // Regression guard against collapsing to the `enum` fallback. timestamptz/
     // interval/oid resolve to their TableDefinition helpers (`t.timestamptz`/
     // `t.interval`/`t.oid`); uuid has no helper and round-trips through the

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -596,7 +596,7 @@ export abstract class SchemaDumper {
           (typeof createDialectDumper === "function"
             ? (createDialectDumper.call(pool, options) as SchemaDumper | undefined | null)
             : undefined) ?? this.create(source, options);
-        return dumper.dump(stream) as Promise<string[]>;
+        return dumper.dump(stream);
       })();
     }
     if (isConnectionPool(pool)) {
@@ -634,45 +634,13 @@ export abstract class SchemaDumper {
     return stream.join("\n");
   }
 
-  dump(stream: string[] = []): string[] | Promise<string[]> {
+  async dump(stream: string[] = []): Promise<string[]> {
     this.header(stream);
-    const schemasResult = this.schemas(stream);
-    // Run header sections sequentially to preserve deterministic output order
-    // (schemas → extensions → types). If any section is async, chain the rest.
-    if (schemasResult instanceof Promise) {
-      return schemasResult
-        .then(() => this.extensions(stream))
-        .then(() => this.types(stream))
-        .then(() => this._finalizeDump(stream));
-    }
-    const extensionsResult = this.extensions(stream);
-    if (extensionsResult instanceof Promise) {
-      return extensionsResult.then(() => this.types(stream)).then(() => this._finalizeDump(stream));
-    }
-    const typesResult = this.types(stream);
-    if (typesResult instanceof Promise) {
-      return typesResult.then(() => this._finalizeDump(stream));
-    }
-    return this._finalizeDump(stream);
-  }
-
-  /** @internal */
-  private _finalizeDump(stream: string[]): string[] | Promise<string[]> {
-    const result = this.tables(stream);
-    if (result instanceof Promise) {
-      return result.then(async () => {
-        await this.virtualTables(stream);
-        this.trailer(stream);
-        return stream;
-      });
-    }
-    const vtResult = this.virtualTables(stream);
-    if (vtResult instanceof Promise) {
-      return vtResult.then(() => {
-        this.trailer(stream);
-        return stream;
-      });
-    }
+    await this.schemas(stream);
+    await this.extensions(stream);
+    await this.types(stream);
+    await this.tables(stream);
+    await this.virtualTables(stream);
     this.trailer(stream);
     return stream;
   }
@@ -709,55 +677,26 @@ export abstract class SchemaDumper {
     stream.push("}");
   }
 
-  private tables(stream: string[]): void | Promise<void> {
-    const tableNames = this._source.tables();
-    if (tableNames instanceof Promise) {
-      return tableNames.then(async (raw) => {
-        const sortedTables = [...raw].sort();
+  private async tables(stream: string[]): Promise<void> {
+    const sortedTables = [...(await this._source.tables())].sort();
 
-        const notIgnoredTables = sortedTables.filter((tableName) => !this.isIgnored(tableName));
+    const notIgnoredTables = sortedTables.filter((tableName) => !this.isIgnored(tableName));
 
-        for (const tableName of notIgnoredTables) {
-          await this.table(tableName, stream);
-        }
-
-        // dump foreign keys at the end to make sure all dependent tables exist.
-        if (this._fkHookHost() !== undefined) {
-          const foreignKeysStream: string[] = [];
-          for (const tbl of notIgnoredTables) {
-            await this.foreignKeys(tbl, foreignKeysStream);
-          }
-
-          for (const line of foreignKeysStream) stream.push(line);
-        }
-      });
+    for (const [index, tableName] of notIgnoredTables.entries()) {
+      await this.table(tableName, stream);
+      if (index < notIgnoredTables.length - 1) stream.push("");
     }
-    const sorted = [...tableNames].sort();
-    for (const tableName of sorted) {
-      if (this.isIgnored(tableName)) continue;
-      const columns = this._source.columns(tableName);
-      const indexes = this._source.indexes(tableName);
-      if (columns instanceof Promise || indexes instanceof Promise) {
-        throw new TypeError(
-          "SchemaSource.columns()/indexes() returned a Promise while tables() was synchronous. " +
-            "Use the async schema dumper path (make tables() return a Promise) or ensure all schema methods are synchronous.",
-        );
+
+    // dump foreign keys at the end to make sure all dependent tables exist.
+    if (this._fkHookHost() !== undefined) {
+      const foreignKeysStream: string[] = [];
+      for (const tbl of notIgnoredTables) {
+        await this.foreignKeys(tbl, foreignKeysStream);
       }
-      const adapterTableOpts = this.fetchTableOptions(tableName);
-      if (adapterTableOpts instanceof Promise) {
-        void adapterTableOpts.catch(() => {});
-        throw new TypeError(
-          "fetchTableOptions() returned a Promise while tables() was synchronous. " +
-            "Use the async schema dumper path (make tables() return a Promise) or ensure all schema methods are synchronous.",
-        );
-      }
-      this.tableName = tableName;
-      try {
-        this.emitTable(stream, tableName, columns, indexes, adapterTableOpts);
-        stream.push("");
-      } finally {
-        this.tableName = undefined;
-      }
+
+      if (foreignKeysStream.length > 0) stream.push("");
+
+      for (const line of foreignKeysStream) stream.push(line);
     }
   }
 
@@ -880,7 +819,6 @@ export abstract class SchemaDumper {
       const remaining = await this.gatherInlineConstraints(table, inlineLines);
       this.emitTable(stream, table, columns, indexes, adapterTableOpts, inlineLines);
       if (remaining && remaining.length > 0) stream.push("", ...remaining);
-      stream.push("");
     } finally {
       this.tableName = undefined;
     }

--- a/packages/activesupport/src/encrypted-file.test.ts
+++ b/packages/activesupport/src/encrypted-file.test.ts
@@ -204,8 +204,8 @@ describe("EncryptedFileTest", () => {
 
   // Rails exercises `Messages::Codec.with(default_serializer: :marshal/:json)`
   // to flip a global serializer across an encrypt/decrypt boundary and
-  // assert the envelope still round-trips. Our port hardcodes
-  // `NullSerializer` (Rails uses Marshal) and exposes serializer choice
+  // assert the envelope still round-trips. Our port hardcodes the `marshal`
+  // serializer, as Rails does, and exposes serializer choice
   // per-MessageEncryptor — there is no global flip-able state, so the
   // "changing" half of this scenario does not apply. Until `Codec.with` is
   // ported, the test reduces to the basic round-trip the name promises.

--- a/packages/activesupport/src/encrypted-file.ts
+++ b/packages/activesupport/src/encrypted-file.ts
@@ -12,15 +12,12 @@
  *
  * - **Async API.** Rails is sync; the async surface is required for
  *   trailties' "async fs only" rule and for browser hosts without sync fs.
- * - **Default serializer = `NullSerializer`** (raw string in/out). Rails
- *   uses `Marshal`; we have no Marshal port. The higher-level
- *   `EncryptedConfiguration` parses contents itself.
  * - **Env lookup goes through `processAdapter.env`**, not `process.env`.
  */
 
 import { getCrypto } from "./crypto-adapter.js";
 import { getFsAsync, getPathAsync } from "./fs-adapter.js";
-import { MessageEncryptor, NullSerializer } from "./message-encryptor.js";
+import { MessageEncryptor } from "./message-encryptor.js";
 import { env as processEnv } from "./process-adapter.js";
 import { chomp } from "./string-utils.js";
 import { Tempfile } from "./tempfile.js";
@@ -187,15 +184,17 @@ export class EncryptedFile {
   /**
    * @missingRailsArgs new — PERMANENT. encrypted_file.rb:113
    *   `MessageEncryptor.new([key].pack("H*"), cipher: CIPHER, serializer: Marshal)`
-   *   — `Buffer.from(key, "hex")` is the `pack("H*")`, and Ruby's `Marshal` has
-   *   no JS equivalent: the file body is already a string, so trails passes
-   *   `NullSerializer`, the settled substitute.
+   *   — `Buffer.from(key, "hex")` is the `pack("H*")`, and Ruby's `Marshal`
+   *   constant is spelled here as the `"marshal"` format key, which is how the
+   *   whole package names the trails Marshal-equivalent
+   *   (`messages/serializer-with-fallback.ts`). Ruby's Marshal wire format is
+   *   excluded project-wide in `scripts/api-compare/unported-files.ts`.
    */
   private async encryptor(): Promise<MessageEncryptor> {
     if (this.memoEncryptor) return this.memoEncryptor;
     this.memoEncryptor = new MessageEncryptor(Buffer.from((await this.key()) ?? "", "hex"), {
       cipher: CIPHER,
-      serializer: NullSerializer,
+      serializer: "marshal",
     });
     return this.memoEncryptor;
   }


### PR DESCRIPTION
Two of a four-story RFC 0112 bundle. The other two were already converged on
`main` and are marked done against the PRs that did the work:
`converge-no-touching-block-onto-apply-to` (#6722 — `apply_to` owns the
push/pop and `no_touching` delegates) and
`execution-context-store-is-process-global-not-async-scoped` (#6734 — the
private `store` reader is ported over `IsolatedExecutionState`).

## SchemaDumper#tables — one body

`schema_dumper.rb:134-155` has a single body. The port had two: an async branch
and a synchronous fast path for mock sources that re-implemented the table walk
inline — never calling `table()`, so it silently skipped `filterIndexesForDump`,
`gatherInlineConstraints` and the foreign keys, and threw two bespoke
`TypeError`s with no Rails counterpart.

`tables()` is now Rails' body verbatim: `sortedTables`, `notIgnoredTables`, the
indexed `table()` loop, and the `supports_foreign_keys?` block over
`foreignKeysStream`. `dump()` collapses with it — the `_finalizeDump`
continuation existed only to thread the sync/async fork, and is now
`schema_dumper.rb:70-77`'s straight-line body.

Absorbed `converge-schema-dumper-section-blank-lines`: `table()` no longer
pushes a trailing `""`. The separator is
`stream.puts if index < not_ignored_tables.count - 1` (`:141`) and the pre-FK
blank is `stream.puts if foreign_keys_string.length > 0` (`:150`), so a
single-table dump and an empty-FK dump gain the Rails shape instead of relying
on the two deviations cancelling out. The PG `table()` override drops the
pop/re-push it needed to work around the trailing blank; MySQL's override needed
no change.

The three trails-only dumper cases that drove a plain-object source now `await`
the dump like every other caller in the repo.

## EncryptedFile#encryptor — `serializer: Marshal`

`encrypted_file.rb:113` passes `serializer: Marshal`; the port passed
`NullSerializer`. trails already has the Marshal-equivalent — the `"marshal"`
format in `messages/serializer-with-fallback.ts`, backed by `cache/coder.ts`
behind Rails' `\x04\x08` signature, which is how the rest of activesupport
spells the constant. `encryptor()` passes that, and the `NullSerializer` bullet
leaves the file header. Ruby's Marshal wire format itself stays excluded
project-wide (`scripts/api-compare/unported-files.ts`), so the remaining
`@missingRailsArgs` records only the spelling, not a missing port.

## Verification

`schema-dumper.test.ts` (40 passed), `schema-dumper.trails.test.ts` (22),
`abstract/schema-dumper.trails.test.ts`, `mysql/schema-dumper.trails.test.ts`,
`adapters/sqlite3/virtual-table.test.ts`, `sqlite3/collation.test.ts`,
`primary-keys.test.ts`, `defaults.test.ts`, `date-time-precision.test.ts`,
`time-precision.test.ts`, `connection-pool.trails.test.ts`,
`activerecord-cli/db-tasks.test.ts`, `encrypted-file.test.ts`,
`encrypted-configuration.test.ts` — all green. `parity:api:calls` and
`parity:api:calls:args` both OK, no new baseline rows.

Closes-story: converge-schema-dumper-tables-single-body
Closes-story: encrypted-file-serializer-marshal-not-nullserializer
