### PR TITLE
refactor(activerecord): adapter Column subclasses keep Rails' ivars private (RFC 0096)

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -12,7 +12,7 @@ import { isPresent } from "@blazetrails/activesupport";
 export class Column extends BaseColumn {
   serial: boolean;
   identity: string | null;
-  generated: string | null;
+  private _generated: string | null;
 
   constructor(
     name: string,
@@ -35,7 +35,7 @@ export class Column extends BaseColumn {
     });
     this.serial = options.serial ?? false;
     this.identity = options.identity ?? null;
-    this.generated = options.generated ?? null;
+    this._generated = options.generated ?? null;
   }
 
   // Mirrors: `delegate :oid, :fmod, to: :sql_type_metadata` (postgresql/column.rb:7).
@@ -92,7 +92,7 @@ export class Column extends BaseColumn {
 
   /** Mirrors: PostgreSQL::Column#virtual? — `@generated.present?` (`postgresql/column.rb:27-30`) */
   override isVirtual(): boolean {
-    return isPresent(this.generated);
+    return isPresent(this._generated);
   }
 
   // Mirrors: Column#has_default? — virtual columns never have a user-visible default
@@ -137,7 +137,7 @@ export class Column extends BaseColumn {
   override initWith(coder: ColumnCoder): void {
     this.serial = (coder["serial"] as boolean) ?? false;
     this.identity = (coder["identity"] as string | null) ?? null;
-    this.generated = (coder["generated"] as string | null) ?? null;
+    this._generated = (coder["generated"] as string | null) ?? null;
     super.initWith(coder);
   }
 
@@ -145,7 +145,7 @@ export class Column extends BaseColumn {
   override encodeWith(coder: ColumnCoder): void {
     coder["serial"] = this.serial;
     coder["identity"] = this.identity;
-    coder["generated"] = this.generated;
+    coder["generated"] = this._generated;
     super.encodeWith(coder);
     coder["class"] = "PostgreSQL::Column";
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2469,7 +2469,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
         columnOptions.as = column.defaultFunction;
         columnOptions.stored = column.isVirtualStored();
         columnOptions.type = column.type;
-      } else if (column.hasDefault && !column.autoIncrement) {
+      } else if (column.hasDefault && !column.isAutoIncrement()) {
         const defaultFunction = column.defaultFunction;
         const deserialized: unknown = this.lookupCastTypeFromColumn(column).deserialize(
           column.default,

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.trails.test.ts
@@ -71,7 +71,7 @@ describe("SQLite3::Column JSON round-trip", () => {
       ].sort(),
     );
     expect(back).toBeInstanceOf(Column);
-    expect(back.autoIncrement).toBe(true);
+    expect(back.isAutoIncrement()).toBe(true);
     expect(back.rowid).toBeUndefined();
     expect(back.isVirtual()).toBe(false);
     expect(back.isVirtualStored()).toBe(false);

--- a/packages/activerecord/src/connection-adapters/sqlite3/column.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/column.ts
@@ -9,7 +9,7 @@ import type { ColumnCoder } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 
 export class Column extends BaseColumn {
-  autoIncrement: boolean;
+  private _autoIncrement: boolean;
   rowid: boolean;
   private _generatedType: "stored" | "virtual" | null;
 
@@ -43,13 +43,19 @@ export class Column extends BaseColumn {
       collation: options.collation,
       defaultFunction: options.defaultFunction,
     });
-    this.autoIncrement = options.autoIncrement ?? false;
+    this._autoIncrement = options.autoIncrement ?? false;
     this.rowid = options.rowid ?? false;
     this._generatedType = options.generatedType ?? null;
   }
 
+  /** Mirrors: SQLite3::Column#auto_increment? (`sqlite3/column.rb:18-20`) */
+  isAutoIncrement(): boolean {
+    return this._autoIncrement;
+  }
+
+  /** Mirrors: SQLite3::Column#auto_incremented_by_db? (`sqlite3/column.rb:22-24`) */
   isAutoIncrementedByDb(): boolean {
-    return this.autoIncrement || this.rowid;
+    return this.isAutoIncrement() || this.rowid;
   }
 
   /**
@@ -71,7 +77,9 @@ export class Column extends BaseColumn {
 
   override equals(other: unknown): boolean {
     return (
-      other instanceof Column && super.equals(other) && this.autoIncrement === other.autoIncrement
+      other instanceof Column &&
+      super.equals(other) &&
+      this.isAutoIncrement() === other.isAutoIncrement()
     );
   }
 
@@ -81,13 +89,13 @@ export class Column extends BaseColumn {
    * dropped by a round-trip upstream too.
    */
   override initWith(coder: ColumnCoder): void {
-    this.autoIncrement = (coder["auto_increment"] as boolean) ?? false;
+    this._autoIncrement = (coder["auto_increment"] as boolean) ?? false;
     super.initWith(coder);
   }
 
   /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
   override encodeWith(coder: ColumnCoder): void {
-    coder["auto_increment"] = this.autoIncrement;
+    coder["auto_increment"] = this._autoIncrement;
     super.encodeWith(coder);
     coder["class"] = "SQLite3::Column";
   }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -355,10 +355,7 @@ class AdapterSchemaSource implements SchemaSource {
         isEnum: col.type === "enum" ? true : undefined,
         isSerial: (col as any).isSerial === true ? true : undefined,
         comment: col.comment ?? undefined,
-        autoIncrement:
-          (typeof (col as any).isAutoIncrement === "function"
-            ? (col as any).isAutoIncrement()
-            : (col as any).autoIncrement === true) || undefined,
+        autoIncrement: (col as any).isAutoIncrement?.() || undefined,
         unsigned:
           (typeof (col as any).isUnsigned === "function"
             ? (col as any).isUnsigned()

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 385,
-    "total": 1392
+    "novel": 384,
+    "total": 1391
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Converges the two adapter `Column` subclasses that exposed as public fields
state Rails keeps in ivars behind predicates.

**PostgreSQL** (`postgresql/column.rb:9-13`, `:27-30`, `:50-60`): Rails has no
`generated` reader — `@generated` is written by `initialize` / `init_with` and
read only by `virtual?`. `generated` becomes `_generated`; `parity:api:extra`
now reports `connection-adapters/postgresql/column.ts — 0 novel`.

**SQLite3** (`sqlite3/column.rb:18-20`, `:22-24`): adds `isAutoIncrement()`,
makes the ivar private, and `isAutoIncrementedByDb()` reads `auto_increment? ||
rowid` through the predicate. `rowid` stays a public reader (`attr_reader
:rowid`, `:7`). Callers (`sqlite3-adapter.ts`, `schema-dumper.ts`) repoint at
the predicate, so the duck-typed `typeof col.isAutoIncrement === "function"`
branch in the dumper's `autoIncrement` projection — added in #7032 because the
two subclasses disagreed — collapses to a plain call. (The wider projection
layer stays with `adapter-schema-source-column-flag-duck-typing` under 0023.)

`extra-surface-mark.json` tightened: activerecord novel 385→384, total
1392→1391.

Verified: `pnpm typecheck`, `pnpm lint`, `parity:api:calls` and
`parity:api:calls:args` both OK, and the touched column / schema-dumper /
column-equality suites green.

Closes-story: adapter-column-subclasses-expose-ivars-rails-keeps-private