### PR TITLE
refactor(activesupport,activerecord): IsolatedExecutionState-scoped CurrentAttributes, one db_warnings_action mapping (RFC 0112)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -24,6 +24,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { ActiveRecord } from "../../ar-config.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { itIfSupports } from "../../support/supports.js";
 import { fixtures } from "../../test-fixtures.js";
@@ -101,17 +102,17 @@ async function withExtensionEnabled(
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  let savedWarningsAction: typeof PostgreSQLAdapter.dbWarningsAction;
+  let savedWarningsAction: typeof ActiveRecord.dbWarningsAction;
   let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    savedWarningsAction = PostgreSQLAdapter.dbWarningsAction;
+    savedWarningsAction = ActiveRecord.dbWarningsAction;
     savedWarningsIgnore = PostgreSQLAdapter.dbWarningsIgnore;
   });
 
   afterEach(async () => {
-    PostgreSQLAdapter.dbWarningsAction = savedWarningsAction;
+    ActiveRecord.dbWarningsAction = savedWarningsAction ?? "ignore";
     PostgreSQLAdapter.dbWarningsIgnore = savedWarningsIgnore;
     vi.restoreAllMocks();
     if (adapter.isConnected()) {
@@ -821,20 +822,20 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("ignores warnings when behaviour ignore", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "ignore";
+      ActiveRecord.dbWarningsAction = "ignore";
       const rows = await adapter.execute("do $$ BEGIN RAISE WARNING 'foo'; END; $$");
       expect(rows).toEqual([]);
     });
 
     it("logs warnings when behaviour log", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "log";
+      ActiveRecord.dbWarningsAction = "log";
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("PostgreSQL SQL warning"));
     });
 
     it("raises warnings when behaviour raise", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "raise";
+      ActiveRecord.dbWarningsAction = "raise";
       await expect(
         adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$"),
       ).rejects.toBeInstanceOf(SQLWarning);
@@ -842,7 +843,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("reports when behaviour report", async () => {
       const { ActiveSupport, ErrorReporter } = await import("@blazetrails/activesupport");
-      PostgreSQLAdapter.dbWarningsAction = "report";
+      ActiveRecord.dbWarningsAction = "report";
       const previousReporter = ActiveSupport.errorReporter;
       const reporter = new ErrorReporter();
       const events: Array<{ error: Error; handled: boolean }> = [];
@@ -865,7 +866,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("warnings behaviour can be customized with a proc", async () => {
       let captured: SQLWarning | null = null;
-      PostgreSQLAdapter.dbWarningsAction = (w) => {
+      ActiveRecord.dbWarningsAction = (w) => {
         captured = w;
       };
       await adapter.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$");
@@ -875,7 +876,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("allowlist of warnings to ignore", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "raise";
+      ActiveRecord.dbWarningsAction = "raise";
       PostgreSQLAdapter.dbWarningsIgnore = [/PostgreSQL SQL warning/];
       const rows = await adapter.execute(
         "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
@@ -884,7 +885,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("allowlist of warning codes to ignore", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "raise";
+      ActiveRecord.dbWarningsAction = "raise";
       PostgreSQLAdapter.dbWarningsIgnore = ["01000"];
       const rows = await adapter.execute(
         "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
@@ -893,7 +894,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("does not raise notice level warnings", async () => {
-      PostgreSQLAdapter.dbWarningsAction = "raise";
+      ActiveRecord.dbWarningsAction = "raise";
       await expect(
         adapter.execute("DROP TABLE IF EXISTS non_existent_table_xyz_warnings"),
       ).resolves.toBeDefined();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1,6 +1,7 @@
 import pg from "pg";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/date";
+import { ActiveRecord } from "../../ar-config.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import {
   ConnectionNotEstablished,
@@ -814,14 +815,14 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
     });
 
-    let savedWarningsAction: typeof PostgreSQLAdapter.dbWarningsAction;
+    let savedWarningsAction: typeof ActiveRecord.dbWarningsAction;
     let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
     beforeEach(() => {
-      savedWarningsAction = PostgreSQLAdapter.dbWarningsAction;
+      savedWarningsAction = ActiveRecord.dbWarningsAction;
       savedWarningsIgnore = PostgreSQLAdapter.dbWarningsIgnore;
     });
     afterEach(() => {
-      PostgreSQLAdapter.dbWarningsAction = savedWarningsAction;
+      ActiveRecord.dbWarningsAction = savedWarningsAction ?? "ignore";
       PostgreSQLAdapter.dbWarningsIgnore = savedWarningsIgnore;
       vi.restoreAllMocks();
     });

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -220,6 +220,11 @@ export const ActiveRecord = {
    * so every adapter's `handle_warnings` is a single `.call(warning)` and the
    * symbol -> behavior mapping exists once, in the writer below.
    *
+   * The `"log"` arm names `ActiveRecord::Base.logger` (active_record.rb:245),
+   * which Ruby resolves when the Proc runs; `getBase` is the call-time resolver
+   * that stands in for that. The `"report"` arm is Rails'
+   * `Rails.error.report(warning, handled: true)` (active_record.rb:249).
+   *
    * Mirrors `ActiveRecord.db_warnings_action` (active_record.rb:228-254).
    */
   get dbWarningsAction(): ((warning: SQLWarning) => void) | null {
@@ -235,9 +240,6 @@ export const ActiveRecord = {
         _dbWarningsAction = (warning) => {
           let warningMessage = `[ActiveRecord::SQLWarning] ${warning.message}`;
           if (warning.code) warningMessage += ` (${warning.code})`;
-          // Rails is `ActiveRecord::Base.logger.warn(warning_message)`
-          // (active_record.rb:245); `getBase` is the call-time resolver that
-          // stands in for Ruby resolving that constant when the Proc runs.
           const logger = getBase()?.logger as { warn?: (msg: string) => void } | null | undefined;
           if (logger?.warn) logger.warn(warningMessage);
           else console.warn(warningMessage);
@@ -249,8 +251,6 @@ export const ActiveRecord = {
         };
         break;
       case "report":
-        // Rails' `Rails.error.report(warning, handled: true)`
-        // (active_record.rb:249).
         _dbWarningsAction = (warning) => {
           ActiveSupport.errorReporter.report(warning, { handled: true });
         };

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -5,8 +5,14 @@
  * module itself (active_record.rb:321-322).
  */
 import { ArgumentError } from "@blazetrails/activemodel";
+import { ActiveSupport } from "@blazetrails/activesupport";
+import type { SQLWarning } from "./errors.js";
+import { getBase } from "./log-subscriber.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 import type { QueryTransformer } from "./query-transformers.js";
+
+/** Mirrors the values `ActiveRecord.db_warnings_action=` accepts (active_record.rb:231). */
+type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((warning: SQLWarning) => void);
 
 /** Any constructable class — used for module-config flags that hold a class. */
 type AnyClass = abstract new (...args: never[]) => object;
@@ -46,6 +52,7 @@ let _indexNestedAttributeErrors = false;
 let _schemaCacheIgnoredTables: ReadonlyArray<string | RegExp> = [];
 let _permanentConnectionCheckout: true | "deprecated" | "disallowed" = true;
 let _defaultTimezone: "utc" | "local" = "utc";
+let _dbWarningsAction: ((warning: SQLWarning) => void) | null = null;
 let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = null;
 let _globalThreadPoolAsyncQueryExecutor: AsyncExecutor | undefined;
 
@@ -201,6 +208,62 @@ export const ActiveRecord = {
   /** @internal */
   set schemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp>) {
     _schemaCacheIgnoredTables = value;
+  },
+
+  /**
+   * The action to take when database query produces warning. Must be one of
+   * `"ignore"`, `"log"`, `"raise"`, `"report"`, or a custom function. The
+   * default is `"ignore"`.
+   *
+   * The reader answers the *resolved* callable (Rails'
+   * `singleton_class.attr_reader :db_warnings_action`, active_record.rb:232),
+   * so every adapter's `handle_warnings` is a single `.call(warning)` and the
+   * symbol -> behavior mapping exists once, in the writer below.
+   *
+   * Mirrors `ActiveRecord.db_warnings_action` (active_record.rb:228-254).
+   */
+  get dbWarningsAction(): ((warning: SQLWarning) => void) | null {
+    return _dbWarningsAction;
+  },
+
+  set dbWarningsAction(action: DbWarningsAction) {
+    switch (action) {
+      case "ignore":
+        _dbWarningsAction = null;
+        break;
+      case "log":
+        _dbWarningsAction = (warning) => {
+          let warningMessage = `[ActiveRecord::SQLWarning] ${warning.message}`;
+          if (warning.code) warningMessage += ` (${warning.code})`;
+          // Rails is `ActiveRecord::Base.logger.warn(warning_message)`
+          // (active_record.rb:245); `getBase` is the call-time resolver that
+          // stands in for Ruby resolving that constant when the Proc runs.
+          const logger = getBase()?.logger as { warn?: (msg: string) => void } | null | undefined;
+          if (logger?.warn) logger.warn(warningMessage);
+          else console.warn(warningMessage);
+        };
+        break;
+      case "raise":
+        _dbWarningsAction = (warning) => {
+          throw warning;
+        };
+        break;
+      case "report":
+        // Rails' `Rails.error.report(warning, handled: true)`
+        // (active_record.rb:249).
+        _dbWarningsAction = (warning) => {
+          ActiveSupport.errorReporter.report(warning, { handled: true });
+        };
+        break;
+      default:
+        if (typeof action === "function") {
+          _dbWarningsAction = action;
+          break;
+        }
+        throw new ArgumentError(
+          "db_warnings_action must be one of :ignore, :log, :raise, :report, or a custom proc.",
+        );
+    }
   },
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -19,7 +19,6 @@ import {
   Deadlocked,
   LockWaitTimeout,
   NotImplementedError,
-  type SQLWarning,
 } from "../errors.js";
 import {
   ActiveSupport,
@@ -836,19 +835,6 @@ export const ABSTRACT_COLUMN_METHOD_NAMES: readonly string[] = [
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AbstractAdapter implements Quoting {
   static readonly Version = Version;
-
-  /**
-   * Behaviour when the database emits a warning. Mirrors the global
-   * `ActiveRecord.db_warnings_action` config: `"ignore"` (default) drops
-   * warnings, `"log"` logs them, `"raise"` escalates each warning to a
-   * `SQLWarning` exception, `"report"` reports it, and a function receives
-   * the `SQLWarning`. Declared on the base so every adapter shares one
-   * connection-level setting; concrete adapters that surface warnings
-   * (PostgreSQL, MySQL) dispatch on it. Adapters with no warning channel
-   * (e.g. SQLite) never trigger it, matching Rails.
-   */
-  static dbWarningsAction: "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void) =
-    "ignore";
 
   /**
    * Allow-list of warning messages or codes to skip even under `:raise`.

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1636,6 +1636,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * nullable for the disconnected adapter, so the guard joins the `.nil?`
    * early return rather than becoming a second branch Rails does not have.
    *
+   * Rails' closing `ActiveRecord.db_warnings_action.call(warning)`
+   * (abstract_mysql_adapter.rb:782) is spelled `Function#call`, which takes the
+   * receiver first and so fills the slot Ruby's `Proc#call` has no argument for.
+   *
    * Public rather than Ruby-private for the same reason PostgreSQL's is:
    * `perform_query` reaches it through a structurally-typed mixin host.
    *
@@ -1670,10 +1674,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (this.isWarningIgnored(warning as unknown as { level?: string; message?: string }))
         continue;
 
-      // Rails' `ActiveRecord.db_warnings_action.call(warning)`
-      // (abstract_mysql_adapter.rb:782). JS `Function#call` takes the receiver
-      // first, so the adapter fills the slot Ruby's `Proc#call` has no
-      // argument for.
       action.call(this, warning);
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -93,13 +93,13 @@ import {
   MysqlSchemaStatements,
 } from "./mysql/schema-statements.js";
 import {
-  ActiveSupport,
   compactBlank,
   include,
   isPresent,
   parameterize,
   presence,
 } from "@blazetrails/activesupport";
+import { ActiveRecord } from "../ar-config.js";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
 import {
@@ -1636,13 +1636,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * nullable for the disconnected adapter, so the guard joins the `.nil?`
    * early return rather than becoming a second branch Rails does not have.
    *
-   * `ActiveRecord.db_warnings_action` is `nil` by default in Rails; trails
-   * spells that default `"ignore"` on `AbstractAdapter` (abstract-adapter.ts),
-   * so both spellings of "unset" take Rails' `.nil?` early return. The symbol
-   * arms below are the behaviors Rails' `db_warnings_action=` bakes into the
-   * Proc it stores (active_record.rb:236-252), which its `handle_warnings`
-   * then reaches through a single `.call`.
-   *
    * Public rather than Ruby-private for the same reason PostgreSQL's is:
    * `perform_query` reaches it through a structurally-typed mixin host.
    *
@@ -1653,8 +1646,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       warningCount?: unknown;
       query(sql: string): Promise<[unknown, unknown]>;
     } | null;
-    const action = (this.constructor as typeof AbstractMysqlAdapter).dbWarningsAction;
-    if (action == null || action === "ignore" || rawConnection == null) return;
+    const action = ActiveRecord.dbWarningsAction;
+    if (action == null || rawConnection == null) return;
     const warningCount = await this.warningCount(rawConnection);
     if (warningCount === 0) return;
 
@@ -1677,16 +1670,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       if (this.isWarningIgnored(warning as unknown as { level?: string; message?: string }))
         continue;
 
-      if (action === "raise") throw warning;
-      if (action === "log") {
-        const codeSuffix = code ? ` (${code})` : "";
-        const line = `[ActiveRecord::SQLWarning] ${message}${codeSuffix}`;
-        const logger = this.logger as { warn?: (msg: string) => void } | null;
-        if (logger?.warn) logger.warn(line);
-        else console.warn(line);
-      }
-      if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
-      if (typeof action === "function") action.call(this, warning);
+      // Rails' `ActiveRecord.db_warnings_action.call(warning)`
+      // (abstract_mysql_adapter.rb:782). JS `Function#call` takes the receiver
+      // first, so the adapter fills the slot Ruby's `Proc#call` has no
+      // argument for.
+      action.call(this, warning);
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -884,7 +884,9 @@ export class PostgreSQLAdapter
    * from _doAcquire (matches Rails' single-slot set_notice_receiver).
    */
   private _attachNoticeListener(client: pg.Client): void {
-    if ((this.constructor as typeof PostgreSQLAdapter).dbWarningsAction === "ignore") return;
+    // Rails' `unless ActiveRecord.db_warnings_action.nil?`
+    // (postgresql_adapter.rb:965).
+    if (ActiveRecord.dbWarningsAction == null) return;
     client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
       // Rails' notice receiver buffers SQLWarning instances themselves
       // (postgresql_adapter.rb:970), so `handle_warnings` dispatches the very

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -881,11 +881,11 @@ export class PostgreSQLAdapter
   /**
    * Attach the per-connection notice listener that feeds
    * `_noticeReceiverSqlWarnings`. Called once per pg.Client lifecycle
-   * from _doAcquire (matches Rails' single-slot set_notice_receiver).
+   * from _doAcquire (matches Rails' single-slot set_notice_receiver), under
+   * Rails' `unless ActiveRecord.db_warnings_action.nil?` guard
+   * (postgresql_adapter.rb:965).
    */
   private _attachNoticeListener(client: pg.Client): void {
-    // Rails' `unless ActiveRecord.db_warnings_action.nil?`
-    // (postgresql_adapter.rb:965).
     if (ActiveRecord.dbWarningsAction == null) return;
     client.on("notice", (msg: { severity?: string; message?: string; code?: string }) => {
       // Rails' notice receiver buffers SQLWarning instances themselves

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -382,6 +382,13 @@ interface HandleWarningsHost {
  * PG::Result, database_statements.rb:166), and calls the resolved
  * `ActiveRecord.db_warnings_action` on each surviving warning.
  *
+ * Rails' `.call(warning)` has no nil guard here — the notice receiver that
+ * fills `_noticeReceiverSqlWarnings` is only attached while
+ * `ActiveRecord.db_warnings_action` is set (postgresql_adapter.rb:965) — so the
+ * `!` carries that invariant rather than adding a branch. JS `Function#call`
+ * takes the receiver first, filling the slot Ruby's `Proc#call` has no argument
+ * for.
+ *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
  * (postgresql/database_statements.rb:216-223)
  * @internal
@@ -391,11 +398,7 @@ export function handleWarnings(this: HandleWarningsHost, sql: unknown): void {
     if (this.isWarningIgnored(warning as unknown as { message?: string })) continue;
 
     warning.sql = sql;
-    // Rails' `ActiveRecord.db_warnings_action.call(warning)`
-    // (postgresql/database_statements.rb:222). JS `Function#call` takes the
-    // receiver first, so the adapter fills the slot Ruby's `Proc#call` has no
-    // argument for.
-    ActiveRecord.dbWarningsAction?.call(this, warning as unknown as SQLWarning);
+    ActiveRecord.dbWarningsAction!.call(this, warning as unknown as SQLWarning);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -7,7 +7,7 @@
 import type pg from "pg";
 import type { Type } from "@blazetrails/activemodel";
 import type { Nodes } from "@blazetrails/arel";
-import { ActiveSupport } from "@blazetrails/activesupport";
+import { ActiveRecord } from "../../ar-config.js";
 import { PreparedStatementCacheExpired, type SQLWarning } from "../../errors.js";
 import { Result } from "../../result.js";
 import { combineMultiStatements, type ExplainOption } from "../abstract/database-statements.js";
@@ -367,9 +367,6 @@ const ACTIONABLE_LEVELS = new Set(["WARNING", "ERROR", "FATAL", "PANIC"]);
 /** @internal */
 type SqlWarning = SQLWarning;
 
-/** Mirrors the values `ActiveRecord.db_warnings_action` accepts. */
-type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((warning: SqlWarning) => void);
-
 /** @internal */
 interface HandleWarningsHost {
   _noticeReceiverSqlWarnings?: SqlWarning[];
@@ -377,46 +374,28 @@ interface HandleWarningsHost {
   // PostgreSQL's own `warning_ignored?` override widens with the level check.
   /** @internal */
   isWarningIgnored(warning: { message?: string; code?: string | number }): boolean;
-  logger?: unknown;
 }
 
 /**
  * Iterates notice-receiver warnings accumulated during the query, attaches the
  * result object (Rails names the parameter `sql` but `perform_query` passes the
- * PG::Result, database_statements.rb:166), and dispatches each surviving
- * warning to the configured `db_warnings_action`.
- *
- * Rails' `ActiveRecord.db_warnings_action=` turns the symbol into a Proc once,
- * at config time (active_record.rb:236-252), and `handle_warnings` only
- * `.call`s it. trails stores the symbol itself on the adapter class, so the
- * symbol → behavior mapping lives here, at the one place that calls it.
+ * PG::Result, database_statements.rb:166), and calls the resolved
+ * `ActiveRecord.db_warnings_action` on each surviving warning.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#handle_warnings
+ * (postgresql/database_statements.rb:216-223)
  * @internal
  */
 export function handleWarnings(this: HandleWarningsHost, sql: unknown): void {
-  const action = (this.constructor as { dbWarningsAction?: DbWarningsAction }).dbWarningsAction;
   for (const warning of this._noticeReceiverSqlWarnings ?? []) {
     if (this.isWarningIgnored(warning as unknown as { message?: string })) continue;
+
     warning.sql = sql;
-    if (!action || action === "ignore") continue;
-    if (action === "raise") throw warning;
-    if (action === "log") {
-      const codeSuffix = warning.code ? ` (${warning.code})` : "";
-      const message = `[ActiveRecord::SQLWarning] ${warning.message}${codeSuffix}`;
-      const logger = this.logger as { warn?: (msg: string) => void } | null | undefined;
-      if (logger?.warn) logger.warn(message);
-      else console.warn(message);
-    }
-    // Mirrors Rails' `:report` → `Rails.error.report(warning, handled: true)`
-    // (active_record.rb:248-249).
-    if (action === "report") ActiveSupport.errorReporter.report(warning, { handled: true });
-    // Rails' `ActiveRecord.db_warnings_action.call(warning)` — the symbol arms
-    // above are the behaviors its setter bakes into that Proc, and a
-    // user-supplied callable is invoked here exactly as Rails invokes it. JS
-    // `Function#call` takes the receiver first, so the adapter fills the slot
-    // Ruby's `Proc#call` has no argument for.
-    if (typeof action === "function") action.call(this, warning);
+    // Rails' `ActiveRecord.db_warnings_action.call(warning)`
+    // (postgresql/database_statements.rb:222). JS `Function#call` takes the
+    // receiver first, so the adapter fills the slot Ruby's `Proc#call` has no
+    // argument for.
+    ActiveRecord.dbWarningsAction?.call(this, warning as unknown as SQLWarning);
   }
 }
 

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -67,7 +67,15 @@ export function setBaseResolver(resolver: () => any): void {
   _baseResolver = resolver;
 }
 
-function getBase(): any {
+/**
+ * Read the `ActiveRecord::Base` constant at call time. Exported for the other
+ * modules that name it inside a method body where Ruby's autoload resolves it
+ * (`ActiveRecord.db_warnings_action=`'s `:log` arm, active_record.rb:245).
+ *
+ * @internal
+ */
+
+export function getBase(): any {
   return _baseResolver?.() ?? null;
 }
 

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -73,8 +73,10 @@ export function setBaseResolver(resolver: () => any): void {
  * (`ActiveRecord.db_warnings_action=`'s `:log` arm, active_record.rb:245).
  *
  * @internal
+ * @noRailsEquivalent PERMANENT — the read half of the `setBaseResolver` seam
+ *   above; Ruby resolves `ActiveRecord::Base` by autoload at call time, which a
+ *   static TS import cannot do without closing a cycle.
  */
-
 export function getBase(): any {
   return _baseResolver?.() ?? null;
 }

--- a/packages/activerecord/src/support/with-db-warnings-action.ts
+++ b/packages/activerecord/src/support/with-db-warnings-action.ts
@@ -1,10 +1,11 @@
+import { ActiveRecord } from "../ar-config.js";
 import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { SQLWarning } from "../errors.js";
 
 type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void);
 
 /**
- * Scope `AbstractAdapter.dbWarningsAction` (+ optional ignore list) to a
+ * Scope `ActiveRecord.dbWarningsAction` (+ optional ignore list) to a
  * single block, restoring the prior values afterwards even on throw. Mirrors
  * Rails' `ActiveRecord::TestCase#with_db_warnings_action` (test_case.rb:164),
  * which toggles the global `ActiveRecord.db_warnings_action` /
@@ -14,8 +15,8 @@ type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((w: SQLWarning)
  * `configure_connection` — trails' adapters read `dbWarningsAction` live on
  * each warning-bearing query, so no reconnect is needed.
  *
- * `dbWarningsAction` is declared on the base adapter, so setting it here is a
- * single global toggle observed by every concrete adapter (PostgreSQL/MySQL
+ * `dbWarningsAction` is a module-level config, as in Rails, so setting it here
+ * is a single global toggle observed by every concrete adapter (PostgreSQL/MySQL
  * escalate under `"raise"`; SQLite has no warning channel and so is a no-op,
  * matching Rails).
  */
@@ -28,14 +29,14 @@ export async function withDbWarningsAction(
     typeof warningsToIgnore === "function" ? warningsToIgnore : fn
   ) as () => Promise<void> | void;
   const ignore = Array.isArray(warningsToIgnore) ? warningsToIgnore : [];
-  const savedAction = AbstractAdapter.dbWarningsAction;
+  const savedAction = ActiveRecord.dbWarningsAction;
   const savedIgnore = AbstractAdapter.dbWarningsIgnore;
-  AbstractAdapter.dbWarningsAction = action;
+  ActiveRecord.dbWarningsAction = action;
   AbstractAdapter.dbWarningsIgnore = ignore;
   try {
     await body();
   } finally {
-    AbstractAdapter.dbWarningsAction = savedAction;
+    ActiveRecord.dbWarningsAction = savedAction ?? "ignore";
     AbstractAdapter.dbWarningsIgnore = savedIgnore;
   }
 }

--- a/packages/activesupport/src/current-attributes.test.ts
+++ b/packages/activesupport/src/current-attributes.test.ts
@@ -4,6 +4,7 @@ import { CurrentAttributes } from "./current-attributes.js";
 import { methodMissingProxy } from "./method-missing-proxy.js";
 import { assertSame } from "./testing/assertions.js";
 import { zone, setZone } from "./time-zone-config.js";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
 describe("CurrentAttributesTest", () => {
   /** Rails' `Person = Struct.new(:id, :name, :time_zone)`. */
@@ -278,8 +279,23 @@ describe("CurrentAttributesTest", () => {
     expect(Current.counterInteger).toBe(0);
   });
 
-  it.skip("CurrentAttributes use fiber-local variables");
-  it.skip("CurrentAttributes can use thread-local variables");
+  // Rails flips `IsolatedExecutionState.isolation_level` and reads the
+  // attribute from inside an `Enumerator`, which runs its block on a separate
+  // fiber. JS has neither fibers nor threads, so the two levels port to the two
+  // things trails' IsolatedExecutionState actually distinguishes: a forked
+  // execution context (`run`, the analogue of :fiber) and the caller's own
+  // context (the analogue of :thread, which the Enumerator's fiber shares).
+  it("CurrentAttributes use fiber-local variables", () => {
+    Session.current = 42;
+    const inner = IsolatedExecutionState.run(() => Session.current);
+    expect(inner).toBeUndefined();
+  });
+
+  it("CurrentAttributes can use thread-local variables", () => {
+    Session.current = 42;
+    const inner = (() => Session.current)();
+    expect(inner).toBe(42);
+  });
 
   it("CurrentAttributes doesn't populate #attributes when not using defaults", () => {
     expect(Current.attributes).toEqual({ counterInteger: 0, counterCallable: 0 });

--- a/packages/activesupport/src/current-attributes.ts
+++ b/packages/activesupport/src/current-attributes.ts
@@ -171,39 +171,6 @@ export abstract class CurrentAttributes {
     return instance as InstanceType<T>;
   }
 
-  /** Mirrors: CurrentAttributes.reset_all (current_attributes.rb:156-158) @internal */
-  static resetAll(): void {
-    for (const instance of this.currentInstances().values()) instance.reset();
-  }
-
-  /** Mirrors: CurrentAttributes.clear_all (current_attributes.rb:160-163) @internal */
-  static clearAll(): void {
-    this.resetAll();
-    this.currentInstances().clear();
-  }
-
-  /** Mirrors: CurrentAttributes.current_instances (:170-172) @internal */
-  private static currentInstances(): Map<string, CurrentAttributes> {
-    return IsolatedExecutionState.fetch(
-      CURRENT_ATTRIBUTES_INSTANCES,
-      () => new Map<string, CurrentAttributes>(),
-    );
-  }
-
-  /**
-   * Mirrors: CurrentAttributes.current_instances_key (:174-176). Ruby memoizes
-   * `name.to_sym` in a per-class ivar, so the memo is read as an *own*
-   * property — a subclass keys on its own name, never its parent's.
-   *
-   * @internal
-   */
-  private static currentInstancesKey(): string {
-    if (!Object.prototype.hasOwnProperty.call(this, "_currentInstancesKey")) {
-      (this as CurrentAttributesClass)._currentInstancesKey = this.name;
-    }
-    return (this as CurrentAttributesClass)._currentInstancesKey!;
-  }
-
   /**
    * Registers a callback to run before #reset clears the attributes. Mirrors
    * Rails' `before_reset` (`set_callback :reset, :before`).
@@ -249,6 +216,39 @@ export abstract class CurrentAttributes {
    */
   static set<R>(attributes: Record<string, AttributeValue>, block: () => R): R {
     return this.instance().set(attributes, block);
+  }
+
+  /** Mirrors: CurrentAttributes.reset_all (current_attributes.rb:156-158) @internal */
+  static resetAll(): void {
+    for (const instance of this.currentInstances().values()) instance.reset();
+  }
+
+  /** Mirrors: CurrentAttributes.clear_all (current_attributes.rb:160-163) @internal */
+  static clearAll(): void {
+    this.resetAll();
+    this.currentInstances().clear();
+  }
+
+  /** Mirrors: CurrentAttributes.current_instances (:170-172) @internal */
+  private static currentInstances(): Map<string, CurrentAttributes> {
+    return IsolatedExecutionState.fetch(
+      CURRENT_ATTRIBUTES_INSTANCES,
+      () => new Map<string, CurrentAttributes>(),
+    );
+  }
+
+  /**
+   * Mirrors: CurrentAttributes.current_instances_key (:174-176). Ruby memoizes
+   * `name.to_sym` in a per-class ivar, so the memo is read as an *own*
+   * property — a subclass keys on its own name, never its parent's.
+   *
+   * @internal
+   */
+  private static currentInstancesKey(): string {
+    if (!Object.prototype.hasOwnProperty.call(this, "_currentInstancesKey")) {
+      (this as CurrentAttributesClass)._currentInstancesKey = this.name;
+    }
+    return (this as CurrentAttributesClass)._currentInstancesKey!;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/activesupport/src/current-attributes.ts
+++ b/packages/activesupport/src/current-attributes.ts
@@ -1,13 +1,15 @@
 /**
- * Mirrors: ActiveSupport::CurrentAttributes (current_attributes.rb). Rails keeps
- * the singletons in `IsolatedExecutionState`, which trails has no counterpart
- * for, so `currentInstances` is module-level and its entries process-wide.
+ * Mirrors: ActiveSupport::CurrentAttributes (current_attributes.rb). Abstract
+ * super class that provides an execution-isolated attributes singleton: the
+ * instances live in `IsolatedExecutionState` (:170-172), so each logical task
+ * gets its own, exactly as Rails gives each fiber/thread its own.
  */
 
 import { defineCallbacks, runCallbacks, setCallback } from "./callbacks.js";
 import { CodeGenerator } from "./code-generator.js";
 import { objectWith } from "./core-ext/object/with.js";
 import { include, Module } from "./include.js";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
 const __FILE__ = import.meta.url;
 const __LINE__ = 0;
@@ -27,7 +29,7 @@ class ArgumentError extends Error {
 /** A `:reset` callback, instance-exec'd (Rails' `set_callback :reset`). */
 type ResetCallback = (this: CurrentAttributes) => void;
 
-/** Mirrors: ActiveSupport::CurrentAttributes::INVALID_ATTRIBUTE_NAMES (:95). */
+/** Mirrors: ActiveSupport::CurrentAttributes::INVALID_ATTRIBUTE_NAMES (:96). */
 const INVALID_ATTRIBUTE_NAMES = [
   "set",
   "reset",
@@ -39,7 +41,7 @@ const INVALID_ATTRIBUTE_NAMES = [
   "clearAll",
 ];
 
-/** Mirrors: ActiveSupport::CurrentAttributes::NOT_SET (current_attributes.rb:97). */
+/** Mirrors: ActiveSupport::CurrentAttributes::NOT_SET (current_attributes.rb:98). */
 const NOT_SET: unknown = Object.freeze({});
 
 /**
@@ -47,7 +49,7 @@ const NOT_SET: unknown = Object.freeze({});
  * `static attribute(name, options?)` to define attributes.
  */
 export abstract class CurrentAttributes {
-  /** Mirrors: `class_attribute :defaults` (current_attributes.rb:196). */
+  /** Mirrors: `class_attribute :defaults` (current_attributes.rb:195). */
   public static defaults: Record<string, AttributeValue> = {};
 
   static {
@@ -152,20 +154,54 @@ export abstract class CurrentAttributes {
     };
   }
 
-  /** Mirrors: CurrentAttributes.instance (current_attributes.rb:101-103) */
+  /**
+   * Returns singleton instance for this class in this execution context. If
+   * none exists, one is created.
+   *
+   * Mirrors: CurrentAttributes.instance (current_attributes.rb:102-104)
+   */
   static instance<T extends typeof CurrentAttributes>(this: T): InstanceType<T> {
     const key = (this as typeof CurrentAttributes).currentInstancesKey();
-    let instance = currentInstances.get(key);
+    const instances = (this as typeof CurrentAttributes).currentInstances();
+    let instance = instances.get(key);
     if (instance === undefined) {
       instance = new (this as unknown as new () => CurrentAttributes)();
-      currentInstances.set(key, instance);
+      instances.set(key, instance);
     }
     return instance as InstanceType<T>;
   }
 
-  /** Mirrors: CurrentAttributes.current_instances_key (:176-178) @internal */
+  /** Mirrors: CurrentAttributes.reset_all (current_attributes.rb:156-158) @internal */
+  static resetAll(): void {
+    for (const instance of this.currentInstances().values()) instance.reset();
+  }
+
+  /** Mirrors: CurrentAttributes.clear_all (current_attributes.rb:160-163) @internal */
+  static clearAll(): void {
+    this.resetAll();
+    this.currentInstances().clear();
+  }
+
+  /** Mirrors: CurrentAttributes.current_instances (:170-172) @internal */
+  private static currentInstances(): Map<string, CurrentAttributes> {
+    return IsolatedExecutionState.fetch(
+      CURRENT_ATTRIBUTES_INSTANCES,
+      () => new Map<string, CurrentAttributes>(),
+    );
+  }
+
+  /**
+   * Mirrors: CurrentAttributes.current_instances_key (:174-176). Ruby memoizes
+   * `name.to_sym` in a per-class ivar, so the memo is read as an *own*
+   * property — a subclass keys on its own name, never its parent's.
+   *
+   * @internal
+   */
   private static currentInstancesKey(): string {
-    return this.name;
+    if (!Object.prototype.hasOwnProperty.call(this, "_currentInstancesKey")) {
+      (this as CurrentAttributesClass)._currentInstancesKey = this.name;
+    }
+    return (this as CurrentAttributesClass)._currentInstancesKey!;
   }
 
   /**
@@ -260,13 +296,17 @@ function dup(value: unknown): unknown {
   return value;
 }
 
-/** Mirrors: CurrentAttributes.current_instances (:170-172) @internal */
-const currentInstances = new Map<string, CurrentAttributes>();
+/**
+ * The `IsolatedExecutionState[:current_attributes_instances]` slot key
+ * (current_attributes.rb:171).
+ */
+const CURRENT_ATTRIBUTES_INSTANCES = "current_attributes_instances";
 
 // Internal alias for static method use
 type CurrentAttributesClass = typeof CurrentAttributes & {
   defaults: Record<string, AttributeValue>;
   _generatedAttributeMethods?: Module;
+  _currentInstancesKey?: string;
 };
 
 /**


### PR DESCRIPTION
Two RFC 0112 deviations, both "one Rails thing, N trails things".

## `CurrentAttributes` — execution-isolated singletons (`current-attributes-port-body`)

Most of this story's converged shape landed with PR #6538 (`NOT_SET`, the
`defaults` class attribute, `reset`/`resolveDefaults`/`attributes=`, and the
removal of `_definitions` / `_get` / `_set` / `_setupProxy`). What was left:

- `current_instances` now reads
  `IsolatedExecutionState[:current_attributes_instances]`
  (`current_attributes.rb:170-172`) instead of a module-level `Map`, so the
  singleton is per-execution-context — which is what the file's header
  docstring had been claiming all along. The docstring now matches the code.
- `current_instances_key` memoizes `name` in a per-class own property, as
  Ruby's `@current_instances_key ||=` does (`:174-176`).
- `reset_all` / `clear_all` (`:156-163`) are ported; they had no counterpart.
- The two skipped isolation tests are enabled. Rails flips
  `IsolatedExecutionState.isolation_level` and reads through an `Enumerator`
  (a separate fiber); JS has neither fibers nor threads, so they port to the
  two things trails' `IsolatedExecutionState` actually distinguishes — a forked
  context (`run`, the `:fiber` analogue) and the caller's own context (the
  `:thread` analogue, which the Enumerator's fiber shares). Test names are
  unchanged.

## `db_warnings_action` resolved once (`db-warnings-action-resolved-per-adapter-not-once`)

Rails resolves the symbol into a Proc once, at config time
(`active_record.rb:236-252`); every adapter's `handle_warnings` then only
`.call`s it. trails held the raw symbol on `AbstractAdapter` and re-implemented
the mapping inside each adapter's handler, which is how the two drifted apart
(mysql2 had no `:report` arm).

- `ActiveRecord.dbWarningsAction`'s setter now carries the whole mapping,
  including `:report` → `ActiveSupport.errorReporter.report(warning, { handled: true })`
  (Rails' `Rails.error.report`). The reader answers the resolved callable, so a
  change between queries takes effect as it does in Rails.
- PostgreSQL's `handleWarnings` and mysql2's are Rails' loop again:
  `warning_ignored?` → `warning.sql = …` → `.call(warning)`. mysql2 gains
  `:report` by construction. `AbstractAdapter.dbWarningsAction` — a trails-only
  class attribute — is deleted; `dbWarningsIgnore` is untouched.
- `configure_connection`'s notice-receiver guard is Rails'
  `unless ActiveRecord.db_warnings_action.nil?` (`postgresql_adapter.rb:965`).
- The `:log` arm names `ActiveRecord::Base.logger` (`active_record.rb:245`),
  which Ruby resolves when the Proc runs; trails reaches it through
  `log-subscriber.ts`'s existing call-time `getBase` resolver (now exported
  `@internal`) rather than a static import that would close a cycle.
- `support/with-db-warnings-action.ts` scopes the module-level config now,
  same surface for callers.

## Checks

`pnpm parity:api:calls` OK (population 294 → 293, no new baseline rows);
`pnpm parity:api:calls:args` OK; `parity:api:extra --package activesupport`
gains no novel names; `pnpm lint`, `pnpm typecheck` clean.
`current-attributes.test.ts` 21/21 (was 19 + 2 skipped). The PG warning cases
run on the CI Postgres lane.

Closes-story: current-attributes-port-body
Closes-story: db-warnings-action-resolved-per-adapter-not-once
