### PR TITLE
fix(scripts,eslint,arel): entity-keyed privates manifest; arel assertion burndown (RFC 0121, RFC 0122)

### DIFF
--- a/eslint/rails-private-jsdoc.mjs
+++ b/eslint/rails-private-jsdoc.mjs
@@ -166,6 +166,46 @@ function fixerInsertInternal(fixer, node, sourceCode, jsdocComment) {
   return fixer.insertTextBeforeRange(node.range, `/** @internal */\n${indent}`);
 }
 
+/**
+ * TS name of the class / interface a member is declared in, or `null` for a
+ * top-level declaration. The manifest's `entities` map is keyed by exactly this
+ * name (the last segment of the contributing Ruby entity's FQN).
+ */
+function enclosingEntityName(node) {
+  for (let cur = node.parent; cur; cur = cur.parent) {
+    if (cur.type === "ClassDeclaration" || cur.type === "ClassExpression") {
+      return cur.id?.name ?? null;
+    }
+    if (cur.type === "TSInterfaceDeclaration") return cur.id?.name ?? null;
+  }
+  return null;
+}
+
+/**
+ * Whether the manifest tags `name` in `rel`.
+ *
+ * The manifest's `entities` entry names the Rails entities that project onto
+ * this TS file. A declaration whose enclosing class/interface is NOT one of
+ * them is a type Rails does not have — `rack/lock.ts` hosts Rails' `Rack::Lock`
+ * (whose `unlock` is private, rack/lib/rack/lock.rb) beside a local `Mutex`
+ * protocol whose `unlock` mirrors the PUBLIC stdlib `Mutex#unlock` — and its
+ * members are not gated by a name some other entity in the file made private.
+ *
+ * A declaration that IS a known entity still reads the file-wide union: Rails
+ * routinely splits one class across sibling modules in one file (`Rack::Request`
+ * and `Rack::Request::Helpers`) that the port folds into a single TS class, so
+ * narrowing to one entity's own names there would drop real gating.
+ *
+ * A top-level declaration has no enclosing entity to resolve — the module-mixin
+ * idiom puts a module's methods there as `this`-typed functions — so it reads
+ * the union too.
+ */
+function manifestTags(manifest, rel, entity, name) {
+  const entities = manifest.entities?.[rel];
+  if (entity !== null && entities && !entities.includes(entity)) return false;
+  return (manifest.files?.[rel] ?? []).includes(name);
+}
+
 function check(context, node, name) {
   if (!name) return;
   // For autofix + comment lookup, use the outer ExportNamedDeclaration
@@ -176,8 +216,7 @@ function check(context, node, name) {
   if (!filename) return;
   const rel = relFromRepoRoot(filename);
   const manifest = loadManifest();
-  const fileNames = manifest.files?.[rel];
-  if (!fileNames || !fileNames.includes(name)) return;
+  if (!manifestTags(manifest, rel, enclosingEntityName(node), name)) return;
 
   const sourceCode = context.sourceCode ?? context.getSourceCode();
   const { tag, comment } = jsdocHasInternal(target, sourceCode);

--- a/eslint/rails-private-jsdoc.test.mjs
+++ b/eslint/rails-private-jsdoc.test.mjs
@@ -15,11 +15,19 @@ const FIXTURE = {
     // lookup.
     "packages/activerecord/src/inheritance.ts": ["computeType"],
     "packages/activerecord/src/base.ts": ["computeType"],
+    // Rails' `Rack::Lock` declares a private `unlock` (rack/lib/rack/lock.rb);
+    // lock.ts also hosts a local `Mutex` protocol whose `unlock` mirrors the
+    // PUBLIC stdlib `Mutex#unlock`.
+    "packages/rack/src/lock.ts": ["unlock"],
+  },
+  entities: {
+    "packages/rack/src/lock.ts": ["Lock", "Rack"],
   },
 };
 setManifestForTests(FIXTURE);
 const inheritanceFile = path.join(REPO_ROOT, "packages/activerecord/src/inheritance.ts");
 const baseFile = path.join(REPO_ROOT, "packages/activerecord/src/base.ts");
+const lockFile = path.join(REPO_ROOT, "packages/rack/src/lock.ts");
 
 const tester = new RuleTester({
   languageOptions: {
@@ -46,6 +54,17 @@ tester.run("rails-private-jsdoc", rule, {
       filename: inheritanceFile,
       code: `/**\n * Doc.\n * @internal\n */\nexport function computeType() {}\n`,
     },
+    // A class Rails does not have: `entities` lists only `Lock` for this file,
+    // so `DefaultMutex#unlock` is not gated by `Rack::Lock`'s private `unlock`.
+    {
+      filename: lockFile,
+      code: `class DefaultMutex {\n  unlock() {}\n}\n`,
+    },
+    // Same for a local protocol interface's method signature.
+    {
+      filename: lockFile,
+      code: `interface Mutex {\n  unlock(): void;\n}\n`,
+    },
     // Class method that's already tagged.
     {
       filename: baseFile,
@@ -53,6 +72,13 @@ tester.run("rails-private-jsdoc", rule, {
     },
   ],
   invalid: [
+    // The entity Rails DOES have in that file is still gated.
+    {
+      filename: lockFile,
+      code: `class Lock {\n  unlock() {}\n}\n`,
+      errors: [{ messageId: "missingInternal" }],
+      output: `class Lock {\n  /** @internal */\n  unlock() {}\n}\n`,
+    },
     // File-scoped match: function with no JSDoc.
     {
       filename: inheritanceFile,

--- a/packages/arel/src/nodes/ascending.test.ts
+++ b/packages/arel/src/nodes/ascending.test.ts
@@ -22,7 +22,7 @@ describe("TestAscending", () => {
 
   it("ascending?", () => {
     const ascending = new Nodes.Ascending("zomg");
-    expect(ascending.isAscending()).toBe(true);
+    expect(ascending.isAscending()).toBeTruthy();
   });
 
   it("descending?", () => {

--- a/packages/arel/src/nodes/bin.test.ts
+++ b/packages/arel/src/nodes/bin.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection, mysqlTestConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("TestBin", () => {
   it("new", () => {
@@ -9,15 +10,13 @@ describe("TestBin", () => {
   });
 
   it("equality with same ivars", () => {
-    const a = new Nodes.Bin("zomg");
-    const b = new Nodes.Bin("zomg");
-    expect(a).toEqual(b);
+    const array = [new Nodes.Bin("zomg"), new Nodes.Bin("zomg")];
+    expect(uniq(array).length).toBe(1);
   });
 
   it("inequality with different ivars", () => {
-    const a = new Nodes.Bin("zomg");
-    const b = new Nodes.Bin("zomg!");
-    expect(a).not.toEqual(b);
+    const array = [new Nodes.Bin("zomg"), new Nodes.Bin("zomg!")];
+    expect(uniq(array).length).toBe(2);
   });
 
   it("default to sql", () => {

--- a/packages/arel/src/nodes/comment.test.ts
+++ b/packages/arel/src/nodes/comment.test.ts
@@ -1,19 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors, Table, star } from "../index.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("CommentTest", () => {
   describe("equality", () => {
-    it("is not equal with different contents", () => {
-      const a = new Nodes.SqlLiteral("NOW()");
-      const b = new Nodes.SqlLiteral("CURRENT_TIMESTAMP");
-      expect(a.value).not.toBe(b.value);
+    it("is equal with equal contents", () => {
+      const array = [new Nodes.Comment(["foo"]), new Nodes.Comment(["foo"])];
+      expect(uniq(array).length).toBe(1);
     });
 
-    it("is equal with equal contents", () => {
-      const a = new Nodes.SqlLiteral("NOW()");
-      const b = new Nodes.SqlLiteral("NOW()");
-      expect(a.value).toBe(b.value);
+    it("is not equal with different contents", () => {
+      const array = [new Nodes.Comment(["foo"]), new Nodes.Comment(["bar"])];
+      expect(uniq(array).length).toBe(2);
     });
   });
 

--- a/packages/arel/src/nodes/count.test.ts
+++ b/packages/arel/src/nodes/count.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel::Nodes::CountTest", () => {
   const users = new Table("users");
   describe("as", () => {
     it("should alias the count", () => {
-      const count = users.get("id").count();
-      const aliased = count.as("user_count");
-      const visitor = new Visitors.ToSql(fakeRecordConnection);
-      expect(visitor.compile(aliased)).toBe('COUNT("users"."id") AS user_count');
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+        users.get("id").count().as("foo"),
+      );
+      expect(sql).toBe('COUNT("users"."id") AS foo');
     });
   });
 
@@ -22,17 +24,19 @@ describe("Arel::Nodes::CountTest", () => {
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const rel = users.project(users.get("id")).ast;
-      const a = new Nodes.Cte("cte", rel);
-      const b = new Nodes.Cte("cte", rel);
-      expect(a.name).toBe(b.name);
-      expect(a.relation).toBe(b.relation);
+      const array = [
+        new Nodes.Count("foo" as unknown as Node),
+        new Nodes.Count("foo" as unknown as Node),
+      ];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.TableAlias(users, "u");
-      const b = new Nodes.TableAlias(users, "v");
-      expect(a.name).not.toBe(b.name);
+      const array = [
+        new Nodes.Count("foo" as unknown as Node),
+        new Nodes.Count("foo!" as unknown as Node),
+      ];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/descending.test.ts
+++ b/packages/arel/src/nodes/descending.test.ts
@@ -27,7 +27,7 @@ describe("TestDescending", () => {
 
   it("descending?", () => {
     const descending = new Nodes.Descending("zomg");
-    expect(descending.isDescending()).toBe(true);
+    expect(descending.isDescending()).toBeTruthy();
   });
 
   it("equality with same ivars", () => {

--- a/packages/arel/src/nodes/distinct.test.ts
+++ b/packages/arel/src/nodes/distinct.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Distinct", () => {
   describe("equality", () => {
     it("is equal to other distinct nodes", () => {
-      const a = new Nodes.Distinct();
-      const b = new Nodes.Distinct();
-      expect(a.constructor).toBe(b.constructor);
+      const array = [new Nodes.Distinct(), new Nodes.Distinct()];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with other nodes", () => {
-      const a = new Nodes.False();
-      expect(a).not.toBeInstanceOf(Nodes.True);
+      const array = [new Nodes.Distinct(), new (Nodes.Node as unknown as new () => Node)()];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -6,11 +6,10 @@ import { uniq } from "../test-helpers/uniq.js";
 describe("Arel::Nodes::ExtractTest", () => {
   const users = new Table("users");
   it("should extract field", () => {
-    const createdAt = users.get("created_at");
-    const node = new Nodes.Extract(createdAt, "YEAR");
-    const visitor = new Visitors.ToSql(fakeRecordConnection);
-    const sql = visitor.compile(node);
-    expect(sql).toBe('EXTRACT(YEAR FROM "users"."created_at")');
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+      users.get("timestamp").extract("date"),
+    );
+    expect(sql).toBe('EXTRACT(DATE FROM "users"."timestamp")');
   });
 
   it("uppercases a lowercase field to match Rails", () => {
@@ -39,18 +38,19 @@ describe("Arel::Nodes::ExtractTest", () => {
 
   describe("as", () => {
     it("should alias the extract", () => {
-      const createdAt = users.get("created_at");
-      const node = new Nodes.Extract(createdAt, "MONTH").as("birth_month");
-      const visitor = new Visitors.ToSql(fakeRecordConnection);
-      const sql = visitor.compile(node);
-      expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at") AS birth_month');
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(
+        users.get("timestamp").extract("date").as("foo"),
+      );
+      expect(sql).toBe('EXTRACT(DATE FROM "users"."timestamp") AS foo');
     });
 
     it("should not mutate the extract", () => {
-      const original = new Nodes.Extract(users.get("created_at"), "YEAR");
-      const aliased = original.as("y");
-      expect(original).toBeInstanceOf(Nodes.Extract);
-      expect(aliased).toBeInstanceOf(Nodes.As);
+      const extract = users.get("timestamp").extract("date");
+      // Rails snapshots with `extract.dup`; arel's TS nodes carry no `dup`, so
+      // the untouched twin stands in for the copy.
+      const before = users.get("timestamp").extract("date");
+      extract.as("foo");
+      expect(extract.eql(before)).toBe(true);
     });
   });
 

--- a/packages/arel/src/nodes/false.test.ts
+++ b/packages/arel/src/nodes/false.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("False", () => {
   describe("equality", () => {
     it("is equal to other false nodes", () => {
-      const a = new Nodes.False();
-      const b = new Nodes.False();
-      expect(a.constructor).toBe(b.constructor);
+      const array = [new Nodes.False(), new Nodes.False()];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with other nodes", () => {
-      const a = new Nodes.True();
-      expect(a).not.toBeInstanceOf(Nodes.False);
+      const array = [new Nodes.False(), new (Nodes.Node as unknown as new () => Node)()];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/grouping.test.ts
+++ b/packages/arel/src/nodes/grouping.test.ts
@@ -1,27 +1,31 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
-import { Table, Nodes, Visitors } from "../index.js";
+import { Nodes, Visitors } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("GroupingTest", () => {
-  const users = new Table("users");
   describe("equality", () => {
-    it("is not equal with different ivars", () => {
-      const w1 = new Nodes.Window();
-      const w2 = new Nodes.Window();
-      w2.order(users.get("id").asc());
-      expect(w1.orders.length).not.toBe(w2.orders.length);
+    it("is equal with equal ivars", () => {
+      const array = [
+        new Nodes.Grouping("foo" as unknown as Node),
+        new Nodes.Grouping("foo" as unknown as Node),
+      ];
+      expect(uniq(array).length).toBe(1);
     });
 
-    it("is equal with equal ivars", () => {
-      const c1 = new Nodes.NamedFunction("COUNT", [users.get("id")]);
-      const c2 = new Nodes.NamedFunction("COUNT", [users.get("id")]);
-      expect(c1.name).toBe(c2.name);
+    it("is not equal with different ivars", () => {
+      const array = [
+        new Nodes.Grouping("foo" as unknown as Node),
+        new Nodes.Grouping("bar" as unknown as Node),
+      ];
+      expect(uniq(array).length).toBe(2);
     });
   });
 
   it("should create Equality nodes", () => {
-    const grouped = new Nodes.Grouping(users.get("id").eq(1));
-    const sql = new Visitors.ToSql(fakeRecordConnection).compile(grouped);
-    expect(sql).toBe('("users"."id" = 1)');
+    const grouping = new Nodes.Grouping(new Nodes.Quoted("foo"));
+    const sql = new Visitors.ToSql(fakeRecordConnection).compile(grouping.eq("foo"));
+    expect(sql).toBe("('foo') = 'foo'");
   });
 });

--- a/packages/arel/src/nodes/grouping.test.ts
+++ b/packages/arel/src/nodes/grouping.test.ts
@@ -3,6 +3,7 @@ import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 import type { Node } from "./node.js";
 import { uniq } from "../test-helpers/uniq.js";
+import { buildQuoted } from "./casted.js";
 
 describe("GroupingTest", () => {
   describe("equality", () => {
@@ -24,7 +25,7 @@ describe("GroupingTest", () => {
   });
 
   it("should create Equality nodes", () => {
-    const grouping = new Nodes.Grouping(new Nodes.Quoted("foo"));
+    const grouping = new Nodes.Grouping(buildQuoted("foo"));
     const sql = new Visitors.ToSql(fakeRecordConnection).compile(grouping.eq("foo"));
     expect(sql).toBe("('foo') = 'foo'");
   });

--- a/packages/arel/src/nodes/infix-operation.test.ts
+++ b/packages/arel/src/nodes/infix-operation.test.ts
@@ -1,38 +1,45 @@
 import { describe, it, expect } from "vitest";
-import { Table, Nodes } from "../index.js";
+import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("TestInfixOperation", () => {
-  const users = new Table("users");
   it("construct", () => {
-    const a = users.get("age");
-    const b = new Nodes.Quoted(10);
-    const node = new Nodes.InfixOperation("||", a, b);
-    expect(node.operator).toBe("||");
-    expect(node.left).toBe(a);
-    expect(node.right).toBe(b);
+    const operation = new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node);
+    expect(operation.operator).toBe("+");
+    expect(operation.left).toBe(1);
+    expect(operation.right).toBe(2);
   });
 
   it("operation alias", () => {
-    const node = new Nodes.InfixOperation("+", users.get("a"), users.get("b"));
-    const aliased = node.as("total");
-    expect(aliased).toBeInstanceOf(Nodes.As);
+    const operation = new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node);
+    const aliaz = operation.as("zomg");
+    expect(aliaz).toBeInstanceOf(Nodes.As);
+    expect(aliaz.left).toBe(operation);
+    expect(String(aliaz.right)).toBe("zomg");
   });
 
   it("operation ordering", () => {
-    const node = new Nodes.UnaryOperation("-", users.get("age"));
-    expect(node.asc()).toBeInstanceOf(Nodes.Ascending);
-    expect(node.desc()).toBeInstanceOf(Nodes.Descending);
+    const operation = new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node);
+    const ordering = operation.desc();
+    expect(ordering).toBeInstanceOf(Nodes.Descending);
+    expect(ordering.expr).toBe(operation);
+    expect(ordering.isDescending()).toBeTruthy();
   });
 
   it("equality with same ivars", () => {
-    const a = new Nodes.InfixOperation("+", users.get("x"), new Nodes.Quoted(1));
-    const b = new Nodes.InfixOperation("+", users.get("x"), new Nodes.Quoted(1));
-    expect(a.operator).toBe(b.operator);
+    const array = [
+      new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node),
+      new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node),
+    ];
+    expect(uniq(array).length).toBe(1);
   });
 
   it("inequality with different ivars", () => {
-    const a = new Nodes.InfixOperation("+", users.get("x"), new Nodes.Quoted(1));
-    const b = new Nodes.InfixOperation("-", users.get("x"), new Nodes.Quoted(1));
-    expect(a.operator).not.toBe(b.operator);
+    const array = [
+      new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node),
+      new Nodes.InfixOperation("+", 1 as unknown as Node, 3 as unknown as Node),
+    ];
+    expect(uniq(array).length).toBe(2);
   });
 });

--- a/packages/arel/src/nodes/named-function.test.ts
+++ b/packages/arel/src/nodes/named-function.test.ts
@@ -1,39 +1,45 @@
 import { describe, it, expect } from "vitest";
-import { Table, star, Nodes } from "../index.js";
+import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("TestNamedFunction", () => {
-  const users = new Table("users");
   it("construct", () => {
-    const fn = new Nodes.NamedFunction("COUNT", [star]);
-    expect(fn.name).toBe("COUNT");
-    expect(fn.expressions.length).toBe(1);
+    const fn = new Nodes.NamedFunction("omg", "zomg" as unknown as Node[]);
+    expect(fn.name).toBe("omg");
+    expect(fn.expressions).toBe("zomg");
   });
 
   it("function alias", () => {
-    const fn = new Nodes.NamedFunction("omg", [new Nodes.SqlLiteral("zomg")]);
-    const returned = fn.as("wth");
-    expect(returned).toBe(fn);
+    let fn = new Nodes.NamedFunction("omg", "zomg" as unknown as Node[]);
+    fn = fn.as("wth");
     expect(fn.name).toBe("omg");
+    expect(fn.expressions).toBe("zomg");
     expect(fn.alias).toBeInstanceOf(Nodes.SqlLiteral);
-    expect((fn.alias as Nodes.SqlLiteral).value).toBe("wth");
+    expect(String(fn.alias)).toBe("wth");
   });
 
   it("construct with alias", () => {
-    const sum = new Nodes.NamedFunction("SUM", [users.get("age")]);
-    expect(users.project(sum.as("total")).toSql()).toBe(
-      'SELECT SUM("users"."age") AS total FROM "users"',
-    );
+    const fn = new Nodes.NamedFunction("omg", "zomg" as unknown as Node[], "wth");
+    expect(fn.name).toBe("omg");
+    expect(fn.expressions).toBe("zomg");
+    expect(fn.alias).toBeInstanceOf(Nodes.SqlLiteral);
+    expect(String(fn.alias)).toBe("wth");
   });
 
   it("equality with same ivars", () => {
-    const a = new Nodes.NamedFunction("COUNT", [star]);
-    const b = new Nodes.NamedFunction("COUNT", [star]);
-    expect(a.name).toBe(b.name);
+    const array = [
+      new Nodes.NamedFunction("omg", "zomg" as unknown as Node[], "wth"),
+      new Nodes.NamedFunction("omg", "zomg" as unknown as Node[], "wth"),
+    ];
+    expect(uniq(array).length).toBe(1);
   });
 
   it("inequality with different ivars", () => {
-    const a = new Nodes.NamedFunction("COUNT", [star]);
-    const b = new Nodes.NamedFunction("SUM", [star]);
-    expect(a.name).not.toBe(b.name);
+    const array = [
+      new Nodes.NamedFunction("omg", "zomg" as unknown as Node[], "wth"),
+      new Nodes.NamedFunction("zomg", "zomg" as unknown as Node[], "wth"),
+    ];
+    expect(uniq(array).length).toBe(2);
   });
 });

--- a/packages/arel/src/nodes/not.test.ts
+++ b/packages/arel/src/nodes/not.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Table, Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel", () => {
   const users = new Table("users");
@@ -14,15 +16,19 @@ describe("Arel", () => {
 
     describe("equality", () => {
       it("is equal with equal ivars", () => {
-        const a = new Nodes.Not(new Nodes.Quoted("foo"));
-        const b = new Nodes.Not(new Nodes.Quoted("foo"));
-        expect(a.hash()).toBe(b.hash());
+        const array = [
+          new Nodes.Not("foo" as unknown as Node),
+          new Nodes.Not("foo" as unknown as Node),
+        ];
+        expect(uniq(array).length).toBe(1);
       });
 
       it("is not equal with different ivars", () => {
-        const a = new Nodes.Not(new Nodes.Quoted("foo"));
-        const b = new Nodes.Not(new Nodes.Quoted("baz"));
-        expect(a.hash()).not.toBe(b.hash());
+        const array = [
+          new Nodes.Not("foo" as unknown as Node),
+          new Nodes.Not("baz" as unknown as Node),
+        ];
+        expect(uniq(array).length).toBe(2);
       });
     });
 

--- a/packages/arel/src/nodes/or.test.ts
+++ b/packages/arel/src/nodes/or.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Table, Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel", () => {
   const users = new Table("users");
@@ -16,15 +18,19 @@ describe("Arel", () => {
 
     describe("equality", () => {
       it("is equal with equal ivars", () => {
-        const a = new Nodes.Or([new Nodes.Quoted("foo"), new Nodes.Quoted("bar")]);
-        const b = new Nodes.Or([new Nodes.Quoted("foo"), new Nodes.Quoted("bar")]);
-        expect(a.hash()).toBe(b.hash());
+        const array = [
+          new Nodes.Or(["foo", "bar"] as unknown as [Node, Node]),
+          new Nodes.Or(["foo", "bar"] as unknown as [Node, Node]),
+        ];
+        expect(uniq(array).length).toBe(1);
       });
 
       it("is not equal with different ivars", () => {
-        const a = new Nodes.Or([new Nodes.Quoted("foo"), new Nodes.Quoted("bar")]);
-        const b = new Nodes.Or([new Nodes.Quoted("foo"), new Nodes.Quoted("baz")]);
-        expect(a.hash()).not.toBe(b.hash());
+        const array = [
+          new Nodes.Or(["foo", "bar"] as unknown as [Node, Node]),
+          new Nodes.Or(["foo", "baz"] as unknown as [Node, Node]),
+        ];
+        expect(uniq(array).length).toBe(2);
       });
     });
 

--- a/packages/arel/src/nodes/sum.test.ts
+++ b/packages/arel/src/nodes/sum.test.ts
@@ -1,30 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Arel::Nodes::SumTest", () => {
   const users = new Table("users");
   describe("as", () => {
     it("should alias the sum", () => {
-      const sum = users.get("age").sum();
-      const aliased = sum.as("total_age");
-      const visitor = new Visitors.ToSql(fakeRecordConnection);
-      expect(visitor.compile(aliased)).toBe('SUM("users"."age") AS total_age');
+      const sql = new Visitors.ToSql(fakeRecordConnection).compile(users.get("id").sum().as("foo"));
+      expect(sql).toBe('SUM("users"."id") AS foo');
     });
   });
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const w1 = new Nodes.Window();
-      const w2 = new Nodes.Window();
-      expect(w1.orders.length).toBe(w2.orders.length);
-      expect(w1.partitions.length).toBe(w2.partitions.length);
+      const array = [
+        new Nodes.Sum(["foo"] as unknown as Node[]),
+        new Nodes.Sum(["foo"] as unknown as Node[]),
+      ];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const s1 = new Nodes.NamedFunction("SUM", [users.get("id")]);
-      const s2 = new Nodes.NamedFunction("SUM", [users.get("name")]);
-      expect(s1.expressions[0]).not.toBe(s2.expressions[0]);
+      const array = [
+        new Nodes.Sum(["foo"] as unknown as Node[]),
+        new Nodes.Sum(["foo!"] as unknown as Node[]),
+      ];
+      expect(uniq(array).length).toBe(2);
     });
   });
 

--- a/packages/arel/src/nodes/table-alias.test.ts
+++ b/packages/arel/src/nodes/table-alias.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Table, Nodes } from "../index.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("table alias", () => {
   const users = new Table("users");
@@ -14,16 +15,21 @@ describe("table alias", () => {
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = new Nodes.TableAlias(users, "u");
-      const b = new Nodes.TableAlias(users, "u");
-      expect(a).toEqual(b);
+      const relation1 = new Table("users");
+      const node1 = new Nodes.TableAlias(relation1, "foo");
+      const relation2 = new Table("users");
+      const node2 = new Nodes.TableAlias(relation2, "foo");
+      const array = [node1, node2];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.Window();
-      a.order(users.get("id").asc());
-      const b = new Nodes.Window();
-      expect(a.orders.length).not.toBe(b.orders.length);
+      const relation1 = new Table("users");
+      const node1 = new Nodes.TableAlias(relation1, "foo");
+      const relation2 = new Table("users");
+      const node2 = new Nodes.TableAlias(relation2, "bar");
+      const array = [node1, node2];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/true.test.ts
+++ b/packages/arel/src/nodes/true.test.ts
@@ -1,17 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("True", () => {
   describe("equality", () => {
     it("is equal to other true nodes", () => {
-      const a = new Nodes.True();
-      const b = new Nodes.True();
-      expect(a.constructor).toBe(b.constructor);
+      const array = [new Nodes.True(), new Nodes.True()];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with other nodes", () => {
-      const a = new Nodes.CurrentRow();
-      expect(a).not.toBeInstanceOf(Nodes.Preceding);
+      const array = [new Nodes.True(), new (Nodes.Node as unknown as new () => Node)()];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/arel/src/nodes/unary-operation.test.ts
+++ b/packages/arel/src/nodes/unary-operation.test.ts
@@ -1,56 +1,44 @@
 import { describe, it, expect } from "vitest";
-import { fakeRecordConnection } from "../test-helpers/connection.js";
-import { Table, Nodes, Visitors } from "../index.js";
+import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("TestUnaryOperation", () => {
-  const users = new Table("users");
   it("construct", () => {
-    const attr = users.get("age");
-    const node = new Nodes.UnaryOperation("-", attr);
-    expect(node.operator).toBe("-");
-    expect(node.expr).toBe(attr);
-    expect(node.expr).toBeInstanceOf(Nodes.Attribute);
+    const operation = new Nodes.UnaryOperation("-", 1 as unknown as Node);
+    expect(operation.operator).toBe("-");
+    expect(operation.expr).toBe(1);
   });
 
   it("operation alias", () => {
-    const node = new Nodes.UnaryOperation("-", users.get("age"));
-    const aliased = node.as("negated_age");
-    expect(aliased).toBeInstanceOf(Nodes.As);
-    expect(aliased.left).toBe(node);
-    expect(aliased.right).toBeInstanceOf(Nodes.SqlLiteral);
-  });
-
-  it("expr", () => {
-    const attr = users.get("id");
-    const node = new Nodes.UnaryOperation("-", attr);
-    expect(node.expr).toBe(attr);
-  });
-
-  it("equality with same ivars", () => {
-    const a = new Nodes.UnaryOperation("-", users.get("age"));
-    const b = new Nodes.UnaryOperation("-", users.get("age"));
-    expect(a).toEqual(b);
-  });
-
-  it("inequality with different ivars", () => {
-    const a = new Nodes.UnaryOperation("-", users.get("age"));
-    const b = new Nodes.UnaryOperation("-", users.get("id"));
-    expect(a).not.toEqual(b);
+    const operation = new Nodes.UnaryOperation("-", 1 as unknown as Node);
+    const aliaz = operation.as("zomg");
+    expect(aliaz).toBeInstanceOf(Nodes.As);
+    expect(aliaz.left).toBe(operation);
+    expect(String(aliaz.right)).toBe("zomg");
   });
 
   it("operation ordering", () => {
-    const node = new Nodes.UnaryOperation("-", users.get("age"));
-    const ordering = node.desc();
+    const operation = new Nodes.UnaryOperation("-", 1 as unknown as Node);
+    const ordering = operation.desc();
     expect(ordering).toBeInstanceOf(Nodes.Descending);
-    expect(ordering.expr).toBe(node);
-    expect(ordering.isDescending()).toBe(true);
+    expect(ordering.expr).toBe(operation);
+    expect(ordering.isDescending()).toBeTruthy();
   });
 
-  // Mirrors Rails: `visit_Arel_Nodes_UnaryOperation` emits ` #{operator} `
-  // verbatim (visitors/to_sql.rb), so internal whitespace in the operator
-  // is preserved rather than trimmed.
-  it("visitor preserves operator whitespace verbatim", () => {
-    const node = new Nodes.UnaryOperation("- ", users.get("age"));
-    expect(new Visitors.ToSql(fakeRecordConnection).compile(node)).toBe(' -  "users"."age"');
+  it("equality with same ivars", () => {
+    const array = [
+      new Nodes.UnaryOperation("-", 1 as unknown as Node),
+      new Nodes.UnaryOperation("-", 1 as unknown as Node),
+    ];
+    expect(uniq(array).length).toBe(1);
+  });
+
+  it("inequality with different ivars", () => {
+    const array = [
+      new Nodes.UnaryOperation("-", 1 as unknown as Node),
+      new Nodes.UnaryOperation("-", 2 as unknown as Node),
+    ];
+    expect(uniq(array).length).toBe(2);
   });
 });

--- a/packages/arel/src/nodes/unary-operation.trails.test.ts
+++ b/packages/arel/src/nodes/unary-operation.trails.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { fakeRecordConnection } from "../test-helpers/connection.js";
+import { Table, Nodes, Visitors } from "../index.js";
+
+describe("TestUnaryOperation", () => {
+  const users = new Table("users");
+
+  // Mirrors Rails: `visit_Arel_Nodes_UnaryOperation` emits ` #{operator} `
+  // verbatim (visitors/to_sql.rb), so internal whitespace in the operator
+  // is preserved rather than trimmed.
+  it("visitor preserves operator whitespace verbatim", () => {
+    const node = new Nodes.UnaryOperation("- ", users.get("age"));
+    expect(new Visitors.ToSql(fakeRecordConnection).compile(node)).toBe(' -  "users"."age"');
+  });
+});

--- a/packages/arel/src/nodes/window.test.ts
+++ b/packages/arel/src/nodes/window.test.ts
@@ -1,20 +1,34 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
+import type { Node } from "./node.js";
+import { uniq } from "../test-helpers/uniq.js";
 
 describe("Window", () => {
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = new Nodes.Window();
-      const b = new Nodes.Window();
-      expect(a.hash()).toBe(b.hash());
+      const window1 = new Nodes.Window();
+      window1.orders = [1, 2] as unknown as Node[];
+      window1.partitions = [1] as unknown as Node[];
+      window1.frame(3 as unknown as Node);
+      const window2 = new Nodes.Window();
+      window2.orders = [1, 2] as unknown as Node[];
+      window2.partitions = [1] as unknown as Node[];
+      window2.frame(3 as unknown as Node);
+      const array = [window1, window2];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.Window();
-      a.orders = [new Nodes.Quoted("foo")];
-      const b = new Nodes.Window();
-      b.orders = [new Nodes.Quoted("bar")];
-      expect(a.hash()).not.toBe(b.hash());
+      const window1 = new Nodes.Window();
+      window1.orders = [1, 2] as unknown as Node[];
+      window1.partitions = [1] as unknown as Node[];
+      window1.frame(3 as unknown as Node);
+      const window2 = new Nodes.Window();
+      window2.orders = [1, 2] as unknown as Node[];
+      window1.partitions = [1] as unknown as Node[];
+      window2.frame(4 as unknown as Node);
+      const array = [window1, window2];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });
@@ -22,15 +36,29 @@ describe("Window", () => {
 describe("NamedWindow", () => {
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = new Nodes.NamedWindow("w");
-      const b = new Nodes.NamedWindow("w");
-      expect(a.hash()).toBe(b.hash());
+      const window1 = new Nodes.NamedWindow("foo");
+      window1.orders = [1, 2] as unknown as Node[];
+      window1.partitions = [1] as unknown as Node[];
+      window1.frame(3 as unknown as Node);
+      const window2 = new Nodes.NamedWindow("foo");
+      window2.orders = [1, 2] as unknown as Node[];
+      window2.partitions = [1] as unknown as Node[];
+      window2.frame(3 as unknown as Node);
+      const array = [window1, window2];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with different ivars", () => {
-      const a = new Nodes.NamedWindow("w1");
-      const b = new Nodes.NamedWindow("w2");
-      expect(a.hash()).not.toBe(b.hash());
+      const window1 = new Nodes.NamedWindow("foo");
+      window1.orders = [1, 2] as unknown as Node[];
+      window1.partitions = [1] as unknown as Node[];
+      window1.frame(3 as unknown as Node);
+      const window2 = new Nodes.NamedWindow("bar");
+      window2.orders = [1, 2] as unknown as Node[];
+      window2.partitions = [1] as unknown as Node[];
+      window2.frame(3 as unknown as Node);
+      const array = [window1, window2];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });
@@ -38,15 +66,13 @@ describe("NamedWindow", () => {
 describe("CurrentRow", () => {
   describe("equality", () => {
     it("is equal to other current row nodes", () => {
-      const a = new Nodes.CurrentRow();
-      const b = new Nodes.CurrentRow();
-      expect(a.hash()).toBe(b.hash());
+      const array = [new Nodes.CurrentRow(), new Nodes.CurrentRow()];
+      expect(uniq(array).length).toBe(1);
     });
 
     it("is not equal with other nodes", () => {
-      const a = new Nodes.CurrentRow();
-      const b = new Nodes.Preceding();
-      expect(a.hash()).not.toBe(b.hash());
+      const array = [new Nodes.CurrentRow(), new (Nodes.Node as unknown as new () => Node)()];
+      expect(uniq(array).length).toBe(2);
     });
   });
 });

--- a/packages/rack/src/lock.ts
+++ b/packages/rack/src/lock.ts
@@ -2,7 +2,6 @@ import type { RackApp } from "./mock-request.js";
 
 interface Mutex {
   lock(): void;
-  /** @internal */
   unlock(): void;
 }
 
@@ -11,7 +10,6 @@ class DefaultMutex implements Mutex {
   lock() {
     this.synchronized = true;
   }
-  /** @internal */
   unlock() {
     this.synchronized = false;
   }

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -31,6 +31,14 @@
  * candidates are therefore subtracted after projection, applying the guard in
  * the TS namespace it actually gates on.
  *
+ * Alongside `files`, the manifest carries `entities` — for each TS file, the
+ * names of the Ruby entities that project onto it (every segment of each
+ * contributing FQN, since a Ruby `KeyValue::Implementation` is a TS class
+ * `KeyValue`). `files` stays the file-wide name union; `entities` lets
+ * `rails-private-jsdoc` tell a Rails-mirroring declaration from a local helper
+ * type that merely shares the file, so one entity's private name no longer
+ * gates an unrelated type's same-named member (RFC 0121).
+ *
  * Run after `pnpm parity:api` (or `ruby scripts/api-compare/extract-ruby-api.rb`):
  *   pnpm rails-privates:manifest
  */
@@ -90,7 +98,7 @@ emitDeprecatedManifest();
 emitCallbackInvocationsManifest();
 
 if (!hasRailsApi) {
-  writeJsonManifest(OUT, { files: {} });
+  writeJsonManifest(OUT, { files: {}, entities: {} });
   flushManifestBatch();
   process.exit(0);
 }
@@ -186,8 +194,9 @@ function ancestorsFor(host: RubyEntity): { instance: RubyEntity[]; klass: RubyEn
 
 interface Manifest {
   files: Record<string, string[]>;
+  entities: Record<string, string[]>;
 }
-const manifest: Manifest = { files: {} };
+const manifest: Manifest = { files: {}, entities: {} };
 
 for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
   const pkgDir = PACKAGE_DIRS[pkg];
@@ -198,6 +207,12 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
   // marked all-private if every contributor declares it private/protected.
   // rubyFile → name → "all-private" | "mixed"
   const fileVis = new Map<string, Map<string, "all-private" | "mixed">>();
+  // The TS entity names a Ruby file contributes — every segment of every
+  // contributing FQN, because the port folds a nested Ruby module onto the
+  // outer name (`I18n::Backend::KeyValue::Implementation` is class `KeyValue`).
+  // A TS class or interface outside this set is a local helper type Rails does
+  // not have, and `rails-private-jsdoc` leaves its members alone (RFC 0121).
+  const fileEntities = new Map<string, Set<string>>();
   const note = (file: string, name: string, vis: string) => {
     let m = fileVis.get(file);
     if (!m) {
@@ -209,11 +224,20 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
     if (prev === undefined) m.set(name, isPriv ? "all-private" : "mixed");
     else if (prev === "all-private" && !isPriv) m.set(name, "mixed");
   };
+  const noteEntity = (file: string, fqn: string) => {
+    let s = fileEntities.get(file);
+    if (!s) {
+      s = new Set();
+      fileEntities.set(file, s);
+    }
+    for (const seg of fqn.split("::")) s.add(seg);
+  };
 
   const visit = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
       const { instance, klass } = ancestorsFor(host);
+      noteEntity(host.file, host.fqn);
       for (const ent of instance) {
         for (const m of ent.instanceMethods ?? []) note(host.file, m.name, m.visibility);
       }
@@ -233,8 +257,10 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
   visit(rubyPkg.classes ?? {});
   visit(rubyPkg.modules ?? {});
 
-  for (const [rubyFile, names] of fileVis) {
-    const tsRel = path.posix.join(pkgDir, rubyFileToTs(rubyFile, pkg).split(path.sep).join("/"));
+  // A Ruby name's `?`/`!` variants share a TS candidate with their bare stem,
+  // so the all-private decision is re-applied in the TS namespace: any name a
+  // `mixed` Ruby name maps onto is subtracted after projection.
+  const project = (names: Map<string, "all-private" | "mixed">): Set<string> => {
     const tsNames = new Set<string>();
     for (const [ruby, status] of names) {
       if (status !== "all-private") continue;
@@ -244,15 +270,30 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
       if (status === "all-private") continue;
       for (const c of rubyMethodToTs(ruby) ?? []) tsNames.delete(c);
     }
-    if (tsNames.size === 0) continue;
-    const existing = manifest.files[tsRel] ?? [];
-    manifest.files[tsRel] = [...new Set([...existing, ...tsNames])].sort();
+    return tsNames;
+  };
+
+  for (const [rubyFile, names] of fileVis) {
+    const tsRel = path.posix.join(pkgDir, rubyFileToTs(rubyFile, pkg).split(path.sep).join("/"));
+    const tsNames = project(names);
+    if (tsNames.size > 0) {
+      const existing = manifest.files[tsRel] ?? [];
+      manifest.files[tsRel] = [...new Set([...existing, ...tsNames])].sort();
+    }
+    const entities = fileEntities.get(rubyFile);
+    if (entities && entities.size > 0) {
+      manifest.entities[tsRel] = [
+        ...new Set([...(manifest.entities[tsRel] ?? []), ...entities]),
+      ].sort();
+    }
   }
 }
 
 const sortedFiles: Record<string, string[]> = {};
 for (const k of Object.keys(manifest.files).sort()) sortedFiles[k] = manifest.files[k];
-const final: Manifest = { files: sortedFiles };
+const sortedEntities: Record<string, string[]> = {};
+for (const k of Object.keys(manifest.entities).sort()) sortedEntities[k] = manifest.entities[k];
+const final: Manifest = { files: sortedFiles, entities: sortedEntities };
 
 writeJsonManifest(OUT, final);
 flushManifestBatch();

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -36,9 +36,9 @@
       "value": 103
     },
     "arel": {
-      "assertionCount": 40,
-      "kind": 84,
-      "value": 11
+      "assertionCount": 32,
+      "kind": 53,
+      "value": 7
     },
     "date": {
       "assertionCount": 1,


### PR DESCRIPTION
Bundle of three RFC 0121 / RFC 0122 stories.

## 1. Privates manifest keys by contributing entity (RFC 0121)

`eslint/rails-private-methods.json` was keyed by (TS file, bare name) only, so a
private name on one Ruby entity gated every same-named member in the TS file —
including members of types Rails does not have. The concrete instance:
`vendor/rack/lib/rack/lock.rb` makes `Rack::Lock#unlock` private, and
`packages/rack/src/lock.ts` also declares a local `Mutex` protocol whose
`unlock` mirrors the PUBLIC stdlib `Mutex#unlock`. PR #7042 had to tag both to
get the lane green; those two tags were wrong on the merits.

The manifest now also carries `entities` — for each TS file, the names of the
Ruby entities that project onto it (every segment of each contributing FQN,
because `I18n::Backend::KeyValue::Implementation` is a TS class `KeyValue`).
`rails-private-jsdoc` resolves the enclosing class/interface of a reported
member and skips it when that name is not a known entity. A declaration that IS
a known entity still reads the file-wide union, because Rails routinely splits
one class across sibling modules in one file (`Rack::Request` /
`Rack::Request::Helpers`) that the port folds into a single TS class — narrowing
to one entity's own names there would drop real gating. The change is therefore
strictly relaxing: it can never demand a tag it did not demand before.

The two `Mutex` / `DefaultMutex` `@internal` tags in `packages/rack/src/lock.ts`
are removed. Re-sweeping the enrolled set (trailties) and rack turns up no other
over-tag. A repo-wide sweep does find ~126 `@internal` tags on members of
trails-local helper interfaces in unenrolled packages that this change makes
unenforced — they are deliberately left in place: removing them would re-enter
those names into the measured surface and move `parity:api:extra` (arel's gate
included), which is per-package burndown work under RFC 0121's enrollment
stories, not a mechanical sweep.

## 2. arel assertion burndown (RFC 0122)

`pnpm parity:test -- --assertions --package arel`: **39 / 81 / 11 → 32 / 53 / 7**
(count / kind / value), with `assertion-mismatch-mark.json` tightened to match
and no other package's mark touched.

Those two figures are both LIVE measurements, taken on `origin/main` and on this
branch. The committed mark this PR replaces read `40 / 84 / 11` — one above the
live count on two dimensions, since a mark is a ceiling and drifts above the
measurement whenever a converged row lands without a re-tighten. The post-state
was re-measured from scratch (`API_COMPARE_FORCE=1 pnpm parity:test --
--assertions --package arel`) rather than derived, and the new mark sits exactly
on it: `32 / 53 / 7`, `pnpm parity:test:assertions` green.

Most of what came out was outright drift, not stylistic difference — several
`equality` describes asserted about entirely unrelated nodes (`grouping.test.ts`
built `Window` and `NamedFunction`; `count.test.ts` built `Cte` and
`TableAlias`; `distinct.test.ts` asserted about `False`). Those bodies are now
the Rails bodies: `array.uniq.size` through the existing
`packages/arel/src/test-helpers/uniq.ts`, Rails' own literals (`"foo"` /
`"zomg"` / `AS foo`), `assert_predicate` as `toBeTruthy()`, and Rails' argument
shapes (`InfixOperation.new :+, 1, 2`). No test name is renamed. The one
trails-only assertion displaced from a mirrored test moved to a new
`packages/arel/src/nodes/unary-operation.trails.test.ts` sibling; nothing was
deleted to move a number.

`arel-assertion-mark-to-zero`'s acceptance is `0 / 0 / 0`, which this PR does
not reach, so it carries **no** `Closes-story` trailer for it — the story stays
in-progress, stamped with this PR. The remainder did not fit the LOC ceiling and
is registered as
`0122-arel-assertion-parity/stories/arel-assertion-residue-to-zero`, with the
per-test residue enumerated — including two `value` rows that are an extractor
gap rather than port drift (an operator-named Ruby Symbol, `:+` / `:-`, extracts
as an empty literal), which that story fixes in `scripts/test-compare/` rather
than by editing a test.

## 3. converge-test-fixtures-class-attribute-stores — BLOCKED, not in this PR

The story's premise does not hold. None of `test_fixtures.rb:31-38`'s eight
`class_attribute` declarations exist in trails in any form:
`packages/activerecord/src/test-fixtures.ts` is the bespoke `fixtures()` DSL,
not a port of `ActiveRecord::TestFixtures`, and a repo-wide grep finds no
`fixtureTableNames` / `fixtureClassNames` / `fixtureSets` / `useTransactionalTests`
/ `preLoadedFixtures` / `lockThreads` / `fixturePaths` store, nor any
`hasOwnProperty` copy-on-first-write helper for them. There is nothing to
converge; declaring the eight would be new surface (a port of the module), which
is a different story. Blocked with that reason rather than closed.

## Verification

- `pnpm vitest run packages/arel` — 87 files, 1465 tests, green.
- `pnpm vitest run eslint/rails-private-jsdoc.test.mjs eslint/unbacked-internal-needs-receipt.test.mjs scripts/api-compare/config.test.ts` — green.
- `pnpm parity:test:assertions` — OK.
- `pnpm parity:api:calls` / `:args` / `parity:api:extra:gate` — OK, no reseed.
- `pnpm typecheck`, `pnpm lint` over the touched trees — clean.

Closes-story: privates-manifest-keys-by-file-not-entity
