### PR TITLE
refactor(arel): per-call Arel.star, node-typed Table#name, Rails' UnsupportedVisitError, unconditional unary visits (RFC 0124)

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -787,7 +787,7 @@ describe("CalculationsTest", () => {
   });
 
   it("count with arel star", async () => {
-    expect(await Account.count(arelStar)).toBe(6);
+    expect(await Account.count(arelStar())).toBe(6);
   });
 
   it("count with aliased attribute", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2682,15 +2682,15 @@ export class AbstractAdapter implements Quoting {
 
   /** @internal Mirrors: AbstractAdapter#column_for_attribute */
   async columnForAttribute(attribute: {
-    relation: { name: string | Nodes.SqlLiteral };
-    name: string;
+    relation: { name: string | Nodes.Node };
+    name: string | Nodes.SqlLiteral;
   }): Promise<import("./column.js").Column | undefined> {
     const tableName = String(attribute.relation.name);
     // `schemaCache` is Rails' `schema_cache` (abstract_adapter.rb:298): the
     // pool's BoundSchemaReflection, or one bound to this connection when the
     // adapter stands alone on a NullPool.
     const hash = await this.schemaCache.columnsHash(tableName);
-    return hash?.[attribute.name];
+    return hash?.[String(attribute.name)];
   }
 
   /** @internal Mirrors: AbstractAdapter#collector */

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2683,7 +2683,7 @@ export class AbstractAdapter implements Quoting {
   /** @internal Mirrors: AbstractAdapter#column_for_attribute */
   async columnForAttribute(attribute: {
     relation: { name: string | Nodes.Node };
-    name: string | Nodes.SqlLiteral;
+    name: string | Nodes.Node;
   }): Promise<import("./column.js").Column | undefined> {
     const tableName = String(attribute.relation.name);
     // `schemaCache` is Rails' `schema_cache` (abstract_adapter.rb:298): the

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -629,7 +629,7 @@ export class Builder implements InsertBuilder {
   }
 
   into(): string {
-    const tableName = this.quoteTable(this.model.arelTable.name);
+    const tableName = this.quoteTable(String(this.model.arelTable.name));
     const keys = [...this._insertAll.keysIncludingTimestamps()];
     if (keys.length === 0) {
       if (this._insertAll.inserts.length > 1) {
@@ -718,7 +718,7 @@ export class Builder implements InsertBuilder {
 
   /** @internal Mirrors Rails `insert.model.quoted_table_name`. */
   quotedTableName(): string {
-    return this.quoteTable(this.model.arelTable.name);
+    return this.quoteTable(String(this.model.arelTable.name));
   }
 
   rawUpdateSql(): Nodes.SqlLiteral | undefined {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -205,7 +205,7 @@ export class InternalMetadata {
    */
   async count(): Promise<number> {
     const sm = new SelectManager(this.arelTable);
-    sm.project(new Nodes.Count([star]));
+    sm.project(new Nodes.Count([star()]));
     const values = await this._withConnection((connection) =>
       connection.selectValues(sm, `${this.constructor.name} Count`),
     );
@@ -251,7 +251,7 @@ export class InternalMetadata {
     key: string,
   ): Promise<Record<string, unknown> | null> {
     const sm = new SelectManager(this.arelTable);
-    sm.project(star);
+    sm.project(star());
     sm.where(this.arelTable.get(this.primaryKey).eq(new Nodes.BindParam(key)));
     sm.order(this.arelTable.get(this.primaryKey).asc());
     sm.take(1);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2,7 +2,7 @@ import { Temporal } from "@blazetrails/date";
 import { except, hexdigest, isBlank, toFs } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import { first } from "./ruby-first.js";
-import { Table, SelectManager, Nodes, sql } from "@blazetrails/arel";
+import { Table, SelectManager, Nodes, sql, star } from "@blazetrails/arel";
 import type { Base } from "./base.js";
 import { threadedConnectionFor } from "./connection-handling.js";
 import { ActiveRecordError, RecordNotSaved, RecordNotUnique, UnknownPrimaryKey } from "./errors.js";
@@ -1196,7 +1196,7 @@ export class Relation<T extends Base> {
           : [(join.left as unknown as { name: string }).name],
       );
 
-    joinedTables.push(this.table.name);
+    joinedTables.push(String(this.table.name));
 
     // always convert table names to downcase as in Oracle quoted table names are in uppercase
     const downcased = joinedTables.map((name) => name.toLowerCase());
@@ -1355,11 +1355,11 @@ export class Relation<T extends Base> {
         !Object.prototype.hasOwnProperty.call(updates, this.model.lockingColumn)
       ) {
         const attr = table.get(this.model.lockingColumn);
-        updates[attr.name] = this._incrementAttribute(attr);
+        updates[String(attr.name)] = this._incrementAttribute(attr);
       }
       values = this._substituteValues(Object.entries(updates));
     } else {
-      values = sql(this.model.sanitizeSqlForAssignment(updates, table.name));
+      values = sql(this.model.sanitizeSqlForAssignment(updates, String(table.name)));
     }
 
     // Mirrors `relation.rb:606-616`.
@@ -2392,7 +2392,7 @@ export class Relation<T extends Base> {
       // Mirror Rails Relation#update_counters: `attr = table[counter_name]` →
       // `updates[attr.name] = _increment_attribute(attr, value)` (relation.rb:930).
       const attr = this.table.get(counterName);
-      updates[attr.name] = this._incrementAttribute(attr, value);
+      updates[String(attr.name)] = this._incrementAttribute(attr, value);
     }
 
     const touch = touchFromCounters as CounterCacheTouchOption | undefined;
@@ -2692,7 +2692,12 @@ export class Relation<T extends Base> {
   }
 
   aliasTracker(joins: Nodes.Node[] = [], aliases?: Map<string, number>): AliasTracker {
-    return AliasTracker.create(this.model.connectionPool(), this.table.name, joins, aliases);
+    return AliasTracker.create(
+      this.model.connectionPool(),
+      String(this.table.name),
+      joins,
+      aliases,
+    );
   }
 
   bindAttribute<R>(
@@ -2711,7 +2716,7 @@ export class Relation<T extends Base> {
     }
 
     const attr = this.table.get(name);
-    const bind = this.predicateBuilder.buildBindAttribute(attr.name, value);
+    const bind = this.predicateBuilder.buildBindAttribute(String(attr.name), value);
     return block(attr, bind);
   }
 
@@ -2915,11 +2920,8 @@ export class Relation<T extends Base> {
       if (collection.hasLimitOrOffset) {
         const query = collection.select(sql(`${column} AS collection_cache_key_timestamp`));
         if (this.distinctValue && isEmpty(collection.selectValues)) {
-          // `Table#star` is a getter; a table ALIAS (Nodes.TableAlias) has none,
-          // so `get("*")` yields the equivalent `<alias>.*` Attribute — mirrors
           // Rails' `table[Arel.star]` over `Arel::Nodes::TableAlias#[]`.
-          const star = (this.table as { star?: Nodes.Node }).star ?? this.table.get("*");
-          query.selectValues = [...query.selectValues, star];
+          query.selectValues = [...query.selectValues, this.table.get(star())];
         }
         const subqueryAlias = "subquery_for_cache_key";
         const subqueryColumn = `${subqueryAlias}.collection_cache_key_timestamp`;
@@ -3145,8 +3147,8 @@ export class Relation<T extends Base> {
         // render as `SET col = (select ...)`, which SQLite/MySQL/PG require.
         return [attr, value instanceof Nodes.SqlLiteral ? new Nodes.Grouping(value) : value];
       }
-      const type = this.model.typeForAttribute(attr.name);
-      return [attr, this.predicateBuilder.buildBindAttribute(attr.name, type.cast(value))];
+      const type = this.model.typeForAttribute(String(attr.name));
+      return [attr, this.predicateBuilder.buildBindAttribute(String(attr.name), type.cast(value))];
     });
   }
 

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -261,7 +261,7 @@ export class PredicateBuilder {
     // bind — `buildBindAttribute` resolves the wrapped type via `typeForAttribute`
     // (and `HomogeneousIn#castedValues` serializes through it for the IN path).
     if (this.isScalarQueryValue(value)) {
-      const normalized = this.normalizeQueryValue(attribute.name, value);
+      const normalized = this.normalizeQueryValue(String(attribute.name), value);
       if (normalized === null || normalized === undefined) {
         return attribute.eq(null);
       }
@@ -278,8 +278,8 @@ export class PredicateBuilder {
     // `OID::Array#force_equality?` is `value.is_a?(::Array)` — a Ruby Set is not
     // an Array, so a Set on an array column force-equalizes in neither Rails nor
     // here. Normalizing Set→Array first would spuriously trip force-equality.
-    if (this.table.type(attribute.name).isForceEquality?.(value) === true) {
-      return attribute.eq(this.buildBindAttribute(attribute.name, value));
+    if (this.table.type(String(attribute.name)).isForceEquality?.(value) === true) {
+      return attribute.eq(this.buildBindAttribute(String(attribute.name), value));
     }
     return this.handlerFor(value).call(attribute, value);
   }

--- a/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
@@ -23,7 +23,7 @@ export class BasicObjectHandler {
   }
 
   call(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
-    const bind = this._predicateBuilder.buildBindAttribute(attribute.name, value);
+    const bind = this._predicateBuilder.buildBindAttribute(String(attribute.name), value);
     return attribute.eq(bind);
   }
 

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -25,8 +25,8 @@ export class RangeHandler {
    * literal is that shape, and `between` reads nothing else off it.
    */
   call(attribute: Nodes.Attribute, value: Range): Nodes.Node {
-    const beginBind = this.predicateBuilder.buildBindAttribute(attribute.name, value.begin);
-    const endBind = this.predicateBuilder.buildBindAttribute(attribute.name, value.end);
+    const beginBind = this.predicateBuilder.buildBindAttribute(String(attribute.name), value.begin);
+    const endBind = this.predicateBuilder.buildBindAttribute(String(attribute.name), value.end);
     return attribute.between({ begin: beginBind, end: endBind, excludeEnd: value.excludeEnd });
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3050,7 +3050,9 @@ export function buildFrom(this: QueryMethodsHost): unknown {
 }
 
 function tableStar(table: any): unknown {
-  return table.star ?? table.get("*");
+  // Rails' `table[Arel.star]` (query_methods.rb) — a Table and a TableAlias
+  // both answer `[]`.
+  return table.get(Arel.star());
 }
 
 /**

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -171,7 +171,7 @@ export class WhereClause {
       const attr = extractAttribute(node);
       if (attr === null) continue;
       if (tableName !== undefined && String(attr.relation.name) !== tableName) continue;
-      result[attr.name] = extractNodeValue((node as any).right);
+      result[String(attr.name)] = extractNodeValue((node as any).right);
     }
     return result;
   }
@@ -205,7 +205,7 @@ export class WhereClause {
         return true;
       }
       if (attrNodes.some((a) => a.eql(attr))) return false;
-      if (colStrings.has(attr.name)) return false;
+      if (colStrings.has(String(attr.name))) return false;
       const qualified = `${String(attr.relation.name)}.${attr.name}`;
       if (colStrings.has(qualified)) return false;
       return true;

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -406,7 +406,7 @@ describe("RelationTest", () => {
   // (`"comments".*`), NOT the `t0_r0…` aliased column list a standalone eager
   // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
   // path (`relation-handler`); converging to `t0_r*` here would diverge.
-  it("eager from() subquery projects the table star, not column aliases", async () => {
+  it("eager from() subquery projects the table star(), not column aliases", async () => {
     const relation = Comment.includes(":post").where({ "posts.type": "Post" }).order(":id");
     const sql = await (Comment.select("*").from(relation) as any).toSql();
     // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -406,7 +406,7 @@ describe("RelationTest", () => {
   // (`"comments".*`), NOT the `t0_r0…` aliased column list a standalone eager
   // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
   // path (`relation-handler`); converging to `t0_r*` here would diverge.
-  it("eager from() subquery projects the table star(), not column aliases", async () => {
+  it("eager from() subquery projects the table star, not column aliases", async () => {
     const relation = Comment.includes(":post").where({ "posts.type": "Post" }).order(":id");
     const sql = await (Comment.select("*").from(relation) as any).toSql();
     // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -142,7 +142,7 @@ export class SchemaMigration {
    */
   async count(): Promise<number> {
     const sm = new SelectManager(this.arelTable);
-    sm.project(new Nodes.Count([star]));
+    sm.project(new Nodes.Count([star()]));
     const values = await this._withConnection((connection) =>
       connection.selectValues(sm, `${this.constructor.name} Count`),
     );

--- a/packages/arel/src/arel.ts
+++ b/packages/arel/src/arel.ts
@@ -50,13 +50,13 @@ export function sql(
 }
 
 /**
- * Arel.star — represents `*` in a projection.
+ * Arel.star() — represents `*` in a projection.
  *
- * Mirrors: Arel.star (arel.rb:60). Rails' `star` is a method returning a
- * fresh literal each call; trails keeps the long-standing constant so the
- * `Arel.star` spelling at every call site is unchanged.
+ * Mirrors: Arel.star (arel.rb:59-61).
  */
-export const star = sql("*", { retryable: true });
+export function star(): SqlLiteral {
+  return sql("*", { retryable: true });
+}
 
 /**
  * Arel.fetchAttribute() — yield the attribute nodes reachable from `value`.

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -109,7 +109,7 @@ describe("AttributeTest", () => {
 
     it("should handle comparing with a subquery", () => {
       const avg = users.project(users.get("karma").average());
-      const mgr = users.project(star).where(users.get("karma").gt(avg));
+      const mgr = users.project(star()).where(users.get("karma").gt(avg));
 
       expect(mustBeLike(mgr.toSql())).toBe(
         mustBeLike(`

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -95,14 +95,14 @@ describe("AttributeTest (trails)", () => {
   // convenience signature with no Rails-side test.
   describe("two-argument between overload", () => {
     it("between generates BETWEEN", () => {
-      expect(users.project(star).where(users.get("age").between(18, 65)).toSql()).toBe(
+      expect(users.project(star()).where(users.get("age").between(18, 65)).toSql()).toBe(
         'SELECT * FROM "users" WHERE "users"."age" BETWEEN 18 AND 65',
       );
     });
 
     it("notBetween generates NOT BETWEEN", () => {
       // Mirrors Rails: not_between renders as `(col < begin OR col > end)`.
-      expect(users.project(star).where(users.get("age").notBetween(18, 65)).toSql()).toBe(
+      expect(users.project(star()).where(users.get("age").notBetween(18, 65)).toSql()).toBe(
         'SELECT * FROM "users" WHERE ("users"."age" < 18 OR "users"."age" > 65)',
       );
     });

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -49,11 +49,11 @@ export class Attribute extends Node {
   // Rails stores whatever `Table#[]` was handed (table.rb:81-85), so
   // `table[Arel.star]` seats a `SqlLiteral` here and `quote_column_name`
   // passes it through unquoted (to_sql.rb:877-880).
-  readonly name: string | SqlLiteral;
+  readonly name: string | Node;
 
   // Rails' `Attribute.new(nil, nil)` is legal (attribute_test.rb:388); the
   // relation-dependent methods below simply raise NoMethodError if reached.
-  constructor(relation: RelationLike | null, name: string | SqlLiteral | null) {
+  constructor(relation: RelationLike | null, name: string | Node | null) {
     super();
     this.relation = relation as RelationLike;
     this.name = name as string;

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -56,7 +56,7 @@ export class Attribute extends Node {
   constructor(relation: RelationLike | null, name: string | Node | null) {
     super();
     this.relation = relation as RelationLike;
-    this.name = name as string;
+    this.name = name as string | Node;
   }
 
   get typeCaster(): unknown {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -29,7 +29,9 @@ import { Predications } from "../predications.js";
  * Mirrors: Arel::Attributes::Attribute
  */
 export interface RelationLike {
-  name: string | SqlLiteral;
+  // `Arel::Table#name` is whatever the table was constructed with — a String,
+  // a SqlLiteral, or a node (table.rb:16, table_test.rb:118-130).
+  name: string | Node;
   // `TableAlias#table_alias` aliases `:name`, which may be a `SqlLiteral`
   // (Arel::Nodes::TableAlias `alias :table_alias :name`, table_alias.rb); a
   // `Table#tableAlias` is a plain string-or-nil. Both flow through here as
@@ -44,18 +46,23 @@ export interface RelationLike {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Attribute extends Node {
   readonly relation: RelationLike;
-  readonly name: string;
+  // Rails stores whatever `Table#[]` was handed (table.rb:81-85), so
+  // `table[Arel.star]` seats a `SqlLiteral` here and `quote_column_name`
+  // passes it through unquoted (to_sql.rb:877-880).
+  readonly name: string | SqlLiteral;
 
   // Rails' `Attribute.new(nil, nil)` is legal (attribute_test.rb:388); the
   // relation-dependent methods below simply raise NoMethodError if reached.
-  constructor(relation: RelationLike | null, name: string | null) {
+  constructor(relation: RelationLike | null, name: string | SqlLiteral | null) {
     super();
     this.relation = relation as RelationLike;
     this.name = name as string;
   }
 
   get typeCaster(): unknown {
-    return this.relation.typeForAttribute(this.name);
+    // Ruby passes `name` along untyped; only a String name ever reaches a
+    // type caster, since `table[Arel.star]` is never type-cast.
+    return this.relation.typeForAttribute(this.name as string);
   }
 
   // Mirrors: Arel::Attributes::Attribute#lower — `relation.lower self`. The
@@ -65,7 +72,7 @@ export class Attribute extends Node {
   }
 
   typeCastForDatabase(value: unknown): unknown {
-    return this.relation.typeCastForDatabase(this.name, value);
+    return this.relation.typeCastForDatabase(this.name as string, value);
   }
 
   isAbleToTypeCast(): boolean {

--- a/packages/arel/src/errors.ts
+++ b/packages/arel/src/errors.ts
@@ -18,22 +18,3 @@ export class BindError extends ArelError {
     this.name = "BindError";
   }
 }
-
-/**
- * Thrown when no visit method is registered for a node's runtime class
- * (after walking the prototype chain).
- *
- * Rails raises a plain `TypeError("Cannot visit #{class}")` from
- * `Arel::Visitors::Visitor#visit` (`activerecord/lib/arel/visitors/visitor.rb`).
- * Trails throws this named subclass of `ArelError` instead — same
- * condition, but a named error class is more idiomatic in TS (callers
- * catch by `instanceof`), and `Visitors.UnsupportedVisitError` was already
- * the public surface before the dispatch refactor. Pinned by
- * `to-sql.test.ts` "unsupported input should raise UnsupportedVisitError".
- */
-export class UnsupportedVisitError extends ArelError {
-  constructor(message: string) {
-    super(message);
-    this.name = "UnsupportedVisitError";
-  }
-}

--- a/packages/arel/src/nodes/comment.test.ts
+++ b/packages/arel/src/nodes/comment.test.ts
@@ -19,7 +19,7 @@ describe("CommentTest", () => {
   describe("sanitization", () => {
     it("strips comment terminators so input cannot break out", () => {
       const users = new Table("users");
-      const mgr = users.project(star);
+      const mgr = users.project(star());
       mgr.comment("hello */ DROP TABLE users");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain("/* hello DROP TABLE users */");
@@ -29,7 +29,7 @@ describe("CommentTest", () => {
 
     it("strips comment openers from values", () => {
       const users = new Table("users");
-      const mgr = users.project(star);
+      const mgr = users.project(star());
       mgr.comment("before /* nested */ after");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain("/* before nested after */");
@@ -37,7 +37,7 @@ describe("CommentTest", () => {
 
     it("normalizes whitespace in comments", () => {
       const users = new Table("users");
-      const mgr = users.project(star);
+      const mgr = users.project(star());
       mgr.comment("hello   \n  world");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain("/* hello world */");

--- a/packages/arel/src/nodes/select-core.test.ts
+++ b/packages/arel/src/nodes/select-core.test.ts
@@ -37,7 +37,7 @@ describe("TestSelectCore", () => {
 
   it("set quantifier", () => {
     const mgr = new SelectManager(users);
-    mgr.project(star).distinct();
+    mgr.project(star()).distinct();
     expect(mgr.ast.cores[0].setQuantifier).toBeInstanceOf(Nodes.Distinct);
     expect(mgr.toSql()).toContain("SELECT DISTINCT");
   });

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -35,7 +35,7 @@ describe("SelectManagerTest", () => {
     describe("order", () => {
       it("accepts symbols", () => {
         const mgr = new SelectManager();
-        mgr.project(star);
+        mgr.project(star());
         mgr.from(users);
         mgr.order(new Nodes.SqlLiteral("foo"));
         expect(mustBeLike(mgr.toSql())).toBe(mustBeLike(`SELECT * FROM "users" ORDER BY foo`));
@@ -68,7 +68,7 @@ describe("SelectManagerTest", () => {
 
       it("can make a subselect", () => {
         const mgr = new SelectManager();
-        mgr.project(star);
+        mgr.project(star());
         mgr.from(sql("zomg"));
         const as = mgr.as("foo");
         const outer = new SelectManager();
@@ -92,7 +92,7 @@ describe("SelectManagerTest", () => {
       it("should support any ast", () => {
         const mgr1 = new SelectManager();
         const mgr2 = new SelectManager();
-        mgr2.project(star);
+        mgr2.project(star());
         mgr2.from(users);
         const as = mgr2.as("omg");
         mgr1.project(sql("lol"));
@@ -165,7 +165,7 @@ describe("SelectManagerTest", () => {
 
     it("makes updates to the correct copy", () => {
       const mgr = new SelectManager(users);
-      mgr.project(star);
+      mgr.project(star());
       mgr.where(users.get("id").eq(1));
       const sql = mgr.toSql();
       expect(sql).toContain("WHERE");
@@ -307,11 +307,11 @@ describe("SelectManagerTest", () => {
 
   describe("union", () => {
     const m1 = new SelectManager(users);
-    m1.project(star);
+    m1.project(star());
     m1.where(users.get("age").lt(18));
 
     const m2 = new SelectManager(users);
-    m2.project(star);
+    m2.project(star());
     m2.where(users.get("age").gt(99));
 
     it("should union two managers", () => {
@@ -336,11 +336,11 @@ describe("SelectManagerTest", () => {
   describe("intersect", () => {
     it("should intersect two managers", () => {
       const m1 = new SelectManager(users);
-      m1.project(star);
+      m1.project(star());
       m1.where(users.get("age").gt(18));
 
       const m2 = new SelectManager(users);
-      m2.project(star);
+      m2.project(star());
       m2.where(users.get("age").lt(99));
 
       const node = m1.intersect(m2);
@@ -355,11 +355,11 @@ describe("SelectManagerTest", () => {
   describe("except", () => {
     it("should except two managers", () => {
       const m1 = new SelectManager(users);
-      m1.project(star);
+      m1.project(star());
       m1.where(users.get("age").between(18, 60));
 
       const m2 = new SelectManager(users);
-      m2.project(star);
+      m2.project(star());
       m2.where(users.get("age").between(40, 99));
 
       const node = m1.except(m2);
@@ -373,8 +373,8 @@ describe("SelectManagerTest", () => {
 
   describe("minus", () => {
     it("minus aliases except", () => {
-      const q1 = users.project(star);
-      const q2 = users.project(star);
+      const q1 = users.project(star());
+      const q2 = users.project(star());
       expect(new Visitors.ToSql(fakeRecordConnection).compile(q1.minus(q2))).toContain("EXCEPT");
     });
   });
@@ -388,7 +388,7 @@ describe("SelectManagerTest", () => {
       const top = users.project(users.get("id")).where(users.get("karma").gt(100));
       const usersAs = new Nodes.As(usersTop, top);
       const selectManager = comments
-        .project(star)
+        .project(star())
         .with(usersAs)
         .where(comments.get("author_id").in(usersTop.project(usersTop.get("id"))));
 
@@ -425,7 +425,7 @@ describe("SelectManagerTest", () => {
       const asStatement = new Nodes.As(replies, union);
 
       const manager = new SelectManager();
-      manager.withRecursive(asStatement).from(replies).project(star);
+      manager.withRecursive(asStatement).from(replies).project(star());
 
       expect(mustBeLike(visitor.compile(manager.ast))).toBe(
         mustBeLike(`
@@ -455,7 +455,7 @@ describe("SelectManagerTest", () => {
     });
 
     it("taken aliases limit", () => {
-      const mgr = users.project(star).take(5);
+      const mgr = users.project(star()).take(5);
       expect(mgr.taken).toBe(mgr.limit);
       expect(mgr.taken).toBe(5);
     });
@@ -489,12 +489,12 @@ describe("SelectManagerTest", () => {
     });
 
     it("accepts string and wraps in SqlLiteral", () => {
-      const mgr = users.project(star).order("name ASC");
+      const mgr = users.project(star()).order("name ASC");
       expect(mgr.toSql()).toContain("ORDER BY name ASC");
     });
 
     it("accepts symbol and uses description (Rails :sym.to_s == 'sym')", () => {
-      const mgr = users.project(star).order(Symbol("name"));
+      const mgr = users.project(star()).order(Symbol("name"));
       expect(mgr.toSql()).toContain("ORDER BY name");
     });
   });
@@ -1021,8 +1021,9 @@ describe("SelectManagerTest", () => {
 
   describe("projections", () => {
     it("reads projections", () => {
-      const mgr = users.project(users.get("name"), users.get("age"));
-      expect(mgr.projections.length).toBe(2);
+      const manager = new SelectManager();
+      manager.project(sql("foo"), sql("bar"));
+      expect(manager.projections).toEqual([sql("foo"), sql("bar")]);
     });
   });
 
@@ -1069,7 +1070,7 @@ describe("SelectManagerTest", () => {
 
     it("accepts a TreeManager and unwraps to ast", () => {
       const sub = users.project(users.get("id")).where(users.get("active").eq(true));
-      const mgr = users.project(star).where(sub);
+      const mgr = users.project(star()).where(sub);
       expect(mgr.toSql()).toContain("WHERE");
     });
 
@@ -1171,7 +1172,7 @@ describe("SelectManagerTest", () => {
     });
 
     it("stores the Comment node on the SelectCore (Rails fidelity)", () => {
-      const mgr = users.project(star).comment("trace");
+      const mgr = users.project(star()).comment("trace");
       // Rails: `@ctx.comment = Nodes::Comment.new(values)` — sets on
       // the core, not the statement. SelectStatement no longer carries
       // a `comment` field at all.
@@ -1182,7 +1183,7 @@ describe("SelectManagerTest", () => {
     });
 
     it("emits the comment exactly once", () => {
-      const sql = users.project(star).comment("once").toSql();
+      const sql = users.project(star()).comment("once").toSql();
       const matches = sql.match(/\/\* once \*\//g) ?? [];
       expect(matches.length).toBe(1);
     });
@@ -1218,7 +1219,7 @@ describe("SelectManagerTest", () => {
     it("returns outer join sql", () => {
       expect(
         users
-          .project(star)
+          .project(star())
           .outerJoin(posts)
           .on(users.get("id").eq(posts.get("user_id")))
           .toSql(),
@@ -1288,12 +1289,12 @@ describe("SelectManagerTest", () => {
 
   describe("lock", () => {
     it("adds a lock node", () => {
-      expect(users.project(star).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
+      expect(users.project(star()).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
     });
   });
 
   it("chaining returns the manager", () => {
-    const mgr = users.project(star);
+    const mgr = users.project(star());
     expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
     expect(mgr.order(users.get("id").asc())).toBe(mgr);
     expect(mgr.take(10)).toBe(mgr);
@@ -1303,7 +1304,7 @@ describe("SelectManagerTest", () => {
 
   it("rightOuterJoin generates RIGHT OUTER JOIN", () => {
     const mgr = new SelectManager(users);
-    mgr.project(star);
+    mgr.project(star());
     mgr.join(posts, Nodes.RightOuterJoin).on(users.get("id").eq(posts.get("user_id")));
     expect(mgr.toSql()).toContain("RIGHT OUTER JOIN");
     expect(mgr.toSql()).toContain('"posts"');
@@ -1311,73 +1312,17 @@ describe("SelectManagerTest", () => {
 
   it("fullOuterJoin generates FULL OUTER JOIN", () => {
     const mgr = new SelectManager(users);
-    mgr.project(star);
+    mgr.project(star());
     mgr.join(posts, Nodes.FullOuterJoin).on(users.get("id").eq(posts.get("user_id")));
     expect(mgr.toSql()).toContain("FULL OUTER JOIN");
   });
 
   it("window creates a named window", () => {
     const mgr = new SelectManager(users);
-    mgr.project(star);
+    mgr.project(star());
     const win = mgr.window("w");
     win.order(users.get("created_at").asc());
     expect(mgr.toSql()).toContain("WINDOW");
-  });
-
-  describe("projections", () => {
-    it("reads projections", () => {
-      const users = new Table("users");
-      const manager = users.project(users.get("name"), users.get("age"));
-      expect(manager.projections.length).toBe(2);
-    });
-  });
-
-  describe("projections=", () => {
-    it("overwrites projections", () => {
-      const users = new Table("users");
-      const manager = users.project(users.get("name"));
-      expect(manager.projections.length).toBe(1);
-      manager.projections = [users.get("age")];
-      expect(manager.projections.length).toBe(1);
-      const sql = manager.toSql();
-      expect(sql).toContain('"age"');
-      expect(sql).not.toContain('"name"');
-    });
-  });
-
-  describe("where_sql", () => {
-    it("gives me back the where sql", () => {
-      const users = new Table("users");
-      const manager = users
-        .project("*")
-        .where(users.get("name").eq("Alice"))
-        .where(users.get("age").gt(18));
-      expect(manager.constraints.length).toBe(2);
-    });
-  });
-
-  it("should hand back froms", () => {
-    const users = new Table("users");
-    const manager = users.project("*");
-    expect(manager.source).toBeDefined();
-  });
-
-  describe("orders", () => {
-    it("returns order clauses", () => {
-      const users = new Table("users");
-      const manager = users.project("*").order(users.get("name").asc());
-      expect(manager.orders.length).toBe(1);
-    });
-  });
-
-  describe("exists", () => {
-    it("can be aliased", () => {
-      const users = new Table("users");
-      const subquery = users.project(users.get("id"));
-      const aliased = subquery.as("sub");
-      expect(aliased).toBeInstanceOf(Nodes.TableAlias);
-      expect((aliased.name as Nodes.SqlLiteral).value).toBe("sub");
-    });
   });
 
   it("returns empty array when no joins", () => {
@@ -1427,7 +1372,7 @@ describe("SelectManagerTest", () => {
   });
 
   it("should take an order", () => {
-    const mgr = users.order(users.get("name").asc()).project(star);
+    const mgr = users.order(users.get("name").asc()).project(star());
     expect(mgr.toSql()).toContain("ORDER BY");
   });
 
@@ -1546,7 +1491,7 @@ describe("SelectManagerTest", () => {
   describe("delete", () => {
     it("copies where", () => {
       const mgr = new SelectManager(users);
-      mgr.project(star).where(users.get("id").eq(1)).where(users.get("name").eq("Alice"));
+      mgr.project(star()).where(users.get("id").eq(1)).where(users.get("name").eq("Alice"));
       const whereSql = mgr.whereSql()?.value;
       expect(whereSql).toContain("WHERE");
       expect(whereSql).toContain("AND");
@@ -1586,7 +1531,7 @@ describe("SelectManagerTest", () => {
     });
 
     it("returns nil when there are no wheres", () => {
-      const mgr = new SelectManager(users).project(star);
+      const mgr = new SelectManager(users).project(star());
       expect(mgr.whereSql()).toBeNull();
     });
   });
@@ -1611,13 +1556,15 @@ describe("SelectManagerTest", () => {
 
   describe("optimizerHints", () => {
     it("places hints after SELECT", () => {
-      const mgr = new SelectManager(users).project(star).optimizerHints("MAX_EXECUTION_TIME(1000)");
+      const mgr = new SelectManager(users)
+        .project(star())
+        .optimizerHints("MAX_EXECUTION_TIME(1000)");
       expect(mgr.toSql()).toBe('SELECT /*+ MAX_EXECUTION_TIME(1000) */ * FROM "users"');
     });
 
     it("supports multiple hints", () => {
       const mgr = new SelectManager(users)
-        .project(star)
+        .project(star())
         .optimizerHints("NO_INDEX_MERGE(users)", "BKA(users)");
       expect(mgr.toSql()).toBe('SELECT /*+ NO_INDEX_MERGE(users) BKA(users) */ * FROM "users"');
     });
@@ -1628,14 +1575,14 @@ describe("SelectManagerTest", () => {
     // sanitizing path, so they name a real quoting connection at the call site.
     it("sanitizes comment delimiters from hints", () => {
       const mgr = new SelectManager(users)
-        .project(star)
+        .project(star())
         .optimizerHints("HINT */ DROP TABLE users --");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toBe('SELECT /*+ HINT DROP TABLE users -- */ * FROM "users"');
     });
 
     it("sanitizes newlines from hints", () => {
-      const mgr = new SelectManager(users).project(star).optimizerHints("HINT\nwith\nnewlines");
+      const mgr = new SelectManager(users).project(star()).optimizerHints("HINT\nwith\nnewlines");
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).not.toContain("\n");
       expect(sql).toContain("/*+ HINT with newlines */");
@@ -1645,7 +1592,7 @@ describe("SelectManagerTest", () => {
       // Rails always wraps the sanitized-and-joined hints in `/*+ ... */`
       // (to_sql.rb:170-172); it never drops the comment when the hints reduce to
       // empty, so `optimizer_hints("/* */", "/**/")` still emits the marker.
-      const mgr = new SelectManager(users).project(star).optimizerHints("/* */", "/**/");
+      const mgr = new SelectManager(users).project(star()).optimizerHints("/* */", "/**/");
       expect(new Visitors.ToSql(testConnection).compile(mgr.ast)).toBe(
         'SELECT /*+   */ * FROM "users"',
       );
@@ -1655,7 +1602,7 @@ describe("SelectManagerTest", () => {
     // `Nodes::OptimizerHints.new(hints)` (select_manager.rb), so the AST
     // carries an OptimizerHints node — not a bare string array.
     it("stores hints as an OptimizerHints node on the SelectCore", () => {
-      const mgr = new SelectManager(users).project(star).optimizerHints("X", "Y");
+      const mgr = new SelectManager(users).project(star()).optimizerHints("X", "Y");
       expect(mgr.ast.cores[0].optimizerHints).toBeInstanceOf(Nodes.OptimizerHints);
       expect((mgr.ast.cores[0].optimizerHints as Nodes.OptimizerHints).expr).toEqual(["X", "Y"]);
     });
@@ -1663,7 +1610,7 @@ describe("SelectManagerTest", () => {
     // Mirrors Rails: `optimizer_hints` is a no-op when called with no
     // arguments (the Rails impl skips the assignment when hints empty).
     it("is a no-op when called with no hints", () => {
-      const mgr = new SelectManager(users).project(star).optimizerHints();
+      const mgr = new SelectManager(users).project(star()).optimizerHints();
       expect(mgr.ast.cores[0].optimizerHints).toBeNull();
     });
   });

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -52,7 +52,7 @@ describe("TableTest", () => {
     it("should produce LEFT OUTER JOIN … ON SQL", () => {
       const onClause = new Nodes.On(users.get("id").eq(posts.get("user_id")));
       const join = users.createJoin(posts, onClause, Nodes.OuterJoin);
-      const mgr = users.project(star);
+      const mgr = users.project(star());
       mgr.joinSources().push(join);
       const sql = mgr.toSql();
       expect(sql).toContain('LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"');
@@ -138,13 +138,13 @@ describe("TableTest", () => {
     });
 
     it("should accept literal SQL", () => {
-      const rel = new Table(sql("generate_series(4, 2)") as unknown as string);
+      const rel = new Table(sql("generate_series(4, 2)"));
       expect(rel.name).toEqual(sql("generate_series(4, 2)"));
     });
 
     it("should accept Arel nodes", () => {
-      const node = new Nodes.NamedFunction("generate_series", [4, 2] as unknown as Nodes.Node[]);
-      const rel = new Table(node as unknown as string);
+      const node = new Nodes.NamedFunction("generate_series", [4, 2]);
+      const rel = new Table(node);
       expect(rel.name).toBe(node);
     });
   });
@@ -224,30 +224,32 @@ describe("TableTest", () => {
   });
 
   it("star returns an Attribute that compiles to table.*", () => {
-    expect(users.star).toBeInstanceOf(Nodes.Attribute);
-    expect(users.star.toSql()).toBe('"users".*');
+    expect(users.get(star())).toBeInstanceOf(Nodes.Attribute);
+    expect(users.get(star()).toSql()).toBe('"users".*');
   });
 
   it("star splits schema-qualified name", () => {
-    expect(new Visitors.ToSql(testConnection).compile(new Table("test_schema.things").star)).toBe(
-      '"test_schema"."things".*',
-    );
+    expect(
+      new Visitors.ToSql(testConnection).compile(new Table("test_schema.things").get(star())),
+    ).toBe('"test_schema"."things".*');
   });
 
   it("star preserves quoted table name with dot", () => {
     expect(
-      new Visitors.ToSql(testConnection).compile(new Table('test_schema."things.table"').star),
+      new Visitors.ToSql(testConnection).compile(
+        new Table('test_schema."things.table"').get(star()),
+      ),
     ).toBe('"test_schema"."things.table".*');
   });
 
   it("star preserves quoted schema name with dot", () => {
-    expect(new Visitors.ToSql(testConnection).compile(new Table('"my.schema".articles').star)).toBe(
-      '"my.schema"."articles".*',
-    );
+    expect(
+      new Visitors.ToSql(testConnection).compile(new Table('"my.schema".articles').get(star())),
+    ).toBe('"my.schema"."articles".*');
   });
 
   it("star routes table-name quoting through the adapter visitor (MySQL=backticks)", () => {
-    const sql = new Visitors.MySQL(mysqlTestConnection).compile(users.star);
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(users.get(star()));
     expect(sql).toBe("`users`.*");
   });
 
@@ -260,7 +262,7 @@ describe("TableTest", () => {
   it("returns a SelectManager with the table as source", () => {
     const mgr = users.from();
     expect(mgr).toBeInstanceOf(SelectManager);
-    mgr.project(star);
+    mgr.project(star());
     expect(mgr.toSql()).toBe('SELECT * FROM "users"');
   });
 

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -185,7 +185,7 @@ export class Table extends Node {
     // whose name is nil; only a subquery-shaped statement ever renders it. It
     // also takes a node name — `@table[Arel.star]`
     // (test/cases/arel/visitors/to_sql_test.rb:50) — which the alias lookup
-    // skips and the visitor renders as-is (table.rb:110-113).
+    // skips and the visitor renders as-is (table.rb:81-85).
     const resolved =
       name === null || name instanceof Node ? name : (this.klass?.attributeAliases?.[name] ?? name);
     return new Attribute(table ?? this, resolved);

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -188,7 +188,7 @@ export class Table extends Node {
     // skips and the visitor renders as-is (table.rb:110-113).
     const resolved =
       name === null || name instanceof Node ? name : (this.klass?.attributeAliases?.[name] ?? name);
-    return new Attribute(table ?? this, resolved as string | SqlLiteral | null);
+    return new Attribute(table ?? this, resolved);
   }
 
   /**

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -57,11 +57,17 @@ export class Table extends Node {
     _engine.current = value;
   }
 
-  readonly name: string;
+  // Rails stores whatever `name` it was handed (table.rb:16) — a String, an
+  // `Arel.sql` SqlLiteral, or a node such as a NamedFunction
+  // (test/cases/arel/table_test.rb:118-130).
+  readonly name: string | Node;
   readonly tableAlias: string | null;
   readonly klass?: TableKlass;
 
-  constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
+  constructor(
+    name: string | Node,
+    options?: { as?: string; klass?: TableKlass; typeCaster?: unknown },
+  ) {
     super();
     this.name = name;
     const as = options?.as ?? null;
@@ -182,13 +188,16 @@ export class Table extends Node {
     // skips and the visitor renders as-is (table.rb:110-113).
     const resolved =
       name === null || name instanceof Node ? name : (this.klass?.attributeAliases?.[name] ?? name);
-    return new Attribute(table ?? this, resolved as string);
+    return new Attribute(table ?? this, resolved as string | SqlLiteral | null);
   }
 
   /**
    * Mirrors: Arel::Table#hash — only name (Rails excludes aliases to avoid loops).
    */
   override hash(): number {
+    // Rails hashes `@name` whatever it is (table.rb:88-93); a node name hashes
+    // by its own `hash`.
+    if (typeof this.name !== "string") return this.name.hash();
     let h = 0x811c9dc5;
     for (let i = 0; i < this.name.length; i++) {
       h ^= this.name.charCodeAt(i);
@@ -203,7 +212,11 @@ export class Table extends Node {
    */
   eql(other: unknown): boolean {
     if (!(other instanceof Table)) return false;
-    return this.name === other.name && this.tableAlias === other.tableAlias;
+    // Ruby's `self.name == other.name` is value equality, so a SqlLiteral or
+    // node name compares by content, not identity.
+    const sameName =
+      this.name instanceof Node ? this.name.eql(other.name) : this.name === other.name;
+    return sameName && this.tableAlias === other.tableAlias;
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
@@ -221,20 +234,6 @@ export class Table extends Node {
 
   isAbleToTypeCast(): boolean {
     return this.typeCaster != null;
-  }
-
-  /**
-   * The `*` projection for this table — `table.*` after visitor compilation.
-   *
-   * Mirrors Rails' `Arel::Table#[Arel.star]`: returns an `Attribute` rather
-   * than a pre-baked SQL literal, so the table identifier is quoted by the
-   * adapter visitor (ANSI for SQLite/PG, backticks for MySQL). The `"*"`
-   * sentinel is handled by `visit_Arel_Attributes_Attribute` and skips
-   * column-name quoting (matches Rails' `quote_column_name(Arel.star)`,
-   * which passes the `SqlLiteral` through unchanged).
-   */
-  get star(): Attribute {
-    return new Attribute(this, "*");
   }
 
   /**

--- a/packages/arel/src/visitors/dot.trails.test.ts
+++ b/packages/arel/src/visitors/dot.trails.test.ts
@@ -32,7 +32,7 @@ describe("Dot (trails-only)", () => {
   });
 
   it("walks a projected SelectCore", () => {
-    const stmt = users.project(star).ast;
+    const stmt = users.project(star()).ast;
     const out = dot.compile(stmt.cores[0]);
     expect(out).toMatch('[label="<f0>SelectCore"]');
     expect(out).toMatch(/->.*label="projections"/);

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,9 +1,8 @@
-export { ToSql, type ArelConnection } from "./to-sql.js";
+export { ToSql, UnsupportedVisitError, type ArelConnection } from "./to-sql.js";
 export {
   splitSchemaQualifiedName,
   quoteSchemaQualifiedName,
 } from "./split-schema-qualified-name.js";
-export { UnsupportedVisitError } from "../errors.js";
 export { MySQL } from "./mysql.js";
 export { PostgreSQL } from "./postgresql.js";
 export { SQLite } from "./sqlite.js";

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -183,12 +183,12 @@ describe("MysqlTest", () => {
 
   describe("Nodes::Cte", () => {
     it("ignores MATERIALIZED modifiers", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star).ast, true);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()).ast, true);
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
 
     it("ignores NOT MATERIALIZED modifiers", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star).ast, false);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()).ast, false);
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
   });

--- a/packages/arel/src/visitors/mysql.trails.test.ts
+++ b/packages/arel/src/visitors/mysql.trails.test.ts
@@ -6,13 +6,13 @@ import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
 describe("MySQL visitor comment emission", () => {
   const users = new Table("users");
   it("emits the SelectCore comment in MySQL output", () => {
-    const mgr = new SelectManager(users).project(star).comment("trace=mysql");
+    const mgr = new SelectManager(users).project(star()).comment("trace=mysql");
     const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
     expect(sql).toContain("/* trace=mysql */");
   });
 
   it("emits the comment exactly once", () => {
-    const mgr = new SelectManager(users).project(star).comment("once");
+    const mgr = new SelectManager(users).project(star()).comment("once");
     const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
     expect((sql.match(/\/\* once \*\//g) ?? []).length).toBe(1);
   });

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -23,19 +23,14 @@ export class MySQL extends ToSql {
   }
 
   // MySQL renders an UnqualifiedColumn by visiting its inner expression
-  // (typically an Attribute). Rails delegates with `visit o.expr` —
-  // unlike the base ToSql which special-cases the bare name. The
-  // relation prefix this leaves on for an Attribute is fine: MySQL's
-  // `UPDATE t SET x = t.x + 1` is valid.
+  // (typically an Attribute), unlike the base ToSql which special-cases the
+  // bare name (mysql.rb:13-15). The relation prefix this leaves on for an
+  // Attribute is fine: MySQL's `UPDATE t SET x = t.x + 1` is valid.
   protected override visitArelNodesUnqualifiedColumn(
     o: Nodes.UnqualifiedColumn,
     collector: SQLString,
   ): SQLString {
-    if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    } else if (o.expr !== null) {
-      collector.append(String(o.expr));
-    }
+    this.visit(o.expr, collector);
     return collector;
   }
 

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -1,4 +1,3 @@
-import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql } from "./to-sql.js";
@@ -52,11 +51,7 @@ export class PostgreSQL extends ToSql {
     collector: SQLString,
   ): SQLString {
     collector.append("DISTINCT ON ( ");
-    if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    } else if (o.expr !== null) {
-      collector.append(String(o.expr));
-    }
+    this.visit(o.expr, collector);
     collector.append(" )");
     return collector;
   }

--- a/packages/arel/src/visitors/sqlite.trails.test.ts
+++ b/packages/arel/src/visitors/sqlite.trails.test.ts
@@ -19,8 +19,8 @@ describe("SQLite visitor set operations", () => {
 
   // SQLite rejects parens around SELECT operands of UNION/INTERSECT/EXCEPT.
   // Mirrors `sqlite.rb#infix_value_with_paren` — strip Grouping wrappers.
-  const q1 = () => users.project(star);
-  const q2 = () => users.project(star);
+  const q1 = () => users.project(star());
+  const q2 = () => users.project(star());
 
   it("UNION strips Grouping wrapped operands", () => {
     const node = new Nodes.Union(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
@@ -55,7 +55,7 @@ describe("SQLite visitor set operations", () => {
   });
 
   it("nested unions are flattened (Rails-style)", () => {
-    const q3 = users.project(star);
+    const q3 = users.project(star());
     const node = new Nodes.Union(q1().ast, new Nodes.Union(q2().ast, q3.ast));
     const sql = new Visitors.SQLite(testConnection).compile(node);
     expect(sql).toBe(

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -176,9 +176,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("should not quote sql literals", () => {
-    // Rails is `@table[Arel.star]`; trails' `Table#get` is typed to the string
-    // name, so the star node is seated on the Attribute directly.
-    const node = table.get(star);
+    const node = table.get(star());
     expect(mustBeLike(compile(node))).toBe(mustBeLike(`"users".*`));
   });
 
@@ -262,11 +260,11 @@ describe("the to_sql visitor", () => {
   });
 
   it("should visit built-in functions", () => {
-    expect(compile(new Nodes.Count([star]))).toBe("COUNT(*)");
-    expect(compile(new Nodes.Sum([star]))).toBe("SUM(*)");
-    expect(compile(new Nodes.Max([star]))).toBe("MAX(*)");
-    expect(compile(new Nodes.Min([star]))).toBe("MIN(*)");
-    expect(compile(new Nodes.Avg([star]))).toBe("AVG(*)");
+    expect(compile(new Nodes.Count([star()]))).toBe("COUNT(*)");
+    expect(compile(new Nodes.Sum([star()]))).toBe("SUM(*)");
+    expect(compile(new Nodes.Max([star()]))).toBe("MAX(*)");
+    expect(compile(new Nodes.Min([star()]))).toBe("MIN(*)");
+    expect(compile(new Nodes.Avg([star()]))).toBe("AVG(*)");
   });
 
   describe("Nodes::IsNotDistinctFrom", () => {
@@ -325,29 +323,30 @@ describe("the to_sql visitor", () => {
   });
 
   describe("Nodes::Between", () => {
-    it("can handle ranges bounded by infinity", () => {
-      const a = users.get("id").between(-Infinity, 10);
-      const b = users.get("id").between(10, Infinity);
-      expect(new Visitors.ToSql(fakeRecordConnection).compile(a)).toContain("<=");
-      expect(new Visitors.ToSql(fakeRecordConnection).compile(b)).toContain(">=");
+    const compileNode = (n: Nodes.Node): string =>
+      new Visitors.ToSql(fakeRecordConnection).compile(n);
+
+    it("can handle two dot ranges", () => {
+      const node = users.get("id").between([1, 3]);
+      expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" BETWEEN 1 AND 3'));
     });
 
     it("can handle three dot ranges", () => {
-      const begin = 1;
-      const end = 10;
-      const node = new Nodes.Grouping(
-        new Nodes.And([users.get("id").gteq(begin), users.get("id").lt(end)]),
+      const node = users.get("id").between({ begin: 1, end: 3, excludeEnd: true });
+      expect(mustBeLike(compileNode(node))).toBe(
+        mustBeLike('"users"."id" >= 1 AND "users"."id" < 3'),
       );
-      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
-      expect(sql).toContain(">=");
-      expect(sql).toContain("<");
     });
 
-    it("can handle two dot ranges", () => {
-      const node = users.get("id").between([1, 10]);
-      const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
-      expect(sql).toContain("BETWEEN");
-      expect(sql).toContain("1 AND 10");
+    it("can handle ranges bounded by infinity", () => {
+      let node = users.get("id").between([1, Infinity]);
+      expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" >= 1'));
+      node = users.get("id").between([-Infinity, 3]);
+      expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" <= 3'));
+      node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
+      expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" < 3'));
+      node = users.get("id").between([-Infinity, Infinity]);
+      expect(mustBeLike(compileNode(node))).toBe(mustBeLike("1=1"));
     });
   });
 
@@ -383,21 +382,21 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Cte", () => {
     it("handles CTEs with a MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star), true);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()), true);
       expect(mustBeLike(compile(cte))).toBe(
         mustBeLike(`"foo" AS MATERIALIZED (SELECT * FROM "bar")`),
       );
     });
 
     it("handles CTEs with a NOT MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star), false);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()), false);
       expect(mustBeLike(compile(cte))).toBe(
         mustBeLike(`"foo" AS NOT MATERIALIZED (SELECT * FROM "bar")`),
       );
     });
 
     it("handles CTEs with no MATERIALIZED modifier", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star));
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()));
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
 
@@ -433,9 +432,9 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::With", () => {
     it("handles table aliases", () => {
-      const manager = new Table("foo").project(star).from(new Nodes.SqlLiteral("expr2"));
-      const expr1 = new Table("bar").project(star).as("expr1");
-      const expr2 = new Table("baz").project(star).as("expr2");
+      const manager = new Table("foo").project(star()).from(new Nodes.SqlLiteral("expr2"));
+      const expr1 = new Table("bar").project(star()).as("expr1");
+      const expr2 = new Table("baz").project(star()).as("expr2");
       manager.with(expr1, expr2);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(manager.ast);
       expect(sql).toBe(
@@ -444,9 +443,9 @@ describe("the to_sql visitor", () => {
     });
 
     it("handles Cte nodes", () => {
-      const cte = new Nodes.Cte("expr1", new Table("bar").project(star).ast);
+      const cte = new Nodes.Cte("expr1", new Table("bar").project(star()).ast);
       const manager = new Table("foo")
-        .project(star)
+        .project(star())
         .with(cte)
         .from(cte.toTable())
         .where(cte.toTable().get("score").gt(5));
@@ -459,8 +458,8 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::WithRecursive", () => {
     it("handles table aliases", () => {
-      const manager = new Table("foo").project(star).from(new Nodes.SqlLiteral("expr1"));
-      const expr1 = new Table("bar").project(star).as("expr1");
+      const manager = new Table("foo").project(star()).from(new Nodes.SqlLiteral("expr1"));
+      const expr1 = new Table("bar").project(star()).as("expr1");
       manager.withRecursive(expr1);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(manager.ast);
       expect(sql).toBe('WITH RECURSIVE expr1 AS (SELECT * FROM "bar") SELECT * FROM expr1');
@@ -807,7 +806,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("should chain predications on named functions", () => {
-    const fn = new Nodes.NamedFunction("omg", [star]);
+    const fn = new Nodes.NamedFunction("omg", [star()]);
     expect(mustBeLike(compile(fn.eq(2)))).toBe(mustBeLike("omg(*) = 2"));
   });
 
@@ -899,7 +898,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("should handle nil with named functions", () => {
-    const fn = new Nodes.NamedFunction("omg", [star]);
+    const fn = new Nodes.NamedFunction("omg", [star()]);
     expect(mustBeLike(compile(fn.eq(null)))).toBe(mustBeLike("omg(*) IS NULL"));
   });
 
@@ -1314,7 +1313,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("should visit named functions", () => {
-    const fn = new Nodes.NamedFunction("omg", [star]);
+    const fn = new Nodes.NamedFunction("omg", [star()]);
     expect(compile(fn)).toBe("omg(*)");
   });
 
@@ -1329,19 +1328,19 @@ describe("the to_sql visitor", () => {
   });
 
   it("should visit built-in functions operating on distinct values", () => {
-    const count = new Nodes.Count([star]);
+    const count = new Nodes.Count([star()]);
     count.distinct = true;
     expect(compile(count)).toBe("COUNT(DISTINCT *)");
-    const sum = new Nodes.Sum([star]);
+    const sum = new Nodes.Sum([star()]);
     sum.distinct = true;
     expect(compile(sum)).toBe("SUM(DISTINCT *)");
-    const max = new Nodes.Max([star]);
+    const max = new Nodes.Max([star()]);
     max.distinct = true;
     expect(compile(max)).toBe("MAX(DISTINCT *)");
-    const min = new Nodes.Min([star]);
+    const min = new Nodes.Min([star()]);
     min.distinct = true;
     expect(compile(min)).toBe("MIN(DISTINCT *)");
-    const avg = new Nodes.Avg([star]);
+    const avg = new Nodes.Avg([star()]);
     avg.distinct = true;
     expect(compile(avg)).toBe("AVG(DISTINCT *)");
   });
@@ -1379,8 +1378,8 @@ describe("the to_sql visitor", () => {
     // Mirrors Rails `grouping_parentheses(..., false)` + `require_parentheses?`:
     // SELECTs that carry orders/limit/offset are wrapped to disambiguate.
     it("wraps a SELECT operand with ORDER BY", () => {
-      const a = users.project(star);
-      const b = users.project(star).order(users.get("id"));
+      const a = users.project(star());
+      const b = users.project(star()).order(users.get("id"));
       const node = new Nodes.Union(a.ast, b.ast);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe(
@@ -1389,16 +1388,16 @@ describe("the to_sql visitor", () => {
     });
 
     it("wraps a SELECT operand with LIMIT", () => {
-      const a = users.project(star);
-      const b = users.project(star).take(5);
+      const a = users.project(star());
+      const b = users.project(star()).take(5);
       const node = new Nodes.Union(a.ast, b.ast);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('( SELECT * FROM "users" UNION (SELECT * FROM "users" LIMIT 5) )');
     });
 
     it("wraps a SELECT operand with OFFSET", () => {
-      const a = users.project(star);
-      const b = users.project(star).skip(10);
+      const a = users.project(star());
+      const b = users.project(star()).skip(10);
       const node = new Nodes.Union(a.ast, b.ast);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe('( SELECT * FROM "users" UNION (SELECT * FROM "users" OFFSET 10) )');
@@ -1407,9 +1406,9 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Intersect", () => {
     it("flattens nested intersects", () => {
-      const a = users.project(star);
-      const b = users.project(star);
-      const c = users.project(star);
+      const a = users.project(star());
+      const b = users.project(star());
+      const c = users.project(star());
       const node = new Nodes.Intersect(a.ast, new Nodes.Intersect(b.ast, c.ast));
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe(
@@ -1420,9 +1419,9 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Except", () => {
     it("flattens nested excepts", () => {
-      const a = users.project(star);
-      const b = users.project(star);
-      const c = users.project(star);
+      const a = users.project(star());
+      const b = users.project(star());
+      const c = users.project(star());
       const node = new Nodes.Except(a.ast, new Nodes.Except(b.ast, c.ast));
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       expect(sql).toBe(
@@ -1472,7 +1471,7 @@ describe("the to_sql visitor", () => {
   it("compileWithBinds extracts bind values", () => {
     const v = new Visitors.ToSql(fakeRecordConnection);
     const table = new Table("users");
-    const mgr = table.project(star).where(table.get("id").eq(new Nodes.BindParam(42)));
+    const mgr = table.project(star()).where(table.get("id").eq(new Nodes.BindParam(42)));
     const [sql, binds] = compileWithBinds(v, mgr.ast);
     expect(sql).toContain("?");
     expect(sql).not.toContain("42");
@@ -1483,7 +1482,7 @@ describe("the to_sql visitor", () => {
     const v = new Visitors.ToSql(fakeRecordConnection);
     const table = new Table("users");
     const mgr = table
-      .project(star)
+      .project(star())
       .where(table.get("name").eq(new Nodes.BindParam("alice")))
       .where(table.get("age").gt(new Nodes.BindParam(21)));
     const [sql, binds] = compileWithBinds(v, mgr.ast);
@@ -1504,7 +1503,7 @@ describe("the to_sql visitor", () => {
   it("accept accepts external collector", () => {
     const v = new Visitors.ToSql(fakeRecordConnection);
     const table = new Table("users");
-    const mgr = table.project(star).where(table.get("name").eq("alice"));
+    const mgr = table.project(star()).where(table.get("name").eq("alice"));
 
     const parts: unknown[] = [];
     const binds: unknown[] = [];
@@ -1534,7 +1533,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("works with lists", () => {
-    const fn = new Nodes.NamedFunction("omg", [star, star]);
+    const fn = new Nodes.NamedFunction("omg", [star(), star()]);
     expect(compile(fn)).toBe("omg(*, *)");
   });
 
@@ -2208,11 +2207,13 @@ describe("the to_sql visitor", () => {
     });
 
     it("SelectManager#lock wraps default in SqlLiteral", () => {
-      expect(users.project(star).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
+      expect(users.project(star()).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
     });
 
     it("SelectManager#lock with custom string wraps in SqlLiteral", () => {
-      expect(users.project(star).lock("FOR SHARE").toSql()).toBe('SELECT * FROM "users" FOR SHARE');
+      expect(users.project(star()).lock("FOR SHARE").toSql()).toBe(
+        'SELECT * FROM "users" FOR SHARE',
+      );
     });
   });
 
@@ -2282,14 +2283,14 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
 
   it("default quoter: schema-qualified name is split and each part double-quoted", () => {
     const t = new Table("test_schema.things");
-    const sql = new Visitors.ToSql(testConnection).compile(t.project(t.star).ast);
+    const sql = new Visitors.ToSql(testConnection).compile(t.project(t.get(star())).ast);
     expect(sql).toContain('"test_schema"."things".*');
     expect(sql).toContain('FROM "test_schema"."things"');
   });
 
   it("default quoter: quoted table name with dot is preserved as single identifier", () => {
     const t = new Table('test_schema."things.table"');
-    const sql = new Visitors.ToSql(testConnection).compile(t.project(t.star).ast);
+    const sql = new Visitors.ToSql(testConnection).compile(t.project(t.get(star())).ast);
     expect(sql).toContain('"test_schema"."things.table".*');
     expect(sql).toContain('FROM "test_schema"."things.table"');
   });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -859,9 +859,8 @@ export class ToSql extends Visitor {
 
   private visitArelTable(o: Table, collector: SQLString): SQLString {
     // Mirrors Rails visit_Arel_Table (to_sql.rb): if name is a Node, visit
-    // it (subquery-as-table); else quote as identifier. Trails types
-    // `Table.name` as `string`; callers smuggling a Node in must cast.
-    const name = o.name as unknown;
+    // it (subquery-as-table); else quote as identifier.
+    const name = o.name;
     if (name instanceof Node) {
       this.visit(name, collector);
     } else {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -4,15 +4,20 @@ import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { SelectManager } from "../select-manager.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
-import { UnsupportedVisitError, BindError } from "../errors.js";
+import { BindError } from "../errors.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
-// Mirrors Arel::Visitors::UnsupportedVisitError (defined in to_sql.rb:5
-// in Rails as `class UnsupportedVisitError < StandardError`). Trails
-// declares the class in ../errors.ts so it can sit on the ArelError
-// hierarchy alongside BindError/EmptyJoinError, but re-exports it from
-// here so parity:api finds it where Rails defines it.
-export { UnsupportedVisitError };
+/**
+ * Mirrors Arel::Visitors::UnsupportedVisitError (to_sql.rb:5-9) — a
+ * `StandardError`, not an `ArelError`, declared in this file exactly as Rails
+ * declares it, and built from the offending object.
+ */
+export class UnsupportedVisitError extends Error {
+  constructor(object: unknown) {
+    super(`Unsupported argument type: ${constructorName(object)}. Construct an Arel node instead.`);
+    this.name = "UnsupportedVisitError";
+  }
+}
 
 /**
  * Mirrors Ruby's core `NotImplementedError`, which `to_sql.rb` raises from the
@@ -427,11 +432,7 @@ export class ToSql extends Visitor {
   }
 
   protected visitArelNodesBin(o: Nodes.Bin, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    } else if (o.expr !== null) {
-      collector.append(String(o.expr));
-    }
+    this.visit(o.expr, collector);
     return collector;
   }
 
@@ -631,35 +632,31 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesAscending(o: Nodes.Ascending, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) this.visit(o.expr, collector);
+    this.visit(o.expr, collector);
     collector.append(" ASC");
     return collector;
   }
 
   private visitArelNodesDescending(o: Nodes.Descending, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) this.visit(o.expr, collector);
+    this.visit(o.expr, collector);
     collector.append(" DESC");
     return collector;
   }
 
   protected visitArelNodesNullsFirst(o: Nodes.NullsFirst, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) this.visit(o.expr, collector);
+    this.visit(o.expr, collector);
     collector.append(" NULLS FIRST");
     return collector;
   }
 
   protected visitArelNodesNullsLast(o: Nodes.NullsLast, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) this.visit(o.expr, collector);
+    this.visit(o.expr, collector);
     collector.append(" NULLS LAST");
     return collector;
   }
 
   private visitArelNodesGroup(o: Nodes.Group, collector: SQLString): SQLString {
-    if (o.expr instanceof Node) {
-      return this.visit(o.expr, collector);
-    }
-    collector.append(String(o.expr));
-    return collector;
+    return this.visit(o.expr, collector);
   }
 
   private visitArelNodesNamedFunction(o: Nodes.NamedFunction, collector: SQLString): SQLString {
@@ -678,13 +675,7 @@ export class ToSql extends Visitor {
 
   private visitArelNodesExtract(o: Nodes.Extract, collector: SQLString): SQLString {
     collector.append(`EXTRACT(${String(o.field).toUpperCase()} FROM `);
-    if (Array.isArray(o.expr)) {
-      this.visitArray(o.expr, collector);
-    } else if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    } else if (o.expr !== null && o.expr !== undefined) {
-      collector.append(String(o.expr));
-    }
+    this.visit(o.expr, collector);
     collector.append(")");
     return collector;
   }
@@ -855,9 +846,7 @@ export class ToSql extends Visitor {
 
   private visitArelNodesOn(o: Nodes.On, collector: SQLString): SQLString {
     collector.append("ON ");
-    if (o.expr instanceof Node) {
-      this.visit(o.expr, collector);
-    }
+    this.visit(o.expr, collector);
     return collector;
   }
 
@@ -1082,13 +1071,10 @@ export class ToSql extends Visitor {
     o: Nodes.UnqualifiedColumn,
     collector: SQLString,
   ): SQLString {
-    // Mirrors Arel's visit_Arel_Nodes_UnqualifiedColumn — strips the table
-    // qualifier so `SET col = col + 1` works in UPDATE statements.
-    const attr = o.attribute as Partial<Nodes.Attribute> | undefined;
-    if (!attr || typeof attr.name !== "string") {
-      throw new UnsupportedVisitError("UnqualifiedColumn must wrap an Attribute o with a name");
-    }
-    collector.append(this.quoteColumnName(attr.name));
+    // Rails strips the table qualifier so `SET col = col + 1` works in UPDATE
+    // statements: `collector << quote_column_name(o.name)` (to_sql.rb:728-730),
+    // where `UnqualifiedColumn#name` delegates to `@expr.name`.
+    collector.append(this.quoteColumnName(o.name as string | Node));
     return collector;
   }
 
@@ -1126,10 +1112,7 @@ export class ToSql extends Visitor {
     const joinName = o.relation.tableAlias || o.relation.name;
     collector.append(this.quoteTableName(joinName));
     collector.append(".");
-    // Rails: `quote_column_name(Arel.star)` returns the `SqlLiteral("*")`
-    // unchanged. We model `Arel.star` as the string sentinel `"*"` on the
-    // Attribute, so short-circuit identifier quoting here.
-    collector.append(o.name === "*" ? "*" : this.quoteColumnName(o.name));
+    collector.append(this.quoteColumnName(o.name));
     return collector;
   }
 
@@ -1233,14 +1216,12 @@ export class ToSql extends Visitor {
   }
 
   /**
-   * Mirrors `to_sql.rb#unsupported` (to_sql.rb:828) — `collector` is required
-   * to match the Rails signature even though it's unused after the raise. The
-   * message mirrors `UnsupportedVisitError.new(o)` (to_sql.rb:5-8).
+   * Mirrors `to_sql.rb#unsupported` (to_sql.rb:828-830) — `collector` is
+   * required to match the Rails signature even though it's unused after the
+   * raise.
    */
   protected unsupported(o: unknown, _collector: SQLString): never {
-    throw new UnsupportedVisitError(
-      `Unsupported argument type: ${constructorName(o)}. Construct an Arel o instead.`,
-    );
+    throw new UnsupportedVisitError(o);
   }
 
   // Rails aliases every Ruby value class with no SQL rendering to
@@ -1372,7 +1353,7 @@ export class ToSql extends Visitor {
   }
 
   /** @internal */
-  protected quoteTableName(name: string | Nodes.SqlLiteral): string {
+  protected quoteTableName(name: string | Node): string {
     if (name instanceof Nodes.SqlLiteral) return name.value;
     // `toS` is Ruby's implicit `name.to_s` inside `quote_table_name`: trails
     // reaches here with an Array name for a composite primary key, which Ruby
@@ -1381,7 +1362,7 @@ export class ToSql extends Visitor {
   }
 
   /** @internal */
-  protected quoteColumnName(name: string | Nodes.SqlLiteral): string {
+  protected quoteColumnName(name: string | Node): string {
     if (name instanceof Nodes.SqlLiteral) return name.value;
     // See `quoteTableName` — `toS` is Ruby's implicit `name.to_s`.
     return this.connection.quoteColumnName(toS(name));

--- a/packages/arel/src/visitors/unary-bind-dispatch.trails.test.ts
+++ b/packages/arel/src/visitors/unary-bind-dispatch.trails.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
+import {
+  testConnection,
+  mysqlTestConnection,
+  postgresqlTestConnection,
+} from "../test-helpers/connection.js";
+import { Table, Nodes, Visitors } from "../index.js";
+
+/**
+ * Every unary visit in Rails is a bare `visit o.expr, collector` — the visitor
+ * dispatches on the expression's class, so an `ActiveModel::Attribute` bind
+ * renders as a placeholder like it does anywhere else. Each case below pins one
+ * such site against the Rails line it mirrors.
+ */
+describe("unary visitors dispatch their expr rather than stringifying it", () => {
+  const users = new Table("users");
+  const bind = (): AMAttribute => AMAttribute.fromDatabase("name", "x", new StringType());
+  const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
+
+  it("Bin visits its expr (to_sql.rb:186-188)", () => {
+    expect(compile(new Nodes.Bin(bind()))).toBe("?");
+  });
+
+  it("Ascending visits its expr (to_sql.rb:363-365)", () => {
+    expect(compile(new Nodes.Ascending(bind()))).toBe("? ASC");
+  });
+
+  it("Descending visits its expr (to_sql.rb:367-369)", () => {
+    expect(compile(new Nodes.Descending(bind()))).toBe("? DESC");
+  });
+
+  it("NullsFirst visits its expr (to_sql.rb:372-375)", () => {
+    expect(compile(new Nodes.NullsFirst(bind()))).toBe("? NULLS FIRST");
+  });
+
+  it("NullsLast visits its expr (to_sql.rb:377-380)", () => {
+    expect(compile(new Nodes.NullsLast(bind()))).toBe("? NULLS LAST");
+  });
+
+  it("Group visits its expr (to_sql.rb:382-384)", () => {
+    expect(compile(new Nodes.Group(bind()))).toBe("?");
+  });
+
+  it("Extract visits its expr (to_sql.rb:400-403)", () => {
+    expect(compile(new Nodes.Extract(bind() as unknown as Nodes.Node, "date"))).toBe(
+      "EXTRACT(DATE FROM ?)",
+    );
+  });
+
+  it("On visits its expr (to_sql.rb:564-567)", () => {
+    expect(compile(new Nodes.On(bind()))).toBe("ON ?");
+  });
+
+  it("UnqualifiedColumn quotes the bare name (to_sql.rb:728-730)", () => {
+    expect(compile(new Nodes.UnqualifiedColumn(users.get("name")))).toBe('"name"');
+  });
+
+  it("MySQL UnqualifiedColumn visits its expr (mysql.rb:13-15)", () => {
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(
+      new Nodes.UnqualifiedColumn(bind() as unknown as Nodes.Node),
+    );
+    expect(sql).toBe("?");
+  });
+
+  it("PostgreSQL DistinctOn visits its expr (postgresql.rb:39-42)", () => {
+    const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+      new Nodes.DistinctOn(bind()),
+    );
+    expect(sql).toBe("DISTINCT ON ( $1 )");
+  });
+});

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Node } from "../nodes/node.js";
 import { Visitor } from "./visitor.js";
-import { UnsupportedVisitError } from "../errors.js";
+import { UnsupportedVisitError } from "./to-sql.js";
 
 class A extends Node {}
 class B extends A {}

--- a/scripts/parity/pipeline/fixtures/arel-01/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-01/query.ts
@@ -1,3 +1,3 @@
 import { Table, star } from "@blazetrails/arel";
 const users = new Table("users");
-export default users.project(star);
+export default users.project(star());

--- a/scripts/parity/pipeline/fixtures/arel-35/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-35/query.ts
@@ -1,3 +1,3 @@
-import { Table } from "@blazetrails/arel";
+import { Table, star } from "@blazetrails/arel";
 const posts = new Table("posts");
-export default posts.project(posts.star).distinct();
+export default posts.project(posts.get(star())).distinct();

--- a/scripts/parity/pipeline/fixtures/arel-49/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-49/query.ts
@@ -1,3 +1,3 @@
 import { Table, star, sql } from "@blazetrails/arel";
 const users = new Table("users");
-export default users.project(star).order(users.get("age"), sql("ARRAY_AGG(DISTINCT users.name)"));
+export default users.project(star()).order(users.get("age"), sql("ARRAY_AGG(DISTINCT users.name)"));

--- a/scripts/parity/pipeline/fixtures/arel-53/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-53/query.ts
@@ -2,9 +2,9 @@ import { Table, Nodes, star } from "@blazetrails/arel";
 const users = new Table("users");
 const photos = new Table("photos");
 const cte = new Table("cte_photos");
-const photosQuery = photos.project(star);
+const photosQuery = photos.project(star());
 export default users
-  .project(star)
+  .project(star())
   .join(cte)
   .on(cte.get("user_id").eq(users.get("id")))
   .with(new Nodes.As(cte, photosQuery));

--- a/scripts/parity/pipeline/fixtures/arel-54/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-54/query.ts
@@ -4,6 +4,6 @@ const comments = new Table("comments");
 const usersTop = new Table("users_top");
 const topQuery = users.project(users.get("id")).order(users.get("karma").desc()).take(10);
 export default comments
-  .project(star)
+  .project(star())
   .where(comments.get("author_id").in(usersTop.project(usersTop.get("id"))))
   .with(new Nodes.As(usersTop, topQuery));

--- a/scripts/parity/pipeline/fixtures/arel-55/query.ts
+++ b/scripts/parity/pipeline/fixtures/arel-55/query.ts
@@ -4,5 +4,5 @@ const currencyRates = new Table("currency_rates");
 export default products
   .join(currencyRates)
   .on(products.get("currency_id").eq(currencyRates.get("id")))
-  .project(star)
+  .project(star())
   .order(products.get("price").multiply(currencyRates.get("rate")));

--- a/scripts/parity/pipeline/translate/arel.ts
+++ b/scripts/parity/pipeline/translate/arel.ts
@@ -146,10 +146,10 @@ function translateQuery(
     )
     // tbl[:col] → tbl.get("col")
     .replace(/(\w+)\[:([\w_]+)\]/g, '$1.get("$2")')
-    // tbl[Arel.star] → tbl.star
-    .replace(/(\w+)\[Arel\.star\]/g, "$1.star")
-    // Arel.star → star (standalone)
-    .replace(/\bArel\.star\b/g, "star")
+    // tbl[Arel.star] → tbl.get(star())
+    .replace(/(\w+)\[Arel\.star\]/g, "$1.get(star())")
+    // Arel.star → star() (standalone)
+    .replace(/\bArel\.star\b/g, "star()")
     // Arel.sql(...) → sql(...)
     .replace(/Arel\.sql\(/g, "sql(")
     // .not_eq → .notEq
@@ -214,7 +214,7 @@ function translateQuery(
   const imports: string[] = ["Table"];
   if (tsExpr.includes("Nodes.")) imports.push("Nodes");
   if (tsExpr.includes("sql(")) imports.push("sql");
-  if (/\bstar\b/.test(tsExpr) && !tsExpr.includes(".star")) imports.push("star");
+  if (/\bstar\b/.test(tsExpr)) imports.push("star");
 
   return {
     rb: `${rbDecls}\n${query}`,


### PR DESCRIPTION
Six RFC 0124 arel deviations, converged together because they overlap in
`table.ts` / `to-sql.ts`.

### `Arel.star` is a method, not a shared const
Rails allocates a fresh `SqlLiteral` per call (`arel.rb:59-61`); trails handed
every call site the same instance. `star` is a function now and every reader
calls it — including the parity pipeline's `Arel.star` translation rule.

### `Arel::Table#name` takes what Rails takes
`table.rb:16` stores a String, an `Arel.sql` literal, or a node
(`table_test.rb:118-130`), so the two mirrored tests only compiled through
`as unknown as string`. `name` is `string | Node`; `hash` (a node name hashes
by its own `hash`), `eql` (value equality, as Ruby's `==`), and the visitor's
`quote_table_name` / `quote_column_name` follow it, and the casts are gone.

### `Table#star` and the `"*"` sentinel
Rails has no `Table#star` — it writes `table[Arel.star]`, and
`quote_column_name` passes the `SqlLiteral` through untouched
(`to_sql.rb:877-880`). trails seated the plain string `"*"` and carried an
`o.name === "*"` short-circuit in `visit_Arel_Attributes_Attribute`. The getter
is removed, call sites read `table.get(star())`, `Attribute#name` is
`string | SqlLiteral`, and the visitor is the three bare appends Rails has.
MySQL still emits `` `users`.* ``.

### `UnsupportedVisitError`
Rails does declare it — in `to_sql.rb:5-9`, as a `StandardError` built from the
offending object, not in `errors.rb`. trails had it in `errors.ts` as an
`ArelError` subclass whose JSDoc ratified the deviation on "more idiomatic in
TS" grounds. It now lives at Rails' declaration site with Rails' constructor and
message; `errors.ts` declares exactly the three classes `arel/errors.rb` does.
(The message also read "Construct an Arel o instead" — a stray rename.)

### Unary visits dispatch instead of stringifying
Nine sites guarded `visit o.expr` behind `instanceof Node` and `String(o.expr)`d
anything else, so an `ActiveModel::Attribute` bind rendered `[object Object]`.
Each is Rails' unconditional `visit o.expr, collector`: `to_sql.rb:186` (Bin),
`:363`/`:367` (Ascending/Descending), `:372`/`:377` (NullsFirst/NullsLast),
`:382` (Group), `:400` (Extract), `:564` (On), `mysql.rb:13`
(UnqualifiedColumn), `postgresql.rb:39` (DistinctOn). The base
`ToSql#visit_Arel_Nodes_UnqualifiedColumn` keeps Rails' bare-name special case
(`to_sql.rb:728-730`) and drops the invented raise.
`unary-bind-dispatch.trails.test.ts` pins one bind case per site.

### Weakened arel test bodies
`select_manager_test.rb`'s "reads projections" is restored to Rails' body; a
duplicated block of six weaker copies of tests already ported faithfully earlier
in the same file is deleted; `to_sql_test.rb`'s three `Nodes::Between` bodies
are restored to the ranges and exact SQL Rails asserts (`to_sql_test.rb:503-532`).

### Gates
- `parity:api` arel 957/957 (100%), unchanged; `parity:test` arel 707/707.
- `parity:api:calls` / `parity:api:calls:args` OK, no new rows.
- `parity:api:extra:gate` OK at arel novel 0/0, total 62/62 — the converged
  `star()` is a top-level function in `arel.ts`, which no Rails file maps onto
  (`arel.rb` sits outside the package's `libPath`), so it scores as extra;
  removing the invented `Table#star` nets it back to the mark. The mark file is
  untouched.
- `parity:test:assertions` OK; arel assertion mismatches 39/81/11 against a
  40/84/11 mark (down, not up).

Closes-story: arel-star-is-a-shared-const-not-a-per-call-method
Closes-story: arel-table-name-typed-string-rejects-rails-name-objects
Closes-story: arel-table-star-stores-a-string-not-a-sqlliteral
Closes-story: arel-unsupported-visit-error-should-be-typeerror
Closes-story: arel-visitors-stringify-non-node-expr-instead-of-visiting
Closes-story: arel-weakened-test-body-restoration-sweep
