### PR TITLE
refactor(activerecord): token_for class_attributes, abstract change_column, acquire_connection (RFC 0112, RFC 0077, RFC 0119)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4591,7 +4591,16 @@ classAttribute.call(Base, "counterCachedAssociationNames", {
 // app.message_verifier("active_record/token_for")` onto ActiveRecord::Base at
 // boot. trails has no railtie, so token-for.ts builds the verifier from the
 // injected secret and this sink performs that assignment.
+let _bootTokenVerifier: _MessageVerifier | null = null;
 _registerGeneratedTokenVerifierSink((verifier) => {
+  // railtie.rb:331 assigns with `||=`, so an explicit
+  // `Base.generatedTokenVerifier = ...` is never overwritten. The seam may
+  // still replace the value it installed itself, which is how a re-injected
+  // secret reaches the slot.
+  if (Base.generatedTokenVerifier != null && Base.generatedTokenVerifier !== _bootTokenVerifier) {
+    return;
+  }
+  _bootTokenVerifier = verifier;
   Base.generatedTokenVerifier = verifier;
 });
 extend(Base, {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -141,16 +141,14 @@ import {
   findSignedBang as _findSignedBang,
 } from "./signed-id.js";
 import {
-  tokenDefinitions as _tokenDefinitions,
-  setTokenDefinitions as _setTokenDefinitions,
-  generatedTokenVerifier as _generatedTokenVerifier,
-  setGeneratedTokenVerifier as _setGeneratedTokenVerifier,
+  registerGeneratedTokenVerifierSink as _registerGeneratedTokenVerifierSink,
+  withFetch as _withFetch,
   generatesTokenFor as _generatesTokenFor,
   generateTokenFor as _generateTokenFor,
   findByTokenFor as _findByTokenFor,
   findByTokenForBang as _findByTokenForBang,
 } from "./token-for.js";
-import type { TokenDefinition as _TokenDefinition } from "./token-for.js";
+import type { TokenDefinitionsHash as _TokenDefinitionsHash } from "./token-for.js";
 import type { MessageVerifier as _MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import {
   getVerboseQueryLogs as _getVerboseQueryLogs,
@@ -1716,26 +1714,14 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.token_definitions
    */
-  static get tokenDefinitions(): ReturnType<typeof _tokenDefinitions> {
-    return _tokenDefinitions(this);
-  }
-
-  static set tokenDefinitions(value: Record<string, _TokenDefinition>) {
-    _setTokenDefinitions(this, value);
-  }
+  declare static tokenDefinitions: _TokenDefinitionsHash;
 
   /**
    * MessageVerifier backing token-for (null until a verifier is configured).
    *
    * Mirrors: ActiveRecord::Base.generated_token_verifier
    */
-  static get generatedTokenVerifier(): _MessageVerifier | null {
-    return _generatedTokenVerifier(this);
-  }
-
-  static set generatedTokenVerifier(value: _MessageVerifier | null) {
-    _setGeneratedTokenVerifier(this, value);
-  }
+  declare static generatedTokenVerifier: _MessageVerifier | null;
 
   // -- Encrypted attributes --
 
@@ -4586,9 +4572,27 @@ classAttribute.call(Base, "timeZoneAwareTypes", {
 });
 classAttribute.call(Base, "nestedAttributesOptions", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "encryptedAttributes");
+// Mirrors token_for.rb:10-11.
+classAttribute.call(Base, "tokenDefinitions", {
+  instanceAccessor: false,
+  instancePredicate: false,
+  default: _withFetch({}),
+});
+classAttribute.call(Base, "generatedTokenVerifier", {
+  instanceAccessor: false,
+  instancePredicate: false,
+});
 classAttribute.call(Base, "counterCachedAssociationNames", {
   instanceWriter: false,
   default: [],
+});
+// The railtie initializer "active_record.generated_token_verifier"
+// (railtie.rb:328-334) assigns `self.generated_token_verifier ||=
+// app.message_verifier("active_record/token_for")` onto ActiveRecord::Base at
+// boot. trails has no railtie, so token-for.ts builds the verifier from the
+// injected secret and this sink performs that assignment.
+_registerGeneratedTokenVerifierSink((verifier) => {
+  Base.generatedTokenVerifier = verifier;
 });
 extend(Base, {
   defaultScope: _defaultScope,

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -709,7 +709,10 @@ export class ConnectionPool implements ReapablePool {
         }
         lease.connection = pinned;
       } else {
-        lease.connection = checkoutAndVerify(this, this._acquireConnection());
+        lease.connection = checkoutAndVerify(
+          this,
+          this.acquireConnectionSync(this.checkoutTimeout),
+        );
       }
     }
     return lease.connection;
@@ -892,42 +895,43 @@ export class ConnectionPool implements ReapablePool {
     return pinned;
   }
 
-  private _acquireConnection(): DatabaseAdapter {
+  /**
+   * The synchronous seams' entry into `acquire_connection`
+   * (connection_pool.rb:862): the same sequence — poll, try a new connection,
+   * reap, retry — minus the blocking `@available.poll(checkout_timeout)`, which
+   * has no synchronous spelling in JS. Where Rails' thread would block and then
+   * raise on expiry, this raises straight away with the same error. The
+   * blocking wait itself lives in {@link acquireConnection}; this exists only
+   * for {@link leaseConnectionSync} and `checkout_for_exclusive_access`, whose
+   * callers (`disconnect!`, `reload`, `Migration#connection`) are synchronous
+   * all the way up.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT Rails' `acquire_connection` blocks the calling
+   *   thread; a JS function that cannot await has no way to wait, so the wait
+   *   branch collapses to its timeout arm.
+   */
+  acquireConnectionSync(checkoutTimeout: number): DatabaseAdapter {
+    // Stands in for `checkout`'s `unless @pinned_connection` guard
+    // (connection_pool.rb:548), which is where both sync seams enter Rails.
     const pinned = this._resolvePinnedConnection();
     if (pinned) return pinned;
-    const conn = this._tryAcquire();
-    if (conn) return conn;
-    throw new ConnectionTimeoutError(
-      `Could not obtain a connection from the pool. All ${this.size} connections are in use.`,
-      { connectionPool: this },
-    );
-  }
-
-  private _tryAcquire(): DatabaseAdapter | undefined {
     if (this.isDiscarded()) {
       throw new ConnectionNotEstablished("Connection pool has been discarded");
     }
-    if (this._available) {
-      const conn = this._available.poll();
-      if (conn) {
-        this._checkedOut.add(conn);
-        return conn;
-      }
+    let conn = this._available?.poll() ?? this.tryToCheckoutNewConnection();
+    if (!conn) {
+      this.reap();
+      conn = this._available?.poll() ?? this.tryToCheckoutNewConnection();
     }
-    if (this._connections && this._connections.length < this.size) {
-      if (!this.automaticReconnect) {
-        throw new ConnectionNotEstablished(
-          "No connection available from pool and automatic_reconnect is disabled",
-          { connectionPool: this },
-        );
-      }
-      const conn = this.newConnection();
-      this._connections.push(conn);
-      this._checkedOut.add(conn);
-      (conn as unknown as PoolManagedConnection).lease?.();
-      return conn;
+    if (!conn) {
+      throw new ConnectionTimeoutError(
+        `Could not obtain a connection from the pool within ${checkoutTimeout} seconds`,
+        { connectionPool: this },
+      );
     }
-    return undefined;
+    this._checkedOut.add(conn);
+    return conn;
   }
 
   checkin(conn: DatabaseAdapter): void {
@@ -1518,7 +1522,7 @@ export class ConnectionPool implements ReapablePool {
   /**
    * Resolve the connection that all checkouts in the current execution
    * context should route to while a pin is active. Centralizes the lookup
-   * used by `checkout` and `_acquireConnection` so every
+   * used by `checkout` and `acquireConnectionSync` so every
    * lease entry point honors `pinConnectionBang` consistently — mirrors
    * Rails' `@pinned_connection` short-circuit in
    * `ConnectionPool#checkout` (connection_pool.rb:547).
@@ -1702,7 +1706,7 @@ function attemptToCheckoutAllExistingConnections(
  */
 function checkoutForExclusiveAccess(pool: Pool, checkoutTimeout: number): DatabaseAdapter | null {
   try {
-    return pool._acquireConnection();
+    return pool.acquireConnectionSync(checkoutTimeout);
   } catch (err) {
     if (err instanceof ConnectionTimeoutError) {
       throw new ExclusiveConnectionTimeoutError(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -579,48 +579,27 @@ export class SchemaStatements {
     }
   }
 
+  /**
+   * Changes the column's definition according to the new options.
+   * See TableDefinition#column for details of the options you can use.
+   *
+   *   changeColumn('suppliers', 'name', 'string', { limit: 80 })
+   *   changeColumn('accounts', 'description', 'text')
+   *
+   * Mirrors: `SchemaStatements#change_column` (`schema_statements.rb:711-713`).
+   * Every adapter overrides it: MySQL and PostgreSQL through
+   * `change_column_for_alter` (abstract_mysql_adapter.rb:396-398,
+   * postgresql/schema_statements.rb:466-471), SQLite through `alter_table`
+   * (sqlite3_adapter.rb:385-389).
+   */
   async changeColumn(
-    tableName: string,
-    columnName: string,
-    type: ColumnType,
-    options: ColumnOptions = {},
+    _tableName: string,
+    _columnName: string,
+    _type: ColumnType,
+    _options: ColumnOptions = {},
   ): Promise<void> {
-    const sqlType = this.schemaCreation.typeToSql(type, options);
-    const table = this.quoteColumnName(tableName);
-    const col = this.quoteColumnName(columnName);
-
-    if (this.adapterName === "mysql2") {
-      const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause =
-        options.default === undefined
-          ? ""
-          : ` DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`;
-      await this.execute(
-        `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
-      );
-    } else if (this.adapterName === "postgres") {
-      const clauses: string[] = [`ALTER COLUMN ${col} TYPE ${sqlType}`];
-      if (options.null !== undefined) {
-        clauses.push(
-          `ALTER COLUMN ${col} ${options.null === false ? "SET NOT NULL" : "DROP NOT NULL"}`,
-        );
-      }
-      if (options.default !== undefined) {
-        clauses.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`,
-        );
-      }
-      await this.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
-    } else {
-      const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause =
-        options.default === undefined
-          ? ""
-          : ` DEFAULT ${await this.quoteDefaultExpression(options.default, { sqlType })}`;
-      await this.execute(
-        `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
-      );
-    }
+    // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:711
+    throw new NotImplementedError("change_column is not implemented");
   }
 
   /**

--- a/packages/activerecord/src/token-for.trails.test.ts
+++ b/packages/activerecord/src/token-for.trails.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { User } from "./test-helpers/models/user.js";
 import { setTokenForSecret } from "./token-for.js";
+import { Base } from "./base.js";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { fixtures } from "./test-fixtures.js";
 
 class TokenUser extends User {
@@ -43,6 +45,18 @@ describe("token-for relation finders", () => {
 
     await user.update({ token: "second" });
     expect(await TokenUser.findByTokenFor("token_snapshot", token)).toBeNull();
+  });
+
+  // railtie.rb:331 assigns the boot verifier with `||=`, so an explicitly
+  // assigned one survives — Rails' own tests inject a verifier that way.
+  it("keeps an explicitly assigned generated_token_verifier when the secret seam re-runs", () => {
+    const explicit = new MessageVerifier("explicit");
+    Base.generatedTokenVerifier = explicit;
+
+    setTokenForSecret("another secret");
+
+    expect(Base.generatedTokenVerifier).toBe(explicit);
+    Base.generatedTokenVerifier = null;
   });
 
   it("raises Ruby's Hash#fetch KeyError when a relation looks up an unknown purpose", async () => {

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -11,15 +11,30 @@ import type { Base } from "./base.js";
 export { InvalidSignature };
 
 let _tokenForSecret: string | (() => string) | null = null;
-// `generated_token_verifier` is a `class_attribute`, so each class has its own
-// slot that subclasses inherit until they assign their own (see resolvedVerifier
-// / ownVerifierEntry).
-const tokenVerifierRegistry = new WeakMap<object, { verifier: MessageVerifier | null }>();
-// The value the railtie initializer assigns onto ActiveRecord::Base at boot
-// (railtie.rb:328-334, `self.generated_token_verifier ||= app.message_verifier(...)`).
-// trails has no railtie/application, so the boot-time assignment lands in this
-// module-level slot, which the reader falls back to when no class has written.
-let _defaultVerifier: MessageVerifier | null = null;
+// The sink base.ts installs so the boot-time verifier lands on
+// `ActiveRecord::Base.generated_token_verifier`, which is where the railtie
+// initializer assigns it (railtie.rb:328-334,
+// `self.generated_token_verifier ||= app.message_verifier(...)`). token-for.ts
+// cannot name `Base` — base.ts imports it at runtime, so a reverse runtime
+// import would close a cycle — so base.ts hands the assignment down instead.
+let _assignBootVerifier: ((verifier: MessageVerifier | null) => void) | null = null;
+
+/**
+ * Install the boot-time `generated_token_verifier` assignment. Same trails-only
+ * railtie seam as {@link setTokenForSecret}, split out because the assignment
+ * target lives in base.ts.
+ *
+ * @internal
+ * @noRailsEquivalent PERMANENT trails has no railtie/application, so the
+ * railtie.rb:328-334 initializer that assigns
+ * `ActiveRecord::Base.generated_token_verifier` has to be injected from base.ts.
+ */
+export function registerGeneratedTokenVerifierSink(
+  sink: (verifier: MessageVerifier | null) => void,
+): void {
+  _assignBootVerifier = sink;
+  buildDefaultVerifier();
+}
 
 /**
  * Configure the secret used for token generation/verification.
@@ -43,32 +58,6 @@ export function setTokenForSecret(secret: string | (() => string) | null): void 
   buildDefaultVerifier();
 }
 
-/**
- * This class's *own* verifier slot, or undefined when the class has never
- * written. A present entry whose `verifier`
- * is null is an explicit nil shadow (Rails: `self.generated_token_verifier = nil`
- * assigns nil to this class), distinct from "no own slot".
- */
-function ownVerifierEntry(modelClass: object): { verifier: MessageVerifier | null } | undefined {
-  return tokenVerifierRegistry.get(modelClass);
-}
-
-/**
- * Resolved `class_attribute` value: the nearest class on the chain with an own
- * slot wins — even a nil shadow stops the walk (so an explicit `= null` does not
- * inherit the parent's verifier). Falls back to the boot-time verifier the
- * railtie stand-in built, and is null when no secret is configured at all.
- */
-function resolvedVerifier(modelClass: object): MessageVerifier | null {
-  let current: any = modelClass;
-  while (current) {
-    const entry = ownVerifierEntry(current);
-    if (entry) return entry.verifier;
-    current = Object.getPrototypeOf(current);
-  }
-  return _defaultVerifier;
-}
-
 function resolveSecret(): string | null {
   if (_tokenForSecret) {
     return typeof _tokenForSecret === "function" ? _tokenForSecret() : _tokenForSecret;
@@ -80,10 +69,8 @@ function resolveSecret(): string | null {
 
 function buildDefaultVerifier(): void {
   const secret = resolveSecret();
-  _defaultVerifier = secret === null ? null : new MessageVerifier(secret);
+  _assignBootVerifier?.(secret === null ? null : new MessageVerifier(secret));
 }
-
-buildDefaultVerifier();
 
 /**
  * TokenDefinition — encapsulates token behavior for a specific purpose.
@@ -161,39 +148,27 @@ export class TokenDefinition {
 }
 
 /**
- * Registry of token definitions per model class.
- */
-const tokenDefinitionRegistry = new WeakMap<object, Map<string, TokenDefinition>>();
-
-/**
- * The nearest class on `modelClass`'s prototype chain (including itself) that has
- * its own registry entry — i.e. the resolved `class_attribute` value. A class
- * that has never written returns its parent's map (live inheritance); a class
- * that has written returns its own snapshot.
- */
-function resolvedDefinitions(modelClass: object): Map<string, TokenDefinition> | undefined {
-  let current: any = modelClass;
-  while (current) {
-    const map = tokenDefinitionRegistry.get(current);
-    if (map) return map;
-    current = Object.getPrototypeOf(current);
-  }
-  return undefined;
-}
-
-/**
  * The `token_definitions` hash. Ruby's Hash carries `fetch`, which every finder
  * goes through (`token_definitions.fetch(purpose)`), so the port hands the same
  * verb back rather than making each caller re-spell the unknown-purpose raise.
  */
-type TokenDefinitionsHash = Readonly<Record<string, TokenDefinition>> & {
+export type TokenDefinitionsHash = Readonly<Record<string, TokenDefinition>> & {
   fetch(purpose: string): TokenDefinition;
-  merge(other: Record<string, TokenDefinition>): Record<string, TokenDefinition>;
+  merge(other: Record<string, TokenDefinition>): TokenDefinitionsHash;
 };
 
-/** `fetch`/`merge` are non-enumerable so the hash still iterates as
- * `purpose => definition`. */
-function withFetch(entries: Record<string, TokenDefinition>): TokenDefinitionsHash {
+/**
+ * `fetch`/`merge` are non-enumerable so the hash still iterates as
+ * `purpose => definition`. Applied to the `token_definitions` class_attribute's
+ * default and to every `merge` result, so the whole `class_attribute` chain
+ * carries Ruby's Hash verbs.
+ *
+ * @internal
+ * @noRailsEquivalent PERMANENT a Ruby Hash carries `fetch`/`merge`; a JS object
+ * does not, and `token_definitions.fetch(purpose)` (token_for.rb:42-51) is the
+ * Rails call every finder makes.
+ */
+export function withFetch(entries: Record<string, TokenDefinition>): TokenDefinitionsHash {
   Object.defineProperty(entries, "fetch", {
     value(purpose: string): TokenDefinition {
       const definition = entries[purpose];
@@ -206,75 +181,11 @@ function withFetch(entries: Record<string, TokenDefinition>): TokenDefinitionsHa
     },
   });
   Object.defineProperty(entries, "merge", {
-    value(other: Record<string, TokenDefinition>): Record<string, TokenDefinition> {
-      return { ...entries, ...other };
+    value(other: Record<string, TokenDefinition>): TokenDefinitionsHash {
+      return withFetch({ ...entries, ...other });
     },
   });
   return entries as TokenDefinitionsHash;
-}
-
-/**
- * Rails: `class_attribute :token_definitions, default: {}` — the per-model
- * `purpose => TokenDefinition` map populated by `generates_token_for`. The
- * `class_attribute` reader inherits the parent value until the subclass writes,
- * at which point `generates_token_for` snapshots the inherited hash via
- * `self.token_definitions = token_definitions.merge(...)`. So a subclass that
- * has declared its own token sees the inherited purposes captured at that point
- * (not parent purposes added afterwards). Trails seeds the subclass's own
- * snapshot on each `generates_token_for` write; the reader returns the
- * resolved map — the class's own snapshot, or the parent's map if it never wrote.
- *
- * Mirrors: ActiveRecord::TokenFor#token_definitions
- */
-export function tokenDefinitions(modelClass: typeof Base): TokenDefinitionsHash {
-  const map = resolvedDefinitions(modelClass);
-  return withFetch(map ? Object.fromEntries(map) : {});
-}
-
-/**
- * Rails-shaped writer for `class_attribute :token_definitions` — Rails'
- * `generates_token_for` assigns `self.token_definitions = token_definitions.merge(...)`,
- * and external callers can replace the map outright. Stores the given hash as
- * this class's own registry entry (subclasses still inherit via the reader).
- *
- * Mirrors: ActiveRecord::TokenFor#token_definitions=
- * @internal
- */
-export function setTokenDefinitions(
-  modelClass: typeof Base,
-  value: Record<string, TokenDefinition>,
-): void {
-  tokenDefinitionRegistry.set(modelClass, new Map(Object.entries(value)));
-}
-
-/**
- * Rails: `class_attribute :generated_token_verifier` — the MessageVerifier used
- * to sign/verify tokens, resolved per class (own slot, else inherited, else the
- * boot-time value the railtie stand-in assigned — see setTokenForSecret).
- *
- * Mirrors: ActiveRecord::TokenFor#generated_token_verifier
- */
-export function generatedTokenVerifier(modelClass: typeof Base): MessageVerifier | null {
-  return resolvedVerifier(modelClass);
-}
-
-/**
- * Rails-shaped writer for `class_attribute :generated_token_verifier` — Rails
- * tests assign `ActiveRecord::Base.generated_token_verifier = MessageVerifier.new(...)`
- * to inject a verifier; `message_verifier`'s `||=` then returns it instead of
- * building from the secret. Assigns to this class's own slot (subclasses inherit
- * via the reader until they assign their own). Assigning null writes an explicit
- * nil shadow on this class — Rails' generated writer assigns to the class, so the
- * reader returns nil rather than the parent's verifier.
- *
- * Mirrors: ActiveRecord::TokenFor#generated_token_verifier=
- * @internal
- */
-export function setGeneratedTokenVerifier(
-  modelClass: typeof Base,
-  verifier: MessageVerifier | null,
-): void {
-  tokenVerifierRegistry.set(modelClass, { verifier });
 }
 
 /**
@@ -290,12 +201,9 @@ export function generatesTokenFor(
     block?: (record: any) => unknown;
   } = {},
 ): void {
-  setTokenDefinitions(
-    this,
-    tokenDefinitions(this).merge({
-      [purpose]: new TokenDefinition(this, purpose, options.expiresIn, options.block),
-    }),
-  );
+  this.tokenDefinitions = this.tokenDefinitions.merge({
+    [purpose]: new TokenDefinition(this, purpose, options.expiresIn, options.block),
+  });
 }
 
 /**


### PR DESCRIPTION
Three of a four-story bundle. The fourth
(`break-schema-statements-join-table-cycle-blocking-module-eval-includes`) is
blocked, with the measurement in its story body — see the end of this
description.

## `token_for`'s two stores are `classAttribute()`s (RFC 0112)

`token_for.rb:10-11` declares

```ruby
class_attribute :token_definitions, instance_accessor: false, instance_predicate: false, default: {}
class_attribute :generated_token_verifier, instance_accessor: false, instance_predicate: false
```

trails hand-rolled both: two WeakMap registries plus prototype-chain walks that
re-derived `class_attribute` read semantics. Both are now `classAttribute()`
declarations on `Base` with Rails' options, so `tokenDefinitionRegistry`,
`tokenVerifierRegistry`, `resolvedDefinitions`, `resolvedVerifier`,
`ownVerifierEntry`, `tokenDefinitions()` / `setTokenDefinitions()` and
`generatedTokenVerifier()` / `setGeneratedTokenVerifier()` are all deleted, and
`generates_token_for` is the plain `self.token_definitions =
token_definitions.merge(...)` Rails writes.

The boot-time verifier is the one wrinkle. The railtie initializer
`"active_record.generated_token_verifier"` (railtie.rb:328-334) assigns
`self.generated_token_verifier ||= app.message_verifier(...)` onto
`ActiveRecord::Base`; with the reader now a `class_attribute` there is no
post-chain fallback, so the value has to land *on `Base`*. token-for.ts cannot
name `Base` (base.ts imports it at runtime), so base.ts installs a sink —
option 1 from the story, an extension of the already-`@noRailsEquivalent`
railtie seam, documented at the call site with the railtie.rb citation.

The `TokenDefinitionsHash` `fetch`/`merge` wrapper survives as the
`class_attribute`'s default, and `merge` now returns a wrapped hash, so every
`token_definitions.fetch(purpose)` call site keeps Ruby's Hash verbs down the
whole chain.

## `change_column` is the abstract raise (RFC 0077)

`SchemaStatements#change_column` (schema_statements.rb:711-713) raises
`NotImplementedError`. trails had one body branching on `this.adapterName`
("mysql2" / "postgres" / else) that quoted the default against a synthetic
`{ sqlType }` object literal — not a Column, so any future `column.type` /
`column.array?` read in the quoter would silently see `undefined`.

All three adapters already override `changeColumn` exactly as Rails does —
MySQL and PG through `change_column_for_alter` and a real
`ChangeColumnDefinition` (abstract_mysql_adapter.rb:396-398,
postgresql/schema_statements.rb:466-471), SQLite through `alter_table`
(sqlite3_adapter.rb:385-389) — so the base body was dead code. It is now the
raise, the `adapterName` switch is gone, and with it the `{ sqlType }`
stand-in: the only remaining default quoting goes through a real
column/ColumnDefinition.

## `acquire_connection` owns the wait, and owns its name (RFC 0119)

`acquireConnection(checkoutTimeout)` already mirrored connection_pool.rb:862 and
`checkout`'s unpinned arm is already the connection_pool.rb:548 one-liner. What
survived was a *second* `_acquireConnection` carrying Rails' name with a
different body — no timeout, no wait, immediate raise — plus its `_tryAcquire`
helper, which re-implemented the poll/create sequence Rails' own privates
already spell.

Both are gone. The two seams that genuinely cannot await (`leaseConnectionSync`,
and `checkout_for_exclusive_access`, whose callers `disconnect!` / `reload` /
`Migration#connection` are synchronous all the way up) now go through
`acquireConnectionSync`, which runs Rails' sequence — `@available.poll`,
`try_to_checkout_new_connection`, `reap`, retry — through the ported privates
and collapses only the blocking `@available.poll(checkout_timeout)` to its
timeout arm, since a JS function that cannot await has no way to wait. It
carries a `@noRailsEquivalent PERMANENT` at the call site, and the timeout error
message is now Rails' rather than the bespoke "All N connections are in use."

## Blocked: the schema-statements → join-table cycle

Cutting `migration/join-table.ts -> model-schema.ts` with a zero-import slot
(the story's preferred approach) *does* break the cycle — `scripts/test-deps/`
goes green with AbstractAdapter's `include`s restored to module scope — but it
reds the whole AR suite at collection time with `Class extends value undefined`
in `associations/collection-proxy.ts`. That edge is also the accidental
load-order guarantee the package relies on: the vitest setup preload entered
`associations.ts` early through join-table → model-schema → associations, so
`associations.ts` was always fully evaluated before `relation.ts`. Cut it and
`relation.ts -> insert-all.ts -> model-schema.ts -> associations.ts ->`
(associations.ts:6, a bare side-effect `import "./associations/collection-proxy.js"`)
`-> relation.ts` crashes with `Relation` still in TDZ.

Approach 2 does not exist: every path from `schema-statements.ts` to
`abstract-adapter.ts` runs through `model-schema.ts`, which reaches
`abstract-adapter.ts` by several independent legs. Cutting
`model-schema -> connection-handling` with a slot was tried and measured, and
`adapter-graph-import-tdz.test.ts` still fails via
`model-schema -> associations -> persistence -> connection-handling`. The story
is blocked on `associations.ts:6` no longer force-loading `collection-proxy.ts`
(its ctor is already published through `associations/collection-proxy-slot.ts`).

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm vitest run` green on token-for (both files), connection-pool (4 files),
  `connection-adapters/abstract/`, `migration/columns`, `migration/change-schema`,
  `migration.test.ts`, `scripts/test-deps/`.
- `pnpm parity:api:calls` OK (363 baselined, 289 unreviewed — unchanged),
  `pnpm parity:api:calls:args` OK, `pnpm parity:api:extra:gate` OK
  (activerecord novel 385/385, total 1392/1392 — unchanged). No baseline row
  added.

Closes-story: converge-token-for-class-attribute-stores
Closes-story: change-column-quotes-default-against-a-synthetic-column
Closes-story: converge-acquire-connection-blocking-wait
