### PR TITLE
fix(scripts): drop the landed-story pointer from PACKAGES_OUTSIDE_MANIFEST

### DIFF
--- a/scripts/api-compare/config.ts
+++ b/scripts/api-compare/config.ts
@@ -159,7 +159,7 @@ export const MANIFEST_PACKAGES = [
  * A rule that demands a `@noRailsEquivalent` receipt for an `@internal` tag
  * with no manifest backing MUST subtract these: for them "no Rails counterpart"
  * and "not covered by the manifest" are the same state, so it has no basis to
- * ask. Tracked by `rails-privates-manifest-missing-gem-packages` (RFC 0121).
+ * ask.
  */
 export const PACKAGES_OUTSIDE_MANIFEST = ["date", "html-sanitizer", "activerecord-cli"] as const;
 


### PR DESCRIPTION
Unit Tests went red on `main` at 8e8fcd60 on `scripts/stale-story-references.test.ts`:

```
+   "scripts/api-compare/config.ts:149 rails-privates-manifest-missing-gem-packages",
```

## Root cause

#7042 (eaf9008bd) closed story `rails-privates-manifest-missing-gem-packages` **and**, in the same PR, added a ``Tracked by `rails-privates-manifest-missing-gem-packages` (RFC 0121)`` pointer to the `PACKAGES_OUTSIDE_MANIFEST` doc comment in `scripts/api-compare/config.ts`. A landed story counts as stale the moment it is marked done, so the citation was stale by construction — the guard only surfaced it on the next full run.

The pointer is also obsolete on the merits: that story added `rack`, `globalid`, `i18n` and `did-you-mean` to `MANIFEST_PACKAGES`, and the three packages the comment describes (`date`, `html-sanitizer`, `activerecord-cli`) are permanently outside the manifest for the reason the comment itself states — there is no Ruby source for the privates projection to run over. They are not tracked debt, so there is nothing left to point at.

## Fix

Delete the stale sentence. No behavioral change; `PACKAGES_OUTSIDE_MANIFEST` itself is untouched.

`pnpm vitest run scripts/stale-story-references.test.ts` → 17 passed.

Closes-story: red-8e8fcd60
