### PR TITLE
refactor(activerecord): AssociationRelation _new/_create under scoping, the real find_target? gate, and InsertAll's constructor tail (RFC 0112)

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -44,8 +44,16 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * returns the plain `Association` instance when this relation was built
    * by `Association#targetScope()` for internal scope merging.
    */
-  get proxyAssociation(): CollectionProxy<T> | Association {
-    return this._association;
+  get proxyAssociation(): Association {
+    // Rails' `@association` is always the `Association` itself; trails' seat
+    // holds the owner's `CollectionProxy` on the user-facing path, so unwrap it
+    // here — `Association#scope`'s
+    // `klass.current_scope.proxy_association == self` branch
+    // (association.rb:110) compares against the association.
+    const association = this._association as CollectionProxy<T> & {
+      proxyAssociation?: Association;
+    };
+    return association.proxyAssociation ?? (this._association as Association);
   }
 
   /**
@@ -115,28 +123,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Build an unsaved associated record. Merges the relation's scope
-   * attributes (e.g. `where(title: "X")` → `{ title: "X" }`) with the
-   * caller's attrs, then delegates to the association so the FK (and, for
-   * polymorphic, the `*_type`) is set and the record is pushed onto the
-   * loaded target.
-   *
-   * Mirrors: ActiveRecord::AssociationRelation#_new / #build
-   */
-  build(attrs: Record<string, unknown>[], block?: (r: T) => void): T[];
-  build(attrs?: Record<string, unknown>, block?: (r: T) => void): T;
-  build(
-    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
-    block?: (r: T) => void,
-  ): T | T[] {
-    if (Array.isArray(attrs)) {
-      return attrs.map((a) => this.build(a, block));
-    }
-    const merged = { ...this.scopeForCreate(), ...attrs };
-    return (this._association as CollectionProxy<T>).build(merged, block);
-  }
-
-  /**
    * Find the first record matching the current scope, or build one (unsaved).
    * Routes build through the association so the FK and polymorphic type are
    * set even when the owner is unsaved (no FK in the where clause).
@@ -150,64 +136,33 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Build and persist an associated record through the owning association.
-   *
-   * Mirrors: ActiveRecord::AssociationRelation#_create / #create
+   * Mirrors: ActiveRecord::AssociationRelation#_new (association_relation.rb:31-33).
+   * The `scoping {}` wrap lives in `Relation#build` (relation.rb:125-132), so
+   * `Association#scope` sees this relation as the current scope while the
+   * record is built.
    */
-  async create(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
-  async create(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
-  async create(
-    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
-    block?: (r: T) => void,
-  ): Promise<T | T[]> {
-    if (Array.isArray(attrs)) {
-      const records: T[] = [];
-      for (const a of attrs) records.push(await this.create(a, block));
-      return records;
-    }
-    const merged = { ...this.scopeForCreate(), ...attrs };
-    // `_association` is the owner's `CollectionProxy` when this relation was
-    // spawned off the proxy, and the OO association when it came from
-    // `Association#scope` (the `delegate(*QueryMethods, to: :scope)` path,
-    // collection_proxy.rb:1128-1137). `HasManyThroughAssociation#build_record`
-    // reads the in-flight scope back off the owner's cached proxy, so resolve
-    // that proxy here rather than stamping the association object.
-    const assoc = this._association as unknown as {
-      owner?: { _collectionProxies?: Map<string, unknown> };
-      reflection?: { name: string };
-    };
-    const proxy = (assoc.owner?._collectionProxies?.get(assoc.reflection?.name ?? "") ??
-      this._association) as CollectionProxy<T> & { _pendingThroughScope?: unknown };
-    const prev = proxy._pendingThroughScope;
-    proxy._pendingThroughScope = this;
-    try {
-      return await proxy.create(merged, block);
-    } finally {
-      proxy._pendingThroughScope = prev;
-    }
+  protected override _new(attributes: Record<string, unknown>): T {
+    return (this._association as CollectionProxy<T>).build(attributes);
   }
 
   /**
-   * Build and persist an associated record, raising on validation failure.
-   * Delegates to `CollectionProxy#createBang`, which throws `RecordInvalid`
-   * directly so FK + loaded-target wiring stay in sync with the non-bang
-   * path.
-   *
-   * Mirrors: ActiveRecord::AssociationRelation#_create! / #create!
+   * Mirrors: ActiveRecord::AssociationRelation#_create (association_relation.rb:35-37).
    */
-  async createBang(attrs: Record<string, unknown>[], block?: (r: T) => void): Promise<T[]>;
-  async createBang(attrs?: Record<string, unknown>, block?: (r: T) => void): Promise<T>;
-  async createBang(
-    attrs: Record<string, unknown> | Record<string, unknown>[] = {},
-    block?: (r: T) => void,
-  ): Promise<T | T[]> {
-    if (Array.isArray(attrs)) {
-      const records: T[] = [];
-      for (const a of attrs) records.push(await this.createBang(a, block));
-      return records;
-    }
-    const merged = { ...this.scopeForCreate(), ...attrs };
-    return (this._association as CollectionProxy<T>).createBang(merged, block);
+  protected override _create(
+    attributes: Record<string, unknown>,
+    block?: (record: T) => void,
+  ): Promise<T> {
+    return (this._association as CollectionProxy<T>).create(attributes, block);
+  }
+
+  /**
+   * Mirrors: ActiveRecord::AssociationRelation#_create! (association_relation.rb:39-41).
+   */
+  protected override _createBang(
+    attributes: Record<string, unknown>,
+    block?: (record: T) => void,
+  ): Promise<T> {
+    return (this._association as CollectionProxy<T>).createBang(attributes, block);
   }
 
   /**

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -41,15 +41,13 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * reflection (`proxy_association.reflection`).
    *
    * Returns `CollectionProxy<T>` for user-facing association relations;
-   * returns the plain `Association` instance when this relation was built
-   * by `Association#targetScope()` for internal scope merging.
+   * Rails' `@association` is always the `Association` itself, while trails'
+   * `_association` seat holds the owner's `CollectionProxy` on the user-facing
+   * path — so the proxy is unwrapped here, and `Association#scope`'s
+   * `klass.current_scope.proxy_association == self` branch
+   * (association.rb:110) compares against the association as in Rails.
    */
   get proxyAssociation(): Association {
-    // Rails' `@association` is always the `Association` itself; trails' seat
-    // holds the owner's `CollectionProxy` on the user-facing path, so unwrap it
-    // here — `Association#scope`'s
-    // `klass.current_scope.proxy_association == self` branch
-    // (association.rb:110) compares against the association.
     const association = this._association as CollectionProxy<T> & {
       proxyAssociation?: Association;
     };
@@ -141,8 +139,8 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * `Association#scope` sees this relation as the current scope while the
    * record is built.
    */
-  protected override _new(attributes: Record<string, unknown>): T {
-    return (this._association as CollectionProxy<T>).build(attributes);
+  protected override _new(attributes: Record<string, unknown>, block?: (record: T) => void): T {
+    return (this._association as CollectionProxy<T>).build(attributes, block);
   }
 
   /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -32,7 +32,6 @@ import type { Association as AssociationInstance } from "./associations/associat
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
 export { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
 import {
-  underscore,
   constantize,
   registerConstant,
   unregisterConstant,
@@ -45,10 +44,7 @@ import { HasOne as HasOneBuilder } from "./associations/builder/has-one.js";
 import { HasMany as HasManyBuilder } from "./associations/builder/has-many.js";
 import { HasAndBelongsToMany as HabtmBuilder } from "./associations/builder/has-and-belongs-to-many.js";
 import * as Reflection from "./reflection.js";
-import type { AssociationReflection } from "./reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
-import { foreignKeyPresentFor } from "./associations/foreign-association.js";
-import { ThroughAssociation } from "./associations/through-association.js";
 
 /**
  * **Rails parity note:** Rails' `Associations.eager_load!` uses Ruby's
@@ -1247,77 +1243,6 @@ export function syncToAssociationInstance(record: Base, assocName: string, resul
     return;
   }
   holder._setTargetFromLoader(result as Base | Base[] | null);
-}
-
-/**
- * Whether a lazy load would actually reach `find_target` — and therefore
- * `violates_strict_loading?`. Rails gates the strict-loading check inside
- * `find_target`, which `find_target?` only enters under macro-specific rules:
- *
- *   - has_one/has_many/habtm (`Association#find_target?`, association.rb:320):
- *     `!loaded? && (!owner.new_record? || foreign_key_present?) && klass` — a
- *     persisted owner always reaches it; a *new* owner only when the FK is
- *     present.
- *   - belongs_to (`BelongsToAssociation#find_target?`,
- *     belongs_to_association.rb:124): `!loaded? && foreign_key_present? && klass`
- *     — there is NO new-record short-circuit; the owner-side FK must be present
- *     even for a persisted owner. (Mirrors the OO belongs_to override of
- *     `findTargetNeeded` in belongs-to-association.ts.)
- *
- * So a strict-loading owner that never reaches `find_target` returns nil/[]
- * silently. This returns false for exactly those cases so callers can skip the
- * violation, matching `find_target?` / `null_scope?`.
- *
- * `foreign_key_present?` has the same two-branch dispatch used by the OO
- * association (`CollectionAssociation#foreignKeyPresent`, which the proxy's
- * `null_scope?` delegates to): a belongs_to reads the
- * owner-side FK columns; a `:through` routes through its belongs_to
- * (`ThroughAssociation#foreign_key_present?`); a vanilla has_one/has_many/habtm
- * requires the owner's `active_record_primary_key`
- * (`ForeignAssociation#foreign_key_present?`).
- *
- * @internal
- */
-export function _findTargetReachable(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-  kind: "belongsTo" | "foreign",
-): boolean {
-  if (kind === "belongsTo") {
-    return _associationForeignKeyPresent(record, assocName, options, kind);
-  }
-  if (!record.isNewRecord()) return true;
-  return _associationForeignKeyPresent(record, assocName, options, kind);
-}
-
-function _associationForeignKeyPresent(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-  kind: "belongsTo" | "foreign",
-): boolean {
-  const ctor = record.constructor as typeof Base;
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  if (options.through) {
-    // No association instance here, so the module's `self` is an owner /
-    // reflection pair that inherits the module — Ruby reaches
-    // `foreign_key_present?` off the association it always has in hand.
-    return reflection
-      ? ThroughAssociation.foreignKeyPresent.call({
-          ...ThroughAssociation,
-          owner: record,
-          reflection,
-        })
-      : false;
-  }
-  if (kind === "belongsTo") {
-    const fk = options.foreignKey ?? options.queryConstraints;
-    const fkNames =
-      typeof fk === "string" ? [fk] : Array.isArray(fk) ? fk : [`${underscore(assocName)}_id`];
-    return fkNames.every((name) => record._readAttribute(name) != null);
-  }
-  return reflection ? foreignKeyPresentFor(reflection as AssociationReflection, record) : false;
 }
 
 /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -425,6 +425,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * behind the proxy's back.
    */
   private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
+    // `CollectionAssociation#load_target` reaches `find_target` only through
+    // `find_target?` (collection_association.rb:272-279, association.rb:190):
+    // a new-record owner without the foreign key present leaves `@target`
+    // unassigned rather than querying — and so never reaches `find_target`'s
+    // `violates_strict_loading?` raise (association.rb:248-250). The predicate
+    // is read off the owner's own holder, whose rich reflection answers
+    // `active_record_primary_key`; the load itself still runs on a fresh holder
+    // for the reason above.
+    if (
+      !queryExecutor &&
+      !(
+        this._collectionAssociation() as unknown as { findTargetNeeded(): boolean }
+      ).findTargetNeeded()
+    ) {
+      return [];
+    }
     const { _buildAssociationInstance } = await import("./instance-methods.js");
     const assoc = _buildAssociationInstance.call(this._record, this.reflection) as unknown as {
       _queryExecutor?: () => Promise<Base[]>;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -418,21 +418,20 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Runs `find_target` (`association.rb:248`) on a freshly built holder for
-   * this proxy's definition rather than on `record.association(name)`: this
-   * proxy IS the owner's holder for that name, so loading through the cached
-   * one would suppress the loader's writeback into it and mark it loaded
-   * behind the proxy's back.
+   * Runs `load_target` (`collection_association.rb:272-279`) for this proxy:
+   * `find_target?` (`association.rb:190`) decides whether to query at all — a
+   * new-record owner without the foreign key present leaves `@target`
+   * unassigned rather than querying, and so never reaches `find_target`'s
+   * `violates_strict_loading?` raise (`association.rb:248-250`).
+   *
+   * The predicate is read off the owner's own holder, whose rich reflection
+   * answers `active_record_primary_key`; `find_target` itself then runs on a
+   * freshly built holder rather than on `record.association(name)`, because
+   * this proxy IS the owner's holder for that name and loading through the
+   * cached one would suppress the loader's writeback into it and mark it
+   * loaded behind the proxy's back.
    */
   private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
-    // `CollectionAssociation#load_target` reaches `find_target` only through
-    // `find_target?` (collection_association.rb:272-279, association.rb:190):
-    // a new-record owner without the foreign key present leaves `@target`
-    // unassigned rather than querying — and so never reaches `find_target`'s
-    // `violates_strict_loading?` raise (association.rb:248-250). The predicate
-    // is read off the owner's own holder, whose rich reflection answers
-    // `active_record_primary_key`; the load itself still runs on a fresh holder
-    // for the reason above.
     if (
       !queryExecutor &&
       !(

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -2,7 +2,6 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   _builtAssociationScope,
-  _findTargetReachable,
   _inlineOwnerKey,
   _inlinePolymorphicKeys,
   _ownerChainReflection,
@@ -590,10 +589,10 @@ async function findTarget(
     }
   }
 
-  // `Association#find_target`'s first statement (association.rb:248-250). Gated
-  // by `find_target?`: a new-record owner without the FK present never reaches
-  // `find_target` and so never raises.
-  if (violatesStrictLoading && _findTargetReachable(record, assocName, options, "foreign")) {
+  // `Association#find_target`'s first statement (association.rb:248-250). The
+  // `find_target?` gate is `Association#loadTarget`'s (association.rb:190), so
+  // the raise itself is unconditional as in Rails.
+  if (violatesStrictLoading) {
     const ctor = record.constructor as typeof Base;
     const reflection = ctor._reflectOnAssociation?.(assocName);
     if (!reflection) throw new AssociationNotFoundError(record, assocName);

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -254,18 +254,9 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     block?: (record: Base) => void,
   ): Base | null {
     this.ensureNotNested();
-    // Rails captures `scope` here inside the caller's `scoping` block, so a
-    // scoped build (`post.people.where(readers: { skimmer: true }).create`)
-    // sees the relation's values. trails carries that relation on the owner's
-    // proxy as `_pendingThroughScope` (association-relation.ts:153) instead of
-    // a current-scope stack, so prefer it when one is in flight.
-    const pendingThroughScope = (
-      this.owner._collectionProxies.get(this.reflection.name) as
-        | { _pendingThroughScope?: unknown }
-        | undefined
-    )?._pendingThroughScope;
-    (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope =
-      pendingThroughScope ?? (this as unknown as { scope?: () => unknown }).scope?.();
+    (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope = (
+      this as unknown as { scope?: () => unknown }
+    ).scope?.();
     try {
       // Rails' `super` lands in `ThroughAssociation#build_record`
       // (through_association.rb:116-129) first; the module is not in the TS

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -18,6 +18,15 @@ import { runCallbacks } from "@blazetrails/activesupport";
  * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation
  */
 export class HasManyThroughAssociation extends HasManyAssociation {
+  /**
+   * Rails' `@through_scope` (`has_many_through_association.rb:69`, exposed by
+   * `attr_reader :through_scope`): the association scope captured for the
+   * duration of `build_record`, which `through_scope_attributes` reads
+   * (`has_many_through_association.rb:71-77`).
+   * @internal
+   */
+  _throughScope?: unknown;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
   }
@@ -254,9 +263,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     block?: (record: Base) => void,
   ): Base | null {
     this.ensureNotNested();
-    (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope = (
-      this as unknown as { scope?: () => unknown }
-    ).scope?.();
+    this._throughScope = this.scope();
     try {
       // Rails' `super` lands in `ThroughAssociation#build_record`
       // (through_association.rb:116-129) first; the module is not in the TS
@@ -264,12 +271,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       throughBuildRecord(this, (attributes ??= {}));
       const record = super.buildRecord(attributes, block);
       if (!record) return record;
-      const built = buildThroughInverseFor(
-        this.owner,
-        this.reflection,
-        record,
-        (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope,
-      );
+      const built = buildThroughInverseFor(this.owner, this.reflection, record, this._throughScope);
       if (built) {
         const inverseAssoc = (
           record as unknown as { association?: (n: string) => any }
@@ -296,7 +298,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       }
       return record;
     } finally {
-      (this as HasManyThroughAssociation & { _throughScope?: unknown })._throughScope = null;
+      this._throughScope = null;
     }
   }
 

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -2,7 +2,6 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
   _builtAssociationScope,
-  _findTargetReachable,
   _ownerChainReflection,
   _routeThroughViaAssociationScope,
   _loadSingularViaStatementCache,
@@ -293,12 +292,9 @@ export class SingularAssociation extends Association {
       if (this.disableJoins) return this.scope().first();
 
       // `Association#find_target`'s first statement (association.rb:248-250).
-      // Gated by `find_target?`: a new-record owner without the key present never
-      // reaches `find_target` and so never raises.
-      if (
-        this.isViolatesStrictLoading() &&
-        _findTargetReachable(owner, assocName, options, isBelongsTo ? "belongsTo" : "foreign")
-      ) {
+      // The `find_target?` gate is `Association#loadTarget`'s
+      // (association.rb:190), so the raise itself is unconditional as in Rails.
+      if (this.isViolatesStrictLoading()) {
         strictLoadingViolationBang({ owner: owner.constructor, reflection });
       }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -57,14 +57,13 @@ interface ResolvedConnectionFacts {
   indexes: (tableName: string) => unknown[];
 }
 
-const EMPTY_CONNECTION_FACTS: ResolvedConnectionFacts = {
-  supportsInsertReturning: false,
-  supportsInsertConflictTarget: false,
-  primaryKeys: [],
-  indexes: () => [],
-};
-
 /**
+ * Resolves the facts above off the connection and schema cache. A missing
+ * support predicate reads as unsupported, matching Rails'
+ * `AbstractAdapter#supports_insert_conflict_target?` returning false, so a
+ * wrapper adapter that forgets to delegate cannot emit a bogus conflict
+ * target.
+ *
  * @noRailsEquivalent The async half of `ResolvedConnectionFacts` above.
  * @internal
  */
@@ -73,11 +72,6 @@ async function resolveConnectionFacts(
   connection: any,
 ): Promise<ResolvedConnectionFacts> {
   const cache = connection.schemaCache;
-  const tableName = model.arelTable.name;
-  // Default to unsupported when a predicate is missing — matches Rails'
-  // `AbstractAdapter#supports_insert_conflict_target?` returning false, so a
-  // wrapper adapter that forgets to delegate doesn't silently fall through and
-  // emit a bogus conflict target.
   const supportsInsertReturning =
     typeof connection.supportsInsertReturning === "function"
       ? await connection.supportsInsertReturning()
@@ -86,12 +80,9 @@ async function resolveConnectionFacts(
     typeof connection.supportsInsertConflictTarget === "function"
       ? await connection.supportsInsertConflictTarget()
       : false;
-  // Rails: `Array(@model.schema_cache.primary_keys(model.table_name))`
-  // (insert_all.rb:61) — the *database* primary keys, not the model's
-  // attribute-derived `primary_key`.
   let primaryKeys: string[] = [];
   if (cache && typeof cache.primaryKeys === "function") {
-    const pk = await cache.primaryKeys(tableName);
+    const pk = await cache.primaryKeys(model.arelTable.name);
     if (pk != null) primaryKeys = Array.isArray(pk) ? pk : [pk];
   }
   const indexesByTable = new Map<string, unknown[]>();
@@ -146,6 +137,10 @@ export class InsertAll {
   }
 
   /**
+   * `facts` carries what Rails' constructor tail (insert_all.rb:38-45) reads
+   * synchronously off the connection and schema cache; see
+   * `ResolvedConnectionFacts`.
+   *
    * @missingRailsArgs except — PERMANENT: Ruby's `scope_for_create.except(col)`
    * is a receiver-form call; JS objects have no `except`, so the activesupport
    * port takes the receiver as its first argument and the argument list is one
@@ -156,7 +151,7 @@ export class InsertAll {
     connection: ModelClass["connection"],
     inserts: Record<string, unknown>[],
     options: InsertAllOptions = {},
-    facts: ResolvedConnectionFacts = EMPTY_CONNECTION_FACTS,
+    facts: ResolvedConnectionFacts,
   ) {
     this._facts = facts;
     this.model = (relation as any)._model as ModelClass;
@@ -200,7 +195,6 @@ export class InsertAll {
 
     this.verifyAttributeNamesAreKnown();
 
-    // insert_all.rb:38-45 — the constructor tail, in Rails' order.
     if (this.returning === undefined) {
       this.returning = facts.supportsInsertReturning ? this.primaryKeys() : false;
     }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -87,13 +87,12 @@ async function resolveConnectionFacts(
     const pk = await cache.primaryKeys(model.arelTable.name);
     if (pk != null) primaryKeys = Array.isArray(pk) ? pk : [pk];
   }
-  const indexesByTable = new Map<string, unknown[]>();
-  if (cache) indexesByTable.set(model.tableName, await cache.indexes(model.tableName));
+  const indexes: unknown[] = cache ? await cache.indexes(model.tableName) : [];
   return {
     supportsInsertReturning,
     supportsInsertConflictTarget,
     primaryKeys,
-    indexes: (name: string) => indexesByTable.get(name) ?? [],
+    indexes: (name: string) => (name === model.tableName ? indexes : []),
   };
 }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -37,6 +37,73 @@ export interface InsertAllOptions {
   recordTimestamps?: boolean;
 }
 
+/**
+ * The connection and schema-cache facts Rails' `InsertAll#initialize` reads
+ * synchronously at `insert_all.rb:38-45` — `supports_insert_returning?`,
+ * `supports_insert_conflict_target?`, `schema_cache.primary_keys(table_name)`
+ * and `schema_cache.indexes(table_name)`. Every one of those is async in
+ * trails, so `InsertAll.execute` resolves them before constructing and the
+ * constructor body stays the pure assignment Rails' is.
+ *
+ * @noRailsEquivalent A genuine TypeScript shortcoming: a constructor cannot
+ *   await. Resolving in the async factory keeps the Rails-named constructor
+ *   tail in place rather than deferring it to `execute`.
+ * @internal
+ */
+interface ResolvedConnectionFacts {
+  supportsInsertReturning: boolean;
+  supportsInsertConflictTarget: boolean;
+  primaryKeys: string[];
+  indexes: (tableName: string) => unknown[];
+}
+
+const EMPTY_CONNECTION_FACTS: ResolvedConnectionFacts = {
+  supportsInsertReturning: false,
+  supportsInsertConflictTarget: false,
+  primaryKeys: [],
+  indexes: () => [],
+};
+
+/**
+ * @noRailsEquivalent The async half of `ResolvedConnectionFacts` above.
+ * @internal
+ */
+async function resolveConnectionFacts(
+  model: ModelClass,
+  connection: any,
+): Promise<ResolvedConnectionFacts> {
+  const cache = connection.schemaCache;
+  const tableName = model.arelTable.name;
+  // Default to unsupported when a predicate is missing — matches Rails'
+  // `AbstractAdapter#supports_insert_conflict_target?` returning false, so a
+  // wrapper adapter that forgets to delegate doesn't silently fall through and
+  // emit a bogus conflict target.
+  const supportsInsertReturning =
+    typeof connection.supportsInsertReturning === "function"
+      ? await connection.supportsInsertReturning()
+      : false;
+  const supportsInsertConflictTarget =
+    typeof connection.supportsInsertConflictTarget === "function"
+      ? await connection.supportsInsertConflictTarget()
+      : false;
+  // Rails: `Array(@model.schema_cache.primary_keys(model.table_name))`
+  // (insert_all.rb:61) — the *database* primary keys, not the model's
+  // attribute-derived `primary_key`.
+  let primaryKeys: string[] = [];
+  if (cache && typeof cache.primaryKeys === "function") {
+    const pk = await cache.primaryKeys(tableName);
+    if (pk != null) primaryKeys = Array.isArray(pk) ? pk : [pk];
+  }
+  const indexesByTable = new Map<string, unknown[]>();
+  if (cache) indexesByTable.set(model.tableName, await cache.indexes(model.tableName));
+  return {
+    supportsInsertReturning,
+    supportsInsertConflictTarget,
+    primaryKeys,
+    indexes: (name: string) => indexesByTable.get(name) ?? [],
+  };
+}
+
 export class InsertAll {
   readonly model: ModelClass;
   readonly connection: ModelClass["connection"];
@@ -58,15 +125,8 @@ export class InsertAll {
   private scopeAttributes: Record<string, unknown>;
   private _recordTimestamps: boolean;
   private _updatableColumns: string[] | undefined;
-  private _uniqueByResolved = false;
   private _keysIncludingTimestamps: Set<string> | undefined;
-  // Resolved from schema_cache.primary_keys(table_name) during the async
-  // _populateUpdatableColumns pass; undefined until then. See primaryKeys().
-  private _schemaCachePrimaryKeys: string[] | undefined;
-  // True when `returning` was auto-defaulted to the primary keys (Rails:
-  // `@returning = primary_keys if @returning == true`), so it can be
-  // re-resolved to the schema-cache value once that's available.
-  private _returningDefaulted = false;
+  private _facts: ResolvedConnectionFacts;
 
   static async execute(
     relation: Relation<any>,
@@ -74,18 +134,18 @@ export class InsertAll {
     options: InsertAllOptions = {},
   ): Promise<Result> {
     const model = (relation as any)._model as ModelClass;
-    return withConnection.call(model as any, (c: any) =>
-      new InsertAll(relation, c, inserts, options).execute(),
+    return withConnection.call(model as any, async (c: any) =>
+      new InsertAll(
+        relation,
+        c,
+        inserts,
+        options,
+        await resolveConnectionFacts(model, c),
+      ).execute(),
     ) as Promise<Result>;
   }
 
   /**
-   * @missingRailsCall find_unique_index_for — PERMANENT: Language shortcoming: Rails
-   * resolves `@unique_by` here (insert_all.rb:42) off a synchronous
-   * `schema_cache.indexes`; that read is async in trails, so the call rides
-   * the deferral in `_populateUpdatableColumns()`, which every path awaits
-   * before anything reads `uniqueBy`.
-   *
    * @missingRailsArgs except — PERMANENT: Ruby's `scope_for_create.except(col)`
    * is a receiver-form call; JS objects have no `except`, so the activesupport
    * port takes the receiver as its first argument and the argument list is one
@@ -96,7 +156,9 @@ export class InsertAll {
     connection: ModelClass["connection"],
     inserts: Record<string, unknown>[],
     options: InsertAllOptions = {},
+    facts: ResolvedConnectionFacts = EMPTY_CONNECTION_FACTS,
   ) {
+    this._facts = facts;
     this.model = (relation as any)._model as ModelClass;
     this.connection = connection;
     this.inserts = inserts.map((r) => ({ ...r }));
@@ -137,14 +199,20 @@ export class InsertAll {
     }
 
     this.verifyAttributeNamesAreKnown();
+
+    // insert_all.rb:38-45 — the constructor tail, in Rails' order.
+    if (this.returning === undefined) {
+      this.returning = facts.supportsInsertReturning ? this.primaryKeys() : false;
+    }
+    if (Array.isArray(this.returning) && this.returning.length === 0) this.returning = false;
+
+    this.uniqueBy = this.findUniqueIndexFor(this.uniqueBy);
+
     this.configureOnDuplicateUpdateLogic();
+    this.ensureValidOptionsForConnectionBang();
   }
 
   async execute(): Promise<Result> {
-    // Resolve uniqueBy before the empty-batch shortcut so the Rails guard
-    // (insert_all.rb#initialize validates uniqueBy in the constructor before
-    // any inserts.empty? check) still fires on upsertAll([], { uniqueBy }).
-    await this._populateUpdatableColumns();
     if (isEmpty(this.inserts)) return Result.empty();
     // Mirrors Rails InsertAll#execute: build the log/instrumentation label
     // ("Book Bulk Insert" / "Book Upsert") and route through exec_insert_all
@@ -165,88 +233,24 @@ export class InsertAll {
     return this.connection.buildInsertSql(new Builder(this));
   }
 
+  /** Mirrors: ActiveRecord::InsertAll#updatable_columns (insert_all.rb:58-60). */
   updatableColumns(): string[] {
-    return this._updatableColumns ?? [];
-  }
-
-  /** @internal Async init: resolves uniqueByColumns via cache.indexes() then finalizes updatableColumns. */
-  private async _populateUpdatableColumns(): Promise<void> {
-    // Rails resolves @unique_by synchronously in the constructor (line 42 of
-    // insert_all.rb), before configure_on_duplicate_update_logic. Our port
-    // defers it because schema-cache reads are async — but it must still
-    // run on every path so updateOnly + uniqueBy still gets validated and
-    // index.where flows through to conflictTarget.
-    // Resolve the database primary keys from the schema cache (Rails'
-    // `primary_keys` is `Array(schema_cache.primary_keys(table_name))`) before
-    // anything reads primaryKeys(), so readonlyColumns and the Builder's
-    // conflict target see the schema-cache value rather than the model's
-    // configured primary key. findUniqueIndexFor still reads model.primaryKey
-    // directly for its `unique_by || model.primary_key` match.
-    if (this._schemaCachePrimaryKeys === undefined) {
-      this._schemaCachePrimaryKeys = await this.dbPrimaryKeys();
-      // Rails runs this in the constructor (`insert_all.rb:38`), keyed off
-      // `@returning.nil?`; `supports_insert_returning?` is async here, so it
-      // rides the same deferral `@unique_by` already takes and `returning`
-      // stays undefined — Ruby's nil — until now.
-      if (this.returning === undefined) {
-        const supportsReturning =
-          typeof (this.connection as any).supportsInsertReturning === "function"
-            ? await (this.connection as any).supportsInsertReturning()
-            : false;
-        this.returning = supportsReturning ? this.primaryKeys() : false;
-        this._returningDefaulted = supportsReturning;
-      }
-      if (this._returningDefaulted) {
-        // Rails: `@returning = primary_keys` then `@returning = false if
-        // @returning == []` (insert_all.rb:39-40). For an id-less table the
-        // schema-cache primary keys are [], so RETURNING is dropped entirely
-        // rather than emitting a bare `RETURNING ""`.
-        const pks = this.primaryKeys();
-        this.returning = pks.length > 0 ? pks : false;
-      }
-    }
-    if (!this._uniqueByResolved) {
-      this.uniqueBy = await this.findUniqueIndexFor(this.uniqueBy);
-      this._uniqueByResolved = true;
-      await this.ensureValidOptionsForConnectionBang();
-    }
-    if (this._updatableColumns) return;
     const exclude = new Set([...this.readonlyColumns(), ...this.uniqueByColumns()]);
-    this._updatableColumns = [...this.keys].filter((k) => !exclude.has(k));
-    // Mirrors Rails' elsif branch: only coerce "update"→"skip" on the auto-generated
-    // update path. Custom SQL (updateSql) and explicit updateOnly are handled earlier
-    // in configureOnDuplicateUpdateLogic and must not be overridden here.
-    if (
-      this.onDuplicate === "update" &&
-      !this.updateSql &&
-      !isPresent(this.updateOnly) &&
-      isEmpty(this._updatableColumns)
-    ) {
-      this.onDuplicate = "skip";
-    }
+    return (this._updatableColumns ??= [...this.keys].filter((k) => !exclude.has(k)));
   }
 
   /**
+   * Mirrors: ActiveRecord::InsertAll#primary_keys (insert_all.rb:61-63) — the
+   * *database* primary keys, empty for an id-less table, distinct from the
+   * model's configured `primary_key`.
+   *
    * @missingRailsCall table_name — PERMANENT: Language shortcoming: Rails reads
-   * `schema_cache.primary_keys(model.table_name)` here (insert_all.rb:61);
-   * that schema-cache read is async in trails, so the table name is passed
-   * at the deferred read in `dbPrimaryKeys()` and this reader returns the
-   * value it resolved.
+   * `schema_cache.primary_keys(model.table_name)` here; that schema-cache read
+   * is async in trails, so the table name is passed where the read happens
+   * (`resolveConnectionFacts`) and this reader returns the resolved value.
    */
   primaryKeys(): string[] {
-    // Rails: `Array(@model.schema_cache.primary_keys(model.table_name))`
-    // (insert_all.rb:61) — the *database* primary keys from the schema cache,
-    // not the model's attribute-derived `primary_key`. Those reads are async
-    // in our port, so they're resolved once into `_schemaCachePrimaryKeys`
-    // during _populateUpdatableColumns. Until that runs (the constructor's
-    // `returning` default and verifyAttributes), fall back to the model's
-    // primary key; for the no-PK case (partitioned table — primaryKey nil/"")
-    // both yield [] so `returning` emits no RETURNING clause rather than
-    // RETURNING "".
-    if (this._schemaCachePrimaryKeys !== undefined) return this._schemaCachePrimaryKeys;
-    const pk = this.model.primaryKey;
-    if (pk == null || pk === "") return [];
-    return Array.isArray(pk) ? pk : [pk];
+    return this._facts.primaryKeys;
   }
 
   skipDuplicates(): boolean {
@@ -334,13 +338,8 @@ export class InsertAll {
 
   /**
    * @internal
-   * @missingRailsCall empty? — PERMANENT: Language shortcoming: Rails' last branch is
-   * `@on_duplicate == :update && updatable_columns.empty?`
-   * (insert_all.rb:140), but `updatable_columns` subtracts
-   * `unique_by_columns`, which trails can only resolve off an async
-   * schema-cache read; that branch therefore runs at the end of
-   * `_populateUpdatableColumns()`, which every path awaits before
-   * `onDuplicate` is read.
+   * Mirrors: ActiveRecord::InsertAll#configure_on_duplicate_update_logic
+   * (insert_all.rb:129-143).
    */
   private configureOnDuplicateUpdateLogic(): void {
     const onDuplicate = this.onDuplicate;
@@ -367,11 +366,8 @@ export class InsertAll {
     } else if (this.isCustomUpdateSqlProvided()) {
       this.updateSql = onDuplicate as Nodes.SqlLiteral;
       this.onDuplicate = "update";
-    } else if (onDuplicate === "skip") {
+    } else if (onDuplicate === "update" && isEmpty(this.updatableColumns())) {
       this.onDuplicate = "skip";
-    } else if (onDuplicate === "update") {
-      // Finalized in _populateUpdatableColumns() after async uniqueIndexes() resolves.
-      this.onDuplicate = "update";
     }
   }
 
@@ -389,12 +385,8 @@ export class InsertAll {
   }
 
   /** @internal */
-  private async ensureValidOptionsForConnectionBang(): Promise<void> {
-    if (
-      this.returning &&
-      typeof (this.connection as any).supportsInsertReturning === "function" &&
-      !(await (this.connection as any).supportsInsertReturning())
-    ) {
+  private ensureValidOptionsForConnectionBang(): void {
+    if (this.returning && !this._facts.supportsInsertReturning) {
       throw new Error(
         `${(this.connection as any).constructor?.name ?? "Adapter"} does not support INSERT...RETURNING`,
       );
@@ -457,22 +449,12 @@ export class InsertAll {
   }
 
   /** @internal Mirrors: ActiveRecord::InsertAll#find_unique_index_for */
-  private async findUniqueIndexFor(
+  private findUniqueIndexFor(
     uniqueBy: string | string[] | IndexDefinition | undefined,
-  ): Promise<IndexDefinition | undefined> {
+  ): IndexDefinition | undefined {
     if (uniqueBy instanceof IndexDefinition) return uniqueBy;
-    // Default to unsupported when the predicate is missing — matches Rails'
-    // AbstractAdapter#supports_insert_conflict_target? returning false, so a
-    // wrapper adapter that forgets to delegate doesn't silently fall through
-    // and emit a bogus conflict target.
-    const conn = this.connection as {
-      supportsInsertConflictTarget?: () => Promise<boolean>;
-    };
-    const supports =
-      typeof conn.supportsInsertConflictTarget === "function"
-        ? await conn.supportsInsertConflictTarget()
-        : false;
-    if (!supports) {
+    const conn = this.connection as { constructor?: { name?: string } };
+    if (!this._facts.supportsInsertConflictTarget) {
       // Rails returns nil for a nil unique_by even when conflict targets are
       // unsupported (plain insertAll on MySQL); a given unique_by raises.
       if (uniqueBy == null) return undefined;
@@ -492,12 +474,12 @@ export class InsertAll {
       uniqueBy == null ? modelPrimaryKeys : Array.isArray(uniqueBy) ? uniqueBy : [uniqueBy];
     const match = nameOrCols.map(String);
     const sortedMatch = [...match].sort().join(",");
-    const tableName = this.model.arelTable.name;
-    const idx = (await this.uniqueIndexes()).find(
+    const idx = this.uniqueIndexes().find(
       (i: any) =>
         match.includes(i.name) ||
         (Array.isArray(i.columns) && [...i.columns].sort().join(",") === sortedMatch),
     ) as { name: string; columns: string[]; where?: string } | undefined;
+    const tableName = this.model.tableName;
     if (idx) {
       return idx instanceof IndexDefinition
         ? idx
@@ -506,8 +488,7 @@ export class InsertAll {
     // The PK fallback is order-sensitive (Rails `match == primary_keys`,
     // insert_all.rb:163) — unlike the index match above, which sorts. A
     // composite PK supplied in a different column order falls through to the
-    // raise, matching Rails. `primaryKeys()` is the schema-cache value, already
-    // resolved in _populateUpdatableColumns before this method runs.
+    // raise, matching Rails. `primaryKeys()` is the schema-cache value.
     const dbPrimaryKeys = this.primaryKeys().map(String);
     if (match.join(",") === dbPrimaryKeys.join(",")) {
       return uniqueBy == null
@@ -524,33 +505,10 @@ export class InsertAll {
 
   /**
    * @internal
-   * Rails' schema_cache.indexes is synchronous; our TS port is async because
-   * the underlying driver call is. Always await this method.
-   *
-   * Mirrors: ActiveRecord::InsertAll#unique_indexes
+   * Mirrors: ActiveRecord::InsertAll#unique_indexes (insert_all.rb:169-171).
    */
-  private async uniqueIndexes(): Promise<unknown[]> {
-    const conn = this.connection as any;
-    const cache = conn.schemaCache;
-    if (!cache) return [];
-    const indexes: unknown[] = await cache.indexes(this.model.tableName);
-    return indexes.filter((i: any) => i.unique);
-  }
-
-  /**
-   * @internal
-   * Mirrors: ActiveRecord::InsertAll#primary_keys —
-   * `Array(model.schema_cache.primary_keys(table_name))`. This is the
-   * *database* primary key (empty for an id-less table), distinct from the
-   * model's configured `primary_key` used to build the conflict match.
-   */
-  private async dbPrimaryKeys(): Promise<string[]> {
-    const conn = this.connection as any;
-    const cache = conn.schemaCache;
-    if (!cache || typeof cache.primaryKeys !== "function") return [];
-    const pk = await cache.primaryKeys(this.model.arelTable.name);
-    if (pk == null) return [];
-    return Array.isArray(pk) ? pk : [pk];
+  private uniqueIndexes(): unknown[] {
+    return this._facts.indexes(this.model.tableName).filter((i: any) => i.unique);
   }
 
   /** @internal */

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -45,9 +45,10 @@ export interface InsertAllOptions {
  * trails, so `InsertAll.execute` resolves them before constructing and the
  * constructor body stays the pure assignment Rails' is.
  *
- * @noRailsEquivalent A genuine TypeScript shortcoming: a constructor cannot
- *   await. Resolving in the async factory keeps the Rails-named constructor
- *   tail in place rather than deferring it to `execute`.
+ * @noRailsEquivalent PERMANENT: a genuine TypeScript shortcoming — a
+ *   constructor cannot await. Resolving in the async factory keeps the
+ *   Rails-named constructor tail in place rather than deferring it to
+ *   `execute`.
  * @internal
  */
 interface ResolvedConnectionFacts {
@@ -64,7 +65,8 @@ interface ResolvedConnectionFacts {
  * wrapper adapter that forgets to delegate cannot emit a bogus conflict
  * target.
  *
- * @noRailsEquivalent The async half of `ResolvedConnectionFacts` above.
+ * @noRailsEquivalent PERMANENT: the async half of `ResolvedConnectionFacts`
+ *   above, for the same constructor-cannot-await reason.
  * @internal
  */
 async function resolveConnectionFacts(

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -792,7 +792,7 @@ export class Relation<T extends Base> {
     modelClass.setCurrentScope(this as any);
     let record: T;
     try {
-      record = new this._model(attrs) as T;
+      record = this._new(attrs);
     } finally {
       modelClass.setCurrentScope(prev);
     }
@@ -3071,15 +3071,15 @@ export class Relation<T extends Base> {
     };
   }
 
-  private _new(attributes: Record<string, unknown>): T {
+  protected _new(attributes: Record<string, unknown>): T {
     return new (this.model as any)(attributes) as T;
   }
 
-  private _create(attributes: Record<string, unknown>, block?: (record: T) => void): Promise<T> {
+  protected _create(attributes: Record<string, unknown>, block?: (record: T) => void): Promise<T> {
     return (this.model as any).create(attributes, block);
   }
 
-  private _createBang(
+  protected _createBang(
     attributes: Record<string, unknown>,
     block?: (record: T) => void,
   ): Promise<T> {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -782,26 +782,21 @@ export class Relation<T extends Base> {
     if (Array.isArray(attrs)) {
       return attrs.map((a) => this.build(a, block));
     }
-    // Rails: `build`/`new` is `scoping { _new(attributes) }` — the new
-    // record's `populate_with_current_scope_attributes` seeds from THIS
-    // relation's `scope_for_create` (which may be empty, e.g. `unscoped`)
-    // rather than the class-level default scope. Set current_scope across the
-    // construction so the constructor's seeding honors the relation's scope.
+    // Rails: `block = current_scope_restoring_block(&block); scoping { _new(attributes, &block) }`
+    // (relation.rb:125-132) — the new record's
+    // `populate_with_current_scope_attributes` seeds from THIS relation's
+    // `scope_for_create` (which may be empty, e.g. `unscoped`) rather than the
+    // class-level default scope, while the block yields with the PRIOR scope
+    // re-installed (relation.rb:1345).
+    const restoring = block ? this.currentScopeRestoringBlock(block) : undefined;
     const modelClass = this._model as any;
     const prev = ScopeRegistry.currentScope(modelClass);
     modelClass.setCurrentScope(this as any);
-    let record: T;
     try {
-      record = this._new(attrs);
+      return this._new(attrs, restoring);
     } finally {
       modelClass.setCurrentScope(prev);
     }
-    // The block runs AFTER current_scope is restored, matching Rails'
-    // `current_scope_restoring_block` (relation.rb:1345): it captures the
-    // PRIOR scope before `scoping {}` and re-installs it before yielding, so
-    // the user block sees the prior scope, not this relation's scope.
-    if (block) block(record);
-    return record;
   }
 
   /**
@@ -3071,8 +3066,8 @@ export class Relation<T extends Base> {
     };
   }
 
-  protected _new(attributes: Record<string, unknown>): T {
-    return new (this.model as any)(attributes) as T;
+  protected _new(attributes: Record<string, unknown>, block?: (record: T) => void): T {
+    return new (this.model as any)(attributes, block) as T;
   }
 
   protected _create(attributes: Record<string, unknown>, block?: (record: T) => void): Promise<T> {

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -4,7 +4,7 @@ import { _buildAssociationInstance } from "../associations/instance-methods.js";
 
 /**
  * Runs a has_many load the way `CollectionProxy` and the through loaders do —
- * `find_target` (`association.rb:248`) on an association holder — for an
+ * `load_target` (`association.rb:189-195`) on an association holder — for an
  * options set that is not necessarily the declared one.
  *
  * The holder is built fresh rather than taken from `record.association(name)`
@@ -12,8 +12,8 @@ import { _buildAssociationInstance } from "../associations/instance-methods.js";
  * suppression, its inverse wiring) untouched, which is what these tests want
  * when they drive the loader directly.
  *
- * Test-only sugar: `find_target` is protected, as in Rails, so every call site
- * would otherwise repeat the same cast. `async` so `check_validity!` — run when
+ * Test-only sugar: every call site would otherwise repeat the same cast.
+ * `async` so `check_validity!` — run when
  * the holder is built, as in `Association#initialize` (`association.rb:41-45`) —
  * surfaces as a rejection like every other load failure.
  *
@@ -44,5 +44,10 @@ export async function findCollectionTarget(
     scope: positionalScope,
     options,
   });
-  return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
+  // `load_target` rather than `find_target`: the `find_target?` gate lives
+  // there (association.rb:190), and `CollectionProxy` now loads through it too.
+  const loaded = await (
+    assoc as unknown as { loadTarget(): Promise<Base[] | Base | null> | Base[] | Base | null }
+  ).loadTarget();
+  return (loaded ?? []) as Base[];
 }

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -3,14 +3,19 @@ import type { AssociationDefinition, AssociationOptions } from "../associations.
 import { _buildAssociationInstance } from "../associations/instance-methods.js";
 
 /**
- * Runs a has_many load the way `CollectionProxy` and the through loaders do —
- * `load_target` (`association.rb:189-195`) on an association holder — for an
- * options set that is not necessarily the declared one.
+ * Runs a has_many load the way `CollectionProxy` does — `find_target?`
+ * (`association.rb:190`) decides whether to query, `find_target`
+ * (`association.rb:248`) does the querying — for an options set that is not
+ * necessarily the declared one.
  *
- * The holder is built fresh rather than taken from `record.association(name)`
- * so the load leaves the record's real holder (its loadedness, its writeback
- * suppression, its inverse wiring) untouched, which is what these tests want
- * when they drive the loader directly.
+ * As in `CollectionProxy._findTargetViaAssociation`, the gate is read off the
+ * owner's own holder (whose reflection answers `klass` and
+ * `active_record_primary_key`) while the load runs on a holder built fresh, so
+ * it leaves the record's real holder — its loadedness, its writeback
+ * suppression, its inverse wiring — untouched, which is what these tests want
+ * when they drive the loader directly. A `name` the owner never declared has no
+ * real holder and so no `find_target?` to consult: Rails has no association
+ * without a reflection, and that inline-fallback shape is trails-only.
  *
  * Test-only sugar: every call site would otherwise repeat the same cast.
  * `async` so `check_validity!` — run when
@@ -38,16 +43,27 @@ export async function findCollectionTarget(
   } else if (scope !== null) {
     options = scope;
   }
+  const declared = (
+    record.constructor as unknown as {
+      _reflectOnAssociation?: (n: string) => unknown;
+    }
+  )._reflectOnAssociation?.(name);
+  if (declared) {
+    const holder = (
+      record as unknown as {
+        association(n: string): { findTargetNeeded(): boolean; target: Base[] };
+      }
+    ).association(name);
+    // `load_target` answers `target` whether or not `find_target?` sent it to
+    // the database (association.rb:189-195), so an already-loaded holder
+    // reports what it holds rather than an empty list.
+    if (!holder.findTargetNeeded()) return holder.target ?? [];
+  }
   const assoc = _buildAssociationInstance.call(record, {
     name,
     type: "hasMany",
     scope: positionalScope,
     options,
   });
-  // `load_target` rather than `find_target`: the `find_target?` gate lives
-  // there (association.rb:190), and `CollectionProxy` now loads through it too.
-  const loaded = await (
-    assoc as unknown as { loadTarget(): Promise<Base[] | Base | null> | Base[] | Base | null }
-  ).loadTarget();
-  return (loaded ?? []) as Base[];
+  return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
 }


### PR DESCRIPTION
Bundle of three RFC 0112 convergence stories.

**1. `AssociationRelation` builds under `scoping`.** The public `build` /
`create` / `create!` overrides are replaced by Rails' private `_new` /
`_create` / `_create!` (`association_relation.rb:31-41`), so the `scoping {}`
wrap in `Relation#build` / `#create` / `#create!` (`relation.rb:125-176`) is
what installs the relation as the current scope — and the ad hoc
`{...scopeForCreate(), ...attrs}` merge goes away, because
`Association#initialize_attributes` picks the scope attributes up as Rails
does. `proxyAssociation` unwraps the `CollectionProxy` seat to the
`Association` so `Association#scope`'s
`klass.current_scope.proxy_association == self` branch
(`association.rb:110`) fires, and `HasManyThroughAssociation#buildRecord`
now sets `@through_scope = scope` unconditionally
(`has_many_through_association.rb:92`). `_pendingThroughScope` and the
`_collectionProxies` reach-back are deleted.

**2. `_findTargetReachable` deleted.** The strict-loading raise is back to
Rails' unconditional first statement of `find_target`
(`association.rb:248-250`); the `find_target?` gate lives where Rails puts it,
in `load_target` (`association.rb:190`). `CollectionProxy._findTargetViaAssociation`
and the `findCollectionTarget` test helper both route through it — the proxy
reads the predicate off the owner's own holder, whose rich reflection answers
`active_record_primary_key`.

**3. `InsertAll`'s constructor tail is back in the constructor.**
`InsertAll.execute` resolves `supports_insert_returning?`,
`supports_insert_conflict_target?` and the schema-cache primary keys / indexes
before constructing, so the constructor runs the whole of
`insert_all.rb:38-45` synchronously. `_populateUpdatableColumns`,
`_returningDefaulted` and `_uniqueByResolved` are gone; `updatable_columns` is
the lazy memo Rails has (`insert_all.rb:58-60`) and
`configure_on_duplicate_update_logic` owns the `:update` → `:skip` coercion
(`insert_all.rb:140-142`). Two `@missingRailsCall` tags retire with it.

**Follow-up filed.** `findCollectionTarget` reads the `find_target?` gate off
the owner's real holder when the name is declared, and skips it for the
undeclared "inline fallback" shape — a holder built from a bare options hash for
a name the owner never declared. Rails has no association without a reflection
(`association.rb:41-45`) and `find_target?` ends in `&& klass`
(`association.rb:320-321`), which a reflection-less holder cannot answer since
#7039 made `klass` the reflection delegate — so there is no gate to consult for
that shape rather than a weaker one to invent. Burning the inline fallback down
is tracked as `find-collection-target-inline-fallback-skips-find-target-gate`
(RFC 0112).

Closes-story: converge-association-relation-through-scope-onto-scoping
Closes-story: converge-find-target-reachable-onto-find-target-gate
Closes-story: insert-all-constructor-tail-deferred-to-execute

